### PR TITLE
Support tunnel routing in Multi-Pool IPAM mode

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -80,7 +80,24 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
 
+  wait-for-images:
+    name: Wait for images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ inputs.SHA || github.sha }}
+
   multi-pool-ipam-conformance-test:
+    needs: [wait-for-images]
     strategy:
       fail-fast: false
       matrix:
@@ -209,14 +226,6 @@ jobs:
           image-tag: ${{ steps.vars.outputs.sha }}
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
           release-version: ${{ env.CILIUM_CLI_VERSION }}
-
-      - name: Wait for images to be available
-        timeout-minutes: 30
-        shell: bash
-        run: |
-          for image in cilium-ci operator-generic-ci hubble-relay-ci; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
-          done
 
       - name: Install Cilium
         id: install-cilium

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -81,6 +81,15 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   multi-pool-ipam-conformance-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 'Direct Routing'
+            tunnel: 'disabled'
+          - name: 'Tunnel Mode'
+            tunnel: 'vxlan'
+
     name: Install and Connectivity Test
     env:
       job_name: "Install and Connectivity Test"
@@ -125,20 +134,15 @@ jobs:
           echo owner=${OWNER} >> $GITHUB_OUTPUT
 
           # Notes:
-          #  - Multi-pool IPAM only supports direct routing, thus we disable
-          #    tunnel mode and enable auto-direct-routes.
-          #  - Multi-pool IPAM only supports endpoint routes, thus we disable
-          #    the local-node-route.
-          #  - helm/kind-action does not support BPF host routing, so we fall
-          #    back on legacy host routing
-          #    (https://github.com/cilium/cilium/issues/23283#issuecomment-1597282247)
+          #  - Multi-pool IPAM only supports endpoint routes
           #  - iptables-based masquerading does not support multiple non-masquerade
           #    CIDRs. Thus, we enable BPF masquerading where we can add multiple
           #    non-masquerade CIDRs.
+          #  - helm/kind-action does not support BPF host routing, so we fall
+          #    back on legacy host routing
+          #    (https://github.com/cilium/cilium/issues/23283#issuecomment-1597282247)
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=hubble.relay.enabled=true \
-            --helm-set=autoDirectNodeRoutes=true \
-            --helm-set=routingMode=native \
             --helm-set=endpointRoutes.enabled=true \
             --helm-set=kubeProxyReplacement=true \
             --helm-set=bpf.masquerade=true \
@@ -155,7 +159,15 @@ jobs:
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.cidrs='{192.168.16.0/20}' \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.maskSize=27"
 
+          if [ "${{ matrix.tunnel }}" == "disabled" ]; then
+            CILIUM_INSTALL_TUNNEL="--helm-set-string=routingMode=native \
+            --helm-set=autoDirectNodeRoutes=true"
+          fi
+
           CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
+            --sysdump-output-filename \"cilium-sysdump-${{ matrix.name }}-<ts>\" \
+            --junit-file \"cilium-junits/${{ env.job_name }} ${{ matrix.name }}.xml\" \
+            --junit-property github_job_step=\"Run tests ${{ matrix.name }}\" \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
@@ -166,7 +178,7 @@ jobs:
                 \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
             }'"
 
-          echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
+          echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL}" >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
@@ -222,14 +234,13 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Features tested
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested"
-          json-filename: "${{ env.job_name }} - 1"
+          json-filename: "${{ env.job_name }} ${{ matrix.name }}"
 
       - name: Collect Pod and Pool IPs
         id: ips
@@ -271,7 +282,7 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: cilium-sysdump-out.zip
+          name: "cilium-sysdumps-${{ matrix.name }}"
           path: cilium-sysdump-*.zip
           retention-days: 5
 
