### PR TITLE
Support IPv6 underlay

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -377,7 +377,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	if (info && info->flag_skip_tunnel)
 		goto skip_tunnel;
 
-	if (info && info->tunnel_endpoint.ip4 != 0) {
+	if (info && info->flag_has_tunnel_ep) {
 		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint.ip4,
 						      encrypt_key, secctx, info->sec_identity,
 						      &trace);
@@ -393,7 +393,7 @@ skip_tunnel:
 
 #if defined(ENABLE_IPSEC) && !defined(TUNNEL_MODE)
 	/* See IPv4 comment. */
-	if (from_proxy && info->tunnel_endpoint.ip4 && encrypt_key)
+	if (from_proxy && info->flag_has_tunnel_ep && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint.ip4,
 					 info->sec_identity, true, false);
 
@@ -834,7 +834,7 @@ skip_vtep:
 	if (info && info->flag_skip_tunnel)
 		goto skip_tunnel;
 
-	if (info && info->tunnel_endpoint.ip4 != 0) {
+	if (info && info->flag_has_tunnel_ep) {
 		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint.ip4,
 						      encrypt_key, secctx, info->sec_identity,
 						      &trace);
@@ -862,7 +862,7 @@ skip_tunnel:
 
 #if defined(ENABLE_IPSEC) && !defined(TUNNEL_MODE)
 	/* We encrypt host to remote pod packets only if they are from proxy. */
-	if (from_proxy && info->tunnel_endpoint.ip4 && encrypt_key)
+	if (from_proxy && info->flag_has_tunnel_ep && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint.ip4,
 					 info->sec_identity, true, false);
 
@@ -1026,7 +1026,7 @@ do_netdev_encrypt_encap(struct __ctx_buff *ctx, __be16 proto, __u32 src_id)
 		break;
 # endif /* ENABLE_IPV4 */
 	}
-	if (!ep || !ep->tunnel_endpoint.ip4)
+	if (!ep || !ep->flag_has_tunnel_ep)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
 	ctx->mark = 0;

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -377,8 +377,8 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	if (info && info->flag_skip_tunnel)
 		goto skip_tunnel;
 
-	if (info && info->tunnel_endpoint != 0) {
-		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
+	if (info && info->tunnel_endpoint.ip4 != 0) {
+		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint.ip4,
 						      encrypt_key, secctx, info->sec_identity,
 						      &trace);
 	}
@@ -393,8 +393,8 @@ skip_tunnel:
 
 #if defined(ENABLE_IPSEC) && !defined(TUNNEL_MODE)
 	/* See IPv4 comment. */
-	if (from_proxy && info->tunnel_endpoint && encrypt_key)
-		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
+	if (from_proxy && info->tunnel_endpoint.ip4 && encrypt_key)
+		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint.ip4,
 					 info->sec_identity, true, false);
 
 	if (from_proxy && !identity_is_cluster(info->sec_identity))
@@ -834,8 +834,8 @@ skip_vtep:
 	if (info && info->flag_skip_tunnel)
 		goto skip_tunnel;
 
-	if (info && info->tunnel_endpoint != 0) {
-		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
+	if (info && info->tunnel_endpoint.ip4 != 0) {
+		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint.ip4,
 						      encrypt_key, secctx, info->sec_identity,
 						      &trace);
 	}
@@ -862,8 +862,8 @@ skip_tunnel:
 
 #if defined(ENABLE_IPSEC) && !defined(TUNNEL_MODE)
 	/* We encrypt host to remote pod packets only if they are from proxy. */
-	if (from_proxy && info->tunnel_endpoint && encrypt_key)
-		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
+	if (from_proxy && info->tunnel_endpoint.ip4 && encrypt_key)
+		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint.ip4,
 					 info->sec_identity, true, false);
 
 	if (from_proxy && !identity_is_cluster(info->sec_identity))
@@ -1026,12 +1026,12 @@ do_netdev_encrypt_encap(struct __ctx_buff *ctx, __be16 proto, __u32 src_id)
 		break;
 # endif /* ENABLE_IPV4 */
 	}
-	if (!ep || !ep->tunnel_endpoint)
+	if (!ep || !ep->tunnel_endpoint.ip4)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
 	ctx->mark = 0;
 
-	return encap_and_redirect_with_nodeid(ctx, ep->tunnel_endpoint, 0,
+	return encap_and_redirect_with_nodeid(ctx, ep->tunnel_endpoint.ip4, 0,
 					      src_id, 0, &trace);
 }
 #endif /* ENABLE_IPSEC && TUNNEL_MODE */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -459,6 +459,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 						__s8 *ext_err)
 {
 	struct ct_state *ct_state, ct_state_new = {};
+	struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
 	union macaddr router_mac = THIS_INTERFACE_MAC;
@@ -471,7 +472,6 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
-	__u32 tunnel_endpoint = 0;
 	__u8 __maybe_unused encrypt_key = 0;
 	bool __maybe_unused skip_tunnel = false;
 	enum ct_status ct_status;
@@ -490,12 +490,10 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	 */
 	if (1) {
 		const union v6addr *daddr = (union v6addr *)&ip6->daddr;
-		struct remote_endpoint_info *info;
 
 		info = lookup_ip6_remote_endpoint(daddr, 0);
 		if (info) {
 			*dst_sec_identity = info->sec_identity;
-			tunnel_endpoint = info->tunnel_endpoint.ip4;
 			encrypt_key = get_min_encrypt_key(info->key);
 			skip_tunnel = info->flag_skip_tunnel;
 		} else {
@@ -551,7 +549,11 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 					     ext_err, &proxy_port);
 
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
+			__u32 tunnel_endpoint = 0;
+
 			auth_type = (__u8)*ext_err;
+			if (info)
+				tunnel_endpoint = info->tunnel_endpoint.ip4;
 			verdict = auth_lookup(ctx, SECLABEL_IPV6, *dst_sec_identity,
 					      tunnel_endpoint, auth_type);
 		}
@@ -723,7 +725,7 @@ ct_recreate6:
 		 * the packet needs IPSec encap so push ctx to stack for encap, or
 		 * (c) packet was redirected to tunnel device so return.
 		 */
-		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
+		ret = encap_and_redirect_lxc(ctx, info, encrypt_key,
 					     SECLABEL_IPV6, *dst_sec_identity,
 					     &trace);
 		switch (ret) {
@@ -770,8 +772,8 @@ pass_to_stack:
 
 #ifndef TUNNEL_MODE
 # ifdef ENABLE_IPSEC
-	if (encrypt_key && tunnel_endpoint) {
-		ret = set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
+	if (encrypt_key && info->flag_has_tunnel_ep) {
+		ret = set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint.ip4,
 					SECLABEL_IPV6, false, false);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
@@ -897,6 +899,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 						__s8 *ext_err)
 {
 	struct ct_state *ct_state, ct_state_new = {};
+	struct remote_endpoint_info *info;
 	struct ipv4_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
 	union macaddr router_mac = THIS_INTERFACE_MAC;
@@ -908,7 +911,6 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
-	__u32 tunnel_endpoint = 0, zero = 0;
 	__u8 __maybe_unused encrypt_key = 0;
 	bool __maybe_unused skip_tunnel = false;
 	bool hairpin_flow = false; /* endpoint wants to access itself via service IP */
@@ -921,6 +923,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	bool from_l7lb = false;
 	__u32 cluster_id = 0;
 	void *ct_map, *ct_related_map = NULL;
+	__u32 zero = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -932,22 +935,17 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 #endif /* ENABLE_PER_PACKET_LB */
 
 	/* Determine the destination category for policy fallback. */
-	if (1) {
-		struct remote_endpoint_info *info;
-
-		info = lookup_ip4_remote_endpoint(ip4->daddr, cluster_id);
-		if (info) {
-			*dst_sec_identity = info->sec_identity;
-			tunnel_endpoint = info->tunnel_endpoint.ip4;
-			encrypt_key = get_min_encrypt_key(info->key);
-			skip_tunnel = info->flag_skip_tunnel;
-		} else {
-			*dst_sec_identity = WORLD_IPV4_ID;
-		}
-
-		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
-			   ip4->daddr, *dst_sec_identity);
+	info = lookup_ip4_remote_endpoint(ip4->daddr, cluster_id);
+	if (info) {
+		*dst_sec_identity = info->sec_identity;
+		encrypt_key = get_min_encrypt_key(info->key);
+		skip_tunnel = info->flag_skip_tunnel;
+	} else {
+		*dst_sec_identity = WORLD_IPV4_ID;
 	}
+
+	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
+		   ip4->daddr, *dst_sec_identity);
 
 	ct_buffer = map_lookup_elem(&cilium_tail_call_buffer4, &zero);
 	if (!ct_buffer)
@@ -998,7 +996,11 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 					     ext_err, &proxy_port);
 
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
+			__u32 tunnel_endpoint = 0;
+
 			auth_type = (__u8)*ext_err;
+			if (info)
+				tunnel_endpoint = info->tunnel_endpoint.ip4;
 			verdict = auth_lookup(ctx, SECLABEL_IPV4, *dst_sec_identity,
 					      tunnel_endpoint, auth_type);
 		}
