### PR TITLE
proxy: Bump envoy version to 1.32.x

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1151,7 +1151,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:7a63365b8651250cf1823acbe05191509aec4b42db281b5cb7a050e43b56d603","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.31.6-1742787318-c0594713884ce0bbd31c80994b91435ca8d0209f","useDigest":true}``
+     - ``{"digest":"sha256:80c0509d71391cb39835d032d255f26ee7732ec092fb9f48a1cd2544d0efe5e0","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.32.4-1742515734-d30064faed34d8936672353d4b6d6dbcfbaa7b2d","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:c3d9ed2736658aac1d7766448
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.31.6-1742787318-c0594713884ce0bbd31c80994b91435ca8d0209f@sha256:7a63365b8651250cf1823acbe05191509aec4b42db281b5cb7a050e43b56d603 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.32.4-1742515734-d30064faed34d8936672353d4b6d6dbcfbaa7b2d@sha256:80c0509d71391cb39835d032d255f26ee7732ec092fb9f48a1cd2544d0efe5e0 as cilium-envoy
 
 #
 # Hubble CLI

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -49,8 +49,8 @@ export CILIUM_NODEINIT_DIGEST:=sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6
 
 # renovate: datasource=docker
 export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy
-export CILIUM_ENVOY_VERSION:=v1.31.6-1742787318-c0594713884ce0bbd31c80994b91435ca8d0209f
-export CILIUM_ENVOY_DIGEST:=sha256:7a63365b8651250cf1823acbe05191509aec4b42db281b5cb7a050e43b56d603
+export CILIUM_ENVOY_VERSION:=v1.32.4-1742515734-d30064faed34d8936672353d4b6d6dbcfbaa7b2d
+export CILIUM_ENVOY_DIGEST:=sha256:80c0509d71391cb39835d032d255f26ee7732ec092fb9f48a1cd2544d0efe5e0
 
 # renovate: datasource=docker
 export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -337,7 +337,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:7a63365b8651250cf1823acbe05191509aec4b42db281b5cb7a050e43b56d603","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.31.6-1742787318-c0594713884ce0bbd31c80994b91435ca8d0209f","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:80c0509d71391cb39835d032d255f26ee7732ec092fb9f48a1cd2544d0efe5e0","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.32.4-1742515734-d30064faed34d8936672353d4b6d6dbcfbaa7b2d","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2080,9 +2080,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.31.6-1742787318-c0594713884ce0bbd31c80994b91435ca8d0209f"
+    tag: "v1.32.4-1742515734-d30064faed34d8936672353d4b6d6dbcfbaa7b2d"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:7a63365b8651250cf1823acbe05191509aec4b42db281b5cb7a050e43b56d603"
+    digest: "sha256:80c0509d71391cb39835d032d255f26ee7732ec092fb9f48a1cd2544d0efe5e0"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.


### PR DESCRIPTION
This is as part of regular maintenance, as envoy 1.31.x will be EOL in 3 months.

https://github.com/envoyproxy/envoy/blob/main/RELEASES.md#major-release-schedule

