### PR TITLE
.github/renovate: do not update LVH images for conformance-runtime

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -182,7 +182,7 @@
         "quay.io/lvh-images/kind",
       ],
       "paths": [
-        ".github/actions/ginkgo/main-k8s-versions.yaml",
+        ".github/workflows/conformance-runtime.yaml",
       ],
       "enabled": false
     },


### PR DESCRIPTION
Skip the workflow that's tracked in
https://github.com/cilium/cilium/issues/38058.

Fixes: 819acb40976d (".github/renovate: do not update LVH images")