### PR TITLE
bgpv2: Introduce script component tests for BGPv2

### DIFF
--- a/pkg/bgpv1/api/printers.go
+++ b/pkg/bgpv1/api/printers.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	bgppacket "github.com/osrg/gobgp/v3/pkg/packet/bgp"
+
+	"github.com/cilium/cilium/api/v1/models"
+)
+
+// PrintBGPPeersTable prints table of provided BGP peers in the provided tab writer.
+func PrintBGPPeersTable(w *tabwriter.Writer, peers []*models.BgpPeer, printUptime bool) {
+	// sort by local AS, if peers from same AS then sort by peer address.
+	sort.Slice(peers, func(i, j int) bool {
+		if peers[i].LocalAsn != peers[j].LocalAsn {
+			return peers[i].LocalAsn < peers[j].LocalAsn
+		}
+		return peers[i].PeerAddress < peers[j].PeerAddress
+	})
+
+	if printUptime {
+		fmt.Fprintln(w, "Local AS\tPeer AS\tPeer Address\tSession\tUptime\tFamily\tReceived\tAdvertised")
+	} else {
+		fmt.Fprintln(w, "Local AS\tPeer AS\tPeer Address\tSession\tFamily\tReceived\tAdvertised")
+	}
+	for _, peer := range peers {
+		fmt.Fprintf(w, "%d\t", peer.LocalAsn)
+		fmt.Fprintf(w, "%d\t", peer.PeerAsn)
+		fmt.Fprintf(w, "%s:%d\t", peer.PeerAddress, peer.PeerPort)
+		fmt.Fprintf(w, "%s\t", peer.SessionState)
+
+		if printUptime {
+			// Time is rounded to nearest second
+			fmt.Fprintf(w, "%s\t", time.Duration(peer.UptimeNanoseconds).Round(time.Second).String())
+		}
+
+		for i, afisafi := range peer.Families {
+			if i > 0 {
+				// move to align with afi-safi
+				tabs := 4
+				if printUptime {
+					tabs++
+				}
+				fmt.Fprint(w, strings.Repeat("\t", tabs))
+			}
+			// AFI and SAFI are concatenated for brevity
+			fmt.Fprintf(w, "%s/%s\t", afisafi.Afi, afisafi.Safi)
+			fmt.Fprintf(w, "%d\t", afisafi.Received)
+			fmt.Fprintf(w, "%d\n", afisafi.Advertised)
+		}
+	}
+	w.Flush()
+}
+
+// PrintBGPRoutesTable prints table of provided BGP routes in the provided tab writer.
+func PrintBGPRoutesTable(w *tabwriter.Writer, routes []*models.BgpRoute, printPeer, printAge bool) error {
+	// sort first by ASN, then by neighbor, then by prefix
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].RouterAsn != routes[j].RouterAsn {
+			return routes[i].RouterAsn < routes[j].RouterAsn
+		}
+		if routes[i].Neighbor != routes[j].Neighbor {
+			return routes[i].Neighbor < routes[j].Neighbor
+		}
+		return routes[i].Prefix < routes[j].Prefix
+	})
+
+	fmt.Fprintf(w, "VRouter\t")
+	if printPeer {
+		fmt.Fprintf(w, "Peer\t")
+	}
+	fmt.Fprintf(w, "Prefix\tNextHop\t")
+	if printAge {
+		fmt.Fprintf(w, "Age\t")
+	}
+	fmt.Fprintf(w, "Attrs\n")
+
+	for _, route := range routes {
+		r, err := ToAgentRoute(route)
+		if err != nil {
+			return err
+		}
+		for _, path := range r.Paths {
+			fmt.Fprintf(w, "%d\t", route.RouterAsn)
+			if printPeer {
+				fmt.Fprintf(w, "%s\t", route.Neighbor)
+			}
+			fmt.Fprintf(w, "%s\t", path.NLRI)
+			fmt.Fprintf(w, "%s\t", NextHopFromPathAttributes(path.PathAttributes))
+			if printAge {
+				fmt.Fprintf(w, "%s\t", time.Duration(path.AgeNanoseconds).Round(time.Second))
+			}
+			fmt.Fprintf(w, "%s\n", path.PathAttributes)
+		}
+	}
+	w.Flush()
+	return nil
+}
+
+// PrintBGPRoutePoliciesTable prints table of provided BGP route policies in the provided tab writer.
+func PrintBGPRoutePoliciesTable(w *tabwriter.Writer, policies []*models.BgpRoutePolicy) {
+	// sort by router ASN, if policies from same ASN then sort by policy name.
+	sort.Slice(policies, func(i, j int) bool {
+		if policies[i].RouterAsn != policies[j].RouterAsn {
+			return policies[i].RouterAsn < policies[j].RouterAsn
+		}
+		return policies[i].Name < policies[j].Name
+	})
+
+	fmt.Fprintln(w, "VRouter\tPolicy Name\tType\tMatch Peers\tMatch Families\tMatch Prefixes (Min..Max Len)\tRIB Action\tPath Actions")
+	for _, policy := range policies {
+		fmt.Fprintf(w, "%d\t", policy.RouterAsn)
+		fmt.Fprintf(w, "%s\t", policy.Name)
+		fmt.Fprintf(w, "%s\t", policy.Type)
+
+		for i, stmt := range policy.Statements {
+			if i > 0 {
+				fmt.Fprint(w, strings.Repeat("\t", 3))
+			}
+			fmt.Fprintf(w, "%s\t", formatStringArray(stmt.MatchNeighbors))
+			fmt.Fprintf(w, "%s\t", formatStringArray(formatFamilies(stmt.MatchFamilies)))
+			fmt.Fprintf(w, "%s\t", formatStringArray(formatMatchPrefixes(stmt.MatchPrefixes)))
+			fmt.Fprintf(w, "%s\t", stmt.RouteAction)
+			fmt.Fprintf(w, "%s\n", formatStringArray(formatPathActions(stmt)))
+		}
+		if len(policy.Statements) == 0 {
+			fmt.Fprintf(w, "\n")
+		}
+	}
+	w.Flush()
+}
+
+// NextHopFromPathAttributes returns the next hop address determined by the list of provided BGP path attributes.
+func NextHopFromPathAttributes(pathAttributes []bgppacket.PathAttributeInterface) string {
+	for _, a := range pathAttributes {
+		switch attr := a.(type) {
+		case *bgppacket.PathAttributeNextHop:
+			return attr.Value.String()
+		case *bgppacket.PathAttributeMpReachNLRI:
+			return attr.Nexthop.String()
+		}
+	}
+	return "0.0.0.0"
+}
+
+func formatStringArray(arr []string) string {
+	if len(arr) == 1 {
+		return arr[0]
+	}
+	res := ""
+	for _, str := range arr {
+		res += "{" + str + "} "
+	}
+	return strings.TrimSpace(res)
+}
+
+func formatFamilies(families []*models.BgpFamily) []string {
+	var res []string
+	for _, f := range families {
+		res = append(res, fmt.Sprintf("%s/%s", f.Afi, f.Safi))
+	}
+	return res
+}
+
+func formatMatchPrefixes(pfxs []*models.BgpRoutePolicyPrefixMatch) []string {
+	var res []string
+	for _, p := range pfxs {
+		res = append(res, fmt.Sprintf("%s (%d..%d)", p.Cidr, p.PrefixLenMin, p.PrefixLenMax))
+	}
+	return res
+}
+
+func formatPathActions(stmt *models.BgpRoutePolicyStatement) []string {
+	var res []string
+	if stmt.SetLocalPreference >= 0 {
+		res = append(res, fmt.Sprintf("SetLocalPreference: %d", stmt.SetLocalPreference))
+	}
+	if len(stmt.AddCommunities) > 0 {
+		res = append(res, fmt.Sprintf("AddCommunities: %v", stmt.AddCommunities))
+	}
+	if len(stmt.AddLargeCommunities) > 0 {
+		res = append(res, fmt.Sprintf("AddLargeCommunities: %v", stmt.AddLargeCommunities))
+	}
+	return res
+}

