### PR TITLE
xds: fix various bugs and simplify control flow

### DIFF
--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -366,7 +366,7 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 	}
 }
 
-// 'ackVersion' is the last version that was acked. 'nackVersion', if greater than 'nackVersion', is the last version that was NACKed.
+// 'ackVersion' is the last version that was acked. 'nackVersion', if greater than 'ackVersion', is the last version that was NACKed.
 func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, nodeIP string, resourceNames []string, typeURL string, detail string) {
 	ackLog := log.WithFields(logrus.Fields{
 		logfields.XDSAckedVersion: ackVersion,

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -263,6 +263,9 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 
 	nodeIP := ""
 	firstRequest := true
+	// Indicates if client received the first response,
+	// but it doesn't necessarily mean that it was ACKed.
+	clientReceivedFirstResponse := false
 
 	for {
 		// Process either a new request from the xDS stream or a response
@@ -343,6 +346,11 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state := &typeStates[index]
 			watcher := s.watchers[typeURL]
 
+			if nonce > 0 {
+				// Non-zero nonce indicates that we have already sent
+				// a response to the client and client saw response.
+				clientReceivedFirstResponse = true
+			}
 			if nonce == 0 && versionInfo > 0 {
 				requestLog.Infof("xDS was restarted, setting nonce to %d", versionInfo)
 				nonce = versionInfo
@@ -353,17 +361,15 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				return ErrInvalidResponseNonce
 			}
 
-			// Response nonce is always the same as the response version.
-			// Request version indicates the last acked version. If the
-			// response nonce in the request is different(bigger) than
-			// request version, all versions upto that version are acked, but
-			// the versions from that to and including the nonce are nacked.
-			ackObserver := s.ackObservers[typeURL]
-			if ackObserver != nil {
-				requestLog.Debug("notifying observers of ACKs")
-				ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
-			} else if firstRequest {
-				requestLog.Info("ACK received but no observers are waiting for ACKs")
+			// We want to trigger HandleResourceVersionAck even for NACKs
+			if clientReceivedFirstResponse {
+				ackObserver := s.ackObservers[typeURL]
+				if ackObserver != nil {
+					requestLog.Debug("notifying observers of ACKs")
+					ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
+				} else {
+					requestLog.Info("ACK received but no observers are waiting for ACKs")
+				}
 			}
 			if versionInfo < nonce {
 				s.metrics.IncreaseNACK(typeURL)

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -348,48 +348,49 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				nonce = versionInfo
 			}
 
-			// Response nonce is always the same as the response version.
-			// Request version indicates the last acked version. If the
-			// response nonce in the request is different (smaller) than
-			// the version, all versions upto that version are acked, but
-			// the versions from that to and including the nonce are nacked.
-			if versionInfo <= nonce {
-				ackObserver := s.ackObservers[typeURL]
-				if ackObserver != nil {
-					requestLog.Debug("notifying observers of ACKs")
-					ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
-				} else if firstRequest {
-					requestLog.Info("ACK received but no observers are waiting for ACKs")
-				}
-				if versionInfo < nonce {
-					s.metrics.IncreaseNACK(typeURL)
-					// versions after VersionInfo, upto and including ResponseNonce are NACKed
-					requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
-					// Watcher will behave as if the sent version was acked.
-					// Otherwise we will just be sending the same failing
-					// version over and over filling logs.
-					versionInfo = nonce
-				}
-
-				if state.pendingWatchCancel != nil {
-					// A pending watch exists for this type URL. Cancel it to
-					// start a new watch.
-					requestLog.Debug("canceling pending watch")
-					state.pendingWatchCancel()
-				}
-
-				respCh := make(chan *VersionedResources, 1)
-				selectCases[index].Chan = reflect.ValueOf(respCh)
-
-				ctx, cancel := context.WithCancel(ctx)
-				state.pendingWatchCancel = cancel
-
-				requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
-				go watcher.WatchResources(ctx, typeURL, versionInfo, nodeIP, req.GetResourceNames(), respCh)
-			} else {
+			if versionInfo > nonce {
 				requestLog.Warning("received invalid nonce in xDS request")
 				return ErrInvalidResponseNonce
 			}
+
+			// Response nonce is always the same as the response version.
+			// Request version indicates the last acked version. If the
+			// response nonce in the request is different(bigger) than
+			// request version, all versions upto that version are acked, but
+			// the versions from that to and including the nonce are nacked.
+			ackObserver := s.ackObservers[typeURL]
+			if ackObserver != nil {
+				requestLog.Debug("notifying observers of ACKs")
+				ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
+			} else if firstRequest {
+				requestLog.Info("ACK received but no observers are waiting for ACKs")
+			}
+			if versionInfo < nonce {
+				s.metrics.IncreaseNACK(typeURL)
+				// versions after VersionInfo, upto and including ResponseNonce are NACKed
+				requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
+				// Watcher will behave as if the sent version was acked.
+				// Otherwise we will just be sending the same failing
+				// version over and over filling logs.
+				versionInfo = nonce
+			}
+
+			if state.pendingWatchCancel != nil {
+				// A pending watch exists for this type URL. Cancel it to
+				// start a new watch.
+				requestLog.Debug("canceling pending watch")
+				state.pendingWatchCancel()
+			}
+
+			respCh := make(chan *VersionedResources, 1)
+			selectCases[index].Chan = reflect.ValueOf(respCh)
+
+			ctx, cancel := context.WithCancel(ctx)
+			state.pendingWatchCancel = cancel
+
+			requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
+			go watcher.WatchResources(ctx, typeURL, versionInfo, nodeIP, req.GetResourceNames(), respCh)
+
 			firstRequest = false
 
 		default: // Pending watch response.

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -351,12 +351,12 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				// a response to the client and client saw response.
 				clientReceivedFirstResponse = true
 			}
-			if nonce == 0 && versionInfo > 0 {
-				requestLog.Infof("xDS was restarted, setting nonce to %d", versionInfo)
-				nonce = versionInfo
+
+			if versionInfo > 0 && firstRequest {
+				requestLog.Infof("xDS was restarted, previous versionInfo: %d", versionInfo)
 			}
 
-			if versionInfo > nonce {
+			if versionInfo > nonce && clientReceivedFirstResponse {
 				requestLog.Warning("received invalid nonce in xDS request")
 				return ErrInvalidResponseNonce
 			}
@@ -371,7 +371,8 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 					requestLog.Info("ACK received but no observers are waiting for ACKs")
 				}
 			}
-			if versionInfo < nonce {
+
+			if versionInfo < nonce && clientReceivedFirstResponse {
 				s.metrics.IncreaseNACK(typeURL)
 				// versions after VersionInfo, upto and including ResponseNonce are NACKed
 				requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -194,11 +194,6 @@ type perTypeStreamState struct {
 	// If nil, no watch is pending.
 	pendingWatchCancel context.CancelFunc
 
-	// version is the last version sent. This is needed so that we'll know
-	// if a new request is an ACK (VersionInfo matches current version), or a NACK
-	// (VersionInfo matches an earlier version).
-	version uint64
-
 	// resourceNames is the list of names of resources sent in the last
 	// response to a request for this resource type.
 	resourceNames []string
@@ -302,9 +297,13 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 
 			requestLog := streamLog.WithFields(getXDSRequestFields(req))
 
-			// Ensure that the version info is a string that was sent by this
-			// server or the empty string (the first request in a stream should
-			// always have an empty version info).
+			// VersionInfo is property of resources,
+			// while nonce is property of the stream.
+			// VersionInfo is only empty for a new client instance that did not
+			// receive any ACKed version of resources previously.
+			// In case of xDS server restart (cilium-agent),
+			// Envoy will send a request with VersionInfo set to the last ACKed version
+			// it received. Additionally, nonce will be empty.
 			var versionInfo uint64
 			if req.GetVersionInfo() != "" {
 				var err error
@@ -369,7 +368,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 					// Watcher will behave as if the sent version was acked.
 					// Otherwise we will just be sending the same failing
 					// version over and over filling logs.
-					versionInfo = state.version
+					versionInfo = nonce
 				}
 
 				if state.pendingWatchCancel != nil {
@@ -444,7 +443,6 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				return err
 			}
 
-			state.version = resp.Version
 			state.resourceNames = resp.ResourceNames
 		}
 	}

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -375,10 +375,6 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				s.metrics.IncreaseNACK(typeURL)
 				// versions after VersionInfo, upto and including ResponseNonce are NACKed
 				requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
-				// Watcher will behave as if the sent version was acked.
-				// Otherwise we will just be sending the same failing
-				// version over and over filling logs.
-				versionInfo = nonce
 			}
 
 			if state.pendingWatchCancel != nil {
@@ -395,7 +391,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state.pendingWatchCancel = cancel
 
 			requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
-			go watcher.WatchResources(ctx, typeURL, versionInfo, nodeIP, req.GetResourceNames(), respCh)
+			go watcher.WatchResources(ctx, typeURL, nonce, nodeIP, req.GetResourceNames(), respCh)
 
 			firstRequest = false
 

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -266,6 +266,9 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 	// Indicates if client received the first response,
 	// but it doesn't necessarily mean that it was ACKed.
 	clientReceivedFirstResponse := false
+	// responseAcked indicates if we already
+	// had some request on this stream that was ACKed by a client.
+	responseAcked := false
 
 	for {
 		// Process either a new request from the xDS stream or a response
@@ -352,6 +355,12 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				clientReceivedFirstResponse = true
 			}
 
+			if clientReceivedFirstResponse && versionInfo == nonce {
+				// Once we get the first ACK,
+				// we can start using versionInfo for ACKing observers.
+				responseAcked = true
+			}
+
 			if versionInfo > 0 && firstRequest {
 				requestLog.Infof("xDS was restarted, previous versionInfo: %d", versionInfo)
 			}
@@ -366,7 +375,15 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				ackObserver := s.ackObservers[typeURL]
 				if ackObserver != nil {
 					requestLog.Debug("notifying observers of ACKs")
-					ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
+					if !responseAcked {
+						// If we haven't received any ACK, it means that versionInfo
+						// is stale and we can't ACK anything.
+						// Also we can't send versionInfo as it would incorrectly be cached
+						// as last acked version.
+						ackObserver.HandleResourceVersionAck(0, nonce, nodeIP, state.resourceNames, typeURL, detail)
+					} else {
+						ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
+					}
 				} else {
 					requestLog.Info("ACK received but no observers are waiting for ACKs")
 				}

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -409,7 +409,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state.pendingWatchCancel = cancel
 
 			requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
-			go watcher.WatchResources(ctx, typeURL, nonce, nodeIP, req.GetResourceNames(), respCh)
+			go watcher.WatchResources(ctx, typeURL, nonce, versionInfo, nodeIP, req.GetResourceNames(), respCh)
 
 			firstRequest = false
 

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -1179,3 +1179,94 @@ func TestTheSameVersionOnRestart(t *testing.T) {
 	case <-streamDone:
 	}
 }
+
+func TestNotAckedAfterRestart(t *testing.T) {
+	// Similar to test case TestNAckFromTheStart
+	// But here we are making sure that we don't issue incorrect ACKs
+	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	metrics := newMockMetrics()
+
+	var err error
+	var req *envoy_service_discovery.DiscoveryRequest
+	var resp *envoy_service_discovery.DiscoveryResponse
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+	wg := completion.NewWaitGroup(ctx)
+
+	cache := NewCache()
+	mutator := NewAckingResourceMutatorWrapper(cache, metrics)
+
+	streamCtx, closeStream := context.WithCancel(ctx)
+	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer stream.Close()
+
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+
+	streamDone := make(chan struct{})
+
+	// Run the server's stream handler concurrently.
+	go func() {
+		defer close(streamDone)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		require.NoError(t, err)
+	}()
+
+	// Create version 2 with resource 0.
+	callback1, comp1 := newCompCallback()
+	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
+	require.Condition(t, isNotCompletedComparison(comp1))
+
+	// Request all resources, with a version higher than the version currently
+	// in Cilium's cache. This happens after the server restarts but the
+	// xDS client survives and continues to request the same version.
+	req = &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   "64",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "",
+	}
+	err = stream.SendRequest(req)
+	require.NoError(t, err)
+
+	// Expecting a response with that resource.
+	resp, err = stream.RecvResponse()
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "65", []proto.Message{resources[0]}, false, typeURL))
+
+	// Version 2 was not ACKED by the last request, so it must NOT be completedInTime successfully.
+	require.Condition(t, isNotCompletedComparison(comp1))
+	// Check that the completion was not NACKed
+	require.NoError(t, comp1.Err())
+	// Simulate that first request on a new stream was NACKed.
+	req = &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   "64",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "65",
+	}
+	err = stream.SendRequest(req)
+	require.NoError(t, err)
+
+	// Since we don't update resources, we expect that we will not receive
+	// any response. However, we want to make sure that previously
+	// pending completions are still not ACKed, but they are NACKed.
+	resp, err = stream.RecvResponse()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	// IsCompleted is true only for completions without error
+	require.Condition(t, isNotCompletedComparison(comp1))
+	// Check that the completion was NACKed
+	require.Error(t, comp1.Err())
+
+	// Close the stream.
+	closeStream()
+
+	select {
+	case <-ctx.Done():
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+	case <-streamDone:
+	}
+}

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -1066,7 +1066,7 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 		VersionInfo:   "64",
 		Node:          nodes[node0],
 		ResourceNames: nil,
-		ResponseNonce: "64",
+		ResponseNonce: "",
 	}
 	err = stream.SendRequest(req)
 	require.NoError(t, err)

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -698,21 +698,19 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.Equal(t, uint64(3), v)
 	require.True(t, mod)
 
