### PR TITLE
bgpv2: Fix service reconciliation by peer IP change

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/neighbor.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/netip"
 
 	"github.com/cilium/hive/cell"
 
@@ -335,26 +334,6 @@ func (r *NeighborReconciler) fetchSecret(name string) (map[string][]byte, bool, 
 		result[k] = []byte(v)
 	}
 	return result, true, nil
-}
-
-// GetPeerAddressFromConfig returns peering address for the given peer from the provided BGPNodeInstance.
-// If no error is returned and "exists" is false, it means that PeerAddress is not present in peer configuration.
-func GetPeerAddressFromConfig(conf *v2.CiliumBGPNodeInstance, peerName string) (addr netip.Addr, exists bool, err error) {
-	if conf == nil {
-		return netip.Addr{}, false, fmt.Errorf("passed instance is nil")
-	}
-
-	for _, peer := range conf.Peers {
-		if peer.Name == peerName {
-			if peer.PeerAddress != nil {
-				addr, err = netip.ParseAddr(*peer.PeerAddress)
-				return addr, true, err
-			} else {
-				return netip.Addr{}, false, nil // PeerAddress not present in peer configuration
-			}
-		}
-	}
-	return netip.Addr{}, false, fmt.Errorf("peer %s not found in instance %s", peerName, conf.Name)
 }
 
 func (r *NeighborReconciler) neighborID(n *v2.CiliumBGPNodePeer) string {

--- a/pkg/bgpv1/manager/reconcilerv2/peer_advertisements.go
+++ b/pkg/bgpv1/manager/reconcilerv2/peer_advertisements.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
@@ -19,10 +20,16 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
+// PeerID identifies the peer within the instance.
+type PeerID struct {
+	Name    string
+	Address string
+}
+
 type (
 	// PeerAdvertisements is a map of peer name to its family advertisements
 	// This is the top level map that is returned to the consumer with requested advertisements.
-	PeerAdvertisements       map[string]PeerFamilyAdvertisements
+	PeerAdvertisements       map[PeerID]PeerFamilyAdvertisements
 	PeerFamilyAdvertisements map[v2.CiliumBGPFamily][]v2.BGPAdvertisement // key is the address family type
 )
 
@@ -88,7 +95,11 @@ func (p *CiliumPeerAdvertisement) GetConfiguredAdvertisements(conf *v2.CiliumBGP
 		if err != nil {
 			return nil, err
 		}
-		result[peer.Name] = peerAdverts
+		id := PeerID{
+			Name:    peer.Name,
+			Address: ptr.Deref(peer.PeerAddress, ""),
+		}
+		result[id] = peerAdverts
 	}
 	return result, nil
 }

--- a/pkg/bgpv1/manager/reconcilerv2/peer_advertisements_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/peer_advertisements_test.go
@@ -273,11 +273,12 @@ func Test_GetAdvertisements(t *testing.T) {
 						PeerConfigRef: &v2.PeerConfigReference{
 							Name: "peer-config-red",
 						},
+						PeerAddress: ptr.To("10.0.0.1"),
 					},
 				},
 			},
 			reqAdvertTypes:  []v2.BGPAdvertisementType{v2.BGPPodCIDRAdvert},
-			expectedAdverts: map[string]PeerFamilyAdvertisements{},
+			expectedAdverts: map[PeerID]PeerFamilyAdvertisements{},
 		},
 		{
 			name: "Expecting PodCIDR advertisement for single peer",
@@ -298,12 +299,13 @@ func Test_GetAdvertisements(t *testing.T) {
 						PeerConfigRef: &v2.PeerConfigReference{
 							Name: "peer-config-red",
 						},
+						PeerAddress: ptr.To("10.0.0.1"),
 					},
 				},
 			},
 			reqAdvertTypes: []v2.BGPAdvertisementType{v2.BGPPodCIDRAdvert},