@@ -279,15 +290,14 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: cilium-junits
+          name: "cilium-junits-${{ matrix.name }}"
           path: cilium-junits/*.xml
-          retention-days: 5
 
       - name: Upload features tested
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: features-tested
+          name: "features-tested-${{ matrix.name }}"
           path: ${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary

--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -215,7 +215,6 @@ Multi-Pool IPAM is a preview feature. The following limitations apply to Cilium 
 Multi-Pool IPAM mode:
 
 .. warning::
-   - Tunnel mode is not supported. Multi-Pool IPAM may only be used in direct routing mode.
    - Transparent encryption is only supported with WireGuard and cannot be used with IPsec.
    - IPAM pools with overlapping CIDRs are not supported. Each pod IP must be
      unique in the cluster due the way Cilium determines the security identity

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -371,17 +371,6 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
 						      encrypt_key, secctx, info->sec_identity,
 						      &trace);
-	} else {
-		struct tunnel_key key = {};
-
-		/* IPv6 lookup key: daddr/96 */
-		ipv6_addr_copy(&key.ip6, dst);
-		key.ip6.p4 = 0;
-		key.family = ENDPOINT_KEY_IPV6;
-
-		ret = encap_and_redirect_netdev(ctx, &key, encrypt_key, secctx, &trace);
-		if (ret != DROP_NO_TUNNEL_ENDPOINT)
-			return ret;
 	}
 skip_tunnel:
 #endif
@@ -839,17 +828,6 @@ skip_vtep:
 		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
 						      encrypt_key, secctx, info->sec_identity,
 						      &trace);
-	} else {
-		/* IPv4 lookup key: daddr & IPV4_MASK */
-		struct tunnel_key key = {};
-
-		key.ip4 = ip4->daddr & IPV4_MASK;
-		key.family = ENDPOINT_KEY_IPV4;
-
-		cilium_dbg(ctx, DBG_NETDEV_ENCAP4, key.ip4, secctx);
-		ret = encap_and_redirect_netdev(ctx, &key, encrypt_key, secctx, &trace);
-		if (ret != DROP_NO_TUNNEL_ENDPOINT)
-			return ret;
 	}
 skip_tunnel:
 #endif

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -731,8 +731,8 @@ ct_recreate6:
 		 * the packet needs IPSec encap so push ctx to stack for encap, or
 		 * (c) packet was redirected to tunnel device so return.
 		 */
-		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, 0, 0, encrypt_key,
-					     &key, SECLABEL_IPV6, *dst_sec_identity,
+		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
+					     SECLABEL_IPV6, *dst_sec_identity,
 					     &trace);
 		switch (ret) {
 		case CTX_ACT_OK:
@@ -1277,8 +1277,7 @@ skip_vtep:
 		}
 #endif
 
