### PR TITLE
gh: phase out testing with kernel-of-the-day LVH images

### DIFF
--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -61,8 +61,8 @@
   ingress-controller: 'true'
   bgp-control-plane: 'true'
 - name: '7'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-next-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   kube-proxy: 'none'
   kpr: 'true'
   devices: '{eth0,eth1}'
@@ -76,8 +76,8 @@
   node-local-dns: 'true'
   misc: 'bpfClockProbe=false,cni.uninstall=false,tls.secretsBackend=k8s,tls.secretSync.enabled=true'
 - name: '8'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-next-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'geneve'
@@ -129,8 +129,8 @@
   local-redirect-policy: 'true'
   node-local-dns: 'true'
 - name: '12'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-next-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   kube-proxy: 'none'
   kpr: 'true'
   devices: '{eth0,eth1}'
@@ -166,8 +166,8 @@
   lb-acceleration: 'testing-only'
   ingress-controller: 'true'
 - name: '15'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-next-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   kube-proxy: 'none'
   kpr: 'true'
   devices: '{eth0,eth1}'
@@ -192,8 +192,8 @@
   ciliumendpointslice: 'true'
   ingress-controller: 'true'
 - name: '17'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   misc: 'bpf.datapathMode=netkit,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
   kube-proxy: 'none'
   kpr: 'true'
@@ -203,8 +203,8 @@
   secondary-network: 'true'
   ingress-controller: 'true'
 - name: '18'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   misc: 'bpf.datapathMode=netkit-l2,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
   kube-proxy: 'none'
   kpr: 'true'
@@ -214,8 +214,8 @@
   secondary-network: 'true'
   ingress-controller: 'true'
 - name: '19'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   misc: 'bpf.datapathMode=netkit'
   kube-proxy: 'none'
   kpr: 'true'
@@ -225,8 +225,8 @@
   ingress-controller: 'true'
   kvstore: 'true'
 - name: '20'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   misc: 'bpf.datapathMode=netkit-l2'
   kube-proxy: 'none'
   kpr: 'true'
@@ -235,8 +235,8 @@
   secondary-network: 'true'
   ingress-controller: 'true'
 - name: '21'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   misc: 'bpf.datapathMode=netkit'
   kube-proxy: 'none'
   kpr: 'true'
@@ -245,8 +245,8 @@
   secondary-network: 'true'
   ingress-controller: 'true'
 - name: '22'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   misc: 'bpf.datapathMode=netkit-l2'
   kube-proxy: 'none'
   kpr: 'true'
@@ -255,8 +255,8 @@
   secondary-network: 'true'
   ingress-controller: 'true'
 - name: '23'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   misc: 'bpf.datapathMode=netkit'
   kube-proxy: 'none'
   kpr: 'true'
@@ -267,8 +267,8 @@
   ingress-controller: 'true'
   host-fw: 'true'
 - name: '24'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-net-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   misc: 'bpf.datapathMode=netkit,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
   kube-proxy: 'none'
   kpr: 'true'
@@ -278,8 +278,8 @@
   endpoint-routes: 'true'
   ingress-controller: 'true'
 - name: '25'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-net-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   misc: 'bpf.datapathMode=netkit-l2,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
   kube-proxy: 'none'
   kpr: 'true'

--- a/.github/actions/ginkgo/k8s-versions-schema.yaml
+++ b/.github/actions/ginkgo/k8s-versions-schema.yaml
@@ -5,3 +5,4 @@ includeItem:
   ip-family: str()
   kube-image: str()
   kernel: str()
+  kernel-type: str()

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -6,7 +6,8 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.32.0@sha256:22cf2864f90cfab0d442fda2decf2eae107edd03483053a902614dec637eff76"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "bpf-next-20250415.134122"
+    kernel: "6.12-20250415.134122"
+    kernel-type: "latest"
 
   - k8s-version: "1.31"
     ip-family: "dual"
@@ -14,6 +15,7 @@ include:
     kube-image: "quay.io/cilium/kindest-node:v1.31.0@sha256:d2b2a8cd6fa282b9a4126938341a4d2924dfa96f60b1f983d519498c9cde1a99"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
     kernel: "rhel8.6-20250415.134122"
+    kernel-type: "oldstable"
 
   - k8s-version: "1.30"
     ip-family: "dual"
@@ -21,6 +23,7 @@ include:
     kube-image: "quay.io/cilium/kindest-node:v1.30.0@sha256:edcb457c0b2ecc69a0fa9b0878bdcfd4a0f1205340cf08bf36a03d3a94a16dd9"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
     kernel: "rhel8.6-20250415.134122"
+    kernel-type: "oldstable"
 
   - k8s-version: "1.29"
     ip-family: "dual"
@@ -28,3 +31,4 @@ include:
     kube-image: "kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
     kernel: "5.4-20250415.134122"
+    kernel-type: "stable"

--- a/.github/actions/ipsec/configs.yaml
+++ b/.github/actions/ipsec/configs.yaml
@@ -25,8 +25,8 @@
   key-two: 'gcm(aes)'
   kvstore: 'true'
 - name: '4'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-next-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'geneve'
@@ -62,8 +62,8 @@
   key-one: 'gcm(aes)'
   key-two: 'gcm(aes)'
 - name: '8'
-  # Skip kernel updates due to https://github.com/cilium/cilium/issues/37520.
-  kernel: 'bpf-next-20250110.013326'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  kernel: '6.12-20250415.134122'
   kube-proxy: 'none'
   kpr: 'true'
   tunnel: 'vxlan'

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -320,7 +320,7 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host/
-            if [[ "${{ matrix.kernel }}" == bpf-next-* ]]; then
+            if [[ "${{ matrix.kernel-type }}" == latest ]]; then
               ./contrib/scripts/kind.sh "" 2 "" "${{ matrix.kube-image }}" "none" "${{ matrix.ip-family }}"
               kubectl label node kind-worker2 cilium.io/ci-node=kind-worker2
               # Avoid re-labeling this node by setting "node-role.kubernetes.io/controlplane"
@@ -390,13 +390,13 @@ jobs:
             kubectl get pods -A -o wide
             export K8S_NODES=2
             export NETNEXT=0
-            if [[ "${{ matrix.kernel }}" == bpf-next-* ]]; then
+            if [[ "${{ matrix.kernel-type }}" == latest ]]; then
                export KERNEL=net-next
                export NETNEXT=1
                export KUBEPROXY=0
                export K8S_NODES=3
                export NO_CILIUM_ON_NODES=kind-worker2
-            elif [[ "${{ matrix.kernel }}" == 5.4-* ]]; then
+            elif [[ "${{ matrix.kernel-type }}" == stable ]]; then
                export KERNEL=54
             fi
             export K8S_VERSION=${{ matrix.k8s-version }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -260,7 +260,7 @@ jobs:
           test-name: runtime-tests
           install-dependencies: true
           # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          image-version: "bpf-next-20250110.013326"
+          image-version: "6.12-20241218.004849"
           host-mount: ./
           images-folder-parent: "/tmp"
           cpu: 4


### PR DESCRIPTION
Testing unstable Cilium changes (from PRs) against unstable infrastructure (random kernel-of-the-day builds) doesn't really give us much information. Switch to the latest LTS kernel instead.

Keeping bpf-next in the datapath verifier workflow (it's a good sniff test for complexity changes).

If we still want to sniff-test against bleeding-edge upstream kernels, then this could be done with scheduled runs. But not in PRs.