### PR TITLE
helm: Add missing secret lookups for  "hubble-relay-client-certs" and "hubble-server-certs" 

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
@@ -3,6 +3,14 @@
 {{- $cn := "*.hubble-relay.cilium.io" }}
 {{- $dns := list $cn }}
 {{- $cert := genSignedCert $cn nil $dns (.Values.hubble.tls.auto.certValidityDuration | int) .commonCA -}}
+{{- $tls_crt := ($cert.Cert | b64enc) }}
+{{- $tls_key := ($cert.Key | b64enc) }}
+{{- with lookup "v1" "Secret" (include "cilium.namespace" .) "hubble-relay-client-certs" }}
+  {{- if and (index .data "tls.crt") (index .data "tls.key") }}
+    {{- $tls_key = (index .data "tls.key") }}
+    {{- $tls_crt = (index .data "tls.crt") }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -21,6 +29,6 @@ metadata:
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .commonCA.Cert | b64enc }}
-  tls.crt: {{ $cert.Cert | b64enc }}
-  tls.key: {{ $cert.Key  | b64enc }}
+  tls.crt: {{ $tls_crt }}
+  tls.key: {{ $tls_key }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
@@ -4,6 +4,14 @@
 {{- $ip := .Values.hubble.tls.server.extraIpAddresses }}
 {{- $dns := prepend .Values.hubble.tls.server.extraDnsNames $cn }}
 {{- $cert := genSignedCert $cn $ip $dns (.Values.hubble.tls.auto.certValidityDuration | int) .commonCA -}}
+{{- $tls_crt := ($cert.Cert | b64enc) }}
+{{- $tls_key := ($cert.Key | b64enc) }}
+{{- with lookup "v1" "Secret" (include "cilium.namespace" .) "hubble-server-certs" }}
+  {{- if and (index .data "tls.crt") (index .data "tls.key") }}
+    {{- $tls_key = (index .data "tls.key") }}
+    {{- $tls_crt = (index .data "tls.crt") }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -22,6 +30,6 @@ metadata:
 type: kubernetes.io/tls
 data:
   ca.crt:  {{ .commonCA.Cert | b64enc }}
-  tls.crt: {{ $cert.Cert | b64enc }}
-  tls.key: {{ $cert.Key  | b64enc }}
+  tls.crt: {{ $tls_crt }}
+  tls.key: {{ $tls_key }}
 {{- end }}


### PR DESCRIPTION
The secrets "hubble-relay-client-certs" and "hubble-server-certs" regenerated their key & cert on every helm upgrade because they didn't check if the secret already existed. This aligns these secrets with the existing approach of using the `lookup` method to check the current values and use those, avoiding changing those values every time.

Fixes: #37065

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

