### PR TITLE
clustermesh-apiserver: enable parsing of ciliumendpointslices

### DIFF
--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh.md
@@ -19,6 +19,7 @@ clustermesh-apiserver clustermesh [flags]
       --controller-group-metrics strings             List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                    Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                        Enable debugging mode
+      --enable-cilium-endpoint-slice                 Enables the CiliumEndpointSlice feature
       --enable-gops                                  Enable gops server (default true)
       --enable-k8s                                   Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                     Enable discovery of Kubernetes API groups and resources with the discovery API

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive.md
@@ -19,6 +19,7 @@ clustermesh-apiserver clustermesh hive [flags]
       --controller-group-metrics strings             List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                    Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                        Enable debugging mode
+      --enable-cilium-endpoint-slice                 Enables the CiliumEndpointSlice feature
       --enable-gops                                  Enable gops server (default true)
       --enable-k8s                                   Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                     Enable discovery of Kubernetes API groups and resources with the discovery API

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive_dot-graph.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive_dot-graph.md
@@ -25,6 +25,7 @@ clustermesh-apiserver clustermesh hive dot-graph [flags]
       --controller-group-metrics strings             List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                    Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                        Enable debugging mode
+      --enable-cilium-endpoint-slice                 Enables the CiliumEndpointSlice feature
       --enable-gops                                  Enable gops server (default true)
       --enable-k8s                                   Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                     Enable discovery of Kubernetes API groups and resources with the discovery API

--- a/clustermesh-apiserver/clustermesh/k8s/ciliumendpointslice.go
+++ b/clustermesh-apiserver/clustermesh/k8s/ciliumendpointslice.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"github.com/spf13/pflag"
+)
+
+type CiliumEndpointSliceConfig struct {
+	EnableCiliumEndpointSlice bool
+}
+
+func (def CiliumEndpointSliceConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("enable-cilium-endpoint-slice", def.EnableCiliumEndpointSlice, "Enables the CiliumEndpointSlice feature")
+}
+
+var DefaultCiliumEndpointSliceConfig = CiliumEndpointSliceConfig{
+	EnableCiliumEndpointSlice: false,
+}

--- a/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
@@ -40,5 +41,18 @@ func CiliumNodeResource(params k8s.CiliumResourceParams, opts ...func(*metav1.Li
 	)
 	return resource.New[*cilium_api_v2.CiliumNode](params.Lifecycle, lw,
 		resource.WithMetric("CiliumNode"), resource.WithCRDSync(params.CRDSyncPromise),
+	), nil
+}
+
+func CiliumEndpointSliceResource(params k8s.CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
+	if !params.ClientSet.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumEndpointSliceList](params.ClientSet.CiliumV2alpha1().CiliumEndpointSlices()),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](params.Lifecycle, lw,
+		resource.WithMetric("CiliumEndpointSlice"), resource.WithCRDSync(params.CRDSyncPromise),
 	), nil
 }

--- a/clustermesh-apiserver/clustermesh/k8s/resources.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resources.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/mcsapi"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
@@ -26,17 +27,20 @@ var (
 		"Clustermesh-apiserver Kubernetes resources",
 
 		cell.Config(k8s.DefaultConfig),
+		cell.Config(DefaultCiliumEndpointSliceConfig),
+
 		cell.Provide(
 			k8s.ServiceResource,
 			mcsapi.ServiceExportResource,
 			k8s.EndpointsResource,
 			CiliumNodeResource,
 			k8s.CiliumIdentityResource,
-			// The CiliumSlimEndpoint resource constructor in the agent depends on the
-			// LocalNodeStore to index its cache. In the clustermesh-apiserver, there is no
-			// cell providing LocalNodeStore, so we provide the resource with a separate
-			// constructor.
+			// The CiliumSlimEndpoint and CiliumEndpointSlice resource constructors in the agent depend
+			// on the LocalNodeStore to index its cache. In the clustermesh-apiserver, there is no
+			// cell providing LocalNodeStore, so we provide the resources with separate
+			// constructors.
 			CiliumSlimEndpointResource,
+			CiliumEndpointSliceResource,
 		),
 	)
 )
