### PR TITLE
pkg/controller: fix data race in update params locked

### DIFF
--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -71,14 +71,18 @@ func (m *Manager) updateController(name string, params ControllerParams) *manage
 
 	ctrl := m.lookupLocked(name)
 	if ctrl != nil {
+		ctrl.mutex.Lock()
 		ctrl.getLogger().Debug("Updating existing controller")
 		ctrl.updateParamsLocked(params)
+		ctrl.mutex.Unlock()
+		ctrl.mutex.RLock()
 
 		// Notify the goroutine of the params update.
 		select {
 		case ctrl.update <- ctrl.params:
 		default:
 		}
+		ctrl.mutex.RUnlock()
 
 		ctrl.getLogger().Debug("Controller update time: ", time.Since(start))
 	} else {


### PR DESCRIPTION
Caught by the race detector:
```
Write at 0x00c002e55ca0 by goroutine 6854:
  github.com/cilium/cilium/pkg/controller.(*managedController).updateParamsLocked()
      /go/src/github.com/cilium/cilium/pkg/controller/manager.go:305 +0x424
  github.com/cilium/cilium/pkg/controller.(*Manager).updateController()
      /go/src/github.com/cilium/cilium/pkg/controller/manager.go:74 +0x304
  github.com/cilium/cilium/pkg/controller.(*Manager).UpdateController()
      /go/src/github.com/cilium/cilium/pkg/controller/manager.go:52 +0x4f3
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RunMetadataResolver()
      /go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1852 +0xe1
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RunRestoredMetadataResolver()
      /go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1903 +0x9e
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RegenerateAfterRestore()
      /go/src/github.com/cilium/cilium/pkg/endpoint/restore.go:202 +0x70
  github.com/cilium/cilium/daemon/cmd.(*Daemon).regenerateRestoredEndpoints.func1()
      /go/src/github.com/cilium/cilium/daemon/cmd/state.go:327 +0x104
  github.com/cilium/cilium/daemon/cmd.(*Daemon).regenerateRestoredEndpoints.gowrap1()
      /go/src/github.com/cilium/cilium/daemon/cmd/state.go:333 +0x4f

Previous read at 0x00c002e55ca0 by goroutine 7204:
  github.com/cilium/cilium/pkg/controller.(*managedController).GetStatusModel()
      /go/src/github.com/cilium/cilium/pkg/controller/manager.go:329 +0x324
  github.com/cilium/cilium/pkg/controller.(*Manager).GetStatusModel()
      /go/src/github.com/cilium/cilium/pkg/controller/manager.go:239 +0x386
  github.com/cilium/cilium/pkg/controller.GetGlobalStatus()
      /go/src/github.com/cilium/cilium/pkg/controller/manager.go:41 +0x30
  github.com/cilium/cilium/daemon/cmd.(*Daemon).startStatusCollector.func16()
      /go/src/github.com/cilium/cilium/daemon/cmd/status.go:788 +0x31
  github.com/cilium/cilium/pkg/status.(*Collector).runProbe.func1()
      /go/src/github.com/cilium/cilium/pkg/status/status.go:206 +0x7c

Goroutine 6854 (running) created at:
  github.com/cilium/cilium/daemon/cmd.(*Daemon).regenerateRestoredEndpoints()
      /go/src/github.com/cilium/cilium/daemon/cmd/state.go:326 +0x73b
  github.com/cilium/cilium/daemon/cmd.(*Daemon).initRestore()
      /go/src/github.com/cilium/cilium/daemon/cmd/state.go:437 +0x8a
  github.com/cilium/cilium/daemon/cmd.startDaemon()
      /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1706 +0x58b
  github.com/cilium/cilium/daemon/cmd.newDaemonPromise.func1.2()
      /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1659 +0x18e

Goroutine 7204 (running) created at:
  github.com/cilium/cilium/pkg/status.(*Collector).runProbe()
      /go/src/github.com/cilium/cilium/pkg/status/status.go:205 +0x4cd
  github.com/cilium/cilium/pkg/status.(*Collector).spawnProbe.func1()
      /go/src/github.com/cilium/cilium/pkg/status/status.go:165 +0x53
```