### PR TITLE
[1.16] Make cilium status independent from K8s status

### DIFF
--- a/Documentation/cmdref/cilium-dbg_status.md
+++ b/Documentation/cmdref/cilium-dbg_status.md
@@ -11,17 +11,18 @@ cilium-dbg status [flags]
 ### Options
 
 ```
-      --all-addresses      Show all allocated addresses, not just count
-      --all-clusters       Show all clusters
-      --all-controllers    Show all controllers, not just failing
-      --all-health         Show all health status, not just failing
-      --all-nodes          Show all nodes, not just localhost
-      --all-redirects      Show all redirects
-      --brief              Only print a one-line status message
-  -h, --help               help for status
-  -o, --output string      json| yaml| jsonpath='{}'
-      --timeout duration   Sets the timeout to use when querying for health (default 30s)
-      --verbose            Equivalent to --all-addresses --all-controllers --all-nodes --all-redirects --all-clusters --all-health
+      --all-addresses              Show all allocated addresses, not just count
+      --all-clusters               Show all clusters
+      --all-controllers            Show all controllers, not just failing
+      --all-health                 Show all health status, not just failing
+      --all-nodes                  Show all nodes, not just localhost
+      --all-redirects              Show all redirects
+      --brief                      Only print a one-line status message
+  -h, --help                       help for status
+  -o, --output string              json| yaml| jsonpath='{}'
+      --require-k8s-connectivity   If true, when the cilium-agent cannot access the Kubernetes control plane, this status command returns a non-zero exit status. (default true)
+      --timeout duration           Sets the timeout to use when querying for health (default 30s)
+      --verbose                    Equivalent to --all-addresses --all-controllers --all-nodes --all-redirects --all-clusters --all-health
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2436,6 +2436,10 @@
      - interval between checks of the liveness probe
      - int
      - ``30``
+   * - :spelling:ignore:`livenessProbe.requireK8sConnectivity`
+     - whether to require k8s connectivity as part of the check.
+     - bool
+     - ``false``
    * - :spelling:ignore:`loadBalancer`
      - Configure service load balancing
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2439,7 +2439,7 @@
    * - :spelling:ignore:`livenessProbe.requireK8sConnectivity`
      - whether to require k8s connectivity as part of the check.
      - bool
-     - ``false``
+     - ``true``
    * - :spelling:ignore:`loadBalancer`
      - Configure service load balancing
      - object

--- a/api/v1/client/daemon/get_healthz_parameters.go
+++ b/api/v1/client/daemon/get_healthz_parameters.go
@@ -72,6 +72,15 @@ type GetHealthzParams struct {
 	*/
 	Brief *bool
 
+	/* RequireK8sConnectivity.
+
+	   If set to true, failure of the agent to connect to the Kubernetes control plane will cause the agent's health status to also fail.
+
+
+	   Default: true
+	*/
+	RequireK8sConnectivity *bool
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -89,7 +98,18 @@ func (o *GetHealthzParams) WithDefaults() *GetHealthzParams {
 //
 // All values with no default are reset to their zero value.
 func (o *GetHealthzParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		requireK8sConnectivityDefault = bool(true)
+	)
+
+	val := GetHealthzParams{
+		RequireK8sConnectivity: &requireK8sConnectivityDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the get healthz params
@@ -136,6 +156,17 @@ func (o *GetHealthzParams) SetBrief(brief *bool) {
 	o.Brief = brief
 }
 
+// WithRequireK8sConnectivity adds the requireK8sConnectivity to the get healthz params
+func (o *GetHealthzParams) WithRequireK8sConnectivity(requireK8sConnectivity *bool) *GetHealthzParams {
+	o.SetRequireK8sConnectivity(requireK8sConnectivity)
+	return o
+}
+
+// SetRequireK8sConnectivity adds the requireK8sConnectivity to the get healthz params
+func (o *GetHealthzParams) SetRequireK8sConnectivity(requireK8sConnectivity *bool) {
+	o.RequireK8sConnectivity = requireK8sConnectivity
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetHealthzParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -148,6 +179,14 @@ func (o *GetHealthzParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 
 		// header param brief
 		if err := r.SetHeaderParam("brief", swag.FormatBool(*o.Brief)); err != nil {
+			return err
+		}
+	}
+
+	if o.RequireK8sConnectivity != nil {
+
+		// header param require-k8s-connectivity
+		if err := r.SetHeaderParam("require-k8s-connectivity", swag.FormatBool(*o.RequireK8sConnectivity)); err != nil {
 			return err
 		}
 	}

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -47,6 +47,13 @@ paths:
         in: header
         required: false
         type: boolean
+      - name: require-k8s-connectivity
+        description: |
+          If set to true, failure of the agent to connect to the Kubernetes control plane will cause the agent's health status to also fail.
+        in: header
+        required: false
+        type: boolean
+        default: true
       responses:
         '200':
           description: Success

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -860,6 +860,13 @@ func init() {
             "description": "Brief will return a brief representation of the Cilium status.\n",
             "name": "brief",
             "in": "header"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "If set to true, failure of the agent to connect to the Kubernetes control plane will cause the agent's health status to also fail.\n",
+            "name": "require-k8s-connectivity",
+            "in": "header"
           }
         ],
         "responses": {
@@ -6422,6 +6429,13 @@ func init() {
             "type": "boolean",
             "description": "Brief will return a brief representation of the Cilium status.\n",
             "name": "brief",
+            "in": "header"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "If set to true, failure of the agent to connect to the Kubernetes control plane will cause the agent's health status to also fail.\n",
+            "name": "require-k8s-connectivity",
             "in": "header"
           }
         ],

--- a/api/v1/server/restapi/daemon/get_healthz_parameters.go
+++ b/api/v1/server/restapi/daemon/get_healthz_parameters.go
@@ -18,11 +18,18 @@ import (
 )
 
 // NewGetHealthzParams creates a new GetHealthzParams object
-//
-// There are no default values defined in the spec.
+// with the default values initialized.
 func NewGetHealthzParams() GetHealthzParams {
 
-	return GetHealthzParams{}
+	var (
+		// initialize parameters with default values
+
+		requireK8sConnectivityDefault = bool(true)
+	)
+
+	return GetHealthzParams{
+		RequireK8sConnectivity: &requireK8sConnectivityDefault,
+	}
 }
 
 // GetHealthzParams contains all the bound params for the get healthz operation
@@ -39,6 +46,12 @@ type GetHealthzParams struct {
 	  In: header
 	*/
 	Brief *bool
+	/*If set to true, failure of the agent to connect to the Kubernetes control plane will cause the agent's health status to also fail.
+
+	  In: header
+	  Default: true
+	*/
+	RequireK8sConnectivity *bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -51,6 +64,10 @@ func (o *GetHealthzParams) BindRequest(r *http.Request, route *middleware.Matche
 	o.HTTPRequest = r
 
 	if err := o.bindBrief(r.Header[http.CanonicalHeaderKey("brief")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.bindRequireK8sConnectivity(r.Header[http.CanonicalHeaderKey("require-k8s-connectivity")], true, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -77,6 +94,29 @@ func (o *GetHealthzParams) bindBrief(rawData []string, hasKey bool, formats strf
 		return errors.InvalidType("brief", "header", "bool", raw)
 	}
 	o.Brief = &value
+
+	return nil
+}
+
+// bindRequireK8sConnectivity binds and validates parameter RequireK8sConnectivity from header.
+func (o *GetHealthzParams) bindRequireK8sConnectivity(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewGetHealthzParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("require-k8s-connectivity", "header", "bool", raw)
+	}
+	o.RequireK8sConnectivity = &value
 
 	return nil
 }

--- a/cilium-dbg/cmd/status.go
+++ b/cilium-dbg/cmd/status.go
@@ -34,11 +34,12 @@ var statusCmd = &cobra.Command{
 }
 
 var (
-	statusDetails pkg.StatusDetails
-	allHealth     bool
-	brief         bool
-	timeout       time.Duration
-	healthLines   = 10
+	statusDetails          pkg.StatusDetails
+	allHealth              bool
+	brief                  bool
+	requireK8sConnectivity bool
+	timeout                time.Duration
+	healthLines            = 10
 )
 
 func init() {
@@ -50,6 +51,7 @@ func init() {
 	statusCmd.Flags().BoolVar(&statusDetails.AllClusters, "all-clusters", false, "Show all clusters")
 	statusCmd.Flags().BoolVar(&allHealth, "all-health", false, "Show all health status, not just failing")
 	statusCmd.Flags().BoolVar(&brief, "brief", false, "Only print a one-line status message")
+	statusCmd.Flags().BoolVar(&requireK8sConnectivity, "require-k8s-connectivity", true, "If true, when the cilium-agent cannot access the Kubernetes control plane, this status command returns a non-zero exit status.")
 	statusCmd.Flags().BoolVar(&verbose, "verbose", false, "Equivalent to --all-addresses --all-controllers --all-nodes --all-redirects --all-clusters --all-health")
 	statusCmd.Flags().DurationVar(&timeout, "timeout", 30*time.Second, "Sets the timeout to use when querying for health")
 	command.AddOutputOption(statusCmd)
@@ -74,6 +76,7 @@ func statusDaemon() {
 	}
 	params := daemon.NewGetHealthzParamsWithTimeout(timeout)
 	params.SetBrief(&brief)
+	params.SetRequireK8sConnectivity(&requireK8sConnectivity)
 	if resp, err := client.Daemon.GetHealthz(params); err != nil {
 		if brief {
 			fmt.Fprintf(os.Stderr, "%s\n", "cilium: daemon unreachable")

--- a/daemon/cmd/debuginfo.go
+++ b/daemon/cmd/debuginfo.go
@@ -29,7 +29,7 @@ func getDebugInfoHandler(d *Daemon, params restapi.GetDebuginfoParams) middlewar
 		dr.KernelVersion = kver.String()
 	}
 
-	status := d.getStatus(false)
+	status := d.getStatus(false, true)
 	dr.CiliumStatus = &status
 
 	var p endpoint.GetEndpointParams

--- a/daemon/cmd/kube_proxy_healthz.go
+++ b/daemon/cmd/kube_proxy_healthz.go
@@ -19,7 +19,7 @@ import (
 
 // DaemonInterface to help with testing.
 type DaemonInterface interface {
-	getStatus(bool) models.StatusResponse
+	getStatus(bool, bool) models.StatusResponse
 }
 
 // ServiceInterface to help with testing.
@@ -79,7 +79,7 @@ func (h kubeproxyHealthzHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	var lastUpdateTs = currentTs
 	// We piggy back here on Cilium daemon health. If Cilium is healthy, we can
 	// reasonably assume that the node networking is ready.
-	sr := h.d.getStatus(true)
+	sr := h.d.getStatus(true, true)
 	if isUnhealthy(&sr) {
 		statusCode = http.StatusServiceUnavailable
 		lastUpdateTs = h.svc.GetLastUpdatedTs()

--- a/daemon/cmd/kube_proxy_healthz_test.go
+++ b/daemon/cmd/kube_proxy_healthz_test.go
@@ -36,7 +36,7 @@ type FakeDaemon struct {
 	injectedStatusResponse models.StatusResponse
 }
 
-func (d *FakeDaemon) getStatus(blah bool) models.StatusResponse {
+func (d *FakeDaemon) getStatus(brief bool, requireK8sConnectivity bool) models.StatusResponse {
 	return d.injectedStatusResponse
 }
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -453,7 +453,8 @@ func (d *Daemon) getBPFMapStatus() *models.BPFMapStatus {
 
 func getHealthzHandler(d *Daemon, params GetHealthzParams) middleware.Responder {
 	brief := params.Brief != nil && *params.Brief
-	sr := d.getStatus(brief)
+	requireK8sConnectivity := params.RequireK8sConnectivity != nil && *params.RequireK8sConnectivity
+	sr := d.getStatus(brief, requireK8sConnectivity)
 	return NewGetHealthzOK().WithPayload(&sr)
 }
 
@@ -659,7 +660,7 @@ func (h *getNodes) Handle(d *Daemon, params GetClusterNodesParams) middleware.Re
 
 // getStatus returns the daemon status. If brief is provided a minimal version
 // of the StatusResponse is provided.
-func (d *Daemon) getStatus(brief bool) models.StatusResponse {
+func (d *Daemon) getStatus(brief bool, requireK8sConnectivity bool) models.StatusResponse {
 	staleProbes := d.statusCollector.GetStaleProbes()
 	stale := make(map[string]strfmt.DateTime, len(staleProbes))
 	for probe, startTime := range staleProbes {
@@ -730,7 +731,7 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 			State: d.statusResponse.ContainerRuntime.State,
 			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
-	case d.clientset.IsEnabled() && d.statusResponse.Kubernetes != nil && d.statusResponse.Kubernetes.State != models.StatusStateOk:
+	case d.clientset.IsEnabled() && d.statusResponse.Kubernetes != nil && d.statusResponse.Kubernetes.State != models.StatusStateOk && requireK8sConnectivity:
 		msg := "Kubernetes service is not ready: " + d.statusResponse.Kubernetes.Msg
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.Kubernetes.State,

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -659,6 +659,7 @@ contributors across the globe, there is almost always someone available to help.
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
+| livenessProbe.requireK8sConnectivity | bool | `false` | whether to require k8s connectivity as part of the check. |
 | loadBalancer | object | `{"acceleration":"disabled","l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
 | loadBalancer.acceleration | string | `"disabled"` | acceleration is the option to accelerate service handling via XDP Applicable values can be: disabled (do not use XDP), native (XDP BPF program is run directly out of the networking driver's early receive path), or best-effort (use native mode XDP acceleration on devices that support it). |
 | loadBalancer.l7 | object | `{"algorithm":"round_robin","backend":"disabled","ports":[]}` | L7 LoadBalancer |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -659,7 +659,7 @@ contributors across the globe, there is almost always someone available to help.
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
-| livenessProbe.requireK8sConnectivity | bool | `false` | whether to require k8s connectivity as part of the check. |
+| livenessProbe.requireK8sConnectivity | bool | `true` | whether to require k8s connectivity as part of the check. |
 | loadBalancer | object | `{"acceleration":"disabled","l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
 | loadBalancer.acceleration | string | `"disabled"` | acceleration is the option to accelerate service handling via XDP Applicable values can be: disabled (do not use XDP), native (XDP BPF program is run directly out of the networking driver's early receive path), or best-effort (use native mode XDP acceleration on devices that support it). |
 | loadBalancer.l7 | object | `{"algorithm":"round_robin","backend":"disabled","ports":[]}` | L7 LoadBalancer |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -152,6 +152,8 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
+            - name: "require-k8s-connectivity"
+              value: {{ .Values.livenessProbe.requireK8sConnectivity | quote }}
           {{- end }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: 1

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3807,6 +3807,9 @@
         },
         "periodSeconds": {
           "type": "integer"
+        },
+        "requireK8sConnectivity": {
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1871,6 +1871,8 @@ livenessProbe:
   failureThreshold: 10
   # -- interval between checks of the liveness probe
   periodSeconds: 30
+  # -- whether to require k8s connectivity as part of the check.
+  requireK8sConnectivity: false
 readinessProbe:
   # -- failure threshold of readiness probe
   failureThreshold: 3

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1872,7 +1872,7 @@ livenessProbe:
   # -- interval between checks of the liveness probe
   periodSeconds: 30
   # -- whether to require k8s connectivity as part of the check.
-  requireK8sConnectivity: false
+  requireK8sConnectivity: true
 readinessProbe:
   # -- failure threshold of readiness probe
   failureThreshold: 3

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1878,6 +1878,8 @@ livenessProbe:
   failureThreshold: 10
   # -- interval between checks of the liveness probe
   periodSeconds: 30
+  # -- whether to require k8s connectivity as part of the check.
+  requireK8sConnectivity: false
 readinessProbe:
   # -- failure threshold of readiness probe
   failureThreshold: 3

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1879,7 +1879,7 @@ livenessProbe:
   # -- interval between checks of the liveness probe
   periodSeconds: 30
   # -- whether to require k8s connectivity as part of the check.
-  requireK8sConnectivity: false
+  requireK8sConnectivity: true
 readinessProbe:
   # -- failure threshold of readiness probe
   failureThreshold: 3


### PR DESCRIPTION
Proposing 1.16 backport of https://github.com/cilium/cilium/pull/32724 due to possible impact on k8s control plane stability. Setting `require-k8s-connectivity` to false improves time to recovery. Some users have been customizing helm charts to remove liveness checks altogether just to work around this.

https://github.com/cilium/cilium/pull/38458 is already proposing changing default to false. Note that the 1.16 default will still be set to true and users need to opt-in to the new behavior.

```upstream-prs
32724
```