### PR TITLE
lrp: Add IP family checks

### DIFF
--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -644,9 +644,9 @@ func (rpm *Manager) deletePolicyBackends(config *LRPConfig, podID podID) {
 				continue
 			}
 			if config.skipRedirectFromBackend {
-				if be.AddrCluster.Is4() {
+				if be.AddrCluster.Is4() && option.Config.EnableIPv4 {
 					rpm.skipLBMap.DeleteLB4ByNetnsCookie(be.podNetnsCookie)
-				} else {
+				} else if option.Config.EnableIPv6 {
 					rpm.skipLBMap.DeleteLB6ByNetnsCookie(be.podNetnsCookie)
 				}
 			}
@@ -671,9 +671,9 @@ func (rpm *Manager) deletePolicyFrontend(config *LRPConfig, frontend *frontend) 
 	if config.skipRedirectFromBackend {
 		// Delete skip_lb map entries.
 		addr := frontend.AddrCluster
-		if addr.Is4() {
+		if addr.Is4() && option.Config.EnableIPv4 {
 			rpm.skipLBMap.DeleteLB4ByAddrPort(addr.AsNetIP(), frontend.Port)
-		} else {
+		} else if option.Config.EnableIPv6 {
 			rpm.skipLBMap.DeleteLB6ByAddrPort(addr.AsNetIP(), frontend.Port)
 		}
 	}
@@ -760,11 +760,11 @@ func (rpm *Manager) plumbSkipLBEntries(mapping *feMapping) error {
 			return fmt.Errorf("no valid pod netns cookie")
 		}
 		addr := mapping.feAddr
-		if addr.AddrCluster.Is4() {
+		if addr.AddrCluster.Is4() && option.Config.EnableIPv4 {
 			if err := rpm.skipLBMap.AddLB4(pb.podNetnsCookie, addr.AddrCluster.AsNetIP(), addr.Port); err != nil {
 				return fmt.Errorf("failed to add entry to skip_lb4 map: %w", err)
 			}
-		} else {
+		} else if option.Config.EnableIPv6 {
 			if err := rpm.skipLBMap.AddLB6(pb.podNetnsCookie, addr.AddrCluster.AsNetIP(), addr.Port); err != nil {
 				return fmt.Errorf("failed to add entry to skip_lb6 map: %w", err)
 			}


### PR DESCRIPTION
Fix panic caused in dual cluster setups where IPv6 is disabled and LRPs with `skipRedirectFromBackend` flag set to true are installed.

```
time="2025-03-27T23:58:50.252534907Z" level=debug msg="Local redirect service for policy cilium-test-1/lrp-address-matcher-skip-redirect-from-backend-v6 not deleted" error="<nil>" subsys=redirectpolicy
"Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
	goroutine 647 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x572a888, 0x901c2e0}, {0x45208a0, 0x8a1cf00})
		/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x572a888, 0x901c2e0}, {0x45208a0, 0x8a1cf00}, {0x901c2e0, 0x0, 0x100000004fceb2d?})
		/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:82 +0x5a
	k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc001ed0840?})
		/go/src/github.com/cilium/cilium/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:59 +0x105
	panic({0x45208a0?, 0x8a1cf00?})
		/usr/local/go/src/runtime/panic.go:792 +0x132
	github.com/cilium/cilium/pkg/ebpf.(*Map).IterateWithCallback(0x0, {0x47fa860, 0xc002076fe0}, {0x46c13c0, 0xc001791f67}, 0xc002df7328)
		/go/src/github.com/cilium/cilium/pkg/ebpf/map.go:182 +0x5f
	github.com/cilium/cilium/pkg/maps/lbmap.(*skipLBMap).DeleteLB6ByAddrPort(0xc0015f4320, {0xc001791f70, 0x10, 0x10}, 0x50)
		/go/src/github.com/cilium/cilium/pkg/maps/lbmap/skip_lb_map.go:265 +0x13a
	github.com/cilium/cilium/pkg/redirectpolicy.(*Manager).deletePolicyFrontend(0xc000caa0a0, 0xc00109fa40, 0xc005032d40)
		/go/src/github.com/cilium/cilium/pkg/redirectpolicy/manager.go:677 +0x415
	github.com/cilium/cilium/pkg/redirectpolicy.(*Manager).DeleteRedirectPolicy(0xc000caa0a0, {{{0x0, 0x0}, {0xc0031a0800, 0x31}, {0xc001e801e0, 0xd}}, {0x0, 0x0}, 0x0, ...})
		/go/src/github.com/cilium/cilium/pkg/redirectpolicy/manager.go:254 +0x5bf
	github.com/cilium/cilium/pkg/k8s/watchers.(*K8sCiliumLRPWatcher).deleteCiliumLocalRedirectPolicy(0xc00013c910, 0xc004f1a600)
		/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_local_redirect_policy.go:162 +0x235
	github.com/cilium/cilium/pkg/k8s/watchers.(*K8sCiliumLRPWatcher).ciliumLocalRedirectPolicyInit.func3({0x4f37fc0?, 0xc004f1a600?})
		/go/src/github.com/cilium/cilium/pkg/k8s/watchers/cilium_local_redirect_policy.go:102 +0xbe
	k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
```

Fixes: https://github.com/cilium/cilium/issues/38570

Reported-by: Michi Mutsuzaki <michi@isovalent.com>
Signed-off-by: Aditi Ghag <aditi@cilium.io>

```release-note
Fix panic caused in dual cluster setups where LRPs with `skipRedirectFromBackend` flag set to true are installed and IPv6 is disabled.
```