### PR TITLE
cilium-cli: run IPv6 test with skipRedirectFromBackend=true on >=v1.17.3

### DIFF
--- a/cilium-cli/connectivity/builder/local_redirect_policy.go
+++ b/cilium-cli/connectivity/builder/local_redirect_policy.go
@@ -30,7 +30,7 @@ func (t localRedirectPolicy) build(ct *check.ConnectivityTest, _ map[string]stri
 	newTest("local-redirect-policy", ct).
 		WithCondition(func() bool {
 			if versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) {
-				if isSocketLBFull(ct) || versioncheck.MustCompile(">=1.17.0")(ct.CiliumVersion) {
+				if ct.IsSocketLBFull() || versioncheck.MustCompile(">=1.17.0")(ct.CiliumVersion) {
 					return true
 				}
 			}
@@ -80,13 +80,4 @@ func (t localRedirectPolicy) build(ct *check.ConnectivityTest, _ map[string]stri
 			}
 			return check.ResultOK, check.ResultNone
 		})
-}
-
-func isSocketLBFull(ct *check.ConnectivityTest) bool {
-	socketLBEnabled, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.KPRSocketLB))
-	if socketLBEnabled {
-		socketLBHostnsOnly, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.KPRSocketLBHostnsOnly))
-		return !socketLBHostnsOnly
-	}
-	return false
 }

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1330,3 +1330,12 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptEgressGateway() bool {
 		!ct.Features[features.KPRNodePortAcceleration].Enabled &&
 		ct.params.MultiCluster == ""
 }
+
+func (ct *ConnectivityTest) IsSocketLBFull() bool {
+	socketLBEnabled, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.KPRSocketLB))
+	if socketLBEnabled {
+		socketLBHostnsOnly, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.KPRSocketLBHostnsOnly))
+		return !socketLBHostnsOnly
+	}
+	return false
+}

--- a/cilium-cli/connectivity/tests/lrp.go
+++ b/cilium-cli/connectivity/tests/lrp.go
@@ -85,7 +85,11 @@ func (s lrp) Run(ctx context.Context, t *check.Test) {
 
 			// Run tests for skipRedirectFromBackend=true policies regardless of SocketLB
 			if s.skipRedirectFromBackend && len(ipv6SkipTruePolicies) > 0 {
-				s.runTestsForIPFamily(ctx, t, ipv6SkipTruePolicies, ipFamily)
+				if versioncheck.MustCompile(">=1.17.3")(t.Context().CiliumVersion) {
+					s.runTestsForIPFamily(ctx, t, ipv6SkipTruePolicies, ipFamily)
+				} else {
+					t.Info("Skipping IPv6 tests for policies with skipRedirectFromBackend=true. It works with >=1.17.3.")
+				}
 			}
 
 			// Run tests for skipRedirectFromBackend=false policies only if SocketLB is fully functional


### PR DESCRIPTION
Run the IPv6 test with skipRedirectFromBackend=true only on Cilium v1.17.3 and newer, where the port endianness issue in NewSkipLB6Key() was fixed (commit b29fdd2bee5c).

Also this PR ensure that cilium-cli skips to apply CLRPs with ipv6 frontend if ipv6 is disabled to avoid the agent crash caused by cilium#38570