### PR TITLE
agent: Remove deprecated --enable-k8s-terminating-endpoint

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -157,7 +157,6 @@ cilium-agent [flags]
       --enable-k8s                                                Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                                 Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-k8s-terminating-endpoint                           Enable auto-detect of terminating endpoint condition (default true)
       --enable-l2-announcements                                   Enable L2 announcements
       --enable-l2-neigh-discovery                                 Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec (default true)
       --enable-l2-pod-announcements                               Enable announcing Pod IPs with Gratuitous ARP

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1128,10 +1128,6 @@
      - Enable Internal Traffic Policy
      - bool
      - ``true``
-   * - :spelling:ignore:`enableK8sTerminatingEndpoint`
-     - Configure whether to enable auto detect of terminating state for endpoints in order to support graceful termination.
-     - bool
-     - ``true``
    * - :spelling:ignore:`enableLBIPAM`
      - Enable LoadBalancer IP Address Management
      - bool

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1449,22 +1449,8 @@ Graceful Termination
 ********************
 
 Cilium's eBPF kube-proxy replacement supports graceful termination of service
-endpoint pods. The feature requires at least Kubernetes version 1.20, and
-the feature gate ``EndpointSliceTerminatingCondition`` needs to be enabled.
-By default, the Cilium agent then detects such terminating Pod events, and
-increments the metric ``k8s_terminating_endpoints_events_total``. If needed,
-the feature can be disabled with the configuration option ``enable-k8s-terminating-endpoint``.
-
-The cilium agent feature flag can be probed by running ``cilium-dbg status`` command:
-
-.. code-block:: shell-session
-
-    $ kubectl -n kube-system exec ds/cilium -- cilium-dbg status --verbose
-    [...]
-    KubeProxyReplacement Details:
-     [...]
-     Graceful Termination:  Enabled
-    [...]
+endpoint pods. The Cilium agent detects such terminating Pod events, and
+increments the metric ``k8s_terminating_endpoints_events_total``.
 
 When Cilium agent receives a Kubernetes update event for a terminating endpoint,
 the datapath state for the endpoint is removed such that it won't service new

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -312,6 +312,8 @@ Removed Options
   EC2API to update the EC2 instance limit.
 * The ``aws-instance-limit-mapping`` CLI flag for the operator has been removed since the operator will only and always use the
   EC2API to update the EC2 instance limit.
+* The previously deprecated flag ``--enable-k8s-terminating-endpoint`` has been removed.
+  The K8s terminating endpoints feature is unconditionally enabled.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/api/v1/models/kube_proxy_replacement.go
+++ b/api/v1/models/kube_proxy_replacement.go
@@ -828,7 +828,7 @@ func (m *KubeProxyReplacementFeaturesExternalIPs) UnmarshalBinary(b []byte) erro
 	return nil
 }
 
