### PR TITLE
daemon: remove dependency to xDS server from daemon

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	hubblecell "github.com/cilium/cilium/pkg/hubble/cell"
@@ -98,7 +97,6 @@ type Daemon struct {
 	buildEndpointSem  *semaphore.Weighted
 	l7Proxy           *proxy.Proxy
 	proxyAccessLogger accesslog.ProxyAccessLogger
-	envoyXdsServer    envoy.XDSServer
 	svc               service.ServiceManager
 	policy            policy.PolicyRepository
 	idmgr             identitymanager.IDManager
@@ -402,7 +400,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		svc:               params.ServiceManager,
 		l7Proxy:           params.L7Proxy,
 		proxyAccessLogger: params.ProxyAccessLogger,
-		envoyXdsServer:    params.EnvoyXdsServer,
 		authManager:       params.AuthManager,
 		settings:          params.Settings,
 		bigTCPConfig:      params.BigTCPConfig,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1550,7 +1550,6 @@ type daemonParams struct {
 	ServiceManager      service.ServiceManager
 	L7Proxy             *proxy.Proxy
 	ProxyAccessLogger   accesslog.ProxyAccessLogger
-	EnvoyXdsServer      envoy.XDSServer
 	DB                  *statedb.DB
 	APILimiterSet       *rate.APILimiterSet
 	AuthManager         *auth.AuthManager

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -72,6 +72,7 @@ type DaemonSuite struct {
 	OnGetCIDRPrefixLengths func() ([]int, []int)
 
 	PolicyImporter policycell.PolicyImporter
+	envoyXdsServer envoy.XDSServer
 }
 
 func setupTestDirectories() string {
@@ -152,6 +153,9 @@ func setupDaemonSuite(tb testing.TB) *DaemonSuite {
 		}),
 		cell.Invoke(func(pi policycell.PolicyImporter) {
 			ds.PolicyImporter = pi
+		}),
+		cell.Invoke(func(envoyXdsServer envoy.XDSServer) {
+			ds.envoyXdsServer = envoyXdsServer
 		}),
 	)
 

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -169,7 +169,7 @@ var (
 // getXDSNetworkPolicies returns the representation of the xDS network policies
 // as a map of IP addresses to NetworkPolicy objects
 func (ds *DaemonSuite) getXDSNetworkPolicies(t *testing.T, resourceNames []string) map[string]*cilium.NetworkPolicy {
-	networkPolicies, err := ds.d.envoyXdsServer.GetNetworkPolicies(resourceNames)
+	networkPolicies, err := ds.envoyXdsServer.GetNetworkPolicies(resourceNames)
 	require.NoError(t, err)
 	return networkPolicies
 }
@@ -291,7 +291,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 		rules[i].Sanitize()
 	}
 
-	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
+	ds.envoyXdsServer.RemoveAllNetworkPolicies()
 
 	ds.policyImport(rules)
 
@@ -468,7 +468,7 @@ func (ds *DaemonSuite) testL4L7Shadowing(t *testing.T) {
 		rules[i].Sanitize()
 	}
 
-	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
+	ds.envoyXdsServer.RemoveAllNetworkPolicies()
 
 	ds.policyImport(rules)
 
@@ -558,7 +558,7 @@ func (ds *DaemonSuite) testL4L7ShadowingShortCircuit(t *testing.T) {
 		rules[i].Sanitize()
 	}
 
-	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
+	ds.envoyXdsServer.RemoveAllNetworkPolicies()
 
 	ds.policyImport(rules)
 
@@ -649,7 +649,7 @@ func (ds *DaemonSuite) testL3DependentL7(t *testing.T) {
 		rules[i].Sanitize()
 	}
 
-	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
+	ds.envoyXdsServer.RemoveAllNetworkPolicies()
 
 	ds.policyImport(rules)
 
@@ -819,7 +819,7 @@ func (ds *DaemonSuite) testRemovePolicy(t *testing.T) {
 		rules[i].Sanitize()
 	}
 
-	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
+	ds.envoyXdsServer.RemoveAllNetworkPolicies()
 
 	ds.policyImport(rules)
 
@@ -911,7 +911,7 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 		rules[i].Sanitize()
 	}
 
-	ds.d.envoyXdsServer.RemoveAllNetworkPolicies()
+	ds.envoyXdsServer.RemoveAllNetworkPolicies()
 
 	ds.policyImport(rules)
 


### PR DESCRIPTION
The Envoy xDS server is no longer used by the daemon initialization - its only usage is in the policy test.

Therefore, this commit moves the xdsServer field from the `Daemon` to the `DaemonSuite`.