### PR TITLE
ipam/eni: Prepare scaffolding for dense IP allocation

### DIFF
--- a/pkg/aws/addressesmanager/noop.go
+++ b/pkg/aws/addressesmanager/noop.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package addressesmanager
+
+import (
+	"net/netip"
+)
+
+type noOpAddressesManager struct{}
+
+func NewNoOp() *noOpAddressesManager {
+	return &noOpAddressesManager{}
+}
+
+func (_ *noOpAddressesManager) FindIPs(subnet netip.Prefix, addressesCount int32) (addresses []string, found bool) {
+	return
+}
+func (_ *noOpAddressesManager) RegisterIPsUsed(ips []string, subnet netip.Prefix) {}
+func (_ *noOpAddressesManager) RegisterIPsUnused(ips []string)                    {}
+
+func ParseAlreadyAssignedError(assignErr error) (alreadyAssignedAddresses []string) {
+	return
+}

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -268,7 +269,7 @@ func (e *API) rateLimit() {
 // CreateNetworkInterface mocks the interface creation. As with the upstream
 // EC2 API, the number of IP addresses in toAllocate are the number of
 // secondary IPs, a primary IP is always allocated.
-func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool) (string, *eniTypes.ENI, error) {
+func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subnet ipamTypes.Subnet, desc string, groups []string, allocatePrefixes bool) (string, *eniTypes.ENI, error) {
 	e.rateLimit()
 	e.delaySim.Delay(CreateNetworkInterface)
 
@@ -279,14 +280,14 @@ func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subn
 		return "", nil, err
 	}
 
-	subnet, ok := e.subnets[subnetID]
+	_, ok := e.subnets[subnet.ID]
 	if !ok {
-		return "", nil, fmt.Errorf("subnet %s not found", subnetID)
+		return "", nil, fmt.Errorf("subnet %s not found", subnet.ID)
 	}
 
 	numAddresses := int(toAllocate) + 1 // include primary IP
 	if numAddresses > subnet.AvailableAddresses {
-		return "", nil, fmt.Errorf("subnet %s has not enough addresses available", subnetID)
+		return "", nil, fmt.Errorf("subnet %s has not enough addresses available", subnet.ID)
 	}
 
 	eniID := uuid.New().String()
@@ -294,7 +295,7 @@ func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subn
 		ID:          eniID,
 		Description: desc,
 		Subnet: eniTypes.AwsSubnet{
-			ID: subnetID,
+			ID: subnet.ID,
 		},
 		SecurityGroups: groups,
 	}
@@ -326,7 +327,7 @@ func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subn
 	return eniID, eni.DeepCopy(), nil
 }
 
