### PR TITLE
bpf: srv6: don't include unused fib.h

### DIFF
--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "lib/common.h"
-#include "lib/fib.h"
 #include "lib/identity.h"
 
 #include "maps.h"


### PR DESCRIPTION
fib.h is not actually used in this file.