-			expectedAdverts: map[string]PeerFamilyAdvertisements{
-				"red-peer-65001": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+			expectedAdverts: map[PeerID]PeerFamilyAdvertisements{
+				{Name: "red-peer-65001", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {redPodCIDRAdvert},
 				},
@@ -328,22 +330,24 @@ func Test_GetAdvertisements(t *testing.T) {
 						PeerConfigRef: &v2.PeerConfigReference{
 							Name: "peer-config-red",
 						},
+						PeerAddress: ptr.To("10.0.0.1"),
 					},
 					{
 						Name: "blue-peer-65001",
 						PeerConfigRef: &v2.PeerConfigReference{
 							Name: "peer-config-blue",
 						},
+						PeerAddress: ptr.To("10.0.0.2"),
 					},
 				},
 			},
 			reqAdvertTypes: []v2.BGPAdvertisementType{v2.BGPPodCIDRAdvert},
-			expectedAdverts: map[string]PeerFamilyAdvertisements{
-				"red-peer-65001": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+			expectedAdverts: map[PeerID]PeerFamilyAdvertisements{
+				{Name: "red-peer-65001", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {redPodCIDRAdvert},
 				},
-				"blue-peer-65001": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+				{Name: "blue-peer-65001", Address: "10.0.0.2"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {bluePodCIDRAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {bluePodCIDRAdvert},
 				},
@@ -368,12 +372,13 @@ func Test_GetAdvertisements(t *testing.T) {
 						PeerConfigRef: &v2.PeerConfigReference{
 							Name: "peer-config-red",
 						},
+						PeerAddress: ptr.To("10.0.0.1"),
 					},
 				},
 			},
 			reqAdvertTypes: []v2.BGPAdvertisementType{v2.BGPPodCIDRAdvert},
-			expectedAdverts: map[string]PeerFamilyAdvertisements{
-				"red-peer-65001": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+			expectedAdverts: map[PeerID]PeerFamilyAdvertisements{
+				{Name: "red-peer-65001", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: nil, // empty advertisement
 					{Afi: "ipv6", Safi: "unicast"}: nil, // empty advertisement
 				},
@@ -398,12 +403,13 @@ func Test_GetAdvertisements(t *testing.T) {
 						PeerConfigRef: &v2.PeerConfigReference{
 							Name: "peer-config-red",
 						},
+						PeerAddress: ptr.To("10.0.0.1"),
 					},
 				},
 			},
 			reqAdvertTypes: []v2.BGPAdvertisementType{v2.BGPPodCIDRAdvert, v2.BGPServiceAdvert},
-			expectedAdverts: map[string]PeerFamilyAdvertisements{
-				"red-peer-65001": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+			expectedAdverts: map[PeerID]PeerFamilyAdvertisements{
+				{Name: "red-peer-65001", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert, redServiceLBAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {redPodCIDRAdvert, redServiceLBAdvert},
 				},
@@ -428,22 +434,24 @@ func Test_GetAdvertisements(t *testing.T) {
 						PeerConfigRef: &v2.PeerConfigReference{
 							Name: "peer-config-red",
 						},
+						PeerAddress: ptr.To("10.0.0.1"),
 					},
 					{
 						Name: "blue-peer-65001",
 						PeerConfigRef: &v2.PeerConfigReference{
 							Name: "peer-config-blue",
 						},
+						PeerAddress: ptr.To("10.0.0.2"),
 					},
 				},
 			},
 			reqAdvertTypes: []v2.BGPAdvertisementType{v2.BGPPodCIDRAdvert, v2.BGPServiceAdvert},
-			expectedAdverts: map[string]PeerFamilyAdvertisements{
-				"red-peer-65001": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+			expectedAdverts: map[PeerID]PeerFamilyAdvertisements{
+				{Name: "red-peer-65001", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert, redServiceLBAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {redPodCIDRAdvert, redServiceLBAdvert},
 				},
-				"blue-peer-65001": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+				{Name: "blue-peer-65001", Address: "10.0.0.2"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {bluePodCIDRAdvert, blueServicePodAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {bluePodCIDRAdvert, blueServicePodAdvert},
 				},
@@ -498,33 +506,33 @@ func Test_PeerAdvertisementsEqual(t *testing.T) {
 		{
 			name: "Empty FamilyAdvertisements in peers",
 			peerAdvert1: PeerAdvertisements{
-				"peer-1": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{},
+				PeerID{Name: "peer-1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{},
 			},
 			peerAdvert2: PeerAdvertisements{
-				"peer-1": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{},
+				PeerID{Name: "peer-1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{},
 			},
 			expectedEqual: true,
 		},
 		{
 			name: "Nil FamilyAdvertisements in peers",
 			peerAdvert1: PeerAdvertisements{
-				"peer-1": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{},
+				PeerID{Name: "peer-1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{},
 			},
 			peerAdvert2: PeerAdvertisements{
-				"peer-1": nil,
+				PeerID{Name: "peer-1"}: nil,
 			},
 			expectedEqual: true,
 		},
 		{
 			name: "Equal FamilyAdvertisements in peers",
 			peerAdvert1: PeerAdvertisements{
-				"peer-1": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+				PeerID{Name: "peer-1", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {bluePodCIDRAdvert},
 				},
 			},
 			peerAdvert2: PeerAdvertisements{
-				"peer-1": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+				PeerID{Name: "peer-1", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {bluePodCIDRAdvert},
 				},
@@ -534,13 +542,13 @@ func Test_PeerAdvertisementsEqual(t *testing.T) {
 		{
 			name: "Unequal length in FamilyAdvertisements in peers",
 			peerAdvert1: PeerAdvertisements{
-				"peer-1": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+				PeerID{Name: "peer-1", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {bluePodCIDRAdvert},
 				},
 			},
 			peerAdvert2: PeerAdvertisements{
-				"peer-1": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+				PeerID{Name: "peer-1", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
 				},
 			},
@@ -549,15 +557,31 @@ func Test_PeerAdvertisementsEqual(t *testing.T) {
 		{
 			name: "Unequal value in FamilyAdvertisements in peers",
 			peerAdvert1: PeerAdvertisements{
-				"peer-1": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+				PeerID{Name: "peer-1", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {bluePodCIDRAdvert},
 				},
 			},
 			peerAdvert2: PeerAdvertisements{
-				"peer-1": map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+				PeerID{Name: "peer-1", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
 					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
 					{Afi: "ipv6", Safi: "unicast"}: {redPodCIDRAdvert},
+				},
+			},
+			expectedEqual: false,
+		},
+		{
+			name: "Unequal Address in PeerID",
+			peerAdvert1: PeerAdvertisements{
+				PeerID{Name: "peer-1", Address: "10.0.0.1"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
+					{Afi: "ipv6", Safi: "unicast"}: {bluePodCIDRAdvert},
+				},
+			},
+			peerAdvert2: PeerAdvertisements{
+				PeerID{Name: "peer-1", Address: "10.0.0.99"}: map[v2.CiliumBGPFamily][]v2.BGPAdvertisement{
+					{Afi: "ipv4", Safi: "unicast"}: {redPodCIDRAdvert},
+					{Afi: "ipv6", Safi: "unicast"}: {bluePodCIDRAdvert},
 				},
 			},
 			expectedEqual: false,

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -136,7 +136,7 @@ func (r *PodCIDRReconciler) reconcileRoutePolicies(ctx context.Context, p Reconc
 	metadata := r.getMetadata(p.BGPInstance)
 
 	// get desired policies
-	desiredRoutePolicies, err := r.getDesiredRoutePolicies(p, desiredPeerAdverts, podPrefixes)
+	desiredRoutePolicies, err := r.getDesiredRoutePolicies(desiredPeerAdverts, podPrefixes)
 	if err != nil {
 		return err
 	}
@@ -191,16 +191,16 @@ func (r *PodCIDRReconciler) getDesiredPathsPerFamily(desiredPeerAdverts PeerAdve
 	return desiredFamilyAdverts
 }
 
-func (r *PodCIDRReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) (RoutePolicyMap, error) {
+func (r *PodCIDRReconciler) getDesiredRoutePolicies(desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) (RoutePolicyMap, error) {
 	desiredPolicies := make(RoutePolicyMap)
 
 	for peer, afAdverts := range desiredPeerAdverts {
-		peerAddr, peerAddrExists, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
-		if err != nil {
-			return nil, err
+		if peer.Address == "" {
+			continue
 		}
-		if !peerAddrExists {
-			return nil, nil
+		peerAddr, err := netip.ParseAddr(peer.Address)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse peer address: %w", err)
 		}
 
 		for family, adverts := range afAdverts {
@@ -221,7 +221,7 @@ func (r *PodCIDRReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPe
 				}
 
 				if len(v6Prefixes) > 0 || len(v4Prefixes) > 0 {
-					name := PolicyName(peer, fam.Afi.String(), advert.AdvertisementType, "")
+					name := PolicyName(peer.Name, fam.Afi.String(), advert.AdvertisementType, "")
 					policy, err := CreatePolicy(name, peerAddr, v4Prefixes, v6Prefixes, advert)
 					if err != nil {
 						return nil, err

--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
@@ -265,7 +265,7 @@ func (r *PodIPPoolReconciler) getPodIPPoolPolicies(p ReconcileParams, pool *v2al
 		for family, adverts := range afAdverts {
 			fam := types.ToAgentFamily(family)
 			for _, advert := range adverts {
-				policy, err := r.getPodIPPoolPolicy(p, peer, fam, pool, advert, lp)
+				policy, err := r.getPodIPPoolPolicy(peer, fam, pool, advert, lp)
 				if err != nil {
 					return nil, err
 				}
@@ -358,14 +358,13 @@ func (r *PodIPPoolReconciler) getDesiredAFPaths(pool *v2alpha1.CiliumPodIPPool, 
 	return desiredFamilyAdverts, nil
 }
 
-func (r *PodIPPoolReconciler) getPodIPPoolPolicy(p ReconcileParams, peer string, family types.Family, pool *v2alpha1.CiliumPodIPPool, advert v2.BGPAdvertisement, lp map[string][]netip.Prefix) (*types.RoutePolicy, error) {
-	// get the peer address
-	peerAddr, peerAddrExists, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get peer address: %w", err)
-	}
-	if !peerAddrExists {
+func (r *PodIPPoolReconciler) getPodIPPoolPolicy(peer PeerID, family types.Family, pool *v2alpha1.CiliumPodIPPool, advert v2.BGPAdvertisement, lp map[string][]netip.Prefix) (*types.RoutePolicy, error) {
+	if peer.Address == "" {
 		return nil, nil
+	}
+	peerAddr, err := netip.ParseAddr(peer.Address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse peer address: %w", err)
 	}
 
 	// check if the pool selector matches the advertisement
@@ -412,7 +411,7 @@ func (r *PodIPPoolReconciler) getPodIPPoolPolicy(p ReconcileParams, peer string,
 		return nil, nil
 	}
 
-	policyName := PolicyName(peer, family.Afi.String(), advert.AdvertisementType, pool.Name)
+	policyName := PolicyName(peer.Name, family.Afi.String(), advert.AdvertisementType, pool.Name)
 	return CreatePolicy(policyName, peerAddr, v4Prefixes, v6Prefixes, advert)
 }
 

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -615,6 +615,11 @@ var (
 		},
 	}
 
+	testPeerID = PeerID{
+		Name:    "red-peer-65001",
+		Address: "10.10.10.1",
+	}
+
 	eps1Local = &k8s.Endpoints{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "svc-1",
@@ -731,7 +736,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: nil,
 						{Afi: "ipv6", Safi: "unicast"}: nil,
 					},
@@ -749,7 +754,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							lbSvcAdvertWithSelector(mismatchSvcSelector),
 						},
@@ -785,7 +790,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							lbSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -821,7 +826,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							lbSvcAdvertWithSelector(redSvcSelector, aggregation),
 						},
@@ -858,7 +863,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							lbSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -895,7 +900,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							lbSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -918,7 +923,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							lbSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -941,7 +946,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							lbSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -1018,7 +1023,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: nil,
 						{Afi: "ipv6", Safi: "unicast"}: nil,
 					},
@@ -1036,7 +1041,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							externalSvcAdvertWithSelector(mismatchSvcSelector),
 						},
@@ -1072,7 +1077,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							externalSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -1108,7 +1113,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							externalSvcAdvertWithSelector(redSvcSelector, aggregation),
 						},
@@ -1145,7 +1150,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							externalSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -1182,7 +1187,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							externalSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -1205,7 +1210,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							externalSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -1273,7 +1278,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							externalSvcAdvertWithSelectorAttributes(redSvcSelector, redPeer65001BgpAttributes),
 							externalSvcAdvertWithSelectorAttributes(redSvcSelector, redPeer65001BgpAttributes2),
@@ -1354,7 +1359,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: nil,
 						{Afi: "ipv6", Safi: "unicast"}: nil,
 					},
@@ -1372,7 +1377,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							clusterIPSvcAdvertWithSelector(mismatchSvcSelector),
 						},
@@ -1408,7 +1413,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							clusterIPSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -1444,7 +1449,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							clusterIPSvcAdvertWithSelector(redSvcSelector, aggregation),
 						},
@@ -1481,7 +1486,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							clusterIPSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -1518,7 +1523,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							clusterIPSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -1541,7 +1546,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							clusterIPSvcAdvertWithSelector(redSvcSelector),
 						},
@@ -1609,7 +1614,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							clusterIPSvcAdvertWithSelectorAttributes(redSvcSelector, redPeer65001BgpAttributes),
 							clusterIPSvcAdvertWithSelectorAttributes(redSvcSelector, redPeer65001BgpAttributes2),
@@ -1691,7 +1696,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: nil,
 						{Afi: "ipv6", Safi: "unicast"}: nil,
 					},
@@ -1735,7 +1740,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							{
 								AdvertisementType: v2.BGPServiceAdvert,
@@ -1813,7 +1818,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							{
 								AdvertisementType: v2.BGPServiceAdvert,
@@ -1866,7 +1871,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							{
 								AdvertisementType: v2.BGPServiceAdvert,
@@ -1933,7 +1938,7 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							{
 								AdvertisementType: v2.BGPServiceAdvert,
@@ -2079,7 +2084,7 @@ func Test_ServiceVIPSharing(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							{
 								AdvertisementType: v2.BGPServiceAdvert,
@@ -2147,7 +2152,7 @@ func Test_ServiceVIPSharing(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							{
 								AdvertisementType: v2.BGPServiceAdvert,
@@ -2203,7 +2208,7 @@ func Test_ServiceVIPSharing(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							{
 								AdvertisementType: v2.BGPServiceAdvert,
@@ -2245,7 +2250,7 @@ func Test_ServiceVIPSharing(t *testing.T) {
 				ServicePaths:         ResourceAFPathsMap{},
 				ServiceRoutePolicies: ResourceRoutePolicyMap{},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							{
 								AdvertisementType: v2.BGPServiceAdvert,
@@ -2335,7 +2340,7 @@ func Test_ServiceVIPSharing(t *testing.T) {
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
-					"red-peer-65001": PeerFamilyAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
 						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
 							lbSvcAdvertWithSelectorAttributes(redSvcSelector, redPeer65001BgpAttributes),
 							lbSvcAdvertWithSelectorAttributes(redSvcSelector, redPeer65001BgpAttributes2),

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -2413,6 +2413,312 @@ func Test_ServiceVIPSharing(t *testing.T) {
 	}
 }
 
+func Test_ServiceAdvertisementWithPeerIPChange(t *testing.T) {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+	peerConfigs := []*v2.CiliumBGPPeerConfig{redPeerConfig}
+
+	steps := []struct {
+		name             string
+		peers            []v2.CiliumBGPNodePeer
+		upsertAdverts    []*v2.CiliumBGPAdvertisement
+		upsertServices   []*slim_corev1.Service
+		deletetServices  []*slim_corev1.Service
+		upsertEPs        []*k8s.Endpoints
+		expectedMetadata ServiceReconcilerMetadata
+	}{
+		{
+			name: "Add service and advertisement",
+			peers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "red-peer-65001",
+					PeerAddress: ptr.To[string]("10.10.10.1"),
+					PeerConfigRef: &v2.PeerConfigReference{
+						Name: "peer-config-red",
+					},
+				},
+			},
+			upsertAdverts: []*v2.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(v2.BGPAdvertisement{
+					AdvertisementType: v2.BGPServiceAdvert,
+					Service: &v2.BGPServiceOptions{
+						Addresses: []v2.BGPServiceAddressType{v2.BGPLoadBalancerIPAddr},
+					},
+					Selector: redSvcSelector,
+					Attributes: &v2.BGPAttributes{
+						Communities: &v2.BGPCommunities{
+							Standard:  []v2.BGPStandardCommunity{"65535:65281"},
+							WellKnown: []v2.BGPWellKnownCommunity{"no-export"},
+						},
+					},
+				}),
+			},
+			upsertServices: []*slim_corev1.Service{redLBSvc},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ResourceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+						},
+					},
+				},
+				ServiceRoutePolicies: ResourceRoutePolicyMap{
+					redSvcKey: RoutePolicyMap{
+						redPeer65001v4LBRPName: &types.RoutePolicy{
+							Name: redPeer65001v4LBRPName,
+							Type: types.RoutePolicyTypeExport,
+							Statements: []*types.RoutePolicyStatement{
+								{
+									Conditions: types.RoutePolicyConditions{
+										MatchNeighbors: []string{"10.10.10.1/32"},
+										MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+											{
+												CIDR:         netip.MustParsePrefix(ingressV4Prefix),
+												PrefixLenMin: 32,
+												PrefixLenMax: 32,
+											},
+										},
+									},
+									Actions: types.RoutePolicyActions{
+										RouteAction:    types.RoutePolicyActionAccept,
+										AddCommunities: []string{"65535:65281"},
+									},
+								},
+							},
+						},
+						redPeer65001v6LBRPName: &types.RoutePolicy{
+							Name: redPeer65001v6LBRPName,
+							Type: types.RoutePolicyTypeExport,
+							Statements: []*types.RoutePolicyStatement{
+								{
+									Conditions: types.RoutePolicyConditions{
+										MatchNeighbors: []string{"10.10.10.1/32"},
+										MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+											{
+												CIDR:         netip.MustParsePrefix(ingressV6Prefix),
+												PrefixLenMin: 128,
+												PrefixLenMax: 128,
+											},
+										},
+									},
+									Actions: types.RoutePolicyActions{
+										RouteAction:    types.RoutePolicyActionAccept,
+										AddCommunities: []string{"65535:65281"},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					PeerID{Name: "red-peer-65001", Address: "10.10.10.1"}: PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
+							{
+								AdvertisementType: v2.BGPServiceAdvert,
+								Service: &v2.BGPServiceOptions{
+									Addresses: []v2.BGPServiceAddressType{v2.BGPLoadBalancerIPAddr},
+								},
+								Selector: redSvcSelector,
+								Attributes: &v2.BGPAttributes{
+									Communities: &v2.BGPCommunities{
+										Standard:  []v2.BGPStandardCommunity{"65535:65281"},
+										WellKnown: []v2.BGPWellKnownCommunity{"no-export"},
+									},
+								},
+							},
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2.BGPAdvertisement{
+							{
+								AdvertisementType: v2.BGPServiceAdvert,
+								Service: &v2.BGPServiceOptions{
+									Addresses: []v2.BGPServiceAddressType{v2.BGPLoadBalancerIPAddr},
+								},
+								Selector: redSvcSelector,
+								Attributes: &v2.BGPAttributes{
+									Communities: &v2.BGPCommunities{
+										Standard:  []v2.BGPStandardCommunity{"65535:65281"},
+										WellKnown: []v2.BGPWellKnownCommunity{"no-export"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Change peer IP address",
+			peers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "red-peer-65001",
+					PeerAddress: ptr.To[string]("10.10.10.99"),
+					PeerConfigRef: &v2.PeerConfigReference{
+						Name: "peer-config-red",
+					},
+				},
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ResourceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+						},
+					},
+				},
+				ServiceRoutePolicies: ResourceRoutePolicyMap{
+					redSvcKey: RoutePolicyMap{
+						redPeer65001v4LBRPName: &types.RoutePolicy{
+							Name: redPeer65001v4LBRPName,
+							Type: types.RoutePolicyTypeExport,
+							Statements: []*types.RoutePolicyStatement{
+								{
+									Conditions: types.RoutePolicyConditions{
+										MatchNeighbors: []string{"10.10.10.99/32"},
+										MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+											{
+												CIDR:         netip.MustParsePrefix(ingressV4Prefix),
+												PrefixLenMin: 32,
+												PrefixLenMax: 32,
+											},
+										},
+									},
+									Actions: types.RoutePolicyActions{
+										RouteAction:    types.RoutePolicyActionAccept,
+										AddCommunities: []string{"65535:65281"},
+									},
+								},
+							},
+						},
+						redPeer65001v6LBRPName: &types.RoutePolicy{
+							Name: redPeer65001v6LBRPName,
+							Type: types.RoutePolicyTypeExport,
+							Statements: []*types.RoutePolicyStatement{
+								{
+									Conditions: types.RoutePolicyConditions{
+										MatchNeighbors: []string{"10.10.10.99/32"},
+										MatchPrefixes: []*types.RoutePolicyPrefixMatch{
+											{
+												CIDR:         netip.MustParsePrefix(ingressV6Prefix),
+												PrefixLenMin: 128,
+												PrefixLenMax: 128,
+											},
+										},
+									},
+									Actions: types.RoutePolicyActions{
+										RouteAction:    types.RoutePolicyActionAccept,
+										AddCommunities: []string{"65535:65281"},
+									},
+								},
+							},
+						},
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					PeerID{Name: "red-peer-65001", Address: "10.10.10.99"}: PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
+							{
+								AdvertisementType: v2.BGPServiceAdvert,
+								Service: &v2.BGPServiceOptions{
+									Addresses: []v2.BGPServiceAddressType{v2.BGPLoadBalancerIPAddr},
+								},
+								Selector: redSvcSelector,
+								Attributes: &v2.BGPAttributes{
+									Communities: &v2.BGPCommunities{
+										Standard:  []v2.BGPStandardCommunity{"65535:65281"},
+										WellKnown: []v2.BGPWellKnownCommunity{"no-export"},
+									},
+								},
+							},
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2.BGPAdvertisement{
+							{
+								AdvertisementType: v2.BGPServiceAdvert,
+								Service: &v2.BGPServiceOptions{
+									Addresses: []v2.BGPServiceAddressType{v2.BGPLoadBalancerIPAddr},
+								},
+								Selector: redSvcSelector,
+								Attributes: &v2.BGPAttributes{
+									Communities: &v2.BGPCommunities{
+										Standard:  []v2.BGPStandardCommunity{"65535:65281"},
+										WellKnown: []v2.BGPWellKnownCommunity{"no-export"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	req := require.New(t)
+	advertStore := store.NewMockBGPCPResourceStore[*v2.CiliumBGPAdvertisement]()
+	serviceStore := store.NewFakeDiffStore[*slim_corev1.Service]()
+	epStore := store.NewFakeDiffStore[*k8s.Endpoints]()
+
+	params := ServiceReconcilerIn{
+		Logger: hivetest.Logger(t),
+		PeerAdvert: NewCiliumPeerAdvertisement(
+			PeerAdvertisementIn{
+				Logger:          hivetest.Logger(t),
+				PeerConfigStore: store.InitMockStore[*v2.CiliumBGPPeerConfig](peerConfigs),
+				AdvertStore:     advertStore,
+			}),
+		SvcDiffStore: serviceStore,
+		EPDiffStore:  epStore,
+	}
+
+	svcReconciler := NewServiceReconciler(params).Reconciler.(*ServiceReconciler)
+	testBGPInstance := instance.NewFakeBGPInstance()
+	svcReconciler.Init(testBGPInstance)
+	defer svcReconciler.Cleanup(testBGPInstance)
+
+	for _, tt := range steps {
+		t.Logf("Running step - %s", tt.name)
+
+		for _, advert := range tt.upsertAdverts {
+			advertStore.Upsert(advert)
+		}
+
+		for _, svc := range tt.upsertServices {
+			serviceStore.Upsert(svc)
+		}
+
+		for _, svc := range tt.deletetServices {
+			serviceStore.Delete(resource.Key{Name: svc.Name, Namespace: svc.Namespace})
+		}
+
+		for _, ep := range tt.upsertEPs {
+			epStore.Upsert(ep)
+		}
+
+		// set peers in the node instance
+		desiredConfigCopy := testBGPInstanceConfig.DeepCopy()
+		desiredConfigCopy.Peers = tt.peers
+
+		err := svcReconciler.Reconcile(context.Background(), ReconcileParams{
+			BGPInstance:   testBGPInstance,
+			DesiredConfig: desiredConfigCopy,
+			CiliumNode:    testCiliumNodeConfig,
+		})
+		req.NoError(err)
+
+		// validate new metadata
+		serviceMetadataEqual(req, tt.expectedMetadata, svcReconciler.getMetadata(testBGPInstance))
+
+		// validate that advertised paths match expected metadata
+		advertisedPrefixesMatch(req, testBGPInstance, tt.expectedMetadata.ServicePaths)
+
+		// validate that advertised policies match expected attributes
+		advertisedPoliciesAttributesMatch(req, testBGPInstance, tt.expectedMetadata.ServiceRoutePolicies)
+	}
+}
+
 func serviceMetadataEqual(req *require.Assertions, expectedMetadata, runningMetadata ServiceReconcilerMetadata) {
 	req.Truef(PeerAdvertisementsEqual(expectedMetadata.ServiceAdvertisements, runningMetadata.ServiceAdvertisements),
 		"ServiceAdvertisements mismatch, expected: %v, got: %v", expectedMetadata.ServiceAdvertisements, runningMetadata.ServiceAdvertisements)


### PR DESCRIPTION
Use peer Name + Address to identify a peer in the `PeerAdvertisements` map instead of just name, as the reconciliation also needs to reflect peer address changes - peer address is part of route policies rendered for the advertisements.

Without this change, the service reconciler would not trigger full reconciliation upon peer address changes, and the service route policies rendered for the peer with the given name would contain the old IP address until the service reconciliation is triggered either by service change, or by full reconciliation triggered by some other event.

Also fixes the logic skipping peers without IP in PodCIDRReconciler, where we returned from the function instead of continuing with other peers while it was possible.

```release-note
bgpv2: Fix service reconciliation by BGP peer IP change
```
