### PR TITLE
experimental: Slim down services table format

### DIFF
--- a/pkg/ciliumenvoyconfig/testdata/anyport.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/anyport.txtar
@@ -4,10 +4,6 @@
 hive start
 db/initialized
 
-# Start with clean state.
-db/cmp services services_empty.table
-db/cmp ciliumenvoyconfigs cec_empty.table
-
 # Set up the services and endpoints
 k8s/add service.yaml
 db/cmp services services.table
@@ -39,7 +35,9 @@ envoy envoy.out
 
 # Drop the service
 k8s/delete service.yaml
-db/cmp services services_empty.table
+
+# Services should be empty
+* db/empty services
 
 # Add back the service and endpoints
 k8s/add service.yaml endpointslice.yaml
@@ -51,8 +49,9 @@ envoy envoy.out
 
 # Cleanup. Remove CEC and check that proxy redirect is gone.
 k8s/delete cec.yaml
-db/cmp ciliumenvoyconfigs cec_empty.table
-db/cmp envoy-resources envoy_resources_empty.table
+
+# Tables should be empty
+* db/empty ciliumenvoyconfigs envoy-resources
 db/cmp services services.table
 
 # The listener should now be deleted.
@@ -61,27 +60,18 @@ envoy envoy.out
 
 # ---------------------------------------------
 
--- services_empty.table --
-Name        ProxyRedirect
-
 -- services.table --
-Name        ProxyRedirect
+Name        Flags
 test/echo   
 
 -- services_redirected.table --
-Name        ProxyRedirect
-test/echo   1000
+Name        Flags
+test/echo   ProxyRedirect=1000
 
 -- backends.table --
 Address
 10.244.1.1:25/TCP
 10.244.1.1:8080/TCP
-
--- cec_empty.table --
-Name    Services
-
--- envoy_resources_empty.table --
-Name
 
 -- cec.table --
 Name                    Services

--- a/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
@@ -4,10 +4,6 @@
 hive start
 db/initialized
 
-# Start with clean state.
-db/cmp services services_empty.table
-db/cmp ciliumenvoyconfigs cec_empty.table
-
 # Set up the services and endpoints. Add the test/frontend first and wait for it
 # to reconcile.
 k8s/add service.yaml endpointslice.yaml
@@ -40,36 +36,32 @@ lb/maps-dump lbmaps.out
 
 # Check that right updates towards Envoy happened.
 envoy envoy.out
-replace 'count=2' 'count=1' envoy.out
 * cmp envoy.out envoy1.expected
 
 # Cleanup
 k8s/delete cec.yaml
-db/cmp services services.table
-db/cmp ciliumenvoyconfigs cec_empty.table
 
-# The listener should now be deleted. The update count may be either
-# 1 or 2 depending on when the controller is woken up.
+# Proxy redirect should be gone and CEC table should be empty
+db/cmp services services.table
+* db/empty ciliumenvoyconfigs
+
+# The listener should now be deleted.
 envoy envoy.out
-replace 'count=2' 'count=1' envoy.out
 * cmp envoy.out envoy2.expected
 
 # ---------------------------------------------
 
--- services_empty.table --
-Name  ProxyRedirect
-
 -- services.table --
-Name                       ProxyRedirect
+Name                       Flags
 test/backend
 test/backend_unnamed_port
 test/frontend   
 
 -- services_redirected.table --
-Name                      ProxyRedirect
+Name                      Flags
 test/backend
 test/backend_unnamed_port
-test/frontend             1000 (ports: [80])
+test/frontend             ProxyRedirect=1000 (ports: [80])
 
 -- frontends1.table --
 Address            Type        ServiceName     PortName   Backends           Status   Error
@@ -94,9 +86,6 @@ Address            Type        ServiceName                PortName   Backends   
 -- envoy-resources.table --
 Name           Listeners             Endpoints                                                                                               Status   Error
 test/ingress   test/ingress/listener test/backend:9080: 2.1.0.1, 2.1.0.2, test/backend_unnamed_port:9080: 3.1.0.1, test/frontend:80: 1.1.0.1 Done
-
--- cec_empty.table --
-Name    Services
 
 -- cec.table --
 Name           Services        BackendServices

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -4,10 +4,6 @@
 hive start
 db/initialized
 
-# Start with clean state.
-db/cmp services services_empty.table
-db/cmp ciliumenvoyconfigs cec_empty.table
-
 # Set up the services and endpoints
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
@@ -26,7 +22,9 @@ envoy envoy.out
 # Test the processing other way around, e.g. CEC exists before
 # the service.
 k8s/delete service.yaml endpointslice.yaml
-db/cmp services services_empty.table
+
+# Services should now be empty
+* db/empty services
 
 # Backends towards Envoy should be updated.
 envoy envoy.out
@@ -40,10 +38,12 @@ db/cmp services services_redirected.table
 envoy envoy.out
 * cmp envoy.out envoy3.expected
 
-# Cleanup. Remove CEC and check that proxy redirect is gone.
+# Remove the CCEC
 k8s/delete ccec.yaml
+
+# Proxy redirect and CEC should be gone
 db/cmp services services.table
-db/cmp ciliumenvoyconfigs cec_empty.table
+* db/empty ciliumenvoyconfigs
 
 # The listener should now be deleted.
 envoy envoy.out
@@ -51,19 +51,13 @@ envoy envoy.out
 
 # ---------------------------------------------
 
--- services_empty.table --
-Name        ProxyRedirect
-
 -- services.table --
-Name        ProxyRedirect
+Name        Flags
 test/echo2    
 
 -- services_redirected.table --
-Name        ProxyRedirect
-test/echo2  1000
-
--- cec_empty.table --
-Name    Services
+Name        Flags
+test/echo2  ProxyRedirect=1000
 
 -- cec.table --
 Name                  Selected  Services    Listeners

