### PR TITLE
operator: report metrics for CiliumNodeSynchronizer queues

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -832,6 +832,24 @@ Name                                        Labels                      Descript
 ``cid_controller_work_queue_latency``       ``resource``, ``phase``     Duration of CID controller work queues enqueuing and processing latencies in seconds
 =========================================== =========================== =====================================================================================
 
+Internal WorkQueues
+~~~~~~~~~~~~~~~~~~~~
+
+The Operator uses internal queues to manage the processing of various tasks. Currently only the Cilium Node Synchronizer queues are reporting the metrics listed below.
+
+==================================================== ============================================= ========== ===========================================================
+Name                                                 Labels                                        Default    Description
+==================================================== ============================================= ========== ===========================================================
+``workqueue_depth``                                  ``queue_name``                                 Enabled    Current depth of workqueue
+``workqueue_adds_total``                             ``queue_name``                                 Enabled    Total number of adds handled by workqueue
+``workqueue_queue_duration_seconds``                 ``queue_name``                                 Enabled    Duration in seconds an item stays in workqueue prior to request
+``workqueue_work_duration_seconds``                  ``queue_name``                                 Enabled    Duration in seconds to process an item from workqueue
+``workqueue_unfinished_work_seconds``                ``queue_name``                                 Enabled    Duration in seconds of work in progress that hasn't been observed by work_duration. Large values indicate stuck threads. You can deduce the number of stuck threads by observing the rate at which this value increases.
+``workqueue_longest_running_processor_seconds``      ``queue_name``                                 Enabled    Duration in seconds of the longest running processor for workqueue
+``workqueue_retries_total``                          ``queue_name``                                 Enabled    Total number of retries handled by workqueue
+==================================================== ============================================= ========== ===========================================================
+
+
 Hubble
 ------
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -118,6 +118,7 @@ Starovoitov
 Stormtroopers
 Suchakra
 Suricata
+Synchronizer
 Talos
 Telco
 Terraform

--- a/operator/cmd/cilium_node_metrics.go
+++ b/operator/cmd/cilium_node_metrics.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/util/workqueue"
+
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+const workqueueSubsystem = "workqueue"
+
+type WorkqueuePrometheusMetricsProvider struct {
+	registry  prometheus.Registerer
+	namespace string
+	subsystem string
+}
+
+func NewWorkqueuePrometheusMetricsProvider() *WorkqueuePrometheusMetricsProvider {
+	return &WorkqueuePrometheusMetricsProvider{
+		registry:  operatorMetrics.Registry,
+		namespace: metrics.CiliumOperatorNamespace,
+		subsystem: workqueueSubsystem,
+	}
+}
+
+func (p WorkqueuePrometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   p.namespace,
+		Subsystem:   p.subsystem,
+		Name:        "depth",
+		Help:        "Current depth of the workqueue",
+		ConstLabels: prometheus.Labels{"queue_name": name},
+	})
+	p.registry.MustRegister(metric)
+	return metric
+}
+
+func (p WorkqueuePrometheusMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	metric := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   p.namespace,
+		Subsystem:   p.subsystem,
+		Name:        "adds_total",
+		Help:        "Total number of adds handled by the workqueue",
+		ConstLabels: prometheus.Labels{"queue_name": name},
+	})
+	p.registry.MustRegister(metric)
+	return metric
+}
+
+func (p WorkqueuePrometheusMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace:   p.namespace,
+		Subsystem:   p.subsystem,
+		Name:        "latency",
+		Help:        "How long in seconds an item stays in workqueue before being requested",
+		Buckets:     prometheus.ExponentialBuckets(10e-9, 10, 10),
+		ConstLabels: prometheus.Labels{"queue_name": name},
+	})
+	p.registry.MustRegister(metric)
+	return metric
+}
+
+func (p WorkqueuePrometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace:   p.namespace,
+		Subsystem:   p.subsystem,
+		Name:        "work_duration",
+		Help:        "How long in seconds processing an item from workqueue takes",
+		Buckets:     prometheus.ExponentialBuckets(10e-9, 10, 10),
+		ConstLabels: prometheus.Labels{"queue_name": name},
+	})
+	p.registry.MustRegister(metric)
+	return metric
+}
+
+func (p WorkqueuePrometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: p.namespace,
+		Subsystem: p.subsystem,
+		Name:      "unfinished_work_seconds",
+		Help: "How many seconds of work has been done that " +
+			"is in progress and hasn't been observed by work_duration. Large " +
+			"values indicate stuck threads. One can deduce the number of stuck " +
+			"threads by observing the rate at which this increases.",
+		ConstLabels: prometheus.Labels{"queue_name": name},
+	})
+	p.registry.MustRegister(metric)
+	return metric
+}
+
+func (p WorkqueuePrometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: p.namespace,
+		Subsystem: p.subsystem,
+		Name:      "longest_running_processor_seconds",
+		Help: "How many seconds has the longest running " +
+			"processor for workqueue been running",
+		ConstLabels: prometheus.Labels{"queue_name": name},
+	})
+	p.registry.MustRegister(metric)
+	return metric
+}
+
+func (p WorkqueuePrometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	metric := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   p.namespace,
+		Subsystem:   p.subsystem,
+		Name:        "retries_total",
+		Help:        "Total number of retries handled by workqueue",
+		ConstLabels: prometheus.Labels{"queue_name": name},
+	})
+	p.registry.MustRegister(metric)
+	return metric
+}


### PR DESCRIPTION
# Description
Internal `CiliumNodeSynchronizer` queues aren't being monitored at all right now. We recently had an incident where the Operator struggled to keep up with `CiliumNode` updates after a significant scale-up in the cluster, and we couldn't track the internal Operator state. This PR adds observability to these internal queues to help us monitor them better.

The metrics implement `client-go`'s workqueue `MetricProvider` interface: https://pkg.go.dev/k8s.io/client-go/util/workqueue#MetricsProvider

This solution doesn't use the new Hive `Metric` Cell because the `CiliumNodeSynchronizer` is [set up](https://github.com/cilium/cilium/blob/15fd4d28ec70bd759e0fdc1c1a8776544b9176a5/operator/cmd/root.go#L676) within the `Legacy` Cell. I followed the same approach as the IPAM [`PrometheusMetrics`](https://github.com/cilium/cilium/blob/4e56ba978c3adae433e99f045f4ac4fd7c02a7cd/pkg/ipam/metrics/metrics.go), which are used in `AllocatorProvider`s within the same `Legacy` Cell. Moving these out of the `Legacy` Cell into their own separate Cells would require a lot of refactoring and IMO this refactoring would be a good opportunity to switch them to Hive Metrics.

I'm also aware that the Agent has its own Workqueue `MetricProvider` [implementation](https://github.com/cilium/cilium/blob/32447d8ebae0b2166c233e2bc2db85e69308c37d/pkg/k8s/watchers/metrics.go#L47-L75). I don't really see how it can be reused in the Operator without significant refactoring though. It's too tightly tied to the Agent metric setup right now.

# Testing
Deployed to a test cluster, verified that new metrics were picked up by the Datadog Prometheus integration:
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/5956e14b-ba62-4cd3-a746-4b6c155962e6" />


<br/><br/>
```release-note
operator: report metrics for internal CiliumNodeSynchronizer queues
```
