### PR TITLE
pkg/endpoint: fix GetLabels data race access

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -695,6 +695,10 @@ func (e *Endpoint) GetID() uint64 {
 
 // GetLabels returns the labels.
 func (e *Endpoint) GetLabels() labels.Labels {
+	if err := e.rlockAlive(); err != nil {
+		return nil
+	}
+	defer e.runlock()
 	if e.SecurityIdentity == nil {
 		return labels.Labels{}
 	}
@@ -702,8 +706,7 @@ func (e *Endpoint) GetLabels() labels.Labels {
 	return e.SecurityIdentity.Labels
 }
 
-// GetSecurityIdentity returns the security identity of the endpoint. It assumes
-// the endpoint's mutex is held.
+// GetSecurityIdentity returns the security identity of the endpoint.
 func (e *Endpoint) GetSecurityIdentity() (*identity.Identity, error) {
 	if err := e.rlockAlive(); err != nil {
 		return nil, err


### PR DESCRIPTION
```
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).SetIdentity()
      /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:1030 +0x164
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).restoreIdentity()
      /go/src/github.com/cilium/cilium/pkg/endpoint/restore.go:401 +0x102e
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).RegenerateAfterRestore()
      /go/src/github.com/cilium/cilium/pkg/endpoint/restore.go:201 +0x7d
  github.com/cilium/cilium/daemon/cmd.(*Daemon).regenerateRestoredEndpoints.func1()
      /go/src/github.com/cilium/cilium/daemon/cmd/state.go:329 +0xfd
  github.com/cilium/cilium/daemon/cmd.(*Daemon).regenerateRestoredEndpoints.gowrap1()
      /go/src/github.com/cilium/cilium/daemon/cmd/state.go:335 +0x4f

Previous read at 0x00c00321a1b0 by goroutine 867:
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).GetLabels()
      /go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:698 +0x3b
  github.com/cilium/cilium/pkg/hubble/parser/common.(*EndpointResolver).ResolveEndpoint()
      /go/src/github.com/cilium/cilium/pkg/hubble/parser/common/endpoint.go:142 +0x9c2
  github.com/cilium/cilium/pkg/hubble/parser/sock.(*Parser).Decode()
      /go/src/github.com/cilium/cilium/pkg/hubble/parser/sock/parser.go:98 +0x3e4
  github.com/cilium/cilium/pkg/hubble/parser.(*Parser).Decode()
      /go/src/github.com/cilium/cilium/pkg/hubble/parser/parser.go:131 +0xc70
  github.com/cilium/cilium/pkg/hubble/observer.(*LocalObserverServer).Start()
      /go/src/github.com/cilium/cilium/pkg/hubble/observer/local_observer.go:139 +0x13a
  github.com/cilium/cilium/pkg/hubble/cell.(*hubbleIntegration).launch.gowrap2()
      /go/src/github.com/cilium/cilium/pkg/hubble/cell/hubbleintegration.go:501 +0x33

Goroutine 3932 (running) created at:
  github.com/cilium/cilium/daemon/cmd.(*Daemon).regenerateRestoredEndpoints()
      /go/src/github.com/cilium/cilium/daemon/cmd/state.go:328 +0x7f1
  github.com/cilium/cilium/daemon/cmd.(*Daemon).initRestore()
      /go/src/github.com/cilium/cilium/daemon/cmd/state.go:439 +0x84
  github.com/cilium/cilium/daemon/cmd.startDaemon()
      /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1695 +0x584
  github.com/cilium/cilium/daemon/cmd.newDaemonPromise.func1.2()
      /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1648 +0x164

Goroutine 867 (running) created at:
  github.com/cilium/cilium/pkg/hubble/cell.(*hubbleIntegration).launch()
      /go/src/github.com/cilium/cilium/pkg/hubble/cell/hubbleintegration.go:501 +0x31d3
  github.com/cilium/cilium/pkg/hubble/cell.(*hubbleIntegration).Launch()
      /go/src/github.com/cilium/cilium/pkg/hubble/cell/hubbleintegration.go:160 +0x7d
  github.com/cilium/cilium/pkg/hubble/cell.newHubbleIntegration.func1()
      /go/src/github.com/cilium/cilium/pkg/hubble/cell/cell.go:102 +0x3e
  github.com/cilium/hive/job.(*jobOneShot).start()
      /go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/oneshot.go:138 +0x823
  github.com/cilium/hive/job.(*group).Start.func1.gowrap1()
      /go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/job.go:161 +0x131a
```
