### PR TITLE
CES: add option to create CES directly from pods

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -49,6 +49,7 @@ cilium-operator-alibabacloud [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -61,6 +61,7 @@ cilium-operator-alibabacloud [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -42,6 +42,7 @@ cilium-operator-alibabacloud hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -36,6 +36,7 @@ cilium-operator-alibabacloud hive [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -48,6 +48,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -53,6 +53,7 @@ cilium-operator-aws [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -65,6 +65,7 @@ cilium-operator-aws [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -36,6 +36,7 @@ cilium-operator-aws hive [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -42,6 +42,7 @@ cilium-operator-aws hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -48,6 +48,7 @@ cilium-operator-aws hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator-aws hive dot-graph [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -52,6 +52,7 @@ cilium-operator-azure [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -64,6 +64,7 @@ cilium-operator-azure [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -36,6 +36,7 @@ cilium-operator-azure hive [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -42,6 +42,7 @@ cilium-operator-azure hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -48,6 +48,7 @@ cilium-operator-azure hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator-azure hive dot-graph [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -48,6 +48,7 @@ cilium-operator-generic [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -60,6 +60,7 @@ cilium-operator-generic [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -42,6 +42,7 @@ cilium-operator-generic hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -36,6 +36,7 @@ cilium-operator-generic hive [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator-generic hive dot-graph [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -48,6 +48,7 @@ cilium-operator-generic hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -70,6 +70,7 @@ cilium-operator [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -58,6 +58,7 @@ cilium-operator [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -42,6 +42,7 @@ cilium-operator hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -36,6 +36,7 @@ cilium-operator hive [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-operator hive dot-graph [flags]
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                         Enable IPsec
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                       Enable LB IPAM (default true)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -48,6 +48,7 @@ cilium-operator hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                     Enable WireGuard
       --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -58,6 +58,7 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/cmdref"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/dial"
 	"github.com/cilium/cilium/pkg/gops"
@@ -171,6 +172,8 @@ var (
 		cell.Provide(func() *operatorOption.OperatorConfig {
 			return operatorOption.Config
 		}),
+
+		ipsec.OperatorCell,
 
 		cell.Provide(func(
 			daemonCfg *option.DaemonConfig,

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -79,6 +79,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/version"
+	wgAgent "github.com/cilium/cilium/pkg/wireguard/agent"
 )
 
 var (
@@ -174,6 +175,7 @@ var (
 		}),
 
 		ipsec.OperatorCell,
+		wgAgent.OperatorCell,
 
 		cell.Provide(func(
 			daemonCfg *option.DaemonConfig,

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -70,8 +70,13 @@ func CiliumNodeResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.Met
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes()),
 		opts...,
 	)
+	indexers := cache.Indexers{
+		// This index will be used to create CES from pods.
+		CiliumNodeIPIndex: CiliumNodeIPIndexFunc,
+	}
 	return resource.New[*cilium_api_v2.CiliumNode](lc, lw, mp,
 		resource.WithMetric("CiliumNode"),
+		resource.WithIndexers(indexers),
 	), nil
 }
 

--- a/operator/pkg/ciliumendpointslice/cell.go
+++ b/operator/pkg/ciliumendpointslice/cell.go
@@ -20,6 +20,9 @@ const (
 
 	// CESRateLimits can be used to configure a custom, stepped dynamic rate limit based on cluster size.
 	CESRateLimits = "ces-rate-limits"
+
+	// CESControllerMode sets the CES controller operation mode.
+	CESControllerMode = "ces-controller-mode"
 )
 
 // Cell is a cell that implements a Cilium Endpoint Slice Controller.
@@ -37,12 +40,14 @@ type Config struct {
 	CESMaxCEPsInCES           int    `mapstructure:"ces-max-ciliumendpoints-per-ces"`
 	CESSlicingMode            string `mapstructure:"ces-slice-mode"`
 	CESDynamicRateLimitConfig string `mapstructure:"ces-rate-limits"`
+	CESControllerMode         string `mapstructure:"ces-controller-mode"`
 }
 
 var defaultConfig = Config{
 	CESMaxCEPsInCES:           100,
 	CESSlicingMode:            fcfsMode,
 	CESDynamicRateLimitConfig: "[{\"nodes\":0,\"limit\":10,\"burst\":20}]",
+	CESControllerMode:         defaultMode,
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
@@ -51,6 +56,8 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.MarkDeprecated(CESSlicingMode, "Slicing mode defaults to the FCFS mode and is now deprecated option. It does not have a functional effect")
 
 	flags.String(CESRateLimits, def.CESDynamicRateLimitConfig, "Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string.")
+	flags.String(CESControllerMode, def.CESControllerMode, "CES controller operation mode. Can be 'default' or 'slim'")
+	flags.MarkHidden(CESControllerMode)
 }
 
 // SharedConfig contains the configuration that is shared between

--- a/operator/pkg/ciliumendpointslice/ceptocesmap.go
+++ b/operator/pkg/ciliumendpointslice/ceptocesmap.go
@@ -23,6 +23,14 @@ type CESData struct {
 	ns   string
 }
 
+// Initializes CESData with given namespace
+func NewCESData(ns string) *CESData {
+	return &CESData{
+		ceps: sets.New[CEPName](),
+		ns:   ns,
+	}
+}
+
 // CESToCEPMapping is used to map Cilium Endpoints to CiliumEndpointSlices and
 // retrieving all the Cilium Endpoints mapped to the given CiliumEndpointSlice.
 // This map is protected by lock for consistent and concurrent access.

--- a/operator/pkg/ciliumendpointslice/cescache.go
+++ b/operator/pkg/ciliumendpointslice/cescache.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+// CESCache stores local CES goal state when the CES controller is running in slim mode.
+type CESCache struct {
+}
+
+// Creates and intializes the new CESCache
+func newCESCache() *CESCache {
+	return &CESCache{}
+}

--- a/operator/pkg/ciliumendpointslice/cescache.go
+++ b/operator/pkg/ciliumendpointslice/cescache.go
@@ -3,11 +3,91 @@
 
 package ciliumendpointslice
 
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type NodeName string
+type EncryptionKey int
+
+// NodeData contains information about the node; the set of coreceps on
+// the node and the known encryption key associated with the node.
+// isKeySet indicates whether the encryption key has been explicitly set for the node
+// after seeing a node update event.
+type NodeData struct {
+	ceps     sets.Set[CEPName]
+	key      EncryptionKey
+	isKeySet bool
+}
+
+func NewNodeData() *NodeData {
+	return &NodeData{
+		ceps:     sets.New[CEPName](),
+		isKeySet: false,
+	}
+}
+
 // CESCache stores local CES goal state when the CES controller is running in slim mode.
+// The CESCache itself is not protected by a lock; the caller should hold a lock in order
+// to safely perform multi-step operations on the cache.
 type CESCache struct {
+	// nodeData is used to map node name to all CiliumEndpoints on the node
+	// and the known encryption key associated with it
+	nodeData map[NodeName]*NodeData
 }
 
 // Creates and intializes the new CESCache
 func newCESCache() *CESCache {
-	return &CESCache{}
+	return &CESCache{
+		nodeData: make(map[NodeName]*NodeData),
+	}
+}
+
+// Update encryption key for node and return all affected CES whose CEPs are on that node,
+// iff the encryption key has changed requiring reconciliation.
+func (c *CESCache) insertNode(nodeName NodeName, encryptionKey EncryptionKey) []CESKey {
+	if _, ok := c.nodeData[nodeName]; !ok {
+		nodeData := NewNodeData()
+		nodeData.setEncryptionKey(encryptionKey)
+		c.nodeData[nodeName] = nodeData
+		return nil
+	}
+
+	// Update the encryption key if it was not set (saw pod update before node update)
+	// or if it has changed.
+	if !c.nodeData[nodeName].isKeySet || c.nodeData[nodeName].key != encryptionKey {
+		c.nodeData[nodeName].setEncryptionKey(encryptionKey)
+		return c.getCESForCEPs(c.nodeData[nodeName].ceps)
+	}
+	return nil
+}
+
+// Remove node from cache and return affected CESs
+func (c *CESCache) deleteNode(nodeName NodeName) []CESKey {
+	if nodeData, ok := c.nodeData[nodeName]; ok {
+		cesKeys := c.getCESForCEPs(nodeData.ceps)
+		delete(c.nodeData, nodeName)
+		return cesKeys
+	}
+	return nil
+}
+
+func (c *CESCache) getEndpointEncryptionKey(nodeName NodeName) (EncryptionKey, bool) {
+	if nodeData, ok := c.nodeData[nodeName]; ok {
+		if nodeData.isKeySet {
+			return nodeData.key, true
+		}
+	}
+	return 0, false
+}
+
+// Return CES keys for the given CEPs. Caller must hold the cache lock.
+func (c *CESCache) getCESForCEPs(ceps sets.Set[CEPName]) []CESKey {
+	// TODO: Implement when CEP/CES state is tracked in cache
+	return nil
+}
+
+func (n *NodeData) setEncryptionKey(encryptionKey EncryptionKey) {
+	n.key = encryptionKey
+	n.isKeySet = true
 }

--- a/operator/pkg/ciliumendpointslice/cescache.go
+++ b/operator/pkg/ciliumendpointslice/cescache.go
@@ -4,11 +4,15 @@
 package ciliumendpointslice
 
 import (
+	"cmp"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type NodeName string
 type EncryptionKey int
+type CID string
+type Labels string
 
 // NodeData contains information about the node; the set of coreceps on
 // the node and the known encryption key associated with the node.
@@ -27,6 +31,22 @@ func NewNodeData() *NodeData {
 	}
 }
 
+// SecIDs contains the selected CID, a set of CIDs and a set of CEPs.
+// One CID from the set is selected to maintain compatibility with duplicate
+// identities.
+type SecIDs struct {
+	selectedID CID
+	ids        sets.Set[CID]
+	ceps       sets.Set[CEPName]
+}
+
+func NewSecIDs() *SecIDs {
+	return &SecIDs{
+		ids:  sets.New[CID](),
+		ceps: sets.New[CEPName](),
+	}
+}
+
 // CESCache stores local CES goal state when the CES controller is running in slim mode.
 // The CESCache itself is not protected by a lock; the caller should hold a lock in order
 // to safely perform multi-step operations on the cache.
@@ -34,12 +54,19 @@ type CESCache struct {
 	// nodeData is used to map node name to all CiliumEndpoints on the node
 	// and the known encryption key associated with it
 	nodeData map[NodeName]*NodeData
+	// globalIdLabelsToCIDSet maps a set of labels to the CEPs and CIDs associated with it.
+	// Compatible with Agent's CID management which can cause duplicate CIDs.
+	globalIdLabelsToCIDSet map[Labels]*SecIDs
+	// cidToGidLabels maps CID to the GID labels associated with it.
+	cidToGidLabels map[CID]Labels
 }
 
 // Creates and intializes the new CESCache
 func newCESCache() *CESCache {
 	return &CESCache{
-		nodeData: make(map[NodeName]*NodeData),
+		nodeData:               make(map[NodeName]*NodeData),
+		globalIdLabelsToCIDSet: make(map[Labels]*SecIDs),
+		cidToGidLabels:         make(map[CID]Labels),
 	}
 }
 
@@ -81,10 +108,94 @@ func (c *CESCache) getEndpointEncryptionKey(nodeName NodeName) (EncryptionKey, b
 	return 0, false
 }
 
+// Insert a CID into the cache and return the CESs which need to be reconciled
+func (c *CESCache) insertCID(cid CID, gidLabels Labels) []CESKey {
+	var cesToReconcile []CESKey
+	// Clean up old state
+	if oldLabels, ok := c.cidToGidLabels[cid]; ok && oldLabels != gidLabels {
+		cidSet := c.globalIdLabelsToCIDSet[oldLabels]
+		cidSet.ids.Delete(cid)
+		// If the selectedID is the same as the CID being removed, update it to another valid CID, if it exists.
+		if cidSet.selectedID == cid {
+			changed := cidSet.setSelectedID("")
+			if changed {
+				cesToReconcile = append(cesToReconcile, c.getCESForCEPs(cidSet.ceps)...)
+			}
+		}
+		c.cleanLabelsMapIfNoState(oldLabels)
+	}
+	c.cidToGidLabels[cid] = gidLabels
+
+	secIDs := c.globalIdLabelsToCIDSet[gidLabels]
+	if secIDs == nil {
+		secIDs = NewSecIDs()
+		c.globalIdLabelsToCIDSet[gidLabels] = secIDs
+	}
+	changed := secIDs.setSelectedID(cid)
+	secIDs.ids.Insert(cid)
+	if changed {
+		cesToReconcile = append(cesToReconcile, c.getCESForCEPs(secIDs.ceps)...)
+	}
+	return cesToReconcile
+}
+
+// Remove CID from cache and return affected CESs
+func (c *CESCache) deleteCID(cid CID) []CESKey {
+	gidLabels, ok := c.cidToGidLabels[cid]
+	if !ok {
+		return nil
+	}
+	delete(c.cidToGidLabels, cid)
+	if secId, ok := c.globalIdLabelsToCIDSet[gidLabels]; ok {
+		var cesKeys []CESKey
+		secId.ids.Delete(cid)
+		if secId.selectedID == cid {
+			// If the selectedID is the same as the CID being removed, update it to another valid CID, if it exists.
+			changed := secId.setSelectedID("")
+			if changed {
+				cesKeys = append(cesKeys, c.getCESForCEPs(secId.ceps)...)
+			}
+		}
+		c.cleanLabelsMapIfNoState(gidLabels)
+		return cesKeys
+	}
+	return nil
+}
+
 // Return CES keys for the given CEPs. Caller must hold the cache lock.
 func (c *CESCache) getCESForCEPs(ceps sets.Set[CEPName]) []CESKey {
 	// TODO: Implement when CEP/CES state is tracked in cache
 	return nil
+}
+
+// Clean up globalIdLabelsToCIDSet map, if no label state exists.
+func (c *CESCache) cleanLabelsMapIfNoState(gidLabels Labels) {
+	if secId, ok := c.globalIdLabelsToCIDSet[gidLabels]; ok {
+		if secId.ceps.Len() == 0 && secId.ids.Len() == 0 {
+			delete(c.globalIdLabelsToCIDSet, gidLabels)
+		}
+	}
+}
+
+// SetSelectedIDLocked will update the selectedID to the given CID if not set.
+// If the passed CID is empty, it will find the next available CID
+// and update selectedID to it, or keep as is if none available.
+// Returns true if selectedID was changed.
+func (s *SecIDs) setSelectedID(newCID CID) bool {
+	if newCID == "" {
+		for nextID := range s.ids {
+			s.selectedID = nextID
+			return true
+		}
+		return false
+	}
+
+	if !s.ids.Has(s.selectedID) {
+		// selectedID was deleted from ids, force update now that valid CID is known
+		s.selectedID = ""
+	}
+	s.selectedID = cmp.Or(s.selectedID, newCID)
+	return s.selectedID == newCID
 }
 
 func (n *NodeData) setEncryptionKey(encryptionKey EncryptionKey) {

--- a/operator/pkg/ciliumendpointslice/cescache_test.go
+++ b/operator/pkg/ciliumendpointslice/cescache_test.go
@@ -200,3 +200,261 @@ func TestCESCacheCESState(t *testing.T) {
 	assert.Empty(t, cmap.cesData)
 	assert.Empty(t, cmap.nsData)
 }
+
+func TestCESCacheChangeCIDLabels(t *testing.T) {
+	// Insert initial CID and labels and validate initial state
+	cid1 := CID("cid1")
+	labels1 := Labels("key1:value1")
+	cmap := newCESCache()
+	cmap.insertCID(cid1, labels1)
+
+	assert.True(t, cmap.hasCID(cid1), "CID 'cid1' should be present in cache")
+	assert.Equal(t, cmap.cidToGidLabels[cid1], labels1, "CID 'cid1' should map to correct labels")
+	assert.Contains(t, cmap.globalIdLabelsToCIDSet[labels1].ids, cid1, "Labels 'key1:value1' should map to CID 'cid1'")
+	storedCID, found := cmap.GetSelectedId(labels1)
+	assert.True(t, found, "Selected ID for labels 'key1:value1' should be found")
+	assert.Equal(t, storedCID, cid1, "Selected ID for labels 'key1:value1' should be 'cid1'")
+
+	// Insert a CEP that uses the CID
+	ces1 := CESName("ces1")
+	cmap.insertCES(ces1, "ns1")
+	node1 := NodeName("node1")
+	cmap.insertNode(node1, EncryptionKey(0))
+	cep1 := NewCEPName("cep1", "ns1")
+	cmap.addCEP(cep1, ces1, node1, labels1)
+
+	// Change CID's labels and validate updated state
+	labels2 := Labels("key2:value2")
+	cmap.insertCID(cid1, labels2)
+	assert.True(t, cmap.hasCID(cid1), "CID 'cid1' should be present in cache after label change")
+	assert.Equal(t, cmap.cidToGidLabels[cid1], labels2, "CID 'cid1' should map to updated labels")
+	assert.NotContains(t, cmap.globalIdLabelsToCIDSet[labels1].ids, cid1, "Old labels 'key1:value1' should NOT map to CID 'cid1'")
+	assert.Contains(t, cmap.globalIdLabelsToCIDSet[labels2].ids, cid1, "New labels 'key2:value2' should map to CID 'cid1'")
+	storedCID, found = cmap.GetSelectedId(labels2)
+	assert.True(t, found, "Selected ID for new labels 'key2:value2' should be found")
+	assert.Equal(t, storedCID, cid1, "Selected ID for new labels 'key2:value2' should be 'cid1'")
+	// Old labels have no more CIDs but do have CEPs, so they map to the same selected ID but have no CIDs
+	storedCID, found = cmap.GetSelectedId(labels1)
+	assert.True(t, found, "Selected ID for old labels 'key1:value1' should still be found")
+	assert.Equal(t, storedCID, cid1, "Selected ID for old labels 'key1:value1' should still be 'cid1'")
+	assert.Empty(t, cmap.globalIdLabelsToCIDSet[labels1].ids, "Old labels are mapped to no CIDs")
+}
+
+func TestCESCacheState(t *testing.T) {
+	testCases := []struct {
+		name      string
+		cepName   CEPName
+		cesName   CESName
+		nodeName  NodeName
+		cid       CID
+		gidLabels Labels
+		count     int
+	}{
+		{
+			name:      "Insert CEP when CID not created yet",
+			cepName:   NewCEPName("cilium-adf8-kube-system", "ns"),
+			cesName:   CESName("ces-dfbkjswert-twis"),
+			nodeName:  NodeName("node1"),
+			cid:       CID(""),
+			gidLabels: Labels("test:hello"),
+			count:     1,
+		},
+		{
+			name:      "Insert CEPs - 1",
+			cepName:   NewCEPName("cilium-adf8-kube-system", "ns"),
+			cesName:   CESName("ces-dfbkjswert-twis"),
+			nodeName:  NodeName("node1"),
+			cid:       CID("cid1"),
+			gidLabels: Labels("test:hello"),
+			count:     1,
+		},
+		{
+			name:      "Insert CEPs - 2",
+			cepName:   NewCEPName("cilium-dtyr-kube-system", "ns"),
+			cesName:   CESName("ces-dfbkjswert-twis"),
+			nodeName:  NodeName("node2"),
+			cid:       CID("cid2"),
+			gidLabels: Labels("key:value"),
+			count:     2,
+		},
+		{
+			name:      "Insert CEPs - 3",
+			cepName:   NewCEPName("cilium-fgh8-kube-system", "ns"),
+			cesName:   CESName("ces-dfbkjswert-twis"),
+			nodeName:  NodeName("node1"),
+			cid:       CID("cid1"),
+			gidLabels: Labels("test:hello"),
+			count:     3,
+		},
+		{
+			name:      "Insert CEPs - 4",
+			cepName:   NewCEPName("cilium-cspn-kube-system", "ns"),
+			cesName:   CESName("ces-dfbkjswert-twis"),
+			nodeName:  NodeName("node3"),
+			cid:       CID("cid2"),
+			gidLabels: Labels("key:value"),
+			count:     4,
+		},
+		{
+			name:      "Check same CEP-name with CES name",
+			cepName:   NewCEPName("cilium-cspn-kube-system", "ns"),
+			cesName:   CESName("ces-dfbkjswert-0wis"),
+			nodeName:  NodeName("node3"),
+			cid:       CID("cid2"),
+			gidLabels: Labels("key:value"),
+			count:     4,
+		},
+		{
+			name:      "Check CEP with same labels, different CID",
+			cepName:   NewCEPName("cilium-asdf-kube-system", "ns"),
+			cesName:   CESName("ces-dfbkjswert-twis"),
+			nodeName:  NodeName("node3"),
+			cid:       CID("cid3"),
+			gidLabels: Labels("key:value"),
+			count:     5,
+		},
+	}
+	cmap := newCESCache()
+
+	// Insert new CEPs in cepCache map and check its total count
+	for _, tc := range testCases {
+		prevSelectedId, _ := cmap.GetSelectedId(tc.gidLabels)
+
+		cmap.insertCES(CESName(tc.cesName), "ns")
+		// Add CEP if CID is empty, else upsert CEP
+		//if tc.cid == "" {
+		cmap.addCEP(tc.cepName, tc.cesName, tc.nodeName, tc.gidLabels)
+		if tc.cid != "" {
+			cmap.insertCID(tc.cid, tc.gidLabels)
+		}
+		// } else {
+		// 	cmap.upsertCEP(tc.cepName, tc.cesName, tc.nodeName, tc.gidLabels, tc.cid)
+		// }
+
+		assert.Equal(t, cmap.countCEPs(), tc.count, "Number of CEP entries in cmap should match with Count")
+		assert.True(t, cmap.hasCEP(tc.cepName), "CEP name should be present in CES cache")
+		assert.False(t, cmap.hasCEP(NewCEPName("not-really-cep", "ns")), "Random string should NOT present in cache as Key")
+		assert.True(t, cmap.hasNode(tc.nodeName), "Node name should be present in cache")
+
+		if tc.cid == "" {
+			assert.False(t, cmap.hasCID(tc.cid), "CEP with empty CID, so CID should NOT be present in CES cache")
+		} else {
+			assert.True(t, cmap.hasCID(tc.cid), "CEP with non-empty CID should be present in CES cache")
+		}
+
+		newSelectedId, _ := cmap.GetSelectedId(tc.gidLabels)
+		if prevSelectedId == "" {
+			assert.Equal(t, newSelectedId, tc.cid, "Newly inserted CID should be selected as the first CID for the GID labels")
+		} else {
+			assert.Equal(t, newSelectedId, prevSelectedId, "Selected CID should not change if it was already set")
+		}
+	}
+
+	// Insert and remove CEPs in cepCache and check for any stale entries present in cepCache.
+	for _, tc := range testCases {
+		cmap.insertCES(CESName(tc.cesName), "ns")
+		cmap.addCEP(tc.cepName, tc.cesName, tc.nodeName, tc.gidLabels)
+		cesName, ok := cmap.getCESName(tc.cepName)
+		assert.True(t, ok, "CEP name should be there in map")
+		assert.Equal(t, cesName, tc.cesName, "CEP name should match with cesName")
+		cmap.deleteCEP(tc.cepName)
+		assert.False(t, cmap.hasCEP(tc.cepName), "CEP name is removed from cache, so it shouldn't be in cache")
+	}
+	assert.Empty(t, cmap.cepData)
+	assert.NotEmpty(t, cmap.cesData)
+	assert.NotEmpty(t, cmap.nodeData)
+	assert.NotEmpty(t, cmap.globalIdLabelsToCIDSet)
+
+	// CEPs removed from all maps
+	for ces := range cmap.cesData {
+		assert.Empty(t, cmap.cesData[ces].ceps)
+	}
+	for n := range cmap.nodeData {
+		assert.Empty(t, cmap.nodeData[n].ceps)
+	}
+	for gidLabels := range cmap.globalIdLabelsToCIDSet {
+		assert.Empty(t, cmap.globalIdLabelsToCIDSet[gidLabels].ceps)
+	}
+
+	// Clean up CES
+	cmap.deleteCES(CESName("ces-dfbkjswert-twis"))
+	cmap.deleteCES(CESName("ces-dfbkjswert-0wis"))
+	assert.Empty(t, cmap.cesData)
+
+	// Clean up CiliumNode
+	cmap.deleteNode("node1")
+	cmap.deleteNode("node2")
+	cmap.deleteNode("node3")
+	assert.Empty(t, cmap.nodeData)
+}
+
+func TestCESCacheClearsStaleState(t *testing.T) {
+	testCases := []struct {
+		name      string
+		cepName   CEPName
+		cesName   CESName
+		nodeName  NodeName
+		cid       CID
+		gidLabels Labels
+		count     int
+	}{
+		{
+			name:      "Insert CEPs - 1",
+			cepName:   NewCEPName("cilium-adf8-kube-system", "ns"),
+			cesName:   CESName("ces-dfbkjswert-twis"),
+			nodeName:  NodeName("node1"),
+			cid:       CID("cid1"),
+			gidLabels: Labels("test:hello"),
+			count:     1,
+		},
+		{
+			name:      "Insert CEPs - 2",
+			cepName:   NewCEPName("cilium-adf8-kube-system", "ns"),
+			cesName:   CESName("ces-dfbkjswert-twis"),
+			nodeName:  NodeName("node2"),
+			cid:       CID("cid2"),
+			gidLabels: Labels("key:value"),
+			count:     1,
+		},
+	}
+	cmap := newCESCache()
+
+	// Insert new CEPs in cepCache map and check its total count
+	for _, tc := range testCases {
+		prevSelectedId, _ := cmap.GetSelectedId(tc.gidLabels)
+		var prevNode NodeName
+		var prevLabel Labels
+		if _, exists := cmap.cepData[tc.cepName]; exists {
+			prevNode = cmap.cepData[tc.cepName].node
+			prevLabel = cmap.cepData[tc.cepName].labels
+		}
+
+		cmap.insertCES(tc.cesName, "ns")
+		cmap.addCEP(tc.cepName, tc.cesName, tc.nodeName, tc.gidLabels)
+		cmap.insertCID(tc.cid, tc.gidLabels)
+
+		assert.Equal(t, cmap.countCEPs(), tc.count, "Number of CEP entries in cmap should match with Count")
+		assert.True(t, cmap.hasCEP(tc.cepName), "CEP name should be present in CES cache")
+		assert.True(t, cmap.hasNode(tc.nodeName), "Node name should be present in cache")
+		assert.True(t, cmap.hasCID(tc.cid), "CEP with non-empty CID should be present in CES cache")
+
+		newSelectedId, _ := cmap.GetSelectedId(tc.gidLabels)
+		// Ensure old state is cleared and new state is set correctly
+		if prevSelectedId != "" {
+			cid, ok := cmap.getCIDForCEP(tc.cepName)
+			assert.True(t, ok, "CEP should have a CID in cache")
+			assert.Equal(t, newSelectedId, cid, "CID should be updated to new CID for CEP")
+			assert.NotContains(t, cmap.cidToGidLabels, prevSelectedId, "Old selected CID should be removed from cidToGidLabels map")
+		}
+		if prevLabel != "" {
+			assert.Equal(t, tc.gidLabels, cmap.cepData[tc.cepName].labels, "GID labels for CEP should be updated to new labels")
+			assert.NotContains(t, cmap.globalIdLabelsToCIDSet[prevLabel].ceps, tc.cepName, "CEP should be removed from previous GID label's CEP list")
+		}
+		if prevNode != "" {
+			assert.Equal(t, tc.nodeName, cmap.cepData[tc.cepName].node, "Node name for CEP should be updated to new node name")
+			assert.NotContains(t, cmap.nodeData[prevNode].ceps, tc.cepName, "CEP should be removed from previous node's CEP list")
+			assert.True(t, cmap.hasNode(prevNode), "Previous node should still be present in cache")
+			assert.True(t, cmap.hasNode(tc.nodeName), "New node should be present in cache")
+		}
+	}
+}

--- a/operator/pkg/ciliumendpointslice/cescache_test.go
+++ b/operator/pkg/ciliumendpointslice/cescache_test.go
@@ -56,3 +56,96 @@ func TestCESCacheNodeState(t *testing.T) {
 
 	assert.Empty(t, cmap.nodeData)
 }
+
+func TestCESCacheCIDState(t *testing.T) {
+	testCases := []struct {
+		name      string
+		cid       CID
+		gidLabels Labels
+		count     int
+		gidCount  int
+	}{
+		{
+			name:      "Insert CID - 1",
+			cid:       CID("cid1"),
+			gidLabels: Labels("test:hello"),
+			count:     1,
+			gidCount:  1,
+		},
+		{
+			name:      "Insert CID - 2",
+			cid:       CID("cid2"),
+			gidLabels: Labels("key:value"),
+			count:     2,
+			gidCount:  2,
+		},
+		{
+			name:      "Insert CID - 3",
+			cid:       CID("cid3"),
+			gidLabels: Labels("hello:world"),
+			count:     3,
+			gidCount:  3,
+		},
+		{
+			name:      "Check new CID with duplicate labels",
+			cid:       CID("cid4"),
+			gidLabels: Labels("key:value"),
+			count:     4,
+			gidCount:  3,
+		},
+	}
+	cmap := newCESCache()
+
+	// Insert new CEPs in cepCache map and check its total count
+	for _, tc := range testCases {
+		prevSelectedId, _ := cmap.GetSelectedId(tc.gidLabels)
+		cmap.insertCID(tc.cid, tc.gidLabels)
+		assert.Len(t, cmap.cidToGidLabels, tc.count, "Number of CIDs in cmap should match with Count")
+		assert.Len(t, cmap.globalIdLabelsToCIDSet, tc.gidCount, "Number of GID label entries in cmap should match with Count")
+		assert.True(t, cmap.hasCID(tc.cid), "CID should present in cmap")
+		assert.False(t, cmap.hasCID("not-really-cid"), "Random string should NOT present in cmap as Key")
+
+		newSelectedId, _ := cmap.GetSelectedId(tc.gidLabels)
+		if prevSelectedId == "" {
+			assert.Equal(t, newSelectedId, tc.cid, "Newly inserted CID should be selected as the first CID for the GID labels")
+		} else {
+			assert.Equal(t, newSelectedId, prevSelectedId, "Selected CID should not change if it was already set")
+		}
+	}
+
+	// Insert and remove CEPs in cepCache and check for any stale entries present in cepCache.
+	for _, tc := range testCases {
+		cmap.insertCID(tc.cid, tc.gidLabels)
+		cmap.deleteCID(tc.cid)
+		assert.False(t, cmap.hasCID(tc.cid), "CID should be removed from cache")
+	}
+	assert.Empty(t, cmap.cidToGidLabels)
+	assert.Empty(t, cmap.globalIdLabelsToCIDSet)
+}
+
+func TestCESCacheCIDUpdates(t *testing.T) {
+	cid1 := CID("cid1")
+	labels1 := Labels("key:value")
+
+	cid2 := CID("cid2")
+
+	cmap := newCESCache()
+
+	// Insert first CID
+	cmap.insertCID(cid1, labels1)
+	selectedId, ok := cmap.GetSelectedId(labels1)
+	assert.True(t, ok, "Selected ID should be present for labels1")
+	assert.Equal(t, selectedId, cid1, "Selected ID should be cid1")
+
+	// Insert second CID with same labels
+	cmap.insertCID(cid2, labels1)
+	selectedId, ok = cmap.GetSelectedId(labels1)
+	assert.True(t, ok, "Selected ID should be present for labels1")
+	assert.Equal(t, selectedId, cid1, "Selected ID should still be cid1")
+
+	// Remove first CID
+	cmap.deleteCID(cid1)
+	selectedId, ok = cmap.GetSelectedId(labels1)
+	assert.True(t, ok, "Selected ID should be present for labels1 after removing cid1")
+	assert.Equal(t, selectedId, cid2, "Selected ID should now be cid2")
+}

--- a/operator/pkg/ciliumendpointslice/cescache_test.go
+++ b/operator/pkg/ciliumendpointslice/cescache_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCESCacheNodeState(t *testing.T) {
+	testCases := []struct {
+		name          string
+		nodeName      NodeName
+		encryptionKey EncryptionKey
+		count         int
+	}{
+		{
+			name:          "Insert Node - 1",
+			nodeName:      NodeName("node1"),
+			encryptionKey: EncryptionKey(1),
+			count:         1,
+		},
+		{
+			name:          "Insert Node - 2",
+			nodeName:      NodeName("node2"),
+			encryptionKey: EncryptionKey(2),
+			count:         2,
+		},
+		{
+			name:          "Insert Same Node with New Key",
+			nodeName:      NodeName("node1"),
+			encryptionKey: EncryptionKey(3),
+			count:         2,
+		},
+	}
+	cmap := newCESCache()
+
+	// Insert new Nodes in CES cache and check its total count
+	for _, tc := range testCases {
+		cmap.insertNode(tc.nodeName, tc.encryptionKey)
+		assert.Len(t, cmap.nodeData, tc.count, "Number of nodes in cmap should match with Count")
+		assert.True(t, cmap.hasNode(tc.nodeName), "Node name should present in cmap")
+		key, ok := cmap.getEncryptionKey(tc.nodeName)
+		assert.True(t, ok, "Encryption key for node should be present")
+		assert.Equal(t, tc.encryptionKey, key, "Encryption key for node should match")
+	}
+
+	// Insert and remove Nodes in CES cache and check for any stale entries present in CES cache.
+	for _, tc := range testCases {
+		cmap.insertNode(tc.nodeName, tc.encryptionKey)
+		cmap.deleteNode(tc.nodeName)
+		assert.False(t, cmap.hasNode(tc.nodeName), "Node name is removed from cache, so it shouldn't be in cache")
+	}
+
+	assert.Empty(t, cmap.nodeData)
+}

--- a/operator/pkg/ciliumendpointslice/cescache_test.go
+++ b/operator/pkg/ciliumendpointslice/cescache_test.go
@@ -149,3 +149,54 @@ func TestCESCacheCIDUpdates(t *testing.T) {
 	assert.True(t, ok, "Selected ID should be present for labels1 after removing cid1")
 	assert.Equal(t, selectedId, cid2, "Selected ID should now be cid2")
 }
+
+func TestCESCacheCESState(t *testing.T) {
+	testCases := []struct {
+		name    string
+		cesName CESName
+		ns      string
+		count   int
+		nsCount int
+	}{
+		{
+			name:    "Insert CES - 1",
+			cesName: CESName("ces-dfbkjswert-twis"),
+			ns:      "ns",
+			count:   1,
+			nsCount: 1,
+		},
+		{
+			name:    "Insert CES - 2",
+			cesName: CESName("ces-dfbkjswert-rsci"),
+			ns:      "ns2",
+			count:   2,
+			nsCount: 1,
+		},
+		{
+			name:    "Insert CES - 3",
+			cesName: CESName("ces-dfbkjswert-fgih"),
+			ns:      "ns2",
+			count:   3,
+			nsCount: 2,
+		},
+	}
+	cmap := newCESCache()
+
+	// Insert new CESs in ces cache and check its total count
+	for _, tc := range testCases {
+		cmap.insertCES(tc.cesName, tc.ns)
+		assert.Equal(t, cmap.getCESCount(), tc.count, "Number of CES entries in cmap should match with Count")
+		assert.Len(t, cmap.getCESInNs(tc.ns), tc.nsCount, "Number of CES entries for the given namespace should match with nsCount")
+	}
+
+	// Insert and remove CES in cescache and check for any stale entries present in cescache.
+	for _, tc := range testCases {
+		cmap.insertCES(tc.cesName, tc.ns)
+		assert.True(t, cmap.hasCESName(tc.cesName), "CES name should be there in map")
+		cmap.deleteCES(tc.cesName)
+		assert.False(t, cmap.hasCESName(tc.cesName), "CES name is removed from cache, so it shouldn't be in cache")
+	}
+
+	assert.Empty(t, cmap.cesData)
+	assert.Empty(t, cmap.nsData)
+}

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -122,6 +122,8 @@ type SlimController struct {
 
 	ipsecEnabled bool
 	wgEnabled    bool
+
+	ciliumIdentity resource.Resource[*v2.CiliumIdentity]
 }
 
 // registerController creates and initializes the CES controller

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -130,6 +130,7 @@ type SlimController struct {
 	wgEnabled    bool
 
 	ciliumIdentity resource.Resource[*v2.CiliumIdentity]
+	pods           resource.Resource[*slim_corev1.Pod]
 }
 
 // registerController creates and initializes the CES controller

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -38,6 +38,8 @@ type params struct {
 	CiliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
 	CiliumNodes         resource.Resource[*v2.CiliumNode]
 	Namespace           resource.Resource[*slim_corev1.Namespace]
+	Pods                resource.Resource[*slim_corev1.Pod]
+	CiliumIdentity      resource.Resource[*v2.CiliumIdentity]
 
 	Cfg          Config
 	SharedCfg    SharedConfig
@@ -178,6 +180,14 @@ func registerController(p params) error {
 		p.Lifecycle.Append(defaultController)
 	} else {
 		p.Logger.Info("CES Controller running in slim mode")
+		slimController := &SlimController{
+			Controller:     cesController,
+			ciliumIdentity: p.CiliumIdentity,
+			pods:           p.Pods,
+			ipsecEnabled:   p.IPSecCfg.Enabled(),
+			wgEnabled:      p.WireguardCfg.Enabled(),
+		}
+		p.Lifecycle.Append(slimController)
 	}
 
 	return nil

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/workerpool"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -38,6 +39,7 @@ type params struct {
 
 	Cfg       Config
 	SharedCfg SharedConfig
+	IPSecCfg  ipsec.EnableConfig
 
 	Metrics                  *Metrics
 	WorkqueueMetricsProvider workqueue.MetricsProvider

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -60,8 +60,6 @@ type Controller struct {
 	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
 	ciliumNodes         resource.Resource[*v2.CiliumNode]
 	namespace           resource.Resource[*slim_corev1.Namespace]
-	// reconciler is an util used to reconcile CiliumEndpointSlice changes.
-	reconciler *reconciler
 
 	maxCEPsInCES int
 
@@ -89,6 +87,8 @@ type Controller struct {
 	priorityNamespaces     map[string]struct{}
 	priorityNamespacesLock lock.RWMutex
 
+	doReconciler doReconciler
+
 	// If the queues are empty, they wait until the condition (adding something to the queues) is met.
 	cond sync.Cond
 
@@ -105,6 +105,9 @@ type DefaultController struct {
 	// It maintains the desired state of the CESs in dataStore
 	manager *defaultManager
 
+	// reconciler is an util used to reconcile CiliumEndpointSlice changes.
+	reconciler *defaultReconciler
+
 	ciliumEndpoint resource.Resource[*v2.CiliumEndpoint]
 
 	wp *workerpool.WorkerPool
@@ -119,6 +122,9 @@ type SlimController struct {
 	// pod changes and enqueues/dequeues the pod changes in CES.
 	// It maintains the desired state of the CESs in dataStore
 	manager *slimManager
+
+	// reconciler is an util used to reconcile CiliumEndpointSlice changes.
+	reconciler *slimReconciler
 
 	ipsecEnabled bool
 	wgEnabled    bool

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -63,10 +63,6 @@ type Controller struct {
 	// reconciler is an util used to reconcile CiliumEndpointSlice changes.
 	reconciler *reconciler
 
-	// Manager is used to create and maintain a local datastore. Manager watches for
-	// cilium endpoint changes and enqueues/dequeues the cilium endpoint changes in CES.
-	// It maintains the desired state of the CESs in dataStore
-	manager      *cesManager
 	maxCEPsInCES int
 
 	// workqueue is used to sync CESs with the api-server. this will rate-limit the
@@ -104,6 +100,11 @@ type Controller struct {
 type DefaultController struct {
 	*Controller
 
+	// Manager is used to create and maintain a local datastore. Manager watches for
+	// cilium endpoint changes and enqueues/dequeues the cilium endpoint changes in CES.
+	// It maintains the desired state of the CESs in dataStore
+	manager *defaultManager
+
 	ciliumEndpoint resource.Resource[*v2.CiliumEndpoint]
 
 	wp *workerpool.WorkerPool
@@ -113,6 +114,11 @@ type DefaultController struct {
 // from Pods.
 type SlimController struct {
 	*Controller
+
+	// Manager is used to create and maintain a local datastore. Manager watches for
+	// pod changes and enqueues/dequeues the pod changes in CES.
+	// It maintains the desired state of the CESs in dataStore
+	manager *slimManager
 
 	ipsecEnabled bool
 	wgEnabled    bool

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/lock"
+	wgAgent "github.com/cilium/cilium/pkg/wireguard/agent"
 )
 
 // params contains all the dependencies for the CiliumEndpointSlice controller.
@@ -37,9 +38,10 @@ type params struct {
 	CiliumNodes         resource.Resource[*v2.CiliumNode]
 	Namespace           resource.Resource[*slim_corev1.Namespace]
 
-	Cfg       Config
-	SharedCfg SharedConfig
-	IPSecCfg  ipsec.EnableConfig
+	Cfg          Config
+	SharedCfg    SharedConfig
+	IPSecCfg     ipsec.EnableConfig
+	WireguardCfg wgAgent.EnableConfig
 
 	Metrics                  *Metrics
 	WorkqueueMetricsProvider workqueue.MetricsProvider

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -34,6 +35,7 @@ func TestRegisterController(t *testing.T) {
 	hive := hive.New(
 		k8sFakeClient.FakeClientBuilderCell(),
 		k8s.ResourcesCell,
+		ipsec.OperatorCell,
 		cell.Provide(func() Config {
 			return defaultConfig
 		}),
@@ -87,6 +89,7 @@ func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
 	h := hive.New(
 		k8sFakeClient.FakeClientBuilderCell(),
 		k8s.ResourcesCell,
+		ipsec.OperatorCell,
 		cell.Provide(func() Config {
 			return defaultConfig
 		}),

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	idtu "github.com/cilium/cilium/operator/pkg/ciliumidentity/testutils"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -22,6 +23,8 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sFakeClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/testutils"
 	wgAgent "github.com/cilium/cilium/pkg/wireguard/agent"
@@ -148,4 +151,112 @@ func createCEPandVerifyCESCreated(t *testing.T, fakeClient k8sClient.Clientset, 
 	}, time.Second)
 	// err == nil means CES was created
 	return err == nil, nil
+}
+
+func TestRegisterControllerNoCEPs(t *testing.T) {
+	defer testutils.GoleakVerifyNone(t)
+
+	fakeClient, pod, ciliumEndpointSlice, namespace, ciliumNode, ciliumIdentity, _, hive := initHiveTest(t, true, true)
+
+	tlog := hivetest.Logger(t)
+	if err := hive.Start(tlog, t.Context()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
+
+	cesCreated, err := createPodandVerifyCESCreated(t, fakeClient, pod, ciliumEndpointSlice, namespace, ciliumIdentity, ciliumNode)
+
+	if err != nil {
+		t.Fatalf("Couldn't verify if CES is created: %s", err)
+	}
+
+	assert.True(t, cesCreated)
+	if err := hive.Stop(tlog, t.Context()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func createPodandVerifyCESCreated(t *testing.T, fakeClient k8sClient.Clientset, pod resource.Resource[*slim_corev1.Pod], ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice], ns resource.Resource[*slim_corev1.Namespace], cid resource.Resource[*cilium_v2.CiliumIdentity], cnode resource.Resource[*cilium_v2.CiliumNode]) (bool, error) {
+	// Create a node, with pod1 (in ns with labels tu.TestLbsA)
+	node := tu.CreateStoreNode("node1")
+	fakeClient.CiliumV2().CiliumNodes().Create(t.Context(), node, meta_v1.CreateOptions{})
+
+	ns1 := idtu.NewNamespace("ns", nil)
+	fakeClient.Slim().CoreV1().Namespaces().Create(t.Context(), ns1, meta_v1.CreateOptions{})
+
+	pod1 := idtu.NewPod("pod1", "ns", tu.TestLbsA, "node1")
+	fakeClient.Slim().CoreV1().Pods("ns").Create(t.Context(), pod1, meta_v1.CreateOptions{})
+
+	id1 := idtu.NewCID("1", tu.TestLbsA)
+	_, err := fakeClient.CiliumV2().CiliumIdentities().Create(t.Context(), id1, meta_v1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to create CiliumIdentity: %w", err)
+	}
+
+	// Verify whether CES is created after pod creation
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	err = testutils.WaitUntil(func() bool {
+		return len(cesStore.List()) > 0
+	}, time.Second)
+
+	return err == nil, nil
+}
+
+func initHiveTest(t *testing.T, enableCES, enableCESwithoutCEPs bool) (k8sClient.Clientset, resource.Resource[*slim_corev1.Pod], resource.Resource[*cilium_v2a1.CiliumEndpointSlice], resource.Resource[*slim_corev1.Namespace], resource.Resource[*cilium_v2.CiliumNode], resource.Resource[*cilium_v2.CiliumIdentity], *Metrics, *hive.Hive) {
+	var fakeClient k8sClient.Clientset
+	var pod resource.Resource[*slim_corev1.Pod]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var ciliumNode resource.Resource[*cilium_v2.CiliumNode]
+	var ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity]
+	var cesMetrics *Metrics
+
+	hive := hive.New(
+		k8sFakeClient.FakeClientBuilderCell(),
+		k8s.ResourcesCell,
+		ipsec.OperatorCell,
+		wgAgent.OperatorCell,
+		cell.Provide(func() Config {
+			config := defaultConfig
+			if enableCESwithoutCEPs {
+				config.CESControllerMode = slimMode
+			}
+			return config
+		}),
+		cell.Provide(func() SharedConfig {
+			return SharedConfig{
+				EnableCiliumEndpointSlice: enableCES,
+			}
+		}),
+		metrics.Metric(NewMetrics),
+		cell.Invoke(func(p params) error {
+			registerController(p)
+			return nil
+		}),
+		cell.Provide(func(f k8sClient.ClientBuilderFunc) k8sClient.Clientset {
+			clientset, _ := f("test-ces-registered")
+			return clientset
+		}),
+		cell.Invoke(func(
+			c k8sClient.Clientset,
+			p resource.Resource[*slim_corev1.Pod],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			ns resource.Resource[*slim_corev1.Namespace],
+			cnode resource.Resource[*cilium_v2.CiliumNode],
+			cid resource.Resource[*cilium_v2.CiliumIdentity],
+			m *Metrics) error {
+			fakeClient = c
+			pod = p
+			ciliumEndpointSlice = ces
+			namespace = ns
+			ciliumNode = cnode
+			ciliumIdentity = cid
+			cesMetrics = m
+			return nil
+		}),
+	)
+	if err := hive.Populate(hivetest.Logger(t)); err != nil {
+		t.Fatalf("failed to populate hive: %s", err)
+	}
+	return fakeClient, pod, ciliumEndpointSlice, namespace, ciliumNode, ciliumIdentity, cesMetrics, hive
 }

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/testutils"
+	wgAgent "github.com/cilium/cilium/pkg/wireguard/agent"
 )
 
 func TestRegisterController(t *testing.T) {
@@ -36,6 +37,7 @@ func TestRegisterController(t *testing.T) {
 		k8sFakeClient.FakeClientBuilderCell(),
 		k8s.ResourcesCell,
 		ipsec.OperatorCell,
+		wgAgent.OperatorCell,
 		cell.Provide(func() Config {
 			return defaultConfig
 		}),
@@ -90,6 +92,7 @@ func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
 		k8sFakeClient.FakeClientBuilderCell(),
 		k8s.ResourcesCell,
 		ipsec.OperatorCell,
+		wgAgent.OperatorCell,
 		cell.Provide(func() Config {
 			return defaultConfig
 		}),

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -157,7 +157,7 @@ func (c *DefaultController) Start(ctx cell.HookContext) error {
 	c.context, c.contextCancel = context.WithCancel(context.Background())
 	defer utilruntime.HandleCrash()
 
-	c.manager = newCESManager(c.maxCEPsInCES, c.logger)
+	c.manager = newDefaultManager(c.maxCEPsInCES, c.logger)
 
 	c.reconciler = newReconciler(c.context, c.clientset.CiliumV2alpha1(), c.manager, c.logger, c.ciliumEndpoint, c.ciliumEndpointSlice, c.metrics)
 

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -159,7 +159,8 @@ func (c *DefaultController) Start(ctx cell.HookContext) error {
 
 	c.manager = newDefaultManager(c.maxCEPsInCES, c.logger)
 
-	c.reconciler = newReconciler(c.context, c.clientset.CiliumV2alpha1(), c.manager, c.logger, c.ciliumEndpoint, c.ciliumEndpointSlice, c.metrics)
+	c.reconciler = newDefaultReconciler(c.context, c.clientset.CiliumV2alpha1(), c.manager, c.logger, c.ciliumEndpoint, c.ciliumEndpointSlice, c.metrics)
+	c.doReconciler = c.reconciler
 
 	c.initializeQueue()
 
@@ -369,7 +370,7 @@ func (c *Controller) processNextWorkItem() bool {
 	c.logger.Debug("Processing CES", logfields.CESName, key.string())
 
 	queueDelay := c.getAndResetCESProcessingDelay(key)
-	err := c.reconciler.reconcileCES(CESName(key.Name))
+	err := c.doReconciler.reconcileCES(CESName(key.Name))
 	if queue == c.fastQueue {
 		c.metrics.CiliumEndpointSliceQueueDelay.WithLabelValues(LabelQueueFast).Observe(queueDelay)
 	} else {

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	log := hivetest.Logger(t)
-	var r *reconciler
+	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, log)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
@@ -53,7 +53,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	)
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -62,11 +62,12 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 			logger:              log,
 			clientset:           fakeClient.Clientset,
 			ciliumEndpointSlice: ciliumEndpointSlice,
-			reconciler:          r,
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
+			doReconciler:        r,
 		},
 		manager:        m,
+		reconciler:     r,
 		ciliumEndpoint: ciliumEndpoint,
 	}
 	cesController.initializeQueue()
@@ -102,7 +103,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 
 func TestDifferentSpeedQueues(t *testing.T) {
 	log := hivetest.Logger(t)
-	var r *reconciler
+	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, log)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
@@ -128,7 +129,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
 
-	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -137,14 +138,15 @@ func TestDifferentSpeedQueues(t *testing.T) {
 			logger:              log,
 			clientset:           fakeClient.Clientset,
 			ciliumEndpointSlice: ciliumEndpointSlice,
-			reconciler:          r,
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
 			metrics:             cesMetrics,
 			priorityNamespaces:  make(map[string]struct{}),
 			syncDelay:           0,
+			doReconciler:        r,
 		},
 		manager:        m,
+		reconciler:     r,
 		ciliumEndpoint: ciliumEndpoint,
 	}
 	cesController.cond = *sync.NewCond(&lock.Mutex{})
@@ -206,7 +208,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 
 func TestCESManagement(t *testing.T) {
 	log := hivetest.Logger(t)
-	var r *reconciler
+	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, log)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
@@ -232,7 +234,7 @@ func TestCESManagement(t *testing.T) {
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
 
-	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -241,14 +243,15 @@ func TestCESManagement(t *testing.T) {
 			logger:              log,
 			clientset:           fakeClient.Clientset,
 			ciliumEndpointSlice: ciliumEndpointSlice,
-			reconciler:          r,
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
 			metrics:             cesMetrics,
 			priorityNamespaces:  make(map[string]struct{}),
 			syncDelay:           0,
+			doReconciler:        r,
 		},
 		manager:        m,
+		reconciler:     r,
 		ciliumEndpoint: ciliumEndpoint,
 	}
 	cesController.cond = *sync.NewCond(&lock.Mutex{})

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -16,17 +16,22 @@ import (
 
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	cidtest "github.com/cilium/cilium/operator/pkg/ciliumidentity/testutils"
+	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/testutils"
+	wgAgent "github.com/cilium/cilium/pkg/wireguard/agent"
 )
 
-func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
+func TestFCFSModeSyncCESsInLocalCacheDefault(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
@@ -51,8 +56,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 			return nil
 		}),
 	)
-	tlog := hivetest.Logger(t)
-	hive.Start(tlog, t.Context())
+	hive.Start(log, t.Context())
 	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
@@ -72,15 +76,15 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	}
 	cesController.initializeQueue()
 
-	cep1 := tu.CreateManagerEndpoint("cep1", 1)
-	cep2 := tu.CreateManagerEndpoint("cep2", 1)
-	cep3 := tu.CreateManagerEndpoint("cep3", 2)
-	cep4 := tu.CreateManagerEndpoint("cep4", 2)
+	cep1 := tu.CreateManagerEndpoint("cep1", 1, "node1")
+	cep2 := tu.CreateManagerEndpoint("cep2", 1, "node2")
+	cep3 := tu.CreateManagerEndpoint("cep3", 2, "node3")
+	cep4 := tu.CreateManagerEndpoint("cep4", 2, "node2")
 	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
 	cesStore.CacheStore().Add(ces1)
-	cep5 := tu.CreateManagerEndpoint("cep5", 1)
-	cep6 := tu.CreateManagerEndpoint("cep6", 1)
-	cep7 := tu.CreateManagerEndpoint("cep7", 2)
+	cep5 := tu.CreateManagerEndpoint("cep5", 1, "node1")
+	cep6 := tu.CreateManagerEndpoint("cep6", 1, "node2")
+	cep7 := tu.CreateManagerEndpoint("cep7", 2, "node3")
 	ces2 := tu.CreateStoreEndpointSlice("ces2", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
 	cesStore.CacheStore().Add(ces2)
 
@@ -98,10 +102,10 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 
 	cesController.fastQueue.ShutDown()
 	cesController.standardQueue.ShutDown()
-	hive.Stop(tlog, t.Context())
+	hive.Stop(log, t.Context())
 }
 
-func TestDifferentSpeedQueues(t *testing.T) {
+func TestDifferentSpeedQueuesDefault(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
@@ -126,8 +130,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 			return nil
 		}),
 	)
-	tlog := hivetest.Logger(t)
-	hive.Start(tlog, t.Context())
+	hive.Start(log, t.Context())
 
 	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 
@@ -161,8 +164,8 @@ func TestDifferentSpeedQueues(t *testing.T) {
 		if i == 6 {
 			ns = "FastNamespace"
 		}
-		cep1 := tu.CreateManagerEndpoint("cep1", int64(2*i+1))
-		cep2 := tu.CreateManagerEndpoint("cep2", int64(2*i))
+		cep1 := tu.CreateManagerEndpoint("cep1", int64(2*i+1), "node1")
+		cep2 := tu.CreateManagerEndpoint("cep2", int64(2*i), "node1")
 
 		ces := tu.CreateStoreEndpointSlice(fmt.Sprintf("ces-%d", i), ns, []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2})
 
@@ -203,10 +206,10 @@ func TestDifferentSpeedQueues(t *testing.T) {
 
 	cesController.fastQueue.ShutDown()
 	cesController.standardQueue.ShutDown()
-	hive.Stop(tlog, t.Context())
+	hive.Stop(log, t.Context())
 }
 
-func TestCESManagement(t *testing.T) {
+func TestCESManagementDefault(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
@@ -231,8 +234,7 @@ func TestCESManagement(t *testing.T) {
 			return nil
 		}),
 	)
-	tlog := hivetest.Logger(t)
-	hive.Start(tlog, t.Context())
+	hive.Start(log, t.Context())
 
 	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 
@@ -279,6 +281,505 @@ func TestCESManagement(t *testing.T) {
 	}, time.Second); err != nil {
 		_, exists, _ := r.cesStore.GetByKey(NewCESKey(key.Name, "").key())
 		assert.True(t, exists)
+	}
+
+	cesController.fastQueue.ShutDown()
+	cesController.standardQueue.ShutDown()
+	hive.Stop(log, t.Context())
+}
+
+func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
+	log := hivetest.Logger(t)
+	var r *slimReconciler
+	var fakeClient *k8sClient.FakeClientset
+	m := newSlimManager(2, log)
+	var pods resource.Resource[*slim_corev1.Pod]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var ciliumNode resource.Resource[*cilium_v2.CiliumNode]
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity]
+	var cesMetrics *Metrics
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		metrics.Metric(NewMetrics),
+		ipsec.OperatorCell,
+		wgAgent.OperatorCell,
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			p resource.Resource[*slim_corev1.Pod],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			node resource.Resource[*cilium_v2.CiliumNode],
+			ns resource.Resource[*slim_corev1.Namespace],
+			identity resource.Resource[*cilium_v2.CiliumIdentity],
+			metrics *Metrics,
+		) error {
+			fakeClient = c
+			pods = p
+			ciliumEndpointSlice = ces
+			ciliumNode = node
+			namespace = ns
+			ciliumIdentity = identity
+			cesMetrics = metrics
+			return nil
+		}),
+	)
+	tlog := hivetest.Logger(t)
+	hive.Start(tlog, t.Context())
+	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
+	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	nodeStore, _ := ciliumNode.Store(t.Context())
+	cidStore, _ := ciliumIdentity.Store(t.Context())
+	podStore, _ := pods.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
+	assert.NoError(t, err)
+	cesController := &SlimController{
+		Controller: &Controller{
+			logger:              log,
+			clientset:           fakeClient.Clientset,
+			ciliumEndpointSlice: ciliumEndpointSlice,
+			ciliumNodes:         ciliumNode,
+			namespace:           namespace,
+			rateLimit:           rateLimitConfig,
+			enqueuedAt:          make(map[CESKey]time.Time),
+			doReconciler:        r,
+			metrics:             cesMetrics,
+			priorityNamespaces:  make(map[string]struct{}),
+		},
+		ipsecEnabled:   false,
+		wgEnabled:      false,
+		manager:        m,
+		reconciler:     r,
+		pods:           pods,
+		ciliumIdentity: ciliumIdentity,
+	}
+	cesController.cond = *sync.NewCond(&lock.Mutex{})
+	cesController.initializeQueue()
+
+	node1 := tu.CreateStoreNode("node1")
+	node2 := tu.CreateStoreNode("node2")
+	nodeStore.CacheStore().Add(node1)
+	nodeStore.CacheStore().Add(node2)
+
+	ns := cidtest.NewNamespace("ns", nil)
+	nsStore.CacheStore().Add(ns)
+
+	pod1 := cidtest.NewPod("pod1", "ns", tu.TestLbsA, "node1")
+	pod2 := cidtest.NewPod("pod2", "ns", tu.TestLbsA, "node2")
+	pod3 := cidtest.NewPod("pod3", "ns", tu.TestLbsB, "node2")
+	pod4 := cidtest.NewPod("pod4", "ns", tu.TestLbsB, "node2")
+	pod5 := cidtest.NewPod("pod5", "ns", tu.TestLbsA, "node1")
+	pod6 := cidtest.NewPod("pod6", "ns", tu.TestLbsA, "node1")
+	pod7 := cidtest.NewPod("pod7", "ns", tu.TestLbsB, "node1")
+	podStore.CacheStore().Add(pod1)
+	podStore.CacheStore().Add(pod2)
+	podStore.CacheStore().Add(pod3)
+	podStore.CacheStore().Add(pod4)
+	podStore.CacheStore().Add(pod5)
+	podStore.CacheStore().Add(pod6)
+	podStore.CacheStore().Add(pod7)
+
+	cid1 := cidtest.NewCIDWithNamespace("1", pod1, ns)
+	cid2 := cidtest.NewCIDWithNamespace("2", pod3, ns)
+	cidStore.CacheStore().Add(cid1)
+	cidStore.CacheStore().Add(cid2)
+
+	cep1 := tu.CreateManagerEndpoint("pod1", 1, "node1")
+	cep2 := tu.CreateManagerEndpoint("pod2", 1, "node2")
+	cep3 := tu.CreateManagerEndpoint("pod3", 2, "node2")
+	cep4 := tu.CreateManagerEndpoint("pod4", 2, "node2")
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
+	cesStore.CacheStore().Add(ces1)
+	cep5 := tu.CreateManagerEndpoint("pod5", 1, "node1")
+	cep6 := tu.CreateManagerEndpoint("pod6", 1, "node1")
+	cep7 := tu.CreateManagerEndpoint("pod7", 2, "node1")
+	ces2 := tu.CreateStoreEndpointSlice("ces2", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
+	cesStore.CacheStore().Add(ces2)
+
+	cesController.syncCESsInLocalCache(t.Context())
+
+	cache := m.mapping
+
+	for _, ces := range []*cilium_v2a1.CiliumEndpointSlice{ces1, ces2} {
+		for _, cep := range ces.Endpoints {
+			cesN, _ := cache.getCESName(NewCEPName(cep.Name, "ns"))
+			// ensure that the CEP is mapped to the correct CES
+			assert.Equal(t, cesN, CESName(ces.Name))
+		}
+	}
+
+	cesController.fastQueue.ShutDown()
+	cesController.standardQueue.ShutDown()
+	hive.Stop(tlog, t.Context())
+}
+
+func TestDifferentSpeedQueues(t *testing.T) {
+	log := hivetest.Logger(t)
+	var r *slimReconciler
+	var fakeClient *k8sClient.FakeClientset
+	m := newSlimManager(2, log)
+	var pods resource.Resource[*slim_corev1.Pod]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var ciliumNode resource.Resource[*cilium_v2.CiliumNode]
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity]
+	var cesMetrics *Metrics
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		metrics.Metric(NewMetrics),
+		ipsec.OperatorCell,
+		wgAgent.OperatorCell,
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			p resource.Resource[*slim_corev1.Pod],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			node resource.Resource[*cilium_v2.CiliumNode],
+			ns resource.Resource[*slim_corev1.Namespace],
+			identity resource.Resource[*cilium_v2.CiliumIdentity],
+			metrics *Metrics,
+		) error {
+			fakeClient = c
+			pods = p
+			ciliumEndpointSlice = ces
+			ciliumNode = node
+			namespace = ns
+			ciliumIdentity = identity
+			cesMetrics = metrics
+			return nil
+		}),
+	)
+	tlog := hivetest.Logger(t)
+	hive.Start(tlog, t.Context())
+	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
+
+	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+
+	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
+	assert.NoError(t, err)
+	cesController := &SlimController{
+		Controller: &Controller{
+			logger:              log,
+			clientset:           fakeClient.Clientset,
+			ciliumEndpointSlice: ciliumEndpointSlice,
+			ciliumNodes:         ciliumNode,
+			namespace:           namespace,
+			rateLimit:           rateLimitConfig,
+			enqueuedAt:          make(map[CESKey]time.Time),
+			doReconciler:        r,
+			metrics:             cesMetrics,
+			priorityNamespaces:  make(map[string]struct{}),
+		},
+		ipsecEnabled:   false,
+		wgEnabled:      false,
+		manager:        m,
+		reconciler:     r,
+		pods:           pods,
+		ciliumIdentity: ciliumIdentity,
+	}
+	cesController.cond = *sync.NewCond(&lock.Mutex{})
+	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
+	cesController.priorityNamespaces["FastNamespace"] = struct{}{}
+	cesController.initializeQueue()
+	var ns = "NotSoImportant"
+	var standardQueueLen int
+	var fastQueueLen int
+
+	for i := range 10 {
+		if i == 6 {
+			ns = "FastNamespace"
+		}
+		cep1 := tu.CreateManagerEndpoint("cep1", int64(2*i+1), "node1")
+		cep2 := tu.CreateManagerEndpoint("cep2", int64(2*i), "node1")
+
+		ces := tu.CreateStoreEndpointSlice(fmt.Sprintf("ces-%d", i), ns, []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2})
+
+		cesController.onSliceUpdate(ces)
+		if i < 6 {
+			standardQueueLen = i + 1
+			fastQueueLen = 0
+		} else {
+			standardQueueLen = 6
+			fastQueueLen = i - 5
+		}
+		//Ensure that the lengths of the queues after adding an element are correct
+		if err := testutils.WaitUntil(func() bool {
+			return cesController.standardQueue.Len() == standardQueueLen && cesController.fastQueue.Len() == fastQueueLen
+		}, time.Second); err != nil {
+			assert.Equal(t, standardQueueLen, cesController.standardQueue.Len())
+			assert.Equal(t, fastQueueLen, cesController.fastQueue.Len())
+		}
+	}
+
+	for i := range 10 {
+		cesController.processNextWorkItem()
+		if i < 4 {
+			standardQueueLen = 6
+			fastQueueLen = 3 - i
+		} else {
+			standardQueueLen = 6 - (i - 3)
+			fastQueueLen = 0
+		}
+		//Ensure that the lengths of the queues after removing an element are correct
+		if err := testutils.WaitUntil(func() bool {
+			return cesController.standardQueue.Len() == standardQueueLen && cesController.fastQueue.Len() == fastQueueLen
+		}, time.Second); err != nil {
+			assert.Equal(t, standardQueueLen, cesController.standardQueue.Len())
+			assert.Equal(t, fastQueueLen, cesController.fastQueue.Len())
+		}
+	}
+
+	cesController.fastQueue.ShutDown()
+	cesController.standardQueue.ShutDown()
+	hive.Stop(tlog, t.Context())
+}
+
+func TestCESManagement(t *testing.T) {
+	log := hivetest.Logger(t)
+	var r *slimReconciler
+	var fakeClient *k8sClient.FakeClientset
+	m := newSlimManager(2, log)
+	var pods resource.Resource[*slim_corev1.Pod]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var ciliumNode resource.Resource[*cilium_v2.CiliumNode]
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity]
+	var cesMetrics *Metrics
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		ipsec.OperatorCell,
+		wgAgent.OperatorCell,
+		metrics.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			p resource.Resource[*slim_corev1.Pod],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			node resource.Resource[*cilium_v2.CiliumNode],
+			ns resource.Resource[*slim_corev1.Namespace],
+			identity resource.Resource[*cilium_v2.CiliumIdentity],
+			metrics *Metrics,
+		) error {
+			fakeClient = c
+			pods = p
+			ciliumEndpointSlice = ces
+			ciliumNode = node
+			namespace = ns
+			ciliumIdentity = identity
+			cesMetrics = metrics
+			return nil
+		}),
+	)
+	tlog := hivetest.Logger(t)
+	hive.Start(tlog, t.Context())
+	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
+
+	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	nodeStore, _ := ciliumNode.Store(t.Context())
+	cidStore, _ := ciliumIdentity.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+
+	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
+	assert.NoError(t, err)
+	cesController := &SlimController{
+		Controller: &Controller{
+			logger:              log,
+			clientset:           fakeClient.Clientset,
+			ciliumEndpointSlice: ciliumEndpointSlice,
+			ciliumNodes:         ciliumNode,
+			namespace:           namespace,
+			rateLimit:           rateLimitConfig,
+			enqueuedAt:          make(map[CESKey]time.Time),
+			doReconciler:        r,
+			metrics:             cesMetrics,
+			priorityNamespaces:  make(map[string]struct{}),
+		},
+		ipsecEnabled:   false,
+		wgEnabled:      false,
+		manager:        m,
+		reconciler:     r,
+		pods:           pods,
+		ciliumIdentity: ciliumIdentity,
+	}
+	cesController.cond = *sync.NewCond(&lock.Mutex{})
+	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
+	cesController.initializeQueue()
+	var ns = "ns"
+
+	node1 := tu.CreateStoreNode("node1")
+	nodeStore.CacheStore().Add(node1)
+	cesController.onNodeUpdate(node1)
+
+	nsObj := cidtest.NewNamespace(ns, nil)
+	nsStore.CacheStore().Add(nsObj)
+	cesController.onNamespaceUpsert(nsObj)
+
+	pod1 := cidtest.NewPod("pod1", ns, tu.TestLbsA, "node1")
+
+	cid := cidtest.NewCIDWithNamespace("cid1", pod1, nsObj)
+	cidStore.CacheStore().Add(cid)
+	cesController.onIdentityUpdate(cid)
+
+	cesController.onPodUpdate(pod1)
+	if err := testutils.WaitUntil(func() bool {
+		return cesController.standardQueue.Len() == 1
+	}, time.Second); err != nil {
+		assert.Equal(t, 1, cesController.standardQueue.Len())
+	}
+	cesController.processNextWorkItem()
+	//A CEP is enqueued and processed. Then, the same CEP (and CES) is enqueued
+	//to test if the CESStore works properly and if the associated CES can be found in the store
+	cesController.onPodUpdate(pod1)
+
+	queue := cesController.getQueue()
+	key, _ := queue.Get()
+	if err := testutils.WaitUntil(func() bool {
+		_, exists, _ := r.cesStore.GetByKey(NewCESKey(key.Name, "").key())
+		return exists == true
+	}, time.Second); err != nil {
+		_, exists, _ := r.cesStore.GetByKey(NewCESKey(key.Name, "").key())
+		assert.True(t, exists)
+	}
+	cesController.onNamespaceDelete(nsObj)
+
+	cesController.fastQueue.ShutDown()
+	cesController.standardQueue.ShutDown()
+	hive.Stop(tlog, t.Context())
+}
+
+func TestSyncCESsInLocalCacheDeletedCID(t *testing.T) {
+	log := hivetest.Logger(t)
+	var r *slimReconciler
+	var fakeClient *k8sClient.FakeClientset
+	m := newSlimManager(2, log)
+	var pods resource.Resource[*slim_corev1.Pod]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var ciliumNode resource.Resource[*cilium_v2.CiliumNode]
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity]
+	var cesMetrics *Metrics
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		metrics.Metric(NewMetrics),
+		ipsec.OperatorCell,
+		wgAgent.OperatorCell,
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			p resource.Resource[*slim_corev1.Pod],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			node resource.Resource[*cilium_v2.CiliumNode],
+			ns resource.Resource[*slim_corev1.Namespace],
+			identity resource.Resource[*cilium_v2.CiliumIdentity],
+			metrics *Metrics,
+		) error {
+			fakeClient = c
+			pods = p
+			ciliumEndpointSlice = ces
+			ciliumNode = node
+			namespace = ns
+			ciliumIdentity = identity
+			cesMetrics = metrics
+			return nil
+		}),
+	)
+	tlog := hivetest.Logger(t)
+	hive.Start(tlog, t.Context())
+	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
+	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	nodeStore, _ := ciliumNode.Store(t.Context())
+	cidStore, _ := ciliumIdentity.Store(t.Context())
+	podStore, _ := pods.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
+	assert.NoError(t, err)
+	cesController := &SlimController{
+		Controller: &Controller{
+			logger:              log,
+			clientset:           fakeClient.Clientset,
+			ciliumEndpointSlice: ciliumEndpointSlice,
+			ciliumNodes:         ciliumNode,
+			namespace:           namespace,
+			rateLimit:           rateLimitConfig,
+			enqueuedAt:          make(map[CESKey]time.Time),
+			doReconciler:        r,
+			metrics:             cesMetrics,
+			priorityNamespaces:  make(map[string]struct{}),
+		},
+		ipsecEnabled:   false,
+		wgEnabled:      false,
+		manager:        m,
+		reconciler:     r,
+		pods:           pods,
+		ciliumIdentity: ciliumIdentity,
+	}
+	cesController.cond = *sync.NewCond(&lock.Mutex{})
+	cesController.initializeQueue()
+
+	node1 := tu.CreateStoreNode("node1")
+	node2 := tu.CreateStoreNode("node2")
+	nodeStore.CacheStore().Add(node1)
+	nodeStore.CacheStore().Add(node2)
+
+	ns := cidtest.NewNamespace("ns", nil)
+	nsStore.CacheStore().Add(ns)
+
+	pod1 := cidtest.NewPod("pod1", "ns", tu.TestLbsA, "node1")
+	pod2 := cidtest.NewPod("pod2", "ns", tu.TestLbsA, "node2")
+	pod3 := cidtest.NewPod("pod3", "ns", tu.TestLbsB, "node2")
+	pod4 := cidtest.NewPod("pod4", "ns", tu.TestLbsB, "node2")
+	pod5 := cidtest.NewPod("pod5", "ns", tu.TestLbsA, "node1")
+	pod6 := cidtest.NewPod("pod6", "ns", tu.TestLbsA, "node1")
+	pod7 := cidtest.NewPod("pod7", "ns", tu.TestLbsB, "node1")
+	podStore.CacheStore().Add(pod1)
+	podStore.CacheStore().Add(pod2)
+	podStore.CacheStore().Add(pod3)
+	podStore.CacheStore().Add(pod4)
+	podStore.CacheStore().Add(pod5)
+	podStore.CacheStore().Add(pod6)
+	podStore.CacheStore().Add(pod7)
+
+	cid1 := cidtest.NewCIDWithNamespace("1", pod1, ns)
+	cid2 := cidtest.NewCIDWithNamespace("2", pod3, ns)
+	cidStore.CacheStore().Add(cid1)
+	cidStore.CacheStore().Add(cid2)
+
+	cep1 := tu.CreateManagerEndpoint("pod1", 1, "node1")
+	cep2 := tu.CreateManagerEndpoint("pod2", 1, "node2")
+	cep3 := tu.CreateManagerEndpoint("pod3", 2, "node2")
+	cep4 := tu.CreateManagerEndpoint("pod4", 2, "node2")
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
+	cesStore.CacheStore().Add(ces1)
+	cep5 := tu.CreateManagerEndpoint("pod5", 1, "node1")
+	cep6 := tu.CreateManagerEndpoint("pod6", 1, "node1")
+	cep7 := tu.CreateManagerEndpoint("pod7", 2, "node1")
+	ces2 := tu.CreateStoreEndpointSlice("ces2", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
+	cesStore.CacheStore().Add(ces2)
+
+	// Delete CID to simulate the scenario where CID deleted during Operator restart
+	cidStore.CacheStore().Delete(cid1)
+
+	cesController.syncCESsInLocalCache(t.Context())
+	// Immediately after sync, CESCache does not contain pods with CID1
+	assert.NotContains(t, m.mapping.cidToGidLabels, cid1)
+	for _, pod := range podStore.List() {
+		if pod.Name == "pod1" || pod.Name == "pod2" || pod.Name == "pod5" || pod.Name == "pod6" {
+			assert.NotContains(t, m.mapping.cepData, NewCEPName(pod.Name, "ns"))
+		} else {
+			assert.Contains(t, m.mapping.cepData, NewCEPName(pod.Name, "ns"))
+		}
+	}
+
+	// After some time, the CESController should reprocess the CEPs
+	cesController.onPodUpdate(pod1)
+	cesController.onPodUpdate(pod2)
+	cesController.onPodUpdate(pod5)
+	cesController.onPodUpdate(pod6)
+	for _, pod := range podStore.List() {
+		assert.Contains(t, m.mapping.cepData, NewCEPName(pod.Name, "ns"))
 	}
 
 	cesController.fastQueue.ShutDown()

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -30,7 +30,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, log)
+	m := newDefaultManager(2, log)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics
@@ -63,10 +63,10 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 			clientset:           fakeClient.Clientset,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			reconciler:          r,
-			manager:             m,
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
 		},
+		manager:        m,
 		ciliumEndpoint: ciliumEndpoint,
 	}
 	cesController.initializeQueue()
@@ -104,7 +104,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, log)
+	m := newDefaultManager(2, log)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics
@@ -138,13 +138,13 @@ func TestDifferentSpeedQueues(t *testing.T) {
 			clientset:           fakeClient.Clientset,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			reconciler:          r,
-			manager:             m,
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
 			metrics:             cesMetrics,
 			priorityNamespaces:  make(map[string]struct{}),
 			syncDelay:           0,
 		},
+		manager:        m,
 		ciliumEndpoint: ciliumEndpoint,
 	}
 	cesController.cond = *sync.NewCond(&lock.Mutex{})
@@ -208,7 +208,7 @@ func TestCESManagement(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, log)
+	m := newDefaultManager(2, log)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics
@@ -242,13 +242,13 @@ func TestCESManagement(t *testing.T) {
 			clientset:           fakeClient.Clientset,
 			ciliumEndpointSlice: ciliumEndpointSlice,
 			reconciler:          r,
-			manager:             m,
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
 			metrics:             cesMetrics,
 			priorityNamespaces:  make(map[string]struct{}),
 			syncDelay:           0,
 		},
+		manager:        m,
 		ciliumEndpoint: ciliumEndpoint,
 	}
 	cesController.cond = *sync.NewCond(&lock.Mutex{})

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -57,15 +57,17 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
-	cesController := &Controller{
-		logger:              log,
-		clientset:           fakeClient.Clientset,
-		ciliumEndpoint:      ciliumEndpoint,
-		ciliumEndpointSlice: ciliumEndpointSlice,
-		reconciler:          r,
-		manager:             m,
-		rateLimit:           rateLimitConfig,
-		enqueuedAt:          make(map[CESKey]time.Time),
+	cesController := &DefaultController{
+		Controller: &Controller{
+			logger:              log,
+			clientset:           fakeClient.Clientset,
+			ciliumEndpointSlice: ciliumEndpointSlice,
+			reconciler:          r,
+			manager:             m,
+			rateLimit:           rateLimitConfig,
+			enqueuedAt:          make(map[CESKey]time.Time),
+		},
+		ciliumEndpoint: ciliumEndpoint,
 	}
 	cesController.initializeQueue()
 
@@ -130,18 +132,20 @@ func TestDifferentSpeedQueues(t *testing.T) {
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
-	cesController := &Controller{
-		logger:              log,
-		clientset:           fakeClient.Clientset,
-		ciliumEndpoint:      ciliumEndpoint,
-		ciliumEndpointSlice: ciliumEndpointSlice,
-		reconciler:          r,
-		manager:             m,
-		rateLimit:           rateLimitConfig,
-		enqueuedAt:          make(map[CESKey]time.Time),
-		metrics:             cesMetrics,
-		priorityNamespaces:  make(map[string]struct{}),
-		syncDelay:           0,
+	cesController := &DefaultController{
+		Controller: &Controller{
+			logger:              log,
+			clientset:           fakeClient.Clientset,
+			ciliumEndpointSlice: ciliumEndpointSlice,
+			reconciler:          r,
+			manager:             m,
+			rateLimit:           rateLimitConfig,
+			enqueuedAt:          make(map[CESKey]time.Time),
+			metrics:             cesMetrics,
+			priorityNamespaces:  make(map[string]struct{}),
+			syncDelay:           0,
+		},
+		ciliumEndpoint: ciliumEndpoint,
 	}
 	cesController.cond = *sync.NewCond(&lock.Mutex{})
 	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
@@ -232,18 +236,20 @@ func TestCESManagement(t *testing.T) {
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
-	cesController := &Controller{
-		logger:              log,
-		clientset:           fakeClient.Clientset,
-		ciliumEndpoint:      ciliumEndpoint,
-		ciliumEndpointSlice: ciliumEndpointSlice,
-		reconciler:          r,
-		manager:             m,
-		rateLimit:           rateLimitConfig,
-		enqueuedAt:          make(map[CESKey]time.Time),
-		metrics:             cesMetrics,
-		priorityNamespaces:  make(map[string]struct{}),
-		syncDelay:           0,
+	cesController := &DefaultController{
+		Controller: &Controller{
+			logger:              log,
+			clientset:           fakeClient.Clientset,
+			ciliumEndpointSlice: ciliumEndpointSlice,
+			reconciler:          r,
+			manager:             m,
+			rateLimit:           rateLimitConfig,
+			enqueuedAt:          make(map[CESKey]time.Time),
+			metrics:             cesMetrics,
+			priorityNamespaces:  make(map[string]struct{}),
+			syncDelay:           0,
+		},
+		ciliumEndpoint: ciliumEndpoint,
 	}
 	cesController.cond = *sync.NewCond(&lock.Mutex{})
 	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -6,7 +6,7 @@ package ciliumendpointslice
 import (
 	"log/slog"
 
-	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -59,7 +59,7 @@ func (c *cesManager) createCES(name, ns string) CESName {
 
 // UpdateCEPMapping is used to insert CEP in local cache, this may result in creating a new
 // CES object or updating an existing CES object.
-func (c *cesManager) UpdateCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) []CESKey {
+func (c *cesManager) UpdateCEPMapping(cep *cilium_v2a1.CoreCiliumEndpoint, ns string) []CESKey {
 	cepName := GetCEPNameFromCCEP(cep, ns)
 	c.logger.Debug("Insert CEP in local cache",
 		logfields.CEPName, cepName.string(),
@@ -90,7 +90,7 @@ func (c *cesManager) UpdateCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns stri
 	return []CESKey{NewCESKey(cesName.string(), ns)}
 }
 
-func (c *cesManager) RemoveCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) CESKey {
+func (c *cesManager) RemoveCEPMapping(cep *cilium_v2a1.CoreCiliumEndpoint, ns string) CESKey {
 	cepName := GetCEPNameFromCCEP(cep, ns)
 	c.logger.Debug("Removing CEP from local cache", logfields.CEPName, cepName.string())
 	cesName, exists := c.mapping.getCESName(cepName)
@@ -127,11 +127,11 @@ func (c *cesManager) getLargestAvailableCESForNamespace(ns string) CESName {
 	return selectedCES
 }
 
-func (c *cesManager) initializeMappingForCES(ces *cilium_v2.CiliumEndpointSlice) CESName {
+func (c *cesManager) initializeMappingForCES(ces *cilium_v2a1.CiliumEndpointSlice) CESName {
 	return c.createCES(ces.Name, ces.Namespace)
 }
 
-func (c *cesManager) initializeMappingCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ns string, ces CESName) {
+func (c *cesManager) initializeMappingCEPtoCES(cep *cilium_v2a1.CoreCiliumEndpoint, ns string, ces CESName) {
 	cepName := GetCEPNameFromCCEP(cep, ns)
 	c.mapping.insertCEP(cepName, ces)
 }

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -213,7 +213,21 @@ func (c *defaultManager) getCEPCountInCES(ces CESName) int {
 	return c.mapping.countCEPsInCES(ces)
 }
 
+func (c *slimManager) getCEPCountInCES(ces CESName) int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.mapping.countCEPsInCES(ces)
+}
+
 func (c *defaultManager) getCESNamespace(ces CESName) string {
+	return c.mapping.getCESNamespace(ces)
+}
+
+func (c *slimManager) getCESNamespace(ces CESName) string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
 	return c.mapping.getCESNamespace(ces)
 }
 
@@ -221,7 +235,22 @@ func (c *defaultManager) getCEPinCES(ces CESName) []CEPName {
 	return c.mapping.getCEPsInCES(ces)
 }
 
+func (c *slimManager) getCEPinCES(ces CESName) []CEPName {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.mapping.getCEPsInCES(ces)
+}
+
 func (c *defaultManager) isCEPinCES(cep CEPName, ces CESName) bool {
+	mappedCES, exists := c.mapping.getCESName(cep)
+	return exists && mappedCES == ces
+}
+
+func (c *slimManager) isCEPinCES(cep CEPName, ces CESName) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
 	mappedCES, exists := c.mapping.getCESName(cep)
 	return exists && mappedCES == ces
 }

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -10,6 +10,7 @@ import (
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -249,6 +250,13 @@ func (c *slimManager) RemoveIdentityMapping(id *cilium_v2.CiliumIdentity) []CESK
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	return c.mapping.deleteCID(CID(id.GetName()))
+}
+
+func (c *slimManager) GetCESInNs(ns *slim_corev1.Namespace) []CESKey {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.mapping.getCESInNs(ns.GetName())
 }
 
 func cidToGidLabels(id *cilium_v2.CiliumIdentity) (CID, Labels) {

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -88,12 +88,20 @@ func newSlimManager(maxCEPsInCES int, logger *slog.Logger) *slimManager {
 //  2. During operator warm boot [after crash or software upgrade], slicing manager
 //     creates a CES, by passing unique name.
 func (c *defaultManager) createCES(name, ns string) CESName {
+	return createCES(name, ns, c.mapping, c.logger)
+}
+
+func (c *slimManager) createCESLocked(name, ns string) CESName {
+	return createCES(name, ns, c.mapping, c.logger)
+}
+
+func createCES(name, ns string, cacher CESCacher, logger *slog.Logger) CESName {
 	if name == "" {
-		name = uniqueCESliceName(c.mapping)
+		name = uniqueCESliceName(cacher)
 	}
 	cesName := CESName(name)
-	c.mapping.insertCES(cesName, ns)
-	c.logger.Debug("Generated CES", logfields.CESName, cesName)
+	cacher.insertCES(cesName, ns)
+	logger.Debug("Generated CES", logfields.CESName, cesName)
 	return cesName
 }
 

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -188,9 +188,25 @@ func (c *defaultManager) initializeMappingForCES(ces *cilium_v2a1.CiliumEndpoint
 	return c.createCES(ces.Name, ces.Namespace)
 }
 
+func (c *slimManager) initializeMappingForCES(ces *cilium_v2a1.CiliumEndpointSlice) CESName {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.createCESLocked(ces.Name, ces.Namespace)
+}
+
 func (c *defaultManager) initializeMappingCEPtoCES(cep *cilium_v2a1.CoreCiliumEndpoint, ns string, ces CESName) {
 	cepName := GetCEPNameFromCCEP(cep, ns)
 	c.mapping.insertCEP(cepName, ces)
+}
+
+func (c *slimManager) initializeMappingPodToNode(cepName CEPName, nodeName NodeName, ces CESName, cid CID, gidLabels Labels, encryptionKey EncryptionKey) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.mapping.addCEP(cepName, ces, nodeName, gidLabels)
+	c.mapping.insertCID(cid, gidLabels)
+	c.mapping.insertNode(nodeName, encryptionKey)
 }
 
 func (c *defaultManager) getCEPCountInCES(ces CESName) int {

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -259,6 +259,13 @@ func (c *slimManager) GetCESInNs(ns *slim_corev1.Namespace) []CESKey {
 	return c.mapping.getCESInNs(ns.GetName())
 }
 
+func (c *slimManager) getCIDForCEP(cep CEPName) (CID, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.mapping.getCIDForCEP(cep)
+}
+
 func cidToGidLabels(id *cilium_v2.CiliumIdentity) (CID, Labels) {
 	cidName := id.GetName()
 	cidKey := key.GetCIDKeyFromLabels(id.SecurityLabels, labels.LabelSourceK8s)

--- a/operator/pkg/ciliumendpointslice/manager_test.go
+++ b/operator/pkg/ciliumendpointslice/manager_test.go
@@ -22,13 +22,13 @@ func getCEP(name string, id int64) *capi_v2a1.CoreCiliumEndpoint {
 func TestFCFSManager(t *testing.T) {
 	log := hivetest.Logger(t)
 	t.Run("Test adding new CEP to map", func(*testing.T) {
-		m := newCESManager(2, log)
+		m := newDefaultManager(2, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		assert.Equal(t, 1, m.mapping.getCESCount(), "Total number of CESs allocated is 1")
 		assert.Equal(t, 1, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test creating enough CESs", func(*testing.T) {
-		m := newCESManager(2, log)
+		m := newDefaultManager(2, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c3", 0), "ns")
@@ -38,7 +38,7 @@ func TestFCFSManager(t *testing.T) {
 		assert.Equal(t, 5, m.mapping.countCEPs(), "Total number of CEPs inserted is 5")
 	})
 	t.Run("Test keeping the CEPs from different namespaces in different CESs", func(*testing.T) {
-		m := newCESManager(5, log)
+		m := newDefaultManager(5, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns1")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns2")
 		m.UpdateCEPMapping(getCEP("c3", 0), "ns3")
@@ -48,14 +48,14 @@ func TestFCFSManager(t *testing.T) {
 		assert.Equal(t, 5, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test keeping the same mapping", func(*testing.T) {
-		m := newCESManager(2, log)
+		m := newDefaultManager(2, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c1", 5), "ns")
 		assert.Equal(t, 1, m.mapping.getCESCount(), "Total number of CESs allocated is 1")
 		assert.Equal(t, 1, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test reusing CES", func(*testing.T) {
-		m := newCESManager(2, log)
+		m := newDefaultManager(2, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns")
 		m.RemoveCEPMapping(getCEP("c1", 0), "ns")

--- a/operator/pkg/ciliumendpointslice/manager_test.go
+++ b/operator/pkg/ciliumendpointslice/manager_test.go
@@ -35,7 +35,7 @@ func newNode(name string, key int) *capi_v2.CiliumNode {
 	}
 }
 
-func TestFCFSManager(t *testing.T) {
+func TestFCFSManagerDefault(t *testing.T) {
 	log := hivetest.Logger(t)
 	t.Run("Test adding new CEP to map", func(*testing.T) {
 		m := newDefaultManager(2, log)

--- a/operator/pkg/ciliumendpointslice/rate_limit_test.go
+++ b/operator/pkg/ciliumendpointslice/rate_limit_test.go
@@ -37,6 +37,7 @@ func TestSingleDynamicRateLimit(t *testing.T) {
 			CESMaxCEPsInCES:           100,
 			CESSlicingMode:            identityMode,
 			CESDynamicRateLimitConfig: "[{\"nodes\": 5, \"limit\": 15.0, \"burst\": 30}]",
+			CESControllerMode:         defaultMode,
 		},
 	}
 	config, err := getRateLimitConfig(p)
@@ -75,6 +76,7 @@ func TestMultipleUnsortedDynamicRateLimit(t *testing.T) {
 			CESMaxCEPsInCES:           100,
 			CESSlicingMode:            identityMode,
 			CESDynamicRateLimitConfig: string(rlJson),
+			CESControllerMode:         defaultMode,
 		},
 	}
 	config, err := getRateLimitConfig(p)

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -8,16 +8,28 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/netip"
+	"strconv"
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
+
+type doReconciler interface {
+	reconcileCES(cesName CESName) error
+}
+
+type endpointGetter interface {
+	getCoreEndpointFromStore(cepName CEPName) *cilium_v2a1.CoreCiliumEndpoint
+}
 
 // reconciler is used to sync the current (i.e. desired) state of the CESs in datastore into current state CESs in the k8s-apiserver.
 // The source of truth is in local datastore.
@@ -25,34 +37,61 @@ type reconciler struct {
 	logger   *slog.Logger
 	client   clientset.CiliumV2alpha1Interface
 	context  context.Context
-	cepStore resource.Store[*cilium_v2.CiliumEndpoint]
 	cesStore resource.Store[*cilium_v2a1.CiliumEndpointSlice]
 	metrics  *Metrics
 
-	cesManager Manager
+	cesManager     Manager
+	endpointGetter endpointGetter
 }
 
-// newReconciler creates and initializes a new reconciler.
-func newReconciler(
+type defaultReconciler struct {
+	reconciler
+
+	manager *defaultManager
+
+	cepStore resource.Store[*cilium_v2.CiliumEndpoint]
+}
+
+type slimReconciler struct {
+	reconciler
+
+	manager *slimManager
+
+	namespaceStore  resource.Store[*slim_corev1.Namespace]
+	cidStore        resource.Store[*cilium_v2.CiliumIdentity]
+	podStore        resource.Store[*slim_corev1.Pod]
+	ciliumNodeStore resource.Store[*cilium_v2.CiliumNode]
+
+	ipsecEnabled bool
+	wgEnabled    bool
+}
+
+// newDefaultReconciler creates and initializes a new defaultReconciler.
+func newDefaultReconciler(
 	ctx context.Context,
 	client clientset.CiliumV2alpha1Interface,
-	cesMgr Manager,
+	cesMgr *defaultManager,
 	logger *slog.Logger,
 	ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint],
 	ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
 	metrics *Metrics,
-) *reconciler {
+) *defaultReconciler {
 	cepStore, _ := ciliumEndpoint.Store(ctx)
 	cesStore, _ := ciliumEndpointSlice.Store(ctx)
-	return &reconciler{
-		context:    ctx,
-		logger:     logger,
-		client:     client,
-		cesManager: cesMgr,
-		cepStore:   cepStore,
-		cesStore:   cesStore,
-		metrics:    metrics,
+	dReconciler := defaultReconciler{
+		reconciler: reconciler{
+			context:    ctx,
+			logger:     logger,
+			client:     client,
+			cesManager: cesMgr,
+			cesStore:   cesStore,
+			metrics:    metrics,
+		},
+		manager:  cesMgr,
+		cepStore: cepStore,
 	}
+	dReconciler.reconciler.endpointGetter = &dReconciler
+	return &dReconciler
 }
 
 func (r *reconciler) reconcileCES(cesName CESName) (err error) {
@@ -93,7 +132,7 @@ func (r *reconciler) reconcileCESCreate(cesName CESName) (err error) {
 	newCES.Namespace = r.cesManager.getCESNamespace(cesName)
 
 	for _, cepName := range ceps {
-		ccep := r.getCoreEndpointFromStore(cepName)
+		ccep := r.endpointGetter.getCoreEndpointFromStore(cepName)
 		r.logger.DebugContext(r.context,
 			fmt.Sprintf("Adding CEP to new CES (exist %v)", ccep != nil),
 			logfields.CESName, cesName.string(),
@@ -129,7 +168,7 @@ func (r *reconciler) reconcileCESUpdate(cesName CESName, cesObj *cilium_v2a1.Cil
 	cepNameToCEP := make(map[CEPName]*cilium_v2a1.CoreCiliumEndpoint)
 	// Get the CEPs objects from the CEP Store and map the names to them
 	for _, cepName := range cepsAssignedToCES {
-		ccep := r.getCoreEndpointFromStore(cepName)
+		ccep := r.endpointGetter.getCoreEndpointFromStore(cepName)
 		r.logger.DebugContext(r.context,
 			fmt.Sprintf("Adding CEP to existing CES (exist %v)", ccep != nil),
 			logfields.CESName, cesName.string(),
@@ -203,7 +242,7 @@ func (r *reconciler) reconcileCESDelete(ces *cilium_v2a1.CiliumEndpointSlice) (e
 	return
 }
 
-func (r *reconciler) getCoreEndpointFromStore(cepName CEPName) *cilium_v2a1.CoreCiliumEndpoint {
+func (r *defaultReconciler) getCoreEndpointFromStore(cepName CEPName) *cilium_v2a1.CoreCiliumEndpoint {
 	cepObj, exists, err := r.cepStore.GetByKey(cepName.key())
 	if err == nil && exists {
 		return k8s.ConvertCEPToCoreCEP(cepObj)
@@ -213,4 +252,166 @@ func (r *reconciler) getCoreEndpointFromStore(cepName CEPName) *cilium_v2a1.Core
 		logfields.CEPName, cepName.string(),
 	)
 	return nil
+}
+
+func (r *slimReconciler) getCoreEndpointFromStore(cepName CEPName) *cilium_v2a1.CoreCiliumEndpoint {
+	podObj, exists, err := r.podStore.GetByKey(cepName.key())
+	if err == nil && exists {
+		return r.convertPodToCoreCEP(podObj)
+	}
+	r.logger.DebugContext(r.context,
+		"Couldn't get Pod from Store",
+		logfields.Error, err,
+		logfields.Exists, exists,
+		logfields.CEPName, cepName.string(),
+	)
+	return nil
+}
+
+// Converts a Pod to a CoreCiliumEndpoint object. Returns nil if no CID has been assigned
+// to the pod.
+// While getting the CoreCEP fields, we typically get the most up-to-date information
+// from the pod object being reconciled.
+// However, in the case of the CID, we used the
+// cached selectedID from the local cescache, in order to reduce churn when duplicate
+// CIDs exist for the same set of labels.
+func (r *slimReconciler) convertPodToCoreCEP(pod *slim_corev1.Pod) *cilium_v2a1.CoreCiliumEndpoint {
+	identityId, err := r.getPodIdentityIDFromCache(pod)
+	if err != nil {
+		r.logger.DebugContext(r.context, "Could not get pod identity ID",
+			logfields.K8sPodName, pod.GetName(),
+			logfields.K8sNamespace, pod.Namespace,
+			logfields.Error, err,
+		)
+		return nil
+	}
+
+	networking, err := GetPodEndpointNetworking(pod)
+	if err != nil {
+		r.logger.DebugContext(r.context, "Could not get pod's endpoint networking",
+			logfields.K8sPodName, pod.GetName(),
+			logfields.K8sNamespace, pod.Namespace,
+			logfields.Error, err,
+		)
+		return nil
+	}
+
+	encryptionKey, err := r.getEndpointEncryptionKey(pod)
+	if err != nil {
+		r.logger.DebugContext(r.context, "Could not get pod's endpoint encryption key",
+			logfields.K8sPodName, pod.GetName(),
+			logfields.K8sNamespace, pod.Namespace,
+			logfields.Error, err,
+		)
+		return nil
+	}
+
+	namedPorts := r.getNamedPorts(pod)
+
+	return &cilium_v2a1.CoreCiliumEndpoint{
+		Name:       pod.GetName(),
+		IdentityID: identityId,
+		Networking: networking,
+		Encryption: cilium_v2.EncryptionSpec{
+			Key: encryptionKey,
+		},
+		NamedPorts:     namedPorts,
+		ServiceAccount: pod.Spec.ServiceAccountName,
+	}
+}
+
+// Get the identity ID for a given pod, from the local cescache.
+func (r *slimReconciler) getPodIdentityIDFromCache(pod *slim_corev1.Pod) (int64, error) {
+	cid, exists := r.manager.getCIDForCEP(GetCEPNameFromPod(pod))
+	if !exists {
+		return 0, fmt.Errorf("pod %s/%s has no known identity", pod.Namespace, pod.Name)
+	}
+	identityId, err := strconv.ParseInt(string(cid), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse CID %s name for pod %s/%s: %w", cid, pod.Namespace, pod.Name, err)
+	}
+	return identityId, nil
+}
+
+// Constructs an EndpointNetworking object for a given pod.
+func GetPodEndpointNetworking(pod *slim_corev1.Pod) (*cilium_v2.EndpointNetworking, error) {
+	addressPair := &cilium_v2.AddressPair{}
+
+	if len(pod.Status.PodIPs) == 0 {
+		return nil, fmt.Errorf("no IPs allocated to pod yet: %s", pod.GetName())
+	}
+
+	for _, podIP := range pod.Status.PodIPs {
+		ip, err := netip.ParseAddr(podIP.IP)
+		if err != nil {
+			return nil, err
+		}
+
+		if ip.Is4() {
+			addressPair.IPV4 = ip.String()
+		} else if ip.Is6() {
+			addressPair.IPV6 = ip.String()
+		}
+	}
+
+	if pod.GetHostIP() == "" {
+		return nil, fmt.Errorf("no hostIP for pod yet: %s", pod.GetName())
+	}
+
+	networking := &cilium_v2.EndpointNetworking{
+		Addressing: cilium_v2.AddressPairList{
+			addressPair,
+		},
+		NodeIP: pod.GetHostIP(),
+	}
+	return networking, nil
+}
+
+func (r *slimReconciler) getEndpointEncryptionKey(pod *slim_corev1.Pod) (int, error) {
+	if pod.Spec.NodeName == "" {
+		return 0, fmt.Errorf("pod %s/%s is not yet scheduled to a node", pod.Namespace, pod.Name)
+	}
+	key, found := r.manager.getEndpointEncryptionKey(NodeName(pod.Spec.NodeName))
+	if !found {
+		return 0, fmt.Errorf("no encryption key found in cache for node %s", pod.Spec.NodeName)
+	}
+	return int(key), nil
+}
+
+func (r *reconciler) getNamedPorts(pod *slim_corev1.Pod) models.NamedPorts {
+	namedPorts := make(models.NamedPorts, 0)
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.Name == "" {
+				continue
+			}
+
+			proto, err := getProtocolString(port.Protocol)
+			if err != nil {
+				continue
+			}
+
+			p := &models.Port{
+				Name:     port.Name,
+				Protocol: proto,
+				Port:     uint16(port.ContainerPort),
+			}
+			namedPorts = append(namedPorts, p)
+		}
+	}
+	return namedPorts
+}
+
+// Convert a slim_corev1.Protocol to models.PortProtocol format.
+func getProtocolString(p slim_corev1.Protocol) (string, error) {
+	switch p {
+	case slim_corev1.ProtocolTCP:
+		return models.PortProtocolTCP, nil
+	case slim_corev1.ProtocolUDP:
+		return models.PortProtocolUDP, nil
+	case slim_corev1.ProtocolSCTP:
+		return models.PortProtocolSCTP, nil
+	default:
+		return "", fmt.Errorf("unknown protocol: %s", p)
+	}
 }

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -22,20 +22,21 @@ import (
 // reconciler is used to sync the current (i.e. desired) state of the CESs in datastore into current state CESs in the k8s-apiserver.
 // The source of truth is in local datastore.
 type reconciler struct {
-	logger     *slog.Logger
-	client     clientset.CiliumV2alpha1Interface
-	context    context.Context
-	cesManager *cesManager
-	cepStore   resource.Store[*cilium_v2.CiliumEndpoint]
-	cesStore   resource.Store[*cilium_v2a1.CiliumEndpointSlice]
-	metrics    *Metrics
+	logger   *slog.Logger
+	client   clientset.CiliumV2alpha1Interface
+	context  context.Context
+	cepStore resource.Store[*cilium_v2.CiliumEndpoint]
+	cesStore resource.Store[*cilium_v2a1.CiliumEndpointSlice]
+	metrics  *Metrics
+
+	cesManager Manager
 }
 
 // newReconciler creates and initializes a new reconciler.
 func newReconciler(
 	ctx context.Context,
 	client clientset.CiliumV2alpha1Interface,
-	cesMgr *cesManager,
+	cesMgr Manager,
 	logger *slog.Logger,
 	ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint],
 	ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice],

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -14,15 +14,18 @@ import (
 
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	cidtest "github.com/cilium/cilium/operator/pkg/ciliumidentity/testutils"
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
-func TestReconcileCreate(t *testing.T) {
+func TestReconcileCreateDefault(t *testing.T) {
 	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, hivetest.Logger(t))
@@ -81,7 +84,7 @@ func TestReconcileCreate(t *testing.T) {
 	hive.Stop(tlog, t.Context())
 }
 
-func TestReconcileUpdate(t *testing.T) {
+func TestReconcileUpdateDefault(t *testing.T) {
 	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, hivetest.Logger(t))
@@ -125,7 +128,7 @@ func TestReconcileUpdate(t *testing.T) {
 	cepStore.CacheStore().Add(cep2)
 	cep3 := tu.CreateStoreEndpoint("cep3", "ns", 2)
 	cepStore.CacheStore().Add(cep3)
-	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{tu.CreateManagerEndpoint("cep1", 1), tu.CreateManagerEndpoint("cep3", 2)})
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{tu.CreateManagerEndpoint("cep1", 1, "node1"), tu.CreateManagerEndpoint("cep3", 2, "node2")})
 	cesStore.CacheStore().Add(ces1)
 	m.mapping.insertCES(CESName("ces1"), "ns")
 	m.mapping.insertCES(CESName("ces2"), "ns")
@@ -146,7 +149,7 @@ func TestReconcileUpdate(t *testing.T) {
 	hive.Stop(tlog, t.Context())
 }
 
-func TestReconcileDelete(t *testing.T) {
+func TestReconcileDeleteDefault(t *testing.T) {
 	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, hivetest.Logger(t))
@@ -190,7 +193,7 @@ func TestReconcileDelete(t *testing.T) {
 	cepStore.CacheStore().Add(cep2)
 	cep3 := tu.CreateStoreEndpoint("cep3", "ns", 2)
 	cepStore.CacheStore().Add(cep3)
-	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{tu.CreateManagerEndpoint("cep1", 1), tu.CreateManagerEndpoint("cep3", 2)})
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{tu.CreateManagerEndpoint("cep1", 1, "node1"), tu.CreateManagerEndpoint("cep3", 2, "node3")})
 	cesStore.CacheStore().Add(ces1)
 	m.mapping.insertCES(CESName("ces1"), "ns")
 	m.mapping.insertCES(CESName("ces2"), "ns")
@@ -205,7 +208,7 @@ func TestReconcileDelete(t *testing.T) {
 	hive.Stop(tlog, t.Context())
 }
 
-func TestReconcileNoop(t *testing.T) {
+func TestReconcileNoopDefault(t *testing.T) {
 	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, hivetest.Logger(t))
@@ -219,7 +222,11 @@ func TestReconcileNoop(t *testing.T) {
 		cell.Invoke(func(
 			c *k8sClient.FakeClientset,
 			cep resource.Resource[*cilium_v2.CiliumEndpoint],
+			p resource.Resource[*slim_corev1.Pod],
 			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			cn resource.Resource[*cilium_v2.CiliumNode],
+			ns resource.Resource[*slim_corev1.Namespace],
+			ci resource.Resource[*cilium_v2.CiliumIdentity],
 			metrics *Metrics,
 		) error {
 			fakeClient = c
@@ -252,6 +259,372 @@ func TestReconcileNoop(t *testing.T) {
 	m.mapping.insertCEP(NewCEPName("cep2", "ns"), CESName("ces2"))
 	m.mapping.insertCEP(NewCEPName("cep3", "ns"), CESName("ces2"))
 	// ces1 contains cep1 and cep3, but it's mapped to nothing so it should be deleted
+	r.reconcileCES(CESName("ces1"))
+
+	assert.True(t, noRequest)
+
+	hive.Stop(tlog, t.Context())
+}
+
+func TestReconcileCreate(t *testing.T) {
+	var r *slimReconciler
+	var fakeClient *k8sClient.FakeClientset
+	m := newSlimManager(2, hivetest.Logger(t))
+	var pods resource.Resource[*slim_corev1.Pod]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var ciliumNode resource.Resource[*cilium_v2.CiliumNode]
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity]
+	var cesMetrics *Metrics
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		metrics.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			p resource.Resource[*slim_corev1.Pod],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			cn resource.Resource[*cilium_v2.CiliumNode],
+			ns resource.Resource[*slim_corev1.Namespace],
+			ci resource.Resource[*cilium_v2.CiliumIdentity],
+			metrics *Metrics,
+		) error {
+			fakeClient = c
+			pods = p
+			ciliumEndpointSlice = ces
+			ciliumNode = cn
+			namespace = ns
+			ciliumIdentity = ci
+			cesMetrics = metrics
+			return nil
+		}),
+	)
+	tlog := hivetest.Logger(t)
+	hive.Start(tlog, t.Context())
+	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
+
+	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	podStore, _ := pods.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	cidStore, _ := ciliumIdentity.Store(t.Context())
+	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
+
+	var createdSlice *cilium_v2a1.CiliumEndpointSlice
+	fakeClient.CiliumFakeClientset.PrependReactor("create", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		pa := action.(k8sTesting.CreateAction)
+		createdSlice = pa.GetObject().(*cilium_v2a1.CiliumEndpointSlice)
+		return true, nil, nil
+	})
+
+	node := tu.CreateStoreNode("node1")
+	ciliumNodeStore.CacheStore().Add(node)
+	m.mapping.insertNode(NodeName("node1"), EncryptionKey(0))
+
+	ns1 := cidtest.NewNamespace("ns", nil)
+	nsStore.CacheStore().Add(ns1)
+	pod1 := cidtest.NewPod("pod1", "ns", tu.TestLbsA, "node1")
+	podStore.CacheStore().Add(pod1)
+	cid1 := cidtest.NewCIDWithNamespace("1", pod1, ns1)
+	cidStore.CacheStore().Add(cid1)
+
+	pod2 := cidtest.NewPod("pod2", "ns", tu.TestLbsB, "node1")
+	podStore.CacheStore().Add(pod2)
+	cid2 := cidtest.NewCIDWithNamespace("2", pod2, ns1)
+	cidStore.CacheStore().Add(cid2)
+
+	pod3 := cidtest.NewPod("pod3", "ns", tu.TestLbsC, "node1")
+	podStore.CacheStore().Add(pod3)
+	cid3 := cidtest.NewCIDWithNamespace("3", pod3, ns1)
+	cidStore.CacheStore().Add(cid3)
+
+	m.mapping.insertCES(CESName("ces1"), "ns")
+	m.mapping.insertCES(CESName("ces2"), "ns")
+
+	_, gidA := cidToGidLabels(cid1)
+	_, gidB := cidToGidLabels(cid2)
+	_, gidC := cidToGidLabels(cid3)
+
+	m.mapping.insertCID("1", gidA)
+	m.mapping.insertCID("2", gidB)
+	m.mapping.insertCID("3", gidC)
+	m.mapping.addCEP(NewCEPName("pod1", "ns"), CESName("ces1"), "node1", gidA)
+	m.mapping.addCEP(NewCEPName("pod2", "ns"), CESName("ces1"), "node1", gidB)
+	m.mapping.addCEP(NewCEPName("pod3", "ns"), CESName("ces2"), "node1", gidC)
+
+	r.reconcileCES(CESName("ces1"))
+
+	assert.Equal(t, "ces1", createdSlice.Name)
+	assert.Len(t, createdSlice.Endpoints, 2)
+	assert.Equal(t, "ns", createdSlice.Namespace)
+	eps := []string{createdSlice.Endpoints[0].Name, createdSlice.Endpoints[1].Name}
+	assert.Contains(t, eps, "pod1")
+	assert.Contains(t, eps, "pod2")
+
+	hive.Stop(tlog, t.Context())
+}
+
+func TestReconcileUpdate(t *testing.T) {
+	var r *slimReconciler
+	var fakeClient *k8sClient.FakeClientset
+	m := newSlimManager(2, hivetest.Logger(t))
+	var pods resource.Resource[*slim_corev1.Pod]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var ciliumNode resource.Resource[*cilium_v2.CiliumNode]
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity]
+	var cesMetrics *Metrics
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		metrics.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			p resource.Resource[*slim_corev1.Pod],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			cn resource.Resource[*cilium_v2.CiliumNode],
+			ns resource.Resource[*slim_corev1.Namespace],
+			ci resource.Resource[*cilium_v2.CiliumIdentity],
+			metrics *Metrics,
+		) error {
+			fakeClient = c
+			pods = p
+			ciliumEndpointSlice = ces
+			ciliumNode = cn
+			namespace = ns
+			ciliumIdentity = ci
+			cesMetrics = metrics
+			return nil
+		}),
+	)
+
+	tlog := hivetest.Logger(t)
+	hive.Start(tlog, t.Context())
+	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	podStore, _ := pods.Store(t.Context())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	cidStore, _ := ciliumIdentity.Store(t.Context())
+	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
+
+	var updatedSlice *cilium_v2a1.CiliumEndpointSlice
+	fakeClient.CiliumFakeClientset.PrependReactor("update", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		pa := action.(k8sTesting.UpdateAction)
+		updatedSlice = pa.GetObject().(*cilium_v2a1.CiliumEndpointSlice)
+		return true, nil, nil
+	})
+
+	node := tu.CreateStoreNode("node1")
+	ciliumNodeStore.CacheStore().Add(node)
+	m.mapping.insertNode(NodeName("node1"), EncryptionKey(0))
+
+	ns1 := cidtest.NewNamespace("ns", nil)
+	nsStore.CacheStore().Add(ns1)
+	pod1 := cidtest.NewPod("pod1", "ns", tu.TestLbsA, "node1")
+	podStore.CacheStore().Add(pod1)
+	cid1 := cidtest.NewCIDWithNamespace("1", pod1, ns1)
+	cidStore.CacheStore().Add(cid1)
+
+	pod2 := cidtest.NewPod("pod2", "ns", tu.TestLbsB, "node1")
+	podStore.CacheStore().Add(pod2)
+	cid2 := cidtest.NewCIDWithNamespace("2", pod2, ns1)
+	cidStore.CacheStore().Add(cid2)
+
+	pod3 := cidtest.NewPod("pod3", "ns", tu.TestLbsB, "node1")
+	podStore.CacheStore().Add(pod3)
+
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{tu.CreateManagerEndpoint("pod1", 1, "node1"), tu.CreateManagerEndpoint("pod3", 2, "node1")})
+	cesStore.CacheStore().Add(ces1)
+
+	m.mapping.insertCES(CESName("ces1"), "ns")
+	m.mapping.insertCES(CESName("ces2"), "ns")
+
+	_, gidA := cidToGidLabels(cid1)
+	_, gidB := cidToGidLabels(cid2)
+	m.mapping.insertCID("1", gidA)
+	m.mapping.insertCID("2", gidB)
+	m.mapping.addCEP(NewCEPName("pod1", "ns"), CESName("ces1"), "node1", gidA)
+	m.mapping.addCEP(NewCEPName("pod2", "ns"), CESName("ces1"), "node1", gidB)
+	m.mapping.addCEP(NewCEPName("pod3", "ns"), CESName("ces2"), "node1", gidB)
+
+	// ces1 contains cep1 and cep3, but it's mapped to cep1 and cep2
+	// so it's expected that after update it would contain cep1 and cep2
+	r.reconcileCES(CESName("ces1"))
+
+	assert.Equal(t, "ces1", updatedSlice.Name)
+	assert.Len(t, updatedSlice.Endpoints, 2)
+	assert.Equal(t, "ns", updatedSlice.Namespace)
+	eps := []string{updatedSlice.Endpoints[0].Name, updatedSlice.Endpoints[1].Name}
+	assert.Contains(t, eps, "pod1")
+	assert.Contains(t, eps, "pod2")
+
+	hive.Stop(tlog, t.Context())
+}
+
+func TestReconcileDelete(t *testing.T) {
+	var r *slimReconciler
+	var fakeClient *k8sClient.FakeClientset
+	m := newSlimManager(2, hivetest.Logger(t))
+	var pods resource.Resource[*slim_corev1.Pod]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var ciliumNode resource.Resource[*cilium_v2.CiliumNode]
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity]
+	var cesMetrics *Metrics
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		metrics.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			p resource.Resource[*slim_corev1.Pod],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			cn resource.Resource[*cilium_v2.CiliumNode],
+			ns resource.Resource[*slim_corev1.Namespace],
+			ci resource.Resource[*cilium_v2.CiliumIdentity],
+			metrics *Metrics,
+		) error {
+			fakeClient = c
+			pods = p
+			ciliumEndpointSlice = ces
+			ciliumNode = cn
+			namespace = ns
+			ciliumIdentity = ci
+			cesMetrics = metrics
+			return nil
+		}),
+	)
+
+	tlog := hivetest.Logger(t)
+	hive.Start(tlog, t.Context())
+	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	podStore, _ := pods.Store(t.Context())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	cidStore, _ := ciliumIdentity.Store(t.Context())
+	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
+
+	var deletedSlice string
+	fakeClient.CiliumFakeClientset.PrependReactor("delete", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		pa := action.(k8sTesting.DeleteAction)
+		deletedSlice = pa.GetName()
+		return true, nil, nil
+	})
+
+	node := tu.CreateStoreNode("node1")
+	ciliumNodeStore.CacheStore().Add(node)
+	m.mapping.insertNode(NodeName("node1"), EncryptionKey(0))
+
+	ns1 := cidtest.NewNamespace("ns", nil)
+	nsStore.CacheStore().Add(ns1)
+	pod1 := cidtest.NewPod("pod1", "ns", tu.TestLbsA, "node1")
+	podStore.CacheStore().Add(pod1)
+	cid1 := cidtest.NewCIDWithNamespace("1", pod1, ns1)
+	cidStore.CacheStore().Add(cid1)
+
+	pod2 := cidtest.NewPod("pod2", "ns", tu.TestLbsB, "node1")
+	podStore.CacheStore().Add(pod2)
+	cid2 := cidtest.NewCIDWithNamespace("2", pod2, ns1)
+	cidStore.CacheStore().Add(cid2)
+	pod3 := cidtest.NewPod("pod3", "ns", tu.TestLbsB, "node1")
+	podStore.CacheStore().Add(pod3)
+
+	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{tu.CreateManagerEndpoint("cep1", 1, "node1"), tu.CreateManagerEndpoint("cep3", 2, "node1")})
+	cesStore.CacheStore().Add(ces1)
+
+	m.mapping.insertCES(CESName("ces1"), "ns")
+	m.mapping.insertCES(CESName("ces2"), "ns")
+	_, gidA := cidToGidLabels(cid1)
+	_, gidB := cidToGidLabels(cid2)
+	m.mapping.insertCID("1", gidA)
+	m.mapping.insertCID("2", gidB)
+	m.mapping.addCEP(NewCEPName("pod1", "ns"), CESName("ces2"), "node1", gidA)
+	m.mapping.addCEP(NewCEPName("pod2", "ns"), CESName("ces2"), "node1", gidB)
+	m.mapping.addCEP(NewCEPName("pod3", "ns"), CESName("ces2"), "node1", gidB)
+
+	// ces1 contains cep1 and cep3, but it's mapped to nothing so it should be deleted
+	r.reconcileCES(CESName("ces1"))
+
+	assert.Equal(t, "ces1", deletedSlice)
+
+	hive.Stop(tlog, t.Context())
+}
+
+func TestReconcileNoop(t *testing.T) {
+	var r *slimReconciler
+	var fakeClient *k8sClient.FakeClientset
+	m := newSlimManager(2, hivetest.Logger(t))
+	var pods resource.Resource[*slim_corev1.Pod]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var ciliumNode resource.Resource[*cilium_v2.CiliumNode]
+	var namespace resource.Resource[*slim_corev1.Namespace]
+	var ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity]
+	var cesMetrics *Metrics
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		metrics.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			p resource.Resource[*slim_corev1.Pod],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			cn resource.Resource[*cilium_v2.CiliumNode],
+			ns resource.Resource[*slim_corev1.Namespace],
+			ci resource.Resource[*cilium_v2.CiliumIdentity],
+			metrics *Metrics,
+		) error {
+			fakeClient = c
+			pods = p
+			ciliumEndpointSlice = ces
+			ciliumNode = cn
+			namespace = ns
+			ciliumIdentity = ci
+			cesMetrics = metrics
+			return nil
+		}),
+	)
+
+	tlog := hivetest.Logger(t)
+	hive.Start(tlog, t.Context())
+	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	podStore, _ := pods.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	cidStore, _ := ciliumIdentity.Store(t.Context())
+	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
+
+	noRequest := true
+	fakeClient.CiliumFakeClientset.PrependReactor("*", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		noRequest = false
+		return true, nil, nil
+	})
+
+	node := tu.CreateStoreNode("node1")
+	ciliumNodeStore.CacheStore().Add(node)
+	m.mapping.insertNode(NodeName("node1"), EncryptionKey(0))
+
+	ns1 := cidtest.NewNamespace("ns", nil)
+	nsStore.CacheStore().Add(ns1)
+	pod1 := cidtest.NewPod("pod1", "ns", tu.TestLbsA, "node1")
+	podStore.CacheStore().Add(pod1)
+	cid1 := cidtest.NewCIDWithNamespace("1", pod1, ns1)
+	cidStore.CacheStore().Add(cid1)
+	pod2 := cidtest.NewPod("pod2", "ns", tu.TestLbsB, "node1")
+	podStore.CacheStore().Add(pod2)
+	cid2 := cidtest.NewCIDWithNamespace("2", pod2, ns1)
+	cidStore.CacheStore().Add(cid2)
+	pod3 := cidtest.NewPod("pod3", "ns", tu.TestLbsB, "node1")
+	podStore.CacheStore().Add(pod3)
+
+	m.mapping.insertCES(CESName("ces1"), "ns")
+	m.mapping.insertCES(CESName("ces2"), "ns")
+	_, gidA := cidToGidLabels(cid1)
+	_, gidB := cidToGidLabels(cid2)
+	m.mapping.insertCID("1", gidA)
+	m.mapping.insertCID("2", gidB)
+	m.mapping.addCEP(NewCEPName("pod1", "ns"), CESName("ces2"), "node1", gidA)
+	m.mapping.addCEP(NewCEPName("pod2", "ns"), CESName("ces2"), "node1", gidB)
+	m.mapping.addCEP(NewCEPName("pod3", "ns"), CESName("ces2"), "node1", gidB)
+
+	// ces1 is mapped to nothing so it won't be reconciled
 	r.reconcileCES(CESName("ces1"))
 
 	assert.True(t, noRequest)

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -25,7 +25,7 @@ import (
 func TestReconcileCreate(t *testing.T) {
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, hivetest.Logger(t))
+	m := newDefaultManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics
@@ -84,7 +84,7 @@ func TestReconcileCreate(t *testing.T) {
 func TestReconcileUpdate(t *testing.T) {
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, hivetest.Logger(t))
+	m := newDefaultManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics
@@ -149,7 +149,7 @@ func TestReconcileUpdate(t *testing.T) {
 func TestReconcileDelete(t *testing.T) {
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, hivetest.Logger(t))
+	m := newDefaultManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics
@@ -208,7 +208,7 @@ func TestReconcileDelete(t *testing.T) {
 func TestReconcileNoop(t *testing.T) {
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, hivetest.Logger(t))
+	m := newDefaultManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestReconcileCreate(t *testing.T) {
-	var r *reconciler
+	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
@@ -48,7 +48,7 @@ func TestReconcileCreate(t *testing.T) {
 	)
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
 
 	var createdSlice *cilium_v2a1.CiliumEndpointSlice
@@ -82,7 +82,7 @@ func TestReconcileCreate(t *testing.T) {
 }
 
 func TestReconcileUpdate(t *testing.T) {
-	var r *reconciler
+	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
@@ -108,7 +108,7 @@ func TestReconcileUpdate(t *testing.T) {
 
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 
@@ -147,7 +147,7 @@ func TestReconcileUpdate(t *testing.T) {
 }
 
 func TestReconcileDelete(t *testing.T) {
-	var r *reconciler
+	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
@@ -173,7 +173,7 @@ func TestReconcileDelete(t *testing.T) {
 
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 
@@ -206,7 +206,7 @@ func TestReconcileDelete(t *testing.T) {
 }
 
 func TestReconcileNoop(t *testing.T) {
-	var r *reconciler
+	var r *defaultReconciler
 	var fakeClient *k8sClient.FakeClientset
 	m := newDefaultManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
@@ -231,7 +231,7 @@ func TestReconcileNoop(t *testing.T) {
 	)
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
 
 	noRequest := true

--- a/operator/pkg/ciliumendpointslice/test_utils.go
+++ b/operator/pkg/ciliumendpointslice/test_utils.go
@@ -16,3 +16,19 @@ func (c *CESCache) getEncryptionKey(nodeName NodeName) (EncryptionKey, bool) {
 	}
 	return 0, false
 }
+
+// Return if given CID is present in cache
+func (c *CESCache) hasCID(cid CID) bool {
+	_, ok := c.cidToGidLabels[cid]
+	return ok
+}
+
+// Return the selected CID for the given GID labels
+func (c *CESCache) GetSelectedId(gid Labels) (CID, bool) {
+	if gidData, ok := c.globalIdLabelsToCIDSet[gid]; ok {
+		if gidData.selectedID != "" {
+			return gidData.selectedID, true
+		}
+	}
+	return "", false
+}

--- a/operator/pkg/ciliumendpointslice/test_utils.go
+++ b/operator/pkg/ciliumendpointslice/test_utils.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+// Return if given node is present in cache
+func (c *CESCache) hasNode(nodeName NodeName) bool {
+	_, ok := c.nodeData[nodeName]
+	return ok
+}
+
+// Return stored encryption key for node.
+func (c *CESCache) getEncryptionKey(nodeName NodeName) (EncryptionKey, bool) {
+	if nodeData, ok := c.nodeData[nodeName]; ok {
+		return nodeData.key, true
+	}
+	return 0, false
+}

--- a/operator/pkg/ciliumendpointslice/test_utils.go
+++ b/operator/pkg/ciliumendpointslice/test_utils.go
@@ -32,3 +32,8 @@ func (c *CESCache) GetSelectedId(gid Labels) (CID, bool) {
 	}
 	return "", false
 }
+
+// Return the total number of CESs.
+func (c *CESCache) getCESCount() int {
+	return len(c.cesData)
+}

--- a/operator/pkg/ciliumendpointslice/test_utils.go
+++ b/operator/pkg/ciliumendpointslice/test_utils.go
@@ -37,3 +37,14 @@ func (c *CESCache) GetSelectedId(gid Labels) (CID, bool) {
 func (c *CESCache) getCESCount() int {
 	return len(c.cesData)
 }
+
+// Return if the given CEP is present in cache
+func (c *CESCache) hasCEP(cepName CEPName) bool {
+	_, ok := c.cepData[cepName]
+	return ok
+}
+
+// Return total number of CEPs stored in cache
+func (c *CESCache) countCEPs() int {
+	return len(c.cepData)
+}

--- a/operator/pkg/ciliumendpointslice/testutils/test_utils.go
+++ b/operator/pkg/ciliumendpointslice/testutils/test_utils.go
@@ -7,6 +7,25 @@ import (
 
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/node/addressing"
+)
+
+var (
+	TestLbsA = map[string]string{
+		"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name": "ns",
+		"k8s:io.cilium.k8s.policy.cluster":                               "",
+		"k8s:io.kubernetes.pod.namespace":                                "ns",
+		"key-a":                                                          "val-1"}
+	TestLbsB = map[string]string{
+		"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name": "ns",
+		"k8s:io.cilium.k8s.policy.cluster":                               "",
+		"k8s:io.kubernetes.pod.namespace":                                "ns",
+		"key-b":                                                          "val-2"}
+	TestLbsC = map[string]string{
+		"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name": "ns",
+		"k8s:io.cilium.k8s.policy.cluster":                               "",
+		"k8s:io.kubernetes.pod.namespace":                                "ns",
+		"key-c":                                                          "val-3"}
 )
 
 var (
@@ -17,10 +36,13 @@ var (
 	}
 )
 
-func CreateManagerEndpoint(name string, identity int64) capi_v2a1.CoreCiliumEndpoint {
+func CreateManagerEndpoint(name string, identity int64, node string) capi_v2a1.CoreCiliumEndpoint {
 	return capi_v2a1.CoreCiliumEndpoint{
 		Name:       name,
 		IdentityID: identity,
+		Networking: &v2.EndpointNetworking{
+			NodeIP: NodeIPs[node],
+		},
 	}
 }
 
@@ -35,6 +57,25 @@ func CreateStoreEndpoint(name string, namespace string, identity int64) *v2.Cili
 				ID: identity,
 			},
 			Networking: &v2.EndpointNetworking{},
+		},
+	}
+}
+
+func CreateStoreNode(name string) *v2.CiliumNode {
+	return &v2.CiliumNode{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v2.NodeSpec{
+			Addresses: []v2.NodeAddress{
+				{
+					Type: addressing.AddressType("InternalIP"),
+					IP:   NodeIPs[name],
+				},
+			},
+			Encryption: v2.EncryptionSpec{
+				Key: 0,
+			},
 		},
 	}
 }

--- a/operator/pkg/ciliumendpointslice/utils.go
+++ b/operator/pkg/ciliumendpointslice/utils.go
@@ -20,7 +20,7 @@ func randomName(n int) string {
 // Generates unique random name for the CiliumEndpointSlice, the format
 // of a CES name is similar to pod k8s naming convention "ces-123456789-abcde".
 // First 3 letters indicates ces resource, followed by random letters.
-func uniqueCESliceName(mapping *CESToCEPMapping) string {
+func uniqueCESliceName(mapping CESCacher) string {
 	var sb strings.Builder
 	for {
 		rn1, rn2 := randomName(9), randomName(5)

--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -278,15 +278,15 @@ func TestCIDUsageInPods(t *testing.T) {
 }
 
 func TestCIDUsageInCES(t *testing.T) {
-	cep1 := cestest.CreateManagerEndpoint("cep1", 1000)
-	cep2 := cestest.CreateManagerEndpoint("cep2", 1000)
-	cep3 := cestest.CreateManagerEndpoint("cep3", 2000)
-	cep4 := cestest.CreateManagerEndpoint("cep4", 3000)
+	cep1 := cestest.CreateManagerEndpoint("cep1", 1000, "node1")
+	cep2 := cestest.CreateManagerEndpoint("cep2", 1000, "node1")
+	cep3 := cestest.CreateManagerEndpoint("cep3", 2000, "node1")
+	cep4 := cestest.CreateManagerEndpoint("cep4", 3000, "node1")
 	ces1 := cestest.CreateStoreEndpointSlice("ces1", "ns", []capi_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
 
-	cep5 := cestest.CreateManagerEndpoint("cep5", 1000)
-	cep6 := cestest.CreateManagerEndpoint("cep6", 1000)
-	cep7 := cestest.CreateManagerEndpoint("cep7", 2000)
+	cep5 := cestest.CreateManagerEndpoint("cep5", 1000, "node1")
+	cep6 := cestest.CreateManagerEndpoint("cep6", 1000, "node1")
+	cep7 := cestest.CreateManagerEndpoint("cep7", 2000, "node1")
 	ces2 := cestest.CreateStoreEndpointSlice("ces2", "ns", []capi_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
 
 	assertTxt := "CES 1 is added"

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -178,7 +178,7 @@ func verifyCIDUsageInCES(ctx context.Context, fakeClient *k8sClient.FakeClientse
 		return err
 	}
 
-	cep1 := cestest.CreateManagerEndpoint("cep1", int64(cidNum))
+	cep1 := cestest.CreateManagerEndpoint("cep1", int64(cidNum), "node1")
 	ces1 := cestest.CreateStoreEndpointSlice("ces1", "ns", []capi_v2a1.CoreCiliumEndpoint{cep1})
 	if _, err := fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(ctx, ces1, metav1.CreateOptions{}); err != nil {
 		return err

--- a/pkg/datapath/linux/ipsec/cell.go
+++ b/pkg/datapath/linux/ipsec/cell.go
@@ -28,6 +28,8 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(buildConfigFrom),
 )
 
+var OperatorCell = cell.Config(defaultEnableConfig)
+
 type params struct {
 	cell.In
 
@@ -71,7 +73,7 @@ func buildConfigFrom(uc UserConfig, dc *option.DaemonConfig) Config {
 }
 
 var defaultUserConfig = UserConfig{
-	EnableIPsec:                              false,
+	EnableConfig:                             defaultEnableConfig,
 	EnableIPsecKeyWatcher:                    true,
 	EnableIPsecXfrmStateCaching:              true,
 	UseCiliumInternalIPForIPsec:              false,
@@ -81,7 +83,7 @@ var defaultUserConfig = UserConfig{
 }
 
 type UserConfig struct {
-	EnableIPsec                              bool
+	EnableConfig                             `mapstructure:",squash"`
 	EnableIPsecKeyWatcher                    bool
 	EnableIPsecXfrmStateCaching              bool
 	UseCiliumInternalIPForIPsec              bool
@@ -91,7 +93,7 @@ type UserConfig struct {
 }
 
 func (def UserConfig) Flags(flags *pflag.FlagSet) {
-	flags.Bool(types.EnableIPSec, def.EnableIPsec, "Enable IPsec")
+	def.EnableConfig.Flags(flags)
 	flags.Bool(types.EnableIPsecKeyWatcher, def.EnableIPsecKeyWatcher, "Enable watcher for IPsec key. If disabled, a restart of the agent will be necessary on key rotations.")
 	flags.Bool(types.EnableIPSecXfrmStateCaching, def.EnableIPsecXfrmStateCaching, "Enable XfrmState cache for IPSec. Significantly reduces CPU usage in large clusters.")
 	flags.MarkHidden(types.EnableIPSecXfrmStateCaching)
@@ -110,14 +112,26 @@ type Config struct {
 	EncryptNode bool
 }
 
-func (c Config) Enabled() bool {
-	return c.EnableIPsec
-}
-
 func (c Config) UseCiliumInternalIP() bool {
 	return c.UseCiliumInternalIPForIPsec
 }
 
 func (c Config) DNSProxyInsecureSkipTransparentModeCheckEnabled() bool {
 	return c.DNSProxyInsecureSkipTransparentModeCheck
+}
+
+var defaultEnableConfig = EnableConfig{
+	EnableIPsec: false,
+}
+
+type EnableConfig struct {
+	EnableIPsec bool
+}
+
+func (def EnableConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool(types.EnableIPSec, def.EnableIPsec, "Enable IPsec")
+}
+
+func (c EnableConfig) Enabled() bool {
+	return c.EnableIPsec
 }

--- a/pkg/datapath/linux/ipsec/cell_test.go
+++ b/pkg/datapath/linux/ipsec/cell_test.go
@@ -157,7 +157,9 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 					return paramsOut{
 						IPSecConfig: Config{
 							UserConfig: UserConfig{
-								EnableIPsec:                              ipsecEnabled,
+								EnableConfig: EnableConfig{
+									EnableIPsec: ipsecEnabled,
+								},
 								EnableIPsecKeyWatcher:                    true,
 								EnableIPsecXfrmStateCaching:              true,
 								UseCiliumInternalIPForIPsec:              false,

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -228,7 +228,9 @@ type config struct {
 func (c *config) toAgentConfig() Config {
 	return Config{
 		UserConfig: UserConfig{
-			EnableWireguard:              true,
+			EnableConfig: EnableConfig{
+				EnableWireguard: true,
+			},
 			WireguardTrackAllIPsFallback: c.Fallback,
 			WireguardPersistentKeepalive: 0,
 			NodeEncryptionOptOutLabels:   "",

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -144,7 +144,9 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 					return paramsOut{
 						WireguardConfig: Config{
 							UserConfig: UserConfig{
-								EnableWireguard:              wireguardEnabled,
+								EnableConfig: EnableConfig{
+									EnableWireguard: wireguardEnabled,
+								},
 								WireguardTrackAllIPsFallback: false,
 								WireguardPersistentKeepalive: 0,
 								NodeEncryptionOptOutLabels:   "",


### PR DESCRIPTION
This PR makes a change to add an option to create CiliumEndpointSlices directly from pods instead of from CiliumEndpoints. This is a step towards eliminating the need for CEPs when CES are present, which will allow us to reduce pressure created on the kube-apiserver by the CEP CRD at high scale.

Descriptions of changes are in each commit.

```release-note
Add option to create CiliumEndpointSlices directly from pods instead of CiliumEndpoints
```
