### PR TITLE
clustermesh: add local endpointslice mirror controller

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -69,7 +69,7 @@ rules:
   resources:
   - endpointslices
   verbs:
-{{- if .Values.clustermesh.enableEndpointSliceSynchronization }}
+{{- if or .Values.clustermesh.enableEndpointSliceSynchronization .Values.clustermesh.enableMCSAPISupport }}
   - create
   - update
   - delete

--- a/pkg/clustermesh/mcsapi/README.md
+++ b/pkg/clustermesh/mcsapi/README.md
@@ -107,8 +107,10 @@ flowchart TD
         localServiceExport & kvstoremesh --> |mcsAPIServiceImportReconciler| serviceImport
 
         bpfMaps["BPF Maps"]
-        endpointslices["Remote EndpointSlices"]
+        remoteEndpointslices["Remote EndpointSlices"]
+        localEndpointslices["Local EndpointSlices"]
         derivedService --> |BPF maps via the global annotations| bpfMaps
-        derivedService --> |endointslicesync via an optional annotation or if the service is Headless| endpointslices
+        derivedService --> |endointslicesync via an optional annotation or if the service is Headless| remoteEndpointslices
+        derivedService --> |mcsAPIEndpointSliceMirrorReconciler| localEndpointslices
     end
 ```

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -107,8 +107,12 @@ func registerMCSAPIController(params mcsAPIParams) error {
 		return err
 	}
 
-	if err := newMCSAPIServiceReconciler(params.CtrlRuntimeManager, params.Logger, params.ClusterInfo.Name).SetupWithManager(params.CtrlRuntimeManager); err != nil {
+	if err := newMCSAPIServiceReconciler(params.CtrlRuntimeManager, params.Logger).SetupWithManager(params.CtrlRuntimeManager); err != nil {
 		return fmt.Errorf("Failed to register MCSAPIServiceReconciler: %w", err)
+	}
+
+	if err := newMCSAPIEndpointSliceMirrorReconciler(params.CtrlRuntimeManager, params.Logger, params.ClusterInfo.Name).SetupWithManager(params.CtrlRuntimeManager); err != nil {
+		return fmt.Errorf("Failed to register MCSAPIEndpointSliceMirrorReconciler: %w", err)
 	}
 
 	// Upstream controller that we use as is to update the ServiceImport

--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+)
+
+const (
+	// endpointSliceLocalMCSAPIControllerName is a unique value used with LabelManagedBy to indicate
+	// the component managing an EndpointSlice.
+	endpointSliceLocalMCSAPIControllerName = "endpointslice-local-mcsapi-controller.cilium.io"
+	localEndpointSliceAnnotation           = annotation.ServicePrefix + "/local-endpointslice"
+)
+
+// mcsAPIEndpointSliceMirrorReconciler is a controller that mirrors local
+// EndpointSlice from a local Service with a ServiceExport to its derived Service.
+// It works by mirroring the EndpointSlice by its suffix name (the name without
+// the generatedName prefix).
+type mcsAPIEndpointSliceMirrorReconciler struct {
+	client.Client
+	Logger *slog.Logger
+
+	clusterName string
+}
+
+func newMCSAPIEndpointSliceMirrorReconciler(mgr ctrl.Manager, logger *slog.Logger, clusterName string) *mcsAPIEndpointSliceMirrorReconciler {
+	return &mcsAPIEndpointSliceMirrorReconciler{
+		Client:      mgr.GetClient(),
+		Logger:      logger,
+		clusterName: clusterName,
+	}
+}
+
+func getLocalEndpointSliceKey(derivedEpSlice *discoveryv1.EndpointSlice) *types.NamespacedName {
+	if derivedEpSlice.Annotations[localEndpointSliceAnnotation] == "" {
+		return nil
+	}
+	return &types.NamespacedName{
+		Name:      derivedEpSlice.Annotations[localEndpointSliceAnnotation],
+		Namespace: derivedEpSlice.Namespace,
+	}
+}
+
+func getLocalDerivedEndpointSliceKey(localEpSlice *discoveryv1.EndpointSlice) *types.NamespacedName {
+	suffix := getSuffix(localEpSlice)
+	derivedServiceName := getDerivedServiceName(localEpSlice)
+	if derivedServiceName == "" {
+		return nil
+	}
+	name := derivedServiceName + "-" + suffix
+	if suffix == "" {
+		name = derivedServiceName
+	}
+	return &types.NamespacedName{Name: name, Namespace: localEpSlice.Namespace}
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) getLocalEndpointSlice(
+	ctx context.Context, derivedEpSlice *discoveryv1.EndpointSlice,
+) (*discoveryv1.EndpointSlice, error) {
+	localEpSliceKey := getLocalEndpointSliceKey(derivedEpSlice)
+	if localEpSliceKey == nil {
+		return nil, nil
+	}
+	var localEpSlice discoveryv1.EndpointSlice
+	if err := r.Client.Get(ctx, *localEpSliceKey, &localEpSlice); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return &localEpSlice, nil
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) shouldMirrorLocalEndpointSlice(
+	ctx context.Context, localEpSlice *discoveryv1.EndpointSlice, derivedService *corev1.Service,
+) (bool, error) {
+	if localEpSlice == nil {
+		return false, nil
+	}
+	serviceName := localEpSlice.Labels[discoveryv1.LabelServiceName]
+	if serviceName == "" {
+		return false, nil
+	}
+	var svcExport mcsapiv1alpha1.ServiceExport
+	if err := r.Client.Get(
+		ctx,
+		types.NamespacedName{Name: serviceName, Namespace: localEpSlice.Namespace},
+		&svcExport,
+	); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+	// Only mirrors EndpointSlice compatible with the derived Service IP family
+	if !slices.Contains(derivedService.Spec.IPFamilies, corev1.IPFamily(localEpSlice.AddressType)) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func getDerivedServiceName(localEpSlice *discoveryv1.EndpointSlice) string {
+	serviceName := localEpSlice.Labels[discoveryv1.LabelServiceName]
+	if serviceName == "" {
+		return ""
+	}
+	return derivedName(types.NamespacedName{
+		Name: serviceName, Namespace: localEpSlice.Namespace,
+	})
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) getLocalDerivedEndpointSlice(
+	ctx context.Context, localEpSlice *discoveryv1.EndpointSlice,
+) (*discoveryv1.EndpointSlice, error) {
+	derivedEpSliceKey := getLocalDerivedEndpointSliceKey(localEpSlice)
+	if derivedEpSliceKey == nil {
+		return nil, nil
+	}
+	var derivedEpSlice discoveryv1.EndpointSlice
+	if err := r.Client.Get(ctx, *derivedEpSliceKey, &derivedEpSlice); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return &derivedEpSlice, nil
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) updateDerivedEndpointSlice(
+	derivedEpSlice, localEpSlice *discoveryv1.EndpointSlice, derivedService *corev1.Service,
+) {
+	controllerutil.SetControllerReference(derivedService, derivedEpSlice, r.Scheme())
+
+	derivedEpSlice.Labels = maps.Clone(derivedService.Labels)
+	if derivedEpSlice.Labels == nil {
+		derivedEpSlice.Labels = map[string]string{}
+	}
+	derivedEpSlice.Labels[mcsapiv1alpha1.LabelServiceName] = localEpSlice.Labels[discoveryv1.LabelServiceName]
+	derivedEpSlice.Labels[discoveryv1.LabelServiceName] = derivedService.Name
+	derivedEpSlice.Labels[mcsapiv1alpha1.LabelSourceCluster] = r.clusterName
+	derivedEpSlice.Labels[discoveryv1.LabelManagedBy] = endpointSliceLocalMCSAPIControllerName
+
+	if derivedEpSlice.Annotations == nil {
+		derivedEpSlice.Annotations = map[string]string{}
+	}
+	derivedEpSlice.Annotations[localEndpointSliceAnnotation] = localEpSlice.Name
+
+	derivedEpSlice.AddressType = localEpSlice.AddressType
+
+	// Beware those are shallow copies, content of the struct should not be modified
+	derivedEpSlice.Endpoints = slices.Clone(localEpSlice.Endpoints)
+	derivedEpSlice.Ports = slices.Clone(localEpSlice.Ports)
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) newDerivedEndpointSlice(
+	localEpSlice *discoveryv1.EndpointSlice, derivedService *corev1.Service,
+) *discoveryv1.EndpointSlice {
+	// Note that derivedEpsliceKey can not return nil here since it has already
+	// been checked by shouldMirrorLocalEndpointSlice that prevents the EndpointSlice
+	// to not have a service label name
+	derivedEpSliceKey := getLocalDerivedEndpointSliceKey(localEpSlice)
+	derivedEndpointSlice := discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      derivedEpSliceKey.Name,
+			Namespace: derivedEpSliceKey.Namespace,
+		},
+	}
+
+	r.updateDerivedEndpointSlice(&derivedEndpointSlice, localEpSlice, derivedService)
+	return &derivedEndpointSlice
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var epSlice discoveryv1.EndpointSlice
+	if err := r.Client.Get(ctx, req.NamespacedName, &epSlice); err != nil {
+		return controllerruntime.Fail(client.IgnoreNotFound(err))
+	}
+
+	var localEpSlice *discoveryv1.EndpointSlice
+	var derivedEpSlice *discoveryv1.EndpointSlice
+	var derivedServiceName string
+	var err error
+
+	if epSlice.Labels[discoveryv1.LabelManagedBy] == endpointSliceLocalMCSAPIControllerName {
+		derivedEpSlice = &epSlice
+		localEpSlice, err = r.getLocalEndpointSlice(ctx, derivedEpSlice)
+		if err != nil {
+			return controllerruntime.Fail(err)
+		}
+		derivedServiceName = derivedEpSlice.Labels[discoveryv1.LabelServiceName]
+	} else {
+		localEpSlice = &epSlice
+		derivedEpSlice, err = r.getLocalDerivedEndpointSlice(ctx, localEpSlice)
+		if err != nil {
+			return controllerruntime.Fail(err)
+		}
+		derivedServiceName = getDerivedServiceName(localEpSlice)
+	}
+
+	if derivedServiceName == "" {
+		return controllerruntime.Success()
+	}
+	var derivedService corev1.Service
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      derivedServiceName,
+		Namespace: req.Namespace,
+	}, &derivedService); err != nil {
+		// If the derived service is not found, it probably isn't created yet
+		// so we can stop there and wait for a future reconciliation where the derived
+		// Service would be created.
+		return controllerruntime.Fail(client.IgnoreNotFound(err))
+	}
+
+	var shouldMirror bool
+	if shouldMirror, err = r.shouldMirrorLocalEndpointSlice(ctx, localEpSlice, &derivedService); err != nil {
+		return controllerruntime.Fail(err)
+	}
+	if !shouldMirror {
+		localEpSlice = nil
+	}
+
+	if localEpSlice == nil && derivedEpSlice != nil {
+		err = r.Client.Delete(ctx, derivedEpSlice)
+	} else if localEpSlice != nil && derivedEpSlice == nil {
+		derivedEpSlice = r.newDerivedEndpointSlice(localEpSlice, &derivedService)
+		err = r.Client.Create(ctx, derivedEpSlice)
+	} else if localEpSlice != nil && r.needUpdate(localEpSlice, derivedEpSlice, &derivedService) {
+		r.updateDerivedEndpointSlice(derivedEpSlice, localEpSlice, &derivedService)
+		err = r.Client.Update(ctx, derivedEpSlice)
+	}
+
+	return controllerruntime.Fail(err)
+}
+
+// endpointSliceMirrorDeleteWatcher watch EndpointSlice and return the predicted
+// mirrored EndpointSlice. If a non derived EndpointSlice it will return a derived
+// EndpointSlice and the other way around. We have to do this because the very first
+// thing we do in the Reconcile method is to get the EndpointSlice requested so on
+// a delete we have to swap the EndpointSlice object essentially.
+type endpointSliceMirrorDeleteWatcher struct{}
+
+func (*endpointSliceMirrorDeleteWatcher) Delete(ctx context.Context, evt event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+	epSlice := evt.Object.(*discoveryv1.EndpointSlice)
+	switch epSlice.Labels[discoveryv1.LabelManagedBy] {
+	case utils.EndpointSliceMeshControllerName:
+		// We can explicitly ignore remote EndpointSlice
+	case endpointSliceLocalMCSAPIControllerName:
+		localEpSliceKey := getLocalEndpointSliceKey(epSlice)
+		if localEpSliceKey == nil {
+			return
+		}
+		q.Add(ctrl.Request{NamespacedName: *localEpSliceKey})
+	default:
+		derivedEpSliceKey := getLocalDerivedEndpointSliceKey(epSlice)
+		if derivedEpSliceKey == nil {
+			return
+		}
+		q.Add(ctrl.Request{NamespacedName: *derivedEpSliceKey})
+	}
+}
+
+func (*endpointSliceMirrorDeleteWatcher) Create(context.Context, event.TypedCreateEvent[client.Object], workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+}
+
+func (*endpointSliceMirrorDeleteWatcher) Update(context.Context, event.TypedUpdateEvent[client.Object], workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+}
+
+func (*endpointSliceMirrorDeleteWatcher) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *mcsAPIEndpointSliceMirrorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("EndpointSliceMirrorMCSAPI").
+		For(&discoveryv1.EndpointSlice{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			switch obj.GetLabels()[discoveryv1.LabelManagedBy] {
+			case utils.EndpointSliceMeshControllerName:
+				// We can explicitly ignore remote EndpointSlice
+			case endpointSliceLocalMCSAPIControllerName:
+				return true
+			default:
+				return true
+			}
+
+			return false
+		}))).
+
+		// Special watchers for EndpointSlice deletion
+		Watches(&discoveryv1.EndpointSlice{}, &endpointSliceMirrorDeleteWatcher{}).
+
+		// Watch for changes to Service to enqueue local EndpointSlice
+		Watches(&mcsapiv1alpha1.ServiceExport{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+			return r.getEndpointSliceFromServiceRequests(ctx, client.ObjectKeyFromObject(obj))
+		})).
+		// Watch for changes to derived Service to enqueue local EndpointSlices.
+		// We need to enqueue the "other" EndpointSlice to allow derived
+		// EndpointSlice initial creation.
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+			svcImportOwner := getOwnerReferenceName(obj.GetOwnerReferences(), mcsapiv1alpha1.GroupVersion.String(), kindServiceImport)
+			if svcImportOwner != "" {
+				return r.getEndpointSliceFromServiceRequests(ctx, types.NamespacedName{Name: svcImportOwner, Namespace: obj.GetNamespace()})
+			}
+			return nil
+		})).
+		Complete(r)
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) getEndpointSliceFromServiceRequests(ctx context.Context, key types.NamespacedName) []ctrl.Request {
+	serviceReq, _ := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{key.Name})
+	selector := labels.NewSelector()
+	selector = selector.Add(*serviceReq)
+
+	var epSliceList discoveryv1.EndpointSliceList
+	if err := r.Client.List(ctx, &epSliceList, &client.ListOptions{Namespace: key.Namespace, LabelSelector: selector}); err != nil {
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0, len(epSliceList.Items))
+	for _, epSlice := range epSliceList.Items {
+		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&epSlice)})
+	}
+	return requests
+}
+
+// getSuffix return the name of the EndpointSlice trimmed by its generatedName
+func getSuffix(endpointSlice *discoveryv1.EndpointSlice) string {
+	suffix := strings.TrimPrefix(endpointSlice.Name, endpointSlice.Labels[discoveryv1.LabelServiceName])
+	suffixLen := min(40, len(suffix))
+	suffix = strings.TrimLeft(suffix[len(suffix)-suffixLen:], "-.")
+	return suffix
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) needUpdate(
+	localEpSlice, derivedEpSlice *discoveryv1.EndpointSlice, derivedService *corev1.Service,
+) bool {
+	desiredDerivedEndpointSlice := r.newDerivedEndpointSlice(localEpSlice, derivedService)
+
+	if !maps.Equal(derivedEpSlice.Labels, desiredDerivedEndpointSlice.Labels) {
+		return true
+	}
+	if derivedEpSlice.Annotations[localEndpointSliceAnnotation] != desiredDerivedEndpointSlice.Annotations[localEndpointSliceAnnotation] {
+		return true
+	}
+	if len(derivedEpSlice.OwnerReferences) != 1 &&
+		derivedEpSlice.OwnerReferences[0].UID != derivedService.UID {
+		return true
+	}
+	if derivedEpSlice.AddressType != desiredDerivedEndpointSlice.AddressType {
+		return true
+	}
+
+	equalsEndpoint := func(a, b discoveryv1.Endpoint) bool {
+		return reflect.DeepEqual(a, b)
+	}
+	if !slices.EqualFunc(derivedEpSlice.Endpoints, desiredDerivedEndpointSlice.Endpoints, equalsEndpoint) {
+		return true
+	}
+
+	equalsEndpointPort := func(a, b discoveryv1.EndpointPort) bool {
+		return reflect.DeepEqual(a, b)
+	}
+	if !slices.EqualFunc(derivedEpSlice.Ports, desiredDerivedEndpointSlice.Ports, equalsEndpointPort) {
+		return true
+	}
+
+	return false
+}

--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+var (
+	commonEndpoints = []discoveryv1.Endpoint{{
+		Addresses: []string{"10.0.0.1", "10.0.0.2"},
+	}}
+	commonPorts = []discoveryv1.EndpointPort{{
+		Port: ptr.To[int32](80),
+	}}
+	commonOwnerReferences = []metav1.OwnerReference{{
+		APIVersion:         "v1",
+		Kind:               "Service",
+		Name:               commonDerivedName,
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}}
+	commonDerivedName = derivedName(types.NamespacedName{Name: "full", Namespace: "default"})
+	commonLabels      = map[string]string{
+		"test-label":                      "copied",
+		mcsapiv1alpha1.LabelServiceName:   "full",
+		discoveryv1.LabelServiceName:      commonDerivedName,
+		mcsapiv1alpha1.LabelSourceCluster: "cluster1",
+		discoveryv1.LabelManagedBy:        endpointSliceLocalMCSAPIControllerName,
+	}
+
+	endpointsliceMirrorFixtures = []client.Object{
+		&mcsapiv1alpha1.ServiceExport{
+			TypeMeta: typeMetaSvcExport,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full",
+				Namespace: "default",
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full",
+				Namespace: "default",
+			},
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-keep",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-update-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-update-2",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-update-3",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-update-4",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-update-5",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-wrong-family-delete",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv6,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-wrong-family-ignore",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv6,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "long-lorem-ipsum-dolor-sit-amet-consectetur-adipiscing",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      commonDerivedName,
+				Namespace: "default",
+				Labels: map[string]string{
+					"test-label": "copied",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				IPFamilies: []corev1.IPFamily{
+					corev1.IPv4Protocol,
+				},
+				Ports: []corev1.ServicePort{{
+					Port: 80,
+				}},
+			},
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            commonDerivedName + "-keep",
+				Namespace:       "default",
+				Labels:          commonLabels,
+				OwnerReferences: commonOwnerReferences,
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            commonDerivedName + "-update-1",
+				Namespace:       "default",
+				Labels:          commonLabels,
+				OwnerReferences: commonOwnerReferences,
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv6,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            commonDerivedName + "-update-2",
+				Namespace:       "default",
+				Labels:          commonLabels,
+				OwnerReferences: commonOwnerReferences,
+			},
+			Endpoints: []discoveryv1.Endpoint{{
+				Hostname: ptr.To("to-update"),
+			}},
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            commonDerivedName + "-update-3",
+				Namespace:       "default",
+				Labels:          commonLabels,
+				OwnerReferences: commonOwnerReferences,
+			},
+			Endpoints: commonEndpoints,
+			Ports: []discoveryv1.EndpointPort{{
+				Port: ptr.To[int32](42),
+			}},
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      commonDerivedName + "-update-4",
+				Namespace: "default",
+				Labels: map[string]string{
+					mcsapiv1alpha1.LabelServiceName: "full",
+					discoveryv1.LabelManagedBy:      endpointSliceLocalMCSAPIControllerName,
+				},
+				OwnerReferences: commonOwnerReferences,
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      commonDerivedName + "-update-5",
+				Namespace: "default",
+				Labels: map[string]string{
+					mcsapiv1alpha1.LabelServiceName: "full",
+					discoveryv1.LabelManagedBy:      endpointSliceLocalMCSAPIControllerName,
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      commonDerivedName + "-delete",
+				Namespace: "default",
+				Labels:    commonLabels,
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      commonDerivedName + "-wrong-family-delete",
+				Namespace: "default",
+				Labels:    commonLabels,
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv6,
+		},
+	}
+)
+
+func Test_mcsEndpointSliceMirror_Reconcile(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithObjects(endpointsliceMirrorFixtures...).
+		WithScheme(testScheme()).
+		Build()
+	r := &mcsAPIEndpointSliceMirrorReconciler{
+		Client:      c,
+		Logger:      hivetest.Logger(t),
+		clusterName: "cluster1",
+	}
+
+	for _, suffix := range []string{"keep", "", "update-1", "update-2", "update-3", "update-4", "update-5"} {
+		t.Run(fmt.Sprintf("Check mirrored Endpoint %s", suffix), func(t *testing.T) {
+			key := types.NamespacedName{
+				Name:      "full-" + suffix,
+				Namespace: "default",
+			}
+			if suffix == "" {
+				key.Name = "full"
+			}
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
+				NamespacedName: key,
+			})
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+			keyDerived := types.NamespacedName{
+				Name:      commonDerivedName + "-" + suffix,
+				Namespace: "default",
+			}
+			if suffix == "" {
+				keyDerived.Name = commonDerivedName
+			}
+			epSlice := &discoveryv1.EndpointSlice{}
+			err = c.Get(t.Context(), keyDerived, epSlice)
+			require.NoError(t, err)
+
+			require.Equal(t, commonOwnerReferences, epSlice.OwnerReferences)
+			require.Equal(t, commonLabels, epSlice.Labels)
+			require.Equal(t, map[string]string{localEndpointSliceAnnotation: key.Name}, epSlice.Annotations)
+			require.Equal(t, commonPorts, epSlice.Ports)
+			require.Equal(t, commonEndpoints, epSlice.Endpoints)
+			require.Equal(t, discoveryv1.AddressTypeIPv4, epSlice.AddressType)
+		})
+	}
+
+	t.Run("Check very long mirrored Endpoint", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "long-lorem-ipsum-dolor-sit-amet-consectetur-adipiscing",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: key,
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		keyDerived := types.NamespacedName{
+			Name:      commonDerivedName + "-um-dolor-sit-amet-consectetur-adipiscing",
+			Namespace: "default",
+		}
+		epSlice := &discoveryv1.EndpointSlice{}
+		err = c.Get(t.Context(), keyDerived, epSlice)
+		require.NoError(t, err)
+	})
+
+	for _, suffix := range []string{"delete", "wrong-family-delete", "wrong-family-ignore"} {
+		t.Run(fmt.Sprintf("Check delete Endpoint %s", suffix), func(t *testing.T) {
+			keyDerived := types.NamespacedName{
+				Name:      commonDerivedName + "-" + suffix,
+				Namespace: "default",
+			}
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
+				NamespacedName: keyDerived,
+			})
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+			epSlice := &discoveryv1.EndpointSlice{}
+			err = c.Get(t.Context(), keyDerived, epSlice)
+			require.True(t, apierrors.IsNotFound(err), "EndpointSlice with delete suffix should be deleted")
+		})
+	}
+}

--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
@@ -5,6 +5,7 @@ package mcsapi
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -20,6 +21,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
+
+func getExpectedDerivedLabels(localEpSliceName string) map[string]string {
+	labels := maps.Clone(commonLabels)
+	labels[localEndpointSliceLabel] = localEpSliceName
+	return labels
+}
 
 var (
 	commonEndpoints = []discoveryv1.Endpoint{{
@@ -178,6 +185,51 @@ var (
 			Ports:       commonPorts,
 			AddressType: discoveryv1.AddressTypeIPv4,
 		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-not-linked-service-1",
+				Namespace: "default",
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-not-linked-service-2",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-not-linked-service-3",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-not-linked-service-4",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
 
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -200,7 +252,7 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            commonDerivedName + "-keep",
 				Namespace:       "default",
-				Labels:          commonLabels,
+				Labels:          getExpectedDerivedLabels("full-keep"),
 				OwnerReferences: commonOwnerReferences,
 			},
 			Endpoints:   commonEndpoints,
@@ -211,7 +263,7 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            commonDerivedName + "-update-1",
 				Namespace:       "default",
-				Labels:          commonLabels,
+				Labels:          getExpectedDerivedLabels("full-update-1"),
 				OwnerReferences: commonOwnerReferences,
 			},
 			Endpoints:   commonEndpoints,
@@ -222,7 +274,7 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            commonDerivedName + "-update-2",
 				Namespace:       "default",
-				Labels:          commonLabels,
+				Labels:          getExpectedDerivedLabels("full-update-2"),
 				OwnerReferences: commonOwnerReferences,
 			},
 			Endpoints: []discoveryv1.Endpoint{{
@@ -235,7 +287,7 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            commonDerivedName + "-update-3",
 				Namespace:       "default",
-				Labels:          commonLabels,
+				Labels:          getExpectedDerivedLabels("full-update-3"),
 				OwnerReferences: commonOwnerReferences,
 			},
 			Endpoints: commonEndpoints,
@@ -251,6 +303,7 @@ var (
 				Labels: map[string]string{
 					mcsapiv1alpha1.LabelServiceName: "full",
 					discoveryv1.LabelManagedBy:      endpointSliceLocalMCSAPIControllerName,
+					localEndpointSliceLabel:         "full-update-4",
 				},
 				OwnerReferences: commonOwnerReferences,
 			},
@@ -265,6 +318,7 @@ var (
 				Labels: map[string]string{
 					mcsapiv1alpha1.LabelServiceName: "full",
 					discoveryv1.LabelManagedBy:      endpointSliceLocalMCSAPIControllerName,
+					localEndpointSliceLabel:         "full-update-5",
 				},
 			},
 			Endpoints:   commonEndpoints,
@@ -273,9 +327,10 @@ var (
 		},
 		&discoveryv1.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      commonDerivedName + "-delete",
-				Namespace: "default",
-				Labels:    commonLabels,
+				Name:            commonDerivedName + "-delete",
+				Namespace:       "default",
+				Labels:          getExpectedDerivedLabels("full-delete"),
+				OwnerReferences: commonOwnerReferences,
 			},
 			Endpoints:   commonEndpoints,
 			Ports:       commonPorts,
@@ -283,13 +338,64 @@ var (
 		},
 		&discoveryv1.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      commonDerivedName + "-wrong-family-delete",
-				Namespace: "default",
-				Labels:    commonLabels,
+				Name:            commonDerivedName + "-wrong-family-delete",
+				Namespace:       "default",
+				Labels:          getExpectedDerivedLabels("full-wrong-family-delete"),
+				OwnerReferences: commonOwnerReferences,
 			},
 			Endpoints:   commonEndpoints,
 			Ports:       commonPorts,
 			AddressType: discoveryv1.AddressTypeIPv6,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            commonDerivedName + "-not-linked-service-1",
+				Namespace:       "default",
+				Labels:          getExpectedDerivedLabels("full-not-linked-service-1"),
+				OwnerReferences: commonOwnerReferences,
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      commonDerivedName + "-not-linked-service-2",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelManagedBy: endpointSliceLocalMCSAPIControllerName,
+					localEndpointSliceLabel:    "full-not-linked-service-2",
+				},
+				OwnerReferences: commonOwnerReferences,
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      commonDerivedName + "-not-linked-service-3",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelManagedBy: endpointSliceLocalMCSAPIControllerName,
+					localEndpointSliceLabel:    "full-not-linked-service-3",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      commonDerivedName + "-not-linked-service-4",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelManagedBy: endpointSliceLocalMCSAPIControllerName,
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
 		},
 	}
 )
@@ -305,14 +411,38 @@ func Test_mcsEndpointSliceMirror_Reconcile(t *testing.T) {
 		clusterName: "cluster1",
 	}
 
-	for _, suffix := range []string{"keep", "", "update-1", "update-2", "update-3", "update-4", "update-5"} {
-		t.Run(fmt.Sprintf("Check mirrored Endpoint %s", suffix), func(t *testing.T) {
+	for _, tt := range []struct {
+		suffix                string
+		derivedReconciliation bool
+	}{
+		{suffix: "keep"},
+		{suffix: ""},
+		{suffix: "update-1"},
+		{suffix: "update-2"},
+		{suffix: "update-3"},
+		{suffix: "update-4"},
+		{suffix: "update-5"},
+		{
+			suffix:                "not-linked-service-2",
+			derivedReconciliation: true,
+		},
+		{
+			suffix:                "not-linked-service-3",
+			derivedReconciliation: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("Check mirrored Endpoint %s", tt.suffix), func(t *testing.T) {
+			fullSuffix := "-" + tt.suffix
+			if tt.suffix == "" {
+				fullSuffix = ""
+			}
+
 			key := types.NamespacedName{
-				Name:      "full-" + suffix,
+				Name:      "full" + fullSuffix,
 				Namespace: "default",
 			}
-			if suffix == "" {
-				key.Name = "full"
+			if tt.derivedReconciliation {
+				key.Name = commonDerivedName + fullSuffix
 			}
 			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: key,
@@ -321,10 +451,10 @@ func Test_mcsEndpointSliceMirror_Reconcile(t *testing.T) {
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			keyDerived := types.NamespacedName{
-				Name:      commonDerivedName + "-" + suffix,
+				Name:      commonDerivedName + "-" + tt.suffix,
 				Namespace: "default",
 			}
-			if suffix == "" {
+			if tt.suffix == "" {
 				keyDerived.Name = commonDerivedName
 			}
 			epSlice := &discoveryv1.EndpointSlice{}
@@ -332,8 +462,8 @@ func Test_mcsEndpointSliceMirror_Reconcile(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, commonOwnerReferences, epSlice.OwnerReferences)
-			require.Equal(t, commonLabels, epSlice.Labels)
-			require.Equal(t, map[string]string{localEndpointSliceAnnotation: key.Name}, epSlice.Annotations)
+			require.Equal(t, getExpectedDerivedLabels("full"+fullSuffix), epSlice.Labels)
+			require.Empty(t, epSlice.Annotations)
 			require.Equal(t, commonPorts, epSlice.Ports)
 			require.Equal(t, commonEndpoints, epSlice.Endpoints)
 			require.Equal(t, discoveryv1.AddressTypeIPv4, epSlice.AddressType)
@@ -360,21 +490,37 @@ func Test_mcsEndpointSliceMirror_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	for _, suffix := range []string{"delete", "wrong-family-delete", "wrong-family-ignore"} {
-		t.Run(fmt.Sprintf("Check delete Endpoint %s", suffix), func(t *testing.T) {
+	for _, tt := range []struct {
+		suffix              string
+		localReconciliation bool
+	}{
+		{suffix: "delete"},
+		{suffix: "wrong-family-delete"},
+		{suffix: "wrong-family-ignore"},
+		{
+			suffix:              "not-linked-service-1",
+			localReconciliation: true,
+		},
+		{suffix: "not-linked-service-4"},
+	} {
+		t.Run(fmt.Sprintf("Check delete Endpoint %s", tt.suffix), func(t *testing.T) {
 			keyDerived := types.NamespacedName{
-				Name:      commonDerivedName + "-" + suffix,
+				Name:      commonDerivedName + "-" + tt.suffix,
 				Namespace: "default",
 			}
+			keyReconcile := keyDerived
+			if tt.localReconciliation {
+				keyReconcile.Name = "full-" + tt.suffix
+			}
 			result, err := r.Reconcile(t.Context(), ctrl.Request{
-				NamespacedName: keyDerived,
+				NamespacedName: keyReconcile,
 			})
 			require.NoError(t, err)
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			epSlice := &discoveryv1.EndpointSlice{}
 			err = c.Get(t.Context(), keyDerived, epSlice)
-			require.True(t, apierrors.IsNotFound(err), "EndpointSlice with delete suffix should be deleted")
+			require.True(t, apierrors.IsNotFound(err), "EndpointSlice should be deleted")
 		})
 	}
 }

--- a/pkg/clustermesh/mcsapi/service_controller_test.go
+++ b/pkg/clustermesh/mcsapi/service_controller_test.go
@@ -249,9 +249,8 @@ func Test_mcsDerivedService_Reconcile(t *testing.T) {
 		WithScheme(testScheme()).
 		Build()
 	r := &mcsAPIServiceReconciler{
-		Client:      c,
-		Logger:      hivetest.Logger(t),
-		clusterName: "cluster1",
+		Client: c,
+		Logger: hivetest.Logger(t),
 	}
 
 	t.Run("Test service creation/update with export and import", func(t *testing.T) {
@@ -278,7 +277,6 @@ func Test_mcsDerivedService_Reconcile(t *testing.T) {
 			require.Len(t, svc.OwnerReferences, 1)
 			require.Equal(t, "ServiceImport", svc.OwnerReferences[0].Kind)
 
-			require.Equal(t, "cluster1", svc.Labels[mcsapiv1alpha1.LabelSourceCluster])
 			require.Equal(t, key.Name, svc.Labels[mcsapiv1alpha1.LabelServiceName])
 			require.Equal(t, "copied", svc.Labels["test-label"])
 
@@ -289,8 +287,6 @@ func Test_mcsDerivedService_Reconcile(t *testing.T) {
 			require.Equal(t, "my-port-1", svc.Spec.Ports[0].Name)
 			require.Equal(t, "my-port-target-port", svc.Spec.Ports[1].Name)
 			require.Equal(t, "test-target-port", svc.Spec.Ports[1].TargetPort.String())
-
-			require.Equal(t, "value", svc.Spec.Selector["selector"])
 
 			svcImport := &mcsapiv1alpha1.ServiceImport{}
 			err = c.Get(context.Background(), key, svcImport)
@@ -323,8 +319,6 @@ func Test_mcsDerivedService_Reconcile(t *testing.T) {
 		require.Equal(t, "ServiceImport", svc.OwnerReferences[0].Kind)
 
 		require.Nil(t, svc.Spec.Selector)
-
-		require.Equal(t, "cluster1", svc.Labels[mcsapiv1alpha1.LabelSourceCluster])
 
 		require.Equal(t, "true", svc.Annotations[annotation.GlobalService])
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Add a new controller that mirror local EndpointSlice instead of relying on copying the selector of the local Service.

This fixes two issues:
- We were not supporting EndpointSlices not create via selectors which was a known limitation of the existing implementation
- Hostnames were not correctly synchronized with MCS-API. This is because usually hostnames in EndpointSlice are set via a StatefulSet to its governing Services. However in the previous implementation because we effectively change the Service name we were not able to have any hostname set.

This new mirroring controller does fixes those two issues because no selectors are now involved and we fully control the content of the EndpointSlice that we create instead of relying on the controller inside kube-controller-manager.

This new controller uses the suffix of the EndpointSlice as key and mirror the content of two EndpointSlice with the same key.

```release-note
clustermesh: add a new MCS-API controller mirroring the local EndpointSlice instead of copying the Service selectors. Cilium MCS-API now support EndpointSlice created outside of Service selectors and it fixes hostname synchronization in the context of MCS-API.
```
