### PR TITLE
aws: change IPv4Masquerade to false in ENI mode

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1123,7 +1123,7 @@
    * - :spelling:ignore:`enableIPv4Masquerade`
      - Enables masquerading of IPv4 traffic leaving the node from endpoints.
      - bool
-     - ``true``
+     - ``true`` unless ipam eni mode is active
    * - :spelling:ignore:`enableIPv6BIGTCP`
      - Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
      - bool

--- a/Documentation/installation/k8s-install-helm.rst
+++ b/Documentation/installation/k8s-install-helm.rst
@@ -123,7 +123,6 @@ Install Cilium
             --namespace kube-system \\
             --set eni.enabled=true \\
             --set ipam.mode=eni \\
-            --set egressMasqueradeInterfaces=eth+ \\
             --set routingMode=native
 
        .. note::
@@ -160,12 +159,6 @@ Install Cilium
                      && iptables -t nat -F AWS-SNAT-CHAIN-1 \\
                      && iptables -t nat -F AWS-CONNMARK-CHAIN-0 \\
                      && iptables -t nat -F AWS-CONNMARK-CHAIN-1
-
-         Some Linux distributions use a different interface naming convention.
-         If you use masquerading with the option ``egressMasqueradeInterfaces=eth+``,
-         remember to replace ``eth+`` with the proper interface name. For
-         reference, Amazon Linux 2 uses ``eth+``, whereas Amazon Linux 2023 uses
-         ``ens+``.
 
     .. group-tab:: OpenShift
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -306,9 +306,11 @@ communicating via the proxy must reconnect to re-establish connections.
   to disable this new behavior, you can add ``!io\.cilium\.k8s\.policy\.serviceaccount`` to your identity-relevant labels to 
   exclude the ``io.cilium.k8s.policy.serviceaccount`` label.
 * If using IPsec encryption the upgrade from v1.17 to v1.18 requires special attention.
-  Please reference :ref:`encryption_ipsec`
-
-
+  Please reference :ref:`encryption_ipsec`.
+* The Helm value of ``enableIPv4Masquerade`` in ``eni`` mode changes from ``true`` to ``false`` by default from 1.18.
+  To keep the ``enableIPv4Masquerade`` enabled, explicitly set the value for
+  this option to ``true``, or use a value strictly lower than 1.18 for
+  ``upgradeCompatibility``.  
 
 Removed Options
 ~~~~~~~~~~~~~~~
@@ -363,6 +365,7 @@ Helm Options
 * ``eni.updateEC2AdapterLimitViaAPI`` is removed since the operator will only and always use the EC2API to update the EC2 instance limit.
 * The Helm option ``l2PodAnnouncements.interface`` has been deprecated in favor of ``l2PodAnnouncements.interfacePattern``
   and will be removed in Cilium 1.19.
+* The Helm value of ``enableIPv4Masquerade`` in ``eni`` mode changes from ``true`` to ``false`` by default from 1.18.
 
 Agent Options
 ~~~~~~~~~~~~~