-		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, ip4->saddr,
-					     ip4->daddr, encrypt_key, &key,
+		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
 					     SECLABEL_IPV4, *dst_sec_identity, &trace);
 		switch (ret) {
 		case CTX_ACT_OK:

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -114,51 +114,17 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
  * CTX_ACT_REDIRECT.
  */
 static __always_inline int
-encap_and_redirect_lxc(struct __ctx_buff *ctx,
-		       __be32 tunnel_endpoint __maybe_unused,
-		       __u32 src_ip __maybe_unused,
-		       __u32 dst_ip __maybe_unused,
-		       __u8 encrypt_key __maybe_unused,
-		       struct tunnel_key *key __maybe_unused,
-		       __u32 seclabel, __u32 dstid,
-		       const struct trace_ctx *trace)
+encap_and_redirect_lxc(struct __ctx_buff *ctx __maybe_unused,
+		       __be32 tunnel_endpoint, __u8 encrypt_key __maybe_unused,
+		       __u32 seclabel __maybe_unused, __u32 dstid __maybe_unused,
+		       const struct trace_ctx *trace __maybe_unused)
 {
-	struct tunnel_value *tunnel __maybe_unused;
-
-	if (tunnel_endpoint)
-		return __encap_and_redirect_lxc(ctx, tunnel_endpoint,
-						encrypt_key, seclabel, dstid,
-						trace);
-
-	tunnel = map_lookup_elem(&cilium_tunnel_map, key);
-	if (!tunnel)
+	if (!tunnel_endpoint)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-# ifdef ENABLE_IPSEC
-	if (tunnel->key) {
-		__u8 min_encrypt_key = get_min_encrypt_key(tunnel->key);
-
-		return set_ipsec_encrypt(ctx, min_encrypt_key, tunnel->ip4,
-					 seclabel, false, false);
-	}
-# endif
-	return __encap_and_redirect_with_nodeid(ctx, tunnel->ip4, seclabel,
-						dstid, NOT_VTEP_DST, trace);
-}
-
-static __always_inline int
-encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
-			  __u8 encrypt_key, __u32 seclabel,
-			  const struct trace_ctx *trace)
-{
-	struct tunnel_value *tunnel;
-
-	tunnel = map_lookup_elem(&cilium_tunnel_map, k);
-	if (!tunnel)
-		return DROP_NO_TUNNEL_ENDPOINT;
-
-	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, encrypt_key,
-					      seclabel, 0, trace);
+	return __encap_and_redirect_lxc(ctx, tunnel_endpoint,
+					encrypt_key, seclabel, dstid,
+					trace);
 }
 #endif /* TUNNEL_MODE */
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1400,9 +1400,6 @@ func initEnv(vp *viper.Viper) {
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMMultiPool {
-		if option.Config.TunnelingEnabled() {
-			log.Fatalf("Cannot specify IPAM mode %s in tunnel mode.", option.Config.IPAM)
-		}
 		if option.Config.EnableIPSec {
 			log.Fatalf("Cannot specify IPAM mode %s with %s.", option.Config.IPAM, option.EnableIPSecName)
 		}

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -256,6 +256,11 @@ func (d dummyNodeManager) Unsubscribe(types.NodeHandler) {
 	panic("unimplemented")
 }
 
+// SetPrefixClusterMutatorFn implements manager.NodeManager
+func (d dummyNodeManager) SetPrefixClusterMutatorFn(mutator func(*nodeTypes.Node) []cmtypes.PrefixClusterOpts) {
+	panic("unimplemented")
+}
+
 var _ nodemanager.NodeManager = dummyNodeManager{}
 
 type dummyRemoteIdentityWatcher struct{}

--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -273,7 +273,7 @@ func (ac AddrCluster) AsNetIP() net.IP {
 }
 
 func (ac AddrCluster) AsPrefixCluster() PrefixCluster {
-	return PrefixClusterFrom(ac.addr, ac.addr.BitLen(), WithClusterID(ac.clusterID))
+	return PrefixClusterFrom(netip.PrefixFrom(ac.addr, ac.addr.BitLen()), WithClusterID(ac.clusterID))
 }
 
 // PrefixCluster is a type that holds a pair of prefix and ClusterID.
@@ -362,8 +362,8 @@ func WithClusterID(id uint32) PrefixClusterOpts {
 	return func(pc *PrefixCluster) { pc.clusterID = id }
 }
 
-func PrefixClusterFrom(addr netip.Addr, bits int, opts ...PrefixClusterOpts) PrefixCluster {
-	pc := PrefixCluster{prefix: netip.PrefixFrom(addr, bits)}
+func PrefixClusterFrom(prefix netip.Prefix, opts ...PrefixClusterOpts) PrefixCluster {
+	pc := PrefixCluster{prefix: prefix}
 	for _, opt := range opts {
 		opt(&pc)
 	}
@@ -381,7 +381,7 @@ func PrefixClusterFromCIDR(c *cidr.CIDR, opts ...PrefixClusterOpts) PrefixCluste
 	}
 	ones, _ := c.Mask.Size()
 
-	return PrefixClusterFrom(addr, ones, opts...)
+	return PrefixClusterFrom(netip.PrefixFrom(addr, ones), opts...)
 }
 
 func (pc0 PrefixCluster) Equal(pc1 PrefixCluster) bool {

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -66,7 +66,7 @@ func (k Key) String() string {
 	prefixLen := int(k.Prefixlen - getStaticPrefixBits())
 	clusterID := uint32(k.ClusterID)
 
-	return cmtypes.PrefixClusterFrom(addr, prefixLen, cmtypes.WithClusterID(clusterID)).String()
+	return cmtypes.PrefixClusterFrom(netip.PrefixFrom(addr, prefixLen), cmtypes.WithClusterID(clusterID)).String()
 }
 
 func (k *Key) New() bpf.MapKey { return &Key{} }

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -79,6 +80,11 @@ type NodeManager interface {
 	// StartNodeNeighborLinkUpdater spawns a controller that watches a queue
 	// for node neighbor link updates.
 	StartNodeNeighborLinkUpdater(nh datapath.NodeNeighbors)
+
+	// SetPrefixClusterMutatorFn allows to inject a custom prefix cluster mutator.
+	// The mutator may then be applied to the PrefixCluster(s) using cmtypes.PrefixClusterFrom,
+	// cmtypes.PrefixClusterFromCIDR and the like.
+	SetPrefixClusterMutatorFn(mutator func(*types.Node) []cmtypes.PrefixClusterOpts)
 }
 
 func newAllNodeManager(in struct {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -825,7 +825,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		prefix := ip.IPToNetPrefix(address.IP)
 		var prefixCluster cmtypes.PrefixCluster
 		if address.Type == addressing.NodeCiliumInternalIP {
-			prefixCluster = cmtypes.PrefixClusterFrom(prefix.Addr(), prefix.Bits(), m.prefixClusterMutatorFn(&n)...)
+			prefixCluster = cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&n)...)
 		} else {
 			prefixCluster = cmtypes.NewLocalPrefixCluster(prefix)
 		}
@@ -924,7 +924,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 			continue
 		}
 
-		prefixCluster := cmtypes.PrefixClusterFrom(prefix.Addr(), prefix.Bits(), m.prefixClusterMutatorFn(&n)...)
+		prefixCluster := cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&n)...)
 
 		if !source.AllowOverwrite(m.ipcache.GetMetadataSourceByPrefix(prefixCluster), n.Source) {
 			dpUpdate = false
@@ -943,7 +943,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 			continue
 		}
 
