### PR TITLE
hubble: send server version using metadata in gRPC responses

### DIFF
--- a/hubble/cmd/common/conn/conn.go
+++ b/hubble/cmd/common/conn/conn.go
@@ -6,11 +6,13 @@ package conn
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 
@@ -30,13 +32,68 @@ var GRPCOptionFuncs []GRPCOptionFunc
 func init() {
 	GRPCOptionFuncs = append(
 		GRPCOptionFuncs,
-		grpcInterceptors,
+		grpcUnaryInterceptors,
+		grpcStreamInterceptors,
 		grpcOptionTLS,
 	)
 }
 
-func grpcInterceptors(vp *viper.Viper) (grpc.DialOption, error) {
-	return grpc.WithUnaryInterceptor(timeout.UnaryClientInterceptor(vp.GetDuration(config.KeyRequestTimeout))), nil
+func grpcUnaryInterceptors(vp *viper.Viper) (grpc.DialOption, error) {
+	option := grpc.WithChainUnaryInterceptor(
+		timeout.UnaryClientInterceptor(vp.GetDuration(config.KeyRequestTimeout)),
+		onReceiveHeaderUnaryInterceptor(logger.Logger, logVersionMismatch()),
+	)
+	return option, nil
+}
+
+func grpcStreamInterceptors(vp *viper.Viper) (grpc.DialOption, error) {
+	option := grpc.WithChainStreamInterceptor(
+		onReceiveHeaderStreamInterceptor(logger.Logger, logVersionMismatch()),
+	)
+	return option, nil
+}
+
+type onReceiveHeader func(log *slog.Logger, header metadata.MD)
+
+// onReceiveHeaderUnaryInterceptor is a gRPC client unary interceptor that retrieves the header
+// metadata and execute the provided function.
+func onReceiveHeaderUnaryInterceptor(log *slog.Logger, fn onReceiveHeader) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req any, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		var header metadata.MD
+		opts = append(opts, grpc.Header(&header))
+		if err := invoker(ctx, method, req, reply, cc, opts...); err != nil {
+			return err
+		}
+		fn(log, header)
+		return nil
+	}
+}
+
+// onReceiveHeaderStreamInterceptor is a gRPC client stream interceptor that retrieves the header
+// metadata and execute the provided function.
+func onReceiveHeaderStreamInterceptor(log *slog.Logger, fn onReceiveHeader) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		stream, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			return nil, err
+		}
+		// stream.Header() blocks until metadata is ready to read.
+		// This could be:
+		//  - Forever if no metadata is ever sent.
+		//  - After the first read from the stream.
+		//  - After an explicit call to SendHeader() server-side.
+		// To avoid a possible deadlock, perform header extraction in a goroutine tied to
+		// the lifetime of the stream (stream.Header() returns on stream close).
+		go func() {
+			header, err := stream.Header()
+			if err != nil {
+				log.Warn("Failed to obtain grpc stream headers in log version mismatch interceptor", logfields.Error, err)
+				return
+			}
+			fn(log, header)
+		}()
+		return stream, nil
+	}
 }
 
 var grpcDialOptions []grpc.DialOption

