### PR TITLE
pkg/bpf: Synchronize access to map in DumpReliablyWithCallback

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -1307,6 +1307,16 @@ func (m *Map) Delete(key MapKey) error {
 	return err
 }
 
+// DeleteLocked deletes the map entry for the given key.
+//
+// This method must be called from within a DumpCallback to avoid deadlocks,
+// as it assumes the m.lock is already acquired.
+func (m *Map) DeleteLocked(key MapKey) error {
+	_, err := m.delete(key, false)
+
+	return err
+}
+
 // DeleteAll deletes all entries of a map by traversing the map and deleting individual
 // entries. Note that if entries are added while the taversal is in progress,
 // such entries may survive the deletion process.

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -561,6 +561,8 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 	}
 	stats := newNatGCStats(natMap, family)
 	defer stats.finish()
+	egressEntriesToDelete := make([]nat.NatKey, 0)
+	ingressEntriesToDelete := make([]nat.NatKey, 0)
 
 	cb := func(key bpf.MapKey, value bpf.MapValue) {
 		natKey := key.(nat.NatKey)
@@ -576,9 +578,7 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 
 			if !ctEntryExist(ctMap, ctKey, nil) {
 				// No egress CT entry is found, delete the orphan ingress SNAT entry
-				if deleted, _ := natMap.Delete(natKey); deleted {
-					stats.IngressDeleted++
-				}
+				ingressEntriesToDelete = append(ingressEntriesToDelete, natKey)
 			} else {
 				stats.IngressAlive++
 			}
@@ -593,9 +593,7 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 			if !ctEntryExist(ctMap, egressCTKey, nil) &&
 				!ctEntryExist(ctMap, dsrCTKey, checkDsr) {
 				// No relevant CT entries were found, delete the orphan egress NAT entry
-				if deleted, _ := natMap.Delete(natKey); deleted {
-					stats.EgressDeleted++
-				}
+				egressEntriesToDelete = append(egressEntriesToDelete, natKey)
 			} else {
 				stats.EgressAlive++
 			}
@@ -605,6 +603,16 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 	if err := natMap.DumpReliablyWithCallback(cb, stats.DumpStats); err != nil {
 		natMap.Logger.Error("NATmap dump failed during GC", logfields.Error, err)
 	} else {
+		for _, key := range egressEntriesToDelete {
+			if deleted, _ := natMap.Delete(key); deleted {
+				stats.EgressDeleted++
+			}
+		}
+		for _, key := range ingressEntriesToDelete {
+			if deleted, _ := natMap.Delete(key); deleted {
+				stats.IngressDeleted++
+			}
+		}
 		natMap.UpdatePressureMetricWithSize(int32(stats.IngressAlive + stats.EgressAlive))
 	}
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -381,7 +381,7 @@ func doGCForFamily(m *Map, filter GCFilter, next4, next6 func(GCEvent), ipv6 boo
 }
 
 func purgeCtEntry(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map, next func(event GCEvent), actCountFailed func(uint16, uint32)) error {
-	err := m.Delete(key)
+	err := m.DeleteLocked(key)
 	if err != nil {
 		return err
 	}

--- a/pkg/maps/nat/nap_flush_test.go
+++ b/pkg/maps/nat/nap_flush_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+func TestFlushNat(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	numEntries := 5
+	v4NatMap := NewMap("test_nap_v4", IPv4, 1000)
+	err := v4NatMap.OpenOrCreate()
+	assert.NoError(t, err)
+	v6NatMap := NewMap("test_nat_v6", IPv6, 1000)
+	err = v6NatMap.OpenOrCreate()
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		v4NatMap.UnpinIfExists()
+		v6NatMap.UnpinIfExists()
+	})
+
+	// Populate the map with dummy entries
+	for i := 1; i <= numEntries; i++ {
+		mapKey := &NatKey4{}
+		ip := types.IPv4{192, 168, 0, byte(i)}
+		mapKey.TupleKey4.SourceAddr = ip
+		mapKey.TupleKey4.DestAddr = [4]byte{}
+		mapKey.TupleKey4.DestPort = 8000 + uint16(i)
+		err := v4NatMap.Update(mapKey, &NatEntry4{})
+		assert.NoError(t, err, "failed to insert NAT entry")
+
+		ip6 := types.IPv6{}
+		ip6[15] = byte(i)
+		mapKey6 := &NatKey6{}
+		mapKey6.TupleKey6.SourceAddr = ip6
+		mapKey6.TupleKey6.DestAddr = [16]byte{}
+		mapKey6.TupleKey6.DestPort = 8000 + uint16(i)
+		err = v6NatMap.Update(mapKey6.ToNetwork(), &NatEntry6{})
+		assert.NoError(t, err)
+	}
+
+	// Verify entry count before flush.
+	var count int
+	assert.NoError(t, v4NatMap.DumpWithCallback(func(_ bpf.MapKey, _ bpf.MapValue) { count++ }))
+	assert.Equal(t, numEntries, count)
+	// Verify entry count after flush.
+	deleted := v4NatMap.Flush()
+	assert.Equal(t, numEntries, deleted)
+	// Confirm the map is empty after flush.
+	count = 0
+	assert.NoError(t, v4NatMap.DumpWithCallback(func(_ bpf.MapKey, _ bpf.MapValue) { count++ }))
+	assert.Equal(t, 0, count)
+
+	assert.NoError(t, v6NatMap.DumpWithCallback(func(_ bpf.MapKey, _ bpf.MapValue) { count++ }))
+	assert.Equal(t, numEntries, count)
+	deleted = v6NatMap.Flush()
+	assert.Equal(t, numEntries, deleted)
+	count = 0
+	assert.NoError(t, v6NatMap.DumpWithCallback(func(_ bpf.MapKey, _ bpf.MapValue) { count++ }))
+	assert.Equal(t, 0, count)
+}

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -256,7 +256,7 @@ func statStartGc(m *Map) gcStats {
 func doFlush4(m *Map) gcStats {
 	stats := statStartGc(m)
 	filterCallback := func(key bpf.MapKey, _ bpf.MapValue) {
-		err := (&m.Map).Delete(key)
+		err := (&m.Map).DeleteLocked(key)
 		if err != nil {
 			m.Logger.Error("Unable to delete NAT entry",
 				logfields.Error, err,
@@ -273,7 +273,7 @@ func doFlush4(m *Map) gcStats {
 func doFlush6(m *Map) gcStats {
 	stats := statStartGc(m)
 	filterCallback := func(key bpf.MapKey, _ bpf.MapValue) {
-		err := (&m.Map).Delete(key)
+		err := (&m.Map).DeleteLocked(key)
 		if err != nil {
 			m.Logger.Error("Unable to delete NAT entry",
 				logfields.Error, err,


### PR DESCRIPTION
The method previously accessed the map construct directly, which could result in race conditions with other operations on the map, such as in the `Close` method.

One such data race was reported in the ctmap, where the map was closed by a periodically running controller while it was simultaneously accessed in `DumpReliablyWithCallback`. Currently, callers can invoke map operations in the callback
that acquire the map (write) lock. To allow such callbacks without causing a deadlock, acquire the (write) lock instead
of RLock.

(snippet)

```
2025-01-30T21:27:22.005325276Z Read at 0x00c0099535a8 by goroutine 6096710:
2025-01-30T21:27:22.005373476Z   github.com/cilium/ebpf/internal/sys.(*FD).Uint()
2025-01-30T21:27:22.005379677Z       /go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/internal/sys/fd.go:71 +0x144
2025-01-30T21:27:22.005446912Z   github.com/cilium/ebpf.(*Map).nextKey()
2025-01-30T21:27:22.005454006Z       /go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/map.go:993 +0x112
2025-01-30T21:27:22.005553101Z   github.com/cilium/ebpf.(*Map).NextKey()
2025-01-30T21:27:22.005560745Z       /go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/map.go:950 +0xae
2025-01-30T21:27:22.005640643Z   github.com/cilium/cilium/pkg/bpf.(*Map).NextKey()
2025-01-30T21:27:22.005647146Z       /go/src/github.com/cilium/cilium/pkg/bpf/map_linux.go:606 +0x11e
2025-01-30T21:27:22.005712027Z   github.com/cilium/cilium/pkg/bpf.(*Map).DumpReliablyWithCallback()
2025-01-30T21:27:22.005718629Z       /go/src/github.com/cilium/cilium/pkg/bpf/map_linux.go:768 +0x71b
2025-01-30T21:27:22.005815760Z   github.com/cilium/cilium/pkg/bpf.(*Map).GetModel()
2025-01-30T21:27:22.005822322Z       /go/src/github.com/cilium/cilium/pkg/bpf/map_linux.go:1413 +0x511
2025-01-30T21:27:22.005880481Z   github.com/cilium/cilium/pkg/bpf.GetOpenMaps()
2025-01-30T21:27:22.005886152Z       /go/src/github.com/cilium/cilium/pkg/bpf/map_register_linux.go:64 +0x2ad
2025-01-30T21:27:22.006024930Z   github.com/cilium/cilium/pkg/maps.(*getMapHandler).Handle()
2025-01-30T21:27:22.006034067Z       /go/src/github.com/cilium/cilium/pkg/maps/api.go:146 +0x24

```

```
2025-01-30T21:27:22.006410985Z Previous write at 0x00c0099535a8 by goroutine 4182:
2025-01-30T21:27:22.006418068Z   github.com/cilium/ebpf/internal/sys.(*FD).Disown()
2025-01-30T21:27:22.006423969Z       /go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/internal/sys/fd.go:93 +0x8e
2025-01-30T21:27:22.006429549Z   github.com/cilium/ebpf/internal/sys.(*FD).Close()
2025-01-30T21:27:22.006435180Z       /go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/internal/sys/fd.go:84 +0x47
2025-01-30T21:27:22.006870411Z   github.com/cilium/ebpf.(*Map).Close()
2025-01-30T21:27:22.006879989Z       /go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/map.go:1371 +0x1e6
2025-01-30T21:27:22.006884858Z   github.com/cilium/cilium/pkg/bpf.(*Map).Close()
2025-01-30T21:27:22.006890338Z       /go/src/github.com/cilium/cilium/pkg/bpf/map_linux.go:591 +0x1ac
2025-01-30T21:27:22.006895778Z   github.com/cilium/cilium/pkg/maps/ctmap.CalculateCTMapPressure.func1.deferwrap1()
2025-01-30T21:27:22.006901959Z       /go/src/github.com/cilium/cilium/pkg/maps/ctmap/ctmap.go:858 +0x33
2025-01-30T21:27:22.006907119Z   runtime.deferreturn()
2025-01-30T21:27:22.006957073Z       /usr/local/go/src/runtime/panic.go:605 +0x5d
2025-01-30T21:27:22.006962683Z   github.com/cilium/cilium/pkg/controller.(*controller).runController()
2025-01-30T21:27:22.007064754Z       /go/src/github.com/cilium/cilium/pkg/controller/controller.go:251 +0xa2
2025-01-30T21:27:22.007072437Z   github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked.gowrap1()
2025-01-30T21:27:22.007077677Z       /go/src/github.com/cilium/cilium/pkg/controller/manager.go:111 +0xbc
```

Fixes: https://github.com/cilium/cilium/issues/37383

```release-note
Fix data race involving DumpReliablyWithCallback map operation.
```
