### PR TITLE
Use modern Go constructs, part 2

### DIFF
--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -385,7 +385,7 @@ func subTest(progSet programSet, resultMap *ebpf.Map, skbMdMap *ebpf.Map) func(t
 				var key int32
 				value := make([]byte, m.ValueSize())
 				m.Lookup(&key, &value)
-				for i := 0; i < len(value); i++ {
+				for i := range value {
 					value[i] = 0
 				}
 				m.Update(&key, &value, ebpf.UpdateAny)

--- a/bugtool/cmd/helper_test.go
+++ b/bugtool/cmd/helper_test.go
@@ -31,7 +31,7 @@ func (t *dummyTarWriter) WriteHeader(h *tar.Header) error {
 }
 
 type logWrapper struct {
-	logf func(format string, args ...interface{})
+	logf func(format string, args ...any)
 }
 
 func (l *logWrapper) Write(p []byte) (n int, err error) {

--- a/bugtool/cmd/mask.go
+++ b/bugtool/cmd/mask.go
@@ -22,7 +22,7 @@ func jsonFieldMaskPostProcess(fieldNames []string) postProcessFunc {
 }
 
 func maskFields(b []byte, fieldNames []string) ([]byte, error) {
-	var data map[string]interface{}
+	var data map[string]any
 
 	if err := json.Unmarshal(b, &data); err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func maskFields(b []byte, fieldNames []string) ([]byte, error) {
 	return json.MarshalIndent(data, "", ident)
 }
 
-func mask(data map[string]interface{}, fieldNames []string) {
+func mask(data map[string]any, fieldNames []string) {
 	for k, v := range data {
 		if slices.Contains(fieldNames, k) {
 			data[k] = redacted
@@ -42,11 +42,11 @@ func mask(data map[string]interface{}, fieldNames []string) {
 		}
 
 		switch t := v.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			mask(t, fieldNames)
-		case []interface{}:
+		case []any:
 			for i, item := range t {
-				if subData, ok := item.(map[string]interface{}); ok {
+				if subData, ok := item.(map[string]any); ok {
 					mask(subData, fieldNames)
 					t[i] = subData
 				}

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -322,7 +322,7 @@ func newConnectivityTests(
 	}
 
 	connTests := make([]*check.ConnectivityTest, 0, params.TestConcurrency)
-	for i := 0; i < params.TestConcurrency; i++ {
+	for i := range params.TestConcurrency {
 		params := params
 		params.TestNamespace = fmt.Sprintf("%s-%d", params.TestNamespace, i+1)
 		params.TestNamespaceIndex = i

--- a/cilium-cli/cli/utils.go
+++ b/cilium-cli/cli/utils.go
@@ -10,7 +10,7 @@ import (
 
 // fatalf prints the Printf formatted message to stderr and exits the program
 // Note: os.Exit(1) is not recoverable and does not fire defers.
-func fatalf(msg string, args ...interface{}) {
+func fatalf(msg string, args ...any) {
 	fmt.Fprintf(os.Stderr, "\nError: %s\n", fmt.Sprintf(msg, args...))
 	os.Exit(1)
 }

--- a/cilium-cli/clustermesh/clustermesh_test.go
+++ b/cilium-cli/clustermesh/clustermesh_test.go
@@ -18,15 +18,15 @@ import (
 )
 
 // Helper function to compare two slices of maps ignoring the order
-func equalClusterSlices(a, b []map[string]interface{}) bool {
+func equalClusterSlices(a, b []map[string]any) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
-	bCopy := make([]map[string]interface{}, len(b))
+	bCopy := make([]map[string]any, len(b))
 	copy(bCopy, b)
 
-	return slices.EqualFunc(a, bCopy, func(m1, m2 map[string]interface{}) bool {
+	return slices.EqualFunc(a, bCopy, func(m1, m2 map[string]any) bool {
 		for i, bm := range bCopy {
 			if reflect.DeepEqual(m1, bm) {
 				bCopy = slices.Delete(bCopy, i, i+1)
@@ -39,26 +39,26 @@ func equalClusterSlices(a, b []map[string]interface{}) bool {
 
 func TestMergeClusters(t *testing.T) {
 	uu := map[string]struct {
-		oc            []map[string]interface{}
-		nc            []map[string]interface{}
+		oc            []map[string]any
+		nc            []map[string]any
 		exceptCluster string
 		err           error
-		e             map[string]interface{}
+		e             map[string]any
 	}{
 		"nil-new-one": {
-			oc: []map[string]interface{}{},
-			nc: []map[string]interface{}{
+			oc: []map[string]any{},
+			nc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
 					"port": "32379",
 				},
 			},
-			e: map[string]interface{}{
-				"clustermesh": map[string]interface{}{
-					"config": map[string]interface{}{
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
 						"enabled": true,
-						"clusters": []map[string]interface{}{
+						"clusters": []map[string]any{
 							{
 								"ips":  []string{"172.19.0.6"},
 								"name": "c3",
@@ -70,8 +70,8 @@ func TestMergeClusters(t *testing.T) {
 			},
 		},
 		"nil-new-some": {
-			oc: []map[string]interface{}{},
-			nc: []map[string]interface{}{
+			oc: []map[string]any{},
+			nc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -88,11 +88,11 @@ func TestMergeClusters(t *testing.T) {
 					"port": "32379",
 				},
 			},
-			e: map[string]interface{}{
-				"clustermesh": map[string]interface{}{
-					"config": map[string]interface{}{
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
 						"enabled": true,
-						"clusters": []map[string]interface{}{
+						"clusters": []map[string]any{
 							{
 								"ips":  []string{"172.19.0.6"},
 								"name": "c3",
@@ -114,7 +114,7 @@ func TestMergeClusters(t *testing.T) {
 			},
 		},
 		"oc-new-some": {
-			oc: []map[string]interface{}{
+			oc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.5"},
 					"name": "c2",
@@ -124,7 +124,7 @@ func TestMergeClusters(t *testing.T) {
 					"name": "c1",
 					"port": "32379"},
 			},
-			nc: []map[string]interface{}{
+			nc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -136,11 +136,11 @@ func TestMergeClusters(t *testing.T) {
 					"port": "32379",
 				},
 			},
-			e: map[string]interface{}{
-				"clustermesh": map[string]interface{}{
-					"config": map[string]interface{}{
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
 						"enabled": true,
-						"clusters": []map[string]interface{}{
+						"clusters": []map[string]any{
 							{
 								"ips":  []string{"172.19.0.5"},
 								"name": "c2",
@@ -165,7 +165,7 @@ func TestMergeClusters(t *testing.T) {
 			},
 		},
 		"already-there": {
-			oc: []map[string]interface{}{
+			oc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -180,18 +180,18 @@ func TestMergeClusters(t *testing.T) {
 					"name": "c1",
 					"port": "32379"},
 			},
-			nc: []map[string]interface{}{
+			nc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
 					"port": "32379",
 				},
 			},
-			e: map[string]interface{}{
-				"clustermesh": map[string]interface{}{
-					"config": map[string]interface{}{
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
 						"enabled": true,
-						"clusters": []map[string]interface{}{
+						"clusters": []map[string]any{
 							{
 								"ips":  []string{"172.19.0.6"},
 								"name": "c3",
@@ -211,7 +211,7 @@ func TestMergeClusters(t *testing.T) {
 			},
 		},
 		"already-there-partially": {
-			oc: []map[string]interface{}{
+			oc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -226,7 +226,7 @@ func TestMergeClusters(t *testing.T) {
 					"name": "c1",
 					"port": "32379"},
 			},
-			nc: []map[string]interface{}{
+			nc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -238,11 +238,11 @@ func TestMergeClusters(t *testing.T) {
 					"port": "32379",
 				},
 			},
-			e: map[string]interface{}{
-				"clustermesh": map[string]interface{}{
-					"config": map[string]interface{}{
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
 						"enabled": true,
-						"clusters": []map[string]interface{}{
+						"clusters": []map[string]any{
 							{
 								"ips":  []string{"172.19.0.6"},
 								"name": "c3",
@@ -266,7 +266,7 @@ func TestMergeClusters(t *testing.T) {
 			},
 		},
 		"except-nc-changed": {
-			oc: []map[string]interface{}{
+			oc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -281,7 +281,7 @@ func TestMergeClusters(t *testing.T) {
 					"name": "c1",
 					"port": "32379"},
 			},
-			nc: []map[string]interface{}{
+			nc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.8"},
 					"name": "c5",
@@ -294,11 +294,11 @@ func TestMergeClusters(t *testing.T) {
 				},
 			},
 			exceptCluster: "c4",
-			e: map[string]interface{}{
-				"clustermesh": map[string]interface{}{
-					"config": map[string]interface{}{
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
 						"enabled": true,
-						"clusters": []map[string]interface{}{
+						"clusters": []map[string]any{
 							{
 								"ips":  []string{"172.19.0.6"},
 								"name": "c3",
@@ -322,7 +322,7 @@ func TestMergeClusters(t *testing.T) {
 			},
 		},
 		"except-nc-same": {
-			oc: []map[string]interface{}{
+			oc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -337,7 +337,7 @@ func TestMergeClusters(t *testing.T) {
 					"name": "c1",
 					"port": "32379"},
 			},
-			nc: []map[string]interface{}{
+			nc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -350,11 +350,11 @@ func TestMergeClusters(t *testing.T) {
 				},
 			},
 			exceptCluster: "c4",
-			e: map[string]interface{}{
-				"clustermesh": map[string]interface{}{
-					"config": map[string]interface{}{
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
 						"enabled": true,
-						"clusters": []map[string]interface{}{
+						"clusters": []map[string]any{
 							{
 								"ips":  []string{"172.19.0.6"},
 								"name": "c3",
@@ -374,7 +374,7 @@ func TestMergeClusters(t *testing.T) {
 			},
 		},
 		"except-oc": {
-			oc: []map[string]interface{}{
+			oc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -389,7 +389,7 @@ func TestMergeClusters(t *testing.T) {
 					"name": "c1",
 					"port": "32379"},
 			},
-			nc: []map[string]interface{}{
+			nc: []map[string]any{
 				{
 					"ips":  []string{"172.19.0.6"},
 					"name": "c3",
@@ -402,11 +402,11 @@ func TestMergeClusters(t *testing.T) {
 				},
 			},
 			exceptCluster: "c2",
-			e: map[string]interface{}{
-				"clustermesh": map[string]interface{}{
-					"config": map[string]interface{}{
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
 						"enabled": true,
-						"clusters": []map[string]interface{}{
+						"clusters": []map[string]any{
 							{
 								"ips":  []string{"172.19.0.6"},
 								"name": "c3",
@@ -441,8 +441,8 @@ func TestMergeClusters(t *testing.T) {
 			}
 
 			// Compare the clusters ignoring the order
-			expectedClusters := u.e["clustermesh"].(map[string]interface{})["config"].(map[string]interface{})["clusters"].([]map[string]interface{})
-			actualClusters := ee["clustermesh"].(map[string]interface{})["config"].(map[string]interface{})["clusters"].([]map[string]interface{})
+			expectedClusters := u.e["clustermesh"].(map[string]any)["config"].(map[string]any)["clusters"].([]map[string]any)
+			actualClusters := ee["clustermesh"].(map[string]any)["config"].(map[string]any)["clusters"].([]map[string]any)
 
 			assert.True(t, equalClusterSlices(expectedClusters, actualClusters))
 		})

--- a/cilium-cli/config/config.go
+++ b/cilium-cli/config/config.go
@@ -43,7 +43,7 @@ func NewK8sConfig(client k8sConfigImplementation, p Parameters) *K8sConfig {
 	}
 }
 
-func (k *K8sConfig) Log(format string, a ...interface{}) {
+func (k *K8sConfig) Log(format string, a ...any) {
 	fmt.Fprintf(k.params.Writer, format+"\n", a...)
 }
 

--- a/cilium-cli/connectivity/check/logger.go
+++ b/cilium-cli/connectivity/check/logger.go
@@ -114,7 +114,7 @@ func (c *ConcurrentLogger) Print(test *Test, msg []byte) {
 }
 
 // Printf schedules message for the test to be printed.
-func (c *ConcurrentLogger) Printf(test *Test, format string, args ...interface{}) {
+func (c *ConcurrentLogger) Printf(test *Test, format string, args ...any) {
 	buf := &bytes.Buffer{}
 	if test.ctx.timestamp() {
 		mustWrite(buf, timestampBytes())
@@ -147,7 +147,7 @@ func mustWrite(writer io.Writer, msg []byte) {
 		panic(fmt.Errorf("failed to print log message: %w", err))
 	}
 }
-func mustFprintf(writer io.Writer, format string, args ...interface{}) {
+func mustFprintf(writer io.Writer, format string, args ...any) {
 	if _, err := fmt.Fprintf(writer, format, args...); err != nil {
 		panic(fmt.Errorf("failed to print log message: %w", err))
 	}

--- a/cilium-cli/connectivity/check/logger_test.go
+++ b/cilium-cli/connectivity/check/logger_test.go
@@ -57,7 +57,7 @@ func TestConcurrentLogger(t *testing.T) {
 
 			connTests := make([]*ConnectivityTest, 0, tt.concurrency)
 			wg := &sync.WaitGroup{}
-			for i := 0; i < tt.concurrency; i++ {
+			for i := range tt.concurrency {
 				connTests = append(connTests, &ConnectivityTest{
 					params: Parameters{TestNamespace: fmt.Sprintf("namespace-%d", i)},
 					logger: logger,
@@ -66,7 +66,7 @@ func TestConcurrentLogger(t *testing.T) {
 				go func(ct *ConnectivityTest) {
 					defer wg.Done()
 					// simulate tests run for the ConnectivityTest instance
-					for j := 0; j < tt.testCount; j++ {
+					for j := range tt.testCount {
 						test := &Test{
 							ctx:  ct,
 							name: fmt.Sprintf("test-%d", j),

--- a/cilium-cli/connectivity/check/logging.go
+++ b/cilium-cli/connectivity/check/logging.go
@@ -32,19 +32,19 @@ const (
 // test suite, individual tests and actions.
 type Logger interface {
 	// Log logs a message.
-	Log(a ...interface{})
+	Log(a ...any)
 	// Logf logs a formatted message.
-	Logf(format string, a ...interface{})
+	Logf(format string, a ...any)
 
 	// Debug logs a debug message.
-	Debug(a ...interface{})
+	Debug(a ...any)
 	// Debugf logs a formatted debug message.
-	Debugf(format string, a ...interface{})
+	Debugf(format string, a ...any)
 
 	// Info logs an informational message.
-	Info(a ...interface{})
+	Info(a ...any)
 	// Infof logs a formatted informational message.
-	Infof(format string, a ...interface{})
+	Infof(format string, a ...any)
 }
 
 var _ Logger = (*ConnectivityTest)(nil)
@@ -58,13 +58,13 @@ var _ Logger = (*Action)(nil)
 //
 
 // Header prints a newline followed by a formatted message.
-func (ct *ConnectivityTest) Header(a ...interface{}) {
+func (ct *ConnectivityTest) Header(a ...any) {
 	fmt.Fprintln(ct.params.Writer, "")
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Headerf prints a newline followed by a formatted message.
-func (ct *ConnectivityTest) Headerf(format string, a ...interface{}) {
+func (ct *ConnectivityTest) Headerf(format string, a ...any) {
 	fmt.Fprintf(ct.params.Writer, "\n"+format+"\n", a...)
 }
 
@@ -76,7 +76,7 @@ func (ct *ConnectivityTest) Timestamp() {
 }
 
 // Log logs a message.
-func (ct *ConnectivityTest) Log(a ...interface{}) {
+func (ct *ConnectivityTest) Log(a ...any) {
 	ct.Timestamp()
 	fmt.Fprintln(ct.params.Writer, a...)
 }
@@ -187,13 +187,13 @@ func (ct *ConnectivityTest) LogOwners(scenarios ...ownedScenario) {
 }
 
 // Logf logs a formatted message.
-func (ct *ConnectivityTest) Logf(format string, a ...interface{}) {
+func (ct *ConnectivityTest) Logf(format string, a ...any) {
 	ct.Timestamp()
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 }
 
 // Debug logs a debug message.
-func (ct *ConnectivityTest) Debug(a ...interface{}) {
+func (ct *ConnectivityTest) Debug(a ...any) {
 	if ct.debug() {
 		ct.Timestamp()
 		fmt.Fprint(ct.params.Writer, debug+" ")
@@ -202,7 +202,7 @@ func (ct *ConnectivityTest) Debug(a ...interface{}) {
 }
 
 // Debugf logs a formatted debug message.
-func (ct *ConnectivityTest) Debugf(format string, a ...interface{}) {
+func (ct *ConnectivityTest) Debugf(format string, a ...any) {
 	if ct.debug() {
 		ct.Timestamp()
 		fmt.Fprint(ct.params.Writer, debug+" ")
@@ -211,56 +211,56 @@ func (ct *ConnectivityTest) Debugf(format string, a ...interface{}) {
 }
 
 // Info logs an informational message.
-func (ct *ConnectivityTest) Info(a ...interface{}) {
+func (ct *ConnectivityTest) Info(a ...any) {
 	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, info+" ")
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Infof logs a formatted informational message.
-func (ct *ConnectivityTest) Infof(format string, a ...interface{}) {
+func (ct *ConnectivityTest) Infof(format string, a ...any) {
 	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, info+" ")
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 }
 
 // Warn logs a warning message.
-func (ct *ConnectivityTest) Warn(a ...interface{}) {
+func (ct *ConnectivityTest) Warn(a ...any) {
 	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, warn+" ")
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Warnf logs a formatted warning message.
-func (ct *ConnectivityTest) Warnf(format string, a ...interface{}) {
+func (ct *ConnectivityTest) Warnf(format string, a ...any) {
 	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, warn+" ")
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 }
 
 // Fail logs a failure message.
-func (ct *ConnectivityTest) Fail(a ...interface{}) {
+func (ct *ConnectivityTest) Fail(a ...any) {
 	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, fail+" ")
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Failf logs a formatted failure message.
-func (ct *ConnectivityTest) Failf(format string, a ...interface{}) {
+func (ct *ConnectivityTest) Failf(format string, a ...any) {
 	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, fail+" ")
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
 }
 
 // Fatal logs an error.
-func (ct *ConnectivityTest) Fatal(a ...interface{}) {
+func (ct *ConnectivityTest) Fatal(a ...any) {
 	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, fatal+" ")
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
 // Fatalf logs a formatted error.
-func (ct *ConnectivityTest) Fatalf(format string, a ...interface{}) {
+func (ct *ConnectivityTest) Fatalf(format string, a ...any) {
 	ct.Timestamp()
 	fmt.Fprint(ct.params.Writer, fatal+" ")
 	fmt.Fprintf(ct.params.Writer, format+"\n", a...)
@@ -276,7 +276,7 @@ func (ct *ConnectivityTest) Fatalf(format string, a ...interface{}) {
 // log takes out a read lock and logs a message to the Test's internal buffer.
 // If the internal log buffer is nil, write to user-specified writer instead.
 // Prefix is an optional prefix to the message.
-func (t *Test) log(prefix string, a ...interface{}) {
+func (t *Test) log(prefix string, a ...any) {
 	t.logMu.RLock()
 	defer t.logMu.RUnlock()
 
@@ -303,7 +303,7 @@ func (t *Test) log(prefix string, a ...interface{}) {
 // logf takes out a read lock and logs a formatted message to the Test's
 // internal buffer. If the internal log buffer is nil, write to user-specified
 // writer instead.
-func (t *Test) logf(format string, a ...interface{}) {
+func (t *Test) logf(format string, a ...any) {
 	t.logMu.RLock()
 	defer t.logMu.RUnlock()
 
@@ -343,36 +343,36 @@ func (t *Test) flush() {
 }
 
 // Log logs a message.
-func (t *Test) Log(a ...interface{}) {
+func (t *Test) Log(a ...any) {
 	t.log("", a...)
 }
 
 // Logf logs a formatted message.
-func (t *Test) Logf(format string, a ...interface{}) {
+func (t *Test) Logf(format string, a ...any) {
 	t.logf(format, a...)
 }
 
 // Debug logs a debug message.
-func (t *Test) Debug(a ...interface{}) {
+func (t *Test) Debug(a ...any) {
 	if t.ctx.debug() {
 		t.log(debug, a...)
 	}
 }
 
 // Debugf logs a formatted debug message.
-func (t *Test) Debugf(format string, a ...interface{}) {
+func (t *Test) Debugf(format string, a ...any) {
 	if t.ctx.debug() {
 		t.logf(debug+" "+format, a...)
 	}
 }
 
 // Info logs an informational message.
-func (t *Test) Info(a ...interface{}) {
+func (t *Test) Info(a ...any) {
 	t.log(info, a...)
 }
 
 // Infof logs a formatted informational message.
-func (t *Test) Infof(format string, a ...interface{}) {
+func (t *Test) Infof(format string, a ...any) {
 	t.logf(info+" "+format, a...)
 }
 
@@ -403,7 +403,7 @@ func (t *Test) failCommon() {
 //
 // Flushes the Test's internal log buffer. Any further logs against the Test
 // will go directly to the user-specified writer.
-func (t *Test) Fail(a ...interface{}) {
+func (t *Test) Fail(a ...any) {
 	t.log(fail, a...)
 	t.failCommon()
 }
@@ -412,14 +412,14 @@ func (t *Test) Fail(a ...interface{}) {
 //
 // Flushes the Test's internal log buffer. Any further logs against the Test
 // will go directly to the user-specified writer.
-func (t *Test) Failf(format string, a ...interface{}) {
+func (t *Test) Failf(format string, a ...any) {
 	t.logf(fail+" "+format, a...)
 	t.failCommon()
 }
 
 // Fatal marks the test as failed, logs an error and exits the
 // calling goroutine.
-func (t *Test) Fatal(a ...interface{}) {
+func (t *Test) Fatal(a ...any) {
 	t.log(fatal, a...)
 	t.failCommon()
 	runtime.Goexit()
@@ -427,7 +427,7 @@ func (t *Test) Fatal(a ...interface{}) {
 
 // Fatalf marks the test as failed, logs a formatted error and exits the
 // calling goroutine.
-func (t *Test) Fatalf(format string, a ...interface{}) {
+func (t *Test) Fatalf(format string, a ...any) {
 	t.logf(fatal+" "+format, a...)
 	t.failCommon()
 	runtime.Goexit()
@@ -438,59 +438,59 @@ func (t *Test) Fatalf(format string, a ...interface{}) {
 //
 
 // Log logs a message.
-func (a *Action) Log(s ...interface{}) {
+func (a *Action) Log(s ...any) {
 	a.test.Log(s...)
 }
 
 // Logf logs a formatted message.
-func (a *Action) Logf(format string, s ...interface{}) {
+func (a *Action) Logf(format string, s ...any) {
 	a.test.Logf(format, s...)
 }
 
 // Debug logs a debug message.
-func (a *Action) Debug(s ...interface{}) {
+func (a *Action) Debug(s ...any) {
 	if a.test.ctx.debug() {
 		a.test.Debug(s...)
 	}
 }
 
 // Debugf logs a formatted debug message.
-func (a *Action) Debugf(format string, s ...interface{}) {
+func (a *Action) Debugf(format string, s ...any) {
 	if a.test.ctx.debug() {
 		a.test.Debugf(format, s...)
 	}
 }
 
 // Info logs a debug message.
-func (a *Action) Info(s ...interface{}) {
+func (a *Action) Info(s ...any) {
 	a.test.Info(s...)
 }
 
 // Infof logs a formatted debug message.
-func (a *Action) Infof(format string, s ...interface{}) {
+func (a *Action) Infof(format string, s ...any) {
 	a.test.Infof(format, s...)
 }
 
 // Fail must be called when the Action is unsuccessful.
-func (a *Action) Fail(s ...interface{}) {
+func (a *Action) Fail(s ...any) {
 	a.fail()
 	a.test.Fail(s...)
 }
 
 // Failf must be called when the Action is unsuccessful.
-func (a *Action) Failf(format string, s ...interface{}) {
+func (a *Action) Failf(format string, s ...any) {
 	a.fail()
 	a.test.Failf(format, s...)
 }
 
 // Fatal must be called when an irrecoverable error was encountered during the Action.
-func (a *Action) Fatal(s ...interface{}) {
+func (a *Action) Fatal(s ...any) {
 	a.fail()
 	a.test.Fatal(s...)
 }
 
 // Fatalf must be called when an irrecoverable error was encountered during the Action.
-func (a *Action) Fatalf(format string, s ...interface{}) {
+func (a *Action) Fatalf(format string, s ...any) {
 	a.fail()
 	a.test.Fatalf(format, s...)
 }

--- a/cilium-cli/connectivity/perf/common/metrics.go
+++ b/cilium-cli/connectivity/perf/common/metrics.go
@@ -197,7 +197,7 @@ func exportSummary(content perfData, reportDir string) error {
 	return nil
 }
 
-func prettyPrintJSON(data interface{}) (string, error) {
+func prettyPrintJSON(data any) (string, error) {
 	output := &bytes.Buffer{}
 	if err := json.NewEncoder(output).Encode(data); err != nil {
 		return "", fmt.Errorf("building encoder error: %w", err)

--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -38,7 +38,7 @@ type Sniffer struct {
 }
 
 type debugLogger interface {
-	Debugf(string, ...interface{})
+	Debugf(string, ...any)
 }
 
 // Start starts a tcpdump capture on the given pod, listening to the specified

--- a/cilium-cli/connectivity/suite.go
+++ b/cilium-cli/connectivity/suite.go
@@ -83,7 +83,7 @@ func runConnectivityTests(ctx context.Context, connTests []*check.ConnectivityTe
 	if err := me.Wait(); err != nil {
 		return err
 	}
-	for i := 0; i < len(connTests); i++ {
+	for i := range connTests {
 		if !finish[i] {
 			// Exit with a non-zero return code.
 			return errors.New("encountered internal error, exiting")

--- a/cilium-cli/connectivity/tests/health.go
+++ b/cilium-cli/connectivity/tests/health.go
@@ -91,7 +91,7 @@ func validateHealthStatus(t *check.ConnectivityTest, pod *check.Pod, out bytes.B
 		}
 	)
 
-	var data interface{}
+	var data any
 	err := json.Unmarshal(out.Bytes(), &data)
 	if err != nil {
 		return fmt.Errorf("Failed to unmarshal cilium-health output: %w", err)

--- a/cilium-cli/hubble/hubble.go
+++ b/cilium-cli/hubble/hubble.go
@@ -32,7 +32,7 @@ type Parameters struct {
 	HelmReleaseName string
 }
 
-func (p *Parameters) Log(format string, a ...interface{}) {
+func (p *Parameters) Log(format string, a ...any) {
 	fmt.Fprintf(p.Writer, format+"\n", a...)
 }
 

--- a/cilium-cli/install/autodetect.go
+++ b/cilium-cli/install/autodetect.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
-func (k *K8sInstaller) detectDatapathMode(helmValues map[string]interface{}) error {
+func (k *K8sInstaller) detectDatapathMode(helmValues map[string]any) error {
 	if k.params.DatapathMode != "" {
 		k.Log("ℹ️  Custom datapath mode: %s", k.params.DatapathMode)
 		return nil
@@ -69,7 +69,7 @@ func (k *K8sInstaller) autodetect(ctx context.Context) {
 	}
 }
 
-func getClusterName(helmValues map[string]interface{}) string {
+func getClusterName(helmValues map[string]any) string {
 	clusterName, _, _ := unstructured.NestedString(helmValues, "cluster", "name")
 	return clusterName
 }
@@ -88,7 +88,7 @@ func trimEKSClusterARN(fullARN string) string {
 	return ""
 }
 
-func (k *K8sInstaller) autodetectAndValidate(ctx context.Context, helmValues map[string]interface{}) error {
+func (k *K8sInstaller) autodetectAndValidate(ctx context.Context, helmValues map[string]any) error {
 	k.autodetect(ctx)
 
 	k.Log("ℹ️  Using Cilium version %s", k.chartVersion)
@@ -122,7 +122,7 @@ func (k *K8sInstaller) autodetectAndValidate(ctx context.Context, helmValues map
 	return nil
 }
 
-func (k *K8sInstaller) autodetectKubeProxy(ctx context.Context, helmValues map[string]interface{}) error {
+func (k *K8sInstaller) autodetectKubeProxy(ctx context.Context, helmValues map[string]any) error {
 	if k.flavor.Kind == k8s.KindK3s {
 		return nil
 	}

--- a/cilium-cli/install/aws.go
+++ b/cilium-cli/install/aws.go
@@ -19,12 +19,12 @@ const (
 	AwsNodeDaemonSetNodeSelectorValue = "true"
 )
 
-func getChainingMode(values map[string]interface{}) string {
+func getChainingMode(values map[string]any) string {
 	chainingMode, _, _ := unstructured.NestedString(values, "cni", "chainingMode")
 	return chainingMode
 }
 
-func (k *K8sInstaller) awsSetupChainingMode(ctx context.Context, values map[string]interface{}) error {
+func (k *K8sInstaller) awsSetupChainingMode(ctx context.Context, values map[string]any) error {
 	// detect chaining mode
 	chainingMode := getChainingMode(values)
 

--- a/cilium-cli/install/aws.go
+++ b/cilium-cli/install/aws.go
@@ -32,7 +32,7 @@ func (k *K8sInstaller) awsSetupChainingMode(ctx context.Context, values map[stri
 	if chainingMode != "aws-cni" && !k.params.IsDryRun() {
 		if _, err := k.client.GetDaemonSet(ctx, AwsNodeDaemonSetNamespace, AwsNodeDaemonSetName, metav1.GetOptions{}); err == nil {
 			k.Log("🔥 Patching the %q DaemonSet to evict its pods...", AwsNodeDaemonSetName)
-			patch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"nodeSelector":{"%s":"%s"}}}}}`, AwsNodeDaemonSetNodeSelectorKey, AwsNodeDaemonSetNodeSelectorValue))
+			patch := fmt.Appendf(nil, `{"spec":{"template":{"spec":{"nodeSelector":{"%s":"%s"}}}}}`, AwsNodeDaemonSetNodeSelectorKey, AwsNodeDaemonSetNodeSelectorValue)
 			if _, err := k.client.PatchDaemonSet(ctx, AwsNodeDaemonSetNamespace, AwsNodeDaemonSetName, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
 				k.Log("❌ Unable to patch the %q DaemonSet", AwsNodeDaemonSetName)
 				return err

--- a/cilium-cli/install/helm.go
+++ b/cilium-cli/install/helm.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
-func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
+func (k *K8sInstaller) getHelmValues() (map[string]any, error) {
 	helmMapOpts := map[string]string{}
 
 	switch {

--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -166,7 +166,7 @@ func NewK8sInstaller(client k8sInstallerImplementation, p Parameters) (*K8sInsta
 	}, nil
 }
 
-func (k *K8sInstaller) Log(format string, a ...interface{}) {
+func (k *K8sInstaller) Log(format string, a ...any) {
 	fmt.Fprintf(k.params.Writer, format+"\n", a...)
 }
 

--- a/cilium-cli/install/uninstall.go
+++ b/cilium-cli/install/uninstall.go
@@ -42,7 +42,7 @@ func NewK8sUninstaller(client k8sInstallerImplementation, p UninstallParameters)
 	}
 }
 
-func (k *K8sUninstaller) Log(format string, a ...interface{}) {
+func (k *K8sUninstaller) Log(format string, a ...any) {
 	fmt.Fprintf(k.params.Writer, format+"\n", a...)
 }
 

--- a/cilium-cli/install/uninstall.go
+++ b/cilium-cli/install/uninstall.go
@@ -91,7 +91,7 @@ func (k *K8sUninstaller) UninstallWithHelm(ctx context.Context, actionConfig *ac
 }
 
 func (k *K8sUninstaller) undoAwsNodeNodeSelector(ctx context.Context) error {
-	bytes := []byte(fmt.Sprintf(`[{"op":"remove","path":"/spec/template/spec/nodeSelector/%s"}]`, strings.ReplaceAll(AwsNodeDaemonSetNodeSelectorKey, "/", "~1")))
+	bytes := fmt.Appendf(nil, `[{"op":"remove","path":"/spec/template/spec/nodeSelector/%s"}]`, strings.ReplaceAll(AwsNodeDaemonSetNodeSelectorKey, "/", "~1"))
 	k.Log("⏪ Undoing the changes to the %q DaemonSet...", AwsNodeDaemonSetName)
 	_, err := k.client.PatchDaemonSet(ctx, AwsNodeDaemonSetNamespace, AwsNodeDaemonSetName, types.JSONPatchType, bytes, metav1.PatchOptions{})
 	if err != nil {

--- a/cilium-cli/internal/helm/helm.go
+++ b/cilium-cli/internal/helm/helm.go
@@ -38,12 +38,12 @@ import (
 var settings = cli.New()
 
 // Merge maps recursively merges the values of b into a copy of a, preferring the values from b
-func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
+func mergeMaps(a, b map[string]any) map[string]any {
 	out := maps.Clone(a)
 	for k, v := range b {
-		if v, ok := v.(map[string]interface{}); ok {
+		if v, ok := v.(map[string]any); ok {
 			if bv, ok := out[k]; ok {
-				if bv, ok := bv.(map[string]interface{}); ok {
+				if bv, ok := bv.(map[string]any); ok {
 					out[k] = mergeMaps(bv, v)
 					continue
 				}
@@ -143,7 +143,7 @@ func ciliumCacheDir() (string, error) {
 func MergeVals(
 	helmFlagOpts values.Options,
 	helmMapOpts map[string]string,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 
 	// Create helm values from helmMapOpts
 	var helmOpts []string
@@ -153,7 +153,7 @@ func MergeVals(
 
 	helmOptsStr := strings.Join(helmOpts, ",")
 
-	helmValues := map[string]interface{}{}
+	helmValues := map[string]any{}
 	err := strvals.ParseInto(helmOptsStr, helmValues)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing helm options %q: %w", helmOptsStr, err)
@@ -174,9 +174,9 @@ func MergeVals(
 // ["some.chart.value=val1", "some.other.value=val2"]
 // and returns a deeply nested map of Values of the form
 // expected by Helm actions.
-func ParseVals(helmStrValues []string) (map[string]interface{}, error) {
+func ParseVals(helmStrValues []string) (map[string]any, error) {
 	helmValStr := strings.Join(helmStrValues, ",")
-	helmValues := map[string]interface{}{}
+	helmValues := map[string]any{}
 	err := strvals.ParseInto(helmValStr, helmValues)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing helm options %q: %w", helmValStr, err)
@@ -278,7 +278,7 @@ type UpgradeParameters struct {
 	// Chart is the Helm chart to use for the release
 	Chart *chart.Chart
 	// Helm values to pass during upgrade.
-	Values map[string]interface{}
+	Values map[string]any
 	// --reset-values flag from Helm upgrade. See https://helm.sh/docs/helm/helm_upgrade/ for details.
 	ResetValues bool
 	// --reuse-values flag from Helm upgrade. See https://helm.sh/docs/helm/helm_upgrade/ for details.

--- a/cilium-cli/internal/helm/helm_test.go
+++ b/cilium-cli/internal/helm/helm_test.go
@@ -70,45 +70,45 @@ func TestParseVals(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   []string
-		want    map[string]interface{}
+		want    map[string]any
 		wantErr bool
 	}{
 		{
 			name:    "simple-val",
 			input:   []string{"simple=true"},
-			want:    map[string]interface{}{"simple": true},
+			want:    map[string]any{"simple": true},
 			wantErr: false,
 		},
 		{
 			name:    "two-levels",
 			input:   []string{"two.levels=true"},
-			want:    map[string]interface{}{"two": map[string]interface{}{"levels": true}},
+			want:    map[string]any{"two": map[string]any{"levels": true}},
 			wantErr: false,
 		},
 		{
 			name:    "multiple-keys",
 			input:   []string{"multiple=true", "keys=true"},
-			want:    map[string]interface{}{"multiple": true, "keys": true},
+			want:    map[string]any{"multiple": true, "keys": true},
 			wantErr: false,
 		},
 		{
 			name:    "string-type",
 			input:   []string{"string=testval"},
-			want:    map[string]interface{}{"string": "testval"},
+			want:    map[string]any{"string": "testval"},
 			wantErr: false,
 		},
 		{
 			name:    "mixed-type",
 			input:   []string{"string=testval", "bool=false"},
-			want:    map[string]interface{}{"string": "testval", "bool": false},
+			want:    map[string]any{"string": "testval", "bool": false},
 			wantErr: false,
 		},
 		{
 			name:  "mixed-levels",
 			input: []string{"two.levels=true", "three.levels.deep=true"},
-			want: map[string]interface{}{
-				"two":   map[string]interface{}{"levels": true},
-				"three": map[string]interface{}{"levels": map[string]interface{}{"deep": true}},
+			want: map[string]any{
+				"two":   map[string]any{"levels": true},
+				"three": map[string]any{"levels": map[string]any{"deep": true}},
 			},
 			wantErr: false,
 		},

--- a/cilium-cli/internal/utils/exec.go
+++ b/cilium-cli/internal/utils/exec.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Logger interface {
-	Log(format string, args ...interface{})
+	Log(format string, args ...any)
 }
 
 func Exec(l Logger, command string, args ...string) ([]byte, error) {

--- a/cilium-cli/internal/utils/exec_test.go
+++ b/cilium-cli/internal/utils/exec_test.go
@@ -13,7 +13,7 @@ type failIfCalled struct {
 	t *testing.T
 }
 
-func (f *failIfCalled) Log(_ string, _ ...interface{}) {
+func (f *failIfCalled) Log(_ string, _ ...any) {
 	f.t.Error("log method should not be called")
 }
 
@@ -21,7 +21,7 @@ type countIfCalled struct {
 	count int
 }
 
-func (c *countIfCalled) Log(_ string, _ ...interface{}) {
+func (c *countIfCalled) Log(_ string, _ ...any) {
 	c.count++
 }
 

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -127,7 +127,7 @@ func NewClient(contextName, kubeconfig, ciliumNamespace string, impersonateAs st
 	// Use the default Helm driver (Kubernetes secret).
 	helmDriver := ""
 	actionConfig := action.Configuration{}
-	logger := func(_ string, _ ...interface{}) {}
+	logger := func(_ string, _ ...any) {}
 	if err := actionConfig.Init(&restClientGetter, ciliumNamespace, helmDriver, logger); err != nil {
 		return nil, err
 	}
@@ -1077,7 +1077,7 @@ func (c *Client) GetHelmValues(_ context.Context, releaseName string, namespace 
 	}
 	helmDriver := ""
 	actionConfig := action.Configuration{}
-	logger := func(_ string, _ ...interface{}) {}
+	logger := func(_ string, _ ...any) {}
 	if err := actionConfig.Init(c.RESTClientGetter, namespace, helmDriver, logger); err != nil {
 		return "", err
 	}
@@ -1101,7 +1101,7 @@ func (c *Client) GetHelmMetadata(_ context.Context, releaseName string, namespac
 	}
 	helmDriver := ""
 	actionConfig := action.Configuration{}
-	logger := func(_ string, _ ...interface{}) {}
+	logger := func(_ string, _ ...any) {}
 	if err := actionConfig.Init(c.RESTClientGetter, namespace, helmDriver, logger); err != nil {
 		return "", err
 	}

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -402,7 +402,7 @@ func (k *K8sStatusCollector) Status(ctx context.Context) (*Status, error) {
 }
 
 func cursorUp(lines int) {
-	for i := 0; i < lines; i++ {
+	for range lines {
 		fmt.Print("\033[A\033[2K")
 	}
 }

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -2193,21 +2193,21 @@ func collectCiliumV2OrV2Alpha1Resource(collector *Collector, resource, title str
 	}
 }
 
-func (c *Collector) log(msg string, args ...interface{}) {
+func (c *Collector) log(msg string, args ...any) {
 	fmt.Fprintf(c.logWriter, msg+"\n", args...)
 }
 
-func (c *Collector) logDebug(msg string, args ...interface{}) {
+func (c *Collector) logDebug(msg string, args ...any) {
 	if c.Options.Debug {
 		c.log("🩺 "+msg, args...)
 	}
 }
 
-func (c *Collector) logTask(msg string, args ...interface{}) {
+func (c *Collector) logTask(msg string, args ...any) {
 	c.log("🔍 "+msg, args...)
 }
 
-func (c *Collector) logWarn(msg string, args ...interface{}) {
+func (c *Collector) logWarn(msg string, args ...any) {
 	c.log("⚠️ "+msg, args...)
 }
 

--- a/cilium-cli/utils/runner/multierror_test.go
+++ b/cilium-cli/utils/runner/multierror_test.go
@@ -14,7 +14,7 @@ func TestMultiError_no_errors(t *testing.T) {
 	m := MultiError{}
 
 	check := make([]int, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		id := i
 		m.Go(func() error {
 			check[id] = 1
@@ -23,7 +23,7 @@ func TestMultiError_no_errors(t *testing.T) {
 	}
 
 	require.NoError(t, m.Wait())
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		require.Equal(t, 1, check[i])
 	}
 }

--- a/cilium-dbg/cmd/bpf_bandwidth_list.go
+++ b/cilium-dbg/cmd/bpf_bandwidth_list.go
@@ -93,7 +93,7 @@ func listBandwidth(bpfBandwidthList map[string][]string) {
 	}
 
 	sort.Slice(rows, func(i, j int) bool {
-		for k := 0; k < numColumns; k++ {
+		for k := range numColumns {
 			c := strings.Compare(rows[i][k], rows[j][k])
 
 			if c != 0 {

--- a/cilium-dbg/cmd/bpf_ct_list.go
+++ b/cilium-dbg/cmd/bpf_ct_list.go
@@ -141,7 +141,7 @@ func doDumpEntries(m ctmap.CtMap) {
 	fmt.Println(out)
 }
 
-func dumpCt(maps []ctmap.CtMap, args ...interface{}) {
+func dumpCt(maps []ctmap.CtMap, args ...any) {
 	entries := make([]ctmap.CtMapRecord, 0)
 
 	t := args[0].(string)

--- a/cilium-dbg/cmd/bpf_ct_list_test.go
+++ b/cilium-dbg/cmd/bpf_ct_list_test.go
@@ -65,7 +65,7 @@ type ctRecord6 struct {
 	Value ctmap.CtEntry
 }
 
-func dumpAndRead[T any](t *testing.T, maps []T, dump func([]T, ...interface{}), args ...interface{}) string {
+func dumpAndRead[T any](t *testing.T, maps []T, dump func([]T, ...any), args ...any) string {
 	// dumpCt() prints to standard output. Let's redirect it to a pipe, and
 	// read the dump from there.
 	stdout := os.Stdout

--- a/cilium-dbg/cmd/bpf_ipcache_get.go
+++ b/cilium-dbg/cmd/bpf_ipcache_get.go
@@ -78,7 +78,7 @@ func dumpIPCache() map[string][]string {
 // keys in entries. The keys in entries must be specified in CIDR notation.
 // If LPM is found, the value associated with that entry is returned
 // along with boolean true. Otherwise, false is returned.
-func getLPMValue(ip net.IP, entries map[string][]string) (interface{}, bool) {
+func getLPMValue(ip net.IP, entries map[string][]string) (any, bool) {
 	type lpmEntry struct {
 		prefix   []byte
 		identity []string

--- a/cilium-dbg/cmd/bpf_ipcache_get_test.go
+++ b/cilium-dbg/cmd/bpf_ipcache_get_test.go
@@ -93,7 +93,7 @@ func toBits(bytes []byte) []byte {
 	var bits []byte
 
 	for _, b := range bytes {
-		for j := 0; j < 8; j++ {
+		for j := range 8 {
 			mask := uint8(128) >> uint8(j)
 
 			if mask&b == 0 {

--- a/cilium-dbg/cmd/bpf_metrics_list.go
+++ b/cilium-dbg/cmd/bpf_metrics_list.go
@@ -146,7 +146,7 @@ func listHumanReadableMetrics(bpfMetricsList []*metricsRow) {
 	}
 
 	sort.Slice(rows, func(i, j int) bool {
-		for k := 0; k < numColumns; k++ {
+		for k := range numColumns {
 			c := strings.Compare(rows[i][k], rows[j][k])
 
 			if c != 0 {

--- a/cilium-dbg/cmd/bpf_metrics_list_test.go
+++ b/cilium-dbg/cmd/bpf_metrics_list_test.go
@@ -94,7 +94,7 @@ func TestDumpMetrics(t *testing.T) {
 		},
 	}
 
-	rawDump := dumpAndRead(t, metricsMap, func(maps []*mockmaps.MetricsMockMap, args ...interface{}) {
+	rawDump := dumpAndRead(t, metricsMap, func(maps []*mockmaps.MetricsMockMap, args ...any) {
 		for _, m := range maps {
 			listMetrics(m)
 		}

--- a/cilium-dbg/cmd/bpf_nat_list.go
+++ b/cilium-dbg/cmd/bpf_nat_list.go
@@ -60,7 +60,7 @@ func init() {
 	command.AddOutputOption(bpfNatListCmd)
 }
 
-func dumpNat(maps []nat.NatMap, args ...interface{}) {
+func dumpNat(maps []nat.NatMap, args ...any) {
 	entries := make([]nat.NatMapRecord, 0)
 
 	for _, m := range maps {

--- a/cilium-dbg/cmd/config.go
+++ b/cilium-dbg/cmd/config.go
@@ -145,7 +145,7 @@ func dumpReadOnlyConfigs(cfgStatus *models.DaemonConfigurationStatus) {
 		v := cfgStatus.DaemonConfigurationMap[k]
 		if reflect.ValueOf(v).Kind() == reflect.Map {
 			mapString := make(map[string]string)
-			m, ok := v.(map[string]interface{})
+			m, ok := v.(map[string]any)
 			if ok {
 				fmt.Println(k)
 				for key, value := range m {

--- a/cilium-dbg/cmd/config_get.go
+++ b/cilium-dbg/cmd/config_get.go
@@ -33,7 +33,7 @@ var configGetCmd = &cobra.Command{
 			Fatalf("Empty configuration status returned")
 		}
 
-		readWriteConfigMap := make(map[string]interface{})
+		readWriteConfigMap := make(map[string]any)
 		readOnlyConfigMap := resp.Status.DaemonConfigurationMap
 
 		for k, v := range resp.Status.Realized.Options {

--- a/cilium-dbg/cmd/encrypt_status.go
+++ b/cilium-dbg/cmd/encrypt_status.go
@@ -140,7 +140,7 @@ func getXfrmStats(mountPoint string) (int64, map[string]int64, error) {
 	countErrors := int64(0)
 	errorMap := make(map[string]int64)
 	if v.Type().Kind() == reflect.Struct {
-		for i := 0; i < v.NumField(); i++ {
+		for i := range v.NumField() {
 			name := v.Type().Field(i).Name
 			value := v.Field(i).Interface().(int)
 			if value != 0 {

--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -36,7 +36,7 @@ import (
 
 // Fatalf prints the Printf formatted message to stderr and exits the program
 // Note: os.Exit(1) is not recoverable
-func Fatalf(msg string, args ...interface{}) {
+func Fatalf(msg string, args ...any) {
 	fmt.Fprintf(os.Stderr, "Error: %s\n", fmt.Sprintf(msg, args...))
 	os.Exit(1)
 }
@@ -44,7 +44,7 @@ func Fatalf(msg string, args ...interface{}) {
 // Usagef prints the Printf formatted message to stderr, prints usage help and
 // exits the program
 // Note: os.Exit(1) is not recoverable
-func Usagef(cmd *cobra.Command, msg string, args ...interface{}) {
+func Usagef(cmd *cobra.Command, msg string, args ...any) {
 	txt := fmt.Sprintf(msg, args...)
 	fmt.Fprintf(os.Stderr, "Error: %s\n\n", txt)
 	cmd.Help()
@@ -162,7 +162,7 @@ func expandNestedJSON(result bytes.Buffer) (bytes.Buffer, error) {
 		// Decode the nested JSON
 		decoded := ""
 		if nestedEnd != 0 {
-			m := make(map[string]interface{})
+			m := make(map[string]any)
 			nested := bytes.NewBufferString(unquoted[nestedStart:nestedEnd])
 			if err := json.NewDecoder(nested).Decode(&m); err != nil {
 				return bytes.Buffer{}, fmt.Errorf("Failed to decode nested JSON: %s (\n%s\n)", err.Error(), unquoted[nestedStart:nestedEnd])
@@ -365,11 +365,11 @@ func dumpConfig(Opts map[string]string, indented bool) {
 	}
 }
 
-func mapKeysToLowerCase(s map[string]interface{}) map[string]interface{} {
-	m := make(map[string]interface{})
+func mapKeysToLowerCase(s map[string]any) map[string]any {
+	m := make(map[string]any)
 	for k, v := range s {
 		if reflect.ValueOf(v).Kind() == reflect.Map {
-			for i, j := range v.(map[string]interface{}) {
+			for i, j := range v.(map[string]any) {
 				m[strings.ToLower(i)] = j
 			}
 		}
@@ -407,7 +407,7 @@ func getIpEnableStatuses() (bool, bool) {
 	return defaults.EnableIPv4, defaults.EnableIPv6
 }
 
-func mergeMaps(m1, m2 map[string]interface{}) map[string]interface{} {
+func mergeMaps(m1, m2 map[string]any) map[string]any {
 	m3 := maps.Clone(m1)
 	maps.Copy(m3, m2)
 	return m3

--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -132,7 +132,7 @@ func expandNestedJSON(result bytes.Buffer) (bytes.Buffer, error) {
 		}
 
 		// Determine the current indentation
-		for i := 0; i < loc[0]-1; i++ {
+		for i := range loc[0] - 1 {
 			idx := loc[0] - i - 1
 			if resBytes[idx] != ' ' {
 				break

--- a/cilium-dbg/cmd/loadinfo.go
+++ b/cilium-dbg/cmd/loadinfo.go
@@ -20,7 +20,7 @@ var LoadInfoCmd = &cobra.Command{
 	},
 }
 
-func printFunc(format string, a ...interface{}) {
+func printFunc(format string, a ...any) {
 	fmt.Printf(format, a...)
 	fmt.Println()
 }

--- a/cilium-health/cmd/root.go
+++ b/cilium-health/cmd/root.go
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 
 // Fatalf prints the Printf formatted message to stderr and exits the program
 // Note: os.Exit(1) is not recoverable
-func Fatalf(msg string, args ...interface{}) {
+func Fatalf(msg string, args ...any) {
 	fmt.Fprintf(os.Stderr, "Error: %s\n", fmt.Sprintf(msg, args...))
 	os.Exit(1)
 }

--- a/clustermesh-apiserver/clustermesh/users_mgmt_test.go
+++ b/clustermesh-apiserver/clustermesh/users_mgmt_test.go
@@ -92,8 +92,7 @@ func TestUsersManagement(t *testing.T) {
 		cell.Invoke(registerUsersManager),
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tlog := hivetest.Logger(t)
 	if err := hive.Start(tlog, ctx); err != nil {

--- a/clustermesh-apiserver/syncstate/syncstate_test.go
+++ b/clustermesh-apiserver/syncstate/syncstate_test.go
@@ -17,7 +17,7 @@ func TestSyncState(t *testing.T) {
 	ss := new(MetricsProvider(), types.ClusterInfo{Name: "test"})
 
 	// add several resource to the SyncState
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		doneFuncs = append(doneFuncs, ss.WaitForResource())
 	}
 	ss.Stop()

--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -465,7 +465,7 @@ func (c *cniConfigManager) findCNINetwork(wantNetwork string) ([]byte, error) {
 			continue
 		}
 
-		rawConfig := make(map[string]interface{})
+		rawConfig := make(map[string]any)
 		if err := json.Unmarshal(contents, &rawConfig); err != nil {
 			c.log.WithError(err).WithField("path", file).Warn("CNI configuration file has invalid json, skipping.")
 			continue
@@ -485,15 +485,15 @@ func (c *cniConfigManager) findCNINetwork(wantNetwork string) ([]byte, error) {
 
 		// Check to see if we need to upconvert to a CNI configuration list.
 		// The presence of a "plugins" configuration key means this is a conflist
-		plugins, ok := rawConfig["plugins"].([]interface{})
+		plugins, ok := rawConfig["plugins"].([]any)
 		if ok && len(plugins) > 0 {
 			return contents, nil
 		}
 
-		rawConfigList := map[string]interface{}{
+		rawConfigList := map[string]any{
 			"name":       wantNetwork,
 			"cniVersion": rawConfig["cniVersion"],
-			"plugins":    []interface{}{rawConfig},
+			"plugins":    []any{rawConfig},
 		}
 
 		return json.Marshal(rawConfigList)

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -86,7 +86,7 @@ func (d *Daemon) getEndpointList(params GetEndpointParams) []*models.Endpoint {
 	epModelsCh := make(chan *models.Endpoint, maxGoroutines)
 
 	epWorkersWg.Add(maxGoroutines)
-	for i := 0; i < maxGoroutines; i++ {
+	for range maxGoroutines {
 		// Run goroutines to process each endpoint and the corresponding model.
 		// The obtained endpoint model is sent to the endpoint models channel from
 		// where it will be aggregated later.

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -44,7 +44,7 @@ func getEPTemplate(t *testing.T, d *Daemon) *models.EndpointChangeRequest {
 			IPV6: ip6.IP.String(),
 			IPV4: ip4.IP.String(),
 		},
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			endpoint.PropertySkipBPFRegeneration: true,
 			endpoint.PropertyFakeEndpoint:        true,
 		},

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -596,7 +596,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 	probes := []status.Probe{
 		{
 			Name: "kvstore",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				if option.Config.KVStore == "" {
 					return &models.Status{State: models.StatusStateDisabled}, nil
 				} else {
@@ -649,7 +649,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 				// 16384 | 1m32s
 				return d.nodeDiscovery.Manager.ClusterSizeDependantInterval(10 * time.Second)
 			},
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				return d.getK8sStatus(), nil
 			},
 			OnStatusUpdate: func(status status.Status) {
@@ -670,7 +670,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "ipam",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				return d.DumpIPAM(), nil
 			},
 			OnStatusUpdate: func(status status.Status) {
@@ -687,7 +687,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "node-monitor",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				return d.monitorAgent.State(), nil
 			},
 			OnStatusUpdate: func(status status.Status) {
@@ -704,7 +704,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "cluster",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				clusterStatus := &models.ClusterStatus{
 					Self: nodeTypes.GetAbsoluteNodeName(),
 				}
@@ -729,7 +729,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "cilium-health",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				if d.ciliumHealth == nil {
 					return nil, nil
 				}
@@ -760,7 +760,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "l7-proxy",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				if d.l7Proxy == nil {
 					return nil, nil
 				}
@@ -780,7 +780,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "controllers",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				return controller.GetGlobalStatus(), nil
 			},
 			OnStatusUpdate: func(status status.Status) {
@@ -797,7 +797,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "clustermesh",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				if d.clustermesh == nil {
 					return nil, nil
 				}
@@ -816,7 +816,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "hubble",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				return d.hubble.Status(ctx), nil
 			},
 			OnStatusUpdate: func(status status.Status) {
@@ -832,7 +832,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "encryption",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				switch {
 				case option.Config.EnableIPSec:
 					return &models.EncryptionStatus{
@@ -868,7 +868,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "kube-proxy-replacement",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				return d.getKubeProxyReplacementStatus(), nil
 			},
 			OnStatusUpdate: func(status status.Status) {
@@ -884,7 +884,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "auth-cert-provider",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				if d.authManager == nil {
 					return &models.Status{State: models.StatusStateDisabled}, nil
 				}
@@ -904,7 +904,7 @@ func (d *Daemon) startStatusCollector(ctx context.Context, cleaner *daemonCleanu
 		},
 		{
 			Name: "cni-config",
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				if d.cniConfigManager == nil {
 					return nil, nil
 				}

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -174,7 +174,7 @@ func (h *ConfigModifyEventHandler) datapathRegen(reasons []string) {
 
 // ConfigModifyEvents are serialized by the event queue, no need for additional locking for
 // changing 'Opts'
-func (h *ConfigModifyEventHandler) configModify(params daemonapi.PatchConfigParams, resChan chan interface{}) {
+func (h *ConfigModifyEventHandler) configModify(params daemonapi.PatchConfigParams, resChan chan any) {
 	cfgSpec := params.Configuration
 
 	om, err := option.Config.Opts.ValidateConfigurationMap(cfgSpec.Options)
@@ -230,7 +230,7 @@ func (h *ConfigModifyEventHandler) configModify(params daemonapi.PatchConfigPara
 			if policyEnforcementChanged {
 				policy.SetPolicyEnabled(oldEnforcementValue)
 			}
-			option.Config.Opts.ApplyValidated(oldConfigOpts, func(string, option.OptionSetting, interface{}) {}, h)
+			option.Config.Opts.ApplyValidated(oldConfigOpts, func(string, option.OptionSetting, any) {}, h)
 			h.endpointManager.OverrideEndpointOpts(oldConfigOpts)
 			h.logger.Debug("finished reverting agent configuration changes")
 			resChan <- api.Error(daemonapi.PatchConfigFailureCode, msg)
@@ -245,7 +245,7 @@ func (h *ConfigModifyEventHandler) configModify(params daemonapi.PatchConfigPara
 	resChan <- daemonapi.NewPatchConfigOK()
 }
 
-func (h *ConfigModifyEventHandler) changedOption(key string, value option.OptionSetting, _ interface{}) {
+func (h *ConfigModifyEventHandler) changedOption(key string, value option.OptionSetting, _ any) {
 	if key == option.Debug {
 		// Set the log level of the agent (this can be a no-op)
 		if option.Config.Opts.IsEnabled(option.Debug) {
@@ -281,7 +281,7 @@ type ConfigModifyEvent struct {
 }
 
 // Handle implements pkg/eventqueue/EventHandler interface.
-func (e *ConfigModifyEvent) Handle(res chan interface{}) {
+func (e *ConfigModifyEvent) Handle(res chan any) {
 	e.eventHandler.configModify(e.params, res)
 }
 
@@ -328,7 +328,7 @@ type getConfigHandler struct {
 func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.Responder {
 	h.logger.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /config request")
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	// Collect config ignoring the mutable options.
 	e := reflect.ValueOf(option.Config).Elem()

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -332,7 +332,7 @@ func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.R
 
 	// Collect config ignoring the mutable options.
 	e := reflect.ValueOf(option.Config).Elem()
-	for i := 0; i < e.NumField(); i++ {
+	for i := range e.NumField() {
 		if e.Field(i).Kind() != reflect.Func {
 			field := e.Type().Field(i)
 			// Only consider exported fields and ignore the mutable options.

--- a/hubble/cmd/config/get.go
+++ b/hubble/cmd/config/get.go
@@ -43,7 +43,7 @@ func runGet(cmd *cobra.Command, vp *viper.Viper, key string) error {
 		return fmt.Errorf("key=%s not bound to a flag", key)
 	}
 
-	var val interface{}
+	var val any
 	switch typ := flag.Value.Type(); typ {
 	case "bool":
 		val = vp.GetBool(key)

--- a/hubble/cmd/config/set.go
+++ b/hubble/cmd/config/set.go
@@ -57,7 +57,7 @@ func runSet(cmd *cobra.Command, vp *viper.Viper, key, value string) error {
 	}
 
 	var err error
-	var newVal interface{}
+	var newVal any
 	typ := flag.Value.Type()
 	switch typ {
 	case "bool":

--- a/hubble/cmd/list/list.go
+++ b/hubble/cmd/list/list.go
@@ -37,7 +37,7 @@ func New(vp *viper.Viper) *cobra.Command {
 	return listCmd
 }
 
-func jsonOutput(buf io.Writer, v interface{}) error {
+func jsonOutput(buf io.Writer, v any) error {
 	bs, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return err

--- a/hubble/cmd/observe/io_reader_observer.go
+++ b/hubble/cmd/observe/io_reader_observer.go
@@ -168,7 +168,7 @@ func (c *ioReaderClient) popFromLastBuffer() *observerpb.GetFlowsResponse {
 			// index into the ring buffer itself
 			// TODO: Add the ability to index into the ring buffer and we could avoid
 			// this copy.
-			c.buffer.Iterate(func(i interface{}) {
+			c.buffer.Iterate(func(i any) {
 				c.resps = append(c.resps, i.(*observerpb.GetFlowsResponse))
 			})
 		}

--- a/hubble/cmd/observe/io_reader_observer_test.go
+++ b/hubble/cmd/observe/io_reader_observer_test.go
@@ -31,7 +31,7 @@ func Test_getFlowsBasic(t *testing.T) {
 	req := observerpb.GetFlowsRequest{}
 	client, err := server.GetFlows(context.Background(), &req)
 	require.NoError(t, err)
-	for i := 0; i < len(flows); i++ {
+	for range flows {
 		_, err = client.Recv()
 		require.NoError(t, err)
 	}

--- a/hubble/pkg/printer/color.go
+++ b/hubble/pkg/printer/color.go
@@ -12,7 +12,7 @@ import (
 )
 
 type sprinter interface {
-	Sprint(a ...interface{}) string
+	Sprint(a ...any) string
 }
 
 type colorer struct {
@@ -79,43 +79,43 @@ func (c *colorer) disable() {
 	}
 }
 
-func (c colorer) port(a interface{}) string {
+func (c colorer) port(a any) string {
 	return c.yellow.Sprint(a)
 }
 
-func (c colorer) host(a interface{}) string {
+func (c colorer) host(a any) string {
 	return c.cyan.Sprint(a)
 }
 
-func (c colorer) identity(a interface{}) string {
+func (c colorer) identity(a any) string {
 	return c.magenta.Sprint(a)
 }
 
-func (c colorer) verdictForwarded(a interface{}) string {
+func (c colorer) verdictForwarded(a any) string {
 	return c.green.Sprint(a)
 }
 
-func (c colorer) verdictDropped(a interface{}) string {
+func (c colorer) verdictDropped(a any) string {
 	return c.red.Sprint(a)
 }
 
-func (c colorer) verdictAudit(a interface{}) string {
+func (c colorer) verdictAudit(a any) string {
 	return c.yellow.Sprint(a)
 }
 
-func (c colorer) verdictTraced(a interface{}) string {
+func (c colorer) verdictTraced(a any) string {
 	return c.yellow.Sprint(a)
 }
 
-func (c colorer) verdictTranslated(a interface{}) string {
+func (c colorer) verdictTranslated(a any) string {
 	return c.yellow.Sprint(a)
 }
 
-func (c colorer) authTestAlwaysFail(a interface{}) string {
+func (c colorer) authTestAlwaysFail(a any) string {
 	return c.red.Sprint(a)
 }
 
-func (c colorer) authIsEnabled(a interface{}) string {
+func (c colorer) authIsEnabled(a any) string {
 	return c.green.Sprint(a)
 }
 

--- a/hubble/pkg/printer/printer_test.go
+++ b/hubble/pkg/printer/printer_test.go
@@ -110,7 +110,7 @@ func TestPrinter_AllFieldsInMask(t *testing.T) {
 	}
 	check := func(msg protoreflect.Message, prefix string) {
 		fds := msg.Descriptor().Fields()
-		for i := 0; i < fds.Len(); i++ {
+		for i := range fds.Len() {
 			fd := fds.Get(i)
 			if !msg.Has(fd) {
 				continue

--- a/hubble/pkg/printer/terminal.go
+++ b/hubble/pkg/printer/terminal.go
@@ -38,14 +38,14 @@ type terminalEscaperWriter struct {
 	err      error
 }
 
-func (tew *terminalEscaperWriter) print(a ...interface{}) {
+func (tew *terminalEscaperWriter) print(a ...any) {
 	if tew.err != nil {
 		return
 	}
 	_, tew.err = tew.replacer.WriteString(tew.w, fmt.Sprint(a...))
 }
 
-func (tew *terminalEscaperWriter) printf(format string, a ...interface{}) {
+func (tew *terminalEscaperWriter) printf(format string, a ...any) {
 	if tew.err != nil {
 		return
 	}

--- a/operator/auth/spire/log_wrapper.go
+++ b/operator/auth/spire/log_wrapper.go
@@ -23,17 +23,17 @@ func newSpiffeLogWrapper(log *slog.Logger) *spiffeLogWrapper {
 }
 
 // Debugf logs a debug message
-func (l *spiffeLogWrapper) Debugf(format string, args ...interface{}) {
+func (l *spiffeLogWrapper) Debugf(format string, args ...any) {
 	l.log.Debug(fmt.Sprintf(format, args...))
 }
 
 // Infof logs an info message
-func (l *spiffeLogWrapper) Infof(format string, args ...interface{}) {
+func (l *spiffeLogWrapper) Infof(format string, args ...any) {
 	l.log.Info(fmt.Sprintf(format, args...))
 }
 
 // Warnf logs a warning message
-func (l *spiffeLogWrapper) Warnf(format string, args ...interface{}) {
+func (l *spiffeLogWrapper) Warnf(format string, args ...any) {
 	l.log.Warn(fmt.Sprintf(format, args...))
 }
 
@@ -42,6 +42,6 @@ func (l *spiffeLogWrapper) Warnf(format string, args ...interface{}) {
 // while the SPIRE server is still starting up. Any errors given by spire will
 // result in an error passed back to the function caller which then is logged
 // as an error.
-func (l *spiffeLogWrapper) Errorf(format string, args ...interface{}) {
+func (l *spiffeLogWrapper) Errorf(format string, args ...any) {
 	l.log.Warn(fmt.Sprintf(format, args...))
 }

--- a/operator/cmd/allocator_test.go
+++ b/operator/cmd/allocator_test.go
@@ -30,7 +30,7 @@ import (
 func TestPodCIDRAllocatorOverlap(t *testing.T) {
 	// We need to run the test multiple times since we are testing a race condition which is dependant on the order
 	// of a hash map.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		fmt.Printf("Run %d/5\n", i+1)
 
 		podCIDRAllocatorOverlapTestRun(t)

--- a/operator/cmd/ccnp_event.go
+++ b/operator/cmd/ccnp_event.go
@@ -43,7 +43,7 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 		&cilium_v2.CiliumClusterwideNetworkPolicy{},
 		0,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				k8sEventMetric(resources.MetricCCNP, resources.MetricCreate)
 				if cnp := informer.CastInformerEvent[types.SlimCNP](logging.DefaultSlogLogger, obj); cnp != nil {
 					// We need to deepcopy this structure because we are writing
@@ -54,7 +54,7 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 					groups.AddDerivativePolicyIfNeeded(logging.DefaultSlogLogger, clientset, cnpCpy.CiliumNetworkPolicy, true)
 				}
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj any) {
 				k8sEventMetric(resources.MetricCCNP, resources.MetricUpdate)
 				if oldCNP := informer.CastInformerEvent[types.SlimCNP](logging.DefaultSlogLogger, oldObj); oldCNP != nil {
 					if newCNP := informer.CastInformerEvent[types.SlimCNP](logging.DefaultSlogLogger, newObj); newCNP != nil {
@@ -72,7 +72,7 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 					}
 				}
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				k8sEventMetric(resources.MetricCCNP, resources.MetricDelete)
 				cnp := informer.CastInformerEvent[types.SlimCNP](logging.DefaultSlogLogger, obj)
 				if cnp == nil {

--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -216,7 +216,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 	// to get the latest state of a CiliumNode.
 	if s.withKVStore || s.nodeManager != nil {
 		resourceEventHandler = cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				if err != nil {
 					log.WithError(err).Warning("Unable to process CiliumNode Add event")
@@ -229,7 +229,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 					kvStoreQueue.Add(key)
 				}
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj any) {
 				if oldNode := informer.CastInformerEvent[cilium_v2.CiliumNode](logging.DefaultSlogLogger, oldObj); oldNode != nil {
 					if newNode := informer.CastInformerEvent[cilium_v2.CiliumNode](logging.DefaultSlogLogger, newObj); newNode != nil {
 						if oldNode.DeepEqual(newNode) {
@@ -253,7 +253,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 					log.Warningf("Unknown CiliumNode object type %T received: %+v", oldNode, oldNode)
 				}
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				if err != nil {
 					log.WithError(err).Warning("Unable to process CiliumNode Delete event")

--- a/operator/cmd/cnp_event.go
+++ b/operator/cmd/cnp_event.go
@@ -44,7 +44,7 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 		&cilium_v2.CiliumNetworkPolicy{},
 		0,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				k8sEventMetric(resources.MetricCNP, resources.MetricCreate)
 				if cnp := informer.CastInformerEvent[types.SlimCNP](logging.DefaultSlogLogger, obj); cnp != nil {
 					// We need to deepcopy this structure because we are writing
@@ -55,7 +55,7 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 					groups.AddDerivativePolicyIfNeeded(logging.DefaultSlogLogger, clientset, cnpCpy.CiliumNetworkPolicy, false)
 				}
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj any) {
 				k8sEventMetric(resources.MetricCNP, resources.MetricUpdate)
 				if oldCNP := informer.CastInformerEvent[types.SlimCNP](logging.DefaultSlogLogger, oldObj); oldCNP != nil {
 					if newCNP := informer.CastInformerEvent[types.SlimCNP](logging.DefaultSlogLogger, newObj); newCNP != nil {
@@ -73,7 +73,7 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 					}
 				}
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				k8sEventMetric(resources.MetricCNP, resources.MetricDelete)
 				cnp := informer.CastInformerEvent[types.SlimCNP](logging.DefaultSlogLogger, obj)
 				if cnp == nil {

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -99,7 +99,7 @@ func TestIdentitiesGC(t *testing.T) {
 		identities *v2.CiliumIdentityList
 		err        error
 	)
-	for retry := 0; retry < 10; retry++ {
+	for range 10 {
 		identities, err = clientset.CiliumV2().CiliumIdentities().List(
 			ctx,
 			metav1.ListOptions{

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -87,8 +87,7 @@ func TestIdentitiesGC(t *testing.T) {
 		cell.Invoke(registerGC),
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tlog := hivetest.Logger(t)
 	if err := hive.Start(tlog, ctx); err != nil {

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -36,7 +36,7 @@ func CiliumEndpointResource(lc cell.Lifecycle, cs client.Clientset, opts ...func
 		lc, lw, resource.WithMetric("CiliumEndpoint"), resource.WithIndexers(indexers)), nil
 }
 
-func identityIndexFunc(obj interface{}) ([]string, error) {
+func identityIndexFunc(obj any) ([]string, error) {
 	switch t := obj.(type) {
 	case *cilium_api_v2.CiliumEndpoint:
 		if t.Status.Identity != nil {

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -84,7 +84,7 @@ func HasCEWithIdentity(cepStore resource.Store[*cilium_api_v2.CiliumEndpoint], i
 }
 
 // podNodeNameIndexFunc indexes pods by node name.
-func PodNodeNameIndexFunc(obj interface{}) ([]string, error) {
+func PodNodeNameIndexFunc(obj any) ([]string, error) {
 	pod := obj.(*slim_corev1.Pod)
 	if pod.Spec.NodeName != "" {
 		return []string{pod.Spec.NodeName}, nil

--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -1164,7 +1164,7 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 				slices.SortFunc(tt.conflictingRelations, sortRelation)
 
 				// Compare the conflicting relations.
-				for i := 0; i < len(tt.conflictingRelations); i++ {
+				for i := range tt.conflictingRelations {
 					if !assert.ElementsMatch(ct, tt.conflictingRelations[i], conflictingRelations[i]) {
 						return
 					}

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -151,7 +151,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 	var standardQueueLen int
 	var fastQueueLen int
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if i == 6 {
 			ns = "FastNamespace"
 		}
@@ -177,7 +177,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		cesController.processNextWorkItem()
 		if i < 4 {
 			standardQueueLen = 6

--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -154,7 +154,7 @@ func TestCIDStateThreadSafety(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	queryStateFunc := func() {
-		for i := 0; i < 500; i++ {
+		for range 500 {
 			state.LookupByID("1000")
 			state.Upsert("1000", k)
 			state.LookupByKey(k)
@@ -166,7 +166,7 @@ func TestCIDStateThreadSafety(t *testing.T) {
 		wg.Done()
 	}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go queryStateFunc()
 	}

--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -416,7 +416,7 @@ func TestSharedIngressTranslator_getClusters(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, res, len(tt.expected))
 
-			for i := 0; i < len(tt.expected); i++ {
+			for i := range tt.expected {
 				cluster := &envoy_config_cluster_v3.Cluster{}
 				err := proto.Unmarshal(res[i].GetValue(), cluster)
 				require.NoError(t, err)

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -42,7 +42,7 @@ var (
 )
 
 // identityIndexFunc index identities by ID.
-func identityIndexFunc(obj interface{}) ([]string, error) {
+func identityIndexFunc(obj any) ([]string, error) {
 	switch t := obj.(type) {
 	case *cilium_api_v2.CiliumEndpoint:
 		if t.Status.Identity != nil {
@@ -84,7 +84,7 @@ func CiliumEndpointsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sC
 // Warning: The CiliumEndpoints created by the converter are not intended to be
 // used for Update operations in k8s. If the given obj can't be cast into either
 // CiliumEndpoint nor DeletedFinalStateUnknown, an error is returned.
-func transformToCiliumEndpoint(obj interface{}) (interface{}, error) {
+func transformToCiliumEndpoint(obj any) (any, error) {
 	switch concreteObj := obj.(type) {
 	case *cilium_api_v2.CiliumEndpoint:
 		p := &cilium_api_v2.CiliumEndpoint{

--- a/operator/watchers/node.go
+++ b/operator/watchers/node.go
@@ -81,11 +81,11 @@ func nodesInit(wg *sync.WaitGroup, slimClient slimclientset.Interface, stopCh <-
 			&slim_corev1.Node{},
 			0,
 			cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {
+				AddFunc: func(obj any) {
 					key, _ := queueKeyFunc(obj)
 					nodeQueue.Add(key)
 				},
-				UpdateFunc: func(_, newObj interface{}) {
+				UpdateFunc: func(_, newObj any) {
 					key, _ := queueKeyFunc(newObj)
 					nodeQueue.Add(key)
 				},
@@ -104,7 +104,7 @@ func nodesInit(wg *sync.WaitGroup, slimClient slimclientset.Interface, stopCh <-
 	})
 }
 
-func transformToNode(obj interface{}) (interface{}, error) {
+func transformToNode(obj any) (any, error) {
 	switch concreteObj := obj.(type) {
 	case *slim_corev1.Node:
 		n := &slim_corev1.Node{

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -130,7 +130,7 @@ func checkAndMarkNode(ctx context.Context, c kubernetes.Interface, nodeGetter sl
 	return nil
 }
 
-func ciliumPodHandler(obj interface{}, queue workqueue.TypedRateLimitingInterface[string], logger *slog.Logger) {
+func ciliumPodHandler(obj any, queue workqueue.TypedRateLimitingInterface[string], logger *slog.Logger) {
 	if pod := informer.CastInformerEvent[slim_corev1.Pod](logger, obj); pod != nil {
 		nodeName := pod.Spec.NodeName
 		// Pod might not yet be scheduled to a node
@@ -153,10 +153,10 @@ func ciliumPodsWatcher(wg *sync.WaitGroup, slimClient slimclientset.Interface, q
 		&slim_corev1.Pod{},
 		0,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				ciliumPodHandler(obj, queue, logger)
 			},
-			UpdateFunc: func(_, newObj interface{}) {
+			UpdateFunc: func(_, newObj any) {
 				ciliumPodHandler(newObj, queue, logger)
 			},
 		},
@@ -207,7 +207,7 @@ func hasAgentNotReadyTaint(k8sNode *slim_corev1.Node) bool {
 }
 
 // hostNameIndexFunc index pods by node name.
-func hostNameIndexFunc(obj interface{}) ([]string, error) {
+func hostNameIndexFunc(obj any) ([]string, error) {
 	switch t := obj.(type) {
 	case *slim_corev1.Pod:
 		return []string{t.Spec.NodeName}, nil
@@ -215,7 +215,7 @@ func hostNameIndexFunc(obj interface{}) ([]string, error) {
 	return nil, fmt.Errorf("%w - found %T", errNoPod, obj)
 }
 
-func transformToCiliumPod(obj interface{}) (interface{}, error) {
+func transformToCiliumPod(obj any) (any, error) {
 	switch concreteObj := obj.(type) {
 	case *slim_corev1.Pod:
 		p := &slim_corev1.Pod{

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -292,7 +292,7 @@ func setNodeNetworkUnavailableFalse(ctx context.Context, c kubernetes.Interface,
 	if err != nil {
 		return err
 	}
-	patch := []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, raw))
+	patch := fmt.Appendf(nil, `{"status":{"conditions":%s}}`, raw)
 	_, err = c.CoreV1().Nodes().PatchStatus(ctx, nodeName, patch)
 	if err != nil {
 		logger.Info("Failed to patch node while setting condition",

--- a/operator/watchers/pod.go
+++ b/operator/watchers/pod.go
@@ -55,7 +55,7 @@ func UnmanagedPodsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 	cache.WaitForCacheSync(ctx.Done(), unmanagedPodInformer.HasSynced)
 }
 
-func TransformToUnmanagedPod(obj interface{}) (interface{}, error) {
+func TransformToUnmanagedPod(obj any) (any, error) {
 	switch concreteObj := obj.(type) {
 	case *slim_corev1.Pod:
 		p := &slim_corev1.Pod{

--- a/pkg/alibabacloud/api/mock/mock.go
+++ b/pkg/alibabacloud/api/mock/mock.go
@@ -219,7 +219,7 @@ func (a *API) CreateNetworkInterface(ctx context.Context, secondaryPrivateIPCoun
 		SecurityGroupIDs: groups,
 		Tags:             tags,
 	}
-	for i := 0; i < secondaryPrivateIPCount+1; i++ {
+	for range secondaryPrivateIPCount + 1 {
 		ip, err := a.allocator.AllocateNext()
 		if err != nil {
 			panic("Unable to allocate IP from allocator")
@@ -293,7 +293,7 @@ func (a *API) AssignPrivateIPAddresses(ctx context.Context, eniID string, toAllo
 				return nil, fmt.Errorf("vSwitch %s don't have enough addresses available", eni.VSwitch.VSwitchID)
 			}
 
-			for i := 0; i < toAllocate; i++ {
+			for range toAllocate {
 				ip, err := a.allocator.AllocateNext()
 				if err != nil {
 					panic("Unable to allocate IP from allocator")

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -163,7 +163,7 @@ func check(name string, toCheck []any, structs map[string]*structInfo, checkOffs
 			continue
 		}
 
-		for i := 0; i < g.NumField(); i++ {
+		for i := range g.NumField() {
 			fieldName := g.Field(i).Tag.Get("align")
 			// Ignore fields without `align` struct tag
 			if fieldName == "" {

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -700,7 +700,7 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 	boff := a.backoffTemplate
 	boff.Name = key.String()
 
-	for attempt := 0; attempt < a.maxAllocAttempts; attempt++ {
+	for attempt := range a.maxAllocAttempts {
 		// Check our list of local keys already in use and increment the
 		// refcnt. The returned key must be released afterwards. No kvstore
 		// operation was performed for this allocation.
@@ -778,7 +778,7 @@ func (a *Allocator) GetWithRetry(ctx context.Context, key AllocatorKey) (idpool.
 	var id idpool.ID
 	var err error
 
-	for attempt := 0; attempt < a.maxAllocAttempts; attempt++ {
+	for attempt := range a.maxAllocAttempts {
 		id, err = getID()
 		if err == nil {
 			return id, nil

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -104,7 +104,7 @@ func (d *dummyLock) Unlock(ctx context.Context) error {
 	return nil
 }
 
-func (d *dummyLock) Comparator() interface{} {
+func (d *dummyLock) Comparator() any {
 	return nil
 }
 

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -414,7 +414,7 @@ func TestObserveAllocatorChanges(t *testing.T) {
 	numAllocations := 10
 
 	// Allocate few ids
-	for i := 0; i < numAllocations; i++ {
+	for i := range numAllocations {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
 		id, new, firstUse, err := allocator.Allocate(context.Background(), key)
 		require.NoError(t, err)
@@ -429,7 +429,7 @@ func TestObserveAllocatorChanges(t *testing.T) {
 	// Subscribe to the changes. This should replay the current state.
 	ctx, cancel := context.WithCancel(context.Background())
 	changes := stream.ToChannel[AllocatorChange](ctx, allocator)
-	for i := 0; i < numAllocations; i++ {
+	for range numAllocations {
 		change := <-changes
 		// Since these are replayed in hash map traversal order, just validate that
 		// the fields are set.

--- a/pkg/api/apierror.go
+++ b/pkg/api/apierror.go
@@ -20,7 +20,7 @@ type APIError struct {
 }
 
 // New creates a API error from the code, msg and extra arguments.
-func New(code int, msg string, args ...interface{}) *APIError {
+func New(code int, msg string, args ...any) *APIError {
 	if code <= 0 {
 		code = 500
 	}

--- a/pkg/api/helpers/delay_simulator.go
+++ b/pkg/api/helpers/delay_simulator.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Operation represents an API operation
-type Operation interface{}
+type Operation any
 
 // DelaySimulator simulates delays in API calls
 type DelaySimulator struct {

--- a/pkg/api/helpers/rate_limit_test.go
+++ b/pkg/api/helpers/rate_limit_test.go
@@ -19,7 +19,7 @@ func TestRateLimitBurst(t *testing.T) {
 	require.NotNil(t, limiter)
 
 	// Exhaust bucket (rate limit should not kick in)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		limiter.Limit(context.TODO(), "test")
 	}
 	require.Equal(t, time.Duration(0), metricsAPI.RateLimit("test"))
@@ -43,7 +43,7 @@ func TestRateLimitWait(t *testing.T) {
 	// Hit rate limit 15 times. The bucket refill rate is 100 per second,
 	// meaning we expect this to take around 15 * 10 = 150 milliseconds
 	start := time.Now()
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		limiter.Limit(context.TODO(), "test")
 	}
 	measured := time.Since(start)

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -355,7 +355,7 @@ func (r *fakeAuthMap) MaxEntries() uint32 {
 }
 
 func assertErrorString(errString string) assert.ErrorAssertionFunc {
-	return func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+	return func(t assert.TestingT, err error, msgAndArgs ...any) bool {
 		return assert.EqualError(t, err, errString, msgAndArgs...)
 	}
 }

--- a/pkg/aws/eni/eni_gc_test.go
+++ b/pkg/aws/eni/eni_gc_test.go
@@ -68,9 +68,7 @@ func TestStartENIGarbageCollector(t *testing.T) {
 		createTaggedENI()
 	}
 
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-	StartENIGarbageCollector(ctx, hivetest.Logger(t), ec2api, GarbageCollectionParams{
+	StartENIGarbageCollector(t.Context(), hivetest.Logger(t), ec2api, GarbageCollectionParams{
 		RunInterval:    0, // for testing, we're triggering the controller manually
 		MaxPerInterval: 4,
 		ENITags:        tags,

--- a/pkg/aws/eni/eni_gc_test.go
+++ b/pkg/aws/eni/eni_gc_test.go
@@ -51,7 +51,7 @@ func TestStartENIGarbageCollector(t *testing.T) {
 	require.NotNil(t, ec2api)
 
 	untaggedENIs := map[string]bool{}
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "subnet-1", "desc", []string{"sg-1", "sg-2"}, false)
 		require.NoError(t, err)
 		untaggedENIs[eniID] = true
@@ -64,7 +64,7 @@ func TestStartENIGarbageCollector(t *testing.T) {
 		require.NoError(t, err)
 		return eniID
 	}
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		createTaggedENI()
 	}
 

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -511,7 +511,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	}
 
 	var attachmentID string
-	for attachRetries := 0; attachRetries < maxAttachRetries; attachRetries++ {
+	for range maxAttachRetries {
 		attachmentID, err = n.manager.api.AttachNetworkInterface(ctx, index, n.node.InstanceID(), eniID)
 
 		// The index is already in use, this can happen if the local

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -1176,7 +1176,7 @@ func withExcludeInterfaceTags(tags map[string]string) func(*v2.CiliumNode) {
 
 func updateCiliumNode(cn *v2.CiliumNode, available, used int) *v2.CiliumNode {
 	cn.Spec.IPAM.Pool = ipamTypes.AllocationMap{}
-	for i := 0; i < used; i++ {
+	for i := range used {
 		cn.Spec.IPAM.Pool[fmt.Sprintf("1.1.1.%d", i)] = ipamTypes.AllocationIP{Resource: "foo"}
 	}
 

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -535,7 +535,7 @@ func (c *Client) AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, v
 	}
 
 	ipConfigurations := make([]*armcompute.VirtualMachineScaleSetIPConfiguration, 0, addresses)
-	for i := 0; i < addresses; i++ {
+	for range addresses {
 		ipConfigurations = append(ipConfigurations,
 			&armcompute.VirtualMachineScaleSetIPConfiguration{
 				Name: to.Ptr(generateIpConfigName()),
@@ -601,7 +601,7 @@ func (c *Client) AssignPrivateIpAddressesVM(ctx context.Context, subnetID, inter
 	}
 
 	ipConfigurations := make([]*armnetwork.InterfaceIPConfiguration, 0, addresses)
-	for i := 0; i < addresses; i++ {
+	for range addresses {
 		ipConfigurations = append(ipConfigurations, &armnetwork.InterfaceIPConfiguration{
 			Name: to.Ptr(generateIpConfigName()),
 			Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -225,7 +225,7 @@ func (a *API) AssignPrivateIpAddressesVMSS(ctx context.Context, vmName, vmssName
 			return fmt.Errorf("subnet %s does not exist", subnetID)
 		}
 
-		for i := 0; i < addresses; i++ {
+		for range addresses {
 			ip, err := s.allocator.AllocateNext()
 			if err != nil {
 				panic("Unable to allocate IP from allocator")

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestJitter(t *testing.T) {
 	var prev time.Duration
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		current := CalculateDuration(time.Second, time.Minute, 2.0, true, 1)
 		require.NotEqual(t, prev, current)
 		prev = current

--- a/pkg/bgpv1/agent/annotations_test.go
+++ b/pkg/bgpv1/agent/annotations_test.go
@@ -160,8 +160,8 @@ func BenchmarkErrNotVRouterAnnoError(b *testing.B) {
 		a: "foo error",
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = e.Error()
 	}
 }
@@ -171,8 +171,8 @@ func BenchmarkErrErrNoASNAnno(b *testing.B) {
 		a: "foo error",
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = e.Error()
 	}
 }
@@ -184,8 +184,8 @@ func BenchmarkErrASNAnno(b *testing.B) {
 		anno: "foo anno",
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = e.Error()
 	}
 }

--- a/pkg/bgpv1/agent/signaler/signaler.go
+++ b/pkg/bgpv1/agent/signaler/signaler.go
@@ -31,7 +31,7 @@ func NewBGPCPSignaler() *BGPCPSignaler {
 //
 // This signature adheres to the common event handling signatures of
 // cache.ResourceEventHandlerFuncs for convenience.
-func (s BGPCPSignaler) Event(_ interface{}) {
+func (s BGPCPSignaler) Event(_ any) {
 	select {
 	case s.Sig <- struct{}{}:
 	default:

--- a/pkg/bgpv1/manager/reconciler/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor_test.go
@@ -295,7 +295,7 @@ func TestNeighborReconciler(t *testing.T) {
 
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name, func(t *testing.T) {
 					err = neighborReconciler.Reconcile(context.Background(), params)
 					if (tt.err == nil) != (err == nil) {

--- a/pkg/bgpv1/manager/reconciler/pod_cidr_test.go
+++ b/pkg/bgpv1/manager/reconciler/pod_cidr_test.go
@@ -142,7 +142,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name, func(t *testing.T) {
 					err = exportPodCIDRReconciler.Reconcile(context.Background(), params)
 					if err != nil {

--- a/pkg/bgpv1/manager/reconciler/pod_ip_pool_test.go
+++ b/pkg/bgpv1/manager/reconciler/pod_ip_pool_test.go
@@ -247,7 +247,7 @@ func TestPodIPPoolReconciler(t *testing.T) {
 
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name, func(t *testing.T) {
 					err = reconciler.Reconcile(context.Background(), ReconcileParams{
 						CurrentServer: testSC,

--- a/pkg/bgpv1/manager/reconciler/preflight_test.go
+++ b/pkg/bgpv1/manager/reconciler/preflight_test.go
@@ -144,7 +144,7 @@ func TestPreflightReconciler(t *testing.T) {
 
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name, func(t *testing.T) {
 					err = preflightReconciler.Reconcile(context.Background(), params)
 					if (tt.err == nil) != (err == nil) {

--- a/pkg/bgpv1/manager/reconciler/route_policy_test.go
+++ b/pkg/bgpv1/manager/reconciler/route_policy_test.go
@@ -630,7 +630,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name+"-init", func(t *testing.T) {
 					err = policyReconciler.Reconcile(context.Background(), params)
 					if tt.expectError {
@@ -660,7 +660,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 			}
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name+"-follow-up", func(t *testing.T) {
 					err = policyReconciler.Reconcile(context.Background(), params)
 					require.NoError(t, err)

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -695,7 +695,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name, func(t *testing.T) {
 					err = reconciler.Reconcile(context.Background(), ReconcileParams{
 						CurrentServer: testSC,
@@ -1360,7 +1360,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name, func(t *testing.T) {
 					err = reconciler.Reconcile(context.Background(), ReconcileParams{
 						CurrentServer: testSC,
@@ -2023,7 +2023,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name, func(t *testing.T) {
 					err = reconciler.Reconcile(context.Background(), ReconcileParams{
 						CurrentServer: testSC,
@@ -2377,7 +2377,7 @@ func TestServiceReconcilerWithExternalIPAndClusterIP(t *testing.T) {
 
 			// Run the reconciler twice to ensure idempotency. This
 			// simulates the retrying behavior of the controller.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				t.Run(tt.name, func(t *testing.T) {
 					err = reconciler.Reconcile(context.Background(), ReconcileParams{
 						CurrentServer: testSC,

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr_test.go
@@ -448,7 +448,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 
 			// reconcile pod cidr
 			// run reconciler twice to ensure idempotency
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				err := podCIDRReconciler.Reconcile(context.Background(), ReconcileParams{
 					BGPInstance:   testBGPInstance,
 					DesiredConfig: tt.testBGPInstanceConfig,

--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool_test.go
@@ -612,7 +612,7 @@ func Test_PodIPPoolAdvertisements(t *testing.T) {
 			})
 
 			// run podIPPoolReconciler twice to ensure idempotency
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				err := podIPPoolReconciler.Reconcile(context.Background(), ReconcileParams{
 					BGPInstance:   testBGPInstance,
 					DesiredConfig: tt.testBGPInstanceConfig,

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -981,7 +981,7 @@ func Test_ServiceLBReconciler(t *testing.T) {
 			defer svcReconciler.Cleanup(testBGPInstance)
 
 			// reconcile twice to validate idempotency
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				err := svcReconciler.Reconcile(context.Background(), ReconcileParams{
 					BGPInstance:   testBGPInstance,
 					DesiredConfig: testBGPInstanceConfig,
@@ -1317,7 +1317,7 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 			defer svcReconciler.Cleanup(testBGPInstance)
 
 			// reconcile twice to validate idempotency
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				err := svcReconciler.Reconcile(context.Background(), ReconcileParams{
 					BGPInstance:   testBGPInstance,
 					DesiredConfig: testBGPInstanceConfig,
@@ -1653,7 +1653,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 			defer svcReconciler.Cleanup(testBGPInstance)
 
 			// reconcile twice to validate idempotency
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				err := svcReconciler.Reconcile(context.Background(), ReconcileParams{
 					BGPInstance:   testBGPInstance,
 					DesiredConfig: testBGPInstanceConfig,

--- a/pkg/bgpv1/test/gobgp.go
+++ b/pkg/bgpv1/test/gobgp.go
@@ -343,7 +343,7 @@ func (g *goBGP) waitForSessionState(ctx context.Context, expectedStates []string
 func (g *goBGP) getRouteEvents(ctx context.Context, numExpectedEvents int) ([]routeEvent, error) {
 	var receivedEvents []routeEvent
 
-	for i := 0; i < numExpectedEvents; i++ {
+	for range numExpectedEvents {
 		select {
 		case r := <-g.routeNotif:
 			g.logger.Info("GoBGP test instance", types.RouteLogField, r)

--- a/pkg/bpf/bpfmap.go
+++ b/pkg/bpf/bpfmap.go
@@ -8,7 +8,7 @@ import "github.com/cilium/hive/cell"
 // BpfMap defines the base interface every BPF map needs to implement.
 //
 // Its main purpose is to register a BPF map via value group `bpf-maps`. See [MapOut].
-type BpfMap interface{}
+type BpfMap any
 
 // MapOut ensures that maps are created before the datapath loader
 // is invoked.

--- a/pkg/bpf/collection_test.go
+++ b/pkg/bpf/collection_test.go
@@ -22,7 +22,7 @@ func TestLoadCollectionResizeLogBuffer(t *testing.T) {
 
 	num := 32
 	insns := make(asm.Instructions, 0, num)
-	for i := 0; i < num-1; i++ {
+	for range num - 1 {
 		insns = append(insns, asm.Mov.Reg(asm.R0, asm.R1))
 	}
 	insns = append(insns, asm.Return())

--- a/pkg/bpf/events.go
+++ b/pkg/bpf/events.go
@@ -97,7 +97,7 @@ func (m *Map) initEventsBuffer(maxSize int, eventsTTL time.Duration) {
 				Group: bpfEventBufferGCControllerGroup,
 				DoFunc: func(_ context.Context) error {
 					m.scopedLogger().Debugf("clearing bpf map events older than %s", b.eventTTL)
-					b.buffer.Compact(func(e interface{}) bool {
+					b.buffer.Compact(func(e any) bool {
 						event, ok := e.(*Event)
 						if !ok {
 							log.WithError(wrongObjTypeErr(e)).Error("Failed to compact the event buffer")
@@ -262,7 +262,7 @@ func wrongObjTypeErr(i any) error {
 	return fmt.Errorf("BUG: wrong object type in event ring buffer: %T", i)
 }
 
-func (eb *eventsBuffer) eventIsValid(e interface{}) bool {
+func (eb *eventsBuffer) eventIsValid(e any) bool {
 	event, ok := e.(*Event)
 	if !ok {
 		log.WithError(wrongObjTypeErr(e)).Error("Could not dump contents of events buffer")
@@ -275,7 +275,7 @@ func (eb *eventsBuffer) eventIsValid(e interface{}) bool {
 type EventCallbackFunc func(*Event)
 
 func (eb *eventsBuffer) dumpWithCallback(callback EventCallbackFunc) {
-	eb.buffer.IterateValid(eb.eventIsValid, func(e interface{}) {
+	eb.buffer.IterateValid(eb.eventIsValid, func(e any) {
 		event, ok := e.(*Event)
 		if !ok {
 			log.WithError(wrongObjTypeErr(e)).Error("Could not dump contents of events buffer")

--- a/pkg/bpf/events_test.go
+++ b/pkg/bpf/events_test.go
@@ -29,7 +29,7 @@ func TestEventsSubscribe(t *testing.T) {
 	assert.Equal("key=123", (<-handle.C()).Key.String())
 	assert.Equal("key=124", (<-handle.C()).Key.String())
 
-	for i := 0; i < eventSubChanBufferSize; i++ {
+	for i := range eventSubChanBufferSize {
 		assert.False(handle.isClosed(), "should not close until buffer is full")
 		assert.Len(eb.subscriptions, 1)
 		assert.Len(eb.subscriptions[0].c, i+1)

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -597,7 +597,7 @@ func (m *Map) Close() error {
 	return nil
 }
 
-func (m *Map) NextKey(key, nextKeyOut interface{}) error {
+func (m *Map) NextKey(key, nextKeyOut any) error {
 	var duration *spanstat.SpanStat
 	if metrics.BPFSyscallDuration.IsEnabled() {
 		duration = spanstat.Start()
@@ -1068,7 +1068,7 @@ func (m *Map) Dump(hash map[string][]string) error {
 
 // BatchLookup returns the count of elements in the map by dumping the map
 // using batch lookup.
-func (m *Map) BatchLookup(cursor *ebpf.MapBatchCursor, keysOut, valuesOut interface{}, opts *ebpf.BatchOptions) (int, error) {
+func (m *Map) BatchLookup(cursor *ebpf.MapBatchCursor, keysOut, valuesOut any, opts *ebpf.BatchOptions) (int, error) {
 	return m.m.BatchLookup(cursor, keysOut, valuesOut, opts)
 }
 

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -928,9 +928,7 @@ func BenchmarkMapLookup(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		if _, err := m.Lookup(&k); err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -652,7 +652,7 @@ func TestDumpReliablyWithCallbackOverlapping(t *testing.T) {
 		}
 	}
 	close(start) // start testing.
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		dump := map[string]string{}
 		ds := NewDumpStats(m)
 		err := m.DumpReliablyWithCallback(func(key MapKey, value MapValue) {
@@ -738,7 +738,7 @@ func TestDumpReliablyWithCallback(t *testing.T) {
 		for i := uint32(4); i < maxEntries; i++ {
 			expect[fmt.Sprintf("key=%d", i)] = fmt.Sprintf("custom-value=%d", i+100)
 		}
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			dump := map[string]string{}
 			customCb := func(key MapKey, value MapValue) {
 				k, err := strconv.ParseUint(strings.TrimPrefix(key.String(), "key="), 10, 32)

--- a/pkg/bufuuid/uuid_test.go
+++ b/pkg/bufuuid/uuid_test.go
@@ -54,7 +54,7 @@ func BenchmarkUUIDGenerator(b *testing.B) {
 		b.Run(fmt.Sprintf("%d slots", slots), func(b *testing.B) {
 			var target uuid.UUID
 			uuider := newWith(rand.Reader, slots)
-			for range b.N {
+			for b.Loop() {
 				uuider.NewInto(&target)
 			}
 		})

--- a/pkg/cgroups/manager/manager_test.go
+++ b/pkg/cgroups/manager/manager_test.go
@@ -286,8 +286,7 @@ func BenchmarkGetPodMetadataForContainer(b *testing.B) {
 	// Add pod, and check for pod metadata for their containers.
 	mm.OnAddPod(pod3)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		got := mm.GetPodMetadataForContainer(c3CId)
 		require.Equal(b, &PodMetadata{Name: pod3.Name, Namespace: pod3.Namespace, IPs: pod3Ipstrs}, got)
 	}

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -74,7 +74,7 @@ func TestClusterMesh(t *testing.T) {
 	t.Cleanup(mgr.Close)
 
 	dir := t.TempDir()
-	etcdConfig := []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
+	etcdConfig := fmt.Appendf(nil, "endpoints:\n- %s\n", kvstore.EtcdDummyAddress())
 
 	// cluster3 doesn't have cluster configuration on kvstore.
 	// We should not be able to establish a connection in this case.

--- a/pkg/clustermesh/common/interceptor.go
+++ b/pkg/clustermesh/common/interceptor.go
@@ -54,7 +54,7 @@ type wrappedClientStream struct {
 }
 
 // RecvMsg implements the grpc.ClientStream interface, adding validation for the etcd cluster ID
-func (w *wrappedClientStream) RecvMsg(m interface{}) error {
+func (w *wrappedClientStream) RecvMsg(m any) error {
 	if err := w.ClientStream.RecvMsg(m); err != nil {
 		return err
 	}

--- a/pkg/clustermesh/common/interceptor_test.go
+++ b/pkg/clustermesh/common/interceptor_test.go
@@ -34,7 +34,7 @@ func newMockClientStream() mockClientStream {
 	}
 }
 
-func (c mockClientStream) RecvMsg(msg interface{}) error {
+func (c mockClientStream) RecvMsg(msg any) error {
 	return nil
 }
 

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -534,7 +534,7 @@ func TestRemoteClusterRemoveShutdown(t *testing.T) {
 	)
 
 	dir := t.TempDir()
-	cfg := []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
+	cfg := fmt.Appendf(nil, "endpoints:\n- %s\n", kvstore.EtcdDummyAddress())
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "remote"), cfg, 0644))
 
 	// Let's manually create a fake cluster configuration for the remote cluster,

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -36,7 +36,7 @@ import (
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
-var etcdConfig = []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
+var etcdConfig = fmt.Appendf(nil, "endpoints:\n- %s\n", kvstore.EtcdDummyAddress())
 
 func (s *ClusterMeshServicesTestSuite) prepareServiceUpdate(tb testing.TB, clusterID uint32, backendIP, portName string, port uint16) (string, string) {
 	tb.Helper()

--- a/pkg/clustermesh/types/option_test.go
+++ b/pkg/clustermesh/types/option_test.go
@@ -136,7 +136,7 @@ func TestValidateRemoteConfig(t *testing.T) {
 		name      string
 		cfg       CiliumClusterConfig
 		mcc       uint32
-		assertion func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool
+		assertion func(t assert.TestingT, err error, msgAndArgs ...any) bool
 	}{
 		{
 			name:      "Empty config",

--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -38,7 +38,7 @@ func GetStringMapStringE(vp *viper.Viper, key string) (map[string]string, error)
 // ToStringMapStringE casts an interface to a map[string]string type. The underlying
 // interface type might be a map or string. In the latter case, it is attempted to be
 // json decoded, falling back to the k1=v2,k2=v2 format in case it doesn't look like json.
-func ToStringMapStringE(data interface{}) (map[string]string, error) {
+func ToStringMapStringE(data any) (map[string]string, error) {
 	if data == nil {
 		return map[string]string{}, nil
 	}

--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -100,7 +100,7 @@ func isValidKeyValuePair(str string) bool {
 func splitKeyValue(str string, sep rune, keyValueSep rune) []string {
 	var sepIndexes, kvValueSepIndexes []int
 	// find all indexes of separator character
-	for i := 0; i < len(str); i++ {
+	for i := range len(str) {
 		switch int32(str[i]) {
 		case sep:
 			sepIndexes = append(sepIndexes, i)
@@ -122,7 +122,7 @@ func splitKeyValue(str string, sep rune, keyValueSep rune) []string {
 
 	var res []string
 	var start = 0
-	for i := 0; i < len(sepIndexes); i++ {
+	for i := range sepIndexes {
 		last := len(str)
 		if i < len(sepIndexes)-1 {
 			last = sepIndexes[i+1]

--- a/pkg/command/map_string_test.go
+++ b/pkg/command/map_string_test.go
@@ -410,7 +410,7 @@ func Test_isValidKeyValuePair(t *testing.T) {
 }
 
 func assertErrorString(errString string) assert.ErrorAssertionFunc {
-	return func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+	return func(t assert.TestingT, err error, msgAndArgs ...any) bool {
 		return assert.EqualError(t, err, errString, msgAndArgs...)
 	}
 }

--- a/pkg/command/output.go
+++ b/pkg/command/output.go
@@ -50,12 +50,12 @@ func ForceJSON() {
 
 // PrintOutput receives an interface and dump the data using the --output flag.
 // ATM only json or jsonpath. In the future yaml
-func PrintOutput(data interface{}) error {
+func PrintOutput(data any) error {
 	return PrintOutputWithType(data, outputOpt)
 }
 
 // PrintOutputWithPatch merges data with patch and dump the data using the --output flag.
-func PrintOutputWithPatch(data interface{}, patch interface{}) error {
+func PrintOutputWithPatch(data any, patch any) error {
 	mergedInterface, err := mergeInterfaces(data, patch)
 	if err != nil {
 		return fmt.Errorf("Unable to merge Interfaces: %w", err)
@@ -63,8 +63,8 @@ func PrintOutputWithPatch(data interface{}, patch interface{}) error {
 	return PrintOutputWithType(mergedInterface, outputOpt)
 }
 
-func mergeInterfaces(data, patch interface{}) (interface{}, error) {
-	var i1, i2 interface{}
+func mergeInterfaces(data, patch any) (any, error) {
+	var i1, i2 any
 
 	data1, err := json.Marshal(data)
 	if err != nil {
@@ -86,10 +86,10 @@ func mergeInterfaces(data, patch interface{}) (interface{}, error) {
 	return recursiveMerge(i1, i2), nil
 }
 
-func recursiveMerge(i1, i2 interface{}) interface{} {
+func recursiveMerge(i1, i2 any) any {
 	switch i1 := i1.(type) {
-	case map[string]interface{}:
-		i2, ok := i2.(map[string]interface{})
+	case map[string]any:
+		i2, ok := i2.(map[string]any)
 		if !ok {
 			return i1
 		}
@@ -101,7 +101,7 @@ func recursiveMerge(i1, i2 interface{}) interface{} {
 			}
 		}
 	case nil:
-		i2, ok := i2.(map[string]interface{})
+		i2, ok := i2.(map[string]any)
 		if ok {
 			return i2
 		}
@@ -111,7 +111,7 @@ func recursiveMerge(i1, i2 interface{}) interface{} {
 
 // PrintOutputWithType receives an interface and dump the data using the --output flag.
 // ATM only json, yaml, or jsonpath.
-func PrintOutputWithType(data interface{}, outputType string) error {
+func PrintOutputWithType(data any, outputType string) error {
 	if outputType == "json" {
 		return dumpJSON(data, "")
 	}
@@ -131,7 +131,7 @@ func PrintOutputWithType(data interface{}, outputType string) error {
 // non-empty, will attempt to do jsonpath filtering using said string. Returns a
 // string containing the JSON in data, or an error if any JSON marshaling,
 // parsing operations fail.
-func DumpJSONToString(data interface{}, jsonPath string) (string, error) {
+func DumpJSONToString(data any, jsonPath string) (string, error) {
 	if len(jsonPath) == 0 {
 		result, err := json.MarshalIndent(data, "", "  ")
 		if err != nil {
@@ -160,7 +160,7 @@ func DumpJSONToString(data interface{}, jsonPath string) (string, error) {
 // dumpJSON dumps the data variable to the stdout as json.
 // If something fails, it returns an error
 // If jsonPath is passed, it runs the json query over data var.
-func dumpJSON(data interface{}, jsonPath string) error {
+func dumpJSON(data any, jsonPath string) error {
 	jsonStr, err := DumpJSONToString(data, jsonPath)
 	if err != nil {
 		return err
@@ -171,7 +171,7 @@ func dumpJSON(data interface{}, jsonPath string) error {
 
 // dumpYAML dumps the data variable to the stdout as yaml.
 // If something fails, it returns an error
-func dumpYAML(data interface{}) error {
+func dumpYAML(data any) error {
 	result, err := yaml.Marshal(data)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't marshal to yaml: '%s'\n", err)

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -465,7 +465,7 @@ func generatePrefix(b *testing.B, r *rand.Rand) netip.Prefix {
 
 func generateCIDRs(b *testing.B, r *rand.Rand, n int) *CIDRTrie[struct{}] {
 	t := NewCIDRTrie[struct{}]()
-	for i := 0; i < n; i++ {
+	for range n {
 		if !t.Upsert(generatePrefix(b, r), struct{}{}) {
 			n++
 		}

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -493,7 +493,7 @@ func BenchmarkTraversal(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			n = 0
 			t.Ancestors(prefix, func(k netip.Prefix, _ struct{}) bool {
 				n++
@@ -507,7 +507,7 @@ func BenchmarkTraversal(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			iter := t.AncestorIterator(prefix)
 			n = 0
 			for ok, _, _ := iter.Next(); ok; ok, _, _ = iter.Next() {
@@ -522,7 +522,7 @@ func BenchmarkTraversal(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			n = 0
 			lastLen = prefixLen
 			t.AncestorsLongestPrefixFirst(prefix, func(k netip.Prefix, _ struct{}) bool {
@@ -541,7 +541,7 @@ func BenchmarkTraversal(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			iter := t.AncestorLongestPrefixFirstIterator(prefix)
 			n = 0
 			lastLen = prefixLen
@@ -559,7 +559,7 @@ func BenchmarkTraversal(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			n = 0
 			t.Descendants(prefix, func(k netip.Prefix, _ struct{}) bool {
 				n++
@@ -573,7 +573,7 @@ func BenchmarkTraversal(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			iter := t.DescendantIterator(prefix)
 			n = 0
 			for ok, _, _ := iter.Next(); ok; ok, _, _ = iter.Next() {
@@ -588,7 +588,7 @@ func BenchmarkTraversal(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			n = 0
 			lastLen = 0
 			t.DescendantsShortestPrefixFirst(prefix, func(k netip.Prefix, _ struct{}) bool {
@@ -607,7 +607,7 @@ func BenchmarkTraversal(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			iter := t.DescendantShortestPrefixFirstIterator(prefix)
 			n = 0
 			lastLen = 0

--- a/pkg/container/cache/cache_test.go
+++ b/pkg/container/cache/cache_test.go
@@ -26,7 +26,7 @@ func TestStringsCache(t *testing.T) {
 
 func BenchmarkStringsCache(b *testing.B) {
 	s := "foobar"
-	for range b.N {
+	for b.Loop() {
 		x := Strings.Get(s)
 		if x != s {
 			b.Fatalf("strings not equal, %q vs %q", s, x)
@@ -38,7 +38,7 @@ func BenchmarkStringsCache(b *testing.B) {
 // are skipped.
 func BenchmarkStringsCache_Large(b *testing.B) {
 	s := strings.Repeat("ni", 500)
-	for range b.N {
+	for b.Loop() {
 		x := Strings.Get(s)
 		if x != s {
 			b.Fatalf("strings not equal, %q vs %q", s, x)
@@ -48,7 +48,7 @@ func BenchmarkStringsCache_Large(b *testing.B) {
 
 func BenchmarkUniqueString(b *testing.B) {
 	s := "foobar"
-	for range b.N {
+	for b.Loop() {
 		x := unique.Make(s)
 		if x.Value() != s {
 			b.Fatalf("strings not equal, %q vs %q", s, x.Value())
@@ -70,7 +70,7 @@ func TestStringMapsCache(t *testing.T) {
 
 func BenchmarkStringMapsCache(b *testing.B) {
 	m := map[string]string{"foo": "bar"}
-	for range b.N {
+	for b.Loop() {
 		x := StringMaps.Get(m)
 		if !maps.Equal(x, m) {
 			b.Fatalf("maps not equal, %q vs %q", m, x)
@@ -86,8 +86,8 @@ func BenchmarkStringMapsCache_Large(b *testing.B) {
 	for range 500 {
 		m[s] = s
 	}
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		x := StringMaps.Get(m)
 		if !maps.Equal(x, m) {
 			b.Fatalf("maps not equal, %q vs %q", m, x)

--- a/pkg/container/immset_test.go
+++ b/pkg/container/immset_test.go
@@ -123,7 +123,7 @@ func TestImmSetUnion(t *testing.T) {
 
 func benchmarkImmSetInsert(b *testing.B, numItems int) {
 	s := NewImmSet[int]()
-	for i := 0; i < numItems; i++ {
+	for i := range numItems {
 		s = s.Insert(i)
 	}
 	for n := 0; n < b.N; n++ {
@@ -138,7 +138,7 @@ func BenchmarkImmSetInsert_10000(b *testing.B) { benchmarkImmSetInsert(b, 10000)
 func benchmarkImmSetInsertMany(b *testing.B, numItems int) {
 	a1 := make([]int, numItems)
 	a2 := make([]int, numItems)
-	for i := 0; i < numItems; i++ {
+	for i := range numItems {
 		a1[i] = int(rand.IntN(numItems))
 		a2[i] = int(rand.IntN(numItems))
 	}
@@ -161,7 +161,7 @@ func BenchmarkImmSetInsertMany_10000(b *testing.B) {
 
 func benchmarkImmSetDelete(b *testing.B, numItems int) {
 	s := NewImmSet[int]()
-	for i := 0; i < numItems; i++ {
+	for i := range numItems {
 		s = s.Insert(i)
 	}
 	idx := rand.IntN(numItems)
@@ -179,7 +179,7 @@ func BenchmarkImmSetDelete_10000(b *testing.B) { benchmarkImmSetDelete(b, 10000)
 func benchmarkImmSetDeleteMany(b *testing.B, numItems int) {
 	s := NewImmSet[int]()
 	a := make([]int, 0, numItems)
-	for i := 0; i < numItems; i++ {
+	for range numItems {
 		s = s.Insert(int(rand.IntN(numItems)))
 		a = append(a, int(rand.IntN(numItems)))
 	}
@@ -203,7 +203,7 @@ func BenchmarkImmSetDeleteMany_10000(b *testing.B) {
 func benchmarkImmSetDifference(b *testing.B, numItems int) {
 	s1 := NewImmSet[int]()
 	s2 := NewImmSet[int]()
-	for i := 0; i < numItems; i++ {
+	for range numItems {
 		s1 = s1.Insert(int(rand.IntN(numItems)))
 		s2 = s2.Insert(int(rand.IntN(numItems)))
 	}
@@ -227,7 +227,7 @@ func BenchmarkImmSetDifference_10000(b *testing.B) {
 func benchmarkImmSetUnion(b *testing.B, numItems int) {
 	a1 := make([]int, numItems)
 	a2 := make([]int, numItems)
-	for i := 0; i < numItems; i++ {
+	for i := range numItems {
 		a1[i] = int(rand.IntN(numItems))
 		a2[i] = int(rand.IntN(numItems))
 	}

--- a/pkg/container/immset_test.go
+++ b/pkg/container/immset_test.go
@@ -126,7 +126,7 @@ func benchmarkImmSetInsert(b *testing.B, numItems int) {
 	for i := range numItems {
 		s = s.Insert(i)
 	}
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		s.Insert(numItems)
 	}
 }
@@ -143,8 +143,8 @@ func benchmarkImmSetInsertMany(b *testing.B, numItems int) {
 		a2[i] = int(rand.IntN(numItems))
 	}
 	s := NewImmSet(a1...)
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+
+	for b.Loop() {
 		s.Insert(a2...)
 	}
 }
@@ -165,9 +165,8 @@ func benchmarkImmSetDelete(b *testing.B, numItems int) {
 		s = s.Insert(i)
 	}
 	idx := rand.IntN(numItems)
-	b.ResetTimer()
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		s.Delete(idx)
 	}
 }
@@ -183,9 +182,8 @@ func benchmarkImmSetDeleteMany(b *testing.B, numItems int) {
 		s = s.Insert(int(rand.IntN(numItems)))
 		a = append(a, int(rand.IntN(numItems)))
 	}
-	b.ResetTimer()
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		s.Delete(a...)
 	}
 }
@@ -207,9 +205,8 @@ func benchmarkImmSetDifference(b *testing.B, numItems int) {
 		s1 = s1.Insert(int(rand.IntN(numItems)))
 		s2 = s2.Insert(int(rand.IntN(numItems)))
 	}
-	b.ResetTimer()
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		s1.Difference(s2)
 	}
 }
@@ -233,8 +230,8 @@ func benchmarkImmSetUnion(b *testing.B, numItems int) {
 	}
 	s1 := NewImmSet(a1...)
 	s2 := NewImmSet(a2...)
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+
+	for b.Loop() {
 		s1.Union(s2)
 	}
 }

--- a/pkg/container/ring_buffer.go
+++ b/pkg/container/ring_buffer.go
@@ -13,7 +13,7 @@ import (
 // be fast than linked-list implementations, and also allows for efficient
 // indexing of ordered data.
 type RingBuffer struct {
-	buffer  []interface{}
+	buffer  []any
 	next    int // index of ring buffer head.
 	maxSize int
 }
@@ -21,7 +21,7 @@ type RingBuffer struct {
 // NewRingBuffer constructs a new ring buffer for a given buffer size.
 func NewRingBuffer(bufferSize int) *RingBuffer {
 	return &RingBuffer{
-		buffer:  make([]interface{}, 0, bufferSize),
+		buffer:  make([]any, 0, bufferSize),
 		maxSize: bufferSize,
 	}
 }
@@ -35,7 +35,7 @@ func (eb *RingBuffer) incr() {
 }
 
 // Add adds an element to the buffer.
-func (eb *RingBuffer) Add(e interface{}) {
+func (eb *RingBuffer) Add(e any) {
 	if eb.maxSize == 0 {
 		return
 	}
@@ -48,20 +48,20 @@ func (eb *RingBuffer) Add(e interface{}) {
 	eb.buffer = append(eb.buffer, e)
 }
 
-func (eb *RingBuffer) dumpWithCallback(callback func(v interface{})) {
-	for i := 0; i < len(eb.buffer); i++ {
+func (eb *RingBuffer) dumpWithCallback(callback func(v any)) {
+	for i := range eb.buffer {
 		callback(eb.at(i))
 	}
 }
 
-func (eb *RingBuffer) at(i int) interface{} {
+func (eb *RingBuffer) at(i int) any {
 	return eb.buffer[eb.mapIndex(i)]
 }
 
 // firstValidIndex returns the first **absolute** index in the buffer that satisfies
 // isValid.
 // note: this value needs to be mapped before indexing the buffer.
-func (eb *RingBuffer) firstValidIndex(isValid func(interface{}) bool) int {
+func (eb *RingBuffer) firstValidIndex(isValid func(any) bool) int {
 	return sort.Search(len(eb.buffer), func(i int) bool {
 		return isValid(eb.at(i))
 	})
@@ -69,7 +69,7 @@ func (eb *RingBuffer) firstValidIndex(isValid func(interface{}) bool) int {
 
 // IterateValid calls the callback on each element of the buffer, starting with
 // the first element in the buffer that satisfies "isValid".
-func (eb *RingBuffer) IterateValid(isValid func(interface{}) bool, callback func(interface{})) {
+func (eb *RingBuffer) IterateValid(isValid func(any) bool, callback func(any)) {
 	startIndex := eb.firstValidIndex(isValid)
 	l := len(eb.buffer) - startIndex
 	for i := range l {
@@ -87,14 +87,14 @@ func (eb *RingBuffer) mapIndex(indexOffset int) int {
 // Compact clears out invalidated elements in the buffer.
 // This may require copying the entire buffer.
 // It is assumed that if buffer[i] is invalid then every entry [0...i-1] is also not valid.
-func (eb *RingBuffer) Compact(isValid func(interface{}) bool) {
+func (eb *RingBuffer) Compact(isValid func(any) bool) {
 	if len(eb.buffer) == 0 {
 		return
 	}
 	startIndex := eb.firstValidIndex(isValid)
 	// In this case, we compact the entire buffer.
 	if startIndex >= len(eb.buffer) {
-		eb.buffer = []interface{}{}
+		eb.buffer = []any{}
 		eb.next = 0
 		return
 	}
@@ -116,7 +116,7 @@ func (eb *RingBuffer) Compact(isValid func(interface{}) bool) {
 		// by the length and mapping it.
 		// [... startIndex+newBufferLen ... startIndex ...]
 		end := eb.mapIndex(startIndex + newBufferLength)
-		tmp := make([]interface{}, len(eb.buffer[:end]))
+		tmp := make([]any, len(eb.buffer[:end]))
 		copy(tmp, eb.buffer[:end])
 
 		eb.buffer = eb.buffer[mappedStart:]
@@ -142,8 +142,8 @@ func (eb *RingBuffer) Compact(isValid func(interface{}) bool) {
 
 // Iterate is a convenience function over IterateValid that iterates
 // all elements in the buffer.
-func (eb *RingBuffer) Iterate(callback func(interface{})) {
-	eb.IterateValid(func(e interface{}) bool { return true }, callback)
+func (eb *RingBuffer) Iterate(callback func(any)) {
+	eb.IterateValid(func(e any) bool { return true }, callback)
 }
 
 // Size returns the size of the buffer.

--- a/pkg/container/ring_buffer.go
+++ b/pkg/container/ring_buffer.go
@@ -72,7 +72,7 @@ func (eb *RingBuffer) firstValidIndex(isValid func(interface{}) bool) int {
 func (eb *RingBuffer) IterateValid(isValid func(interface{}) bool, callback func(interface{})) {
 	startIndex := eb.firstValidIndex(isValid)
 	l := len(eb.buffer) - startIndex
-	for i := 0; i < l; i++ {
+	for i := range l {
 		index := eb.mapIndex(startIndex + i)
 		callback(eb.buffer[index])
 	}

--- a/pkg/container/ring_buffer_test.go
+++ b/pkg/container/ring_buffer_test.go
@@ -95,7 +95,7 @@ func TestRingBuffer_AddingAndIterating(t *testing.T) {
 
 func TestEventBuffer_GC(t *testing.T) {
 	assert := assert.New(t)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		buffer := NewRingBuffer(100)
 		for i := 1; i <= 102; i++ {
 			buffer.Add(i)
@@ -217,7 +217,7 @@ func Test_firstValidIndex(t *testing.T) {
 	assert := assert.New(t)
 	buffer := NewRingBuffer(4)
 	df := dumpFunc(buffer)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		buffer.Add(i)
 	}
 	assert.IsNonDecreasing(df())
@@ -237,7 +237,7 @@ func Test_firstValidIndex2(t *testing.T) {
 		s := rand.IntN(1000)
 		buffer := NewRingBuffer(s)
 		df := dumpFunc(buffer)
-		for i := 0; i < s+1; i++ {
+		for i := range s + 1 {
 			buffer.Add(i)
 		}
 		assert.IsNonDecreasing(df())

--- a/pkg/container/ring_buffer_test.go
+++ b/pkg/container/ring_buffer_test.go
@@ -12,7 +12,7 @@ import (
 
 func dumpBuffer(b *RingBuffer) []int {
 	acc := []int{}
-	b.dumpWithCallback(func(n interface{}) {
+	b.dumpWithCallback(func(n any) {
 		acc = append(acc, n.(int))
 	})
 	return acc
@@ -21,7 +21,7 @@ func dumpBuffer(b *RingBuffer) []int {
 func dumpFunc(b *RingBuffer) func() []int {
 	return func() []int {
 		acc := []int{}
-		b.Iterate(func(i interface{}) {
+		b.Iterate(func(i any) {
 			acc = append(acc, i.(int))
 		})
 		return acc
@@ -46,39 +46,39 @@ func TestRingBuffer_AddingAndIterating(t *testing.T) {
 	assert.Equal([]int{7, 8, 9, 10, 11}, acc)
 
 	d := []int{}
-	buffer.Iterate(func(i interface{}) {
+	buffer.Iterate(func(i any) {
 		d = append(d, i.(int))
 	})
 	assert.IsNonDecreasing(d)
 	assert.Equal([]int{7, 8, 9, 10, 11}, d)
 	acc = []int{}
-	buffer.IterateValid(func(n interface{}) bool {
+	buffer.IterateValid(func(n any) bool {
 		return n.(int) >= 9
-	}, func(n interface{}) {
+	}, func(n any) {
 		acc = append(acc, n.(int))
 	})
 	assert.Equal([]int{9, 10, 11}, acc)
 
 	acc = []int{}
-	buffer.IterateValid(func(n interface{}) bool {
+	buffer.IterateValid(func(n any) bool {
 		return n.(int) >= 0
-	}, func(n interface{}) {
+	}, func(n any) {
 		acc = append(acc, n.(int))
 	})
 	assert.Equal([]int{7, 8, 9, 10, 11}, acc)
 
 	acc = []int{}
-	buffer.IterateValid(func(n interface{}) bool {
+	buffer.IterateValid(func(n any) bool {
 		return n.(int) >= 11
-	}, func(n interface{}) {
+	}, func(n any) {
 		acc = append(acc, n.(int))
 	})
 	assert.Equal([]int{11}, acc)
 
 	acc = []int{}
-	buffer.IterateValid(func(n interface{}) bool {
+	buffer.IterateValid(func(n any) bool {
 		return n.(int) > 11
-	}, func(n interface{}) {
+	}, func(n any) {
 		acc = append(acc, n.(int))
 	})
 	assert.Empty(acc)
@@ -100,17 +100,17 @@ func TestEventBuffer_GC(t *testing.T) {
 		for i := 1; i <= 102; i++ {
 			buffer.Add(i)
 		}
-		buffer.Compact(func(n interface{}) bool {
+		buffer.Compact(func(n any) bool {
 			return n.(int) > 95
 		})
 		df := dumpFunc(buffer)
 		assert.Equal([]int{96, 97, 98, 99, 100, 101, 102}, df())
 
-		buffer.Compact(func(n interface{}) bool { return true })
+		buffer.Compact(func(n any) bool { return true })
 		assert.Equal(7, buffer.Size(), "always valid shouldn't clear anything")
-		buffer.Compact(func(n interface{}) bool { return false })
+		buffer.Compact(func(n any) bool { return false })
 		assert.Equal(0, buffer.Size(), "nothing valid should empty buffer")
-		buffer.Compact(func(n interface{}) bool { return true })
+		buffer.Compact(func(n any) bool { return true })
 		assert.Equal(0, buffer.Size(), "test gc empty buffer")
 	}
 }
@@ -119,17 +119,17 @@ func TestEventBuffer_GC2(t *testing.T) {
 	assert := assert.New(t)
 	buffer := NewRingBuffer(3)
 	df := dumpFunc(buffer)
-	buffer.buffer = []interface{}{3, 1, 2}
+	buffer.buffer = []any{3, 1, 2}
 	buffer.next = 1
-	buffer.Compact(func(n interface{}) bool {
+	buffer.Compact(func(n any) bool {
 		return n.(int) >= 2
 	})
 	assert.Equal([]int{2, 3}, df())
-	buffer.Compact(func(n interface{}) bool {
+	buffer.Compact(func(n any) bool {
 		return n.(int) >= 2 // noop
 	})
 	assert.Equal([]int{2, 3}, df())
-	buffer.Compact(func(n interface{}) bool {
+	buffer.Compact(func(n any) bool {
 		return n.(int) >= 3
 	})
 	assert.Equal([]int{3}, df())
@@ -148,9 +148,9 @@ func TestEventBuffer_GCFullBufferWithOverlap(t *testing.T) {
 	df := dumpFunc(buffer)
 	assert.Equal([]int{3, 4, 5, 6, 7}, df())
 	assert.True(buffer.isFull(), "this is a full buffer, which has gone around past its tail")
-	assert.Equal([]interface{}{6, 7, 3, 4, 5}, buffer.buffer)
+	assert.Equal([]any{6, 7, 3, 4, 5}, buffer.buffer)
 	assert.Equal(2, buffer.next)
-	buffer.Compact(func(n interface{}) bool {
+	buffer.Compact(func(n any) bool {
 		return n.(int) >= 5 // -> 5, 6, 7
 	})
 	acc := dumpBuffer(buffer)
@@ -165,12 +165,12 @@ func TestEventBuffer_GCFullBuffer(t *testing.T) {
 	buffer.Add(3)
 	buffer.Add(4)
 	buffer.Add(5)
-	assert.Equal([]interface{}{1, 2, 3, 4, 5}, buffer.buffer)
+	assert.Equal([]any{1, 2, 3, 4, 5}, buffer.buffer)
 	assert.True(buffer.isFull())
-	buffer.Compact(func(n interface{}) bool {
+	buffer.Compact(func(n any) bool {
 		return n.(int) >= 2
 	})
-	assert.Equal([]interface{}{2, 3, 4, 5}, buffer.buffer)
+	assert.Equal([]any{2, 3, 4, 5}, buffer.buffer)
 }
 
 func TestEventBuffer_GCNotFullBuffer(t *testing.T) {
@@ -180,34 +180,34 @@ func TestEventBuffer_GCNotFullBuffer(t *testing.T) {
 	buffer.Add(2)
 	buffer.Add(3)
 	buffer.Add(4)
-	assert.Equal([]interface{}{1, 2, 3, 4}, buffer.buffer)
+	assert.Equal([]any{1, 2, 3, 4}, buffer.buffer)
 	assert.False(buffer.isFull())
-	i := buffer.firstValidIndex(func(n interface{}) bool {
+	i := buffer.firstValidIndex(func(n any) bool {
 		return n.(int) > 3
 	})
 	assert.Equal(3, i)
-	i = buffer.firstValidIndex(func(n interface{}) bool {
+	i = buffer.firstValidIndex(func(n any) bool {
 		return n.(int) > 4
 	})
 	assert.Equal(4, i, "should be out of bounds")
-	buffer.Compact(func(n interface{}) bool {
+	buffer.Compact(func(n any) bool {
 		return n.(int) > 4
 	})
-	assert.Equal([]interface{}{}, buffer.buffer)
+	assert.Equal([]any{}, buffer.buffer)
 	buffer.Add(1)
 	buffer.Add(1)
 	buffer.Add(1)
 	buffer.Add(1)
 	buffer.Add(1)
-	i = buffer.firstValidIndex(func(n interface{}) bool {
+	i = buffer.firstValidIndex(func(n any) bool {
 		return n.(int) >= 1
 	})
 	assert.Equal(0, i)
-	buffer.Compact(func(n interface{}) bool {
+	buffer.Compact(func(n any) bool {
 		return n.(int) > 0
 	})
-	assert.Equal([]interface{}{1, 1, 1, 1, 1}, buffer.buffer)
-	buffer.Compact(func(n interface{}) bool {
+	assert.Equal([]any{1, 1, 1, 1, 1}, buffer.buffer)
+	buffer.Compact(func(n any) bool {
 		return false
 	})
 	assert.Empty(buffer.buffer)
@@ -222,13 +222,13 @@ func Test_firstValidIndex(t *testing.T) {
 	}
 	assert.IsNonDecreasing(df())
 	for i := 1; i <= 4; i++ {
-		assert.Equal(i, buffer.firstValidIndex(func(ii interface{}) bool {
+		assert.Equal(i, buffer.firstValidIndex(func(ii any) bool {
 			return ii.(int) > i
 		}))
 	}
-	assert.Equal(4, buffer.firstValidIndex(func(ii interface{}) bool { return ii.(int) > 4 }))
-	assert.Equal(4, buffer.firstValidIndex(func(ii interface{}) bool { return false }))
-	assert.Equal(0, buffer.firstValidIndex(func(ii interface{}) bool { return true }))
+	assert.Equal(4, buffer.firstValidIndex(func(ii any) bool { return ii.(int) > 4 }))
+	assert.Equal(4, buffer.firstValidIndex(func(ii any) bool { return false }))
+	assert.Equal(0, buffer.firstValidIndex(func(ii any) bool { return true }))
 }
 
 func Test_firstValidIndex2(t *testing.T) {
@@ -242,12 +242,12 @@ func Test_firstValidIndex2(t *testing.T) {
 		}
 		assert.IsNonDecreasing(df())
 		for i := 1; i <= s; i++ {
-			assert.Equal(i, buffer.firstValidIndex(func(ii interface{}) bool {
+			assert.Equal(i, buffer.firstValidIndex(func(ii any) bool {
 				return ii.(int) > i
 			}))
 		}
-		assert.Equal(s, buffer.firstValidIndex(func(ii interface{}) bool { return ii.(int) > s }))
-		assert.Equal(s, buffer.firstValidIndex(func(ii interface{}) bool { return false }))
-		assert.Equal(0, buffer.firstValidIndex(func(ii interface{}) bool { return true }))
+		assert.Equal(s, buffer.firstValidIndex(func(ii any) bool { return ii.(int) > s }))
+		assert.Equal(s, buffer.firstValidIndex(func(ii any) bool { return false }))
+		assert.Equal(0, buffer.firstValidIndex(func(ii any) bool { return true }))
 	}
 }

--- a/pkg/container/versioned/value.go
+++ b/pkg/container/versioned/value.go
@@ -520,7 +520,7 @@ func (s VersionedSlice[T]) Append(value T, tx *Tx) VersionedSlice[T] {
 func (s VersionedSlice[T]) Before(keepVersion KeepVersion) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		version := version(keepVersion)
-		for n := 0; n < len(s); n++ {
+		for n := range s {
 			if s[n].version >= version {
 				break
 			}

--- a/pkg/container/versioned/value_test.go
+++ b/pkg/container/versioned/value_test.go
@@ -58,7 +58,7 @@ func (c *testCleaner) cleanValues(keepVersion KeepVersion, values []Value[[]uint
 	oldest := c.oldestVersion.load()
 	if oldest < version(keepVersion) {
 		// remove old versions for all values before bumping 'oldestVersion'
-		for i := 0; i < len(values); i++ {
+		for i := range values {
 			values[i].RemoveBefore(keepVersion)
 		}
 		c.oldestVersion.store(version(keepVersion))
@@ -341,7 +341,7 @@ func TestVersionedChaos(t *testing.T) {
 
 	cv := Coordinator{
 		Cleaner: func(keepVersion KeepVersion) {
-			for i := 0; i < nValues; i++ {
+			for range nValues {
 				cleaner.cleanValues(keepVersion, values)
 			}
 		},
@@ -349,7 +349,7 @@ func TestVersionedChaos(t *testing.T) {
 
 	// Initially empty
 	handle := cv.GetVersionHandle()
-	for i := 0; i < nValues; i++ {
+	for i := range nValues {
 		assert.Empty(t, values[i].At(handle))
 	}
 	assert.NoError(t, handle.Close())
@@ -357,8 +357,8 @@ func TestVersionedChaos(t *testing.T) {
 
 	var mutex lock.Mutex
 	var writerWg, readerWg sync.WaitGroup
-	for j := 0; j < 1000; j++ {
-		for k := 0; k < 100; k++ {
+	for range 1000 {
+		for range 100 {
 			readerWg.Add(1)
 			go func() {
 				time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
@@ -404,7 +404,7 @@ func TestVersionedChaos(t *testing.T) {
 	defer mutex.Unlock()
 
 	tx := cv.PrepareNextVersion()
-	for i := 0; i < nValues; i++ {
+	for i := range nValues {
 		assert.NoError(t, values[i].RemoveAt(tx))
 	}
 	tx.Commit()
@@ -413,7 +413,7 @@ func TestVersionedChaos(t *testing.T) {
 	cleaner.waitUntilOldest(t, tx.nextVersion)
 
 	// Check that all values were removed
-	for i := 0; i < nValues; i++ {
+	for i := range nValues {
 		assert.Nil(t, values[i].head.Load())
 	}
 

--- a/pkg/datapath/config/unmarshal.go
+++ b/pkg/datapath/config/unmarshal.go
@@ -68,7 +68,7 @@ func structFields(structVal reflect.Value, tag string, visited map[reflect.Type]
 	}
 
 	fields := make([]structField, 0, structType.NumField())
-	for i := 0; i < structType.NumField(); i++ {
+	for i := range structType.NumField() {
 		field := structField{structType.Field(i), structVal.Field(i)}
 
 		// If the field is tagged, gather it and move on.

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -25,7 +25,7 @@ var (
 
 // monitorNotify is an interface to notify the monitor about ipcache changes.
 type monitorNotify interface {
-	SendEvent(typ int, event interface{}) error
+	SendEvent(typ int, event any) error
 }
 
 type Map interface {

--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -607,7 +607,7 @@ func BenchmarkManager(b *testing.B) {
 			time.Sleep(time.Millisecond)
 
 		}
-		for i := 0; i < numEntries; i++ {
+		for i := range numEntries {
 			ip := toNetIP(i)
 			mgr.RemoveFromIPSet(CiliumNodeIPSetV4, ip)
 		}

--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -586,8 +586,6 @@ func BenchmarkManager(b *testing.B) {
 	tlog := hivetest.Logger(b)
 	assert.NoError(b, hive.Start(tlog, context.Background()))
 
-	b.ResetTimer()
-
 	numEntries := 1000
 
 	toNetIP := func(i int) netip.Addr {
@@ -596,8 +594,8 @@ func BenchmarkManager(b *testing.B) {
 		return netip.AddrFrom4(addr1)
 	}
 
-	for n := 0; n < b.N; n++ {
-		for i := 0; i < numEntries; i++ {
+	for b.Loop() {
+		for i := range numEntries {
 			ip := toNetIP(i)
 			mgr.AddToIPSet(CiliumNodeIPSetV4, INetFamily, ip)
 		}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1573,7 +1573,7 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 	count := 30
 	var wg sync.WaitGroup
 	wg.Add(count)
-	for i := 0; i < count; i++ {
+	for range count {
 		go func() {
 			defer wg.Done()
 			ticker := time.NewTicker(100 * time.Millisecond)
@@ -1587,7 +1587,7 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 			}
 		}()
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		mac := rndHWAddr()
 		// Change MAC
 		ns.Do(func() error {
@@ -2599,7 +2599,7 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 	count := 30
 	var wg sync.WaitGroup
 	wg.Add(count)
-	for i := 0; i < count; i++ {
+	for range count {
 		go func() {
 			defer wg.Done()
 			ticker := time.NewTicker(100 * time.Millisecond)
@@ -2613,7 +2613,7 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 			}
 		}()
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		mac := rndHWAddr()
 		// Change MAC
 		ns.Do(func() error {

--- a/pkg/datapath/linux/utime/utime.go
+++ b/pkg/datapath/linux/utime/utime.go
@@ -114,7 +114,7 @@ func getBoottime() (t time.Time, err error) {
 	defer runtime.UnlockOSThread()
 	// Keep the minimum difference out of 10 samples to estimate the drift between boottime and
 	// monotonic clocks at the time this call.
-	for i := 0; i < nClockSamples; i++ {
+	for range nClockSamples {
 		var monotonicTimespec unix.Timespec
 		err = unix.ClockGettime(unix.CLOCK_MONOTONIC, &monotonicTimespec)
 		if err != nil {

--- a/pkg/datapath/loader/cache_test.go
+++ b/pkg/datapath/loader/cache_test.go
@@ -70,7 +70,7 @@ func TestObjectCacheParallel(t *testing.T) {
 	ep := testutils.NewTestEndpoint()
 
 	var wg sync.WaitGroup
-	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+	for range runtime.GOMAXPROCS(0) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -256,8 +256,7 @@ func BenchmarkCompileOnly(b *testing.B) {
 	dirInfo := getDirs(b)
 	option.Config.Debug = true
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := compileDatapath(ctx, dirInfo, false, log); err != nil {
 			b.Fatal(err)
 		}
@@ -282,8 +281,8 @@ func BenchmarkReplaceDatapath(b *testing.B) {
 	}
 
 	objPath := fmt.Sprintf("%s/%s", dirInfo.Output, endpointObj)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		spec, err := bpf.LoadCollectionSpec(objPath)
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -172,7 +172,7 @@ func BenchmarkSocketReqSerialize(b *testing.B) {
 		},
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, req := range requests {
 			req.Serialize()
 		}
@@ -185,7 +185,7 @@ func BenchmarkSocketDeserialize(b *testing.B) {
 		{2, 1, 0, 0, 189, 137, 1, 187, 192, 168, 50, 194, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 151, 99, 52, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 146, 138, 10, 0, 5, 0, 8, 0, 0, 0, 0, 0, 8, 0, 15, 0, 0, 0, 0, 0, 12, 0, 21, 0, 1, 42, 0, 0, 0, 0, 0, 0, 6, 0, 22, 0, 80, 0, 0, 0},
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, buf := range buffers {
 			var sock Socket
 			sock.Deserialize(buf)

--- a/pkg/dynamiclifecycle/reconciler_test.go
+++ b/pkg/dynamiclifecycle/reconciler_test.go
@@ -56,7 +56,7 @@ func TestManager_Enablement(t *testing.T) {
 	wTxn.Commit()
 
 	// Repeat the operation 2 times
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		// Start the registered feature
 		wTxn = db.WriteTxn(dc)
 		c := dynamicconfig.DynamicConfig{

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -42,7 +42,7 @@ var (
 // IterateCallback represents the signature of the callback function expected by
 // the IterateWithCallback method, which in turn is used to iterate all the
 // keys/values of a map.
-type IterateCallback func(key, value interface{})
+type IterateCallback func(key, value any)
 
 // Map represents an eBPF map.
 type Map struct {
@@ -178,7 +178,7 @@ func (m *Map) OpenOrCreate() error {
 
 // IterateWithCallback iterates through all the keys/values of a map, passing
 // each key/value pair to the cb callback.
-func (m *Map) IterateWithCallback(key, value interface{}, cb IterateCallback) error {
+func (m *Map) IterateWithCallback(key, value any, cb IterateCallback) error {
 	if m.Map == nil {
 		if err := m.OpenOrCreate(); err != nil {
 			return err
@@ -213,6 +213,6 @@ func (m *Map) GetModel() *models.BPFMap {
 func (m *Map) IsEmpty() bool {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	var key, value interface{}
+	var key, value any
 	return !m.Iterate().Next(key, value)
 }

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -626,7 +626,7 @@ func createTestInterface(tb testing.TB, sysctl sysctl.Sysctl, iface string, addr
 func ensureRPFilterIsEnabled(tb testing.TB, sysctl sysctl.Sysctl, iface string) {
 	rpFilterSetting := []string{"net", "ipv4", "conf", iface, "rp_filter"}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		if err := sysctl.Enable(rpFilterSetting); err != nil {
 			tb.Fatal(err)
 		}
@@ -644,7 +644,7 @@ func ensureRPFilterIsEnabled(tb testing.TB, sysctl sysctl.Sysctl, iface string) 
 }
 
 func waitForReconciliationRun(tb testing.TB, egressGatewayManager *Manager, currentRun uint64) uint64 {
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		count := egressGatewayManager.reconciliationEventsCount.Load()
 		if count > currentRun {
 			return count

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -68,7 +68,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if err := bm.write(bm.output); err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/endpoint/directory_test.go
+++ b/pkg/endpoint/directory_test.go
@@ -98,8 +98,7 @@ func benchmarkMoveNewFilesTo(b *testing.B, numFiles int) {
 		}
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := copyExistingState(oldDir, newDir); err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/endpoint/directory_test.go
+++ b/pkg/endpoint/directory_test.go
@@ -85,7 +85,7 @@ func benchmarkMoveNewFilesTo(b *testing.B, numFiles int) {
 	newDir := b.TempDir()
 	numDuplicates := int(math.Round(float64(numFiles) * 0.25))
 
-	for n := 0; n < numFiles; n++ {
+	for n := range numFiles {
 		name := fmt.Sprintf("file%d", n)
 		if err := os.WriteFile(filepath.Join(oldDir, name), []byte{}, os.FileMode(0644)); err != nil {
 			b.Fatal(err)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -438,7 +438,7 @@ type Endpoint struct {
 	ciliumEndpointUID k8sTypes.UID
 
 	// properties is used to store some internal properties about this Endpoint.
-	properties map[string]interface{}
+	properties map[string]any
 
 	// Root scope for all of this endpoints reporters.
 	reporterScope       cell.Health
@@ -643,7 +643,7 @@ func createEndpoint(dnsRulesApi DNSRulesAPI, epBuildQueue EndpointBuildQueue, lo
 		allocator:        allocator,
 		logLimiter:       logging.NewLimiter(10*time.Second, 3), // 1 log / 10 secs, burst of 3
 		noTrackPort:      0,
-		properties:       map[string]interface{}{},
+		properties:       map[string]any{},
 		ctMapGC:          ctMapGC,
 
 		forcePolicyCompute: true,
@@ -867,7 +867,7 @@ func (e *Endpoint) String() string {
 
 // optionChanged is a callback used with pkg/option to apply the options to an
 // endpoint.  Not used for anything at the moment.
-func optionChanged(key string, value option.OptionSetting, data interface{}) {
+func optionChanged(key string, value option.OptionSetting, data any) {
 }
 
 // applyOptsLocked applies the given options to the endpoint's options and
@@ -2360,7 +2360,7 @@ func (e *Endpoint) setPolicyRevision(rev uint64) {
 
 	now := time.Now()
 	e.policyRevision = rev
-	e.UpdateLogger(map[string]interface{}{
+	e.UpdateLogger(map[string]any{
 		logfields.DatapathPolicyRevision: e.policyRevision,
 	})
 	for ps := range e.policyRevisionSignals {
@@ -2661,14 +2661,14 @@ func (e *Endpoint) GetCreatedAt() time.Time {
 }
 
 // GetPropertyValue returns the metadata value for this key.
-func (e *Endpoint) GetPropertyValue(key string) interface{} {
+func (e *Endpoint) GetPropertyValue(key string) any {
 	e.mutex.RWMutex.RLock()
 	defer e.mutex.RWMutex.RUnlock()
 	return e.properties[key]
 }
 
 // SetPropertyValue sets the metadata value for this key.
-func (e *Endpoint) SetPropertyValue(key string, value interface{}) interface{} {
+func (e *Endpoint) SetPropertyValue(key string, value any) any {
 	e.mutex.RWMutex.Lock()
 	defer e.mutex.RWMutex.Unlock()
 	old := e.properties[key]

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -709,7 +709,7 @@ func BenchmarkEndpointGetModel(b *testing.B) {
 
 	e := NewTestEndpointWithState(nil, nil, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(), nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 123, StateWaitingForIdentity)
 
-	for i := 0; i < 256; i++ {
+	for range 256 {
 		e.LogStatusOK(BPF, "Hello World!")
 	}
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -714,8 +714,8 @@ func BenchmarkEndpointGetModel(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		e.GetModel()
 	}
 }

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -606,7 +606,7 @@ var (
 	deadlockTestTimeout = 3*deadlockTimeout + 1*time.Second
 )
 
-func (n *EndpointDeadlockEvent) Handle(ifc chan interface{}) {
+func (n *EndpointDeadlockEvent) Handle(ifc chan any) {
 	// We need to sleep here so that we are consuming an event off the queue,
 	// but not acquiring the lock yet.
 	// There isn't much of a better way to ensure that an Event is being

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -779,14 +779,11 @@ func TestMetadataResolver(t *testing.T) {
 	for _, restored := range []bool{false, true} {
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("%s (restored=%t)", tt.name, restored), func(t *testing.T) {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
 				ep := NewTestEndpointWithState(nil, nil, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(), nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{},
 					testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 123, StateWaitingForIdentity)
 				ep.K8sNamespace, ep.K8sPodName, ep.K8sUID = "bar", "foo", "uid"
 
-				_, err := ep.metadataResolver(ctx, restored, true, labels.Labels{}, &fakeTypes.BandwidthManager{}, tt.resolveMetadata)
+				_, err := ep.metadataResolver(t.Context(), restored, true, labels.Labels{}, &fakeTypes.BandwidthManager{}, tt.resolveMetadata)
 				tt.assert(t, err)
 			})
 		}

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -26,7 +26,7 @@ type EndpointRegenerationEvent struct {
 }
 
 // Handle handles the regeneration event for the endpoint.
-func (ev *EndpointRegenerationEvent) Handle(res chan interface{}) {
+func (ev *EndpointRegenerationEvent) Handle(res chan any) {
 	e := ev.ep
 	regenContext := ev.regenContext
 
@@ -104,7 +104,7 @@ type EndpointRevisionBumpEvent struct {
 }
 
 // Handle handles the revision bump event for the Endpoint.
-func (ev *EndpointRevisionBumpEvent) Handle(res chan interface{}) {
+func (ev *EndpointRevisionBumpEvent) Handle(res chan any) {
 	// TODO: if the endpoint is not in a 'ready' state that means that
 	// we cannot set the policy revision, as something else has
 	// changed endpoint state which necessitates regeneration,
@@ -139,7 +139,7 @@ type EndpointNoTrackEvent struct {
 }
 
 // Handle handles the NOTRACK rule update.
-func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
+func (ev *EndpointNoTrackEvent) Handle(res chan any) {
 	var port uint16
 
 	e := ev.ep
@@ -206,7 +206,7 @@ type EndpointPolicyBandwidthEvent struct {
 }
 
 // Handle handles the policy bandwidth update.
-func (ev *EndpointPolicyBandwidthEvent) Handle(res chan interface{}) {
+func (ev *EndpointPolicyBandwidthEvent) Handle(res chan any) {
 	var bps, ingressBps, prio uint64
 
 	if !ev.bwm.Enabled() {
@@ -347,7 +347,7 @@ func (e *Endpoint) Start(id uint16) {
 	defer e.unlock()
 
 	e.ID = id
-	e.UpdateLogger(map[string]interface{}{
+	e.UpdateLogger(map[string]any{
 		logfields.EndpointID: e.ID,
 	})
 

--- a/pkg/endpoint/id/id_test.go
+++ b/pkg/endpoint/id/id_test.go
@@ -88,8 +88,8 @@ func BenchmarkSplitID(b *testing.B) {
 		{string(PodNamePrefix + ":default:foobar"), PodNamePrefix, "default:foobar"},
 	}
 	count := 0
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for _, test := range tests {
 			pt, str := splitID(test.str)
 			if pt == test.prefixType && str == test.id {

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -68,7 +68,7 @@ func (e *Endpoint) Logger(subsystem string) *logrus.Entry {
 // Note: You must hold Endpoint.mutex.Lock() to synchronize logger pointer
 // updates if the endpoint is already exposed. Callers that create new
 // endpoints do not need locks to call this.
-func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
+func (e *Endpoint) UpdateLogger(fields map[string]any) {
 	e.updatePolicyLogger(fields)
 	epLogger := e.logger.Load()
 	if fields != nil && epLogger != nil {
@@ -125,7 +125,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 }
 
 // Only to be called from UpdateLogger() above
-func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
+func (e *Endpoint) updatePolicyLogger(fields map[string]any) {
 	policyLogger := e.policyLogger.Load()
 	// e.Options check needed for unit testing.
 	if policyLogger == nil && e.Options != nil && e.Options.IsEnabled(option.DebugPolicy) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -115,7 +115,7 @@ func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16
 // Must be called with the endpoint lock held for at least reading
 func (e *Endpoint) setNextPolicyRevision(revision uint64) {
 	e.nextPolicyRevision = revision
-	e.UpdateLogger(map[string]interface{}{
+	e.UpdateLogger(map[string]any{
 		logfields.DesiredPolicyRevision: e.nextPolicyRevision,
 	})
 }
@@ -1049,7 +1049,7 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 			logfields.IdentityLabels: identity.Labels.String(),
 		}).Info("Identity of endpoint changed")
 	}
-	e.UpdateLogger(map[string]interface{}{
+	e.UpdateLogger(map[string]any{
 		logfields.Identity: identity.StringID(),
 	})
 }

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -114,7 +114,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 
 	// simulate ipcache churn: continuously allocate IDs and push them to the policy engine.
 	go func() {
-		for i := 0; i < testfactor; i++ {
+		for i := range testfactor {
 			if i%100 == 0 {
 				t.Log(i)
 			}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -328,9 +328,7 @@ func TestRedirectWithDeny(t *testing.T) {
 		ruleL4L7Allow.WithEndpointSelector(selectBar_),
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cmp := completion.NewWaitGroup(ctx)
+	cmp := completion.NewWaitGroup(t.Context())
 	s.computePolicyForTest(t, ep, cmp)
 
 	// Redirect is still created, even if all MapState entries may have been overridden by a
@@ -460,9 +458,7 @@ func TestRedirectWithPriority(t *testing.T) {
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cmp := completion.NewWaitGroup(ctx)
+	cmp := completion.NewWaitGroup(t.Context())
 	s.computePolicyForTest(t, ep, cmp)
 
 	// Check that all redirects have been created.
@@ -515,9 +511,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cmp := completion.NewWaitGroup(ctx)
+	cmp := completion.NewWaitGroup(t.Context())
 	s.computePolicyForTest(t, ep, cmp)
 
 	// Check that all redirects have been created.

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -550,7 +550,7 @@ type serializableEndpoint struct {
 	CiliumEndpointUID types.UID
 
 	// Properties are used to store some internal property about this Endpoint.
-	Properties map[string]interface{}
+	Properties map[string]any
 
 	// NetnsCookie is the network namespace cookie of the Endpoint.
 	NetnsCookie uint64
@@ -613,7 +613,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	if r.Properties != nil {
 		ep.properties = r.Properties
 	} else {
-		ep.properties = map[string]interface{}{}
+		ep.properties = map[string]any{}
 	}
 	ep.NetNsCookie = r.NetnsCookie
 }

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -211,8 +211,6 @@ func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 func BenchmarkReadEPsFromDirNames(b *testing.B) {
 	s := setupEndpointSuite(b)
 
-	b.StopTimer()
-
 	// For this benchmark, the real linux datapath is necessary to properly
 	// serialize config files to disk and benchmark the restore.
 
@@ -239,9 +237,8 @@ func BenchmarkReadEPsFromDirNames(b *testing.B) {
 
 		epsNames = append(epsNames, ep.DirectoryPath())
 	}
-	b.StartTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		eps := ReadEPsFromDirNames(context.TODO(), nil, nil, nil, s.orchestrator, nil, nil, nil, nil, nil, nil, s.repo, nil, tmpDir, epsNames)
 		require.Len(b, eps, len(epsWanted))
 	}

--- a/pkg/endpointcleanup/cleanup_test.go
+++ b/pkg/endpointcleanup/cleanup_test.go
@@ -231,9 +231,7 @@ func TestGC(t *testing.T) {
 				}),
 			)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
+			ctx := t.Context()
 			tlog := hivetest.Logger(t)
 			assert.NoError(t, hive.Start(tlog, ctx))
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -705,7 +705,7 @@ func (mgr *endpointManager) AddEndpoint(ep *endpoint.Endpoint) (err error) {
 	// when endpoint and its logger are created pod details are not populated
 	// and all subsequent logs have empty pod details like ip addresses, k8sPodName
 	// this update will populate pod details in logger
-	ep.UpdateLogger(map[string]interface{}{
+	ep.UpdateLogger(map[string]any{
 		logfields.ContainerID: ep.GetShortContainerID(),
 		logfields.IPv4:        ep.GetIPv4Address(),
 		logfields.IPv6:        ep.GetIPv6Address(),

--- a/pkg/envoy/envoyadminclient.go
+++ b/pkg/envoy/envoyadminclient.go
@@ -122,7 +122,7 @@ func (a *EnvoyAdminClient) GetEnvoyVersion() (string, error) {
 		return "", fmt.Errorf("failed to read ServerInfo response: %w", err)
 	}
 
-	serverInfo := map[string]interface{}{}
+	serverInfo := map[string]any{}
 	if err := json.Unmarshal(body, &serverInfo); err != nil {
 		return "", fmt.Errorf("failed to parse ServerInfo: %w", err)
 	}

--- a/pkg/eventqueue/eventqueue.go
+++ b/pkg/eventqueue/eventqueue.go
@@ -97,7 +97,7 @@ func NewEventQueueBuffered(name string, numBufferedEvents int) *EventQueue {
 // waiting to receive on such a channel will block forever. Returns an error
 // if the Event has been previously enqueued, if the Event is nil, or the queue
 // itself is not initialized properly.
-func (q *EventQueue) Enqueue(ev *Event) (<-chan interface{}, error) {
+func (q *EventQueue) Enqueue(ev *Event) (<-chan any, error) {
 	if q.notSafeToAccess() || ev == nil {
 		return nil, fmt.Errorf("unable to Enqueue event")
 	}
@@ -145,7 +145,7 @@ type Event struct {
 	// eventResults is a channel on which the results of the event are sent.
 	// It is populated by the EventQueue itself, not by the queuer. This channel
 	// is closed if the event is cancelled.
-	eventResults chan interface{}
+	eventResults chan any
 
 	// cancelled signals that the given Event was not ran. This can happen
 	// if the EventQueue processing this Event was closed before the Event was
@@ -181,7 +181,7 @@ type eventStatistics struct {
 func NewEvent(meta EventHandler) *Event {
 	return &Event{
 		Metadata:     meta,
-		eventResults: make(chan interface{}, 1),
+		eventResults: make(chan any, 1),
 		cancelled:    make(chan struct{}),
 		stats:        eventStatistics{},
 	}
@@ -310,5 +310,5 @@ func (q *EventQueue) getLogger() *logrus.Entry {
 // in a generic way. To be processed by the EventQueue, all event types must
 // implement any function specified in this interface.
 type EventHandler interface {
-	Handle(chan interface{})
+	Handle(chan any)
 }

--- a/pkg/eventqueue/eventqueue_test.go
+++ b/pkg/eventqueue/eventqueue_test.go
@@ -80,7 +80,7 @@ func TestNewEvent(t *testing.T) {
 
 type DummyEvent struct{}
 
-func (d *DummyEvent) Handle(ifc chan interface{}) {
+func (d *DummyEvent) Handle(ifc chan any) {
 	ifc <- struct{}{}
 }
 
@@ -106,7 +106,7 @@ type NewHangEvent struct {
 	processed bool
 }
 
-func (n *NewHangEvent) Handle(ifc chan interface{}) {
+func (n *NewHangEvent) Handle(ifc chan any) {
 	<-n.Channel
 	n.processed = true
 	ifc <- struct{}{}
@@ -137,7 +137,7 @@ func TestDrain(t *testing.T) {
 	require.NoError(t, err)
 
 	var (
-		rcvChan <-chan interface{}
+		rcvChan <-chan any
 		err2    error
 	)
 

--- a/pkg/fqdn/bootstrap/fqdn_bootstrapper_test.go
+++ b/pkg/fqdn/bootstrap/fqdn_bootstrapper_test.go
@@ -179,10 +179,10 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
+
 	// Simulate parallel DNS responses from the upstream DNS for cilium.io and
 	// ebpf.io, done by every endpoint.
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, ep := range endpoints {
 			wg.Add(1)
 			go func() {

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -305,7 +305,7 @@ func (c *DNSCache) cleanupOverLimitEntries() (affectedNames sets.Set[string], re
 			return sortedEntries[i].entry.ExpirationTime.Before(sortedEntries[j].entry.ExpirationTime)
 		})
 
-		for i := 0; i < overlimit; i++ {
+		for i := range overlimit {
 			key := sortedEntries[i]
 			delete(entries, key.ip)
 			c.remove(key.ip, key.entry)

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -371,7 +371,7 @@ func makeEntries(now time.Time, live, redundant, expired uint32) (entries []*cac
 
 // Note: each "op" works on size things
 func BenchmarkGetIPs(b *testing.B) {
-	b.StopTimer()
+
 	now := time.Now()
 	cache := NewDNSCache(0)
 	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 60)
@@ -379,16 +379,15 @@ func BenchmarkGetIPs(b *testing.B) {
 	for _, entry := range entriesOrig {
 		cache.updateWithEntryIPs(entries, entry)
 	}
-	b.StartTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		entries.getIPs(now)
 	}
 }
 
 // Note: each "op" works on size things
 func BenchmarkUpdateIPs(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 		now := time.Now()
 		cache := NewDNSCache(0)
@@ -437,7 +436,7 @@ func BenchmarkMarshalJSON1000Repeat2(b *testing.B) {
 // Note: It assumes the JSON only uses data in DNSCache.forward when generating
 // the data. Changes to the implementation need to also change this benchmark.
 func benchmarkMarshalJSON(b *testing.B, numDNSEntries int) {
-	b.StopTimer()
+
 	ips := makeIPs(uint32(numIPsPerEntry))
 
 	cache := NewDNSCache(0)
@@ -445,9 +444,8 @@ func benchmarkMarshalJSON(b *testing.B, numDNSEntries int) {
 		// TTL needs to be far enough in the future that the entry is serialized
 		cache.Update(time.Now(), fmt.Sprintf("domain-%v.com", i), ips, 86400)
 	}
-	b.StartTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := cache.MarshalJSON()
 		require.NoError(b, err)
 	}
@@ -458,7 +456,7 @@ func benchmarkMarshalJSON(b *testing.B, numDNSEntries int) {
 // Note: It assumes the JSON only uses data in DNSCache.forward when generating
 // the data. Changes to the implementation need to also change this benchmark.
 func benchmarkUnmarshalJSON(b *testing.B, numDNSEntries int) {
-	b.StopTimer()
+
 	ips := makeIPs(uint32(numIPsPerEntry))
 
 	cache := NewDNSCache(0)
@@ -470,13 +468,13 @@ func benchmarkUnmarshalJSON(b *testing.B, numDNSEntries int) {
 	data, err := cache.MarshalJSON()
 	require.NoError(b, err)
 
-	emptyCaches := make([]*DNSCache, b.N)
-	for i := 0; i < b.N; i++ {
+	n := b.N
+	emptyCaches := make([]*DNSCache, n)
+	for i := 0; i < n; i++ {
 		emptyCaches[i] = NewDNSCache(0)
 	}
-	b.StartTimer()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; i < n; i++ {
 		err := emptyCaches[i].UnmarshalJSON(data)
 		require.NoError(b, err)
 	}

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -441,7 +441,7 @@ func benchmarkMarshalJSON(b *testing.B, numDNSEntries int) {
 	ips := makeIPs(uint32(numIPsPerEntry))
 
 	cache := NewDNSCache(0)
-	for i := 0; i < numDNSEntries; i++ {
+	for i := range numDNSEntries {
 		// TTL needs to be far enough in the future that the entry is serialized
 		cache.Update(time.Now(), fmt.Sprintf("domain-%v.com", i), ips, 86400)
 	}
@@ -462,7 +462,7 @@ func benchmarkUnmarshalJSON(b *testing.B, numDNSEntries int) {
 	ips := makeIPs(uint32(numIPsPerEntry))
 
 	cache := NewDNSCache(0)
-	for i := 0; i < numDNSEntries; i++ {
+	for i := range numDNSEntries {
 		// TTL needs to be far enough in the future that the entry is serialized
 		cache.Update(time.Now(), fmt.Sprintf("domain-%v.com", i), ips, 86400)
 	}
@@ -568,7 +568,7 @@ func TestOverlimitEntriesWithValidLimit(t *testing.T) {
 func TestOverlimitEntriesWithoutLimit(t *testing.T) {
 	limit := 0
 	cache := NewDNSCacheWithLimit(0, limit)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))}, i)
 	}
 	affectedNames, _ := cache.cleanupOverLimitEntries()
@@ -784,14 +784,14 @@ func TestZombiesGCOverLimitWithCTGC(t *testing.T) {
 
 	// Limit the number of IPs per hostname, but associate 'test.com' with
 	// more IPs.
-	for i := 0; i < maxConnections+1; i++ {
+	for i := range maxConnections + 1 {
 		zombies.Upsert(now, netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i+1)), "test.com")
 	}
 
 	// Simulate that CT garbage collection marks some IPs as live, we'll
 	// use the first 'maxConnections' IPs just so we can sort the output
 	// in the test below.
-	for i := 0; i < maxConnections; i++ {
+	for i := range maxConnections {
 		zombies.MarkAlive(afterNow, netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i+1)))
 	}
 	zombies.SetCTGCTime(afterNow, afterNow.Add(5*time.Minute))
@@ -1274,7 +1274,7 @@ func validateZombieSort(t *testing.T, zombies []*DNSZombieMapping) {
 	}
 	// Don't try to be efficient, just check that the properties we want hold
 	// for every pair of zombie mappings.
-	for i := 0; i < sl; i++ {
+	for i := range sl {
 		for j := i + 1; j < sl; j++ {
 			if zombies[i].AliveAt.Before(zombies[j].AliveAt) {
 				continue
@@ -1389,7 +1389,7 @@ func Test_sortZombieMappingSlice(t *testing.T) {
 	}
 
 	// Five random tests:
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		ts := make([]*DNSZombieMapping, len(allMappings))
 		copy(ts, allMappings)
 		rand.Shuffle(len(ts), func(i, j int) {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1235,9 +1235,8 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	pea := perEPAllow{}
 	c := regexCache{}
 	b.ReportAllocs()
-	b.StopTimer()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for epID := uint64(0); epID < nEPs; epID++ {
 			pea.setPortRulesForID(c, epID, udpProtoPort8053, nil)
 		}
@@ -1352,8 +1351,8 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	pea := perEPAllow{}
 	c := regexCache{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for epID := uint64(0); epID < numEPs; epID++ {
 			pea.setPortRulesForID(c, epID, udpProtoPort8053, rules)
 		}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1209,14 +1209,14 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	rulesPerEP := make([]policy.L7DataMap, 0, nEPs)
 
 	var defaultRules []api.PortRuleDNS
-	for i := 0; i < nMatchPatterns; i++ {
+	for i := range nMatchPatterns {
 		defaultRules = append(defaultRules, api.PortRuleDNS{MatchPattern: "*.bar" + strconv.Itoa(i) + "another.very.long.domain.here"})
 	}
-	for i := 0; i < nMatchNames; i++ {
+	for i := range nMatchNames {
 		defaultRules = append(defaultRules, api.PortRuleDNS{MatchName: strconv.Itoa(i) + "very.long.domain.containing.a.lot.of.chars"})
 	}
 
-	for i := 0; i < nEPs; i++ {
+	for i := range nEPs {
 		commonRules := slices.Clone(defaultRules)
 		if i%everyNIsEqual != 0 {
 			commonRules = append(

--- a/pkg/fqdn/dnsproxy/shared_client.go
+++ b/pkg/fqdn/dnsproxy/shared_client.go
@@ -279,7 +279,7 @@ func handler(wg *sync.WaitGroup, client *dns.Client, conn *dns.Conn, requests ch
 			// it's likely to happen with small number (~200) of concurrent requests
 			// which would result in goroutine leak as we would never close req.ch
 			if _, duplicate := waitingResponses[req.msg.Id]; duplicate {
-				for n := 0; n < 5; n++ {
+				for range 5 {
 					// Try a new ID
 					id := dns.Id()
 					if _, duplicate = waitingResponses[id]; !duplicate {

--- a/pkg/fqdn/dnsproxy/udp.go
+++ b/pkg/fqdn/dnsproxy/udp.go
@@ -143,7 +143,7 @@ func (f *sessionUDPFactory) SetSocketOptions(_ *net.UDPConn) error {
 
 // InitPool initializes a pool of buffers to be used with SessionUDP.
 func (f *sessionUDPFactory) InitPool(msgSize int) {
-	f.udpPool.New = func() interface{} {
+	f.udpPool.New = func() any {
 		return &sessionUDP{
 			f:   f,
 			m:   make([]byte, msgSize),

--- a/pkg/fqdn/namemanager/bench_test.go
+++ b/pkg/fqdn/namemanager/bench_test.go
@@ -88,7 +88,7 @@ func BenchmarkFqdnCache(b *testing.B) {
 	const endpoints = 8
 
 	caches := make([]*fqdn.DNSCache, 0, endpoints)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		lookupTime := time.Now()
 		dnsHistory := fqdn.NewDNSCache(0)
 
@@ -111,8 +111,7 @@ func BenchmarkFqdnCache(b *testing.B) {
 	prefixMatcher := func(_ netip.Addr) bool { return true }
 	nameMatcher := func(_ string) bool { return true }
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		nameManager.dnsHistoryModel("", prefixMatcher, nameMatcher, "")
 	}
 }

--- a/pkg/fqdn/namemanager/bench_test.go
+++ b/pkg/fqdn/namemanager/bench_test.go
@@ -48,7 +48,7 @@ func BenchmarkUpdateGenerateDNS(b *testing.B) {
 		IPCache: testipcache.NewMockIPCache(),
 	})
 
-	for i := 0; i < numSelectors; i++ {
+	for i := range numSelectors {
 		nameManager.RegisterFQDNSelector(api.FQDNSelector{
 			MatchName: fmt.Sprintf("%d.example.com", i),
 		})
@@ -64,7 +64,7 @@ func BenchmarkUpdateGenerateDNS(b *testing.B) {
 	ip := netip.MustParseAddr("10.0.0.0")
 
 	b.ResetTimer() // Don't benchmark adding selectors, just evaluating them
-	for i := 0; i < b.N*numSelectors; i++ {
+	for i := range b.N * numSelectors {
 		t = t.Add(1 * time.Second)
 		ip = ip.Next()
 
@@ -92,7 +92,7 @@ func BenchmarkFqdnCache(b *testing.B) {
 		lookupTime := time.Now()
 		dnsHistory := fqdn.NewDNSCache(0)
 
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			dnsHistory.Update(lookupTime, fmt.Sprintf("domain-%d.com.", i), makeIPs(10), 1000)
 		}
 

--- a/pkg/health/client/client_test.go
+++ b/pkg/health/client/client_test.go
@@ -336,7 +336,7 @@ func createNodes(healthy int, unhealthy int, unknown int) []*models.NodeStatus {
 
 	nodes := make([]*models.NodeStatus, healthy+unhealthy)
 
-	for i := 0; i < healthy; i++ {
+	for i := range healthy {
 		nodes[i] = &models.NodeStatus{
 			Name: fmt.Sprintf("node%d", i),
 			Host: &models.HostStatus{

--- a/pkg/health/client/tree.go
+++ b/pkg/health/client/tree.go
@@ -167,10 +167,7 @@ func dumpVals(w io.Writer, level, maxLevel int, levelsEnded []int, edge decorati
 
 	val := dumpVal(level, node)
 	if node.meta != "" {
-		c := maxLevel - level
-		if c < 0 {
-			c = 0
-		}
+		c := max(maxLevel-level, 0)
 		fmt.Fprintf(w, "%s %-"+strconv.Itoa(leafMaxWidth+c*2)+"s%s%s\n", edge, val, strings.Repeat("  ", c), node.meta)
 		return
 	}

--- a/pkg/health/client/tree.go
+++ b/pkg/health/client/tree.go
@@ -157,7 +157,7 @@ func dumpNodes(w io.Writer, level, maxLevel int, levelsEnded []int, nodes []*nod
 }
 
 func dumpVals(w io.Writer, level, maxLevel int, levelsEnded []int, edge decoration, node *node) {
-	for i := 0; i < level; i++ {
+	for i := range level {
 		if isEnded(levelsEnded, i) {
 			fmt.Fprint(w, strings.Repeat(" ", indentSize+1))
 			continue

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -102,7 +102,7 @@ func New(cells ...cell.Cell) *Hive {
 
 var decodeHooks = cell.DecodeHooks{
 	// Decode *cidr.CIDR fields
-	func(from reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
+	func(from reflect.Type, to reflect.Type, data any) (any, error) {
 		if from.Kind() != reflect.String {
 			return data, nil
 		}

--- a/pkg/hubble/api/v1/types.go
+++ b/pkg/hubble/api/v1/types.go
@@ -14,7 +14,7 @@ type Event struct {
 	// Timestamp when event was observed in Hubble
 	Timestamp *timestamppb.Timestamp
 	// Event contains the actual event
-	Event interface{}
+	Event any
 }
 
 // GetFlow returns the decoded flow, or nil if the event is nil or not a flow

--- a/pkg/hubble/cell/config.go
+++ b/pkg/hubble/cell/config.go
@@ -201,9 +201,6 @@ func (cfg *config) normalize() {
 }
 
 func getDefaultMonitorQueueSize(numCPU int) int {
-	monitorQueueSize := numCPU * ciliumDefaults.MonitorQueueSizePerCPU
-	if monitorQueueSize > ciliumDefaults.MonitorQueueSizePerCPUMaximum {
-		monitorQueueSize = ciliumDefaults.MonitorQueueSizePerCPUMaximum
-	}
+	monitorQueueSize := min(numCPU*ciliumDefaults.MonitorQueueSizePerCPU, ciliumDefaults.MonitorQueueSizePerCPUMaximum)
 	return monitorQueueSize
 }

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestRingReader_Previous(t *testing.T) {
 	ring := NewRing(Capacity15)
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 	}
 	tests := []struct {
@@ -76,7 +76,7 @@ func TestRingReader_Previous(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			reader := NewRingReader(ring, tt.start)
 			var got []*v1.Event
-			for i := 0; i < tt.count; i++ {
+			for range tt.count {
 				event, err := reader.Previous()
 				if !errors.Is(err, tt.wantErr) {
 					t.Errorf(`"%s" error = %v, wantErr %v`, name, err, tt.wantErr)
@@ -94,7 +94,7 @@ func TestRingReader_Previous(t *testing.T) {
 
 func TestRingReader_PreviousLost(t *testing.T) {
 	ring := NewRing(Capacity15)
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 	}
 	reader := NewRingReader(ring, ^uint64(0))
@@ -113,7 +113,7 @@ func TestRingReader_PreviousLost(t *testing.T) {
 
 func TestRingReader_Next(t *testing.T) {
 	ring := NewRing(Capacity15)
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 	}
 
@@ -163,7 +163,7 @@ func TestRingReader_Next(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			reader := NewRingReader(ring, tt.start)
 			var got []*v1.Event
-			for i := 0; i < tt.count; i++ {
+			for range tt.count {
 				event, err := reader.Next()
 				if !errors.Is(err, tt.wantErr) {
 					t.Errorf(`"%s" error = %v, wantErr %v`, name, err, tt.wantErr)
@@ -181,7 +181,7 @@ func TestRingReader_Next(t *testing.T) {
 
 func TestRingReader_NextLost(t *testing.T) {
 	ring := NewRing(Capacity15)
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 	}
 	expected := &v1.Event{
@@ -206,7 +206,7 @@ func TestRingReader_NextFollow(t *testing.T) {
 		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("io.(*pipe).read"))
 	ring := NewRing(Capacity15)
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 	}
 
@@ -258,7 +258,7 @@ func TestRingReader_NextFollow(t *testing.T) {
 			reader := NewRingReader(ring, tt.start)
 			var timedOut bool
 			var got []*v1.Event
-			for i := 0; i < tt.count; i++ {
+			for i := range tt.count {
 				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 				got = append(got, reader.NextFollow(ctx))
 				select {

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -29,8 +29,8 @@ func BenchmarkRingWrite(b *testing.B) {
 	entry := &v1.Event{}
 	s := NewRing(capacity(b.N))
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		s.Write(entry)
 	}
 }
@@ -40,12 +40,12 @@ func BenchmarkRingRead(b *testing.B) {
 	s := NewRing(capacity(b.N))
 	a := make([]*v1.Event, b.N)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.Write(entry)
 	}
-	b.ResetTimer()
+
 	lastWriteIdx := s.LastWriteParallel()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		a[i], _ = s.read(lastWriteIdx)
 		lastWriteIdx--
 	}
@@ -57,7 +57,7 @@ func BenchmarkTimeLibListRead(b *testing.B) {
 	a := make([]*v1.Event, b.N)
 	i := 0
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.PushFront(entry)
 	}
 	b.ResetTimer()
@@ -72,12 +72,12 @@ func BenchmarkTimeLibRingRead(b *testing.B) {
 	a := make([]*v1.Event, b.N)
 	i := 0
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		s.Value = entry
 		s.Next()
 	}
-	s.Do(func(e interface{}) {
+	s.Do(func(e any) {
 		a[i], _ = e.(*v1.Event)
 		i++
 	})
@@ -140,7 +140,7 @@ func TestNewRing(t *testing.T) {
 			assert.Equal(t, uint64(0), r.Len())
 			assert.Equal(t, uint64(n), r.Cap())
 			// fill half the buffer
-			for j := 0; j < n/2; j++ {
+			for range n / 2 {
 				r.Write(&v1.Event{})
 			}
 			assert.Equal(t, uint64(n/2), r.Len())
@@ -152,7 +152,7 @@ func TestNewRing(t *testing.T) {
 			assert.Equal(t, uint64(n), r.Len())
 			assert.Equal(t, uint64(n), r.Cap())
 			// write more events
-			for j := 0; j < n; j++ {
+			for range n {
 				r.Write(&v1.Event{})
 			}
 			assert.Equal(t, uint64(n), r.Len())

--- a/pkg/hubble/dropeventemitter/fake_recorder.go
+++ b/pkg/hubble/dropeventemitter/fake_recorder.go
@@ -26,8 +26,8 @@ type FakeRecorder struct {
 func objectString(object runtime.Object, includeObject bool) string {
 	var uid string
 	uo, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
-	if err != nil && uo["metadata"] != nil && uo["metadata"].(map[string]interface{})["uid"] != nil {
-		uid = uo["metadata"].(map[string]interface{})["uid"].(string)
+	if err != nil && uo["metadata"] != nil && uo["metadata"].(map[string]any)["uid"] != nil {
+		uid = uo["metadata"].(map[string]any)["uid"].(string)
 	}
 	if !includeObject {
 		return ""
@@ -47,7 +47,7 @@ func annotationsString(annotations map[string]string) string {
 	}
 }
 
-func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...any) {
 	if f.Events != nil {
 		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
 			objectString(object, f.IncludeObject) + annotationsString(annotations)
@@ -58,11 +58,11 @@ func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message s
 	f.writeEvent(object, nil, eventtype, reason, "%s", message)
 }
 
-func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...any) {
 	f.writeEvent(object, nil, eventtype, reason, messageFmt, args...)
 }
 
-func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...any) {
 	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args...)
 }
 

--- a/pkg/hubble/exporter/config_watcher_test.go
+++ b/pkg/hubble/exporter/config_watcher_test.go
@@ -4,7 +4,6 @@
 package exporter
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -25,10 +24,7 @@ func TestReloadNotificationReceived(t *testing.T) {
 		configReceived = true
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go watcher.watch(ctx, 1*time.Millisecond)
+	go watcher.watch(t.Context(), 1*time.Millisecond)
 
 	// then
 	assert.Eventually(t, func() bool {

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -70,9 +70,8 @@ func TestExporter(t *testing.T) {
 	exporter, err := newExporter(log, opts)
 	assert.NoError(t, err)
 
-	ctx := context.Background()
 	for _, ev := range events {
-		err := exporter.Export(ctx, ev)
+		err := exporter.Export(t.Context(), ev)
 		assert.NoError(t, err)
 
 	}
@@ -279,11 +278,8 @@ func TestExporterWithFieldMask(t *testing.T) {
 	exporter, err := newExporter(log, opts)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	for _, ev := range events {
-		err := exporter.Export(ctx, ev)
+		err := exporter.Export(t.Context(), ev)
 		assert.NoError(t, err)
 	}
 
@@ -471,8 +467,7 @@ func BenchmarkExporter(b *testing.B) {
 	exporter, err := newExporter(log, opts)
 	assert.NoError(b, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := b.Context()
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -469,8 +469,7 @@ func BenchmarkExporter(b *testing.B) {
 
 	ctx := b.Context()
 
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		event := &allowEvent
 		if i%10 == 0 { // 10% doesn't match allow filter
 			event = &noAllowEvent

--- a/pkg/hubble/filters/filters_benchmark_test.go
+++ b/pkg/hubble/filters/filters_benchmark_test.go
@@ -23,8 +23,8 @@ var (
 func runFilterBenchmark(b *testing.B, ff *flowpb.FlowFilter, events []*v1.Event) {
 	filterFuncs, err := BuildFilter(context.Background(), ff, DefaultFilters(hivetest.Logger(b)))
 	require.NoError(b, err)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for _, ev := range events {
 			filterFuncs.MatchOne(ev)
 		}
@@ -33,7 +33,7 @@ func runFilterBenchmark(b *testing.B, ff *flowpb.FlowFilter, events []*v1.Event)
 
 func duplicateEvent(ev *v1.Event, n int) []*v1.Event {
 	evs := make([]*v1.Event, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		evs[i] = matchingEvent
 	}
 	return evs

--- a/pkg/hubble/metrics/metric_config_watcher.go
+++ b/pkg/hubble/metrics/metric_config_watcher.go
@@ -131,7 +131,7 @@ func calculateMetricHash(file []byte) uint64 {
 }
 
 func (c *metricConfigWatcher) validateMetricConfig(config *api.Config) error {
-	metrics := make(map[string]interface{})
+	metrics := make(map[string]any)
 	var errs error
 
 	for i, newMetric := range config.Metrics {

--- a/pkg/hubble/monitor/consumer.go
+++ b/pkg/hubble/monitor/consumer.go
@@ -71,7 +71,7 @@ func (c *consumer) sendNumLostEvents() bool {
 	}
 
 	if c.cachedLostNotification == nil {
-		c.cachedLostNotification = c.newEvent(func() interface{} {
+		c.cachedLostNotification = c.newEvent(func() any {
 			return &observerTypes.LostEvent{
 				Source:        observerTypes.LostEventSourceEventsQueue,
 				NumLostEvents: c.numEventsLost,
@@ -103,7 +103,7 @@ func (c *consumer) sendNumLostEvents() bool {
 // sendEvent enqueues an event in the observer. If this is not possible, it
 // keeps a counter of lost events, which it will regularly try to send to the
 // observer as well
-func (c *consumer) sendEvent(payloader func() interface{}) {
+func (c *consumer) sendEvent(payloader func() any) {
 	if c.numEventsLost > 0 {
 		if !c.sendNumLostEvents() {
 			// We just failed sending the lost notification, hence it doesn't
@@ -121,7 +121,7 @@ func (c *consumer) sendEvent(payloader func() interface{}) {
 	}
 }
 
-func (c *consumer) newEvent(payloader func() interface{}) *observerTypes.MonitorEvent {
+func (c *consumer) newEvent(payloader func() any) *observerTypes.MonitorEvent {
 	ev := &observerTypes.MonitorEvent{
 		Timestamp: time.Now(),
 		NodeName:  nodeTypes.GetAbsoluteNodeName(),
@@ -149,8 +149,8 @@ func (c *consumer) countDroppedEvent() {
 }
 
 // NotifyAgentEvent implements monitorConsumer.MonitorConsumer
-func (c *consumer) NotifyAgentEvent(typ int, message interface{}) {
-	c.sendEvent(func() interface{} {
+func (c *consumer) NotifyAgentEvent(typ int, message any) {
+	c.sendEvent(func() any {
 		return &observerTypes.AgentEvent{
 			Type:    typ,
 			Message: message,
@@ -160,7 +160,7 @@ func (c *consumer) NotifyAgentEvent(typ int, message interface{}) {
 
 // NotifyPerfEvent implements monitorConsumer.MonitorConsumer
 func (c *consumer) NotifyPerfEvent(data []byte, cpu int) {
-	c.sendEvent(func() interface{} {
+	c.sendEvent(func() any {
 		return &observerTypes.PerfEvent{
 			Data: data,
 			CPU:  cpu,
@@ -170,7 +170,7 @@ func (c *consumer) NotifyPerfEvent(data []byte, cpu int) {
 
 // NotifyPerfEventLost implements monitorConsumer.MonitorConsumer
 func (c *consumer) NotifyPerfEventLost(numLostEvents uint64, cpu int) {
-	c.sendEvent(func() interface{} {
+	c.sendEvent(func() any {
 		return &observerTypes.LostEvent{
 			Source:        observerTypes.LostEventSourcePerfRingBuffer,
 			NumLostEvents: numLostEvents,

--- a/pkg/hubble/observer/local_node_watcher_test.go
+++ b/pkg/hubble/observer/local_node_watcher_test.go
@@ -4,7 +4,6 @@
 package observer
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,8 +14,7 @@ import (
 )
 
 func Test_LocalNodeWatcher(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	localNode := node.LocalNode{
 		Node: types.Node{

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -229,7 +229,7 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 	m := s.GetEventsChannel()
 	input := make([]*observerpb.Flow, numFlows)
 
-	for i := 0; i < numFlows; i++ {
+	for i := range numFlows {
 		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
 		macOnly := func(mac string) net.HardwareAddr {
 			m, _ := net.ParseMAC(mac)
@@ -371,7 +371,7 @@ func TestLocalObserverServer_GetAgentEvents(t *testing.T) {
 	go s.Start()
 
 	m := s.GetEventsChannel()
-	for i := 0; i < numEvents; i++ {
+	for i := range numEvents {
 		ts := time.Unix(int64(i), 0)
 		node := fmt.Sprintf("node #%03d", i)
 		var msg monitorAPI.AgentNotifyMessage
@@ -524,7 +524,7 @@ func TestHooks(t *testing.T) {
 	go s.Start()
 
 	m := s.GetEventsChannel()
-	for i := 0; i < numFlows; i++ {
+	for i := range numFlows {
 		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
 		data := testutils.MustCreateL3L4Payload(tn)
 		m <- &observerTypes.MonitorEvent{
@@ -579,7 +579,7 @@ func TestLocalObserverServer_OnFlowDelivery(t *testing.T) {
 	go s.Start()
 
 	m := s.GetEventsChannel()
-	for i := 0; i < numFlows; i++ {
+	for i := range numFlows {
 		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
 		data := testutils.MustCreateL3L4Payload(tn)
 		m <- &observerTypes.MonitorEvent{
@@ -643,7 +643,7 @@ func TestLocalObserverServer_OnGetFlows(t *testing.T) {
 	go s.Start()
 
 	m := s.GetEventsChannel()
-	for i := 0; i < numFlows; i++ {
+	for i := range numFlows {
 		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
 		data := testutils.MustCreateL3L4Payload(tn)
 		m <- &observerTypes.MonitorEvent{

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -668,8 +668,7 @@ func TestLocalObserverServer_OnGetFlows(t *testing.T) {
 // TestLocalObserverServer_NodeLabels test the LocalNodeWatcher integration
 // with the observer.
 func TestLocalObserverServer_NodeLabels(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// local node stuff setup.
 	localNode := node.LocalNode{

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -804,8 +804,8 @@ func Benchmark_TrackNamespaces(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		s.trackNamespaces(f)
 	}
 }

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -80,7 +80,7 @@ func TestLocalObserverServer_ServerStatus(t *testing.T) {
 func TestGetFlowRate(t *testing.T) {
 	type event struct {
 		offset int
-		event  interface{}
+		event  any
 	}
 
 	tcs := map[string]struct {

--- a/pkg/hubble/observer/types/types.go
+++ b/pkg/hubble/observer/types/types.go
@@ -34,7 +34,7 @@ type MonitorEvent struct {
 	// NodeName where the event occurred
 	NodeName string
 	// Payload is one of: AgentEvent, PerfEvent or LostEvent
-	Payload interface{}
+	Payload any
 }
 
 // AgentEvent is any agent event
@@ -42,7 +42,7 @@ type AgentEvent struct {
 	// Type is a monitorAPI.MessageType* value
 	Type int
 	// Message is the agent message, e.g. accesslog.LogRecord, monitorAPI.AgentNotifyMessage
-	Message interface{}
+	Message any
 }
 
 // PerfEvent is a raw event obtained from a BPF perf ring buffer

--- a/pkg/hubble/parser/fieldmask/fieldmask.go
+++ b/pkg/hubble/parser/fieldmask/fieldmask.go
@@ -73,7 +73,7 @@ func (f FieldMask) Copy(dst, src protoreflect.Message) {
 // Alloc creates all nested protoreflect.Message fields to avoid allocation later.
 func (f FieldMask) Alloc(src protoreflect.Message) {
 	fds := src.Descriptor().Fields()
-	for i := 0; i < fds.Len(); i++ {
+	for i := range fds.Len() {
 		fd := fds.Get(i)
 		if next, ok := f[string(fd.Name())]; ok {
 			if len(next) > 0 {

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -81,8 +81,8 @@ func BenchmarkL7Decode(b *testing.B) {
 
 	f := &flowpb.Flow{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = parser.Decode(lr, f)
 	}
 }

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -319,8 +319,8 @@ func BenchmarkL34Decode(b *testing.B) {
 
 	f := &flowpb.Flow{}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = parser.Decode(d, f)
 	}
 }

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -745,7 +745,7 @@ func TestDecodeDropReason(t *testing.T) {
 func TestDecodeTraceReason(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	parseFlow := func(event interface{}, srcIPv4, dstIPv4 string) *flowpb.Flow {
+	parseFlow := func(event any, srcIPv4, dstIPv4 string) *flowpb.Flow {
 		data, err := testutils.CreateL3L4Payload(event,
 			&layers.Ethernet{
 				SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
@@ -1090,7 +1090,7 @@ func TestDecodeIsReply(t *testing.T) {
 
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	parseFlow := func(event interface{}, srcIPv4, dstIPv4 net.IP) *flowpb.Flow {
+	parseFlow := func(event any, srcIPv4, dstIPv4 net.IP) *flowpb.Flow {
 		data, err := testutils.CreateL3L4Payload(event,
 			&layers.Ethernet{
 				SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},

--- a/pkg/hubble/peer/buffer_test.go
+++ b/pkg/hubble/peer/buffer_test.go
@@ -20,7 +20,7 @@ func TestBufferPush(t *testing.T) {
 	assert.NotNil(t, buf)
 	assert.Equal(t, 0, buf.Len())
 	assert.Equal(t, 0, buf.Cap())
-	for i := 0; i < max; i++ {
+	for i := range max {
 		assert.NoError(t, buf.Push(&peerpb.ChangeNotification{}))
 		assert.Equal(t, i+1, buf.Len())
 	}
@@ -41,11 +41,11 @@ func TestBufferPop(t *testing.T) {
 	assert.NotNil(t, buf)
 	assert.Equal(t, 0, buf.Len())
 	assert.Equal(t, 0, buf.Cap())
-	for i := 0; i < max; i++ {
+	for i := range max {
 		assert.NoError(t, buf.Push(&peerpb.ChangeNotification{Name: fmt.Sprintf("#%d", i)}))
 		assert.Equal(t, i+1, buf.Len())
 	}
-	for i := 0; i < max; i++ {
+	for i := range max {
 		cn, err := buf.Pop()
 		assert.NoError(t, err)
 		assert.Equal(t, &peerpb.ChangeNotification{Name: fmt.Sprintf("#%d", i)}, cn)
@@ -84,7 +84,7 @@ func TestBufferPopWithClosedStopChan(t *testing.T) {
 	assert.Equal(t, 0, buf.Len())
 	assert.Equal(t, 0, buf.Cap())
 
-	for i := 0; i < max; i++ {
+	for i := range max {
 		assert.NoError(t, buf.Push(&peerpb.ChangeNotification{}))
 		assert.Equal(t, i+1, buf.Len())
 	}

--- a/pkg/hubble/peer/handler_test.go
+++ b/pkg/hubble/peer/handler_test.go
@@ -479,7 +479,7 @@ func TestNodeUpdate(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go func() {
-				for i := 0; i < len(tt.want); i++ {
+				for range tt.want {
 					got = append(got, <-h.C)
 				}
 				wg.Done()

--- a/pkg/hubble/recorder/sink/dispatch.go
+++ b/pkg/hubble/recorder/sink/dispatch.go
@@ -204,7 +204,7 @@ func estimateBootTimeOffset() (bootTimeOffset int64, err error) {
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	for round := 0; round < estimationRounds; round++ {
+	for range estimationRounds {
 		var bootTimespec unix.Timespec
 
 		// Ideally we would use __vdso_clock_gettime for both clocks here,

--- a/pkg/hubble/recorder/sink/dispatch.go
+++ b/pkg/hubble/recorder/sink/dispatch.go
@@ -264,6 +264,6 @@ func (d *Dispatch) NotifyPerfEventLost(numLostEvents uint64, cpu int) {
 }
 
 // NotifyAgentEvent implements consumer.MonitorConsumer
-func (d *Dispatch) NotifyAgentEvent(typ int, message interface{}) {
+func (d *Dispatch) NotifyAgentEvent(typ int, message any) {
 	// ignored
 }

--- a/pkg/hubble/relay/queue/priority_queue.go
+++ b/pkg/hubble/relay/queue/priority_queue.go
@@ -87,12 +87,12 @@ func (h minHeap) Swap(i, j int) {
 	}
 }
 
-func (h *minHeap) Push(x interface{}) {
+func (h *minHeap) Push(x any) {
 	resp := x.(*observerpb.GetFlowsResponse)
 	*h = append(*h, resp)
 }
 
-func (h *minHeap) Pop() interface{} {
+func (h *minHeap) Pop() any {
 	old := *h
 	n := len(old)
 	if n == 0 {

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -73,7 +73,7 @@ var endpoints map[string]*testutils.FakeEndpointInfo
 
 func init() {
 	endpoints = make(map[string]*testutils.FakeEndpointInfo, 254)
-	for i := 0; i < 254; i++ {
+	for i := range 254 {
 		ip := fake.IP(fake.WithIPv4())
 		endpoints[ip] = &testutils.FakeEndpointInfo{
 			ID:           uint64(i),
@@ -105,7 +105,7 @@ func newHubbleObserver(t testing.TB, nodeName string, numFlows int) *observer.Lo
 
 	m := s.GetEventsChannel()
 
-	for i := 0; i < numFlows; i++ {
+	for i := range numFlows {
 		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
 		src := getRandomEndpoint()
 		dst := getRandomEndpoint()

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -220,7 +220,7 @@ func (r *FakePeerLister) List() []poolTypes.Peer {
 type FakeClientConn struct {
 	OnGetState  func() connectivity.State
 	OnClose     func() error
-	OnInvoke    func(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error
+	OnInvoke    func(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error
 	OnNewStream func(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error)
 }
 
@@ -241,7 +241,7 @@ func (c FakeClientConn) Close() error {
 }
 
 // Invoke implements poolTypes.ClientConn.Invoke.
-func (c FakeClientConn) Invoke(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error {
+func (c FakeClientConn) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
 	if c.OnInvoke != nil {
 		return c.OnInvoke(ctx, method, args, reply, opts...)
 	}

--- a/pkg/hubble/testutils/grpc.go
+++ b/pkg/hubble/testutils/grpc.go
@@ -18,8 +18,8 @@ type FakeGRPCServerStream struct {
 	OnSendHeader func(metadata.MD) error
 	OnSetTrailer func(m metadata.MD)
 	OnContext    func() context.Context
-	OnSendMsg    func(m interface{}) error
-	OnRecvMsg    func(m interface{}) error
+	OnSendMsg    func(m any) error
+	OnRecvMsg    func(m any) error
 }
 
 // SetHeader implements grpc.ServerStream.SetHeader.
@@ -55,7 +55,7 @@ func (s *FakeGRPCServerStream) Context() context.Context {
 }
 
 // SendMsg implements grpc.ServerStream.SendMsg.
-func (s *FakeGRPCServerStream) SendMsg(m interface{}) error {
+func (s *FakeGRPCServerStream) SendMsg(m any) error {
 	if s.OnSendMsg != nil {
 		return s.OnSendMsg(m)
 	}
@@ -63,7 +63,7 @@ func (s *FakeGRPCServerStream) SendMsg(m interface{}) error {
 }
 
 // RecvMsg implements grpc.ServerStream.RecvMsg.
-func (s *FakeGRPCServerStream) RecvMsg(m interface{}) error {
+func (s *FakeGRPCServerStream) RecvMsg(m any) error {
 	if s.OnRecvMsg != nil {
 		return s.OnRecvMsg(m)
 	}
@@ -77,8 +77,8 @@ type FakeGRPCClientStream struct {
 	OnTrailer   func() metadata.MD
 	OnCloseSend func() error
 	OnContext   func() context.Context
-	OnSendMsg   func(m interface{}) error
-	OnRecvMsg   func(m interface{}) error
+	OnSendMsg   func(m any) error
+	OnRecvMsg   func(m any) error
 }
 
 // Header implements grpc.ClientStream.Header.
@@ -114,7 +114,7 @@ func (c *FakeGRPCClientStream) Context() context.Context {
 }
 
 // SendMsg implements grpc.ClientStream.SendMsg.
-func (c *FakeGRPCClientStream) SendMsg(m interface{}) error {
+func (c *FakeGRPCClientStream) SendMsg(m any) error {
 	if c.OnSendMsg != nil {
 		return c.OnSendMsg(m)
 	}
@@ -122,7 +122,7 @@ func (c *FakeGRPCClientStream) SendMsg(m interface{}) error {
 }
 
 // RecvMsg implements grpc.ClientStream.RecvMsg.
-func (c *FakeGRPCClientStream) RecvMsg(m interface{}) error {
+func (c *FakeGRPCClientStream) RecvMsg(m any) error {
 	if c.OnRecvMsg != nil {
 		return c.OnRecvMsg(m)
 	}

--- a/pkg/hubble/testutils/payload.go
+++ b/pkg/hubble/testutils/payload.go
@@ -17,7 +17,7 @@ import (
 )
 
 // CreateL3L4Payload assembles a L3/L4 payload for testing purposes
-func CreateL3L4Payload(message interface{}, layers ...gopacket.SerializableLayer) ([]byte, error) {
+func CreateL3L4Payload(message any, layers ...gopacket.SerializableLayer) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	switch messageType := message.(type) {
 	case monitor.DebugCapture,
@@ -52,7 +52,7 @@ func CreateL3L4Payload(message interface{}, layers ...gopacket.SerializableLayer
 }
 
 // MustCreateL3L4Payload wraps CreateL3L4Payload, but panics on error
-func MustCreateL3L4Payload(message interface{}, layers ...gopacket.SerializableLayer) []byte {
+func MustCreateL3L4Payload(message any, layers ...gopacket.SerializableLayer) []byte {
 	payload, err := CreateL3L4Payload(message, layers...)
 	if err != nil {
 		panic(err)

--- a/pkg/hubble/testutils/payload_test.go
+++ b/pkg/hubble/testutils/payload_test.go
@@ -148,7 +148,7 @@ func TestCreateL3L4Payload(t *testing.T) {
 	}
 
 	type args struct {
-		msg interface{}
+		msg any
 		l   []gopacket.SerializableLayer
 	}
 	tests := []struct {

--- a/pkg/identity/basicallocator/basic_allocator_test.go
+++ b/pkg/identity/basicallocator/basic_allocator_test.go
@@ -41,7 +41,7 @@ func TestBasicIDAllocator_AllocateRandom(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			allocator := NewBasicIDAllocator(idpool.ID(minID), idpool.ID(maxID))
 
-			for i := 0; i < tc.allocations; i++ {
+			for i := range tc.allocations {
 				_, err := allocator.AllocateRandom()
 
 				if i < poolSize && err != nil {

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -186,7 +186,7 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 	minID := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
 	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
 
-	log.WithFields(map[string]interface{}{
+	log.WithFields(map[string]any{
 		"min":        minID,
 		"max":        maxID,
 		"cluster-id": option.Config.ClusterID,

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -499,7 +499,7 @@ func BenchmarkIPIdentityPair_PrefixString(b *testing.B) {
 	b.ResetTimer()
 	for _, tt := range cases {
 		b.Run(tt.name, func(bb *testing.B) {
-			for i := 0; i < bb.N; i++ {
+			for bb.Loop() {
 				_ = tt.pair.PrefixString()
 			}
 		})

--- a/pkg/idpool/idpool.go
+++ b/pkg/idpool/idpool.go
@@ -144,10 +144,7 @@ type idCache struct {
 }
 
 func newIDCache(minID ID, maxID ID) *idCache {
-	n := int(maxID - minID + 1)
-	if n < 0 {
-		n = 0
-	}
+	n := max(int(maxID-minID+1), 0)
 
 	c := &idCache{
 		ids:    make(map[ID]struct{}, n),

--- a/pkg/idpool/idpool_test.go
+++ b/pkg/idpool/idpool_test.go
@@ -308,7 +308,7 @@ func testAllocatedID(t *testing.T, nGoRoutines int) {
 	allocated := make(chan ID, bufferChannelSize)
 	var allocators sync.WaitGroup
 
-	for i := 0; i < nGoRoutines; i++ {
+	for range nGoRoutines {
 		allocators.Add(1)
 		go func() {
 			for i := 1; i <= maxID; i++ {

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -196,12 +196,12 @@ func getNetworkPrefix(ipNet *net.IPNet) *net.IP {
 
 	if ipNet.IP.To4() == nil {
 		mask = make(net.IP, net.IPv6len)
-		for i := 0; i < len(ipNet.Mask); i++ {
+		for i := range ipNet.Mask {
 			mask[net.IPv6len-i-1] = ipNet.IP[net.IPv6len-i-1] & ^ipNet.Mask[i]
 		}
 	} else {
 		mask = make(net.IP, net.IPv4len)
-		for i := 0; i < net.IPv4len; i++ {
+		for i := range net.IPv4len {
 			mask[net.IPv4len-i-1] = ipNet.IP[net.IPv6len-i-1] & ^ipNet.Mask[i]
 		}
 	}

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -1055,7 +1055,7 @@ func BenchmarkSortAddrList(b *testing.B) {
 	size := 1000
 
 	var lists [][]netip.Addr
-	for range b.N {
+	for b.Loop() {
 		list := make([]netip.Addr, size)
 		for i := range size {
 			bits := r.Uint32()

--- a/pkg/ipalloc/ipalloc.go
+++ b/pkg/ipalloc/ipalloc.go
@@ -373,7 +373,7 @@ func (abl *availableBlockList) put(ip netip.Addr) error {
 
 	curr := (*abl)[0]
 	var prev *linkedBlock
-	for i := 0; i < maxIter; i++ {
+	for i := range maxIter {
 		if ip.Compare(curr.from) < 0 {
 			// Is `ip` on the left current block
 

--- a/pkg/ipalloc/ipalloc.go
+++ b/pkg/ipalloc/ipalloc.go
@@ -469,12 +469,12 @@ func (abl availableBlockList) Less(i, j int) bool {
 }
 
 // Push implements heap.Interface
-func (abl *availableBlockList) Push(x interface{}) {
+func (abl *availableBlockList) Push(x any) {
 	*abl = append(*abl, x.(*linkedBlock))
 }
 
 // Pop implements heap.Interface
-func (abl *availableBlockList) Pop() interface{} {
+func (abl *availableBlockList) Pop() any {
 	n := len(*abl) - 1
 	elem := (*abl)[n]
 	*abl = slices.Delete(*abl, n, n+1)

--- a/pkg/ipalloc/ipalloc_test.go
+++ b/pkg/ipalloc/ipalloc_test.go
@@ -446,9 +446,7 @@ func BenchmarkHashAlloc_AllocFullRand(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		ip, ok := netip.AddrFromSlice(buf[i*4 : (i+1)*4])
 		if !ok {
 			b.Fatal("can't convert IP")
@@ -471,9 +469,7 @@ func BenchmarkHashAlloc_AllocAny(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err = alloc.AllocAny(true)
 		if err != nil && !errors.Is(err, ErrInUse) {
 			b.Fatal(err)
@@ -564,7 +560,7 @@ func BenchmarkHashAlloc_AllocPerStage(b *testing.B) {
 
 			bb.ResetTimer()
 
-			for i := 0; i < bb.N; i++ {
+			for i := 0; bb.Loop(); i++ {
 				ip, ok := netip.AddrFromSlice(append([]byte{0}, buf[i*3:(i+1)*3]...))
 				if !ok {
 					b.Fatal("can't convert IP")

--- a/pkg/ipalloc/ipalloc_test.go
+++ b/pkg/ipalloc/ipalloc_test.go
@@ -502,7 +502,7 @@ func BenchmarkHashAlloc_AllocBalanced(b *testing.B) {
 
 			bb.ResetTimer()
 
-			for i := 0; i < bb.N/r; i++ {
+			for i := range bb.N / r {
 				ip, ok := netip.AddrFromSlice(append([]byte{0}, buf[i*3:(i+1)*3]...))
 				if !ok {
 					b.Fatal("can't convert IP")
@@ -513,7 +513,7 @@ func BenchmarkHashAlloc_AllocBalanced(b *testing.B) {
 					b.Fatal(err)
 				}
 
-				for ii := 0; ii < a; ii++ {
+				for range a {
 					_, err = alloc.AllocAny(true)
 					if err != nil && !errors.Is(err, ErrInUse) {
 						b.Fatal(err)
@@ -544,7 +544,7 @@ func BenchmarkHashAlloc_AllocPerStage(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			for i := 0; i < p; i++ {
+			for i := range p {
 				ip, ok := netip.AddrFromSlice(append([]byte{0}, buf[i*3:(i+1)*3]...))
 				if !ok {
 					b.Fatal("can't convert IP")

--- a/pkg/ipam/cidrset/cidr_set.go
+++ b/pkg/ipam/cidrset/cidr_set.go
@@ -166,8 +166,7 @@ func (s *CidrSet) AllocateNext() (*net.IPNet, error) {
 		return nil, ErrCIDRRangeNoCIDRsRemaining
 	}
 	candidate := s.nextCandidate
-	var i int
-	for i = 0; i < s.maxCIDRs; i++ {
+	for range s.maxCIDRs {
 		if s.used.Bit(candidate) == 0 {
 			break
 		}

--- a/pkg/ipam/cidrset/cidr_set_test.go
+++ b/pkg/ipam/cidrset/cidr_set_test.go
@@ -218,7 +218,7 @@ func TestCIDRSet_RandomishAllocation(t *testing.T) {
 		// allocate all the CIDRs
 		var cidrs []*net.IPNet
 
-		for i := 0; i < 256; i++ {
+		for range 256 {
 			if c, err := a.AllocateNext(); err == nil {
 				cidrs = append(cidrs, c)
 			} else {
@@ -232,13 +232,13 @@ func TestCIDRSet_RandomishAllocation(t *testing.T) {
 			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
 		}
 		// release them all
-		for i := 0; i < len(cidrs); i++ {
+		for i := range cidrs {
 			a.Release(cidrs[i])
 		}
 
 		// allocate the CIDRs again
 		var rcidrs []*net.IPNet
-		for i := 0; i < 256; i++ {
+		for i := range 256 {
 			if c, err := a.AllocateNext(); err == nil {
 				rcidrs = append(rcidrs, c)
 			} else {
@@ -280,7 +280,7 @@ func TestCIDRSet_AllocationOccupied(t *testing.T) {
 		var cidrs []*net.IPNet
 		var numCIDRs = 256
 
-		for i := 0; i < numCIDRs; i++ {
+		for range numCIDRs {
 			if c, err := a.AllocateNext(); err == nil {
 				cidrs = append(cidrs, c)
 			} else {
@@ -294,7 +294,7 @@ func TestCIDRSet_AllocationOccupied(t *testing.T) {
 			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
 		}
 		// release them all
-		for i := 0; i < len(cidrs); i++ {
+		for i := range cidrs {
 			a.Release(cidrs[i])
 		}
 		// occupy the last 128 CIDRs
@@ -304,7 +304,7 @@ func TestCIDRSet_AllocationOccupied(t *testing.T) {
 
 		// allocate the first 128 CIDRs again
 		var rcidrs []*net.IPNet
-		for i := 0; i < numCIDRs/2; i++ {
+		for i := range numCIDRs / 2 {
 			if c, err := a.AllocateNext(); err == nil {
 				rcidrs = append(rcidrs, c)
 			} else {

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -121,7 +121,7 @@ func newNodeStore(logger *slog.Logger, nodeName string, conf *option.DaemonConfi
 		&ciliumv2.CiliumNode{},
 		0,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				var valid, equal bool
 				defer func() { k8sEventReg.K8sEventReceived(apiGroup, "CiliumNode", "create", valid, equal) }()
 				if node, ok := obj.(*ciliumv2.CiliumNode); ok {
@@ -136,7 +136,7 @@ func newNodeStore(logger *slog.Logger, nodeName string, conf *option.DaemonConfi
 					)
 				}
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj any) {
 				var valid, equal bool
 				defer func() { k8sEventReg.K8sEventReceived(apiGroup, "CiliumNode", "update", valid, equal) }()
 				if oldNode, ok := oldObj.(*ciliumv2.CiliumNode); ok {
@@ -170,7 +170,7 @@ func newNodeStore(logger *slog.Logger, nodeName string, conf *option.DaemonConfi
 					)
 				}
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				// Given we are watching a single specific
 				// resource using the node name, any delete
 				// notification means that the resource

--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -140,7 +140,7 @@ const (
 )
 
 func waitForNetlinkDevices(logger *slog.Logger, configByMac configMap) (linkByMac linkMap, err error) {
-	for try := 0; try < waitForNetlinkDevicesMaxTries; try++ {
+	for try := range waitForNetlinkDevicesMaxTries {
 		links, err := safenetlink.LinkList()
 		if err != nil {
 			logger.Warn("failed to obtain eni link list - retrying", logfields.Error, err)

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -76,7 +76,7 @@ func (h *hostScopeAllocator) Dump() (map[Pool]map[string]string, string) {
 		origIP = big.NewInt(0).SetBytes(h.allocCIDR.IP.To16())
 	}
 	bits := big.NewInt(0).SetBytes(data)
-	for i := 0; i < bits.BitLen(); i++ {
+	for i := range bits.BitLen() {
 		if bits.Bit(i) != 0 {
 			ip := net.IP(big.NewInt(0).Add(origIP, big.NewInt(int64(uint(i+1)))).Bytes()).String()
 			alloc[ip] = ""

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -275,7 +275,7 @@ func Test_MultiPoolManager(t *testing.T) {
 	// exhaust mars ipv4 pool (/27 contains 30 IPs)
 	allocatedMarsIPs := []net.IP{}
 	numMarsIPs := 30
-	for i := 0; i < numMarsIPs; i++ {
+	for i := range numMarsIPs {
 		// set upstreamSync to true for last allocation, to ensure we only get one upsert event
 		ar, err := c.allocateNext(fmt.Sprintf("mars-pod-%d", i), "mars", IPv4, i == numMarsIPs-1)
 		assert.NoError(t, err)

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -375,10 +375,7 @@ func calculateExcessIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAbov
 	// interface restrictions, less than max-above-watermark may have been
 	// allocated but we never want to release IPs that have been allocated
 	// because of max-above-watermark.
-	excessIPs = availableIPs - usedIPs - preAllocate - maxAboveWatermark
-	if excessIPs < 0 {
-		excessIPs = 0
-	}
+	excessIPs = max(availableIPs-usedIPs-preAllocate-maxAboveWatermark, 0)
 
 	return
 }

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -1102,7 +1102,7 @@ func (n *Node) syncToAPIServer() error {
 	// second attempt fails as well we are likely under heavy contention,
 	// fall back to the controller based background interval to retry.
 	maxRetries := 2
-	for retry := 0; retry < maxRetries; retry++ {
+	for retry := range maxRetries {
 		if node.Status.IPAM.Used == nil {
 			node.Status.IPAM.Used = ipamTypes.AllocationMap{}
 		}
@@ -1122,7 +1122,7 @@ func (n *Node) syncToAPIServer() error {
 		}
 	}
 
-	for retry := 0; retry < maxRetries; retry++ {
+	for retry := range maxRetries {
 		node.Spec.IPAM.Pool = pool
 		n.logger.Load().Debug("Updating node in apiserver", logfields.PoolSize, len(node.Spec.IPAM.Pool))
 

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -121,7 +121,7 @@ func (n *nodeOperationsMock) AllocateIPs(ctx context.Context, allocation *Alloca
 	n.mutex.Lock()
 	n.allocator.mutex.Lock()
 	n.allocator.allocatedIPs += allocation.IPv4.AvailableForAllocation
-	for i := 0; i < allocation.IPv4.AvailableForAllocation; i++ {
+	for range allocation.IPv4.AvailableForAllocation {
 		n.allocator.ipGenerator++
 		n.allocatedIPs = append(n.allocatedIPs, fmt.Sprintf("%d", n.allocator.ipGenerator))
 	}

--- a/pkg/ipam/service/allocator/bitmap.go
+++ b/pkg/ipam/service/allocator/bitmap.go
@@ -190,7 +190,7 @@ func (rss randomScanStrategy) AllocateBit(allocated *big.Int, max, count int) (i
 		return 0, false
 	}
 	offset := rand.IntN(max)
-	for i := 0; i < max; i++ {
+	for i := range max {
 		at := (offset + i) % max
 		if allocated.Bit(at) == 0 {
 			return at, true
@@ -208,7 +208,7 @@ func (contiguousScanStrategy) AllocateBit(allocated *big.Int, max, count int) (i
 	if count >= max {
 		return 0, false
 	}
-	for i := 0; i < max; i++ {
+	for i := range max {
 		if allocated.Bit(i) == 0 {
 			return i, true
 		}

--- a/pkg/ipam/service/allocator/utils_test.go
+++ b/pkg/ipam/service/allocator/utils_test.go
@@ -36,7 +36,7 @@ func BenchmarkCountBits(b *testing.B) {
 	if !ok {
 		b.Fatal("Failed to set bigN")
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		countBits(bigN)
 	}
 }

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -533,7 +533,7 @@ func (m *InstanceMap) updateLocked(instanceID string, iface InterfaceRevision) {
 	i.Interfaces[iface.Resource.InterfaceID()] = iface
 }
 
-type Address interface{}
+type Address any
 
 // AddressIterator is the function called by the ForeachAddress iterator
 type AddressIterator func(instanceID, interfaceID, ip, poolID string, address Address) error

--- a/pkg/ipcache/ipcache_bench_test.go
+++ b/pkg/ipcache/ipcache_bench_test.go
@@ -40,12 +40,13 @@ func BenchmarkInjectLabels(b *testing.B) {
 
 	addr := netip.MustParseAddr("1.0.0.0")
 	lbls := labels.NewLabelsFromSortedList(labels.LabelSourceCIDRGroup + ":foo=bar")
+
 	prefixes := make([]cmtypes.PrefixCluster, 0, b.N)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		pfx := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(addr, 30))
 		for range 4 {
 			addr = addr.Next()

--- a/pkg/ipcache/ipcache_bench_test.go
+++ b/pkg/ipcache/ipcache_bench_test.go
@@ -47,7 +47,7 @@ func BenchmarkInjectLabels(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		pfx := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(addr, 30))
-		for j := 0; j < 4; j++ {
+		for range 4 {
 			addr = addr.Next()
 		}
 		prefixes = append(prefixes, ipc.metadata.upsertLocked(pfx, source.Kubernetes, "cidr-policy", lbls)...)

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -540,9 +540,7 @@ func benchmarkIPCacheUpsert(b *testing.B, num int) {
 		nms[i] = strconv.Itoa(i)
 	}
 
-	b.StopTimer()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ctx, cancel := context.WithCancel(context.Background())
 		allocator := testidentity.NewMockIdentityAllocator(nil)
 		ipcache := NewIPCache(&Configuration{

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -554,7 +554,7 @@ func benchmarkIPCacheUpsert(b *testing.B, num int) {
 
 		// We only want to measure the calls to upsert.
 		b.StartTimer()
-		for j := 0; j < num; j++ {
+		for j := range num {
 			meta.PodName = nms[j]
 			_, err := ipcache.Upsert(ips[j], nil, 0, &meta, Identity{
 				ID:     identityPkg.NumericIdentity(j),

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -59,7 +59,7 @@ func updateNodeAnnotation(c kubernetes.Interface, nodeName string, annotation no
 	if err != nil {
 		return err
 	}
-	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":%s}}`, raw))
+	patch := fmt.Appendf(nil, `{"metadata":{"annotations":%s}}`, raw)
 
 	_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, k8sTypes.StrategicMergePatchType, patch, metav1.PatchOptions{}, "status")
 

--- a/pkg/k8s/annotate_test.go
+++ b/pkg/k8s/annotate_test.go
@@ -87,7 +87,7 @@ func TestPatchingCIDRAnnotation(t *testing.T) {
 				if err != nil {
 					require.NoError(t, err)
 				}
-				patchWanted := []byte(fmt.Sprintf(`{"metadata":{"annotations":%s}}`, raw))
+				patchWanted := fmt.Appendf(nil, `{"metadata":{"annotations":%s}}`, raw)
 
 				patchReceived := action.(k8stesting.PatchAction).GetPatch()
 				require.Equal(t, string(patchWanted), string(patchReceived))
@@ -144,7 +144,7 @@ func TestPatchingCIDRAnnotation(t *testing.T) {
 				if err != nil {
 					require.NoError(t, err)
 				}
-				patchWanted := []byte(fmt.Sprintf(`{"metadata":{"annotations":%s}}`, raw))
+				patchWanted := fmt.Appendf(nil, `{"metadata":{"annotations":%s}}`, raw)
 
 				patchReceived := action.(k8stesting.PatchAction).GetPatch()
 				require.Equal(t, string(patchWanted), string(patchReceived))

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -625,7 +625,7 @@ func BenchmarkSpecEquals(b *testing.B) {
 	b.Run("Reflected SpecEquals", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			reflect.DeepEqual(r.Spec, o.Spec)
 			reflect.DeepEqual(r.Specs, o.Specs)
 		}
@@ -633,7 +633,7 @@ func BenchmarkSpecEquals(b *testing.B) {
 	b.Run("Generated SpecEquals", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			r.DeepEqual(o)
 		}
 	})

--- a/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields.go
@@ -66,7 +66,7 @@ func detectUnknownFields(logger *slog.Logger, policy *unstructured.Unstructured)
 		return err
 	}
 
-	var filtered map[string]interface{}
+	var filtered map[string]any
 	switch kind {
 	case cilium_v2.CNPKindDefinition:
 		cnp := new(cilium_v2.CiliumNetworkPolicy)
@@ -158,7 +158,7 @@ func (e ErrUnknownKind) Error() string {
 	return fmt.Sprintf("unknown kind %q", e.kind)
 }
 
-func getFields(u map[string]interface{}) ([]string, error) {
+func getFields(u map[string]any) ([]string, error) {
 	flat, err := flattenObject(u)
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func getFields(u map[string]interface{}) ([]string, error) {
 //   - specs.0.ingress.0.fromEndpoints.0.matchExpressions.*
 var arbitraryLabelRegex = regexp.MustCompile(`^(.+\.(matchLabels|matchExpressions))\..+$`)
 
-func flattenObject(obj map[string]interface{}) (map[string]interface{}, error) {
+func flattenObject(obj map[string]any) (map[string]any, error) {
 	return flatten.Flatten(obj, "", flatten.DotStyle)
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/unknown_fields_test.go
@@ -13,7 +13,7 @@ import (
 func Test_getFields(t *testing.T) {
 	tests := []struct {
 		name      string
-		structure map[string]interface{}
+		structure map[string]any
 		expected  []string
 		err       error
 	}{
@@ -25,7 +25,7 @@ func Test_getFields(t *testing.T) {
 		},
 		{
 			name: "empty structure",
-			structure: map[string]interface{}{
+			structure: map[string]any{
 				"": "",
 			},
 			expected: []string{""},
@@ -33,7 +33,7 @@ func Test_getFields(t *testing.T) {
 		},
 		{
 			name: "simple structure",
-			structure: map[string]interface{}{
+			structure: map[string]any{
 				"spec": "",
 			},
 			expected: []string{"spec"},
@@ -41,11 +41,11 @@ func Test_getFields(t *testing.T) {
 		},
 		{
 			name: "nested structure",
-			structure: map[string]interface{}{
-				"spec": map[string]interface{}{
+			structure: map[string]any{
+				"spec": map[string]any{
 					"more":   "",
 					"fields": "",
-					"another": map[string]interface{}{
+					"another": map[string]any{
 						"field": "",
 					},
 				},
@@ -55,10 +55,10 @@ func Test_getFields(t *testing.T) {
 		},
 		{
 			name: `contains "matchLabels"`,
-			structure: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"endpointSelector": map[string]interface{}{
-						"matchLabels": map[string]interface{}{
+			structure: map[string]any{
+				"spec": map[string]any{
+					"endpointSelector": map[string]any{
+						"matchLabels": map[string]any{
 							"app": "",
 						},
 					},
@@ -69,10 +69,10 @@ func Test_getFields(t *testing.T) {
 		},
 		{
 			name: `contains multiple labels inside multiple "matchLabels"`,
-			structure: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"endpointSelector": map[string]interface{}{
-						"matchLabels": map[string]interface{}{
+			structure: map[string]any{
+				"spec": map[string]any{
+					"endpointSelector": map[string]any{
+						"matchLabels": map[string]any{
 							"app":      "",
 							"key":      "",
 							"operator": "",
@@ -85,21 +85,21 @@ func Test_getFields(t *testing.T) {
 		},
 		{
 			name: `contains multiple labels inside "matchLabels" based on real policy`,
-			structure: map[string]interface{}{
-				"specs": []interface{}{
-					map[string]interface{}{
+			structure: map[string]any{
+				"specs": []any{
+					map[string]any{
 						"description": "Policy to test multiple rules in a single file",
-						"endpointSelector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+						"endpointSelector": map[string]any{
+							"matchLabels": map[string]any{
 								"app":     "",
 								"version": "",
 							},
 						},
-						"ingress": []interface{}{
-							map[string]interface{}{
-								"fromEndpoints": []interface{}{
-									map[string]interface{}{
-										"matchLabels": map[string]interface{}{
+						"ingress": []any{
+							map[string]any{
+								"fromEndpoints": []any{
+									map[string]any{
+										"matchLabels": map[string]any{
 											"app":     "",
 											"track":   "",
 											"version": "",
@@ -109,19 +109,19 @@ func Test_getFields(t *testing.T) {
 							},
 						},
 					},
-					map[string]interface{}{
-						"endpointSelector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+					map[string]any{
+						"endpointSelector": map[string]any{
+							"matchLabels": map[string]any{
 								"app":     "details",
 								"track":   "stable",
 								"version": "v1",
 							},
 						},
-						"ingress": []interface{}{
-							map[string]interface{}{
-								"fromEndpoints": []interface{}{
-									map[string]interface{}{
-										"matchLabels": map[string]interface{}{
+						"ingress": []any{
+							map[string]any{
+								"fromEndpoints": []any{
+									map[string]any{
+										"matchLabels": map[string]any{
 											"app":     "productpage",
 											"track":   "stable",
 											"version": "v1",
@@ -142,20 +142,20 @@ func Test_getFields(t *testing.T) {
 		},
 		{
 			name: `contains "matchLabels" and "matchExpressions" based on real policy`,
-			structure: map[string]interface{}{
-				"spec": map[string]interface{}{
+			structure: map[string]any{
+				"spec": map[string]any{
 					"description": "Policy to test matchExpressions key",
-					"endpointSelector": map[string]interface{}{
-						"matchLabels": map[string]interface{}{
+					"endpointSelector": map[string]any{
+						"matchLabels": map[string]any{
 							"id": "app1",
 						},
 					},
-					"ingress": []interface{}{
-						map[string]interface{}{
-							"fromEndpoints": []interface{}{
-								map[string]interface{}{
-									"matchExpressions": []interface{}{
-										map[string]interface{}{
+					"ingress": []any{
+						map[string]any{
+							"fromEndpoints": []any{
+								map[string]any{
+									"matchExpressions": []any{
+										map[string]any{
 											"key":      "",
 											"operator": "Exists",
 										},

--- a/pkg/k8s/client/client_test.go
+++ b/pkg/k8s/client/client_test.go
@@ -279,7 +279,7 @@ func Test_clientMultipleAPIServers(t *testing.T) {
 	K8sAPIServerFilePath = apiStateFile.Name()
 
 	servers := make([]*httptest.Server, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		servers[i] = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requests.Store(r.URL.Path, r)
 
@@ -360,7 +360,7 @@ func Test_clientMultipleAPIServersServiceSwitchover(t *testing.T) {
 	K8sAPIServerFilePath = apiStateFile.Name()
 
 	servers := make([]*httptest.Server, 3)
-	for i := 0; i < len(servers); i++ {
+	for i := range servers {
 		servers[i] = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requests.Store(r.URL.Path, r)
 
@@ -472,7 +472,7 @@ func Test_clientMultipleAPIServersFailedRestore(t *testing.T) {
 	K8sAPIServerFilePath = apiStateFile.Name()
 
 	servers := make([]*httptest.Server, 4)
-	for i := 0; i < len(servers); i++ {
+	for i := range servers {
 		servers[i] = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requests.Store(r.URL.Path, r)
 
@@ -574,7 +574,7 @@ func Test_clientMultipleAPIServersFailedHeartbeat(t *testing.T) {
 	K8sAPIServerFilePath = apiStateFile.Name()
 
 	servers := make([]*httptest.Server, 3)
-	for i := 0; i < len(servers); i++ {
+	for i := range servers {
 		servers[i] = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requests.Store(r.URL.Path, r)
 
@@ -713,7 +713,7 @@ func BenchmarkIsConnReadyMultipleAPIServers(b *testing.B) {
 	K8sAPIServerFilePath = apiStateFile.Name()
 
 	servers := make([]*httptest.Server, 3)
-	for i := 0; i < len(servers); i++ {
+	for i := range servers {
 		servers[i] = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			switch r.URL.Path {
@@ -754,7 +754,7 @@ func BenchmarkIsConnReadyMultipleAPIServers(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var wg sync.WaitGroup
 		wg.Add(num)
-		for j := 0; j < num; j++ {
+		for range num {
 			go func() {
 				require.NoError(b, isConnReady(clientset))
 				wg.Done()

--- a/pkg/k8s/client/client_test.go
+++ b/pkg/k8s/client/client_test.go
@@ -699,7 +699,7 @@ func BenchmarkIsConnReady(b *testing.B) {
 	tlog := hivetest.Logger(b)
 	require.NoError(b, h.Start(tlog, ctx))
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		require.NoError(b, isConnReady(clientset))
 	}
 
@@ -751,7 +751,7 @@ func BenchmarkIsConnReadyMultipleAPIServers(b *testing.B) {
 	require.NoError(b, h.Start(tlog, ctx))
 
 	num := 20
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var wg sync.WaitGroup
 		wg.Add(num)
 		for range num {

--- a/pkg/k8s/error_helpers.go
+++ b/pkg/k8s/error_helpers.go
@@ -45,7 +45,7 @@ var k8sObjDecodeErrRe = regexp.MustCompile("invalid character.*looking for begin
 // K8sErrorHandler handles the error messages in a non verbose way by omitting
 // repeated instances of the same error message for a timeout defined with
 // k8sErrLogTimeout.
-func K8sErrorHandler(_ context.Context, e error, _ string, _ ...interface{}) {
+func K8sErrorHandler(_ context.Context, e error, _ string, _ ...any) {
 	if e == nil {
 		return
 	}

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -122,7 +122,7 @@ func ConvertToNetworkV1IngressLoadBalancerIngress(slimLBIngs []slim_corev1.LoadB
 // in its Obj, obj is returned without any transformations. If the given obj can't be
 // cast into either *cilium_v2.CiliumClusterwideNetworkPolicy nor
 // cache.DeletedFinalStateUnknown, an error is returned.
-func TransformToCCNP(obj interface{}) (interface{}, error) {
+func TransformToCCNP(obj any) (any, error) {
 	switch concreteObj := obj.(type) {
 	case *cilium_v2.CiliumClusterwideNetworkPolicy:
 		return &types.SlimCNP{
@@ -170,7 +170,7 @@ func TransformToCCNP(obj interface{}) (interface{}, error) {
 // *types.SlimCNP in its Obj, obj is returned without any transformations.
 // If the given obj can't be cast into either *cilium_v2.CiliumNetworkPolicy
 // nor cache.DeletedFinalStateUnknown, an error is returned.
-func TransformToCNP(obj interface{}) (interface{}, error) {
+func TransformToCNP(obj any) (any, error) {
 	switch concreteObj := obj.(type) {
 	case *cilium_v2.CiliumNetworkPolicy:
 		return &types.SlimCNP{
@@ -257,7 +257,7 @@ func convertToTaints(v1Taints []v1.Taint) []slim_corev1.Taint {
 // a *types.CiliumEndpoint in its Obj, obj is returned without any transformations.
 // If the given obj can't be cast into either *cilium_v2.CiliumEndpoint nor
 // cache.DeletedFinalStateUnknown, an error is returned.
-func TransformToCiliumEndpoint(obj interface{}) (interface{}, error) {
+func TransformToCiliumEndpoint(obj any) (any, error) {
 	switch concreteObj := obj.(type) {
 	case *cilium_v2.CiliumEndpoint:
 		return &types.CiliumEndpoint{

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -1029,12 +1029,12 @@ func Test_ConvertToNetworkV1IngressLoadBalancerIngress(t *testing.T) {
 
 func Test_TransformToCNP(t *testing.T) {
 	type args struct {
-		obj interface{}
+		obj any
 	}
 	tests := []struct {
 		name     string
 		args     args
-		want     interface{}
+		want     any
 		expected bool
 	}{
 		{
@@ -1118,12 +1118,12 @@ func Test_TransformToCNP(t *testing.T) {
 
 func Test_TransformToCCNP(t *testing.T) {
 	type args struct {
-		obj interface{}
+		obj any
 	}
 	tests := []struct {
 		name     string
 		args     args
-		want     interface{}
+		want     any
 		expected bool
 	}{
 		{
@@ -1217,12 +1217,12 @@ func Test_TransformToCCNP(t *testing.T) {
 
 func Test_TransformToCiliumEndpoint(t *testing.T) {
 	type args struct {
-		obj interface{}
+		obj any
 	}
 	tests := []struct {
 		name     string
 		args     args
-		want     interface{}
+		want     any
 		expected bool
 	}{
 		{

--- a/pkg/k8s/identitybackend/identity_test.go
+++ b/pkg/k8s/identitybackend/identity_test.go
@@ -4,7 +4,6 @@
 package identitybackend
 
 import (
-	"context"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -197,8 +196,7 @@ func TestGetIdentity(t *testing.T) {
 				t.Fatalf("Can't create CRD Backend: %s", err)
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			addWaitGroup := sync.WaitGroup{}
 			addWaitGroup.Add(len(tc.identities))

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -428,8 +428,8 @@ func benchmarkInformer(ctx context.Context, nCycles int, newInformer bool, b *te
 			&slim_corev1.Node{},
 			0,
 			cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {},
-				UpdateFunc: func(oldObj, newObj interface{}) {
+				AddFunc: func(obj any) {},
+				UpdateFunc: func(oldObj, newObj any) {
 					if oldK8sNP := informer.CastInformerEvent[slim_corev1.Node](hivetest.Logger(b), oldObj); oldK8sNP != nil {
 						if newK8sNP := informer.CastInformerEvent[slim_corev1.Node](hivetest.Logger(b), newObj); newK8sNP != nil {
 							if reflect.DeepEqual(oldK8sNP, newK8sNP) {
@@ -438,7 +438,7 @@ func benchmarkInformer(ctx context.Context, nCycles int, newInformer bool, b *te
 						}
 					}
 				},
-				DeleteFunc: func(obj interface{}) {
+				DeleteFunc: func(obj any) {
 					k8sNP := informer.CastInformerEvent[slim_corev1.Node](hivetest.Logger(b), obj)
 					if k8sNP == nil {
 						deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -465,8 +465,8 @@ func benchmarkInformer(ctx context.Context, nCycles int, newInformer bool, b *te
 			&slim_corev1.Node{},
 			0,
 			cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {},
-				UpdateFunc: func(oldObj, newObj interface{}) {
+				AddFunc: func(obj any) {},
+				UpdateFunc: func(oldObj, newObj any) {
 					if oldK8sNP := OldCopyObjToV1Node(oldObj); oldK8sNP != nil {
 						if newK8sNP := OldCopyObjToV1Node(newObj); newK8sNP != nil {
 							if OldEqualV1Node(oldK8sNP, newK8sNP) {
@@ -475,7 +475,7 @@ func benchmarkInformer(ctx context.Context, nCycles int, newInformer bool, b *te
 						}
 					}
 				},
-				DeleteFunc: func(obj interface{}) {
+				DeleteFunc: func(obj any) {
 					k8sNP := OldCopyObjToV1Node(obj)
 					if k8sNP == nil {
 						deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -515,7 +515,7 @@ func OldEqualV1Node(node1, node2 *slim_corev1.Node) bool {
 		node1.GetAnnotations()[annotation.CiliumHostIP] == node2.GetAnnotations()[annotation.CiliumHostIP]
 }
 
-func OldCopyObjToV1Node(obj interface{}) *slim_corev1.Node {
+func OldCopyObjToV1Node(obj any) *slim_corev1.Node {
 	node, ok := obj.(*slim_corev1.Node)
 	if !ok {
 		return nil

--- a/pkg/k8s/informer/cast.go
+++ b/pkg/k8s/informer/cast.go
@@ -15,7 +15,7 @@ import (
 // CastInformerEvent tries to cast obj to type typ, directly
 // or by DeletedFinalStateUnknown type. It returns nil and logs
 // an error if obj doesn't contain type typ.
-func CastInformerEvent[typ any](logger *slog.Logger, obj interface{}) *typ {
+func CastInformerEvent[typ any](logger *slog.Logger, obj any) *typ {
 	k8sObj, ok := obj.(*typ)
 	if ok {
 		return k8sObj

--- a/pkg/k8s/informer/informer.go
+++ b/pkg/k8s/informer/informer.go
@@ -21,7 +21,7 @@ import (
 func init() {
 	utilRuntime.PanicHandlers = append(
 		utilRuntime.PanicHandlers,
-		func(_ context.Context, r interface{}) {
+		func(_ context.Context, r any) {
 			// from k8s library
 			if err, ok := r.(error); ok && errors.Is(err, http.ErrAbortHandler) {
 				// honor the http.ErrAbortHandler sentinel panic value:
@@ -85,11 +85,11 @@ func NewInformerWithStore(
 		FullResyncPeriod: resyncPeriod,
 		RetryOnError:     false,
 
-		Process: func(obj interface{}, isInInitialList bool) error {
+		Process: func(obj any, isInInitialList bool) error {
 			// from oldest to newest
 			for _, d := range obj.(cache.Deltas) {
 
-				var obj interface{}
+				var obj any
 				if transformer != nil {
 					var err error
 					if obj, err = transformer(d.Object); err != nil {

--- a/pkg/k8s/json_patch.go
+++ b/pkg/k8s/json_patch.go
@@ -11,7 +11,7 @@ const (
 
 // JSONPatch structure based on the RFC 6902
 type JSONPatch struct {
-	OP    string      `json:"op,omitempty"`
-	Path  string      `json:"path,omitempty"`
-	Value interface{} `json:"value"`
+	OP    string `json:"op,omitempty"`
+	Path  string `json:"path,omitempty"`
+	Value any    `json:"value"`
 }

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -749,7 +749,7 @@ func (r *resource[T]) newInformer() (cache.Indexer, cache.Controller) {
 		ObjectType:       r.opts.sourceObj(),
 		FullResyncPeriod: 0,
 		RetryOnError:     false,
-		Process: func(obj interface{}, isInInitialList bool) error {
+		Process: func(obj any, isInInitialList bool) error {
 			// Processing of the deltas is done under the resource mutex. This
 			// avoids emitting double events for new subscribers that list the
 			// keys in the store.
@@ -757,7 +757,7 @@ func (r *resource[T]) newInformer() (cache.Indexer, cache.Controller) {
 			defer r.mu.RUnlock()
 
 			for _, d := range obj.(cache.Deltas) {
-				var obj interface{}
+				var obj any
 				if transformer != nil {
 					var err error
 					if obj, err = transformer(d.Object); err != nil {

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -329,7 +329,7 @@ func TestResource_RepeatedDelete(t *testing.T) {
 	// Repeatedly create and delete the node in the background
 	// while "unreliably" processing some of the delete events.
 	go func() {
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			node.ObjectMeta.ResourceVersion = fmt.Sprintf("%d", i)
 
 			lw.events <- watch.Event{
@@ -678,7 +678,7 @@ func TestResource_WithIndexers(t *testing.T) {
 	events := nodeResource.Events(ctx)
 
 	// wait for the upsert events
-	for i := 0; i < len(nodes); i++ {
+	for range len(nodes) {
 		ev, ok := <-events
 		require.True(t, ok)
 		require.Equal(t, resource.Upsert, ev.Kind)

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -635,7 +635,7 @@ func TestResource_WithIndexers(t *testing.T) {
 		fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 
 		indexName = "node-index-key"
-		indexFunc = func(obj interface{}) ([]string, error) {
+		indexFunc = func(obj any) ([]string, error) {
 			switch t := obj.(type) {
 			case *corev1.Node:
 				return []string{t.Name}, nil

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -972,14 +972,12 @@ func BenchmarkResource(b *testing.B) {
 	assert.Equal(b, resource.Sync, ev.Kind)
 	ev.Done(nil)
 
-	b.ResetTimer()
-
 	var wg sync.WaitGroup
 
 	// Feed in b.N nodes as watcher events
 	wg.Add(1)
 	go func() {
-		for i := 0; i < b.N; i++ {
+		for i := 0; b.Loop(); i++ {
 			name := fmt.Sprintf("node-%d", i)
 			lw.events <- watch.Event{Type: watch.Added, Object: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -992,7 +990,7 @@ func BenchmarkResource(b *testing.B) {
 	}()
 
 	// Consume the events via the resource
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ev, ok := <-events
 		assert.True(b, ok)
 		assert.Equal(b, resource.Upsert, ev.Kind)

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -73,8 +73,8 @@ func namespaceIndexFunc(obj any) ([]string, error) {
 	return []string{object.GetNamespace()}, nil
 }
 
-func GetIdentitiesByKeyFunc(keyFunc func(map[string]string) allocator.AllocatorKey) func(obj interface{}) ([]string, error) {
-	return func(obj interface{}) ([]string, error) {
+func GetIdentitiesByKeyFunc(keyFunc func(map[string]string) allocator.AllocatorKey) func(obj any) ([]string, error) {
+	return func(obj any) ([]string, error) {
 		if identity, ok := obj.(*cilium_api_v2.CiliumIdentity); ok {
 			return []string{keyFunc(identity.SecurityLabels).GetKey()}, nil
 		}

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -1689,8 +1689,7 @@ func BenchmarkCorrelateEndpoints(b *testing.B) {
 		}(i), &swg)
 	}
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		eps, ready := cache.correlateEndpoints(id)
 		assert.True(b, ready)
 		assert.Len(b, eps.Backends, epslices*epsPerSlice)

--- a/pkg/k8s/slim/k8s/apis/meta/v1/time.go
+++ b/pkg/k8s/slim/k8s/apis/meta/v1/time.go
@@ -154,7 +154,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 }
 
 // ToUnstructured implements the value.UnstructuredConverter interface.
-func (t Time) ToUnstructured() interface{} {
+func (t Time) ToUnstructured() any {
 	if t.IsZero() {
 		return nil
 	}

--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -453,25 +453,25 @@ type cacheStoreListener struct {
 	onReplace                 func([]any)
 }
 
-func (s *cacheStoreListener) Add(obj interface{}) error {
+func (s *cacheStoreListener) Add(obj any) error {
 	s.onAdd(obj)
 	return nil
 }
 
-func (s *cacheStoreListener) Update(obj interface{}) error {
+func (s *cacheStoreListener) Update(obj any) error {
 	s.onUpdate(obj)
 	return nil
 }
 
-func (s *cacheStoreListener) Delete(obj interface{}) error {
+func (s *cacheStoreListener) Delete(obj any) error {
 	s.onDelete(obj)
 	return nil
 }
 
-func (s *cacheStoreListener) Replace(items []interface{}, resourceVersion string) error {
+func (s *cacheStoreListener) Replace(items []any, resourceVersion string) error {
 	if items == nil {
 		// Always emit a non-nil slice for replace.
-		items = []interface{}{}
+		items = []any{}
 	}
 	s.onReplace(items)
 	return nil
@@ -479,14 +479,14 @@ func (s *cacheStoreListener) Replace(items []interface{}, resourceVersion string
 
 // These methods are never called by cache.Reflector:
 
-func (*cacheStoreListener) Get(obj interface{}) (item interface{}, exists bool, err error) {
+func (*cacheStoreListener) Get(obj any) (item any, exists bool, err error) {
 	panic("unimplemented")
 }
-func (*cacheStoreListener) GetByKey(key string) (item interface{}, exists bool, err error) {
+func (*cacheStoreListener) GetByKey(key string) (item any, exists bool, err error) {
 	panic("unimplemented")
 }
-func (*cacheStoreListener) List() []interface{} { panic("unimplemented") }
-func (*cacheStoreListener) ListKeys() []string  { panic("unimplemented") }
-func (*cacheStoreListener) Resync() error       { panic("unimplemented") }
+func (*cacheStoreListener) List() []any        { panic("unimplemented") }
+func (*cacheStoreListener) ListKeys() []string { panic("unimplemented") }
+func (*cacheStoreListener) Resync() error      { panic("unimplemented") }
 
 var _ cache.Store = &cacheStoreListener{}

--- a/pkg/k8s/statedb_test.go
+++ b/pkg/k8s/statedb_test.go
@@ -579,10 +579,8 @@ func BenchmarkStateDBReflector(b *testing.B) {
 		objs[i] = obj
 	}
 
-	b.ResetTimer()
-
 	// Do n rounds of upserting and deleting [numObjects] to benchmark the throughput
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		for _, obj := range objs {
 			lw.Upsert(obj.DeepCopy())
 		}

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -147,8 +147,8 @@ func SyncCRDs(ctx context.Context, logger *slog.Logger, clientset client.Clients
 		&slim_metav1.PartialObjectMetadata{},
 		0,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { crds.add(obj) },
-			DeleteFunc: func(obj interface{}) { crds.remove(obj) },
+			AddFunc:    func(obj any) { crds.add(obj) },
+			DeleteFunc: func(obj any) { crds.remove(obj) },
 		},
 		nil,
 	)
@@ -238,7 +238,7 @@ func SyncCRDs(ctx context.Context, logger *slog.Logger, clientset client.Clients
 	}
 }
 
-func (s *crdState) add(obj interface{}) {
+func (s *crdState) add(obj any) {
 	if pom := informer.CastInformerEvent[slim_metav1.PartialObjectMetadata](s.logger, obj); pom != nil {
 		s.Lock()
 		s.m[CRDResourceName(pom.GetName())] = true
@@ -246,7 +246,7 @@ func (s *crdState) add(obj interface{}) {
 	}
 }
 
-func (s *crdState) remove(obj interface{}) {
+func (s *crdState) remove(obj any) {
 	if pom := informer.CastInformerEvent[slim_metav1.PartialObjectMetadata](s.logger, obj); pom != nil {
 		s.Lock()
 		s.m[CRDResourceName(pom.GetName())] = false

--- a/pkg/k8s/watchers/cilium_local_redirect_policy.go
+++ b/pkg/k8s/watchers/cilium_local_redirect_policy.go
@@ -75,7 +75,7 @@ func (k *K8sCiliumLRPWatcher) ciliumLocalRedirectPolicyInit() {
 		&cilium_v2.CiliumLocalRedirectPolicy{},
 		0,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				var valid, equal bool
 				defer func() {
 					k.k8sEventReporter.K8sEventReceived(apiGroup, metricCLRP, resources.MetricCreate, valid, equal)
@@ -86,10 +86,10 @@ func (k *K8sCiliumLRPWatcher) ciliumLocalRedirectPolicyInit() {
 					k.k8sEventReporter.K8sEventProcessed(metricCLRP, resources.MetricCreate, err == nil)
 				}
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj any) {
 				k.logger.Info("Local Redirect Policy updates are not handled")
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				var valid, equal bool
 				defer func() {
 					k.k8sEventReporter.K8sEventReceived(apiGroup, metricCLRP, resources.MetricDelete, valid, equal)

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -190,7 +190,6 @@ func (k *K8sPodWatcher) podsInit(ctx context.Context) {
 					}
 					k.k8sResourceSynced.SetEventTimestamp(podApiGroup)
 					pods[name] = pod
-
 				} else {
 					k.deleteK8sPodV1(pod)
 					k.k8sResourceSynced.SetEventTimestamp(podApiGroup)

--- a/pkg/k8s/watchers/subscriber/raw.go
+++ b/pkg/k8s/watchers/subscriber/raw.go
@@ -34,7 +34,7 @@ func (l *RawChain) Register(cb cache.ResourceEventHandler) {
 }
 
 // NotifyAdd notifies all the subscribers of an add event to an object.
-func (l *RawChain) OnAdd(obj interface{}, isInInitialList bool) {
+func (l *RawChain) OnAdd(obj any, isInInitialList bool) {
 	l.RLock()
 	defer l.RUnlock()
 	for _, s := range l.subs {
@@ -43,7 +43,7 @@ func (l *RawChain) OnAdd(obj interface{}, isInInitialList bool) {
 }
 
 // NotifyUpdate notifies all the subscribers of an update event to an object.
-func (l *RawChain) OnUpdate(oldObj, newObj interface{}) {
+func (l *RawChain) OnUpdate(oldObj, newObj any) {
 	l.RLock()
 	defer l.RUnlock()
 	for _, s := range l.subs {
@@ -52,7 +52,7 @@ func (l *RawChain) OnUpdate(oldObj, newObj interface{}) {
 }
 
 // NotifyDelete notifies all the subscribers of an update event to an object.
-func (l *RawChain) OnDelete(obj interface{}) {
+func (l *RawChain) OnDelete(obj any) {
 	l.RLock()
 	defer l.RUnlock()
 	for _, s := range l.subs {

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -83,8 +83,7 @@ func benchmarkAllocate(b *testing.B) {
 	require.NotNil(b, a)
 	defer a.DeleteAllKeys()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		_, _, _, err := a.Allocate(context.Background(), TestAllocatorKey(fmt.Sprintf("key%04d", i)))
 		require.NoError(b, err)
 	}

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -31,7 +31,7 @@ func testLock(t *testing.T) {
 	Client().DeletePrefix(context.TODO(), prefix)
 	defer Client().DeletePrefix(context.TODO(), prefix)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		lock, err := LockPath(context.Background(), hivetest.Logger(t), Client(), fmt.Sprintf("%sfoo/%d", prefix, i))
 		require.NoError(t, err)
 		require.NotNil(t, lock)
@@ -64,7 +64,7 @@ func testGetSet(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, pairs)
 
-	for i := 0; i < maxID; i++ {
+	for i := range maxID {
 		val, err := Client().Get(context.TODO(), testKey(prefix, i))
 		require.NoError(t, err)
 		require.Nil(t, val)
@@ -80,7 +80,7 @@ func testGetSet(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, pairs, maxID)
 
-	for i := 0; i < maxID; i++ {
+	for i := range maxID {
 		require.NoError(t, Client().Delete(context.TODO(), testKey(prefix, i)))
 
 		val, err := Client().Get(context.TODO(), testKey(prefix, i))

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -107,8 +107,7 @@ func benchmarkGet(b *testing.B) {
 	key := testKey(prefix, 1)
 	require.NoError(b, Client().Update(context.TODO(), key, []byte(testValue(100)), false))
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := Client().Get(context.TODO(), key)
 		require.NoError(b, err)
 	}
@@ -126,8 +125,8 @@ func benchmarkSet(b *testing.B) {
 	defer Client().DeletePrefix(context.TODO(), prefix)
 
 	key, val := testKey(prefix, 1), testValue(100)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		require.NoError(b, Client().Update(context.TODO(), key, []byte(val), false))
 	}
 }

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -396,7 +396,7 @@ func (e *etcdMutex) Unlock(ctx context.Context) (err error) {
 	return e.mutex.Unlock(ctx)
 }
 
-func (e *etcdMutex) Comparator() interface{} {
+func (e *etcdMutex) Comparator() any {
 	return e.mutex.IsOwner()
 }
 

--- a/pkg/kvstore/etcd_lease_test.go
+++ b/pkg/kvstore/etcd_lease_test.go
@@ -96,14 +96,14 @@ func TestLeaseManager(t *testing.T) {
 	})
 
 	// Get the lease ID five times, and assert that the same ID is always returned
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		leaseID, err := mgr.GetLeaseID(ctx, fmt.Sprintf("key%d", i))
 		require.NoError(t, err, "GetLeaseID should succeed")
 		require.Equal(t, client.LeaseID(1), leaseID)
 	}
 
 	// Get the lease ID five more times, and assert that the same ID is always returned
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		leaseID, err := mgr.GetLeaseID(ctx, fmt.Sprintf("key%d", i+5))
 		require.NoError(t, err, "GetLeaseID should succeed")
 		require.Equal(t, client.LeaseID(2), leaseID)
@@ -160,7 +160,7 @@ func TestLeaseManagerParallel(t *testing.T) {
 	// assert that they all return the same lease ID
 	cl.grantDelay = 500 * time.Millisecond
 
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		go func(idx int) {
 			if idx%2 == 0 {
 				leaseID, err := mgr.GetLeaseID(ctx, fmt.Sprintf("key%d", idx))
@@ -174,7 +174,7 @@ func TestLeaseManagerParallel(t *testing.T) {
 		}(i)
 	}
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		require.Equal(t, client.LeaseID(1), <-ch)
 	}
 }
@@ -189,7 +189,7 @@ func TestLeaseManagerReleasePrefix(t *testing.T) {
 		mgr.Wait()
 	})
 
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		leaseID, err := mgr.GetLeaseID(ctx, fmt.Sprintf("key%d%d", i/3, i))
 		require.NoError(t, err, "GetLeaseID should succeed")
 		require.Equal(t, client.LeaseID(1+i/5), leaseID)
@@ -198,7 +198,7 @@ func TestLeaseManagerReleasePrefix(t *testing.T) {
 	// Delete the prefix which includes keys attached to both leases
 	mgr.ReleasePrefix("key1")
 
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		// Verify that the leases for the keys matching the prefix have been
 		// released, and that the others are still in place.
 		require.Equal(t, i/3 != 1, mgr.KeyHasLease(fmt.Sprintf("key%d%d", i/3, i), client.LeaseID(1+i/5)))
@@ -221,7 +221,7 @@ func TestLeaseManagerCancelIfExpired(t *testing.T) {
 		mgr.Wait()
 	})
 
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		leaseID, err := mgr.GetLeaseID(ctx, fmt.Sprintf("key%d", i))
 		require.NoError(t, err, "GetLeaseID should succeed")
 		require.Equal(t, client.LeaseID(1+i/5), leaseID)
@@ -245,7 +245,7 @@ func TestLeaseManagerCancelIfExpired(t *testing.T) {
 
 	// Ensure consistent ordering since the expired entries are retrieved from a map.
 	var expired []string
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		expired = append(expired, <-expiredCH)
 	}
 	slices.Sort(expired)
@@ -267,7 +267,7 @@ func TestLeaseManagerKeyHasLease(t *testing.T) {
 		mgr.Wait()
 	})
 
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		leaseID, err := mgr.GetLeaseID(ctx, fmt.Sprintf("key%d", i))
 		require.NoError(t, err, "GetLeaseID should succeed")
 		require.Equal(t, client.LeaseID(1+i/5), leaseID)

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -1179,7 +1179,7 @@ func TestShuffleEndpoints(t *testing.T) {
 	copy(s2, s1)
 
 	var same int
-	for retry := 0; retry < 10; retry++ {
+	for range 10 {
 		same = 0
 		shuffleEndpoints(s2)
 		for i := range s1 {
@@ -1376,7 +1376,7 @@ func testEtcdRateLimiter(t *testing.T, qps, count int, cmp func(require.TestingT
 			})
 
 			if tt.populateKVPairs {
-				for i := 0; i < count; i++ {
+				for i := range count {
 					_, err := client.Put(ctx, getKey(i), value)
 					require.NoError(t, err)
 				}
@@ -1398,7 +1398,7 @@ func testEtcdRateLimiter(t *testing.T, qps, count int, cmp func(require.TestingT
 
 			start := time.Now()
 			wg := sync.WaitGroup{}
-			for i := 0; i < count; i++ {
+			for i := range count {
 				wg.Add(1)
 				go func(wg *sync.WaitGroup, i int) {
 					defer wg.Done()

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -1208,7 +1208,7 @@ func TestEtcdRateLimiter(t *testing.T) {
 	})
 }
 
-func testEtcdRateLimiter(t *testing.T, qps, count int, cmp func(require.TestingT, interface{}, interface{}, ...interface{})) {
+func testEtcdRateLimiter(t *testing.T, qps, count int, cmp func(require.TestingT, any, any, ...any)) {
 	const (
 		prefix  = "foo"
 		condKey = prefix + "-cond-key"

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -36,7 +36,7 @@ type KVLocker interface {
 	// Comparator returns an object that should be used by the KVStore to make
 	// sure if the lock is still valid for its client or nil if no such
 	// verification exists.
-	Comparator() interface{}
+	Comparator() any
 }
 
 // getLockPath returns the lock path representation of the given path.
@@ -169,6 +169,6 @@ func (l *Lock) Unlock(ctx context.Context) error {
 	return err
 }
 
-func (l *Lock) Comparator() interface{} {
+func (l *Lock) Comparator() any {
 	return l.kvLock.Comparator()
 }

--- a/pkg/kvstore/store/syncstore_test.go
+++ b/pkg/kvstore/store/syncstore_test.go
@@ -59,7 +59,7 @@ func GetFactory(t *testing.T) (Factory, *Metrics) {
 func (fb *fakeBackend) Update(ctx context.Context, key string, value []byte, lease bool) error {
 	if lease != fb.expectLease {
 		key = "error"
-		value = []byte(fmt.Sprintf("incorrect lease setting, expected(%v) - found(%v)", fb.expectLease, lease))
+		value = fmt.Appendf(nil, "incorrect lease setting, expected(%v) - found(%v)", fb.expectLease, lease)
 	}
 
 	select {

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -367,7 +367,7 @@ func TestHappyPathPermutations(t *testing.T) {
 		} else {
 			generate(k-1, fns)
 
-			for i := 0; i < k-1; i++ {
+			for i := range k - 1 {
 				if k%2 == 0 {
 					fns[i], fns[k-1] = fns[k-1], fns[i]
 				} else {

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -274,10 +274,7 @@ func (ls LabelArray) Equals(b LabelArray) bool {
 func (ls LabelArray) Less(b LabelArray) bool {
 	lsLen, bLen := len(ls), len(b)
 
-	minLen := lsLen
-	if bLen < minLen {
-		minLen = bLen
-	}
+	minLen := min(bLen, lsLen)
 
 	for i := range minLen {
 		switch {

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -279,7 +279,7 @@ func (ls LabelArray) Less(b LabelArray) bool {
 		minLen = bLen
 	}
 
-	for i := 0; i < minLen; i++ {
+	for i := range minLen {
 		switch {
 		// Key
 		case ls[i].Key < b[i].Key:

--- a/pkg/labels/array_test.go
+++ b/pkg/labels/array_test.go
@@ -276,8 +276,8 @@ func TestOutputConversions(t *testing.T) {
 func BenchmarkLabelArray_GetModel(b *testing.B) {
 	l := NewLabelArrayFromSortedList("a;b;c;d;e;f;g;h;i;j;k;l;m;n;o;p;q;r;s;t;u;v;w;x;y;z")
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = l.GetModel()
 	}
 }
@@ -285,8 +285,8 @@ func BenchmarkLabelArray_GetModel(b *testing.B) {
 func BenchmarkLabelArray_String(b *testing.B) {
 	l := NewLabelArrayFromSortedList("a;b;c;d;e;f;g;h;i;j;k;l;m;n;o;p;q;r;s;t;u;v;w;x;y;z")
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = l.String()
 	}
 }

--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -33,7 +33,7 @@ func maskedIPToLabel(ipStr string, prefix int) Label {
 			1, /* '/' */
 	)
 
-	for i := 0; i < len(ipStr); i++ {
+	for i := range len(ipStr) {
 		if ipStr[i] == ':' {
 			// EndpointSelector keys can't start or end with a "-", so insert a
 			// zero at the start or end if it would otherwise have a "-" at that

--- a/pkg/labels/cidr_test.go
+++ b/pkg/labels/cidr_test.go
@@ -234,7 +234,7 @@ func BenchmarkIPStringToLabel(b *testing.B) {
 	} {
 		b.Run(ip, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_, err := IPStringToLabel(ip)
 				if err != nil {
 					b.Fatal(err)

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -195,8 +195,8 @@ func BenchmarkParseLabel(b *testing.B) {
 		{LabelSourceReservedKeyPrefix + "host", NewLabel("host", "", LabelSourceReserved)},
 	}
 	count := 0
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for _, test := range tests {
 			if ParseLabel(test.str).Source == LabelSourceUnspec {
 				count++
@@ -510,16 +510,16 @@ func TestLabels_HasSource(t *testing.T) {
 
 func BenchmarkNewFrom(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = NewFrom(lbls)
 	}
 }
 
 func BenchmarkLabels_SortedList(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = lbls.SortedList()
 	}
 }
@@ -527,8 +527,8 @@ func BenchmarkLabels_SortedList(b *testing.B) {
 func BenchmarkLabel_FormatForKVStore(b *testing.B) {
 	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", LabelSourceK8s)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = l.FormatForKVStore()
 	}
 }
@@ -536,16 +536,16 @@ func BenchmarkLabel_FormatForKVStore(b *testing.B) {
 func BenchmarkLabel_String(b *testing.B) {
 	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", LabelSourceK8s)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = l.String()
 	}
 }
 
 func BenchmarkGenerateLabelString(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+
+	for b.Loop() {
 		generateLabelString("foo", "key", "value")
 	}
 }

--- a/pkg/loadbalancer/experimental/benchmark/benchmark.go
+++ b/pkg/loadbalancer/experimental/benchmark/benchmark.go
@@ -126,7 +126,7 @@ func RunBenchmark(testSize int, iterations int, loglevel slog.Level, validate bo
 
 	var runs []run
 
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		runtime.GC()
 		var memory memoryPair
 		runtime.ReadMemStats(&memory.before)

--- a/pkg/loadbalancer/experimental/benchmark_test.go
+++ b/pkg/loadbalancer/experimental/benchmark_test.go
@@ -56,11 +56,9 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int) {
 	}
 	wtxn.Commit()
 
-	b.ResetTimer()
-
 	// Benchmark the speed at which a new service is upserted. 'numObjects' are inserted in one
 	// WriteTxn.
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		wtxn := p.Writer.WriteTxn()
 		for i := range numObjects {
 			name := loadbalancer.ServiceName{Namespace: "test-new", Name: fmt.Sprintf("svc-%d", i)}
@@ -110,13 +108,11 @@ func BenchmarkInsertBackend(b *testing.B) {
 	)
 	wtxn.Commit()
 
-	b.ResetTimer()
-
 	// Create 100 backends for the single service & frontend to benchmark a more extreme
 	// case.
 	numObjects := 100
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		wtxn = p.Writer.WriteTxn()
 		for i := range numObjects {
 			beAddr := *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster2, uint16(i), loadbalancer.ScopeExternal)
@@ -172,9 +168,8 @@ func BenchmarkReplaceBackend(b *testing.B) {
 	)
 	wtxn.Commit()
 
-	b.ResetTimer()
 	wtxn = p.Writer.WriteTxn()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		p.Writer.UpsertBackends(
 			wtxn,
 			name,
@@ -215,11 +210,9 @@ func BenchmarkReplaceService(b *testing.B) {
 
 	wtxn.Commit()
 
-	b.ResetTimer()
-
 	// Replace the service b.N times
 	wtxn = p.Writer.WriteTxn()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		p.Writer.UpsertServiceAndFrontends(
 			wtxn,
 			&Service{

--- a/pkg/loadbalancer/experimental/benchmark_test.go
+++ b/pkg/loadbalancer/experimental/benchmark_test.go
@@ -35,7 +35,7 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int) {
 	// realistic as we'll then have existing objects in the table which makes the
 	// inserts slightly more costly.
 	wtxn := p.Writer.WriteTxn()
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		name := loadbalancer.ServiceName{Namespace: "test-existing", Name: fmt.Sprintf("svc-%d", i)}
 		var addr1 [4]byte
 		binary.BigEndian.PutUint32(addr1[:], 0x02000000+uint32(i))
@@ -62,7 +62,7 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int) {
 	// WriteTxn.
 	for n := 0; n < b.N; n++ {
 		wtxn := p.Writer.WriteTxn()
-		for i := 0; i < numObjects; i++ {
+		for i := range numObjects {
 			name := loadbalancer.ServiceName{Namespace: "test-new", Name: fmt.Sprintf("svc-%d", i)}
 			var addr1 [4]byte
 			binary.BigEndian.PutUint32(addr1[:], 0x01000000+uint32(i))
@@ -118,7 +118,7 @@ func BenchmarkInsertBackend(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		wtxn = p.Writer.WriteTxn()
-		for i := 0; i < numObjects; i++ {
+		for i := range numObjects {
 			beAddr := *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster2, uint16(i), loadbalancer.ScopeExternal)
 			p.Writer.UpsertBackends(
 				wtxn,

--- a/pkg/loadbalancer/experimental/reflector_test.go
+++ b/pkg/loadbalancer/experimental/reflector_test.go
@@ -36,8 +36,7 @@ func BenchmarkConvertService(b *testing.B) {
 	}
 	svc := obj.(*slim_corev1.Service)
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		convertService(benchmarkExternalConfig, slog.New(slog.DiscardHandler), svc)
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "services/sec")
@@ -50,8 +49,8 @@ func BenchmarkParseEndpointSlice(b *testing.B) {
 	}
 	epSlice := obj.(*slim_discovery_v1.EndpointSlice)
 	logger := hivetest.Logger(b)
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		k8s.ParseEndpointSliceV1(logger, epSlice)
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpointslices/sec")
@@ -66,8 +65,7 @@ func BenchmarkConvertEndpoints(b *testing.B) {
 	logger := hivetest.Logger(b)
 	eps := k8s.ParseEndpointSliceV1(logger, epSlice)
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		convertEndpoints(benchmarkExternalConfig, eps)
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpoints/sec")

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -725,8 +725,8 @@ func TestServiceNameYAML(t *testing.T) {
 
 func benchmarkHash(b *testing.B, addr *L3n4Addr) {
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		addr.Hash()
 	}
 }
@@ -753,9 +753,9 @@ func BenchmarkL3n4Addr_Hash_IPv6_Max(b *testing.B) {
 
 func benchmarkString(b *testing.B, addr *L3n4Addr) {
 	b.ReportAllocs()
-	b.ResetTimer()
+
 	var length int
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		length += len(addr.String())
 	}
 }
@@ -772,8 +772,8 @@ func BenchmarkL3n4Addr_String_IPv6_Max(b *testing.B) {
 
 func benchmarkStringWithProtocol(b *testing.B, addr *L3n4Addr) {
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		addr.StringWithProtocol()
 	}
 }

--- a/pkg/loadinfo/loadinfo.go
+++ b/pkg/loadinfo/loadinfo.go
@@ -31,7 +31,7 @@ const (
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "loadinfo")
 
 // LogFunc is the function to used to log the system load
-type LogFunc func(format string, args ...interface{})
+type LogFunc func(format string, args ...any)
 
 func toMB(total uint64) uint64 {
 	return total / 1024 / 1024

--- a/pkg/lock/sortable_mutex_test.go
+++ b/pkg/lock/sortable_mutex_test.go
@@ -44,7 +44,7 @@ func TestSortableMutex_Chaos(t *testing.T) {
 
 	monkey := func() {
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			// Take a random subset of the sortable mutexes.
 			subSmus := slices.Clone(smus)
 			rand.Shuffle(len(subSmus), func(i, j int) {
@@ -61,7 +61,7 @@ func TestSortableMutex_Chaos(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < nMonkeys; i++ {
+	for range nMonkeys {
 		go monkey()
 	}
 

--- a/pkg/lock/stoppable_waitgroup_test.go
+++ b/pkg/lock/stoppable_waitgroup_test.go
@@ -173,7 +173,7 @@ func TestParallelism(t *testing.T) {
 	var adds atomic.Int64
 	var wg sync.WaitGroup
 	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			defer wg.Done()
 			for a := range in {

--- a/pkg/logging/logfields/helpers.go
+++ b/pkg/logging/logfields/helpers.go
@@ -8,6 +8,6 @@ import (
 )
 
 // Repr formats an object with the Printf %+v formatter
-func Repr(s interface{}) string {
+func Repr(s any) string {
 	return fmt.Sprintf("%+v", s)
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -152,7 +152,7 @@ func severityOverrideWriter(level logrus.Level, log *logrus.Entry, overrides []l
 func writerScanner(
 	entry *logrus.Entry,
 	reader *io.PipeReader,
-	defaultPrintFunc func(args ...interface{}),
+	defaultPrintFunc func(args ...any),
 	overrides []logLevelOverride) {
 
 	defer reader.Close()
@@ -397,7 +397,7 @@ func getLogDriverConfig(logDriver string, logOpts LogOptions) LogOptions {
 
 // MultiLine breaks a multi line text into individual log entries and calls the
 // logging function to log each entry
-func MultiLine(logFn func(args ...interface{}), output string) {
+func MultiLine(logFn func(args ...any), output string) {
 	scanner := bufio.NewScanner(bytes.NewReader([]byte(output)))
 	for scanner.Scan() {
 		logFn(scanner.Text())

--- a/pkg/mac/mac.go
+++ b/pkg/mac/mac.go
@@ -82,7 +82,7 @@ func (m MAC) MarshalJSON() ([]byte, error) {
 	if len(m) != 6 {
 		return nil, fmt.Errorf("invalid MAC address length %s", string(m))
 	}
-	return []byte(fmt.Sprintf("\"%02x:%02x:%02x:%02x:%02x:%02x\"", m[0], m[1], m[2], m[3], m[4], m[5])), nil
+	return fmt.Appendf(nil, "\"%02x:%02x:%02x:%02x:%02x:%02x\"", m[0], m[1], m[2], m[3], m[4], m[5]), nil
 }
 
 func (m MAC) MarshalIndentJSON(prefix, indent string) ([]byte, error) {

--- a/pkg/maglev/maglev_test.go
+++ b/pkg/maglev/maglev_test.go
@@ -237,8 +237,7 @@ func benchmarkGetMaglevTable(b *testing.B, m uint64) {
 		backends[i].setHashString()
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		table := ml.GetLookupTable(slices.Values(backends))
 		require.Len(b, table, int(m))
 	}

--- a/pkg/maglev/maglev_test.go
+++ b/pkg/maglev/maglev_test.go
@@ -34,7 +34,7 @@ func TestPermutations(t *testing.T) {
 	}
 	for _, bCount := range []int{0, 1, 2, 5, 111, 222, 333, 1001} {
 		backends := make([]BackendInfo, bCount)
-		for i := 0; i < len(backends); i++ {
+		for i := range backends {
 			backends[i] = BackendInfo{
 				Addr:   mkAddr(int32(i)),
 				ID:     loadbalancer.BackendID(i),
@@ -230,7 +230,7 @@ func benchmarkGetMaglevTable(b *testing.B, m uint64) {
 	ml.backendInfosBuffer = make([]BackendInfo, 0, 1024)
 
 	backends := make([]BackendInfo, backendCount)
-	for i := 0; i < backendCount; i++ {
+	for i := range backendCount {
 		backends[i] = BackendInfo{ID: loadbalancer.BackendID(i), Weight: 1, Addr: mkAddr(int32(i))}
 		// Already compute hash string so we compare apples-to-apples to prev benchmarks. Previously
 		// the backends were passed in as map[string]*Backend so these strings precomputed.

--- a/pkg/maps/authmap/auth_map.go
+++ b/pkg/maps/authmap/auth_map.go
@@ -108,7 +108,7 @@ type IterateCallback func(*AuthKey, *AuthInfo)
 
 func (m *authMap) IterateWithCallback(cb IterateCallback) error {
 	return m.bpfMap.IterateWithCallback(&AuthKey{}, &AuthInfo{},
-		func(k, v interface{}) {
+		func(k, v any) {
 			key := k.(*AuthKey)
 			value := v.(*AuthInfo)
 			cb(key, value)

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -762,21 +762,14 @@ func calculateInterval(prevInterval time.Duration, maxDeleteRatio float64) (inte
 			maxDeleteRatio = 0.9
 		}
 		// 25%..90% => 1.3x..10x shorter
-		interval = time.Duration(float64(interval) * (1.0 - maxDeleteRatio)).Round(time.Second)
-
-		if interval < defaults.ConntrackGCMinInterval {
-			interval = defaults.ConntrackGCMinInterval
-		}
+		interval = max(time.Duration(float64(interval)*(1.0-maxDeleteRatio)).Round(time.Second), defaults.ConntrackGCMinInterval)
 
 	case maxDeleteRatio < 0.05:
 		// When less than 5% of entries were deleted, increase the
 		// interval. Use a simple 1.5x multiplier to start growing slowly
 		// as a new node may not be seeing workloads yet and thus the
 		// scan will return a low deletion ratio at first.
-		interval = time.Duration(float64(interval) * 1.5).Round(time.Second)
-		if interval > defaults.ConntrackGCMaxLRUInterval {
-			interval = defaults.ConntrackGCMaxLRUInterval
-		}
+		interval = min(time.Duration(float64(interval)*1.5).Round(time.Second), defaults.ConntrackGCMaxLRUInterval)
 	}
 
 	cachedGCInterval = interval

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -45,8 +45,8 @@ func BenchmarkMapBatchLookup(b *testing.B) {
 	_ = populateFakeDataCTMap4(b, m, option.CTMapEntriesGlobalTCPDefault)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		count, err := m.Count(context.TODO())
 		assert.NoError(b, err)
 		assert.Greater(b, count, option.CTMapEntriesGlobalAnyDefault)
@@ -85,7 +85,7 @@ func Benchmark_MapUpdate(b *testing.B) {
 	}
 
 	require.Less(b, b.N, 0xFFFF*0xFFFF)
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		key.DestPort = uint16(i % 0xFFFF)
 		key.SourcePort = uint16(i / 0xFFFF)
 		err := m.Map.Update(key, value)
@@ -852,7 +852,7 @@ func BenchmarkCtGcTcpM(t *testing.B) {
 }
 
 func benchmarkCtGc(t *testing.B, size int) {
-	for range t.N {
+	for t.Loop() {
 		t.StopTimer()
 		setupCTMap(t)
 		// Init maps

--- a/pkg/maps/ctmap/per_cluster_ctmap_test.go
+++ b/pkg/maps/ctmap/per_cluster_ctmap_test.go
@@ -25,7 +25,7 @@ func setup(tb testing.TB) {
 }
 
 func BenchmarkPerClusterCTMapUpdate(b *testing.B) {
-	b.StopTimer()
+
 	setup(b)
 
 	om := newPerClusterCTMap(mapTypeIPv4TCPGlobal)
@@ -37,9 +37,7 @@ func BenchmarkPerClusterCTMapUpdate(b *testing.B) {
 		require.NoError(b, CleanupPerClusterCTMaps(true, true), "Failed to cleanup maps")
 	})
 
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		require.NoError(b, om.createClusterCTMap(1), "Failed to create map")
 	}
 
@@ -47,7 +45,7 @@ func BenchmarkPerClusterCTMapUpdate(b *testing.B) {
 }
 
 func BenchmarkPerClusterCTMapLookup(b *testing.B) {
-	b.StopTimer()
+
 	setup(b)
 
 	om := newPerClusterCTMap(mapTypeIPv4TCPGlobal)
@@ -61,10 +59,8 @@ func BenchmarkPerClusterCTMapLookup(b *testing.B) {
 
 	require.NoError(b, om.createClusterCTMap(1), "Failed to create map")
 
-	b.StartTimer()
-
 	key := &PerClusterCTMapKey{1}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := om.Lookup(key)
 		require.NoError(b, err, "Failed to lookup element")
 	}

--- a/pkg/maps/eventsmap/cell.go
+++ b/pkg/maps/eventsmap/cell.go
@@ -25,7 +25,7 @@ var (
 	MaxEntries int
 )
 
-type Map interface{}
+type Map any
 
 func newEventsMap(lifecycle cell.Lifecycle) bpf.MapOut[Map] {
 	eventsMap := &eventsMap{}

--- a/pkg/maps/l2respondermap/l2_responder_map4.go
+++ b/pkg/maps/l2respondermap/l2_responder_map4.go
@@ -103,7 +103,7 @@ type IterateCallback func(*L2ResponderKey, *L2ResponderStats)
 // passing each key/value pair to the cb callback.
 func (m *l2ResponderMap) IterateWithCallback(cb IterateCallback) error {
 	return m.Map.IterateWithCallback(&L2ResponderKey{}, &L2ResponderStats{},
-		func(k, v interface{}) {
+		func(k, v any) {
 			key := k.(*L2ResponderKey)
 			value := v.(*L2ResponderStats)
 			cb(key, value)

--- a/pkg/maps/lbmap/skip_lb_map.go
+++ b/pkg/maps/lbmap/skip_lb_map.go
@@ -114,7 +114,7 @@ func (m *skipLBMap) AllLB4() iter.Seq2[*SkipLB4Key, *SkipLB4Value] {
 		}
 		stop := false
 		m.bpfMap4.IterateWithCallback(&SkipLB4Key{}, &SkipLB4Value{},
-			func(k, v interface{}) {
+			func(k, v any) {
 				key := k.(*SkipLB4Key)
 				value := v.(*SkipLB4Value)
 				key.Port = byteorder.NetworkToHost16(key.Port)
@@ -132,7 +132,7 @@ func (m *skipLBMap) AllLB6() iter.Seq2[*SkipLB6Key, *SkipLB6Value] {
 		}
 		stop := false
 		m.bpfMap6.IterateWithCallback(&SkipLB6Key{}, &SkipLB6Value{},
-			func(k, v interface{}) {
+			func(k, v any) {
 				key := k.(*SkipLB6Key)
 				value := v.(*SkipLB6Value)
 				key.Port = byteorder.NetworkToHost16(key.Port)
@@ -188,7 +188,7 @@ func (m *skipLBMap) DeleteLB4ByAddrPort(ip net.IP, port uint16) {
 		}
 	}
 	if err := m.bpfMap4.IterateWithCallback(&SkipLB4Key{}, &SkipLB4Value{},
-		func(k, v interface{}) {
+		func(k, v any) {
 			key := k.(*SkipLB4Key)
 			value := v.(*SkipLB4Value)
 			deleteEntry(key, value)
@@ -226,7 +226,7 @@ func (m *skipLBMap) DeleteLB4ByNetnsCookie(cookie uint64) {
 		}
 	}
 	if err := m.bpfMap4.IterateWithCallback(&SkipLB4Key{}, &SkipLB4Value{},
-		func(k, v interface{}) {
+		func(k, v any) {
 			key := k.(*SkipLB4Key)
 			value := v.(*SkipLB4Value)
 			deleteEntry(key, value)
@@ -263,7 +263,7 @@ func (m *skipLBMap) DeleteLB6ByAddrPort(ip net.IP, port uint16) {
 		}
 	}
 	if err := m.bpfMap6.IterateWithCallback(&SkipLB6Key{}, &SkipLB6Value{},
-		func(k, v interface{}) {
+		func(k, v any) {
 			key := k.(*SkipLB6Key)
 			value := v.(*SkipLB6Value)
 			deleteEntry(key, value)
@@ -301,7 +301,7 @@ func (m *skipLBMap) DeleteLB6ByNetnsCookie(cookie uint64) {
 		}
 	}
 	if err := m.bpfMap6.IterateWithCallback(&SkipLB6Key{}, &SkipLB6Value{},
-		func(k, v interface{}) {
+		func(k, v any) {
 			key := k.(*SkipLB6Key)
 			value := v.(*SkipLB6Value)
 			deleteEntry(key, value)

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -104,7 +104,7 @@ type Values []Value
 // IterateWithCallback iterates through all the keys/values of a metrics map,
 // passing each key/value pair to the cb callback
 func (m metricsMap) IterateWithCallback(cb IterateCallback) error {
-	return m.Map.IterateWithCallback(&Key{}, &Values{}, func(k, v interface{}) {
+	return m.Map.IterateWithCallback(&Key{}, &Values{}, func(k, v any) {
 		key := k.(*Key)
 		values := v.(*Values)
 		cb(key, values)

--- a/pkg/maps/nat/nat_batch_test.go
+++ b/pkg/maps/nat/nat_batch_test.go
@@ -20,7 +20,7 @@ func TestDumpBatch4(t *testing.T) {
 	err := m.OpenOrCreate()
 	assert.NoError(t, err)
 	defer assert.NoError(t, m.UnpinIfExists())
-	for i := 0; i < 1024+1; i++ {
+	for i := range 1024 + 1 {
 		var ip types.IPv4
 		ip[0] = byte(i)
 		ip[1] = byte(i >> 8)

--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -333,7 +333,7 @@ func (t *topk) Push(key SNATTupleAccessor, count int) {
 }
 
 func (t *topk) popForEach(fn func(key SNATTupleAccessor, count, ith int)) {
-	for i := 0; i < t.size; i++ {
+	for i := range t.size {
 		tuple := heap.Pop(t.mq).(tupleBucket)
 		fn(tuple.key, tuple.count, t.size-i)
 	}

--- a/pkg/maps/nodemap/node_map.go
+++ b/pkg/maps/nodemap/node_map.go
@@ -114,7 +114,7 @@ type NodeIterateCallback func(*NodeKey, *NodeValue)
 
 func (m *nodeMap) IterateWithCallback(cb NodeIterateCallback) error {
 	return m.bpfMap.IterateWithCallback(&NodeKey{}, &NodeValue{},
-		func(k, v interface{}) {
+		func(k, v any) {
 			key := k.(*NodeKey)
 			value := v.(*NodeValue)
 

--- a/pkg/maps/nodemap/node_map_v2.go
+++ b/pkg/maps/nodemap/node_map_v2.go
@@ -121,7 +121,7 @@ type NodeIterateCallbackV2 func(*NodeKey, *NodeValueV2)
 
 func (m *nodeMapV2) IterateWithCallback(cb NodeIterateCallbackV2) error {
 	return m.bpfMap.IterateWithCallback(&NodeKey{}, &NodeValueV2{},
-		func(k, v interface{}) {
+		func(k, v any) {
 			key, ok := k.(*NodeKey)
 			if !ok {
 				log.WithField("key", k).Error("failed to cast key to NodeKey")

--- a/pkg/metrics/bpf.go
+++ b/pkg/metrics/bpf.go
@@ -113,7 +113,7 @@ func (s *bpfCollector) Collect(ch chan<- prometheus.Metric) {
 
 	// Avoid querying BPF multiple times concurrently, if it happens, additional callers will wait for the
 	// first one to finish and reuse its resulting values.
-	results, err, _ := s.sfg.Do("collect", func() (interface{}, error) {
+	results, err, _ := s.sfg.Do("collect", func() (any, error) {
 		var (
 			results = bpfUsageResults{}
 			err     error

--- a/pkg/metrics/bpf.go
+++ b/pkg/metrics/bpf.go
@@ -128,7 +128,7 @@ func (s *bpfCollector) Collect(ch chan<- prometheus.Metric) {
 
 		if results.programs, err = getBPFUsage("prog", func(entry memoryEntry) bool {
 			// Filter on programs related to cilium maps
-			for i := 0; i < len(entry.MapIDs); i++ {
+			for i := range entry.MapIDs {
 				if slices.Contains(results.maps.ids, entry.MapIDs[i]) {
 					return true
 				}

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -70,7 +70,7 @@ func Metric[S any](ctor func() S) cell.Cell {
 
 	withMetaTyp := reflect.TypeOf(&withMeta).Elem()
 	collectorTyp := reflect.TypeOf(&collector).Elem()
-	for i := 0; i < outTyp.NumField(); i++ {
+	for i := range outTyp.NumField() {
 		field := outTyp.Field(i)
 		if !field.IsExported() {
 			panic(fmt.Errorf(
@@ -118,7 +118,7 @@ func provideMetrics[S any](metricSet S) hiveMetricOut {
 		return hiveMetricOut{}
 	}
 
-	for i := 0; i < typ.NumField(); i++ {
+	for i := range typ.NumField() {
 		if withMeta, ok := value.Field(i).Interface().(pkgmetric.WithMetadata); ok {
 			metrics = append(metrics, withMeta)
 		}

--- a/pkg/metrics/metric/collections/product.go
+++ b/pkg/metrics/metric/collections/product.go
@@ -24,7 +24,7 @@ func CartesianProduct[T any](vs ...[]T) [][]T {
 	}
 
 	lastm := 1
-	for i := 0; i < dimension; i++ {
+	for i := range dimension {
 		permuteColumn[T](dst, i, lastm, vs[i])
 		lastm = lastm * len(vs[i])
 	}
@@ -67,7 +67,7 @@ func permuteColumn[T any](dst [][]T, col int, leftPermSize int, vec []T) {
 	// You want to skip along, lastm elements at a time.
 	for i := 0; i < len(dst); i += leftPermSize { // So we're skipping n rows at a time,
 		vi := (i / leftPermSize) % len(vec)
-		for off := 0; off < leftPermSize; off++ { // this is a repeat
+		for off := range leftPermSize { // this is a repeat
 			dst[i+off][col] = vec[vi]
 		}
 	}

--- a/pkg/metrics/metric/collections/product_test.go
+++ b/pkg/metrics/metric/collections/product_test.go
@@ -59,5 +59,5 @@ func TestIteratorProductEmpty(t *testing.T) {
 	assert.Empty(CartesianProduct([]string{}, []string{}, []string{}))
 	assert.Empty(CartesianProduct[int]())
 	assert.Len(CartesianProduct([]string{""}, []string{""}, []string{""}), 1)
-	CartesianProduct[interface{}](nil, nil) // Test some weird cases.
+	CartesianProduct[any](nil, nil) // Test some weird cases.
 }

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -39,7 +39,7 @@ func (rw *ResponderWrapper) WriteHeader(code int) {
 //	"/v1/endpoint/container-id:597.." -> "/v1/endpoint"
 func getShortPath(s string) string {
 	var idxSum int
-	for nThSlash := 0; nThSlash < 3; nThSlash++ {
+	for range 3 {
 		idx := strings.IndexByte(s[idxSum:], '/')
 		if idx == -1 {
 			return s

--- a/pkg/metrics/plot.go
+++ b/pkg/metrics/plot.go
@@ -81,8 +81,8 @@ func PlotSamples(w io.Writer, rate bool, name, labels string, timeSpan, sampling
 
 	// Set up a canvas into which to draw in.
 	canvas := make([]rune, width*height)
-	for x := 0; x < width; x++ {
-		for y := 0; y < height; y++ {
+	for x := range width {
+		for y := range height {
 			if x >= originX && y <= originY {
 				// initialize the plot area to the braille base. this way we can
 				// just OR in the dots we want to show.
@@ -190,7 +190,7 @@ func PlotSamples(w io.Writer, rate bool, name, labels string, timeSpan, sampling
 	}
 
 	// Plot the samples (up to second to last column)
-	for x := 0; x < plotWidthDots-1; x++ {
+	for x := range plotWidthDots - 1 {
 		if v, exists := getSample(x); exists {
 			setDot(x, mapToY(v))
 		}

--- a/pkg/monitor/agent/agent.go
+++ b/pkg/monitor/agent/agent.go
@@ -42,7 +42,7 @@ func isCtxDone(ctx context.Context) bool {
 
 type Agent interface {
 	AttachToEventsMap(nPages int) error
-	SendEvent(typ int, event interface{}) error
+	SendEvent(typ int, event any) error
 	RegisterNewListener(newListener listener.MonitorListener)
 	RemoveListener(ml listener.MonitorListener)
 	RegisterNewConsumer(newConsumer consumer.MonitorConsumer)
@@ -130,7 +130,7 @@ func (a *agent) AttachToEventsMap(nPages int) error {
 }
 
 // SendEvent distributes an event to all monitor listeners
-func (a *agent) SendEvent(typ int, event interface{}) error {
+func (a *agent) SendEvent(typ int, event any) error {
 	if a == nil {
 		return fmt.Errorf("monitor agent is not set up")
 	}
@@ -403,7 +403,7 @@ func (a *agent) State() *models.MonitorStatus {
 }
 
 // notifyAgentEvent notifies all consumers about an agent event.
-func (a *agent) notifyAgentEvent(typ int, message interface{}) {
+func (a *agent) notifyAgentEvent(typ int, message any) {
 	a.Lock()
 	defer a.Unlock()
 	for mc := range a.consumers {

--- a/pkg/monitor/agent/cell.go
+++ b/pkg/monitor/agent/cell.go
@@ -79,10 +79,7 @@ func newMonitorAgent(params agentParams) Agent {
 						log.WithError(err).Error("failed to get number of possible CPUs")
 						return fmt.Errorf("failed to get number of possible CPUs: %w", err)
 					}
-					queueSize = possibleCPUs * defaults.MonitorQueueSizePerCPU
-					if queueSize > defaults.MonitorQueueSizePerCPUMaximum {
-						queueSize = defaults.MonitorQueueSizePerCPUMaximum
-					}
+					queueSize = min(possibleCPUs*defaults.MonitorQueueSizePerCPU, defaults.MonitorQueueSizePerCPUMaximum)
 				}
 
 				err = ServeMonitorAPI(ctx, agent, queueSize)

--- a/pkg/monitor/agent/consumer/consumer.go
+++ b/pkg/monitor/agent/consumer/consumer.go
@@ -10,7 +10,7 @@ type MonitorConsumer interface {
 	// depends on the value of typ:
 	//  - MessageTypeAccessLog:		accesslog.LogRecord
 	//  - MessageTypeAgent:			api.AgentNotify
-	NotifyAgentEvent(typ int, message interface{})
+	NotifyAgentEvent(typ int, message any)
 
 	// NotifyPerfEvent informs the consumer about an datapath event obtained
 	// via perf events ring buffer.

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -198,7 +198,7 @@ type AgentNotify struct {
 // constructors in this package for possible values.
 type AgentNotifyMessage struct {
 	Type         AgentNotification
-	Notification interface{}
+	Notification any
 }
 
 // ToJSON encodes a AgentNotifyMessage to its JSON-based AgentNotify representation

--- a/pkg/monitor/datapath_debug_test.go
+++ b/pkg/monitor/datapath_debug_test.go
@@ -54,9 +54,8 @@ func BenchmarkNewDecodeDebugCapture(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dbg := &DebugCapture{}
 		if err := DecodeDebugCapture(buf.Bytes(), dbg); err != nil {
 			b.Fatal(err)
@@ -73,9 +72,8 @@ func BenchmarkOldDecodeDebugCapture(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dbg := &DebugCapture{}
 		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, dbg); err != nil {
 			b.Fatal(err)
@@ -124,9 +122,8 @@ func BenchmarkNewDecodeDebugMsg(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dbg := &DebugMsg{}
 		if err := DecodeDebugMsg(buf.Bytes(), dbg); err != nil {
 			b.Fatal(err)
@@ -143,9 +140,8 @@ func BenchmarkOldDecodeDebugMsg(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dbg := &DebugMsg{}
 		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, dbg); err != nil {
 			b.Fatal(err)

--- a/pkg/monitor/datapath_drop_test.go
+++ b/pkg/monitor/datapath_drop_test.go
@@ -70,9 +70,8 @@ func BenchmarkNewDecodeDropNotify(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dn := &DropNotify{}
 		if err := DecodeDropNotify(buf.Bytes(), dn); err != nil {
 			b.Fatal(err)
@@ -89,9 +88,8 @@ func BenchmarkOldDecodeDropNotify(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		dn := &DropNotify{}
 		if err := binary.Read(bytes.NewReader(buf.Bytes()), byteorder.Native, dn); err != nil {
 			b.Fatal(err)

--- a/pkg/monitor/datapath_policy_test.go
+++ b/pkg/monitor/datapath_policy_test.go
@@ -69,9 +69,8 @@ func BenchmarkNewDecodePolicyVerdictNotify(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		pvn := &PolicyVerdictNotify{}
 		if err := DecodePolicyVerdictNotify(buf.Bytes(), pvn); err != nil {
 			b.Fatal(err)
@@ -88,9 +87,8 @@ func BenchmarkOldDecodePolicyVerdictNotify(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		pvn := &PolicyVerdictNotify{}
 		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, pvn); err != nil {
 			b.Fatal(err)

--- a/pkg/monitor/datapath_sock_trace_test.go
+++ b/pkg/monitor/datapath_sock_trace_test.go
@@ -64,9 +64,8 @@ func BenchmarkNewDecodeTraceSockNotify(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		tsn := &TraceSockNotify{}
 		if err := DecodeTraceSockNotify(buf.Bytes(), tsn); err != nil {
 			b.Fatal(err)
@@ -83,9 +82,8 @@ func BenchmarkOldDecodeTraceSockNotify(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		tsn := &TraceSockNotify{}
 		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, tsn); err != nil {
 			b.Fatal(err)

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -354,9 +354,8 @@ func BenchmarkDecodeTraceNotifyVersion0(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		tn := &TraceNotifyV0{}
 		if err := tn.decodeTraceNotifyVersion0(buf.Bytes()); err != nil {
 			b.Fatal(err)
@@ -373,9 +372,8 @@ func BenchmarkDecodeTraceNotifyVersion1(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		tn := &TraceNotifyV1{}
 		if err := tn.decodeTraceNotifyVersion1(buf.Bytes()); err != nil {
 			b.Fatal(err)

--- a/pkg/mtu/endpoint_updater.go
+++ b/pkg/mtu/endpoint_updater.go
@@ -351,7 +351,7 @@ func (emu *endpointUpdater) updateHealthEndpoint(routeMTUs []RouteMTU) error {
 		err error
 	)
 
-	for i := 0; i < healthEPRetries; i++ {
+	for range healthEPRetries {
 		pid, err = pidfile.Read(healthPIDPath)
 		if err == nil {
 			break
@@ -370,7 +370,7 @@ func (emu *endpointUpdater) updateHealthEndpoint(routeMTUs []RouteMTU) error {
 
 	file := fmt.Sprintf("/proc/%d/ns/net", pid)
 	var healthNS *netns.NetNS
-	for i := 0; i < healthEPRetries; i++ {
+	for range healthEPRetries {
 		healthNS, err = netns.OpenPinned(file)
 		if err == nil {
 			break

--- a/pkg/murmur3/murmur3.go
+++ b/pkg/murmur3/murmur3.go
@@ -23,7 +23,7 @@ func Hash128(data []byte, seed uint32) (uint64, uint64) {
 	h1 := uint64(seed)
 	h2 := uint64(seed)
 
-	for i := 0; i < nblocks; i++ {
+	for i := range nblocks {
 		tmp := (*[2]uint64)(unsafe.Pointer(&data[i*16]))
 		k1 := tmp[0]
 		k2 := tmp[1]

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -108,9 +108,8 @@ func BenchmarkLocalNodeStoreGet(b *testing.B) {
 	lns := NewTestLocalNodeStore(LocalNode{})
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = lns.Get(ctx)
 	}
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -432,13 +432,12 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		n := nodeTypes.Node{Name: fmt.Sprintf("%d", i), Source: source.Local}
 		mngr.NodeUpdated(n)
 	}
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		n := nodeTypes.Node{Name: fmt.Sprintf("%d", i), Source: source.Local}
 		mngr.NodeDeleted(n)
 	}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -458,7 +458,7 @@ func TestClusterSizeDependantInterval(t *testing.T) {
 
 	prevInterval := time.Nanosecond
 
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		n := nodeTypes.Node{Name: fmt.Sprintf("%d", i), Source: source.Local, IPAddresses: []nodeTypes.Address{
 			{
 				Type: addressing.NodeInternalIP,
@@ -504,7 +504,7 @@ func TestBackgroundSync(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		n := nodeTypes.Node{Name: fmt.Sprintf("%d", i), Source: source.Kubernetes, IPAddresses: []nodeTypes.Address{
 			{
 				Type: addressing.NodeInternalIP,
@@ -972,7 +972,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 	status, _ = checkStatus()
 	assert.Equal(types.LevelOK, string(status.Level))
 
-	for i := 0; i < cap(nh1.Stop); i++ {
+	for range cap(nh1.Stop) {
 		nh1.Stop <- struct{}{}
 	}
 }

--- a/pkg/node/manager/queue_test.go
+++ b/pkg/node/manager/queue_test.go
@@ -28,7 +28,7 @@ func TestQPush(t *testing.T) {
 			for i := range u.items {
 				q.push(&u.items[i])
 			}
-			for i := 0; i < len(u.items); i++ {
+			for i := range u.items {
 				v, ok := q.pop()
 				assert.True(t, ok)
 				assert.Less(t, i, len(u.e))

--- a/pkg/node/manager/rest_api_test.go
+++ b/pkg/node/manager/rest_api_test.go
@@ -50,7 +50,7 @@ func Test_getNodesHandle(t *testing.T) {
 	const numberOfClients = 10
 
 	clientIDs := make([]int64, 0, numberOfClients)
-	for i := 0; i < numberOfClients; i++ {
+	for range numberOfClients {
 		clientIDs = append(clientIDs, randGen.Int64())
 	}
 

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -220,7 +220,7 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ln *node.LocalNode) {
 
 	performGet := true
 	var nodeResource *ciliumv2.CiliumNode
-	for retryCount := 0; retryCount < maxRetryCount; retryCount++ {
+	for retryCount := range maxRetryCount {
 		performUpdate := true
 		if performGet {
 			var err error

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3152,7 +3152,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 
 	monitorAggregationFlags := vp.GetStringSlice(MonitorAggregationFlags)
 	var ctMonitorReportFlags uint16
-	for i := 0; i < len(monitorAggregationFlags); i++ {
+	for i := range monitorAggregationFlags {
 		value := strings.ToLower(monitorAggregationFlags[i])
 		flag, exists := TCPFlags[value]
 		if !exists {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2715,8 +2715,8 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 
 // ReadDirConfig reads the given directory and returns a map that maps the
 // filename to the contents of that file.
-func ReadDirConfig(dirName string) (map[string]interface{}, error) {
-	m := map[string]interface{}{}
+func ReadDirConfig(dirName string) (map[string]any, error) {
+	m := map[string]any{}
 	files, err := os.ReadDir(dirName)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("unable to read configuration directory: %w", err)
@@ -2757,7 +2757,7 @@ func ReadDirConfig(dirName string) (map[string]interface{}, error) {
 }
 
 // MergeConfig merges the given configuration map with viper's configuration.
-func MergeConfig(vp *viper.Viper, m map[string]interface{}) error {
+func MergeConfig(vp *viper.Viper, m map[string]any) error {
 	err := vp.MergeConfigMap(m)
 	if err != nil {
 		return fmt.Errorf("unable to read merge directory configuration: %w", err)
@@ -2773,7 +2773,7 @@ func MergeConfig(vp *viper.Viper, m map[string]interface{}) error {
 // Once we remove them from this function we also need to remove them from
 // daemon_main.go and warn users about the old environment variable nor the
 // option in the configuration map have any effect.
-func ReplaceDeprecatedFields(m map[string]interface{}) {
+func ReplaceDeprecatedFields(m map[string]any) {
 	deprecatedFields := map[string]string{
 		"monitor-aggregation-level":   MonitorAggregationName,
 		"ct-global-max-entries-tcp":   CTMapEntriesGlobalTCPName,
@@ -3926,7 +3926,7 @@ func sanitizeIntParam(vp *viper.Viper, paramName string, paramDefault int) int {
 	return intParam
 }
 
-func validateConfigMapFlag(flag *pflag.Flag, key string, value interface{}) error {
+func validateConfigMapFlag(flag *pflag.Flag, key string, value any) error {
 	var err error
 	switch t := flag.Value.Type(); t {
 	case "bool":
@@ -3973,7 +3973,7 @@ func validateConfigMapFlag(flag *pflag.Flag, key string, value interface{}) erro
 }
 
 // validateConfigMap checks whether the flag exists and validate its value
-func validateConfigMap(cmd *cobra.Command, m map[string]interface{}) error {
+func validateConfigMap(cmd *cobra.Command, m map[string]any) error {
 	flags := cmd.Flags()
 
 	for key, value := range m {

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -124,7 +124,7 @@ func TestReadDirConfig(t *testing.T) {
 		dirName string
 	}
 	type want struct {
-		allSettings map[string]interface{}
+		allSettings map[string]any
 		err         error
 	}
 	tests := []struct {
@@ -149,7 +149,7 @@ func TestReadDirConfig(t *testing.T) {
 			},
 			setupWant: func() want {
 				return want{
-					allSettings: map[string]interface{}{},
+					allSettings: map[string]any{},
 					err:         nil,
 				}
 			},
@@ -180,7 +180,7 @@ func TestReadDirConfig(t *testing.T) {
 			},
 			setupWant: func() want {
 				return want{
-					allSettings: map[string]interface{}{"test": `"1"`},
+					allSettings: map[string]any{"test": `"1"`},
 					err:         nil,
 				}
 			},

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -420,7 +420,7 @@ func (o *IntOptions) Validate(n models.ConfigurationMap) error {
 }
 
 // ChangedFunc is called by `Apply()` for each option changed
-type ChangedFunc func(key string, value OptionSetting, data interface{})
+type ChangedFunc func(key string, value OptionSetting, data any)
 
 // enable enables the option `name` with all its dependencies
 func (o *IntOptions) enable(name string) {
@@ -471,7 +471,7 @@ type changedOptions struct {
 //
 // The caller is expected to have validated the configuration options prior to
 // calling this function.
-func (o *IntOptions) ApplyValidated(n OptionMap, changed ChangedFunc, data interface{}) int {
+func (o *IntOptions) ApplyValidated(n OptionMap, changed ChangedFunc, data any) int {
 	changes := make([]changedOptions, 0, len(n))
 
 	o.optsMU.Lock()

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -423,7 +423,7 @@ func TestApplyValidated(t *testing.T) {
 		k6: OptionEnabled,
 	}
 	actualChanges := OptionMap{}
-	var changed ChangedFunc = func(key string, value OptionSetting, data interface{}) {
+	var changed ChangedFunc = func(key string, value OptionSetting, data any) {
 		require.Equal(t, &cfg, data)
 		actualChanges[key] = value
 	}

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -23,7 +23,7 @@ func TestWrite(t *testing.T) {
 
 	content, err := os.ReadFile(path)
 	require.NoError(t, err)
-	require.Equal(t, content, []byte(fmt.Sprintf("%d\n", os.Getpid())))
+	require.Equal(t, content, fmt.Appendf(nil, "%d\n", os.Getpid()))
 }
 
 func TestKill(t *testing.T) {

--- a/pkg/policy/api/decision_test.go
+++ b/pkg/policy/api/decision_test.go
@@ -9,8 +9,8 @@ import (
 
 func BenchmarkDecisionMarshalJSON(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for _, d := range []Decision{
 			Undecided,
 			Allowed,

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -73,8 +73,8 @@ func TestPortRuleDNSSanitize(t *testing.T) {
 // cases, and allows good ones.
 func BenchmarkFQDNSelectorString(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for _, s := range []FQDNSelector{
 			{MatchName: "cilium.io"},
 			{MatchPattern: "[a-z]*.cilium.io"},

--- a/pkg/policy/api/groups_test.go
+++ b/pkg/policy/api/groups_test.go
@@ -107,8 +107,8 @@ func BenchmarkGetCIDRSet(b *testing.B) {
 	RegisterToGroupsProvider(AWSProvider, cb)
 	group := GetGroupsRule()
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := group.GetCidrSet(context.TODO())
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -149,7 +149,7 @@ func (r *Rule) MarshalJSON() ([]byte, error) {
 		Description       string            `json:"description,omitempty"`
 	}
 
-	var a interface{}
+	var a any
 	ruleCommon := common{
 		Ingress:           r.Ingress,
 		IngressDeny:       r.IngressDeny,

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -1374,8 +1374,8 @@ func BenchmarkCIDRSanitize(b *testing.B) {
 	cidr6 := CIDRRule{Cidr: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128"}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		err := cidr4.sanitize()
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/policy/api/selector_test.go
+++ b/pkg/policy/api/selector_test.go
@@ -70,7 +70,7 @@ func TestLabelSelectorToRequirements(t *testing.T) {
 
 func benchmarkMatchesSetup(match string, count int) (EndpointSelector, labels.LabelArray) {
 	stringLabels := []string{}
-	for i := 0; i < count; i++ {
+	for i := range count {
 		stringLabels = append(stringLabels, fmt.Sprintf("%d", i))
 	}
 	lbls := labels.NewLabelsFromModel(stringLabels)
@@ -79,16 +79,16 @@ func benchmarkMatchesSetup(match string, count int) (EndpointSelector, labels.La
 
 func BenchmarkMatchesValid1000(b *testing.B) {
 	es, match := benchmarkMatchesSetup("42", 1000)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		es.Matches(match)
 	}
 }
 
 func BenchmarkMatchesInvalid1000(b *testing.B) {
 	es, match := benchmarkMatchesSetup("foo", 1000)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		es.Matches(match)
 	}
 }

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -498,7 +498,7 @@ func BenchmarkContainsAllL3L4(b *testing.B) {
 	port := uint16(rand.IntN(65535))
 
 	b.ReportAllocs()
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		b.StartTimer()
 		proxyID := ProxyID(id, true, "TCP", port, "")
 		if proxyID != strconv.FormatInt(int64(id), 10)+"ingress:TCP:8080:" {

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -28,11 +28,11 @@ func (s *SearchContext) TraceEnabled() bool {
 
 // PolicyTrace logs the given message into the SearchContext logger only if
 // TRACE_ENABLED or TRACE_VERBOSE is enabled in the receiver's SearchContext.
-func (s *SearchContext) PolicyTrace(format string, a ...interface{}) {
+func (s *SearchContext) PolicyTrace(format string, a ...any) {
 	if s.TraceEnabled() {
 		if s.Logging != nil {
 			format = "%-" + s.CallDepth() + "s" + format
-			a = append([]interface{}{""}, a...)
+			a = append([]any{""}, a...)
 			s.Logging.Printf(format, a...)
 		}
 	}
@@ -40,7 +40,7 @@ func (s *SearchContext) PolicyTrace(format string, a ...interface{}) {
 
 // PolicyTraceVerbose logs the given message into the SearchContext logger only
 // if TRACE_VERBOSE is enabled in the receiver's SearchContext.
-func (s *SearchContext) PolicyTraceVerbose(format string, a ...interface{}) {
+func (s *SearchContext) PolicyTraceVerbose(format string, a ...any) {
 	switch s.Trace {
 	case TRACE_VERBOSE:
 		if s.Logging != nil {

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -65,8 +65,8 @@ func TestSearchContextString(t *testing.T) {
 
 func BenchmarkSearchContextString(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for _, sc := range []SearchContext{
 			{
 				Trace: 1,

--- a/pkg/policy/portrange_test.go
+++ b/pkg/policy/portrange_test.go
@@ -328,7 +328,7 @@ func TestPortRange(t *testing.T) {
 		},
 	}
 
-	for i := 0; i < len(testCases); i++ {
+	for i := range testCases {
 		test := &testCases[i]
 		maskedPorts := PortRangeToMaskedPorts(test.start, test.end)
 		// Sort the returned slice so that PortRangeToMaskedPorts() can return masked ports

--- a/pkg/policy/proxyid_test.go
+++ b/pkg/policy/proxyid_test.go
@@ -38,7 +38,7 @@ func BenchmarkProxyID(b *testing.B) {
 	port := uint16(rand.IntN(65535))
 
 	b.ReportAllocs()
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		b.StartTimer()
 		proxyID := ProxyID(id, true, "TCP", port, "")
 		if proxyID != strconv.FormatInt(int64(id), 10)+"ingress:TCP:8080:" {

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -267,7 +267,6 @@ func BenchmarkParseLabel(b *testing.B) {
 	td := newTestData(hivetest.Logger(b))
 	repo := td.repo
 
-	b.ResetTimer()
 	var err error
 	var cntAdd, cntFound int
 
@@ -276,7 +275,7 @@ func BenchmarkParseLabel(b *testing.B) {
 		I := fmt.Sprintf("%d", i)
 		lbls[i] = labels.LabelArray{labels.NewLabel("tag3", I, labels.LabelSourceK8s), labels.NewLabel("namespace", "default", labels.LabelSourceK8s)}
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for j := range 100 {
 			J := fmt.Sprintf("%d", j)
 			_, _, err = repo.mustAdd(api.Rule{

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -272,12 +272,12 @@ func BenchmarkParseLabel(b *testing.B) {
 	var cntAdd, cntFound int
 
 	lbls := make([]labels.LabelArray, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		I := fmt.Sprintf("%d", i)
 		lbls[i] = labels.LabelArray{labels.NewLabel("tag3", I, labels.LabelSourceK8s), labels.NewLabel("namespace", "default", labels.LabelSourceK8s)}
 	}
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 100; j++ {
+		for j := range 100 {
 			J := fmt.Sprintf("%d", j)
 			_, _, err = repo.mustAdd(api.Rule{
 				EndpointSelector: api.NewESFromLabels(labels.NewLabel("foo", J, labels.LabelSourceK8s), labels.NewLabel("namespace", "default", labels.LabelSourceK8s)),
@@ -293,7 +293,7 @@ func BenchmarkParseLabel(b *testing.B) {
 		}
 
 		repo.mutex.RLock()
-		for j := 0; j < 100; j++ {
+		for j := range 100 {
 			cntFound += len(repo.searchRLocked(lbls[j]))
 		}
 		repo.mutex.RUnlock()
@@ -1469,7 +1469,7 @@ func TestIterate(t *testing.T) {
 
 	numRules := 10
 	lbls := make([]labels.Label, 10)
-	for i := 0; i < numRules; i++ {
+	for i := range numRules {
 		it := fmt.Sprintf("baz%d", i)
 		epSelector := api.NewESFromLabels(
 			labels.NewLabel(

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -188,8 +188,8 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 	ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 	owner := DummyOwner{logger: logger}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		epPolicy := ip.DistillPolicy(logger, owner, nil)
 		owner.mapStateSize = epPolicy.policyMapState.Len()
 		epPolicy.Ready()

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -204,8 +204,8 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 	ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 	owner := DummyOwner{logger: hivetest.Logger(b)}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		epPolicy := ip.DistillPolicy(hivetest.Logger(b), owner, nil)
 		owner.mapStateSize = epPolicy.policyMapState.Len()
 		epPolicy.Ready()
@@ -217,8 +217,8 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {
 	td := newTestData(hivetest.Logger(b))
 	td.bootstrapRepo(GenerateL3IngressRules, 1000, b)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		policy := ip.DistillPolicy(hivetest.Logger(b), DummyOwner{logger: hivetest.Logger(b)}, nil)
 		policy.Ready()
@@ -229,8 +229,8 @@ func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {
 func BenchmarkRegenerateL3EgressPolicyRules(b *testing.B) {
 	td := newTestData(hivetest.Logger(b))
 	td.bootstrapRepo(GenerateL3EgressRules, 1000, b)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		policy := ip.DistillPolicy(hivetest.Logger(b), DummyOwner{logger: hivetest.Logger(b)}, nil)
 		policy.Ready()

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -42,8 +42,7 @@ var testRedirects = map[string]uint16{
 
 func generateNumIdentities(numIdentities int) identity.IdentityMap {
 	c := make(identity.IdentityMap, numIdentities)
-	for i := 0; i < numIdentities; i++ {
-
+	for i := range numIdentities {
 		identityLabel := labels.NewLabel(fmt.Sprintf("k8s:foo%d", i), "", "")
 		clusterLabel := labels.NewLabel("io.cilium.k8s.policy.cluster=default", "", labels.LabelSourceK8s)
 		serviceAccountLabel := labels.NewLabel("io.cilium.k8s.policy.serviceaccount=default", "", labels.LabelSourceK8s)

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2280,8 +2280,8 @@ func BenchmarkRuleString(b *testing.B) {
 		},
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = r.String()
 	}
 }

--- a/pkg/proxy/accesslog/proxy_access_logger_test.go
+++ b/pkg/proxy/accesslog/proxy_access_logger_test.go
@@ -174,7 +174,7 @@ func benchWithoutListeners(b *testing.B, notifier LogRecordNotifier) {
 					// related events trigger one `notifyOnDNSMsg` callback each and
 					// consequently the event logging.
 					var wg sync.WaitGroup
-					for j := 0; j < bm.nRecords; j++ {
+					for range bm.nRecords {
 						wg.Add(1)
 						go func() {
 							defer wg.Done()
@@ -207,7 +207,7 @@ func benchWithListeners(accessLogger ProxyAccessLogger, listener *MockMonitorLis
 					// related events trigger one `notifyOnDNSMsg` callback each and
 					// consequently the event logging.
 					var logWg sync.WaitGroup
-					for j := 0; j < bm.nRecords; j++ {
+					for range bm.nRecords {
 						logWg.Add(1)
 						go func() {
 							defer logWg.Done()

--- a/pkg/proxy/accesslog/proxy_access_logger_test.go
+++ b/pkg/proxy/accesslog/proxy_access_logger_test.go
@@ -168,7 +168,7 @@ func benchWithoutListeners(b *testing.B, notifier LogRecordNotifier) {
 		for _, bm := range benchCases {
 			b.Run(bm.name, func(b *testing.B) {
 				b.ReportAllocs()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					// Each goroutine will deliver a single notification concurrently.
 					// This is done to simulate what happens when a high rate of DNS
 					// related events trigger one `notifyOnDNSMsg` callback each and
@@ -201,7 +201,7 @@ func benchWithListeners(accessLogger ProxyAccessLogger, listener *MockMonitorLis
 
 				b.ReportAllocs()
 				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					// Each goroutine will deliver a single notification concurrently.
 					// This is done to simulate what happens when a high rate of DNS
 					// related events trigger one `notifyOnDNSMsg` callback each and

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -213,7 +213,7 @@ func (p *Proxy) createNewRedirect(
 
 	var impl RedirectImplementation
 	var err error
-	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {
+	for nRetry := range redirectCreationAttempts {
 		if err != nil {
 			// an error occurred and we are retrying
 			scopedLog.Warn("Unable to create proxy, retrying",

--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -436,12 +436,8 @@ func (l *APILimiter) delayedAdjustment(current, min, max float64) (n float64) {
 
 func (l *APILimiter) calculateAdjustmentFactor() float64 {
 	f := l.params.EstimatedProcessingDuration.Seconds() / l.meanProcessingDuration
-	if f > l.params.MaxAdjustmentFactor {
-		f = l.params.MaxAdjustmentFactor
-	}
-	if f < 1.0/l.params.MaxAdjustmentFactor {
-		f = 1.0 / l.params.MaxAdjustmentFactor
-	}
+	f = min(f, l.params.MaxAdjustmentFactor)
+	f = max(f, 1.0/l.params.MaxAdjustmentFactor)
 	return f
 }
 

--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -171,7 +171,7 @@ func TestMinParallelRequests(t *testing.T) {
 		Log:                         true,
 	}, nil)
 
-	for i := 0; i < maxParallelReqs; i++ {
+	for range maxParallelReqs {
 		req, err := a.Wait(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, req)
@@ -205,7 +205,7 @@ func TestMaxWaitDurationExceeded(t *testing.T) {
 	var mutex lock.Mutex
 	failedRequests := 0
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			req, err := a.Wait(context.Background())
 			if err != nil {
@@ -262,7 +262,7 @@ func TestLimitWaitDurationExceeded(t *testing.T) {
 	var mutex lock.Mutex
 	failedRequests := 0
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			req, err := a.Wait(context.Background())
 			if err != nil {
@@ -635,7 +635,7 @@ func TestSkipInitial(t *testing.T) {
 		ParallelRequests: 2,
 	}, nil)
 
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		req, err := a.Wait(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, req)
@@ -736,7 +736,7 @@ func testStressRateLimiter(t *testing.T, nGoRoutines int) {
 	)
 
 	go func() {
-		for i := 0; i < nGoRoutines; i++ {
+		for range nGoRoutines {
 			sem.Acquire(context.Background(), 1)
 			go func() {
 				var (
@@ -787,7 +787,7 @@ func TestReservationCancel(t *testing.T) {
 	// All of these requests must fail due to having to wait too long as
 	// the only parallel request slot is occupied. The rate limiter should
 	// not get occupied with these requests though.
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		go func() {
 			_, err := a.Wait(context.Background())
 			require.Error(t, err)
@@ -801,7 +801,7 @@ func TestReservationCancel(t *testing.T) {
 	req.Done()
 
 	// All of these requests should now succeed
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		req2, err := a.Wait(context.Background())
 		require.NoError(t, err)
 		req2.Done()

--- a/pkg/service/id_test.go
+++ b/pkg/service/id_test.go
@@ -211,7 +211,7 @@ func BenchmarkAllocation(b *testing.B) {
 
 	logger := hivetest.Logger(b)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		addr.L4Addr.Port = uint16(b.N)
 		_, err := AcquireID(logger, addr, 0)
 		require.NoError(b, err)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -2494,7 +2494,7 @@ func (f *FakeMonitorAgent) RemoveConsumer(mc consumer.MonitorConsumer) {
 func (f *FakeMonitorAgent) RemoveListener(ml listener.MonitorListener) {
 }
 
-func (f *FakeMonitorAgent) SendEvent(typ int, event interface{}) error {
+func (f *FakeMonitorAgent) SendEvent(typ int, event any) error {
 	return nil
 }
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -584,8 +584,7 @@ func TestRestoreServices(t *testing.T) {
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	m.newServiceMock(ctx, lbmap)
 
@@ -665,8 +664,7 @@ func TestSyncWithK8sFinished(t *testing.T) {
 	// Restart service, but keep the lbmap to restore services from
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	m.newServiceMock(ctx, lbmap)
 
@@ -1519,8 +1517,7 @@ func TestRestoreServiceWithTerminatingBackends(t *testing.T) {
 	// Simulate agent restart.
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	m.newServiceMock(ctx, lbmap)
 
@@ -1989,8 +1986,7 @@ func TestRestoreServiceWithBackendStates(t *testing.T) {
 	// Simulate agent restart.
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	m.newServiceMock(ctx, lbmap)
 
@@ -2564,8 +2560,7 @@ func TestHealthCheckInitialSync(t *testing.T) {
 	// Upsert the service before subscription
 	m.svc.UpsertService(p1)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	m.svc.Subscribe(ctx, func(svcInfo HealthUpdateSvcInfo) {
 		receivedServices = append(receivedServices, svcInfo.Name)

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -23,8 +23,8 @@ func Unique[S ~[]T, T comparable](s S) S {
 
 	if len(s) < 192 {
 	Loop:
-		for i := 0; i < len(s); i++ {
-			for j := 0; j < last; j++ {
+		for i := range len(s) {
+			for j := range last {
 				if s[i] == s[j] {
 					continue Loop
 				}
@@ -34,7 +34,7 @@ func Unique[S ~[]T, T comparable](s S) S {
 		}
 	} else {
 		set := make(map[T]struct{}, len(s))
-		for i := 0; i < len(s); i++ {
+		for i := range len(s) {
 			if _, ok := set[s[i]]; ok {
 				continue
 			}
@@ -59,7 +59,7 @@ func UniqueFunc[S ~[]T, T any, K comparable](s S, key func(i int) K) S {
 	last := 0
 
 	set := make(map[K]struct{}, len(s))
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		if _, ok := set[key(i)]; ok {
 			continue
 		}

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -450,7 +450,7 @@ func benchmarkUnique(b *testing.B, benchUniqueFunc bool) {
 
 			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				b.StopTimer()
 				values = values[:cap(values)]
 				copy(values, orig)
@@ -497,7 +497,7 @@ func BenchmarkSubsetOf(b *testing.B) {
 
 				b.ResetTimer()
 
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					_, _ = SubsetOf(subset, superset)
 				}
 			},

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -96,7 +96,7 @@ func TestUniqueKeepOrdering(t *testing.T) {
 		t.Fatalf("expected slice of %d elements, got %d", len(expected), len(got))
 	}
 
-	for i := 0; i < len(expected); i++ {
+	for i := range expected {
 		if got[i] != *expected[i] {
 			t.Fatalf("expected value %q at index %d, got %q", *expected[i], i, got[i])
 		}
@@ -486,12 +486,12 @@ func BenchmarkSubsetOf(b *testing.B) {
 				b.ReportAllocs()
 
 				subset := make([]string, 0, bc.subsetSz)
-				for i := 0; i < bc.subsetSz; i++ {
+				for range bc.subsetSz {
 					subset = append(subset, strconv.Itoa(rand.IntN(bc.subsetSz)))
 				}
 
 				superset := make([]string, 0, bc.supersetSz)
-				for i := 0; i < bc.supersetSz; i++ {
+				for range bc.supersetSz {
 					superset = append(superset, strconv.Itoa(rand.IntN(bc.subsetSz)))
 				}
 

--- a/pkg/spanstat/spanstat_test.go
+++ b/pkg/spanstat/spanstat_test.go
@@ -77,7 +77,7 @@ func TestSpanStatSecondsRaceCondition(t *testing.T) {
 	span1 := Start()
 	var wg sync.WaitGroup
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func(span *SpanStat) {
 			defer wg.Done()
@@ -159,7 +159,7 @@ func TestSpanStatRaceCondition(t *testing.T) {
 			span := Start()
 			var wg sync.WaitGroup
 
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				wg.Add(1)
 				go func(span *SpanStat) {
 					defer wg.Done()

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -32,7 +32,7 @@ var (
 type Status struct {
 	// Data is non-nil when the probe has completed successfully. Data is
 	// set to the value returned by Probe()
-	Data interface{}
+	Data any
 
 	// Err is non-nil if either the probe file or the Failure or Warning
 	// threshold has been reached
@@ -46,7 +46,7 @@ type Status struct {
 type Probe struct {
 	Name string
 
-	Probe func(ctx context.Context) (interface{}, error)
+	Probe func(ctx context.Context) (any, error)
 
 	// OnStatusUpdate is called whenever the status of the probe changes
 	OnStatusUpdate func(status Status)
@@ -189,7 +189,7 @@ func (c *Collector) spawnProbe(p *Probe, firstRunCompleted func()) {
 // or after the collector has been closed.
 func (c *Collector) runProbe(p *Probe) {
 	var (
-		statusData       interface{}
+		statusData       any
 		err              error
 		warningThreshold = time.After(c.config.WarningThreshold)
 		hardTimeout      = false
@@ -258,7 +258,7 @@ func (c *Collector) runProbe(p *Probe) {
 	}
 }
 
-func (c *Collector) updateProbeStatus(p *Probe, data interface{}, stale bool, err error) {
+func (c *Collector) updateProbeStatus(p *Probe, data any, stale bool, err error) {
 	// Update stale status of the probe
 	c.Lock()
 	startTime := c.probeStartTime[p.Name]

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -60,7 +60,7 @@ func TestVariableProbeInterval(t *testing.T) {
 				// Ensure that the regular interval would never retry
 				return time.Minute
 			},
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				// Let 5 runs fail and then succeed
 				if runs.Add(1) < 5 {
 					return nil, fmt.Errorf("still failing")
@@ -93,7 +93,7 @@ func TestCollectorFailureTimeout(t *testing.T) {
 
 	p := []Probe{
 		{
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				time.Sleep(s.Config().FailureThreshold * 2)
 				return nil, nil
 			},
@@ -127,7 +127,7 @@ func TestCollectorSuccess(t *testing.T) {
 
 	p := []Probe{
 		{
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				if ok.Load() > 3 {
 					return nil, err
 				}
@@ -163,7 +163,7 @@ func TestCollectorSuccessAfterTimeout(t *testing.T) {
 
 	p := []Probe{
 		{
-			Probe: func(ctx context.Context) (interface{}, error) {
+			Probe: func(ctx context.Context) (any, error) {
 				if timeout.Load() == 0 {
 					time.Sleep(2 * s.Config().FailureThreshold)
 				}
@@ -194,7 +194,7 @@ func TestWaitForFirstRun(t *testing.T) {
 	s := setUpTest(t)
 
 	unlock := make(chan struct{})
-	probeFn := func(ctx context.Context) (interface{}, error) {
+	probeFn := func(ctx context.Context) (any, error) {
 		<-unlock
 		return nil, nil
 	}

--- a/pkg/trigger/trigger_test.go
+++ b/pkg/trigger/trigger_test.go
@@ -122,7 +122,7 @@ func TestShutdownFunc(t *testing.T) {
 func BenchmarkUntriggeredTrigger(b *testing.B) {
 	b.ReportAllocs()
 
-	for range b.N {
+	for b.Loop() {
 		tr, err := NewTrigger(Parameters{
 			TriggerFunc:   func(reasons []string) {},
 			ShutdownFunc:  func() {},

--- a/pkg/trigger/trigger_test.go
+++ b/pkg/trigger/trigger_test.go
@@ -50,7 +50,7 @@ func TestMinInterval(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tr)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		tr.Trigger()
 		time.Sleep(time.Millisecond * 20)
 	}
@@ -81,7 +81,7 @@ func TestLongTrigger(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tr)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		tr.Trigger()
 		time.Sleep(time.Millisecond * 20)
 	}

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -271,9 +271,6 @@ func TestAgent_PeerConfig(t *testing.T) {
 		{"TunnelRouting Without Fallback", option.RoutingModeTunnel, false, tunnelRoutingAllowedIPs},
 	} {
 		t.Run(c.Name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			prevRoutingMode := option.Config.RoutingMode
 			defer func() { option.Config.RoutingMode = prevRoutingMode }()
 			option.Config.RoutingMode = c.RoutingMode
@@ -282,7 +279,7 @@ func TestAgent_PeerConfig(t *testing.T) {
 			defer func() { option.Config.WireguardTrackAllIPsFallback = prevFallback }()
 			option.Config.WireguardTrackAllIPsFallback = c.Fallback
 
-			wgAgent, ipCache := newTestAgent(ctx, newFakeWgClient())
+			wgAgent, ipCache := newTestAgent(t.Context(), newFakeWgClient())
 			defer ipCache.Shutdown()
 
 			// Test that IPCache updates before UpdatePeer are handled correctly
@@ -480,8 +477,6 @@ func TestAgent_AllowedIPsRestoration(t *testing.T) {
 		{"TunnelRouting Without Fallback", option.RoutingModeTunnel, false, tunnelRoutingAllowedIPs},
 	} {
 		t.Run(c.Name, func(t *testing.T) {
-			ctx := context.Background()
-
 			prevRoutingMode := option.Config.RoutingMode
 			defer func() { option.Config.RoutingMode = prevRoutingMode }()
 			option.Config.RoutingMode = c.RoutingMode
@@ -501,7 +496,7 @@ func TestAgent_AllowedIPsRestoration(t *testing.T) {
 				},
 			})
 
-			wgAgent, ipCache := newTestAgent(ctx, wgClient)
+			wgAgent, ipCache := newTestAgent(t.Context(), wgClient)
 			defer ipCache.Shutdown()
 
 			assertAllowedIPs := func(e expectation) {

--- a/pkg/xds/experimental/client/client_test.go
+++ b/pkg/xds/experimental/client/client_test.go
@@ -762,11 +762,11 @@ func TestObserve(t *testing.T) {
 }
 
 type FakeClientConn struct {
-	OnInvoke    func(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error
+	OnInvoke    func(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error
 	OnNewStream func(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error)
 }
 
-func (f *FakeClientConn) Invoke(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error {
+func (f *FakeClientConn) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
 	return f.OnInvoke(ctx, method, args, reply, opts...)
 }
 

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -101,7 +101,7 @@ func NewDriver(ciliumSockPath, dockerHostPath string) (Driver, error) {
 
 	d := &driver{client: c, dockerClient: dockerCli}
 
-	for tries := 0; tries < 24; tries++ {
+	for tries := range 24 {
 		if res, err := c.ConfigGet(); err != nil {
 			if tries == 23 {
 				scopedLog.WithError(err).Fatal("Unable to connect to cilium daemon")

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -285,7 +285,7 @@ func sendError(w http.ResponseWriter, msg string, code int) {
 	http.Error(w, msg, code)
 }
 
-func objectResponse(w http.ResponseWriter, obj interface{}) {
+func objectResponse(w http.ResponseWriter, obj any) {
 	if err := json.NewEncoder(w).Encode(obj); err != nil {
 		sendError(w, "Could not JSON encode response", http.StatusInternalServerError)
 		return
@@ -460,7 +460,7 @@ func (driver *driver) infoEndpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.WithField(logfields.Request, logfields.Repr(&info)).Debug("Endpoint info request")
-	objectResponse(w, &api.EndpointInfoResponse{Value: map[string]interface{}{}})
+	objectResponse(w, &api.EndpointInfoResponse{Value: map[string]any{}})
 	log.WithField(logfields.Response, info.EndpointID).Debug("Endpoint info")
 }
 

--- a/test/controlplane/node/localnode.go
+++ b/test/controlplane/node/localnode.go
@@ -55,7 +55,7 @@ type errorer struct {
 	err error
 }
 
-func (e *errorer) Errorf(format string, args ...interface{}) {
+func (e *errorer) Errorf(format string, args ...any) {
 	e.err = errors.Join(e.err, fmt.Errorf(format, args...))
 }
 

--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -156,7 +156,7 @@ func CurrnetScopeCounter() int32 {
 // By allows you to document such flows.  By must be called within a runnable
 // node (It, BeforeEach, Measure, etc...)
 // By will simply log the passed in text to the GinkgoWriter.
-func By(message string, optionalValues ...interface{}) {
+func By(message string, optionalValues ...any) {
 	if len(optionalValues) > 0 {
 		message = fmt.Sprintf(message, optionalValues...)
 	}
@@ -165,7 +165,7 @@ func By(message string, optionalValues ...interface{}) {
 }
 
 // GinkgoPrint send the given message to the test writers to store it.
-func GinkgoPrint(message string, optionalValues ...interface{}) {
+func GinkgoPrint(message string, optionalValues ...any) {
 	if len(optionalValues) > 0 {
 		message = fmt.Sprintf(message, optionalValues...)
 	}
@@ -430,7 +430,7 @@ func BeforeEach(body func(), timeout ...float64) bool {
 	}, timeout...)
 }
 
-func beforeEach(body interface{}, timeout ...float64) bool {
+func beforeEach(body any, timeout ...float64) bool {
 	if currentScope == nil {
 		return ginkgo.BeforeEach(body, timeout...)
 	}
@@ -495,7 +495,7 @@ func wrapNilContextFunc(fn func(string, func()) bool) func(string, func()) bool 
 // wrapItFunc wraps gingko.It to track invocations and correctly
 // execute AfterAll. This is tracked via scope.focusedTests and .normalTests.
 // This function is similar to wrapMeasureFunc.
-func wrapItFunc(fn func(string, interface{}, ...float64) bool, focused bool) func(string, interface{}, ...float64) bool {
+func wrapItFunc(fn func(string, any, ...float64) bool, focused bool) func(string, any, ...float64) bool {
 	if rootScope.isUnset() {
 		rootScope.setSafely(0)
 		BeforeSuite(func() {
@@ -503,7 +503,7 @@ func wrapItFunc(fn func(string, interface{}, ...float64) bool, focused bool) fun
 			rootScope.setSafely(c)
 		})
 	}
-	return func(text string, body interface{}, timeout ...float64) bool {
+	return func(text string, body any, timeout ...float64) bool {
 		if currentScope == nil {
 			return fn(text, body, timeout...)
 		}
@@ -519,7 +519,7 @@ func wrapItFunc(fn func(string, interface{}, ...float64) bool, focused bool) fun
 // wrapMeasureFunc wraps gingko.Measure to track invocations and correctly
 // execute AfterAll. This is tracked via scope.focusedTests and .normalTests.
 // This function is similar to wrapItFunc.
-func wrapMeasureFunc(fn func(text string, body interface{}, samples int) bool, focused bool) func(text string, body interface{}, samples int) bool {
+func wrapMeasureFunc(fn func(text string, body any, samples int) bool, focused bool) func(text string, body any, samples int) bool {
 	if rootScope.isUnset() {
 		rootScope.setSafely(0)
 		BeforeSuite(func() {
@@ -527,7 +527,7 @@ func wrapMeasureFunc(fn func(text string, body interface{}, samples int) bool, f
 			rootScope.setSafely(c)
 		})
 	}
-	return func(text string, body interface{}, samples int) bool {
+	return func(text string, body any, samples int) bool {
 		if currentScope == nil {
 			return fn(text, body, samples)
 		}
@@ -568,7 +568,7 @@ func isTestFocused(text string) bool {
 	return false
 }
 
-func applyAdvice(f interface{}, before, after func()) interface{} {
+func applyAdvice(f any, before, after func()) any {
 	fn := reflect.ValueOf(f)
 	template := func(in []reflect.Value) []reflect.Value {
 		if before != nil {
@@ -583,7 +583,7 @@ func applyAdvice(f interface{}, before, after func()) interface{} {
 	return v.Interface()
 }
 
-func wrapTest(f interface{}) interface{} {
+func wrapTest(f any) any {
 	cs := currentScope
 	after := func() {
 		for cs != nil {
@@ -696,6 +696,6 @@ func SkipItIf(condition func() bool, text string, body func(), timeout ...float6
 }
 
 // Failf calls Fail with a formatted string
-func Failf(msg string, args ...interface{}) {
+func Failf(msg string, args ...any) {
 	Fail(fmt.Sprintf(msg, args...))
 }

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -79,7 +79,7 @@ func (b *CmdStreamBuffer) KVOutput() map[string]string {
 // JSONPath filter in a buffer. Returns an error if the unmarshalling of the
 // contents of res's stdout fails.
 func (b *CmdStreamBuffer) Filter(filter string) (*FilterBuffer, error) {
-	var data interface{}
+	var data any
 	result := new(bytes.Buffer)
 
 	err := json.Unmarshal(b.Bytes(), &data)
@@ -107,7 +107,7 @@ func (b *CmdStreamBuffer) FilterLinesJSONPath(filter *jsonpath.JSONPath) ([]Filt
 			continue
 		}
 
-		var data interface{}
+		var data any
 		result := new(bytes.Buffer)
 		err := json.Unmarshal([]byte(line), &data)
 		if err != nil {
@@ -213,7 +213,7 @@ func (res *CmdRes) WasSuccessful() bool {
 
 // ExpectFail asserts whether res failed to execute. It accepts an optional
 // parameter that can be used to annotate failure messages.
-func (res *CmdRes) ExpectFail(optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectFail(optionalDescription ...any) bool {
 	return gomega.ExpectWithOffset(1, res).ShouldNot(
 		CMDSuccess(), optionalDescription...)
 }
@@ -221,7 +221,7 @@ func (res *CmdRes) ExpectFail(optionalDescription ...interface{}) bool {
 // ExpectFailWithError asserts whether res failed to execute with the
 // error output containing the given data.  It accepts an optional
 // parameter that can be used to annotate failure messages.
-func (res *CmdRes) ExpectFailWithError(data string, optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectFailWithError(data string, optionalDescription ...any) bool {
 	return gomega.ExpectWithOffset(1, res).ShouldNot(
 		CMDSuccess(), optionalDescription...) &&
 		gomega.ExpectWithOffset(1, res.Stderr()).To(
@@ -230,7 +230,7 @@ func (res *CmdRes) ExpectFailWithError(data string, optionalDescription ...inter
 
 // ExpectSuccess asserts whether res executed successfully. It accepts an optional
 // parameter that can be used to annotate failure messages.
-func (res *CmdRes) ExpectSuccess(optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectSuccess(optionalDescription ...any) bool {
 	return gomega.ExpectWithOffset(1, res).Should(
 		CMDSuccess(), optionalDescription...)
 }
@@ -238,7 +238,7 @@ func (res *CmdRes) ExpectSuccess(optionalDescription ...interface{}) bool {
 // ExpectContains asserts a string into the stdout of the response of executed
 // command. It accepts an optional parameter that can be used to annotate
 // failure messages.
-func (res *CmdRes) ExpectContains(data string, optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectContains(data string, optionalDescription ...any) bool {
 	return gomega.ExpectWithOffset(1, res.Stdout()).To(
 		gomega.ContainSubstring(data), optionalDescription...)
 }
@@ -246,7 +246,7 @@ func (res *CmdRes) ExpectContains(data string, optionalDescription ...interface{
 // ExpectMatchesRegexp asserts that the stdout of the executed command
 // matches the regexp. It accepts an optional parameter that can be
 // used to annotate failure messages.
-func (res *CmdRes) ExpectMatchesRegexp(regexp string, optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectMatchesRegexp(regexp string, optionalDescription ...any) bool {
 	return gomega.ExpectWithOffset(1, res.Stdout()).To(
 		gomega.MatchRegexp(regexp), optionalDescription...)
 }
@@ -256,7 +256,7 @@ func (res *CmdRes) ExpectMatchesRegexp(regexp string, optionalDescription ...int
 // matches at least one of the lines.
 // It accepts an optional parameter that can be used to annotate failure
 // messages.
-func (res *CmdRes) ExpectContainsFilterLine(filter, expected string, optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectContainsFilterLine(filter, expected string, optionalDescription ...any) bool {
 	lines, err := res.FilterLines(filter)
 	gomega.ExpectWithOffset(1, err).To(gomega.BeNil(), optionalDescription...)
 	sLines := []string{}
@@ -270,7 +270,7 @@ func (res *CmdRes) ExpectContainsFilterLine(filter, expected string, optionalDes
 // ExpectDoesNotContain asserts that a string is not contained in the stdout of
 // the executed command. It accepts an optional parameter that can be used to
 // annotate failure messages.
-func (res *CmdRes) ExpectDoesNotContain(data string, optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectDoesNotContain(data string, optionalDescription ...any) bool {
 	return gomega.ExpectWithOffset(1, res.Stdout()).ToNot(
 		gomega.ContainSubstring(data), optionalDescription...)
 }
@@ -278,7 +278,7 @@ func (res *CmdRes) ExpectDoesNotContain(data string, optionalDescription ...inte
 // ExpectDoesNotMatchRegexp asserts that the stdout of the executed command
 // doesn't match the regexp. It accepts an optional parameter that can be used
 // to annotate failure messages.
-func (res *CmdRes) ExpectDoesNotMatchRegexp(regexp string, optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectDoesNotMatchRegexp(regexp string, optionalDescription ...any) bool {
 	return gomega.ExpectWithOffset(1, res.Stdout()).ToNot(
 		gomega.MatchRegexp(regexp), optionalDescription...)
 }
@@ -288,7 +288,7 @@ func (res *CmdRes) ExpectDoesNotMatchRegexp(regexp string, optionalDescription .
 // does not matches any of the lines.
 // It accepts an optional parameter that can be used to annotate failure
 // messages.
-func (res *CmdRes) ExpectDoesNotContainFilterLine(filter, expected string, optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectDoesNotContainFilterLine(filter, expected string, optionalDescription ...any) bool {
 	lines, err := res.FilterLines(filter)
 	gomega.ExpectWithOffset(1, err).To(gomega.BeNil(), optionalDescription...)
 	sLines := []string{}
@@ -343,7 +343,7 @@ func (res *CmdRes) InRange(min, max int) error {
 // the unmarshalling of the stdout of res fails.
 // TODO - what exactly is the need for this vs. Filter function below?
 func (res *CmdRes) FindResults(filter string) ([]reflect.Value, error) {
-	var data interface{}
+	var data any
 	var result []reflect.Value
 
 	err := json.Unmarshal(res.stdout.Bytes(), &data)
@@ -423,7 +423,7 @@ func (res *CmdRes) OutputPrettyPrint() string {
 // ExpectEqual asserts whether cmdRes.Output().String() and expected are equal.
 // It accepts an optional parameter that can be used to annotate failure
 // messages.
-func (res *CmdRes) ExpectEqual(expected string, optionalDescription ...interface{}) bool {
+func (res *CmdRes) ExpectEqual(expected string, optionalDescription ...any) bool {
 	return gomega.ExpectWithOffset(1, res.Stdout()).Should(
 		gomega.Equal(expected), optionalDescription...)
 }
@@ -442,7 +442,7 @@ func (res *CmdRes) SingleOut() string {
 
 // Unmarshal unmarshalls res's stdout into data. It assumes that the stdout of
 // res is in JSON format. Returns an error if the unmarshalling fails.
-func (res *CmdRes) Unmarshal(data interface{}) error {
+func (res *CmdRes) Unmarshal(data any) error {
 	return json.Unmarshal(res.stdout.Bytes(), data)
 }
 
@@ -564,7 +564,7 @@ type BeSuccesfulMatcher struct{}
 // Match validates that the given interface will be a `*CmdRes` struct and it
 // was successful. In case of not a valid CmdRes will return an error. If the
 // command was not successful it returns false.
-func (matcher *BeSuccesfulMatcher) Match(actual interface{}) (success bool, err error) {
+func (matcher *BeSuccesfulMatcher) Match(actual any) (success bool, err error) {
 	res, ok := actual.(*CmdRes)
 	if !ok {
 		return false, fmt.Errorf("%q is not a valid *CmdRes type", actual)
@@ -574,7 +574,7 @@ func (matcher *BeSuccesfulMatcher) Match(actual interface{}) (success bool, err 
 
 // FailureMessage it returns a pretty printed error message in the case of the
 // command was not successful.
-func (matcher *BeSuccesfulMatcher) FailureMessage(actual interface{}) (message string) {
+func (matcher *BeSuccesfulMatcher) FailureMessage(actual any) (message string) {
 	res, _ := actual.(*CmdRes)
 	return fmt.Sprintf("Expected command: %s \nTo succeed, but it failed:\n%s",
 		res.GetCmd(), res.OutputPrettyPrint())
@@ -582,7 +582,7 @@ func (matcher *BeSuccesfulMatcher) FailureMessage(actual interface{}) (message s
 
 // NegatedFailureMessage returns a pretty printed error message in case of the
 // command is tested with a negative
-func (matcher *BeSuccesfulMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (matcher *BeSuccesfulMatcher) NegatedFailureMessage(actual any) (message string) {
 	res, _ := actual.(*CmdRes)
 	return fmt.Sprintf("Expected command: %s\nTo have failed, but it was successful:\n%s",
 		res.GetCmd(), res.OutputPrettyPrint())

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -90,7 +90,7 @@ func (s *SSHMeta) containerInspectNet(name string, network string) (map[string]s
 	}
 	for _, val := range data {
 		iface := val.Interface()
-		for k, v := range iface.(map[string]interface{}) {
+		for k, v := range iface.(map[string]any) {
 			if key, ok := properties[k]; ok {
 				result[key] = fmt.Sprintf("%s", v)
 			}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2944,7 +2944,7 @@ func (kub *Kubectl) CiliumExecContext(ctx context.Context, pod string, cmd strin
 	// 'limitTimes' retries has been exhausted.
 	// https://github.com/cilium/cilium/issues/22476
 	// [1]: https://github.com/golang/go/blob/go1.20rc1/src/os/exec_posix.go#L128-L130
-	for i := 0; i < limitTimes; i++ {
+	for i := range limitTimes {
 		res = execute()
 		switch res.GetExitCode() {
 		case 0:

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2965,7 +2965,7 @@ func (kub *Kubectl) CiliumExecContext(ctx context.Context, pod string, cmd strin
 
 // CiliumExecMustSucceed runs cmd in the specified Cilium pod.
 // it causes a test failure if the command was not successful.
-func (kub *Kubectl) CiliumExecMustSucceed(ctx context.Context, pod, cmd string, optionalDescription ...interface{}) *CmdRes {
+func (kub *Kubectl) CiliumExecMustSucceed(ctx context.Context, pod, cmd string, optionalDescription ...any) *CmdRes {
 	res := kub.CiliumExecContext(ctx, pod, cmd)
 	if !res.WasSuccessful() {
 		res.SendToLog(false)
@@ -2977,7 +2977,7 @@ func (kub *Kubectl) CiliumExecMustSucceed(ctx context.Context, pod, cmd string, 
 
 // CiliumExecMustSucceedOnAll does the same as CiliumExecMustSucceed, just that
 // it execs cmd on all cilium-agent pods.
-func (kub *Kubectl) CiliumExecMustSucceedOnAll(ctx context.Context, cmd string, optionalDescription ...interface{}) {
+func (kub *Kubectl) CiliumExecMustSucceedOnAll(ctx context.Context, cmd string, optionalDescription ...any) {
 	pods, err := kub.GetCiliumPods()
 	gomega.Expect(err).Should(gomega.BeNil(), "failed to retrieve Cilium pods")
 

--- a/test/helpers/logutils/utils.go
+++ b/test/helpers/logutils/utils.go
@@ -78,7 +78,7 @@ func getErrorWarningMsgs(logs string, n int) []string {
 	}
 
 	result := make([]string, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		result[i] = errs[i].msg
 	}
 	return result

--- a/test/helpers/proto.go
+++ b/test/helpers/proto.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
-func AssertProtoEqual(t *testing.T, want, got any, msgAndArgs ...interface{}) bool {
+func AssertProtoEqual(t *testing.T, want, got any, msgAndArgs ...any) bool {
 	t.Helper()
 	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 		return assert.Fail(t, fmt.Sprintf("not equal (-want +got):\n%s", diff), msgAndArgs...)

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -47,7 +47,7 @@ func Ping(endpoint string) string {
 // variadic optionalValues argument. This is passed on to fmt.Sprintf() and
 // used into the curl message. Note that `endpoint` is expected to be a format
 // string (first argument to fmt.Sprintf()) if optionalValues are used.
-func CurlFail(endpoint string, optionalValues ...interface{}) string {
+func CurlFail(endpoint string, optionalValues ...any) string {
 	statsInfo := `time-> DNS: '%{time_namelookup}(%{remote_ip})', Connect: '%{time_connect}',` +
 		`Transfer '%{time_starttransfer}', total '%{time_total}'`
 
@@ -61,7 +61,7 @@ func CurlFail(endpoint string, optionalValues ...interface{}) string {
 
 // CurlFailNoStats does the same as CurlFail() except that it does not print
 // the stats info. See note about optionalValues on CurlFail().
-func CurlFailNoStats(endpoint string, optionalValues ...interface{}) string {
+func CurlFailNoStats(endpoint string, optionalValues ...any) string {
 	if len(optionalValues) > 0 {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
 	}
@@ -75,7 +75,7 @@ func CurlFailNoStats(endpoint string, optionalValues ...interface{}) string {
 // endpoint. It takes a variadic optinalValues argument. This is passed on to
 // fmt.Sprintf() and uses into the curl message. See note about optionalValues
 // on CurlFail().
-func CurlWithHTTPCode(endpoint string, optionalValues ...interface{}) string {
+func CurlWithHTTPCode(endpoint string, optionalValues ...any) string {
 	if len(optionalValues) > 0 {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
 	}
@@ -91,7 +91,7 @@ func CurlWithHTTPCode(endpoint string, optionalValues ...interface{}) string {
 // function will call CurlFail() and add --retry flag at the end of the command
 // and return.  If flag "fail" is false, the function will generate the command
 // with --retry flag and return. See note about optionalValues on CurlFail().
-func CurlWithRetries(endpoint string, retries int, fail bool, optionalValues ...interface{}) string {
+func CurlWithRetries(endpoint string, retries int, fail bool, optionalValues ...any) string {
 	if fail {
 		return fmt.Sprintf(
 			`%s --retry %d`,
@@ -107,7 +107,7 @@ func CurlWithRetries(endpoint string, retries int, fail bool, optionalValues ...
 
 // CurlTimeout does the same as CurlFail() except you can define the timeout.
 // See note about optionalValues on CurlFail().
-func CurlTimeout(endpoint string, timeout time.Duration, optionalValues ...interface{}) string {
+func CurlTimeout(endpoint string, timeout time.Duration, optionalValues ...any) string {
 	statsInfo := `time-> DNS: '%{time_namelookup}(%{remote_ip})', Connect: '%{time_connect}',` +
 		`Transfer '%{time_starttransfer}', total '%{time_total}'`
 

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -520,7 +520,7 @@ var _ = Describe("RuntimeAgentFQDNPolicies", func() {
 		}
 
 		By("Testing %q and %q containers are allow to work with roundrobin dns", helpers.App1, helpers.App2)
-		for i := 0; i < numberOfTries; i++ {
+		for range numberOfTries {
 			for _, container := range []string{helpers.App1, helpers.App2} {
 				By("Testing connectivity to Cilium.test domain")
 				res := vm.ContainerExec(container, helpers.CurlFail(target))

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -1161,8 +1161,8 @@ var _ = Describe("RuntimeAgentFQDNPolicies", func() {
 // returned array will be sorted by map keys, the reason is that Golang does
 // not support ordered maps and for DNS-config the values need to be always
 // sorted.
-func getMapValues(m map[string]string) []interface{} {
-	values := make([]interface{}, len(m))
+func getMapValues(m map[string]string) []any {
+	values := make([]any, len(m))
 	for i, k := range slices.Sorted(maps.Keys(m)) {
 		values[i] = m[k]
 	}

--- a/test/runtime/net_policies.go
+++ b/test/runtime/net_policies.go
@@ -181,7 +181,7 @@ var _ = Describe("RuntimeAgentPolicies", func() {
 
 		// curlWithRetry retries the curl, to make sure that allowed curls don't
 		// flake on bad connectivity
-		curlWithRetry := func(name string, cmd string, optionalArgs ...interface{}) (res *helpers.CmdRes) {
+		curlWithRetry := func(name string, cmd string, optionalArgs ...any) (res *helpers.CmdRes) {
 			for range 5 {
 				res = vm.ContainerExec(name, helpers.CurlFail(cmd, optionalArgs...))
 				if res.WasSuccessful() {

--- a/test/runtime/net_policies.go
+++ b/test/runtime/net_policies.go
@@ -182,7 +182,7 @@ var _ = Describe("RuntimeAgentPolicies", func() {
 		// curlWithRetry retries the curl, to make sure that allowed curls don't
 		// flake on bad connectivity
 		curlWithRetry := func(name string, cmd string, optionalArgs ...interface{}) (res *helpers.CmdRes) {
-			for try := 0; try < 5; try++ {
+			for range 5 {
 				res = vm.ContainerExec(name, helpers.CurlFail(cmd, optionalArgs...))
 				if res.WasSuccessful() {
 					return res
@@ -465,7 +465,7 @@ var _ = Describe("RuntimeAgentPolicies", func() {
 
 			By("Testing egress access to the world")
 			curlFailures := 0
-			for i := 0; i < retries; i++ {
+			for range retries {
 				By("Accessing index.html using Docker container using host networking from %q (should work)", helpers.App1)
 				res = vm.ContainerExec(helpers.App1, helpers.CurlFail("%s://%s/index.html", proto, cloudFlare))
 				if !res.WasSuccessful() {


### PR DESCRIPTION
Follow-up to #38126 and #38157. Change all the remaining instances where modern Go constructs may be used.

Generated using `modernize` by running:

    go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...

and committing the relevant changes with some minor manual edits (e.g. reordering added imports).

The only change that was left out was replacing `omitempty` by `omitzero` in structs since these might introduce API-breaking changes and need to be reviewed individually. This will be done in a separate follow-up PR together with enabling `modernize` in CI.

See individual commit messages for details.

---

Sorry for the huge PR touching many pieces of the code base and requiring many code reviewers :cry: Best reviewed by filtering for "Only files owned by you" so you only see changes for your own review groups:

![image](https://github.com/user-attachments/assets/10a32cde-3eac-459e-9789-8e70e1bd10ad)