--- a/pkg/bgpv1/test/commands/bgp.go
+++ b/pkg/bgpv1/test/commands/bgp.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+
+	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/api"
+)
+
+const (
+	peerFlag      = "peer"
+	peerFlagShort = "p"
+
+	routerASNFlag      = "router-asn"
+	routerASNFlagShort = "r"
+)
+
+func BGPScriptCmds(bgpMgr agent.BGPRouterManager) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"bgp/peers":          BGPPPeersCmd(bgpMgr),
+		"bgp/routes":         BGPPRoutesCmd(bgpMgr),
+		"bgp/route-policies": BGPPRoutePolicies(bgpMgr),
+	}
+}
+
+func BGPPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "List BGP peers on Cilium",
+			Flags: func(fs *pflag.FlagSet) {
+				addOutFileFlag(fs)
+			},
+			Detail: []string{
+				"List current state of all BGP peers configured in Cilium BGP Control Plane.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return func(*script.State) (stdout, stderr string, err error) {
+				tw, buf, f, err := getCmdTabWriter(s)
+				if err != nil {
+					return "", "", err
+				}
+				if f != nil {
+					defer f.Close()
+				}
+
+				peers, err := bgpMgr.GetPeers(s.Context())
+				if err != nil {
+					return "", "", err
+				}
+				api.PrintBGPPeersTable(tw, peers, false)
+
+				return buf.String(), "", err
+			}, nil
+		},
+	)
+}
+
+func BGPPRoutesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "List BGP routes on Cilium",
+			Args:    "[available|advertised] [afi] [safi]",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP(peerFlag, peerFlagShort, "", "IP address of the peer. If provided, routes advertised to the specified peer are listed.")
+				fs.Uint32P(routerASNFlag, routerASNFlagShort, 0, "ASN number of the Cilium router instance. Lists routes of all instances if omitted.")
+				addOutFileFlag(fs)
+			},
+			Detail: []string{
+				"List routes in the BGP Control Plane's RIBs",
+				"",
+				"'available' lists routes from the local RIB, 'advertised' lists routes from the RIB-OUT of BGP peer(s).",
+				"When none of them is provided, lists 'available' routes",
+				"",
+				"'afi' is Address Family Indicator, defaults to 'ipv4'.",
+				"'safi' is Subsequent Address Family Identifier, defaults to 'unicast'.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			peer, err := s.Flags.GetString(peerFlag)
+			if err != nil {
+				return nil, err
+			}
+			asn, err := s.Flags.GetUint32(routerASNFlag)
+			if err != nil {
+				return nil, err
+			}
+			return func(*script.State) (stdout, stderr string, err error) {
+				tw, buf, f, err := getCmdTabWriter(s)
+				if err != nil {
+					return "", "", err
+				}
+				if f != nil {
+					defer f.Close()
+				}
+
+				params := restapi.GetBgpRoutesParams{
+					TableType: "loc-rib",
+					Afi:       "ipv4",
+					Safi:      "unicast",
+				}
+				if len(args) > 0 && args[0] == "advertised" {
+					params.TableType = "adj-rib-out"
+				}
+				if len(args) > 1 && args[1] != "" {
+					params.Afi = args[1]
+				}
+				if len(args) > 2 && args[2] != "" {
+					params.Safi = args[2]
+				}
+				if peer != "" {
+					params.Neighbor = &peer
+				}
+				if asn != 0 {
+					asn64 := int64(asn)
+					params.RouterAsn = &asn64
+				}
+				routes, err := bgpMgr.GetRoutes(s.Context(), params)
+				if err != nil {
+					return "", "", err
+				}
+				err = api.PrintBGPRoutesTable(tw, routes, params.TableType == "adj-rib-out", false)
+
+				return buf.String(), "", err
+			}, nil
+		},
+	)
+}
+
+func BGPPRoutePolicies(bgpMgr agent.BGPRouterManager) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "List BGP route policies on Cilium",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.Uint32P(routerASNFlag, routerASNFlagShort, 0, "ASN number of the Cilium router instance. Lists policies of all instances if omitted.")
+				addOutFileFlag(fs)
+			},
+			Detail: []string{
+				"Lists route policies configured in Cilium BGP Control Plane.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			asn, err := s.Flags.GetUint32(routerASNFlag)
+			if err != nil {
+				return nil, err
+			}
+			return func(*script.State) (stdout, stderr string, err error) {
+				tw, buf, f, err := getCmdTabWriter(s)
+				if err != nil {
+					return "", "", err
+				}
+				if f != nil {
+					defer f.Close()
+				}
+
+				params := restapi.GetBgpRoutePoliciesParams{}
+				if asn != 0 {
+					asn64 := int64(asn)
+					params.RouterAsn = &asn64
+				}
+				policies, err := bgpMgr.GetRoutePolicies(s.Context(), params)
+				if err != nil {
+					return "", "", err
+				}
+				api.PrintBGPRoutePoliciesTable(tw, policies)
+
+				return buf.String(), "", err
+			}, nil
+		},
+	)
+}

