### PR TITLE
docs: Document BPF host routing incompatibility with Istio

### DIFF
--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -48,6 +48,9 @@ eBPF-based
    file a GitHub issue if you experience any problems. IPv4 BPF masquerading is
    production-ready.
 
+.. note::
+   BPF masquerading is incompatible with Istio.
+
 The eBPF-based implementation is the most efficient implementation. It can be enabled with
 the ``bpf.masquerade=true`` helm option.
 

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -161,6 +161,9 @@ whether your installation is running with eBPF host-routing, run ``cilium status
 in any of the Cilium pods and look for the line reporting the status for
 "Host Routing" which should state "BPF".
 
+.. note::
+   BPF host routing is incompatible with Istio (see :gh-issue:`36022` for details).
+
 **Requirements:**
 
 * Kernel >= 5.10


### PR DESCRIPTION
Related to - https://github.com/cilium/cilium/issues/36022

Clayton Moss (clayton@cilium.io) verified that there were no issues with BPF masquerading with Istio. 