### PR TITLE
cilium-cli: Add IPv6 test for node-local-dns

### DIFF
--- a/cilium-cli/connectivity/tests/lrp.go
+++ b/cilium-cli/connectivity/tests/lrp.go
@@ -215,10 +215,11 @@ func (s lrpWithNodeDNS) Run(ctx context.Context, t *check.Test) {
 	for _, client := range ct.ClientPods() {
 		for _, externalEchoSvc := range ct.EchoExternalServices() {
 			externalEcho := externalEchoSvc.ToEchoIPService()
-
-			actionName := fmt.Sprintf("lrp-node-dns-http-to-%s-%d", externalEcho.NameWithoutNamespace(), i)
-			t.NewAction(s, actionName, &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
+			t.ForEachIPFamily(func(family features.IPFamily) {
+				actionName := fmt.Sprintf("lrp-node-dns-http-to-%s-%s-%d", externalEcho.NameWithoutNamespace(), family, i)
+				t.NewAction(s, actionName, &client, externalEcho, family).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
+				})
 			})
 			i++
 		}


### PR DESCRIPTION
The local-redirect-policy-with-node-dns test currently covers only IPv4. This commit adds a corresponding test case for IPv6.