### PR TITLE
policy: Add validation and docs for TLS SNI ServerNames

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -72,6 +72,12 @@ var (
 	//go:embed manifests/client-egress-tls-sni.yaml
 	clientEgressTLSSNIPolicyYAML string
 
+	//go:embed manifests/client-egress-tls-sni-wildcard.yaml
+	clientEgressTLSSNIWildcardPolicyYAML string
+
+	//go:embed manifests/client-egress-tls-sni-double-wildcard.yaml
+	clientEgressTLSSNIDoubleWildcardPolicyYAML string
+
 	//go:embed manifests/client-egress-tls-sni-other.yaml
 	clientEgressTLSSNIOtherPolicyYAML string
 
@@ -311,6 +317,8 @@ func renderTemplates(clusterName string, param check.Parameters) (map[string]str
 		"clientEgressL7HTTPNamedPortPolicyYAML":              clientEgressL7HTTPNamedPortPolicyYAML,
 		"clientEgressToFQDNsPolicyYAML":                      clientEgressToFQDNsPolicyYAML,
 		"clientEgressTLSSNIPolicyYAML":                       clientEgressTLSSNIPolicyYAML,
+		"clientEgressTLSSNIWildcardPolicyYAML":               clientEgressTLSSNIWildcardPolicyYAML,
+		"clientEgressTLSSNIDoubleWildcardPolicyYAML":         clientEgressTLSSNIDoubleWildcardPolicyYAML,
 		"clientEgressTLSSNIOtherPolicyYAML":                  clientEgressTLSSNIOtherPolicyYAML,
 		"clientEgressL7TLSSNIPolicyYAML":                     clientEgressL7TLSSNIPolicyYAML,
 		"clientEgressL7TLSOtherSNIPolicyYAML":                clientEgressL7TLSOtherSNIPolicyYAML,

--- a/cilium-cli/connectivity/builder/check_log_errors.go
+++ b/cilium-cli/connectivity/builder/check_log_errors.go
@@ -17,5 +17,6 @@ func (t checkLogErrors) build(ct *check.ConnectivityTest, _ map[string]string) {
 			return versioncheck.MustCompile(">=1.14.0")(ct.CiliumVersion) || ct.Params().IncludeUnsafeTests
 		}).
 		WithSysdumpPolicy(check.SysdumpPolicyOnce).
-		WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion, ct.Params().LogCheckLevels, ct.Params().ExternalTarget))
+		WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion, ct.Params().LogCheckLevels, ct.Params().ExternalTarget,
+			ct.Params().ExternalOtherTarget))
 }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-double-wildcard.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-double-wildcard.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "client-egress-tls-sni-double-wildcard"
+specs:
+- description: "TLS SNI policy with double wildcard to match multiple labels"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{wildcardPrefix (trimSuffix .ExternalTarget ".") 2}}"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-wildcard.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-wildcard.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "client-egress-tls-sni-wildcard"
+specs:
+- description: "TLS SNI policy with wildcard"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{wildcardPrefix (trimSuffix .ExternalTarget ".") 1}}"

--- a/cilium-cli/connectivity/builder/manifests/template/template.go
+++ b/cilium-cli/connectivity/builder/manifests/template/template.go
@@ -21,6 +21,18 @@ func Render(temp string, data any) (string, error) {
 				return ipString + "/32" // otherwise assume IPv4
 			}
 		},
+		"wildcardPrefix": func(in string, times int) string {
+			labels := strings.Split(in, ".")
+			if times <= 0 || times > len(labels) {
+				return in
+			}
+
+			if times == 1 {
+				labels[0] = "*"
+				return strings.Join(labels[0:], ".")
+			}
+			return "**." + strings.Join(labels[times:], ".")
+		},
 	}
 
 	tm, err := template.New("template").Funcs(fns).Parse(temp)