-	// Request the next version of resources, with a stale nonce.
+	// Request the next version of resources, with a stale nonce and version.
 	req = &envoy_service_discovery.DiscoveryRequest{
 		TypeUrl:       typeURL,
-		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		VersionInfo:   "1",
 		Node:          nodes[node0],
 		ResourceNames: nil,
-		ResponseNonce: "0",
+		ResponseNonce: "1",
 	}
 	// Do not update the nonce.
 	err = stream.SendRequest(req)
 	require.NoError(t, err)
 
-	// Server correctly detects 0 nonce and resets it to the correct value.
-
-	// Expecting a response with both resources.
+	// Server correctly detects stale Nonce and sends response.
 	resp, err = stream.RecvResponse()
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)


### PR DESCRIPTION
Please review commit by commit, it should be much simpler. 

High level summary:
- Added two tests that shows that current implementation had bugs - TestTheSameVersionOnRestart and TestNotAckedAfterRestart:
1. TestTheSameVersionOnRestart shows that we were not sending response in case of new stream while accidentally previous versionInfo was equal to current version in xds cache.
2. TestNotAckedAfterRestart shows that in case of reciving NACK on a new stream, we were still ACKing observers instead of NACKs.
- Fixed two previous tests that were just incorrect - TestRequestStaleNonce and TestRequestHighVersionFromTheStart - fixing them did not break previous implementation. 
1. Test TestRequestStaleNonce previously used nonce=0 and versionInfo=2. We had special handling for nonce=0. if we only switched to nonce=1 an versionInfo=2 it would result in hitting `ErrInvalidResponseNonce` case. So instead switch to both versionInfo and nonce being stale. 
2. TestRequestHighVersionFromTheStart - just had nonce set to versionInfo, but first request on stream needs nonce empty.
Following commits after tests are simplifying control plane and fixing control plane for newly added tests.


```release-note
xds: Fix a case in which after cilium-agent we were not sending updated resources to Envoy
```
