### PR TITLE
Reduce duplicate identities for identical pods

### DIFF
--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -263,7 +263,7 @@ func TestSelectID(t *testing.T) {
 
 	// allocate all available IDs
 	for i := minID; i <= maxID; i++ {
-		id, val, unmaskedID := a.selectAvailableID()
+		id, val, unmaskedID := a.selectAvailableID(1)
 		require.NotEqual(t, idpool.NoID, id)
 		require.Equal(t, id.String(), val)
 		require.Equal(t, unmaskedID, id)
@@ -273,7 +273,7 @@ func TestSelectID(t *testing.T) {
 	}
 
 	// we should be out of IDs
-	id, val, unmaskedID := a.selectAvailableID()
+	id, val, unmaskedID := a.selectAvailableID(2)
 	require.Equal(t, idpool.ID(0), id)
 	require.Equal(t, unmaskedID, id)
 	require.Equal(t, "", val)
@@ -288,7 +288,7 @@ func TestPrefixMask(t *testing.T) {
 
 	// allocate all available IDs
 	for i := minID; i <= maxID; i++ {
-		id, val, unmaskedID := a.selectAvailableID()
+		id, val, unmaskedID := a.selectAvailableID(3)
 		require.NotEqual(t, idpool.NoID, id)
 		require.Equal(t, idpool.ID(1), id>>16)
 		require.NotEqual(t, unmaskedID, id)

--- a/pkg/identity/key/global_identity.go
+++ b/pkg/identity/key/global_identity.go
@@ -19,20 +19,28 @@ const (
 )
 
 // GlobalIdentity is the structure used to store an identity
+// Note: GlobalIdentity is immutable; use the mutator methods.
 type GlobalIdentity struct {
 	labels.LabelArray
 
 	// metadata contains metadata that are stored for example by the backends.
 	metadata map[any]any
+
+	// memoized key
+	key string
 }
 
 // GetKey encodes an Identity as string
 func (gi *GlobalIdentity) GetKey() string {
+	if gi.key != "" {
+		return gi.key
+	}
 	var str strings.Builder
 	for _, l := range gi.LabelArray {
 		str.Write(l.FormatForKVStore())
 	}
-	return str.String()
+	gi.key = str.String()
+	return gi.key
 }
 
 // GetAsMap encodes a GlobalIdentity a map of keys to values. The keys will

--- a/pkg/idpool/idpool_test.go
+++ b/pkg/idpool/idpool_test.go
@@ -241,6 +241,29 @@ func TestOperationsOnUnavailableIDs(t *testing.T) {
 	leaseAllIDs(p4, minID, minID-1, t)
 }
 
+func TestLeaseIDSeeded(t *testing.T) {
+	minID, maxID := 1, 5
+	p := NewIDPool(ID(minID), ID(maxID))
+	expected := make([]int, 0)
+	actual := make([]int, 0)
+	for i := minID; i <= maxID; i++ {
+		id := p.LeaseRandomID(uint64(i))
+		require.NotEqual(t, NoID, id)
+		actual = append(actual, int(id))
+		expected = append(expected, i)
+	}
+	// We should be out of IDs.
+	id := p.LeaseAvailableID()
+	require.Equal(t, NoID, id)
+
+	// We should be out of IDs.
+	id = p.LeaseRandomID(1234)
+	require.Equal(t, NoID, id)
+
+	// Unique ids must have been leased.
+	require.ElementsMatch(t, actual, expected)
+}
+
 func leaseAllIDs(p *IDPool, minID int, maxID int, t *testing.T) {
 	expected := make([]int, 0)
 	actual := make([]int, 0)
@@ -312,7 +335,7 @@ func testAllocatedID(t *testing.T, nGoRoutines int) {
 		allocators.Add(1)
 		go func() {
 			for i := 1; i <= maxID; i++ {
-				id := p.AllocateID()
+				id := p.AllocateRandomID(uint64(i))
 				if id == NoID {
 					t.Error("ID expected to be allocated")
 				}


### PR DESCRIPTION
When multiple agents create pods with the same set of labels -- like when a large DaemonSet or Deployment is created -- they all randomly select a distinct numeric identity. This causes unnecessary numeric identities to be created.

This PR reduces this in two ways:

1. Add a small jitter before attempting identity allocation. We now wait ~20 milliseconds, jittered, before attempting identity allocation. This should give one agent a chance to win the race.
2. Use a RNG, seeded on a CRC64 of the labels, to select the numeric identity. This means that agents should generally select the same number when allocating. The kvstore (k8s or etcd) will then reject all subsequent allocations.

```release-note
The number duplicate identities created for similar pods should be significantly reduced.
```
