### PR TITLE
Introduce `--underlay-protocol`

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -389,6 +389,7 @@ cilium-agent [flags]
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")
+      --underlay-protocol string                                  IP family for the underlay ("ipv4" or "ipv6") (default "ipv4")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
       --version                                                   Print version information
       --vlan-bpf-bypass strings                                   List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -182,6 +182,7 @@ cilium-agent hive [flags]
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")
+      --underlay-protocol string                                  IP family for the underlay ("ipv4" or "ipv6") (default "ipv4")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
 ```

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -187,6 +187,7 @@ cilium-agent hive dot-graph [flags]
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")
+      --underlay-protocol string                                  IP family for the underlay ("ipv4" or "ipv6") (default "ipv4")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
 ```

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3464,6 +3464,10 @@
      - Configure VXLAN and Geneve tunnel source port range hint.
      - string
      - 0-0 to let the kernel driver decide the range
+   * - :spelling:ignore:`underlayProtocol`
+     - IP family for the underlay.
+     - string
+     - ``"ipv4"``
    * - :spelling:ignore:`updateStrategy`
      - Cilium agent update strategy
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -356,8 +356,9 @@ Helm Options
 Agent Options
 ~~~~~~~~~~~~~
 
-``k8s-api-server-urls``: This option specifies a list of URLs for Kubernetes API server instances to support high availability
-for the servers. The agent will fail over to an active instance in case of connectivity failures at runtime.
+* The new agent flag ``underlay-protocol`` allows selecting the IP family for the underlay. It defaults to IPv4.
+* ``k8s-api-server-urls``: This option specifies a list of URLs for Kubernetes API server instances to support high availability
+  for the servers. The agent will fail over to an active instance in case of connectivity failures at runtime.
 
 Bugtool Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -347,6 +347,7 @@ Helm Options
   ``k8sClientExponentialBackoff.backoffMaxDurationSeconds``. Users who were already setting these
   using ``extraEnv`` should either remove them from ``extraEnv`` or set ``k8sClientExponentialBackoff.enabled=false``.
 * The deprecated Helm option ``hubble.relay.dialTimeout`` has been removed.
+* The new Helm option ``underlayProtocol`` allows selecting the IP family for the underlay. It defaults to IPv4.
 * ``k8s.apiServerURLs`` has been introduced to specify multiple Kubernetes API servers so that the agent can fail over
   to an active instance.
 * ``eni.updateEC2AdapterLimitViaAPI`` is removed since the operator will only and always use the EC2API to update the EC2 instance limit.

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -295,6 +295,12 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		}
 	}
 