--- a/hubble/cmd/common/conn/version.go
+++ b/hubble/cmd/common/conn/version.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package conn
+
+import (
+	"log/slog"
+
+	"github.com/blang/semver/v4"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/cilium/cilium/hubble/pkg"
+	serverdefaults "github.com/cilium/cilium/pkg/hubble/defaults"
+	relaydefaults "github.com/cilium/cilium/pkg/hubble/relay/defaults"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	// cliVersionComparator allows comparing a semver version to the Hubble CLI version
+	// that ignores version parts lower than Minor (Patch/Pre/Build).
+	cliVersionComparator = newMinorVersionComparator(pkg.SemverVersion)
+
+	// zeroVersion is used as sentinel value when a version could not be parsed using semver.
+	zeroVersion = semver.Version{}
+)
+
+// logVersionMismatch returns an onReceiveHeader func that emits a warning log when the Hubble CLI
+// version is lower than the remote server version (Hubble server or Hubble relay). We ignore
+// Patch/Pre/Build parts of the semver version as these should only contain backward-compatible
+// fixes.
+func logVersionMismatch() onReceiveHeader {
+	return func(log *slog.Logger, header metadata.MD) {
+		relayVersion, err := parseVersionFromHeader(header, relaydefaults.GRPCMetadataRelayVersionKey)
+		if err != nil {
+			log.Debug("Could not parse relay version from grpc headers", logfields.Error, err)
+		}
+		serverVersion, err := parseVersionFromHeader(header, serverdefaults.GRPCMetadataServerVersionKey)
+		if err != nil {
+			log.Debug("Could not parse server version from grpc headers", logfields.Error, err)
+		}
+
+		if cliVersionComparator.IsLowerThan(relayVersion) {
+			log.Warn("Hubble CLI version is lower than Hubble Relay, API compatibility is not guaranteed, updating to a matching or higher version is recommended",
+				logfields.HubbleCLIVersion, pkg.SemverVersion.String(),
+				logfields.HubbleRelayVersion, relayVersion.String(),
+			)
+		}
+
+		if cliVersionComparator.IsLowerThan(serverVersion) {
+			log.Warn("Hubble CLI version is lower than Hubble Server, API compatibility is not guaranteed, updating to a matching or higher version is recommended",
+				logfields.HubbleCLIVersion, pkg.SemverVersion.String(),
+				logfields.HubbleServerVersion, serverVersion.String(),
+			)
+		}
+	}
+}
+
+type minorVersionComparator struct {
+	version semver.Version
+}
+
+func newMinorVersionComparator(v semver.Version) *minorVersionComparator {
+	return &minorVersionComparator{version: versionTruncateMinor(v)}
+}
+
+func (c *minorVersionComparator) IsLowerThan(v semver.Version) bool {
+	versionMissing := v.EQ(zeroVersion)
+	return !versionMissing && c.version.LT(versionTruncateMinor(v))
+}
+
+func versionTruncateMinor(v semver.Version) semver.Version {
+	minorV := v
+	minorV.Patch = 0
+	minorV.Pre = nil
+	minorV.Build = nil
+	return minorV
+}
+
+func parseVersionFromHeader(header metadata.MD, key string) (semver.Version, error) {
+	versionHeaders := header.Get(key)
+	if len(versionHeaders) == 0 {
+		return zeroVersion, nil
+	}
+	return semver.ParseTolerant(versionHeaders[0])
+}

