### PR TITLE
hubble/exporter: Fix logging exporter options as JSON

### DIFF
--- a/pkg/hubble/exporter/exporter.go
+++ b/pkg/hubble/exporter/exporter.go
@@ -77,11 +77,11 @@ func NewExporter(logger *slog.Logger, options ...Option) (*exporter, error) {
 
 // newExporter let's you supply your own WriteCloser for tests.
 func newExporter(logger *slog.Logger, opts Options) (*exporter, error) {
-	writer, err := opts.NewWriterFunc()
+	writer, err := opts.NewWriterFunc()()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create writer: %w", err)
 	}
-	encoder, err := opts.NewEncoderFunc(writer)
+	encoder, err := opts.NewEncoderFunc()(writer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create encoder: %w", err)
 	}

--- a/pkg/hubble/exporter/option.go
+++ b/pkg/hubble/exporter/option.go
@@ -16,18 +16,19 @@ import (
 
 // DefaultOptions specifies default values for Hubble exporter options.
 var DefaultOptions = Options{
-	NewWriterFunc:  StdoutNoOpWriter,
-	NewEncoderFunc: JsonEncoder,
+	newWriterFunc:  StdoutNoOpWriter,
+	newEncoderFunc: JsonEncoder,
 }
 
 // Options stores all the configurations values for Hubble exporter.
 type Options struct {
-	NewWriterFunc       NewWriterFunc
-	NewEncoderFunc      NewEncoderFunc
 	AllowList, DenyList []*flowpb.FlowFilter
 	FieldMask           fieldmask.FieldMask
 	OnExportEvent       []OnExportEvent
 
+	// keep types that can't be marshalled as JSON private
+	newWriterFunc             NewWriterFunc
+	newEncoderFunc            NewEncoderFunc
 	allowFilters, denyFilters filters.FilterFuncs
 }
 
@@ -37,7 +38,7 @@ type Option func(o *Options) error
 // WithNewWriterFunc sets the constructor function for the export event writer.
 func WithNewWriterFunc(newWriterFunc NewWriterFunc) Option {
 	return func(o *Options) error {
-		o.NewWriterFunc = newWriterFunc
+		o.newWriterFunc = newWriterFunc
 		return nil
 	}
 }
@@ -45,7 +46,7 @@ func WithNewWriterFunc(newWriterFunc NewWriterFunc) Option {
 // WithNewEncoderFunc sets the constructor function for the exporter encoder.
 func WithNewEncoderFunc(newEncoderFunc NewEncoderFunc) Option {
 	return func(o *Options) error {
-		o.NewEncoderFunc = newEncoderFunc
+		o.newEncoderFunc = newEncoderFunc
 		return nil
 	}
 }
@@ -109,4 +110,12 @@ func (o *Options) AllowFilters() filters.FilterFuncs {
 
 func (o *Options) DenyFilters() filters.FilterFuncs {
 	return o.denyFilters
+}
+
+func (o *Options) NewWriterFunc() NewWriterFunc {
+	return o.newWriterFunc
+}
+
+func (o *Options) NewEncoderFunc() NewEncoderFunc {
+	return o.newEncoderFunc
 }


### PR DESCRIPTION
Similar to: e0bb77ad0eeddc69c53f807bdd69b5ce7c79a0a2

NewWriterFunc and NewEncoderFunc are interfaces and can't be marshaled by slog. When an error occurs, slog will store
the error in the field with the prefix '!ERROR' like:
```
{..., "options":"!ERROR:json: unsupported type: exporter.NewWriterFunc"}
```

Fix this by using unexported fields to store the funcs and expose accessor methods instead.

Add a test to validate the behaviour and avoid regressions.

I will manually backport to 1.17 as it will require some changes following the migration from logrus to slog.
EDIT: v1.17 backport: https://github.com/cilium/cilium/pull/38476

Related: #37473
