### PR TITLE
experimental/redirectpolicy: Extend the tests to cover IPv6

### DIFF
--- a/pkg/loadbalancer/experimental/redirectpolicy/redirectpolicy.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/redirectpolicy.go
@@ -126,8 +126,7 @@ func (lrp *LocalRedirectPolicy) TableHeader() []string {
 func (lrp *LocalRedirectPolicy) TableRow() []string {
 	mappings := make([]string, 0, len(lrp.FrontendMappings))
 	for _, feM := range lrp.FrontendMappings {
-		addr := feM.feAddr
-		mappings = append(mappings, fmt.Sprintf("%s:%d %s", addr.AddrCluster, addr.Port, addr.Protocol))
+		mappings = append(mappings, feM.feAddr.StringWithProtocol())
 	}
 	return []string{
 		lrp.ID.Namespace + "/" + lrp.ID.Name,

--- a/pkg/loadbalancer/experimental/redirectpolicy/skiplb.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/skiplb.go
@@ -149,6 +149,7 @@ func (dsl *desiredSkipLB) TableRow() []string {
 			skipRedirects = append(skipRedirects, addr.StringWithProtocol())
 		}
 	}
+	sort.Strings(skipRedirects)
 
 	return []string{
 		dsl.PodNamespacedName,

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/address.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/address.txtar
@@ -1,48 +1,53 @@
 hive start
 db/initialized
 
-# Add a pod and an address-based redirection
+# Add a pod and an address-based redirection. Add IPv4 first then
+# IPv6 for consistent ordering.
 k8s/add pod.yaml lrp-addr.yaml
 
-# Check tables
+# Wait for the IPv4 frontend
+db/show frontends
+* stdout '169.254.169.254:8080/TCP.*10.244.2.1:80/TCP.*Done'
+
+# Then add IPv6 and check tables
+k8s/add lrp-addr-ipv6.yaml
 db/cmp localredirectpolicies lrp.table
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table
 
-# Maps should have the created frontend: 169.254.169.254 => 10.244.2.1
+# Maps should have the created frontends:
+# 169.254.169.254 => 10.244.2.1
+# 2001::1 => 2002::2
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.actual maps.expected
 
 # Deleting the LRP cleans up the tables.
-k8s/delete lrp-addr.yaml
-db/cmp services services-empty.table
-db/cmp frontends frontends-empty.table
+k8s/delete lrp-addr.yaml lrp-addr-ipv6.yaml
 
-# Maps should now be empty.
+# Tables and maps should now be empty.
+* db/empty services frontends backends localredirectpolicies
 * lb/maps-empty
 
 -- lrp.table --
-Name           Type     FrontendType      Frontends
-test/lrp-addr  address  addr-single-port  169.254.169.254:8080 TCP
-
--- services-empty.table --
-Name                          Source
+Name               Type     FrontendType      Frontends
+test/lrp-addr      address  addr-single-port  169.254.169.254:8080/TCP
+test/lrp-addr-ipv6 address  addr-single-port  [2001::1]:8080/TCP
 
 -- services.table --
-Name                          Source
-test/lrp-addr:local-redirect  k8s   
-
--- frontends-empty.table --
-Address                    Type        ServiceName
+Name                              Source
+test/lrp-addr-ipv6:local-redirect k8s
+test/lrp-addr:local-redirect      k8s   
 
 -- frontends.table --
-Address                    Type          ServiceName                    Backends            RedirectTo  Status
-169.254.169.254:8080/TCP   LocalRedirect test/lrp-addr:local-redirect   10.244.2.1:80/TCP               Done
+Address                    Type          ServiceName                       Backends            RedirectTo  Status
+169.254.169.254:8080/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:80/TCP               Done
+[2001::1]:8080/TCP         LocalRedirect test/lrp-addr-ipv6:local-redirect [2002::2]:80/TCP                Done
 
 -- backends.table --
 Address             Instances
-10.244.2.1:80/TCP   test/lrp-addr:local-redirect (tcp)
+10.244.2.1:80/TCP   test/lrp-addr-ipv6:local-redirect (tcp), test/lrp-addr:local-redirect (tcp)
+[2002::2]:80/TCP    test/lrp-addr-ipv6:local-redirect (tcp), test/lrp-addr:local-redirect (tcp)
 
 -- lrp-addr.yaml --
 apiVersion: "cilium.io/v2"
@@ -54,6 +59,27 @@ spec:
   redirectFrontend:
     addressMatcher:
       ip: "169.254.169.254"
+      toPorts:
+        - port: "8080"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- lrp-addr-ipv6.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr-ipv6"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "2001::1"
       toPorts:
         - port: "8080"
           protocol: TCP
@@ -89,6 +115,7 @@ status:
   podIP: 10.244.2.1
   podIPs:
   - ip: 10.244.2.1
+  - ip: 2002::2
   qosClass: BestEffort
   startTime: "2024-07-10T16:20:42Z"
   conditions:
@@ -99,6 +126,10 @@ status:
 
 -- maps.expected --
 BE: ID=1 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=2 ADDR=[2002::2]:80/TCP STATE=active
 REV: ID=1 ADDR=169.254.169.254:8080
+REV: ID=2 ADDR=[2001::1]:8080
 SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=[2001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=[2001::1]:8080/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/service.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/service.txtar
@@ -81,55 +81,83 @@ test/lrp-svc:local-redirect   k8s
 -- frontends-before.table --
 Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
 169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.1.1:7070/UDP                                 Done
-169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done 
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done
+[1001::1]:7070/UDP         ClusterIP   test/echo     udp                                                            Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                            Done
 
 -- frontends.table --
 Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
 169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.2.1:70/UDP     test/lrp-svc:local-redirect   Done
 169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
-
-
+[1001::1]:7070/UDP         ClusterIP   test/echo     udp        [2001::1]:70/UDP      test/lrp-svc:local-redirect   Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done
 -- frontends-no-tcp-redirect.table --
 Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
 169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.2.1:70/UDP     test/lrp-svc:local-redirect   Done
-169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done 
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done
+[1001::1]:7070/UDP         ClusterIP   test/echo     udp        [2001::1]:70/UDP      test/lrp-svc:local-redirect   Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                            Done
 
 -- maps-before.expected --
 BE: ID=1 ADDR=10.244.1.1:7070/UDP STATE=active
 BE: ID=2 ADDR=10.244.1.1:8080/TCP STATE=active
 REV: ID=1 ADDR=169.254.169.254:7070
 REV: ID=2 ADDR=169.254.169.254:8080
+REV: ID=3 ADDR=[1001::1]:7070
+REV: ID=4 ADDR=[1001::1]:8080
 SVC: ID=1 ADDR=169.254.169.254:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=1 ADDR=169.254.169.254:7070/UDP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=2 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=2 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=[1001::1]:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 -- maps.expected --
 BE: ID=3 ADDR=10.244.2.1:70/UDP STATE=active
 BE: ID=4 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=5 ADDR=[2001::1]:70/UDP STATE=active
+BE: ID=6 ADDR=[2001::1]:80/TCP STATE=active
 REV: ID=1 ADDR=169.254.169.254:7070
 REV: ID=2 ADDR=169.254.169.254:8080
+REV: ID=3 ADDR=[1001::1]:7070
+REV: ID=4 ADDR=[1001::1]:8080
 SVC: ID=1 ADDR=169.254.169.254:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=1 ADDR=169.254.169.254:7070/UDP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=2 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=2 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=[1001::1]:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=[1001::1]:7070/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=[1001::1]:8080/TCP SLOT=1 BEID=6 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 -- maps-readded.expected --
-BE: ID=7 ADDR=10.244.2.1:70/UDP STATE=active
-BE: ID=8 ADDR=10.244.2.1:80/TCP STATE=active
-REV: ID=3 ADDR=169.254.169.254:7070
-REV: ID=4 ADDR=169.254.169.254:8080
-SVC: ID=3 ADDR=169.254.169.254:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
-SVC: ID=3 ADDR=169.254.169.254:7070/UDP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
-SVC: ID=4 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
-SVC: ID=4 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+BE: ID=10 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=11 ADDR=[2001::1]:70/UDP STATE=active
+BE: ID=12 ADDR=[2001::1]:80/TCP STATE=active
+BE: ID=9 ADDR=10.244.2.1:70/UDP STATE=active
+REV: ID=5 ADDR=169.254.169.254:7070
+REV: ID=6 ADDR=169.254.169.254:8080
+REV: ID=7 ADDR=[1001::1]:7070
+REV: ID=8 ADDR=[1001::1]:8080
+SVC: ID=5 ADDR=169.254.169.254:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=5 ADDR=169.254.169.254:7070/UDP SLOT=1 BEID=9 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=6 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=6 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=10 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=7 ADDR=[1001::1]:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=7 ADDR=[1001::1]:7070/UDP SLOT=1 BEID=11 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=8 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=8 ADDR=[1001::1]:8080/TCP SLOT=1 BEID=12 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 -- maps-after.expected --
-BE: ID=11 ADDR=10.244.1.1:7070/UDP STATE=active
-BE: ID=12 ADDR=10.244.1.1:8080/TCP STATE=active
-REV: ID=3 ADDR=169.254.169.254:7070
-REV: ID=4 ADDR=169.254.169.254:8080
-SVC: ID=3 ADDR=169.254.169.254:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=3 ADDR=169.254.169.254:7070/UDP SLOT=1 BEID=11 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=4 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=4 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=12 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+BE: ID=16 ADDR=10.244.1.1:7070/UDP STATE=active
+BE: ID=17 ADDR=10.244.1.1:8080/TCP STATE=active
+REV: ID=5 ADDR=169.254.169.254:7070
+REV: ID=6 ADDR=169.254.169.254:8080
+REV: ID=7 ADDR=[1001::1]:7070
+REV: ID=8 ADDR=[1001::1]:8080
+SVC: ID=5 ADDR=169.254.169.254:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=169.254.169.254:7070/UDP SLOT=1 BEID=16 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=17 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=[1001::1]:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 -- lrp-svc.yaml --
 apiVersion: "cilium.io/v2"
 kind: CiliumLocalRedirectPolicy
@@ -180,6 +208,7 @@ status:
   podIP: 10.244.2.1
   podIPs:
   - ip: 10.244.2.1
+  - ip: 2001::1
   qosClass: BestEffort
   startTime: "2024-07-10T16:20:42Z"
   conditions:
@@ -198,11 +227,13 @@ spec:
   clusterIP: 169.254.169.254
   clusterIPs:
   - 169.254.169.254
+  - 1001::1
   externalTrafficPolicy: Cluster
   internalTrafficPolicy: Cluster
   ipFamilies:
   - IPv4
-  ipFamilyPolicy: SingleStack
+  - IPv6
+  ipFamilyPolicy: DualStack
   ports:
   - name: tcp
     port: 8080
@@ -212,7 +243,6 @@ spec:
     port: 7070
     protocol: UDP
     targetPort: 7070
-    
   selector:
     name: echo
   sessionAffinity: None

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb-addr.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb-addr.txtar
@@ -12,8 +12,16 @@ db/initialized
 # coming from the EndpointManager.
 db/insert desired-skiplbmap pod-cookie.yaml
 
-# Add pods, services and endpoints.
+# Add pod and the IPv4 policy. Adding IPv6 separately for consistent
+# ordering.
 k8s/add pod.yaml lrp.yaml
+
+# Wait until frontend is created
+db/show frontends
+* stdout '169.254.169.255:8080/TCP.*10.244.2.1:80/TCP.*Done'
+
+# Add IPv6 and check the tables.
+k8s/add lrp-ipv6.yaml
 db/cmp localredirectpolicies lrp.table
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -30,14 +38,16 @@ skiplbmap skiplbmap.actual
 # Turn off the redirect. The SkipLB map entry should be removed.
 cp lrp.yaml lrp-noredirect.yaml
 replace 'skipRedirectFromBackend: true' 'skipRedirectFromBackend: false' lrp-noredirect.yaml
-k8s/update lrp-noredirect.yaml
+cp lrp-ipv6.yaml lrp-ipv6-noredirect.yaml
+replace 'skipRedirectFromBackend: true' 'skipRedirectFromBackend: false' lrp-ipv6-noredirect.yaml
+k8s/update lrp-noredirect.yaml lrp-ipv6-noredirect.yaml
 
 # Compare SkipLB map (should be empty now)
 skiplbmap skiplbmap.actual
 * cmp skiplbmap.actual skiplbmap.empty
 
 # Cleanup
-k8s/delete pod.yaml lrp.yaml
+k8s/delete pod.yaml lrp.yaml lrp-ipv6.yaml
 db/delete desired-skiplbmap pod-cookie.yaml
 
 # Wait until empty
@@ -48,8 +58,15 @@ skiplbmap skiplbmap.actual
 
 ### Case 2: 1) pod & LRP 2) cookie
 
-# Add pod and LRP, but no cookie.
+# Add pod and IPv4 LRP, but no cookie for pod.
 k8s/add pod.yaml lrp.yaml
+
+# Wait until IPv4 frontend is created
+db/show frontends
+* stdout '169.254.169.255:8080/TCP.*10.244.2.1:80/TCP.*Done'
+
+# Add IPv6 and check the tables.
+k8s/add lrp-ipv6.yaml
 db/cmp localredirectpolicies lrp.table
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -69,7 +86,6 @@ skiplbmap skiplbmap.actual
 # Add the cookie. Here we rely on the [desiredSkipLBMap] struct being
 # trivially serializable, allowing us to manipulate it.
 db/get desired-skiplbmap test/lrp-pod -f yaml -o skiplbmap.yaml
-cat skiplbmap.yaml
 replace 'netnscookie: null' 'netnscookie: 12345' skiplbmap.yaml
 replace 'kind: \"\"' 'kind: Pending' skiplbmap.yaml
 db/insert desired-skiplbmap skiplbmap.yaml
@@ -80,7 +96,7 @@ skiplbmap skiplbmap.actual
 * cmp skiplbmap.actual skiplbmap.expected
 
 # Cleanup
-k8s/delete pod.yaml lrp.yaml
+k8s/delete pod.yaml lrp.yaml lrp-ipv6.yaml
 db/delete desired-skiplbmap pod-cookie.yaml
 
 # Wait until empty
@@ -90,23 +106,27 @@ skiplbmap skiplbmap.actual
 * cmp skiplbmap.actual skiplbmap.empty
 * lb/maps-empty
 
+###
+
 -- pod-cookie.yaml --
 podnamespacedname: test/lrp-pod
 netnscookie: 12345
 
 -- lrp.table --
-Name           Type     FrontendType                Frontends
-test/lrp-addr  address  addr-single-port            169.254.169.255:8080 TCP
+Name               Type     FrontendType                Frontends
+test/lrp-addr      address  addr-single-port            169.254.169.255:8080/TCP
+test/lrp-addr-ipv6 address  addr-single-port            [1001::1]:8080/TCP
 
 -- skiplbmap.table --
 Pod            SkipRedirects                                 NetnsCookie  Status
-test/lrp-pod   169.254.169.255:8080/TCP                      12345        Done
+test/lrp-pod   169.254.169.255:8080/TCP, [1001::1]:8080/TCP  12345        Done
 
 -- skiplbmap-nocookie.table --
 Pod            SkipRedirects                                 NetnsCookie  Status
-test/lrp-pod   169.254.169.255:8080/TCP                      <unset>
+test/lrp-pod   169.254.169.255:8080/TCP, [1001::1]:8080/TCP  <unset>
 
 -- skiplbmap.expected --
+COOKIE=12345 IP=1001::1 PORT=8080
 COOKIE=12345 IP=169.254.169.255 PORT=8080
 -- skiplbmap.empty --
 -- services-before.table --
@@ -114,23 +134,33 @@ Name                          Source
 test/echo                     k8s   
 
 -- services.table --
-Name                          Source
-test/lrp-addr:local-redirect  k8s
+Name                               Source
+test/lrp-addr-ipv6:local-redirect  k8s
+test/lrp-addr:local-redirect       k8s
 
 -- frontends.table --
-Address                    Type          ServiceName                    PortName   Backends              RedirectTo                    Status
-169.254.169.255:8080/TCP   LocalRedirect test/lrp-addr:local-redirect              10.244.2.1:80/TCP                                   Done
+Address                    Type          ServiceName                       PortName   Backends              RedirectTo                    Status
+169.254.169.255:8080/TCP   LocalRedirect test/lrp-addr:local-redirect                 10.244.2.1:80/TCP                                   Done
+[1001::1]:8080/TCP         LocalRedirect test/lrp-addr-ipv6:local-redirect            [2002::2]:80/TCP                                    Done
 
 -- maps-case1.expected --
 BE: ID=1 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=2 ADDR=[2002::2]:80/TCP STATE=active
 REV: ID=1 ADDR=169.254.169.255:8080
+REV: ID=2 ADDR=[1001::1]:8080
 SVC: ID=1 ADDR=169.254.169.255:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=1 ADDR=169.254.169.255:8080/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=[1001::1]:8080/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 -- maps-case2.expected --
-BE: ID=2 ADDR=10.244.2.1:80/TCP STATE=active
-REV: ID=2 ADDR=169.254.169.255:8080
-SVC: ID=2 ADDR=169.254.169.255:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
-SVC: ID=2 ADDR=169.254.169.255:8080/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+BE: ID=3 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=4 ADDR=[2002::2]:80/TCP STATE=active
+REV: ID=3 ADDR=169.254.169.255:8080
+REV: ID=4 ADDR=[1001::1]:8080
+SVC: ID=3 ADDR=169.254.169.255:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=169.254.169.255:8080/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=[1001::1]:8080/TCP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 -- lrp.yaml --
 apiVersion: "cilium.io/v2"
 kind: CiliumLocalRedirectPolicy
@@ -142,6 +172,28 @@ spec:
   redirectFrontend:
     addressMatcher:
       ip: "169.254.169.255"
+      toPorts:
+        - port: "8080"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- lrp-ipv6.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr-ipv6"
+  namespace: "test"
+spec:
+  skipRedirectFromBackend: true
+  redirectFrontend:
+    addressMatcher:
+      ip: "1001::1"
       toPorts:
         - port: "8080"
           protocol: TCP

--- a/pkg/loadbalancer/experimental/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/experimental/testdata/marshalling.txtar
@@ -251,10 +251,7 @@ Address              Instances
   ]
 }
 -- services-expected.yaml --
-name:
-    namespace: test
-    name: echo
-    cluster: ""
+name: test/echo
 source: k8s
 labels: {}
 annotations: {}
@@ -277,10 +274,7 @@ properties: []
 frontendparams:
     address: 10.96.50.104:80/TCP
     type: ClusterIP
-    servicename:
-        namespace: test
-        name: echo
-        cluster: ""
+    servicename: test/echo
     portname: http
     serviceport: 80
 status:
@@ -306,10 +300,7 @@ redirectto: null
 frontendparams:
     address: '[2001::1]:80/TCP'
     type: ClusterIP
-    servicename:
-        namespace: test
-        name: echo
-        cluster: ""
+    servicename: test/echo
     portname: http
     serviceport: 80
 status:
@@ -335,10 +326,7 @@ redirectto: null
 address: 10.244.1.1:8080/TCP
 instances:
     - k:
-        servicename:
-            namespace: test
-            name: echo
-            cluster: ""
+        servicename: test/echo
         sourcepriority: 4
       v:
         address: 10.244.1.1:8080/TCP
@@ -357,10 +345,7 @@ instances:
 address: '[2002::2]:8080/TCP'
 instances:
     - k:
-        servicename:
-            namespace: test
-            name: echo
-            cluster: ""
+        servicename: test/echo
         sourcepriority: 4
       v:
         address: '[2002::2]:8080/TCP'

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -479,6 +479,29 @@ type ServiceName struct {
 	Cluster   string
 }
 
+func (m ServiceName) MarshalYAML() (any, error) {
+	return m.String(), nil
+}
+
+func (m *ServiceName) UnmarshalYAML(value *yaml.Node) error {
+	parts := strings.Split(value.Value, "/")
+	switch len(parts) {
+	case 0: /* empty name */
+	case 1:
+		m.Name = parts[0]
+	case 2:
+		m.Namespace = parts[0]
+		m.Name = parts[1]
+	case 3:
+		m.Cluster = parts[0]
+		m.Namespace = parts[1]
+		m.Name = parts[2]
+	default:
+		return fmt.Errorf("expected 0, 1 or 2 slashes, got %d", len(parts))
+	}
+	return nil
+}
+
 func (n *ServiceName) Equal(other ServiceName) bool {
 	return n.Namespace == other.Namespace &&
 		n.Name == other.Name &&

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -686,6 +686,43 @@ func TestServiceFlags_String(t *testing.T) {
 	}
 }
 
+func TestServiceNameYAML(t *testing.T) {
+	tests := []struct {
+		name ServiceName
+		want string
+	}{
+		{
+			name: ServiceName{},
+			want: "/",
+		},
+		{
+			name: ServiceName{Name: "foo"},
+			want: "/foo",
+		},
+		{
+			name: ServiceName{Name: "foo", Namespace: "bar"},
+			want: "bar/foo",
+		},
+		{
+			name: ServiceName{Name: "foo", Namespace: "bar", Cluster: "quux"},
+			want: "quux/bar/foo",
+		},
+	}
+	for _, test := range tests {
+		out, err := yaml.Marshal(test.name)
+		if assert.NoError(t, err, "Marshal") {
+			s := strings.TrimSpace(string(out))
+			assert.Equal(t, test.want, s)
+
+			var name ServiceName
+			err := yaml.Unmarshal(out, &name)
+			if assert.NoError(t, err, "Unmarshal") {
+				assert.True(t, test.name.Equal(name), "Equal")
+			}
+		}
+	}
+}
+
 func benchmarkHash(b *testing.B, addr *L3n4Addr) {
 	b.ReportAllocs()
 	b.ResetTimer()


### PR DESCRIPTION
Extend the redirectpolicy test cases to cover IPv6 as well.

The ServiceName YAML marshalling was implemented to be able to nicely YAML marshal [desiredSkipLB.SkipRedirectForFrontends] (ServiceName used as map key).