### PR TITLE
Fix cli disconnect error message

### DIFF
--- a/cilium-cli/cli/clustermesh_test.go
+++ b/cilium-cli/cli/clustermesh_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/cilium-cli/clustermesh"
+)
+
+func TestClusterMeshDisconnectWithoutDestination(t *testing.T) {
+	// Create clustermesh parameters without destination context
+	params := clustermesh.Parameters{}
+
+	// Create a K8sClusterMesh instance directly
+	cm := clustermesh.NewK8sClusterMesh(nil, params)
+
+	// Call DisconnectWithHelm and check the error
+	err := cm.DisconnectWithHelm(context.Background())
+
+	// Verify the error message
+	assert.Equal(t, "no destination context specified, use --destination-context to specify which cluster to disconnect from", err.Error())
+}

--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -1529,6 +1529,11 @@ func (k *K8sClusterMesh) disconnectRemoteWithHelm(ctx context.Context, clusterNa
 }
 
 func (k *K8sClusterMesh) DisconnectWithHelm(ctx context.Context) error {
+	// Check if destination context is provided
+	if len(k.params.DestinationContext) == 0 {
+		return fmt.Errorf("no destination context specified, use --destination-context to specify which cluster to disconnect from")
+	}
+
 	localClient := k.client.(*k8s.Client)
 	err := k.checkConnectionMode()
 	if err != nil {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

## Description

This PR fixes issue #36994 where the `cilium clustermesh disconnect` command doesn't provide any feedback when run without a destination context.

### Problem
When running `cilium clustermesh disconnect` without specifying a destination context via the `--destination-context` flag, the command silently executes but doesn't display any message or error to the user. This creates a confusing user experience as the user doesn't know what happened.

Current behavior:
```
cilium clustermesh disconnect -n cilium-system
ℹ️ Configuring Cilium in cluster kind-mgmt to disconnect from cluster

<no further output>
```

### Solution
This PR adds a check at the beginning of the `DisconnectWithHelm` function to verify if a destination context was provided. If not, it returns a clear error message explaining that a destination context is required.

New behavior:
```
cilium clustermesh disconnect -n cilium-system

Error: Unable to disconnect clusters: no destination context specified, use --destination-context to specify which cluster to disconnect from
```

This makes the CLI behavior consistent with the case where an invalid destination context is provided, which already shows an error message.

## Testing Information

This PR includes a unit test to verify the error behavior:

1. `TestClusterMeshDisconnectWithoutDestination` in `cilium-cli/cli/clustermesh_test.go` directly tests the DisconnectWithHelm function and verifies that it returns the correct error message when no destination context is provided.

This test ensures that the error message is displayed correctly to users when they attempt to use the `clustermesh disconnect` command without specifying a destination context.

### To run the test

```bash
cd cilium-cli
go test -v ./cli -run TestClusterMeshDisconnectWithoutDestination
```

The test validates our fix by confirming the error message is exactly:
"no destination context specified, use --destination-context to specify which cluster to disconnect from"

Fixes: #36994 

```release-note
Fix cli disconnect error message
```
