### PR TITLE
gha/scale-egw: make masquerade delay thresholds configurable

### DIFF
--- a/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
+++ b/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
@@ -1,3 +1,7 @@
+{{$MASQ_DELAY_THRESHOLD := DefaultParam .CL2_EGW_MASQ_DELAY_THRESHOLD 1}}
+{{$CPU_USAGE_THRESHOLD := DefaultParam .CL2_EGW_MASQ_CPU_USAGE_THRESHOLD 0.12}}
+{{$MEM_USAGE_THRESHOLD := DefaultParam .CL2_EGW_MASQ_MEM_USAGE_THRESHOLD 250}}
+
 steps:
 - name: "{{ .action }} masquerade delay metrics"
   measurements:
@@ -12,16 +16,16 @@ steps:
       queries:
       - name: P50
         query: quantile(0.5, egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"})
-        threshold: 1
+        threshold: {{ $MASQ_DELAY_THRESHOLD }}
       - name: P90
         query: quantile(0.9, egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"})
-        threshold: 1
+        threshold: {{ $MASQ_DELAY_THRESHOLD }}
       - name: P95
         query: quantile(0.95, egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"})
-        threshold: 2
+        threshold: {{ $MASQ_DELAY_THRESHOLD }}
       - name: P99
         query: quantile(0.99, egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"})
-        threshold: 2
+        threshold: {{ MultiplyFloat $MASQ_DELAY_THRESHOLD 1.25 }}
 
   - Identifier: MasqueradeDelayLeakedPingsTotal{{ .metricsSuffix }}
     Method: GenericPrometheusQuery
@@ -65,7 +69,7 @@ steps:
         query: quantile(0.50, avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
       - name: Max
         query: max(avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
-        threshold: 0.15
+        threshold: {{ $CPU_USAGE_THRESHOLD }}
 
   - Identifier: MasqueradeDelayCiliumMemUsage{{ .metricsSuffix }}
     Method: GenericPrometheusQuery
@@ -80,4 +84,4 @@ steps:
         query: quantile(0.5, max_over_time(cilium_process_resident_memory_bytes[%v]) / 1024 / 1024)
       - name: Max
         query: max(max_over_time(cilium_process_resident_memory_bytes[%v]) / 1024 / 1024)
-        threshold: 260
+        threshold: {{ $MEM_USAGE_THRESHOLD }}

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -93,38 +93,38 @@ triggers:
 
 workflows:
   conformance-aks.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-aws-cni.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-clustermesh.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-delegated-ipam.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-ipsec-e2e.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-eks.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-gateway-api.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-ginkgo.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation)/|(.github/renovate\.json5|CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md)$)
   conformance-gke.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-ingress.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-multi-pool.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-runtime.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation)/|(.github/renovate\.json5|CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md)$)
   integration-test.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|Documentation)/|(.github/renovate\.json5|CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md)$)
   tests-clustermesh-upgrade.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   tests-datapath-verifier.yaml:
-    paths-regex: (bpf|test/verifier|vendor|images)/
+    paths-regex: (bpf|test/verifier|vendor|images|.github/actions/cl2-modules)/
   tests-e2e-upgrade.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   tests-ipsec-upgrade.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   hubble-cli-integration-test.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation)/|(.github/renovate\.json5|CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md)$)


### PR DESCRIPTION
So that it is easier to tune them if necessary. While being there, let's also tighten a bit the thresholds, based on the outcome of the previous runs. While being there, let's also update the Ariane configuration so that we don't unnecessarily trigger the full CI when clusterloader2 configurations are modified.