### PR TITLE
[v1.17] check-encryption-leak:fix:backport

### DIFF
--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -269,6 +269,23 @@ kprobe:udpv6_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
   }
 }
 
+// Clear traced UDP connections.
+kprobe:udp_destroy_sock
+{
+  $sk = ((struct sock *) arg0);
+  $inet_family = $sk->__sk_common.skc_family;
+
+  if ($inet_family == AF_INET) {
+    delete(@trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_UDP]);
+  }
+
+  if ($inet_family == AF_INET6) {
+    delete(@trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_UDP]);
+  }
+
+  delete(@trace_sk[$sk]);
+}
+
 // Additionally trace traffic flows in which the source got masquerated.
 kprobe:__dev_queue_xmit
 {

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -207,7 +207,11 @@ kprobe:br_forward
 }
 
 // Trace TCP connections established by the L7 proxy, even if the source address belongs to the host.
-// Ignore connections with the destination address outside pod CIDRs.
+// Ignore connections:
+// - with the destination address outside PodCIDR;
+// - with CiliumInternalIPs (IPSec only).
+// In CI we don't test the `--use-cilium-internal-ip-for-ipsec` flag: in that case, we'd need to
+// rework this CiliumInternalIP condition.
 kprobe:tcp_connect
 {
   if (strncmp(comm, "wrk:", 4) != 0) {
@@ -219,27 +223,43 @@ kprobe:tcp_connect
   $dst_is_pod = false;
 
   if ($inet_family == AF_INET) {
+    $src_is_pod = (bswap($sk->__sk_common.skc_rcv_saddr) & MASK4) == CIDR4;
     $dst_is_pod = (bswap($sk->__sk_common.skc_daddr) & MASK4) == CIDR4;
+
+    $src_is_internal =
+        $sk->__sk_common.skc_rcv_saddr == (uint32)pton(str($1)) ||
+        $sk->__sk_common.skc_rcv_saddr == (uint32)pton(str($3)) ||
+        $sk->__sk_common.skc_rcv_saddr == (uint32)pton(str($5));
+    $dst_is_internal =
+        $sk->__sk_common.skc_daddr == (uint32)pton(str($1)) ||
+        $sk->__sk_common.skc_daddr == (uint32)pton(str($3)) ||
+        $sk->__sk_common.skc_daddr == (uint32)pton(str($5));
+
+    if ($dst_is_pod && !(str($8) == "ipsec" && ($src_is_internal || $dst_is_internal))) {
+      @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_TCP] = true;
+      @trace_sk[$sk] = true;
+      @sanity[TYPE_PROXY_L7_IP4] = true;
+    }
   }
 
   if ($inet_family == AF_INET6) {
+    $src_is_pod = bswap($sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr16[0]) == CIDR6;
     $dst_is_pod = bswap($sk->__sk_common.skc_v6_daddr.in6_u.u6_addr16[0]) == CIDR6;
-  }
 
-  if (!$dst_is_pod) {
-    return
-  }
+    $src_is_internal =
+        $sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 == pton(str($2)) ||
+        $sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 == pton(str($4)) ||
+        $sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 == pton(str($6));
+    $dst_is_internal =
+        $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8 == pton(str($2)) ||
+        $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8 == pton(str($4)) ||
+        $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8 == pton(str($6));
 
-  if ($inet_family == AF_INET) {
-    @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_TCP] = true;
-    @trace_sk[$sk] = true;
-    @sanity[TYPE_PROXY_L7_IP4] = true;
-  }
-
-  if ($inet_family == AF_INET6) {
-    @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_TCP] = true;
-    @trace_sk[$sk] = true;
-    @sanity[TYPE_PROXY_L7_IP6] = true;
+    if ($dst_is_pod && !(str($8) == "ipsec" && ($src_is_internal || $dst_is_internal))) {
+      @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_TCP] = true;
+      @trace_sk[$sk] = true;
+      @sanity[TYPE_PROXY_L7_IP6] = true;
+    }
   }
 }
 

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -54,6 +54,7 @@ kprobe:br_forward
   $ip4h = ((struct iphdr *) ($skb->head + $skb->network_header));
   $ip6h = ((struct ipv6hdr *) ($skb->head + $skb->network_header));
   $udph = ((struct udphdr*) ($skb->head + $skb->transport_header));
