### PR TITLE
ingress: don't cleanup ingress status of unmanaged Ingress resources

### DIFF
--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -76,14 +76,6 @@ func (r *ingressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return controllerruntime.Fail(err)
 		}
 
-		scopedLog.Debug("Trying to cleanup Ingress status of unmanaged Ingress")
-		if err := r.tryCleanupIngressStatus(ctx, ingress); err != nil {
-			// One attempt to cleanup the status of the Ingress.
-			// Don't fail (and retry) on an error, as this might result in
-			// interferences with the new responsible Ingress controller.
-			scopedLog.Warn("Failed to cleanup Ingress status", logfields.Error, err)
-		}
-
 		scopedLog.Info("Successfully cleaned Ingress resources")
 		return controllerruntime.Success()
 	}
@@ -452,16 +444,6 @@ func (r *ingressReconciler) updateIngressLoadbalancerStatus(ctx context.Context,
 
 	if err := r.client.Status().Update(ctx, ingress); err != nil {
 		return fmt.Errorf("failed to write Ingress status: %w", err)
-	}
-
-	return nil
-}
-
-func (r *ingressReconciler) tryCleanupIngressStatus(ctx context.Context, ingress *networkingv1.Ingress) error {
-	ingress.Status.LoadBalancer.Ingress = []networkingv1.IngressLoadBalancerIngress{}
-
-	if err := r.client.Status().Update(ctx, ingress); err != nil {
-		return fmt.Errorf("failed to update Ingress status: %w", err)
 	}
 
 	return nil

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -440,7 +440,7 @@ func TestReconcile(t *testing.T) {
 		require.True(t, k8sApiErrors.IsNotFound(err))
 	})
 
-	t.Run("Reconcile of non Cilium Ingress will cleanup any potentially existing resources (dedicated and shared) and reset the Ingress status", func(t *testing.T) {
+	t.Run("Reconcile of non Cilium Ingress will cleanup any potentially existing resources (dedicated and shared)", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(testScheme()).
 			WithObjects(
@@ -536,7 +536,7 @@ func TestReconcile(t *testing.T) {
 		ingress := networkingv1.Ingress{}
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &ingress)
 		require.NoError(t, err)
-		require.Empty(t, ingress.Status.LoadBalancer.Ingress, "Loadbalancer status of Ingress should be reset")
+		require.NotEmpty(t, ingress.Status.LoadBalancer.Ingress, "Loadbalancer status of Ingress should not be changed (its up to the new owning Ingress Controller to update it accordingly)")
 	})
 
 	t.Run("Reconcile of dedicated Cilium Ingress with loadbalancer class will create the dedicated loadbalancer service with the specified class", func(t *testing.T) {


### PR DESCRIPTION
Currently, during reconciliation of an Ingress resource which isn't managed by the Cilium Ingress Controller, the reconciliation attempts to reset the status of the Ingress. The idea was to reset the status in the cases where a previously owned Ingress has changed it's ownership.

But this causes issues in case of Operator restarts where the Cilium Operator is temporarily resetting the status - until its changed back by the owning Ingress Controller.

Therefore, this commit removes this logic completely.

Note: Removing the cleanup might lead to situations where the Ingress IP's are never cleaned up (e.g. if there's no other Ingress Controller that owns and updates the Ingress). Which might causes tools like [external-dns](https://github.com/kubernetes-sigs/external-dns/) to continue using these IPs. It would have been an option to perform the status cleanup only if either cleaning up the shared or dedicated resources was successful. But IMO this isn't worth the effort (and couldn't be easily implemented in a idempotent way (e.g. if updating the Ingress status fails on the first attempt)).

Fixes: #38529