### PR TITLE
[v1.17] hubble/exporter: Fix logging exporter options as JSON

### DIFF
--- a/pkg/hubble/exporter/exporter.go
+++ b/pkg/hubble/exporter/exporter.go
@@ -60,11 +60,11 @@ func NewExporter(logger logrus.FieldLogger, options ...Option) (*exporter, error
 
 // newExporter let's you supply your own WriteCloser for tests.
 func newExporter(logger logrus.FieldLogger, opts Options) (*exporter, error) {
-	writer, err := opts.NewWriterFunc()
+	writer, err := opts.NewWriterFunc()()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create writer: %w", err)
 	}
-	encoder, err := opts.NewEncoderFunc(writer)
+	encoder, err := opts.NewEncoderFunc()(writer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create encoder: %w", err)
 	}

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -28,6 +28,19 @@ type ioWriteCloser struct{ io.Writer }
 
 func (wc *ioWriteCloser) Close() error { return nil }
 
+func TestNewExporterLogOptionsJSON(t *testing.T) {
+	// when logrus encounters a marshalling error, it aborts logging and outputs
+	// the error to stderr. Example:
+	//   Failed to obtain reader, failed to marshal fields to JSON, json: unsupported type: exporter.NewWriterFunc
+	var buf bytes.Buffer
+	log := logrus.New()
+	log.SetOutput(&buf)
+	log.SetFormatter(&logrus.JSONFormatter{})
+	_, err := NewExporter(log)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Configuring Hubble event exporter")
+}
+
 func TestExporter(t *testing.T) {
 	// override node name for unit test.
 	nodeName := nodeTypes.GetName()
@@ -52,7 +65,7 @@ func TestExporter(t *testing.T) {
 	log.SetOutput(io.Discard)
 
 	opts := DefaultOptions
-	opts.NewWriterFunc = func() (io.WriteCloser, error) {
+	opts.newWriterFunc = func() (io.WriteCloser, error) {
 		return buf, nil
 	}
 
@@ -124,7 +137,7 @@ func TestExporterWithFilters(t *testing.T) {
 	log.SetOutput(io.Discard)
 
 	opts := DefaultOptions
-	opts.NewWriterFunc = func() (io.WriteCloser, error) {
+	opts.newWriterFunc = func() (io.WriteCloser, error) {
 		return buf, nil
 	}
 
@@ -175,7 +188,7 @@ func TestEventToExportEvent(t *testing.T) {
 	log.SetOutput(io.Discard)
 
 	opts := DefaultOptions
-	opts.NewWriterFunc = func() (io.WriteCloser, error) {
+	opts.newWriterFunc = func() (io.WriteCloser, error) {
 		return buf, nil
 	}
 
@@ -258,7 +271,7 @@ func TestExporterWithFieldMask(t *testing.T) {
 	log.SetOutput(io.Discard)
 
 	opts := DefaultOptions
-	opts.NewWriterFunc = func() (io.WriteCloser, error) {
+	opts.newWriterFunc = func() (io.WriteCloser, error) {
 		return buf, nil
 	}
 	for _, opt := range []Option{
@@ -323,7 +336,7 @@ func TestExporterOnExportEvent(t *testing.T) {
 	log.SetOutput(io.Discard)
 
 	opts := DefaultOptions
-	opts.NewWriterFunc = func() (io.WriteCloser, error) {
+	opts.newWriterFunc = func() (io.WriteCloser, error) {
 		return buf, nil
 	}
 	for _, opt := range []Option{
@@ -444,7 +457,7 @@ func BenchmarkExporter(b *testing.B) {
 	log.SetOutput(io.Discard)
 
 	opts := DefaultOptions
-	opts.NewWriterFunc = func() (io.WriteCloser, error) {
+	opts.newWriterFunc = func() (io.WriteCloser, error) {
 		return buf, nil
 	}
 	for _, opt := range []Option{

--- a/pkg/hubble/exporter/option.go
+++ b/pkg/hubble/exporter/option.go
@@ -16,18 +16,19 @@ import (
 
 // DefaultOptions specifies default values for Hubble exporter options.
 var DefaultOptions = Options{
-	NewWriterFunc:  StdoutNoOpWriter,
-	NewEncoderFunc: JsonEncoder,
+	newWriterFunc:  StdoutNoOpWriter,
+	newEncoderFunc: JsonEncoder,
 }
 
 // Options stores all the configurations values for Hubble exporter.
 type Options struct {
-	NewWriterFunc       NewWriterFunc
-	NewEncoderFunc      NewEncoderFunc
 	AllowList, DenyList []*flowpb.FlowFilter
 	FieldMask           fieldmask.FieldMask
 	OnExportEvent       []OnExportEvent
 
+	// keep types that can't be marshalled as JSON private
+	newWriterFunc             NewWriterFunc
+	newEncoderFunc            NewEncoderFunc
 	allowFilters, denyFilters filters.FilterFuncs
 }
 
@@ -37,7 +38,7 @@ type Option func(o *Options) error
 // WithNewWriterFunc sets the constructor function for the export event writer.
 func WithNewWriterFunc(newWriterFunc NewWriterFunc) Option {
 	return func(o *Options) error {
-		o.NewWriterFunc = newWriterFunc
+		o.newWriterFunc = newWriterFunc
 		return nil
 	}
 }
@@ -45,7 +46,7 @@ func WithNewWriterFunc(newWriterFunc NewWriterFunc) Option {
 // WithNewEncoderFunc sets the constructor function for the exporter encoder.
 func WithNewEncoderFunc(newEncoderFunc NewEncoderFunc) Option {
 	return func(o *Options) error {
-		o.NewEncoderFunc = newEncoderFunc
+		o.newEncoderFunc = newEncoderFunc
 		return nil
 	}
 }
@@ -109,4 +110,12 @@ func (o *Options) AllowFilters() filters.FilterFuncs {
 
 func (o *Options) DenyFilters() filters.FilterFuncs {
 	return o.denyFilters
+}
+
+func (o *Options) NewWriterFunc() NewWriterFunc {
+	return o.newWriterFunc
+}
+
+func (o *Options) NewEncoderFunc() NewEncoderFunc {
+	return o.newEncoderFunc
 }


### PR DESCRIPTION
Similar to: e0bb77ad0eeddc69c53f807bdd69b5ce7c79a0a2

NewWriterFunc and NewEncoderFunc are interfaces and can't be marshaled by logrus. When an error occurs, logrus will output the error to stderr like "Failed to obtain reader, failed to marshal fields to JSON, json: unsupported type: exporter.NewWriterFunc".

Fix this by using unexported fields to store the funcs and expose accessor methods instead.

Add a test to validate the behaviour and avoid regressions.

Fix for main: https://github.com/cilium/cilium/pull/38476

Fixes: #37473
