### PR TITLE
ipcache: reduce labels map memory churn in resolveLabels a bit

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -779,22 +779,22 @@ func resolveLabels(prefix cmtypes.PrefixCluster, lbls labels.Labels) labels.Labe
 
 	// In-cluster entities must not have reserved:world.
 	if isInCluster {
-		out = out.Remove(labels.LabelWorld)
-		out = out.Remove(labels.LabelWorldIPv4)
-		out = out.Remove(labels.LabelWorldIPv6)
+		out.Remove(labels.LabelWorld)
+		out.Remove(labels.LabelWorldIPv4)
+		out.Remove(labels.LabelWorldIPv6)
 	}
 
 	// In-cluster entities must not have cidr or fqdn labels.
 	// Exception: nodes may, when PolicyCIDRMatchesNodes() is enabled.
 	if isInCluster && !(isNode && option.Config.PolicyCIDRMatchesNodes()) {
-		out = out.RemoveFromSource(labels.LabelSourceCIDR)
-		out = out.RemoveFromSource(labels.LabelSourceFQDN)
-		out = out.RemoveFromSource(labels.LabelSourceCIDRGroup)
+		out.RemoveFromSource(labels.LabelSourceCIDR)
+		out.RemoveFromSource(labels.LabelSourceFQDN)
+		out.RemoveFromSource(labels.LabelSourceCIDRGroup)
 	}
 
 	// Remove all labels with source `node:`, unless this is a node *and* node labels are enabled.
 	if !(isNode && option.Config.PerNodeLabelsEnabled()) {
-		out = out.RemoveFromSource(labels.LabelSourceNode)
+		out.RemoveFromSource(labels.LabelSourceNode)
 	}
 
 	// No empty labels allowed.

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -294,14 +294,10 @@ func (l Labels) GetFromSource(source string) Labels {
 }
 
 // RemoveFromSource removes all labels that are from the given source
-func (l Labels) RemoveFromSource(source string) Labels {
-	lbls := Labels{}
-	for k, v := range l {
-		if v.Source != source {
-			lbls[k] = v
-		}
-	}
-	return lbls
+func (l Labels) RemoveFromSource(source string) {
+	maps.DeleteFunc(l, func(k string, v Label) bool {
+		return v.Source == source
+	})
 }
 
 // NewLabel returns a new label from the given key, value and source. If source is empty,
@@ -629,16 +625,13 @@ func (l Labels) MergeLabels(from Labels) {
 	maps.Copy(l, from)
 }
 
-// Remove is similar to MergeLabels, but returns a new Labels object with the
-// specified Labels removed. The received Labels is not modified.
-func (l Labels) Remove(from Labels) Labels {
-	result := make(Labels, len(l))
-	for k, v := range l {
-		if _, exists := from[k]; !exists {
-			result[k] = v
-		}
-	}
-	return result
+// Remove is similar to MergeLabels, but removes the specified Labels from l.
+// The received Labels is not modified.
+func (l Labels) Remove(from Labels) {
+	maps.DeleteFunc(l, func(k string, v Label) bool {
+		_, exists := from[k]
+		return exists
+	})
 }
 
 // FormatForKVStore returns the label as a formatted string, ending in

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -110,6 +110,34 @@ func TestMergeLabels(t *testing.T) {
 	require.EqualValues(t, want, to)
 }
 
+func TestRemove(t *testing.T) {
+	to := Labels{
+		"key1": NewLabel("key1", "value1", "source1"),
+		"key2": NewLabel("key2", "value3", "source4"),
+	}
+	remove := Labels{
+		"key1": NewLabel("key1", "value3", "source4"),
+	}
+	want := Labels{
+		"key2": NewLabel("key2", "value3", "source4"),
+	}
+	to.Remove(remove)
+	require.EqualValues(t, want, to)
+}
+
+func TestRemoveFromSource(t *testing.T) {
+	to := Labels{
+		"key1": NewLabel("key1", "value1", "source1"),
+		"key2": NewLabel("key2", "value3", "source4"),
+		"key3": NewLabel("key2", "value5", "source1"),
+	}
+	want := Labels{
+		"key2": NewLabel("key2", "value3", "source4"),
+	}
+	to.RemoveFromSource("source1")
+	require.EqualValues(t, want, to)
+}
+
 func TestParseLabel(t *testing.T) {
 	tests := []struct {
 		str string


### PR DESCRIPTION
Both `labels.Labels.Remove` and `labels.Labels.RemoveFromSource` allocate a new `Labels` map but all current callers assign the result back to the original `Labels` map. Avoid a bit of memory churn and GC pressure by modifying the maps in-place.