### PR TITLE
Make ipcache async api cluster id aware

### DIFF
--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/statedb"
 	"go4.org/netipx"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/identity"
 	ippkg "github.com/cilium/cilium/pkg/ip"
@@ -194,12 +195,11 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 
 		lbls := ipIDLblsPair.Labels
 		if ipIDLblsPair.ID.IsWorld() {
-			p := netip.PrefixFrom(netipx.MustFromStdIP(ipIDLblsPair.IP), 0)
+			p := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(netipx.MustFromStdIP(ipIDLblsPair.IP), 0))
 			s.params.IPCache.OverrideIdentity(p, lbls, source.Local, daemonResourceID)
 		} else {
-			s.params.IPCache.UpsertMetadata(ippkg.IPToNetPrefix(ipIDLblsPair.IP),
-				source.Local, daemonResourceID, lbls,
-			)
+			p := cmtypes.NewLocalPrefixCluster(ippkg.IPToNetPrefix(ipIDLblsPair.IP))
+			s.params.IPCache.UpsertMetadata(p, source.Local, daemonResourceID, lbls)
 		}
 	}
 
@@ -212,7 +212,8 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 			} else {
 				log.Debugf("Removed outdated host IP %s from endpoint map", hostIP)
 			}
-			s.params.IPCache.RemoveMetadata(ippkg.IPToNetPrefix(ip), daemonResourceID, labels.LabelHost)
+			p := cmtypes.NewLocalPrefixCluster(ippkg.IPToNetPrefix(ip))
+			s.params.IPCache.RemoveMetadata(p, daemonResourceID, labels.LabelHost)
 		}
 	}
 

--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -197,9 +197,8 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 			p := netip.PrefixFrom(netipx.MustFromStdIP(ipIDLblsPair.IP), 0)
 			s.params.IPCache.OverrideIdentity(p, lbls, source.Local, daemonResourceID)
 		} else {
-			s.params.IPCache.UpsertLabels(ippkg.IPToNetPrefix(ipIDLblsPair.IP),
-				lbls,
-				source.Local, daemonResourceID,
+			s.params.IPCache.UpsertMetadata(ippkg.IPToNetPrefix(ipIDLblsPair.IP),
+				source.Local, daemonResourceID, lbls,
 			)
 		}
 	}
@@ -213,7 +212,7 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 			} else {
 				log.Debugf("Removed outdated host IP %s from endpoint map", hostIP)
 			}
-			s.params.IPCache.RemoveLabels(ippkg.IPToNetPrefix(ip), labels.LabelHost, daemonResourceID)
+			s.params.IPCache.RemoveMetadata(ippkg.IPToNetPrefix(ip), daemonResourceID, labels.LabelHost)
 		}
 	}
 

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -186,7 +186,11 @@ func (d *Daemon) dumpOldIPCache() (map[netip.Prefix]identity.NumericIdentity, er
 		v := value.(*ipcachemap.RemoteEndpointInfo)
 		nid := identity.NumericIdentity(v.SecurityIdentity)
 
-		if nid.Scope() == identity.IdentityScopeLocal || (nid == identity.ReservedIdentityIngress && v.TunnelEndpoint.IsZero()) {
+		if !v.TunnelEndpoint.IsZero() || k.ClusterID != 0 {
+			return
+		}
+
+		if nid.Scope() == identity.IdentityScopeLocal || nid == identity.ReservedIdentityIngress {
 			localPrefixes[k.Prefix()] = nid
 		}
 	})
