### PR TITLE
bpf: wireguard: avoid ipcache lookup for source's security identity

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -57,7 +57,8 @@
 #include "lib/vtep.h"
 
  #define host_egress_policy_hook(ctx, src_sec_identity, ext_err) CTX_ACT_OK
- #define host_wg_encrypt_hook(ctx, proto) wg_maybe_redirect_to_encrypt(ctx, proto)
+ #define host_wg_encrypt_hook(ctx, proto, src_sec_identity)			\
+	 wg_maybe_redirect_to_encrypt(ctx, proto, src_sec_identity)
 
 /* Bit 0 is skipped for robustness, as it's used in some places to indicate from_host itself. */
 #define FROM_HOST_FLAG_NEED_HOSTFW (1 << 1)
@@ -1647,7 +1648,7 @@ skip_egress_gateway:
 	 * is set before the redirect.
 	 */
 	if (!ctx_mark_is_wireguard(ctx)) {
-		ret = host_wg_encrypt_hook(ctx, proto);
+		ret = host_wg_encrypt_hook(ctx, proto, src_sec_identity);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 		else if (IS_ERR(ret))

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -57,7 +57,8 @@ ctx_is_wireguard(struct __ctx_buff *ctx, int l4_off, __u8 protocol, __u32 identi
 }
 
 static __always_inline int
-wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
+wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
+			     __u32 src_sec_identity)
 {
 	struct remote_endpoint_info *dst = NULL;
 	struct remote_endpoint_info __maybe_unused *src = NULL;
@@ -96,7 +97,14 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 		}
 #endif
 		dst = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
-		src = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
+
+		if (src_sec_identity == UNKNOWN_ID) {
+			src = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
+			if (!src)
+				return CTX_ACT_OK;
+
+			src_sec_identity = src->sec_identity;
+		}
 		break;
 #endif
 #ifdef ENABLE_IPV4
@@ -115,7 +123,14 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 # endif /* HAVE_ENCAP */
 
 		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-		src = lookup_ip4_remote_endpoint(ip4->saddr, 0);
+
+		if (src_sec_identity == UNKNOWN_ID) {
+			src = lookup_ip4_remote_endpoint(ip4->saddr, 0);
+			if (!src)
+				return CTX_ACT_OK;
+
+			src_sec_identity = src->sec_identity;
+		}
 		break;
 #endif
 	default:
@@ -146,20 +161,20 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 	 * This means that the packet won't be encrypted. This is fine,
 	 * as with --encrypt-node=false we encrypt only pod-to-pod packets.
 	 */
-	if (!src || src->sec_identity == HOST_ID)
+	if (src_sec_identity == HOST_ID)
 		goto out;
 #endif /* !ENABLE_NODE_ENCRYPTION */
 
 	/* We don't want to encrypt any traffic that originates from outside
 	 * the cluster. This check excludes DSR traffic from the LB node to a remote backend.
 	 */
-	if (!src || !identity_is_cluster(src->sec_identity))
+	if (!identity_is_cluster(src_sec_identity))
 		goto out;
 
 	/* If source is remote node we should treat it like outside traffic.
 	 * This is possible when connection is done from pod to load balancer with DSR enabled.
 	 */
-	if (identity_is_remote_node(src->sec_identity))
+	if (identity_is_remote_node(src_sec_identity))
 		goto out;
 
 maybe_encrypt: __maybe_unused
@@ -167,8 +182,7 @@ maybe_encrypt: __maybe_unused
 	 * required.
 	 */
 	if (dst && dst->key) {
-		if (src)
-			set_identity_mark(ctx, src->sec_identity, MARK_MAGIC_IDENTITY);
+		set_identity_mark(ctx, src_sec_identity, MARK_MAGIC_IDENTITY);
 overlay_encrypt: __maybe_unused
 		return ctx_redirect(ctx, WG_IFINDEX, 0);
 	}


### PR DESCRIPTION
When the wireguard hook in to-netdev decides whether the packet should be encrypted, it considers the source's security identity. For this it currently looks up the source IP in the ipcache.

But for a typical packet that exited a local pod, the from-container program also provides the source identity through the skb->mark. And the to-netdev program already extracts this identity - so we just need to pass this through to the wireguard hook.

This in particular helps for packets where the source endpoint has already been torn down by the time that the packet reaches the to-netdev program at a native network interface. Currently the source identity for such a packet is selected as WORLD_ID, and the packet therefore skips encryption.