--- a/cilium-cli/connectivity/builder/manifests/template/template_test.go
+++ b/cilium-cli/connectivity/builder/manifests/template/template_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package template
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRender(t *testing.T) {
+	type args struct {
+		data any
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "trim suffix",
+			args: args{
+				data: struct {
+					ExternalTarget string
+				}{
+					ExternalTarget: "one.one.one.one.",
+				},
+			},
+		},
+		{
+			name: "ip to cidr",
+			args: args{
+				data: struct {
+					ExternalCIDR string
+					ExternalIP   string
+				}{
+					ExternalCIDR: "10.0.0.0/16",
+					ExternalIP:   "10.0.0.2",
+				},
+			},
+		},
+		{
+			name: "wildcard prefix",
+			args: args{
+				data: struct {
+					ExternalTarget string
+				}{
+					ExternalTarget: "one.one.one.one.",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := fmt.Sprintf("testdata/%s", strings.ReplaceAll(tt.name, " ", "_"))
+			tmpl, err := os.ReadFile(fmt.Sprintf("%s/in.yaml", testDir))
+			require.NoError(t, err)
+
+			got, err := Render(string(tmpl), tt.args.data)
+			require.NoError(t, err)
+
+			expected, err := os.ReadFile(fmt.Sprintf("%s/out.yaml", testDir))
+			require.NoError(t, err)
+			require.YAMLEq(t, string(expected), got)
+		})
+	}
+}

--- a/cilium-cli/connectivity/builder/manifests/template/testdata/ip_to_cidr/in.yaml
+++ b/cilium-cli/connectivity/builder/manifests/template/testdata/ip_to_cidr/in.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-cidr-deny
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toCIDRSet:
+    - cidr: "{{.ExternalCIDR}}"
+      except:
+      - "{{.ExternalIP | ipToCIDR }}"

--- a/cilium-cli/connectivity/builder/manifests/template/testdata/ip_to_cidr/out.yaml
+++ b/cilium-cli/connectivity/builder/manifests/template/testdata/ip_to_cidr/out.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-cidr-deny
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toCIDRSet:
+    - cidr: 10.0.0.0/16
+      except:
+      - 10.0.0.2/32

--- a/cilium-cli/connectivity/builder/manifests/template/testdata/trim_suffix/in.yaml
+++ b/cilium-cli/connectivity/builder/manifests/template/testdata/trim_suffix/in.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "client-egress-tls-sni"
+specs:
+- description: "TLS SNI policy"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{trimSuffix .ExternalTarget "."}}"

--- a/cilium-cli/connectivity/builder/manifests/template/testdata/trim_suffix/out.yaml
+++ b/cilium-cli/connectivity/builder/manifests/template/testdata/trim_suffix/out.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "client-egress-tls-sni"
+specs:
+- description: "TLS SNI policy"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - one.one.one.one

--- a/cilium-cli/connectivity/builder/manifests/template/testdata/wildcard_prefix/in.yaml
+++ b/cilium-cli/connectivity/builder/manifests/template/testdata/wildcard_prefix/in.yaml
@@ -1,0 +1,38 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "client-egress-tls-sni-wildcard"
+specs:
+- description: "TLS SNI policy with wildcard"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{wildcardPrefix (trimSuffix .ExternalTarget ".") 1}}"
+- description: "TLS SNI policy with wildcard multiple"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{wildcardPrefix (trimSuffix .ExternalTarget ".") 2}}"
+- description: "Another TLS SNI policy with wildcard multiple"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{wildcardPrefix (trimSuffix .ExternalTarget ".") 3}}"

--- a/cilium-cli/connectivity/builder/manifests/template/testdata/wildcard_prefix/out.yaml
+++ b/cilium-cli/connectivity/builder/manifests/template/testdata/wildcard_prefix/out.yaml
@@ -1,0 +1,38 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "client-egress-tls-sni-wildcard"
+specs:
+- description: "TLS SNI policy with wildcard"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "*.one.one.one"
+- description: "TLS SNI policy with wildcard multiple"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "**.one.one"
+- description: "Another TLS SNI policy with wildcard multiple"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "**.one"

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -44,7 +44,7 @@ func (r regexMatcher) IsMatch(log string) bool {
 // NoErrorsInLogs checks whether there are no error messages in cilium-agent
 // logs. The error messages are defined in badLogMsgsWithExceptions, which key
 // is an error message, while values is a list of ignored messages.
-func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, externalTarget string) check.Scenario {
+func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, externalTarget string, externalOtherTarget string) check.Scenario {
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
 	errorLogExceptions := []logMatcher{
@@ -55,7 +55,8 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR, klogLeaderElectionFail)
 	}
 
