### PR TITLE
Deduplicate go build flags when building with CGO enabled

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -156,7 +156,7 @@ GO_BUILD_FLAGS += -mod=vendor
 GO_TEST_FLAGS += -mod=vendor -vet=all
 GO_CLEAN_FLAGS += -mod=vendor
 
-GO_BUILD = CGO_ENABLED=0 $(GO) build
+CGO_ENABLED ?= 0
 
 # Support CGO cross-compiling for amd64 and arm64 targets
 CGO_CC =
@@ -169,15 +169,16 @@ ifeq ($(CROSS_ARCH),arm64)
 else ifeq ($(CROSS_ARCH),amd64)
     CGO_CC = CC=x86_64-linux-gnu-gcc
 endif
-GO_BUILD_WITH_CGO = CGO_ENABLED=1 $(CGO_CC) $(GO) build
+
+GO_BUILD = CGO_ENABLED=$(CGO_ENABLED) $(CGO_CC) $(GO) build
 
 ifneq ($(RACE),)
     GO_BUILD_FLAGS += -race
     GO_TEST_FLAGS += -race
     GOTEST_COVER_OPTS += -covermode=atomic
 
-    # GO_BUILD becomes GO_BUILD_WITH_CGO as `-race` requires CGO
-    GO_BUILD = $(GO_BUILD_WITH_CGO)
+    # `-race` requires CGO
+    CGO_ENABLED = 1
     ifeq ($(LOCKDEBUG),)
         LOCKDEBUG=1
     endif
@@ -197,7 +198,6 @@ ifeq ($(NOOPT),1)
 endif
 
 GO_BUILD += $(GO_BUILD_FLAGS)
-GO_BUILD_WITH_CGO += $(GO_BUILD_FLAGS)
 
 GO_TEST = CGO_ENABLED=0 $(GO) test $(GO_TEST_FLAGS)
 GO_CLEAN = $(GO) clean $(GO_CLEAN_FLAGS)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
Deduplicate go build flags when building with CGO enabled
```

---

Currently, when building with CGO enabled (for example when race detection is enabled), all go build tags are duplicated. For example running `RACE=1 make -C operator cilium-operator-aws` yields the following:
```sh
make: Entering directory '/home/hadrien/go/src/github.com/cilium/cilium/operator'
CGO_ENABLED=1  go build -mod=vendor -race -ldflags '-X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.18.0-dev 606279ec66 2025-03-12T15:05:15+02:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=7235681768200a4effbbebb019e5d51b60a57daa" ' -tags=osusergo,lockdebug,ipam_provider_aws  -mod=vendor -race -ldflags '-X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.18.0-dev 606279ec66 2025-03-12T15:05:15+02:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=7235681768200a4effbbebb019e5d51b60a57daa" ' -tags=osusergo,lockdebug,ipam_provider_aws  -o cilium-operator-aws
```

We can see that this string `-mod=vendor -race -ldflags '-X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.18.0-dev 606279ec66 2025-03-12T15:05:15+02:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=7235681768200a4effbbebb019e5d51b60a57daa" ' -tags=osusergo,lockdebug,ipam_provider_aws` is duplicated in that command.

This is because this string comes from the `GO_BUILD_FLAGS` variable, which is appended to both the `GO_BUILD` and `GO_BUILD_WITH_CGO` variables [here](https://github.com/cilium/cilium/blob/1271223b84049edd879c952c2f75a8324f14ce66/Makefile.defs#L199-L200).

But since we have  `GO_BUILD = $(GO_BUILD_WITH_CGO)` [here](https://github.com/cilium/cilium/blob/1271223b84049edd879c952c2f75a8324f14ce66/Makefile.defs#L180), this means that the `GO_BUILD` variable actually gets `GO_BUILD_FLAGS` appended twice as it's using a recursive variable assignment.

[Ref](https://www.gnu.org/software/make/manual/html_node/Setting.html):
> Variables defined with ‘=’ are recursively expanded variables. Variables defined with ‘:=’ or ‘::=’ are simply expanded variables; these definitions can contain variable references which will be expanded before the definition is made.

We do need to keep `GO_BUILD` as a recurvive variable assignment so that downstream Makefiles can tweak it by changing related variables (for example by updating `GO_TAGS_FLAGS` like [here](https://github.com/cilium/cilium/blob/20aae6b3c31b9abb38f26f0952a2b85d90b310ad/operator/Makefile#L21)).

To solve this, this PR removes the `GO_BUILD_WITH_CGO` variable and instead makes `GO_BUILD` dynamic by relying on a new `CGO_ENABLED` variable. This ensures we still have the flexibility of using CGO by simply setting `CGO_ENABLED` to 1, while avoiding duplication of go build flags.




With this patch, the build flags are no longer duplicated: `RACE=1 make -C operator cilium-operator-aws`
```sh
make: Entering directory '/home/hadrien/go/src/github.com/cilium/cilium/operator'
CGO_ENABLED=1  go build -mod=vendor -race -ldflags '-X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.18.0-dev 3acd62d624 2025-03-19T15:49:39+01:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=7235681768200a4effbbebb019e5d51b60a57daa" ' -tags=osusergo,lockdebug,ipam_provider_aws  -o cilium-operator-aws
```