### PR TITLE
daemon: Switch to new load-balancing control-plane

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2683,7 +2683,7 @@
    * - :spelling:ignore:`loadBalancer`
      - Configure service load balancing
      - object
-     - ``{"acceleration":"disabled","experimental":false,"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}``
+     - ``{"acceleration":"disabled","experimental":true,"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}``
    * - :spelling:ignore:`loadBalancer.acceleration`
      - acceleration is the option to accelerate service handling via XDP Applicable values can be: disabled (do not use XDP), native (XDP BPF program is run directly out of the networking driver's early receive path), or best-effort (use native mode XDP acceleration on devices that support it).
      - string
@@ -2691,7 +2691,7 @@
    * - :spelling:ignore:`loadBalancer.experimental`
      - experimental enables support for the experimental load-balancing control-plane.
      - bool
-     - ``false``
+     - ``true``
    * - :spelling:ignore:`loadBalancer.l7`
      - L7 LoadBalancer
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -720,9 +720,9 @@ contributors across the globe, there is almost always someone available to help.
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | livenessProbe.requireK8sConnectivity | bool | `false` | whether to require k8s connectivity as part of the check. |
-| loadBalancer | object | `{"acceleration":"disabled","experimental":false,"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
+| loadBalancer | object | `{"acceleration":"disabled","experimental":true,"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
 | loadBalancer.acceleration | string | `"disabled"` | acceleration is the option to accelerate service handling via XDP Applicable values can be: disabled (do not use XDP), native (XDP BPF program is run directly out of the networking driver's early receive path), or best-effort (use native mode XDP acceleration on devices that support it). |
-| loadBalancer.experimental | bool | `false` | experimental enables support for the experimental load-balancing control-plane. |
+| loadBalancer.experimental | bool | `true` | experimental enables support for the experimental load-balancing control-plane. |
 | loadBalancer.l7 | object | `{"algorithm":"round_robin","backend":"disabled","ports":[]}` | L7 LoadBalancer |
 | loadBalancer.l7.algorithm | string | `"round_robin"` | Default LB algorithm The default LB algorithm to be used for services, which can be overridden by the service annotation (e.g. service.cilium.io/lb-l7-algorithm) Applicable values: round_robin, least_request, random |
 | loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. service.cilium.io/lb-l7, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration.  Applicable values:   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.   - disabled: Disable L7 load balancing by way of service annotation. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2218,7 +2218,7 @@ loadBalancer:
 
   # -- experimental enables support for the experimental load-balancing
   # control-plane.
-  experimental: false
+  experimental: true
   # -- L7 LoadBalancer
   l7:
     # -- Enable L7 service load balancing via envoy proxy.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2235,7 +2235,7 @@ loadBalancer:
 
   # -- experimental enables support for the experimental load-balancing
   # control-plane.
-  experimental: false
+  experimental: true
 
   # -- L7 LoadBalancer
   l7:

--- a/operator/pkg/model/translation/envoy_route_configuration.go
+++ b/operator/pkg/model/translation/envoy_route_configuration.go
@@ -64,8 +64,21 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 	}
 
 	for _, port := range []string{insecureHost, secureHost} {
+		// the route name should match the value in http connection manager
+		// otherwise the request will be dropped by envoy
+		routeName := fmt.Sprintf("listener-%s", port)
+
 		hostNames, exists := portHostNameRedirect[port]
 		if !exists {
+			if port == insecureHost && !m.IsHTTPListenerConfigured() ||
+				port == secureHost && !m.IsHTTPSListenerConfigured() {
+				continue
+			}
+			rc, err := routeConfiguration(routeName, nil)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, rc)
 			continue
 		}
 		var virtualhosts []*envoy_config_route_v3.VirtualHost
@@ -103,9 +116,6 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 			virtualhosts = append(virtualhosts, vhs)
 		}
 
-		// the route name should match the value in http connection manager
-		// otherwise the request will be dropped by envoy
-		routeName := fmt.Sprintf("listener-%s", port)
 		goslices.SortStableFunc(virtualhosts, func(a, b *envoy_config_route_v3.VirtualHost) int { return cmp.Compare(a.Name, b.Name) })
 		rc, err := routeConfiguration(routeName, virtualhosts)
 		if err != nil {

--- a/pkg/ciliumenvoyconfig/exp_cell.go
+++ b/pkg/ciliumenvoyconfig/exp_cell.go
@@ -46,7 +46,7 @@ var (
 			cecListerWatchers,
 		),
 		cell.Invoke(
-			registerCECReflector,
+			registerCECK8sReflector,
 			registerEnvoyReconciler,
 		),
 	)

--- a/pkg/ciliumenvoyconfig/exp_node_labels_controller.go
+++ b/pkg/ciliumenvoyconfig/exp_node_labels_controller.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"sync/atomic"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+// nodeLabels stores the current node labels. Used in the k8s to CEC table
+// reflector to compute [CEC.SelectsLocalNode] field at reflection time.
+type nodeLabels struct {
+	initialized chan struct{}
+	ptr         atomic.Pointer[map[string]string]
+}
+
+func (nl *nodeLabels) Load() map[string]string {
+	<-nl.initialized
+	return *nl.ptr.Load()
+}
+
+func (nl *nodeLabels) store(labels map[string]string) {
+	nl.ptr.Store(&labels)
+}
+
+func newNodeLabels(params nodeLabelControllerParams) *nodeLabels {
+	nl := &nodeLabels{
+		initialized: make(chan struct{}),
+	}
+	if !params.ExpConfig.EnableExperimentalLB {
+		return nil
+	}
+	c := &nodeLabelController{nodeLabelControllerParams: params, nodeLabels: nl}
+	params.JobGroup.Add(job.Observer("node-labels", c.process, params.LocalNodeStore))
+
+	return nl
+}
+
+type nodeLabelControllerParams struct {
+	cell.In
+
+	DB       *statedb.DB
+	JobGroup job.Group
+	Log      *slog.Logger
+
+	ExpConfig      experimental.Config
+	LocalNodeStore *node.LocalNodeStore
+	CECs           statedb.RWTable[*CEC]
+}
+
+// nodeLabelController updates the [nodeLabels] and [CEC.SelectsLocalNode] field when
+// the node labels change.
+// The [cecController] will recompute when it has been changed.
+type nodeLabelController struct {
+	nodeLabelControllerParams
+
+	nodeLabels *nodeLabels
+}
+
+func (c *nodeLabelController) process(ctx context.Context, localNode node.LocalNode) error {
+	newLabels := localNode.Labels
+	oldLabels := c.nodeLabels.ptr.Load()
+
+	if oldLabels == nil || !maps.Equal(newLabels, *oldLabels) {
+		c.Log.Debug("Labels changed",
+			logfields.Old, oldLabels,
+			logfields.New, newLabels,
+		)
+
+		// Since the labels changed, recompute 'SelectsLocalNode'
+		// for all CECs.
+		wtxn := c.DB.WriteTxn(c.CECs)
+
+		// Store the new labels so the reflector can compute 'SelectsLocalNode'
+		// on the fly. The reflector may already update 'SelectsLocalNode' to the
+		// correct value, so the recomputation that follows may be duplicate for
+		// some CECs, but that's fine. This is updated with the CEC table lock held
+		// and read by CEC reflector with the table lock which ensures consistency.
+		// With the Table[Node] changes in https://github.com/cilium/cilium/pull/32144
+		// this can be removed and we can instead read the labels directly from the node
+		// table.
+		labelSet := labels.Set(newLabels)
+		c.nodeLabels.store(newLabels)
+
+		for cec := range c.CECs.All(wtxn) {
+			if cec.Selector != nil {
+				selects := cec.Selector.Matches(labelSet)
+				if selects != cec.SelectsLocalNode {
+					cec = cec.Clone()
+					cec.SelectsLocalNode = selects
+					c.CECs.Insert(wtxn, cec)
+				}
+			}
+		}
+		wtxn.Commit()
+
+		if oldLabels == nil {
+			close(c.nodeLabels.initialized)
+		}
+	}
+	return nil
+}

--- a/pkg/ciliumenvoyconfig/exp_reconciler.go
+++ b/pkg/ciliumenvoyconfig/exp_reconciler.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"iter"
 	"log/slog"
-	"maps"
 
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/reconciler"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
@@ -23,15 +23,16 @@ type envoyOps struct {
 	xds           resourceMutator
 	policyTrigger policyTrigger
 	writer        *experimental.Writer
+	portAllocator PortAllocator
 }
 
 // Delete implements reconciler.Operations.
 func (ops *envoyOps) Delete(ctx context.Context, _ statedb.ReadTxn, res *EnvoyResource) error {
-	if len(res.Redirects) > 0 {
+	if res.Redirects.Len() > 0 {
 		// Remove redirects from services no longer selected by the CEC
 		wtxn := ops.writer.WriteTxn()
 		defer wtxn.Abort()
-		for name := range res.ReconciledRedirects {
+		for name := range res.ReconciledRedirects.All() {
 			svc, _, found := ops.writer.Services().Get(wtxn, experimental.ServiceByName(name))
 			if found {
 				svc = svc.Clone()
@@ -42,13 +43,31 @@ func (ops *envoyOps) Delete(ctx context.Context, _ statedb.ReadTxn, res *EnvoyRe
 		wtxn.Commit()
 	}
 
+	releasedListeners := sets.New[string]()
+
 	var err error
 	if prev := res.ReconciledResources; prev != nil {
 		// Perform the deletion with the resources that were last successfully reconciled
 		// instead of whatever the latest one is (which would have not been pushed to Envoy).
 		err = ops.xds.DeleteEnvoyResources(ctx, *prev)
+
+		for _, listener := range prev.Listeners {
+			ops.portAllocator.ReleaseProxyPort(listener.Name)
+			releasedListeners.Insert(listener.Name)
+		}
 	}
-	ops.policyTrigger.TriggerPolicyUpdates()
+
+	// Release the proxy ports of any unreconciled resources
+	for _, listener := range res.Resources.Listeners {
+		if !releasedListeners.Has(listener.Name) {
+			ops.portAllocator.ReleaseProxyPort(listener.Name)
+			releasedListeners.Insert(listener.Name)
+		}
+	}
+
+	if len(releasedListeners) > 0 {
+		ops.policyTrigger.TriggerPolicyUpdates()
+	}
 	return err
 }
 
@@ -68,26 +87,32 @@ func (ops *envoyOps) Update(ctx context.Context, txn statedb.ReadTxn, res *Envoy
 	if res.ReconciledResources != nil {
 		prevResources = *res.ReconciledResources
 	}
+
 	err := ops.xds.UpdateEnvoyResources(ctx, prevResources, resources)
 	if err == nil {
 		if prevResources.ListenersAddedOrDeleted(&resources) {
 			ops.policyTrigger.TriggerPolicyUpdates()
 		}
 
+		res.ReconciledResources = &resources
+		res.ReconciledResources.PortAllocationCallbacks = nil
+
 		// With the envoy resources successfully pushed to Envoy, set the proxy redirections
 		// for the associated services.
-		if len(res.Redirects) > 0 || len(res.ReconciledRedirects) > 0 {
+		if res.Redirects.Len() > 0 || res.ReconciledRedirects.Len() > 0 {
 			wtxn := ops.writer.WriteTxn()
-			for name, redirect := range res.Redirects {
+			orphanRedirects := res.ReconciledRedirects
+			for name, redirect := range res.Redirects.All() {
 				svc, _, found := ops.writer.Services().Get(wtxn, experimental.ServiceByName(name))
 				if found && !svc.ProxyRedirect.Equal(redirect) {
 					svc = svc.Clone()
 					svc.ProxyRedirect = redirect
 					ops.writer.UpsertService(wtxn, svc)
 				}
+				orphanRedirects = orphanRedirects.Delete(name)
 			}
-			for name := range res.ReconciledRedirects {
-				if _, found := res.Redirects[name]; !found {
+			for name := range orphanRedirects.All() {
+				if _, found := res.Redirects.Get(name); !found {
 					svc, _, found := ops.writer.Services().Get(wtxn, experimental.ServiceByName(name))
 					if found {
 						svc = svc.Clone()
@@ -97,10 +122,8 @@ func (ops *envoyOps) Update(ctx context.Context, txn statedb.ReadTxn, res *Envoy
 				}
 			}
 			wtxn.Commit()
-			res.ReconciledRedirects = maps.Clone(res.Redirects)
+			res.ReconciledRedirects = res.Redirects
 		}
-
-		res.ReconciledResources = &resources
 	}
 	return err
 }
@@ -115,6 +138,7 @@ func registerEnvoyReconciler(
 	params reconciler.Params,
 	writer *experimental.Writer,
 	envoyResources statedb.RWTable[*EnvoyResource],
+	portAllocator PortAllocator,
 ) error {
 	ops := &envoyOps{
 		config:        config,
@@ -122,6 +146,7 @@ func registerEnvoyReconciler(
 		xds:           xds,
 		writer:        writer,
 		policyTrigger: pt,
+		portAllocator: portAllocator,
 	}
 	_, err := reconciler.Register(
 		params,

--- a/pkg/ciliumenvoyconfig/exp_tables.go
+++ b/pkg/ciliumenvoyconfig/exp_tables.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/statedb/reconciler"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -23,6 +24,9 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
+// CEC is the agent model of the parsed Cilium(Clusterwide)EnvoyConfig.
+// These are stored in the 'ciliumenvoyconfigs' table that can be inspected
+// with "db/show ciliumenvoyconfigs" in "cilium-dbg shell".
 type CEC struct {
 	Name k8sTypes.NamespacedName
 	Spec *ciliumv2.CiliumEnvoyConfigSpec
@@ -30,6 +34,8 @@ type CEC struct {
 	Selector         labels.Selector `json:"-" yaml:"-"`
 	SelectsLocalNode bool
 	Listeners        part.Map[string, uint16]
+
+	ServicePorts map[loadbalancer.ServiceName]sets.Set[string] `json:"-" yaml:"-"`
 
 	// Resources is the parsed envoy.Resources with the endpoints filled in.
 	Resources envoy.Resources
@@ -125,15 +131,117 @@ func NewCECTable(db *statedb.DB) (statedb.RWTable[*CEC], error) {
 	return tbl, db.RegisterTable(tbl)
 }
 
+type EnvoyResourceOrigin string
+
+func (k EnvoyResourceOrigin) String() string {
+	return string(k)
+}
+
+const (
+	EnvoyResourceOriginCEC         = EnvoyResourceOrigin("cec")
+	EnvoyResourceOriginBackendSync = EnvoyResourceOrigin("backendsync")
+)
+
+// EnvoyResourceName is the unique identifier for [EnvoyResource]. These can be created from
+// to origins:
+// - cec: derived from the Cilium(Clusterwide)EnvoyConfig. Name is the name of the CiliumEnvoyConfig.
+// - backendsync: cluster load assignments derived from backends. Name is the name of the service.
+type EnvoyResourceName struct {
+	Origin    EnvoyResourceOrigin
+	Cluster   string
+	Namespace string
+	Name      string
+}
+
+func (n EnvoyResourceName) String() string {
+	var b strings.Builder
+	b.WriteString(string(n.Origin))
+	b.WriteRune(':')
+	if n.Cluster != "" {
+		b.WriteString(n.Cluster)
+		b.WriteRune('/')
+	}
+	b.WriteString(n.Namespace)
+	b.WriteRune('/')
+	b.WriteString(n.Name)
+	return b.String()
+}
+
+// EnvoyResource is either a "cec" resource created from CEC, or a "backendsync" resource
+// created from a service that one ore more CECs refer to.
 type EnvoyResource struct {
-	Name      CECName
-	Resources envoy.Resources
-	Redirects map[loadbalancer.ServiceName]*experimental.ProxyRedirect `json:"-"`
-
-	ReconciledResources *envoy.Resources
-	ReconciledRedirects map[loadbalancer.ServiceName]*experimental.ProxyRedirect `json:"-"`
-
+	Name   EnvoyResourceName
 	Status reconciler.Status
+
+	// Resources to reconcile with Envoy
+	Resources envoy.Resources
+
+	// ReconciledResources are the last resources that were successfully reconciled.
+	// Used when updating or deleting to compute the delta.
+	ReconciledResources *envoy.Resources
+
+	// Redirects are the proxy redirects to set. Redirection of services is performed after
+	// the resources have been reconciled to Envoy.
+	Redirects part.Map[loadbalancer.ServiceName, *experimental.ProxyRedirect]
+
+	// ReconciledRedirects are the redirects that were successfully set.
+	ReconciledRedirects part.Map[loadbalancer.ServiceName, *experimental.ProxyRedirect]
+
+	ReferencedServices part.Set[loadbalancer.ServiceName]
+
+	// ClusterReferences to CECs. Only applicable for "backendsync" resources. This is
+	// used to keep track of how many CECs refer to a "backendsync" resource (via service name).
+	// When no references remain the "backendsync" resource is deleted.
+	ClusterReferences clusterReferences `json:"-"`
+}
+
+func (r *EnvoyResource) ClusterServiceName() loadbalancer.ServiceName {
+	return loadbalancer.ServiceName{
+		Namespace: r.Name.Namespace,
+		Name:      r.Name.Name,
+		Cluster:   r.Name.Cluster,
+	}
+}
+
+type clusterReference struct {
+	CECName   CECName
+	PortNames sets.Set[string]
+}
+
+type clusterReferences []clusterReference
+
+func (refs clusterReferences) HasPortName(portName string) bool {
+	for _, ref := range refs {
+		if ref.PortNames.Has(portName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (refs clusterReferences) Remove(cec CECName) clusterReferences {
+	out := make([]clusterReference, 0, len(refs))
+	for _, ref := range refs {
+		if ref.CECName != cec {
+			out = append(out, ref)
+		}
+	}
+	return clusterReferences(out)
+}
+
+func (refs clusterReferences) Add(cec CECName, portNames sets.Set[string]) clusterReferences {
+	out := make([]clusterReference, 0, len(refs)+1)
+	for _, ref := range refs {
+		if ref.CECName != cec {
+			out = append(out, ref)
+		}
+	}
+	out = append(out, clusterReference{CECName: cec, PortNames: portNames})
+	return clusterReferences(out)
+}
+
+func (r *EnvoyResource) Key() index.Key {
+	return index.String(r.Name.String())
 }
 
 func (r *EnvoyResource) SetStatus(newStatus reconciler.Status) *EnvoyResource {
@@ -155,6 +263,7 @@ func (*EnvoyResource) TableHeader() []string {
 		"Name",
 		"Listeners",
 		"Endpoints",
+		"References",
 		"Status",
 		"Since",
 		"Error",
@@ -189,11 +298,20 @@ func (r *EnvoyResource) showEndpoints() string {
 	return strings.Join(out, ", ")
 }
 
+func (r *EnvoyResource) showReferences() string {
+	out := []string{}
+	for _, ref := range r.ClusterReferences {
+		out = append(out, ref.CECName.String())
+	}
+	return strings.Join(out, ", ")
+}
+
 func (r *EnvoyResource) TableRow() []string {
 	return []string{
 		r.Name.String(),
 		r.showListeners(),
 		r.showEndpoints(),
+		r.showReferences(),
 		string(r.Status.Kind),
 		duration.HumanDuration(time.Since(r.Status.UpdatedAt)),
 		r.Status.Error,
@@ -205,22 +323,35 @@ const (
 )
 
 var (
-	envoyResourceNameIndex = statedb.Index[*EnvoyResource, CECName]{
+	envoyResourceNameIndex = statedb.Index[*EnvoyResource, EnvoyResourceName]{
 		Name: "name",
 		FromObject: func(obj *EnvoyResource) index.KeySet {
-			return index.NewKeySet(index.String(obj.Name.String()))
+			return index.NewKeySet(obj.Key())
 		},
-		FromKey: index.Stringer[CECName],
-		Unique:  true,
+		FromKey:    index.Stringer[EnvoyResourceName],
+		FromString: index.FromString,
+		Unique:     true,
+	}
+	EnvoyResourceByName = envoyResourceNameIndex.Query
+
+	envoyResourceOriginIndex = statedb.Index[*EnvoyResource, EnvoyResourceOrigin]{
+		Name: "kind",
+		FromObject: func(obj *EnvoyResource) index.KeySet {
+			return index.NewKeySet(index.String(string(obj.Name.Origin)))
+		},
+		FromKey:    index.Stringer[EnvoyResourceOrigin],
+		FromString: index.FromString,
+		Unique:     false,
 	}
 
-	EnvoyResourceByName = envoyResourceNameIndex.Query
+	EnvoyResourceByOrigin = envoyResourceOriginIndex.Query
 )
 
 func NewEnvoyResourcesTable(db *statedb.DB) (statedb.RWTable[*EnvoyResource], error) {
 	tbl, err := statedb.NewTable(
 		EnvoyResourcesTableName,
 		envoyResourceNameIndex,
+		envoyResourceOriginIndex,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/ciliumenvoyconfig/exp_test.go
+++ b/pkg/ciliumenvoyconfig/exp_test.go
@@ -4,24 +4,36 @@
 package ciliumenvoyconfig
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"flag"
 	"fmt"
+	"log/slog"
 	"maps"
 	"os"
-	"sort"
+	"slices"
+	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/hive/script"
 	"github.com/cilium/hive/script/scripttest"
+	envoy_config_cluster "github.com/cilium/proxy/go/envoy/config/cluster/v3"
+	envoy_config_endpoint "github.com/cilium/proxy/go/envoy/config/endpoint/v3"
+	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
+	envoy_config_route "github.com/cilium/proxy/go/envoy/config/route/v3"
+	envoy_config_tls "github.com/cilium/proxy/go/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/cilium/statedb"
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -32,6 +44,8 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -40,13 +54,17 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
 func TestScript(t *testing.T) {
 	// Catch any leaked goroutines.
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	version.Force(testutils.DefaultVersion)
 	setup := func(t testing.TB, args []string) *script.Engine {
-		fakeEnvoy := &fakeEnvoySyncerAndPolicyTrigger{}
+		fakeEnvoy := &fakeEnvoySyncerAndPolicyTrigger{
+			store: resourceStore{},
+		}
 		var lns *node.LocalNodeStore
 
 		h := hive.New(
@@ -84,7 +102,7 @@ func TestScript(t *testing.T) {
 				cell.Group(
 					cell.Provide(
 						newCECResourceParser,
-						func() PortAllocator { return staticPortAllocator{} },
+						func(log *slog.Logger) PortAllocator { return staticPortAllocator{log} },
 					),
 					node.LocalNodeStoreCell,
 					cell.Invoke(func(lns_ *node.LocalNodeStore) { lns = lns_ }),
@@ -108,7 +126,12 @@ func TestScript(t *testing.T) {
 		h.RegisterFlags(flags)
 		flags.Set("enable-experimental-lb", "true")
 
-		log := hivetest.Logger(t)
+		var opts []hivetest.LogOption
+		if *debug {
+			opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+		}
+		log := hivetest.Logger(t, opts...)
+
 		t.Cleanup(func() {
 			assert.NoError(t, h.Stop(log, context.TODO()))
 		})
@@ -116,53 +139,67 @@ func TestScript(t *testing.T) {
 		require.NoError(t, err, "ScriptCommands")
 		maps.Insert(cmds, maps.All(script.DefaultCmds()))
 
-		cmds["envoy"] = script.Command(
-			script.CmdUsage{Summary: "Show last Envoy resources", Args: "file"},
+		cmds["envoy/cmp"] = script.Command(
+			script.CmdUsage{
+				Summary: "Compare Envoy resources",
+				Args:    "file",
+				Detail: []string{
+					"The expected file is a simple sectioned text file with the format:",
+					"section1:",
+					"__section1_line1",
+					"__section1_line2",
+					"section2:",
+					"__section2_line2",
+					"",
+					"Each section (except policy-trigger-count) is unmarshalled using",
+					"prototext into a Envoy protobuf message and these are then compared",
+					"using proto.Equal to the current resources.",
+					"",
+					"You are not supposed to maintain the expected file by hand, instead",
+					"if the test case is new/changed you should run with '-scripttest.update'",
+					"to update the expected file.",
+					"",
+					"For a new test case just add an empty file to the end of the txtar",
+					"and run once with '-scripttest.update'.",
+					"",
+					"Do remember to verify the expected content carefully!",
+				},
+			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
 				if len(args) != 1 {
-					return nil, fmt.Errorf("expected output filename")
+					return nil, fmt.Errorf("expected filename")
 				}
-				f, err := os.OpenFile(s.Path(args[0]), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+				b, err := os.ReadFile(s.Path(args[0]))
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to read %q: %w", args[0], err)
 				}
-				defer f.Close()
-				_, err = fmt.Fprintf(f, "policy-trigger-count: %d\n", fakeEnvoy.policyTriggerCount.Load())
+
+				if s.DoUpdate {
+					// To avoid comparing too early when doing expected file updates
+					// sleep a bit to make it much more likely that we'll get the
+					// version we actually want.
+					time.Sleep(500 * time.Millisecond)
+				}
+
+				expected, err := fakeEnvoy.compare(b)
+				if err != nil && s.DoUpdate {
+					// If -scripttest.update is set provide the expected output
+					s.FileUpdates[args[0]] = expected
+					return nil, nil
+				}
 				if err != nil {
-					return nil, err
+					s.Logf("%s\n", err)
+					diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+						A:        difflib.SplitLines(expected),
+						FromFile: "<actual>",
+						B:        difflib.SplitLines(string(b)),
+						ToFile:   args[0],
+						Context:  4,
+					})
+					s.Logf("%s\n", diff)
+					s.Logf("(to update expected files run test again with -scripttest.update)\n")
 				}
-				for _, info := range fakeEnvoy.all() {
-					if info.res == nil {
-						_, err = fmt.Fprintf(f, "%s: listeners=<nil> endpoints=<nil>\n", info.name)
-						if err != nil {
-							return nil, err
-						}
-						continue
-					}
-					var listeners, endpoints []string
-					for _, l := range info.res.Listeners {
-						listeners = append(listeners,
-							fmt.Sprintf("%s/%d", l.Name, l.Address.GetSocketAddress().GetPortValue()))
-					}
-					sort.Strings(listeners)
-					for _, cla := range info.res.Endpoints {
-						for _, eps := range cla.Endpoints {
-							backends := make([]string, 0, len(eps.LbEndpoints))
-							for _, lep := range eps.LbEndpoints {
-								ep := lep.GetEndpoint()
-								sa := ep.Address.GetSocketAddress()
-								backends = append(backends, fmt.Sprintf("%s:%d", sa.Address, sa.GetPortValue()))
-							}
-							endpoints = append(endpoints, cla.ClusterName+"="+strings.Join(backends, ","))
-						}
-					}
-					sort.Strings(endpoints)
-					_, err = fmt.Fprintf(f, "%s: listeners=%s endpoints=%s\n", info.name, strings.Join(listeners, ","), strings.Join(endpoints, ","))
-					if err != nil {
-						return nil, err
-					}
-				}
-				return nil, nil
+				return nil, err
 			},
 		)
 		cmds["set-node-labels"] = script.Command(
@@ -201,43 +238,228 @@ func TestScript(t *testing.T) {
 
 }
 
-type resourceStore struct {
-	count atomic.Int32
-	res   atomic.Pointer[envoy.Resources]
+type resourceKey struct {
+	kind string // kind is listener/secret/etc.
+	name string
 }
 
-func (r *resourceStore) incr(res *envoy.Resources) {
-	r.count.Add(1)
-	r.res.Store(res)
+func (k resourceKey) String() string {
+	return k.kind + ":" + k.name
+}
+
+type resourceStore map[string]proto.Message
+
+const (
+	listenerKey  = "listener"
+	secretKey    = "secret"
+	routeKey     = "route"
+	clustersKey  = "clusters"
+	endpointsKey = "endpoints"
+)
+
+func (rs resourceStore) equal(other resourceStore) bool {
+	return maps.EqualFunc(rs, other, proto.Equal)
+}
+
+func (rs resourceStore) update(res *envoy.Resources) {
+	for _, l := range res.Listeners {
+		rs[resourceKey{kind: listenerKey, name: l.Name}.String()] = l
+	}
+	for _, s := range res.Secrets {
+		rs[resourceKey{kind: secretKey, name: s.Name}.String()] = s
+	}
+	for _, r := range res.Routes {
+		rs[resourceKey{kind: routeKey, name: r.Name}.String()] = r
+	}
+	for _, c := range res.Clusters {
+		rs[resourceKey{kind: clustersKey, name: c.Name}.String()] = c
+	}
+	for _, e := range res.Endpoints {
+		rs[resourceKey{kind: endpointsKey, name: e.ClusterName}.String()] = e
+	}
+}
+
+func (rs resourceStore) delete(res *envoy.Resources) {
+	for _, l := range res.Listeners {
+		delete(rs, resourceKey{kind: listenerKey, name: l.Name}.String())
+	}
+	for _, s := range res.Secrets {
+		delete(rs, resourceKey{kind: secretKey, name: s.Name}.String())
+	}
+	for _, r := range res.Routes {
+		delete(rs, resourceKey{kind: routeKey, name: r.Name}.String())
+	}
+	for _, c := range res.Clusters {
+		delete(rs, resourceKey{kind: clustersKey, name: c.Name}.String())
+	}
+	for _, e := range res.Endpoints {
+		delete(rs, resourceKey{kind: endpointsKey, name: e.ClusterName}.String())
+	}
 }
 
 type fakeEnvoySyncerAndPolicyTrigger struct {
-	update, delete     resourceStore
-	policyTriggerCount atomic.Int32
+	lock.Mutex
+	store              resourceStore
+	policyTriggerCount int
 }
 
-type resourceInfo struct {
-	name  string
-	count int32
-	res   *envoy.Resources
+type section struct {
+	name    string
+	content []byte
 }
 
-func (f *fakeEnvoySyncerAndPolicyTrigger) all() []resourceInfo {
-	return []resourceInfo{
-		{"update", f.update.count.Load(), f.update.res.Load()},
-		{"delete", f.delete.count.Load(), f.delete.res.Load()},
+func (s section) String() string {
+	return fmt.Sprintf("%s: %q", s.name, s.content)
+}
+
+// parseSections parses a file formatted into indented sections:
+//
+//	section1:
+//	  s1line1
+//	  s1line2
+//	section2:
+//	  s2line1
+//
+// This returns: [{"section1", "s1line1\ns1line2"}, "section2", "s2line1\n"}]
+func parseSections(b []byte) (sections []section, err error) {
+	var currentName string
+	var contentBuilder bytes.Buffer
+	for line := range bytes.SplitSeq(b, []byte{'\n'}) {
+		switch {
+		case len(line) == 0:
+			contentBuilder.WriteRune('\n')
+		case line[0] == ' ':
+			if line[1] != ' ' {
+				return nil, fmt.Errorf("bad section format, expected double space on line: %q", line)
+			}
+			contentBuilder.Write(line[2:])
+			contentBuilder.WriteRune('\n')
+		default:
+			if currentName != "" {
+				sections = append(sections, section{currentName, contentBuilder.Bytes()})
+				contentBuilder = bytes.Buffer{}
+			}
+			currentName, _ = strings.CutSuffix(string(line), ":")
+		}
 	}
+	if currentName != "" {
+		sections = append(sections, section{currentName, contentBuilder.Bytes()})
+	}
+	return sections, nil
+}
+
+func sectionToMessage(sectionName string) proto.Message {
+	switch {
+	case strings.HasPrefix(sectionName, listenerKey):
+		return &envoy_config_listener.Listener{}
+	case strings.HasPrefix(sectionName, secretKey):
+		return &envoy_config_tls.Secret{}
+	case strings.HasPrefix(sectionName, routeKey):
+		return &envoy_config_route.RouteConfiguration{}
+	case strings.HasPrefix(sectionName, clustersKey):
+		return &envoy_config_cluster.Cluster{}
+	case strings.HasPrefix(sectionName, endpointsKey):
+		return &envoy_config_endpoint.ClusterLoadAssignment{}
+	default:
+		return nil
+	}
+}
+
+func (f *fakeEnvoySyncerAndPolicyTrigger) compare(b []byte) (expected string, err error) {
+	f.Lock()
+	defer f.Unlock()
+
+	expected = f.summary()
+
+	resources := resourceStore{}
+	sections, err := parseSections(b)
+	if err != nil {
+		return expected, err
+	}
+
+	triggerCount := 0
+
+	for _, section := range sections {
+		if strings.HasPrefix("policy-trigger-count", section.name) {
+			if c, err := strconv.ParseInt(strings.TrimSpace(string(section.content)), 10, 64); err == nil {
+				triggerCount = int(c)
+			} else {
+				return expected, err
+			}
+			continue
+		}
+		msg := sectionToMessage(section.name)
+		if msg == nil {
+			err = fmt.Errorf("unhandled section %s", section.name)
+			return
+		}
+		if err = prototext.Unmarshal(section.content, msg); err != nil {
+			err = fmt.Errorf("unmarshaling %q failed: %w", section.name, err)
+			return
+		}
+		resources[section.name] = msg
+	}
+
+	// Compare the resources using proto.Equal. This way we do not rely on stability of prototext
+	// (it inserts spaces randomly to stop this sort of thing).
+	if triggerCount != f.policyTriggerCount || !resources.equal(f.store) {
+		// The resources are not equal, return the expected output.
+		return expected, errors.New("resources not equal")
+	}
+	return expected, nil
+}
+
+func (f *fakeEnvoySyncerAndPolicyTrigger) summary() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "policy-trigger-count:\n  %d\n", f.policyTriggerCount)
+
+	for _, k := range slices.Sorted(maps.Keys(f.store)) {
+		v := f.store[k]
+		fmt.Fprintf(&b, "%s:\n  %s\n", k, indentLines(prototext.Format(v)))
+	}
+	return b.String()
+}
+
+func indentLines(s string) string {
+	return strings.ReplaceAll(s, "\n", "\n  ")
 }
 
 // DeleteResources implements envoySyncer.
 func (f *fakeEnvoySyncerAndPolicyTrigger) DeleteEnvoyResources(ctx context.Context, res envoy.Resources) error {
-	f.delete.incr(&res)
+	f.Lock()
+	defer f.Unlock()
+	f.store.delete(&res)
+
+	for _, listener := range res.Listeners {
+		if cb := res.PortAllocationCallbacks[listener.Name]; cb != nil {
+			cb(ctx)
+		}
+	}
 	return nil
 }
 
 // UpdateResources implements envoySyncer.
 func (f *fakeEnvoySyncerAndPolicyTrigger) UpdateEnvoyResources(ctx context.Context, old envoy.Resources, new envoy.Resources) error {
-	f.update.incr(&new)
+	f.Lock()
+	defer f.Unlock()
+	f.store.delete(&old)
+	f.store.update(&new)
+
+	for _, oldListener := range old.Listeners {
+		for _, newListener := range new.Listeners {
+			if newListener.Name == oldListener.Name {
+				delete(new.PortAllocationCallbacks, newListener.Name)
+			}
+		}
+	}
+
+	for _, listener := range new.Listeners {
+		if cb := new.PortAllocationCallbacks[listener.Name]; cb != nil {
+			cb(ctx)
+		}
+	}
+
 	return nil
 }
 
@@ -245,15 +467,20 @@ var _ resourceMutator = &fakeEnvoySyncerAndPolicyTrigger{}
 
 // TriggerPolicyUpdates implements policyTrigger.
 func (f *fakeEnvoySyncerAndPolicyTrigger) TriggerPolicyUpdates() {
-	f.policyTriggerCount.Add(1)
+	f.Lock()
+	defer f.Unlock()
+	f.policyTriggerCount++
 }
 
 var _ policyTrigger = &fakeEnvoySyncerAndPolicyTrigger{}
 
-type staticPortAllocator struct{}
+type staticPortAllocator struct {
+	log *slog.Logger
+}
 
 // AckProxyPort implements PortAllocator.
 func (s staticPortAllocator) AckProxyPort(ctx context.Context, name string) error {
+	s.log.Info("AckProxyPort", logfields.Listener, name)
 	return nil
 }
 
@@ -264,6 +491,7 @@ func (s staticPortAllocator) AllocateCRDProxyPort(name string) (uint16, error) {
 
 // ReleaseProxyPort implements PortAllocator.
 func (s staticPortAllocator) ReleaseProxyPort(name string) error {
+	s.log.Info("ReleaseProxyPort", logfields.Listener, name)
 	return nil
 }
 

--- a/pkg/ciliumenvoyconfig/stress.sh
+++ b/pkg/ciliumenvoyconfig/stress.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eux
+[ ! -f $HOME/go/bin/stress ] && go install golang.org/x/tools/cmd/stress@latest
+
+go test -c -o stress.test
+$HOME/go/bin/stress -count 500 ./stress.test
+rm stress.test

--- a/pkg/ciliumenvoyconfig/testdata/anyport.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/anyport.txtar
@@ -22,16 +22,14 @@ lb/maps-dump lbmaps.out
 * cmp lbmaps.out lbmaps.expected
 
 # Check that right updates towards Envoy happened.
-envoy envoy.out
-* cmp envoy.out envoy1.expected
+* envoy/cmp envoy1.expected
 
 # Test the processing other way around, e.g. CEC exists before
 # the service. Start by dropping the backends.
 k8s/delete endpointslice.yaml
 
 # Backends towards Envoy should be dropped.
-envoy envoy.out
-* cmp envoy.out envoy2.expected
+* envoy/cmp envoy2.expected
 
 # Drop the service
 k8s/delete service.yaml
@@ -44,8 +42,7 @@ k8s/add service.yaml endpointslice.yaml
 db/cmp services services_redirected.table
 
 # Check again that updates happened.
-envoy envoy.out
-* cmp envoy.out envoy3.expected
+* envoy/cmp envoy3.expected
 
 # Cleanup. Remove CEC and check that proxy redirect is gone.
 k8s/delete cec.yaml
@@ -55,8 +52,7 @@ k8s/delete cec.yaml
 db/cmp services services.table
 
 # The listener should now be deleted.
-envoy envoy.out
-* cmp envoy.out envoy4.expected
+* envoy/cmp envoy4.expected
 
 # ---------------------------------------------
 
@@ -162,18 +158,198 @@ SVC: ID=3 ADDR=10.96.50.104:25/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterI
 SVC: ID=4 ADDR=10.96.50.104:80/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
 SVC: ID=4 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
 -- envoy1.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/echo:
+  cluster_name:  "test/echo"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  25
+          }
+        }
+      }
+    }
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  8080
+          }
+        }
+      }
+    }
+  }
+  
+endpoints:test/echo:*:
+  cluster_name:  "test/echo:*"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  25
+          }
+        }
+      }
+    }
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/envoy-lb-listener/envoy-lb-listener:
+  name:  "test/envoy-lb-listener/envoy-lb-listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy2.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+listener:test/envoy-lb-listener/envoy-lb-listener:
+  name:  "test/envoy-lb-listener/envoy-lb-listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy3.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/echo:
+  cluster_name:  "test/echo"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  25
+          }
+        }
+      }
+    }
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  8080
+          }
+        }
+      }
+    }
+  }
+  
+endpoints:test/echo:*:
+  cluster_name:  "test/echo:*"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  25
+          }
+        }
+      }
+    }
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/envoy-lb-listener/envoy-lb-listener:
+  name:  "test/envoy-lb-listener/envoy-lb-listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy4.expected --
-policy-trigger-count: 2
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
-delete: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
+policy-trigger-count:
+  2

--- a/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
@@ -35,19 +35,17 @@ lb/maps-dump lbmaps.out
 * cmp lbmaps.out lbmaps.expected
 
 # Check that right updates towards Envoy happened.
-envoy envoy.out
-* cmp envoy.out envoy1.expected
+* envoy/cmp envoy1.expected
 
 # Cleanup
 k8s/delete cec.yaml
 
 # Proxy redirect should be gone and CEC table should be empty
 db/cmp services services.table
-* db/empty ciliumenvoyconfigs
+* db/empty ciliumenvoyconfigs envoy-resources
 
 # The listener should now be deleted.
-envoy envoy.out
-* cmp envoy.out envoy2.expected
+* envoy/cmp envoy2.expected
 
 # ---------------------------------------------
 
@@ -84,8 +82,11 @@ Address            Type        ServiceName                PortName   Backends   
 3.0.0.1:9080/TCP   ClusterIP   test/backend_unnamed_port             3.1.0.1:9080/TCP                    Done
 
 -- envoy-resources.table --
-Name           Listeners             Endpoints                                                                                               Status   Error
-test/ingress   test/ingress/listener test/backend:9080: 2.1.0.1, 2.1.0.2, test/backend_unnamed_port:9080: 3.1.0.1, test/frontend:80: 1.1.0.1 Done
+Name                                         Listeners                   Endpoints                                    References    Status   Error
+backendsync:test/backend                                                 test/backend:9080: 2.1.0.1, 2.1.0.2          test/ingress  Done
+backendsync:test/backend_unnamed_port                                    test/backend_unnamed_port:9080: 3.1.0.1      test/ingress  Done
+backendsync:test/frontend                                                test/frontend:80: 1.1.0.1                    test/ingress  Done
+cec:test/ingress                             test/ingress/listener                                                                  Done
 
 -- cec.table --
 Name           Services        BackendServices
@@ -284,10 +285,91 @@ SVC: ID=4 ADDR=2.0.0.1:9081/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+n
 SVC: ID=5 ADDR=3.0.0.1:9080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=5 ADDR=3.0.0.1:9080/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 -- envoy1.expected --
-policy-trigger-count: 1
-update: listeners=test/ingress/listener/1000 endpoints=test/backend:9080=2.1.0.1:9080,2.1.0.2:9080,test/backend_unnamed_port:9080=3.1.0.1:9080,test/frontend:80=1.1.0.1:8080
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/backend:9080:
+  cluster_name:  "test/backend:9080"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "2.1.0.1"
+            port_value:  9080
+          }
+        }
+      }
+    }
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "2.1.0.2"
+            port_value:  9080
+          }
+        }
+      }
+    }
+  }
+  
+endpoints:test/backend_unnamed_port:9080:
+  cluster_name:  "test/backend_unnamed_port:9080"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "3.1.0.1"
+            port_value:  9080
+          }
+        }
+      }
+    }
+  }
+  
+endpoints:test/frontend:80:
+  cluster_name:  "test/frontend:80"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "1.1.0.1"
+            port_value:  8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/ingress/listener:
+  name:  "test/ingress/listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy2.expected --
-policy-trigger-count: 2
-update: listeners=test/ingress/listener/1000 endpoints=test/backend:9080=2.1.0.1:9080,2.1.0.2:9080,test/backend_unnamed_port:9080=3.1.0.1:9080,test/frontend:80=1.1.0.1:8080
-delete: listeners=test/ingress/listener/1000 endpoints=test/backend:9080=2.1.0.1:9080,2.1.0.2:9080,test/backend_unnamed_port:9080=3.1.0.1:9080,test/frontend:80=1.1.0.1:8080
+policy-trigger-count:
+  2

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -11,32 +11,32 @@ db/cmp services services.table
 # Add the CiliumClusterwideEnvoyConfig and wait for it to be ingested.
 k8s/add ccec.yaml
 db/cmp ciliumenvoyconfigs cec.table
