### PR TITLE
fqdn: extract FQDN bootstrap logic from daemon

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -363,7 +363,6 @@ Makefile* @cilium/build
 /daemon/ @cilium/sig-agent
 /daemon/cmd/datapath.go @cilium/sig-datapath
 /daemon/cmd/endpoint* @cilium/endpoint
-/daemon/cmd/fqdn* @cilium/fqdn
 /daemon/cmd/health* @cilium/sig-agent
 /daemon/cmd/ipcache* @cilium/ipcache
 /daemon/cmd/kube_proxy* @cilium/sig-datapath

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
-	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	fqdnRules "github.com/cilium/cilium/pkg/fqdn/rules"
 	hubblecell "github.com/cilium/cilium/pkg/hubble/cell"
 	"github.com/cilium/cilium/pkg/identity"
@@ -109,10 +108,6 @@ type Daemon struct {
 	routes           statedb.Table[*datapathTables.Route]
 	devices          statedb.Table[*datapathTables.Device]
 	nodeAddrs        statedb.Table[datapathTables.NodeAddress]
-
-	// dnsNameManager tracks which api.FQDNSelector are present in policy which
-	// apply to locally running endpoints.
-	dnsNameManager namemanager.NameManager
 
 	// Used to synchronize generation of daemon's BPF programs and endpoint BPF
 	// programs.
@@ -410,7 +405,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		lrpManager:        params.LRPManager,
 		ctMapGC:           params.CTNATMapGC,
 		maglevConfig:      params.MaglevConfig,
-		dnsNameManager:    params.NameManager,
 		explbConfig:       params.ExpLBConfig,
 		dnsProxy:          params.DNSProxy,
 		dnsRulesAPI:       params.DNSRulesAPI,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -71,7 +71,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	policyAPI "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy"
-	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/resiliency"
@@ -89,16 +88,15 @@ const (
 // Daemon is the cilium daemon that is in charge of perform all necessary plumbing,
 // monitoring when a LXC starts.
 type Daemon struct {
-	ctx               context.Context
-	logger            *slog.Logger
-	clientset         k8sClient.Clientset
-	db                *statedb.DB
-	epBuildQueue      endpoint.EndpointBuildQueue
-	l7Proxy           *proxy.Proxy
-	proxyAccessLogger accesslog.ProxyAccessLogger
-	svc               service.ServiceManager
-	policy            policy.PolicyRepository
-	idmgr             identitymanager.IDManager
+	ctx          context.Context
+	logger       *slog.Logger
+	clientset    k8sClient.Clientset
+	db           *statedb.DB
+	epBuildQueue endpoint.EndpointBuildQueue
+	l7Proxy      *proxy.Proxy
+	svc          service.ServiceManager
+	policy       policy.PolicyRepository
+	idmgr        identitymanager.IDManager
 
 	statusCollectMutex lock.RWMutex
 	statusResponse     models.StatusResponse
@@ -395,7 +393,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		monitorAgent:      params.MonitorAgent,
 		svc:               params.ServiceManager,
 		l7Proxy:           params.L7Proxy,
-		proxyAccessLogger: params.ProxyAccessLogger,
 		authManager:       params.AuthManager,
 		settings:          params.Settings,
 		bigTCPConfig:      params.BigTCPConfig,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -103,7 +103,6 @@ import (
 	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
-	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
@@ -1545,7 +1544,6 @@ type daemonParams struct {
 	L2Announcer         *l2announcer.L2Announcer
 	ServiceManager      service.ServiceManager
 	L7Proxy             *proxy.Proxy
-	ProxyAccessLogger   accesslog.ProxyAccessLogger
 	DB                  *statedb.DB
 	APILimiterSet       *rate.APILimiterSet
 	AuthManager         *auth.AuthManager

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
+	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	fqdnRules "github.com/cilium/cilium/pkg/fqdn/rules"
@@ -1583,6 +1584,7 @@ type daemonParams struct {
 	ExpLBConfig         experimental.Config
 	DNSProxy            defaultdns.Proxy
 	DNSRulesAPI         fqdnRules.DNSRulesService
+	DNSBootstrapper     bootstrap.FQDNProxyBootstrapper
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -60,7 +60,6 @@ import (
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
-	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	fqdnRules "github.com/cilium/cilium/pkg/fqdn/rules"
 	"github.com/cilium/cilium/pkg/hive"
 	hubblecell "github.com/cilium/cilium/pkg/hubble/cell"
@@ -1578,7 +1577,6 @@ type daemonParams struct {
 	Hubble              hubblecell.HubbleIntegration
 	LRPManager          *redirectpolicy.Manager
 	MaglevConfig        maglev.Config
-	NameManager         namemanager.NameManager
 	ExpLBConfig         experimental.Config
 	DNSProxy            defaultdns.Proxy
 	DNSRulesAPI         fqdnRules.DNSRulesService
@@ -1770,7 +1768,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 				return
 			}
 		}
-		d.dnsNameManager.CompleteBootstrap()
+		d.dnsBootstrapper.CompleteBootstrap()
 
 		ms := maps.NewMapSweeper(&EndpointMapManager{
 			EndpointManager: d.endpointManager,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -59,7 +59,6 @@ import (
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
-	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
 	fqdnRules "github.com/cilium/cilium/pkg/fqdn/rules"
 	"github.com/cilium/cilium/pkg/hive"
 	hubblecell "github.com/cilium/cilium/pkg/hubble/cell"
@@ -1578,9 +1577,8 @@ type daemonParams struct {
 	LRPManager          *redirectpolicy.Manager
 	MaglevConfig        maglev.Config
 	ExpLBConfig         experimental.Config
-	DNSProxy            defaultdns.Proxy
 	DNSRulesAPI         fqdnRules.DNSRulesService
-	DNSBootstrapper     bootstrap.FQDNProxyBootstrapper
+	DNSProxy            bootstrap.FQDNProxyBootstrapper
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
@@ -1768,7 +1766,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 				return
 			}
 		}
-		d.dnsBootstrapper.CompleteBootstrap()
+		params.DNSProxy.CompleteBootstrap()
 
 		ms := maps.NewMapSweeper(&EndpointMapManager{
 			EndpointManager: d.endpointManager,

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -58,6 +58,7 @@ type DaemonSuite struct {
 
 	PolicyImporter policycell.PolicyImporter
 	envoyXdsServer envoy.XDSServer
+	dnsProxy       defaultdns.Proxy
 }
 
 func setupTestDirectories() string {
@@ -134,6 +135,9 @@ func setupDaemonSuite(tb testing.TB) *DaemonSuite {
 		cell.Invoke(func(envoyXdsServer envoy.XDSServer) {
 			ds.envoyXdsServer = envoyXdsServer
 		}),
+		cell.Invoke(func(dnsProxy defaultdns.Proxy) {
+			ds.dnsProxy = dnsProxy
+		}),
 	)
 
 	// bootstrap global config
@@ -151,7 +155,7 @@ func setupDaemonSuite(tb testing.TB) *DaemonSuite {
 	ds.d, err = daemonPromise.Await(ctx)
 	require.NoError(tb, err)
 
-	ds.d.dnsProxy.Set(fqdnproxy.MockFQDNProxy{})
+	ds.dnsProxy.Set(fqdnproxy.MockFQDNProxy{})
 	kvstore.Client().DeletePrefix(ctx, kvstore.BaseKeyPrefix)
 
 	ds.d.policy.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
-	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
 	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
@@ -91,14 +90,6 @@ func TestMain(m *testing.M) {
 	time.Local = time.UTC
 
 	os.Exit(m.Run())
-}
-
-type dummyEpSyncher struct{}
-
-func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, h cell.Health) {
-}
-
-func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
 }
 
 func setupDaemonSuite(tb testing.TB) *DaemonSuite {

--- a/pkg/fqdn/bootstrap/cell.go
+++ b/pkg/fqdn/bootstrap/cell.go
@@ -24,6 +24,7 @@ var Cell = cell.Module(
 	"Bootstraps the FQDN policy subsystem",
 
 	cell.Provide(newFQDNProxyBootstrapper),
+	cell.Provide(newDNSRequestHandler),
 )
 
 type fqdnProxyBootstrapperParams struct {
@@ -34,10 +35,10 @@ type fqdnProxyBootstrapperParams struct {
 	NameManager       namemanager.NameManager
 	ProxyInstance     defaultdns.Proxy
 	ProxyPorts        *proxy.Proxy
-	ProxyAccessLogger accesslog.ProxyAccessLogger
 	PolicyRepo        policy.PolicyRepository
 	IPCache           *ipcache.IPCache
 	EndpointManager   endpointmanager.EndpointManager
+	DNSRequestHandler DNSRequestHandler
 }
 
 func newFQDNProxyBootstrapper(params fqdnProxyBootstrapperParams) FQDNProxyBootstrapper {
@@ -49,10 +50,10 @@ func newFQDNProxyBootstrapper(params fqdnProxyBootstrapperParams) FQDNProxyBoots
 		nameManager:       params.NameManager,
 		proxyInstance:     params.ProxyInstance,
 		proxyPorts:        params.ProxyPorts,
-		proxyAccessLogger: params.ProxyAccessLogger,
 		policyRepo:        params.PolicyRepo,
 		ipcache:           params.IPCache,
 		endpointManager:   params.EndpointManager,
+		dnsRequestHandler: params.DNSRequestHandler,
 	}
 
 	params.Lifecycle.Append(cell.Hook{
@@ -63,4 +64,35 @@ func newFQDNProxyBootstrapper(params fqdnProxyBootstrapperParams) FQDNProxyBoots
 	})
 
 	return bootstrapper
+}
+
+type dnsRequestHandlerParams struct {
+	cell.In
+
+	Lifecycle         cell.Lifecycle
+	Logger            *slog.Logger
+	NameManager       namemanager.NameManager
+	ProxyInstance     defaultdns.Proxy
+	ProxyAccessLogger accesslog.ProxyAccessLogger
+}
+
+func newDNSRequestHandler(params dnsRequestHandlerParams) DNSRequestHandler {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	handler := &dnsRequestHandler{
+		ctx:               ctx,
+		logger:            params.Logger,
+		nameManager:       params.NameManager,
+		proxyInstance:     params.ProxyInstance,
+		proxyAccessLogger: params.ProxyAccessLogger,
+	}
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStop: func(hookContext cell.HookContext) error {
+			cancelCtx()
+			return nil
+		},
+	})
+
+	return handler
 }

--- a/pkg/fqdn/bootstrap/cell.go
+++ b/pkg/fqdn/bootstrap/cell.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bootstrap
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
+	"github.com/cilium/cilium/pkg/fqdn/namemanager"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/proxy"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
+)
+
+// Cell provides the FQDN bootstrap functionality
+var Cell = cell.Module(
+	"fqdn-bootstrap",
+	"Bootstraps the FQDN policy subsystem",
+
+	cell.Provide(newFQDNProxyBootstrapper),
+)
+
+type fqdnProxyBootstrapperParams struct {
+	cell.In
+
+	Lifecycle         cell.Lifecycle
+	Logger            *slog.Logger
+	NameManager       namemanager.NameManager
+	ProxyInstance     defaultdns.Proxy
+	ProxyPorts        *proxy.Proxy
+	ProxyAccessLogger accesslog.ProxyAccessLogger
+	PolicyRepo        policy.PolicyRepository
+	IPCache           *ipcache.IPCache
+	EndpointManager   endpointmanager.EndpointManager
+}
+
+func newFQDNProxyBootstrapper(params fqdnProxyBootstrapperParams) FQDNProxyBootstrapper {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	bootstrapper := &fqdnProxyBootstrapper{
+		ctx:               ctx,
+		logger:            params.Logger,
+		nameManager:       params.NameManager,
+		proxyInstance:     params.ProxyInstance,
+		proxyPorts:        params.ProxyPorts,
+		proxyAccessLogger: params.ProxyAccessLogger,
+		policyRepo:        params.PolicyRepo,
+		ipcache:           params.IPCache,
+		endpointManager:   params.EndpointManager,
+	}
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStop: func(hookContext cell.HookContext) error {
+			cancelCtx()
+			return nil
+		},
+	})
+
+	return bootstrapper
+}

--- a/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
+++ b/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
@@ -53,6 +53,7 @@ const (
 type FQDNProxyBootstrapper interface {
 	BootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, preCachePath string) error
 	UpdateDNSDatapathRules(ctx context.Context) error
+	CompleteBootstrap()
 }
 
 type fqdnProxyBootstrapper struct {
@@ -418,4 +419,8 @@ func (b *fqdnProxyBootstrapper) notifyOnDNSMsg(
 	b.proxyAccessLogger.Log(record)
 
 	return nil
+}
+
+func (b *fqdnProxyBootstrapper) CompleteBootstrap() {
+	b.nameManager.CompleteBootstrap()
 }

--- a/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
+++ b/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
@@ -54,6 +54,7 @@ type FQDNProxyBootstrapper interface {
 	BootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, preCachePath string) error
 	UpdateDNSDatapathRules(ctx context.Context) error
 	CompleteBootstrap()
+	Cleanup()
 }
 
 type fqdnProxyBootstrapper struct {
@@ -423,4 +424,10 @@ func (b *fqdnProxyBootstrapper) notifyOnDNSMsg(
 
 func (b *fqdnProxyBootstrapper) CompleteBootstrap() {
 	b.nameManager.CompleteBootstrap()
+}
+
+func (b *fqdnProxyBootstrapper) Cleanup() {
+	if p := b.proxyInstance.Get(); p != nil {
+		p.Cleanup()
+	}
 }

--- a/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
+++ b/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
@@ -9,45 +9,21 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
-	"strings"
-
-	"github.com/cilium/dns"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/fqdn/re"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy"
-	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	proxytypes "github.com/cilium/cilium/pkg/proxy/types"
-	"github.com/cilium/cilium/pkg/time"
-	"github.com/cilium/cilium/pkg/u8proto"
-)
-
-const (
-	upstreamTime    = "upstreamTime"
-	processingTime  = "processingTime"
-	semaphoreTime   = "semaphoreTime"
-	policyCheckTime = "policyCheckTime"
-	policyGenTime   = "policyGenerationTime"
-	dataplaneTime   = "dataplaneTime"
-	totalTime       = "totalTime"
-
-	metricErrorTimeout = "timeout"
-	metricErrorProxy   = "proxyErr"
-	metricErrorDenied  = "denied"
-	metricErrorAllow   = "allow"
 )
 
 type FQDNProxyBootstrapper interface {
@@ -63,10 +39,10 @@ type fqdnProxyBootstrapper struct {
 	nameManager       namemanager.NameManager
 	proxyInstance     defaultdns.Proxy
 	proxyPorts        *proxy.Proxy
-	proxyAccessLogger accesslog.ProxyAccessLogger
 	policyRepo        policy.PolicyRepository
 	ipcache           *ipcache.IPCache
 	endpointManager   endpointmanager.EndpointManager
+	dnsRequestHandler DNSRequestHandler
 }
 
 var _ FQDNProxyBootstrapper = &fqdnProxyBootstrapper{}
@@ -122,8 +98,7 @@ func (b *fqdnProxyBootstrapper) BootstrapFQDN(possibleEndpoints map[uint16]*endp
 		ConcurrencyGracePeriod: option.Config.DNSProxyConcurrencyProcessingGracePeriod,
 	}
 	var dnsProxy fqdnproxy.DNSProxier
-	dnsProxy, err = dnsproxy.StartDNSProxy(dnsProxyConfig, b.lookupEPByIP, b.ipcache.LookupSecIDByIP, b.ipcache.LookupByIdentity,
-		b.notifyOnDNSMsg)
+	dnsProxy, err = dnsproxy.StartDNSProxy(dnsProxyConfig, b.lookupEPByIP, b.ipcache.LookupSecIDByIP, b.ipcache.LookupByIdentity, b.dnsRequestHandler.NotifyOnDNSMsg)
 	b.proxyInstance.Set(dnsProxy)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
@@ -169,257 +144,6 @@ func (b *fqdnProxyBootstrapper) lookupEPByIP(endpointAddr netip.Addr) (endpoint 
 	}
 
 	return nil, false, fmt.Errorf("cannot find endpoint with IP %s", endpointAddr)
-}
-
-// notifyOnDNSMsg handles DNS data in the daemon by emitting monitor
-// events, proxy metrics and storing DNS data in the DNS cache. This may
-// result in rule generation.
-// It will:
-//   - Report a monitor error event and proxy metrics when the proxy sees an
-//     error, and when it can't process something in this function
-//   - Report the verdict in a monitor event and emit proxy metrics
-//   - Insert the DNS data into the cache when msg is a DNS response, and we
-//     can lookup the endpoint related to it.
-//
-// It may return dnsproxy.ErrDNSRequestNoEndpoint{} error if the endpoint is nil.
-// Note that the caller should log beforehand the contextualized error.
-
-// epIPPort and serverAddrPort should match the original request, where epAddr is
-// the source for egress (the only case current).
-// serverID is the destination server security identity at the time of the DNS event.
-func (b *fqdnProxyBootstrapper) notifyOnDNSMsg(
-	lookupTime time.Time,
-	ep *endpoint.Endpoint,
-	epIPPort string,
-	serverID identity.NumericIdentity,
-	serverAddrPort netip.AddrPort,
-	msg *dns.Msg,
-	protocol string,
-	allowed bool,
-	stat *dnsproxy.ProxyRequestContext,
-) error {
-	protoID := u8proto.ProtoIDs[strings.ToLower(protocol)]
-	var verdict accesslog.FlowVerdict
-	var reason string
-	metricError := metricErrorAllow
-	stat.ProcessingTime.Start()
-
-	endMetric := func() {
-		stat.DataplaneTime.End(true)
-		stat.ProcessingTime.End(true)
-		stat.TotalTime.End(true)
-		if errors.As(stat.Err, &dnsproxy.ErrFailedAcquireSemaphore{}) || errors.As(stat.Err, &dnsproxy.ErrTimedOutAcquireSemaphore{}) {
-			metrics.FQDNSemaphoreRejectedTotal.Inc()
-		}
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, totalTime).Observe(
-			stat.TotalTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, upstreamTime).Observe(
-			stat.UpstreamTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
-			stat.ProcessingTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, semaphoreTime).Observe(
-			stat.SemaphoreAcquireTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyGenTime).Observe(
-			stat.PolicyGenerationTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
-			stat.PolicyCheckTime.Total().Seconds())
-		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, dataplaneTime).Observe(
-			stat.DataplaneTime.Total().Seconds())
-	}
-
-	switch {
-	case stat.IsTimeout():
-		metricError = metricErrorTimeout
-		endMetric()
-		return nil
-	case stat.Err != nil:
-		metricError = metricErrorProxy
-		verdict = accesslog.VerdictError
-		reason = "Error: " + stat.Err.Error()
-	case allowed:
-		verdict = accesslog.VerdictForwarded
-		reason = "Allowed by policy"
-	case !allowed:
-		metricError = metricErrorDenied
-		verdict = accesslog.VerdictDenied
-		reason = "Denied by policy"
-	}
-
-	if ep == nil {
-		// This is a hard fail. We cannot proceed because record.Log requires a
-		// non-nil ep, and we also don't want to insert this data into the
-		// cache if we don't know that an endpoint asked for it (this is
-		// asserted via ep != nil here and msg.Response && msg.Rcode ==
-		// dns.RcodeSuccess below).
-		endMetric()
-		return dnsproxy.ErrDNSRequestNoEndpoint{}
-	}
-
-	// We determine the direction based on the DNS packet. The observation
-	// point is always Egress, however.
-	var flowType accesslog.FlowType
-	var addrInfo accesslog.AddressingInfo
-	serverAddrPortStr := serverAddrPort.String()
-	if msg.Response {
-		flowType = accesslog.TypeResponse
-		addrInfo.DstIPPort = epIPPort
-		addrInfo.DstEPID = ep.GetID()
-		// ignore error; log fields are best effort. Only returns error if endpoint
-		// is going away.
-		addrInfo.DstSecIdentity, _ = ep.GetSecurityIdentity()
-		addrInfo.SrcIPPort = serverAddrPortStr
-		addrInfo.SrcIdentity = serverID
-	} else {
-		flowType = accesslog.TypeRequest
-		addrInfo.SrcIPPort = epIPPort
-		addrInfo.SrcEPID = ep.GetID()
-		// ignore error; same reason as above.
-		addrInfo.SrcSecIdentity, _ = ep.GetSecurityIdentity()
-		addrInfo.DstIPPort = serverAddrPortStr
-		addrInfo.DstIdentity = serverID
-	}
-
-	qname, responseIPs, TTL, CNAMEs, rcode, recordTypes, qTypes, err := dnsproxy.ExtractMsgDetails(msg)
-	if err != nil {
-		b.logger.Error("cannot extract DNS message details",
-			logfields.Error, err,
-			logfields.DNSName, qname,
-		)
-		return fmt.Errorf("failed to extract DNS message details: %w", err)
-	}
-
-	if msg.Response && msg.Rcode == dns.RcodeSuccess && len(responseIPs) > 0 {
-		stat.PolicyGenerationTime.Start()
-
-		// Create a critical section especially for when multiple DNS requests
-		// are in-flight for the same name (i.e. cilium.io).
-		//
-		// In the absence of such a critical section, consider the following
-		// race condition:
-		//
-		//              G1                                    G2
-		//
-		// T0 --> NotifyOnDNSMsg()               NotifyOnDNSMsg()            <-- T0
-		//
-		// T1 --> UpdateGenerateDNS()            UpdateGenerateDNS()         <-- T1
-		//
-		// T2 ----> mutex.Lock()                 +--------------------------+
-		//                                       |No selectors need updating|
-		// T3 ----> wg := UpdatePolicyMaps()     +--------------------------+
-		//
-		// T4 ----> mutex.Unlock()               mutex.Lock() / mutex.Unlock() <-- T4
-		//
-		// T5 ----> wg.Wait()                    DNS released back to pod    <-- T5
-		//                                                    |
-		// T6 --> DNS released back to pod                    |
-		//              |                                     |
-		//              |                                     |
-		//              v                                     v
-		//       Traffic flows fine                   Leads to policy drop until T6
-		//
-		// Note how G2 releases the DNS msg back to the pod at T5 because
-		// UpdateGenerateDNS() was a no-op. It's a no-op because G1 had executed
-		// UpdateGenerateDNS() first at T1 and performed the necessary policy
-		// updates for the response IPs. Due to G1 performing all the work
-		// first, G2 executes T4 also as a no-op and releases the msg back to the
-		// pod at T5 before G1 would at T6.
-		//
-		// We do not do a `defer unlock()` here, as we should release the lock before
-		// doing final bookkeeping.
-		mutexAcquireStart := time.Now()
-		b.nameManager.LockName(qname)
-
-		if d := time.Since(mutexAcquireStart); d >= option.Config.DNSProxyLockTimeout {
-			b.logger.Warn(fmt.Sprintf("Name lock acquisition time took longer than expected. Potentially too many parallel DNS requests being processed, consider adjusting --%s and/or --%s", option.DNSProxyLockCount, option.DNSProxyLockTimeout),
-				logfields.DNSName, qname,
-				logfields.Duration, d,
-				logfields.Expected, option.Config.DNSProxyLockTimeout,
-			)
-		}
-
-		b.logger.Debug("Recording DNS lookup in endpoint specific cache", logfields.EndpointID, ep.ID)
-
-		// This must happen before the NameManager update below, to ensure that
-		// this data is included in the serialized Endpoint object.
-		// We also need to add to the cache before we purge any matching zombies
-		// because they are locked separately and we want to keep the allowed IPs
-		// consistent if a regeneration happens between the two steps. If an update
-		// doesn't happen in the case, we play it safe and don't purge the zombie
-		// in case of races.
-		if updated := ep.DNSHistory.Update(lookupTime, qname, responseIPs, int(TTL)); updated {
-			ep.DNSZombies.ForceExpireByNameIP(lookupTime, qname, responseIPs...)
-			ep.SyncEndpointHeaderFile()
-		}
-
-		b.logger.Debug("Updating DNS name in cache from response to query",
-			logfields.DNSName, qname,
-			logfields.IPAddrs, responseIPs,
-		)
-
-		updateCtx, updateCancel := context.WithTimeout(b.ctx, option.Config.FQDNProxyResponseMaxDelay)
-		defer updateCancel()
-		updateStart := time.Now()
-
-		dpUpdates := b.nameManager.UpdateGenerateDNS(updateCtx, lookupTime, qname, &fqdn.DNSIPRecords{
-			IPs: responseIPs,
-			TTL: int(TTL),
-		})
-
-		stat.PolicyGenerationTime.End(true)
-		stat.DataplaneTime.Start()
-
-		if err := <-dpUpdates; err != nil {
-			b.logger.Warn("Timed out waiting for datapath updates of FQDN IP information; returning response. Consider increasing --tofqdns-proxy-response-max-delay if this keeps happening.")
-			metrics.ProxyDatapathUpdateTimeout.Inc()
-		}
-
-		// Policy updates for this name have been pushed out; we can release the lock.
-		b.nameManager.UnlockName(qname)
-
-		b.logger.Debug("Waited for endpoints to regenerate due to a DNS response",
-			logfields.Duration, time.Since(updateStart),
-			logfields.EndpointID, ep.GetID(),
-			logfields.DNSName, qname,
-		)
-
-		endMetric()
-	}
-
-	stat.ProcessingTime.End(true)
-
-	bindPort := uint16(0)
-	if dnsProxy := b.proxyInstance.Get(); dnsProxy != nil {
-		bindPort = dnsProxy.GetBindPort()
-	}
-	ep.UpdateProxyStatistics("fqdn", strings.ToUpper(protocol), serverAddrPort.Port(), bindPort, false, !msg.Response, verdict)
-
-	// Ensure that there are no early returns from this function before the
-	// code below, otherwise the log record will not be made.
-	//
-	// Restrict label enrichment time to 10ms; we don't want to block DNS
-	// requests because an identity isn't in the local cache yet.
-	logContext, lcncl := context.WithTimeout(b.ctx, 10*time.Millisecond)
-	defer lcncl()
-	record := b.proxyAccessLogger.NewLogRecord(flowType, false,
-		func(lr *accesslog.LogRecord, _ accesslog.EndpointInfoRegistry) {
-			lr.TransportProtocol = accesslog.TransportProtocol(protoID)
-		},
-		accesslog.LogTags.Verdict(verdict, reason),
-		accesslog.LogTags.Addressing(logContext, addrInfo),
-		accesslog.LogTags.DNS(&accesslog.LogRecordDNS{
-			Query:             qname,
-			IPs:               responseIPs,
-			TTL:               TTL,
-			CNAMEs:            CNAMEs,
-			ObservationSource: stat.DataSource,
-			RCode:             rcode,
-			QTypes:            qTypes,
-			AnswerTypes:       recordTypes,
-		}),
-	)
-	b.proxyAccessLogger.Log(record)
-
-	return nil
 }
 
 func (b *fqdnProxyBootstrapper) CompleteBootstrap() {

--- a/pkg/fqdn/bootstrap/fqdn_request_handler.go
+++ b/pkg/fqdn/bootstrap/fqdn_request_handler.go
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"strings"
+
+	"github.com/cilium/dns"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn"
+	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/namemanager"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+const (
+	upstreamTime    = "upstreamTime"
+	processingTime  = "processingTime"
+	semaphoreTime   = "semaphoreTime"
+	policyCheckTime = "policyCheckTime"
+	policyGenTime   = "policyGenerationTime"
+	dataplaneTime   = "dataplaneTime"
+	totalTime       = "totalTime"
+
+	metricErrorTimeout = "timeout"
+	metricErrorProxy   = "proxyErr"
+	metricErrorDenied  = "denied"
+	metricErrorAllow   = "allow"
+)
+
+type DNSRequestHandler interface {
+	NotifyOnDNSMsg(lookupTime time.Time,
+		ep *endpoint.Endpoint,
+		epIPPort string,
+		serverID identity.NumericIdentity,
+		serverAddrPort netip.AddrPort,
+		msg *dns.Msg,
+		protocol string,
+		allowed bool,
+		stat *dnsproxy.ProxyRequestContext,
+	) error
+}
+
+type dnsRequestHandler struct {
+	ctx               context.Context
+	logger            *slog.Logger
+	nameManager       namemanager.NameManager
+	proxyInstance     defaultdns.Proxy
+	proxyAccessLogger accesslog.ProxyAccessLogger
+}
+
+var _ DNSRequestHandler = &dnsRequestHandler{}
+
+// notifyOnDNSMsg handles DNS data in the daemon by emitting monitor
+// events, proxy metrics and storing DNS data in the DNS cache. This may
+// result in rule generation.
+// It will:
+//   - Report a monitor error event and proxy metrics when the proxy sees an
+//     error, and when it can't process something in this function
+//   - Report the verdict in a monitor event and emit proxy metrics
+//   - Insert the DNS data into the cache when msg is a DNS response, and we
+//     can lookup the endpoint related to it.
+//
+// It may return dnsproxy.ErrDNSRequestNoEndpoint{} error if the endpoint is nil.
+// Note that the caller should log beforehand the contextualized error.
+
+// epIPPort and serverAddrPort should match the original request, where epAddr is
+// the source for egress (the only case current).
+// serverID is the destination server security identity at the time of the DNS event.
+func (b *dnsRequestHandler) NotifyOnDNSMsg(
+	lookupTime time.Time,
+	ep *endpoint.Endpoint,
+	epIPPort string,
+	serverID identity.NumericIdentity,
+	serverAddrPort netip.AddrPort,
+	msg *dns.Msg,
+	protocol string,
+	allowed bool,
+	stat *dnsproxy.ProxyRequestContext,
+) error {
+	protoID := u8proto.ProtoIDs[strings.ToLower(protocol)]
+	var verdict accesslog.FlowVerdict
+	var reason string
+	metricError := metricErrorAllow
+	stat.ProcessingTime.Start()
+
+	endMetric := func() {
+		stat.DataplaneTime.End(true)
+		stat.ProcessingTime.End(true)
+		stat.TotalTime.End(true)
+		if errors.As(stat.Err, &dnsproxy.ErrFailedAcquireSemaphore{}) || errors.As(stat.Err, &dnsproxy.ErrTimedOutAcquireSemaphore{}) {
+			metrics.FQDNSemaphoreRejectedTotal.Inc()
+		}
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, totalTime).Observe(
+			stat.TotalTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, upstreamTime).Observe(
+			stat.UpstreamTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, processingTime).Observe(
+			stat.ProcessingTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, semaphoreTime).Observe(
+			stat.SemaphoreAcquireTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyGenTime).Observe(
+			stat.PolicyGenerationTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, policyCheckTime).Observe(
+			stat.PolicyCheckTime.Total().Seconds())
+		metrics.ProxyUpstreamTime.WithLabelValues(metricError, metrics.L7DNS, dataplaneTime).Observe(
+			stat.DataplaneTime.Total().Seconds())
+	}
+
+	switch {
+	case stat.IsTimeout():
+		metricError = metricErrorTimeout
+		endMetric()
+		return nil
+	case stat.Err != nil:
+		metricError = metricErrorProxy
+		verdict = accesslog.VerdictError
+		reason = "Error: " + stat.Err.Error()
+	case allowed:
+		verdict = accesslog.VerdictForwarded
+		reason = "Allowed by policy"
+	case !allowed:
+		metricError = metricErrorDenied
+		verdict = accesslog.VerdictDenied
+		reason = "Denied by policy"
+	}
+
+	if ep == nil {
+		// This is a hard fail. We cannot proceed because record.Log requires a
+		// non-nil ep, and we also don't want to insert this data into the
+		// cache if we don't know that an endpoint asked for it (this is
+		// asserted via ep != nil here and msg.Response && msg.Rcode ==
+		// dns.RcodeSuccess below).
+		endMetric()
+		return dnsproxy.ErrDNSRequestNoEndpoint{}
+	}
+
+	// We determine the direction based on the DNS packet. The observation
+	// point is always Egress, however.
+	var flowType accesslog.FlowType
+	var addrInfo accesslog.AddressingInfo
+	serverAddrPortStr := serverAddrPort.String()
+	if msg.Response {
+		flowType = accesslog.TypeResponse
+		addrInfo.DstIPPort = epIPPort
+		addrInfo.DstEPID = ep.GetID()
+		// ignore error; log fields are best effort. Only returns error if endpoint
+		// is going away.
+		addrInfo.DstSecIdentity, _ = ep.GetSecurityIdentity()
+		addrInfo.SrcIPPort = serverAddrPortStr
+		addrInfo.SrcIdentity = serverID
+	} else {
+		flowType = accesslog.TypeRequest
+		addrInfo.SrcIPPort = epIPPort
+		addrInfo.SrcEPID = ep.GetID()
+		// ignore error; same reason as above.
+		addrInfo.SrcSecIdentity, _ = ep.GetSecurityIdentity()
+		addrInfo.DstIPPort = serverAddrPortStr
+		addrInfo.DstIdentity = serverID
+	}
+
+	qname, responseIPs, TTL, CNAMEs, rcode, recordTypes, qTypes, err := dnsproxy.ExtractMsgDetails(msg)
+	if err != nil {
+		b.logger.Error("cannot extract DNS message details",
+			logfields.Error, err,
+			logfields.DNSName, qname,
+		)
+		return fmt.Errorf("failed to extract DNS message details: %w", err)
+	}
+
+	if msg.Response && msg.Rcode == dns.RcodeSuccess && len(responseIPs) > 0 {
+		stat.PolicyGenerationTime.Start()
+
+		// Create a critical section especially for when multiple DNS requests
+		// are in-flight for the same name (i.e. cilium.io).
+		//
+		// In the absence of such a critical section, consider the following
+		// race condition:
+		//
+		//              G1                                    G2
+		//
+		// T0 --> NotifyOnDNSMsg()               NotifyOnDNSMsg()            <-- T0
+		//
+		// T1 --> UpdateGenerateDNS()            UpdateGenerateDNS()         <-- T1
+		//
+		// T2 ----> mutex.Lock()                 +--------------------------+
+		//                                       |No selectors need updating|
+		// T3 ----> wg := UpdatePolicyMaps()     +--------------------------+
+		//
+		// T4 ----> mutex.Unlock()               mutex.Lock() / mutex.Unlock() <-- T4
+		//
+		// T5 ----> wg.Wait()                    DNS released back to pod    <-- T5
+		//                                                    |
+		// T6 --> DNS released back to pod                    |
+		//              |                                     |
+		//              |                                     |
+		//              v                                     v
+		//       Traffic flows fine                   Leads to policy drop until T6
+		//
+		// Note how G2 releases the DNS msg back to the pod at T5 because
+		// UpdateGenerateDNS() was a no-op. It's a no-op because G1 had executed
+		// UpdateGenerateDNS() first at T1 and performed the necessary policy
+		// updates for the response IPs. Due to G1 performing all the work
+		// first, G2 executes T4 also as a no-op and releases the msg back to the
+		// pod at T5 before G1 would at T6.
+		//
+		// We do not do a `defer unlock()` here, as we should release the lock before
+		// doing final bookkeeping.
+		mutexAcquireStart := time.Now()
+		b.nameManager.LockName(qname)
+
+		if d := time.Since(mutexAcquireStart); d >= option.Config.DNSProxyLockTimeout {
+			b.logger.Warn(fmt.Sprintf("Name lock acquisition time took longer than expected. Potentially too many parallel DNS requests being processed, consider adjusting --%s and/or --%s", option.DNSProxyLockCount, option.DNSProxyLockTimeout),
+				logfields.DNSName, qname,
+				logfields.Duration, d,
+				logfields.Expected, option.Config.DNSProxyLockTimeout,
+			)
+		}
+
+		b.logger.Debug("Recording DNS lookup in endpoint specific cache", logfields.EndpointID, ep.ID)
+
+		// This must happen before the NameManager update below, to ensure that
+		// this data is included in the serialized Endpoint object.
+		// We also need to add to the cache before we purge any matching zombies
+		// because they are locked separately and we want to keep the allowed IPs
+		// consistent if a regeneration happens between the two steps. If an update
+		// doesn't happen in the case, we play it safe and don't purge the zombie
+		// in case of races.
+		if updated := ep.DNSHistory.Update(lookupTime, qname, responseIPs, int(TTL)); updated {
+			ep.DNSZombies.ForceExpireByNameIP(lookupTime, qname, responseIPs...)
+			ep.SyncEndpointHeaderFile()
+		}
+
+		b.logger.Debug("Updating DNS name in cache from response to query",
+			logfields.DNSName, qname,
+			logfields.IPAddrs, responseIPs,
+		)
+
+		updateCtx, updateCancel := context.WithTimeout(b.ctx, option.Config.FQDNProxyResponseMaxDelay)
+		defer updateCancel()
+		updateStart := time.Now()
+
+		dpUpdates := b.nameManager.UpdateGenerateDNS(updateCtx, lookupTime, qname, &fqdn.DNSIPRecords{
+			IPs: responseIPs,
+			TTL: int(TTL),
+		})
+
+		stat.PolicyGenerationTime.End(true)
+		stat.DataplaneTime.Start()
+
+		if err := <-dpUpdates; err != nil {
+			b.logger.Warn("Timed out waiting for datapath updates of FQDN IP information; returning response. Consider increasing --tofqdns-proxy-response-max-delay if this keeps happening.")
+			metrics.ProxyDatapathUpdateTimeout.Inc()
+		}
+
+		// Policy updates for this name have been pushed out; we can release the lock.
+		b.nameManager.UnlockName(qname)
+
+		b.logger.Debug("Waited for endpoints to regenerate due to a DNS response",
+			logfields.Duration, time.Since(updateStart),
+			logfields.EndpointID, ep.GetID(),
+			logfields.DNSName, qname,
+		)
+
+		endMetric()
+	}
+
+	stat.ProcessingTime.End(true)
+
+	bindPort := uint16(0)
+	if dnsProxy := b.proxyInstance.Get(); dnsProxy != nil {
+		bindPort = dnsProxy.GetBindPort()
+	}
+	ep.UpdateProxyStatistics("fqdn", strings.ToUpper(protocol), serverAddrPort.Port(), bindPort, false, !msg.Response, verdict)
+
+	// Ensure that there are no early returns from this function before the
+	// code below, otherwise the log record will not be made.
+	//
+	// Restrict label enrichment time to 10ms; we don't want to block DNS
+	// requests because an identity isn't in the local cache yet.
+	logContext, lcncl := context.WithTimeout(b.ctx, 10*time.Millisecond)
+	defer lcncl()
+	record := b.proxyAccessLogger.NewLogRecord(flowType, false,
+		func(lr *accesslog.LogRecord, _ accesslog.EndpointInfoRegistry) {
+			lr.TransportProtocol = accesslog.TransportProtocol(protoID)
+		},
+		accesslog.LogTags.Verdict(verdict, reason),
+		accesslog.LogTags.Addressing(logContext, addrInfo),
+		accesslog.LogTags.DNS(&accesslog.LogRecordDNS{
+			Query:             qname,
+			IPs:               responseIPs,
+			TTL:               TTL,
+			CNAMEs:            CNAMEs,
+			ObservationSource: stat.DataSource,
+			RCode:             rcode,
+			QTypes:            qTypes,
+			AnswerTypes:       recordTypes,
+		}),
+	)
+	b.proxyAccessLogger.Log(record)
+
+	return nil
+}

--- a/pkg/fqdn/cell/cell.go
+++ b/pkg/fqdn/cell/cell.go
@@ -6,6 +6,7 @@ package cell
 import (
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/fqdn/rules"
 )
@@ -17,6 +18,9 @@ var Cell = cell.Module(
 
 	// The FQDN NameManager stores DNS mappings.
 	namemanager.Cell,
+
+	// The FQDN bootstrap logic
+	bootstrap.Cell,
 
 	cell.Provide(rules.NewDNSRulesService),
 )


### PR DESCRIPTION
This PR extracts the FQDN bootstrap & request handling logic from the daemon package into a Hive component.

Please review the individual commits.