### PR TITLE
ci: improve gateway api version (commit) evaluation

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -206,7 +206,7 @@ jobs:
 
       - name: Install Gateway API CRDs
         run: |
-          gateway_api_version=$(grep "sigs.k8s.io/gateway-api" go.mod |  awk '{print $2}' | awk -F'-' '{print (NF>2)?$NF:$0}')
+          gateway_api_version=$(grep -m 1 "sigs.k8s.io/gateway-api" go.mod | awk '{print $2}' | awk -F'-' '{print (NF>2)?$NF:$0}')
           # Install Gateway CRDs
           kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/${{ matrix.crd-channel }}/gateway.networking.k8s.io_gatewayclasses.yaml
           kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/${{ matrix.crd-channel }}/gateway.networking.k8s.io_gateways.yaml


### PR DESCRIPTION
Currently, the Gateway API conformance test GH action evaluates the Gateway API version (commit) by reading it from the `go.mod` file.

This breaks if the gateway-api go dependency has been replaced with an `replace` directive - which is handy to evaluate and test changes.

Therefore, this commit adjusts the command to extract the version to only check the first match of the string `sigs.k8s.io/gateway-api` in the `go.mod` file. This way a replace directive can be placed after the dependencies block.

e.g.

```
require (
	...
	sigs.k8s.io/gateway-api v1.2.1-0.20250319040149-e8b8afabf889
)

replace sigs.k8s.io/gateway-api => github.com/mhofstetter/gateway-api v0.0.0-20250325164945-7e932aa7f804
```
