### PR TITLE
wireguard: cleanup cilium_calls map upon downgrading from v1.18

### DIFF
--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/netip"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -467,6 +468,8 @@ func attachNetworkDevices(cfg *datapath.LocalNodeConfiguration, ep datapath.Endp
 				linkDir, netlink.HANDLE_MIN_INGRESS); err != nil {
 				log.WithField("device", device).Error(err)
 			}
+			// Cleanup also calls map from v1.18 after downgrade.
+			os.RemoveAll(filepath.Join(bpf.TCGlobalsPath(), fmt.Sprintf("cilium_calls_wireguard_%d", iface.Attrs().Index)))
 		}
 
 		if option.Config.AreDevicesRequired() {
@@ -673,6 +676,8 @@ func replaceWireguardDatapath(ctx context.Context, cArgs []string, device netlin
 			linkDir, netlink.HANDLE_MIN_INGRESS); err != nil {
 			log.WithField("device", device).Error(err)
 		}
+		// Cleanup also calls map from v1.18 after downgrade.
+		os.RemoveAll(filepath.Join(bpf.TCGlobalsPath(), fmt.Sprintf("cilium_calls_wireguard_%d", device.Attrs().Index)))
 	}
 	if err := commit(); err != nil {
 		return fmt.Errorf("committing bpf pins: %w", err)


### PR DESCRIPTION
This patch is needed by https://github.com/cilium/cilium/pull/38077, where we are forced to rename the `cilium_calls_wireguard_` map to prevent `MissingTailCall` when downgrading from v1.18 to v1.17.
In that case, the program detach logic would smoothly work, but as soon as the Wireguard program in v1.17 (only to-wireguard) is recompiled and the loader invokes `commit()`, the tail call map is being completely overwritten. However, there would still be the from-wireguard program from v1.18 attached to the ingress, and it would lose the reference to those tail calls. 

For further details, please refer to the commit message.