### PR TITLE
gh: e2e-upgrade: also test NS & EGW disruptivity during downgrade

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -804,7 +804,10 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test \
+            --include-unsafe-tests \
             --include-conn-disrupt-test \
+            --include-conn-disrupt-test-ns-traffic \
+            --include-conn-disrupt-test-egw \
             --conn-disrupt-test-setup \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
@@ -846,7 +849,10 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            --include-unsafe-tests \
             --include-conn-disrupt-test \
+            --include-conn-disrupt-test-ns-traffic \
+            --include-conn-disrupt-test-egw \
             --test "no-interrupted-connections" \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts"
 


### PR DESCRIPTION
The e2e-upgrade workflow
1. first upgrades from a stable base (tip of the n-1 branch) to the PR branch,
2. and later downgrades back to the stable base

820a62d24233 ("ci: enable conn-disrupt-test for NS traffic") and 29e5974f168e ("ci: enable conn-disrupt-test for Egress Gateway") added disruptivity testing during the upgrade. Add the same testing for the downgrade step.