--- a/pkg/ciliumenvoyconfig/testdata/headless.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/headless.txtar
@@ -4,10 +4,6 @@
 hive start
 db/initialized
 
-# Start with clean state.
-db/cmp services services_empty.table
-db/cmp ciliumenvoyconfigs cec_empty.table
-
 # Set up the services and endpoints
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
@@ -32,7 +28,9 @@ envoy envoy.out
 # Drop the service. No changes towards envoy as the load assignments
 # do not change.
 k8s/delete service.yaml
-db/cmp services services_empty.table
+
+# Wait until empty
+* db/empty services
 
 # Add back the service and endpoints
 k8s/add service.yaml endpointslice.yaml
@@ -51,10 +49,12 @@ envoy envoy.out
 
 k8s/delete unrelated_service.yaml unrelated_endpointslice.yaml
 
-# Cleanup. Remove CEC and check that proxy redirect is gone.
+# Remove the CEC
 k8s/delete cec.yaml
+
+# Check tables, the redirect should be gone and ciliumenvoyconfigs should be empty.
+* db/empty ciliumenvoyconfigs
 db/cmp services services.table
-db/cmp ciliumenvoyconfigs cec_empty.table
 
 # The listener should now be deleted.
 envoy envoy.out
@@ -62,15 +62,9 @@ envoy envoy.out
 
 # ---------------------------------------------
 
--- services_empty.table --
-Name        ProxyRedirect
-
 -- services.table --
-Name        ProxyRedirect
-test/echo
-
--- cec_empty.table --
-Name    Services
+Name       Source   PortNames  TrafficPolicy  Flags
+test/echo  k8s      http=80    Cluster
 
 -- cec.table --
 Name                    BackendServices  Services

--- a/pkg/ciliumenvoyconfig/testdata/labels.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/labels.txtar
@@ -24,9 +24,6 @@ envoy envoy.out
 
 # ---------------------------------------------
 
--- cec_empty.table --
-Name    Services
-
 -- cec_a.table --
 Name                    Selected  NodeSelector
 test/envoy-a            true      foo=a       

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -7,10 +7,6 @@ db/insert node-addresses addrv4.yaml
 hive start
 db/initialized
 
-# Start with clean state.
-db/cmp services services_empty.table
-db/cmp ciliumenvoyconfigs cec_empty.table
-
 # Set up the services and endpoints
 k8s/add service.yaml
 db/cmp services services.table
@@ -43,7 +39,9 @@ envoy envoy.out
 
 # Drop the service
 k8s/delete service.yaml
-db/cmp services services_empty.table
+
+# Services should be empty
+* db/empty services
 
 # Add back the service and endpoints
 k8s/add service.yaml endpointslice.yaml
@@ -65,8 +63,10 @@ db/cmp services services.table
 k8s/update cec.yaml
 db/cmp services services_redirected.table
 k8s/delete cec.yaml
+
+# Proxy redirect should be goneand CEC empty.
 db/cmp services services.table
-db/cmp ciliumenvoyconfigs cec_empty.table
+* db/empty ciliumenvoyconfigs
 
 # The listener should now be deleted.
 envoy envoy.out
@@ -80,16 +80,13 @@ nodeport: true
 primary: true
 devicename: test
 
--- services_empty.table --
-Name        ProxyRedirect
-
 -- services.table --
-Name        ProxyRedirect
+Name        Flags
 test/echo   
 
 -- services_redirected.table --
-Name        ProxyRedirect
-test/echo   1000 (ports: [80])
+Name        Flags
+test/echo   ProxyRedirect=1000 (ports: [80])
 
 -- backends.table --
 Address

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/address.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/address.txtar
@@ -20,8 +20,7 @@ db/cmp services services-empty.table
 db/cmp frontends frontends-empty.table
 
 # Maps should now be empty.
-lb/maps-dump lbmaps.actual
-* cmp lbmaps.actual maps-empty.expected
+* lb/maps-empty
 
 -- lrp.table --
 Name           Type     FrontendType      Frontends
@@ -44,13 +43,6 @@ Address                    Type          ServiceName                    Backends
 -- backends.table --
 Address             Instances
 10.244.2.1:80/TCP   test/lrp-addr:local-redirect (tcp)
-
--- maps.expected --
-BE: ID=1 ADDR=10.244.2.1:80/TCP STATE=active
-REV: ID=1 ADDR=169.254.169.254:8080
-SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
-SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
--- maps-empty.expected --
 
 -- lrp-addr.yaml --
 apiVersion: "cilium.io/v2"
@@ -105,3 +97,8 @@ status:
     status: 'True'
     type: Ready
 
+-- maps.expected --
+BE: ID=1 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=1 ADDR=169.254.169.254:8080
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb-addr.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb-addr.txtar
@@ -44,8 +44,7 @@ db/delete desired-skiplbmap pod-cookie.yaml
 * db/empty frontends localredirectpolicies services desired-skiplbmap
 skiplbmap skiplbmap.actual
 * cmp skiplbmap.actual skiplbmap.empty
-lb/maps-dump lbmaps.actual
-* cmp lbmaps.actual maps.empty
+* lb/maps-empty
 
 ### Case 2: 1) pod & LRP 2) cookie
 
@@ -89,8 +88,7 @@ db/delete desired-skiplbmap pod-cookie.yaml
 db/show desired-skiplbmap
 skiplbmap skiplbmap.actual
 * cmp skiplbmap.actual skiplbmap.empty
-lb/maps-dump lbmaps.actual
-* cmp lbmaps.actual maps.empty
+* lb/maps-empty
 
 -- pod-cookie.yaml --
 podnamespacedname: test/lrp-pod
