### PR TITLE
Update json-mock image tag to support connectivity-check on both amd64 and arm64 kubernetes nodes

### DIFF
--- a/examples/kubernetes/clustermesh/cluster1.yaml
+++ b/examples/kubernetes/clustermesh/cluster1.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: x-wing-container
-        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/clustermesh/cluster2.yaml
+++ b/examples/kubernetes/clustermesh/cluster2.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: x-wing-container
-        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -81,7 +81,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -137,7 +137,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -205,7 +205,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -261,7 +261,7 @@ spec:
         - name: PORT
           value: "21002"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -81,7 +81,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -137,7 +137,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check-netpol-only.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-netpol-only.yaml
@@ -22,7 +22,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -79,7 +79,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -134,7 +134,7 @@ spec:
         - name: PORT
           value: "41000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.0@sha256:2729064827fa9dbfface8d3df424feb6c792a0ba07117b844349635c93c06d2b
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -24,7 +24,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -80,7 +80,7 @@ spec:
         - name: PORT
           value: "21002"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -905,7 +905,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -983,7 +983,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -1060,7 +1060,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -1148,7 +1148,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -1249,7 +1249,7 @@ spec:
         - name: PORT
           value: "21002"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -687,7 +687,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -765,7 +765,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -842,7 +842,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -930,7 +930,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -1031,7 +1031,7 @@ spec:
         - name: PORT
           value: "21002"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -81,7 +81,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -137,7 +137,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -81,7 +81,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -137,7 +137,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -2,7 +2,7 @@ package connectivity_check
 
 // Default parameters for echo servers (may be overridden).
 _echoDeployment: {
-	_image:       "quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be"
+	_image:       "quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603"
 	_probeTarget: *"localhost:8080" | string
 	_probePath:   ""
 }

--- a/examples/kubernetes/servicemesh/envoy/test-application-proxy-circuit-breaker.yaml
+++ b/examples/kubernetes/servicemesh/envoy/test-application-proxy-circuit-breaker.yaml
@@ -92,7 +92,7 @@ spec:
         - env:
             - name: PORT
               value: "8080"
-          image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+          image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
           imagePullPolicy: IfNotPresent
           name: echo-service
           ports:

--- a/examples/kubernetes/servicemesh/envoy/test-application-proxy-loadbalancing.yaml
+++ b/examples/kubernetes/servicemesh/envoy/test-application-proxy-loadbalancing.yaml
@@ -99,7 +99,7 @@ spec:
         - env:
             - name: PORT
               value: "8080"
-          image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+          image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
           imagePullPolicy: IfNotPresent
           name: echo-service
           ports:

--- a/examples/kubernetes/servicemesh/envoy/test-application.yaml
+++ b/examples/kubernetes/servicemesh/envoy/test-application.yaml
@@ -147,7 +147,7 @@ spec:
         - env:
             - name: PORT
               value: "8080"
-          image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+          image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
           imagePullPolicy: IfNotPresent
           name: echo-service-1
           ports:
@@ -238,7 +238,7 @@ spec:
         - env:
             - name: PORT
               value: "8080"
-          image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
+          image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
           imagePullPolicy: IfNotPresent
           name: echo-service-2
           ports:

--- a/examples/policies/kubernetes/namespace/demo-pods.yaml
+++ b/examples/policies/kubernetes/namespace/demo-pods.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: leia-container
-        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
 ---
 apiVersion: v1
 kind: Service
@@ -50,7 +50,7 @@ metadata:
 spec:
   containers:
   - name: luke-container
-    image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
 ---
 apiVersion: v1
 kind: Pod
@@ -62,4 +62,4 @@ metadata:
 spec:
   containers:
   - name: vader-container
-    image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603

--- a/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
+++ b/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: leia
       containers:
       - name: leia-container
-        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
 ---
 apiVersion: v1
 kind: Service
@@ -51,7 +51,7 @@ spec:
   serviceAccountName: luke
   containers:
   - name: luke-container
-    image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
 ---
 apiVersion: v1
 kind: Pod
@@ -61,4 +61,4 @@ spec:
   serviceAccountName: vader
   containers:
   - name: vader-container
-    image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603


### PR DESCRIPTION
Previously, connectivity-check.yaml used the json-mock:1.3.2 tag, which, despite being multi-arch, caused an exec format error on ARM64 nodes during validation. 
This fix updates the tag to 1.3.8, ensuring compatibility with both ARM64 and AMD64. I temporarily modified connectivity-check.yaml locally to unblock myself but am updating it here for others who haven't yet switched.

### With `json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be` image tag
Pods crashloopbackoff on `arm64` kubernetes nodes. 
<img width="1122" alt="Screenshot 2025-04-01 at 2 37 34 PM" src="https://github.com/user-attachments/assets/95479245-53e1-4edf-b7a3-3ccab1814108" />
<img width="453" alt="Screenshot 2025-04-01 at 2 37 41 PM" src="https://github.com/user-attachments/assets/af78aa7c-dfeb-477d-bf0e-a3fafa434ac9" />

### with `json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603` image tag
Pods are running on both `amd64` and `arm64` kubernetes nodes. 
<img width="1087" alt="Screenshot 2025-04-01 at 2 30 18 PM" src="https://github.com/user-attachments/assets/5fcadbf1-fd1a-42b7-ad7a-e7c661b909b1" />




```release-note
Updated quay.io/cilium/json-mock image tag from 1.3.2 to 1.3.8 to support validation on both amd64 and arm64 nodes.
```