--- a/hubble/cmd/common/conn/version_test.go
+++ b/hubble/cmd/common/conn/version_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package conn
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestParseVersionFromHeader(t *testing.T) {
+	tests := []struct {
+		name      string
+		header    metadata.MD
+		key       string
+		expected  semver.Version
+		expectErr bool
+	}{
+		{
+			name:     "missing-key",
+			header:   metadata.Pairs("another-key", "1.1.1"),
+			key:      "my-key",
+			expected: zeroVersion,
+		},
+		{
+			name:      "invalid-version",
+			header:    metadata.Pairs("my-key", "1,1.1"),
+			key:       "my-key",
+			expectErr: true,
+		},
+		{
+			name:     "valid-version",
+			header:   metadata.Pairs("my-key", "1.1.1-alpha-1+123456.789"), // Build is not compared
+			key:      "my-key",
+			expected: semver.Version{Major: 1, Minor: 1, Patch: 1, Pre: []semver.PRVersion{{VersionStr: "alpha-1"}}},
+		},
+		{
+			name:     "valid-version-whitespaces",
+			header:   metadata.Pairs("my-key", "    1.1.1-alpha-1+123456.789 "), // Build is not compared
+			key:      "my-key",
+			expected: semver.Version{Major: 1, Minor: 1, Patch: 1, Pre: []semver.PRVersion{{VersionStr: "alpha-1"}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parseVersionFromHeader(tc.header, tc.key)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.Truef(t, tc.expected.EQ(parsed), "expected: %+v got: +%v", tc.expected, parsed)
+		})
+	}
+}
+
+func TestIsVersionlowerThanCLI(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    semver.Version
+		cliVersion semver.Version
+		isLower    bool
+	}{
+		{
+			name:       "major-lower",
+			version:    semver.Version{Major: 2, Minor: 0, Patch: 0},
+			cliVersion: semver.Version{Major: 1, Minor: 0, Patch: 0},
+			isLower:    true,
+		},
+		{
+			name:       "minor-lower",
+			version:    semver.Version{Major: 1, Minor: 1, Patch: 0},
+			cliVersion: semver.Version{Major: 1, Minor: 0, Patch: 0},
+			isLower:    true,
+		},
+		{
+			name:       "patch-not-lower",
+			version:    semver.Version{Major: 1, Minor: 0, Patch: 1},
+			cliVersion: semver.Version{Major: 1, Minor: 0, Patch: 0},
+			isLower:    false,
+		},
+		{
+			name:       "pre-not-lower",
+			version:    semver.Version{Major: 1, Minor: 0, Patch: 0, Pre: []semver.PRVersion{{VersionNum: 1, IsNum: true}}},
+			cliVersion: semver.Version{Major: 1, Minor: 0, Patch: 0},
+			isLower:    false,
+		},
+		{
+			name:       "build-not-lower",
+			version:    semver.Version{Major: 1, Minor: 0, Patch: 0, Build: []string{"my-build"}},
+			cliVersion: semver.Version{Major: 1, Minor: 0, Patch: 0},
+			isLower:    false,
+		},
+		{
+			name:       "zero-version-not-lower",
+			version:    zeroVersion,
+			cliVersion: semver.Version{Major: 1, Minor: 0, Patch: 0},
+			isLower:    false,
+		},
+		{
+			name:       "cli-version-major-not-lower",
+			version:    semver.Version{Major: 1, Minor: 0, Patch: 0},
+			cliVersion: semver.Version{Major: 2, Minor: 0, Patch: 0},
+			isLower:    false,
+		},
+		{
+			name:       "cli-version-minor-not-lower",
+			version:    semver.Version{Major: 1, Minor: 0, Patch: 0},
+			cliVersion: semver.Version{Major: 1, Minor: 1, Patch: 0},
+			isLower:    false,
+		},
+		{
+			name:       "cli-version-patch-not-lower",
+			version:    semver.Version{Major: 1, Minor: 0, Patch: 0},
+			cliVersion: semver.Version{Major: 1, Minor: 0, Patch: 1},
+			isLower:    false,
+		},
+		{
+			name:       "cli-version-pre-not-lower",
+			version:    semver.Version{Major: 1, Minor: 0, Patch: 0},
+			cliVersion: semver.Version{Major: 1, Minor: 0, Patch: 1, Pre: []semver.PRVersion{{VersionNum: 1, IsNum: true}}},
+			isLower:    false,
+		},
+		{
+			name:       "cli-version-build-not-lower",
+			version:    semver.Version{Major: 1, Minor: 0, Patch: 0},
+			cliVersion: semver.Version{Major: 1, Minor: 0, Patch: 1, Build: []string{"my-build"}},
+			isLower:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			comparator := newMinorVersionComparator(tc.cliVersion)
+			isLower := comparator.IsLowerThan(tc.version)
+			assert.Equal(t, tc.isLower, isLower)
+		})
+	}
+}

--- a/hubble/pkg/version.go
+++ b/hubble/pkg/version.go
@@ -3,6 +3,10 @@
 
 package pkg
 
