### PR TITLE
[v1.17] ipsec:cli:doc: reject key rotations with different keySize, then enable pod-to-pod-with-l7-policy-encryption for IPv6

### DIFF
--- a/.github/actions/ipsec/configs.yaml
+++ b/.github/actions/ipsec/configs.yaml
@@ -5,7 +5,7 @@
   kpr: 'false'
   tunnel: 'vxlan'
   key-one: 'gcm(aes)'
-  key-two: 'cbc(aes)'
+  key-two: 'gcm(aes)'
 - name: '2'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.4-20250226.175419'
@@ -32,7 +32,7 @@
   tunnel: 'geneve'
   endpoint-routes: 'true'
   key-one: 'cbc(aes)'
-  key-two: 'gcm(aes)'
+  key-two: 'cbc(aes)'
   kvstore: 'true'
 - name: '5'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -364,18 +364,11 @@ jobs:
         shell: bash
         run: |
           mkdir -p cilium-junits
-
-          TEST='--test "!seq-.*"'
-          if [ "${{ matrix.key-one }}" = "gcm(aes)" ] && [ "${{ matrix.key-two }}" = "cbc(aes)" ]; then
-            # Until https://github.com/cilium/cilium/issues/29480 is resolved
-            TEST='--test "!(seq-.*|pod-to-pod-no-frag)"'
-          fi
-
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            $TEST \
+            --test "!seq-.*" \
             --test-concurrency=${{ env.test_concurrency }}
 
       - name: Features tested

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -184,6 +184,13 @@ Key Rotation
    is, all nodes in the cluster (or clustermesh) should be on the same Cilium
    version before rotating keys.
 
+.. attention::
+
+   It is not recommended to change algorithms that involve different authentication
+   key lengths during key rotations. If this is attempted, Cilium will delay the
+   application of the new key until the agent restarts and will continue using the
+   previous key. This is designed to maintain uninterrupted IPv6 pod-to-pod connectivity.
+
 To replace cilium-ipsec-keys secret with a new key:
 
 .. code-block:: shell-session

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -83,11 +83,12 @@ const (
 )
 
 type ipSecKey struct {
-	Spi   uint8
-	ReqID int
-	Auth  *netlink.XfrmStateAlgo
-	Crypt *netlink.XfrmStateAlgo
-	Aead  *netlink.XfrmStateAlgo
+	Spi    uint8
+	KeyLen int
+	ReqID  int
+	Auth   *netlink.XfrmStateAlgo
+	Crypt  *netlink.XfrmStateAlgo
+	Aead   *netlink.XfrmStateAlgo
 }
 
 type oldXfrmStateKey struct {
@@ -1092,10 +1093,14 @@ func LoadIPSecKeys(log *slog.Logger, r io.Reader) (int, uint8, error) {
 		}
 
 		ipSecKey.Spi = spi
+		ipSecKey.KeyLen = keyLen
 
 		if oldKey, ok := ipSecKeysGlobal[""]; ok {
 			if oldKey.Spi == spi {
 				return 0, 0, fmt.Errorf("invalid SPI: changing IPSec keys requires incrementing the key id")
+			}
+			if oldKey.KeyLen != keyLen {
+				return 0, 0, fmt.Errorf("invalid key rotation: key length must not change")
 			}
 			ipSecKeysRemovalTime[oldKey.Spi] = time.Now()
 		}


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/37936.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 37936
```