### PR TITLE
bpf: Fix comment above ct_is_reply

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -398,10 +398,16 @@ ct_lookup_select_tuple_type(enum ct_dir dir, enum ct_scope scope)
 /* The function determines whether an egress flow identified by the given
  * tuple is a reply.
  *
- * The datapath creates a CT entry in a reverse order. E.g., if a pod sends a
- * request to outside, the CT entry stored in the BPF map will be TUPLE_F_IN:
- * pod => outside. So, we can leverage this fact to determine whether the given
- * flow is a reply.
+ * The datapath creates a CT entry with addresses in a reverse order. If a
+ * connection to a pod is initiated from outside the cluster, the CT entry is:
+ *     TUPLE_F_IN: pod_addr:world_port -> world_addr:pod_port
+ * The tuple in the egress context in datapath is created with addresses in the
+ * correct order, but with ports reversed:
+ *     TUPLE_F_OUT: pod_addr:world_port -> world_addr:pod_port
+ *
+ * The only difference between these tuples is flags. Therefore, in the egress
+ * context, this function may be used to check whether the packet corresponds to
+ * an existing world->cluster connection.
  */
 #define DEFINE_FUNC_CT_IS_REPLY(FAMILY)						\
 static __always_inline bool							\


### PR DESCRIPTION
The comment above the DEFINE_FUNC_CT_IS_REPLY macro (which is used to define ct_is_reply4 and ct_is_reply6) mistakenly says:

> if a pod sends a request to outside, the CT entry stored in the BPF
> map will be TUPLE_F_IN: pod => outside

It was supposed to say "if an outside client opens a connection to a pod", i.e. the opposite direction to what's said in the comment. In that case, the CT entry indeed looks as described. This is also the intended meaning, because ct_is_reply is then used to find egressing packets that belong to externally initiated connections.

Rephrase the comment to fix the typo, and also add more details about the order of the ports in the CT entry and in the egress tuple. Highlight the applicability of this function (egress context).