@@ -1219,6 +1221,7 @@ ct_recreate4:
 	 */
 #if defined(ENABLE_VTEP)
 	{
+		struct remote_endpoint_info fake_info = {0};
 		struct vtep_key vkey = {};
 		struct vtep_value *vtep;
 
@@ -1230,7 +1233,9 @@ ct_recreate4:
 		if (vtep->vtep_mac && vtep->tunnel_endpoint) {
 			if (eth_store_daddr(ctx, (__u8 *)&vtep->vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;
-			return __encap_and_redirect_with_nodeid(ctx, vtep->tunnel_endpoint,
+			fake_info.tunnel_endpoint.ip4 = vtep->tunnel_endpoint;
+			fake_info.flag_has_tunnel_ep = true;
+			return __encap_and_redirect_with_nodeid(ctx, &fake_info,
 								SECLABEL_IPV4, WORLD_IPV4_ID,
 								WORLD_IPV4_ID, &trace);
 		}
@@ -1268,12 +1273,14 @@ skip_vtep:
 		 * and this is the reply for that. In that case, we need to send it back to tunnel.
 		 */
 		if (ct_status == CT_REPLY) {
-			if (identity_is_remote_node(*dst_sec_identity) && ct_state->from_tunnel)
-				tunnel_endpoint = ip4->daddr;
+			if (identity_is_remote_node(*dst_sec_identity) && ct_state->from_tunnel) {
+				info->tunnel_endpoint.ip4 = ip4->daddr;
+				info->flag_has_tunnel_ep = true;
+			}
 		}
 #endif
 
-		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
+		ret = encap_and_redirect_lxc(ctx, info, encrypt_key,
 					     SECLABEL_IPV4, *dst_sec_identity, &trace);
 		switch (ret) {
 		case CTX_ACT_OK:
@@ -1327,8 +1334,8 @@ pass_to_stack:
 
 #ifndef TUNNEL_MODE
 # ifdef ENABLE_IPSEC
-	if (encrypt_key && tunnel_endpoint) {
-		ret = set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
+	if (encrypt_key && info->flag_has_tunnel_ep) {
+		ret = set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint.ip4,
 					SECLABEL_IPV4, false, false);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -495,7 +495,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		info = lookup_ip6_remote_endpoint(daddr, 0);
 		if (info) {
 			*dst_sec_identity = info->sec_identity;
-			tunnel_endpoint = info->tunnel_endpoint;
+			tunnel_endpoint = info->tunnel_endpoint.ip4;
 			encrypt_key = get_min_encrypt_key(info->key);
 			skip_tunnel = info->flag_skip_tunnel;
 		} else {
@@ -938,7 +938,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		info = lookup_ip4_remote_endpoint(ip4->daddr, cluster_id);
 		if (info) {
 			*dst_sec_identity = info->sec_identity;
-			tunnel_endpoint = info->tunnel_endpoint;
+			tunnel_endpoint = info->tunnel_endpoint.ip4;
 			encrypt_key = get_min_encrypt_key(info->key);
 			skip_tunnel = info->flag_skip_tunnel;
 		} else {
@@ -1643,7 +1643,7 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 			if (sep) {
 				auth_type = (__u8)*ext_err;
 				verdict = auth_lookup(ctx, SECLABEL_IPV6, src_label,
-						      sep->tunnel_endpoint, auth_type);
+						      sep->tunnel_endpoint.ip4, auth_type);
 			}
 		}
 
@@ -1988,7 +1988,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 			if (sep) {
 				auth_type = (__u8)*ext_err;
 				verdict = auth_lookup(ctx, SECLABEL_IPV4, src_label,
-						      sep->tunnel_endpoint, auth_type);
+						      sep->tunnel_endpoint.ip4, auth_type);
 			}
 		}
 		/* Emit verdict if drop or if allow for CT_NEW. */

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -683,12 +683,10 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 		/* If packets are decrypted the key has already been pushed into metadata. */
 		if (!decrypted) {
 			struct bpf_tunnel_key key = {};
-			__u32 key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
 
-			if (unlikely(ctx_get_tunnel_key(ctx, &key, key_size, 0) < 0)) {
-				ret = DROP_NO_TUNNEL_KEY;
+			ret = get_tunnel_key(ctx, &key);
+			if (unlikely(ret < 0))
 				goto out;
-			}
 			cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
 
 			src_sec_identity = get_id_from_tunnel_id(key.tunnel_id, proto);

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -544,6 +544,7 @@ int tail_handle_ipv4(struct __ctx_buff *ctx)
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_ARP)
 int tail_handle_arp(struct __ctx_buff *ctx)
 {
+	struct remote_endpoint_info fake_info = {0};
 	union macaddr mac = THIS_INTERFACE_MAC;
 	union macaddr smac;
 	struct trace_ctx trace = {
@@ -573,7 +574,9 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 	if (unlikely(ret != 0))
 		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_EGRESS);
 	if (info->tunnel_endpoint) {
-		ret = __encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
+		fake_info.tunnel_endpoint.ip4 = info->tunnel_endpoint;
+		fake_info.flag_has_tunnel_ep = true;
+		ret = __encap_and_redirect_with_nodeid(ctx, &fake_info,
 						       LOCAL_NODE_ID, WORLD_IPV4_ID,
 						       WORLD_IPV4_ID, &trace);
 		if (IS_ERR(ret))

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -347,7 +347,13 @@ struct edt_info {
 struct remote_endpoint_info {
 	__u32		sec_identity;
 	union {
-		__u32	ip4;
+		struct {
+			__u32	ip4;
+			__u32	pad1;
+			__u32	pad2;
+			__u32	pad3;
+		};
+		union v6addr	ip6;
 	} tunnel_endpoint;
 	__u16		pad;
 	__u8		key;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -352,7 +352,9 @@ struct remote_endpoint_info {
 	__u16		pad;
 	__u8		key;
 	__u8		flag_skip_tunnel:1,
-			pad2:7;
+			flag_has_tunnel_ep:1,
+			flag_ipv6_tunnel_ep:1,
+			pad2:5;
 };
 
 /*

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -346,7 +346,9 @@ struct edt_info {
 
 struct remote_endpoint_info {
 	__u32		sec_identity;
-	__u32		tunnel_endpoint;
+	union {
+		__u32	ip4;
+	} tunnel_endpoint;
 	__u16		pad;
 	__u8		key;
 	__u8		flag_skip_tunnel:1,

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -213,10 +213,10 @@ bool egress_gw_reply_needs_redirect_hook(struct iphdr *ip4, __u32 *tunnel_endpoi
 		struct remote_endpoint_info *info;
 
 		info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-		if (!info || info->tunnel_endpoint == 0)
+		if (!info || info->tunnel_endpoint.ip4 == 0)
 			return false;
 
-		*tunnel_endpoint = info->tunnel_endpoint;
+		*tunnel_endpoint = info->tunnel_endpoint.ip4;
 		*dst_sec_identity = info->sec_identity;
 
 		return true;
@@ -437,10 +437,10 @@ bool egress_gw_reply_needs_redirect_hook_v6(struct ipv6hdr *ip6, __u32 *tunnel_e
 		struct remote_endpoint_info *info;
 
 		info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
-		if (!info || info->tunnel_endpoint == 0)
+		if (!info || info->tunnel_endpoint.ip4 == 0)
 			return false;
 
-		*tunnel_endpoint = info->tunnel_endpoint;
+		*tunnel_endpoint = info->tunnel_endpoint.ip4;
 		*dst_sec_identity = info->sec_identity;
 
 		return true;

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -231,6 +231,7 @@ int egress_gw_handle_packet(struct __ctx_buff *ctx,
 			    __u32 src_sec_identity, __u32 dst_sec_identity,
 			    const struct trace_ctx *trace)
 {
+	struct remote_endpoint_info fake_info = {0};
 	struct endpoint_info *gateway_node_ep;
 	__be32 gateway_ip = 0;
 	int ret;
@@ -259,7 +260,9 @@ int egress_gw_handle_packet(struct __ctx_buff *ctx,
 		return CTX_ACT_OK;
 
 	/* Send the packet to egress gateway node through a tunnel. */
-	return __encap_and_redirect_with_nodeid(ctx, gateway_ip,
+	fake_info.tunnel_endpoint.ip4 = gateway_ip;
+	fake_info.flag_has_tunnel_ep = true;
+	return __encap_and_redirect_with_nodeid(ctx, &fake_info,
 						src_sec_identity, dst_sec_identity,
 						NOT_VTEP_DST, trace);
 }
@@ -455,6 +458,7 @@ int egress_gw_handle_packet_v6(struct __ctx_buff *ctx,
 			       __u32 src_sec_identity, __u32 dst_sec_identity,
 			       const struct trace_ctx *trace)
 {
+	struct remote_endpoint_info fake_info = {0};
 	struct endpoint_info *gateway_node_ep;
 	__be32 gateway_ip = 0;
 	int ret;
@@ -483,7 +487,9 @@ int egress_gw_handle_packet_v6(struct __ctx_buff *ctx,
 		return CTX_ACT_OK;
 
 	/* Send the packet to egress gateway node through a tunnel. */
-	return __encap_and_redirect_with_nodeid(ctx, gateway_ip, src_sec_identity,
+	fake_info.tunnel_endpoint.ip4 = gateway_ip;
+	fake_info.flag_has_tunnel_ep = true;
+	return __encap_and_redirect_with_nodeid(ctx, &fake_info, src_sec_identity,
 						dst_sec_identity, NOT_VTEP_DST, trace);
 }
 #endif /* ENABLE_IPV6 */

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -213,7 +213,7 @@ bool egress_gw_reply_needs_redirect_hook(struct iphdr *ip4, __u32 *tunnel_endpoi
 		struct remote_endpoint_info *info;
 
 		info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-		if (!info || info->tunnel_endpoint.ip4 == 0)
+		if (!info || !info->flag_has_tunnel_ep)
 			return false;
 
 		*tunnel_endpoint = info->tunnel_endpoint.ip4;

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -224,4 +224,26 @@ set_geneve_dsr_opt6(__be16 port, const union v6addr *addr,
 	gopt->port = port;
 }
 #endif
+
+# if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
+static __always_inline int
+get_tunnel_key(struct __ctx_buff *ctx, struct bpf_tunnel_key *key)
+{
+	__u32 key_size __maybe_unused = TUNNEL_KEY_WITHOUT_SRC_IP;
+	int ret __maybe_unused;
+
+#  ifdef ENABLE_IPV4
+	ret = ctx_get_tunnel_key(ctx, key, key_size, 0);
+	if (!ret)
+		return ret;
+#  endif /* ENABLE_IPV4 */
+#  ifdef ENABLE_IPV6
+	ret = ctx_get_tunnel_key(ctx, key, key_size, BPF_F_TUNINFO_IPV6);
+	if (!ret)
+		return ret;
+#  endif /* ENABLE_IPV6 */
+
+	return DROP_NO_TUNNEL_KEY;
+}
+# endif /* ENABLE_IPV4 || ENABLE_IPV6 */
 #endif /* HAVE_ENCAP */

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -46,8 +46,8 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
 			  *ifindex, ct_reason, monitor);
 
-	return ctx_set_encap_info(ctx, src_ip, src_port, tunnel_endpoint, seclabel, vni,
-				  NULL, 0);
+	return ctx_set_encap_info4(ctx, src_ip, src_port, tunnel_endpoint, seclabel, vni,
+				   NULL, 0);
 }
 
 static __always_inline int
@@ -165,8 +165,8 @@ __encap_with_nodeid_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
 			  *ifindex, ct_reason, monitor);
 
-	return ctx_set_encap_info(ctx, src_ip, src_port, tunnel_endpoint, seclabel, vni, opt,
-				  opt_len);
+	return ctx_set_encap_info4(ctx, src_ip, src_port, tunnel_endpoint, seclabel, vni, opt,
+				   opt_len);
 }
 
 static __always_inline void

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -23,10 +23,10 @@ struct {
 } cilium_tunnel_map __section_maps_btf;
 
 static __always_inline int
-__encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
-		    __be32 tunnel_endpoint,
-		    __u32 seclabel, __u32 dstid, __u32 vni,
-		    enum trace_reason ct_reason, __u32 monitor, int *ifindex)
+__encap_with_nodeid4(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
+		     __be32 tunnel_endpoint,
+		     __u32 seclabel, __u32 dstid, __u32 vni,
+		     enum trace_reason ct_reason, __u32 monitor, int *ifindex)
 {
 	/* When encapsulating, a packet originating from the local host is
 	 * being considered as a packet from a remote node as it is being
@@ -51,6 +51,30 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 }
 
 static __always_inline int
+__encap_with_nodeid6(struct __ctx_buff *ctx, const union v6addr *tunnel_endpoint,
+		     __u32 seclabel, __u32 dstid, enum trace_reason ct_reason,
+		     __u32 monitor, int *ifindex)
+{
+	/* When encapsulating, a packet originating from the local host is
+	 * being considered as a packet from a remote node as it is being
+	 * received.
+	 */
+	if (seclabel == HOST_ID)
+		seclabel = LOCAL_NODE_ID;
+
+#if __ctx_is == __ctx_skb
+	*ifindex = ENCAP_IFINDEX;
+#else
+	*ifindex = 0;
+#endif
+
+	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
+			  *ifindex, ct_reason, monitor);
+
+	return ctx_set_encap_info6(ctx, tunnel_endpoint, seclabel);
+}
+
+static __always_inline int
 __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx,
 				 const struct remote_endpoint_info *info,
 				 __u32 seclabel, __u32 dstid, __u32 vni,
@@ -59,9 +83,15 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx,
 	int ifindex;
 	int ret = 0;
 
-	ret = __encap_with_nodeid(ctx, 0, 0, info->tunnel_endpoint.ip4,
-				  seclabel, dstid, vni, trace->reason,
-				  trace->monitor, &ifindex);
+	if (info->flag_ipv6_tunnel_ep)
+		ret = __encap_with_nodeid6(ctx, &info->tunnel_endpoint.ip6,
+					   seclabel, dstid, trace->reason,
+					   trace->monitor, &ifindex);
+	else
+		ret = __encap_with_nodeid4(ctx, 0, 0,
+					   info->tunnel_endpoint.ip4, seclabel,
+					   dstid, vni, trace->reason,
+					   trace->monitor, &ifindex);
 	if (ret != CTX_ACT_REDIRECT)
 		return ret;
 

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -75,7 +75,7 @@ struct {
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, IPCACHE_MAP_SIZE);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
-} cilium_ipcache __section_maps_btf;
+} cilium_ipcache_v2 __section_maps_btf;
 
 /* IPCACHE_STATIC_PREFIX gets sizeof non-IP, non-prefix part of ipcache_key */
 #define IPCACHE_STATIC_PREFIX							\
@@ -127,6 +127,6 @@ ipcache_lookup4(const void *map, __be32 addr, __u32 prefix, __u32 cluster_id)
 }
 
 #define lookup_ip6_remote_endpoint(addr, cluster_id) \
-	ipcache_lookup6(&cilium_ipcache, addr, V6_CACHE_KEY_LEN, cluster_id)
+	ipcache_lookup6(&cilium_ipcache_v2, addr, V6_CACHE_KEY_LEN, cluster_id)
 #define lookup_ip4_remote_endpoint(addr, cluster_id) \
-	ipcache_lookup4(&cilium_ipcache, addr, V4_CACHE_KEY_LEN, cluster_id)
+	ipcache_lookup4(&cilium_ipcache_v2, addr, V4_CACHE_KEY_LEN, cluster_id)

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -107,7 +107,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
 	if (info && info->sec_identity) {
 		dst_sec_identity = info->sec_identity;
-		tunnel_endpoint = info->tunnel_endpoint;
+		tunnel_endpoint = info->tunnel_endpoint.ip4;
 	}
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
 		   ip6->daddr.s6_addr32[3], dst_sec_identity);
@@ -238,7 +238,7 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
 	if (info && info->sec_identity) {
 		*src_sec_identity = info->sec_identity;
-		tunnel_endpoint = info->tunnel_endpoint;
+		tunnel_endpoint = info->tunnel_endpoint.ip4;
 	}
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
 		   ip6->saddr.s6_addr32[3], *src_sec_identity);
