### PR TITLE
feat(hubble): decouple the payloadparser from hubble control plane.

### DIFF
--- a/pkg/hubble/cell/config.go
+++ b/pkg/hubble/cell/config.go
@@ -26,9 +26,6 @@ type config struct {
 	// EventQueueSize specifies the buffer size of the channel to receive
 	// monitor events.
 	EventQueueSize int `mapstructure:"hubble-event-queue-size"`
-	// SkipUnknownCGroupIDs specifies if events with unknown cgroup ids should
-	// be skipped.
-	SkipUnknownCGroupIDs bool `mapstructure:"hubble-skip-unknown-cgroup-ids"`
 	// MonitorEvents specifies Cilium monitor events for Hubble to observe. By
 	// default, Hubble observes all monitor events.
 	MonitorEvents []string `mapstructure:"hubble-monitor-events"`
@@ -89,22 +86,6 @@ type config struct {
 	// RecorderSinkQueueSize is the queue size for each recorder sink.
 	RecorderSinkQueueSize int `mapstructure:"hubble-recorder-sink-queue-size"`
 
-	// EnableRedact controls if sensitive information will be redacted from L7
-	// flows.
-	EnableRedact bool `mapstructure:"hubble-redact-enabled"`
-	// RedactHttpURLQuery controls if the URL query will be redacted from flows.
-	RedactHttpURLQuery bool `mapstructure:"hubble-redact-http-urlquery"`
-	// RedactHttpUserInfo controls if the user info will be redacted from flows.
-	RedactHttpUserInfo bool `mapstructure:"hubble-redact-http-userinfo"`
-	// RedactHttpHeadersAllow controls which http headers will not be redacted
-	// from flows.
-	RedactHttpHeadersAllow []string `mapstructure:"hubble-redact-http-headers-allow"`
-	// RedactHttpHeadersDeny controls which http headers will be redacted from
-	// flows.
-	RedactHttpHeadersDeny []string `mapstructure:"hubble-redact-http-headers-deny"`
-	// RedactKafkaAPIKey controls if Kafka API key will be redacted from flows.
-	RedactKafkaAPIKey bool `mapstructure:"hubble-redact-kafka-apikey"`
-
 	// EnableK8sDropEvents controls whether Hubble should create v1.Events for
 	// packet drops related to pods.
 	EnableK8sDropEvents bool `mapstructure:"hubble-drop-events"`
@@ -120,10 +101,9 @@ type config struct {
 var defaultConfig = config{
 	EnableHubble: false,
 	// Hubble internals (parser, ringbuffer) configuration
-	EventBufferCapacity:  observeroption.Default.MaxFlows.AsInt(),
-	EventQueueSize:       0, // see getDefaultMonitorQueueSize()
-	SkipUnknownCGroupIDs: true,
-	MonitorEvents:        []string{},
+	EventBufferCapacity: observeroption.Default.MaxFlows.AsInt(),
+	EventQueueSize:      0, // see getDefaultMonitorQueueSize()
+	MonitorEvents:       []string{},
 	// Hubble local server configuration
 	SocketPath: hubbleDefaults.SocketPath,
 	// Hubble TCP server configuration
@@ -148,13 +128,6 @@ var defaultConfig = config{
 	EnableRecorderAPI:     true,
 	RecorderStoragePath:   hubbleDefaults.RecorderStoragePath,
 	RecorderSinkQueueSize: 1024,
-	// Hubble field redaction configuration
-	EnableRedact:           false,
-	RedactHttpURLQuery:     false,
-	RedactHttpUserInfo:     true,
-	RedactHttpHeadersAllow: []string{},
-	RedactHttpHeadersDeny:  []string{},
-	RedactKafkaAPIKey:      false,
 	// Hubble k8s v1.Events integration configuration.
 	EnableK8sDropEvents:            false,
 	K8sDropEventsInterval:          2 * time.Minute,
@@ -167,7 +140,6 @@ func (def config) Flags(flags *pflag.FlagSet) {
 	// Hubble internals (parser, ringbuffer) configuration
 	flags.Int("hubble-event-buffer-capacity", def.EventBufferCapacity, "Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535)")
 	flags.Int("hubble-event-queue-size", def.EventQueueSize, "Buffer size of the channel to receive monitor events.")
-	flags.Bool("hubble-skip-unknown-cgroup-ids", def.SkipUnknownCGroupIDs, "Skip Hubble events with unknown cgroup ids")
 	flags.StringSlice("hubble-monitor-events", def.MonitorEvents,
 		fmt.Sprintf(
 			"Cilium monitor events for Hubble to observe: [%s]. By default, Hubble observes all monitor events.",
@@ -197,13 +169,6 @@ func (def config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-hubble-recorder-api", def.EnableRecorderAPI, "Enable the Hubble recorder API")
 	flags.String("hubble-recorder-storage-path", def.RecorderStoragePath, "Directory in which pcap files created via the Hubble Recorder API are stored")
 	flags.Int("hubble-recorder-sink-queue-size", def.RecorderSinkQueueSize, "Queue size of each Hubble recorder sink")
-	// Hubble field redaction configuration
-	flags.Bool("hubble-redact-enabled", def.EnableRedact, "Hubble redact sensitive information from flows")
-	flags.Bool("hubble-redact-http-urlquery", def.RedactHttpURLQuery, "Hubble redact http URL query from flows")
-	flags.Bool("hubble-redact-http-userinfo", def.RedactHttpUserInfo, "Hubble redact http user info from flows")
-	flags.StringSlice("hubble-redact-http-headers-allow", def.RedactHttpHeadersAllow, "HTTP headers to keep visible in flows")
-	flags.StringSlice("hubble-redact-http-headers-deny", def.RedactHttpHeadersDeny, "HTTP headers to redact from flows")
-	flags.Bool("hubble-redact-kafka-apikey", def.RedactKafkaAPIKey, "Hubble redact Kafka API key from flows")
 	// Hubble k8s v1.Events integration configuration.
 	flags.Bool("hubble-drop-events", def.EnableK8sDropEvents, "Emit packet drop Events related to pods (alpha)")
 	flags.Duration("hubble-drop-events-interval", def.K8sDropEventsInterval, "Minimum time between emitting same events")
@@ -233,13 +198,6 @@ func (cfg *config) normalize() {
 	if len(cfg.K8sDropEventsReasons) == 1 {
 		cfg.K8sDropEventsReasons = strings.Fields(cfg.K8sDropEventsReasons[0])
 	}
-}
-
-func (cfg config) validate() error {
-	if len(cfg.RedactHttpHeadersAllow) > 0 && len(cfg.RedactHttpHeadersDeny) > 0 {
-		return fmt.Errorf("Only one of --hubble-redact-http-headers-allow and --hubble-redact-http-headers-deny can be specified, not both")
-	}
-	return nil
 }
 
 func getDefaultMonitorQueueSize(numCPU int) int {

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package cell
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/cgroups/manager"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/link"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/hubble/parser"
+	hubbleGetters "github.com/cilium/cilium/pkg/hubble/parser/getters"
+	parserOptions "github.com/cilium/cilium/pkg/hubble/parser/options"
+	"github.com/cilium/cilium/pkg/identity"
+	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/service"
+)
+
+var Cell = cell.Module(
+	"payload-parser",
+	"Provides a payload parser for Hubble",
+
+	link.Cell,
+
+	cell.Provide(newPayloadParser),
+	cell.Config(defaultConfig),
+)
+
+func newPayloadParser(params payloadParserParams) (parser.Decoder, error) {
+	if err := params.Config.validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate configuration: %w", err)
+	}
+	g := &payloadGetters{
+		log:               params.Log,
+		identityAllocator: params.IdentityAllocator,
+		endpointManager:   params.EndpointManager,
+		ipcache:           params.Ipcache,
+		serviceManager:    params.ServiceManager,
+	}
+	var parserOpts []parserOptions.Option
+	if params.Config.EnableRedact {
+		parserOpts = append(
+			parserOpts,
+			parserOptions.WithRedact(
+				params.Log,
+				params.Config.RedactHttpURLQuery,
+				params.Config.RedactHttpUserInfo,
+				params.Config.RedactKafkaAPIKey,
+				params.Config.RedactHttpHeadersAllow,
+				params.Config.RedactHttpHeadersDeny,
+			),
+		)
+	}
+	return parser.New(params.Log, g, g, g, params.Ipcache, g, params.LinkCache, params.CGroupManager, params.Config.SkipUnknownCGroupIDs, parserOpts...)
+}
+
+type payloadParserParams struct {
+	cell.In
+
+	Log *slog.Logger
+
+	IdentityAllocator identitycell.CachingIdentityAllocator
+	EndpointManager   endpointmanager.EndpointManager
+	Ipcache           *ipcache.IPCache
+	ServiceManager    service.ServiceManager
+	CGroupManager     manager.CGroupManager
+	LinkCache         *link.LinkCache
+
+	Config config
+}
+
+type payloadGetters struct {
+	log *slog.Logger
+
+	identityAllocator identitycell.CachingIdentityAllocator
+	endpointManager   endpointmanager.EndpointManager
+	ipcache           *ipcache.IPCache
+	serviceManager    service.ServiceManager
+}
+
+// GetIdentity implements IdentityGetter. It looks up identity by ID from
+// Cilium's identity cache. Hubble uses the identity info to populate flow
+// source and destination labels.
+func (p *payloadGetters) GetIdentity(securityIdentity uint32) (*identity.Identity, error) {
+	ident := p.identityAllocator.LookupIdentityByID(context.Background(), identity.NumericIdentity(securityIdentity))
+	if ident == nil {
+		return nil, fmt.Errorf("identity %d not found", securityIdentity)
+	}
+	return ident, nil
+}
+
+// GetEndpointInfo implements EndpointGetter. It returns endpoint info for a
+// given IP address. Hubble uses this function to populate fields like
+// namespace and pod name for local endpoints.
+func (h *payloadGetters) GetEndpointInfo(ip netip.Addr) (endpoint hubbleGetters.EndpointInfo, ok bool) {
+	if !ip.IsValid() {
+		return nil, false
+	}
+	ep := h.endpointManager.LookupIP(ip)
+	if ep == nil {
+		return nil, false
+	}
+	return ep, true
+}
+
+// GetEndpointInfoByID implements EndpointGetter. It returns endpoint info for
+// a given Cilium endpoint id. Used by Hubble.
+func (h *payloadGetters) GetEndpointInfoByID(id uint16) (endpoint hubbleGetters.EndpointInfo, ok bool) {
+	ep := h.endpointManager.LookupCiliumID(id)
+	if ep == nil {
+		return nil, false
+	}
+	return ep, true
+}
+
+// GetNamesOf implements DNSGetter.GetNamesOf. It looks up DNS names of a given
+// IP from the FQDN cache of an endpoint specified by sourceEpID.
+func (h *payloadGetters) GetNamesOf(sourceEpID uint32, ip netip.Addr) []string {
+	ep := h.endpointManager.LookupCiliumID(uint16(sourceEpID))
+	if ep == nil {
+		return nil
+	}
+
+	if !ip.IsValid() {
+		return nil
+	}
+	names := ep.DNSHistory.LookupIP(ip)
+
+	for i := range names {
+		names[i] = strings.TrimSuffix(names[i], ".")
+	}
+
+	return names
+}
+
+// GetServiceByAddr implements ServiceGetter. It looks up service by IP/port.
+// Hubble uses this function to annotate flows with service information.
+func (h *payloadGetters) GetServiceByAddr(ip netip.Addr, port uint16) *flowpb.Service {
+	if !ip.IsValid() {
+		return nil
+	}
+	addrCluster := cmtypes.AddrClusterFrom(ip, 0)
+	addr := loadbalancer.L3n4Addr{
+		AddrCluster: addrCluster,
+		L4Addr: loadbalancer.L4Addr{
+			Port: port,
+		},
+	}
+	namespace, name, ok := h.serviceManager.GetServiceNameByAddr(addr)
+	if !ok {
+		return nil
+	}
+	return &flowpb.Service{
+		Namespace: namespace,
+		Name:      name,
+	}
+}

--- a/pkg/hubble/parser/cell/config.go
+++ b/pkg/hubble/parser/cell/config.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package cell
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type config struct {
+	// SkipUnknownCGroupIDs specifies if events with unknown cgroup ids should
+	// be skipped.
+	SkipUnknownCGroupIDs bool `mapstructure:"hubble-skip-unknown-cgroup-ids"`
+
+	// EnableRedact controls if sensitive information will be redacted from L7
+	// flows.
+	EnableRedact bool `mapstructure:"hubble-redact-enabled"`
+	// RedactHttpURLQuery controls if the URL query will be redacted from flows.
+	RedactHttpURLQuery bool `mapstructure:"hubble-redact-http-urlquery"`
+	// RedactHttpUserInfo controls if the user info will be redacted from flows.
+	RedactHttpUserInfo bool `mapstructure:"hubble-redact-http-userinfo"`
+	// RedactHttpHeadersAllow controls which http headers will not be redacted
+	// from flows.
+	RedactHttpHeadersAllow []string `mapstructure:"hubble-redact-http-headers-allow"`
+	// RedactHttpHeadersDeny controls which http headers will be redacted from
+	// flows.
+	RedactHttpHeadersDeny []string `mapstructure:"hubble-redact-http-headers-deny"`
+	// RedactKafkaAPIKey controls if Kafka API key will be redacted from flows.
+	RedactKafkaAPIKey bool `mapstructure:"hubble-redact-kafka-apikey"`
+}
+
+var defaultConfig = config{
+	SkipUnknownCGroupIDs:   true,
+	EnableRedact:           false,
+	RedactHttpURLQuery:     false,
+	RedactHttpUserInfo:     true,
+	RedactHttpHeadersAllow: []string{},
+	RedactHttpHeadersDeny:  []string{},
+	RedactKafkaAPIKey:      false,
+}
+
+func (cfg config) validate() error {
+	if len(cfg.RedactHttpHeadersAllow) > 0 && len(cfg.RedactHttpHeadersDeny) > 0 {
+		return fmt.Errorf("Only one of --hubble-redact-http-headers-allow and --hubble-redact-http-headers-deny can be specified, not both")
+	}
+	return nil
+}
+
+func (def config) Flags(flags *pflag.FlagSet) {
+	flags.Bool("hubble-skip-unknown-cgroup-ids", def.SkipUnknownCGroupIDs, "Skip Hubble events with unknown cgroup ids")
+	// Hubble field redaction configuration
+	flags.Bool("hubble-redact-enabled", def.EnableRedact, "Hubble redact sensitive information from flows")
+	flags.Bool("hubble-redact-http-urlquery", def.RedactHttpURLQuery, "Hubble redact http URL query from flows")
+	flags.Bool("hubble-redact-http-userinfo", def.RedactHttpUserInfo, "Hubble redact http user info from flows")
+	flags.StringSlice("hubble-redact-http-headers-allow", def.RedactHttpHeadersAllow, "HTTP headers to keep visible in flows")
+	flags.StringSlice("hubble-redact-http-headers-deny", def.RedactHttpHeadersDeny, "HTTP headers to redact from flows")
+	flags.Bool("hubble-redact-kafka-apikey", def.RedactKafkaAPIKey, "Hubble redact Kafka API key from flows")
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!
 
---

This pull request introduces important changes to integrate a payload parser for Hubble. Currently, the parser (or Decoder) is tightly coupled with the launch code for Hubble, making it impossible to run Hubble without the Cilium dataplane. While we expose Hubble as a cell, we do not explicitly expose the parser as a dependency.

In this update, I have extracted the parser initiation and exposed it as a cell. This change allows Hubble to operate as a standalone component, fully decoupled from the Cilium dataplane.

### Integration of Payload Parser

* Added `parser.Cell` to the imports and setup in `daemon/cmd/cells.go` to integrate the new payload parser for Hubble. [[1]](diffhunk://#diff-b6fe215b8eec2781238ff563daf11bc43763cef03cc353b1be2386f5aa18b4e8R42) [[2]](diffhunk://#diff-b6fe215b8eec2781238ff563daf11bc43763cef03cc353b1be2386f5aa18b4e8R324-R326)
* Introduced a new `payloadParser` field in `hubbleParams` and `hubbleIntegration` structs, and updated the relevant functions to utilize this new field in `pkg/hubble/cell/cell.go` and `pkg/hubble/cell/hubbleintegration.go`. [[1]](diffhunk://#diff-2a19105a1374b57275fcdb27e96330b640f64ec98ee611e0ca8dfddbd5a0e69aR69-R70) [[2]](diffhunk://#diff-2a19105a1374b57275fcdb27e96330b640f64ec98ee611e0ca8dfddbd5a0e69aR96) [[3]](diffhunk://#diff-e494eb1c9e37714c15e89b2d4d5cf6d3f88754874ba16d7c17c800cbed5c8de3R86-R88) [[4]](diffhunk://#diff-e494eb1c9e37714c15e89b2d4d5cf6d3f88754874ba16d7c17c800cbed5c8de3R109) [[5]](diffhunk://#diff-e494eb1c9e37714c15e89b2d4d5cf6d3f88754874ba16d7c17c800cbed5c8de3R142) [[6]](diffhunk://#diff-e494eb1c9e37714c15e89b2d4d5cf6d3f88754874ba16d7c17c800cbed5c8de3L493-R393)

These changes streamline the Hubble integration and improve the maintainability of the codebase.

```release-note
This change decouples the payload parser from the Hubble control plane, allowing Hubble to work as a standalone component without the Cilium dataplane.
```
