### PR TITLE
cilium-dbg: Set terminal size in 'cilium-dbg shell'

### DIFF
--- a/cilium-dbg/cmd/shell.go
+++ b/cilium-dbg/cmd/shell.go
@@ -135,6 +135,9 @@ func interactiveShell() {
 	}
 
 	console := term.NewTerminal(stdReadWriter, hostName+"> ")
+	if width, height, err := term.GetSize(0); err == nil {
+		console.SetSize(width, height)
+	}
 	printShellGreeting(console)
 
 	for {


### PR DESCRIPTION
If we can get the terminal size use that instead of the default 80x24 so that we don't get surprising wrapping of lines.
Manually tested.