### PR TITLE
ci:awscni: restore node taints

### DIFF
--- a/.github/actions/setup-eks-nodegroup/action.yml
+++ b/.github/actions/setup-eks-nodegroup/action.yml
@@ -45,6 +45,10 @@ runs:
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 25
+          taints:
+           - key: "node.cilium.io/agent-not-ready"
+             value: "true"
+             effect: "NoExecute"
         - name: ng-arm64
           instanceTypes:
            - t4g.medium
@@ -53,6 +57,10 @@ runs:
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 25
+          taints:
+           - key: "node.cilium.io/agent-not-ready"
+             value: "true"
+             effect: "NoExecute"
         EOF
 
         eksctl create nodegroup -f ./eks-nodegroups.yaml


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/37289

```release-note
Restore node taints when creating EKS cluster in CI to prevent timeout DNS requests with WireGuard.
```