### PR TITLE
cnp: correct http header matching field description and docu

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1071,6 +1071,11 @@ Headers
   Headers is a list of HTTP headers which must be present in the request. If
   omitted or empty, requests are allowed regardless of headers present.
 
+  It's also possible to do some more advanced header matching against header
+  values. ``HeaderMatches`` is a list of HTTP headers which must be present and
+  match against the given values. Mismatch field can be used to specify what
+  to do when there is no match.
+
 Allow GET /public
 ~~~~~~~~~~~~~~~~~
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -802,8 +802,8 @@ spec:
                                       items:
                                         description: |-
                                           HeaderMatch extends the HeaderValue for matching requirement of a
-                                          named header field against an immediate string, a secret value, or
-                                          a regex.  If none of the optional fields is present, then the
+                                          named header field against an immediate string or a secret value.
+                                          If none of the optional fields is present, then the
                                           header value is not matched, only presence of the header is enough.
                                         properties:
                                           mismatch:
@@ -2638,8 +2638,8 @@ spec:
                                       items:
                                         description: |-
                                           HeaderMatch extends the HeaderValue for matching requirement of a
-                                          named header field against an immediate string, a secret value, or
-                                          a regex.  If none of the optional fields is present, then the
+                                          named header field against an immediate string or a secret value.
+                                          If none of the optional fields is present, then the
                                           header value is not matched, only presence of the header is enough.
                                         properties:
                                           mismatch:
@@ -4261,8 +4261,8 @@ spec:
                                         items:
                                           description: |-
                                             HeaderMatch extends the HeaderValue for matching requirement of a
-                                            named header field against an immediate string, a secret value, or
-                                            a regex.  If none of the optional fields is present, then the
+                                            named header field against an immediate string or a secret value.
+                                            If none of the optional fields is present, then the
                                             header value is not matched, only presence of the header is enough.
                                           properties:
                                             mismatch:
@@ -6099,8 +6099,8 @@ spec:
                                         items:
                                           description: |-
                                             HeaderMatch extends the HeaderValue for matching requirement of a
-                                            named header field against an immediate string, a secret value, or
-                                            a regex.  If none of the optional fields is present, then the
+                                            named header field against an immediate string or a secret value.
+                                            If none of the optional fields is present, then the
                                             header value is not matched, only presence of the header is enough.
                                           properties:
                                             mismatch:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -805,8 +805,8 @@ spec:
                                       items:
                                         description: |-
                                           HeaderMatch extends the HeaderValue for matching requirement of a
-                                          named header field against an immediate string, a secret value, or
-                                          a regex.  If none of the optional fields is present, then the
+                                          named header field against an immediate string or a secret value.
+                                          If none of the optional fields is present, then the
                                           header value is not matched, only presence of the header is enough.
                                         properties:
                                           mismatch:
@@ -2641,8 +2641,8 @@ spec:
                                       items:
                                         description: |-
                                           HeaderMatch extends the HeaderValue for matching requirement of a
-                                          named header field against an immediate string, a secret value, or
-                                          a regex.  If none of the optional fields is present, then the
+                                          named header field against an immediate string or a secret value.
+                                          If none of the optional fields is present, then the
                                           header value is not matched, only presence of the header is enough.
                                         properties:
                                           mismatch:
@@ -4264,8 +4264,8 @@ spec:
                                         items:
                                           description: |-
                                             HeaderMatch extends the HeaderValue for matching requirement of a
-                                            named header field against an immediate string, a secret value, or
-                                            a regex.  If none of the optional fields is present, then the
+                                            named header field against an immediate string or a secret value.
+                                            If none of the optional fields is present, then the
                                             header value is not matched, only presence of the header is enough.
                                           properties:
                                             mismatch:
@@ -6102,8 +6102,8 @@ spec:
                                         items:
                                           description: |-
                                             HeaderMatch extends the HeaderValue for matching requirement of a
-                                            named header field against an immediate string, a secret value, or
-                                            a regex.  If none of the optional fields is present, then the
+                                            named header field against an immediate string or a secret value.
+                                            If none of the optional fields is present, then the
                                             header value is not matched, only presence of the header is enough.
                                           properties:
                                             mismatch:

--- a/pkg/policy/api/http.go
+++ b/pkg/policy/api/http.go
@@ -22,8 +22,8 @@ const (
 )
 
 // HeaderMatch extends the HeaderValue for matching requirement of a
-// named header field against an immediate string, a secret value, or
-// a regex.  If none of the optional fields is present, then the
+// named header field against an immediate string or a secret value.
+// If none of the optional fields is present, then the
 // header value is not matched, only presence of the header is enough.
 type HeaderMatch struct {
 	// Mismatch identifies what to do in case there is no match. The default is
@@ -113,7 +113,6 @@ type PortRuleHTTP struct {
 // of regular expressions (e.g. that specified by ECMAScript), so this function
 // may return some false positives. If the rule is invalid, returns an error.
 func (h *PortRuleHTTP) Sanitize() error {
-
 	if h.Path != "" {
 		_, err := regexp.Compile(h.Path)
 		if err != nil {


### PR DESCRIPTION
Currently, CiliumNetworkPolicy doesn't support HTTP header matching by regex (neither via `headers` nor `headerMatches`) - even though it's documented in the CRD field description.

Therefore, this commit changes the field description accordingly. In addition it mentions how to use the field `HeaderMatches` in the documentation.

Related Slack discussion: https://cilium.slack.com/archives/C01JALNQAR1/p1742241181046369

Questions that came to my mind:

* Should this be supported? Browsing the git history it seems this never worked with regex. (Maybe the user from Slack is going to open an issue)
* Have we ever thought about deprecating `headers` in favor of `headerMatches` (if we ever gonna release a new version of the (C)CNP)