### PR TITLE
[v1.17] k8s/statedb: Fix buffering order of objects

### DIFF
--- a/pkg/container/insert_ordered_map.go
+++ b/pkg/container/insert_ordered_map.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package container
+
+import (
+	"iter"
+)
+
+// InsertOrderedMap is a map that allows iterating over the keys in the order
+// they were inserted.
+type InsertOrderedMap[K comparable, V any] struct {
+	indexes map[K]int
+	kvs     []keyValuePair[K, V]
+}
+
+type keyValuePair[K, V any] struct {
+	key   K
+	value V
+}
+
+// NewInsertOrderedMap creates a new insert-ordered map.
+func NewInsertOrderedMap[K comparable, V any]() *InsertOrderedMap[K, V] {
+	return &InsertOrderedMap[K, V]{
+		indexes: map[K]int{},
+		kvs:     []keyValuePair[K, V]{},
+	}
+}
+
+// Clear the map.
+func (m *InsertOrderedMap[K, V]) Clear() {
+	clear(m.indexes)
+	m.kvs = m.kvs[:0]
+}
+
+// Len returns the number of items in the map.
+func (m *InsertOrderedMap[K, V]) Len() int {
+	return len(m.kvs)
+}
+
+// All returns an iterator for keys and values in the map in insertion order.
+func (m *InsertOrderedMap[K, V]) All() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for _, kv := range m.kvs {
+			if !yield(kv.key, kv.value) {
+				break
+			}
+		}
+	}
+}
+
+// Keys returns an iterator for the keys in the map in insertion order.
+func (m *InsertOrderedMap[K, V]) Keys() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for _, kv := range m.kvs {
+			if !yield(kv.key) {
+				break
+			}
+		}
+	}
+}
+
+// Values returns an iterator for the values in the map in insertion order.
+func (m *InsertOrderedMap[K, V]) Values() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, kv := range m.kvs {
+			if !yield(kv.value) {
+				break
+			}
+		}
+	}
+}
+
+// Get a value from the map. O(1).
+func (m *InsertOrderedMap[K, V]) Get(k K) (v V, found bool) {
+	var idx int
+	idx, found = m.indexes[k]
+	if !found {
+		return
+	}
+	return m.kvs[idx].value, true
+}
+
+// Delete a key from the map. O(n).
+func (m *InsertOrderedMap[K, V]) Delete(k K) (found bool) {
+	var idx int
+	idx, found = m.indexes[k]
+	if !found {
+		return
+	}
+	delete(m.indexes, k)
+
+	// Shift over the deleted element and update indexes
+	for i := idx; i < len(m.kvs)-1; i++ {
+		m.kvs[i] = m.kvs[i+1]
+		m.indexes[m.kvs[i].key] = i
+	}
+	m.kvs = m.kvs[:len(m.kvs)-1]
+	return true
+}
+
+// Insert or update a key in the map. O(1).
+// An update will not affect the ordering.
+func (m *InsertOrderedMap[K, V]) Insert(k K, v V) {
+	idx, found := m.indexes[k]
+	if found {
+		m.kvs[idx].value = v
+		return
+	}
+
+	idx = len(m.kvs)
+	m.indexes[k] = idx
+	m.kvs = append(m.kvs, struct {
+		key   K
+		value V
+	}{k, v})
+}

