### PR TITLE
bpf:trace: cleanup build_bug_on for TRACE_{FROM,TO}_CRYPTO

### DIFF
--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -134,24 +134,24 @@ _update_trace_metrics(struct __ctx_buff *ctx, enum trace_point obs_point,
 	/* We define TRACE_{FROM,TO}_CRYPTO only (a) when Wireguard is enabled and (b) for:
 	 * - bpf_wireguard (cil_to_wireguard), attached as egress to cilium_wg0;
 	 * - bpf_host (cil_from_netdev), attached as ingress to cilium_wg0.
-	 * In both the cases, THIS_INTERFACE_IFINDEX is set to WG_IFINDEX value.
+	 * In both the cases, THIS_INTERFACE_IFINDEX should be equal to WG_IFINDEX, but we
+	 * cannot throw a build_bug for cil_from_netdev since it has already been compiled
+	 * (we simply rewrite the constant THIS_INTERFACE_IFINDEX).
 	 * Using these obs points from different programs would result in a build bug.
 	 */
-#if defined(ENABLE_WIREGUARD) && (defined(IS_BPF_WIREGUARD) || defined(IS_BPF_HOST))
+#if defined(IS_BPF_WIREGUARD) || (defined(IS_BPF_HOST) && defined(ENABLE_WIREGUARD))
 	case TRACE_TO_CRYPTO:
-		build_bug_on(THIS_INTERFACE_IFINDEX != WG_IFINDEX);
 		_update_metrics(ctx_full_len(ctx), METRIC_EGRESS,
 				REASON_ENCRYPTING, line, file);
 		break;
 	case TRACE_FROM_CRYPTO:
-		build_bug_on(THIS_INTERFACE_IFINDEX != WG_IFINDEX);
 		_update_metrics(ctx_full_len(ctx), METRIC_INGRESS,
 				REASON_DECRYPTING, line, file);
 		break;
 #else
 	case TRACE_TO_CRYPTO:
 	case TRACE_FROM_CRYPTO:
-		build_bug_on(obs_point);
+		__throw_build_bug();
 		break;
 #endif
 	}


### PR DESCRIPTION
```release-note
Throw build bug when using TRACE_{FROM,TO}_CRYPTO from unexpected files and cleanup unevaluated build_bug_on.
```
