### PR TITLE
endpoint: Avoid installing no-track rules when IP family is disabled

### DIFF
--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -171,7 +171,7 @@ func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
 
 	if port != e.noTrackPort {
 		log.Debug("Updating NOTRACK rules")
-		if e.IPv4.IsValid() {
+		if option.Config.EnableIPv4 && e.IPv4.IsValid() {
 			if port > 0 {
 				e.owner.IPTablesManager().InstallNoTrackRules(e.IPv4, port)
 			}
@@ -179,7 +179,7 @@ func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
 				e.owner.IPTablesManager().RemoveNoTrackRules(e.IPv4, e.noTrackPort)
 			}
 		}
-		if e.IPv6.IsValid() {
+		if option.Config.EnableIPv6 && e.IPv6.IsValid() {
 			if port > 0 {
 				e.owner.IPTablesManager().InstallNoTrackRules(e.IPv6, port)
 			}


### PR DESCRIPTION
Currently, the IptablesManager installs no-track rules if an endpoint has a valid IPv4 or IPv6 address, even when the corresponding IP family is disabled.

This behavior can cause issues in chaining modes such as aws-cni, where cilium-cni retrieves the IPv4/IPv6 addresses configured on the link inside the pod's network namespace and sets them on the endpoint regardless of the EnableIPv4/EnableIPv6 configuration.

Installing no-track rules for a disabled IP family results in a "Failed to enforce endpoint notrack" error. This PR ensures that no-track rules are installed only when the respective IP family is enabled.

```release-note
Avoid installing no-track rules when IP family is disabled
```
