### PR TITLE
ipcache: modify labels map in-place in `resolveLabels`

### DIFF
--- a/pkg/ipcache/ipcache_bench_test.go
+++ b/pkg/ipcache/ipcache_bench_test.go
@@ -25,7 +25,6 @@ func (d *dummyOwner) GetNodeSuffix() string {
 }
 
 func BenchmarkInjectLabels(b *testing.B) {
-
 	ctx, cancel := context.WithCancel(context.Background())
 	alloc := cache.NewCachingIdentityAllocator(&dummyOwner{}, cache.AllocatorConfig{})
 	//<-alloc.InitIdentityAllocator(nil)
@@ -41,9 +40,10 @@ func BenchmarkInjectLabels(b *testing.B) {
 
 	addr := netip.MustParseAddr("1.0.0.0")
 	lbls := labels.NewLabelsFromSortedList(labels.LabelSourceCIDRGroup + ":foo=bar")
-	b.ResetTimer()
-
 	prefixes := make([]cmtypes.PrefixCluster, 0, b.N)
+
+	b.ReportAllocs()
+	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		pfx := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(addr, 30))


### PR DESCRIPTION
The only caller of `resolveLabels` in `(*IPCache).resolveIdentity` assigns the returned map of labels back to the map of labels passed as an argument, so there is no need to create a copy.

This improves `BenchmarkInjectLabels` as follows:

```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/ipcache
cpu: 13th Gen Intel(R) Core(TM) i7-1365U
                │   old.txt   │              new.txt               │
                │   sec/op    │   sec/op     vs base               │
InjectLabels-12   7.400µ ± 3%   6.857µ ± 1%  -7.34% (p=0.000 n=20)

                │   old.txt    │               new.txt                │
                │     B/op     │     B/op      vs base                │
InjectLabels-12   5.614Ki ± 1%   4.798Ki ± 2%  -14.53% (p=0.000 n=20)

                │  old.txt   │              new.txt              │
                │ allocs/op  │ allocs/op   vs base               │
InjectLabels-12   55.00 ± 0%   53.00 ± 0%  -3.64% (p=0.000 n=20)
```