@@ -404,7 +404,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 	if (info && info->sec_identity) {
 		dst_sec_identity = info->sec_identity;
-		tunnel_endpoint = info->tunnel_endpoint;
+		tunnel_endpoint = info->tunnel_endpoint.ip4;
 	}
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
 		   ip4->daddr, dst_sec_identity);
@@ -529,7 +529,7 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 	info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 	if (info && info->sec_identity) {
 		*src_sec_identity = info->sec_identity;
-		tunnel_endpoint = info->tunnel_endpoint;
+		tunnel_endpoint = info->tunnel_endpoint.ip4;
 	}
 	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
 		   ip4->saddr, *src_sec_identity);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -341,10 +341,10 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 
 	dst = (union v6addr *)&ip6->daddr;
 	info = lookup_ip6_remote_endpoint(dst, 0);
-	if (!info || info->tunnel_endpoint == 0)
+	if (!info || info->tunnel_endpoint.ip4 == 0)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-	tunnel_endpoint = info->tunnel_endpoint;
+	tunnel_endpoint = info->tunnel_endpoint.ip4;
 	dst_sec_identity = info->sec_identity;
 
 	fraginfo = ipv6_get_fraginfo(ctx, ip6);
@@ -910,8 +910,8 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 			struct remote_endpoint_info *info;
 
 			info = lookup_ip6_remote_endpoint(dst, 0);
-			if (info && info->tunnel_endpoint && !info->flag_skip_tunnel) {
-				tunnel_endpoint = info->tunnel_endpoint;
+			if (info && info->tunnel_endpoint.ip4 && !info->flag_skip_tunnel) {
+				tunnel_endpoint = info->tunnel_endpoint.ip4;
 				src_sec_identity = REMOTE_NODE_ID;
 				dst_sec_identity = info->sec_identity;
 				goto encap_redirect;
@@ -1147,8 +1147,8 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 #ifdef TUNNEL_MODE
 	dst = (union v6addr *)&ip6->daddr;
 	info = lookup_ip6_remote_endpoint(dst, 0);
-	if (info && info->tunnel_endpoint != 0 && !info->flag_skip_tunnel) {
-		tunnel_endpoint = info->tunnel_endpoint;
+	if (info && info->tunnel_endpoint.ip4 != 0 && !info->flag_skip_tunnel) {
+		tunnel_endpoint = info->tunnel_endpoint.ip4;
 		dst_sec_identity = info->sec_identity;
 
 		target.addr = CONFIG(router_ipv6);
@@ -1654,10 +1654,10 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, int l3_
 #endif
 
 	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-	if (!info || info->tunnel_endpoint == 0)
+	if (!info || info->tunnel_endpoint.ip4 == 0)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-	tunnel_endpoint = info->tunnel_endpoint;
+	tunnel_endpoint = info->tunnel_endpoint.ip4;
 	dst_sec_identity = info->sec_identity;
 
 	if (ip4->protocol == IPPROTO_TCP) {
@@ -2198,8 +2198,8 @@ nodeport_rev_dnat_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 			struct remote_endpoint_info *info;
 
 			info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-			if (info && info->tunnel_endpoint && !info->flag_skip_tunnel) {
-				tunnel_endpoint = info->tunnel_endpoint;
+			if (info && info->tunnel_endpoint.ip4 && !info->flag_skip_tunnel) {
+				tunnel_endpoint = info->tunnel_endpoint.ip4;
 				src_sec_identity = REMOTE_NODE_ID;
 				dst_sec_identity = info->sec_identity;
 			}
@@ -2448,8 +2448,8 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 
 #ifdef TUNNEL_MODE
 	info = lookup_ip4_remote_endpoint(ip4->daddr, cluster_id);
-	if (info && info->tunnel_endpoint != 0 && !info->flag_skip_tunnel) {
-		tunnel_endpoint = info->tunnel_endpoint;
+	if (info && info->tunnel_endpoint.ip4 != 0 && !info->flag_skip_tunnel) {
+		tunnel_endpoint = info->tunnel_endpoint.ip4;
 		dst_sec_identity = info->sec_identity;
 
 		target.addr = IPV4_GATEWAY;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -97,9 +97,9 @@ nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 			return ret;
 	}
 
-	return __encap_with_nodeid(ctx, src_ip, src_port, dst_ip,
-				   src_sec_identity, dst_sec_identity, NOT_VTEP_DST,
-				   ct_reason, monitor, ifindex);
+	return __encap_with_nodeid4(ctx, src_ip, src_port, dst_ip,
+				    src_sec_identity, dst_sec_identity, NOT_VTEP_DST,
+				    ct_reason, monitor, ifindex);
 }
 
 # if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -264,10 +264,10 @@ static __always_inline bool ctx_egw_done(const struct __sk_buff *ctx)
 
 #ifdef HAVE_ENCAP
 static __always_inline __maybe_unused int
-ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,
-		   __be16 src_port __maybe_unused, __u32 tunnel_endpoint,
-		   __u32 seclabel, __u32 vni __maybe_unused,
-		   void *opt, __u32 opt_len)
+ctx_set_encap_info4(struct __sk_buff *ctx, __u32 src_ip,
+		    __be16 src_port __maybe_unused, __u32 tunnel_endpoint,
+		    __u32 seclabel, __u32 vni __maybe_unused,
+		    void *opt, __u32 opt_len)
 {
 	struct bpf_tunnel_key key = {};
 	__u32 key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
@@ -296,6 +296,28 @@ ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,
 		if (unlikely(ret < 0))
 			return DROP_WRITE_ERROR;
 	}
+
+	return CTX_ACT_REDIRECT;
+}
+
+static __always_inline __maybe_unused int
+ctx_set_encap_info6(struct __sk_buff *ctx, const union v6addr *tunnel_endpoint,
+		    __u32 seclabel)
+{
+	struct bpf_tunnel_key key = {};
+	__u32 key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
+	int ret;
+
+	key.tunnel_id = get_tunnel_id(seclabel);
+	key.remote_ipv6[0] = tunnel_endpoint->p1;
+	key.remote_ipv6[1] = tunnel_endpoint->p2;
+	key.remote_ipv6[2] = tunnel_endpoint->p3;
+	key.remote_ipv6[3] = tunnel_endpoint->p4;
+	key.tunnel_ttl = IPDEFTTL;
+
+	ret = ctx_set_tunnel_key(ctx, &key, key_size, BPF_F_TUNINFO_IPV6);
+	if (unlikely(ret < 0))
+		return DROP_WRITE_ERROR;
 
 	return CTX_ACT_REDIRECT;
 }

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -168,9 +168,9 @@ static __always_inline bool ctx_snat_done(struct xdp_md *ctx)
 
 #ifdef HAVE_ENCAP
 static __always_inline __maybe_unused int
-ctx_set_encap_info(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
-		   __u32 daddr, __u32 seclabel __maybe_unused,
-		   __u32 vni __maybe_unused, void *opt, __u32 opt_len)
+ctx_set_encap_info4(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
+		    __u32 daddr, __u32 seclabel __maybe_unused,
+		    __u32 vni __maybe_unused, void *opt, __u32 opt_len)
 {
 	__u32 inner_len = (__u32)ctx_full_len(ctx);
 	__u32 tunnel_hdr_len = 8; /* geneve / vxlan */
@@ -248,6 +248,14 @@ ctx_set_encap_info(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 	eth->h_proto = bpf_htons(ETH_P_IP);
 
 	return CTX_ACT_REDIRECT;
+}
+
+static __always_inline __maybe_unused int
+ctx_set_encap_info6(struct xdp_md *ctx __maybe_unused,
+		    const union v6addr *tunnel_endpoint __maybe_unused,
+		    __u32 seclabel __maybe_unused)
+{
+	return 0;
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -14,7 +14,7 @@ __ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 	struct remote_endpoint_info value = {};
 
 	value.sec_identity = sec_identity;
-	value.tunnel_endpoint = tunnel_ep;
+	value.tunnel_endpoint.ip4 = tunnel_ep;
 	value.key = spi;
 	value.flag_skip_tunnel = flag_skip_tunnel;
 
@@ -62,7 +62,7 @@ __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_iden
 	struct remote_endpoint_info value = {};
 
 	value.sec_identity = sec_identity;
-	value.tunnel_endpoint = tunnel_ep;
+	value.tunnel_endpoint.ip4 = tunnel_ep;
 	value.key = spi;
 	value.flag_skip_tunnel = flag_skip_tunnel;
 

--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -17,6 +17,8 @@ __ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 	value.tunnel_endpoint.ip4 = tunnel_ep;
 	value.key = spi;
 	value.flag_skip_tunnel = flag_skip_tunnel;
+	if (tunnel_ep)
+		value.flag_has_tunnel_ep = true;
 
 	map_update_elem(&cilium_ipcache, &key, &value, BPF_ANY);
 }
@@ -65,6 +67,8 @@ __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_iden
 	value.tunnel_endpoint.ip4 = tunnel_ep;
 	value.key = spi;
 	value.flag_skip_tunnel = flag_skip_tunnel;
+	if (tunnel_ep)
+		value.flag_has_tunnel_ep = true;
 
 	memcpy(&key.ip6, addr, sizeof(*addr));
 

--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -20,7 +20,7 @@ __ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 	if (tunnel_ep)
 		value.flag_has_tunnel_ep = true;
 
-	map_update_elem(&cilium_ipcache, &key, &value, BPF_ANY);
+	map_update_elem(&cilium_ipcache_v2, &key, &value, BPF_ANY);
 }
 
 static __always_inline void
@@ -72,7 +72,7 @@ __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_iden
 
 	memcpy(&key.ip6, addr, sizeof(*addr));
 
-	map_update_elem(&cilium_ipcache, &key, &value, BPF_ANY);
+	map_update_elem(&cilium_ipcache_v2, &key, &value, BPF_ANY);
 }
 
 static __always_inline void

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -85,6 +85,7 @@ var bpfMapsPath = []string{
 	"tc/globals/cilium_tunnel_map",
 	"tc/globals/cilium_ktime_cache",
 	"tc/globals/cilium_ipcache",
+	"tc/globals/cilium_ipcache_v2",
 	"tc/globals/cilium_events",
 	"tc/globals/cilium_signals",
 	"tc/globals/cilium_capture4_rules",

--- a/cilium-cli/connectivity/tests/pod.go
+++ b/cilium-cli/connectivity/tests/pod.go
@@ -456,7 +456,7 @@ func remoteNodesPodCIDRs(ctx context.Context, ciliumPod check.Pod) ([]netip.Pref
 	return prefixes, nil
 }
 
-var ipcacheGetPat = regexp.MustCompile(`identity=(\d+)\s+encryptkey=(\d+)\s+tunnelendpoint=([\d\.]+)`)
+var ipcacheGetPat = regexp.MustCompile(`identity=(\d+)\s+encryptkey=(\d+)\s+tunnelendpoint=([^\s]+)`)
 
 // ipcacheDeleteAndRestore removes matching ipcache entry and return a function to revert the deletion.
 func ipcacheDeleteAndRestore(

--- a/cilium-dbg/cmd/bpf_ipcache_update.go
+++ b/cilium-dbg/cmd/bpf_ipcache_update.go
@@ -49,10 +49,6 @@ var bpfIPCacheUpdateCmd = &cobra.Command{
 		if tunnelEndpoint == nil {
 			Usagef(cmd, "Invalid tunnel endpoint. "+usage)
 		}
-		if tunnelEndpoint.To4() == nil {
-			Usagef(cmd, "Invalid tunnel endpoint, must be an IPv4. "+usage)
-		}
-		tunnelEndpoint = tunnelEndpoint.To4()
 
 		identity, err := cmd.Flags().GetUint32("identity")
 		if err != nil {

--- a/cilium-dbg/cmd/bpf_ipcache_update.go
+++ b/cilium-dbg/cmd/bpf_ipcache_update.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/maps/ipcache"
-	"github.com/cilium/cilium/pkg/types"
 )
 
 func init() {
@@ -81,12 +80,7 @@ var bpfIPCacheUpdateCmd = &cobra.Command{
 		ip := net.IP(prefix.Addr().AsSlice())
 		mask := net.CIDRMask(prefix.Bits(), 32)
 		key := ipcache.NewKey(ip, mask, clusterID)
-		value := ipcache.RemoteEndpointInfo{
-			SecurityIdentity: identity,
-			TunnelEndpoint:   types.IPv4(tunnelEndpoint),
-			Key:              encryptKey,
-			Flags:            flags,
-		}
+		value := ipcache.NewValue(identity, tunnelEndpoint, encryptKey, flags)
 		if err := ipcache.IPCacheMap().Update(&key, &value); err != nil {
 			fmt.Fprintf(os.Stderr, "Error updating entry %s: %v\n", key, err)
 			os.Exit(1)

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -350,7 +350,7 @@ func setupRouteToVtepCidr() error {
 	}
 
 	addedVtepRoutes, removedVtepRoutes := cidr.DiffCIDRLists(routeCidrs, option.Config.VtepCIDRs)
-	vtepMTU := mtu.EthernetMTU - mtu.TunnelOverhead
+	vtepMTU := mtu.EthernetMTU - mtu.TunnelOverheadIPv4
 
 	if option.Config.EnableL7Proxy {
 		for _, prefix := range addedVtepRoutes {

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -201,6 +201,37 @@ func (d *Daemon) dumpOldIPCache() (map[netip.Prefix]identity.NumericIdentity, er
 	if err != nil {
 		// ignore non-existent cache
 		if errors.Is(err, fs.ErrNotExist) {
+			// We might be in the upgrade case, with the ipcache v1 from v1.18
+			// still around.
+			return d.dumpOldIPCacheV1()
+		}
+	}
+	log.Debugf("dumping ipache found %d local identities", len(localPrefixes))
+	return localPrefixes, err
+}
+
+// dumpOldIPCacheV1 does the same as dumpOldIPCache but for the v1 of the ipcache map.
+func (d *Daemon) dumpOldIPCacheV1() (map[netip.Prefix]identity.NumericIdentity, error) {
+	localPrefixes := map[netip.Prefix]identity.NumericIdentity{}
+
+	// Dump the bpf ipcache, recording any prefixes with local or ingress
+	// numeric identities.
+	err := ipcachemap.IPCacheMapV1().DumpWithCallback(func(key bpf.MapKey, value bpf.MapValue) {
+		k := key.(*ipcachemap.Key)
+		v := value.(*ipcachemap.RemoteEndpointInfoV1)
+		nid := identity.NumericIdentity(v.SecurityIdentity)
+
+		if nid.Scope() == identity.IdentityScopeLocal || (nid == identity.ReservedIdentityIngress && v.TunnelEndpoint.IsZero()) {
+			localPrefixes[k.Prefix()] = nid
+		}
+	})
+	// dumpwithcallback() leaves the ipcache map open, must close before opened for
+	// parallel mode in daemon.initmaps()
+	ipcachemap.IPCacheMapV1().Close()
+
+	if err != nil {
+		// ignore non-existent cache
+		if errors.Is(err, fs.ErrNotExist) {
 			err = nil
 		}
 	}

--- a/pkg/ciliumenvoyconfig/testdata/anyport.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/anyport.txtar
@@ -161,24 +161,24 @@ SVC: ID=4 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterI
 policy-trigger-count:
   1
 endpoints:test/echo:
-  cluster_name:  "test/echo"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  25
+  cluster_name: "test/echo"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 25
           }
         }
       }
     }
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  8080
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
           }
         }
       }
@@ -186,24 +186,24 @@ endpoints:test/echo:
   }
   
 endpoints:test/echo:*:
-  cluster_name:  "test/echo:*"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  25
+  cluster_name: "test/echo:*"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 25
           }
         }
       }
     }
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  8080
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
           }
         }
       }
