### PR TITLE
renovate: Allow cilium-envoy 1.32 for 1.16

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -581,7 +581,6 @@
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
       "allowedVersions": "/^v1\\.31\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
-        "v1.16",
         "v1.15",
       ]
     },
@@ -593,6 +592,7 @@
       "allowedVersions": "/^v1\\.32\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "v1.17",
+        "v1.16",
       ]
     },
     {


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/38307


