### PR TITLE
[1.17] AWS ENI IPAM: Move UpdateEC2AdapterLimitViaAPI logic to prevent performance regression

### DIFF
--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -215,6 +215,13 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 			return time.Time{}
 		}
 
+		if operatorOption.Config.UpdateEC2AdapterLimitViaAPI {
+			if err := limits.UpdateFromEC2API(ctx, m.api); err != nil {
+				log.WithError(err).Warning("Unable to update instance type to adapter limits from EC2 API")
+				return time.Time{}
+			}
+		}
+
 		log.WithFields(logrus.Fields{
 			"numInstances":      instances.NumInstances(),
 			"numVPCs":           len(vpcs),
@@ -247,13 +254,6 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 	m.subnets = subnets
 	m.vpcs = vpcs
 	m.securityGroups = securityGroups
-
-	if operatorOption.Config.UpdateEC2AdapterLimitViaAPI {
-		if err := limits.UpdateFromEC2API(ctx, m.api); err != nil {
-			log.WithError(err).Warning("Unable to update instance type to adapter limits from EC2 API")
-			return time.Time{}
-		}
-	}
 
 	return resyncStart
 }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/cilium/cilium/pull/30308. The idea is to prevent the performance regression identified in https://github.com/cilium/cilium/issues/33654#issuecomment-2751717274.

There are two improvements here:
- The `UpdateFromEC2API` call will only be made for "full resync" operations every minute and will no longer be made for "individual node resync" operations
- The call will be done without holding the global `mutex` lock for the `InstancesManager` 

This change is a hotfix for 1.16 and 1.17. The regression will be fully fixed in https://github.com/cilium/cilium/pull/36922 which will be released in 1.18 (it contains a breaking change so cannot be easily backported)

Related 1.16 PR: https://github.com/cilium/cilium/pull/38533

```release-note
fix AWS ENI IPAM mode performance regression in the Operator when `--update-ec2-adapter-limit-via-api` is set to `true`
```