### PR TITLE
[v1.15] ipsec:cli:doc: reject key rotations with different keySize, then enable pod-to-pod-with-l7-policy-encryption for IPv6

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -110,7 +110,7 @@ jobs:
             encryption: 'ipsec'
             encryption-node: 'false'
             key-one: 'gcm(aes)'
-            key-two: 'cbc(aes)'
+            key-two: 'gcm(aes)'
             key-type-one: '+'
             key-type-two: '+'
 
@@ -152,7 +152,7 @@ jobs:
             encryption-node: 'false'
             endpoint-routes: 'true'
             key-one: 'cbc(aes)'
-            key-two: 'gcm(aes)'
+            key-two: 'cbc(aes)'
             key-type-one: ''
             key-type-two: ''
             kvstore: 'true'
@@ -384,18 +384,12 @@ jobs:
         run: |
           mkdir -p cilium-junits
 
-          TEST=""
-          if [ "${{ matrix.key-one }}" = "gcm(aes)" ] && [ "${{ matrix.key-two }}" = "cbc(aes)" ]; then
-            # Until https://github.com/cilium/cilium/issues/29480 is resolved
-            TEST='--test "!pod-to-pod-no-frag"'
-          fi
-
           ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --flush-ct $TEST
+            --flush-ct
 
       - name: Features tested
         uses: ./.github/actions/feature-status

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -174,6 +174,13 @@ Key Rotation
    is, all nodes in the cluster (or clustermesh) should be on the same Cilium
    version before rotating keys.
 
+.. attention::
+
+   It is not recommended to change algorithms that involve different authentication
+   key lengths during key rotations. If this is attempted, Cilium will delay the
+   application of the new key until the agent restarts and will continue using the
+   previous key. This is designed to maintain uninterrupted IPv6 pod-to-pod connectivity.
+
 To replace cilium-ipsec-keys secret with a new key:
 
 .. code-block:: shell-session


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/37936.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 37936
```