+db/cmp envoy-resources envoy-resources.table
 
 # Check that both services are now redirected to proxy.
 db/cmp services services_redirected.table
 
 # Check that right updates towards Envoy happened.
-envoy envoy.out
-* cmp envoy.out envoy1.expected
+* envoy/cmp envoy1.expected
 
 # Test the processing other way around, e.g. CEC exists before
 # the service.
 k8s/delete service.yaml endpointslice.yaml
 
-# Services should now be empty
+# Services should now be empty and there should be no backends in the
+# cluster resource.
 * db/empty services
+db/cmp envoy-resources envoy-resources-no-backends.table
 
 # Backends towards Envoy should be updated.
-envoy envoy.out
-* cmp envoy.out envoy2.expected
+* envoy/cmp envoy2.expected
 
 # Add back the service and endpoints
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services_redirected.table
 
 # Check again that updates happened.
-envoy envoy.out
-* cmp envoy.out envoy3.expected
+* envoy/cmp envoy3.expected
 
 # Remove the CCEC
 k8s/delete ccec.yaml
@@ -44,10 +44,10 @@ k8s/delete ccec.yaml
 # Proxy redirect and CEC should be gone
 db/cmp services services.table
 * db/empty ciliumenvoyconfigs
+* db/empty envoy-resources
 
 # The listener should now be deleted.