--- a/pkg/container/insert_ordered_map_test.go
+++ b/pkg/container/insert_ordered_map_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package container
+
+import (
+	"maps"
+	"math/rand/v2"
+	"slices"
+	"testing"
+	"testing/quick"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsertOrderedMap_Empty(t *testing.T) {
+	m := NewInsertOrderedMap[int, int]()
+	require.Empty(t, maps.Collect(m.All()), "All()")
+	require.Empty(t, slices.Collect(m.Keys()), "Keys()")
+	require.Empty(t, slices.Collect(m.Values()), "Values()")
+	_, found := m.Get(0)
+	require.False(t, found, "Get")
+	found = m.Delete(0)
+	require.False(t, found, "Delete")
+	m.Clear()
+}
+
+func TestInsertOrderedMap_Insert(t *testing.T) {
+	m := NewInsertOrderedMap[int, string]()
+	m.Insert(1, "1")
+	m.Insert(2, "2")
+	m.Insert(3, "3")
+	m.Insert(3, "3-3")
+	m.Insert(2, "2-2")
+	m.Insert(1, "1-1")
+	require.Equal(t, []int{1, 2, 3}, slices.Collect(m.Keys()))
+	require.Equal(t, []string{"1-1", "2-2", "3-3"}, slices.Collect(m.Values()))
+	require.Equal(t, 3, m.Len(), "Len()")
+	m.Clear()
+}
+
+func TestInsertOrderedMap_Quick(t *testing.T) {
+	err := quick.Check(func(keys []int) bool {
+		if len(keys) < 1 {
+			// We need some keys to test with.
+			return true
+		}
+
+		m := NewInsertOrderedMap[int, int]()
+		for _, k := range keys {
+			m.Insert(k, k)
+		}
+
+		// Update the keys in random order. This does not affect the
+		// iteration order.
+		randomized := slices.Clone(keys)
+		rand.Shuffle(len(randomized), func(i, j int) {
+			randomized[i], randomized[j] = randomized[j], randomized[i]
+		})
+		for _, k := range randomized {
+			m.Insert(k, k*2)
+		}
+		keysCopy := slices.Clone(keys)
+		numUnique := 0
+		for k, v := range m.All() {
+			numUnique++
+			expected := keys[0]
+			keys = keys[1:]
+			if k != expected || v != expected*2 {
+				t.Logf("Unexpected order or value: key=%v (expected %v), value=%v (expected %v)",
+					k, expected, v, expected*2)
+				return false
+			}
+
+			v, found := m.Get(k)
+			if !found {
+				t.Logf("%v not found", k)
+				return false
+			}
+			if v != k*2 {
+				t.Logf("value %v not the expected %v", v, k*2)
+			}
+		}
+		if m.Len() != numUnique {
+			t.Logf("Len() returned %d, expected %d", m.Len(), numUnique)
+			return false
+		}
+		keys = keysCopy
+
+		// Delete a random key. Ordering should not be affected and all keys are found.
+		if !m.Delete(randomized[0]) {
+			t.Logf("Delete did not return true")
+		}
+		for i, k := range keys {
+			if k == randomized[0] {
+				keys = slices.Delete(keys, i, i+1)
+				break
+			}
+		}
+
+		for k := range m.Keys() {
+			v, found := m.Get(k)
+			if !found {
+				t.Logf("%v not found", k)
+				return false
+			}
+			expected := keys[0]
+			keys = keys[1:]
+			if k != expected || v != expected*2 {
+				t.Logf("Unexpected order or value: key=%v (expected %v), value=%v (expected %v)",
+					k, expected, v, expected*2)
+				return false
+			}
+		}
+		return true
+	}, nil)
+	require.NoError(t, err)
+}

--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"sync"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -17,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/cilium/cilium/pkg/container"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -232,7 +234,14 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 	}
 	type buffer struct {
 		replaceItems []any
-		entries      map[string]entry
+		entries      *container.InsertOrderedMap[string, entry]
+	}
+	var bufferPool = sync.Pool{
+		New: func() any {
+			return &buffer{
+				entries: container.NewInsertOrderedMap[string, entry](),
+			}
+		},
 	}
 	bufferSize := r.BufferSize
 	waitTime := r.BufferWaitTime
@@ -286,17 +295,13 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 
 		// Buffer the events into a map, coalescing them by key.
 		func(buf *buffer, ev CacheStoreEvent) *buffer {
-			switch {
-			case ev.Kind == CacheStoreEventReplace:
-				return &buffer{
-					replaceItems: ev.Obj.([]any),
-					entries:      make(map[string]entry, bufferSize), // Forget prior entries
-				}
-			case buf == nil:
-				buf = &buffer{
-					replaceItems: nil,
-					entries:      make(map[string]entry, bufferSize),
-				}
+			if buf == nil {
+				buf = bufferPool.Get().(*buffer)
+			}
+			if ev.Kind == CacheStoreEventReplace {
+				buf.replaceItems = ev.Obj.([]any)
+				buf.entries.Clear()
+				return buf
 			}
 
 			var entry entry
@@ -315,7 +320,7 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 			} else {
 				key = entry.name
 			}
-			buf.entries[key] = entry
+			buf.entries.Insert(key, entry)
 			return buf
 		},
 	)
@@ -356,7 +361,7 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 			r.initDone(txn)
 		}
 
-		for _, entry := range buf.entries {
+		for entry := range buf.entries.Values() {
 			for _, obj := range transformMany(txn, entry.obj) {
 				if !entry.deleted {
 					if _, _, err := table.Modify(txn, obj, merge); err != nil {
@@ -376,6 +381,10 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 
 		numTotal := table.NumObjects(txn)
 		txn.Commit()
+
+		buf.replaceItems = nil
+		buf.entries.Clear()
+		bufferPool.Put(buf)
 
 		health.OK(fmt.Sprintf("%d upserted, %d deleted, %d total objects", numUpserted, numDeleted, numTotal))
 	}


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/38584 without the commits to the experimental load-balancer code which are not relevant for backporting.