### PR TITLE
docs: Fix quotes in CiliumNodeConfig example

### DIFF
--- a/Documentation/configuration/per-node-config.rst
+++ b/Documentation/configuration/per-node-config.rst
@@ -92,7 +92,7 @@ nodes with ``io.cilium.migration/kube-proxy-replacement: true``
               io.cilium.migration/kube-proxy-replacement: "true"
           defaults:
             kube-proxy-replacement: "true"
-            kube-proxy-replacement-healthz-bind-address: "0.0.0.0:10256"
+            kube-proxy-replacement-healthz-bind-address: "'0.0.0.0:10256'"
 
         EOF
 
@@ -129,7 +129,7 @@ nodes with ``io.cilium.migration/kube-proxy-replacement: true``
     .. code-block:: shell-session
 
         cilium config set --restart=false kube-proxy-replacement true
-        cilium config set --restart=false kube-proxy-replacement-healthz-bind-address "0.0.0.0:10256"
+        cilium config set --restart=false kube-proxy-replacement-healthz-bind-address '0.0.0.0:10256'
         kubectl -n kube-system delete ciliumnodeconfig kube-proxy-replacement
 
 #. Cleanup: delete kube-proxy daemonset, unlabel nodes


### PR DESCRIPTION
Fix quoting issue in CiliumNodeConfig documentation that prevented users from creating CiliumNodeConfig objects due to improper parsing of the bind address. Use nested quotes for YAML value and consistent single quotes in shell commands. Fixes: #38006

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!