-// KubeProxyReplacementFeaturesGracefulTermination kube proxy replacement features graceful termination
+// KubeProxyReplacementFeaturesGracefulTermination Deprecated
 //
 // swagger:model KubeProxyReplacementFeaturesGracefulTermination
 type KubeProxyReplacementFeaturesGracefulTermination struct {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2351,6 +2351,7 @@ definitions:
               enabled:
                 type: boolean
           gracefulTermination:
+            description: Deprecated
             type: object
             properties:
               enabled:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3759,6 +3759,7 @@ func init() {
               }
             },
             "gracefulTermination": {
+              "description": "Deprecated",
               "type": "object",
               "properties": {
                 "enabled": {
@@ -9576,6 +9577,7 @@ func init() {
               }
             },
             "gracefulTermination": {
+              "description": "Deprecated",
               "type": "object",
               "properties": {
                 "enabled": {
@@ -9761,6 +9763,7 @@ func init() {
           }
         },
         "gracefulTermination": {
+          "description": "Deprecated",
           "type": "object",
           "properties": {
             "enabled": {
@@ -9907,6 +9910,7 @@ func init() {
       }
     },
     "KubeProxyReplacementFeaturesGracefulTermination": {
+      "description": "Deprecated",
       "type": "object",
       "properties": {
         "enabled": {

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -160,9 +160,6 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 			if f.HostPort != nil {
 				result[features.KPRHostPort] = features.Status{Enabled: f.HostPort.Enabled}
 			}
-			if f.GracefulTermination != nil {
-				result[features.KPRGracefulTermination] = features.Status{Enabled: f.GracefulTermination.Enabled}
-			}
 			if f.NodePort != nil {
 				result[features.KPRNodePort] = features.Status{Enabled: f.NodePort.Enabled}
 				acceleration := strings.ToLower(f.NodePort.Acceleration)

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -28,7 +28,6 @@ const (
 
 	KPRMode                 Feature = "kpr-mode"
 	KPRExternalIPs          Feature = "kpr-external-ips"
-	KPRGracefulTermination  Feature = "kpr-graceful-termination"
 	KPRHostPort             Feature = "kpr-hostport"
 	KPRSocketLB             Feature = "kpr-socket-lb"
 	KPRSocketLBHostnsOnly   Feature = "kpr-socket-lb-hostns-only"

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -969,9 +969,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableCiliumEndpointSlice, false, "Enable the CiliumEndpointSlice watcher in place of the CiliumEndpoint watcher (beta)")
 	option.BindEnv(vp, option.EnableCiliumEndpointSlice)
 
-	flags.Bool(option.EnableK8sTerminatingEndpoint, true, "Enable auto-detect of terminating endpoint condition")
-	option.BindEnv(vp, option.EnableK8sTerminatingEndpoint)
-
 	flags.Bool(option.EnableVTEP, defaults.EnableVTEP, "Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)")
 	option.BindEnv(vp, option.EnableVTEP)
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -284,7 +284,6 @@ func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
 		SocketLB:              &models.KubeProxyReplacementFeaturesSocketLB{},
 		SocketLBTracing:       &models.KubeProxyReplacementFeaturesSocketLBTracing{},
 		SessionAffinity:       &models.KubeProxyReplacementFeaturesSessionAffinity{},
-		GracefulTermination:   &models.KubeProxyReplacementFeaturesGracefulTermination{},
 		Nat46X64:              &models.KubeProxyReplacementFeaturesNat46X64{},
 		BpfSocketLBHostnsOnly: option.Config.BPFSocketLBHostnsOnly,
 	}

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -332,9 +332,6 @@ func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
 	if option.Config.EnableSessionAffinity {
 		features.SessionAffinity.Enabled = true
 	}
-	if option.Config.EnableK8sTerminatingEndpoint {
-		features.GracefulTermination.Enabled = true
-	}
 	if option.Config.NodePortNat46X64 || option.Config.EnableNat46X64Gateway {
 		features.Nat46X64.Enabled = true
 		gw := &models.KubeProxyReplacementFeaturesNat46X64Gateway{

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -332,7 +332,6 @@ contributors across the globe, there is almost always someone available to help.
 | enableIPv6BIGTCP | bool | `false` | Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods |
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
 | enableInternalTrafficPolicy | bool | `true` | Enable Internal Traffic Policy |
-| enableK8sTerminatingEndpoint | bool | `true` | Configure whether to enable auto detect of terminating state for endpoints in order to support graceful termination. |
 | enableLBIPAM | bool | `true` | Enable LoadBalancer IP Address Management |
 | enableMasqueradeRouteSource | bool | `false` | Enables masquerading to the source of the route for traffic leaving the node from endpoints. |
 | enableNonDefaultDenyPolicies | bool | `true` | Enable Non-Default-Deny policies |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1231,10 +1231,6 @@ data:
 
   identity-management-mode: {{ .Values.identityManagementMode | quote }}
 
-{{- if hasKey .Values "enableK8sTerminatingEndpoint" }}
-  enable-k8s-terminating-endpoint: {{ .Values.enableK8sTerminatingEndpoint | quote }}
-{{- end }}
-
 {{- if hasKey .Values.sctp "enabled" }}
   enable-sctp: {{ .Values.sctp.enabled | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1704,9 +1704,6 @@
     "enableInternalTrafficPolicy": {
       "type": "boolean"
     },
-    "enableK8sTerminatingEndpoint": {
-      "type": "boolean"
-    },
     "enableLBIPAM": {
       "type": "boolean"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3683,9 +3683,6 @@ cgroup:
 sysctlfix:
   # -- Enable the sysctl override. When enabled, the init container will mount the /proc of the host so that the `sysctlfix` utility can execute.
   enabled: true
-# -- Configure whether to enable auto detect of terminating state for endpoints
-# in order to support graceful termination.
-enableK8sTerminatingEndpoint: true
 # -- Configure whether to unload DNS policy rules on graceful shutdown
 # dnsPolicyUnloadOnShutdown: false
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3712,9 +3712,6 @@ cgroup:
 sysctlfix:
   # -- Enable the sysctl override. When enabled, the init container will mount the /proc of the host so that the `sysctlfix` utility can execute.
   enabled: true
-# -- Configure whether to enable auto detect of terminating state for endpoints
-# in order to support graceful termination.
-enableK8sTerminatingEndpoint: true
 # -- Configure whether to unload DNS policy rules on graceful shutdown
 # dnsPolicyUnloadOnShutdown: false
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -717,11 +717,6 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 			socketLBCoverage = "Hostns-only"
 		}
 
-		gracefulTerm := "Disabled"
-		if sr.KubeProxyReplacement.Features.GracefulTermination.Enabled {
-			gracefulTerm = "Enabled"
-		}
-
 		nat46X64 := "Disabled"
 		nat46X64GW := "Disabled"
 		nat46X64SVC := "Disabled"
@@ -756,7 +751,6 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 			fmt.Fprintf(tab, "  Backend Selection:\t%s\n", selection)
 		}
 		fmt.Fprintf(tab, "  Session Affinity:\t%s\n", affinity)
-		fmt.Fprintf(tab, "  Graceful Termination:\t%s\n", gracefulTerm)
 		if nat46X64 == "Disabled" {
 			fmt.Fprintf(tab, "  NAT46/64 Support:\t%s\n", nat46X64)
 		} else {

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -62,7 +62,6 @@ func TestScript(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t, leakOpts) })
 
 	version.Force(testutils.DefaultVersion)
-	option.Config.EnableK8sTerminatingEndpoint = true
 
 	var opts []hivetest.LogOption
 	if *debug {

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -16,7 +16,6 @@ import (
 	slim_discovery_v1beta1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1beta1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/option"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 )
 
@@ -869,58 +868,7 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 				return svcEP
 			},
 		},
-		{
-			name: "endpoints with some addresses not ready and terminating, EnableK8sTerminatingEndpoint disabled",
-			setupArgs: func() args {
-				return args{
-					eps: &slim_discovery_v1beta1.EndpointSlice{
-						AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
-						ObjectMeta:  meta,
-						Endpoints: []slim_discovery_v1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"172.0.0.1",
-								},
-							},
-							{
-								Conditions: slim_discovery_v1beta1.EndpointConditions{
-									Ready:       func() *bool { a := false; return &a }(),
-									Terminating: func() *bool { a := true; return &a }(),
-								},
-								Addresses: []string{
-									"172.0.0.2",
-								},
-							},
-						},
-						Ports: []slim_discovery_v1beta1.EndpointPort{
-							{
-								Name:     func() *string { a := "http-test-svc"; return &a }(),
-								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
-								Port:     func() *int32 { a := int32(8080); return &a }(),
-							},
-							{
-								Name:     func() *string { a := "http-test-svc-2"; return &a }(),
-								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
-								Port:     func() *int32 { a := int32(8081); return &a }(),
-							},
-						},
-					},
-					overrideConfig: func() {
-						option.Config.EnableK8sTerminatingEndpoint = false
-					},
-				}
-			},
-			setupWanted: func() *Endpoints {
-				svcEP := newEmptyEndpoints()
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
-					Ports: serviceStore.PortConfiguration{
-						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
-						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
-					},
-				}
-				return svcEP
-			},
-		},
+
 		{
 			name: "endpoints with all addresses not ready and terminating",
 			setupArgs: func() args {
@@ -982,58 +930,7 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 				return svcEP
 			},
 		},
-		{
-			name: "endpoints with some addresses not ready and terminating, EnableK8sTerminatingEndpoint disabled",
-			setupArgs: func() args {
-				return args{
-					eps: &slim_discovery_v1beta1.EndpointSlice{
-						AddressType: slim_discovery_v1beta1.AddressTypeIPv4,
-						ObjectMeta:  meta,
-						Endpoints: []slim_discovery_v1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"172.0.0.1",
-								},
-							},
-							{
-								Conditions: slim_discovery_v1beta1.EndpointConditions{
-									Ready:       func() *bool { a := false; return &a }(),
-									Terminating: func() *bool { a := true; return &a }(),
-								},
-								Addresses: []string{
-									"172.0.0.2",
-								},
-							},
-						},
-						Ports: []slim_discovery_v1beta1.EndpointPort{
-							{
-								Name:     func() *string { a := "http-test-svc"; return &a }(),
-								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
-								Port:     func() *int32 { a := int32(8080); return &a }(),
-							},
-							{
-								Name:     func() *string { a := "http-test-svc-2"; return &a }(),
-								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
-								Port:     func() *int32 { a := int32(8081); return &a }(),
-							},
-						},
-					},
-					overrideConfig: func() {
-						option.Config.EnableK8sTerminatingEndpoint = false
-					},
-				}
-			},
-			setupWanted: func() *Endpoints {
-				svcEP := newEmptyEndpoints()
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
-					Ports: serviceStore.PortConfiguration{
-						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
-						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
-					},
-				}
-				return svcEP
-			},
-		},
+
 		{
 			name: "endpoints with SCTP",
 			setupArgs: func() args {
@@ -1137,8 +1034,6 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 		want := tt.setupWanted()
 		if args.overrideConfig != nil {
 			args.overrideConfig()
-		} else {
-			option.Config.EnableK8sTerminatingEndpoint = true
 		}
 		got := ParseEndpointSliceV1Beta1(args.eps)
 		require.EqualValuesf(t, want, got, "Test name: %q", tt.name)
@@ -1647,58 +1542,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 				return svcEP
 			},
 		},
-		{
-			name: "endpoints with some addresses not ready and terminating, EnableK8sTerminatingEndpoint disabled",
-			setupArgs: func() args {
-				return args{
-					eps: &slim_discovery_v1.EndpointSlice{
-						AddressType: slim_discovery_v1.AddressTypeIPv4,
-						ObjectMeta:  meta,
-						Endpoints: []slim_discovery_v1.Endpoint{
-							{
-								Addresses: []string{
-									"172.0.0.1",
-								},
-							},
-							{
-								Conditions: slim_discovery_v1.EndpointConditions{
-									Ready:       func() *bool { a := false; return &a }(),
-									Terminating: func() *bool { a := true; return &a }(),
-								},
-								Addresses: []string{
-									"172.0.0.2",
-								},
-							},
-						},
-						Ports: []slim_discovery_v1.EndpointPort{
-							{
-								Name:     func() *string { a := "http-test-svc"; return &a }(),
-								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
-								Port:     func() *int32 { a := int32(8080); return &a }(),
-							},
-							{
-								Name:     func() *string { a := "http-test-svc-2"; return &a }(),
-								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
-								Port:     func() *int32 { a := int32(8081); return &a }(),
-							},
-						},
-					},
-					overrideConfig: func() {
-						option.Config.EnableK8sTerminatingEndpoint = false
-					},
-				}
-			},
-			setupWanted: func() *Endpoints {
-				svcEP := newEmptyEndpoints()
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
-					Ports: serviceStore.PortConfiguration{
-						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
-						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
-					},
-				}
-				return svcEP
-			},
-		},
+
 		{
 			name: "endpoints with all addresses ready and serving and terminating",
 			setupArgs: func() args {
@@ -1855,58 +1699,6 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 			},
 		},
 		{
-			name: "endpoints with some addresses not ready and terminating, EnableK8sTerminatingEndpoint disabled",
-			setupArgs: func() args {
-				return args{
-					eps: &slim_discovery_v1.EndpointSlice{
-						AddressType: slim_discovery_v1.AddressTypeIPv4,
-						ObjectMeta:  meta,
-						Endpoints: []slim_discovery_v1.Endpoint{
-							{
-								Addresses: []string{
-									"172.0.0.1",
-								},
-							},
-							{
-								Conditions: slim_discovery_v1.EndpointConditions{
-									Ready:       func() *bool { a := false; return &a }(),
-									Terminating: func() *bool { a := true; return &a }(),
-								},
-								Addresses: []string{
-									"172.0.0.2",
-								},
-							},
-						},
-						Ports: []slim_discovery_v1.EndpointPort{
-							{
-								Name:     func() *string { a := "http-test-svc"; return &a }(),
-								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
-								Port:     func() *int32 { a := int32(8080); return &a }(),
-							},
-							{
-								Name:     func() *string { a := "http-test-svc-2"; return &a }(),
-								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
-								Port:     func() *int32 { a := int32(8081); return &a }(),
-							},
-						},
-					},
-					overrideConfig: func() {
-						option.Config.EnableK8sTerminatingEndpoint = false
-					},
-				}
-			},
-			setupWanted: func() *Endpoints {
-				svcEP := newEmptyEndpoints()
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
-					Ports: serviceStore.PortConfiguration{
-						"http-test-svc":   loadbalancer.NewL4Addr(loadbalancer.TCP, 8080),
-						"http-test-svc-2": loadbalancer.NewL4Addr(loadbalancer.TCP, 8081),
-					},
-				}
-				return svcEP
-			},
-		},
-		{
 			name: "endpoints have zone hints",
 			setupArgs: func() args {
 				return args{
@@ -2011,8 +1803,6 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 		want := tt.setupWanted()
 		if args.overrideConfig != nil {
 			args.overrideConfig()
-		} else {
-			option.Config.EnableK8sTerminatingEndpoint = true
 		}
 		got := ParseEndpointSliceV1(hivetest.Logger(t), args.eps)
 		require.EqualValues(t, want, got, "Test name: %q", tt.name)

--- a/pkg/loadbalancer/experimental/benchmark/benchmark.go
+++ b/pkg/loadbalancer/experimental/benchmark/benchmark.go
@@ -56,10 +56,6 @@ var (
 )
 
 func RunBenchmark(testSize int, iterations int, loglevel slog.Level, validate bool) {
-	// As we're using k8s.Endpoints we need to set this to ask ParseEndpoint*
-	// to handle the termination state. Eventually this should migrate to the
-	// package for the k8s data source.
-	option.Config.EnableK8sTerminatingEndpoint = true
 	option.Config.EnableIPv4 = true
 	option.Config.EnableIPv6 = true
 

--- a/pkg/loadbalancer/experimental/script_test.go
+++ b/pkg/loadbalancer/experimental/script_test.go
@@ -55,9 +55,6 @@ func TestScript(t *testing.T) {
 	// Issue for fixing this: https://github.com/cilium/cilium/issues/35537
 	version.Force(testutils.DefaultVersion)
 
-	// pkg/k8s/endpoints.go uses this in ParseEndpointSlice*
-	option.Config.EnableK8sTerminatingEndpoint = true
-
 	// Set the node name
 	nodeTypes.SetName("testnode")
 
@@ -100,7 +97,6 @@ func TestScript(t *testing.T) {
 							EnableHealthCheckNodePort:       cfg.EnableHealthCheckNodePort,
 							KubeProxyReplacement:            option.KubeProxyReplacementTrue,
 							EnableNodePort:                  true,
-							EnableK8sTerminatingEndpoint:    true,
 							ExternalClusterIP:               cfg.ExternalClusterIP,
 							LoadBalancerAlgorithmAnnotation: cfg.LoadBalancerAlgorithmAnnotation,
 						}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1433,8 +1433,6 @@ const (
 
 	LenBackends = "lenBackends"
 
-	EnableK8sTerminatingEndpoint = "enableK8sTerminatingEndpoint"
-
 	CRDs = "CRDs"
 
 	PodCIDRs = "podCIDRs"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1049,10 +1049,6 @@ const (
 	// regardless of whether it's available in the pool.
 	BypassIPAvailabilityUponRestore = "bypass-ip-availability-upon-restore"
 
-	// EnableK8sTerminatingEndpoint enables the option to auto detect terminating
-	// state for endpoints in order to support graceful termination.
-	EnableK8sTerminatingEndpoint = "enable-k8s-terminating-endpoint"
-
 	// EnableVTEP enables cilium VXLAN VTEP integration
 	EnableVTEP = "enable-vtep"
 
@@ -2142,10 +2138,6 @@ type DaemonConfig struct {
 	// within IPAM upon endpoint restore and allows the use of the restored IP
 	// regardless of whether it's available in the pool.
 	BypassIPAvailabilityUponRestore bool
-
-	// EnableK8sTerminatingEndpoint enables auto-detect of terminating state for
-	// Kubernetes service endpoints.
-	EnableK8sTerminatingEndpoint bool
 
 	// EnableVTEP enable Cilium VXLAN VTEP integration
 	EnableVTEP bool
@@ -3308,7 +3300,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableICMPRules = vp.GetBool(EnableICMPRules)
 	c.UseCiliumInternalIPForIPsec = vp.GetBool(UseCiliumInternalIPForIPsec)
 	c.BypassIPAvailabilityUponRestore = vp.GetBool(BypassIPAvailabilityUponRestore)
-	c.EnableK8sTerminatingEndpoint = vp.GetBool(EnableK8sTerminatingEndpoint)
 
 	// VTEP integration enable option
 	c.EnableVTEP = vp.GetBool(EnableVTEP)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -2242,7 +2242,7 @@ func isWildcardAddr(frontend lb.L3n4AddrID) bool {
 }
 
 // segregateBackends returns the list of active, preferred and nonActive backends to be
-// added to the lbmaps. If EnableK8sTerminatingEndpoint and there are no active backends,
+// added to the lbmaps. If there are no active backends,
 // segregateBackends will return all terminating backends as active.
 func segregateBackends(backends []*lb.Backend) (preferredBackends map[string]*lb.Backend,
 	activeBackends map[string]*lb.Backend, nonActiveBackends []lb.BackendID,
@@ -2271,7 +2271,7 @@ func segregateBackends(backends []*lb.Backend) (preferredBackends map[string]*lb
 	// In case that there are no Active backends, use the Backends in TerminatingState to answer new requests
 	// and avoid traffic disruption until new active backends are created.
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1669-proxy-terminating-endpoints
-	if option.Config.EnableK8sTerminatingEndpoint && len(activeBackends) == 0 {
+	if len(activeBackends) == 0 {
 		nonActiveBackends = []lb.BackendID{}
 		for _, b := range backends {
 			if b.State == lb.BackendStateTerminating {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1397,7 +1397,7 @@ func TestUpsertServiceWithOnlyTerminatingBackends(t *testing.T) {
 	require.Equal(t, lb.ID(1), id1)
 	require.Len(t, m.lbmap.ServiceByID[uint16(id1)].Backends, 1)
 	require.Len(t, m.lbmap.BackendByID, 1)
-	require.Equal(t, 0, m.lbmap.SvcActiveBackendsCount[uint16(id1)])
+	require.Equal(t, 1, m.lbmap.SvcActiveBackendsCount[uint16(id1)])
 
 	// Delete terminating backends.
 	p.Backends = []*lb.Backend{}

--- a/test/controlplane/services/graceful-termination/graceful_termination.go
+++ b/test/controlplane/services/graceful-termination/graceful_termination.go
@@ -26,10 +26,6 @@ func testGracefulTermination(t *testing.T) {
 
 	abs := func(f string) string { return path.Join(cwd, "services", "graceful-termination", f) }
 
-	modConfig := func(cfg *option.DaemonConfig) {
-		cfg.EnableK8sTerminatingEndpoint = true
-	}
-
 	k8sVersions := controlplane.K8sVersions()
 	// We only need to test the last k8s version
 	test := suite.NewControlPlaneTest(t, "graceful-term-control-plane", k8sVersions[len(k8sVersions)-1])
@@ -39,7 +35,7 @@ func testGracefulTermination(t *testing.T) {
 	test.
 		UpdateObjectsFromFile(abs("init.yaml")).
 		SetupEnvironment().
-		StartAgent(modConfig).
+		StartAgent(func(cfg *option.DaemonConfig) {}).
 		EnsureWatchers("endpointslices", "services").
 
 		// Step 1: Initial creation of the services and backends


### PR DESCRIPTION
The deprecation PR https://github.com/cilium/cilium/pull/37351 (v1.17).