### PR TITLE
cilium-cli: Add strict-mode-test v2

### DIFF
--- a/cilium-cli/connectivity/builder/strict_mode_encryption.go
+++ b/cilium-cli/connectivity/builder/strict_mode_encryption.go
@@ -15,7 +15,7 @@ func (t strictModeEncryption) build(ct *check.ConnectivityTest, _ map[string]str
 	newTest("strict-mode-encryption", ct).
 		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
 		// Until https://github.com/cilium/cilium/pull/35454 is backported to <1.17.0
-		WithCiliumVersion(">=1.17.0").
+		WithCiliumVersion(">=1.17.0 <1.18.0").
 		WithFeatureRequirements(
 			features.RequireEnabled(features.EncryptionStrictMode),
 			// Strict mode is only supported with WireGuard
@@ -24,6 +24,21 @@ func (t strictModeEncryption) build(ct *check.ConnectivityTest, _ map[string]str
 			features.RequireDisabled(features.Tunnel),
 		).
 		WithScenarios(tests.PodToPodMissingIPCache()).
+		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
+			return check.ResultEgressUnencryptedDrop, check.ResultEgressUnencryptedDrop
+		})
+
+	newTest("strict-mode-encryption-v2", ct).
+		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithCiliumVersion(">=1.18.0").
+		WithFeatureRequirements(
+			features.RequireEnabled(features.EncryptionStrictMode),
+			// Strict mode is only supported with WireGuard
+			features.RequireMode(features.EncryptionPod, "wireguard"),
+			// Strict mode always allows host-to-host tunnel traffic
+			features.RequireDisabled(features.Tunnel),
+		).
+		WithScenarios(tests.PodToPodMissingIPCacheV2()).
 		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
 			return check.ResultEgressUnencryptedDrop, check.ResultEgressUnencryptedDrop
 		})


### PR DESCRIPTION
The `strict-mode-test` verifies that in Wireguard strict mode, no
unecrypted pod-to-pod traffic is leaked. To do that, it temporarily
removes all the ipcache entries related to the echo pods IP. Doing so,
the pod IP is assigned the "world" identity and since no encryption key
can be found, this leads to send unencrypted traffic is dropped as
expected.

Since v1.18, besides the pod IPs, the ipcache BPF map now stores the pod
CIDRs too.  Thus, removing just the IP is not enough to have a pod
without an associated encryption key in the ipcache: the key can still
be found from the pod CIDR entry and all the traffic from the client
pods to the echo pods is encrypted.

Despite this, the test still passes (somehow accidentally), because the
reply traffic from the echo pod is now dropped. Since only pod CIDRs
from remote nodes are inserted into the ipcache, no entry is found for
the local endpoint on the remote agent, thus the egress reply traffic
from that endpoint is leaked.

To restore the test as was originally intended, the commit adds a new
version that removes the ipcache pod CIDR entries too. To do that it
relies on the `cilium-dbg bpf ipcache match` command, to find the pod
CIDRs with an exact match and restore them at the end of the test.

Example run: https://github.com/cilium/cilium/actions/runs/14173035345

Related: https://github.com/cilium/cilium/pull/38483
~Blocked by: https://github.com/cilium/cilium/pull/38483 and https://github.com/cilium/cilium/pull/38579~