@@ -680,9 +683,9 @@ and one where the source of truth comes from CRDs (``--identity-allocation-mode=
 The high-level migration plan looks as follows:
 
 #. Starting state: Cilium is running in KVStore mode.
-#. Switch Cilium to “Double Write” mode with all reads happening from the KVStore. This is almost the same as the
+#. Switch Cilium to "Double Write" mode with all reads happening from the KVStore. This is almost the same as the
    pure KVStore mode with the only difference being that all identities are duplicated as CRDs but are not used.
-#. Switch Cilium to “Double Write” mode with all reads happening from CRDs. This is equivalent to Cilium running in
+#. Switch Cilium to "Double Write" mode with all reads happening from CRDs. This is equivalent to Cilium running in
    pure CRD mode but identities will still be updated in the KVStore to allow for the possibility of a fast rollback.
 #. Switch Cilium to CRD mode. The KVStore will no longer be used and will be ready for decommission.
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -323,6 +323,7 @@ endpointSelector
 endpointmanager
 enet
 enetc
+eni
 enqueuing
 etcd
 etcdinit

--- a/cilium-cli/install/helm.go
+++ b/cilium-cli/install/helm.go
@@ -64,13 +64,6 @@ func (k *K8sInstaller) getHelmValues() (map[string]any, error) {
 				// Can be removed once we drop support for <1.14.0
 				helmMapOpts["tunnel"] = tunnelDisabled
 			}
-			if versioncheck.MustCompile(">=1.17.0")(k.chartVersion) {
-				// AL2023 uses ens interfaces, but we default to eth interfaces for everything else for backwards compatibility,
-				// since the CLI was assuming eth interfaces before support for AL2023 was introduced
-				helmMapOpts["egressMasqueradeInterfaces"] = "eth+ ens+"
-			} else {
-				helmMapOpts["egressMasqueradeInterfaces"] = "eth+"
-			}
 
 		case DatapathGKE:
 			helmMapOpts["ipam.mode"] = ipamKubernetes

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -330,7 +330,7 @@ contributors across the globe, there is almost always someone available to help.
 | enableCiliumEndpointSlice | bool | `false` | Enable CiliumEndpointSlice feature (deprecated, please use `ciliumEndpointSlice.enabled` instead). |
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
 | enableIPv4BIGTCP | bool | `false` | Enables IPv4 BIG TCP support which increases maximum IPv4 GSO/GRO limits for nodes and pods |
-| enableIPv4Masquerade | bool | `true` | Enables masquerading of IPv4 traffic leaving the node from endpoints. |
+| enableIPv4Masquerade | bool | `true` unless ipam eni mode is active  | Enables masquerading of IPv4 traffic leaving the node from endpoints. |
 | enableIPv6BIGTCP | bool | `false` | Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods |
 | enableIPv6Masquerade | bool | `true` | Enables masquerading of IPv6 traffic leaving the node from endpoints. |
 | enableInternalTrafficPolicy | bool | `true` | Enable Internal Traffic Policy |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -15,6 +15,7 @@
 {{- $defaultK8sClientQPS := 5 -}}
 {{- $defaultK8sClientBurst := 10 -}}
 {{- $defaultDNSProxyEnableTransparentMode := "false" -}}
+{{- $defaultEnableIPv4Masquerade := "true" -}}
 {{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
 {{- $readSecretsOnlyFromSecretsNamespace := eq (include "readSecretsOnlyFromSecretsNamespace" .) "true" -}}
 {{- $secretSyncEnabled := eq (include "secretSyncEnabled" .) "true" -}}
@@ -61,6 +62,14 @@
   {{- $defaultKubeProxyReplacement = "false" -}}
 {{- end -}}
 
+{{- /* Default values when 1.18 was initially deployed */ -}}
+{{- if semverCompare ">=1.18" (default "1.18" .Values.upgradeCompatibility) -}}
+  {{- /* defaultIPv4Masquerad in ENI mode for 1.18 needed to override earlier version defaults set above when upgradeCompatibility is not specified */ -}}
+  {{- if .Values.eni.enabled }}
+    {{- $defaultEnableIPv4Masquerade = "false" -}}
+    # Will also do this for ipv6 when ENI mode works with ipv6.
+  {{- end }}
+{{- end -}}
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}
 {{- $bpfCtTcpMax := (coalesce .Values.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}
 {{- $bpfCtAnyMax := (coalesce .Values.bpf.ctAnyMax $defaultBpfCtAnyMax) -}}
@@ -626,7 +635,11 @@ data:
 {{- end }}
 {{- end }}
 
-  enable-ipv4-masquerade: {{ .Values.enableIPv4Masquerade | quote }}
+{{- if (not (kindIs "invalid" .Values.enableIPv4Masquerade)) }}
+  enable-ipv4-masquerade: {{.Values.enableIPv4Masquerade | quote }}
+{{- else }}
+  enable-ipv4-masquerade: {{ $defaultEnableIPv4Masquerade | quote }}
+{{- end }}
   enable-ipv4-big-tcp: {{ .Values.enableIPv4BIGTCP | quote }}
   enable-ipv6-big-tcp: {{ .Values.enableIPv6BIGTCP | quote }}
   enable-ipv6-masquerade: {{ .Values.enableIPv6Masquerade | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1699,7 +1699,10 @@
       "type": "boolean"
     },
     "enableIPv4Masquerade": {
-      "type": "boolean"
+      "type": [
+        "null",
+        "boolean"
+      ]
     },
     "enableIPv6BIGTCP": {
       "type": "boolean"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2129,8 +2129,12 @@ maglev: {}
 # -- hashSeed is the cluster-wide base64 encoded seed for the hashing
 # hashSeed:
 
-# -- Enables masquerading of IPv4 traffic leaving the node from endpoints.
-enableIPv4Masquerade: true
+# @schema
+# type: [null, boolean]
+# @schema
+# -- (bool) Enables masquerading of IPv4 traffic leaving the node from endpoints.
+# @default -- `true` unless ipam eni mode is active 
+enableIPv4Masquerade: ~
 # -- Enables masquerading of IPv6 traffic leaving the node from endpoints.
 enableIPv6Masquerade: true
 # -- Enables masquerading to the source of the route for traffic leaving the node from endpoints.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2144,8 +2144,12 @@ maglev: {}
 # -- hashSeed is the cluster-wide base64 encoded seed for the hashing
 # hashSeed:
 
-# -- Enables masquerading of IPv4 traffic leaving the node from endpoints.
-enableIPv4Masquerade: true
+# @schema
+# type: [null, boolean]
+# @schema
+# -- (bool) Enables masquerading of IPv4 traffic leaving the node from endpoints.
+# @default -- `true` unless ipam eni mode is active 
+enableIPv4Masquerade: ~
 # -- Enables masquerading of IPv6 traffic leaving the node from endpoints.
 enableIPv6Masquerade: true
 # -- Enables masquerading to the source of the route for traffic leaving the node from endpoints.


### PR DESCRIPTION
In the ENI mode, all the pods IP address are routable in the VPC.
By default we still have IPv4Masquerade enabled, but we have the following iptable rules
to skip the SNAT for the VPC traffic.

-A CILIUM_POST_nat ! -d 192.168.0.0/16 -o eth+ -m comment --comment "cilium masquerade non-cluster" -j MASQUERADE

This commit will just disable the IPv4Masquerade in the ENI mode by default, we expect that
AWS NAT gateway will perform SNAT when the traffic accessing the Internet.

- Change the helm values of IPv4Masquerade from true to false in ENI mode
- Update the upgradeCompatibility so users could have smooth upgrade
- Remove the IPv4Masquerade in the doc and remove egressMasqueradeInterfaces config.
- Remove the IPv4Masquerade in the cilium-cli in ENI mode and remove
  egressMasqueradeInterfaces config.
- Update the upgrade doc

Fixes: #38661

```release-note
New clusters created in ENI mode will no longer masquerade pod traffic to the external world.
```