+  $tcph = ((struct tcphdr*) ($skb->head + $skb->transport_header));
 
   if ($skb->encapsulation) {
     // $skb->inner_protocol does not appear to be correctly initialized
@@ -61,6 +62,7 @@ kprobe:br_forward
     $ip4h = ((struct iphdr*) ($skb->head + $skb->inner_network_header));
     $ip6h = ((struct ipv6hdr*) ($skb->head + $skb->inner_network_header));
     $udph = ((struct udphdr*) ($skb->head + $skb->inner_transport_header));
+    $tcph = ((struct tcphdr*) ($skb->head + $skb->inner_transport_header));
 
     if ($proto == PROTO_IPV4) {
       $pod_to_pod_via_proxy =
@@ -114,9 +116,7 @@ kprobe:br_forward
             @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol]);
 
       if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
-        $tcph = (struct tcphdr*)$udph;
-
-        if (!$tcph->rst) {
+        if ($ip4h->protocol != PROTO_TCP || !$tcph->rst) {
           printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),
             ntop($ip4h->saddr),
@@ -164,9 +164,7 @@ kprobe:br_forward
             @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr]);
 
       if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
-        $tcph = (struct tcphdr*)$udph;
-
-        if (!$tcph->rst) {
+        if ($ip6h->nexthdr != PROTO_TCP || !$tcph->rst) {
           printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),
             ntop($ip6h->saddr.in6_u.u6_addr8),

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -287,25 +287,45 @@ kprobe:tcp_close
   }
 }
 
-// Trace UDP messages sent by the DNS proxy, even if the source address belongs to the host.
+// Trace UDP messages sent by the DNS proxy.
+// Ignore messages with the source address equal to a CiliumInternalIP (IPSec only).
+// In CI we don't test the `--use-cilium-internal-ip-for-ipsec` flag: in that case,
+// we'd need to rework this CiliumInternalIP condition.
 kprobe:udp_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
 {
   $sk = ((struct sock *) arg0);
   if (bswap($sk->__sk_common.skc_dport) == PORT_DNS) {
-    @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_UDP] = true;
-    @trace_sk[$sk] = true;
-    @sanity[TYPE_PROXY_DNS_IP4] = true;
+    $src_is_internal =
+        $sk->__sk_common.skc_rcv_saddr == (uint32)pton(str($1)) ||
+        $sk->__sk_common.skc_rcv_saddr == (uint32)pton(str($3)) ||
+        $sk->__sk_common.skc_rcv_saddr == (uint32)pton(str($5));
+
+    if (!(str($8) == "ipsec" && $src_is_internal)) {
+      @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_UDP] = true;
+      @trace_sk[$sk] = true;
+      @sanity[TYPE_PROXY_DNS_IP4] = true;
+    }
   }
 }
 
-// Trace UDP6 messages sent by the DNS proxy, even if the source address belongs to the host.
+// Trace UDP6 messages sent by the DNS proxy.
+// Ignore messages with the source address equal to a CiliumInternalIP (IPSec only).
+// In CI we don't test the `--use-cilium-internal-ip-for-ipsec` flag: in that case,
+// we'd need to rework this CiliumInternalIP condition.
 kprobe:udpv6_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
 {
   $sk = ((struct sock *) arg0);
   if (bswap($sk->__sk_common.skc_dport) == PORT_DNS) {
-    @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_UDP] = true;
-    @trace_sk[$sk] = true;
-    @sanity[TYPE_PROXY_DNS_IP6] = true;
+    $src_is_internal =
+        $sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 == pton(str($2)) ||
+        $sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 == pton(str($4)) ||
+        $sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 == pton(str($6));
+
+    if (!(str($8) == "ipsec" && $src_is_internal)) {
+      @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_UDP] = true;
+      @trace_sk[$sk] = true;
+      @sanity[TYPE_PROXY_DNS_IP6] = true;
+    }
   }
 }
 

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -21,6 +21,8 @@
 #define AF_INET	2
 #define AF_INET6 10
 
+#define PORT_VXLAN 8472
+#define PORT_GENEVE 6081
 #define PORT_DNS 53
 #define PORT_WIREGUARD 51871
 
@@ -56,7 +58,15 @@ kprobe:br_forward
   $udph = ((struct udphdr*) ($skb->head + $skb->transport_header));
   $tcph = ((struct tcphdr*) ($skb->head + $skb->transport_header));
 