--- a/pkg/bgpv1/test/commands/gobgp.go
+++ b/pkg/bgpv1/test/commands/gobgp.go
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"text/tabwriter"
+	"time"
+
+	"github.com/cilium/hive/script"
+	gobgpapi "github.com/osrg/gobgp/v3/api"
+	"github.com/osrg/gobgp/v3/pkg/server"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/bgpv1/api"
+	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+)
+
+const (
+	serverASNFlag      = "server-asn"
+	serverASNFlagShort = "s"
+
+	routerIDFlag      = "router-id"
+	routerIDFlagShort = "r"
+
+	timeoutFlag      = "timeout"
+	timeoutFlagShort = "t"
+)
+
+type GoBGPCmdContext struct {
+	servers map[uint32]*server.BgpServer
+}
+
+func NewGoBGPCmdContext() *GoBGPCmdContext {
+	return &GoBGPCmdContext{
+		servers: make(map[uint32]*server.BgpServer),
+	}
+}
+
+func (ctx *GoBGPCmdContext) Cleanup() {
+	for _, s := range ctx.servers {
+		s.Stop()
+	}
+}
+
+func GoBGPScriptCmds(ctx *GoBGPCmdContext) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"gobgp/add-server": GoBGPAddServerCmd(ctx),
+		"gobgp/add-peer":   GoBGPAddPeerCmd(ctx),
+		"gobgp/wait-state": GoBGPWaitStateCmd(ctx),
+		"gobgp/peers":      GoBGPPeersCmd(ctx),
+		"gobgp/routes":     GoBGPRoutesCmd(ctx),
+	}
+}
+
+func GoBGPAddServerCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Add a new GoBGP server instance",
+			Args:    "asn ip port",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP(routerIDFlag, routerIDFlagShort, "", "router-id of the server. Defaults to server ip if not provided.")
+			},
+			Detail: []string{
+				"Add a new GoBGP server instance with the specified parameters.",
+				"",
+				"'ASN' is the autonomous system number of this instance.",
+				"'ip' is the IP address on which the server listens for incoming connections.",
+				"'port' is the port number on which the server listens for incoming connections.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) < 3 {
+				return nil, fmt.Errorf("invalid command format, should be: 'gobgp/add-server asn ip port'")
+			}
+			asn, err := strconv.Atoi(args[0])
+			if err != nil {
+				return nil, fmt.Errorf("could not parse asn: %w", err)
+			}
+			port, err := strconv.Atoi(args[2])
+			if err != nil {
+				return nil, fmt.Errorf("could not parse port: %w", err)
+			}
+			routerID, err := s.Flags.GetString(routerIDFlag)
+			if err != nil {
+				return nil, err
+			}
+			if routerID == "" {
+				routerID = args[1]
+			}
+
+			// start new GoBGP server
+			gobgpServer := server.NewBgpServer(server.LoggerOption(gobgp.NewServerLogger(slog.Default(), gobgp.LogParams{
+				AS:        uint32(asn),
+				Component: "test",
+				SubSys:    "gobgp",
+			})))
+			go gobgpServer.Serve()
+			err = gobgpServer.StartBgp(s.Context(), &gobgpapi.StartBgpRequest{Global: &gobgpapi.Global{
+				Asn:             uint32(asn),
+				RouterId:        routerID,
+				ListenAddresses: []string{args[1]},
+				ListenPort:      int32(port),
+			}})
+			if err != nil {
+				gobgpServer.Stop()
+				return nil, err
+			}
+			cmdCtx.servers[uint32(asn)] = gobgpServer
+
+			s.Logf("Started GoBGP Server ASN: %d, ip: %s, port: %d\n", asn, args[1], port)
+			return nil, nil
+		},
+	)
+}
+
+func GoBGPAddPeerCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Add a new peer the GoBGP server instance",
+			Args:    "ip remote-asn",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.Uint32P(serverASNFlag, serverASNFlagShort, 0, "ASN number of the GoBGP server instance. Can be omitted if only one instance is active.")
+			},
+			Detail: []string{
+				"Add a new peer with the given IP and remote ASN to the GoBGP server instance.",
+				"",
+				"'ip' is IP address of the peer.",
+				"'remote-asn' is the remote ASN number of the peer.",
+				"If there are multiple server instances configured, the server-asn flag needs to be specified.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) < 2 {
+				return nil, fmt.Errorf("invalid command format, should be: 'gobgp/ass-peer ip remote-asn'")
+			}
+			gobgpServer, err := getGoBGPServer(s, cmdCtx)
+			if err != nil {
+				return nil, err
+			}
+
+			peer := &gobgpapi.Peer{
+				Conf: &gobgpapi.PeerConf{
+					NeighborAddress: args[0],
+				},
+				Transport: &gobgpapi.Transport{
+					PassiveMode: true,
+				},
+				AfiSafis: []*gobgpapi.AfiSafi{
+					{
+						Config: &gobgpapi.AfiSafiConfig{
+							Family: &gobgpapi.Family{
+								Afi:  gobgpapi.Family_AFI_IP,
+								Safi: gobgpapi.Family_SAFI_UNICAST,
+							},
+						},
+					},
+					{
+						Config: &gobgpapi.AfiSafiConfig{
+							Family: &gobgpapi.Family{
+								Afi:  gobgpapi.Family_AFI_IP6,
+								Safi: gobgpapi.Family_SAFI_UNICAST,
+							},
+						},
+					},
+				},
+			}
+			_, err = fmt.Sscanf(args[1], "%d", &peer.Conf.PeerAsn)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse remote-asn: %w", err)
+			}
+			s.Logf("Added peer to GoBGP Server: %+v\n", peer)
+
+			err = gobgpServer.AddPeer(s.Context(), &gobgpapi.AddPeerRequest{Peer: peer})
+			if err != nil {
+				return nil, fmt.Errorf("error by adding peer to server: %w", err)
+			}
+			return nil, nil
+		},
+	)
+}
+
+func GoBGPWaitStateCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Wait until the GoBGP peer is in the specified state",
+			Args:    "peer state",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.Uint32P(serverASNFlag, serverASNFlagShort, 0, "ASN number of the GoBGP server instance. Can be omitted if only one instance is active.")
+				fs.DurationP(timeoutFlag, timeoutFlagShort, 15*time.Second, "Maximum amount of time to wait for the peering state")
+			},
+			Detail: []string{
+				"Wait until the specified peer is in the specified state.",
+				"",
+				"'peer' is IP address of a previously configured peer.",
+				"'state' is one of: 'UNKNOWN', 'IDLE', 'CONNECT', 'ACTIVE', 'OPENSENT', 'OPENCONFIRM', 'ESTABLISHED'.",
+				"If there are multiple server instances configured, the server-asn flag needs to be specified.",
+				"The default wait timeout is 15 seconds.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) < 2 {
+				return nil, fmt.Errorf("invalid command format, should be: 'gobgp/wait-state peer state'")
+			}
+			timeout, err := s.Flags.GetDuration("timeout")
+			if err != nil {
+				return nil, fmt.Errorf("could not parse timeout: %w", err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			gobgpServer, err := getGoBGPServer(s, cmdCtx)
+			if err != nil {
+				return nil, err
+			}
+
+			doneCh := make(chan struct{})
+			watchRequest := &gobgpapi.WatchEventRequest{
+				Peer: &gobgpapi.WatchEventRequest_Peer{},
+			}
+			err = gobgpServer.WatchEvent(ctx, watchRequest, func(r *gobgpapi.WatchEventResponse) {
+				if p := r.GetPeer(); p != nil && p.Type == gobgpapi.WatchEventResponse_PeerEvent_STATE {
+					s.Logf("peer %s %s\n", p.Peer.Conf.NeighborAddress, p.Peer.State.SessionState)
+					if p.Peer.State.SessionState == gobgpapi.PeerState_SessionState(gobgpapi.PeerState_SessionState_value[args[1]]) {
+						if p.Peer.Conf.NeighborAddress == args[0] {
+							doneCh <- struct{}{}
+						}
+					}
+				}
+			})
+			if err != nil {
+				return nil, err
+			}
+			select {
+			case <-s.Context().Done():
+				return nil, s.Context().Err()
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-doneCh:
+			}
+			return nil, nil
+		},
+	)
+}
+
+func GoBGPPeersCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "List peers on the GoBGP server",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.Uint32P(serverASNFlag, serverASNFlagShort, 0, "ASN number of the GoBGP server instance. Can be omitted if only one instance is active.")
+				addOutFileFlag(fs)
+			},
+			Detail: []string{
+				"List peers configured on the GoBGP server",
+				"",
+				"If there are multiple server instances configured, the server-asn flag needs to be specified.",
+			},
+		},
+		func(s *script.State, args ...string) (waitFunc script.WaitFunc, err error) {
+			gobgpServer, err := getGoBGPServer(s, cmdCtx)
+			if err != nil {
+				return nil, err
+			}
+			return func(*script.State) (stdout, stderr string, err error) {
+				tw, buf, f, err := getCmdTabWriter(s)
+				if err != nil {
+					return "", "", err
+				}
+				if f != nil {
+					defer f.Close()
+				}
+
+				var peers []*gobgpapi.Peer
+				err = gobgpServer.ListPeer(s.Context(), &gobgpapi.ListPeerRequest{EnableAdvertised: true}, func(p *gobgpapi.Peer) {
+					peers = append(peers, p)
+				})
+				sort.Slice(peers, func(i, j int) bool {
+					return peers[i].State.PeerAsn < peers[j].State.PeerAsn || peers[i].Conf.NeighborAddress < peers[j].Conf.NeighborAddress
+				})
+
+				printPeerHeader(tw)
+				for _, peer := range peers {
+					printPeer(tw, peer)
+				}
+				tw.Flush()
+				return buf.String(), "", err
+			}, nil
+		},
+	)
+}
+
+func GoBGPRoutesCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "List routes on the GoBGP server",
+			Args:    "[afi] [safi]",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.Uint32P(serverASNFlag, serverASNFlagShort, 0, "ASN number of the GoBGP server instance. Can be omitted if only one instance is active.")
+				addOutFileFlag(fs)
+			},
+			Detail: []string{
+				"List all routes in the global RIB on the GoBGP server",
+				"",
+				"'afi' is Address Family Indicator, defaults to 'ipv4'.",
+				"'safi' is Subsequent Address Family Identifier, defaults to 'unicast'.",
+				"If there are multiple server instances configured, the server-asn flag needs to be specified.",
+			},
+		},
+		func(s *script.State, args ...string) (waitFunc script.WaitFunc, err error) {
+			gobgpServer, err := getGoBGPServer(s, cmdCtx)
+			if err != nil {
+				return nil, err
+			}
+			return func(*script.State) (stdout, stderr string, err error) {
+				tw, buf, f, err := getCmdTabWriter(s)
+				if err != nil {
+					return "", "", err
+				}
+				if f != nil {
+					defer f.Close()
+				}
+
+				req := &gobgpapi.ListPathRequest{
+					TableType: gobgpapi.TableType_GLOBAL,
+					Family: &gobgpapi.Family{
+						Afi:  gobgpapi.Family_AFI_IP,
+						Safi: gobgpapi.Family_SAFI_UNICAST,
+					},
+				}
+				if len(args) > 0 && args[0] != "" {
+					req.Family.Afi = gobgpapi.Family_Afi(types.ParseAfi(args[0]))
+				}
+				if len(args) > 1 && args[1] != "" {
+					req.Family.Safi = gobgpapi.Family_Safi(types.ParseSafi(args[1]))
+				}
+				var paths []*gobgpapi.Destination
+				err = gobgpServer.ListPath(s.Context(), req, func(dst *gobgpapi.Destination) {
+					paths = append(paths, dst)
+				})
+				sort.Slice(paths, func(i, j int) bool {
+					return paths[i].String() < paths[j].String()
+				})
+
+				printPathHeader(tw)
+				for _, path := range paths {
+					printPath(tw, path)
+				}
+				tw.Flush()
+				return buf.String(), "", err
+			}, nil
+		},
+	)
+}
+
+func getGoBGPServer(s *script.State, ctx *GoBGPCmdContext) (*server.BgpServer, error) {
+	if len(ctx.servers) == 0 {
+		return nil, fmt.Errorf("no GoBGP servers configured")
+	}
+	asn, err := s.Flags.GetUint32(serverASNFlag)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse %s: %w", serverASNFlag, err)
+	}
+	if asn == 0 {
+		// asn not specified
+		if len(ctx.servers) > 1 {
+			return nil, fmt.Errorf("multiple GoBGP servers are active, %s flag is required", serverASNFlag)
+		} else {
+			// only one server configured, return it
+			for _, serv := range ctx.servers {
+				return serv, nil
+			}
+		}
+	}
+	return ctx.servers[asn], nil
+}
+
+func printPeerHeader(w *tabwriter.Writer) {
+	fmt.Fprintln(w, "PeerAddress\tPeerASN\tSessionState\tHoldTime")
+}
+
+func printPeer(w *tabwriter.Writer, peer *gobgpapi.Peer) {
+	fmt.Fprintf(w, "%s\t%d\t%s\t%d\n", peer.Conf.NeighborAddress, peer.State.PeerAsn, peer.State.SessionState, peer.Timers.State.NegotiatedHoldTime)
+}
+
+func printPathHeader(w *tabwriter.Writer) {
+	fmt.Fprintln(w, "Prefix\tNextHop\tAttrs")
+}
+
+func printPath(w *tabwriter.Writer, dst *gobgpapi.Destination) {
+	aPaths, _ := gobgp.ToAgentPaths(dst.Paths)
+	for _, path := range aPaths {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", dst.Prefix, api.NextHopFromPathAttributes(path.PathAttributes), path.PathAttributes)
+	}
+}

