### PR TITLE
bugtool: collect more detailed link statistics

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -182,7 +182,7 @@ func miscSystemCommands() []string {
 		"ip a",
 		"ip -4 r",
 		"ip -6 r",
-		"ip -d -s l",
+		"ip -d -s -s l",
 		"ip -4 n",
 		"ip -6 n",
 		"ss -t -p -a -i -s -n -e",


### PR DESCRIPTION
```
Collect the detailed error counts in `ip link` for better debugability.

Before
    ...
    RX:  bytes packets errors dropped  missed   mcast
             0       0      0       0       0       0
    ...

After:
    ...
    RX:  bytes packets errors dropped  missed   mcast
             0       0      0       0       0       0
    RX errors:  length    crc   frame    fifo overrun
                     0      0       0       0       0
    ...
```