### PR TITLE
[aws][eni] Ensure security-groups are sorted

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -347,6 +347,7 @@ func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.ENISpec
 			for _, secGroup := range securityGroups {
 				groups = append(groups, secGroup.ID)
 			}
+			slices.Sort(groups)
 			return groups, nil
 		}
 	}
@@ -366,6 +367,8 @@ func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.ENISpec
 	if securityGroups == nil {
 		return nil, errors.New("failed to get security group ids")
 	}
+
+	slices.Sort(securityGroups)
 
 	return securityGroups, nil
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This is a updated version of https://github.com/cilium/cilium/pull/26508 

AWS will sometimes not return security groups in the exact same ordering. When this occurs, the operator triggers an update to all of the `CiliumNode` objects. In the past, usually there is a subsequent "flip back" when AWS changes the order again. This small patch ensures that the operator will sort the groups before processing them to ensure that we avoid this large scale `CiliumNode` update events. I believe it's as low in the operators logic as I can go to ensure we sort at the source for the various ways security groups can be returned.

```release-note
In `--ipam=eni` mode, ensure that `securityGroup` information is always sorted. 
```