@@ -247,7 +251,7 @@ func (d *Daemon) restoreIPCache(localPrefixes map[netip.Prefix]identity.NumericI
 		// Restore Ingress IPs as necessary
 		if nid == identity.ReservedIdentityIngress {
 			metaUpdates = append(metaUpdates, ipcache.MU{
-				Prefix:   prefix,
+				Prefix:   cmtypes.NewLocalPrefixCluster(prefix),
 				Source:   source.Restored,
 				Resource: ingressResource,
 				Metadata: []ipcache.IPMetadata{labels.LabelIngress},
@@ -283,7 +287,7 @@ func (d *Daemon) restoreIPCache(localPrefixes map[netip.Prefix]identity.NumericI
 
 			// Commit to ipcache.
 			metaUpdates = append(metaUpdates, ipcache.MU{
-				Prefix:   prefix,
+				Prefix:   cmtypes.NewLocalPrefixCluster(prefix),
 				Source:   source.Restored,
 				Resource: restoredCIDRResource,
 				Metadata: metadata,
@@ -301,7 +305,7 @@ func (d *Daemon) restoreIPCache(localPrefixes map[netip.Prefix]identity.NumericI
 			// be present in the new IPCache during endpoint regeneration to
 			// avoid drops.
 			metaUpdates = append(metaUpdates, ipcache.MU{
-				Prefix:   prefix,
+				Prefix:   cmtypes.NewLocalPrefixCluster(prefix),
 				Source:   source.Restored,
 				Resource: restoredCIDRResource,
 				Metadata: []ipcache.IPMetadata{id.Labels},
@@ -360,7 +364,7 @@ func (d *Daemon) releaseRestoredIdentities() {
 	for prefix, nid := range d.restoredCIDRs {
 		nids = append(nids, nid)
 		updates = append(updates, ipcache.MU{
-			Prefix:   prefix,
+			Prefix:   cmtypes.NewLocalPrefixCluster(prefix),
 			Resource: restoredCIDRResource,
 			Metadata: []ipcache.IPMetadata{
 				ipcachetypes.RequestedIdentity(0), // remove requsted ID, if present

--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -286,6 +286,18 @@ type PrefixCluster struct {
 	clusterID uint32
 }
 
+// NewPrefixCluster builds an instance of a PrefixCluster with the input
+// prefix and clusterID.
+func NewPrefixCluster(prefix netip.Prefix, clusterID uint32) PrefixCluster {
+	return PrefixCluster{prefix, clusterID}
+}
+
+// NewLocalPrefixCluster builds an instance of a PrefixCluster with the input
+// prefix and clusterID set to 0.
+func NewLocalPrefixCluster(prefix netip.Prefix) PrefixCluster {
+	return NewPrefixCluster(prefix, 0)
+}
+
 // ParsePrefixCluster parses s as an Prefix + ClusterID and returns PrefixCluster.
 // The string s can be a bare IP prefix string (any prefix format allowed in
 // netip.ParsePrefix()) or prefix string + @ + ClusterID with decimal. Bare prefix

--- a/pkg/container/bitlpm/cidr_map.go
+++ b/pkg/container/bitlpm/cidr_map.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bitlpm
+
+import "net/netip"
+
+// CIDRTrieMap holds a map of CIDRTries, keyed by a generic comparable type,
+// where each trie is capable of storing both IPv4 and IPv6 prefixes at the same time.
+type CIDRTrieMap[K comparable, T any] struct {
+	m map[K]*CIDRTrie[T]
+}
+
+// NewCIDRTrieMap creates a new CIDRTrieMap[K comparable, T any].
+func NewCIDRTrieMap[K comparable, T any]() *CIDRTrieMap[K, T] {
+	return &CIDRTrieMap[K, T]{make(map[K]*CIDRTrie[T])}
+}
+
+// Descendants iterates over every CIDR that is contained by the CIDR argument in the trie identified by key.
+func (cm *CIDRTrieMap[K, T]) Descendants(key K, cidr netip.Prefix, fn func(k netip.Prefix, v T) bool) {
+	if cm.m[key] == nil {
+		return
+	}
+	cm.m[key].Descendants(cidr, fn)
+}
+
+// Upsert adds or updates the value for a given prefix in the trie identified by key.
+// If the key has no trie associated, a new empty one is created.
+func (cm *CIDRTrieMap[K, T]) Upsert(key K, cidr netip.Prefix, v T) bool {
+	if cm.m[key] == nil {
+		cm.m[key] = NewCIDRTrie[T]()
+	}
+	return cm.m[key].Upsert(cidr, v)
+}
+
+// Delete removes a given prefix from the trie identified by key.
+func (cm *CIDRTrieMap[K, T]) Delete(key K, cidr netip.Prefix) bool {
+	if cm.m[key] == nil {
+		return false
+	}
+	found := cm.m[key].Delete(cidr)
+	if cm.m[key].Len() == 0 {
+		delete(cm.m, key)
+	}
+	return found
+}

--- a/pkg/container/bitlpm/cidr_map_test.go
+++ b/pkg/container/bitlpm/cidr_map_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bitlpm
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCIDRTrieMapUpsertDelete(t *testing.T) {
+	trieMap := NewCIDRTrieMap[string, string]()
+
+	prefix1 := netip.MustParsePrefix("1.1.1.1/32")
+	prefix2 := netip.MustParsePrefix("2.2.2.2/32")
+	prefix3 := netip.MustParsePrefix("3.3.3.3/32")
+	prefix4 := netip.MustParsePrefix("4.4.4.4/32")
+
+	// new trie map should be empty
+	assert.Empty(t, trieMap.m)
+
+	// first upsert is insertion, next one should be an update
+	assert.True(t, trieMap.Upsert("key1", prefix1, "prefix"))
+	assert.False(t, trieMap.Upsert("key1", prefix1, "prefix1"))
+
+	// same prefix and value in other tries should be insertions, not updates
+	assert.True(t, trieMap.Upsert("key2", prefix1, "prefix1"))
+	assert.True(t, trieMap.Upsert("key3", prefix1, "prefix1"))
+
+	// further insertions for new prefixes
+	assert.True(t, trieMap.Upsert("key1", prefix2, "prefix2"))
+	assert.True(t, trieMap.Upsert("key2", prefix3, "prefix3"))
+	assert.True(t, trieMap.Upsert("key3", prefix4, "prefix4"))
+
+	// delete prefix2 from "key1" trie, subsequent deletion should fail
+	assert.True(t, trieMap.Delete("key1", prefix2))
+	assert.False(t, trieMap.Delete("key1", prefix2))
+
+	// prefix3 should not be found in "key1" or "key3" tries
+	assert.False(t, trieMap.Delete("key1", prefix3))
+	assert.False(t, trieMap.Delete("key3", prefix3))
+
+	// deletion from "non-existent" trie should fail
+	assert.False(t, trieMap.Delete("non-existent", prefix1))
+
+	// delete all remaining values from "key1" trie
+	assert.True(t, trieMap.Delete("key1", prefix1))
+
+	// "key1" should not be found anymore in the map
+	assert.NotContains(t, trieMap.m, "key1")
+
+	// same for "key2" and "key3" trie
+	assert.True(t, trieMap.Delete("key2", prefix1))
+	assert.True(t, trieMap.Delete("key2", prefix3))
+	assert.NotContains(t, trieMap.m, "key2")
+	assert.True(t, trieMap.Delete("key3", prefix1))
+	assert.True(t, trieMap.Delete("key3", prefix4))
+	assert.NotContains(t, trieMap.m, "key3")
+
+	// trie map should be empty
+	assert.Empty(t, trieMap.m)
+}
+
+func TestCIDRTrieMapDescendants(t *testing.T) {
+	trieMap := NewCIDRTrieMap[int, int]()
+
+	prefixes := [][]netip.Prefix{
+		{
+			netip.MustParsePrefix("192.168.1.1/24"),
+			netip.MustParsePrefix("192.168.1.1/28"),
+			netip.MustParsePrefix("192.168.1.1/32"),
+		},
+		{
+			netip.MustParsePrefix("192.168.2.1/24"),
+			netip.MustParsePrefix("192.168.2.1/28"),
+			netip.MustParsePrefix("192.168.2.1/32"),
+		},
+		{
+			netip.MustParsePrefix("192.168.3.1/24"),
+			netip.MustParsePrefix("192.168.3.1/28"),
+			netip.MustParsePrefix("192.168.3.1/32"),
+		},
+	}
+
+	for i, keyPrefixes := range prefixes {
+		for value, prefix := range keyPrefixes {
+			// insert i-th prefix into trie with key "i" and associate "value" to it
+			assert.True(t, trieMap.Upsert(i, prefix, value))
+		}
+	}
+
+	// for each trie, check that the expected descendants (in the correct order) are returned
+	for i := range prefixes {
+		got := make([]netip.Prefix, len(prefixes[i]))
+		trieMap.Descendants(i, prefixes[i][0], func(k netip.Prefix, v int) bool {
+			got[v] = k
+			return true
+		})
+		assert.Equal(t, prefixes[i], got)
+	}
+}

--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -16,6 +16,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
@@ -264,7 +265,7 @@ func (n *manager) RestoreCache(preCachePath string, eps map[uint16]*endpoint.End
 
 			prefix := netip.PrefixFrom(addr, addr.BitLen())
 			ipcacheUpdates = append(ipcacheUpdates, ipcache.MU{
-				Prefix:   prefix,
+				Prefix:   cmtypes.NewLocalPrefixCluster(prefix),
 				Source:   source.Restored,
 				Resource: restorationIPCacheResource,
 				Metadata: []ipcache.IPMetadata{

--- a/pkg/fqdn/namemanager/manager.go
+++ b/pkg/fqdn/namemanager/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
@@ -170,7 +171,7 @@ func (n *manager) CompleteBootstrap() {
 		ipcacheUpdates := make([]ipcache.MU, 0, len(n.restoredPrefixes))
 		for prefix := range n.restoredPrefixes {
 			ipcacheUpdates = append(ipcacheUpdates, ipcache.MU{
-				Prefix:   prefix,
+				Prefix:   cmtypes.NewLocalPrefixCluster(prefix),
 				Source:   source.Restored,
 				Resource: restorationIPCacheResource,
 				Metadata: []ipcache.IPMetadata{
@@ -291,7 +292,7 @@ func (n *manager) updateMetadata(nameToMetadata map[string]nameMetadata) (ipcach
 
 		for _, addr := range metadata.addrs {
 			updates = append(updates, ipcache.MU{
-				Prefix:   netip.PrefixFrom(addr, addr.BitLen()),
+				Prefix:   cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(addr, addr.BitLen())),
 				Source:   source.Generated,
 				Resource: resource,
 				Metadata: []ipcache.IPMetadata{
@@ -332,7 +333,7 @@ func (n *manager) maybeRemoveMetadata(maybeRemoved map[netip.Addr][]string) {
 	for ip, names := range maybeRemoved {
 		for _, name := range names {
 			ipCacheUpdates = append(ipCacheUpdates, ipcache.MU{
-				Prefix:   netip.PrefixFrom(ip, ip.BitLen()),
+				Prefix:   cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(ip, ip.BitLen())),
 				Source:   source.Generated,
 				Resource: ipcacheResource(name),
 				Metadata: []ipcache.IPMetadata{

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -10,9 +10,11 @@ package restore
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/netip"
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -20,6 +22,10 @@ import (
 
 // PortProtoV2 is 1 value at bit position 24.
 const PortProtoV2 = 1 << 24
+
+// ErrRemoteClusterAddr is returned when trying to parse a non local
+// (i.e: not belonging to the local cluster) IP or CIDR.
+var ErrRemoteClusterAddr = errors.New("IP or CIDR from remote cluster")
 
 // PortProto is uint32 that encodes two different
 // versions of port protocol keys. Version 1 is protocol
@@ -130,7 +136,21 @@ func (ip RuleIPOrCIDR) MarshalText() ([]byte, error) {
 
 func (ip *RuleIPOrCIDR) UnmarshalText(b []byte) (err error) {
 	if b == nil {
-		return fmt.Errorf("cannot unmarshal nil into RuleIPOrCIDR")
+		return errors.New("cannot unmarshal nil into RuleIPOrCIDR")
+	}
+	if i := bytes.IndexByte(b, byte('@')); i >= 0 {
+		if i == len(b)-1 {
+			return errors.New("unexpected trailing @")
+		}
+		clusterIDStr := string(b[i+1:])
+		clusterID, err := strconv.ParseUint(clusterIDStr, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unable to parse clusterID: %w", err)
+		}
+		if clusterID != 0 {
+			return ErrRemoteClusterAddr
+		}
+		b = b[:i]
 	}
 	if i := bytes.IndexByte(b, byte('/')); i < 0 {
 		var addr netip.Addr

--- a/pkg/fqdn/restore/restore_test.go
+++ b/pkg/fqdn/restore/restore_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package restore
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRuleIPOrCIDR(t *testing.T) {
+	rule, err := ParseRuleIPOrCIDR("172.18.0.1")
+	assert.NoError(t, err)
+	assert.True(t, rule.IsAddr())
+	assert.Equal(t, rule.Addr(), netip.MustParseAddr("172.18.0.1"))
+
+	rule, err = ParseRuleIPOrCIDR("172.18.0.1/32")
+	assert.NoError(t, err)
+	assert.False(t, rule.IsAddr())
+	assert.Equal(t, netip.Prefix(rule), netip.MustParsePrefix("172.18.0.1/32"))
+
+	rule, err = ParseRuleIPOrCIDR("172.18.0.0/16")
+	assert.NoError(t, err)
+	assert.False(t, rule.IsAddr())
+	assert.Equal(t, netip.Prefix(rule), netip.MustParsePrefix("172.18.0.0/16"))
+
+	rule, err = ParseRuleIPOrCIDR("172.18.0.2@0")
+	assert.NoError(t, err)
+	assert.True(t, rule.IsAddr())
+	assert.Equal(t, rule.Addr(), netip.MustParseAddr("172.18.0.2"))
+
+	rule, err = ParseRuleIPOrCIDR("172.18.0.2/32@0")
+	assert.NoError(t, err)
+	assert.False(t, rule.IsAddr())
+	assert.Equal(t, netip.Prefix(rule), netip.MustParsePrefix("172.18.0.2/32"))
+
+	rule, err = ParseRuleIPOrCIDR("172.18.0.0/16@0")
+	assert.NoError(t, err)
+	assert.False(t, rule.IsAddr())
+	assert.Equal(t, netip.Prefix(rule), netip.MustParsePrefix("172.18.0.0/16"))
+
+	_, err = ParseRuleIPOrCIDR("172.18.0.0/16@")
+	assert.Error(t, err)
+
+	_, err = ParseRuleIPOrCIDR("172.18.0.0/16@wrong")
+	assert.Error(t, err)
+
+	_, err = ParseRuleIPOrCIDR("172.18.0.1@5")
+	assert.ErrorIs(t, err, ErrRemoteClusterAddr)
+
+	_, err = ParseRuleIPOrCIDR("172.18.0.1/16@5")
+	assert.ErrorIs(t, err, ErrRemoteClusterAddr)
+}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -506,7 +506,7 @@ func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
 
 // MU is a batched metadata update, the short name is to cut down on visual clutter.
 type MU struct {
-	Prefix   netip.Prefix
+	Prefix   cmtypes.PrefixCluster
 	Source   source.Source
 	Resource ipcacheTypes.ResourceID
 	Metadata []IPMetadata
@@ -517,7 +517,7 @@ type MU struct {
 // to pass into this function. This will trigger asynchronous calculation of
 // any datapath updates necessary to implement the logic associated with the
 // specified metadata.
-func (ipc *IPCache) UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID, aux ...IPMetadata) {
+func (ipc *IPCache) UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcacheTypes.ResourceID, aux ...IPMetadata) {
 	ipc.UpsertMetadataBatch(MU{Prefix: prefix, Source: src, Resource: resource, Metadata: aux})
 }
 
@@ -526,7 +526,7 @@ func (ipc *IPCache) UpsertMetadata(prefix netip.Prefix, src source.Source, resou
 //
 // Returns a revision number that can be passed to WaitForRevision().
 func (ipc *IPCache) UpsertMetadataBatch(updates ...MU) (revision uint64) {
-	prefixes := make([]netip.Prefix, 0, len(updates))
+	prefixes := make([]cmtypes.PrefixCluster, 0, len(updates))
 	ipc.metadata.Lock()
 	for _, upd := range updates {
 		prefixes = append(prefixes, ipc.metadata.upsertLocked(upd.Prefix, upd.Source, upd.Resource, upd.Metadata...)...)
@@ -548,14 +548,14 @@ func (ipc *IPCache) UpsertMetadataBatch(updates ...MU) (revision uint64) {
 // This removes all labels from the given resource:
 //
 //	RemoveMetadata(pfx, resource, Labels{})
-func (ipc *IPCache) RemoveMetadata(prefix netip.Prefix, resource ipcacheTypes.ResourceID, aux ...IPMetadata) {
+func (ipc *IPCache) RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcacheTypes.ResourceID, aux ...IPMetadata) {
 	ipc.RemoveMetadataBatch(MU{Prefix: prefix, Resource: resource, Metadata: aux})
 }
 
 // RemoveMetadataBatch is a batched version of RemoveMetadata.
 // Returns a revision number that can be passed to WaitForRevision().
 func (ipc *IPCache) RemoveMetadataBatch(updates ...MU) (revision uint64) {
-	prefixes := make([]netip.Prefix, 0, len(updates))
+	prefixes := make([]cmtypes.PrefixCluster, 0, len(updates))
 	ipc.metadata.Lock()
 	for _, upd := range updates {
 		prefixes = append(prefixes, ipc.metadata.remove(upd.Prefix, upd.Resource, upd.Metadata...)...)
@@ -587,11 +587,11 @@ func (ipc *IPCache) RemoveMetadataBatch(updates ...MU) (revision uint64) {
 // the same netip prefixes. Using this API may cause feature incompatibilities
 // with users of other APIs such as UpsertMetadata() and other variations on
 // inserting metadata into the IPCache.
-func (ipc *IPCache) OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
+func (ipc *IPCache) OverrideIdentity(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
 	ipc.UpsertMetadata(prefix, src, resource, overrideIdentity(true), identityLabels)
 }
 
-func (ipc *IPCache) RemoveIdentityOverride(cidr netip.Prefix, identityLabels labels.Labels, resource ipcacheTypes.ResourceID) {
+func (ipc *IPCache) RemoveIdentityOverride(cidr cmtypes.PrefixCluster, identityLabels labels.Labels, resource ipcacheTypes.ResourceID) {
 	ipc.RemoveMetadata(cidr, resource, overrideIdentity(true), identityLabels)
 }
 

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -282,7 +282,7 @@ func (ipc *IPCache) getEndpointFlagsRLocked(ip string) uint8 {
 // When deleting ipcache entries that were previously inserted via this
 // function, ensure that the corresponding delete occurs via Delete().
 //
-// Deprecated: Prefer UpsertLabels() instead.
+// Deprecated: Prefer UpsertMetadata() instead.
 func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (namedPortsChanged bool, err error) {
 	ipc.mutex.Lock()
 	defer ipc.mutex.Unlock()
@@ -566,21 +566,6 @@ func (ipc *IPCache) RemoveMetadataBatch(updates ...MU) (revision uint64) {
 	return
 }
 
-// UpsertLabels upserts a given IP and its corresponding labels associated
-// with it into the ipcache metadata map. The given labels are not modified nor
-// is its reference saved, as they're copied when inserting into the map.
-// This will trigger asynchronous calculation of any local identity changes
-// that must occur to associate the specified labels with the prefix, and push
-// any datapath updates necessary to implement the logic associated with the
-// metadata currently associated with the 'prefix'.
-func (ipc *IPCache) UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
-	ipc.UpsertMetadata(prefix, src, resource, lbls)
-}
-
-func (ipc *IPCache) RemoveLabels(cidr netip.Prefix, lbls labels.Labels, resource ipcacheTypes.ResourceID) {
-	ipc.RemoveMetadata(cidr, resource, lbls)
-}
-
 // OverrideIdentity overrides the identity for a given prefix in the IPCache metadata
 // map. This is used when a resource indicates that this prefix already has a
 // defined identity, and where any additional labels associated with the prefix
@@ -595,13 +580,13 @@ func (ipc *IPCache) RemoveLabels(cidr netip.Prefix, lbls labels.Labels, resource
 // Callers must arrange for RemoveIdentityOverride() to eventually be called
 // to reverse this operation if the underlying resource is removed.
 //
-// Use with caution: For most use cases, UpsertLabels() is a better API to
+// Use with caution: For most use cases, UpsertMetadata() is a better API to
 // allow metadata to be associated with the prefix. This will delegate identity
 // resolution to the IPCache internally, which provides better compatibility
 // between various features that may use the IPCache to associate metadata with
 // the same netip prefixes. Using this API may cause feature incompatibilities
-// with users of other APIs such as UpsertLabels(), UpsertMetadata() and other
-// variations on inserting metadata into the IPCache.
+// with users of other APIs such as UpsertMetadata() and other variations on
+// inserting metadata into the IPCache.
 func (ipc *IPCache) OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
 	ipc.UpsertMetadata(prefix, src, resource, overrideIdentity(true), identityLabels)
 }

--- a/pkg/ipcache/ipcache_bench_test.go
+++ b/pkg/ipcache/ipcache_bench_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
@@ -42,10 +43,10 @@ func BenchmarkInjectLabels(b *testing.B) {
 	lbls := labels.NewLabelsFromSortedList(labels.LabelSourceCIDRGroup + ":foo=bar")
 	b.ResetTimer()
 
-	prefixes := make([]netip.Prefix, 0, b.N)
+	prefixes := make([]cmtypes.PrefixCluster, 0, b.N)
 
 	for i := 0; i < b.N; i++ {
-		pfx := netip.PrefixFrom(addr, 30)
+		pfx := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(addr, 30))
 		for j := 0; j < 4; j++ {
 			addr = addr.Next()
 		}

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/bitlpm"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
@@ -36,6 +37,9 @@ var (
 
 	injectLabelsControllerGroup = controller.NewGroup("ipcache-inject-labels")
 )
+
+// clusterID is the type of the key to use in the metadata CIDRTrieMap
+type clusterID uint32
 
 // metadata contains the ipcache metadata. Mainily it holds a map which maps IP
 // prefixes (x.x.x.x/32) to a set of information (prefixInfo).
@@ -73,10 +77,11 @@ type metadata struct {
 	lock.RWMutex
 
 	// m is the actual map containing the mappings.
-	m map[netip.Prefix]prefixInfo
+	m map[cmtypes.PrefixCluster]prefixInfo
 
-	// prefixes is a trie of prefixes, for finding descendants efficiently
-	prefixes *bitlpm.CIDRTrie[struct{}]
+	// prefixes is a map of tries. Each trie holds the prefixes for the same
+	// clusterID, in order to find descendants efficiently.
+	prefixes *bitlpm.CIDRTrieMap[clusterID, struct{}]
 
 	// queued* handle updates into the IPCache. Whenever a label is added
 	// or removed from a specific IP prefix, that prefix is added into
@@ -84,7 +89,7 @@ type metadata struct {
 	// process the metadata changes for these prefixes and potentially
 	// generate updates into the ipcache, policy engine and datapath.
 	queuedChangesMU lock.Mutex
-	queuedPrefixes  map[netip.Prefix]struct{}
+	queuedPrefixes  map[cmtypes.PrefixCluster]struct{}
 
 	// queuedRevision is the "version" of the prefix queue. It is incremented
 	// on every *dequeue*. If injection is successful, then injectedRevision
@@ -111,9 +116,9 @@ type metadata struct {
 
 func newMetadata() *metadata {
 	return &metadata{
-		m:              make(map[netip.Prefix]prefixInfo),
-		prefixes:       bitlpm.NewCIDRTrie[struct{}](),
-		queuedPrefixes: make(map[netip.Prefix]struct{}),
+		m:              make(map[cmtypes.PrefixCluster]prefixInfo),
+		prefixes:       bitlpm.NewCIDRTrieMap[clusterID, struct{}](),
+		queuedPrefixes: make(map[cmtypes.PrefixCluster]struct{}),
 		queuedRevision: 1,
 
 		injectedRevisionCond: sync.NewCond(&lock.Mutex{}),
@@ -125,13 +130,13 @@ func newMetadata() *metadata {
 // dequeuePrefixUpdates returns the set of queued prefixes, as well as the revision
 // that should be passed to setInjectedRevision once label injection has successfully
 // completed.
-func (m *metadata) dequeuePrefixUpdates() (modifiedPrefixes []netip.Prefix, revision uint64) {
+func (m *metadata) dequeuePrefixUpdates() (modifiedPrefixes []cmtypes.PrefixCluster, revision uint64) {
 	m.queuedChangesMU.Lock()
-	modifiedPrefixes = make([]netip.Prefix, 0, len(m.queuedPrefixes))
+	modifiedPrefixes = make([]cmtypes.PrefixCluster, 0, len(m.queuedPrefixes))
 	for p := range m.queuedPrefixes {
 		modifiedPrefixes = append(modifiedPrefixes, p)
 	}
-	m.queuedPrefixes = make(map[netip.Prefix]struct{})
+	m.queuedPrefixes = make(map[cmtypes.PrefixCluster]struct{})
 	revision = m.queuedRevision
 	m.queuedRevision++ // Increment, as any newly-queued prefixes are now subject to the next revision cycle
 	m.queuedChangesMU.Unlock()
@@ -141,7 +146,7 @@ func (m *metadata) dequeuePrefixUpdates() (modifiedPrefixes []netip.Prefix, revi
 
 // enqueuePrefixUpdates queues prefixes for label injection. It returns the "next"
 // queue revision number, which can be passed to waitForRevision.
-func (m *metadata) enqueuePrefixUpdates(prefixes ...netip.Prefix) uint64 {
+func (m *metadata) enqueuePrefixUpdates(prefixes ...cmtypes.PrefixCluster) uint64 {
 	m.queuedChangesMU.Lock()
 	defer m.queuedChangesMU.Unlock()
 
@@ -188,31 +193,34 @@ func (m *metadata) waitForRevision(ctx context.Context, rev uint64) error {
 	return nil
 }
 
-// canonicalPrefix returns the canonical version of the prefix which must be
-// used for lookups in the metadata prefix map. The canonical representation of
-// a prefix has the lower bits of the address always zeroed out and does
-// not contain any IPv4-mapped IPv6 address
-func canonicalPrefix(prefix netip.Prefix) netip.Prefix {
-	if !prefix.IsValid() {
-		return prefix // no canonical version of invalid prefix
+// canonicalPrefix returns the prefixCluster with its prefix in canonicalized form.
+// The canonical version of the prefix must be used for lookups in the metadata prefixCluster
+// map. The canonical representation of a prefix has the lower bits of the address always
+// zeroed out and does not contain any IPv4-mapped IPv6 address.
+func canonicalPrefix(prefixCluster cmtypes.PrefixCluster) cmtypes.PrefixCluster {
+	if !prefixCluster.AsPrefix().IsValid() {
+		return prefixCluster // no canonical version of invalid prefix
 	}
+
+	prefix := prefixCluster.AsPrefix()
+	clusterID := prefixCluster.ClusterID()
 
 	// Prefix() always zeroes out the lower bits
 	p, err := prefix.Addr().Unmap().Prefix(prefix.Bits())
 	if err != nil {
-		return prefix // no canonical version of invalid prefix
+		return prefixCluster // no canonical version of invalid prefix
 	}
 
-	return p
+	return cmtypes.NewPrefixCluster(p, clusterID)
 }
 
-func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource types.ResourceID, info ...IPMetadata) []netip.Prefix {
+func (m *metadata) upsertLocked(prefix cmtypes.PrefixCluster, src source.Source, resource types.ResourceID, info ...IPMetadata) []cmtypes.PrefixCluster {
 	prefix = canonicalPrefix(prefix)
 	changed := false
 	if _, ok := m.m[prefix]; !ok {
 		changed = true
 		m.m[prefix] = make(prefixInfo)
-		m.prefixes.Upsert(prefix, struct{}{})
+		m.prefixes.Upsert(clusterID(prefix.ClusterID()), prefix.AsPrefix(), struct{}{})
 	}
 	if _, ok := m.m[prefix][resource]; !ok {
 		changed = true
@@ -227,7 +235,10 @@ func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource
 	}
 
 	if m.m[prefix][resource].shouldLogConflicts() {
-		m.m[prefix].logConflicts(log.WithField(logfields.CIDR, prefix))
+		m.m[prefix].logConflicts(log.WithFields(logrus.Fields{
+			logfields.ClusterID: prefix.ClusterID(),
+			logfields.CIDR:      prefix.AsPrefix(),
+		}))
 	}
 
 	if !changed {
@@ -239,13 +250,13 @@ func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource
 
 // GetMetadataSourceByPrefix returns the highest precedence source which has
 // provided metadata for this prefix
-func (ipc *IPCache) GetMetadataSourceByPrefix(prefix netip.Prefix) source.Source {
+func (ipc *IPCache) GetMetadataSourceByPrefix(prefix cmtypes.PrefixCluster) source.Source {
 	ipc.metadata.RLock()
 	defer ipc.metadata.RUnlock()
 	return ipc.metadata.getLocked(prefix).Source()
 }
 
-func (m *metadata) getLocked(prefix netip.Prefix) prefixInfo {
+func (m *metadata) getLocked(prefix cmtypes.PrefixCluster) prefixInfo {
 	return m.m[canonicalPrefix(prefix)]
 }
 
@@ -257,14 +268,15 @@ func (m *metadata) getLocked(prefix netip.Prefix) prefixInfo {
 // - 10.1.0.0/16 -> "a=c"
 // - 10.1.1.0/24 -> "d=e"
 // the complete set of labels for 10.1.1.0/24 is [a=c, d=e, foo=bar]
-func (m *metadata) mergeParentLabels(lbls labels.Labels, prefix netip.Prefix) {
+func (m *metadata) mergeParentLabels(lbls labels.Labels, prefixCluster cmtypes.PrefixCluster) {
 	hasCIDR := lbls.HasSource(labels.LabelSourceCIDR) // we should only merge one CIDR label
 
 	// Iterate over all shorter prefixes, from `prefix` to 0.0.0.0/0 // ::/0.
 	// Merge all labels, preferring those from longer prefixes, but only merge a single "cidr:XXX" label at most.
+	prefix := prefixCluster.AsPrefix()
 	for bits := prefix.Bits() - 1; bits >= 0; bits-- {
 		parent, _ := prefix.Addr().Unmap().Prefix(bits) // canonical
-		if info, ok := m.m[parent]; ok {
+		if info, ok := m.m[cmtypes.NewPrefixCluster(parent, prefixCluster.ClusterID())]; ok {
 			for k, v := range info.ToLabels() {
 				if v.Source == labels.LabelSourceCIDR && hasCIDR {
 					continue
@@ -282,13 +294,13 @@ func (m *metadata) mergeParentLabels(lbls labels.Labels, prefix netip.Prefix) {
 
 // findAffectedChildPrefixes returns the list of all child prefixes which are
 // affected by an update to the parent prefix
-func (m *metadata) findAffectedChildPrefixes(parent netip.Prefix) (children []netip.Prefix) {
+func (m *metadata) findAffectedChildPrefixes(parent cmtypes.PrefixCluster) (children []cmtypes.PrefixCluster) {
 	if parent.IsSingleIP() {
-		return []netip.Prefix{parent} // no children
+		return []cmtypes.PrefixCluster{parent} // no children
 	}
 
-	m.prefixes.Descendants(parent, func(child netip.Prefix, _ struct{}) bool {
-		children = append(children, child)
+	m.prefixes.Descendants(clusterID(parent.ClusterID()), parent.AsPrefix(), func(child netip.Prefix, _ struct{}) bool {
+		children = append(children, cmtypes.NewPrefixCluster(child, parent.ClusterID()))
 		return true
 	})
 
@@ -316,7 +328,7 @@ func (m *metadata) findAffectedChildPrefixes(parent netip.Prefix) (children []ne
 // the caller must trigger forced policy regenerations on all endpoints.
 //
 // Do not call this directly; rather, use TriggerLabelInjection()
-func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip.Prefix) (remainingPrefixes []netip.Prefix, mutated bool, err error) {
+func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []cmtypes.PrefixCluster) (remainingPrefixes []cmtypes.PrefixCluster, mutated bool, err error) {
 	if ipc.IdentityAllocator == nil {
 		return modifiedPrefixes, false, ErrLocalIdentityAllocatorUninitialized
 	}
@@ -337,17 +349,17 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 	var (
 		// previouslyAllocatedIdentities maps IP Prefix -> Identity for
 		// old identities where the prefix will now map to a new identity
-		previouslyAllocatedIdentities = make(map[netip.Prefix]Identity)
+		previouslyAllocatedIdentities = make(map[cmtypes.PrefixCluster]Identity)
 		// idsToAdd stores the identities that must be updated via the
 		// selector cache.
 		idsToAdd    = make(map[identity.NumericIdentity]labels.LabelArray)
 		idsToDelete = make(map[identity.NumericIdentity]labels.LabelArray)
 		// entriesToReplace stores the identity to replace in the ipcache.
-		entriesToReplace = make(map[netip.Prefix]ipcacheEntry)
-		entriesToDelete  = make(map[netip.Prefix]Identity)
+		entriesToReplace = make(map[cmtypes.PrefixCluster]ipcacheEntry)
+		entriesToDelete  = make(map[cmtypes.PrefixCluster]Identity)
 		// unmanagedPrefixes is the set of prefixes for which we no longer have
 		// any metadata, but were created by a call directly to Upsert()
-		unmanagedPrefixes = make(map[netip.Prefix]Identity)
+		unmanagedPrefixes = make(map[cmtypes.PrefixCluster]Identity)
 	)
 
 	ipc.metadata.RLock()
@@ -529,8 +541,8 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 		// it is being deleted or changing IDs), we need to recompute the labels
 		// for reserved:host and push that to the SelectorCache
 		if entryExists && oldID.ID == identity.ReservedIdentityHost &&
-			(newID == nil || newID.ID != identity.ReservedIdentityHost) {
-			i := ipc.updateReservedHostLabels(prefix, nil)
+			(newID == nil || newID.ID != identity.ReservedIdentityHost) && prefix.ClusterID() == 0 {
+			i := ipc.updateReservedHostLabels(prefix.AsPrefix(), nil)
 			idsToAdd[i.ID] = i.Labels.LabelArray()
 		}
 
@@ -673,14 +685,15 @@ func (ipc *IPCache) UpdatePolicyMaps(ctx context.Context, addedIdentities, delet
 //   - If the entry is not inserted (for instance, because the bpf IPCache map
 //     already has the same IP -> identity entry in the map), immediately release
 //     the reference.
-func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, info prefixInfo, restoredIdentity identity.NumericIdentity) (*identity.Identity, bool, error) {
+func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix cmtypes.PrefixCluster, info prefixInfo, restoredIdentity identity.NumericIdentity) (*identity.Identity, bool, error) {
 	// Override identities always take precedence
 	if identityOverrideLabels, ok := info.identityOverride(); ok {
 		id, isNew, err := ipc.IdentityAllocator.AllocateIdentity(ctx, identityOverrideLabels, false, identity.InvalidIdentity)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
-				logfields.IPAddr: prefix,
-				logfields.Labels: identityOverrideLabels,
+				logfields.ClusterID: prefix.ClusterID(),
+				logfields.IPAddr:    prefix,
+				logfields.Labels:    identityOverrideLabels,
 			}).Warning("Failed to allocate new identity for prefix's IdentityOverrideLabels.")
 		}
 		return id, isNew, err
@@ -694,7 +707,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 	// Enforce certain label invariants, e.g. adding or removing `reserved:world`.
 	lbls = resolveLabels(prefix, lbls)
 
-	if lbls.HasHostLabel() {
+	if prefix.ClusterID() == 0 && lbls.HasHostLabel() {
 		// Associate any new labels with the host identity.
 		//
 		// This case is a bit special, because other parts of Cilium
@@ -714,7 +727,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 		// As an extra gotcha, we need need to merge all labels for all IPs
 		// that resolve to the reserved:host identity, otherwise we can
 		// flap identities labels depending on which prefix writes first. See GH-28259.
-		i := ipc.updateReservedHostLabels(prefix, lbls)
+		i := ipc.updateReservedHostLabels(prefix.AsPrefix(), lbls)
 		return i, false, nil
 	}
 
@@ -755,7 +768,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 //
 // However, nodes *are* allowed to be selectable by CIDR and CIDR equivalents
 // if PolicyCIDRMatchesNodes() is true.
-func resolveLabels(prefix netip.Prefix, lbls labels.Labels) labels.Labels {
+func resolveLabels(prefix cmtypes.PrefixCluster, lbls labels.Labels) labels.Labels {
 	out := labels.NewFrom(lbls)
 
 	isNode := lbls.HasRemoteNodeLabel() || lbls.HasHostLabel()
@@ -788,12 +801,12 @@ func resolveLabels(prefix netip.Prefix, lbls labels.Labels) labels.Labels {
 	// Add in (cidr:<address/prefix>) label as a fallback.
 	// This should not be hit in production, but is used in tests.
 	if len(out) == 0 {
-		out = labels.GetCIDRLabels(prefix)
+		out = labels.GetCIDRLabels(prefix.AsPrefix())
 	}
 
 	// add world if not in-cluster.
 	if !isInCluster {
-		out.AddWorldLabel(prefix.Addr())
+		out.AddWorldLabel(prefix.AsPrefix().Addr())
 	}
 
 	return out
@@ -845,13 +858,13 @@ func appendAPIServerLabelsForDeletion(lbls labels.Labels, currentLabels labels.L
 // these changes down into the policy engine and ipcache datapath maps.
 func (ipc *IPCache) RemoveLabelsExcluded(
 	lbls labels.Labels,
-	toExclude map[netip.Prefix]struct{},
+	toExclude map[cmtypes.PrefixCluster]struct{},
 	rid types.ResourceID,
 ) {
 	ipc.metadata.Lock()
 	defer ipc.metadata.Unlock()
 
-	var affectedPrefixes []netip.Prefix
+	var affectedPrefixes []cmtypes.PrefixCluster
 	oldSet := ipc.metadata.filterByLabels(lbls)
 	for _, ip := range oldSet {
 		if _, ok := toExclude[ip]; !ok {
@@ -868,8 +881,8 @@ func (ipc *IPCache) RemoveLabelsExcluded(
 // full match.
 //
 // Assumes that the ipcache metadata read lock is taken!
-func (m *metadata) filterByLabels(filter labels.Labels) []netip.Prefix {
-	var matching []netip.Prefix
+func (m *metadata) filterByLabels(filter labels.Labels) []cmtypes.PrefixCluster {
+	var matching []cmtypes.PrefixCluster
 	sortedFilter := filter.SortedList()
 	for prefix, info := range m.m {
 		lbls := info.ToLabels()
@@ -883,7 +896,7 @@ func (m *metadata) filterByLabels(filter labels.Labels) []netip.Prefix {
 // remove asynchronously removes the labels association for a prefix.
 //
 // This function assumes that the ipcache metadata lock is held for writing.
-func (m *metadata) remove(prefix netip.Prefix, resource types.ResourceID, aux ...IPMetadata) []netip.Prefix {
+func (m *metadata) remove(prefix cmtypes.PrefixCluster, resource types.ResourceID, aux ...IPMetadata) []cmtypes.PrefixCluster {
 	prefix = canonicalPrefix(prefix)
 	info, ok := m.m[prefix]
 	if !ok || info[resource] == nil {
@@ -902,7 +915,7 @@ func (m *metadata) remove(prefix netip.Prefix, resource types.ResourceID, aux ..
 	}
 	if !info.isValid() { // Labels empty, delete
 		delete(m.m, prefix)
-		m.prefixes.Delete(prefix)
+		m.prefixes.Delete(clusterID(prefix.ClusterID()), prefix.AsPrefix())
 	}
 
 	return affected
@@ -978,7 +991,7 @@ func (ipc *IPCache) handleLabelInjection(ctx context.Context) error {
 	}
 
 	// Any prefixes that have failed and must be retried
-	var retry []netip.Prefix
+	var retry []cmtypes.PrefixCluster
 	var err error
 
 	idsToModify, rev := ipc.metadata.dequeuePrefixUpdates()
@@ -999,7 +1012,7 @@ func (ipc *IPCache) handleLabelInjection(ctx context.Context) error {
 		chunk := idsToModify[0:idx]
 		idsToModify = idsToModify[idx:]
 
-		var failed []netip.Prefix
+		var failed []cmtypes.PrefixCluster
 
 		// If individual prefixes failed injection, doInjectLabels() the set of failed prefixes
 		// and sets err. We must ensure the failed prefixes are re-queued for injection.

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -351,7 +351,7 @@ func TestInjectExisting(t *testing.T) {
 	defer cancel()
 
 	// mimic fqdn policy:
-	// - NameManager.updateDNSIPs calls UpsertPrefixes() when then inserts them
+	// - NameManager.updateDNSIPs calls UpsertMetadataBatch() when then inserts them
 	//   via TriggerLabelInjection.
 	fqdnResourceID := types.NewResourceID(types.ResourceKindDaemon, "", "fqdn-name-manager")
 	prefix := netip.MustParsePrefix("172.19.0.5/32")
@@ -373,7 +373,7 @@ func TestInjectExisting(t *testing.T) {
 		types.ResourceKindEndpoint, "default", "kubernetes")
 	IPIdentityCache.metadata.upsertLocked(prefix, source.KubeAPIServer, resource, labels.LabelKubeAPIServer)
 
-	// Now, emulate a ToServices policy, which calls UpsertPrefixes
+	// Now, emulate a ToServices policy, which calls UpsertMetadataBatch
 	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, "policy-uid", labels.GetCIDRLabels(prefix))
 
 	// Now, the second half of UpsertLabels -- identity injection
@@ -450,7 +450,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.NotNil(t, id)
 	assert.Equal(t, 1, id.ReferenceCount)
 
-	// Simulate adding CIDR policy by simulating UpsertPrefixes
+	// Simulate adding CIDR policy by simulating UpsertMetadataBatch
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "policy-uid", labels.GetCIDRLabels(worldPrefix))
 	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -367,7 +367,7 @@ func TestInjectExisting(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, wantID, id.ID)
 
-	// Simulate the first half of UpsertLabels -- insert the labels only in to the metadata cache
+	// Simulate the first half of UpsertMetadata -- insert the labels only in to the metadata cache
 	// This is to "force" a race condition
 	resource := types.NewResourceID(
 		types.ResourceKindEndpoint, "default", "kubernetes")
@@ -376,7 +376,7 @@ func TestInjectExisting(t *testing.T) {
 	// Now, emulate a ToServices policy, which calls UpsertMetadataBatch
 	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, "policy-uid", labels.GetCIDRLabels(prefix))
 
-	// Now, the second half of UpsertLabels -- identity injection
+	// Now, the second half of UpsertMetadata -- identity injection
 	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(context.Background(), []netip.Prefix{prefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
@@ -483,7 +483,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.Equal(t, 1, id.ReferenceCount) // CIDR policy is left
 
 	// Simulate removing CIDR policy.
-	IPIdentityCache.RemoveLabels(worldPrefix, labels.Labels{}, "policy-uid")
+	IPIdentityCache.RemoveMetadata(worldPrefix, "policy-uid", labels.Labels{})
 	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -29,12 +30,12 @@ const (
 )
 
 var (
-	worldPrefix        = netip.MustParsePrefix("1.1.1.1/32")
-	inClusterPrefix    = netip.MustParsePrefix("10.0.0.4/32")
-	inClusterPrefix2   = netip.MustParsePrefix("10.0.0.5/32")
-	aPrefix            = netip.MustParsePrefix("100.4.16.32/32")
-	allIPv4CIDRsPrefix = netip.MustParsePrefix(ipv4All)
-	allIPv6CIDRsPrefix = netip.MustParsePrefix(ipv6All)
+	worldPrefix        = cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("1.1.1.1/32"))
+	inClusterPrefix    = cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.4/32"))
+	inClusterPrefix2   = cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.5/32"))
+	aPrefix            = cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("100.4.16.32/32"))
+	allIPv4CIDRsPrefix = cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix(ipv4All))
+	allIPv6CIDRsPrefix = cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix(ipv6All))
 )
 
 func TestInjectLabels(t *testing.T) {
@@ -52,7 +53,7 @@ func TestInjectLabels(t *testing.T) {
 	option.Config.PolicyCIDRMatchMode = []string{}
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, hostChanged, err := IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, hostChanged, err := IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.Empty(t, remaining)
 	assert.NoError(t, err)
 	assert.True(t, hostChanged)
@@ -62,7 +63,7 @@ func TestInjectLabels(t *testing.T) {
 	// a CIDR ID for this IP.
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServer)
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -75,7 +76,7 @@ func TestInjectLabels(t *testing.T) {
 	prefixes := IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "node-uid", labels.LabelRemoteNode)
 	assert.Len(t, prefixes, 1)
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -90,7 +91,7 @@ func TestInjectLabels(t *testing.T) {
 	// Insert another node, see that it gets the RemoteNode ID but not kube-apiserver
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix2, source.CustomResource, "node-uid", labels.LabelRemoteNode)
 	assert.Len(t, IPIdentityCache.metadata.m, 3)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix2})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -101,10 +102,10 @@ func TestInjectLabels(t *testing.T) {
 	option.Config.PolicyCIDRMatchMode = []string{"nodes"}
 
 	// Insert CIDR labels for the remote nodes (this is done by the node manager, but we need to test that it goes through)
-	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "node-uid-cidr", labels.GetCIDRLabels(inClusterPrefix))
-	IPIdentityCache.metadata.upsertLocked(inClusterPrefix2, source.CustomResource, "node-uid-cidr", labels.GetCIDRLabels(inClusterPrefix2))
+	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "node-uid-cidr", labels.GetCIDRLabels(inClusterPrefix.AsPrefix()))
+	IPIdentityCache.metadata.upsertLocked(inClusterPrefix2, source.CustomResource, "node-uid-cidr", labels.GetCIDRLabels(inClusterPrefix2.AsPrefix()))
 
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix, inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -134,7 +135,7 @@ func TestInjectLabels(t *testing.T) {
 	// Remove remote-node label, ensure transition to local cidr identity space
 	IPIdentityCache.metadata.remove(inClusterPrefix, "node-uid", overrideIdentity(false), labels.LabelRemoteNode)
 	IPIdentityCache.metadata.remove(inClusterPrefix2, "node-uid", overrideIdentity(false), labels.LabelRemoteNode)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix, inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -162,7 +163,7 @@ func TestInjectLabels(t *testing.T) {
 	IPIdentityCache.metadata.remove(inClusterPrefix, "node-uid-cidr", overrideIdentity(false), labels.Labels{})
 	IPIdentityCache.metadata.remove(inClusterPrefix2, "node-uid-cidr", overrideIdentity(false), labels.Labels{})
 	IPIdentityCache.metadata.remove(inClusterPrefix, "kube-uid", overrideIdentity(false), labels.LabelKubeAPIServer)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix, inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -172,7 +173,7 @@ func TestInjectLabels(t *testing.T) {
 	// reserved health ID.
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.Local, "node-uid", labels.LabelHealth)
 	assert.Len(t, IPIdentityCache.metadata.m, 2)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -184,7 +185,7 @@ func TestInjectLabels(t *testing.T) {
 	// reserved ingress ID.
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix2, source.Local, "node-uid", labels.LabelIngress)
 	assert.Len(t, IPIdentityCache.metadata.m, 3)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix2})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -193,7 +194,7 @@ func TestInjectLabels(t *testing.T) {
 	assert.Equal(t, identity.ReservedIdentityIngress, IPIdentityCache.ipToIdentityCache["10.0.0.5/32"].ID)
 	// Clean up.
 	IPIdentityCache.metadata.remove(inClusterPrefix2, "node-uid", overrideIdentity(false), labels.LabelIngress)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix2})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix2})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -204,14 +205,14 @@ func TestInjectLabels(t *testing.T) {
 	// within the cluster.
 	IPIdentityCache.metadata.upsertLocked(aPrefix, source.Generated, "cnp-uid", labels.LabelWorld)
 	assert.Len(t, IPIdentityCache.metadata.m, 3)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{aPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{aPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 3)
 	assert.True(t, IPIdentityCache.ipToIdentityCache["100.4.16.32/32"].ID.HasLocalScope())
 	IPIdentityCache.metadata.upsertLocked(aPrefix, source.CustomResource, "node-uid", labels.LabelRemoteNode)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{aPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{aPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -222,7 +223,7 @@ func TestInjectLabels(t *testing.T) {
 	// reserved world-ipv4 ID.
 	IPIdentityCache.metadata.upsertLocked(allIPv4CIDRsPrefix, source.Local, "daemon-uid", labels.LabelWorldIPv4)
 	assert.Len(t, IPIdentityCache.metadata.m, 4)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{allIPv4CIDRsPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{allIPv4CIDRsPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -234,7 +235,7 @@ func TestInjectLabels(t *testing.T) {
 	// reserved world-ipv6 ID.
 	IPIdentityCache.metadata.upsertLocked(allIPv6CIDRsPrefix, source.Local, "daemon-uid", labels.LabelWorldIPv6)
 	assert.Len(t, IPIdentityCache.metadata.m, 5)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{allIPv6CIDRsPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{allIPv6CIDRsPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -247,7 +248,7 @@ func TestInjectLabels(t *testing.T) {
 	option.Config.EnableIPv6 = false
 	IPIdentityCache.metadata.upsertLocked(allIPv4CIDRsPrefix, source.Local, "daemon-uid", labels.LabelWorld)
 	assert.Len(t, IPIdentityCache.metadata.m, 5)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{allIPv4CIDRsPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{allIPv4CIDRsPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -277,15 +278,15 @@ func TestUpdateLocalNode(t *testing.T) {
 		assert.Equal(t, lbls.LabelArray(), id)
 	}
 
-	injectLabels := func(ip netip.Prefix) {
+	injectLabels := func(ip cmtypes.PrefixCluster) {
 		t.Helper()
-		remaining, hostChanged, err := IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{ip})
+		remaining, hostChanged, err := IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{ip})
 		assert.NoError(t, err)
 		assert.True(t, hostChanged)
 		assert.Empty(t, remaining)
 	}
 
-	idIs := func(ip netip.Prefix, id identity.NumericIdentity) {
+	idIs := func(ip cmtypes.PrefixCluster, id identity.NumericIdentity) {
 		t.Helper()
 		assert.Equal(t, IPIdentityCache.ipToIdentityCache[ip.String()].ID, id)
 	}
@@ -354,9 +355,9 @@ func TestInjectExisting(t *testing.T) {
 	// - NameManager.updateDNSIPs calls UpsertMetadataBatch() when then inserts them
 	//   via TriggerLabelInjection.
 	fqdnResourceID := types.NewResourceID(types.ResourceKindDaemon, "", "fqdn-name-manager")
-	prefix := netip.MustParsePrefix("172.19.0.5/32")
+	prefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("172.19.0.5/32"))
 	IPIdentityCache.metadata.upsertLocked(prefix, source.Generated, fqdnResourceID)
-	remaining, hostChanged, err := IPIdentityCache.doInjectLabels(context.Background(), []netip.Prefix{prefix})
+	remaining, hostChanged, err := IPIdentityCache.doInjectLabels(context.Background(), []cmtypes.PrefixCluster{prefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -374,10 +375,10 @@ func TestInjectExisting(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(prefix, source.KubeAPIServer, resource, labels.LabelKubeAPIServer)
 
 	// Now, emulate a ToServices policy, which calls UpsertMetadataBatch
-	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, "policy-uid", labels.GetCIDRLabels(prefix))
+	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, "policy-uid", labels.GetCIDRLabels(prefix.AsPrefix()))
 
 	// Now, the second half of UpsertMetadata -- identity injection
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(context.Background(), []netip.Prefix{prefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(context.Background(), []cmtypes.PrefixCluster{prefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -397,8 +398,14 @@ func TestFilterMetadataByLabels(t *testing.T) {
 	cancel := setupTest(t)
 	defer cancel()
 
-	IPIdentityCache.metadata.upsertLocked(netip.MustParsePrefix("2.1.1.1/32"), source.Generated, "gen-uid", labels.LabelWorld)
-	IPIdentityCache.metadata.upsertLocked(netip.MustParsePrefix("3.1.1.1/32"), source.Generated, "gen-uid-2", labels.LabelWorld)
+	IPIdentityCache.metadata.upsertLocked(
+		cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("2.1.1.1/32")),
+		source.Generated, "gen-uid", labels.LabelWorld,
+	)
+	IPIdentityCache.metadata.upsertLocked(
+		cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("3.1.1.1/32")),
+		source.Generated, "gen-uid-2", labels.LabelWorld,
+	)
 
 	assert.Len(t, IPIdentityCache.metadata.filterByLabels(labels.LabelKubeAPIServer), 1)
 	assert.Len(t, IPIdentityCache.metadata.filterByLabels(labels.LabelWorld), 2)
@@ -410,7 +417,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	ctx := context.Background()
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, hostChanged, err := IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, hostChanged, err := IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.True(t, hostChanged)
@@ -419,13 +426,13 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// Attempting to remove a label for a ResourceID which does not exist
 	// should not remove anything.
 	IPIdentityCache.RemoveLabelsExcluded(
-		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
+		labels.LabelKubeAPIServer, map[cmtypes.PrefixCluster]struct{}{},
 		"foo")
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
 	assert.Contains(t, IPIdentityCache.metadata.m[worldPrefix].ToLabels(), labels.IDNameKubeAPIServer)
 
 	IPIdentityCache.RemoveLabelsExcluded(
-		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
+		labels.LabelKubeAPIServer, map[cmtypes.PrefixCluster]struct{}{},
 		"kube-uid")
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
 	assert.Equal(t, labels.LabelHost, IPIdentityCache.metadata.m[worldPrefix].ToLabels())
@@ -439,7 +446,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	// the cluster, and thus will have a CIDR identity when InjectLabels() is
 	// called.
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "kube-uid", labels.LabelKubeAPIServer)
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.True(t, hostChanged)
@@ -451,8 +458,8 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.Equal(t, 1, id.ReferenceCount)
 
 	// Simulate adding CIDR policy by simulating UpsertMetadataBatch
-	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "policy-uid", labels.GetCIDRLabels(worldPrefix))
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "policy-uid", labels.GetCIDRLabels(worldPrefix.AsPrefix()))
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Zero(t, remaining)
 	assert.False(t, hostChanged)
@@ -467,9 +474,9 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 
 	// Remove kube-apiserver label
 	IPIdentityCache.RemoveLabelsExcluded(
-		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
+		labels.LabelKubeAPIServer, map[cmtypes.PrefixCluster]struct{}{},
 		"kube-uid")
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -484,7 +491,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 
 	// Simulate removing CIDR policy.
 	IPIdentityCache.RemoveMetadata(worldPrefix, "policy-uid", labels.Labels{})
-	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, hostChanged, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.False(t, hostChanged)
@@ -504,15 +511,15 @@ func TestRemoveAPIServerIdentityExternal(t *testing.T) {
 	ctx := context.Background()
 
 	assert.Len(t, IPIdentityCache.metadata.m, 1)
-	remaining, _, err := IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, _, err := IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
 	IPIdentityCache.RemoveLabelsExcluded(
-		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
+		labels.LabelKubeAPIServer, map[cmtypes.PrefixCluster]struct{}{},
 		"kube-uid")
-	remaining, _, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, _, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, IPIdentityCache.metadata.m)
 	assert.Empty(t, remaining)
@@ -543,7 +550,7 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Create CIDR identity from labels
 	ipc.metadata.upsertLocked(worldPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServer)
-	remaining, _, err := ipc.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, _, err := ipc.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
@@ -554,7 +561,7 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Force an identity override
 	ipc.metadata.upsertLocked(worldPrefix, source.CustomResource, "cep-uid", overrideIdentity(true), fooLabels)
-	remaining, _, err = ipc.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, _, err = ipc.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
@@ -565,7 +572,7 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Remove identity override from prefix, should assign a CIDR identity again
 	ipc.metadata.remove(worldPrefix, "cep-uid", overrideIdentity(true), fooLabels)
-	remaining, _, err = ipc.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, _, err = ipc.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
@@ -577,7 +584,7 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Remove remaining labels from prefix, this should remove the entry
 	ipc.metadata.remove(worldPrefix, "kube-uid", labels.LabelKubeAPIServer)
-	remaining, _, err = ipc.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, _, err = ipc.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
@@ -586,13 +593,13 @@ func TestOverrideIdentity(t *testing.T) {
 
 	// Create a new entry again via override
 	ipc.metadata.upsertLocked(worldPrefix, source.CustomResource, "cep-uid", overrideIdentity(true), barLabels)
-	remaining, _, err = ipc.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, _, err = ipc.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
 	// Add labels, those will be ignored due to override
 	ipc.metadata.upsertLocked(worldPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServer)
-	remaining, _, err = ipc.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, _, err = ipc.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
@@ -604,7 +611,7 @@ func TestOverrideIdentity(t *testing.T) {
 	// Remove all metadata at once, this should remove the whole entry
 	ipc.metadata.remove(worldPrefix, "kube-uid", labels.LabelKubeAPIServer)
 	ipc.metadata.remove(worldPrefix, "cep-uid", overrideIdentity(true), barLabels)
-	remaining, _, err = ipc.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	remaining, _, err = ipc.doInjectLabels(ctx, []cmtypes.PrefixCluster{worldPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
@@ -622,7 +629,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "node-uid",
 		types.TunnelPeer{Addr: netip.MustParseAddr("192.168.1.100")},
 		types.EncryptKey(7))
-	remaining, _, err := IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, _, err := IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
@@ -636,7 +643,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.Generated, "generated-uid",
 		types.TunnelPeer{Addr: netip.MustParseAddr("192.168.1.101")},
 		types.EncryptKey(6))
-	_, _, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	_, _, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix})
 	assert.NoError(t, err)
 	ip, key = IPIdentityCache.getHostIPCacheRLocked(inClusterPrefix.String())
 	assert.Equal(t, "192.168.1.100", ip.String())
@@ -645,7 +652,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	// Remove the entry with the encryptKey=7 and encryptKey=6.
 	IPIdentityCache.metadata.remove(inClusterPrefix, "node-uid", types.EncryptKey(7))
 	IPIdentityCache.metadata.remove(inClusterPrefix, "generated-uid", types.EncryptKey(6))
-	remaining, _, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, _, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
@@ -662,7 +669,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.KubeAPIServer, "kube-uid",
 		labels.LabelKubeAPIServer,
 	)
-	remaining, _, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	remaining, _, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix})
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
@@ -672,7 +679,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 		types.TunnelPeer{Addr: netip.MustParseAddr("192.168.1.101")},
 		types.EncryptKey(6),
 	)
-	_, _, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
+	_, _, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix})
 	assert.NoError(t, err)
 	ip, key = IPIdentityCache.getHostIPCacheRLocked(inClusterPrefix.String())
 	assert.Equal(t, "192.168.1.101", ip.String())
@@ -686,14 +693,14 @@ func TestRequestIdentity(t *testing.T) {
 	cancel := setupTest(t)
 	cancel()
 
-	injectLabels := func(prefixes ...netip.Prefix) {
+	injectLabels := func(prefixes ...cmtypes.PrefixCluster) {
 		t.Helper()
 		remaining, _, err := IPIdentityCache.doInjectLabels(context.Background(), prefixes)
 		assert.NoError(t, err)
 		assert.Empty(t, remaining)
 	}
 
-	hasIdentity := func(prefix netip.Prefix, nid identity.NumericIdentity) {
+	hasIdentity := func(prefix cmtypes.PrefixCluster, nid identity.NumericIdentity) {
 		t.Helper()
 		id, _ := IPIdentityCache.LookupByPrefix(prefix.String())
 		assert.EqualValues(t, nid, id.ID)
@@ -726,18 +733,18 @@ func TestInjectFailedAllocate(t *testing.T) {
 	ipc := IPIdentityCache
 	cancel()
 
-	ipc.metadata.upsertLocked(inClusterPrefix, source.Restored, "daemon-uid", labels.GetCIDRLabels(inClusterPrefix))
-	ipc.metadata.upsertLocked(inClusterPrefix2, source.Restored, "daemon-uid", labels.GetCIDRLabels(inClusterPrefix2))
+	ipc.metadata.upsertLocked(inClusterPrefix, source.Restored, "daemon-uid", labels.GetCIDRLabels(inClusterPrefix.AsPrefix()))
+	ipc.metadata.upsertLocked(inClusterPrefix2, source.Restored, "daemon-uid", labels.GetCIDRLabels(inClusterPrefix2.AsPrefix()))
 
-	Allocator.Reject(labels.GetCIDRLabels(inClusterPrefix))
-	remaining, _, err := ipc.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
+	Allocator.Reject(labels.GetCIDRLabels(inClusterPrefix.AsPrefix()))
+	remaining, _, err := ipc.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix, inClusterPrefix2})
 	require.Error(t, err)
 	require.Len(t, remaining, 2)
 
-	Allocator.Unreject(labels.GetCIDRLabels(inClusterPrefix))
-	Allocator.Reject(labels.GetCIDRLabels(inClusterPrefix2))
+	Allocator.Unreject(labels.GetCIDRLabels(inClusterPrefix.AsPrefix()))
+	Allocator.Reject(labels.GetCIDRLabels(inClusterPrefix2.AsPrefix()))
 
-	remaining, _, err = ipc.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
+	remaining, _, err = ipc.doInjectLabels(ctx, []cmtypes.PrefixCluster{inClusterPrefix, inClusterPrefix2})
 	require.Error(t, err)
 	require.Len(t, remaining, 1)
 }
@@ -756,8 +763,8 @@ func TestHandleLabelInjection(t *testing.T) {
 	ipc := IPIdentityCache
 	cancel()
 
-	ipc.metadata.upsertLocked(inClusterPrefix, source.Restored, "daemon-uid", labels.GetCIDRLabels(inClusterPrefix))
-	ipc.metadata.upsertLocked(inClusterPrefix2, source.Restored, "daemon-uid", labels.GetCIDRLabels(inClusterPrefix2))
+	ipc.metadata.upsertLocked(inClusterPrefix, source.Restored, "daemon-uid", labels.GetCIDRLabels(inClusterPrefix.AsPrefix()))
+	ipc.metadata.upsertLocked(inClusterPrefix2, source.Restored, "daemon-uid", labels.GetCIDRLabels(inClusterPrefix2.AsPrefix()))
 	ipc.metadata.enqueuePrefixUpdates(inClusterPrefix, inClusterPrefix2)
 
 	// Removing the allocator will cause injection to fail
@@ -773,7 +780,7 @@ func TestHandleLabelInjection(t *testing.T) {
 
 	// enable allocation, but reject one of the prefixes
 	ipc.IdentityAllocator = Allocator
-	Allocator.Reject(labels.GetCIDRLabels(inClusterPrefix))
+	Allocator.Reject(labels.GetCIDRLabels(inClusterPrefix.AsPrefix()))
 
 	err = ipc.handleLabelInjection(ctx)
 	// May be 1 or 2 pending prefixes, depending on which came first
@@ -782,7 +789,7 @@ func TestHandleLabelInjection(t *testing.T) {
 	require.Error(t, err)
 	require.NotContains(t, ipc.ipToIdentityCache, inClusterPrefix.String())
 
-	Allocator.Unreject(labels.GetCIDRLabels(inClusterPrefix))
+	Allocator.Unreject(labels.GetCIDRLabels(inClusterPrefix.AsPrefix()))
 
 	// No more issues, we should succeed
 	err = ipc.handleLabelInjection(ctx)
@@ -797,8 +804,8 @@ func TestHandleLabelInjection(t *testing.T) {
 func TestMetadataRevision(t *testing.T) {
 	m := newMetadata()
 
-	p1 := netip.MustParsePrefix("1.1.1.1/32")
-	p2 := netip.MustParsePrefix("1::1/128")
+	p1 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("1.1.1.1/32"))
+	p2 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("1::1/128"))
 
 	rev := m.enqueuePrefixUpdates(p1)
 	assert.Equal(t, uint64(1), rev)
@@ -851,15 +858,16 @@ func TestUpsertMetadataInheritedCIDRPrefix(t *testing.T) {
 	ctx := context.Background()
 
 	// Simulate CIDR policy
-	parent := netip.MustParsePrefix("10.0.0.0/8")
-	prefixes := IPIdentityCache.metadata.upsertLocked(parent, source.Kubernetes, "cidr-policy", labels.GetCIDRLabels(parent))
+	parent := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.0/8"))
+	prefixes := IPIdentityCache.metadata.upsertLocked(parent, source.Kubernetes, "cidr-policy", labels.GetCIDRLabels(parent.AsPrefix()))
+
 	remaining, _, err := IPIdentityCache.doInjectLabels(ctx, prefixes)
 	require.NoError(t, err)
 	require.Empty(t, remaining)
 
 	// Simulate first FQDN lookup
 	fqdnLabels := labels.NewLabelsFromSortedList("fqdn:*.internal")
-	child := netip.MustParsePrefix("10.10.0.1/32")
+	child := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.10.0.1/32"))
 	prefixes = IPIdentityCache.metadata.upsertLocked(child, source.Generated, "fqdn-lookup", fqdnLabels)
 	remaining, _, err = IPIdentityCache.doInjectLabels(ctx, prefixes)
 	require.NoError(t, err)
@@ -872,7 +880,7 @@ func TestUpsertMetadataInheritedCIDRPrefix(t *testing.T) {
 	require.Equal(t, "cidr:10.0.0.0/8,fqdn:*.internal,reserved:world-ipv4", ident.Labels.String())
 
 	// Add second fqdn ip, it should get the same identity
-	sibling := netip.MustParsePrefix("10.10.0.2/32")
+	sibling := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.10.0.2/32"))
 	prefixes = IPIdentityCache.metadata.upsertLocked(sibling, source.Generated, "fqdn-lookup", fqdnLabels)
 	remaining, _, err = IPIdentityCache.doInjectLabels(ctx, prefixes)
 	require.NoError(t, err)
@@ -899,8 +907,8 @@ func TestUpsertMetadataInheritedCIDRPrefix(t *testing.T) {
 	require.Equal(t, id.ID, newID.ID)
 
 	// Re-add different CIDR policy
-	parent = netip.MustParsePrefix("10.10.0.0/16")
-	prefixes = IPIdentityCache.metadata.upsertLocked(parent, source.Kubernetes, "cidr-policy", labels.GetCIDRLabels(parent))
+	parent = cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.10.0.0/16"))
+	prefixes = IPIdentityCache.metadata.upsertLocked(parent, source.Kubernetes, "cidr-policy", labels.GetCIDRLabels(parent.AsPrefix()))
 	remaining, _, err = IPIdentityCache.doInjectLabels(ctx, prefixes)
 	require.NoError(t, err)
 	require.Empty(t, remaining)
@@ -1043,13 +1051,13 @@ func TestResolveIdentity(t *testing.T) {
 
 			for pfx, lstr := range tc.prefixes {
 				lbls := labels.NewLabelsFromSortedList(lstr)
-				prefix := netip.MustParsePrefix(pfx)
+				prefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix(pfx))
 				IPIdentityCache.metadata.upsertLocked(prefix, source.Generated, "tc", lbls)
 			}
 
 			for pfx, lstr := range tc.expected {
 				lbls := labels.NewLabelsFromSortedList(lstr)
-				prefix := netip.MustParsePrefix(pfx)
+				prefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix(pfx))
 				info := IPIdentityCache.metadata.getLocked(prefix)
 				require.NotNil(t, info)
 				id, _, err := IPIdentityCache.resolveIdentity(context.Background(), prefix, info, 0)
@@ -1068,12 +1076,12 @@ func TestResolveIdentity(t *testing.T) {
 // TestUpsertMetadataCIDRGroup tests that cidr group labels
 // propagate down to all CIDRs
 func TestUpsertMetadataCIDRGroup(t *testing.T) {
-	p1 := netip.MustParsePrefix("10.0.0.0/8")
-	p2 := netip.MustParsePrefix("10.0.0.0/16")
-	p3 := netip.MustParsePrefix("10.0.0.0/24")
-	p4 := netip.MustParsePrefix("10.0.0.0/25")
-	p5 := netip.MustParsePrefix("10.0.0.0/26")
-	p6 := netip.MustParsePrefix("10.0.0.0/27")
+	p1 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.0/8"))
+	p2 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.0/16"))
+	p3 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.0/24"))
+	p4 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.0/25"))
+	p5 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.0/26"))
+	p6 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.0/27"))
 
 	cancel := setupTest(t)
 	defer cancel()
@@ -1084,7 +1092,7 @@ func TestUpsertMetadataCIDRGroup(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(p2, source.Generated, "r1", labels.NewLabelsFromSortedList("cidrgroup:b="))
 	IPIdentityCache.metadata.upsertLocked(p3, source.Generated, "r1", labels.NewLabelsFromSortedList("cidrgroup:c="))
 
-	_, _, err := IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{p1, p2, p3})
+	_, _, err := IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{p1, p2, p3})
 	require.NoError(t, err)
 
 	hasLabels := func(prefix netip.Prefix, wantl string) {
@@ -1098,21 +1106,21 @@ func TestUpsertMetadataCIDRGroup(t *testing.T) {
 		require.Equal(t, wantlbls, id.Labels)
 	}
 
-	hasLabels(p1, "cidrgroup:a=;reserved:world-ipv4=")
-	hasLabels(p2, "cidrgroup:a=;cidrgroup:b=;reserved:world-ipv4=")
-	hasLabels(p3, "cidrgroup:a=;cidrgroup:b=;cidrgroup:c=;reserved:world-ipv4=")
+	hasLabels(p1.AsPrefix(), "cidrgroup:a=;reserved:world-ipv4=")
+	hasLabels(p2.AsPrefix(), "cidrgroup:a=;cidrgroup:b=;reserved:world-ipv4=")
+	hasLabels(p3.AsPrefix(), "cidrgroup:a=;cidrgroup:b=;cidrgroup:c=;reserved:world-ipv4=")
 
 	// Now, test overlapping CIDR, CIDRGroup, and FQDN labels
-	IPIdentityCache.metadata.upsertLocked(p4, source.Generated, "r1", labels.GetCIDRLabels(p4))
-	IPIdentityCache.metadata.upsertLocked(p5, source.Generated, "r1", labels.GetCIDRLabels(p5))
+	IPIdentityCache.metadata.upsertLocked(p4, source.Generated, "r1", labels.GetCIDRLabels(p4.AsPrefix()))
+	IPIdentityCache.metadata.upsertLocked(p5, source.Generated, "r1", labels.GetCIDRLabels(p5.AsPrefix()))
 	IPIdentityCache.metadata.upsertLocked(p6, source.Generated, "r1", labels.NewLabelsFromSortedList("fqdn:*.cilium.io="))
 
-	_, _, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{p4, p5, p6})
+	_, _, err = IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{p4, p5, p6})
 	require.NoError(t, err)
 
-	hasLabels(p4, "cidr:10.0.0.0/25=;cidrgroup:a=;cidrgroup:b=;cidrgroup:c=;reserved:world-ipv4=")
-	hasLabels(p5, "cidr:10.0.0.0/26=;cidrgroup:a=;cidrgroup:b=;cidrgroup:c=;reserved:world-ipv4=")
-	hasLabels(p6, "cidr:10.0.0.0/26=;cidrgroup:a=;cidrgroup:b=;cidrgroup:c=;reserved:world-ipv4=;fqdn:*.cilium.io=")
+	hasLabels(p4.AsPrefix(), "cidr:10.0.0.0/25=;cidrgroup:a=;cidrgroup:b=;cidrgroup:c=;reserved:world-ipv4=")
+	hasLabels(p5.AsPrefix(), "cidr:10.0.0.0/26=;cidrgroup:a=;cidrgroup:b=;cidrgroup:c=;reserved:world-ipv4=")
+	hasLabels(p6.AsPrefix(), "cidr:10.0.0.0/26=;cidrgroup:a=;cidrgroup:b=;cidrgroup:c=;reserved:world-ipv4=;fqdn:*.cilium.io=")
 
 }
 
@@ -1192,33 +1200,33 @@ func (m *mockTriggerer) UpdatePolicyMaps(ctx context.Context, wg *sync.WaitGroup
 func Test_canonicalPrefix(t *testing.T) {
 	tests := []struct {
 		name   string
-		prefix netip.Prefix
-		want   netip.Prefix
+		prefix cmtypes.PrefixCluster
+		want   cmtypes.PrefixCluster
 	}{
 		{
 			name:   "identity",
-			prefix: netip.MustParsePrefix("10.10.10.10/32"),
-			want:   netip.MustParsePrefix("10.10.10.10/32"),
+			prefix: cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.10.10.10/32")),
+			want:   cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.10.10.10/32")),
 		},
 		{
 			name:   "masked",
-			prefix: netip.MustParsePrefix("10.10.10.10/16"),
-			want:   netip.MustParsePrefix("10.10.0.0/16"),
+			prefix: cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.10.10.10/16")),
+			want:   cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.10.0.0/16")),
 		},
 		{
 			name:   "v4inv6",
-			prefix: netip.MustParsePrefix("::ffff:10.10.10.10/24"),
-			want:   netip.MustParsePrefix("10.10.10.0/24"),
+			prefix: cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("::ffff:10.10.10.10/24")),
+			want:   cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.10.10.0/24")),
 		},
 		{
 			name:   "ipv6",
-			prefix: netip.MustParsePrefix("2001:db8::dead/32"),
-			want:   netip.MustParsePrefix("2001:db8::/32"),
+			prefix: cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("2001:db8::dead/32")),
+			want:   cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("2001:db8::/32")),
 		},
 		{
 			name:   "invalid",
-			prefix: netip.PrefixFrom(netip.MustParseAddr("::ffff:10.10.10.10"), -1),
-			want:   netip.PrefixFrom(netip.MustParseAddr("::ffff:10.10.10.10"), -1),
+			prefix: cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(netip.MustParseAddr("::ffff:10.10.10.10"), -1)),
+			want:   cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(netip.MustParseAddr("::ffff:10.10.10.10"), -1)),
 		},
 	}
 	for _, tt := range tests {
@@ -1310,7 +1318,7 @@ func Test_metadata_mergeParentLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := newMetadata()
 			for prefix, lbls := range tt.existing {
-				pfx := netip.MustParsePrefix(prefix)
+				pfx := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix(prefix))
 				m.m[pfx] = prefixInfo{
 					"resource": {
 						labels: lbls,
@@ -1318,7 +1326,7 @@ func Test_metadata_mergeParentLabels(t *testing.T) {
 				}
 			}
 
-			pfx := netip.MustParsePrefix(tt.prefix)
+			pfx := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix(tt.prefix))
 
 			lbls := m.getLocked(pfx).ToLabels()
 			m.mergeParentLabels(lbls, pfx)
@@ -1331,8 +1339,8 @@ func Test_metadata_mergeParentLabels(t *testing.T) {
 func BenchmarkManyResources(b *testing.B) {
 	m := newMetadata()
 
-	prefix := netip.MustParsePrefix("1.1.1.1/32")
-	lbls := labels.GetCIDRLabels(prefix)
+	prefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("1.1.1.1/32"))
+	lbls := labels.GetCIDRLabels(prefix.AsPrefix())
 
 	for i := range b.N {
 		resource := types.NewResourceID(types.ResourceKindCNP, fmt.Sprintf("namespace_%d", i), "my-policy")

--- a/pkg/k8s/watchers/endpoints.go
+++ b/pkg/k8s/watchers/endpoints.go
@@ -167,6 +167,6 @@ func (k *K8sEndpointsWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map
 	)
 
 	for ip := range desiredIPs {
-		k.ipcache.UpsertLabels(ip, labels.LabelKubeAPIServer, src, rid)
+		k.ipcache.UpsertMetadata(ip, src, rid, labels.LabelKubeAPIServer)
 	}
 }

--- a/pkg/k8s/watchers/endpoints.go
+++ b/pkg/k8s/watchers/endpoints.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -124,10 +125,10 @@ func (k *K8sEndpointsWatcher) addKubeAPIServerServiceEndpoints(eps *k8s.Endpoint
 		eps.ObjectMeta.GetNamespace(),
 		eps.ObjectMeta.GetName(),
 	)
-	desiredIPs := make(map[netip.Prefix]struct{})
+	desiredIPs := make(map[cmtypes.PrefixCluster]struct{})
 	for addrCluster := range eps.Backends {
 		addr := addrCluster.Addr()
-		desiredIPs[netip.PrefixFrom(addr, addr.BitLen())] = struct{}{}
+		desiredIPs[cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(addr, addr.BitLen()))] = struct{}{}
 	}
 	k.handleKubeAPIServerServiceEPChanges(desiredIPs, resource)
 }
@@ -142,7 +143,7 @@ func (k *K8sEndpointsWatcher) addKubeAPIServerServiceEndpoints(eps *k8s.Endpoint
 //
 // The actual implementation of this logic down to the datapath is handled
 // asynchronously.
-func (k *K8sEndpointsWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[netip.Prefix]struct{}, rid ipcacheTypes.ResourceID) {
+func (k *K8sEndpointsWatcher) handleKubeAPIServerServiceEPChanges(desiredIPs map[cmtypes.PrefixCluster]struct{}, rid ipcacheTypes.ResourceID) {
 	src := source.KubeAPIServer
 
 	// We must perform a diff on the ipcache.identityMetadata map in order to

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -108,7 +108,7 @@ type ipcacheManager interface {
 	LookupByIP(IP string) (ipcache.Identity, bool)
 	Delete(IP string, source source.Source) (namedPortsChanged bool)
 
-	UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcacheTypes.ResourceID)
+	UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
 	RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcacheTypes.ResourceID)
 	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool)
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"net/netip"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -108,8 +108,8 @@ type ipcacheManager interface {
 	LookupByIP(IP string) (ipcache.Identity, bool)
 	Delete(IP string, source source.Source) (namedPortsChanged bool)
 
-	UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
-	RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcacheTypes.ResourceID)
+	UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
+	RemoveLabelsExcluded(lbls labels.Labels, toExclude map[cmtypes.PrefixCluster]struct{}, resource ipcacheTypes.ResourceID)
 	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool)
 }
 

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -91,21 +92,21 @@ func (i *ipcacheMock) Delete(ip string, source source.Source) bool {
 	return false
 }
 
-func (i *ipcacheMock) GetMetadataSourceByPrefix(prefix netip.Prefix) source.Source {
+func (i *ipcacheMock) GetMetadataSourceByPrefix(prefix cmtypes.PrefixCluster) source.Source {
 	return source.Unspec
 }
-func (i *ipcacheMock) UpsertMetadata(prefix netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
+func (i *ipcacheMock) UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
 	i.Upsert(prefix.String(), nil, 0, nil, ipcache.Identity{})
 }
-func (i *ipcacheMock) OverrideIdentity(prefix netip.Prefix, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
+func (i *ipcacheMock) OverrideIdentity(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
 	i.UpsertMetadata(prefix, src, resource)
 }
 
-func (i *ipcacheMock) RemoveMetadata(prefix netip.Prefix, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
+func (i *ipcacheMock) RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
 	i.Delete(prefix.String(), source.CustomResource)
 }
 
-func (i *ipcacheMock) RemoveIdentityOverride(prefix netip.Prefix, identityLabels labels.Labels, resource ipcacheTypes.ResourceID) {
+func (i *ipcacheMock) RemoveIdentityOverride(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, resource ipcacheTypes.ResourceID) {
 	i.Delete(prefix.String(), source.CustomResource)
 }
 

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/hive/job"
 	"github.com/cilium/stream"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
@@ -165,7 +166,7 @@ func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policyty
 		if resource == ResourceIDAnonymous {
 			for _, prefix := range newPrefixes {
 				ipcUpdates = append(ipcUpdates, ipcache.MU{
-					Prefix:   prefix,
+					Prefix:   cmtypes.NewLocalPrefixCluster(prefix),
 					Source:   prefixSource[resource],
 					Resource: resource,
 					Metadata: []ipcache.IPMetadata{labels.GetCIDRLabels(prefix)},
@@ -197,7 +198,7 @@ func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policyty
 			}
 
 			ipcUpdates = append(ipcUpdates, ipcache.MU{
-				Prefix:   prefix,
+				Prefix:   cmtypes.NewLocalPrefixCluster(prefix),
 				Source:   prefixSource[resource],
 				Resource: resource,
 				Metadata: []ipcache.IPMetadata{labels.GetCIDRLabels(prefix)},
@@ -241,7 +242,7 @@ func (i *policyImporter) prunePrefixes(prunePrefixes map[ipcachetypes.ResourceID
 		// Prune all stale prefixes
 		for _, oldPrefix := range oldPrefixes {
 			ipcUpdates = append(ipcUpdates, ipcache.MU{
-				Prefix:   oldPrefix,
+				Prefix:   cmtypes.NewLocalPrefixCluster(oldPrefix),
 				Resource: resource,
 				Metadata: []ipcache.IPMetadata{labels.Labels{}},
 			})

--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -9,6 +9,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	cilium_v2_alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -97,7 +98,7 @@ func (p *policyWatcher) applyCIDRGroup(name string) {
 		cidrLbls.AddWorldLabel(newCIDR.Addr())
 
 		mu = append(mu, ipcache.MU{
-			Prefix:   newCIDR,
+			Prefix:   cmtypes.NewLocalPrefixCluster(newCIDR),
 			Source:   source.Generated,
 			Resource: resourceID,
 			Metadata: []ipcache.IPMetadata{cidrLbls},
@@ -111,7 +112,7 @@ func (p *policyWatcher) applyCIDRGroup(name string) {
 	mu = make([]ipcache.MU, 0, len(oldCIDRs))
 	for oldCIDR := range oldCIDRs {
 		mu = append(mu, ipcache.MU{
-			Prefix:   oldCIDR,
+			Prefix:   cmtypes.NewLocalPrefixCluster(oldCIDR),
 			Source:   source.Generated,
 			Resource: resourceID,
 			Metadata: []ipcache.IPMetadata{labels.Labels{}},

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -52,13 +52,6 @@ func (m *MockIPCache) DeleteOnMetadataMatch(IP string, source source.Source, nam
 	return false
 }
 
-func (m *MockIPCache) UpsertPrefixes(prefixes []netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID) uint64 {
-	return 0
-}
-
-func (m *MockIPCache) RemovePrefixes(prefixes []netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID) {
-}
-
 func (m *MockIPCache) UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64) {
 	return 0
 }

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -42,9 +42,6 @@ func (m *MockIPCache) Delete(IP string, source source.Source) (namedPortsChanged
 	return false
 }
 
-func (m *MockIPCache) UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
-}
-
 func (m *MockIPCache) RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcacheTypes.ResourceID) {
 }
 


### PR DESCRIPTION
The clusterID is already part of the ipcache BPF map key. That allows to support a multiple clusters scenario where the ipcache may store multiple entries with the same prefix but different clusterIDs.

The controlplane part of the ipcache allows to specificy a clusterID when upserting an address only with the legacy sync api, that is, through the `Upsert` method. But it lacks support to do the same with the new async api (`UpsertMetadata`, `RemoveMetadata` and so on).

The async api works internally by enqueuing multiple metadata updates, and then reconciling them to emit a set of changes to the underlying BPF map. A CIDRTrie is used to store the upserted prefixes and to efficiently find the affected child prefixes for each metadata upsertion or removal.

To support the multi-clusterID case, the CIDRTrie is changed to a map of CIDRTries, in order to keep one separate trie for each clusterID. Then, the async api are updated to accept a `PrefixCluster` instead of a bare prefix.

The remaining changes update all the ipcache users to pass a clusterID alongside the prefix. For now the clusterID is always set to 0, that is, the prefixes are all considered as local to the cluster.

The ability to specify a clusterID will be used in https://github.com/cilium/cilium/pull/38015  to allow the insertion of remote nodes pod allocation CIDRs into the ipcache map with their clusterID, just like it is currently done with the tunnel map.

Notes to the reviewers: please review commit by commit