### PR TITLE
policy/api: Fix JSON Marhalling and add source prefix to label selector keys 

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -189,6 +189,7 @@ func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger) (api.Rules, error) {
 	}
 
 	if r.Spec != nil {
+		r.Spec.ReplaceExtendedKey()
 		if err := r.Spec.Sanitize(); err != nil {
 			return nil, NewErrParse(fmt.Sprintf("Invalid CiliumNetworkPolicy spec: %s", err))
 		}
@@ -200,6 +201,7 @@ func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger) (api.Rules, error) {
 	}
 	if r.Specs != nil {
 		for _, rule := range r.Specs {
+			rule.ReplaceExtendedKey()
 			if err := rule.Sanitize(); err != nil {
 				return nil, NewErrParse(fmt.Sprintf("Invalid CiliumNetworkPolicy specs: %s", err))
 

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -263,7 +263,7 @@ var (
 
 func TestCiliumNetworkPolicyParse(t *testing.T) {
 	// Build CNP with basic Ingress and Egress rules and labels
-	es := api.NewESFromMatchRequirementsWithoutRequirements(
+	es := api.NewESFromMatchRequirements(
 		map[string]string{
 			fmt.Sprintf("%s.role", labels.LabelSourceAny): "backend",
 		},
@@ -286,7 +286,7 @@ func TestCiliumNetworkPolicyParse(t *testing.T) {
 		Spec: &apiRuleWithLabels,
 	}
 
-	expectedES := api.NewESFromMatchRequirementsWithoutRequirements(
+	expectedES := api.NewESFromMatchRequirements(
 		map[string]string{
 			fmt.Sprintf("%s.role", labels.LabelSourceAny):                           "backend",
 			fmt.Sprintf("%s.%s", labels.LabelSourceK8s, k8sConst.PodNamespaceLabel): "default",
@@ -358,7 +358,7 @@ func TestCiliumNetworkPolicyParseJSONUnmarshalToMarshal(t *testing.T) {
 
 	apiRule.EndpointSelector = es
 
-	expectedPolicyRule := &CiliumNetworkPolicy{
+	cnp := &CiliumNetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "rule1",
@@ -369,16 +369,19 @@ func TestCiliumNetworkPolicyParseJSONUnmarshalToMarshal(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 
-	_, err := expectedPolicyRule.Parse(logger)
+	_, err := cnp.Parse(logger)
 	require.NoError(t, err)
 
-	b, err := json.Marshal(expectedPolicyRule)
+	b, err := json.Marshal(cnp)
 	require.NoError(t, err)
-	var expectedPolicyRuleUnmarshalled CiliumNetworkPolicy
-	err = json.Unmarshal(b, &expectedPolicyRuleUnmarshalled)
+	var cnpUnmarshalled CiliumNetworkPolicy
+	err = json.Unmarshal(b, &cnpUnmarshalled)
 	require.NoError(t, err)
-	expectedPolicyRuleUnmarshalled.Parse(logger)
-	require.Equal(t, *expectedPolicyRule, expectedPolicyRuleUnmarshalled)
+
+	_, err = cnpUnmarshalled.Parse(logger)
+	require.NoError(t, err)
+
+	require.Equal(t, *cnp, cnpUnmarshalled)
 }
 
 func TestParseSpec(t *testing.T) {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -518,7 +518,7 @@ func GetExtendedKeyFrom(str string) string {
 			return str
 		}
 	}
-	// Remove an eventually value
+	// Remove an eventual value
 	i := strings.IndexByte(next, '=')
 	if i >= 0 {
 		return src + PathDelimiter + next[:i]

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -511,7 +511,12 @@ func GetCiliumKeyFrom(extKey string) string {
 func GetExtendedKeyFrom(str string) string {
 	src, next := parseSource(str, ':')
 	if src == "" {
-		src = LabelSourceAny
+		src, next = parseSource(str, '.')
+		if src == "" {
+			src = LabelSourceAny
+		} else {
+			return str
+		}
 	}
 	// Remove an eventually value
 	i := strings.IndexByte(next, '=')

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -803,8 +803,8 @@ func (r *IngressRule) ParseExtendedKey() {
 			n.MatchExpressions = newMatchExpr
 		}
 
-		n.requirements = labelSelectorToRequirements(n.LabelSelector)
-		n.cachedLabelSelectorString = n.LabelSelector.String()
+		n.requirements = nil
+		n.cachedLabelSelectorString = ""
 	}
 
 	for _, n := range r.FromNodes {
@@ -824,8 +824,8 @@ func (r *IngressRule) ParseExtendedKey() {
 			n.MatchExpressions = newMatchExpr
 		}
 
-		n.requirements = labelSelectorToRequirements(n.LabelSelector)
-		n.cachedLabelSelectorString = n.LabelSelector.String()
+		n.requirements = nil
+		n.cachedLabelSelectorString = ""
 	}
 }
 
@@ -847,8 +847,8 @@ func (r *IngressDenyRule) ParseExtendedKey() {
 			n.MatchExpressions = newMatchExpr
 		}
 
-		n.requirements = labelSelectorToRequirements(n.LabelSelector)
-		n.cachedLabelSelectorString = n.LabelSelector.String()
+		n.requirements = nil
+		n.cachedLabelSelectorString = ""
 	}
 
 	for _, n := range r.FromNodes {
@@ -868,8 +868,8 @@ func (r *IngressDenyRule) ParseExtendedKey() {
 			n.MatchExpressions = newMatchExpr
 		}
 
-		n.requirements = labelSelectorToRequirements(n.LabelSelector)
-		n.cachedLabelSelectorString = n.LabelSelector.String()
+		n.requirements = nil
+		n.cachedLabelSelectorString = ""
 	}
 }
 
@@ -891,8 +891,8 @@ func (r *EgressRule) ParseExtendedKey() {
 			n.MatchExpressions = newMatchExpr
 		}
 
-		n.requirements = labelSelectorToRequirements(n.LabelSelector)
-		n.cachedLabelSelectorString = n.LabelSelector.String()
+		n.requirements = nil
+		n.cachedLabelSelectorString = ""
 	}
 
 	for _, n := range r.ToNodes {
@@ -912,8 +912,8 @@ func (r *EgressRule) ParseExtendedKey() {
 			n.MatchExpressions = newMatchExpr
 		}
 
-		n.requirements = labelSelectorToRequirements(n.LabelSelector)
-		n.cachedLabelSelectorString = n.LabelSelector.String()
+		n.requirements = nil
+		n.cachedLabelSelectorString = ""
 	}
 }
 
@@ -935,8 +935,8 @@ func (r *EgressDenyRule) ParseExtendedKey() {
 			n.MatchExpressions = newMatchExpr
 		}
 
-		n.requirements = labelSelectorToRequirements(n.LabelSelector)
-		n.cachedLabelSelectorString = n.LabelSelector.String()
+		n.requirements = nil
+		n.cachedLabelSelectorString = ""
 	}
 
 	for _, n := range r.ToNodes {
@@ -956,7 +956,7 @@ func (r *EgressDenyRule) ParseExtendedKey() {
 			n.MatchExpressions = newMatchExpr
 		}
 
-		n.requirements = labelSelectorToRequirements(n.LabelSelector)
-		n.cachedLabelSelectorString = n.LabelSelector.String()
+		n.requirements = nil
+		n.cachedLabelSelectorString = ""
 	}
 }

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/iana"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -758,4 +759,204 @@ func (c *CIDRRule) sanitize() error {
 	}
 
 	return nil
+}
+
+// ReplaceExtendedKey replaces all Cilium key in the form of `:` into `.`
+func (r *Rule) ReplaceExtendedKey() {
+	if r.EndpointSelector.LabelSelector != nil {
+		r.EndpointSelector.ParseExtendedKey()
+	}
+
+	if r.NodeSelector.LabelSelector != nil {
+		r.NodeSelector.ParseExtendedKey()
+	}
+
+	for _, c := range r.Ingress {
+		c.ParseExtendedKey()
+	}
+	for _, c := range r.IngressDeny {
+		c.ParseExtendedKey()
+	}
+	for _, c := range r.Egress {
+		c.ParseExtendedKey()
+	}
+	for _, c := range r.EgressDeny {
+		c.ParseExtendedKey()
+	}
+}
+
+func (r *IngressRule) ParseExtendedKey() {
+	for _, n := range r.FromEndpoints {
+		if n.MatchLabels != nil {
+			ml := map[string]string{}
+			for k, v := range n.MatchLabels {
+				ml[labels.GetExtendedKeyFrom(k)] = v
+			}
+			n.MatchLabels = ml
+		}
+		if n.MatchExpressions != nil {
+			newMatchExpr := make([]slim_metav1.LabelSelectorRequirement, len(n.MatchExpressions))
+			for i, v := range n.MatchExpressions {
+				v.Key = labels.GetExtendedKeyFrom(v.Key)
+				newMatchExpr[i] = v
+			}
+			n.MatchExpressions = newMatchExpr
+		}
+
+		n.requirements = labelSelectorToRequirements(n.LabelSelector)
+		n.cachedLabelSelectorString = n.LabelSelector.String()
+	}
+
+	for _, n := range r.FromNodes {
+		if n.MatchLabels != nil {
+			ml := map[string]string{}
+			for k, v := range n.MatchLabels {
+				ml[labels.GetExtendedKeyFrom(k)] = v
+			}
+			n.MatchLabels = ml
+		}
+		if n.MatchExpressions != nil {
+			newMatchExpr := make([]slim_metav1.LabelSelectorRequirement, len(n.MatchExpressions))
+			for i, v := range n.MatchExpressions {
+				v.Key = labels.GetExtendedKeyFrom(v.Key)
+				newMatchExpr[i] = v
+			}
+			n.MatchExpressions = newMatchExpr
+		}
+
+		n.requirements = labelSelectorToRequirements(n.LabelSelector)
+		n.cachedLabelSelectorString = n.LabelSelector.String()
+	}
+}
+
+func (r *IngressDenyRule) ParseExtendedKey() {
+	for _, n := range r.FromEndpoints {
+		if n.MatchLabels != nil {
+			ml := map[string]string{}
+			for k, v := range n.MatchLabels {
+				ml[labels.GetExtendedKeyFrom(k)] = v
+			}
+			n.MatchLabels = ml
+		}
+		if n.MatchExpressions != nil {
+			newMatchExpr := make([]slim_metav1.LabelSelectorRequirement, len(n.MatchExpressions))
+			for i, v := range n.MatchExpressions {
+				v.Key = labels.GetExtendedKeyFrom(v.Key)
+				newMatchExpr[i] = v
+			}
+			n.MatchExpressions = newMatchExpr
+		}
+
+		n.requirements = labelSelectorToRequirements(n.LabelSelector)
+		n.cachedLabelSelectorString = n.LabelSelector.String()
+	}
+
+	for _, n := range r.FromNodes {
+		if n.MatchLabels != nil {
+			ml := map[string]string{}
+			for k, v := range n.MatchLabels {
+				ml[labels.GetExtendedKeyFrom(k)] = v
+			}
+			n.MatchLabels = ml
+		}
+		if n.MatchExpressions != nil {
+			newMatchExpr := make([]slim_metav1.LabelSelectorRequirement, len(n.MatchExpressions))
+			for i, v := range n.MatchExpressions {
+				v.Key = labels.GetExtendedKeyFrom(v.Key)
+				newMatchExpr[i] = v
+			}
+			n.MatchExpressions = newMatchExpr
+		}
+
+		n.requirements = labelSelectorToRequirements(n.LabelSelector)
+		n.cachedLabelSelectorString = n.LabelSelector.String()
+	}
+}
+
+func (r *EgressRule) ParseExtendedKey() {
+	for _, n := range r.ToEndpoints {
+		if n.MatchLabels != nil {
+			ml := map[string]string{}
+			for k, v := range n.MatchLabels {
+				ml[labels.GetExtendedKeyFrom(k)] = v
+			}
+			n.MatchLabels = ml
+		}
+		if n.MatchExpressions != nil {
+			newMatchExpr := make([]slim_metav1.LabelSelectorRequirement, len(n.MatchExpressions))
+			for i, v := range n.MatchExpressions {
+				v.Key = labels.GetExtendedKeyFrom(v.Key)
+				newMatchExpr[i] = v
+			}
+			n.MatchExpressions = newMatchExpr
+		}
+
+		n.requirements = labelSelectorToRequirements(n.LabelSelector)
+		n.cachedLabelSelectorString = n.LabelSelector.String()
+	}
+
+	for _, n := range r.ToNodes {
+		if n.MatchLabels != nil {
+			ml := map[string]string{}
+			for k, v := range n.MatchLabels {
+				ml[labels.GetExtendedKeyFrom(k)] = v
+			}
+			n.MatchLabels = ml
+		}
+		if n.MatchExpressions != nil {
+			newMatchExpr := make([]slim_metav1.LabelSelectorRequirement, len(n.MatchExpressions))
+			for i, v := range n.MatchExpressions {
+				v.Key = labels.GetExtendedKeyFrom(v.Key)
+				newMatchExpr[i] = v
+			}
+			n.MatchExpressions = newMatchExpr
+		}
+
+		n.requirements = labelSelectorToRequirements(n.LabelSelector)
+		n.cachedLabelSelectorString = n.LabelSelector.String()
+	}
+}
+
+func (r *EgressDenyRule) ParseExtendedKey() {
+	for _, n := range r.ToEndpoints {
+		if n.MatchLabels != nil {
+			ml := map[string]string{}
+			for k, v := range n.MatchLabels {
+				ml[labels.GetExtendedKeyFrom(k)] = v
+			}
+			n.MatchLabels = ml
+		}
+		if n.MatchExpressions != nil {
+			newMatchExpr := make([]slim_metav1.LabelSelectorRequirement, len(n.MatchExpressions))
+			for i, v := range n.MatchExpressions {
+				v.Key = labels.GetExtendedKeyFrom(v.Key)
+				newMatchExpr[i] = v
+			}
+			n.MatchExpressions = newMatchExpr
+		}
+
+		n.requirements = labelSelectorToRequirements(n.LabelSelector)
+		n.cachedLabelSelectorString = n.LabelSelector.String()
+	}
+
+	for _, n := range r.ToNodes {
+		if n.MatchLabels != nil {
+			ml := map[string]string{}
+			for k, v := range n.MatchLabels {
+				ml[labels.GetExtendedKeyFrom(k)] = v
+			}
+			n.MatchLabels = ml
+		}
+		if n.MatchExpressions != nil {
+			newMatchExpr := make([]slim_metav1.LabelSelectorRequirement, len(n.MatchExpressions))
+			for i, v := range n.MatchExpressions {
+				v.Key = labels.GetExtendedKeyFrom(v.Key)
+				newMatchExpr[i] = v
+			}
+			n.MatchExpressions = newMatchExpr
+		}
+
+		n.requirements = labelSelectorToRequirements(n.LabelSelector)
+		n.cachedLabelSelectorString = n.LabelSelector.String()
+	}
 }

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -66,7 +66,6 @@ func (n *EndpointSelector) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	n.ParseExtendedKey()
 	return nil
 }
 

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -86,8 +86,8 @@ func (n *EndpointSelector) ParseExtendedKey() {
 		n.MatchExpressions = newMatchExpr
 	}
 
-	n.requirements = labelSelectorToRequirements(n.LabelSelector)
-	n.cachedLabelSelectorString = n.LabelSelector.String()
+	//n.requirements = labelSelectorToRequirements(n.LabelSelector)
+	//n.cachedLabelSelectorString = n.LabelSelector.String()
 }
 
 // MarshalJSON returns a JSON representation of the byte array.
@@ -212,8 +212,8 @@ func NewESFromMatchRequirements(matchLabels map[string]string, reqs []slim_metav
 	}
 	return EndpointSelector{
 		LabelSelector:             labelSelector,
-		requirements:              labelSelectorToRequirements(labelSelector),
-		cachedLabelSelectorString: labelSelector.String(),
+		requirements:              nil,
+		cachedLabelSelectorString: "",
 	}
 }
 
@@ -287,8 +287,8 @@ func (n *EndpointSelector) AddMatch(key, value string) {
 		n.MatchLabels = map[string]string{}
 	}
 	n.MatchLabels[key] = value
-	n.requirements = labelSelectorToRequirements(n.LabelSelector)
-	n.cachedLabelSelectorString = n.LabelSelector.String()
+	n.requirements = nil
+	n.cachedLabelSelectorString = ""
 }
 
 // AddMatchExpression adds a match expression to label selector of the endpoint selector.
@@ -301,8 +301,8 @@ func (n *EndpointSelector) AddMatchExpression(key string, op slim_metav1.LabelSe
 
 	// Update cache of the EndopintSelector from the embedded label selector.
 	// This is to make sure we have updates caches containing the required selectors.
-	n.requirements = labelSelectorToRequirements(n.LabelSelector)
-	n.cachedLabelSelectorString = n.LabelSelector.String()
+	n.requirements = nil
+	n.cachedLabelSelectorString = ""
 }
 
 // Matches returns true if the endpoint selector Matches the `lblsToMatch`.

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -66,6 +66,11 @@ func (n *EndpointSelector) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
+	n.ParseExtendedKey()
+	return nil
+}
+
+func (n *EndpointSelector) ParseExtendedKey() {
 	if n.MatchLabels != nil {
 		ml := map[string]string{}
 		for k, v := range n.MatchLabels {
@@ -81,9 +86,9 @@ func (n *EndpointSelector) UnmarshalJSON(b []byte) error {
 		}
 		n.MatchExpressions = newMatchExpr
 	}
+
 	n.requirements = labelSelectorToRequirements(n.LabelSelector)
 	n.cachedLabelSelectorString = n.LabelSelector.String()
-	return nil
 }
 
 // MarshalJSON returns a JSON representation of the byte array.


### PR DESCRIPTION
See commit messages for details.

Fixes: #38010

```release-note
policy/api: Remove sources assignation from json marshalling and add source prefix "k8s" to label selector keys
```