-	envoyTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalTarget))}
+	envoyExternalTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalTarget))}
+	envoyExternalOtherTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalOtherTarget))}
 	warningLogExceptions := []logMatcher{cantEnableJIT, delMissingService, podCIDRUnavailable,
 		unableGetNode, sessionAffinitySocketLB, objectHasBeenModified, noBackendResponse,
 		legacyBGPFeature, etcdTimeout, endpointRestoreFailed, unableRestoreRouterIP,
@@ -64,8 +65,9 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		hubbleQueueFull, reflectPanic, svcNotFound, unableTranslateCIDRgroups, gobgpWarnings,
 		endpointMapDeleteFailed, etcdReconnection, epRestoreMissingState, mutationDetectorKlog,
 		hubbleFailedCreatePeer, fqdnDpUpdatesTimeout, longNetpolUpdate, failedToGetEpLabels,
-		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI, envoyTLSWarning,
-		ciliumNodeConfigDeprecation, hubbleUIEnvVarFallback, k8sClientNetworkStatusError, bgpAlphaResourceDeprecation}
+		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI,
+		envoyExternalTargetTLSWarning, envoyExternalOtherTargetTLSWarning, ciliumNodeConfigDeprecation,
+		hubbleUIEnvVarFallback, k8sClientNetworkStatusError, bgpAlphaResourceDeprecation}
 	// The list is adopted from cilium/cilium/test/helper/utils.go
 	var errorMsgsWithExceptions = map[string][]logMatcher{
 		panicMessage:         nil,

--- a/cilium-cli/connectivity/tests/errors_test.go
+++ b/cilium-cli/connectivity/tests/errors_test.go
@@ -74,7 +74,7 @@ level=error msg="bar"
 			},
 		},
 	} {
-		s := NoErrorsInLogs(tt.version, tt.levels, "one.one.one.one").(*noErrorsInLogs)
+		s := NoErrorsInLogs(tt.version, tt.levels, "one.one.one.one", "k8s.io").(*noErrorsInLogs)
 		fails := s.findUniqueFailures([]byte(errs))
 		assert.Len(t, fails, tt.wantLen)
 		for wantMsg, wantCount := range tt.wantLogsCount {

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -986,8 +986,22 @@ spec:
                               TLS must be present and one of the provided SNIs must be indicated in the
                               TLS handshake.
                             items:
+                              description: |-
+                                ServerName allows using prefix only wildcards to match DNS names.
+
+                                - "*" matches 0 or more DNS valid characters, and may only occur at the
+                                beginning of the pattern. As a special case a "*" as the leftmost character,
+                                without a following "." matches all subdomains as well as the name to the right.
+
+                                Examples:
+                                  - `*.cilium.io` matches exactly one subdomain of cilium at that level www.cilium.io and blog.cilium.io match, cilium.io and google.com do not.
+                                  - `**.cilium.io` matches more than one subdomain of cilium, e.g. sub1.sub2.cilium.io and sub.cilium.io match, cilium.io do not.
+                              maxLength: 255
+                              pattern: ^(\*?\*\.)?([-a-zA-Z0-9_]+\.?)+$
                               type: string
+                            minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                           terminatingTLS:
                             description: |-
                               TerminatingTLS is the TLS context for the connection terminated by
@@ -2822,8 +2836,22 @@ spec:
                               TLS must be present and one of the provided SNIs must be indicated in the
                               TLS handshake.
                             items:
+                              description: |-
+                                ServerName allows using prefix only wildcards to match DNS names.
+
+                                - "*" matches 0 or more DNS valid characters, and may only occur at the
+                                beginning of the pattern. As a special case a "*" as the leftmost character,
+                                without a following "." matches all subdomains as well as the name to the right.
+
+                                Examples:
+                                  - `*.cilium.io` matches exactly one subdomain of cilium at that level www.cilium.io and blog.cilium.io match, cilium.io and google.com do not.
+                                  - `**.cilium.io` matches more than one subdomain of cilium, e.g. sub1.sub2.cilium.io and sub.cilium.io match, cilium.io do not.
+                              maxLength: 255
+                              pattern: ^(\*?\*\.)?([-a-zA-Z0-9_]+\.?)+$
                               type: string
+                            minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                           terminatingTLS:
                             description: |-
                               TerminatingTLS is the TLS context for the connection terminated by
@@ -4445,8 +4473,22 @@ spec:
                                 TLS must be present and one of the provided SNIs must be indicated in the
                                 TLS handshake.
                               items:
+                                description: |-
+                                  ServerName allows using prefix only wildcards to match DNS names.
+
+                                  - "*" matches 0 or more DNS valid characters, and may only occur at the
+                                  beginning of the pattern. As a special case a "*" as the leftmost character,
+                                  without a following "." matches all subdomains as well as the name to the right.
+
+                                  Examples:
+                                    - `*.cilium.io` matches exactly one subdomain of cilium at that level www.cilium.io and blog.cilium.io match, cilium.io and google.com do not.
+                                    - `**.cilium.io` matches more than one subdomain of cilium, e.g. sub1.sub2.cilium.io and sub.cilium.io match, cilium.io do not.
+                                maxLength: 255
+                                pattern: ^(\*?\*\.)?([-a-zA-Z0-9_]+\.?)+$
                                 type: string
+                              minItems: 1
                               type: array
+                              x-kubernetes-list-type: set
                             terminatingTLS:
                               description: |-
                                 TerminatingTLS is the TLS context for the connection terminated by
@@ -6283,8 +6325,22 @@ spec:
                                 TLS must be present and one of the provided SNIs must be indicated in the
                                 TLS handshake.
                               items:
+                                description: |-
+                                  ServerName allows using prefix only wildcards to match DNS names.
+
+                                  - "*" matches 0 or more DNS valid characters, and may only occur at the
+                                  beginning of the pattern. As a special case a "*" as the leftmost character,
+                                  without a following "." matches all subdomains as well as the name to the right.
+
+                                  Examples:
+                                    - `*.cilium.io` matches exactly one subdomain of cilium at that level www.cilium.io and blog.cilium.io match, cilium.io and google.com do not.
+                                    - `**.cilium.io` matches more than one subdomain of cilium, e.g. sub1.sub2.cilium.io and sub.cilium.io match, cilium.io do not.
+                                maxLength: 255
+                                pattern: ^(\*?\*\.)?([-a-zA-Z0-9_]+\.?)+$
                                 type: string
+                              minItems: 1
                               type: array
+                              x-kubernetes-list-type: set
                             terminatingTLS:
                               description: |-
                                 TerminatingTLS is the TLS context for the connection terminated by

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -989,8 +989,22 @@ spec:
                               TLS must be present and one of the provided SNIs must be indicated in the
                               TLS handshake.
                             items:
+                              description: |-
+                                ServerName allows using prefix only wildcards to match DNS names.
+
+                                - "*" matches 0 or more DNS valid characters, and may only occur at the
+                                beginning of the pattern. As a special case a "*" as the leftmost character,
+                                without a following "." matches all subdomains as well as the name to the right.
+
+                                Examples:
+                                  - `*.cilium.io` matches exactly one subdomain of cilium at that level www.cilium.io and blog.cilium.io match, cilium.io and google.com do not.
+                                  - `**.cilium.io` matches more than one subdomain of cilium, e.g. sub1.sub2.cilium.io and sub.cilium.io match, cilium.io do not.
+                              maxLength: 255
+                              pattern: ^(\*?\*\.)?([-a-zA-Z0-9_]+\.?)+$
                               type: string
+                            minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                           terminatingTLS:
                             description: |-
                               TerminatingTLS is the TLS context for the connection terminated by
@@ -2825,8 +2839,22 @@ spec:
                               TLS must be present and one of the provided SNIs must be indicated in the
                               TLS handshake.
                             items:
+                              description: |-
+                                ServerName allows using prefix only wildcards to match DNS names.
+
+                                - "*" matches 0 or more DNS valid characters, and may only occur at the
+                                beginning of the pattern. As a special case a "*" as the leftmost character,
+                                without a following "." matches all subdomains as well as the name to the right.
+
+                                Examples:
+                                  - `*.cilium.io` matches exactly one subdomain of cilium at that level www.cilium.io and blog.cilium.io match, cilium.io and google.com do not.
+                                  - `**.cilium.io` matches more than one subdomain of cilium, e.g. sub1.sub2.cilium.io and sub.cilium.io match, cilium.io do not.
+                              maxLength: 255
+                              pattern: ^(\*?\*\.)?([-a-zA-Z0-9_]+\.?)+$
                               type: string
+                            minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                           terminatingTLS:
                             description: |-
                               TerminatingTLS is the TLS context for the connection terminated by
@@ -4448,8 +4476,22 @@ spec:
                                 TLS must be present and one of the provided SNIs must be indicated in the
                                 TLS handshake.
                               items:
+                                description: |-
+                                  ServerName allows using prefix only wildcards to match DNS names.
+
+                                  - "*" matches 0 or more DNS valid characters, and may only occur at the
+                                  beginning of the pattern. As a special case a "*" as the leftmost character,
+                                  without a following "." matches all subdomains as well as the name to the right.
+
+                                  Examples:
+                                    - `*.cilium.io` matches exactly one subdomain of cilium at that level www.cilium.io and blog.cilium.io match, cilium.io and google.com do not.
+                                    - `**.cilium.io` matches more than one subdomain of cilium, e.g. sub1.sub2.cilium.io and sub.cilium.io match, cilium.io do not.
+                                maxLength: 255
+                                pattern: ^(\*?\*\.)?([-a-zA-Z0-9_]+\.?)+$
                                 type: string
+                              minItems: 1
                               type: array
+                              x-kubernetes-list-type: set
                             terminatingTLS:
                               description: |-
                                 TerminatingTLS is the TLS context for the connection terminated by
@@ -6286,8 +6328,22 @@ spec:
                                 TLS must be present and one of the provided SNIs must be indicated in the
                                 TLS handshake.
                               items:
+                                description: |-
+                                  ServerName allows using prefix only wildcards to match DNS names.
+
+                                  - "*" matches 0 or more DNS valid characters, and may only occur at the
+                                  beginning of the pattern. As a special case a "*" as the leftmost character,
+                                  without a following "." matches all subdomains as well as the name to the right.
+
+                                  Examples:
+                                    - `*.cilium.io` matches exactly one subdomain of cilium at that level www.cilium.io and blog.cilium.io match, cilium.io and google.com do not.
+                                    - `**.cilium.io` matches more than one subdomain of cilium, e.g. sub1.sub2.cilium.io and sub.cilium.io match, cilium.io do not.
+                                maxLength: 255
+                                pattern: ^(\*?\*\.)?([-a-zA-Z0-9_]+\.?)+$
                                 type: string
+                              minItems: 1
                               type: array
+                              x-kubernetes-list-type: set
                             terminatingTLS:
                               description: |-
                                 TerminatingTLS is the TLS context for the connection terminated by

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -511,7 +511,7 @@ func Test_ruleType(t *testing.T) {
 						{
 							ToPorts: api.PortRules{
 								{
-									ServerNames: []string{""},
+									ServerNames: []api.ServerName{""},
 									Rules: &api.L7Rules{
 										HTTP: []api.PortRuleHTTP{
 											{

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -277,7 +277,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 					Ports: []PortProtocol{
 						{Port: "443", Protocol: ProtoTCP},
 					},
-					ServerNames: []string{"foo.bar.com", "bar.foo.com"},
+					ServerNames: []ServerName{"foo.bar.com", "bar.foo.com"},
 				}},
 			},
 		},
@@ -297,7 +297,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 					Ports: []PortProtocol{
 						{Port: "443", Protocol: ProtoTCP},
 					},
-					ServerNames: []string{""},
+					ServerNames: []ServerName{""},
 				}},
 			},
 		},
@@ -317,7 +317,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 					Ports: []PortProtocol{
 						{Port: "443", Protocol: ProtoTCP},
 					},
-					ServerNames: []string{"foo.bar.com", "bar.foo.com"},
+					ServerNames: []ServerName{"foo.bar.com", "bar.foo.com"},
 					Rules: &L7Rules{
 						HTTP: []PortRuleHTTP{
 							{Method: "GET", Path: "/"},
@@ -348,7 +348,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 							Name: "test-secret",
 						},
 					},
-					ServerNames: []string{"foo.bar.com", "bar.foo.com"},
+					ServerNames: []ServerName{"foo.bar.com", "bar.foo.com"},
 					Rules: &L7Rules{
 						HTTP: []PortRuleHTTP{
 							{Method: "GET", Path: "/"},

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -853,7 +853,7 @@ func (in *PortRule) DeepCopyInto(out *PortRule) {
 	}
 	if in.ServerNames != nil {
 		in, out := &in.ServerNames, &out.ServerNames
-		*out = make([]string, len(*in))
+		*out = make([]ServerName, len(*in))
 		copy(*out, *in)
 	}
 	if in.Listener != nil {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -966,7 +966,7 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints api.EndpointSelectorS
 	pr := rule.GetPortRule()
 	if pr != nil {
 		rules = pr.Rules
-		sni = pr.ServerNames
+		sni = pr.GetServerNames()
 
 		// Get TLS contexts, if any
 		var err error

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -933,7 +933,7 @@ func TestMergeTLSSNIPolicy(t *testing.T) {
 							Name: "tls-ca-certs",
 						},
 					},
-					ServerNames: []string{"www.foo.com"},
+					ServerNames: []api.ServerName{"www.foo.com"},
 				}},
 			},
 			{
@@ -944,7 +944,7 @@ func TestMergeTLSSNIPolicy(t *testing.T) {
 					Ports: []api.PortProtocol{
 						{Port: "443", Protocol: api.ProtoTCP},
 					},
-					ServerNames: []string{"www.bar.com"},
+					ServerNames: []api.ServerName{"www.bar.com"},
 				}, {
 					Ports: []api.PortProtocol{
 						{Port: "443", Protocol: api.ProtoTCP},


### PR DESCRIPTION
### Description 

After the below PR, TLS SNI server names are now supporting prefix wildcard match, this PR is to update the docs and basic validation for the same.

Relates: https://github.com/cilium/proxy/pull/1242

Note: Wait for https://github.com/cilium/cilium/pull/38603 to land in first

---
### Testing

Testing was done locally as per below

```
$ test_name=client-egress-tls-sni
$ cilium connectivity test --test=$test_name
[=] [cilium-test-1] Test [client-egress-tls-sni] [75/119]
.........
[=] [cilium-test-1] Test [client-egress-tls-sni-denied] [76/119]
.........
[=] [cilium-test-1] Test [client-egress-tls-sni-wildcard] [77/119]
.........
[=] [cilium-test-1] Test [client-egress-tls-sni-wildcard-denied] [78/119]
...
[=] [cilium-test-1] Test [client-egress-tls-sni-double-wildcard] [79/119]
.........
[=] [cilium-test-1] Test [client-egress-tls-sni-double-wildcard-denied] [80/119]
...
✅ [cilium-test-1] All 6 tests (42 actions) successful, 113 tests skipped, 0 scenarios skipped.
```