@@ -45,10 +49,11 @@ var (
 type Resources struct {
 	cell.In
 
-	Services            resource.Resource[*slim_corev1.Service]
-	ServiceExports      resource.Resource[*mcsapiv1alpha1.ServiceExport]
-	Endpoints           resource.Resource[*k8s.Endpoints]
-	CiliumNodes         resource.Resource[*cilium_api_v2.CiliumNode]
-	CiliumIdentities    resource.Resource[*cilium_api_v2.CiliumIdentity]
-	CiliumSlimEndpoints resource.Resource[*types.CiliumEndpoint]
+	Services             resource.Resource[*slim_corev1.Service]
+	ServiceExports       resource.Resource[*mcsapiv1alpha1.ServiceExport]
+	Endpoints            resource.Resource[*k8s.Endpoints]
+	CiliumNodes          resource.Resource[*cilium_api_v2.CiliumNode]
+	CiliumIdentities     resource.Resource[*cilium_api_v2.CiliumIdentity]
+	CiliumSlimEndpoints  resource.Resource[*types.CiliumEndpoint]
+	CiliumEndpointSlices resource.Resource[*cilium_api_v2a1.CiliumEndpointSlice]
 }

--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -6,6 +6,7 @@ package clustermesh
 import (
 	"context"
 	"errors"
+	"iter"
 	"log/slog"
 	"net"
 	"path"
@@ -27,6 +28,7 @@ import (
 	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumv2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/types"
@@ -78,6 +80,7 @@ type parameters struct {
 	BackendPromise promise.Promise[kvstore.BackendOperations]
 	StoreFactory   store.Factory
 	SyncState      syncstate.SyncState
+	CESConfig      cmk8s.CiliumEndpointSliceConfig
 
 	Logger *slog.Logger
 }
@@ -94,7 +97,7 @@ func registerHooks(lc cell.Lifecycle, params parameters) error {
 				return err
 			}
 
-			startServer(params.ClusterInfo, params.Clientset, backend, params.Resources, params.StoreFactory, params.SyncState, params.CfgMCSAPI.ClusterMeshEnableMCSAPI, params.Logger)
+			startServer(params.ClusterInfo, params.Clientset, backend, params.Resources, params.StoreFactory, params.SyncState, params.CfgMCSAPI.ClusterMeshEnableMCSAPI, params.Logger, params.CESConfig.EnableCiliumEndpointSlice)
 			return nil
 		},
 	})
