### PR TITLE
policy: don't drop policy update notifications on full channel

### DIFF
--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -343,14 +343,8 @@ func (i *policyImporter) processUpdates(ctx context.Context, updates []*policyty
 		idsToRegen.Merge(*regen)
 
 		// Report that the policy has been inserted in to the repository.
-		// Paranoia: only do so if this will never block.
 		if upd.DoneChan != nil {
-			select {
-			case upd.DoneChan <- endRevision:
-			default:
-				// should never happen
-				i.log.Warn("BUG: failed to deliver policy apply update notification")
-			}
+			upd.DoneChan <- endRevision
 		}
 
 		// Send a policy update notification

--- a/pkg/policy/k8s/watcher.go
+++ b/pkg/policy/k8s/watcher.go
@@ -73,13 +73,13 @@ func (p *policyWatcher) watchResources(ctx context.Context) {
 	// Only used during initialization
 	var knpDone, cnpDone, ccnpDone chan uint64
 	if p.config.EnableK8sNetworkPolicy {
-		knpDone = make(chan uint64, 100)
+		knpDone = make(chan uint64, 1024)
 	}
 	if p.config.EnableCiliumNetworkPolicy {
-		cnpDone = make(chan uint64, 100)
+		cnpDone = make(chan uint64, 1024)
 	}
 	if p.config.EnableCiliumClusterwideNetworkPolicy {
-		ccnpDone = make(chan uint64, 100)
+		ccnpDone = make(chan uint64, 1024)
 	}
 
 	// Consume result channels, decrement outstanding work counter.


### PR DESCRIPTION
Out of paranoia, we were dropping policy update notifications if the channel was full. However, this caused a bug where agents failed to start when the cluster contained large numbers of policies. This was because we didn't get the feedback that all policies had been ingested, thus never marked k8s resources as synced.

Since the policy importer doesn't hold any locks, this paranoia was misplaced. Dropping a notification was, in fact, a serious correctness issue.

Fixes: #38070

```release-note
Fixes an issue where the agent failed to start on clusters with large numbers of network policies.
```
