### PR TITLE
check-encryption-leak:fix: L4 ports usages when no TCP/UDP packet

### DIFF
--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -64,8 +64,10 @@ kprobe:br_forward
 
     if ($proto == PROTO_IPV4) {
       $pod_to_pod_via_proxy =
-        @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
-        @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
+        !($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ?
+          @trace_ip4[$ip4h->saddr, 0, 0] :
+          (@trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
+            @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol]);
 
       // Skip CiliumInternalIP addresses, as they belong to the PodCIDR,
       // unless the given flow is explicitly marked as traced (i.e., from proxy).
@@ -79,8 +81,10 @@ kprobe:br_forward
 
     if ($proto == PROTO_IPV6) {
       $pod_to_pod_via_proxy =
-        @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
-        @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
+          !($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ?
+          @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, 0, 0] :
+          (@trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
+            @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr]);
 
       // Skip CiliumInternalIP addresses, as they belong to the PodCIDR
       // unless the given flow is explicitly marked as traced (i.e., from proxy).
@@ -102,8 +106,10 @@ kprobe:br_forward
       $dst_is_pod = (bswap($ip4h->daddr) & MASK4) == CIDR4;
 
       $pod_to_pod_via_proxy =
-          @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
-          @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
+          !($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ?
+          @trace_ip4[$ip4h->saddr, 0, 0] :
+          (@trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
+            @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol]);
 
       if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
         $tcph = (struct tcphdr*)$udph;
@@ -111,8 +117,10 @@ kprobe:br_forward
         if (!$tcph->rst) {
           printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),
-            ntop($ip4h->saddr), bswap($udph->source),
-            ntop($ip4h->daddr), bswap($udph->dest),
+            ntop($ip4h->saddr),
+            ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
+            ntop($ip4h->daddr),
+            ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->dest) : 0,
             $ip4h->protocol,
             $ip4h->protocol == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
             $ip4h->protocol == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
@@ -146,8 +154,10 @@ kprobe:br_forward
       $dst_is_pod = bswap($ip6h->daddr.in6_u.u6_addr16[0]) == CIDR6;
 
       $pod_to_pod_via_proxy =
-          @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
-          @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
+          !($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ?
+          @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, 0, 0] :
+          (@trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
+            @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr]);
 
       if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
         $tcph = (struct tcphdr*)$udph;
@@ -155,8 +165,10 @@ kprobe:br_forward
         if (!$tcph->rst) {
           printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),
-            ntop($ip6h->saddr.in6_u.u6_addr8), bswap($udph->source),
-            ntop($ip6h->daddr.in6_u.u6_addr8), bswap($udph->dest),
+            ntop($ip6h->saddr.in6_u.u6_addr8),
+            ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
+            ntop($ip6h->daddr.in6_u.u6_addr8),
+            ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->dest) : 0,
             $ip6h->nexthdr,
             $ip6h->nexthdr == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
             $ip6h->nexthdr == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,


### PR DESCRIPTION
```release-note
Ensure packet protocol before using L4 ports in the check-encryption-leak script.
```