+	if option.Config.TunnelingEnabled() && params.TunnelConfig.UnderlayProtocol() == tunnel.IPv6 {
+		if option.Config.EnableIPSec || option.Config.EnableWireguard {
+			return nil, nil, fmt.Errorf("Transparent encryption (both IPsec and WireGuard) requires an IPv4 underlay")
+		}
+	}
+
 	// Check the kernel if we can make use of managed neighbor entries which
 	// simplifies and fully 'offloads' L2 resolution handling to the kernel.
 	if !option.Config.DryMode {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -290,7 +290,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		if !option.Config.TunnelingEnabled() {
 			return nil, nil, fmt.Errorf("EncryptedOverlay support requires VXLAN tunneling mode")
 		}
-		if params.TunnelConfig.Protocol() != tunnel.VXLAN {
+		if params.TunnelConfig.EncapProtocol() != tunnel.VXLAN {
 			return nil, nil, fmt.Errorf("EncryptedOverlay support requires VXLAN tunneling protocol")
 		}
 	}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -149,6 +149,10 @@ func initKubeProxyReplacementOptions(sysctl sysctl.Sysctl, tunnelConfig tunnel.C
 			log.Warning("NodePort BPF configured without bind(2) protection against service ports")
 		}
 
+		if option.Config.TunnelingEnabled() && tunnelConfig.UnderlayProtocol() == tunnel.IPv6 {
+			return fmt.Errorf("BPF NodePort cannot be used over an IPv6 underlay")
+		}
+
 		if option.Config.TunnelingEnabled() && tunnelConfig.EncapProtocol() == tunnel.VXLAN &&
 			option.Config.LoadBalancerUsesDSR() {
 			return fmt.Errorf("Node Port %q mode cannot be used with %s tunneling.", option.Config.NodePortMode, tunnel.VXLAN)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -149,7 +149,7 @@ func initKubeProxyReplacementOptions(sysctl sysctl.Sysctl, tunnelConfig tunnel.C
 			log.Warning("NodePort BPF configured without bind(2) protection against service ports")
 		}
 
-		if option.Config.TunnelingEnabled() && tunnelConfig.Protocol() == tunnel.VXLAN &&
+		if option.Config.TunnelingEnabled() && tunnelConfig.EncapProtocol() == tunnel.VXLAN &&
 			option.Config.LoadBalancerUsesDSR() {
 			return fmt.Errorf("Node Port %q mode cannot be used with %s tunneling.", option.Config.NodePortMode, tunnel.VXLAN)
 		}
@@ -162,7 +162,7 @@ func initKubeProxyReplacementOptions(sysctl sysctl.Sysctl, tunnelConfig tunnel.C
 
 		if option.Config.LoadBalancerUsesDSR() &&
 			option.Config.LoadBalancerDSRDispatch == option.DSRDispatchGeneve &&
-			tunnelConfig.Protocol() != tunnel.Geneve {
+			tunnelConfig.EncapProtocol() != tunnel.Geneve {
 			return fmt.Errorf("Node Port %q mode with %s dispatch requires %s tunnel protocol.",
 				option.Config.NodePortMode, option.Config.LoadBalancerDSRDispatch, tunnel.Geneve)
 		}

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -39,7 +39,7 @@ type kprConfig struct {
 	expectedErrorRegex string
 
 	routingMode    string
-	tunnelProtocol tunnel.Protocol
+	tunnelProtocol tunnel.EncapProtocol
 	nodePortMode   string
 	dispatchMode   string
 }

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -199,7 +199,7 @@ func (d *Daemon) getRoutingStatus() *models.Routing {
 	s := &models.Routing{
 		IntraHostRoutingMode: models.RoutingIntraHostRoutingModeBPF,
 		InterHostRoutingMode: models.RoutingInterHostRoutingModeTunnel,
-		TunnelProtocol:       d.tunnelConfig.Protocol().String(),
+		TunnelProtocol:       d.tunnelConfig.EncapProtocol().String(),
 	}
 	if option.Config.EnableHostLegacyRouting {
 		s.IntraHostRoutingMode = models.RoutingIntraHostRoutingModeLegacy

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -415,7 +415,7 @@ func (h *getConfigHandler) getIPLocalReservedPorts() string {
 	// default, but is user configurable and thus should be included regardless.
 	// The Linux kernel documentation explicitly allows to reserve ports which
 	// are not part of the ephemeral port range, in which case this is a no-op.
-	if h.tunnelConfig.Protocol() != tunnel.Disabled {
+	if h.tunnelConfig.EncapProtocol() != tunnel.Disabled {
 		ports = append(ports, fmt.Sprintf("%d", h.tunnelConfig.Port()))
 	}
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -916,6 +916,7 @@ contributors across the globe, there is almost always someone available to help.
 | tunnelPort | int | Port 8472 for VXLAN, Port 6081 for Geneve | Configure VXLAN and Geneve tunnel port. |
 | tunnelProtocol | string | `"vxlan"` | Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve |
 | tunnelSourcePortRange | string | 0-0 to let the kernel driver decide the range | Configure VXLAN and Geneve tunnel source port range hint. |
+| underlayProtocol | string | `"ipv4"` | IP family for the underlay. |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | Cilium agent update strategy |
 | upgradeCompatibility | string | `nil` | upgradeCompatibility helps users upgrading to ensure that the configMap for Cilium will not change critical values to ensure continued operation This flag is not required for new installations. For example: '1.7', '1.8', '1.9' |
 | vtep.cidr | string | `""` | A space separated list of VTEP device CIDRs, for example "1.1.1.0/24 1.1.2.0/24" |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -541,6 +541,9 @@ data:
 {{- if .Values.tunnelSourcePortRange }}
   tunnel-source-port-range: {{ .Values.tunnelSourcePortRange | quote }}
 {{- end }}
+{{- if .Values.underlayProtocol }}
+  underlay-protocol: {{ .Values.underlayProtocol | quote }}
+{{- end }}
 
 {{- if .Values.serviceNoBackendResponse }}
   service-no-backend-response: "{{ .Values.serviceNoBackendResponse }}"

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5618,6 +5618,9 @@
     "tunnelSourcePortRange": {
       "type": "string"
     },
+    "underlayProtocol": {
+      "type": "string"
+    },
     "updateStrategy": {
       "properties": {
         "rollingUpdate": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2757,6 +2757,9 @@ tls:
 #   - geneve
 # @default -- `"vxlan"`
 tunnelProtocol: ""
+# -- IP family for the underlay.
+# @default -- `"ipv4"`
+underlayProtocol: ""
 # -- Enable native-routing mode or tunneling mode.
 # Possible values:
 #   - ""

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2779,6 +2779,9 @@ tls:
 #   - geneve
 # @default -- `"vxlan"`
 tunnelProtocol: ""
+# -- IP family for the underlay.
+# @default -- `"ipv4"`
+underlayProtocol: ""
 # -- Enable native-routing mode or tunneling mode.
 # Possible values:
 #   - ""

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -250,9 +250,9 @@ func (l *loader) reinitializeIPSec(lnc *datapath.LocalNodeConfiguration) error {
 }
 
 func reinitializeOverlay(ctx context.Context, lnc *datapath.LocalNodeConfiguration, tunnelConfig tunnel.Config) error {
-	// tunnelConfig.Protocol() can be one of tunnel.[Disabled, VXLAN, Geneve]
+	// tunnelConfig.EncapProtocol() can be one of tunnel.[Disabled, VXLAN, Geneve]
 	// if it is disabled, the overlay network programs don't have to be (re)initialized
-	if tunnelConfig.Protocol() == tunnel.Disabled {
+	if tunnelConfig.EncapProtocol() == tunnel.Disabled {
 		return nil
 	}
 
@@ -395,9 +395,9 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfig
 		}
 	}
 
-	if err := setupTunnelDevice(l.sysctl, tunnelConfig.Protocol(), tunnelConfig.Port(),
+	if err := setupTunnelDevice(l.sysctl, tunnelConfig.EncapProtocol(), tunnelConfig.Port(),
 		tunnelConfig.SrcPortLow(), tunnelConfig.SrcPortHigh(), lnc.DeviceMTU); err != nil {
-		return fmt.Errorf("failed to setup %s tunnel device: %w", tunnelConfig.Protocol(), err)
+		return fmt.Errorf("failed to setup %s tunnel device: %w", tunnelConfig.EncapProtocol(), err)
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMENI {

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -172,7 +172,7 @@ func addHostDeviceAddr(hostDev netlink.Link, ipv4, ipv6 net.IP) error {
 
 // setupTunnelDevice ensures the cilium_{mode} device is created and
 // unused leftover devices are cleaned up in case mode changes.
-func setupTunnelDevice(sysctl sysctl.Sysctl, mode tunnel.Protocol, port, srcPortLow, srcPortHigh uint16, mtu int) error {
+func setupTunnelDevice(sysctl sysctl.Sysctl, mode tunnel.EncapProtocol, port, srcPortLow, srcPortHigh uint16, mtu int) error {
 	switch mode {
 	case tunnel.Geneve:
 		if err := setupGeneveDevice(sysctl, port, srcPortLow, srcPortHigh, mtu); err != nil {

--- a/pkg/datapath/tunnel/tunnel.go
+++ b/pkg/datapath/tunnel/tunnel.go
@@ -15,23 +15,23 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 )
 
-// Protocol represents the valid types of encapsulation protocols.
-type Protocol string
+// EncapProtocol represents the valid types of encapsulation protocols.
+type EncapProtocol string
 
 const (
 	// VXLAN specifies VXLAN encapsulation
-	VXLAN Protocol = "vxlan"
+	VXLAN EncapProtocol = "vxlan"
 
 	// Geneve specifies Geneve encapsulation
-	Geneve Protocol = "geneve"
+	Geneve EncapProtocol = "geneve"
 
 	// Disabled specifies to disable encapsulation
-	Disabled Protocol = ""
+	Disabled EncapProtocol = ""
 )
 
-func (tp Protocol) String() string { return string(tp) }
+func (tp EncapProtocol) String() string { return string(tp) }
 
-func (tp Protocol) toDpID() string {
+func (tp EncapProtocol) toDpID() string {
 	switch tp {
 	case VXLAN:
 		return "1"
@@ -46,7 +46,7 @@ func (tp Protocol) toDpID() string {
 // depending on the user configuration and optional overrides required by
 // additional features.
 type Config struct {
-	protocol       Protocol
+	protocol       EncapProtocol
 	port           uint16
 	srcPortLow     uint16
 	srcPortHigh    uint16
@@ -73,14 +73,14 @@ var (
 )
 
 func newConfig(in newConfigIn) (Config, error) {
-	switch Protocol(in.Cfg.TunnelProtocol) {
+	switch EncapProtocol(in.Cfg.TunnelProtocol) {
 	case VXLAN, Geneve:
 	default:
 		return configDisabled, fmt.Errorf("invalid tunnel protocol %q", in.Cfg.TunnelProtocol)
 	}
 
 	cfg := Config{
-		protocol:       Protocol(in.Cfg.TunnelProtocol),
+		protocol:       EncapProtocol(in.Cfg.TunnelProtocol),
 		port:           in.Cfg.TunnelPort,
 		srcPortLow:     0,
 		srcPortHigh:    0,
@@ -127,7 +127,7 @@ func newConfig(in newConfigIn) (Config, error) {
 }
 
 // NewTestConfig returns a new TunnelConfig for testing purposes.
-func NewTestConfig(proto Protocol) Config {
+func NewTestConfig(proto EncapProtocol) Config {
 	//exhaustruct:ignore // Test code can underspecify the default config
 	cfg := Config{protocol: proto}
 
@@ -143,11 +143,11 @@ func NewTestConfig(proto Protocol) Config {
 	return cfg
 }
 
-// Protocol returns the enabled tunnel protocol. The tunnel protocol may be
+// EncapProtocol returns the enabled tunnel protocol. The tunnel protocol may be
 // set to either VXLAN or Geneve even when the primary mode is native routing, in
 // case an additional feature (e.g., egress gateway) may request some traffic to
 // be routed through a tunnel.
-func (cfg Config) Protocol() Protocol { return cfg.protocol }
+func (cfg Config) EncapProtocol() EncapProtocol { return cfg.protocol }
 
 // Port returns the port used by the tunnel (0 if disabled).
 func (cfg Config) Port() uint16 { return cfg.port }
@@ -169,10 +169,10 @@ func (cfg Config) datapathConfigProvider() (dpcfgdef.NodeOut, dpcfgdef.NodeFnOut
 	defines := make(dpcfgdef.Map)
 	definesFn := func() (dpcfgdef.Map, error) { return nil, nil }
 
-	if cfg.Protocol() != Disabled {
+	if cfg.EncapProtocol() != Disabled {
 		defines[fmt.Sprintf("TUNNEL_PROTOCOL_%s", strings.ToUpper(VXLAN.String()))] = VXLAN.toDpID()
 		defines[fmt.Sprintf("TUNNEL_PROTOCOL_%s", strings.ToUpper(Geneve.String()))] = Geneve.toDpID()
-		defines["TUNNEL_PROTOCOL"] = cfg.Protocol().toDpID()
+		defines["TUNNEL_PROTOCOL"] = cfg.EncapProtocol().toDpID()
 		defines["TUNNEL_PORT"] = fmt.Sprintf("%d", cfg.Port())
 		defines["TUNNEL_SRC_PORT_LOW"] = fmt.Sprintf("%d", cfg.SrcPortLow())
 		defines["TUNNEL_SRC_PORT_HIGH"] = fmt.Sprintf("%d", cfg.SrcPortHigh())
@@ -214,7 +214,7 @@ func NewEnabler(enable bool, opts ...enablerOpt) EnablerOut {
 // WithValidator allows to register extra validation functions
 // to assert that the configured tunnel protocol matches the one expected by
 // the given feature.
-func WithValidator(validator func(Protocol) error) enablerOpt {
+func WithValidator(validator func(EncapProtocol) error) enablerOpt {
 	return func(te *enabler) {
 		te.validators = append(te.validators, validator)
 	}
@@ -231,7 +231,7 @@ func WithoutMTUAdaptation() enablerOpt {
 type enabler struct {
 	enable             bool
 	needsMTUAdaptation bool
-	validators         []func(Protocol) error
+	validators         []func(EncapProtocol) error
 }
 
 type enablerOpt func(*enabler)

--- a/pkg/datapath/tunnel/tunnel_test.go
+++ b/pkg/datapath/tunnel/tunnel_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 )
 
-var defaultTestConfig = userCfg{TunnelProtocol: string(Geneve), TunnelPort: 0, TunnelSourcePortRange: defaults.TunnelSourcePortRange}
+var defaultTestConfig = userCfg{UnderlayProtocol: string(IPv4), TunnelProtocol: string(Geneve), TunnelPort: 0, TunnelSourcePortRange: defaults.TunnelSourcePortRange}
 
 func TestConfig(t *testing.T) {
 	enabler := func(enable bool, opts ...enablerOpt) any {
@@ -36,7 +36,7 @@ func TestConfig(t *testing.T) {
 	}{
 		{
 			name:      "invalid protocol",
-			ucfg:      userCfg{TunnelProtocol: "invalid", TunnelPort: 0, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
+			ucfg:      userCfg{UnderlayProtocol: string(IPv4), TunnelProtocol: "invalid", TunnelPort: 0, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
 			shallFail: true,
 		},
 		{
@@ -52,7 +52,7 @@ func TestConfig(t *testing.T) {
 		},
 		{
 			name:           "tunnel enabled, vxlan",
-			ucfg:           userCfg{TunnelProtocol: string(VXLAN), TunnelPort: 0, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
+			ucfg:           userCfg{UnderlayProtocol: string(IPv4), TunnelProtocol: string(VXLAN), TunnelPort: 0, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
 			enablers:       []any{enabler(true), enabler(false)},
 			proto:          VXLAN,
 			port:           defaults.TunnelPortVXLAN,
@@ -61,7 +61,7 @@ func TestConfig(t *testing.T) {
 		},
 		{
 			name:           "tunnel enabled, vxlan, custom port",
-			ucfg:           userCfg{TunnelProtocol: string(VXLAN), TunnelPort: 1234, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
+			ucfg:           userCfg{UnderlayProtocol: string(IPv4), TunnelProtocol: string(VXLAN), TunnelPort: 1234, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
 			enablers:       []any{enabler(false), enabler(true)},
 			proto:          VXLAN,
 			port:           1234,
@@ -79,7 +79,7 @@ func TestConfig(t *testing.T) {
 		},
 		{
 			name:           "tunnel enabled, geneve, custom port",
-			ucfg:           userCfg{TunnelProtocol: string(Geneve), TunnelPort: 1234, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
+			ucfg:           userCfg{UnderlayProtocol: string(IPv4), TunnelProtocol: string(Geneve), TunnelPort: 1234, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
 			enablers:       []any{enabler(true), enabler(false)},
 			proto:          Geneve,
 			port:           1234,
@@ -182,6 +182,7 @@ func TestConfigDatapathProvider(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out, _ := Config{
+				underlay:       "ipv4",
 				protocol:       tt.proto,
 				port:           1234,
 				srcPortLow:     1,

--- a/pkg/datapath/tunnel/tunnel_test.go
+++ b/pkg/datapath/tunnel/tunnel_test.go
@@ -29,7 +29,7 @@ func TestConfig(t *testing.T) {
 		enablers []any
 
 		shallFail      bool
-		proto          Protocol
+		proto          EncapProtocol
 		port           uint16
 		deviceName     string
 		shouldAdaptMTU bool
@@ -89,7 +89,7 @@ func TestConfig(t *testing.T) {
 		{
 			name: "tunnel enabled, validation function",
 			ucfg: defaultTestConfig,
-			enablers: []any{enabler(true, WithValidator(func(proto Protocol) error {
+			enablers: []any{enabler(true, WithValidator(func(proto EncapProtocol) error {
 				if proto == Geneve {
 					return errors.New("invalid protocol")
 				}
@@ -134,7 +134,7 @@ func TestConfig(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.proto, out.Protocol())
+			assert.Equal(t, tt.proto, out.EncapProtocol())
 			assert.Equal(t, tt.port, out.Port())
 			assert.Equal(t, tt.deviceName, out.DeviceName())
 			assert.Equal(t, tt.shouldAdaptMTU, out.ShouldAdaptMTU())
@@ -145,7 +145,7 @@ func TestConfig(t *testing.T) {
 func TestConfigDatapathProvider(t *testing.T) {
 	tests := []struct {
 		name     string
-		proto    Protocol
+		proto    EncapProtocol
 		expected dpcfgdef.Map
 	}{
 		{

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -507,6 +507,9 @@ const (
 	// zero means that we rely on the kernel driver defaults.
 	TunnelSourcePortRange = "0-0"
 
+	// UnderlayProtocol is the default IP family for the underlay.
+	UnderlayProtocol = "ipv4"
+
 	// ServiceNoBackendResponse is the default response for services without backends
 	ServiceNoBackendResponse = "reject"
 

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -90,8 +90,8 @@ type featuresParams struct {
 	DynamicConfigSource dynamicconfig.ConfigSource
 }
 
-func (fp *featuresParams) TunnelProtocol() tunnel.Protocol {
-	return fp.TunnelConfig.Protocol()
+func (fp *featuresParams) TunnelProtocol() tunnel.EncapProtocol {
+	return fp.TunnelConfig.EncapProtocol()
 }
 
 func (fp *featuresParams) GetChainingMode() string {
@@ -119,7 +119,7 @@ func (fp *featuresParams) IsDynamicConfigSourceKindNodeConfig() bool {
 }
 
 type enabledFeatures interface {
-	TunnelProtocol() tunnel.Protocol
+	TunnelProtocol() tunnel.EncapProtocol
 	GetChainingMode() string
 	IsMutualAuthEnabled() bool
 	IsBandwidthManagerEnabled() bool

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 type mockFeaturesParams struct {
-	TunnelConfig                        tunnel.Protocol
+	TunnelConfig                        tunnel.EncapProtocol
 	CNIChainingMode                     string
 	MutualAuth                          bool
 	BandwidthManager                    bool
@@ -24,7 +24,7 @@ type mockFeaturesParams struct {
 	isDynamicConfigSourceKindNodeConfig bool
 }
 
-func (m mockFeaturesParams) TunnelProtocol() tunnel.Protocol {
+func (m mockFeaturesParams) TunnelProtocol() tunnel.EncapProtocol {
 	return m.TunnelConfig
 }
 
@@ -69,7 +69,7 @@ func TestUpdateNetworkMode(t *testing.T) {
 	tests := []struct {
 		name         string
 		tunnelMode   string
-		tunnelProto  tunnel.Protocol
+		tunnelProto  tunnel.EncapProtocol
 		expectedMode string
 	}{
 		{


### PR DESCRIPTION
This pull request introduces a new tunneling flag called `underlay-protocol`. This new flag isn't doing anything in this pull request, but will be used in [a ready-to-go follow up PR](https://github.com/cilium/cilium/pull/36359) (I'm simply splitting to ease reviews). This new flag will allow us to select IPv6 as the underlay for our tunnels.