### PR TITLE
ipam: Update node information retrieval logic

### DIFF
--- a/daemon/k8s/init.go
+++ b/daemon/k8s/init.go
@@ -36,7 +36,8 @@ func retrieveNodeInformation(ctx context.Context, log logrus.FieldLogger, localN
 		return nil
 	}
 
-	if option.Config.IPAM == ipamOption.IPAMClusterPool {
+	if option.Config.IPAM == ipamOption.IPAMClusterPool ||
+		option.Config.IPAM == ipamOption.IPAMMultiPool {
 		for event := range localCiliumNodeResource.Events(ctx) {
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				log.WithField(logfields.NodeName, nodeTypes.GetName()).Error("Timeout while waiting for CiliumNode resource: API server connection issue")


### PR DESCRIPTION
~~Change the logic now retrieves node information from Kubernetes nodes when using `IPAMKubernetes`, and from Cilium nodes when using the default configuration to cover the multi pool IPAM and other possible values for IPAM.~~

The CiliumNode is created early when the IPAM mode is cluster pool and multi pool. 

We will retrive the node info from CiliumNode when the ipam mode is cluster pool or multi pool.


Fixes: #38471

```release-note
Fix the ipv6 only cluster doesn't work with multi pool in some k8s distribution(Openshift)
```
