### PR TITLE
Add support to capture kernel profiles during performance testing

### DIFF
--- a/.github/actions/cl2-modules/egw/modules/perf-test.yaml
+++ b/.github/actions/cl2-modules/egw/modules/perf-test.yaml
@@ -34,6 +34,7 @@ steps:
       - --tolerations=node.kubernetes.io/not-ready,cilium.io/no-schedule
       - --node-selector-server=cilium.io/no-schedule=true
       - --node-selector-client=role.scaffolding/egw-client=true
+      - --unsafe-capture-kernel-profiles
 
 - name: Sleep to allow scraping
   measurements:

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -293,7 +293,7 @@ jobs:
         id: run-perf
         run: |
           mkdir output
-          cilium connectivity perf --duration=30s --host-net=true --pod-net=true --report-dir=./output
+          cilium connectivity perf --duration=30s --host-net=true --pod-net=true --report-dir=./output --unsafe-capture-kernel-profiles
           sudo chmod -R +r ./output
 
       - name: Features tested

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -242,7 +242,7 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 		Use:   "perf",
 		Short: "Test network performance",
 		Long:  ``,
-		PreRun: func(_ *cobra.Command, _ []string) {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			// This is a bit of hack that allows us to override default values
 			// of these parameters that are not visible in perf subcommand options
 			// as we can't have different defaults specified in test and perf subcommands
@@ -250,6 +250,14 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 			params.Perf = true
 			params.ForceDeploy = true
 			params.Hubble = false
+
+			if reportDir := params.PerfParameters.ReportDir; reportDir != "" {
+				if err := os.MkdirAll(reportDir, 0755); err != nil {
+					return fmt.Errorf("could not create report dir %q: %w", reportDir, err)
+				}
+			}
+
+			return nil
 		},
 		RunE: RunE(hooks),
 	}

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -255,6 +255,9 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 				if err := os.MkdirAll(reportDir, 0755); err != nil {
 					return fmt.Errorf("could not create report dir %q: %w", reportDir, err)
 				}
+			} else if params.PerfParameters.KernelProfiles {
+				fmt.Println("⚠️  Requested kernel profiles, but report-dir is unset, skipping")
+				params.PerfParameters.KernelProfiles = false
 			}
 
 			return nil
@@ -279,6 +282,9 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.PerfParameters.SameNode, "same-node", true, "Run tests in which the client and the server are hosted on the same node")
 	cmd.Flags().BoolVar(&params.PerfParameters.OtherNode, "other-node", true, "Run tests in which the client and the server are hosted on difference nodes")
 	cmd.Flags().BoolVar(&params.PerfParameters.NetQos, "net-qos", false, "Test pod network Quality of Service")
