### PR TITLE
datapath/linux: call RouteGetWithOptions with OifIndex

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -607,7 +607,7 @@ var errNodeIPNotRoutable = errors.New("remote node IP is non-routable")
 
 func getNextHopIP(nodeIP net.IP, link netlink.Link) (nextHopIP net.IP, err error) {
 	// Figure out whether nodeIP is directly reachable (i.e. in the same L2)
-	routes, err := netlink.RouteGetWithOptions(nodeIP, &netlink.RouteGetOptions{Oif: link.Attrs().Name, FIBMatch: true})
+	routes, err := netlink.RouteGetWithOptions(nodeIP, &netlink.RouteGetOptions{OifIndex: link.Attrs().Index, FIBMatch: true})
 	if err != nil && !errors.Is(err, unix.EHOSTUNREACH) && !errors.Is(err, unix.ENETUNREACH) {
 		return nil, fmt.Errorf("failed to retrieve route for remote node IP: %w", err)
 	}


### PR DESCRIPTION
The `RouteGetWithOptions` function in the netlink library fundamentally
needs a ifindex to get routes. But in older versions of the library
we could only supply a `Oif` field containing the name of the interface.

The netlink library would then do a netlink call to query the ifindex
by its name, which is actually fairly expensive. Especially since we
already have the ifindex available.

In the latest version of the library we can now supply the ifindex
directly, which should improve performance of next hop lookups.

This should partially help with #38321