### PR TITLE
bgp router ID ip pool implementation

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -23,7 +23,8 @@ cilium-agent [flags]
       --arping-refresh-period duration                            Period for remote node ARP entry refresh (set 0 to disable) (default 30s)
       --auto-create-cilium-node-resource                          Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                                   Enable automatic L2 routing between nodes
-      --bgp-router-id-allocation-mode string                      BGP router-id allocation mode. Currently supported values: 'default'  (default "default")
+      --bgp-router-id-allocation-ip-pool string                   IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
+      --bgp-router-id-allocation-mode string                      BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
       --bpf-auth-map-max int                                      Maximum number of entries in auth map (default 524288)
       --bpf-conntrack-accounting                                  Enable CT accounting for packets and bytes (default false)
       --bpf-ct-global-any-max int                                 Maximum number of entries in non-TCP CT table (default 262144)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -275,7 +275,7 @@
    * - :spelling:ignore:`bgpControlPlane`
      - This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs.
      - object
-     - ``{"enabled":false,"routerIDAllocation":{"mode":"default"},"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}``
+     - ``{"enabled":false,"routerIDAllocation":{"ipPool":"","mode":"default"},"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}``
    * - :spelling:ignore:`bgpControlPlane.enabled`
      - Enables the BGP control plane.
      - bool
@@ -283,7 +283,11 @@
    * - :spelling:ignore:`bgpControlPlane.routerIDAllocation`
      - BGP router-id allocation mode
      - object
-     - ``{"mode":"default"}``
+     - ``{"ipPool":"","mode":"default"}``
+   * - :spelling:ignore:`bgpControlPlane.routerIDAllocation.ipPool`
+     - IP pool to allocate the BGP router-id from when the mode is ip-pool.
+     - string
+     - ``""``
    * - :spelling:ignore:`bgpControlPlane.routerIDAllocation.mode`
      - BGP router-id allocation mode. In default mode, the router-id is derived from the IPv4 address if it is available, or else it is determined by the lower 32 bits of the MAC address.
      - string

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -938,8 +938,11 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableBGPControlPlaneStatusReport, true, "Enable the BGP control plane status reporting")
 	option.BindEnv(vp, option.EnableBGPControlPlaneStatusReport)
 
-	flags.String(option.BGPRouterIDAllocationMode, defaults.BGPRouterIDAllocationMode, "BGP router-id allocation mode. Currently supported values: 'default' ")
+	flags.String(option.BGPRouterIDAllocationMode, option.BGPRouterIDAllocationModeDefault, "BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool'")
 	option.BindEnv(vp, option.BGPRouterIDAllocationMode)
+
+	flags.String(option.BGPRouterIDAllocationIPPool, "", "IP pool to allocate the BGP router-id from when the mode is 'ip-pool'")
+	option.BindEnv(vp, option.BGPRouterIDAllocationIPPool)
 
 	flags.Bool(option.EnablePMTUDiscovery, false, "Enable path MTU discovery to send ICMP fragmentation-needed replies to the client")
 	option.BindEnv(vp, option.EnablePMTUDiscovery)

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -118,9 +118,10 @@ contributors across the globe, there is almost always someone available to help.
 | bandwidthManager.bbr | bool | `false` | Activate BBR TCP congestion control for Pods |
 | bandwidthManager.bbrHostNamespaceOnly | bool | `false` | Activate BBR TCP congestion control for Pods in the host namespace only. |
 | bandwidthManager.enabled | bool | `false` | Enable bandwidth manager infrastructure (also prerequirement for BBR) |
-| bgpControlPlane | object | `{"enabled":false,"routerIDAllocation":{"mode":"default"},"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
+| bgpControlPlane | object | `{"enabled":false,"routerIDAllocation":{"ipPool":"","mode":"default"},"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
-| bgpControlPlane.routerIDAllocation | object | `{"mode":"default"}` | BGP router-id allocation mode |
+| bgpControlPlane.routerIDAllocation | object | `{"ipPool":"","mode":"default"}` | BGP router-id allocation mode |
+| bgpControlPlane.routerIDAllocation.ipPool | string | `""` | IP pool to allocate the BGP router-id from when the mode is ip-pool. |
 | bgpControlPlane.routerIDAllocation.mode | string | `"default"` | BGP router-id allocation mode. In default mode, the router-id is derived from the IPv4 address if it is available, or else it is determined by the lower 32 bits of the MAC address. |
 | bgpControlPlane.secretsNamespace | object | `{"create":false,"name":"kube-system"}` | SecretsNamespace is the namespace which BGP support will retrieve secrets from. |
 | bgpControlPlane.secretsNamespace.create | bool | `false` | Create secrets namespace for BGP secrets. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1228,6 +1228,7 @@ data:
   bgp-secrets-namespace: {{ .Values.bgpControlPlane.secretsNamespace.name | quote }}
   enable-bgp-control-plane-status-report: {{ .Values.bgpControlPlane.statusReport.enabled | quote }}
   bgp-router-id-allocation-mode: {{ .Values.bgpControlPlane.routerIDAllocation.mode | quote }}
+  bgp-router-id-allocation-ip-pool: {{ .Values.bgpControlPlane.routerIDAllocation.ipPool | quote }}
 {{- end }}
 
 {{- if .Values.pmtuDiscovery.enabled }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -465,6 +465,9 @@
         },
         "routerIDAllocation": {
           "properties": {
+            "ipPool": {
+              "type": "string"
+            },
             "mode": {
               "type": "string"
             }

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -489,6 +489,8 @@ bgpControlPlane:
   routerIDAllocation:
     # -- BGP router-id allocation mode. In default mode, the router-id is derived from the IPv4 address if it is available, or else it is determined by the lower 32 bits of the MAC address.
     mode: "default"
+    # -- IP pool to allocate the BGP router-id from when the mode is ip-pool.
+    ipPool: ""
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
   # the client.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -492,6 +492,8 @@ bgpControlPlane:
   routerIDAllocation:
     # -- BGP router-id allocation mode. In default mode, the router-id is derived from the IPv4 address if it is available, or else it is determined by the lower 32 bits of the MAC address.
     mode: "default"
+    # -- IP pool to allocate the BGP router-id from when the mode is ip-pool.
+    ipPool: ""
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
   # the client.

--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -41,7 +41,7 @@ type fixture struct {
 	bgpnClient cilium_client_v2.CiliumBGPNodeConfigInterface
 }
 
-func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, enableStatusReport bool) (*fixture, func()) {
+func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, dc *option.DaemonConfig) (*fixture, func()) {
 	rws := map[string]*struct {
 		once    sync.Once
 		watchCh chan any
@@ -132,12 +132,7 @@ func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, enab
 		}),
 
 		cell.Provide(func() *option.DaemonConfig {
-			return &option.DaemonConfig{
-				EnableBGPControlPlane:             true,
-				Debug:                             true,
-				BGPSecretsNamespace:               "kube-system",
-				EnableBGPControlPlaneStatusReport: enableStatusReport,
-			}
+			return dc
 		}),
 
 		cell.Provide(func() k8s_client.Clientset {

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1355,7 +1355,7 @@ func ipRangeFromBlock(block cilium_api_v2.CiliumLoadBalancerIPPoolIPBlock) (to, 
 			return netip.Addr{}, netip.Addr{}, false, fmt.Errorf("error parsing cidr '%s': %w", block.Cidr, err)
 		}
 
-		to, from = rangeFromPrefix(prefix)
+		to, from = RangeFromPrefix(prefix)
 		return to, from, true, nil
 	}
 
@@ -1939,7 +1939,7 @@ func isIPv6(ip netip.Addr) bool {
 	return ip.BitLen() == 128
 }
 
-func rangeFromPrefix(prefix netip.Prefix) (netip.Addr, netip.Addr) {
+func RangeFromPrefix(prefix netip.Prefix) (netip.Addr, netip.Addr) {
 	prefix = prefix.Masked()
 	return prefix.Addr(), netipx.PrefixLastIP(prefix)
 }

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -2361,7 +2361,7 @@ func TestRangeFromPrefix(t *testing.T) {
 				tt.Fatal(err)
 			}
 
-			from, to := rangeFromPrefix(prefix)
+			from, to := RangeFromPrefix(prefix)
 			if to.Compare(expectedTo) != 0 {
 				tt.Fatalf("expected '%s', got '%s'", expectedTo, to)
 			}

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -1235,8 +1235,14 @@ func getRouterID(config *v2.CiliumBGPNodeInstance, ciliumNode *v2.CiliumNode, as
 		}
 		return routerID, nil
 	case option.BGPRouterIDAllocationModeIPPool:
-		// TODO: implement IP pool allocation
-		return "", fmt.Errorf("IP pool allocation mode not implemented")
+		if config.RouterID == nil {
+			return "", fmt.Errorf("can't find the router-id in the CiliumBGPNodeInstance")
+		}
+		routerID := *config.RouterID
+		if net.ParseIP(routerID).To4() == nil {
+			return "", fmt.Errorf("the router-id %s is not a valid IPv4 address", routerID)
+		}
+		return routerID, nil
 	default:
 		return "", fmt.Errorf("invalid router-id allocation mode: %s (supported modes: %s, %s)", option.Config.BGPRouterIDAllocationMode, option.BGPRouterIDAllocationModeDefault, option.BGPRouterIDAllocationModeIPPool)
 	}

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -1223,8 +1223,8 @@ func getRouterID(config *v2.CiliumBGPNodeInstance, ciliumNode *v2.CiliumNode, as
 	}
 
 	// If there are no annotations about router-id, router-id will be allocated based on the allocation mode
-	// TODO: implement other allocation modes
-	if option.Config.BGPRouterIDAllocationMode == defaults.BGPRouterIDAllocationMode {
+	switch option.Config.BGPRouterIDAllocationMode {
+	case option.BGPRouterIDAllocationModeDefault:
 		if nodeIP := ciliumNode.GetIP(false); nodeIP != nil {
 			routerID = nodeIP.String()
 		} else {
@@ -1234,8 +1234,12 @@ func getRouterID(config *v2.CiliumBGPNodeInstance, ciliumNode *v2.CiliumNode, as
 			}
 		}
 		return routerID, nil
+	case option.BGPRouterIDAllocationModeIPPool:
+		// TODO: implement IP pool allocation
+		return "", fmt.Errorf("IP pool allocation mode not implemented")
+	default:
+		return "", fmt.Errorf("invalid router-id allocation mode: %s (supported modes: %s, %s)", option.Config.BGPRouterIDAllocationMode, option.BGPRouterIDAllocationModeDefault, option.BGPRouterIDAllocationModeIPPool)
 	}
-	return "", fmt.Errorf("no router-id found")
 }
 
 // getLocalPort returns the local port for the given ASN. If the local port is defined in the desired config, it will

--- a/pkg/bgpv1/test/script_test.go
+++ b/pkg/bgpv1/test/script_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/test/commands"
-	"github.com/cilium/cilium/pkg/defaults"
 	ciliumhive "github.com/cilium/cilium/pkg/hive"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -94,7 +93,7 @@ func TestScript(t *testing.T) {
 				option.Config = &option.DaemonConfig{
 					EnableBGPControlPlane:     true,
 					BGPSecretsNamespace:       testSecretsNamespace,
-					BGPRouterIDAllocationMode: defaults.BGPRouterIDAllocationMode,
+					BGPRouterIDAllocationMode: option.BGPRouterIDAllocationModeDefault,
 					IPAM:                      *ipam,
 				}
 				return option.Config

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -563,9 +563,6 @@ const (
 	// EnableSourceIPVerification is the default value for source ip validation
 	EnableSourceIPVerification = true
 
-	// BGPRouterIDAllocationMode is default BGP router-id allocation mode
-	BGPRouterIDAllocationMode = "default"
-
 	// WireguardTrackAllIPsFallback forces the WireGuard agent to track all IPs.
 	WireguardTrackAllIPsFallback = false
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1030,8 +1030,11 @@ const (
 	// EnableBGPControlPlaneStatusReport enables BGP Control Plane CRD status reporting
 	EnableBGPControlPlaneStatusReport = "enable-bgp-control-plane-status-report"
 
-	// BGP router-id allocation mode in ipv6 standalone environment
+	// BGP router-id allocation mode
 	BGPRouterIDAllocationMode = "bgp-router-id-allocation-mode"
+
+	// BGP router-id allocation IP pool
+	BGPRouterIDAllocationIPPool = "bgp-router-id-allocation-ip-pool"
 
 	// EnableRuntimeDeviceDetection is the name of the option to enable detection
 	// of new and removed datapath devices during the agent runtime.
@@ -1202,6 +1205,14 @@ const (
 	// IdentityManagementModeBoth means cilium-agent and cilium-operator both manage identities
 	// (used only during migration between "agent" and "operator").
 	IdentityManagementModeBoth = "both"
+)
+
+const (
+	// BGPRouterIDAllocationModeDefault means the router-id is allocated per node
+	BGPRouterIDAllocationModeDefault = "default"
+
+	// BGPRouterIDAllocationModeIPPool means the router-id is allocated per IP pool
+	BGPRouterIDAllocationModeIPPool = "ip-pool"
 )
 
 // getEnvName returns the environment variable to be used for the given option name.
@@ -2055,8 +2066,11 @@ type DaemonConfig struct {
 	// Enables BGP control plane status reporting.
 	EnableBGPControlPlaneStatusReport bool
 
-	// BGPRouterIDAllocationMode is the mode to allocate the BGP router-id in ipv6 standalone environment.
+	// BGPRouterIDAllocationMode is the mode to allocate the BGP router-id.
 	BGPRouterIDAllocationMode string
+
+	// BGPRouterIDAllocationIPPool is the IP pool to allocate the BGP router-id from.
+	BGPRouterIDAllocationIPPool string
 
 	// BPFMapEventBuffers has configuration on what BPF map event buffers to enabled
 	// and configuration options for those.
@@ -3191,8 +3205,9 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	// Enable BGP control plane status reporting
 	c.EnableBGPControlPlaneStatusReport = vp.GetBool(EnableBGPControlPlaneStatusReport)
 
-	// BGP router-id allocation mode in IPv6 standalone environment
+	// BGP router-id allocation mode
 	c.BGPRouterIDAllocationMode = vp.GetString(BGPRouterIDAllocationMode)
+	c.BGPRouterIDAllocationIPPool = vp.GetString(BGPRouterIDAllocationIPPool)
 
 	// Support failure-mode for policy map overflow
 	c.EnableEndpointLockdownOnPolicyOverflow = vp.GetBool(EnableEndpointLockdownOnPolicyOverflow)


### PR DESCRIPTION
Implement the Option1 in #30333


> Option1: Via Helm configuration
> 
> Provide Router ID pool through Cilium operator's configuration like bgpControlPlane.routerIDPool=10.0.0.0/16 which will ultimately rendered as a cilium-config ConfigMap entry. This is easy to implement, but changing or extending the range requires operator restart.
> 
> 

more details in commits messages 

Fixes: #30333
```release-note
Introduce a new ip pool mode for BGP router ID allocation so cilium can pick up the router ID from a pool.
```