@@ -211,30 +211,30 @@ endpoints:test/echo:*:
   }
   
 listener:test/envoy-lb-listener/envoy-lb-listener:
-  name:  "test/envoy-lb-listener/envoy-lb-listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "test/envoy-lb-listener/envoy-lb-listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -243,30 +243,30 @@ listener:test/envoy-lb-listener/envoy-lb-listener:
 policy-trigger-count:
   1
 listener:test/envoy-lb-listener/envoy-lb-listener:
-  name:  "test/envoy-lb-listener/envoy-lb-listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "test/envoy-lb-listener/envoy-lb-listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -275,24 +275,24 @@ listener:test/envoy-lb-listener/envoy-lb-listener:
 policy-trigger-count:
   1
 endpoints:test/echo:
-  cluster_name:  "test/echo"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  25
+  cluster_name: "test/echo"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 25
           }
         }
       }
     }
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  8080
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
           }
         }
       }
@@ -300,24 +300,24 @@ endpoints:test/echo:
   }
   
 endpoints:test/echo:*:
-  cluster_name:  "test/echo:*"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  25
+  cluster_name: "test/echo:*"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 25
           }
         }
       }
     }
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  8080
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
           }
         }
       }
@@ -325,30 +325,30 @@ endpoints:test/echo:*:
   }
   
 listener:test/envoy-lb-listener/envoy-lb-listener:
-  name:  "test/envoy-lb-listener/envoy-lb-listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "test/envoy-lb-listener/envoy-lb-listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }

--- a/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
@@ -288,24 +288,24 @@ SVC: ID=5 ADDR=3.0.0.1:9080/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+n
 policy-trigger-count:
   1
 endpoints:test/backend:9080:
-  cluster_name:  "test/backend:9080"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "2.1.0.1"
-            port_value:  9080
+  cluster_name: "test/backend:9080"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "2.1.0.1"
+            port_value: 9080
           }
         }
       }
     }
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "2.1.0.2"
-            port_value:  9080
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "2.1.0.2"
+            port_value: 9080
           }
         }
       }
@@ -313,14 +313,14 @@ endpoints:test/backend:9080:
   }
   
 endpoints:test/backend_unnamed_port:9080:
-  cluster_name:  "test/backend_unnamed_port:9080"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "3.1.0.1"
-            port_value:  9080
+  cluster_name: "test/backend_unnamed_port:9080"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "3.1.0.1"
+            port_value: 9080
           }
         }
       }
@@ -328,14 +328,14 @@ endpoints:test/backend_unnamed_port:9080:
   }
   
 endpoints:test/frontend:80:
-  cluster_name:  "test/frontend:80"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "1.1.0.1"
-            port_value:  8080
+  cluster_name: "test/frontend:80"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "1.1.0.1"
+            port_value: 8080
           }
         }
       }
@@ -343,30 +343,30 @@ endpoints:test/frontend:80:
   }
   
 listener:test/ingress/listener:
-  name:  "test/ingress/listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "test/ingress/listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -136,14 +136,14 @@ ports:
 policy-trigger-count:
   1
 endpoints:test/echo2:
-  cluster_name:  "test/echo2"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.2"
-            port_value:  8081
+  cluster_name: "test/echo2"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.2"
+            port_value: 8081
           }
         }
       }
@@ -151,14 +151,14 @@ endpoints:test/echo2:
   }
   
 endpoints:test/echo2:*:
-  cluster_name:  "test/echo2:*"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.2"
-            port_value:  8081
+  cluster_name: "test/echo2:*"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.2"
+            port_value: 8081
           }
         }
       }
@@ -166,30 +166,30 @@ endpoints:test/echo2:*:
   }
   
 listener:/envoy-lb-listener-2/envoy-lb-listener-2:
-  name:  "/envoy-lb-listener-2/envoy-lb-listener-2"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "/envoy-lb-listener-2/envoy-lb-listener-2"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -198,30 +198,30 @@ listener:/envoy-lb-listener-2/envoy-lb-listener-2:
 policy-trigger-count:
   1
 listener:/envoy-lb-listener-2/envoy-lb-listener-2:
-  name:  "/envoy-lb-listener-2/envoy-lb-listener-2"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "/envoy-lb-listener-2/envoy-lb-listener-2"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -230,14 +230,14 @@ listener:/envoy-lb-listener-2/envoy-lb-listener-2:
 policy-trigger-count:
   1
 endpoints:test/echo2:
-  cluster_name:  "test/echo2"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.2"
-            port_value:  8081
+  cluster_name: "test/echo2"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.2"
+            port_value: 8081
           }
         }
       }
@@ -245,14 +245,14 @@ endpoints:test/echo2:
   }
   
 endpoints:test/echo2:*:
-  cluster_name:  "test/echo2:*"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.2"
-            port_value:  8081
+  cluster_name: "test/echo2:*"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.2"
+            port_value: 8081
           }
         }
       }