-  if ($skb->encapsulation) {
+  // $skb->encapsulation might be unset when encap headers are manually pushed,
+  // despite $skb->inner references being correct.
+  $encap =
+      (($proto == PROTO_IPV4 && $ip4h->protocol == PROTO_UDP) ||
+        ($proto == PROTO_IPV6 && $ip6h->nexthdr == PROTO_UDP)) &&
+      ((bswap($udph->source) == PORT_VXLAN || bswap($udph->dest) == PORT_VXLAN) ||
+        (bswap($udph->source) == PORT_GENEVE || bswap($udph->dest) == PORT_GENEVE));
+
+  if ($skb->encapsulation || $encap) {
     // $skb->inner_protocol does not appear to be correctly initialized
     $proto = bswap(*((uint16*) ($skb->head + $skb->inner_mac_header + 12)));
     $ip4h = ((struct iphdr*) ($skb->head + $skb->inner_network_header));
@@ -117,7 +127,7 @@ kprobe:br_forward
 
       if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
         if ($ip4h->protocol != PROTO_TCP || !$tcph->rst) {
-          printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
+          printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),
             ntop($ip4h->saddr),
             ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -128,7 +138,7 @@ kprobe:br_forward
             $ip4h->protocol == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
             $ip4h->protocol == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
             $ip4h->protocol == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
-            $skb->encapsulation,
+            $encap, $skb->encapsulation,
             $skb->dev->ifindex,
             $skb->dev->nd_net.net->ns.inum,
             $pod_to_pod_via_proxy);
@@ -165,7 +175,7 @@ kprobe:br_forward
 
       if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
         if ($ip6h->nexthdr != PROTO_TCP || !$tcph->rst) {
-          printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
+          printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),
             ntop($ip6h->saddr.in6_u.u6_addr8),
             ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -176,7 +186,7 @@ kprobe:br_forward
             $ip6h->nexthdr == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
             $ip6h->nexthdr == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
             $ip6h->nexthdr == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
-            $skb->encapsulation,
+            $encap, $skb->encapsulation,
             $skb->dev->ifindex,
             $skb->dev->nd_net.net->ns.inum,
             $pod_to_pod_via_proxy);

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -48,6 +48,24 @@ struct dnshdr {
   u16 arcount;
 }
 
