### PR TITLE
bpf: __snat_v4_nat adapt to older version of bpf Verifier

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -852,7 +852,7 @@ __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, fraginfo_t fr
 	      int l4_off, bool update_tuple, const struct ipv4_nat_target *target,
 	      __u16 port_off, struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ipv4_nat_entry *state, tmp;
+	struct ipv4_nat_entry *state = NULL, tmp;
 	int ret;
 
 	ret = snat_v4_nat_handle_mapping(ctx, tuple, fraginfo, &state, &tmp,
@@ -860,10 +860,11 @@ __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, fraginfo_t fr
 	if (ret < 0)
 		return ret;
 
-	ret = snat_v4_rewrite_headers(ctx, tuple->nexthdr, ETH_HLEN,
-				      ipfrag_has_l4_header(fraginfo), l4_off,
-				      tuple->saddr, state->to_saddr, IPV4_SADDR_OFF,
-				      tuple->sport, state->to_sport, port_off);
+	if (state)
+		ret = snat_v4_rewrite_headers(ctx, tuple->nexthdr, ETH_HLEN,
+					      ipfrag_has_l4_header(fraginfo), l4_off,
+					      tuple->saddr, state->to_saddr, IPV4_SADDR_OFF,
+					      tuple->sport, state->to_sport, port_off);
 
 	if (update_tuple) {
 		tuple->saddr = state->to_saddr;


### PR DESCRIPTION
__snat_v4_nat defines "struct ipv4_nat_entry *state", but variable "state" is initialized in snat_v4_nat_handle_mapping which is called by __snat_v4_nat.  Some kernel like 5.4, the bpf verifier report error "invalid mem access 'map_value_or_null' ".

We had the same problem using v1.18.0.
root# cilium version
Client: 1.18.0-dev c08d93682a 2025-03-06T17:57:45+08:00 go version go1.24.0 linux/amd64
Daemon: 1.18.0-dev c08d93682a 2025-03-06T17:57:45+08:00 go version go1.24.0 linux/amd64
root# 

time="2025-03-30T06:40:00.979409343Z" level=info msg="Program cil_from_host with priority 1 attached to device cilium_host using legacy tc" subsys=datapath-loader
time="2025-03-30T06:40:01.030520275Z" level=info msg="Program cil_to_host with priority 1 attached to device cilium_net using legacy tc" subsys=datapath-loader
Verifier error: program tail_handle_snat_fwd_ipv4: load program: permission denied: 1446: (69) r3 = *(u16 *)(r7 +36): R7 invalid mem access 'map_value_or_null' (8008 line(s) omitted)
Verifier log: load program: permission denied:
        ; int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
        0: (bf) r6 = r1
        1: (b4) w4 = 0
        ; ctx->cb[off] = data;
        2: (63) *(u32 *)(r6 +52) = r4
        ; return ctx->cb[off];
        3: (61) r5 = *(u32 *)(r6 +48)
        ; ctx->cb[off] = data;
        4: (63) *(u32 *)(r6 +48) = r4
        ; struct ipv4_ct_tuple tuple = {};
        5: (63) *(u32 *)(r10 -152) = r4
        last_idx 5 first_idx 0


Fixes: #37478

```release-note
bpf: __snat_v4_nat adapt to older version of bpf Verifier
```