-envoy envoy.out
-* cmp envoy.out envoy4.expected
+* envoy/cmp envoy4.expected
 
 # ---------------------------------------------
 
@@ -62,6 +62,16 @@ test/echo2  ProxyRedirect=1000
 -- cec.table --
 Name                  Selected  Services    Listeners
 /envoy-lb-listener-2  true      test/echo2  /envoy-lb-listener-2/envoy-lb-listener-2:1000
+
+-- envoy-resources.table --
+Name                       Listeners                                  Endpoints                                          References             Status   Error
+backendsync:test/echo2                                                test/echo2:*: 10.244.1.2, test/echo2: 10.244.1.2   /envoy-lb-listener-2   Done     
+cec:/envoy-lb-listener-2   /envoy-lb-listener-2/envoy-lb-listener-2                                                                             Done     
+
+-- envoy-resources-no-backends.table --
+Name                       Listeners                                  Endpoints                                          References             Status   Error
+backendsync:test/echo2                                                                                                   /envoy-lb-listener-2   Done     
+cec:/envoy-lb-listener-2   /envoy-lb-listener-2/envoy-lb-listener-2                                                                             Done     
 
 -- ccec.yaml --
 apiVersion: cilium.io/v2
@@ -123,18 +133,158 @@ ports:
   protocol: TCP
 
 -- envoy1.expected --