+// Monitor and log plain text pod-to-pod packets passing through the bridge if:
+// 1. packet traced by proxy and at least one IP is in PodCIDR, or
+// 2. both IPs are in PodCIDR and not CiliumInternalIPs.
+// In addition, skip TCP RST packets, as they might be kernel-level packet due
+// to proxy timeout sockets (https://github.com/cilium/cilium/issues/35485).
+//
+// Shift header references to inner packet in case of encapsulation:
+// - EinV (< v1.18):  outer packet is plaintext overlay, checks must be against inner packet.
+// - VinE (>=v1.18):  outer packet is encrypted (encap bit not set).
+//                    in case of plaintext encap'd packet, shift headers and check:
+//                    * if ESP, then might be a legit EinV upgrade/downgrade scenario
+//                    * otherwise, report leakage if not pod-to-pod.
+// - WG pod-to-pod:   outer packet is encrypted (encap bit not set), similarly as VinE.
+// - WG node-to-node: currently unsupported, only pod-to-pod leak detection checks.
+//
+// Note: br_forward is not exclusive of Kind. We run this script in CI where we
+// expect only br-kind-cilium (and br-kind-cilium-secondary). To run this script
+// on a local setup, ensure that no other bridges interfere.
 kprobe:br_forward
 {
   $skb = ((struct sk_buff *) arg1);
@@ -73,40 +91,6 @@ kprobe:br_forward
     $ip6h = ((struct ipv6hdr*) ($skb->head + $skb->inner_network_header));
     $udph = ((struct udphdr*) ($skb->head + $skb->inner_transport_header));
     $tcph = ((struct tcphdr*) ($skb->head + $skb->inner_transport_header));
-
-    if ($proto == PROTO_IPV4) {
-      $pod_to_pod_via_proxy =
-        !($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ?
-          @trace_ip4[$ip4h->saddr, 0, 0] :
-          (@trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
-            @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol]);
-
-      // Skip CiliumInternalIP addresses, as they belong to the PodCIDR,
-      // unless the given flow is explicitly marked as traced (i.e., from proxy).
-      if (!$pod_to_pod_via_proxy &&
-           ($ip4h->saddr == (uint32)pton(str($1)) || $ip4h->daddr == (uint32)pton(str($1)) ||
-            $ip4h->saddr == (uint32)pton(str($3)) || $ip4h->daddr == (uint32)pton(str($3)) ||
-            $ip4h->saddr == (uint32)pton(str($5)) || $ip4h->daddr == (uint32)pton(str($5)))) {
-        return;
-      }
-    }
-
-    if ($proto == PROTO_IPV6) {
-      $pod_to_pod_via_proxy =
-          !($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ?
-          @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, 0, 0] :
-          (@trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
-            @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr]);
-
-      // Skip CiliumInternalIP addresses, as they belong to the PodCIDR
-      // unless the given flow is explicitly marked as traced (i.e., from proxy).
-      if (!$pod_to_pod_via_proxy &&
-           ($ip6h->saddr.in6_u.u6_addr8 == pton(str($2)) || $ip6h->daddr.in6_u.u6_addr8 == pton(str($2)) ||
-            $ip6h->saddr.in6_u.u6_addr8 == pton(str($4)) || $ip6h->daddr.in6_u.u6_addr8 == pton(str($4)) ||
-            $ip6h->saddr.in6_u.u6_addr8 == pton(str($6)) || $ip6h->daddr.in6_u.u6_addr8 == pton(str($6)))) {
-        return;
-      }
-    }
   }
 
   if ($proto == PROTO_IPV4) {
@@ -119,13 +103,26 @@ kprobe:br_forward
       $src_is_pod = (bswap($ip4h->saddr) & MASK4) == CIDR4;
       $dst_is_pod = (bswap($ip4h->daddr) & MASK4) == CIDR4;
 
+      $src_is_internal =
+        $ip4h->saddr == (uint32)pton(str($1)) ||
+        $ip4h->saddr == (uint32)pton(str($3)) ||
+        $ip4h->saddr == (uint32)pton(str($5));
+
+      $dst_is_internal =
+        $ip4h->daddr == (uint32)pton(str($1)) ||
+        $ip4h->daddr == (uint32)pton(str($3)) ||
+        $ip4h->daddr == (uint32)pton(str($5));
+
       $pod_to_pod_via_proxy =
           !($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ?
           @trace_ip4[$ip4h->saddr, 0, 0] :
           (@trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
             @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol]);
 
-      if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
+      if (
+          (!$pod_to_pod_via_proxy && ($src_is_pod && $dst_is_pod) && (!$src_is_internal && !$dst_is_internal)) ||
+          ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))
+        ) {
         if ($ip4h->protocol != PROTO_TCP || !$tcph->rst) {
           printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),
@@ -167,13 +164,26 @@ kprobe:br_forward
       $src_is_pod = bswap($ip6h->saddr.in6_u.u6_addr16[0]) == CIDR6;
       $dst_is_pod = bswap($ip6h->daddr.in6_u.u6_addr16[0]) == CIDR6;
 
+      $src_is_internal =
+        $ip6h->saddr.in6_u.u6_addr8 == pton(str($2)) ||
+        $ip6h->saddr.in6_u.u6_addr8 == pton(str($4)) ||
+        $ip6h->saddr.in6_u.u6_addr8 == pton(str($6));
+
+      $dst_is_internal =
+        $ip6h->daddr.in6_u.u6_addr8 == pton(str($2)) ||
+        $ip6h->daddr.in6_u.u6_addr8 == pton(str($4)) ||
+        $ip6h->daddr.in6_u.u6_addr8 == pton(str($6));
+
       $pod_to_pod_via_proxy =
           !($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ?
           @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, 0, 0] :
           (@trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
             @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr]);
 
