### PR TITLE
ci: disable GW API mirroring conformance tests in conformance-profile too

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -299,6 +299,7 @@ jobs:
               -v ./operator/pkg/gateway-api \
               --gateway-class cilium \
               --all-features \
+              --exempt-features "HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors,HTTPRouteRequestPercentageMirror" \
               --skip-tests "${{ steps.vars.outputs.skipped_tests }}" \
               --allow-crds-mismatch \
               --conformance-profiles GATEWAY-HTTP,GATEWAY-TLS,GATEWAY-GRPC,MESH-HTTP,MESH-GRPC \


### PR DESCRIPTION
This PR disables the Gateway API mirroring conformance test in the conformance-profile too.

Tracking issue: https://github.com/cilium/cilium/issues/38464