### PR TITLE
k8s: Add additional CEL validation for CiliumBGPAdvertisement

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpadvertisements.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpadvertisements.yaml
@@ -147,7 +147,8 @@ spec:
                     selector:
                       description: |-
                         Selector is a label selector to select objects of the type specified by AdvertisementType.
-                        If not specified, no objects of the type specified by AdvertisementType are selected for advertisement.
+                        For the PodCIDR AdvertisementType it is not applicable. For other advertisement types,
+                        if not specified, no objects of the type specified by AdvertisementType are selected for advertisement.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
@@ -242,6 +243,8 @@ spec:
                   x-kubernetes-validations:
                   - message: service field is required for the 'Service' advertisementType
                     rule: self.advertisementType != 'Service' || has(self.service)
+                  - message: selector field is not allowed for the 'PodCIDR' advertisementType
+                    rule: self.advertisementType != 'PodCIDR' || !has(self.selector)
                 type: array
             required:
             - advertisements
@@ -382,7 +385,8 @@ spec:
                     selector:
                       description: |-
                         Selector is a label selector to select objects of the type specified by AdvertisementType.
-                        If not specified, no objects of the type specified by AdvertisementType are selected for advertisement.
+                        For the PodCIDR AdvertisementType it is not applicable. For other advertisement types,
+                        if not specified, no objects of the type specified by AdvertisementType are selected for advertisement.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
@@ -477,6 +481,8 @@ spec:
                   x-kubernetes-validations:
                   - message: service field is required for the 'Service' advertisementType
                     rule: self.advertisementType != 'Service' || has(self.service)
+                  - message: selector field is not allowed for the 'PodCIDR' advertisementType
+                    rule: self.advertisementType != 'PodCIDR' || !has(self.selector)
                 type: array
             required:
             - advertisements

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.31.6"
+	CustomResourceDefinitionSchemaVersion = "1.31.7"
 )

--- a/pkg/k8s/apis/cilium.io/v2/bgp_advert_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/bgp_advert_types.go
@@ -102,6 +102,7 @@ type CiliumBGPAdvertisementSpec struct {
 // set to the advertised routes.
 //
 // +kubebuilder:validation:XValidation:rule="self.advertisementType != 'Service' || has(self.service)", message="service field is required for the 'Service' advertisementType"
+// +kubebuilder:validation:XValidation:rule="self.advertisementType != 'PodCIDR' || !has(self.selector)", message="selector field is not allowed for the 'PodCIDR' advertisementType"
 type BGPAdvertisement struct {
 	// AdvertisementType defines type of advertisement which has to be advertised.
 	//
@@ -114,7 +115,8 @@ type BGPAdvertisement struct {
 	Service *BGPServiceOptions `json:"service,omitempty"`
 
 	// Selector is a label selector to select objects of the type specified by AdvertisementType.
-	// If not specified, no objects of the type specified by AdvertisementType are selected for advertisement.
+	// For the PodCIDR AdvertisementType it is not applicable. For other advertisement types,
+	// if not specified, no objects of the type specified by AdvertisementType are selected for advertisement.
 	//
 	// +kubebuilder:validation:Optional
 	Selector *slimv1.LabelSelector `json:"selector,omitempty"`

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
@@ -97,6 +97,7 @@ type CiliumBGPAdvertisementSpec struct {
 // set to the advertised routes.
 //
 // +kubebuilder:validation:XValidation:rule="self.advertisementType != 'Service' || has(self.service)", message="service field is required for the 'Service' advertisementType"
+// +kubebuilder:validation:XValidation:rule="self.advertisementType != 'PodCIDR' || !has(self.selector)", message="selector field is not allowed for the 'PodCIDR' advertisementType"
 type BGPAdvertisement struct {
 	// AdvertisementType defines type of advertisement which has to be advertised.
 	//
@@ -109,7 +110,8 @@ type BGPAdvertisement struct {
 	Service *BGPServiceOptions `json:"service,omitempty"`
 
 	// Selector is a label selector to select objects of the type specified by AdvertisementType.
-	// If not specified, no objects of the type specified by AdvertisementType are selected for advertisement.
+	// For the PodCIDR AdvertisementType it is not applicable. For other advertisement types,
+	// if not specified, no objects of the type specified by AdvertisementType are selected for advertisement.
 	//
 	// +kubebuilder:validation:Optional
 	Selector *slimv1.LabelSelector `json:"selector,omitempty"`


### PR DESCRIPTION
Check that selector field is not set for the 'PodCIDR' advertisementType, as it causes incorrect expectations of the users - selector is ignored for the PodCIDR advertisements, and only node-local PodCIDR can be ever advertised.


```release-note
Add CEL validation requiring empty `selector` for the PodCIDR `advertisementType`  in `BGPAdvertisement` CRD
```