-      if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
+      if (
+          (!$pod_to_pod_via_proxy && ($src_is_pod && $dst_is_pod) && (!$src_is_internal && !$dst_is_internal)) ||
+          ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))
+        ) {
         if ($ip6h->nexthdr != PROTO_TCP || !$tcph->rst) {
           printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -100,7 +100,9 @@ kprobe:br_forward
   if ($proto == PROTO_IPV4) {
     if (
       (str($8) == "ipsec" && $ip4h->protocol != PROTO_ESP) ||
-      (str($8) == "wireguard" && !($ip4h->protocol == PROTO_UDP && ($udph->dest == PORT_WIREGUARD || $udph->source == PORT_WIREGUARD)))
+      (str($8) == "wireguard" && !($ip4h->protocol == PROTO_UDP &&
+                                      (bswap($udph->dest) == PORT_WIREGUARD ||
+                                        bswap($udph->source) == PORT_WIREGUARD)))
       ) {
       $src_is_pod = (bswap($ip4h->saddr) & MASK4) == CIDR4;
       $dst_is_pod = (bswap($ip4h->daddr) & MASK4) == CIDR4;
@@ -148,7 +150,9 @@ kprobe:br_forward
   if ($proto == PROTO_IPV6) {
     if (
       (str($8) == "ipsec" && $ip6h->nexthdr != PROTO_ESP) ||
-      (str($8) == "wireguard" && !($ip6h->nexthdr == PROTO_UDP && ($udph->dest == PORT_WIREGUARD || $udph->source == PORT_WIREGUARD)))
+      (str($8) == "wireguard" && !($ip6h->nexthdr == PROTO_UDP &&
+                                      (bswap($udph->dest) == PORT_WIREGUARD ||
+                                        bswap($udph->source) == PORT_WIREGUARD)))
       ) {
       $src_is_pod = bswap($ip6h->saddr.in6_u.u6_addr16[0]) == CIDR6;
       $dst_is_pod = bswap($ip6h->daddr.in6_u.u6_addr16[0]) == CIDR6;

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -248,7 +248,7 @@ kprobe:udp_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
 kprobe:udpv6_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
 {
   $sk = ((struct sock *) arg0);
-  if ($sk->__sk_common.skc_num == PORT_DNS) {
+  if (bswap($sk->__sk_common.skc_dport) == PORT_DNS) {
     @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_UDP] = true;
     @trace_sk[$sk] = true;
     @sanity[TYPE_PROXY_DNS_IP6] = true;

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -64,8 +64,10 @@ kprobe:br_forward
 
     if ($proto == PROTO_IPV4) {
       $pod_to_pod_via_proxy =
-        @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
-        @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
+        !($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ?
+          @trace_ip4[$ip4h->saddr, 0, 0] :
+          (@trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
+            @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol]);
 
       // Skip CiliumInternalIP addresses, as they belong to the PodCIDR,
       // unless the given flow is explicitly marked as traced (i.e., from proxy).
@@ -79,8 +81,10 @@ kprobe:br_forward
 
     if ($proto == PROTO_IPV6) {
       $pod_to_pod_via_proxy =
-        @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
-        @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
+          !($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ?
+          @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, 0, 0] :
+          (@trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
+            @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr]);
 
       // Skip CiliumInternalIP addresses, as they belong to the PodCIDR
       // unless the given flow is explicitly marked as traced (i.e., from proxy).
@@ -102,8 +106,10 @@ kprobe:br_forward
       $dst_is_pod = (bswap($ip4h->daddr) & MASK4) == CIDR4;
 
       $pod_to_pod_via_proxy =
-          @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
-          @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
+          !($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ?
+          @trace_ip4[$ip4h->saddr, 0, 0] :
+          (@trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
+            @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol]);
 
       if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
         $tcph = (struct tcphdr*)$udph;
@@ -111,8 +117,10 @@ kprobe:br_forward
         if (!$tcph->rst) {
           printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),
-            ntop($ip4h->saddr), bswap($udph->source),
-            ntop($ip4h->daddr), bswap($udph->dest),
+            ntop($ip4h->saddr),
+            ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
+            ntop($ip4h->daddr),
+            ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->dest) : 0,
             $ip4h->protocol,
             $ip4h->protocol == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
             $ip4h->protocol == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
@@ -146,8 +154,10 @@ kprobe:br_forward
       $dst_is_pod = bswap($ip6h->daddr.in6_u.u6_addr16[0]) == CIDR6;
 
       $pod_to_pod_via_proxy =
-          @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
-          @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
+          !($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ?
+          @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, 0, 0] :
+          (@trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
+            @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr]);
 
       if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
         $tcph = (struct tcphdr*)$udph;
@@ -155,8 +165,10 @@ kprobe:br_forward
         if (!$tcph->rst) {
           printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
             strftime("%H:%M:%S:%f", nsecs),
-            ntop($ip6h->saddr.in6_u.u6_addr8), bswap($udph->source),
-            ntop($ip6h->daddr.in6_u.u6_addr8), bswap($udph->dest),
+            ntop($ip6h->saddr.in6_u.u6_addr8),
+            ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
+            ntop($ip6h->daddr.in6_u.u6_addr8),
+            ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->dest) : 0,
             $ip6h->nexthdr,
             $ip6h->nexthdr == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
             $ip6h->nexthdr == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,


### PR DESCRIPTION
Manual backport of:
* [ ] https://github.com/cilium/cilium/pull/38264
* [ ] https://github.com/cilium/cilium/pull/38265
* [ ] https://github.com/cilium/cilium/pull/38287
* [ ] https://github.com/cilium/cilium/pull/38289
* [ ] https://github.com/cilium/cilium/pull/38290
* [ ] https://github.com/cilium/cilium/pull/38291
* [ ] https://github.com/cilium/cilium/pull/38292
* [ ] https://github.com/cilium/cilium/pull/38293
* [ ] https://github.com/cilium/cilium/pull/38280

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 38264 38265 38287 38289 38290 38291 38292 38293 38280
```