### PR TITLE
[v1.17] bpf: ipsec: improve handling of source security identity in encrypted-overlay code

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1561,7 +1561,8 @@ skip_egress_gateway:
 
 #if defined(ENABLE_IPSEC)
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_ENCRYPT) {
-		ret =  ipsec_maybe_redirect_to_encrypt(ctx, proto);
+		ret =  ipsec_maybe_redirect_to_encrypt(ctx, proto,
+						       src_sec_identity);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 		else if (IS_ERR(ret))

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -256,11 +256,6 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 
-		ip_proto = ip4->protocol;
-
-		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-		src = lookup_ip4_remote_endpoint(ip4->saddr, 0);
-
 #  if defined(TUNNEL_MODE)
 		/* tunnel mode needs a bit of special handling when
 		 * encapsulated packets get here the destination address is
@@ -325,6 +320,11 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 			goto overlay_encrypt;
 		}
 #  endif /* TUNNEL_MODE */
+
+		ip_proto = ip4->protocol;
+
+		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
+		src = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 
 		break;
 # endif /* ENABLE_IPV4 */

--- a/bpf/tests/ipsec_encryption_on_egress.c
+++ b/bpf/tests/ipsec_encryption_on_egress.c
@@ -24,7 +24,8 @@
 bool hook_reached;
 
 int mock_ipsec_maybe_redirect_to_encrypt(__maybe_unused struct __ctx_buff *ctx,
-					 __maybe_unused __be16 proto)
+					 __maybe_unused __be16 proto,
+					 __maybe_unused __u32 src_sec_identity)
 {
 	hook_reached = true;
 	return CTX_ACT_REDIRECT;

--- a/bpf/tests/ipsec_redirect_generic.h
+++ b/bpf/tests/ipsec_redirect_generic.h
@@ -28,6 +28,7 @@ int mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 #define SOURCE_MAC mac_one
 #define DST_MAC mac_two
 #define SOURCE_IP v4_pod_one
+#define SOURCE_IDENTITY 0xAB
 #define DST_IP v4_pod_two
 #define DST_NODE_ID 0x08b9
 #define TARGET_SPI 2

--- a/bpf/tests/ipsec_redirect_native.c
+++ b/bpf/tests/ipsec_redirect_native.c
@@ -48,7 +48,7 @@ int ipsec_redirect_check(__maybe_unused struct __ctx_buff *ctx)
 	};
 	map_update_elem(&ENCRYPT_MAP, &ret, &cfg, BPF_ANY);
 
-	ipcache_v4_add_entry(SOURCE_IP, 0, 0xAB, 0, BAD_SPI);
+	ipcache_v4_add_entry(SOURCE_IP, 0, SOURCE_IDENTITY, 0, BAD_SPI);
 	/* this IPcache fill is not a representation of how things work during
 	 * Cilium runtime, a IPCache entry would not point to itself as its
 	 * tunnel_endpoint, this just makes the test a bit simpler.
@@ -57,7 +57,8 @@ int ipsec_redirect_check(__maybe_unused struct __ctx_buff *ctx)
 	 */
 	ipcache_v4_add_entry(DST_IP, 0, 0xAC, DST_IP, TARGET_SPI);
 
-	ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP));
+	ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+					      SOURCE_IDENTITY);
 	assert(ret == CTX_ACT_REDIRECT);
 
 	/* assert we set the correct mark */


### PR DESCRIPTION
Address a few areas of improvement in https://github.com/cilium/cilium/pull/37993.