-policy-trigger-count: 1
-update: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=10.244.1.2:8081,test/echo2=10.244.1.2:8081
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/echo2:
+  cluster_name:  "test/echo2"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.2"
+            port_value:  8081
+          }
+        }
+      }
+    }
+  }
+  
+endpoints:test/echo2:*:
+  cluster_name:  "test/echo2:*"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.2"
+            port_value:  8081
+          }
+        }
+      }
+    }
+  }
+  
+listener:/envoy-lb-listener-2/envoy-lb-listener-2:
+  name:  "/envoy-lb-listener-2/envoy-lb-listener-2"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy2.expected --
-policy-trigger-count: 1
-update: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+listener:/envoy-lb-listener-2/envoy-lb-listener-2:
+  name:  "/envoy-lb-listener-2/envoy-lb-listener-2"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy3.expected --
-policy-trigger-count: 1
-update: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=10.244.1.2:8081,test/echo2=10.244.1.2:8081
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/echo2:
+  cluster_name:  "test/echo2"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.2"
+            port_value:  8081
+          }
+        }
+      }
+    }
+  }
+  
+endpoints:test/echo2:*:
+  cluster_name:  "test/echo2:*"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.2"
+            port_value:  8081
+          }
+        }
+      }
+    }
+  }
+  
+listener:/envoy-lb-listener-2/envoy-lb-listener-2:
+  name:  "/envoy-lb-listener-2/envoy-lb-listener-2"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy4.expected --
-policy-trigger-count: 2
-update: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=10.244.1.2:8081,test/echo2=10.244.1.2:8081
-delete: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=10.244.1.2:8081,test/echo2=10.244.1.2:8081
+policy-trigger-count:
+  2