-func (e *API) DeleteNetworkInterface(ctx context.Context, eniID string) error {
+func (e *API) DeleteNetworkInterface(ctx context.Context, eniID string, addresses []string) error {
 	e.rateLimit()
 	e.delaySim.Delay(DeleteNetworkInterface)
 
@@ -409,11 +410,13 @@ func (e *API) ModifyNetworkInterface(ctx context.Context, eniID, attachmentID st
 	return nil
 }
 
-func (e *API) GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.Tags, maxResults int32) ([]string, error) {
-	result := make([]string, 0, int(maxResults))
+func (e *API) GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.Tags, maxResults int32) ([]ec2_types.NetworkInterface, error) {
+	result := make([]ec2_types.NetworkInterface, 0, int(maxResults))
 	for _, eni := range e.unattached {
 		if ipamTypes.Tags(eni.Tags).Match(tags) {
-			result = append(result, eni.ID)
+			result = append(result, ec2_types.NetworkInterface{
+				NetworkInterfaceId: aws.String(eni.ID),
+			})
 		}
 
 		if len(result) >= int(maxResults) {
@@ -423,7 +426,7 @@ func (e *API) GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.T
 	return result, nil
 }
 
-func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) ([]string, error) {
+func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addressesCount int32, subnet netip.Prefix) ([]string, error) {
 	e.rateLimit()
 	e.delaySim.Delay(AssignPrivateIpAddresses)
 
@@ -441,18 +444,18 @@ func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addres
 				return nil, fmt.Errorf("subnet %s not found", eni.Subnet.ID)
 			}
 
-			if int(addresses) > subnet.AvailableAddresses {
+			if int(addressesCount) > subnet.AvailableAddresses {
 				return nil, fmt.Errorf("subnet %s has not enough addresses available", eni.Subnet.ID)
 			}
 
-			for i := int32(0); i < addresses; i++ {
+			for i := int32(0); i < addressesCount; i++ {
 				ip, err := e.allocator.AllocateNext()
 				if err != nil {
 					panic("Unable to allocate IP from allocator")
 				}
 				eni.Addresses = append(eni.Addresses, ip.String())
 			}
-			subnet.AvailableAddresses -= int(addresses)
+			subnet.AvailableAddresses -= int(addressesCount)
 			return eni.Addresses, nil
 		}
 	}

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"log/slog"
 	"maps"
+	"net/netip"
 	"slices"
 
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -32,16 +33,16 @@ type EC2API interface {
 	GetVpcs(ctx context.Context) (ipamTypes.VirtualNetworkMap, error)
 	GetRouteTables(ctx context.Context) (ipamTypes.RouteTableMap, error)
 	GetSecurityGroups(ctx context.Context) (types.SecurityGroupMap, error)
-	GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.Tags, maxResults int32) ([]string, error)
-	CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool) (string, *eniTypes.ENI, error)
+	GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.Tags, maxResults int32) ([]ec2_types.NetworkInterface, error)
+	CreateNetworkInterface(ctx context.Context, toAllocate int32, subnet ipamTypes.Subnet, desc string, groups []string, allocatePrefixes bool) (string, *eniTypes.ENI, error)
 	AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string) (string, error)
-	DeleteNetworkInterface(ctx context.Context, eniID string) error
+	DeleteNetworkInterface(ctx context.Context, eniID string, addresses []string) error
 	ModifyNetworkInterface(ctx context.Context, eniID, attachmentID string, deleteOnTermination bool) error
-	AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) ([]string, error)
+	AssignPrivateIpAddresses(ctx context.Context, eniID string, addressesCount int32, subnet netip.Prefix) ([]string, error)
 	UnassignPrivateIpAddresses(ctx context.Context, eniID string, addresses []string) error
 	AssignENIPrefixes(ctx context.Context, eniID string, prefixes int32) error
 	UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []string) error
-	GetInstanceTypes(context.Context) ([]ec2_types.InstanceTypeInfo, error)
+	GetInstanceTypes(ctx context.Context) ([]ec2_types.InstanceTypeInfo, error)
 	AssociateEIP(ctx context.Context, instanceID string, eipTags ipamTypes.Tags) (string, error)
 }
 

