### PR TITLE
k8s,docs: Deprecate CiliumBGPPeeringPolicy CRD

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -297,6 +297,8 @@ communicating via the proxy must reconnect to re-establish connections.
   ``CiliumBGPNodeConfigOverride`` CRDs was deprecated in favor of the ``v2`` version. Change ``apiVersion: cilium.io/v2alpha1``
   to ``apiVersion: cilium.io/v2`` for these CRDs in all your BGP configs. The previously deprecated field
   ``spec.transport.localPort`` in ``CiliumBGPPeerConfig`` has been removed and will be ignored if it was configured in the ``v2alpha1`` version.
+* The ``CiliumBGPPeeringPolicy`` CRD is deprecated and will be removed in a future release. Please migrate to ``cilium.io/v2``
+  BGP CRDs (``CiliumBGPClusterConfig``, ``CiliumBGPPeerConfig``, ``CiliumBGPAdvertisement``, ``CiliumBGPNodeConfigOverride``) to configure BGP.
 
 
 Removed Options

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -23,6 +23,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: cilium.io/v2alpha1 CiliumBGPPeeringPolicy is deprecated; use
+      cilium.io/v2 CRDs (CiliumBGPClusterConfig, CiliumBGPPeerConfig, CiliumBGPAdvertisement,
+      CiliumBGPNodeConfigOverride) to configure BGP.
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.31.4"
+	CustomResourceDefinitionSchemaVersion = "1.31.5"
 )

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -47,6 +47,7 @@ const (
 // +kubebuilder:resource:categories={cilium,ciliumbgp},singular="ciliumbgppeeringpolicy",path="ciliumbgppeeringpolicies",scope="Cluster",shortName={bgpp}
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="cilium.io/v2alpha1 CiliumBGPPeeringPolicy is deprecated; use cilium.io/v2 CRDs (CiliumBGPClusterConfig, CiliumBGPPeerConfig, CiliumBGPAdvertisement, CiliumBGPNodeConfigOverride) to configure BGP."
 
 // CiliumBGPPeeringPolicy is a Kubernetes third-party resource for instructing
 // Cilium's BGP control plane to create virtual BGP routers.


### PR DESCRIPTION
 In v1.16 we introduced new CRDs to configure BGP on Cilium (e.g. `CiliumBGPClusterConfig`, `CiliumBGPPeerConfig`, `CiliumBGPAdvertisement`, `CiliumBGPNodeConfigOverride`). 

Recently, we promoted them to stable version (`v2`). Users should stop using the old `v2alpha1.CiliumBGPPeeringPolicy` CRD to configure BGP, as it will be removed in a future version.

```release-note
Deprecate `CiliumBGPPeeringPolicy` CRD in favor of `cilium.io/v2` CRDs (`CiliumBGPClusterConfig`, `CiliumBGPPeerConfig`, `CiliumBGPAdvertisement`, `CiliumBGPNodeConfigOverride`)
```