+
+	cmd.Flags().BoolVar(&params.PerfParameters.KernelProfiles, "unsafe-capture-kernel-profiles", false,
+		"Capture kernel profiles during test execution. Warning: run on disposable nodes only, as it installs additional software and modifies their configuration")
 
 	cmd.Flags().Var(option.NewNamedMapOptions("node-selector-server", &params.PerfParameters.NodeSelectorServer, nil),
 		"node-selector-server", "Node selector for the server pod (and client same-node)")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -41,6 +41,7 @@ type PerfParameters struct {
 	UDP             bool
 	Image           string
 	NetQos          bool
+	KernelProfiles  bool
 
 	NodeSelectorServer map[string]string
 	NodeSelectorClient map[string]string

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -74,6 +74,7 @@ type ConnectivityTest struct {
 	clientCPPods         map[string]Pod
 	perfClientPods       []Pod
 	perfServerPod        []Pod
+	perfProfilingPods    map[string]Pod
 	PerfResults          []common.PerfSummary
 	echoServices         map[string]Service
 	echoExternalServices map[string]Service
@@ -227,6 +228,7 @@ func NewConnectivityTest(
 		clientCPPods:             make(map[string]Pod),
 		lrpClientPods:            make(map[string]Pod),
 		lrpBackendPods:           make(map[string]Pod),
+		perfProfilingPods:        make(map[string]Pod),
 		socatServerPods:          []Pod{},
 		socatClientPods:          []Pod{},
 		perfClientPods:           []Pod{},
@@ -1116,6 +1118,10 @@ func (ct *ConnectivityTest) PerfServerPod() []Pod {
 
 func (ct *ConnectivityTest) PerfClientPods() []Pod {
 	return ct.perfClientPods
+}
+
+func (ct *ConnectivityTest) PerfProfilingPods() map[string]Pod {
+	return ct.perfProfilingPods
 }
 
 func (ct *ConnectivityTest) SocatServerPods() []Pod {

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1968,7 +1968,6 @@ func (ct *ConnectivityTest) validateDeploymentPerf(ctx context.Context) error {
 			ct.perfServerPod = append(ct.perfServerPod, Pod{
 				K8sClient: ct.client,
 				Pod:       perfPod.DeepCopy(),
-				port:      5201,
 			})
 		} else {
 			ct.perfClientPods = append(ct.perfClientPods, Pod{

--- a/cilium-cli/connectivity/perf/benchmarks/profiler/profiler.go
+++ b/cilium-cli/connectivity/perf/benchmarks/profiler/profiler.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package profiler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+)
+
+type logger interface {
+	Debugf(format string, args ...any)
+}
+
+type Profiler struct {
+	enabled   bool
+	target    check.Pod
+	duration  time.Duration
+	reportDir string
+}
+
+type Profile struct {
+	enabled   bool
+	reportDir string
+	grp       errgroup.Group
+	data      bytes.Buffer
+}
+
+func New(target check.Pod, params check.PerfParameters) *Profiler {
+	return &Profiler{
+		enabled:   params.KernelProfiles,
+		target:    target,
+		duration:  params.Duration,
+		reportDir: params.ReportDir,
+	}
+}
+
+func (p *Profiler) Run(ctx context.Context, logger logger) *Profile {
+	if !p.enabled {
+		return &Profile{}
+	}
+
+	profile := &Profile{enabled: true, reportDir: p.reportDir}
+	profile.grp.Go(func() (err error) {
+		profile.data, err = p.run(ctx, logger)
+		return err
+	})
+
+	return profile
+}
+
+func (p *Profiler) run(ctx context.Context, logger logger) (bytes.Buffer, error) {
+	var (
+		// Sleep one tenth of the test duration before starting to record the profile,
+		// and symmetrically stop the profile one tenth of the duration before the end,
+		// so that we increase the likelihood of only capturing the profile during the
+		// active period, considering that it is started via a separate exec operation.
+		delay    = strconv.FormatInt(p.duration.Milliseconds()/10, 10)
+		duration = strconv.FormatFloat(p.duration.Seconds()*0.8, 'f', 1, 64)
+
+		nsenter = []string{"nsenter", "--target=1", "--mount", "--"}
+		record  = []string{"perf", "record", "--freq", "99", "--all-cpus", "-g", "--delay", delay, "-o", "/tmp/perf.data", "--", "sleep", duration}
+		script  = []string{"perf", "script", "-i", "/tmp/perf.data"}
+	)
+
+	logger.Debugf("Starting profile capture on %s: %s", p.target.Name(), strings.Join(slices.Concat(nsenter, record), " "))
+	_, stderr, err := p.target.K8sClient.ExecInPodWithStderr(ctx, p.target.Namespace(), p.target.NameWithoutNamespace(),
+		"profiler", slices.Concat(nsenter, record))
+	if err != nil {
+		return bytes.Buffer{}, fmt.Errorf("capturing profile: %w: %v", err, stderr.String())
+	}
+
+	logger.Debugf("Parsing profile on %s: %s", p.target.Name(), strings.Join(slices.Concat(nsenter, script), " "))
+	stdout, stderr, err := p.target.K8sClient.ExecInPodWithStderr(ctx, p.target.Namespace(), p.target.NameWithoutNamespace(),
+		"profiler", slices.Concat(nsenter, script))
+	if err != nil {
+		return bytes.Buffer{}, fmt.Errorf("parsing profile: %w: %v", err, stderr.String())
+	}
+	logger.Debugf("Profile successfully retrieved from %s", p.target.Name())
+
+	return stdout, nil
+}
+
+func (p *Profile) Save(filename string, logger logger) error {
+	if !p.enabled {
+		return nil
+	}
+
+	if err := p.grp.Wait(); err != nil {
+		return err
+	}
+
+	target := path.Join(p.reportDir, filename)
+	if err := os.WriteFile(target, p.data.Bytes(), 0600); err != nil {
+		return fmt.Errorf("saving profile: %w", err)
+	}
+	logger.Debugf("Profile saved to %q", target)
+
+	return nil
+}


### PR DESCRIPTION
Extend the connectivity perf command with an extra option to automatically capture kernel profiles during the execution of each performance test, for later inspection. The resulting profiles, saved into the result directory, can be converted into an interactive SVG file via (see \[1] for more info): 

```
  stackcollapse-perf.pl $file | flamegraph.pl > out.svg
```

Note that the kernel profiles capture shall be enabled only when running against disposable nodes dedicated for this scope. Indeed, the capture makes use of privileged pods to escape into the underlying host, install the necessary additional software and eventually run the appropriate `perf` commands. `perf` needs to be installed on the host, rather than in a container, as the version is specific to the underlying kernel.

Additionally, enable this new feature in the net-perf-gke and scale-egw workflows.

Currently builds on top of https://github.com/cilium/cilium/pull/38245

\[1]: https://github.com/brendangregg/FlameGraph