--- a/pkg/bgpv1/test/commands/utils.go
+++ b/pkg/bgpv1/test/commands/utils.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+)
+
+const (
+	outFileFlag      = "out"
+	outFileFlagShort = "o"
+
+	tabPadding     = 3
+	tabMinWidth    = 5
+	tabPaddingChar = ' '
+)
+
+func addOutFileFlag(fs *pflag.FlagSet) {
+	fs.StringP(outFileFlag, outFileFlagShort, "", "File to write to instead of stdout")
+}
+
+func getCmdTabWriter(s *script.State) (tw *tabwriter.Writer, buf *strings.Builder, f *os.File, err error) {
+	fileName := ""
+	fileName, err = s.Flags.GetString(outFileFlag)
+	if err != nil {
+		return
+	}
+
+	buf = &strings.Builder{}
+	var writer io.Writer
+	if fileName == "" {
+		// will write to string buffer
+		writer = buf
+	} else {
+		// will write to file
+		f, err = os.OpenFile(s.Path(fileName), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		if err != nil {
+			err = fmt.Errorf("error opening file %s: %w", fileName, err)
+			return
+		}
+		writer = f
+	}
+
+	tw = tabwriter.NewWriter(writer, tabMinWidth, 0, tabPadding, tabPaddingChar, 0)
+	return
+}

--- a/pkg/bgpv1/test/script_test.go
+++ b/pkg/bgpv1/test/script_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"net/netip"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/bgpv1"
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/test/commands"
+	"github.com/cilium/cilium/pkg/defaults"
+	ciliumhive "github.com/cilium/cilium/pkg/hive"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+const (
+	testTimeout  = 60 * time.Second
+	testLinkName = "cilium-bgp-test"
+)
+
+func TestScript(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	slog.SetLogLoggerLevel(slog.LevelInfo)
+
+	// setup test link
+	dummy := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: testLinkName},
+	}
+	netlink.LinkDel(dummy) // cleanup from potential previous test run
+	err := netlink.LinkAdd(dummy)
+	require.NoError(t, err, "error by adding test link %s", testLinkName)
+	t.Cleanup(func() {
+		netlink.LinkDel(dummy)
+	})
+
+	setup := func(t testing.TB, args []string) *script.Engine {
+		var err error
+		var bgpMgr agent.BGPRouterManager
+
+		h := ciliumhive.New(
+			client.FakeClientCell,
+			daemonk8s.ResourcesCell,
+			metrics.Cell,
+			bgpv1.Cell,
+
+			cell.Provide(func() *option.DaemonConfig {
+				// BGP Manager uses the global variable option.Config so we need to set it there as well
+				option.Config = &option.DaemonConfig{
+					EnableBGPControlPlane:     true,
+					BGPSecretsNamespace:       "bgp-secrets",
+					BGPRouterIDAllocationMode: defaults.BGPRouterIDAllocationMode,
+					IPAM:                      ipamOption.IPAMKubernetes,
+				}
+				return option.Config
+			}),
+
+			cell.Invoke(func() {
+				types.SetName("test-node")
+			}),
+			cell.Invoke(func(m agent.BGPRouterManager) {
+				bgpMgr = m
+			}),
+		)
+
+		hiveLog := hivetest.Logger(t, hivetest.LogLevel(slog.LevelInfo))
+		t.Cleanup(func() {
+			assert.NoError(t, h.Stop(hiveLog, context.TODO()))
+		})
+
+		// parse the shebang arguments in the script.
+		flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
+		peeringIPs := flags.StringSlice("test-peering-ips", nil, "List of IPs used for peering in the test")
+		require.NoError(t, flags.Parse(args), "Error parsing test flags")
+
+		// setup test peering IPs
+		l, err := netlink.LinkByName(testLinkName)
+		require.NoError(t, err)
+		for _, ip := range *peeringIPs {
+			ipAddr, err := netip.ParseAddr(ip)
+			require.NoError(t, err)
+			bits := 32
+			if ipAddr.Is6() {
+				bits = 128
+			}
+			prefix := netip.PrefixFrom(ipAddr, bits)
+			err = netlink.AddrAdd(l, toNetlinkAddr(prefix))
+			if err != nil && os.IsExist(err) {
+				t.Fatalf("Peering address %s is probably already used by another test", ip)
+			}
+			require.NoError(t, err)
+		}
+
+		// set up GoBGP command
+		gobgpCmdCtx := commands.NewGoBGPCmdContext()
+		t.Cleanup(gobgpCmdCtx.Cleanup)
+
+		cmds, err := h.ScriptCommands(hiveLog)
+		require.NoError(t, err, "ScriptCommands")
+		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+		maps.Insert(cmds, maps.All(commands.GoBGPScriptCmds(gobgpCmdCtx)))
+		maps.Insert(cmds, maps.All(commands.BGPScriptCmds(bgpMgr)))
+
+		return &script.Engine{
+			Cmds: cmds,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	t.Cleanup(cancel)
+
+	scripttest.Test(t,
+		ctx,
+		setup,
+		[]string{"PATH=" + os.Getenv("PATH")},
+		"testdata/*.txtar")
+}

--- a/pkg/bgpv1/test/testdata/dualstack.txtar
+++ b/pkg/bgpv1/test/testdata/dualstack.txtar
@@ -1,0 +1,116 @@
+#! --test-peering-ips=fd00::aa:bb:cc:101,fd00::aa:bb:cc:102
+# NOTE: Each test should use unique peering IPs, as the tests are executed in parallel.
+
+# HINT: Put "break" anywhere in the test to observe the state with "bgp" and "gobgp" commands. For example:
+# - "bgp/peers" shows peers on the Cilium side
+# - "gobgp/peers" shows peers on the test GoBGP server side
+
+# Start the hive
+hive start
+
+# Wait for k8s watchers to be initialized
+k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
+
+# Configure gobgp server
+gobgp/add-server --router-id=1.2.3.4 65000 fd00::aa:bb:cc:101 1790
+gobgp/add-peer fd00::aa:bb:cc:102 65001
+
+# Configure BGP on Cilium
+k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
+
+# Wait for peering to be established
+gobgp/wait-state fd00::aa:bb:cc:102 ESTABLISHED
+
+# Validate peering state
+gobgp/peers -o peers.actual
+* cmp gobgp-peers.expected peers.actual
+
+# Validate IPv4 PodCIDR routes
+gobgp/routes -o routes.actual ipv4 unicast
+* cmp gobgp-routes-ipv4.expected routes.actual
+
+# Validate IPv6 PodCIDR routes
+gobgp/routes -o routes.actual ipv6 unicast
+* cmp gobgp-routes-ipv6.expected routes.actual
+
+#####
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  addresses:
+  - ip: 10.0.1.201
+    type: InternalIP
+  - ip: 10.0.1.201
+    type: CiliumInternalIP
+  - ip: fd00::aa:bb:cc:102
+    type: InternalIP
+  - ip: fd00::aa:bb:cc:102
+    type: CiliumInternalIP
+  ipam:
+    podCIDRs:
+    - 10.244.0.0/24
+    - fd00:11:22::/64
+
+-- bgp-node-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfig
+metadata:
+  name: test-node
+spec:
+  bgpInstances:
+  - localASN: 65001
+    name: tor
+    peers:
+    - name: gobgp-peer
+      peerASN: 65000
+      peerAddress: fd00::aa:bb:cc:101
+      localAddress: fd00::aa:bb:cc:102
+      peerConfigRef:
+        name: gobgp-peer-config
+
+-- bgp-peer-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: gobgp-peer-config
+spec:
+  transport:
+    peerPort: 1790
+  timers:
+    connectRetryTimeSeconds: 10
+  families:
+  - afi: ipv4
+    safi: unicast
+    advertisements:
+      matchLabels:
+        advertise: bgp
+  - afi: ipv6
+    safi: unicast
+    advertisements:
+      matchLabels:
+        advertise: bgp
+
+-- bgp-advertisement.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  labels:
+    advertise: bgp
+  name: bgp-advertisements
+spec:
+  advertisements:
+  - advertisementType: PodCIDR
+
+-- gobgp-peers.expected --
+PeerAddress          PeerASN   SessionState   HoldTime
+fd00::aa:bb:cc:102   65001     ESTABLISHED    90
+-- gobgp-routes-ipv4.expected --
+Prefix          NextHop              Attrs
+10.244.0.0/24   fd00::aa:bb:cc:102   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::aa:bb:cc:102, NLRIs: [10.244.0.0/24]}}]
+-- gobgp-routes-ipv6.expected --
+Prefix            NextHop              Attrs
+fd00:11:22::/64   fd00::aa:bb:cc:102   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::aa:bb:cc:102, NLRIs: [fd00:11:22::/64]}}]