-		prefixCluster := cmtypes.PrefixClusterFrom(prefix.Addr(), prefix.Bits(), m.prefixClusterMutatorFn(&n)...)
+		prefixCluster := cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&n)...)
 
 		if !source.AllowOverwrite(m.ipcache.GetMetadataSourceByPrefix(prefixCluster), n.Source) {
 			dpUpdate = false
@@ -1096,7 +1096,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 
 		var oldPrefixCluster cmtypes.PrefixCluster
 		if address.Type == addressing.NodeCiliumInternalIP {
-			oldPrefixCluster = cmtypes.PrefixClusterFrom(prefix.Addr(), prefix.Bits(), m.prefixClusterMutatorFn(&oldNode)...)
+			oldPrefixCluster = cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&oldNode)...)
 		} else {
 			oldPrefixCluster = cmtypes.NewLocalPrefixCluster(prefix)
 		}
@@ -1167,7 +1167,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			continue
 		}
 
-		prefixCluster := cmtypes.PrefixClusterFrom(prefix.Addr(), prefix.Bits(), m.prefixClusterMutatorFn(&oldNode)...)
+		prefixCluster := cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&oldNode)...)
 
 		m.ipcache.RemoveMetadata(prefixCluster, resource,
 			labels.LabelHealth,
@@ -1182,7 +1182,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			continue
 		}
 
