### PR TITLE
hubble/cli: Add --from-node-labels and --to-node-labels filters

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -375,6 +375,8 @@ multiple fields are set, then all fields must match for the filter to match.
 | tcp_flags | [TCPFlags](#flow-TCPFlags) | repeated | tcp_flags filters flows based on TCP header flags |
 | node_name | [string](#string) | repeated | node_name is a list of patterns to filter on the node name, e.g. &#34;k8s*&#34;, &#34;test-cluster/*.domain.com&#34;, &#34;cluster-name/&#34; etc. |
 | node_labels | [string](#string) | repeated | node_labels filters on a list of node label selectors. Selectors support the full Kubernetes label selector syntax. |
+| source_node_labels | [string](#string) | repeated | source_node_labels filters flows originating from nodes matching label selectors. Selectors support the full Kubernetes label selector syntax. |
+| destination_node_labels | [string](#string) | repeated | destination_node_labels filters flows destined to nodes matching label selectors. Selectors support the full Kubernetes label selector syntax. |
 | ip_version | [IPVersion](#flow-IPVersion) | repeated | filter based on IP version (ipv4 or ipv6) |
 | trace_id | [string](#string) | repeated | trace_id filters flows by trace ID |
 | experimental | [FlowFilter.Experimental](#flow-FlowFilter-Experimental) |  | experimental contains filters that are not stable yet. Support for experimental features is always optional and subject to change. |

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -3145,6 +3145,12 @@ type FlowFilter struct {
 	// node_labels filters on a list of node label selectors. Selectors support
 	// the full Kubernetes label selector syntax.
 	NodeLabels []string `protobuf:"bytes,36,rep,name=node_labels,json=nodeLabels,proto3" json:"node_labels,omitempty"`
+	// source_node_labels filters flows originating from nodes matching label selectors.
+	// Selectors support the full Kubernetes label selector syntax.
+	SourceNodeLabels []string `protobuf:"bytes,39,rep,name=source_node_labels,json=sourceNodeLabels,proto3" json:"source_node_labels,omitempty"`
+	// destination_node_labels filters flows destined to nodes matching label selectors.
+	// Selectors support the full Kubernetes label selector syntax.
+	DestinationNodeLabels []string `protobuf:"bytes,40,rep,name=destination_node_labels,json=destinationNodeLabels,proto3" json:"destination_node_labels,omitempty"`
 	// filter based on IP version (ipv4 or ipv6)
 	IpVersion []IPVersion `protobuf:"varint,25,rep,packed,name=ip_version,json=ipVersion,proto3,enum=flow.IPVersion" json:"ip_version,omitempty"`
 	// trace_id filters flows by trace ID
@@ -3434,6 +3440,20 @@ func (x *FlowFilter) GetNodeName() []string {
 func (x *FlowFilter) GetNodeLabels() []string {
 	if x != nil {
 		return x.NodeLabels
+	}
+	return nil
+}
+
+func (x *FlowFilter) GetSourceNodeLabels() []string {
+	if x != nil {
+		return x.SourceNodeLabels
+	}
+	return nil
+}
+
+func (x *FlowFilter) GetDestinationNodeLabels() []string {
+	if x != nil {
+		return x.DestinationNodeLabels
 	}
 	return nil
 }
@@ -5033,7 +5053,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\bsub_type\x18\x03 \x01(\x05R\asubType\"@\n" +
 	"\x0fCiliumEventType\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\x05R\x04type\x12\x19\n" +
-	"\bsub_type\x18\x02 \x01(\x05R\asubType\"\xa4\r\n" +
+	"\bsub_type\x18\x02 \x01(\x05R\asubType\"\x8a\x0e\n" +
 	"\n" +
 	"FlowFilter\x12\x12\n" +
 	"\x04uuid\x18\x1d \x03(\tR\x04uuid\x12\x1b\n" +
@@ -5079,7 +5099,9 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\ttcp_flags\x18\x17 \x03(\v2\x0e.flow.TCPFlagsR\btcpFlags\x12\x1b\n" +
 	"\tnode_name\x18\x18 \x03(\tR\bnodeName\x12\x1f\n" +
 	"\vnode_labels\x18$ \x03(\tR\n" +
-	"nodeLabels\x12.\n" +
+	"nodeLabels\x12,\n" +
+	"\x12source_node_labels\x18' \x03(\tR\x10sourceNodeLabels\x126\n" +
+	"\x17destination_node_labels\x18( \x03(\tR\x15destinationNodeLabels\x12.\n" +
 	"\n" +
 	"ip_version\x18\x19 \x03(\x0e2\x0f.flow.IPVersionR\tipVersion\x12\x19\n" +
 	"\btrace_id\x18\x1c \x03(\tR\atraceId\x12B\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -614,6 +614,12 @@ message FlowFilter {
     // node_labels filters on a list of node label selectors. Selectors support
     // the full Kubernetes label selector syntax.
     repeated string node_labels = 36;
+    // source_node_labels filters flows originating from nodes matching label selectors.
+    // Selectors support the full Kubernetes label selector syntax.
+    repeated string source_node_labels = 39;
+    // destination_node_labels filters flows destined to nodes matching label selectors.
+    // Selectors support the full Kubernetes label selector syntax.
+    repeated string destination_node_labels = 40;
 
     // filter based on IP version (ipv4 or ipv6)
     repeated IPVersion ip_version = 25;

--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -358,6 +358,12 @@ func newFlowsCmdHelper(usage cmdUsage, vp *viper.Viper, ofilter *flowFilter) *co
 		"node-label", ofilter,
 		`Show only flows observed on nodes matching the given label filter (e.g. "key1=value1", "io.cilium/egress-gateway")`))
 	filterFlags.Var(filterVar(
+		"from-node-labels", ofilter,
+		`Show only flows originating from nodes matching the given label filter (e.g. "key1=value1", "io.cilium/egress-gateway")`))
+	filterFlags.Var(filterVar(
+		"to-node-labels", ofilter,
+		`Show only flows destined to nodes matching the given label filter (e.g. "key1=value1", "io.cilium/egress-gateway")`))
+	filterFlags.Var(filterVar(
 		"from-cluster", ofilter,
 		"Show all flows originating from endpoints known to be in the given cluster name"))
 	filterFlags.Var(filterVar(

--- a/hubble/cmd/observe/flows_filter.go
+++ b/hubble/cmd/observe/flows_filter.go
@@ -209,6 +209,8 @@ func newFlowFilter() *flowFilter {
 			{"workload", "to-workload"},
 			{"workload", "from-workload"},
 			{"node-label"},
+			{"from-node-labels"},
+			{"to-node-labels"},
 			{"tcp-flags"},
 			{"uuid"},
 			{"traffic-direction"},
@@ -684,6 +686,22 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 	case "node-label":
 		f.apply(func(f *flowpb.FlowFilter) {
 			f.NodeLabels = append(f.GetNodeLabels(), val)
+		})
+	case "from-node-labels":
+		f.apply(func(f *flowpb.FlowFilter) {
+			if f.SourceNodeLabels == nil {
+				f.SourceNodeLabels = []string{val}
+			} else {
+				f.SourceNodeLabels = append(f.SourceNodeLabels, val)
+			}
+		})
+	case "to-node-labels":
+		f.apply(func(f *flowpb.FlowFilter) {
+			if f.DestinationNodeLabels == nil {
+				f.DestinationNodeLabels = []string{val}
+			} else {
+				f.DestinationNodeLabels = append(f.DestinationNodeLabels, val)
+			}
 		})
 
 	// cluster name filters

--- a/hubble/cmd/observe_help.txt
+++ b/hubble/cmd/observe_help.txt
@@ -68,6 +68,8 @@ Filters Flags:
   -l, --label filter                        Show only flows related to an endpoint with the given labels (e.g. "key1=value1", "reserved:world")
   -n, --namespace filter                    Show all flows related to the given Kubernetes namespace.
       --node-label filter                   Show only flows observed on nodes matching the given label filter (e.g. "key1=value1", "io.cilium/egress-gateway")
+      --from-node-labels filter             Show only flows originating from nodes matching the given label filter (e.g. "key1=value1", "io.cilium/egress-gateway")
+      --to-node-labels filter               Show only flows destined to nodes matching the given label filter (e.g. "key1=value1", "io.cilium/egress-gateway")
       --node-name filter                    Show all flows which match the given node names (e.g. "k8s*", "test-cluster/*.company.com")
       --not filter[=true]                   Reverses the next filter to be blacklist i.e. --not --from-ip 2.2.2.2
       --pod filter                          Show all flows related to the given pod name prefix ([namespace/]<pod-name>). If namespace is not provided, 'default' is used.

--- a/pkg/hubble/filters/labels_test.go
+++ b/pkg/hubble/filters/labels_test.go
@@ -574,6 +574,80 @@ func TestLabelSelectorFilter(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "source node label filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceNodeLabels: []string{"src1, src2=val2"},
+					},
+				},
+				ev: []*v1.Event{
+					{
+						Event: &flowpb.Flow{
+							NodeLabels: []string{"src1", "src2=val2"},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							NodeLabels: []string{"other1", "other2=val2"},
+						},
+					},
+				},
+			},
+			want: []bool{
+				true,
+				false,
+			},
+		},
+		{
+			name: "destination node label filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						DestinationNodeLabels: []string{"dest1, dest2=val2"},
+					},
+				},
+				ev: []*v1.Event{
+					{
+						Event: &flowpb.Flow{
+							NodeLabels: []string{"dest1", "dest2=val2"},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							NodeLabels: []string{"other1", "other2=val2"},
+						},
+					},
+				},
+			},
+			want: []bool{
+				true,
+				false,
+			},
+		},
+		{
+			name: "invalid source node label filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceNodeLabels: []string{"!"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid destination node label filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						DestinationNodeLabels: []string{"()"},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
This PR adds two new filters to the Hubble CLI's observe command:
- `--from-node-labels`: Filters flows originating from nodes with specific labels
- `--to-node-labels`: Filters flows destined to nodes with specific labels

These filters work similarly to the existing `--node-label` filter but allow for 
more precise filtering based on traffic direction. This addresses issue #34133.

The implementation includes:
1. New fields in the FlowFilter protobuf definition
2. Handler functions in the filter logic
3. Updated tests for both the CLI and filter implementations
4. Updated help documentation

Fixes: #34133 

## Testing Instructions

### Building and Running

To test these new filters, you'll need to build the Hubble CLI from the branch:

```bash
cd /path/to/cilium
make generate-hubble-api  # Ensure protobuf definitions are up-to-date
cd hubble/cmd/hubble
go build -o hubble
```

### Example Usage

#### Filter flows originating from nodes with specific labels:

```bash
./hubble observe flows --from-node-labels "zone=east"
```

This will show only flows that originated from nodes with the label `zone=east`.

#### Filter flows destined to nodes with specific labels:

```bash
./hubble observe flows --to-node-labels "role=worker"
```

This will show only flows that are destined to nodes with the label `role=worker`.

#### Combine with other filters:

```bash
./hubble observe flows --from-node-labels "zone=east" --to-node-labels "role=worker" --verdict FORWARDED
```

This will show only FORWARDED flows that originated from nodes in the "east" zone and are destined to worker nodes.

### Running Tests

To verify the code changes, run the following tests:

```bash
# Test the node label filters in the Hubble CLI
go test -v -run=TestNodeLabels ./hubble/cmd/observe/...

# Test the label filter functionality in the Hubble filter package
go test -v -run="TestLabelSelectorFilter/.*node_label.*" ./pkg/hubble/filters/...
```

```release-note
hubble/cli: Add --from-node-labels and --to-node-labels filters
```
