### PR TITLE
Remove insertions and deletions to deprecated tunnel map

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -300,7 +300,7 @@ func TestAll(t *testing.T) {
 			})
 			t.Run("TestNodeValidationDirectRouting", func(t *testing.T) {
 				s := setup(t, tt)
-				s.TestAgentRestartOptionChanges(t)
+				s.TestNodeValidationDirectRouting(t)
 			})
 		})
 	}

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -4,7 +4,6 @@
 package linux
 
 import (
-	"net"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -14,7 +13,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -46,37 +44,6 @@ var (
 	}
 	cr1 = cidr.MustParseCIDR("10.1.0.0/16")
 )
-
-func TestTunnelCIDRUpdateRequired(t *testing.T) {
-	nilPrefixCluster := cmtypes.PrefixCluster{}
-	c1 := cmtypes.PrefixClusterFromCIDR(cidr.MustParseCIDR("10.1.0.0/16"))
-	c2 := cmtypes.PrefixClusterFromCIDR(cidr.MustParseCIDR("10.2.0.0/16"))
-	ip1 := net.ParseIP("1.1.1.1")
-	ip2 := net.ParseIP("2.2.2.2")
-
-	require.False(t, cidrNodeMappingUpdateRequired(nilPrefixCluster, nilPrefixCluster, ip1, ip1, 0, 0)) // disabled -> disabled
-	require.True(t, cidrNodeMappingUpdateRequired(nilPrefixCluster, c1, ip1, ip1, 0, 0))                // disabled -> c1
-	require.False(t, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 0))                             // c1 -> c1
-	require.True(t, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0))                              // c1 -> c1 (changed host IP, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0))
-	require.True(t, cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2, 0, 0))                              // c1 -> c2
-	require.False(t, cidrNodeMappingUpdateRequired(c2, nilPrefixCluster, ip2, ip2, 0, 0))               // c2 -> disabled
-	require.True(t, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 1))                              // key upgrade 0 -> 1
-	require.True(t, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 1, 0))                              // key downgrade 1 -> 0
-
-	c1 = cmtypes.PrefixClusterFromCIDR(cidr.MustParseCIDR("f00d::a0a:0:0:0/96"))
-	c2 = cmtypes.PrefixClusterFromCIDR(cidr.MustParseCIDR("f00d::b0b:0:0:0/96"))
-	ip1 = net.ParseIP("cafe::1")
-	ip2 = net.ParseIP("cafe::2")
-
-	require.False(t, cidrNodeMappingUpdateRequired(nilPrefixCluster, nilPrefixCluster, ip1, ip1, 0, 0)) // disabled -> disabled
-	require.True(t, cidrNodeMappingUpdateRequired(nilPrefixCluster, c1, ip1, ip1, 0, 0))                // disabled -> c1
-	require.False(t, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 0))                             // c1 -> c1
-	require.True(t, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0))                              // c1 -> c1 (changed host IP, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0))
-	require.True(t, cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2, 0, 0))                              // c1 -> c2
-	require.False(t, cidrNodeMappingUpdateRequired(c2, nilPrefixCluster, ip2, ip2, 0, 0))               // c2 -> disabled
-	require.True(t, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 1))                              // key upgrade 0 -> 1
-	require.True(t, cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 1, 0))                              // key downgrade 1 -> 0
-}
 
 func TestCreateNodeRoute(t *testing.T) {
 	dpConfig := DatapathConfiguration{


### PR DESCRIPTION
Tunnel map has been deprecated in favor of the ipcache map in https://github.com/cilium/cilium/pull/38483. Since we recreate the tunnel map at each agent restart, the insertions and deletions of the node allocation CIDRs into the tunnel map are not needed for backward compatibility.

The PR removes the stale code in the linux node manager, leaving just the bpf tunnel map to ease the agent upgrade and downgrade processes. Moreover, the PR extends the node manager unit tests to have the same coverage we had with the previous tunnel map based implementation.

~Blocked waiting for https://github.com/cilium/cilium/pull/38483 to be merged first.~