@@ -122,8 +120,6 @@ test/lrp-addr:local-redirect  k8s
 -- frontends.table --
 Address                    Type          ServiceName                    PortName   Backends              RedirectTo                    Status
 169.254.169.255:8080/TCP   LocalRedirect test/lrp-addr:local-redirect              10.244.2.1:80/TCP                                   Done
-
--- maps.empty --
 
 -- maps-case1.expected --
 BE: ID=1 ADDR=10.244.2.1:80/TCP STATE=active

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb.txtar
@@ -45,11 +45,9 @@ db/delete desired-skiplbmap pod-cookie.yaml
 
 # Wait until empty
 * db/empty frontends localredirectpolicies services desired-skiplbmap
-db/show desired-skiplbmap
 skiplbmap skiplbmap.actual
 * cmp skiplbmap.actual skiplbmap.empty
-lb/maps-dump lbmaps.actual
-* cmp lbmaps.actual maps.empty
+* lb/maps-empty
 
 ### Case 2: 1) pod,service,eps, 2) LRP, 3) cookie
 
@@ -111,11 +109,9 @@ db/delete desired-skiplbmap pod-cookie.yaml
 
 # Wait until empty
 * db/empty frontends localredirectpolicies services desired-skiplbmap
-db/show desired-skiplbmap
+* lb/maps-empty
 skiplbmap skiplbmap.actual
 * cmp skiplbmap.actual skiplbmap.empty
-lb/maps-dump lbmaps.actual
-* cmp lbmaps.actual maps.empty
 
 -- pod-cookie.yaml --
 podnamespacedname: test/lrp-pod