@@ -260,30 +260,30 @@ endpoints:test/echo2:*:
   }
   
 listener:/envoy-lb-listener-2/envoy-lb-listener-2:
-  name:  "/envoy-lb-listener-2/envoy-lb-listener-2"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "/envoy-lb-listener-2/envoy-lb-listener-2"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }

--- a/pkg/ciliumenvoyconfig/testdata/headless.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/headless.txtar
@@ -216,7 +216,7 @@ listener:test/envoy-lb-listener/envoy-lb-listener:
         bpf_root: "/sys/fs/bpf"
         use_original_source_address: true
         proxy_id: 1000
-        ipcache_name: "cilium_ipcache"
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -247,7 +247,7 @@ listener:test/envoy-lb-listener/envoy-lb-listener:
         bpf_root: "/sys/fs/bpf"
         use_original_source_address: true
         proxy_id: 1000
-        ipcache_name: "cilium_ipcache"
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -293,7 +293,7 @@ listener:test/envoy-lb-listener/envoy-lb-listener:
         bpf_root: "/sys/fs/bpf"
         use_original_source_address: true
         proxy_id: 1000
-        ipcache_name: "cilium_ipcache"
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }

--- a/pkg/ciliumenvoyconfig/testdata/ingress.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/ingress.txtar
@@ -452,144 +452,144 @@ ports:
 policy-trigger-count:
   1
 clusters:default/cilium-ingress-default-basic-ingress/default:details:9080:
-  name:  "default/cilium-ingress-default-basic-ingress/default:details:9080"
-  type:  EDS
-  eds_cluster_config:  {
-    eds_config:  {
-      api_config_source:  {
-        api_type:  GRPC
-        transport_api_version:  V3
-        grpc_services:  {
-          envoy_grpc:  {
-            cluster_name:  "xds-grpc-cilium"
+  name: "default/cilium-ingress-default-basic-ingress/default:details:9080"
+  type: EDS
+  eds_cluster_config: {
+    eds_config: {
+      api_config_source: {
+        api_type: GRPC
+        transport_api_version: V3
+        grpc_services: {
+          envoy_grpc: {
+            cluster_name: "xds-grpc-cilium"
           }
         }
-        set_node_on_first_message_only:  true
+        set_node_on_first_message_only: true
       }
-      initial_fetch_timeout:  {
-        seconds:  30
+      initial_fetch_timeout: {
+        seconds: 30
       }
-      resource_api_version:  V3
+      resource_api_version: V3
     }
-    service_name:  "default/details:9080"
+    service_name: "default/details:9080"
   }
-  connect_timeout:  {
-    seconds:  5
+  connect_timeout: {
+    seconds: 5
   }
-  circuit_breakers:  {
-    thresholds:  {
-      max_retries:  {
-        value:  128
+  circuit_breakers: {
+    thresholds: {
+      max_retries: {
+        value: 128
       }
     }
   }
-  typed_extension_protocol_options:  {
-    key:  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
-    value:  {
-      [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions]:  {
-        common_http_protocol_options:  {
-          idle_timeout:  {
-            seconds:  60
+  typed_extension_protocol_options: {
+    key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+    value: {
+      [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions]: {
+        common_http_protocol_options: {
+          idle_timeout: {
+            seconds: 60
           }
         }
-        use_downstream_protocol_config:  {
-          http2_protocol_options:  {}
+        use_downstream_protocol_config: {
+          http2_protocol_options: {}
         }
-        http_filters:  {
-          name:  "cilium.l7policy"
-          typed_config:  {
-            [type.googleapis.com/cilium.L7Policy]:  {
-              access_log_path:  "envoy/sockets/access_log.sock"
+        http_filters: {
+          name: "cilium.l7policy"
+          typed_config: {
+            [type.googleapis.com/cilium.L7Policy]: {
+              access_log_path: "envoy/sockets/access_log.sock"
             }
           }
         }
-        http_filters:  {
-          name:  "envoy.filters.http.upstream_codec"
-          typed_config:  {
-            [type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec]:  {}
+        http_filters: {
+          name: "envoy.filters.http.upstream_codec"
+          typed_config: {
+            [type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec]: {}
           }
         }
       }
     }
   }
-  outlier_detection:  {
-    split_external_local_origin_errors:  true
+  outlier_detection: {
+    split_external_local_origin_errors: true
   }
   
 clusters:default/cilium-ingress-default-basic-ingress/default:productpage:9080:
-  name:  "default/cilium-ingress-default-basic-ingress/default:productpage:9080"
-  type:  EDS
-  eds_cluster_config:  {
-    eds_config:  {
-      api_config_source:  {
-        api_type:  GRPC
-        transport_api_version:  V3
-        grpc_services:  {
-          envoy_grpc:  {
-            cluster_name:  "xds-grpc-cilium"
+  name: "default/cilium-ingress-default-basic-ingress/default:productpage:9080"
+  type: EDS
+  eds_cluster_config: {
+    eds_config: {
+      api_config_source: {
+        api_type: GRPC
+        transport_api_version: V3
+        grpc_services: {
+          envoy_grpc: {
+            cluster_name: "xds-grpc-cilium"
           }
         }
-        set_node_on_first_message_only:  true
+        set_node_on_first_message_only: true
       }
-      initial_fetch_timeout:  {
-        seconds:  30
+      initial_fetch_timeout: {
+        seconds: 30
       }
-      resource_api_version:  V3
+      resource_api_version: V3
     }
-    service_name:  "default/productpage:9080"
+    service_name: "default/productpage:9080"
   }
-  connect_timeout:  {
-    seconds:  5
+  connect_timeout: {
+    seconds: 5
   }
-  circuit_breakers:  {
-    thresholds:  {
-      max_retries:  {
-        value:  128
+  circuit_breakers: {
+    thresholds: {
+      max_retries: {
+        value: 128
       }
     }
   }
-  typed_extension_protocol_options:  {
-    key:  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
-    value:  {
-      [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions]:  {
-        common_http_protocol_options:  {
-          idle_timeout:  {
-            seconds:  60
+  typed_extension_protocol_options: {
+    key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+    value: {
+      [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions]: {
+        common_http_protocol_options: {
+          idle_timeout: {
+            seconds: 60
           }
         }
-        use_downstream_protocol_config:  {
-          http2_protocol_options:  {}
+        use_downstream_protocol_config: {
+          http2_protocol_options: {}
         }
-        http_filters:  {
-          name:  "cilium.l7policy"
-          typed_config:  {
-            [type.googleapis.com/cilium.L7Policy]:  {
-              access_log_path:  "envoy/sockets/access_log.sock"
+        http_filters: {
+          name: "cilium.l7policy"
+          typed_config: {
+            [type.googleapis.com/cilium.L7Policy]: {
+              access_log_path: "envoy/sockets/access_log.sock"
             }
           }
         }
-        http_filters:  {
-          name:  "envoy.filters.http.upstream_codec"
-          typed_config:  {
-            [type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec]:  {}
+        http_filters: {
+          name: "envoy.filters.http.upstream_codec"
+          typed_config: {
+            [type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec]: {}
           }
         }
       }
     }
   }
-  outlier_detection:  {
-    split_external_local_origin_errors:  true
+  outlier_detection: {
+    split_external_local_origin_errors: true
   }
   
 endpoints:default/details:9080:
-  cluster_name:  "default/details:9080"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.197"
-            port_value:  9080
+  cluster_name: "default/details:9080"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.197"
+            port_value: 9080
           }
         }
       }
@@ -597,14 +597,14 @@ endpoints:default/details:9080:
   }
   
 endpoints:default/productpage:9080:
-  cluster_name:  "default/productpage:9080"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.243"
-            port_value:  9080
+  cluster_name: "default/productpage:9080"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.243"
+            port_value: 9080
           }
         }
       }
@@ -612,192 +612,192 @@ endpoints:default/productpage:9080:
   }
   
 listener:default/cilium-ingress-default-basic-ingress/listener:
-  name:  "default/cilium-ingress-default-basic-ingress/listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "default/cilium-ingress-default-basic-ingress/listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  filter_chains:  {
-    filter_chain_match:  {
-      transport_protocol:  "raw_buffer"
+  filter_chains: {
+    filter_chain_match: {
+      transport_protocol: "raw_buffer"
     }
-    filters:  {
-      name:  "cilium.network"
-      typed_config:  {
-        [type.googleapis.com/cilium.NetworkFilter]:  {}
+    filters: {
+      name: "cilium.network"
+      typed_config: {
+        [type.googleapis.com/cilium.NetworkFilter]: {}
       }
     }
-    filters:  {
-      name:  "envoy.filters.network.http_connection_manager"
-      typed_config:  {
-        [type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager]:  {
-          stat_prefix:  "listener-insecure"
-          rds:  {
-            config_source:  {
-              api_config_source:  {
-                api_type:  GRPC
-                transport_api_version:  V3
-                grpc_services:  {
-                  envoy_grpc:  {
-                    cluster_name:  "xds-grpc-cilium"
+    filters: {
+      name: "envoy.filters.network.http_connection_manager"
+      typed_config: {
+        [type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager]: {
+          stat_prefix: "listener-insecure"
+          rds: {
+            config_source: {
+              api_config_source: {
+                api_type: GRPC
+                transport_api_version: V3
+                grpc_services: {
+                  envoy_grpc: {
+                    cluster_name: "xds-grpc-cilium"
                   }
                 }
-                set_node_on_first_message_only:  true
+                set_node_on_first_message_only: true
               }
-              initial_fetch_timeout:  {
-                seconds:  30
+              initial_fetch_timeout: {
+                seconds: 30
               }
-              resource_api_version:  V3
+              resource_api_version: V3
             }
-            route_config_name:  "default/cilium-ingress-default-basic-ingress/listener-insecure"
+            route_config_name: "default/cilium-ingress-default-basic-ingress/listener-insecure"
           }
-          http_filters:  {
-            name:  "envoy.filters.http.grpc_web"
-            typed_config:  {
-              [type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb]:  {}
-            }
-          }
-          http_filters:  {
-            name:  "envoy.filters.http.grpc_stats"
-            typed_config:  {
-              [type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig]:  {
-                emit_filter_state:  true
-                enable_upstream_stats:  true
-              }
+          http_filters: {
+            name: "envoy.filters.http.grpc_web"
+            typed_config: {
+              [type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb]: {}
             }
           }
-          http_filters:  {
-            name:  "cilium.l7policy"
-            typed_config:  {
-              [type.googleapis.com/cilium.L7Policy]:  {
-                access_log_path:  "envoy/sockets/access_log.sock"
+          http_filters: {
+            name: "envoy.filters.http.grpc_stats"
+            typed_config: {
+              [type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig]: {
+                emit_filter_state: true
+                enable_upstream_stats: true
               }
             }
           }
-          http_filters:  {
-            name:  "envoy.filters.http.router"
-            typed_config:  {
-              [type.googleapis.com/envoy.extensions.filters.http.router.v3.Router]:  {}
-            }
-          }
-          common_http_protocol_options:  {
-            max_stream_duration:  {}
-          }
-          stream_idle_timeout:  {
-            seconds:  300
-          }
-          use_remote_address:  {
-            value:  true
-          }
-          internal_address_config:  {
-            cidr_ranges:  {
-              address_prefix:  "10.0.0.0"
-              prefix_len:  {
-                value:  8
-              }
-            }
-            cidr_ranges:  {
-              address_prefix:  "172.16.0.0"
-              prefix_len:  {
-                value:  12
-              }
-            }
-            cidr_ranges:  {
-              address_prefix:  "192.168.0.0"
-              prefix_len:  {
-                value:  16
-              }
-            }
-            cidr_ranges:  {
-              address_prefix:  "127.0.0.1"
-              prefix_len:  {
-                value:  32
+          http_filters: {
+            name: "cilium.l7policy"
+            typed_config: {
+              [type.googleapis.com/cilium.L7Policy]: {
+                access_log_path: "envoy/sockets/access_log.sock"
               }
             }
           }
-          upgrade_configs:  {
-            upgrade_type:  "websocket"
+          http_filters: {
+            name: "envoy.filters.http.router"
+            typed_config: {
+              [type.googleapis.com/envoy.extensions.filters.http.router.v3.Router]: {}
+            }
+          }
+          common_http_protocol_options: {
+            max_stream_duration: {}
+          }
+          stream_idle_timeout: {
+            seconds: 300
+          }
+          use_remote_address: {
+            value: true
+          }
+          internal_address_config: {
+            cidr_ranges: {
+              address_prefix: "10.0.0.0"
+              prefix_len: {
+                value: 8
+              }
+            }
+            cidr_ranges: {
+              address_prefix: "172.16.0.0"
+              prefix_len: {
+                value: 12
+              }
+            }
+            cidr_ranges: {
+              address_prefix: "192.168.0.0"
+              prefix_len: {
+                value: 16
+              }
+            }
+            cidr_ranges: {
+              address_prefix: "127.0.0.1"
+              prefix_len: {
+                value: 32
+              }
+            }
+          }
+          upgrade_configs: {
+            upgrade_type: "websocket"
           }
         }
       }
     }
   }
-  listener_filters:  {
-    name:  "envoy.filters.listener.tls_inspector"
-    typed_config:  {
-      [type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector]:  {}
+  listener_filters: {
+    name: "envoy.filters.listener.tls_inspector"
+    typed_config: {
+      [type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector]: {}
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
-  socket_options:  {
-    description:  "Enable TCP keep-alive (default to enabled)"
-    level:  1
-    name:  9
-    int_value:  1
+  socket_options: {
+    description: "Enable TCP keep-alive (default to enabled)"
+    level: 1
+    name: 9
+    int_value: 1
   }
-  socket_options:  {
-    description:  "TCP keep-alive idle time (in seconds) (defaults to 10s)"
-    level:  6
-    name:  4
-    int_value:  10
+  socket_options: {
+    description: "TCP keep-alive idle time (in seconds) (defaults to 10s)"
+    level: 6
+    name: 4
+    int_value: 10
   }
-  socket_options:  {
-    description:  "TCP keep-alive probe intervals (in seconds) (defaults to 5s)"
-    level:  6
-    name:  5
-    int_value:  5
+  socket_options: {
+    description: "TCP keep-alive probe intervals (in seconds) (defaults to 5s)"
+    level: 6
+    name: 5
+    int_value: 5
   }
-  socket_options:  {
-    description:  "TCP keep-alive probe max failures."
-    level:  6
-    name:  6
-    int_value:  10
+  socket_options: {
+    description: "TCP keep-alive probe max failures."
+    level: 6
+    name: 6
+    int_value: 10
   }
   
 route:default/cilium-ingress-default-basic-ingress/listener-insecure:
-  name:  "default/cilium-ingress-default-basic-ingress/listener-insecure"
-  virtual_hosts:  {
-    name:  "default/cilium-ingress-default-basic-ingress/*"
-    domains:  "*"
-    routes:  {
-      match:  {
-        path_separated_prefix:  "/details"
+  name: "default/cilium-ingress-default-basic-ingress/listener-insecure"
+  virtual_hosts: {
+    name: "default/cilium-ingress-default-basic-ingress/*"
+    domains: "*"
+    routes: {
+      match: {
+        path_separated_prefix: "/details"
       }
-      route:  {
-        cluster:  "default/cilium-ingress-default-basic-ingress/default:details:9080"
-        max_stream_duration:  {
-          max_stream_duration:  {}
+      route: {
+        cluster: "default/cilium-ingress-default-basic-ingress/default:details:9080"
+        max_stream_duration: {
+          max_stream_duration: {}
         }
       }
     }
-    routes:  {
-      match:  {
-        prefix:  "/"
+    routes: {
+      match: {
+        prefix: "/"
       }
-      route:  {
-        cluster:  "default/cilium-ingress-default-basic-ingress/default:productpage:9080"
-        max_stream_duration:  {
-          max_stream_duration:  {}
+      route: {
+        cluster: "default/cilium-ingress-default-basic-ingress/default:productpage:9080"
+        max_stream_duration: {
+          max_stream_duration: {}
         }
       }
     }

--- a/pkg/ciliumenvoyconfig/testdata/labels.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/labels.txtar
@@ -89,30 +89,30 @@ cec:test/envoy-b           test/envoy-b/envoy-lb-listener                       
 policy-trigger-count:
   1
 listener:test/envoy-a/envoy-lb-listener:
-  name:  "test/envoy-a/envoy-lb-listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "test/envoy-a/envoy-lb-listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -121,30 +121,30 @@ listener:test/envoy-a/envoy-lb-listener:
 policy-trigger-count:
   3
 listener:test/envoy-b/envoy-lb-listener:
-  name:  "test/envoy-b/envoy-lb-listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "test/envoy-b/envoy-lb-listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }

--- a/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
@@ -155,7 +155,7 @@ spec:
             "ConfigType": {
               "TypedConfig": {
                 "type_url": "type.googleapis.com/cilium.BpfMetadata",
-                "value": "Cgsvc3lzL2ZzL2JwZhgBIAFA6AdiDmNpbGl1bV9pcGNhY2hl"
+                "value": "Cgsvc3lzL2ZzL2JwZhgBIAFA6AdiEWNpbGl1bV9pcGNhY2hlX3Yy"
               }
             }
           }
@@ -300,7 +300,7 @@ spec:
             "ConfigType": {
               "TypedConfig": {
                 "type_url": "type.googleapis.com/cilium.BpfMetadata",
-                "value": "Cgsvc3lzL2ZzL2JwZhgBIAFA6AdiDmNpbGl1bV9pcGNhY2hl"
+                "value": "Cgsvc3lzL2ZzL2JwZhgBIAFA6AdiEWNpbGl1bV9pcGNhY2hlX3Yy"
               }
             }
           }
@@ -347,7 +347,7 @@ spec:
             "ConfigType": {
               "TypedConfig": {
                 "type_url": "type.googleapis.com/cilium.BpfMetadata",
-                "value": "Cgsvc3lzL2ZzL2JwZhgBIAFA6AdiDmNpbGl1bV9pcGNhY2hl"
+                "value": "Cgsvc3lzL2ZzL2JwZhgBIAFA6AdiEWNpbGl1bV9pcGNhY2hlX3Yy"
               }
             }
           }

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -240,7 +240,7 @@ listener:test/envoy-lb-listener/envoy-lb-listener:
         use_original_source_address: true
         is_l7lb: true
         proxy_id: 1000
-        ipcache_name: "cilium_ipcache"
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -248,21 +248,6 @@ listener:test/envoy-lb-listener/envoy-lb-listener:
 -- envoy2.expected --
 policy-trigger-count:
   1
-endpoints:test/echo:80:
-  cluster_name: "test/echo:80"
-  endpoints: {
-    lb_endpoints: {
-      endpoint: {
-        address: {
-          socket_address: {
-            address: "10.244.1.1"
-            port_value: 8080
-          }
-        }
-      }
-    }
-  }
-  
 listener:test/envoy-lb-listener/envoy-lb-listener:
   name: "test/envoy-lb-listener/envoy-lb-listener"
   address: {
@@ -287,7 +272,7 @@ listener:test/envoy-lb-listener/envoy-lb-listener:
         use_original_source_address: true
         is_l7lb: true
         proxy_id: 1000
-        ipcache_name: "cilium_ipcache"
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -334,7 +319,7 @@ listener:test/envoy-lb-listener/envoy-lb-listener:
         use_original_source_address: true
         is_l7lb: true
         proxy_id: 1000
-        ipcache_name: "cilium_ipcache"
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }

--- a/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
@@ -220,39 +220,39 @@ SVC: ID=6 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterI
 policy-trigger-count:
   2
 clusters:test/listener-a/test:echo:80:
-  name:  "test/listener-a/test:echo:80"
-  eds_cluster_config:  {
-    service_name:  "test/echo:80"
+  name: "test/listener-a/test:echo:80"
+  eds_cluster_config: {
+    service_name: "test/echo:80"
   }
-  connect_timeout:  {
-    seconds:  5
+  connect_timeout: {
+    seconds: 5
   }
-  circuit_breakers:  {
-    thresholds:  {
-      max_retries:  {
-        value:  128
+  circuit_breakers: {
+    thresholds: {
+      max_retries: {
+        value: 128
       }
     }
   }
-  typed_extension_protocol_options:  {
-    key:  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
-    value:  {
-      [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions]:  {
-        use_downstream_protocol_config:  {
-          http2_protocol_options:  {}
+  typed_extension_protocol_options: {
+    key: "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+    value: {
+      [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions]: {
+        use_downstream_protocol_config: {
+          http2_protocol_options: {}
         }
-        http_filters:  {
-          name:  "cilium.l7policy"
-          typed_config:  {
-            [type.googleapis.com/cilium.L7Policy]:  {
-              access_log_path:  "envoy/sockets/access_log.sock"
+        http_filters: {
+          name: "cilium.l7policy"
+          typed_config: {
+            [type.googleapis.com/cilium.L7Policy]: {
+              access_log_path: "envoy/sockets/access_log.sock"
             }
           }
         }
-        http_filters:  {
-          name:  "envoy.filters.http.upstream_codec"
-          typed_config:  {
-            [type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec]:  {}
+        http_filters: {
+          name: "envoy.filters.http.upstream_codec"
+          typed_config: {
+            [type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec]: {}
           }
         }
       }
@@ -260,89 +260,89 @@ clusters:test/listener-a/test:echo:80:
   }
   
 clusters:test/listener-b/test:echo:80:
-  name:  "test/listener-b/test:echo:80"
-  eds_cluster_config:  {
-    service_name:  "test/echo:80"
+  name: "test/listener-b/test:echo:80"
+  eds_cluster_config: {
+    service_name: "test/echo:80"
   }
-  connect_timeout:  {
-    seconds:  5
+  connect_timeout: {
+    seconds: 5
   }
-  circuit_breakers:  {
-    thresholds:  {
-      max_retries:  {
-        value:  128
+  circuit_breakers: {
+    thresholds: {
+      max_retries: {
+        value: 128
       }
     }
   }
   
 endpoints:test/echo:80:
-  cluster_name:  "test/echo:80"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  8080
+  cluster_name: "test/echo:80"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
           }
         }
       }
     }
   }
   
-listener:test/listener-a/listener
-  name:  "test/listener-a/listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+listener:test/listener-a/listener:
+  name: "test/listener-a/listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        is_l7lb:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
   
 listener:test/listener-b/listener:
-  name:  "test/listener-b/listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "test/listener-b/listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }
@@ -351,30 +351,30 @@ listener:test/listener-b/listener:
 policy-trigger-count:
   3
 clusters:test/listener-b/test:echo:80:
-  name:  "test/listener-b/test:echo:80"
-  eds_cluster_config:  {
-    service_name:  "test/echo:80"
+  name: "test/listener-b/test:echo:80"
+  eds_cluster_config: {
+    service_name: "test/echo:80"
   }
-  connect_timeout:  {
-    seconds:  5
+  connect_timeout: {
+    seconds: 5
   }
-  circuit_breakers:  {
-    thresholds:  {
-      max_retries:  {
-        value:  128
+  circuit_breakers: {
+    thresholds: {
+      max_retries: {
+        value: 128
       }
     }
   }
   
 endpoints:test/echo:80:
-  cluster_name:  "test/echo:80"
-  endpoints:  {
-    lb_endpoints:  {
-      endpoint:  {
-        address:  {
-          socket_address:  {
-            address:  "10.244.1.1"
-            port_value:  8080
+  cluster_name: "test/echo:80"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
           }
         }
       }
@@ -382,29 +382,29 @@ endpoints:test/echo:80:
   }
   
 listener:test/listener-b/listener:
-  name:  "test/listener-b/listener"
-  address:  {
-    socket_address:  {
-      address:  "127.0.0.1"
-      port_value:  1000
+  name: "test/listener-b/listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
     }
   }
-  additional_addresses:  {
-    address:  {
-      socket_address:  {
-        address:  "::1"
-        port_value:  1000
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
       }
     }
   }
-  listener_filters:  {
-    name:  "cilium.bpf_metadata"
-    typed_config:  {
-      [type.googleapis.com/cilium.BpfMetadata]:  {
-        bpf_root:  "/sys/fs/bpf"
-        use_original_source_address:  true
-        proxy_id:  1000
-        ipcache_name:  "cilium_ipcache"
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        proxy_id: 1000
+        ipcache_name: "cilium_ipcache_v2"
       }
     }
   }

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -115,12 +115,7 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 
 	switch modType {
 	case ipcache.Upsert:
-		value := ipcacheMap.RemoteEndpointInfo{
-			SecurityIdentity: uint32(newID.ID),
-			Key:              encryptKey,
-			Flags:            ipcacheMap.RemoteEndpointInfoFlags(endpointFlags),
-		}
-
+		var tunnelEndpoint net.IP
 		if newHostIP != nil {
 			// If the hostIP is specified and it doesn't point to
 			// the local host, then the ipcache should be populated
@@ -128,9 +123,11 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 			// to a tunnel endpoint destination.
 			nodeIPv4 := node.GetIPv4()
 			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
-				copy(value.TunnelEndpoint[:], ip4)
+				tunnelEndpoint = ip4
 			}
 		}
+		value := ipcacheMap.NewValue(uint32(newID.ID), tunnelEndpoint, encryptKey,
+			ipcacheMap.RemoteEndpointInfoFlags(endpointFlags))
 		err := l.bpfMap.Update(&key, &value)
 		if err != nil {
 			scopedLog.Warn(

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	ipcacheMap "github.com/cilium/cilium/pkg/maps/ipcache"
@@ -36,14 +37,18 @@ type BPFListener struct {
 
 	// monitorNotify is used to notify the monitor about ipcache updates
 	monitorNotify monitorNotify
+
+	// tunnelConf holds the tunneling configuration.
+	tunnelConf tunnel.Config
 }
 
 // NewListener returns a new listener to push IPCache entries into BPF maps.
-func NewListener(m Map, mn monitorNotify, logger *slog.Logger) *BPFListener {
+func NewListener(m Map, mn monitorNotify, tunnelConf tunnel.Config, logger *slog.Logger) *BPFListener {
 	return &BPFListener{
 		logger:        logger,
 		bpfMap:        m,
 		monitorNotify: mn,
+		tunnelConf:    tunnelConf,
 	}
 }
 
@@ -121,9 +126,17 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 			// the local host, then the ipcache should be populated
 			// with the hostIP so that this traffic can be guided
 			// to a tunnel endpoint destination.
-			nodeIPv4 := node.GetIPv4()
-			if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
-				tunnelEndpoint = ip4
+			switch l.tunnelConf.UnderlayProtocol() {
+			case tunnel.IPv4:
+				nodeIPv4 := node.GetIPv4()
+				if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
+					tunnelEndpoint = ip4
+				}
+			case tunnel.IPv6:
+				nodeIPv6 := node.GetIPv6()
+				if !newHostIP.Equal(nodeIPv6) {
+					tunnelEndpoint = newHostIP
+				}
 			}
 		}
 		value := ipcacheMap.NewValue(uint32(newID.ID), tunnelEndpoint, encryptKey,

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -101,7 +101,7 @@ func setupLinuxPrivilegedBaseTestSuite(tb testing.TB, addressing datapath.NodeAd
 	s.sysctl = sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
 
 	rlimit.RemoveMemlock()
-	mtuConfig := mtu.NewConfiguration(0, false, false, false)
+	mtuConfig := mtu.NewConfiguration(0, false, false, false, false)
 	s.mtuCalc = mtuConfig.Calculate(1500)
 	s.enableIPv6 = enableIPv6
 	s.enableIPv4 = enableIPv4

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -34,7 +34,7 @@ var (
 		RouteMTU:            calcMtu.RouteMTU,
 		RoutePostEncryptMTU: calcMtu.RoutePostEncryptMTU,
 	}
-	mtuConfig = mtu.NewConfiguration(0, false, false, false)
+	mtuConfig = mtu.NewConfiguration(0, false, false, false, false)
 	calcMtu   = mtuConfig.Calculate(100)
 	nh        = linuxNodeHandler{
 		nodeConfig: nodeConfig,

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -161,6 +161,25 @@ func (v *RemoteEndpointInfo) String() string {
 
 func (v *RemoteEndpointInfo) New() bpf.MapValue { return &RemoteEndpointInfo{} }
 
+// NewValue returns a RemoteEndpointInfo based on the provided security
+// identity, tunnel endpoint IP, IPsec key, and flags. The address family is
+// automatically detected.
+func NewValue(secID uint32, tunnelEndpoint net.IP, key uint8, flags RemoteEndpointInfoFlags) RemoteEndpointInfo {
+	result := RemoteEndpointInfo{}
+
+	result.SecurityIdentity = secID
+	result.Key = key
+	result.Flags = flags
+
+	if ip4 := tunnelEndpoint.To4(); ip4 != nil {
+		copy(result.TunnelEndpoint[:], ip4)
+	} else {
+		copy(result.TunnelEndpoint[:], tunnelEndpoint)
+	}
+
+	return result
+}
+
 // Map represents an IPCache BPF map.
 type Map struct {
 	bpf.Map

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -24,7 +24,7 @@ const (
 	MaxEntries = 512000
 
 	// Name is the canonical name for the IPCache map on the filesystem.
-	Name = "cilium_ipcache"
+	Name = "cilium_ipcache_v2"
 )
 
 // Key implements the bpf.MapKey interface.
@@ -161,16 +161,24 @@ const (
 // RemoteEndpointInfo implements the bpf.MapValue interface. It contains the
 // security identity of a remote endpoint.
 type RemoteEndpointInfo struct {
-	SecurityIdentity uint32     `align:"sec_identity"`
-	TunnelEndpoint   types.IPv4 `align:"tunnel_endpoint"`
-	_                uint16
-	Key              uint8                   `align:"key"`
-	Flags            RemoteEndpointInfoFlags `align:"flag_skip_tunnel"`
+	SecurityIdentity uint32 `align:"sec_identity"`
+	// represents both IPv6 and IPv4 (in the lowest four bytes)
+	TunnelEndpoint types.IPv6 `align:"tunnel_endpoint"`
+	_              uint16
+	Key            uint8                   `align:"key"`
+	Flags          RemoteEndpointInfoFlags `align:"flag_skip_tunnel"`
 }
 
 func (v *RemoteEndpointInfo) String() string {
 	return fmt.Sprintf("identity=%d encryptkey=%d tunnelendpoint=%s flags=%s",
-		v.SecurityIdentity, v.Key, v.TunnelEndpoint, v.Flags)
+		v.SecurityIdentity, v.Key, v.getTunnelEndpoint(), v.Flags)
+}
+
+func (v *RemoteEndpointInfo) getTunnelEndpoint() net.IP {
+	if v.Flags&FlagIPv6TunnelEndpoint == 0 {
+		return v.TunnelEndpoint[:4]
+	}
+	return v.TunnelEndpoint[:]
 }
 
 func (v *RemoteEndpointInfo) New() bpf.MapValue { return &RemoteEndpointInfo{} }

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -127,14 +128,21 @@ type RemoteEndpointInfoFlags uint8
 // The output format is the string name of each flag contained in the flag set,
 // separated by a comma. If no flags are set, then "<none>" is returned.
 func (f RemoteEndpointInfoFlags) String() string {
-	// If more flags are added in the future, then this method will need
-	// a re-work to support multiple flags.
-	// Right now, it only supports checking for FlagSkipTunnel.
-	if f&FlagSkipTunnel == FlagSkipTunnel {
-		return "skiptunnel"
+	flags := ""
+	if f&FlagSkipTunnel != 0 {
+		flags += "skiptunnel,"
+	}
+	if f&FlagHasTunnelEndpoint != 0 {
+		flags += "hastunnel,"
+	}
+	if f&FlagIPv6TunnelEndpoint != 0 {
+		flags += "ipv6tunnel,"
 	}
 
-	return "<none>"
+	if flags == "" {
+		return "<none>"
+	}
+	return strings.TrimSuffix(flags, ",")
 }
 
 const (

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -23,6 +23,9 @@ const (
 	// RemoteEndpointMap.
 	MaxEntries = 512000
 
+	// OldName is the canonical name for the v1 IPCache map on the filesystem.
+	OldName = "cilium_ipcache"
+
 	// Name is the canonical name for the IPCache map on the filesystem.
 	Name = "cilium_ipcache_v2"
 )
@@ -183,6 +186,23 @@ func (v *RemoteEndpointInfo) getTunnelEndpoint() net.IP {
 
 func (v *RemoteEndpointInfo) New() bpf.MapValue { return &RemoteEndpointInfo{} }
 
+// RemoteEndpointInfoV1 implements the bpf.MapValue interface for the v1
+// ipcache map value.
+type RemoteEndpointInfoV1 struct {
+	SecurityIdentity uint32     `align:"sec_identity"`
+	TunnelEndpoint   types.IPv4 `align:"tunnel_endpoint"`
+	_                uint16
+	Key              uint8                   `align:"key"`
+	Flags            RemoteEndpointInfoFlags `align:"flag_skip_tunnel"`
+}
+
+func (v *RemoteEndpointInfoV1) String() string {
+	return fmt.Sprintf("identity=%d encryptkey=%d tunnelendpoint=%s flags=%s",
+		v.SecurityIdentity, v.Key, v.TunnelEndpoint, v.Flags)
+}
+
+func (v *RemoteEndpointInfoV1) New() bpf.MapValue { return &RemoteEndpointInfoV1{} }
+
 // NewValue returns a RemoteEndpointInfo based on the provided security
 // identity, tunnel endpoint IP, IPsec key, and flags. The address family is
 // automatically detected.
@@ -223,6 +243,16 @@ func newIPCacheMap(name string) *bpf.Map {
 		bpf.BPF_F_NO_PREALLOC)
 }
 
+func newIPCacheMapV1(name string) *bpf.Map {
+	return bpf.NewMap(
+		name,
+		ebpf.LPMTrie,
+		&Key{},
+		&RemoteEndpointInfoV1{},
+		MaxEntries,
+		bpf.BPF_F_NO_PREALLOC)
+}
+
 // NewMap instantiates a Map.
 func NewMap(name string) *Map {
 	return &Map{
@@ -237,6 +267,9 @@ var (
 	// It is a singleton; there is only one such map per agent.
 	ipcache *Map
 	once    = &sync.Once{}
+
+	oldIPcache     *Map
+	onceOldIPcache = &sync.Once{}
 )
 
 // IPCacheMap gets the ipcache Map singleton. If it has not already been done,
@@ -246,4 +279,15 @@ func IPCacheMap() *Map {
 		ipcache = NewMap(Name)
 	})
 	return ipcache
+}
+
+// IPCacheMapV1 does the same as IPCacheMap but for the v1 ipcache map,
+// from v1.18.
+func IPCacheMapV1() *Map {
+	onceOldIPcache.Do(func() {
+		oldIPcache = &Map{
+			Map: *newIPCacheMapV1(OldName),
+		}
+	})
+	return oldIPcache
 }

--- a/pkg/maps/ipcache/ipcache_test.go
+++ b/pkg/maps/ipcache/ipcache_test.go
@@ -25,6 +25,11 @@ func TestRemoteEndpointInfoFlagsStringReturnsCorrectValue(t *testing.T) {
 			in:   FlagSkipTunnel,
 			out:  "skiptunnel",
 		},
+		{
+			name: "Multiple flags",
+			in:   FlagSkipTunnel | FlagIPv6TunnelEndpoint,
+			out:  "skiptunnel,ipv6tunnel",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -91,11 +91,13 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 	lc.Append(group)
 	lc.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
+			tunnelOverIPv6 := !option.Config.EnableIPv4 && option.Config.RoutingMode == option.RoutingModeTunnel
 			*c = NewConfiguration(
 				p.IPsec.AuthKeySize(),
 				option.Config.EnableIPSec,
 				p.TunnelConfig.ShouldAdaptMTU(),
 				option.Config.EnableWireguard,
+				tunnelOverIPv6,
 			)
 
 			configuredMTU := option.Config.MTU

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -11,57 +11,62 @@ import (
 
 func TestNewConfiguration(t *testing.T) {
 	// Add routes with no encryption or tunnel
-	conf := NewConfiguration(0, false, false, false)
+	conf := NewConfiguration(0, false, false, false, false)
 	require.NotEqual(t, 0, conf.getDeviceMTU(0))
 	require.Equal(t, conf.getDeviceMTU(0), conf.getRouteMTU(0))
 
 	// Add routes with no encryption or tunnel and set MTU
-	conf = NewConfiguration(0, false, false, false)
+	conf = NewConfiguration(0, false, false, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400), conf.getRouteMTU(1400))
 
 	// Add routes with tunnel
-	conf = NewConfiguration(0, false, true, false)
+	conf = NewConfiguration(0, false, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
-	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverhead, conf.getRouteMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverheadIPv4, conf.getRouteMTU(1400))
+
+	// Add routes with tunnel over IPv6
+	conf = NewConfiguration(0, false, true, false, true)
+	require.Equal(t, 1400, conf.getDeviceMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverheadIPv6, conf.getRouteMTU(1400))
 
 	// Add routes with tunnel and set MTU
-	conf = NewConfiguration(0, false, true, false)
+	conf = NewConfiguration(0, false, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
-	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverhead, conf.getRouteMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverheadIPv4, conf.getRouteMTU(1400))
 
 	// Add routes with encryption and set MTU using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, false, false)
+	conf = NewConfiguration(16, true, false, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-EncryptionIPsecOverhead, conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, true, false, false)
+	conf = NewConfiguration(32, true, false, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(12, true, false, false)
+	conf = NewConfiguration(12, true, false, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(EncryptionIPsecOverhead-4), conf.getRouteMTU(1400))
 
 	// Add routes with encryption and tunnels using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, true, false)
+	conf = NewConfiguration(16, true, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
-	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverhead+EncryptionIPsecOverhead), conf.getRouteMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+EncryptionIPsecOverhead), conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, true, true, false)
+	conf = NewConfiguration(32, true, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
-	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverhead+EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, true, true, false)
+	conf = NewConfiguration(32, true, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
-	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverhead+EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
 
 	// Add routes with WireGuard enabled
-	conf = NewConfiguration(32, false, false, true)
+	conf = NewConfiguration(32, false, false, true, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-WireguardOverhead, conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, false, true, true)
+	conf = NewConfiguration(32, false, true, true, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
-	require.Equal(t, conf.getDeviceMTU(1400)-(WireguardOverhead+TunnelOverhead), conf.getRouteMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-(WireguardOverhead+TunnelOverheadIPv4), conf.getRouteMTU(1400))
 }

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -295,10 +295,14 @@ func AutoComplete(directRoutingDevice string) error {
 // ValidatePostInit validates the entire addressing setup and completes it as
 // required
 func ValidatePostInit() error {
-	if option.Config.EnableIPv4 || option.Config.TunnelingEnabled() {
+	if option.Config.EnableIPv4 {
 		if GetIPv4() == nil {
 			return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
 		}
+	}
+
+	if option.Config.TunnelingEnabled() && GetIPv4() == nil && GetIPv6() == nil {
+		return fmt.Errorf("external node address could not be derived, please configure via --ipv4-node or --ipv6-node")
 	}
 
 	if option.Config.EnableIPv4 && GetInternalIPv4Router() == nil {

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -11,6 +11,7 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -89,6 +90,7 @@ type NodeManager interface {
 
 func newAllNodeManager(in struct {
 	cell.In
+	TunnelConf  tunnel.Config
 	Lifecycle   cell.Lifecycle
 	IPCache     *ipcache.IPCache
 	IPSetMgr    ipset.Manager
@@ -100,7 +102,7 @@ func newAllNodeManager(in struct {
 	Devices     statedb.Table[*tables.Device]
 },
 ) (NodeManager, error) {
-	mngr, err := New(option.Config, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices)
+	mngr, err := New(option.Config, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
@@ -149,6 +150,8 @@ type manager struct {
 	// conf is the configuration of the caller passed in via NewManager.
 	// This field is immutable after NewManager()
 	conf *option.DaemonConfig
+
+	underlay tunnel.UnderlayProtocol
 
 	// ipcache is the set operations performed against the ipcache
 	ipcache IPCache
@@ -305,6 +308,7 @@ func NewNodeMetrics() *nodeMetrics {
 // New returns a new node manager
 func New(
 	c *option.DaemonConfig,
+	tunnelConf tunnel.Config,
 	ipCache IPCache,
 	ipsetMgr ipset.Manager,
 	ipsetFilter IPSetFilterFn,
@@ -322,6 +326,7 @@ func New(
 		nodes:                  map[nodeTypes.Identity]*nodeEntry{},
 		restoredNodes:          map[nodeTypes.Identity]*nodeTypes.Node{},
 		conf:                   c,
+		underlay:               tunnelConf.UnderlayProtocol(),
 		controllerManager:      controller.NewManager(),
 		nodeHandlers:           map[datapath.NodeHandler]struct{}{},
 		ipcache:                ipCache,
@@ -806,7 +811,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	nodeIdentifier := n.Identity()
 	dpUpdate := true
 	var nodeIP netip.Addr
-	if nIP := n.GetNodeIP(false); nIP != nil {
+	if nIP := n.GetNodeIP(m.underlay == tunnel.IPv6); nIP != nil {
 		// GH-24829: Support IPv6-only nodes.
 
 		// Skip returning the error here because at this level, we assume that

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -30,6 +30,7 @@ import (
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/health"
@@ -266,7 +267,7 @@ func TestNodeLifecycle(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(&option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 
@@ -345,7 +346,7 @@ func TestMultipleSources(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(&option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -428,7 +429,7 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(&option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(b, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -451,7 +452,7 @@ func TestClusterSizeDependantInterval(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(&option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -476,7 +477,7 @@ func TestBackgroundSync(t *testing.T) {
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(&option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	mngr.Subscribe(signalNodeHandler)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -545,7 +546,7 @@ func TestIpcache(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(&option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -689,7 +690,7 @@ func TestIpcacheHealthIP(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(&option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -737,7 +738,7 @@ func TestNodeEncryption(t *testing.T) {
 	mngr, err := New(&option.DaemonConfig{
 		EncryptNode: true,
 		EnableIPSec: true,
-	}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -860,7 +861,7 @@ func TestNode(t *testing.T) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(&option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -988,6 +989,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 		cell.Provide(func() testParams {
 			return testParams{
 				Config:        config,
+				TunnelConf:    tunnel.Config{},
 				IPCache:       ipcacheMock,
 				IPSet:         newIPSetMock(),
 				NodeMetrics:   NewNodeMetrics(),
@@ -1078,6 +1080,7 @@ func TestCarrierDownReconciler(t *testing.T) {
 		cell.Provide(func() testParams {
 			return testParams{
 				Config:        &option.DaemonConfig{},
+				TunnelConf:    tunnel.Config{},
 				IPCache:       newIPcacheMock(),
 				IPSet:         newIPSetMock(),
 				NodeMetrics:   NewNodeMetrics(),
@@ -1279,6 +1282,7 @@ func (mh *mockHealth) Close() {}
 type testParams struct {
 	cell.Out
 	Config        *option.DaemonConfig
+	TunnelConf    tunnel.Config
 	IPCache       IPCache
 	IPSet         ipset.Manager
 	NodeMetrics   *nodeMetrics
@@ -1314,7 +1318,7 @@ func TestNodeWithSameInternalIP(t *testing.T) {
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(&option.DaemonConfig{
 		LocalRouterIPv4: "169.254.4.6",
-	}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	}, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1414,7 +1418,7 @@ func TestNodeIpset(t *testing.T) {
 	mngr, err := New(&option.DaemonConfig{
 		RoutingMode:          option.RoutingModeNative,
 		EnableIPv4Masquerade: true,
-	}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil)
+	}, tunnel.Config{}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -1595,7 +1599,7 @@ func TestNodesStartupPruning(t *testing.T) {
 	mngr, err := New(&option.DaemonConfig{
 		StateDir:    tmp,
 		ClusterName: "c1",
-	}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		mngr.Stop(context.TODO())

--- a/pkg/node/manager/rest_api_test.go
+++ b/pkg/node/manager/rest_api_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -33,7 +34,7 @@ func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {
 	option.Config.IPv6ServiceRange = "auto"
 
 	h, _ := cell.NewSimpleHealth()
-	nm, err := New(fakeConfig, nil, &fakeTypes.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil)
+	nm, err := New(fakeConfig, tunnel.Config{}, nil, &fakeTypes.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(tb, err)
 
 	g := &GetNodesSuite{

--- a/pkg/types/ipv6.go
+++ b/pkg/types/ipv6.go
@@ -11,6 +11,15 @@ import (
 // IPv6 is the binary representation for encoding in binary structs.
 type IPv6 [16]byte
 
+func (v6 IPv6) IsZero() bool {
+	for i := 0; i < 16; i++ {
+		if v6[i] != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func (v6 IPv6) IP() net.IP {
 	return v6[:]
 }


### PR DESCRIPTION
This pull request adds support for IPv6 as a tunneling underlay when running with kube-proxy. Support for KPR will come as a follow up pull request.

The main changes here are in the datapath, to change the ipcache map layout to support IPv6 tunnel endpoints, but there are also of course changes in the agent to populate those IPv6 tunnel endpoints. I've tried to split commits as much as possible to ease rebasing and reviewing, but if you think it can be improved, please shout out.

There isn't an end-to-end test in this pull request. That will come as a follow up pull request as well.

```release-note
Support IPv6 as a tunneling underlay.
```