### PR TITLE
doc: Clarify KPR (kube-proxy replacement) support with SCTP

### DIFF
--- a/Documentation/configuration/sctp.rst
+++ b/Documentation/configuration/sctp.rst
@@ -37,6 +37,8 @@ Cilium supports basic SCTP support. Specifically, the following is supported:
    Cilium does not support the following for SCTP:
     - Multihoming
     - Policies for pod-to-VIP
-    - KPR
+    - :ref:`Kube-proxy replacement (KPR)<kubeproxy-free>` when port rewriting
+      is necessary: for example, NodePort Services are not supported with the
+      combination of KPR and SCTP.    
     - BPF masquerading
     - Egress gateway

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1967,8 +1967,9 @@ Limitations
     * Cilium's DSR NodePort mode currently does not operate well in environments with
       TCP Fast Open (TFO) enabled. It is recommended to switch to ``snat`` mode in this
       situation.
-    * Cilium's eBPF kube-proxy replacement does not support the SCTP transport protocol.
-      Only TCP and UDP is supported as a transport for services at this point.
+    * Cilium's eBPF kube-proxy replacement does not support the SCTP transport protocol except
+      in a few basic cases. For more information, see :ref:`sctp`. Only TCP and UDP are fully 
+      supported as a transport for services at this time.
     * Cilium's eBPF kube-proxy replacement does not allow ``hostPort`` port configurations
       for Pods that overlap with the configured NodePort range. In such case, the ``hostPort``
       setting will be ignored and a warning emitted to the Cilium agent log. Similarly,


### PR DESCRIPTION
Previously, it was stated in the doc that KPR was not supported with SCTP. However, it's more precise to say that KPR is supported with SCTP, except for situations that require port rewriting.  This PR clarifies this in the doc. This PR also spells out the acronym KPR for users who might not be familiar with it.

FIxes: #38540

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!
