### PR TITLE
bpf: ipsec: add helper to encode the magic ENCRYPT mark value

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -775,14 +775,6 @@ struct encrypt_config {
 	__u8 encrypt_key;
 } __packed;
 
-/**
- * or_encrypt_key - mask and shift key into encryption format
- */
-static __always_inline __u32 or_encrypt_key(__u8 key)
-{
-	return (((__u32)key & 0x0F) << 12) | MARK_MAGIC_ENCRYPT;
-}
-
 /*
  * ctx->tc_index uses
  *

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -114,21 +114,6 @@ set_identity_meta(struct __sk_buff *ctx, __u32 identity)
 }
 
 /**
- * set_encrypt_key - pushes 8 bit key, 16 bit node ID, and encryption marker into ctx mark value.
- */
-static __always_inline __maybe_unused void
-set_encrypt_key_mark(struct __sk_buff *ctx, __u8 key, __u32 node_id)
-{
-	ctx->mark = or_encrypt_key(key) | node_id << 16;
-}
-
-static __always_inline __maybe_unused void
-set_encrypt_key_meta(struct __sk_buff *ctx, __u8 key, __u32 node_id)
-{
-	ctx->cb[CB_ENCRYPT_MAGIC] = or_encrypt_key(key) | node_id << 16;
-}
-
-/**
  * set_cluster_id_mark - sets the cluster_id mark.
  */
 static __always_inline __maybe_unused void

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -54,18 +54,6 @@ set_identity_meta(struct xdp_md *ctx __maybe_unused,
 }
 
 static __always_inline __maybe_unused void
-set_encrypt_key_mark(struct xdp_md *ctx __maybe_unused, __u8 key __maybe_unused,
-		     __u32 node_id __maybe_unused)
-{
-}
-
-static __always_inline __maybe_unused void
-set_encrypt_key_meta(struct __sk_buff *ctx __maybe_unused, __u8 key __maybe_unused,
-		     __u32 node_id __maybe_unused)
-{
-}
-
-static __always_inline __maybe_unused void
 ctx_set_cluster_id_mark(struct xdp_md *ctx __maybe_unused, __u32 cluster_id __maybe_unused)
 {
 }

--- a/bpf/tests/ipsec_from_host_generic.h
+++ b/bpf/tests/ipsec_from_host_generic.h
@@ -106,7 +106,7 @@ int ipv4_ipsec_from_host_setup(struct __ctx_buff *ctx)
 	 */
 	ipcache_v4_add_entry(v4_pod_two, 0, 233, v4_node_two, 0);
 
-	set_encrypt_key_mark(ctx, ENCRYPT_KEY, NODE_ID);
+	ctx->mark = ipsec_encode_encryption_mark(ENCRYPT_KEY, NODE_ID);
 	set_identity_meta(ctx, SECLABEL_IPV4);
 	tail_call_static(ctx, entry_call_map, FROM_HOST);
 	return TEST_ERROR;
@@ -226,7 +226,7 @@ int ipv6_ipsec_from_host_setup(struct __ctx_buff *ctx)
 	/* See comment for IPv4 counterpart. */
 	ipcache_v6_add_entry((union v6addr *)v6_pod_two, 0, 233, v4_node_two, 0);
 
-	set_encrypt_key_mark(ctx, ENCRYPT_KEY, NODE_ID);
+	ctx->mark = ipsec_encode_encryption_mark(ENCRYPT_KEY, NODE_ID);
 	set_identity_meta(ctx, SECLABEL_IPV6);
 	tail_call_static(ctx, entry_call_map, FROM_HOST);
 	return TEST_ERROR;

--- a/bpf/tests/ipsec_from_lxc_generic.h
+++ b/bpf/tests/ipsec_from_lxc_generic.h
@@ -147,7 +147,7 @@ int ipv4_from_lxc_encrypt_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	status_code = data;
 	assert(*status_code == CTX_ACT_OK);
-	assert(ctx->mark == (NODE_ID << 16 | ENCRYPT_KEY << 12 | MARK_MAGIC_ENCRYPT));
+	assert(ctx->mark == ipsec_encode_encryption_mark(ENCRYPT_KEY, NODE_ID));
 	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == SECLABEL_IPV4);
 
 	l2 = data + sizeof(*status_code);
@@ -236,7 +236,7 @@ int ipv4_from_lxc_new_local_key_check(__maybe_unused const struct __ctx_buff *ct
 
 	status_code = data;
 	assert(*status_code == CTX_ACT_OK);
-	assert(ctx->mark == (NODE_ID << 16 | ENCRYPT_KEY << 12 | MARK_MAGIC_ENCRYPT));
+	assert(ctx->mark == ipsec_encode_encryption_mark(ENCRYPT_KEY, NODE_ID));
 	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == SECLABEL_IPV4);
 
 	test_finish();
@@ -281,7 +281,7 @@ int ipv4_from_lxc_new_remote_key_check(__maybe_unused const struct __ctx_buff *c
 
 	status_code = data;
 	assert(*status_code == CTX_ACT_OK);
-	assert(ctx->mark == (NODE_ID << 16 | ENCRYPT_KEY << 12 | MARK_MAGIC_ENCRYPT));
+	assert(ctx->mark == ipsec_encode_encryption_mark(ENCRYPT_KEY, NODE_ID));
 	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == SECLABEL_IPV4);
 
 	test_finish();
@@ -350,7 +350,7 @@ int ipv6_from_lxc_encrypt_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	status_code = data;
 	assert(*status_code == CTX_ACT_OK);
-	assert(ctx->mark == (NODE_ID << 16 | ENCRYPT_KEY << 12 | MARK_MAGIC_ENCRYPT));
+	assert(ctx->mark == ipsec_encode_encryption_mark(ENCRYPT_KEY, NODE_ID));
 	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == SECLABEL_IPV6);
 
 	l2 = data + sizeof(*status_code);

--- a/bpf/tests/tc_host_encrypted_overlay.c
+++ b/bpf/tests/tc_host_encrypted_overlay.c
@@ -181,7 +181,7 @@ int tc_host_encrypted_overlay_01_check(const struct __ctx_buff *ctx)
 	if (tunnel_vni_to_sec_identity(vxlan->vx_vni) != POD1_SEC_IDENTITY)
 		test_fatal("VNI has not been updated");
 
-	assert(ctx->mark == (or_encrypt_key(NODE1_SPI) | (NODE2_ID << 16)));
+	assert(ctx->mark == ipsec_encode_encryption_mark(NODE1_SPI, NODE2_ID));
 	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == POD1_SEC_IDENTITY);
 
 	test_finish();


### PR DESCRIPTION
Don't spread the encoding logic across multiple places, and keep the tests consistent with the production path.