### PR TITLE
[v1.17] lbmap: fix endianness of port in NewSkipLB6Key()

### DIFF
--- a/pkg/maps/lbmap/skip_lb_map.go
+++ b/pkg/maps/lbmap/skip_lb_map.go
@@ -297,7 +297,7 @@ type SkipLB6Value struct {
 func NewSkipLB6Key(netnsCookie uint64, address net.IP, port uint16) *SkipLB6Key {
 	key := SkipLB6Key{
 		NetnsCookie: netnsCookie,
-		Port:        port,
+		Port:        byteorder.HostToNetwork16(port),
 	}
 	copy(key.Address[:], address.To16())
 


### PR DESCRIPTION
The datapath expects this field to be in network byte-order. This matches the IPv4 version of the code.

This fix was extracted from a larger upstream change: 02c6c1075164 ("redirectpolicy,skiplbmap: Add OpenOrCreate, AllLB*, DeleteLB*")

Fixes: 33552812c3f0 ("pkg/maps: Add new maps to skip service load-balancing")
Reported-by: Yusuke Suzuki <yusuke.suzuki@isovalent.com>

```release-note
Fix IPv6 for LocalRedirectPolicy with `skipRedirectFromBackend` option.
```