@@ -238,69 +241,59 @@ func (ns *nodeSynchronizer) synced(ctx context.Context) error {
 type ipmap map[string]struct{}
 
 type endpointSynchronizer struct {
-	store        store.SyncStore
-	cache        map[string]ipmap
-	syncCallback func(context.Context)
-	logger       *slog.Logger
+	store                     store.SyncStore
+	cache                     map[string]ipmap
+	syncCallback              func(context.Context)
+	logger                    *slog.Logger
+	enableCiliumEndpointSlice bool
 }
 
-func newEndpointSynchronizer(ctx context.Context, logger *slog.Logger, cinfo cmtypes.ClusterInfo, backend kvstore.BackendOperations, factory store.Factory, syncCallback func(context.Context)) synchronizer {
+func newEndpointSynchronizer(ctx context.Context, logger *slog.Logger, cinfo cmtypes.ClusterInfo, backend kvstore.BackendOperations, factory store.Factory, syncCallback func(context.Context), enableCiliumEndpointSlice bool) synchronizer {
 	endpointsStore := factory.NewSyncStore(cinfo.Name, backend,
 		path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
 		store.WSSWithSyncedKeyOverride(ipcache.IPIdentitiesPath))
 	go endpointsStore.Run(ctx)
 
 	return &endpointSynchronizer{
-		store:        endpointsStore,
-		cache:        make(map[string]ipmap),
-		syncCallback: syncCallback,
-		logger:       logger,
+		store:                     endpointsStore,
+		cache:                     make(map[string]ipmap),
+		syncCallback:              syncCallback,
+		logger:                    logger,
+		enableCiliumEndpointSlice: enableCiliumEndpointSlice,
 	}
 }
 
 func (es *endpointSynchronizer) upsert(ctx context.Context, key resource.Key, obj runtime.Object) error {
-	endpoint := obj.(*types.CiliumEndpoint)
+	var epIter iter.Seq2[string, identity.IPIdentityPair]
+	if es.enableCiliumEndpointSlice {
+		epIter = es.cesIterator(obj)
+	} else {
+		epIter = es.cepIterator(obj)
+	}
+	es.upsertEndpoints(ctx, key, epIter)
+
+	return nil
+}
+
+func (es *endpointSynchronizer) upsertEndpoints(ctx context.Context, key resource.Key, pairs iter.Seq2[string, identity.IPIdentityPair]) error {
 	ips := make(ipmap)
 	stale := es.cache[key.String()]
 
 	log := es.logger.With(logfields.Endpoint, key)
 
-	if n := endpoint.Networking; n != nil {
-		for _, address := range n.Addressing {
-			for _, ip := range []string{address.IPV4, address.IPV6} {
-				if ip == "" {
-					continue
-				}
-
-				entry := identity.IPIdentityPair{
-					IP:           net.ParseIP(ip),
-					HostIP:       net.ParseIP(n.NodeIP),
-					K8sNamespace: endpoint.Namespace,
-					K8sPodName:   endpoint.Name,
-				}
-
-				if endpoint.Identity != nil {
-					entry.ID = identity.NumericIdentity(endpoint.Identity.ID)
-				}
-
-				if endpoint.Encryption != nil {
-					entry.Key = uint8(endpoint.Encryption.Key)
-				}
-
-				log.Info("Upserting endpoint in etcd", logfields.IPAddr, ip)
-				if err := es.store.UpsertKey(ctx, &entry); err != nil {
-					// The only errors surfaced by WorkqueueSyncStore are the unrecoverable ones.
-					log.Warn("Unable to upsert endpoint in etcd",
-						logfields.Error, err,
-						logfields.IPAddr, ip,
-					)
-					continue
-				}
-
-				ips[ip] = struct{}{}
-				delete(stale, ip)
-			}
+	for ip, entry := range pairs {
+		log.Info("Upserting endpoint in etcd", logfields.IPAddr, ip)
+		if err := es.store.UpsertKey(ctx, &entry); err != nil {
+			// The only errors surfaced by WorkqueueSyncStore are the unrecoverable ones.
+			log.Warn("Unable to upsert endpoint in etcd",
+				logfields.Error, err,
+				logfields.IPAddr, ip,
+			)
+			continue
 		}
+
+		ips[ip] = struct{}{}
+		delete(stale, ip)
 	}
 
 	// Delete the stale endpoint IPs from the KVStore.
@@ -308,6 +301,71 @@ func (es *endpointSynchronizer) upsert(ctx context.Context, key resource.Key, ob
 	es.cache[key.String()] = ips
 
 	return nil
+}
+
+func (es *endpointSynchronizer) cepIterator(obj runtime.Object) iter.Seq2[string, identity.IPIdentityPair] {
+	return func(yield func(string, identity.IPIdentityPair) bool) {
+		endpoint := obj.(*types.CiliumEndpoint)
+
+		if n := endpoint.Networking; n != nil {
+			for _, address := range n.Addressing {
+				for _, ip := range []string{address.IPV4, address.IPV6} {
+					if ip == "" {
+						continue
+					}
+					entry := identity.IPIdentityPair{
+						IP:           net.ParseIP(ip),
+						HostIP:       net.ParseIP(n.NodeIP),
+						K8sNamespace: endpoint.Namespace,
+						K8sPodName:   endpoint.Name,
+					}
+
+					if endpoint.Identity != nil {
+						entry.ID = identity.NumericIdentity(endpoint.Identity.ID)
+					}
+
+					if endpoint.Encryption != nil {
+						entry.Key = uint8(endpoint.Encryption.Key)
+					}
+
+					if !yield(ip, entry) {
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+func (es *endpointSynchronizer) cesIterator(obj runtime.Object) iter.Seq2[string, identity.IPIdentityPair] {
+	return func(yield func(string, identity.IPIdentityPair) bool) {
+		endpointslice := obj.(*ciliumv2a1.CiliumEndpointSlice)
+
+		for _, endpoint := range endpointslice.Endpoints {
+			if n := endpoint.Networking; n != nil {
+				for _, address := range n.Addressing {
+					for _, ip := range []string{address.IPV4, address.IPV6} {
+						if ip == "" {
+							continue
+						}
+
+						entry := identity.IPIdentityPair{
+							IP:           net.ParseIP(ip),
+							HostIP:       net.ParseIP(n.NodeIP),
+							K8sNamespace: endpointslice.Namespace,
+							K8sPodName:   endpoint.Name,
+							ID:           identity.NumericIdentity(endpoint.IdentityID),
+							Key:          uint8(endpoint.Encryption.Key),
+						}
+
+						if !yield(ip, entry) {
+							return
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 func (es *endpointSynchronizer) delete(ctx context.Context, key resource.Key) error {
@@ -365,6 +423,7 @@ func startServer(
 	syncState syncstate.SyncState,
 	clusterMeshEnableMCSAPI bool,
 	logger *slog.Logger,
+	enableCiliumEndpointSlice bool,
 ) {
 	logger.Info(
 		"Starting clustermesh-apiserver...",
@@ -389,7 +448,15 @@ func startServer(
 	ctx := context.Background()
 	go synchronize(ctx, resources.CiliumIdentities, newIdentitySynchronizer(ctx, logger, cinfo, backend, factory, syncState.WaitForResource()))
 	go synchronize(ctx, resources.CiliumNodes, newNodeSynchronizer(ctx, logger, cinfo, backend, factory, syncState.WaitForResource()))
-	go synchronize(ctx, resources.CiliumSlimEndpoints, newEndpointSynchronizer(ctx, logger, cinfo, backend, factory, syncState.WaitForResource()))
+
+	if enableCiliumEndpointSlice {
+		logger.Info("Synchronizing endpoints using CiliumEndpointSlices")
+		go synchronize(ctx, resources.CiliumEndpointSlices, newEndpointSynchronizer(ctx, logger, cinfo, backend, factory, syncState.WaitForResource(), enableCiliumEndpointSlice))
+	} else {
+		logger.Info("Synchronizing endpoints using CiliumEndpoints")
+		go synchronize(ctx, resources.CiliumSlimEndpoints, newEndpointSynchronizer(ctx, logger, cinfo, backend, factory, syncState.WaitForResource(), enableCiliumEndpointSlice))
+	}
+
 	operatorWatchers.StartSynchronizingServices(ctx, &sync.WaitGroup{}, operatorWatchers.ServiceSyncParameters{
 		ClusterInfo:  cinfo,
 		Clientset:    clientset,

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -19,6 +19,7 @@ rules:
   - ciliumidentities
   - ciliumendpoints
   - ciliumnodes
+  - ciliumendpointslices
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -211,6 +211,9 @@ spec:
         {{- if .Values.clustermesh.enableMCSAPISupport }}
         - --clustermesh-enable-mcs-api
         {{- end }}
+        {{- if .Values.ciliumEndpointSlice.enabled }}
+        - --enable-cilium-endpoint-slice
+        {{- end }}
         {{- with .Values.clustermesh.apiserver.extraArgs }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
So far, the clustermesh apiserver has only updated endpoint information after reading CiliumEndpoints. This PR aims to make the clustermesh apiserver explicitly compatible with CiliumEndpointSlices and not dependent on the existence of CiliumEndpoints.

This is a predecessor to #38388 and its follow-ups.

```release-note
Enable clustermesh apiserver to parse CiliumEndpointSlices
```