### PR TITLE
policy/group: de-duplicate derivative policy add/update/delete operations

### DIFF
--- a/operator/cmd/ccnp_event.go
+++ b/operator/cmd/ccnp_event.go
@@ -51,7 +51,7 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
 					cnpCpy := cnp.DeepCopy()
 
-					groups.AddDerivativeCCNPIfNeeded(logging.DefaultSlogLogger, clientset, cnpCpy.CiliumNetworkPolicy)
+					groups.AddDerivativePolicyIfNeeded(logging.DefaultSlogLogger, clientset, cnpCpy.CiliumNetworkPolicy, true)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
@@ -68,7 +68,7 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 						newCNPCpy := newCNP.DeepCopy()
 						oldCNPCpy := oldCNP.DeepCopy()
 
-						groups.UpdateDerivativeCCNPIfNeeded(logging.DefaultSlogLogger, clientset, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy)
+						groups.UpdateDerivativePolicyIfNeeded(logging.DefaultSlogLogger, clientset, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, true)
 					}
 				}
 			},

--- a/operator/cmd/cnp_event.go
+++ b/operator/cmd/cnp_event.go
@@ -52,7 +52,7 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
 					cnpCpy := cnp.DeepCopy()
 
-					groups.AddDerivativeCNPIfNeeded(logging.DefaultSlogLogger, clientset, cnpCpy.CiliumNetworkPolicy)
+					groups.AddDerivativePolicyIfNeeded(logging.DefaultSlogLogger, clientset, cnpCpy.CiliumNetworkPolicy, false)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
@@ -69,7 +69,7 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 						newCNPCpy := newCNP.DeepCopy()
 						oldCNPCpy := oldCNP.DeepCopy()
 
-						groups.UpdateDerivativeCNPIfNeeded(logging.DefaultSlogLogger, clientset, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy)
+						groups.UpdateDerivativePolicyIfNeeded(logging.DefaultSlogLogger, clientset, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, false)
 					}
 				}
 			},

--- a/pkg/k8s/informer/informer.go
+++ b/pkg/k8s/informer/informer.go
@@ -59,20 +59,6 @@ func NewInformer(
 	return clientState, NewInformerWithStore(lw, objType, resyncPeriod, h, transformer, clientState)
 }
 
-// NewIndexerInformer is a copy of k8s.io/client-go/tools/cache/NewIndexerInformer but includes the
-// default cache MutationDetector.
-func NewIndexerInformer(
-	lw cache.ListerWatcher,
-	objType k8sRuntime.Object,
-	resyncPeriod time.Duration,
-	h cache.ResourceEventHandler,
-	transformer cache.TransformFunc,
-	indexers cache.Indexers,
-) (cache.Indexer, cache.Controller) {
-	clientState := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
-	return clientState, NewInformerWithStore(lw, objType, resyncPeriod, h, transformer, clientState)
-}
-
 // NewInformerWithStore uses the same arguments as NewInformer for which a caller can also set a
 // cache.Store and includes the default cache MutationDetector.
 func NewInformerWithStore(


### PR DESCRIPTION
Most of these functions are almost the same for CNP vs. CCNP. De-duplicate them to use the same function and controller where it makes sense.