--- a/pkg/ciliumenvoyconfig/testdata/headless.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/headless.txtar
@@ -14,16 +14,14 @@ db/cmp ciliumenvoyconfigs cec.table
 db/cmp envoy-resources envoy-resources.table
 
 # Check that right updates towards Envoy happened.
-envoy envoy.out
-* cmp envoy.out envoy1.expected
+* envoy/cmp envoy1.expected
 
 # Test the processing other way around, e.g. CEC exists before
 # the service. Start by dropping the backends.
 k8s/delete endpointslice.yaml
 
 # Backends towards Envoy should be dropped.
-envoy envoy.out
-* cmp envoy.out envoy2.expected
+* envoy/cmp envoy2.expected
 
 # Drop the service. No changes towards envoy as the load assignments
 # do not change.
@@ -37,16 +35,13 @@ k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 
 # Check again that updates happened.
-envoy envoy.out
-* cmp envoy.out envoy3.expected
+* envoy/cmp envoy3.expected
 
 # Adding an unrelated service does not trigger updates.
 k8s/add unrelated_service.yaml unrelated_endpointslice.yaml
 
 # No updates should happen.
-envoy envoy.out
-* cmp envoy.out envoy3.expected
-
+envoy/cmp envoy3.expected
 k8s/delete unrelated_service.yaml unrelated_endpointslice.yaml
 
 # Remove the CEC
@@ -57,8 +52,7 @@ k8s/delete cec.yaml
 db/cmp services services.table
 
 # The listener should now be deleted.
-envoy envoy.out
-* cmp envoy.out envoy4.expected
+* envoy/cmp envoy4.expected
 
 # ---------------------------------------------
 
@@ -71,8 +65,9 @@ Name                    BackendServices  Services
 test/envoy-lb-listener  test/echo
 
 -- envoy-resources.table --
-Name                     Status
-test/envoy-lb-listener   Done 
+Name                             Status
+backendsync:test/echo            Done
+cec:test/envoy-lb-listener       Done
 
 -- cec.yaml --
 apiVersion: cilium.io/v2
@@ -181,18 +176,125 @@ ports:
   protocol: TCP
 
 -- envoy1.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/echo:80:
+  cluster_name: "test/echo:80"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/envoy-lb-listener/envoy-lb-listener:
+  name: "test/envoy-lb-listener/envoy-lb-listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
+    }
+  }
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
+      }
+    }
+  }
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        proxy_id: 1000
+      }
+    }
+  }
+  
 -- envoy2.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+listener:test/envoy-lb-listener/envoy-lb-listener:
+  name:  "test/envoy-lb-listener/envoy-lb-listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy3.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/echo:80:
+  cluster_name:  "test/echo:80"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/envoy-lb-listener/envoy-lb-listener:
+  name:  "test/envoy-lb-listener/envoy-lb-listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy4.expected --
-policy-trigger-count: 2
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
-delete: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
+policy-trigger-count:
+  2

--- a/pkg/ciliumenvoyconfig/testdata/ingress.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/ingress.txtar
@@ -31,6 +31,9 @@ lb/maps-dump maps.actual
 ! grep '10.96.171.236:443/TCP.*L7Proxy=1000' maps.actual
 ! grep '0.0.0.0:30979/TCP.*L7Proxy=1000' maps.actual
 
+# Validate the resources sent to Envoy
+* envoy/cmp envoy.expected
+
 ###
 
 -- services.table --
@@ -54,8 +57,11 @@ Address               Instances                  NodeName
 10.244.1.243:9080/TCP default/productpage (http) kind-worker
 
 -- envoy.table --
-Name                                          Listeners                                              Endpoints                                                                   Status   Error
-default/cilium-ingress-default-basic-ingress  default/cilium-ingress-default-basic-ingress/listener  default/details:9080: 10.244.1.197, default/productpage:9080: 10.244.1.243  Done
+Name                                                    Listeners                                              Endpoints                                 Status   Error
+backendsync:default/cilium-ingress-basic-ingress                                                                                                         Done
+backendsync:default/details                                                                                    default/details:9080: 10.244.1.197        Done
+backendsync:default/productpage                                                                                default/productpage:9080: 10.244.1.243    Done
+cec:default/cilium-ingress-default-basic-ingress        default/cilium-ingress-default-basic-ingress/listener                                            Done
 
 -- cec.table --
 Name                                          Services                              BackendServices
@@ -284,7 +290,6 @@ spec:
     ports:
     - 80
 
-
 -- svc-details.yaml --
 apiVersion: v1
 kind: Service
@@ -443,20 +448,357 @@ ports:
   port: 9080
   protocol: TCP
 