--- a/pkg/bgpv1/test/testdata/multi-peer.txtar
+++ b/pkg/bgpv1/test/testdata/multi-peer.txtar
@@ -1,0 +1,216 @@
+#! --test-peering-ips=10.99.0.101,10.99.0.102,10.99.0.103
+# NOTE: Each test should use unique peering IPs, as the tests are executed in parallel.
+
+# HINT: Put "break" anywhere in the test to observe the state with "bgp" and "gobgp" commands. For example:
+# - "bgp/peers" shows peers on the Cilium side
+# - "gobgp/peers" shows peers on the test GoBGP server side
+
+# Start the hive
+hive start
+
+# Wait for k8s watchers to be initialized
+k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
+
+# Configure gobgp servers
+gobgp/add-server 65010 10.99.0.101 1790
+gobgp/add-server 65011 10.99.0.102 1790
+
+# Configure peers on GoBGP
+gobgp/add-peer --server-asn=65010 10.99.0.103 65001
+gobgp/add-peer --server-asn=65011 10.99.0.103 65001
+
+# Configure BGP on Cilium - only first peer
+k8s/add cilium-node.yaml bgp-peer-config.yaml bgp-advertisement.yaml
+k8s/add bgp-node-config-1.yaml
+
+# Wait for first peering to be established
+gobgp/wait-state --server-asn=65010 10.99.0.103 ESTABLISHED
+
+# Validate peering state (server 65010)
+gobgp/peers --server-asn=65010 -o peers.actual
+* cmp gobgp-peers.expected peers.actual
+
+# Validate PodCIDR routes (server 65010)
+gobgp/routes --server-asn=65010 -o routes.actual
+* cmp gobgp-routes-podcidr.expected routes.actual
+
+# Configure BGP on Cilium - add second peer
+k8s/update bgp-node-config-2.yaml
+
+# Wait for second peering to be established
+gobgp/wait-state --server-asn=65011 10.99.0.103 ESTABLISHED
+
+# Validate peering state (server 65011)
+gobgp/peers --server-asn=65011 -o peers.actual
+* cmp gobgp-peers.expected peers.actual
+
+# Validate PodCIDR routes (server 65011)
+gobgp/routes --server-asn=65011 -o routes.actual
+* cmp gobgp-routes-podcidr.expected routes.actual
+
+# Add a k8s service
+k8s/add service.yaml
+
+# Validate PodCIDR + Service routes (server 65010)
+gobgp/routes --server-asn=65010 -o routes.actual
+* cmp gobgp-routes-all.expected routes.actual
+
+# Validate PodCIDR + Service routes (server 65011)
+gobgp/routes --server-asn=65011 -o routes.actual
+* cmp gobgp-routes-all.expected routes.actual
+
+# Validate peers on Cilium
+bgp/peers -o peers.actual
+* cmp cilium-peers.expected peers.actual
+
+# Validate advertised routes on Cilium
+bgp/routes -o routes.actual advertised
+* cmp cilium-routes.expected routes.actual
+
+# Validate route-policies on Cilium
+bgp/route-policies -o policies.actual
+* cmp cilium-route-policies.expected policies.actual
+
+#####
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  addresses:
+  - ip: 10.99.0.103
+    type: InternalIP
+  - ip: 10.99.0.103
+    type: CiliumInternalIP
+  ipam:
+    podCIDRs:
+    - 10.244.0.0/24
+
+-- bgp-node-config-1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfig
+metadata:
+  name: test-node
+spec:
+  bgpInstances:
+  - localASN: 65001
+    name: tor-65001
+    peers:
+    - name: gobgp-peer-1
+      peerASN: 65010
+      peerAddress: 10.99.0.101
+      localAddress: 10.99.0.103
+      peerConfigRef:
+        name: gobgp-peer-config
+
+-- bgp-node-config-2.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfig
+metadata:
+  name: test-node
+spec:
+  bgpInstances:
+  - localASN: 65001
+    name: tor-65001
+    peers:
+    - name: gobgp-peer-1
+      peerASN: 65010
+      peerAddress: 10.99.0.101
+      localAddress: 10.99.0.103
+      peerConfigRef:
+        name: gobgp-peer-config
+    - name: gobgp-peer-2
+      peerASN: 65011
+      peerAddress: 10.99.0.102
+      localAddress: 10.99.0.103
+      peerConfigRef:
+        name: gobgp-peer-config
+
+-- bgp-peer-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: gobgp-peer-config
+spec:
+  transport:
+    peerPort: 1790
+  timers:
+    keepAliveTimeSeconds: 3
+    holdTimeSeconds: 9
+    connectRetryTimeSeconds: 10
+  gracefulRestart:
+    enabled: true
+    restartTimeSeconds: 30
+  families:
+  - afi: ipv4
+    safi: unicast
+    advertisements:
+      matchLabels:
+        advertise: bgp
+
+-- bgp-advertisement.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  labels:
+    advertise: bgp
+  name: bgp-advertisements
+spec:
+  advertisements:
+  - advertisementType: PodCIDR
+  - advertisementType: Service
+    service:
+      addresses:
+        - ClusterIP
+    selector:
+      matchExpressions:
+        - { key: bgp, operator: NotIn, values: [ nonExistingValue ] }
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+
+-- gobgp-peers.expected --
+PeerAddress   PeerASN   SessionState   HoldTime
+10.99.0.103   65001     ESTABLISHED    9
+-- gobgp-routes-podcidr.expected --
+Prefix          NextHop       Attrs
+10.244.0.0/24   10.99.0.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.103}]
+-- gobgp-routes-all.expected --
+Prefix            NextHop       Attrs
+10.244.0.0/24     10.99.0.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.103}]
+10.96.50.104/32   10.99.0.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.103}]
+-- cilium-peers.expected --
+Local AS   Peer AS   Peer Address       Session       Family         Received   Advertised
+65001      65010     10.99.0.101:1790   established   ipv4/unicast   0          2
+65001      65011     10.99.0.102:1790   established   ipv4/unicast   0          2
+-- cilium-routes.expected --
+VRouter   Peer          Prefix            NextHop       Attrs
+65001     10.99.0.101   10.244.0.0/24     10.99.0.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.103}]
+65001     10.99.0.101   10.96.50.104/32   10.99.0.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.103}]
+65001     10.99.0.102   10.244.0.0/24     10.99.0.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.103}]
+65001     10.99.0.102   10.96.50.104/32   10.99.0.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.103}]
+-- cilium-route-policies.expected --
+VRouter   Policy Name                                     Type     Match Peers      Match Families   Match Prefixes (Min..Max Len)   RIB Action   Path Actions
+65001     allow-local                                     import                                                                     accept       
+65001     gobgp-peer-1-ipv4-PodCIDR                       export   10.99.0.101/32                    10.244.0.0/24 (24..24)          accept       
+65001     gobgp-peer-1-ipv4-Service-echo-test-ClusterIP   export   10.99.0.101/32                    10.96.50.104/32 (32..32)        accept       
+65001     gobgp-peer-2-ipv4-PodCIDR                       export   10.99.0.102/32                    10.244.0.0/24 (24..24)          accept       
+65001     gobgp-peer-2-ipv4-Service-echo-test-ClusterIP   export   10.99.0.102/32                    10.96.50.104/32 (32..32)        accept       