-		prefixCluster := cmtypes.PrefixClusterFrom(prefix.Addr(), prefix.Bits(), m.prefixClusterMutatorFn(&oldNode)...)
+		prefixCluster := cmtypes.PrefixClusterFrom(prefix, m.prefixClusterMutatorFn(&oldNode)...)
 
 		m.ipcache.RemoveMetadata(prefixCluster, resource,
 			labels.LabelIngress,

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
@@ -92,6 +93,8 @@ type IPCache interface {
 	OverrideIdentity(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID)
 	RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
 	RemoveIdentityOverride(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, resource ipcacheTypes.ResourceID)
+	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
+	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
 }
 
 // IPSetFilterFn is a function allowing to optionally filter out the insertion
@@ -772,6 +775,15 @@ func (m *manager) nodeIdentityLabels(n nodeTypes.Node) (nodeLabels labels.Labels
 	return nodeLabels, hasOverride
 }
 
+// worldLabelForPrefix returns the labels which will resolve to
+// reserved:world identity given the provided prefix and the
+// current cluster configuration in terms of dual-stack.
+func worldLabelForPrefix(prefix netip.Prefix) labels.Labels {
+	lbls := make(labels.Labels, 1)
+	lbls.AddWorldLabel(prefix.Addr())
+	return lbls
+}
+
 // NodeUpdated is called after the information of a node has been updated. The
 // node in the manager is added or updated if the source is allowed to update
 // the node. If an update or addition has occurred, NodeUpdate() of the datapath
@@ -803,7 +815,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	nodeLabels, nodeIdentityOverride := m.nodeIdentityLabels(n)
 
 	var ipsetEntries []netip.Prefix
-	var nodeIPsAdded, healthIPsAdded, ingressIPsAdded []netip.Prefix
+	var nodeIPsAdded, healthIPsAdded, ingressIPsAdded, podCIDRsAdded []netip.Prefix
 
 	for _, address := range n.IPAddresses {
 		prefixCluster := cmtypes.NewLocalPrefixCluster(ip.IPToNetPrefix(address.IP))
@@ -877,6 +889,25 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	m.ipsetMgr.AddToIPSet(ipset.CiliumNodeIPSetV4, ipset.INetFamily, v4Addrs...)
 	m.ipsetMgr.AddToIPSet(ipset.CiliumNodeIPSetV6, ipset.INet6Family, v6Addrs...)
 
+	// Add the remote node's Pod CIDRs as fallback entries into IPCache with
+	// the nodeIP as the tunnel endpoint (no tunnel endpoint fallback is needed
+	// for the local node).
+	if !n.IsLocal() {
+		ipv4PodCIDRs := n.GetIPv4AllocCIDRs()
+		ipv6PodCIDRs := n.GetIPv6AllocCIDRs()
+
+		mu := make([]ipcache.MU, 0, len(ipv4PodCIDRs)+len(ipv6PodCIDRs))
+		for entry := range m.podCIDREntries(n.Source, resource, ipv4PodCIDRs, nodeIP, n.EncryptionKey) {
+			mu = append(mu, entry)
+			podCIDRsAdded = append(podCIDRsAdded, entry.Prefix.AsPrefix())
+		}
+		for entry := range m.podCIDREntries(n.Source, resource, ipv6PodCIDRs, nodeIP, n.EncryptionKey) {
+			mu = append(mu, entry)
+			podCIDRsAdded = append(podCIDRsAdded, entry.Prefix.AsPrefix())
+		}
+		m.ipcache.UpsertMetadataBatch(mu...)
+	}
+
 	for _, address := range []net.IP{n.IPv4HealthIP, n.IPv6HealthIP} {
 		healthIP := cmtypes.NewLocalPrefixCluster(ip.IPToNetPrefix(address))
 		if !healthIP.AsPrefix().IsValid() {
@@ -948,7 +979,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 			}
 		}
 
-		m.removeNodeFromIPCache(oldNode, resource, ipsetEntries, nodeIPsAdded, healthIPsAdded, ingressIPsAdded)
+		m.removeNodeFromIPCache(oldNode, resource, ipsetEntries, nodeIPsAdded, healthIPsAdded, ingressIPsAdded, podCIDRsAdded)
 
 		entry.mutex.Unlock()
 	} else {
@@ -987,13 +1018,45 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	}
 }
 
+func (m *manager) podCIDREntries(source source.Source, resource ipcacheTypes.ResourceID, podCIDRs []*cidr.CIDR, tunnelIP netip.Addr, encryptKey uint8) iter.Seq[ipcache.MU] {
+	return func(yield func(ipcache.MU) bool) {
+		for _, podCIDR := range podCIDRs {
+			if podCIDR == nil {
+				continue
+			}
+
+			prefix, ok := netipx.FromStdIPNet(podCIDR.IPNet)
+			if !ok {
+				continue
+			}
+
+			metadata := []ipcache.IPMetadata{
+				worldLabelForPrefix(prefix),
+				ipcacheTypes.TunnelPeer{Addr: tunnelIP},
+				ipcacheTypes.EncryptKey(encryptKey),
+			}
+
+			if !yield(ipcache.MU{
+				Prefix:   cmtypes.NewLocalPrefixCluster(prefix),
+				Source:   source,
+				Resource: resource,
+				Metadata: metadata,
+			}) {
+				return
+			}
+		}
+	}
+}
+
 // removeNodeFromIPCache removes all addresses associated with oldNode from the IPCache,
 // unless they are present in the nodeIPsAdded, healthIPsAdded, ingressIPsAdded lists.
+// Removes all pod CIDRs associated with the oldNode from IPCache, unless they are present
+// in podCIDRsAdded.
 // Removes ipset entry associated with oldNode if it is not present in ipsetEntries.
 //
 // The removal logic in this function should mirror the upsert logic in NodeUpdated.
 func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcacheTypes.ResourceID,
