### PR TITLE
bpf: nodeport: preserve monitor aggregation in egress path

### DIFF
--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -142,6 +142,7 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, bool *snat_done,
 	struct ipv6_ct_tuple tuple __align_stack_8 = {};
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
+	__u32 monitor = 0;
 	int ret, l4_off;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
@@ -178,9 +179,10 @@ skip_fib:
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
 			      SCOPE_REVERSE, CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
-			      NULL, &trace->monitor);
+			      NULL, &monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
+		trace->monitor = monitor;
 
 		ret = __lb6_rev_nat(ctx, l4_off, &tuple, nat_info);
 		if (IS_ERR(ret))
@@ -441,6 +443,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, bool *snat_done,
 	void *data, *data_end;
 	bool has_l4_header, is_fragment;
 	struct iphdr *ip4;
+	__u32 monitor = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -483,13 +486,14 @@ skip_fib:
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, is_fragment,
 			      l4_off, has_l4_header, CT_INGRESS, SCOPE_REVERSE,
 			      CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
-			      &ct_state, &trace->monitor);
+			      &ct_state, &monitor);
 
 	/* nodeport_rev_dnat_get_info_ipv4() just checked that such a
 	 * CT entry exists:
 	 */
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
+		trace->monitor = monitor;
 
 		ret = __lb4_rev_nat(ctx, l3_off, l4_off, &tuple,
 				    nat_info, false, has_l4_header);


### PR DESCRIPTION
Don't clear trace->monitor if we didn't match the expected CT entry. See a25fbdcc7ed2 ("bpf: nodeport: preserve monitor aggregation in RevDNAT path") for more details.

Here it's not as problematic, since we previously already checked that such a CT entry exists. But let's be consistent.