### PR TITLE
Remove most usages of the kvstore.Client() global getter

### DIFF
--- a/cilium-dbg/cmd/kvstore.go
+++ b/cilium-dbg/cmd/kvstore.go
@@ -26,7 +26,7 @@ var kvstoreCmd = &cobra.Command{
 	Short: "Direct access to the kvstore",
 }
 
-func setupKvstore(ctx context.Context, logger *slog.Logger) {
+func setupKvstore(ctx context.Context, logger *slog.Logger) kvstore.BackendOperations {
 	if kvStore == "" || len(kvStoreOpts) == 0 {
 		resp, err := client.ConfigGet()
 		if err != nil {
@@ -47,9 +47,17 @@ func setupKvstore(ctx context.Context, logger *slog.Logger) {
 		}
 	}
 
-	if err := kvstore.Setup(ctx, logger, kvStore, kvStoreOpts, nil); err != nil {
-		Fatalf("Unable to setup kvstore: %s", err)
+	client, errch := kvstore.NewClient(ctx, logger, kvStore, kvStoreOpts, nil)
+	select {
+	case <-ctx.Done():
+		Fatalf("Unable to connect to the kvstore")
+	case err, isErr := <-errch:
+		if isErr {
+			Fatalf("Unable to connect to the kvstore: %v", err)
+		}
 	}
+
+	return client
 }
 
 func init() {

--- a/cilium-dbg/cmd/kvstore_delete.go
+++ b/cilium-dbg/cmd/kvstore_delete.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
 )
 
@@ -25,14 +24,14 @@ var kvstoreDeleteCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		setupKvstore(ctx, logging.DefaultSlogLogger)
+		client := setupKvstore(ctx, logging.DefaultSlogLogger)
 
 		if recursive {
-			if err := kvstore.Client().DeletePrefix(ctx, args[0]); err != nil {
+			if err := client.DeletePrefix(ctx, args[0]); err != nil {
 				Fatalf("Unable to delete keys: %s", err)
 			}
 		} else {
-			if err := kvstore.Client().Delete(ctx, args[0]); err != nil {
+			if err := client.Delete(ctx, args[0]); err != nil {
 				Fatalf("Unable to delete key: %s", err)
 			}
 		}

--- a/cilium-dbg/cmd/kvstore_get.go
+++ b/cilium-dbg/cmd/kvstore_get.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/command"
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
 )
 
@@ -30,10 +29,10 @@ var kvstoreGetCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		setupKvstore(ctx, logging.DefaultSlogLogger)
+		client := setupKvstore(ctx, logging.DefaultSlogLogger)
 
 		if recursive {
-			pairs, err := kvstore.Client().ListPrefix(ctx, key)
+			pairs, err := client.ListPrefix(ctx, key)
 			if err != nil {
 				Fatalf("Unable to list keys: %s", err)
 			}
@@ -47,7 +46,7 @@ var kvstoreGetCmd = &cobra.Command{
 				fmt.Printf("%s => %s\n", k, v.Data)
 			}
 		} else {
-			val, err := kvstore.Client().Get(ctx, key)
+			val, err := client.Get(ctx, key)
 			if err != nil {
 				Fatalf("Unable to retrieve key %s: %s", key, err)
 			}

--- a/cilium-dbg/cmd/kvstore_set.go
+++ b/cilium-dbg/cmd/kvstore_set.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
 )
 
@@ -30,9 +29,9 @@ var kvstoreSetCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		setupKvstore(ctx, logging.DefaultSlogLogger)
+		client := setupKvstore(ctx, logging.DefaultSlogLogger)
 
-		err := kvstore.Client().Update(ctx, key, []byte(value), false)
+		err := client.Update(ctx, key, []byte(value), false)
 		if err != nil {
 			Fatalf("Unable to set key: %s", err)
 		}

--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -25,7 +25,6 @@ import (
 	ciliumClient "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/identitybackend"
-	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -241,14 +240,14 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset) (crdBackend all
 // find identities at the default cilium paths.
 func initKVStore(ctx, wctx context.Context) (kvstoreBackend allocator.Backend) {
 	log.Info("Setting up kvstore client")
-	setupKvstore(ctx, logging.DefaultSlogLogger)
+	client := setupKvstore(ctx, logging.DefaultSlogLogger)
 
-	if err := <-kvstore.Client().Connected(wctx); err != nil {
+	if err := <-client.Connected(wctx); err != nil {
 		log.WithError(err).Fatal("Cannot connect to the kvstore")
 	}
 
 	idPath := path.Join(cache.IdentitiesPath, "id")
-	kvstoreBackend, err := kvstoreallocator.NewKVStoreBackend(logging.DefaultSlogLogger, kvstoreallocator.KVStoreBackendConfiguration{BasePath: cache.IdentitiesPath, Suffix: idPath, Typ: &cacheKey.GlobalIdentity{}, Backend: kvstore.Client()})
+	kvstoreBackend, err := kvstoreallocator.NewKVStoreBackend(logging.DefaultSlogLogger, kvstoreallocator.KVStoreBackendConfiguration{BasePath: cache.IdentitiesPath, Suffix: idPath, Typ: &cacheKey.GlobalIdentity{}, Backend: client})
 	if err != nil {
 		log.WithError(err).Fatal("Cannot create kvstore identity backend")
 	}

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -156,7 +156,6 @@ func setupDaemonSuite(tb testing.TB) *DaemonSuite {
 	require.NoError(tb, err)
 
 	ds.dnsProxy.Set(fqdnproxy.MockFQDNProxy{})
-	kvstore.Client().DeletePrefix(ctx, kvstore.BaseKeyPrefix)
 
 	ds.d.policy.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 

--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -26,6 +26,7 @@ import (
 	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -116,6 +117,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 
 			ciliumNodeKVStore, err = store.JoinSharedStore(logging.DefaultSlogLogger,
 				store.Configuration{
+					Backend:    kvstore.Client(),
 					Prefix:     nodeStore.NodeStorePrefix,
 					KeyCreator: nodeStore.KeyCreator,
 				})

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -66,7 +66,7 @@ func TestClusterMesh(t *testing.T) {
 		wg.Wait()
 	}()
 
-	kvstore.SetupDummy(t, "etcd")
+	client := kvstore.SetupDummy(t, "etcd")
 
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
@@ -91,7 +91,7 @@ func TestClusterMesh(t *testing.T) {
 			config.Capabilities.SyncedCanaries = true
 		}
 
-		err := cmutils.SetClusterConfig(ctx, name, config, kvstore.Client())
+		err := cmutils.SetClusterConfig(ctx, name, config, client)
 		require.NoErrorf(t, err, "Failed to set cluster config for %s", name)
 	}
 
@@ -127,7 +127,7 @@ func TestClusterMesh(t *testing.T) {
 	})
 	require.NotNil(t, cm, "Failed to initialize clustermesh")
 	// cluster2 is the cluster which is tested with sync canaries
-	nodesWSS := storeFactory.NewSyncStore("cluster2", kvstore.Client(), nodeStore.NodeStorePrefix)
+	nodesWSS := storeFactory.NewSyncStore("cluster2", client, nodeStore.NodeStorePrefix)
 	wg.Add(1)
 	go func() {
 		nodesWSS.Run(ctx)
@@ -157,7 +157,7 @@ func TestClusterMesh(t *testing.T) {
 			MaxConnectedClusters: 255,
 		},
 	}
-	err := cmutils.SetClusterConfig(ctx, "cluster1", config, kvstore.Client())
+	err := cmutils.SetClusterConfig(ctx, "cluster1", config, client)
 	require.NoErrorf(t, err, "Failed to set cluster config for cluster1")
 	// Ugly hack to trigger config update
 	etcdConfigNew := append(etcdConfig, []byte("\n")...)

--- a/pkg/clustermesh/common/clustermesh_test.go
+++ b/pkg/clustermesh/common/clustermesh_test.go
@@ -47,7 +47,7 @@ func (f *fakeRemoteCluster) Remove(ctx context.Context) {
 
 func TestClusterMesh(t *testing.T) {
 	testutils.IntegrationTest(t)
-	kvstore.SetupDummy(t, "etcd")
+	client := kvstore.SetupDummy(t, "etcd")
 
 	baseDir := t.TempDir()
 	path := func(name string) string { return filepath.Join(baseDir, name) }
@@ -56,7 +56,7 @@ func TestClusterMesh(t *testing.T) {
 	capabilities := types.CiliumClusterConfigCapabilities{Cached: true, MaxConnectedClusters: 511}
 	for i, cluster := range []string{"cluster1", "cluster2", "cluster3"} {
 		cfg := types.CiliumClusterConfig{ID: uint32(i + 1), Capabilities: capabilities}
-		require.NoError(t, utils.SetClusterConfig(context.Background(), cluster, cfg, kvstore.Client()))
+		require.NoError(t, utils.SetClusterConfig(context.Background(), cluster, cfg, client))
 	}
 
 	var ready, stopped, removed lock.Map[string, bool]
@@ -191,7 +191,7 @@ func TestClusterMesh(t *testing.T) {
 
 func TestClusterMeshMultipleAddRemove(t *testing.T) {
 	testutils.IntegrationTest(t)
-	kvstore.SetupDummy(t, "etcd")
+	client := kvstore.SetupDummy(t, "etcd")
 
 	baseDir := t.TempDir()
 	path := func(name string) string { return filepath.Join(baseDir, name) }
@@ -199,7 +199,7 @@ func TestClusterMeshMultipleAddRemove(t *testing.T) {
 	for i, cluster := range []string{"cluster1", "cluster2", "cluster3", "cluster4"} {
 		writeFile(t, path(cluster), fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
 		cfg := types.CiliumClusterConfig{ID: uint32(i + 1)}
-		require.NoError(t, utils.SetClusterConfig(context.Background(), cluster, cfg, kvstore.Client()))
+		require.NoError(t, utils.SetClusterConfig(context.Background(), cluster, cfg, client))
 	}
 
 	var ready lock.Map[string, bool]

--- a/pkg/clustermesh/common/remote_cluster_test.go
+++ b/pkg/clustermesh/common/remote_cluster_test.go
@@ -32,12 +32,12 @@ func (fb *fakeBackend) StatusCheckErrors() <-chan error {
 
 func TestRemoteClusterWatchdog(t *testing.T) {
 	testutils.IntegrationTest(t)
-	kvstore.SetupDummy(t, "etcd")
+	client := kvstore.SetupDummy(t, "etcd")
 
 	const name = "remote"
 	path := filepath.Join(t.TempDir(), name)
 	writeFile(t, path, fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
-	require.NoError(t, utils.SetClusterConfig(context.Background(), name, types.CiliumClusterConfig{ID: 2}, kvstore.Client()))
+	require.NoError(t, utils.SetClusterConfig(context.Background(), name, types.CiliumClusterConfig{ID: 2}, client))
 
 	wait := func(t *testing.T, ch <-chan struct{}, msg string) {
 		t.Helper()

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -599,8 +599,6 @@ func TestRemoteClusterStatus(t *testing.T) {
 	t.Cleanup(func() {
 		cancel()
 		wg.Wait()
-
-		require.NoError(t, kvstore.Client().DeletePrefix(context.Background(), kvstore.BaseKeyPrefix))
 	})
 
 	remoteClient := &remoteEtcdClientWrapper{

--- a/pkg/clustermesh/mcsapi/serviceexportsync_test.go
+++ b/pkg/clustermesh/mcsapi/serviceexportsync_test.go
@@ -146,11 +146,11 @@ func Test_mcsServiceExportSync_Reconcile(t *testing.T) {
 		require.NoError(t, serviceExportStore.CacheStore().Add(svcExport))
 	}
 
-	kvstore.SetupDummy(t, "etcd")
+	client := kvstore.SetupDummy(t, "etcd")
 
 	clusterName := "cluster1"
 	storeFactory := store.NewFactory(hivetest.Logger(t), store.MetricsProvider())
-	kvs := storeFactory.NewSyncStore(clusterName, kvstore.Client(), types.ServiceExportStorePrefix)
+	kvs := storeFactory.NewSyncStore(clusterName, client, types.ServiceExportStorePrefix)
 	require.NoError(t, kvs.UpsertKey(ctx, &types.MCSAPIServiceSpec{
 		Cluster:                 clusterName,
 		Name:                    "remove-service",
@@ -179,7 +179,7 @@ func Test_mcsServiceExportSync_Reconcile(t *testing.T) {
 		name := "basic"
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			storeKey := "cilium/state/serviceexports/v1/cluster1/default/" + name
-			v, err := kvstore.Client().Get(ctx, storeKey)
+			v, err := client.Get(ctx, storeKey)
 			assert.NoError(c, err)
 			mcsAPISvcSpec := types.MCSAPIServiceSpec{}
 			assert.NoError(c, mcsAPISvcSpec.Unmarshal("", v))
@@ -201,7 +201,7 @@ func Test_mcsServiceExportSync_Reconcile(t *testing.T) {
 		name := "headless"
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			storeKey := "cilium/state/serviceexports/v1/cluster1/default/" + name
-			v, err := kvstore.Client().Get(ctx, storeKey)
+			v, err := client.Get(ctx, storeKey)
 			assert.NoError(c, err)
 			mcsAPISvcSpec := types.MCSAPIServiceSpec{}
 			assert.NoError(c, mcsAPISvcSpec.Unmarshal("", v))
@@ -214,7 +214,7 @@ func Test_mcsServiceExportSync_Reconcile(t *testing.T) {
 		name := "remove-service"
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			storeKey := "cilium/state/serviceexports/v1/cluster1/default/" + name
-			v, err := kvstore.Client().Get(ctx, storeKey)
+			v, err := client.Get(ctx, storeKey)
 			assert.NoError(c, err)
 			assert.Empty(c, string(v))
 		}, timeout, tick, "MCSAPIServiceSpec is not correctly synced")
@@ -224,7 +224,7 @@ func Test_mcsServiceExportSync_Reconcile(t *testing.T) {
 		name := "remove-service-export"
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			storeKey := "cilium/state/serviceexports/v1/cluster1/default/" + name
-			v, err := kvstore.Client().Get(ctx, storeKey)
+			v, err := client.Get(ctx, storeKey)
 			assert.NoError(c, err)
 			assert.Empty(c, string(v))
 		}, timeout, tick, "MCSAPIServiceSpec is not correctly synced")

--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -184,8 +184,6 @@ func TestRemoteClusterHooks(t *testing.T) {
 	t.Cleanup(func() {
 		cancel()
 		wg.Wait()
-
-		require.NoError(t, kvstore.Client().DeletePrefix(context.Background(), kvstore.BaseKeyPrefix))
 	})
 	logger := hivetest.Logger(t)
 	st := store.NewFactory(logger, store.MetricsProvider())

--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -32,7 +32,7 @@ var (
 func TestRemoteClusterStatus(t *testing.T) {
 	testutils.IntegrationTest(t)
 
-	kvstore.SetupDummy(t, "etcd")
+	client := kvstore.SetupDummy(t, "etcd")
 	kvsService := map[string]string{
 		"cilium/state/services/v1/foo/baz/bar": `{"name": "bar", "namespace": "baz", "cluster": "foo", "clusterID": 1}`,
 	}
@@ -84,7 +84,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 				cancel()
 				wg.Wait()
 
-				require.NoError(t, kvstore.Client().DeletePrefix(context.Background(), kvstore.BaseKeyPrefix))
+				require.NoError(t, client.DeletePrefix(context.Background(), kvstore.BaseKeyPrefix))
 			})
 
 			metrics := NewMetrics()
@@ -102,11 +102,11 @@ func TestRemoteClusterStatus(t *testing.T) {
 
 			// Populate the kvstore with the appropriate KV pairs
 			for key, value := range kvsService {
-				require.NoErrorf(t, kvstore.Client().Update(ctx, key, []byte(value), false), "Failed to set %s=%s", key, value)
+				require.NoErrorf(t, client.Update(ctx, key, []byte(value), false), "Failed to set %s=%s", key, value)
 			}
 			if tt.capabilityServiceExportsEnabled != nil {
 				for key, value := range kvsServiceExport {
-					require.NoErrorf(t, kvstore.Client().Update(ctx, key, []byte(value), false), "Failed to set %s=%s", key, value)
+					require.NoErrorf(t, client.Update(ctx, key, []byte(value), false), "Failed to set %s=%s", key, value)
 				}
 			}
 
@@ -142,7 +142,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 			ready := make(chan error)
 			wg.Add(1)
 			go func() {
-				rc.Run(ctx, kvstore.Client(), cfg, ready)
+				rc.Run(ctx, client, cfg, ready)
 				wg.Done()
 			}()
 
@@ -177,7 +177,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 func TestRemoteClusterHooks(t *testing.T) {
 	testutils.IntegrationTest(t)
 
-	kvstore.SetupDummy(t, "etcd")
+	client := kvstore.SetupDummy(t, "etcd")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -217,7 +217,7 @@ func TestRemoteClusterHooks(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		rc.Run(ctx, kvstore.Client(), cfg, ready)
+		rc.Run(ctx, client, cfg, ready)
 		wg.Done()
 	}()
 

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -280,10 +280,7 @@ func TestRemoteClusterClusterIDChange(t *testing.T) {
 	allocator := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
 	<-allocator.InitIdentityAllocator(nil)
 
-	t.Cleanup(func() {
-		allocator.Close()
-		require.NoError(t, kvstore.Client().DeletePrefix(context.Background(), kvstore.BaseKeyPrefix))
-	})
+	t.Cleanup(allocator.Close)
 
 	var obs fakeObserver
 	cm := ClusterMesh{

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -81,8 +81,6 @@ func setup(tb testing.TB) *ClusterMeshServicesTestSuite {
 	clusterName1 := s.randomName + "1"
 	clusterName2 := s.randomName + "2"
 
-	require.NoError(tb, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName))
-
 	db := statedb.New()
 
 	nodeAddrs, err := datapathTables.NewNodeAddressTable()

--- a/pkg/kvstore/allocator/doublewrite/backend_test.go
+++ b/pkg/kvstore/allocator/doublewrite/backend_test.go
@@ -28,12 +28,12 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func setup(tb testing.TB) (string, *k8sClient.FakeClientset, allocator.Backend) {
+func setup(tb testing.TB) (string, *k8sClient.FakeClientset, kvstore.BackendOperations, allocator.Backend) {
 	tb.Helper()
 
 	testutils.IntegrationTest(tb)
 
-	kvstore.SetupDummy(tb, "etcd")
+	kvstoreClient := kvstore.SetupDummy(tb, "etcd")
 	kvstorePrefix := fmt.Sprintf("test-prefix-%s", rand.String(12))
 	kubeClient, _ := k8sClient.NewFakeClientset(hivetest.Logger(tb))
 	backend, err := NewDoubleWriteBackend(
@@ -49,18 +49,18 @@ func setup(tb testing.TB) (string, *k8sClient.FakeClientset, allocator.Backend) 
 				BasePath: kvstorePrefix,
 				Suffix:   "a",
 				Typ:      &key.GlobalIdentity{},
-				Backend:  kvstore.Client(),
+				Backend:  kvstoreClient,
 			},
 			ReadFromKVStore: true,
 		})
 	require.NoError(tb, err)
 	require.NotNil(tb, backend)
 
-	return kvstorePrefix, kubeClient, backend
+	return kvstorePrefix, kubeClient, kvstoreClient, backend
 }
 
 func TestAllocateID(t *testing.T) {
-	kvstorePrefix, kubeClient, backend := setup(t)
+	kvstorePrefix, kubeClient, kvstoreClient, backend := setup(t)
 
 	// Allocate a new identity
 	lbls := labels.NewLabelsFromSortedList("id=foo")
@@ -81,7 +81,7 @@ func TestAllocateID(t *testing.T) {
 	)
 
 	// 2. KVStore
-	kvPairs, err := kvstore.Client().ListPrefix(context.Background(), path.Join(kvstorePrefix, "id"))
+	kvPairs, err := kvstoreClient.ListPrefix(context.Background(), path.Join(kvstorePrefix, "id"))
 	require.NoError(t, err)
 	require.Len(t, kvPairs, 1)
 	require.Equal(t,
@@ -91,7 +91,7 @@ func TestAllocateID(t *testing.T) {
 }
 
 func TestAllocateIDFailure(t *testing.T) {
-	kvstorePrefix, kubeClient, backend := setup(t)
+	kvstorePrefix, kubeClient, kvstoreClient, backend := setup(t)
 
 	// Allocate a new identity
 	lbls := labels.NewLabelsFromSortedList("id=foo")
@@ -99,7 +99,7 @@ func TestAllocateIDFailure(t *testing.T) {
 	identityID := idpool.ID(10)
 
 	// Pre-create the identity in the KVStore so as to trigger failure during allocation
-	_, err := kvstore.Client().CreateOnly(context.Background(), path.Join(kvstorePrefix, "id", strconv.FormatUint(uint64(identityID), 10)), []byte(k.GetKey()), false)
+	_, err := kvstoreClient.CreateOnly(context.Background(), path.Join(kvstorePrefix, "id", strconv.FormatUint(uint64(identityID), 10)), []byte(k.GetKey()), false)
 	require.NoError(t, err)
 
 	_, err = backend.AllocateID(context.Background(), identityID, k)
@@ -113,7 +113,7 @@ func TestAllocateIDFailure(t *testing.T) {
 }
 
 func TestGetID(t *testing.T) {
-	kvstorePrefix, kubeClient, backend := setup(t)
+	kvstorePrefix, kubeClient, kvstoreClient, backend := setup(t)
 
 	// Allocate a new identity
 	lbls := labels.NewLabelsFromSortedList("id=foo")
@@ -137,7 +137,7 @@ func TestGetID(t *testing.T) {
 	require.Equal(t, returnedKey.GetKey(), k.GetKey())
 
 	// Delete the KVStore identity
-	err = kvstore.Client().Delete(context.Background(), path.Join(kvstorePrefix, "id", identityID.String()))
+	err = kvstoreClient.Delete(context.Background(), path.Join(kvstorePrefix, "id", identityID.String()))
 	require.NoError(t, err)
 
 	// Verify that we can't retrieve the identity anymore

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -28,9 +28,6 @@ func TestLock(t *testing.T) {
 func testLock(t *testing.T) {
 	prefix := "locktest/"
 
-	Client().DeletePrefix(context.TODO(), prefix)
-	defer Client().DeletePrefix(context.TODO(), prefix)
-
 	for i := range 10 {
 		lock, err := LockPath(context.Background(), hivetest.Logger(t), Client(), fmt.Sprintf("%sfoo/%d", prefix, i))
 		require.NoError(t, err)
@@ -56,9 +53,6 @@ func TestGetSet(t *testing.T) {
 func testGetSet(t *testing.T) {
 	prefix := "unit-test/"
 	maxID := 8
-
-	Client().DeletePrefix(context.TODO(), prefix)
-	defer Client().DeletePrefix(context.TODO(), prefix)
 
 	pairs, err := Client().ListPrefix(context.Background(), prefix)
 	require.NoError(t, err)
@@ -101,8 +95,6 @@ func BenchmarkGet(b *testing.B) {
 
 func benchmarkGet(b *testing.B) {
 	prefix := "unit-test/"
-	Client().DeletePrefix(context.TODO(), prefix)
-	defer Client().DeletePrefix(context.TODO(), prefix)
 
 	key := testKey(prefix, 1)
 	require.NoError(b, Client().Update(context.TODO(), key, []byte(testValue(100)), false))
@@ -121,8 +113,6 @@ func BenchmarkSet(b *testing.B) {
 
 func benchmarkSet(b *testing.B) {
 	prefix := "unit-test/"
-	Client().DeletePrefix(context.TODO(), prefix)
-	defer Client().DeletePrefix(context.TODO(), prefix)
 
 	key, val := testKey(prefix, 1), testValue(100)
 
@@ -139,9 +129,6 @@ func TestUpdate(t *testing.T) {
 
 func testUpdate(t *testing.T) {
 	prefix := "unit-test/"
-
-	Client().DeletePrefix(context.TODO(), prefix)
-	defer Client().DeletePrefix(context.TODO(), prefix)
 
 	// create
 	require.NoError(t, Client().Update(context.Background(), testKey(prefix, 0), []byte(testValue(0)), true))
@@ -166,9 +153,6 @@ func TestCreateOnly(t *testing.T) {
 
 func testCreateOnly(t *testing.T) {
 	prefix := "unit-test/"
-
-	Client().DeletePrefix(context.TODO(), prefix)
-	defer Client().DeletePrefix(context.TODO(), prefix)
 
 	success, err := Client().CreateOnly(context.Background(), testKey(prefix, 0), []byte(testValue(0)), false)
 	require.NoError(t, err)
@@ -210,9 +194,6 @@ func TestListAndWatch(t *testing.T) {
 func testListAndWatch(t *testing.T) {
 	key1, key2 := "foo2/key1", "foo2/key2"
 	val1, val2 := "val1", "val2"
-
-	Client().DeletePrefix(context.TODO(), "foo2/")
-	defer Client().DeletePrefix(context.TODO(), "foo2/")
 
 	success, err := Client().CreateOnly(context.Background(), key1, []byte(val1), false)
 	require.NoError(t, err)

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -21,15 +21,12 @@ var (
 
 func TestLock(t *testing.T) {
 	testutils.IntegrationTest(t)
-	SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
-	testLock(t)
-}
+	client := SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
 
-func testLock(t *testing.T) {
 	prefix := "locktest/"
 
 	for i := range 10 {
-		lock, err := LockPath(context.Background(), hivetest.Logger(t), Client(), fmt.Sprintf("%sfoo/%d", prefix, i))
+		lock, err := LockPath(context.Background(), hivetest.Logger(t), client, fmt.Sprintf("%sfoo/%d", prefix, i))
 		require.NoError(t, err)
 		require.NotNil(t, lock)
 		lock.Unlock(context.TODO())
@@ -46,127 +43,112 @@ func testValue(i int) string {
 
 func TestGetSet(t *testing.T) {
 	testutils.IntegrationTest(t)
-	SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
-	testGetSet(t)
-}
+	client := SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
 
-func testGetSet(t *testing.T) {
 	prefix := "unit-test/"
 	maxID := 8
 
-	pairs, err := Client().ListPrefix(context.Background(), prefix)
+	pairs, err := client.ListPrefix(context.Background(), prefix)
 	require.NoError(t, err)
 	require.Empty(t, pairs)
 
 	for i := range maxID {
-		val, err := Client().Get(context.TODO(), testKey(prefix, i))
+		val, err := client.Get(context.TODO(), testKey(prefix, i))
 		require.NoError(t, err)
 		require.Nil(t, val)
 
-		require.NoError(t, Client().Update(context.TODO(), testKey(prefix, i), []byte(testValue(i)), false))
+		require.NoError(t, client.Update(context.TODO(), testKey(prefix, i), []byte(testValue(i)), false))
 
-		val, err = Client().Get(context.TODO(), testKey(prefix, i))
+		val, err = client.Get(context.TODO(), testKey(prefix, i))
 		require.NoError(t, err)
 		require.Equal(t, testValue(i), string(val))
 	}
 
-	pairs, err = Client().ListPrefix(context.Background(), prefix)
+	pairs, err = client.ListPrefix(context.Background(), prefix)
 	require.NoError(t, err)
 	require.Len(t, pairs, maxID)
 
 	for i := range maxID {
-		require.NoError(t, Client().Delete(context.TODO(), testKey(prefix, i)))
+		require.NoError(t, client.Delete(context.TODO(), testKey(prefix, i)))
 
-		val, err := Client().Get(context.TODO(), testKey(prefix, i))
+		val, err := client.Get(context.TODO(), testKey(prefix, i))
 		require.NoError(t, err)
 		require.Nil(t, val)
 	}
 
-	pairs, err = Client().ListPrefix(context.Background(), prefix)
+	pairs, err = client.ListPrefix(context.Background(), prefix)
 	require.NoError(t, err)
 	require.Empty(t, pairs)
 }
 
 func BenchmarkGet(b *testing.B) {
 	testutils.IntegrationTest(b)
-	SetupDummyWithConfigOpts(b, "etcd", etcdOpts)
-	benchmarkGet(b)
-}
+	client := SetupDummyWithConfigOpts(b, "etcd", etcdOpts)
 
-func benchmarkGet(b *testing.B) {
 	prefix := "unit-test/"
 
 	key := testKey(prefix, 1)
-	require.NoError(b, Client().Update(context.TODO(), key, []byte(testValue(100)), false))
+	require.NoError(b, client.Update(context.TODO(), key, []byte(testValue(100)), false))
 
 	for b.Loop() {
-		_, err := Client().Get(context.TODO(), key)
+		_, err := client.Get(context.TODO(), key)
 		require.NoError(b, err)
 	}
 }
 
 func BenchmarkSet(b *testing.B) {
 	testutils.IntegrationTest(b)
-	SetupDummyWithConfigOpts(b, "etcd", etcdOpts)
-	benchmarkSet(b)
-}
+	client := SetupDummyWithConfigOpts(b, "etcd", etcdOpts)
 
-func benchmarkSet(b *testing.B) {
 	prefix := "unit-test/"
 
 	key, val := testKey(prefix, 1), testValue(100)
 
 	for b.Loop() {
-		require.NoError(b, Client().Update(context.TODO(), key, []byte(val), false))
+		require.NoError(b, client.Update(context.TODO(), key, []byte(val), false))
 	}
 }
 
 func TestUpdate(t *testing.T) {
 	testutils.IntegrationTest(t)
-	SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
-	testUpdate(t)
-}
+	client := SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
 
-func testUpdate(t *testing.T) {
 	prefix := "unit-test/"
 
 	// create
-	require.NoError(t, Client().Update(context.Background(), testKey(prefix, 0), []byte(testValue(0)), true))
+	require.NoError(t, client.Update(context.Background(), testKey(prefix, 0), []byte(testValue(0)), true))
 
-	val, err := Client().Get(context.TODO(), testKey(prefix, 0))
+	val, err := client.Get(context.TODO(), testKey(prefix, 0))
 	require.NoError(t, err)
 	require.Equal(t, testValue(0), string(val))
 
 	// update
-	require.NoError(t, Client().Update(context.Background(), testKey(prefix, 0), []byte(testValue(0)), true))
+	require.NoError(t, client.Update(context.Background(), testKey(prefix, 0), []byte(testValue(0)), true))
 
-	val, err = Client().Get(context.TODO(), testKey(prefix, 0))
+	val, err = client.Get(context.TODO(), testKey(prefix, 0))
 	require.NoError(t, err)
 	require.Equal(t, testValue(0), string(val))
 }
 
 func TestCreateOnly(t *testing.T) {
 	testutils.IntegrationTest(t)
-	SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
-	testCreateOnly(t)
-}
+	client := SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
 
-func testCreateOnly(t *testing.T) {
 	prefix := "unit-test/"
 
-	success, err := Client().CreateOnly(context.Background(), testKey(prefix, 0), []byte(testValue(0)), false)
+	success, err := client.CreateOnly(context.Background(), testKey(prefix, 0), []byte(testValue(0)), false)
 	require.NoError(t, err)
 	require.True(t, success)
 
-	val, err := Client().Get(context.TODO(), testKey(prefix, 0))
+	val, err := client.Get(context.TODO(), testKey(prefix, 0))
 	require.NoError(t, err)
 	require.Equal(t, testValue(0), string(val))
 
-	success, err = Client().CreateOnly(context.Background(), testKey(prefix, 0), []byte(testValue(1)), false)
+	success, err = client.CreateOnly(context.Background(), testKey(prefix, 0), []byte(testValue(1)), false)
 	require.NoError(t, err)
 	require.False(t, success)
 
-	val, err = Client().Get(context.TODO(), testKey(prefix, 0))
+	val, err = client.Get(context.TODO(), testKey(prefix, 0))
 	require.NoError(t, err)
 	require.Equal(t, testValue(0), string(val))
 }
@@ -187,44 +169,41 @@ func expectEvent(t *testing.T, events EventChan, typ EventType, key string, val 
 
 func TestListAndWatch(t *testing.T) {
 	testutils.IntegrationTest(t)
-	SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
-	testListAndWatch(t)
-}
+	client := SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
 
-func testListAndWatch(t *testing.T) {
 	key1, key2 := "foo2/key1", "foo2/key2"
 	val1, val2 := "val1", "val2"
 
-	success, err := Client().CreateOnly(context.Background(), key1, []byte(val1), false)
+	success, err := client.CreateOnly(context.Background(), key1, []byte(val1), false)
 	require.NoError(t, err)
 	require.True(t, success)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	events := Client().ListAndWatch(ctx, "foo2/")
+	events := client.ListAndWatch(ctx, "foo2/")
 	require.NotNil(t, t)
 
 	expectEvent(t, events, EventTypeCreate, key1, val1)
 	expectEvent(t, events, EventTypeListDone, "", "")
 
-	success, err = Client().CreateOnly(context.Background(), key2, []byte(val2), false)
+	success, err = client.CreateOnly(context.Background(), key2, []byte(val2), false)
 	require.NoError(t, err)
 	require.True(t, success)
 	expectEvent(t, events, EventTypeCreate, key2, val2)
 
-	err = Client().Delete(context.TODO(), key1)
+	err = client.Delete(context.TODO(), key1)
 	require.NoError(t, err)
 	expectEvent(t, events, EventTypeDelete, key1, val1)
 
-	success, err = Client().CreateOnly(context.Background(), key1, []byte(val1), false)
+	success, err = client.CreateOnly(context.Background(), key1, []byte(val1), false)
 	require.NoError(t, err)
 	require.True(t, success)
 	expectEvent(t, events, EventTypeCreate, key1, val1)
 
-	err = Client().Delete(context.TODO(), key1)
+	err = client.Delete(context.TODO(), key1)
 	require.NoError(t, err)
 	expectEvent(t, events, EventTypeDelete, key1, val1)
 
-	err = Client().Delete(context.TODO(), key2)
+	err = client.Delete(context.TODO(), key2)
 	require.NoError(t, err)
 	expectEvent(t, events, EventTypeDelete, key2, val2)
 

--- a/pkg/kvstore/dummy.go
+++ b/pkg/kvstore/dummy.go
@@ -22,8 +22,8 @@ var (
 // the creation of two clients at the same time, to avoid interferences in case
 // different tests are run in parallel. A cleanup function is automatically
 // registered to delete all keys and close the client when the test terminates.
-func SetupDummy(tb testing.TB, dummyBackend string) {
-	SetupDummyWithConfigOpts(tb, dummyBackend, nil)
+func SetupDummy(tb testing.TB, dummyBackend string) BackendOperations {
+	return SetupDummyWithConfigOpts(tb, dummyBackend, nil)
 }
 
 // SetupDummyWithConfigOpts sets up the dummy kvstore for tests but also
@@ -32,7 +32,7 @@ func SetupDummy(tb testing.TB, dummyBackend string) {
 // in case different tests are run in parallel. A cleanup function is
 // automatically registered to delete all keys and close the client when the
 // test terminates.
-func SetupDummyWithConfigOpts(tb testing.TB, dummyBackend string, opts map[string]string) {
+func SetupDummyWithConfigOpts(tb testing.TB, dummyBackend string, opts map[string]string) BackendOperations {
 	module := getBackend(dummyBackend)
 	if module == nil {
 		tb.Fatalf("Unknown dummy kvstore backend %s", dummyBackend)
@@ -51,18 +51,20 @@ func SetupDummyWithConfigOpts(tb testing.TB, dummyBackend string, opts map[strin
 		tb.Fatalf("Unable to initialize kvstore client: %v", err)
 	}
 
+	client := Client()
+
 	tb.Cleanup(func() {
-		if err := Client().DeletePrefix(context.Background(), ""); err != nil {
+		if err := client.DeletePrefix(context.Background(), ""); err != nil {
 			tb.Fatalf("Unable to delete all kvstore keys: %v", err)
 		}
 
-		Client().Close()
+		client.Close()
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	if err := <-Client().Connected(ctx); err != nil {
+	if err := <-client.Connected(ctx); err != nil {
 		tb.Fatalf("Failed waiting for kvstore connection to be established: %v", err)
 	}
 
@@ -73,13 +75,13 @@ func SetupDummyWithConfigOpts(tb testing.TB, dummyBackend string, opts map[strin
 	// the locking abstraction), so that we can release it in the same atomic
 	// transaction that also removes all the other keys.
 	for {
-		succeeded, err := Client().CreateOnly(ctx, ".lock", []byte(""), true)
+		succeeded, err := client.CreateOnly(ctx, ".lock", []byte(""), true)
 		if err != nil {
 			tb.Fatalf("Unable to acquire the kvstore lock: %v", err)
 		}
 
 		if succeeded {
-			return
+			return client
 		}
 
 		select {

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -59,8 +59,7 @@ type Configuration struct {
 	// key is discovered. This parameter is required.
 	KeyCreator KeyCreator
 
-	// Backend is the kvstore to use as a backend. If no backend is
-	// specified, kvstore.Client() is being used.
+	// Backend is the kvstore to use as a backend. This parameter is required.
 	Backend kvstore.BackendOperations
 
 	// Observer is the observe that will receive events on key mutations
@@ -85,7 +84,7 @@ func (c *Configuration) validate() error {
 	}
 
 	if c.Backend == nil {
-		c.Backend = kvstore.Client()
+		return fmt.Errorf("backend must be specified")
 	}
 
 	if c.Context == nil {

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -155,6 +155,7 @@ func (nr *NodeRegistrar) RegisterNode(n *nodeTypes.Node, manager NodeExtendedMan
 
 	// Join the shared store holding node information of entire cluster
 	nodeStore, err := store.JoinSharedStore(logging.DefaultSlogLogger, store.Configuration{
+		Backend:              kvstore.Client(),
 		Prefix:               NodeStorePrefix,
 		KeyCreator:           ValidatingKeyCreator(),
 		SharedKeyDeleteDelay: defaults.NodeDeleteDelay,


### PR DESCRIPTION
Remove almost all usages of the `kvstore.Client()` global getter, in order to simplify its subsequent removal and conversion  to a proper Cell. The remaining usages should be trivial to remove once the kvstore cell is provided through Hive.

Please review commit by commit, and refer to the commit descriptions for additional details.