### PR TITLE
policy: sync policy map for fake endpoints

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -781,6 +781,14 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		datapathRegenCtxt.policyMapSyncDone = true
 	}
 
+	// sync policy map for fake endpoints, bpf compilation will be skipped for them.
+	if e.isProperty(PropertyFakeEndpoint) {
+		err = e.policyMapSync(nil, stats)
+		if err != nil {
+			return fmt.Errorf("fake ep policymap synchronization failed: %w", err)
+		}
+	}
+
 	if e.isProperty(PropertySkipBPFRegeneration) {
 		return nil
 	}


### PR DESCRIPTION
Fake endpoint can have associated policies, so for them we should sync policy map.

cc @jrajahalme 