@@ -164,8 +160,6 @@ Address                    Type        ServiceName   PortName   Backends        
 Address                    Type        ServiceName   PortName   Backends              RedirectTo        Status
 169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                     Done
 [1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:8080/TCP                      Done
-
--- maps.empty --
 
 -- maps-case1.expected --
 BE: ID=3 ADDR=10.244.2.1:80/TCP STATE=active

--- a/pkg/loadbalancer/experimental/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/experimental/testdata/clusterip.txtar
@@ -18,15 +18,12 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
-k8s/delete service.yaml endpointslice.yaml 
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+k8s/delete service.yaml endpointslice.yaml
 
 # Check that BPF maps are emptied as otherwise the reconciler might
 # not have yet processed the deletion
-lb/maps-dump lbmaps.actual
-* cmp lbmaps.empty lbmaps.actual
+* db/empty services frontends backends
+* lb/maps-empty
 
 # Do it again but this time add endpoint slice first and then service.
 k8s/add endpointslice.yaml
@@ -41,12 +38,11 @@ lb/maps-dump lbmaps.actual
 
 # Remove service and add it back
 k8s/delete service.yaml
-db/cmp services services_empty.table
 
 # Check that BPF maps are emptied as otherwise the reconciler might
 # not have yet processed the deletion
-lb/maps-dump lbmaps.actual
-* cmp lbmaps.empty lbmaps.actual
+* db/empty services
+* lb/maps-empty
 
 # Add the service back. We should now get the same map contents, except
 # with new IDs.
@@ -88,21 +84,18 @@ db/cmp frontends frontends.table
 lb/maps-dump lbmaps.actual
 * cmp lbmaps6.expected lbmaps.actual
 
-# Cleanup
-k8s/delete service.yaml endpointslice.yaml 
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+# Remove the services and endpoint slices.
+k8s/delete service.yaml endpointslice.yaml
 
-# Check that BPF maps are now empty
-lb/maps-dump lbmaps.actual
-* cmp lbmaps.empty lbmaps.actual
+# Check that tables and BPF maps are now empty
+* db/empty services frontends backends
+* lb/maps-empty
 
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster            42s               0                     false
+Name        Source   PortNames  TrafficPolicy   Flags
+test/echo   k8s      http=80    Cluster         SessionAffinity=42s
 
 -- frontends.table --
 Address               Type        ServiceName   PortName   Backends           Status
@@ -119,15 +112,6 @@ Address               Type        ServiceName   PortName   Backends  Status
 -- backends.table --
 Address             Instances          Shadows
 10.244.1.1:80/TCP   test/echo (http)
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
--- backends_empty.table --
-Address
 
 -- service.yaml --
 apiVersion: v1
@@ -210,8 +194,6 @@ ports:
 - name: http
   port: 80
   protocol: TCP
-
--- lbmaps.empty --
 
 -- lbmaps.expected --
 AFF: ID=1 BEID=1

--- a/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
@@ -27,9 +27,9 @@ lb/maps-dump lbmaps.actual
 
 # Cleanup
 k8s/delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+
+# Tables should be empty
+* db/empty services frontends backends
 
 #####
 
@@ -51,8 +51,8 @@ Address NodePort Primary DeviceName
 2001::1 true     true    test
 
 -- services.table --
-Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-default/echo-dualstack   k8s                  Cluster            Cluster                              0                     false
+Name                     Source   PortNames         TrafficPolicy   Flags
+default/echo-dualstack   k8s      http=80, tftp=69  Cluster
 
 -- frontends-ipv4.table --
 Address                     Type        ServiceName              PortName   Backends                                                     Status
@@ -86,16 +86,6 @@ Address                        Instances
 [fd00:10:244:1::247e]:80/TCP   default/echo-dualstack (http)
 [fd00:10:244:2::a314]:69/UDP   default/echo-dualstack (tftp)
 [fd00:10:244:2::a314]:80/TCP   default/echo-dualstack (http)
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
--- frontends_empty.table --
-Address  Type        ServiceName   PortName   Status  Backends
-
--- backends_empty.table --
-Address
-
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/dualstack.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack.txtar
@@ -26,9 +26,9 @@ lb/maps-dump lbmaps.actual
 
 # Cleanup
 k8s/delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+
+# Tables should be empty
+* db/empty services frontends backends
 
 #####
 
@@ -50,8 +50,8 @@ Address NodePort Primary DeviceName
 2001::1 true     true    test
 
 -- services.table --
-Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-default/echo-dualstack   k8s                  Cluster            Cluster                              0                     false              
+Name                     Source   PortNames         TrafficPolicy   Flags
+default/echo-dualstack   k8s      http=80, tftp=69  Cluster
 
 -- frontends-ipv4.table --
 Address                     Type        ServiceName              PortName   Backends                                                     Status
@@ -85,15 +85,6 @@ Address                        Instances
 [fd00:10:244:1::247e]:80/TCP   default/echo-dualstack (http)
 [fd00:10:244:2::a314]:69/UDP   default/echo-dualstack (tftp)
 [fd00:10:244:2::a314]:80/TCP   default/echo-dualstack (http)
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
--- backends_empty.table --
-Address
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
@@ -49,16 +49,17 @@ db/cmp frontends frontends-terminating2.table
 db/cmp backends backends-terminating2.table
 
 # Cleanup
-k8s/delete service.yaml endpointslice.yaml 
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+k8s/delete service.yaml endpointslice.yaml
+
+# Tables and maps should be empty now
+* db/empty services frontends backends
+* lb/maps-empty
 
 #####
 
 -- services.table --
-Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/graceful-term-svc   k8s                  Cluster            Cluster                              0                     false              
+Name                     Source   PortNames  TrafficPolicy   Flags
+test/graceful-term-svc   k8s      =8081      Cluster         
 
 -- frontends.table --
 Address                 Type        ServiceName              Status  Backends                              
@@ -82,15 +83,6 @@ Address                 Instances                              NodeName
 Address                 Instances                             NodeName
 10.244.0.112:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
 10.244.0.113:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
--- backends_empty.table --
-Address
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/headless.txtar
+++ b/pkg/loadbalancer/experimental/testdata/headless.txtar
@@ -6,22 +6,23 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 db/initialized
 
-# Add a headless service with backends. It should appear in the services table, but should have
-# no frontends.
+# Add a headless service with backends.
 k8s/add service_clusterip_none.yaml endpointslice.yaml
+
+# Check tables. The headless service should exist, but without frontends.
 db/cmp services services.table
 db/cmp backends backends.table 
-db/cmp frontends frontends_empty.table
+* db/empty frontends
 
 # The BPF maps should be empty since there are no frontends.
-lb/maps-dump lbmaps.actual
-cmp lbmaps.empty lbmaps.actual
+* lb/maps-empty
 
 # Cleanup the headless service. The endpoint slice is not deleted
 # so we still have backends referencing the removed service.
 k8s/delete service_clusterip_none.yaml
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
+
+# Check tables
+* db/empty services frontends
 db/cmp backends backends.table
 
 # Add a non-headless service
@@ -39,38 +40,28 @@ replace 'placeholder' 'service.kubernetes.io/headless' service.yaml
 k8s/update service.yaml
 
 # Frontends are now removed.
+* db/empty frontends
 db/cmp services services.table
-db/cmp backends backends.table 
-db/cmp frontends frontends_empty.table
+db/cmp backends backends.table
 
 # The BPF maps should be empty since there are no frontends.
-lb/maps-dump lbmaps.actual
-* cmp lbmaps.empty lbmaps.actual
+* lb/maps-empty
 
 # Clean up everything.
 k8s/delete service.yaml endpointslice.yaml
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+
+# Tables should be empty
+* db/empty services frontends backends
 
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster                              0                     false
-
--- services_empty.table --
-Name  Source
+Name        Source   PortNames  TrafficPolicy  Flags
+test/echo   k8s      http=80    Cluster
 
 -- backends.table --
 Address             Instances          Shadows        NodeName
 10.244.1.1:80/TCP   test/echo (http)                  nodeport-worker
-
--- backends_empty.table --
-Address
-
--- frontends_empty.table --
-Address  Type
 
 -- frontends.table --
 Address        Type       Status  Backends 
@@ -153,8 +144,6 @@ ports:
 - name: http
   port: 80
   protocol: TCP
-
--- lbmaps.empty --
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active

--- a/pkg/loadbalancer/experimental/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/experimental/testdata/healthserver.txtar
@@ -126,9 +126,9 @@ loadbalancer.reflector      job-reflect-pods                  OK      Running
 loadbalancer.reflector      job-reflect-services-endpoints    OK      Running
 
 -- services.table --
-Name                   Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   HealthCheckNodePort
-test/echo              k8s                  Local              Local              $HEALTHPORT1
-test/echo:healthserver local                Local              Local              0
+Name                   Source   PortNames  TrafficPolicy   Flags
+test/echo              k8s      http=80    Local           HealthCheckNodePort=$HEALTHPORT1
+test/echo:healthserver local               Local
 
 -- frontends.table --
 Address               Type         ServiceName            PortName   Status  Backends
@@ -156,10 +156,6 @@ Address               Type         ServiceName            PortName   Status  Bac
 10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    
 172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    
 
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
-
 -- backends1.table --
 Instances              Address
 test/echo (http)       10.244.1.1:80/TCP
@@ -179,9 +175,6 @@ test/echo (http)       10.244.1.4:80/TCP
 Address               Instances              NodeName
 10.244.1.3:80/TCP     test/echo (http)       othernode
 10.244.1.4:80/TCP     test/echo (http)       othernode
-
--- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/hostport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/hostport.txtar
@@ -29,12 +29,14 @@ lb/maps-dump lbmaps.actual
 # "terminate" the pod
 replace 'phase: Running' 'phase: Succeeded' pod.yaml
 k8s/update pod.yaml
-db/cmp services services2.table
+
+# Services should be empty
+* db/empty services
 
 # Add a new pod to take over the HostPort
 k8s/add other-pod.yaml
-db/cmp frontends frontends3.table
-db/cmp services services3.table
+db/cmp frontends frontends2.table
+db/cmp services services2.table
 
 # Check that BPF maps now contain the new pod for the same host port.
 lb/maps-dump lbmaps.actual
@@ -44,8 +46,8 @@ lb/maps-dump lbmaps.actual
 k8s/delete pod.yaml
 
 # Check that tables and the BPF maps are the same.
-db/cmp frontends frontends3.table
-db/cmp services services3.table
+db/cmp frontends frontends2.table
+db/cmp services services2.table
 lb/maps-dump lbmaps.actual
 * cmp lbmaps2.expected lbmaps.actual
 
@@ -53,8 +55,8 @@ lb/maps-dump lbmaps.actual
 db/show backends
 replace 4444 5555 other-pod.yaml
 k8s/update other-pod.yaml
-db/cmp frontends frontends4.table
-db/cmp backends backends4.table
+db/cmp frontends frontends3.table
+db/cmp backends backends3.table
 
 # Check that BPF maps now have the port 5555
 lb/maps-dump lbmaps.actual
@@ -62,9 +64,10 @@ lb/maps-dump lbmaps.actual
 
 # Cleanup
 k8s/delete other-pod.yaml
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+
+# Tables and maps should be empty
+* db/empty services frontends backends
+* lb/maps-empty
 
 #####
 
@@ -84,20 +87,17 @@ default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8    k8s
 
 -- services2.table --
 Name                                                                  Source
-
--- services3.table --
-Name                                                                  Source
 default/other-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 k8s
 
 -- frontends.table --
 Address           Type      Status  ServiceName                                                         Backends
 0.0.0.0:4444/TCP  HostPort  Done    default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8  10.244.1.113:80/TCP
 
--- frontends3.table --
+-- frontends2.table --
 Address           Type      Status  ServiceName                                                           Backends
 0.0.0.0:4444/TCP  HostPort  Done    default/other-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.114:80/TCP
 
--- frontends4.table --
+-- frontends3.table --
 Address           Type      Status  ServiceName                                                           Backends
 0.0.0.0:5555/TCP  HostPort  Done    default/other-app:host-port:5555:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.114:80/TCP
 
@@ -105,18 +105,9 @@ Address           Type      Status  ServiceName                                 
 Address             Instances 
 10.244.1.113:80/TCP default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8
 
--- backends4.table --
+-- backends3.table --
 Address             Instances 
 10.244.1.114:80/TCP default/other-app:host-port:5555:22222222-2e9b-4c61-8454-ae81344876d8
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
--- backends_empty.table --
-Address
 
 -- pod.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/loadbalancer.txtar
+++ b/pkg/loadbalancer/experimental/testdata/loadbalancer.txtar
@@ -27,12 +27,15 @@ lb/maps-dump lbmaps.actual
 
 # Cleanup. Backends first in this test.
 k8s/delete endpointslice.yaml
-db/cmp backends backends_empty.table
-db/cmp frontends frontends_nobackends.table
 
+# Backends should now be empty
+* db/empty backends
+db/cmp frontends frontends_nobackends.table
 k8s/delete service.yaml
-db/cmp frontends frontends_empty.table
-db/cmp services services_empty.table
+
+# Tables and BPF maps should now be empty
+* db/empty services frontends backends
+* lb/maps-empty
 
 #####
 
@@ -47,11 +50,8 @@ Address NodePort Primary DeviceName
 1.1.1.1 true     true    test
 
 -- services.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo    k8s                  Cluster            Cluster                              0                     false              
-
--- services_empty.table --
-Name         Source
+Name         Source   PortNames  TrafficPolicy   Flags
+test/echo    k8s      http=80    Cluster         
 
 -- frontends1.table --
 Address               Type         ServiceName   PortName   Status  Backends
@@ -71,16 +71,10 @@ Address               Type         ServiceName   PortName   Status  Backends
 10.96.50.104:80/TCP   ClusterIP    test/echo     http       Done        
 172.16.1.1:80/TCP     LoadBalancer test/echo     http       Done
 
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
 -- backends.table --
 Address             Instances            NodeName
 10.244.1.1:80/TCP   test/echo (http)     nodeport-worker
 10.244.1.2:80/TCP   test/echo (http)     nodeport-worker2
-
--- backends_empty.table --
-Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active

--- a/pkg/loadbalancer/experimental/testdata/multiport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/multiport.txtar
@@ -16,19 +16,18 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
-k8s/delete service.yaml endpointslice.yaml 
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+k8s/delete service.yaml endpointslice.yaml
+
+# Tables should be empty now
+* db/empty services frontends backends
 
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster                              0                     false              
+Name        Source   PortNames           TrafficPolicy   Flags
+test/echo   k8s      http=80, https=443  Cluster         
 
 -- frontends.table --
-
 Address                Type        ServiceName   PortName   Backends             Status
 10.96.50.104:80/TCP    ClusterIP   test/echo     http       10.244.1.1:80/TCP    Done
 10.96.50.104:443/TCP   ClusterIP   test/echo     https      10.244.1.1:443/TCP   Done
@@ -37,15 +36,6 @@ Address                Type        ServiceName   PortName   Backends            
 Address              Instances           NodeName
 10.244.1.1:80/TCP    test/echo (http)    nodeport-worker
 10.244.1.1:443/TCP   test/echo (https)   nodeport-worker
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
--- backends_empty.table --
-Address
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/nodeport-addr.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-addr.txtar
@@ -8,10 +8,6 @@ db/cmp node-addresses nodeaddrs.table
 
 # Start the test application
 hive start
-
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-# (otherwise might miss events due to List() vs Watch() race in fake client).
-# NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
 db/initialized
 
 # Add the first service and endpoints
@@ -46,12 +42,16 @@ lb/maps-dump lbmaps-updated.actual
 
 # Cleanup. Backends first in this test.
 k8s/delete endpointslice.yaml endpointslice2.yaml
-db/cmp backends backends_empty.table
+
+# Backends should be empty now.
+* db/empty backends
 db/cmp frontends frontends_nobackends.table
 
+# Then delete the services
 k8s/delete service.yaml service2.yaml
-db/cmp frontends frontends_empty.table
-db/cmp services services_empty.table
+
+# All tables should be empty
+* db/empty frontends services backends
 
 #####
 
@@ -83,13 +83,9 @@ Address NodePort Primary DeviceName
 3.3.3.3 false    true    test3
 
 -- services.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo    k8s                  Cluster            Cluster                              0                     false              
-test/echo2   k8s                  Cluster            Cluster                              0                     false              
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
+Name         Source   PortNames  TrafficPolicy   Flags
+test/echo    k8s      http=80    Cluster         
+test/echo2   k8s      http2=80   Cluster         
 
 -- frontends1.table --
 Address               Type        ServiceName   PortName   Status  Backends
@@ -110,10 +106,6 @@ Address               Type        ServiceName   PortName   Status  Backends
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done        
 10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done        
 
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
-
 -- backends1.table --
 Address             Instances            NodeName        
 10.244.1.1:80/TCP   test/echo (http)     nodeport-worker 
@@ -131,9 +123,6 @@ Address             Instances            NodeName
 10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker 
 10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2
 10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2
-
--- backends_empty.table --
-Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active

--- a/pkg/loadbalancer/experimental/testdata/nodeport-explicit-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-explicit-maglev.txtar
@@ -32,16 +32,17 @@ lb/maps-dump lbmaps.actual
 
 # Cleanup. Backends first in this test.
 k8s/delete endpointslice.yaml endpointslice2.yaml
-db/cmp backends backends_empty.table
+
+# Check tables
+* db/empty backends
 db/cmp frontends frontends_nobackends.table
 
+# Then delete the service
 k8s/delete service.yaml service2.yaml
-db/cmp frontends frontends_empty.table
-db/cmp services services_empty.table
 
-# Check that BPF maps are empty
-lb/maps-dump lbmaps.actual
-* cmp lbmaps-empty.expected lbmaps.actual
+# Check that tables and BPF maps are empty
+* db/empty services frontends backends
+* lb/maps-empty
 
 #####
 
@@ -56,12 +57,9 @@ Address NodePort Primary DeviceName
 1.1.1.1 true     true    test
 
 -- services.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges   ExplicitLBAlgorithm
-test/echo    k8s                  Cluster            Cluster                              0                     false                             undef
-test/echo2   k8s                  Cluster            Cluster                              0                     false                             maglev
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   PortNames  TrafficPolicy   Flags
+test/echo    k8s      http=80    Cluster
+test/echo2   k8s      http2=80   Cluster         ExplicitLBAlgorithm=maglev
 
 -- frontends1.table --
 Address               Type        ServiceName   PortName   Status  Backends
@@ -82,10 +80,6 @@ Address               Type        ServiceName   PortName   Status  Backends
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done
 10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done
 
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
-
 -- backends1.table --
 Address             Instances            NodeName
 10.244.1.1:80/TCP   test/echo (http)     nodeport-worker 
@@ -103,9 +97,6 @@ Address             Instances            NodeName
 10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker 
 10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2
 10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2
-
--- backends_empty.table --
-Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
@@ -153,8 +144,6 @@ SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterI
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- lbmaps-empty.expected --
-
 -- service.yaml --
 apiVersion: v1
 kind: Service

--- a/pkg/loadbalancer/experimental/testdata/nodeport-explicit-random.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-explicit-random.txtar
@@ -33,16 +33,17 @@ lb/maps-dump lbmaps.actual
 
 # Cleanup. Backends first in this test.
 k8s/delete endpointslice.yaml endpointslice2.yaml
-db/cmp backends backends_empty.table
-db/cmp frontends frontends_nobackends.table
 
+# Backends should now be empty.
+* db/empty backends
+db/cmp frontends frontends_no_backends.table
+
+# Then delete the service
 k8s/delete service.yaml service2.yaml
-db/cmp frontends frontends_empty.table
-db/cmp services services_empty.table
 
-# Check that BPF maps are empty
-lb/maps-dump lbmaps.actual
-* cmp lbmaps-empty.expected lbmaps.actual
+# Check that tables and BPF maps are empty
+* db/empty frontends services backends
+* lb/maps-empty
 
 #####
 
@@ -57,13 +58,9 @@ Address NodePort Primary DeviceName
 1.1.1.1 true     true    test
 
 -- services.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges   ExplicitLBAlgorithm
-test/echo    k8s                  Cluster            Cluster                              0                     false                             undef
-test/echo2   k8s                  Cluster            Cluster                              0                     false                             random
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
+Name         Source   PortNames   TrafficPolicy   Flags
+test/echo    k8s      http=80     Cluster         
+test/echo2   k8s      http2=80    Cluster         ExplicitLBAlgorithm=random
 
 -- frontends1.table --
 Address               Type        ServiceName   PortName   Status  Backends
@@ -77,16 +74,12 @@ Address               Type        ServiceName   PortName   Status  Backends
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
 10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
 
--- frontends_nobackends.table --
+-- frontends_no_backends.table --
 Address               Type        ServiceName   PortName   Status  Backends
 0.0.0.0:30781/TCP     NodePort    test/echo     http       Done
 0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done
 10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done
-
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
 
 -- backends1.table --
 Address             Instances            NodeName
@@ -105,9 +98,6 @@ Address             Instances            NodeName
 10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker
 10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2
 10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2
-
--- backends_empty.table --
-Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
@@ -155,8 +145,6 @@ SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterI
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- lbmaps-empty.expected --
-
 -- service.yaml --
 apiVersion: v1
 kind: Service

--- a/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
@@ -32,16 +32,17 @@ lb/maps-dump lbmaps.actual
 
 # Cleanup. Backends first in this test.
 k8s/delete endpointslice.yaml endpointslice2.yaml
-db/cmp backends backends_empty.table
+
+# Backends should be empty
+* db/empty backends
 db/cmp frontends frontends_nobackends.table
 
+# Finally remove the services
 k8s/delete service.yaml service2.yaml
-db/cmp frontends frontends_empty.table
-db/cmp services services_empty.table
 
-# Check that BPF maps are empty
-lb/maps-dump lbmaps.actual
-* cmp lbmaps-empty.expected lbmaps.actual
+# Check that tables and BPF maps are empty
+* db/empty services frontends backends
+* lb/maps-empty
 
 #####
 
@@ -56,13 +57,9 @@ Address NodePort Primary DeviceName
 1.1.1.1 true     true    test
 
 -- services.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo    k8s                  Cluster            Cluster                              0                     false
-test/echo2   k8s                  Cluster            Cluster                              0                     false
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
+Name         Source   PortNames  TrafficPolicy   Flags
+test/echo    k8s      http=80    Cluster         
+test/echo2   k8s      http2=80   Cluster         
 
 -- frontends1.table --
 Address               Type        ServiceName   PortName   Status  Backends
@@ -83,9 +80,6 @@ Address               Type        ServiceName   PortName   Status  Backends
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done
 10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done
 
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
 -- backends1.table --
 Address             Instances            NodeName         
 10.244.1.1:80/TCP   test/echo (http)     nodeport-worker  
@@ -103,9 +97,6 @@ Address             Instances            NodeName
 10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker  
 10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2 
 10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2 
-
--- backends_empty.table --
-Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
@@ -154,8 +145,6 @@ SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterI
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- lbmaps-empty.expected --
-
 -- service.yaml --
 apiVersion: v1
 kind: Service

--- a/pkg/loadbalancer/experimental/testdata/nodeport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport.txtar
@@ -41,8 +41,10 @@ lb/maps-dump lbmaps.actual
 
 # Delete the remaining endpointslice
 k8s/delete endpointslice.yaml
+
+# Backends should now be empty
+* db/empty backends
 db/cmp frontends frontends_nobackends.table
-db/cmp backends backends_empty.table
 
 # Check BPF maps
 lb/maps-dump lbmaps.actual
@@ -50,12 +52,10 @@ lb/maps-dump lbmaps.actual
 
 # Finally delete the services
 k8s/delete service.yaml service2.yaml
-db/cmp frontends frontends_empty.table
-db/cmp services services_empty.table
 
-# Check BPF maps
-lb/maps-dump lbmaps.actual
-* cmp lbmaps-empty.expected lbmaps.actual
+# Check that tables and BPF maps are empty
+* db/empty services frontends backends
+* lb/maps-empty
 
 #####
 
@@ -70,12 +70,9 @@ Address NodePort Primary DeviceName
 1.1.1.1 true     true    test
 
 -- services.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo    k8s                  Cluster            Cluster                              0                     false              
-test/echo2   k8s                  Cluster            Cluster                              0                     false              
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   PortNames   TrafficPolicy   Flags
+test/echo    k8s      http=80     Cluster         
+test/echo2   k8s      http2=80    Cluster         
 
 
 -- frontends1.table --
@@ -104,9 +101,6 @@ Address               Type        ServiceName   PortName   Status  Backends
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done        
 10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done        
 
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
 -- backends.table --
 Address             Instances            NodeName
 10.244.1.1:80/TCP   test/echo (http)     nodeport-worker
@@ -124,9 +118,6 @@ Address             Instances            NodeName
 10.244.1.2:80/TCP   test/echo (http)     nodeport-worker    
 10.244.1.3:80/TCP   test/echo (http)     nodeport-worker2   
 10.244.1.4:80/TCP   test/echo (http)     nodeport-worker2   
-
--- backends_empty.table --
-Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
@@ -215,8 +206,6 @@ SVC: ID=3 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOU
 SVC: ID=4 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
 SVC: ID=5 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=NodePort
 SVC: ID=6 ADDR=10.96.50.105:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- lbmaps-empty.expected --
-
 -- service.yaml --
 apiVersion: v1
 kind: Service

--- a/pkg/loadbalancer/experimental/testdata/pruning.txtar
+++ b/pkg/loadbalancer/experimental/testdata/pruning.txtar
@@ -25,14 +25,11 @@ cmp lbmaps.expected lbmaps.actual
 lb/maps-snapshot
 
 # Cleanup
-k8s/delete service.yaml endpointslice.yaml 
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+k8s/delete service.yaml endpointslice.yaml
 
-# Maps should be empty now.
-lb/maps-dump lbmaps.actual
-* cmp lbmaps-empty.expected lbmaps.actual
+# Tables and maps should be empty
+* db/empty services frontends backends
+* lb/maps-empty
 
 # Restore the contents from the earlier snapshot.
 lb/maps-restore
@@ -43,14 +40,13 @@ cmp lbmaps.expected lbmaps.actual
 lb/prune
 
 # Check that everything gets cleaned up
-lb/maps-dump lbmaps.actual
-* cmp lbmaps-empty.expected lbmaps.actual
+* lb/maps-empty
 
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster                              0                     false              
+Name        Source   PortNames TrafficPolicy   Flags
+test/echo   k8s      http=80   Cluster
 
 -- frontends.table --
 Address               Type        ServiceName   PortName   Backends                                                  Status
@@ -62,15 +58,6 @@ Address             Instances
 10.244.1.1:80/TCP   test/echo (http)
 10.244.1.2:80/TCP   test/echo (http)
 10.244.1.3:80/TCP   test/echo (http)
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
--- backends_empty.table --
-Address
 
 -- service.yaml --
 apiVersion: v1
@@ -145,5 +132,3 @@ SVC: ID=2 ADDR=10.96.50.105:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=3 QCOU
 SVC: ID=2 ADDR=10.96.50.105:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=2 ADDR=10.96.50.105:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=2 ADDR=10.96.50.105:80/TCP SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- lbmaps-empty.expected --
-

--- a/pkg/loadbalancer/experimental/testdata/quarantined.txtar
+++ b/pkg/loadbalancer/experimental/testdata/quarantined.txtar
@@ -26,13 +26,11 @@ k8s/delete service.yaml endpointslice.yaml
 
 # Check that everything empty
 * db/empty frontends services backends
-lb/maps-dump maps.actual
-* cmp maps.actual maps.empty
+* lb/maps-empty
 
 # Restore previous BPF map state and reset BPF ops to restore state from maps.
 lb/maps-restore
 test/bpfops-reset
-lb/maps-dump
 
 # We should see a quarantined restored backend.
 test/bpfops-summary

--- a/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
+++ b/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
@@ -15,16 +15,17 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
-k8s/delete service.yaml endpointslice.yaml 
-db/cmp services services_empty.table
-db/cmp frontends frontends_empty.table
-db/cmp backends backends_empty.table
+k8s/delete service.yaml endpointslice.yaml
+
+# Maps and tables should be empty
+* db/empty services frontends backends
+* lb/maps-empty
 
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster                              0                     false              10.0.0.0/8
+Name        Source   PortNames  TrafficPolicy   Flags
+test/echo   k8s      http=80    Cluster         SourceRanges=10.0.0.0/8
 
 -- frontends.table --
 Address               Type          ServiceName   PortName   Backends            Status
@@ -34,15 +35,6 @@ Address               Type          ServiceName   PortName   Backends           
 -- backends.table --
 Address             Instances          NodeName
 10.244.1.1:80/TCP   test/echo (http)   nodeport-worker
-
--- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-
--- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
-
--- backends_empty.table --
-Address
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/svc-type-annotation.txtar
+++ b/pkg/loadbalancer/experimental/testdata/svc-type-annotation.txtar
@@ -38,8 +38,8 @@ db/cmp services services.table
 #####
 
 -- services.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo    k8s                  Cluster            Cluster                              0                     false              
+Name         Source   TrafficPolicy   Flags
+test/echo    k8s      Cluster
 
 -- frontends-all.table --
 Address               Type         ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/experimental/testdata/trafficpolicy.txtar
+++ b/pkg/loadbalancer/experimental/testdata/trafficpolicy.txtar
@@ -8,20 +8,33 @@ db/initialized
 
 # Create a LoadBalancer service with Local traffic policies and associate two backends 
 # to it, one of them on this node ("testnode") and one on another node.
-k8s/add service.yaml endpointslice.yaml
+k8s/add service_tp_local.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
 
 # Check the BPF maps
 lb/maps-dump lbmaps.actual
-* cmp lbmaps.expected lbmaps.actual
+* cmp lbmaps.actual lbmaps.expected
+
+# Update service to have mixed traffic policy
+k8s/update service_tp_mixed.yaml
+db/cmp services services_tp_mixed.table
+
+# Check the BPF maps. We should now have an external and internal frontends
+# with matching traffic policies.
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual lbmaps_tp_mixed.expected
 
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy
-test/echo   k8s                  Local              Local           
+Name        Source   PortNames  TrafficPolicy   Flags
+test/echo   k8s      http=80    Local           
+
+-- services_tp_mixed.table --
+Name        Source   PortNames  TrafficPolicy           Flags
+test/echo   k8s      http=80    Ext=Cluster, Int=Local
 
 -- frontends.table --
 Address               Type         ServiceName   PortName   Backends            Status
@@ -33,7 +46,7 @@ Address             Instances          NodeName
 10.244.1.1:80/TCP   test/echo (http)   testnode
 10.244.2.1:80/TCP   test/echo (http)   othernode
 
--- service.yaml --
+-- service_tp_local.yaml --
 apiVersion: v1
 kind: Service
 metadata:
@@ -46,6 +59,33 @@ spec:
   clusterIPs:
   - 10.96.50.104
   externalTrafficPolicy: Local
+  internalTrafficPolicy: Local
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 1.1.1.1
+
+-- service_tp_mixed.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalTrafficPolicy: Cluster
   internalTrafficPolicy: Local
   ports:
   - name: http
@@ -101,3 +141,16 @@ SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 
 SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
 SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
 SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
+-- lbmaps_tp_mixed.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=1 ADDR=1.1.1.1:80
+REV: ID=2 ADDR=10.96.50.104:80
+REV: ID=3 ADDR=1.1.1.1:80
+SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer+InternalLocal+two-scopes
+SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+InternalLocal+two-scopes
+SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+InternalLocal+two-scopes
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+InternalLocal+non-routable
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+InternalLocal+non-routable
+SVC: ID=3 ADDR=1.1.1.1:80/TCP/i SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+InternalLocal+two-scopes
+SVC: ID=3 ADDR=1.1.1.1:80/TCP/i SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+InternalLocal+two-scopes


### PR DESCRIPTION
The table output for services started to get quite busy with more niche columns being added to it.
This collapses rare data into "Flags" column.

Before:
```
Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
test/echo   k8s                  Cluster            Cluster            42s               0                     false
```

After:
```
Name        Source   PortNames  TrafficPolicy   Flags
test/echo   k8s      http=80    Cluster         SessionAffinity=42s
```