### PR TITLE
fix SBOM attestation documentation

### DIFF
--- a/Documentation/configuration/sbom.rst
+++ b/Documentation/configuration/sbom.rst
@@ -26,7 +26,7 @@ Prerequisites
 
 - `Install cosign`_
 
-.. _`Install cosign`: https://docs.sigstore.dev/cosign/installation/
+.. _`Install cosign`: https://docs.sigstore.dev/cosign/system_config/installation/
 
 Download SBOM
 =============
@@ -35,7 +35,7 @@ You can download the SBOM in-toto attestation from the supplied Cilium image usi
 
 .. code-block:: shell-session
 
-    $ cosign download attestation --predicate-type spdxjson <Image URI> | jq -r .payload | base64 -d | jq .predicate > ciliumSBOM.spdx.json
+    $ cosign download attestation --predicate-type spdxjson <IMAGE URI> | jq -r .payload | base64 -d | jq .predicate > ciliumSBOM.spdx.json
 
 Verify SBOM attestation
 =======================
@@ -44,11 +44,11 @@ To verify the SBOM in-toto attestation on the supplied Cilium image, run the fol
 
 .. parsed-literal::
     
-    $ TAG = |IMAGE_TAG|
+    $ TAG=|IMAGE_TAG|
     $ cosign verify-attestation --certificate-github-workflow-repository cilium/cilium \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
     --certificate-identity-regexp https://github.com/cilium/cilium/.github/workflows \
-    --type spdxjson <Image URI> | 2>&1   | head -n 13
+    --type spdxjson <IMAGE URI> 2>&1 | head -n 13
 
 For example:
 
@@ -57,7 +57,7 @@ For example:
     $ cosign verify-attestation --certificate-github-workflow-repository cilium/cilium \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
     --certificate-identity-regexp https://github.com/cilium/cilium/.github/workflows \
-    --type spdxjson quay.io/cilium/cilium-ci:d2d270a42b674ca1e7c536186691d8ac8317fd64  2>&1 | head -n 13
+    --type spdxjson quay.io/cilium/cilium-ci:d2d270a42b674ca1e7c536186691d8ac8317fd64 2>&1 | head -n 13
 
     Verification for quay.io/cilium/cilium-ci:d2d270a42b674ca1e7c536186691d8ac8317fd64 --
     The following checks were performed on each of these signatures:


### PR DESCRIPTION
- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

<!-- Description of change -->

This commit addresses several issues in the SBOM verification documentation:

- Fixed the Install cosign link that was previously broken
- Corrected shell command syntax for setting the TAG variable (removed spaces)
- Fixed improper redirection syntax (| 2>&1 | → 2>&1 |)

**before**
```
$ TAG = v1.17.2
TAG: command not found
```
**after**
```
$ TAG=v1.17.2
$ cosign verify-attestation --certificate-github-workflow-repository cilium/cilium --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp https://github.com/cilium/cilium/.github/workflows --type spdxjson $IMAGE_URI 2>&1 | head -n 13

Verification for quay.io/cilium/cilium-ci:d2d270a42b674ca1e7c536186691d8ac8317fd64 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
Certificate subject: https://github.com/cilium/cilium/.github/workflows/build-images-ci.yaml@refs/pull/34011/merge
Certificate issuer URL: https://token.actions.githubusercontent.com
GitHub Workflow Trigger: pull_request
GitHub Workflow SHA: 7d967b8355489cef6a787558ac70c9c619463284
GitHub Workflow Name: Image CI Build
GitHub Workflow Repository: cilium/cilium
GitHub Workflow Ref: refs/pull/34011/merge
```

Fixes: #38380

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