--- maps.expected --
-BE: ADDR=10.244.1.197:9080/TCP STATE=active
-BE: ADDR=10.244.1.243:9080/TCP STATE=active
-REV: ADDR=0.0.0.0:30979
-REV: ADDR=0.0.0.0:31988
-REV: ADDR=10.96.171.236:80
-REV: ADDR=10.96.171.236:443
-REV: ADDR=10.96.252.74:9080
-REV: ADDR=10.96.44.54:9080
-SVC: ADDR=0.0.0.0:30979/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
-SVC: ADDR=0.0.0.0:31988/TCP SLOT=0 L7Proxy=1000 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable+l7-load-balancer
-SVC: ADDR=10.96.171.236:80/TCP SLOT=0 L7Proxy=1000 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
-SVC: ADDR=10.96.171.236:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ADDR=10.96.252.74:9080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ADDR=10.96.252.74:9080/TCP SLOT=1 BECOUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ADDR=10.96.44.54:9080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ADDR=10.96.44.54:9080/TCP SLOT=1 BECOUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- envoy.expected --
+policy-trigger-count:
+  1
+clusters:default/cilium-ingress-default-basic-ingress/default:details:9080:
+  name:  "default/cilium-ingress-default-basic-ingress/default:details:9080"
+  type:  EDS
+  eds_cluster_config:  {
+    eds_config:  {
+      api_config_source:  {
+        api_type:  GRPC
+        transport_api_version:  V3
+        grpc_services:  {
+          envoy_grpc:  {
+            cluster_name:  "xds-grpc-cilium"
+          }
+        }
+        set_node_on_first_message_only:  true
+      }
+      initial_fetch_timeout:  {
+        seconds:  30
+      }
+      resource_api_version:  V3
+    }
+    service_name:  "default/details:9080"
+  }
+  connect_timeout:  {
+    seconds:  5
+  }
+  circuit_breakers:  {
+    thresholds:  {
+      max_retries:  {
+        value:  128
+      }
+    }
+  }
+  typed_extension_protocol_options:  {
+    key:  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+    value:  {
+      [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions]:  {
+        common_http_protocol_options:  {
+          idle_timeout:  {
+            seconds:  60
+          }
+        }
+        use_downstream_protocol_config:  {
+          http2_protocol_options:  {}
+        }
+        http_filters:  {
+          name:  "cilium.l7policy"
+          typed_config:  {
+            [type.googleapis.com/cilium.L7Policy]:  {
+              access_log_path:  "envoy/sockets/access_log.sock"
+            }
+          }
+        }
+        http_filters:  {
+          name:  "envoy.filters.http.upstream_codec"
+          typed_config:  {
+            [type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec]:  {}
+          }
+        }
+      }
+    }
+  }
+  outlier_detection:  {
+    split_external_local_origin_errors:  true
+  }
+  
+clusters:default/cilium-ingress-default-basic-ingress/default:productpage:9080:
+  name:  "default/cilium-ingress-default-basic-ingress/default:productpage:9080"
+  type:  EDS
+  eds_cluster_config:  {
+    eds_config:  {
+      api_config_source:  {
+        api_type:  GRPC
+        transport_api_version:  V3
+        grpc_services:  {
+          envoy_grpc:  {
+            cluster_name:  "xds-grpc-cilium"
+          }
+        }
+        set_node_on_first_message_only:  true
+      }
+      initial_fetch_timeout:  {
+        seconds:  30
+      }
+      resource_api_version:  V3
+    }
+    service_name:  "default/productpage:9080"
+  }
+  connect_timeout:  {
+    seconds:  5
+  }
+  circuit_breakers:  {
+    thresholds:  {
+      max_retries:  {
+        value:  128
+      }
+    }
+  }
+  typed_extension_protocol_options:  {
+    key:  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+    value:  {
+      [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions]:  {
+        common_http_protocol_options:  {
+          idle_timeout:  {
+            seconds:  60
+          }
+        }
+        use_downstream_protocol_config:  {
+          http2_protocol_options:  {}
+        }
+        http_filters:  {
+          name:  "cilium.l7policy"
+          typed_config:  {
+            [type.googleapis.com/cilium.L7Policy]:  {
+              access_log_path:  "envoy/sockets/access_log.sock"
+            }
+          }
+        }
+        http_filters:  {
+          name:  "envoy.filters.http.upstream_codec"
+          typed_config:  {
+            [type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec]:  {}
+          }
+        }
+      }
+    }
+  }
+  outlier_detection:  {
+    split_external_local_origin_errors:  true
+  }
+  
+endpoints:default/details:9080:
+  cluster_name:  "default/details:9080"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.197"
+            port_value:  9080
+          }
+        }
+      }
+    }
+  }
+  
+endpoints:default/productpage:9080:
+  cluster_name:  "default/productpage:9080"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.243"
+            port_value:  9080
+          }
+        }
+      }
+    }
+  }
+  
+listener:default/cilium-ingress-default-basic-ingress/listener:
+  name:  "default/cilium-ingress-default-basic-ingress/listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  filter_chains:  {
+    filter_chain_match:  {
+      transport_protocol:  "raw_buffer"
+    }
+    filters:  {
+      name:  "cilium.network"
+      typed_config:  {
+        [type.googleapis.com/cilium.NetworkFilter]:  {}
+      }
+    }
+    filters:  {
+      name:  "envoy.filters.network.http_connection_manager"
+      typed_config:  {
+        [type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager]:  {
+          stat_prefix:  "listener-insecure"
+          rds:  {
+            config_source:  {
+              api_config_source:  {
+                api_type:  GRPC
+                transport_api_version:  V3
+                grpc_services:  {
+                  envoy_grpc:  {
+                    cluster_name:  "xds-grpc-cilium"
+                  }
+                }
+                set_node_on_first_message_only:  true
+              }
+              initial_fetch_timeout:  {
+                seconds:  30
+              }
+              resource_api_version:  V3
+            }
+            route_config_name:  "default/cilium-ingress-default-basic-ingress/listener-insecure"
+          }
+          http_filters:  {
+            name:  "envoy.filters.http.grpc_web"
+            typed_config:  {
+              [type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb]:  {}
+            }
+          }
+          http_filters:  {
+            name:  "envoy.filters.http.grpc_stats"
+            typed_config:  {
+              [type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig]:  {
+                emit_filter_state:  true
+                enable_upstream_stats:  true
+              }
+            }
+          }
+          http_filters:  {
+            name:  "cilium.l7policy"
+            typed_config:  {
+              [type.googleapis.com/cilium.L7Policy]:  {
+                access_log_path:  "envoy/sockets/access_log.sock"
+              }
+            }
+          }
+          http_filters:  {
+            name:  "envoy.filters.http.router"
+            typed_config:  {
+              [type.googleapis.com/envoy.extensions.filters.http.router.v3.Router]:  {}
+            }
+          }
+          common_http_protocol_options:  {
+            max_stream_duration:  {}
+          }
+          stream_idle_timeout:  {
+            seconds:  300
+          }
+          use_remote_address:  {
+            value:  true
+          }
+          internal_address_config:  {
+            cidr_ranges:  {
+              address_prefix:  "10.0.0.0"
+              prefix_len:  {
+                value:  8
+              }
+            }
+            cidr_ranges:  {
+              address_prefix:  "172.16.0.0"
+              prefix_len:  {
+                value:  12
+              }
+            }
+            cidr_ranges:  {
+              address_prefix:  "192.168.0.0"
+              prefix_len:  {
+                value:  16
+              }
+            }
+            cidr_ranges:  {
+              address_prefix:  "127.0.0.1"
+              prefix_len:  {
+                value:  32
+              }
+            }
+          }
+          upgrade_configs:  {
+            upgrade_type:  "websocket"
+          }
+        }
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "envoy.filters.listener.tls_inspector"
+    typed_config:  {
+      [type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector]:  {}
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  socket_options:  {
+    description:  "Enable TCP keep-alive (default to enabled)"
+    level:  1
+    name:  9
+    int_value:  1
+  }
+  socket_options:  {
+    description:  "TCP keep-alive idle time (in seconds) (defaults to 10s)"
+    level:  6
+    name:  4
+    int_value:  10
+  }
+  socket_options:  {
+    description:  "TCP keep-alive probe intervals (in seconds) (defaults to 5s)"
+    level:  6
+    name:  5
+    int_value:  5
+  }
+  socket_options:  {
+    description:  "TCP keep-alive probe max failures."
+    level:  6
+    name:  6
+    int_value:  10
+  }
+  
+route:default/cilium-ingress-default-basic-ingress/listener-insecure:
+  name:  "default/cilium-ingress-default-basic-ingress/listener-insecure"
+  virtual_hosts:  {
+    name:  "default/cilium-ingress-default-basic-ingress/*"
+    domains:  "*"
+    routes:  {
+      match:  {
+        path_separated_prefix:  "/details"
+      }
+      route:  {
+        cluster:  "default/cilium-ingress-default-basic-ingress/default:details:9080"
+        max_stream_duration:  {
+          max_stream_duration:  {}
+        }
+      }
+    }
+    routes:  {
+      match:  {
+        prefix:  "/"
+      }
+      route:  {
+        cluster:  "default/cilium-ingress-default-basic-ingress/default:productpage:9080"
+        max_stream_duration:  {
+          max_stream_duration:  {}
+        }
+      }
+    }
+  }
+  

--- a/pkg/ciliumenvoyconfig/testdata/labels.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/labels.txtar
@@ -11,16 +11,20 @@ k8s/add cec_a.yaml cec_b.yaml
 
 # CEC with foo=a should be selected.
 db/cmp ciliumenvoyconfigs cec_a.table
-envoy envoy.out
-* cmp envoy.out envoy_a.expected
+db/cmp envoy-resources envoy-resources-a.table
+
+# Envoy should be updated
+* envoy/cmp envoy_a.expected
 
 # Update the node labels to flip the selected CECs
 set-node-labels foo=b
 
 # CEC with foo=b should be selected.
 db/cmp ciliumenvoyconfigs cec_b.table
-envoy envoy.out
-* cmp envoy.out envoy_b.expected
+db/cmp envoy-resources envoy-resources-b.table
+
+# Envoy should be updated
+* envoy/cmp envoy_b.expected
 
 # ---------------------------------------------
 
@@ -70,11 +74,76 @@ spec:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       name: envoy-lb-listener
 
+
+-- envoy-resources-a.table --
+Name                       Listeners                                  Endpoints                                          References             Status   Error
+backendsync:test/a                                                                                                       test/envoy-a           Done     
+cec:test/envoy-a           test/envoy-a/envoy-lb-listener                                                                                       Done     
+
+-- envoy-resources-b.table --
+Name                       Listeners                                  Endpoints                                          References             Status   Error
+backendsync:test/b                                                                                                       test/envoy-b           Done
+cec:test/envoy-b           test/envoy-b/envoy-lb-listener                                                                                       Done
+
 -- envoy_a.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-a/envoy-lb-listener/1000 endpoints=
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+listener:test/envoy-a/envoy-lb-listener:
+  name:  "test/envoy-a/envoy-lb-listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
 -- envoy_b.expected --
-policy-trigger-count: 3
-update: listeners=test/envoy-b/envoy-lb-listener/1000 endpoints=
-delete: listeners=test/envoy-a/envoy-lb-listener/1000 endpoints=
+policy-trigger-count:
+  3
+listener:test/envoy-b/envoy-lb-listener:
+  name:  "test/envoy-b/envoy-lb-listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  

--- a/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
@@ -1,0 +1,400 @@
+# Test the JSON marshalling for Table[CEC] and Table[EnvoyResource]
+
+# Start the hive and wait for tables to be synchronized before adding k8s objects.
+hive start
+db/initialized
+
+# Add the objects and wait for it to be ingested.
+k8s/add service.yaml endpointslice.yaml cec.yaml
+db/cmp ciliumenvoyconfigs cec.table
+db/cmp envoy-resources envoy-resources.table
+
+# Test JSON marshalling
+db/show ciliumenvoyconfigs --format=json --out=actual.json
+cmp actual.json cec-expected.json
+
+db/show envoy-resources --format=json --out=actual.json
+sed '"updated-at":.*' '"updated-at": <redacted>,' actual.json
+sed '"id":.*' '"id": <redacted>' actual.json
+cmp actual.json envoy-resources-expected.json
+
+##### 
+
+-- cec.table --
+Name                    Services
+test/envoy-lb-listener  test/echo
+
+-- envoy-resources.table --
+Name                            Listeners                                  Endpoints                  References             Status   Error
+backendsync:test/echo                                                      test/echo:80: 10.244.1.1   test/envoy-lb-listener Done     
+cec:test/envoy-lb-listener      test/envoy-lb-listener/envoy-lb-listener                                                     Done     
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: NodePort
+status:
+  loadBalancer: {}
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+
+-- cec.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: envoy-lb-listener
+  namespace: test
+spec:
+  services:
+    - name: echo
+      namespace: test
+      listener: envoy-lb-listener
+      ports:
+      - 80
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: envoy-lb-listener
+
+
+-- cec-expected.json --
+{
+  "Name": {
+    "Namespace": "test",
+    "Name": "envoy-lb-listener"
+  },
+  "Spec": {
+    "services": [
+      {
+        "name": "echo",
+        "namespace": "test",
+        "ports": [
+          80
+        ],
+        "listener": "envoy-lb-listener"
+      }
+    ],
+    "resources": [
+      {
+        "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+        "name": "envoy-lb-listener"
+      }
+    ]
+  },
+  "SelectsLocalNode": true,
+  "Listeners": [
+    {
+      "k": "test/envoy-lb-listener/envoy-lb-listener",
+      "v": 1000
+    }
+  ],
+  "Resources": {
+    "Listeners": [
+      {
+        "name": "test/envoy-lb-listener/envoy-lb-listener",
+        "address": {
+          "Address": {
+            "SocketAddress": {
+              "address": "127.0.0.1",
+              "PortSpecifier": {
+                "PortValue": 1000
+              }
+            }
+          }
+        },
+        "additional_addresses": [
+          {
+            "address": {
+              "Address": {
+                "SocketAddress": {
+                  "address": "::1",
+                  "PortSpecifier": {
+                    "PortValue": 1000
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "listener_filters": [
+          {
+            "name": "cilium.bpf_metadata",
+            "ConfigType": {
+              "TypedConfig": {
+                "type_url": "type.googleapis.com/cilium.BpfMetadata",
+                "value": "Cgsvc3lzL2ZzL2JwZhgBIAFA6Ac="
+              }
+            }
+          }
+        ],
+        "ListenerSpecifier": null
+      }
+    ],
+    "Secrets": null,
+    "Routes": null,
+    "Clusters": null,
+    "Endpoints": null
+  }
+}
+-- envoy-resources-expected.json --
+{
+  "Name": {
+    "Origin": "backendsync",
+    "Cluster": "",
+    "Namespace": "test",
+    "Name": "echo"
+  },
+  "Status": {
+    "kind": "Done",
+    "updated-at": <redacted>,
+    "id": <redacted>
+  },
+  "Resources": {
+    "Listeners": null,
+    "Secrets": null,
+    "Routes": null,
+    "Clusters": null,
+    "Endpoints": [
+      {
+        "cluster_name": "test/echo:80",
+        "endpoints": [
+          {
+            "lb_endpoints": [
+              {
+                "HostIdentifier": {
+                  "Endpoint": {
+                    "address": {
+                      "Address": {
+                        "SocketAddress": {
+                          "address": "10.244.1.1",
+                          "PortSpecifier": {
+                            "PortValue": 8080
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "LbConfig": null
+          }
+        ]
+      }
+    ]
+  },
+  "ReconciledResources": {
+    "Listeners": null,
+    "Secrets": null,
+    "Routes": null,
+    "Clusters": null,
+    "Endpoints": [
+      {
+        "cluster_name": "test/echo:80",
+        "endpoints": [
+          {
+            "lb_endpoints": [
+              {
+                "HostIdentifier": {
+                  "Endpoint": {
+                    "address": {
+                      "Address": {
+                        "SocketAddress": {
+                          "address": "10.244.1.1",
+                          "PortSpecifier": {
+                            "PortValue": 8080
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "LbConfig": null
+          }
+        ]
+      }
+    ]
+  },
+  "Redirects": [],
+  "ReconciledRedirects": [],
+  "ReferencedServices": []
+}
+{
+  "Name": {
+    "Origin": "cec",
+    "Cluster": "",
+    "Namespace": "test",
+    "Name": "envoy-lb-listener"
+  },
+  "Status": {
+    "kind": "Done",
+    "updated-at": <redacted>,
+    "id": <redacted>
+  },
+  "Resources": {
+    "Listeners": [
+      {
+        "name": "test/envoy-lb-listener/envoy-lb-listener",
+        "address": {
+          "Address": {
+            "SocketAddress": {
+              "address": "127.0.0.1",
+              "PortSpecifier": {
+                "PortValue": 1000
+              }
+            }
+          }
+        },
+        "additional_addresses": [
+          {
+            "address": {
+              "Address": {
+                "SocketAddress": {
+                  "address": "::1",
+                  "PortSpecifier": {
+                    "PortValue": 1000
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "listener_filters": [
+          {
+            "name": "cilium.bpf_metadata",
+            "ConfigType": {
+              "TypedConfig": {
+                "type_url": "type.googleapis.com/cilium.BpfMetadata",
+                "value": "Cgsvc3lzL2ZzL2JwZhgBIAFA6Ac="
+              }
+            }
+          }
+        ],
+        "ListenerSpecifier": null
+      }
+    ],
+    "Secrets": null,
+    "Routes": null,
+    "Clusters": null,
+    "Endpoints": null
+  },
+  "ReconciledResources": {
+    "Listeners": [
+      {
+        "name": "test/envoy-lb-listener/envoy-lb-listener",
+        "address": {
+          "Address": {
+            "SocketAddress": {
+              "address": "127.0.0.1",
+              "PortSpecifier": {
+                "PortValue": 1000
+              }
+            }
+          }
+        },
+        "additional_addresses": [
+          {
+            "address": {
+              "Address": {
+                "SocketAddress": {
+                  "address": "::1",
+                  "PortSpecifier": {
+                    "PortValue": 1000
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "listener_filters": [
+          {
+            "name": "cilium.bpf_metadata",
+            "ConfigType": {
+              "TypedConfig": {
+                "type_url": "type.googleapis.com/cilium.BpfMetadata",
+                "value": "Cgsvc3lzL2ZzL2JwZhgBIAFA6Ac="
+              }
+            }
+          }
+        ],
+        "ListenerSpecifier": null
+      }
+    ],
+    "Secrets": null,
+    "Routes": null,
+    "Clusters": null,
+    "Endpoints": null
+  },
+  "Redirects": [
+    {
+      "k": {
+        "Namespace": "test",
+        "Name": "echo",
+        "Cluster": ""
+      },
+      "v": {
+        "ProxyPort": 1000,
+        "Ports": [
+          80
+        ]
+      }
+    }
+  ],
+  "ReconciledRedirects": [
+    {
+      "k": {
+        "Namespace": "test",
+        "Name": "echo",
+        "Cluster": ""
+      },
+      "v": {
+        "ProxyPort": 1000,
+        "Ports": [
+          80
+        ]
+      }
+    }
+  ],
+  "ReferencedServices": [
+    {
+      "Namespace": "test",
+      "Name": "echo",
+      "Cluster": ""
+    }
+  ]
+}

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -16,6 +16,7 @@ db/cmp backends backends.table
 # Add the CiliumEnvoyConfig and wait for it to be ingested.
 k8s/add cec.yaml
 db/cmp ciliumenvoyconfigs cec.table
+db/cmp envoy-resources envoy-resources.table
 
 # Check that both services are now redirected to proxy.
 db/cmp services services_redirected.table
@@ -26,16 +27,14 @@ lb/maps-dump lbmaps.out
 * cmp lbmaps.out lbmaps.expected
 
 # Check that right updates towards Envoy happened.
-envoy envoy.out
-* cmp envoy.out envoy1.expected
+* envoy/cmp envoy1.expected
 
 # Test the processing other way around, e.g. CEC exists before
 # the service. Start by dropping the backends.
 k8s/delete endpointslice.yaml
 
 # Backends towards Envoy should be dropped.
-envoy envoy.out
-* cmp envoy.out envoy2.expected
+* envoy/cmp envoy2.expected
 
 # Drop the service
 k8s/delete service.yaml
@@ -48,8 +47,7 @@ k8s/add service.yaml endpointslice.yaml
 db/cmp services services_redirected.table
 
 # Check again that updates happened.
-envoy envoy.out
-* cmp envoy.out envoy3.expected
+* envoy/cmp envoy3.expected
 
 # Change the service name in the CEC and check that
 # proxy redirect gets removed.
@@ -64,13 +62,12 @@ k8s/update cec.yaml
 db/cmp services services_redirected.table
 k8s/delete cec.yaml
 
-# Proxy redirect should be goneand CEC empty.
+# Proxy redirect should be gone and CEC/resources empty.
 db/cmp services services.table
-* db/empty ciliumenvoyconfigs
+* db/empty ciliumenvoyconfigs envoy-resources
 
 # The listener should now be deleted.
-envoy envoy.out
-* cmp envoy.out envoy4.expected
+* envoy/cmp envoy4.expected
 
 # ---------------------------------------------
 
@@ -100,12 +97,14 @@ Address               Type        ServiceName   PortName   Status  Backends
 10.96.50.104:25/TCP   ClusterIP   test/echo     smtp       Done    10.244.1.1:25/TCP
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:8080/TCP
 
--- cec_empty.table --
-Name    Services
-
 -- cec.table --
 Name                    Services
 test/envoy-lb-listener  test/echo
+
+-- envoy-resources.table --
+Name                            Listeners                                  Endpoints                    References             Status   Error
+backendsync:test/echo                                                      test/echo:80: 10.244.1.1     test/envoy-lb-listener Done     
+cec:test/envoy-lb-listener      test/envoy-lb-listener/envoy-lb-listener                                                       Done     
 
 -- cec.yaml --
 apiVersion: cilium.io/v2
@@ -200,18 +199,143 @@ SVC: ID=5 ADDR=10.96.50.104:25/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterI
 SVC: ID=6 ADDR=10.96.50.104:80/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
 SVC: ID=6 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
 -- envoy1.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/echo:80:
+  cluster_name: "test/echo:80"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/envoy-lb-listener/envoy-lb-listener:
+  name: "test/envoy-lb-listener/envoy-lb-listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
+    }
+  }
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
+      }
+    }
+  }
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+      }
+    }
+  }
+  
 -- envoy2.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/echo:80:
+  cluster_name: "test/echo:80"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/envoy-lb-listener/envoy-lb-listener:
+  name: "test/envoy-lb-listener/envoy-lb-listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
+    }
+  }
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
+      }
+    }
+  }
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+      }
+    }
+  }
+  
 -- envoy3.expected --
-policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
-delete: listeners=<nil> endpoints=<nil>
+policy-trigger-count:
+  1
+endpoints:test/echo:80:
+  cluster_name: "test/echo:80"
+  endpoints: {
+    lb_endpoints: {
+      endpoint: {
+        address: {
+          socket_address: {
+            address: "10.244.1.1"
+            port_value: 8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/envoy-lb-listener/envoy-lb-listener:
+  name: "test/envoy-lb-listener/envoy-lb-listener"
+  address: {
+    socket_address: {
+      address: "127.0.0.1"
+      port_value: 1000
+    }
+  }
+  additional_addresses: {
+    address: {
+      socket_address: {
+        address: "::1"
+        port_value: 1000
+      }
+    }
+  }
+  listener_filters: {
+    name: "cilium.bpf_metadata"
+    typed_config: {
+      [type.googleapis.com/cilium.BpfMetadata]: {
+        bpf_root: "/sys/fs/bpf"
+        use_original_source_address: true
+        is_l7lb: true
+        proxy_id: 1000
+      }
+    }
+  }
+  
 -- envoy4.expected --
-policy-trigger-count: 2
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
-delete: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
+policy-trigger-count:
+  2

--- a/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
@@ -1,0 +1,411 @@
+# Test sharing of a cluster resource between two CiliumEnvoyConfigs.
+
+# Add a node address for NodePort services
+db/insert node-addresses addrv4.yaml
+
+# Start the hive and wait for tables to be synchronized before adding k8s objects.
+hive start
+db/initialized
+
+# Set up the services and endpoints
+k8s/add service.yaml
+db/cmp services services.table
+k8s/add endpointslice.yaml
+db/cmp backends backends.table
+
+# cecA.yaml adds a listener and redirects the service to it,
+k8s/add cecA.yaml
+
+# Wait for ingestion before we add cecB.yaml.
+!* db/empty envoy-resources
+
+# cecB.yaml adds an internal listener and just pulls the backends without
+# redirection.
+k8s/add cecB.yaml
+db/cmp ciliumenvoyconfigs cec.table
+db/cmp envoy-resources envoy-resources.table
+
+# Check that both services are now redirected to proxy.
+db/cmp services services_redirected.table
+db/cmp frontends frontends.table
+
+# Check BPF maps. The service should have L7 redirect set.
+lb/maps-dump lbmaps.out
+* cmp lbmaps.out lbmaps.expected
+
+# Check that right updates towards Envoy happened.
+# We should have two listeners and one cluster.
+* envoy/cmp envoy1.expected
+
+# Removing cecA.yaml won't affect the endpoints of cecB.yaml.
+k8s/delete cecA.yaml
+db/cmp envoy-resources envoy-resources-only-b.table
+
+# Check envoy updates. Should still have a listener-b and endpoints.
+* envoy/cmp envoy2.expected
+
+# Removing cecB.yaml will clean up everything.
+k8s/delete cecB.yaml
+
+# Tables are empty
+* db/empty ciliumenvoyconfigs envoy-resources
+
+# No resources for Envoy
+* envoy/cmp envoy3.expected
+
+# ---------------------------------------------
+
+-- addrv4.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+
+-- services.table --
+Name        Flags
+test/echo   
+
+-- services_redirected.table --
+Name        Flags
+test/echo   ProxyRedirect=1000 (ports: [80])
+
+-- backends.table --
+Address
+10.244.1.1:25/TCP
+10.244.1.1:8080/TCP
+
+-- frontends.table --
+Address               Type        ServiceName   PortName   Status  Backends
+0.0.0.0:30725/TCP     NodePort    test/echo     smtp       Done    10.244.1.1:25/TCP
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:8080/TCP
+10.96.50.104:25/TCP   ClusterIP   test/echo     smtp       Done    10.244.1.1:25/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:8080/TCP
+
+-- cec.table --
+Name                    Services     BackendServices
+test/listener-a         test/echo
+test/listener-b                      test/echo
+
+-- envoy-resources.table --
+Name                        Listeners                  Endpoints                     References                        Status   Error
+backendsync:test/echo                                  test/echo:80: 10.244.1.1      test/listener-a, test/listener-b  Done
+cec:test/listener-a         test/listener-a/listener                                                                   Done
+cec:test/listener-b         test/listener-b/listener                                                                   Done
+
+
+-- envoy-resources-only-b.table --
+Name                        Listeners                  Endpoints                     References       Status   Error
+backendsync:test/echo                                  test/echo:80: 10.244.1.1      test/listener-b  Done
+cec:test/listener-b         test/listener-b/listener                                                  Done
+
+-- cecA.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: listener-a
+  namespace: test
+spec:
+  services:
+    - name: echo
+      namespace: test
+      cec: listener
+      ports:
+      - 80
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: listener
+    - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+      connectTimeout: 5s
+      name: test:echo:80
+      edsClusterConfig:
+        serviceName: test/echo:80
+
+-- cecB.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: listener-b
+  namespace: test
+spec:
+  backendServices:
+    - name: echo
+      namespace: test
+      number:
+      - "80"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: listener
+    - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+      connectTimeout: 5s
+      name: test:echo:80
+      edsClusterConfig:
+        serviceName: test/echo:80
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: smtp
+    nodePort: 30725
+    port: 25
+    protocol: TCP
+    targetPort: 25
+  selector:
+    name: echo
+  type: NodePort
+status:
+  loadBalancer: {}
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: smtp
+  port: 25
+  protocol: TCP
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:25/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.1:8080/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30725
+REV: ID=2 ADDR=1.1.1.1:30725
+REV: ID=3 ADDR=0.0.0.0:30781
+REV: ID=4 ADDR=1.1.1.1:30781
+REV: ID=5 ADDR=10.96.50.104:25
+REV: ID=6 ADDR=10.96.50.104:80
+SVC: ID=1 ADDR=0.0.0.0:30725/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30725/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=1.1.1.1:30725/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30725/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=0.0.0.0:30781/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable+l7-load-balancer
+SVC: ID=3 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable+l7-load-balancer
+SVC: ID=4 ADDR=1.1.1.1:30781/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=NodePort+l7-load-balancer
+SVC: ID=4 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+l7-load-balancer
+SVC: ID=5 ADDR=10.96.50.104:25/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=10.96.50.104:25/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:80/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+SVC: ID=6 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+-- envoy1.expected --
+policy-trigger-count:
+  2
+clusters:test/listener-a/test:echo:80:
+  name:  "test/listener-a/test:echo:80"
+  eds_cluster_config:  {
+    service_name:  "test/echo:80"
+  }
+  connect_timeout:  {
+    seconds:  5
+  }
+  circuit_breakers:  {
+    thresholds:  {
+      max_retries:  {
+        value:  128
+      }
+    }
+  }
+  typed_extension_protocol_options:  {
+    key:  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+    value:  {
+      [type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions]:  {
+        use_downstream_protocol_config:  {
+          http2_protocol_options:  {}
+        }
+        http_filters:  {
+          name:  "cilium.l7policy"
+          typed_config:  {
+            [type.googleapis.com/cilium.L7Policy]:  {
+              access_log_path:  "envoy/sockets/access_log.sock"
+            }
+          }
+        }
+        http_filters:  {
+          name:  "envoy.filters.http.upstream_codec"
+          typed_config:  {
+            [type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec]:  {}
+          }
+        }
+      }
+    }
+  }
+  
+clusters:test/listener-b/test:echo:80:
+  name:  "test/listener-b/test:echo:80"
+  eds_cluster_config:  {
+    service_name:  "test/echo:80"
+  }
+  connect_timeout:  {
+    seconds:  5
+  }
+  circuit_breakers:  {
+    thresholds:  {
+      max_retries:  {
+        value:  128
+      }
+    }
+  }
+  
+endpoints:test/echo:80:
+  cluster_name:  "test/echo:80"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/listener-a/listener
+  name:  "test/listener-a/listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        is_l7lb:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
+listener:test/listener-b/listener:
+  name:  "test/listener-b/listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
+-- envoy2.expected --
+policy-trigger-count:
+  3
+clusters:test/listener-b/test:echo:80:
+  name:  "test/listener-b/test:echo:80"
+  eds_cluster_config:  {
+    service_name:  "test/echo:80"
+  }
+  connect_timeout:  {
+    seconds:  5
+  }
+  circuit_breakers:  {
+    thresholds:  {
+      max_retries:  {
+        value:  128
+      }
+    }
+  }
+  
+endpoints:test/echo:80:
+  cluster_name:  "test/echo:80"
+  endpoints:  {
+    lb_endpoints:  {
+      endpoint:  {
+        address:  {
+          socket_address:  {
+            address:  "10.244.1.1"
+            port_value:  8080
+          }
+        }
+      }
+    }
+  }
+  
+listener:test/listener-b/listener:
+  name:  "test/listener-b/listener"
+  address:  {
+    socket_address:  {
+      address:  "127.0.0.1"
+      port_value:  1000
+    }
+  }
+  additional_addresses:  {
+    address:  {
+      socket_address:  {
+        address:  "::1"
+        port_value:  1000
+      }
+    }
+  }
+  listener_filters:  {
+    name:  "cilium.bpf_metadata"
+    typed_config:  {
+      [type.googleapis.com/cilium.BpfMetadata]:  {
+        bpf_root:  "/sys/fs/bpf"
+        use_original_source_address:  true
+        proxy_id:  1000
+      }
+    }
+  }
+  
+-- envoy3.expected --
+policy-trigger-count:
+  4

--- a/pkg/ciliumenvoyconfig/watch.sh
+++ b/pkg/ciliumenvoyconfig/watch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# watch.sh watches the current and testdata directories and will
+# either recompile or execute the test for the changes test script.
+# This is useful when working on a test case as "go test" can be slow
+# due to slow linking as we pull in the client-go.
+#
+# https://github.com/kubernetes/kubernetes/issues/127888 is an issue
+# for making client-go lighter that should improve the binary size and
+# compilation times.
+
+set -ux
+go test -c || exit 1
+
+inotifywait -e close_write -m . testdata |
+while read -r directory events filename; do
+  case "$directory" in
+    ./)
+      go test -c && ./ciliumenvoyconfig.test -test.v -test.failfast
+      ;;
+    testdata/) 
+      ./ciliumenvoyconfig.test -test.run TestScript/$filename -test.v
+      ;;
+  esac
+done
+

--- a/pkg/loadbalancer/experimental/config.go
+++ b/pkg/loadbalancer/experimental/config.go
@@ -28,7 +28,7 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 }
 
 var DefaultConfig = Config{
-	EnableExperimentalLB: false,
+	EnableExperimentalLB: true,
 	RetryBackoffMin:      50 * time.Millisecond,
 	RetryBackoffMax:      time.Minute,
 }

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/node-local-dns.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/node-local-dns.txtar
@@ -15,8 +15,13 @@ db/cmp frontends frontends-before.table
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.actual lbmaps-before.expected
 
-# Add the redirect and the pod.
-k8s/add lrp-kubedns.yaml pod-1-nodelocaldns.yaml pod-2-nodelocaldns.yaml
+# Add the redirect and the first pod
+k8s/add lrp-kubedns.yaml pod-1-nodelocaldns.yaml
+db/cmp frontends frontends-no-pod2.table
+
+# Add the second pod separately to make sure we get backends
+# in consistent order.
+k8s/add pod-2-nodelocaldns.yaml
 db/cmp services services-after.table
 db/cmp frontends frontends-after.table
 
@@ -28,7 +33,7 @@ lb/maps-dump lbmaps.actual
 # as LRP backend and then revert.
 sed 'k8s-app: node-local-dns' 'k8s-app: foo' pod-2-nodelocaldns.yaml
 k8s/update pod-2-nodelocaldns.yaml
-db/cmp frontends frontends-after-no-pod2.table
+db/cmp frontends frontends-no-pod2.table
 
 sed 'k8s-app: foo' 'k8s-app: node-local-dns' pod-2-nodelocaldns.yaml
 k8s/update pod-2-nodelocaldns.yaml
@@ -65,7 +70,7 @@ Address                    Type        ServiceName           PortName   Redirect
 10.96.0.10:53/UDP          ClusterIP   kube-system/kube-dns  dns        kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/UDP, 10.244.0.226:53/UDP
 10.96.0.10:9153/TCP        ClusterIP   kube-system/kube-dns  metrics                                             Done    10.244.1.51:9153/TCP, 10.244.1.68:9153/TCP
 
--- frontends-after-no-pod2.table --
+-- frontends-no-pod2.table --
 Address                    Type        ServiceName           PortName   RedirectTo                               Status  Backends
 10.96.0.10:53/TCP          ClusterIP   kube-system/kube-dns  dns-tcp    kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/TCP
 10.96.0.10:53/UDP          ClusterIP   kube-system/kube-dns  dns        kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/UDP
@@ -95,16 +100,16 @@ BE: ID=10 ADDR=10.244.0.226:53/UDP STATE=active
 BE: ID=5 ADDR=10.244.1.51:9153/TCP STATE=active
 BE: ID=6 ADDR=10.244.1.68:9153/TCP STATE=active
 BE: ID=7 ADDR=10.244.0.225:53/TCP STATE=active
-BE: ID=8 ADDR=10.244.0.226:53/TCP STATE=active
-BE: ID=9 ADDR=10.244.0.225:53/UDP STATE=active
+BE: ID=8 ADDR=10.244.0.225:53/UDP STATE=active
+BE: ID=9 ADDR=10.244.0.226:53/TCP STATE=active
 REV: ID=1 ADDR=10.96.0.10:53
 REV: ID=2 ADDR=10.96.0.10:53
 REV: ID=3 ADDR=10.96.0.10:9153
 SVC: ID=1 ADDR=10.96.0.10:53/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=1 ADDR=10.96.0.10:53/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
-SVC: ID=1 ADDR=10.96.0.10:53/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=10.96.0.10:53/TCP SLOT=2 BEID=9 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=2 ADDR=10.96.0.10:53/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LocalRedirect
-SVC: ID=2 ADDR=10.96.0.10:53/UDP SLOT=1 BEID=9 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=10.96.0.10:53/UDP SLOT=1 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=2 ADDR=10.96.0.10:53/UDP SLOT=2 BEID=10 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=3 ADDR=10.96.0.10:9153/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=3 ADDR=10.96.0.10:9153/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable


### PR DESCRIPTION
Enable the "enable-experimental-lb" by default to start using the new implementation. The experimental nomenclature will be removed in follow-up PRs and by v1.18 release the old control-plane will be removed.

The CiliumEnvoyConfig handling was updated to process listeners separately from the backends to properly handle multiple listeners referring to the same services.

```release-note
The service load-balancing control-plane in the Cilium agent has been redesigned which reduces memory usage and improves future extensibility of load-balancing features.
```