--- a/pkg/aws/eni/instances_test.go
+++ b/pkg/aws/eni/instances_test.go
@@ -17,55 +17,43 @@ import (
 )
 
 var (
-	subnets = []*ipamTypes.Subnet{
-		{
-			ID:                 "subnet-1",
-			AvailableAddresses: 10,
-			VirtualNetworkID:   "vpc-1",
-			AvailabilityZone:   "us-west-1",
-			Tags: map[string]string{
-				"tag1": "tag1",
-			},
+	subnet1 = &ipamTypes.Subnet{
+		ID:                 "subnet-1",
+		AvailableAddresses: 10,
+		VirtualNetworkID:   "vpc-1",
+		AvailabilityZone:   "us-west-1",
+		Tags: map[string]string{
+			"tag1": "tag1",
 		},
-		{
-			ID:                 "subnet-2",
-			AvailableAddresses: 20,
-			VirtualNetworkID:   "vpc-2",
-			AvailabilityZone:   "us-east-1",
-			Tags: map[string]string{
-				"tag1": "tag1",
-			},
+	}
+	subnet2 = &ipamTypes.Subnet{
+		ID:                 "subnet-2",
+		AvailableAddresses: 20,
+		VirtualNetworkID:   "vpc-2",
+		AvailabilityZone:   "us-east-1",
+		Tags: map[string]string{
+			"tag1": "tag1",
+		},
+	}
+	subnet3 = &ipamTypes.Subnet{
+		ID:                 "subnet-3",
+		AvailableAddresses: 0,
+		VirtualNetworkID:   "vpc-1",
+		AvailabilityZone:   "us-west-1",
+		Tags: map[string]string{
+			"tag2": "tag2",
 		},
 	}
 
+	subnets = []*ipamTypes.Subnet{
+		subnet1,
+		subnet2,
+	}
+
 	subnets2 = []*ipamTypes.Subnet{
-		{
-			ID:                 "subnet-1",
-			AvailableAddresses: 10,
-			VirtualNetworkID:   "vpc-1",
-			AvailabilityZone:   "us-west-1",
-			Tags: map[string]string{
-				"tag1": "tag1",
-			},
-		},
-		{
-			ID:                 "subnet-2",
-			AvailableAddresses: 20,
-			VirtualNetworkID:   "vpc-2",
-			AvailabilityZone:   "us-east-1",
-			Tags: map[string]string{
-				"tag1": "tag1",
-			},
-		},
-		{
-			ID:                 "subnet-3",
-			AvailableAddresses: 0,
-			VirtualNetworkID:   "vpc-1",
-			AvailabilityZone:   "us-west-1",
-			Tags: map[string]string{
-				"tag2": "tag2",
-			},
-		},
+		subnet1,
+		subnet2,
+		subnet3,
 	}
 
 	vpcs = []*ipamTypes.VirtualNetwork{

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -18,6 +18,7 @@ import (
 	ec2mock "github.com/cilium/cilium/pkg/aws/ec2/mock"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/aws/types"
+	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/ipam"
 	metricsmock "github.com/cilium/cilium/pkg/ipam/metrics/mock"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
@@ -29,6 +30,7 @@ import (
 var (
 	testSubnet = &ipamTypes.Subnet{
 		ID:                 "s-1",
+		CIDR:               cidr.MustParseCIDR("10.0.1.0/24"),
 		AvailabilityZone:   "us-west-1",
 		VirtualNetworkID:   "vpc-1",
 		AvailableAddresses: 200,
@@ -149,7 +151,7 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -195,7 +197,7 @@ func TestNodeManagerPrefixDelegation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, true)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, pdTestSubnet, "desc", []string{"sg1", "sg2"}, true)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -266,7 +268,7 @@ func TestNodeManagerENIWithSGTags(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -328,7 +330,7 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -386,7 +388,7 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -453,7 +455,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -557,7 +559,7 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	err = ec2api.TagENI(context.TODO(), eniID1, map[string]string{
 		"foo":                 "bar",
@@ -627,7 +629,7 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -676,6 +678,7 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 
 	testSubnet2 := &ipamTypes.Subnet{
 		ID:                 "s-2",
+		CIDR:               cidr.MustParseCIDR("10.0.2.0/24"),
 		AvailabilityZone:   "us-west-1",
 		VirtualNetworkID:   "vpc-1",
 		AvailableAddresses: 500, // more than s-1
@@ -687,7 +690,7 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, testSubnet.ID, "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -741,11 +744,14 @@ func TestNodeManagerManyNodes(t *testing.T) {
 		minAllocate = 10
 	)
 
+	//		CIDR: cidr.MustParseCIDR("10.0.2.0/24"),
+
+	mgmtSubnet := &ipamTypes.Subnet{ID: "mgmt-1", CIDR: cidr.MustParseCIDR("10.0.0.0/24"), AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 100}
 	subnets := []*ipamTypes.Subnet{
-		{ID: "mgmt-1", AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 100},
-		{ID: "s-1", AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 400},
-		{ID: "s-2", AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 400},
-		{ID: "s-3", AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 400},
+		mgmtSubnet,
+		{ID: "s-1", CIDR: cidr.MustParseCIDR("10.0.1.0/24"), AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 400},
+		{ID: "s-2", CIDR: cidr.MustParseCIDR("10.0.2.0/24"), AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 400},
+		{ID: "s-3", CIDR: cidr.MustParseCIDR("10.0.3.0/24"), AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 400},
 	}
 
 	ec2api := ec2mock.NewAPI(subnets, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
@@ -759,7 +765,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	state := make([]*nodeState, numNodes)
 
 	for i := range state {
-		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "mgmt-1", "desc", []string{"sg1", "sg2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *mgmtSubnet, "desc", []string{"sg1", "sg2"}, false)
 		require.NoError(t, err)
 		_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, fmt.Sprintf("i-testNodeManagerManyNodes-%d", i), eniID)
 		require.NoError(t, err)
@@ -824,7 +830,7 @@ func TestNodeManagerInstanceNotRunning(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -871,11 +877,11 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	eniID2, _, err := ec2api.CreateNetworkInterface(context.TODO(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID2, _, err := ec2api.CreateNetworkInterface(context.TODO(), 8, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 1, instanceID, eniID2)
 	require.NoError(t, err)
@@ -897,11 +903,11 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	// deleting the instance. The deletion should be detected.
 	err = ec2api.DetachNetworkInterface(context.TODO(), instanceID, eniID1)
 	require.NoError(t, err)
-	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID1)
+	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID1, []string{})
 	require.NoError(t, err)
 	err = ec2api.DetachNetworkInterface(context.TODO(), instanceID, eniID2)
 	require.NoError(t, err)
-	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID2)
+	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID2, []string{})
 	require.NoError(t, err)
 	// Resync instances from mocked AWS
 	instances.Resync(context.TODO())
@@ -932,7 +938,7 @@ func TestNodeManagerStaticIP(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -978,7 +984,7 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -1002,9 +1008,9 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 }
 
 func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rateLimit float64, burst int) {
-	testSubnet1 := &ipamTypes.Subnet{ID: "s-1", AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 1000000}
-	testSubnet2 := &ipamTypes.Subnet{ID: "s-2", AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 1000000}
-	testSubnet3 := &ipamTypes.Subnet{ID: "s-3", AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 1000000}
+	testSubnet1 := &ipamTypes.Subnet{ID: "s-1", CIDR: cidr.MustParseCIDR("10.0.1.0/24"), AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 1000000}
+	testSubnet2 := &ipamTypes.Subnet{ID: "s-2", CIDR: cidr.MustParseCIDR("10.0.2.0/24"), AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 1000000}
+	testSubnet3 := &ipamTypes.Subnet{ID: "s-3", CIDR: cidr.MustParseCIDR("10.0.3.0/24"), AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 1000000}
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet1, testSubnet2, testSubnet3}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, routeTables)
 	ec2api.SetDelay(ec2mock.AllOperations, delay)
@@ -1020,7 +1026,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 
 	b.ResetTimer()
 	for i := range state {
-		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, *testSubnet, "desc", []string{"sg1", "sg2"}, false)
 		require.NoError(b, err)
 		_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, fmt.Sprintf("i-benchmarkAllocWorker-%d", i), eniID)
 		require.NoError(b, err)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
ipam/eni: Prepare scaffolding for dense IP allocation
```

---


Context for this PR is described in #38499.

This PR is the first part of the solution described in that issue. It prepares the scaffolding in order to allow a followup PR to add the actual new logic that solves the issue. As such this PR does not contain functional changes to the behavior of the operator.

Summary of changes:
* `pkg/aws/addressesmanager`: new package where the future solution logic will live, currently this package only contains a default noop implementation of the `AddressesManager` interface
* `pkg/aws/ec2`: 
  * add `AddressesManager` interface as described in #38499 and add it to the `Client`
  * `GetDetachedNetworkInterfaces`: change return type from list of ENI IDs (strings) to list of EC2 ENI type so that both ENI ID and ENI IPs are available when ENIs are garbage collected to register those IPs as freed
  * `CreateNetworkInterface`: update to use the client's `addressesManager` to try to find IPs, fallback to random IPs on failure and register assigned IPs as used
  * `DeleteNetworkInterface`: update to take list of IPs assigned to the ENI to be destroyed and register those IPs as freed upon ENI deletion
  * `AssignPrivateIpAddresses`: update to use the client's `addressesManager` to try to find IPs, fallback to random IPs on failure and register assigned IPs as used
* `pkg/aws/ec2/mock`: basic update to match function signature changes
* `pkg/aws/eni`:
  * `StartENIGarbageCollector`: update to pass down the list of IPs assigned to the ENI to the `DeleteNetworkInterface` call
* `pkg/aws/eni`: update the `EC2API` interface to match the function signature changes described above and adapt the tests to match those changes