--- a/pkg/bgpv1/test/testdata/svc-adverts.txtar
+++ b/pkg/bgpv1/test/testdata/svc-adverts.txtar
@@ -1,0 +1,179 @@
+#! --test-peering-ips=10.0.1.102,10.0.1.103
+# NOTE: Each test should use unique peering IPs, as the tests are executed in parallel.
+
+# HINT: Put "break" anywhere in the test to observe the state with "bgp" and "gobgp" commands. For example:
+# - "bgp/peers" shows peers on the Cilium side
+# - "gobgp/peers" shows peers on the test GoBGP server side
+
+# Start the hive
+hive start
+
+# Wait for k8s watchers to be initialized
+k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
+
+# Configure gobgp server
+gobgp/add-server 65000 10.0.1.102 1790
+gobgp/add-peer 10.0.1.103 65001
+
+# Configure BGP on Cilium
+k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
+
+# Wait for peering to be established
+gobgp/wait-state 10.0.1.103 ESTABLISHED
+
+# Validate no routes are advertised
+gobgp/routes -o routes.actual
+* cmp gobgp-routes-empty.expected routes.actual
+
+# Add a LoadBalancer service
+k8s/add service-lb.yaml
+
+# Validate LoadBalancer service routes
+gobgp/routes -o routes.actual
+* cmp gobgp-routes-lb.expected routes.actual
+
+# Add a ClusterIP service
+k8s/add service-cluster.yaml
+
+# Validate all service routes
+gobgp/routes -o routes.actual
+* cmp gobgp-routes-all.expected routes.actual
+
+# Remove the LoadBalancer service
+k8s/delete service-lb.yaml
+
+# Validate ClusterIP service routes
+gobgp/routes -o routes.actual
+* cmp gobgp-routes-cluster.expected routes.actual
+
+#####
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  addresses:
+  - ip: 10.0.1.103
+    type: InternalIP
+  - ip: 10.0.1.103
+    type: CiliumInternalIP
+  ipam:
+    podCIDRs:
+    - 10.244.0.0/24
+
+-- bgp-node-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfig
+metadata:
+  name: test-node
+spec:
+  bgpInstances:
+  - localASN: 65001
+    name: tor
+    peers:
+    - name: gobgp-peer
+      peerASN: 65000
+      peerAddress: 10.0.1.102
+      localAddress: 10.0.1.103
+      peerConfigRef:
+        name: gobgp-peer-config
+
+-- bgp-peer-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: gobgp-peer-config
+spec:
+  transport:
+    peerPort: 1790
+  timers:
+    connectRetryTimeSeconds: 10
+  families:
+  - afi: ipv4
+    safi: unicast
+    advertisements:
+      matchLabels:
+        advertise: bgp
+
+-- bgp-advertisement.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  labels:
+    advertise: bgp
+  name: bgp-advertisements
+spec:
+  advertisements:
+  - advertisementType: Service
+    service:
+      addresses:
+        - ClusterIP
+        - LoadBalancerIP
+    selector:
+      matchExpressions:
+        - { key: bgp, operator: NotIn, values: [ nonExistingValue ] }
+
+-- service-lb.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo1
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- service-cluster.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo2
+  namespace: test
+spec:
+  clusterIP: 10.96.50.105
+  clusterIPs:
+  - 10.96.50.105
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+
+-- gobgp-routes-empty.expected --
+Prefix   NextHop   Attrs
+-- gobgp-routes-lb.expected --
+Prefix            NextHop      Attrs
+10.96.50.104/32   10.0.1.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.0.1.103}]
+172.16.1.1/32     10.0.1.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.0.1.103}]
+-- gobgp-routes-all.expected --
+Prefix            NextHop      Attrs
+10.96.50.104/32   10.0.1.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.0.1.103}]
+10.96.50.105/32   10.0.1.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.0.1.103}]
+172.16.1.1/32     10.0.1.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.0.1.103}]
+-- gobgp-routes-cluster.expected --
+Prefix            NextHop      Attrs
+10.96.50.105/32   10.0.1.103   [{Origin: i} {AsPath: 65001} {Nexthop: 10.0.1.103}]