+import (
+	"github.com/blang/semver/v4"
+)
+
 // The following variables are set at compile time via LDFLAGS.
 var (
 	// Version is the software version.
@@ -12,3 +16,10 @@ var (
 	// GitHash is the git checksum of the most recent commit in HEAD.
 	GitHash string
 )
+
+// SemverVersion is a parsed representation of Version as semver.
+var SemverVersion semver.Version
+
+func init() {
+	SemverVersion, _ = semver.ParseTolerant(Version)
+}

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/models"
@@ -24,7 +26,9 @@ import (
 	"github.com/cilium/cilium/pkg/crypto/certloader"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/build"
 	"github.com/cilium/cilium/pkg/hubble/container"
+	"github.com/cilium/cilium/pkg/hubble/defaults"
 	"github.com/cilium/cilium/pkg/hubble/dropeventemitter"
 	"github.com/cilium/cilium/pkg/hubble/exporter"
 	exportercell "github.com/cilium/cilium/pkg/hubble/exporter/cell"
@@ -429,6 +433,8 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 		serveroption.WithObserverService(hubbleObserver),
 		serveroption.WithPeerService(peerSvc),
 		serveroption.WithInsecure(),
+		serveroption.WithGRPCUnaryInterceptor(serverVersionUnaryInterceptor()),
+		serveroption.WithGRPCStreamInterceptor(serverVersionStreamInterceptor()),
 	)
 
 	if h.agentConfig.EnableRecorder && h.config.EnableRecorderAPI {
@@ -481,6 +487,8 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 			serveroption.WithHealthService(),
 			serveroption.WithPeerService(peerSvc),
 			serveroption.WithObserverService(hubbleObserver),
+			serveroption.WithGRPCUnaryInterceptor(serverVersionUnaryInterceptor()),
+			serveroption.WithGRPCStreamInterceptor(serverVersionStreamInterceptor()),
 		}
 
 		// Hubble TLS/mTLS setup.
@@ -558,4 +566,21 @@ func getPort(addr string) (int, error) {
 		return 0, fmt.Errorf("parse port number: %w", err)
 	}
 	return portNum, nil
+}
+
+var serverVersionHeader = metadata.Pairs(defaults.GRPCMetadataServerVersionKey, build.ServerVersion.SemVer())
+
+func serverVersionUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		resp, err := handler(ctx, req)
+		grpc.SetHeader(ctx, serverVersionHeader)
+		return resp, err
+	}
+}
+
+func serverVersionStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ss.SetHeader(serverVersionHeader)
+		return handler(srv, ss)
+	}
 }