-	ipsetEntries, nodeIPsAdded, healthIPsAdded, ingressIPsAdded []netip.Prefix,
+	ipsetEntries, nodeIPsAdded, healthIPsAdded, ingressIPsAdded, podCIDRsAdded []netip.Prefix,
 ) {
 	var oldNodeIP netip.Addr
 	if nIP := oldNode.GetNodeIP(false); nIP != nil {
@@ -1047,6 +1110,27 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 
 	m.ipsetMgr.RemoveFromIPSet(ipset.CiliumNodeIPSetV4, v4Addrs...)
 	m.ipsetMgr.RemoveFromIPSet(ipset.CiliumNodeIPSetV6, v6Addrs...)
+
+	// Remove old pod CIDR fallback entries from IPCache
+	if !oldNode.IsLocal() {
+		oldIPv4PodCIDRs := oldNode.GetIPv4AllocCIDRs()
+		oldIPv6PodCIDRs := oldNode.GetIPv6AllocCIDRs()
+
+		mu := make([]ipcache.MU, 0, len(oldIPv4PodCIDRs)+len(oldIPv6PodCIDRs))
+		for entry := range m.podCIDREntries(oldNode.Source, resource, oldIPv4PodCIDRs, oldNodeIP, oldNode.EncryptionKey) {
+			if slices.Contains(podCIDRsAdded, entry.Prefix.AsPrefix()) {
+				continue
+			}
+			mu = append(mu, entry)
+		}
+		for entry := range m.podCIDREntries(oldNode.Source, resource, oldIPv6PodCIDRs, oldNodeIP, oldNode.EncryptionKey) {
+			if slices.Contains(podCIDRsAdded, entry.Prefix.AsPrefix()) {
+				continue
+			}
+			mu = append(mu, entry)
+		}
+		m.ipcache.RemoveMetadataBatch(mu...)
+	}
 
 	// Delete the old health IP addresses if they have changed in this node.
 	for _, address := range []net.IP{oldNode.IPv4HealthIP, oldNode.IPv6HealthIP} {
@@ -1130,7 +1214,7 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 	// The ipcache is recreated from scratch on startup, no need to prune restored stale nodes.
 	if n.Source != source.Restored {
 		resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
-		m.removeNodeFromIPCache(entry.node, resource, nil, nil, nil, nil)
+		m.removeNodeFromIPCache(entry.node, resource, nil, nil, nil, nil, nil)
 	}
 
 	m.metrics.NumNodes.Dec()


### PR DESCRIPTION
Rework of https://github.com/cilium/cilium/pull/38015 after the introduction of clusterID aware ipcache in https://github.com/cilium/cilium/pull/38379

The main difference with https://github.com/cilium/cilium/pull/38015 is commit https://github.com/cilium/cilium/pull/38483/commits/fa35fa0247909ada83f72952daef85a284bc1f40 where we take advantage of the `ClusterPrefix` parameter type in ipcache API to enrich the node prefixes (namely, the CiliumInternalIP, the Ingress and health IPs and the v4/v6 allocation CIDRs) with the result of a customizable PrefixClusterMutatorFn. This guarantees feature parity with the  tunnel map previously used for node allocation CIDRs.

Description of the previous version of the PR (https://github.com/cilium/cilium/pull/38015) below:

---

This PR introduces support for tunnel routing with the Multi-Pool IPAM mode. This is achieved by removing the reliance on the tunnel map as a fallback mechanism and instead use Pod CIDR entries in IPCache that act as this fallback. The pod CIDR entries contain the node's tunnel endpoint and encryption key and have the `reserved:world` identity (i.e. the same identity as the existing catch-all fallback, which would have been hit before this PR). 

The bulk of the work in this PR was done by @pippolo84. This PR is a replacement for his PR https://github.com/cilium/cilium/pull/37146 with a few notable changes:

1. The first commit has been reworked to add unit tests and fix up some issues in the previous version (c.f. https://github.com/cilium/cilium/pull/37146#discussion_r1973593637).
2. A commit has been added adding some unit tests to the IPCache package emulating some of the expected corner cases.
3. Commit `node: Remove insertions and deletions to tunnel map` has been dropped. In other words, even though the tunnel map is no longer used in the `main` branch, we still populate it. This addresses concerns with regards to downgrades.
4. The Conformance Multi-Pool workflow has been extended to also test in tunnel mode.

This change will eventually allow us to remove the tunnel map completely (ref https://github.com/cilium/cilium/issues/20170).

---

```release-note
Add support for tunnel routing in multi-pool IPAM mode
```