### PR DESCRIPTION
This PR introduces component tests for BGPv2 based on [hive/script](https://docs.cilium.io/en/latest/contributing/development/hive/#testing-with-hive-script).

It adds script commands for observing BGP state on Cilium (`bgp/*`), script commands for creating and managing GoBGP test instances to peer with Cilium (`gobgp/*`) and some example tests (see `testdata` folder). More tests will be added in follow-up PRs.

New script commands:
```
bgp/peers [-o] [--out=string]
	List BGP peers on Cilium
bgp/route-policies [-or] [--out=string] [--router-asn=uint32]
	List BGP route policies on Cilium
bgp/routes [-opr] [--out=string] [--peer=string] [--router-asn=uint32] [available|advertised] [afi] [safi]
	List BGP routes on Cilium

gobgp/add-peer [-s] [--server-asn=uint32] ip remote-asn
	Add a new peer the GoBGP server instance
gobgp/add-server [-r] [--router-id=string] asn ip port
	Add a new GoBGP server instance
gobgp/peers [-os] [--out=string] [--server-asn=uint32]
	List peers on the GoBGP server
gobgp/routes [-os] [--out=string] [--server-asn=uint32] [afi] [safi]
	List routes on the GoBGP server
gobgp/wait-state [-st] [--server-asn=uint32] [--timeout=duration] peer state
	Wait until the GoBGP peer is in the specified state
```

This allows to test the whole BGP Control Plane component that runs as part of the agent. GoBGP test instances to peer with Cilium are brought up using the above gobgp script commands. Each test needs to use unique peering IPs, as the tests are executed in parallel. These should be passed to the test infra via the `test-peering-ips` arg in the shebang at the beginning of the test.