--- a/pkg/hubble/defaults/defaults.go
+++ b/pkg/hubble/defaults/defaults.go
@@ -16,6 +16,9 @@ const (
 	// GRPCServiceName is the name of the Hubble gRPC service.
 	GRPCServiceName = "hubble-grpc"
 
+	// GRPCMetadataServerVersionKey is the grpc metadata key for the Hubble server version.
+	GRPCMetadataServerVersionKey = "hubble-server-version"
+
 	// DomainName specifies the domain name to use when constructing the server
 	// name for peer change notifications.
 	DomainName = "cilium.io"

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -41,6 +41,9 @@ const (
 	// PeerUpdateInterval is the time interval in which relay is checking for
 	// newly joined peers for long running requests
 	PeerUpdateInterval = 2 * time.Second
+
+	// GRPCMetadataRelayVersionKey is the grpc metadata key for the Hubble relay server version.
+	GRPCMetadataRelayVersionKey = "hubble-relay-version"
 )
 
 var (

--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -98,11 +98,11 @@ func New(options ...Option) (*Server, error) {
 
 	var serverOpts []grpc.ServerOption
 
-	for _, interceptor := range opts.grpcUnaryInterceptors {
-		serverOpts = append(serverOpts, grpc.UnaryInterceptor(interceptor))
+	if len(opts.grpcUnaryInterceptors) > 0 {
+		serverOpts = append(serverOpts, grpc.ChainUnaryInterceptor(opts.grpcUnaryInterceptors...))
 	}
-	for _, interceptor := range opts.grpcStreamInterceptors {
-		serverOpts = append(serverOpts, grpc.StreamInterceptor(interceptor))
+	if len(opts.grpcStreamInterceptors) > 0 {
+		serverOpts = append(serverOpts, grpc.ChainStreamInterceptor(opts.grpcStreamInterceptors...))
 	}
 
 	if opts.serverTLSConfig != nil {

--- a/pkg/hubble/server/server.go
+++ b/pkg/hubble/server/server.go
@@ -54,11 +54,11 @@ func NewServer(log *slog.Logger, options ...serveroption.Option) (*Server, error
 
 func (s *Server) newGRPCServer() *grpc.Server {
 	var opts []grpc.ServerOption
-	for _, interceptor := range s.opts.GRPCUnaryInterceptors {
-		opts = append(opts, grpc.UnaryInterceptor(interceptor))
+	if len(s.opts.GRPCUnaryInterceptors) > 0 {
+		opts = append(opts, grpc.ChainUnaryInterceptor(s.opts.GRPCUnaryInterceptors...))
 	}
-	for _, interceptor := range s.opts.GRPCStreamInterceptors {
-		opts = append(opts, grpc.StreamInterceptor(interceptor))
+	if len(s.opts.GRPCStreamInterceptors) > 0 {
+		opts = append(opts, grpc.ChainStreamInterceptor(s.opts.GRPCStreamInterceptors...))
 	}
 	if s.opts.ServerTLSConfig != nil {
 		// NOTE: gosec is unable to resolve the constant and warns about "TLS

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1559,6 +1559,12 @@ const (
 
 	CEPUIDOld = "old-" + CEPUID
 
+	HubbleCLIVersion = "hubble-cli-version"
+
+	HubbleRelayVersion = "hubble-relay-version"
+
+	HubbleServerVersion = "hubble-server-version"
+
 	Resources = "resources"
 
 	LastModifiedVersion = "lastModifiedVersion"


### PR DESCRIPTION
Use gRPC interceptors to set the server version as a new metadata header in gRPC responses. Do the same for relay.

From Hubble CLI, emit a warning log when the its version is lower than the version of hubble-server or hubble-relay, but only consider Major.Minor as anything else should be backward-compatible.

In the future, we could use this to modify the CLI behaviour based on the server version.

Example unary RPC:
```
$ hubble list namespaces -P
time=2025-04-10T17:11:17.532-04:00 level=WARN msg="Hubble CLI version is lower than Hubble Relay, API compatibility is not guaranteed, updating to a matching or higher version is recommended" hubble-cli-version=1.17.0-dev hubble-relay-version=1.18.0-dev+gcedd4f58ae
NAMESPACE
cert-manager
...
```

Example stream RPC:
```
$ hubble observe -P
time=2025-04-10T17:12:33.242-04:00 level=WARN msg="Hubble CLI version is lower than Hubble Relay, API compatibility is not guaranteed, updating to a matching or higher version is recommended" hubble-cli-version=1.17.0-dev hubble-relay-version=1.18.0-dev+gcedd4f58ae
Apr 10 21:12:33.323 [hubble-relay-66546b79f5-z6kf7]: Receiving flows from 1 nodes: cilium-oss/cilium-oss-control-plane
Apr 10 21:12:33.294: kube-system/hubble-relay-66546b79f5-z6kf7:34916 (ID:92743) -> 172.18.0.2:4244 (host) to-stack FORWARDED (TCP Flags: ACK)
Apr 10 21:12:33.313: 127.0.0.1:43282 (world) <> kube-system/hubble-relay-66546b79f5-z6kf7 (ID:92743) pre-xlate-rev TRACED (TCP)
...
```

Fixes: #35724
