### PR TITLE
feat(sdp): Adding the cilium grpc server

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -177,6 +177,7 @@ cilium-agent [flags]
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-sctp                                               Enable SCTP support (beta)
       --enable-service-topology                                   Enable support for service topology aware hints
+      --enable-standalone-dns-proxy                               Enables standalone DNS proxy
       --enable-svc-source-range-check                             Enable check of service source ranges (currently, only for LoadBalancer) (default true)
       --enable-tcx                                                Attach endpoint programs using tcx if supported by the kernel (default true)
       --enable-tracing                                            Enable tracing while determining policy (debugging)
@@ -376,6 +377,7 @@ cilium-agent [flags]
       --routing-mode string                                       Routing mode ("native" or "tunnel") (default "tunnel")
       --service-no-backend-response string                        Response to traffic for a service without backends (default "reject")
       --socket-path string                                        Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
+      --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 40045)
       --state-dir string                                          Directory path to store runtime state (default "/var/run/cilium")
       --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --status-collector-failure-threshold duration               The duration after which a probe is considered failed (default 1m0s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -63,6 +63,7 @@ cilium-agent hive [flags]
       --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
+      --enable-standalone-dns-proxy                               Enables standalone DNS proxy
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
@@ -180,6 +181,7 @@ cilium-agent hive [flags]
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
+      --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 40045)
       --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --status-collector-failure-threshold duration               The duration after which a probe is considered failed (default 1m0s)
       --status-collector-interval duration                        The interval between probe invocations (default 5s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -69,6 +69,7 @@ cilium-agent hive dot-graph [flags]
       --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
+      --enable-standalone-dns-proxy                               Enables standalone DNS proxy
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
@@ -185,6 +186,7 @@ cilium-agent hive dot-graph [flags]
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
+      --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 40045)
       --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --status-collector-failure-threshold duration               The duration after which a probe is considered failed (default 1m0s)
       --status-collector-interval duration                        The interval between probe invocations (default 5s)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -273,9 +273,9 @@ func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWa
 	)
 
 	// create or update proxy redirects
-	for l4, perSelectorPolicy := range selectorPolicy.RedirectFilters() {
+	for l4, policySelectorTuple := range selectorPolicy.RedirectFilters() {
 		// Possible listener name for both the proxy ID and the proxyPolicy below.
-		listener := perSelectorPolicy.GetListener()
+		listener := policySelectorTuple.Policy.GetListener()
 
 		// proxyID() returns also the destination port for the policy,
 		// which may be resolved from a named port
@@ -295,7 +295,7 @@ func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWa
 			continue
 		}
 
-		pp := newProxyPolicy(l4, perSelectorPolicy.L7Parser, listener, dstPort, dstProto)
+		pp := newProxyPolicy(l4, policySelectorTuple.Policy.L7Parser, listener, dstPort, dstProto)
 		proxyPort, err, revertFunc := e.proxy.CreateOrUpdateRedirect(e.aliveCtx, &pp, proxyID, e.ID, proxyWaitGroup)
 		if err != nil {
 			// Skip redirects that can not be created or updated.  This
@@ -317,7 +317,7 @@ func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWa
 		// Update the endpoint API model to report that Cilium manages a
 		// redirect for that port.
 		statsKey := policy.ProxyStatsKey(l4.Ingress, string(l4.Protocol), dstPort, proxyPort)
-		proxyStats := e.getProxyStatistics(statsKey, string(perSelectorPolicy.L7Parser), dstPort, l4.Ingress, proxyPort)
+		proxyStats := e.getProxyStatistics(statsKey, string(policySelectorTuple.Policy.L7Parser), dstPort, l4.Ingress, proxyPort)
 		updatedStats = append(updatedStats, proxyStats)
 	}
 
@@ -673,6 +673,15 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		if err != nil {
 			return fmt.Errorf("unable to regenerate policy for '%s': %w", e.StringID(), err)
 		}
+	}
+
+	// Once the policy has been calculated, we can update the standalone dns proxy as well.
+	// We need to send the snapshot of the policyRules to SDP.
+	if !e.isProperty(PropertyFakeEndpoint) && !e.IsProxyDisabled() {
+		repo := e.policyRepo
+		e.getLogger().Debug("Updating standalone DNS proxy with policy rules")
+		policyRules := repo.GetPolicySnapshot()
+		e.proxy.UpdateSDP(policyRules)
 	}
 
 	// Any possible DNS redirects had their rules updated by 'e.regeneratePolicy' above, so we

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
@@ -17,6 +18,7 @@ import (
 type EndpointProxy interface {
 	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string)
+	UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy)
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
@@ -56,3 +58,6 @@ func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, pol
 
 // RemoveNetworkPolicy does nothing.
 func (f *FakeEndpointProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {}
+
+func (f *FakeEndpointProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -119,6 +119,10 @@ func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, po
 // RemoveNetworkPolicy does nothing.
 func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {}
 
+// UpdateSDP does nothing.
+func (r *RedirectSuiteProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+}
+
 // DummyIdentityAllocatorOwner implements
 // pkg/identity/cache/IdentityAllocatorOwner. It is used for unit testing.
 type DummyIdentityAllocatorOwner struct{}

--- a/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
+++ b/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -41,7 +42,7 @@ type fqdnProxyBootstrapper struct {
 	policyRepo        policy.PolicyRepository
 	ipcache           *ipcache.IPCache
 	endpointManager   endpointmanager.EndpointManager
-	dnsRequestHandler DNSRequestHandler
+	dnsMessageHandler messagehandler.DNSMessageHandler
 }
 
 var _ FQDNProxyBootstrapper = (*fqdnProxyBootstrapper)(nil)
@@ -92,7 +93,7 @@ func (b *fqdnProxyBootstrapper) BootstrapFQDN(possibleEndpoints map[uint16]*endp
 		ConcurrencyLimit:       option.Config.DNSProxyConcurrencyLimit,
 		ConcurrencyGracePeriod: option.Config.DNSProxyConcurrencyProcessingGracePeriod,
 	}
-	dnsProxy := dnsproxy.NewDNSProxy(dnsProxyConfig, b.lookupEPByIP, b.ipcache.LookupSecIDByIP, b.ipcache.LookupByIdentity, b.dnsRequestHandler.NotifyOnDNSMsg)
+	dnsProxy := dnsproxy.NewDNSProxy(dnsProxyConfig, b.lookupEPByIP, b.ipcache.LookupSecIDByIP, b.ipcache.LookupByIdentity, b.dnsMessageHandler.NotifyOnDNSMsg)
 	b.proxyInstance.Set(dnsProxy)
 
 	if err := dnsProxy.Listen(); err != nil {

--- a/pkg/fqdn/cell/cell.go
+++ b/pkg/fqdn/cell/cell.go
@@ -7,8 +7,10 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
+	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/fqdn/rules"
+	"github.com/cilium/cilium/pkg/fqdn/service"
 )
 
 // Cell provides the FQDN proxy controlplane functionality
@@ -21,6 +23,18 @@ var Cell = cell.Module(
 
 	// The FQDN bootstrap logic
 	bootstrap.Cell,
+
+	// The FQDN Message handler is responsible for handling DNS messages
+	// (requests and responses) sent by the proxy and updating the DNS cache,
+	// metrics and policy rules accordingly.
+	messagehandler.Cell,
+
+	// GRPC server for the standalone DNS proxy
+	// This server is responsible for sending the DNS rules and IP cache updates
+	// to the standalone DNS proxy. It also handles the DNS responses
+	// from the standalone DNS proxy and updates the DNS rules and IP cache
+	// accordingly using the DNSMessageHandler.
+	service.Cell,
 
 	cell.Provide(rules.NewDNSRulesService),
 )

--- a/pkg/fqdn/messagehandler/cell.go
+++ b/pkg/fqdn/messagehandler/cell.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package messagehandler
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
+	"github.com/cilium/cilium/pkg/fqdn/namemanager"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
+)
+
+// Cell provides the FQDN Message handler functionality
+// It is responsible for handling DNS messages(requests and responses)
+// sent by the proxy and updating the DNS cache, metrics and policy rules
+// accordingly using the DNSMessageHandler.
+var Cell = cell.Module(
+	"fqdn-msg-handler",
+	"FQDN Message handler functionality",
+
+	cell.Provide(NewDNSMessageHandler),
+)
+
+type DNSMessageHandlerParams struct {
+	cell.In
+
+	Lifecycle         cell.Lifecycle
+	Logger            *slog.Logger
+	NameManager       namemanager.NameManager
+	ProxyInstance     defaultdns.Proxy
+	ProxyAccessLogger accesslog.ProxyAccessLogger
+}
+
+func NewDNSMessageHandler(params DNSMessageHandlerParams) DNSMessageHandler {
+	handler := &dnsMessageHandler{
+		logger:            params.Logger,
+		nameManager:       params.NameManager,
+		proxyInstance:     params.ProxyInstance,
+		proxyAccessLogger: params.ProxyAccessLogger,
+	}
+
+	return handler
+}

--- a/pkg/fqdn/service/cell.go
+++ b/pkg/fqdn/service/cell.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// Cell provides the standalone DNS proxy gRPC server.
+// It is responsible for sending the DNS rules and IP cache updates
+// to the standalone DNS proxy. It also handles the DNS responses
+// from the standalone DNS proxy and updates the DNS rules and IP cache
+// accordingly. It receives the DNS rules during the endpoint regeneration
+// event and listens for ip cache updates from the ipcache.
+var Cell = cell.Module(
+	"sdp-grpc-server",
+	"Provides the standalone DNS proxy gRPC server",
+
+	cell.Config(defaultConfig),
+	cell.Provide(newDefaultListener),
+	cell.Provide(newServer),
+)
+
+type serverParams struct {
+	cell.In
+
+	Logger            *slog.Logger
+	EndpointManager   endpointmanager.EndpointManager
+	DNSRequestHandler messagehandler.DNSMessageHandler
+	IPCache           *ipcache.IPCache
+	JobGroup          job.Group
+	Config            FQDNConfig
+	DaemonConfig      *option.DaemonConfig
+	DefaultListener   listenConfig
+}
+
+func newServer(params serverParams) *FQDNDataServer {
+	srv := NewServer(params.EndpointManager, params.DNSRequestHandler, params.Config.StandaloneDNSProxyServerPort, params.Logger, params.DefaultListener)
+
+	if !params.Config.EnableStandaloneDNSProxy {
+		return srv
+	}
+
+	if !params.DaemonConfig.EnableL7Proxy {
+		srv.log.Error("Standalone DNS proxy requires L7 proxy to be enabled")
+		return srv
+	}
+
+	if params.DaemonConfig.ToFQDNsProxyPort == 0 || params.Config.StandaloneDNSProxyServerPort == 0 {
+		srv.log.Error("Standalone DNS proxy requires a valid port number to be set")
+		return srv
+	}
+
+	params.IPCache.AddListener(srv)
+
+	params.JobGroup.Add(job.OneShot("sdp-grpc-server", srv.ListenAndServe,
+		job.WithRetry(3, &job.ExponentialBackoff{Min: 1 * time.Second, Max: 5 * time.Second}),
+		job.WithShutdown()))
+
+	return srv
+}
+
+const (
+	// EnableStandaloneDNSProxy is the name of the option to enable standalone DNS proxy
+	EnableStandaloneDNSProxy = "enable-standalone-dns-proxy"
+
+	// StandaloneDNSProxyServerPort is the port on which the standalone DNS proxy gRPC server should listen.
+	StandaloneDNSProxyServerPort = "standalone-dns-proxy-server-port"
+)
+
+type FQDNConfig struct {
+	// EnableStandaloneDNSProxy is the option to enable standalone DNS proxy
+	EnableStandaloneDNSProxy bool
+
+	// StandaloneDNSProxyServerPort is the user-configured global, Standalone DNS proxy gRPC server port
+	StandaloneDNSProxyServerPort int
+}
+
+var defaultConfig = FQDNConfig{
+	EnableStandaloneDNSProxy:     false,
+	StandaloneDNSProxyServerPort: 40045,
+}
+
+func (def FQDNConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool(EnableStandaloneDNSProxy, def.EnableStandaloneDNSProxy, "Enables standalone DNS proxy")
+	flags.Int(StandaloneDNSProxyServerPort, def.StandaloneDNSProxyServerPort, "Global port on which the gRPC server for standalone DNS proxy should listen")
+}

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"slices"
+
+	"github.com/cilium/hive/cell"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/counter"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+// FQDNDataServer is the server for the standalone DNS proxy grpc server
+// It is responsible for handling the FQDN mapping requests from the SDP
+// and sending the DNS Policy updates to the SDP.
+type FQDNDataServer struct {
+	pb.UnimplementedFQDNDataServer
+
+	// port is the port on which the standalone DNS proxy grpc server will run
+	port int
+
+	// grpcServer is the grpc server for the standalone DNS proxy
+	grpcServer *grpc.Server
+
+	endpointManager endpointmanager.EndpointManager
+
+	// updateOnDNSMsg is a function to update the DNS message in the cilium agent on receiving the FQDN mapping
+	updateOnDNSMsg messagehandler.DNSMessageHandler
+
+	// identityToIPMutex is a mutex to protect the current state of the identity to Ip mapping
+	identityToIPMutex lock.Mutex
+
+	// currentIdentityToIP is a map of the identity to list of IPs
+	currentIdentityToIP map[identity.NumericIdentity][]netip.Prefix
+
+	// prefixLengths tracks the unique set of prefix lengths for IPv4 and
+	// IPv6 addresses in order to optimize longest prefix match lookups.
+	prefixLengths *counter.PrefixLengthCounter
+
+	// log is the logger for the FQDNDataServer
+	log *slog.Logger
+
+	// listener is used to create a net.Listener when starting the grpc server
+	listener listenConfig
+}
+
+var (
+	kaep = keepalive.EnforcementPolicy{
+		PermitWithoutStream: true, // Allow pings even when there are no active streams
+	}
+	kasp = keepalive.ServerParameters{
+		Time:    5 * time.Second, // Ping the client if it is idle for 5 seconds to ensure the connection is still active
+		Timeout: 1 * time.Second, // Wait 1 second for the ping ack before assuming the connection is dead
+	}
+)
+
+// listenConfig is an interface that abstracts the creation of a net.Listener.
+type listenConfig interface {
+	Listen(ctx context.Context, network, addr string) (net.Listener, error)
+}
+
+// defaultListener implements Listener by using net.ListenConfig.
+type defaultListener struct{}
+
+func (d *defaultListener) Listen(ctx context.Context, network, addr string) (net.Listener, error) {
+	var lc net.ListenConfig
+	return lc.Listen(ctx, network, addr)
+}
+
+var _ listenConfig = &defaultListener{}
+
+func newDefaultListener() listenConfig {
+	return &defaultListener{}
+}
+
+type PolicyUpdater interface {
+	// UpdatePolicyRules is used to update the current state of the policy rules at the
+	// gRPC server. These rules are sent to the standalone DNS proxy.
+	// This is currently being called whenever there is a policy regeneration event
+	// for an endpoint.
+	UpdatePolicyRules(map[identity.NumericIdentity]policy.SelectorPolicy, bool) error
+}
+
+// StreamPolicyState is a bidirectional streaming RPC to subscribe to DNS policies
+// SDP calls this method to subscribe to DNS policies
+// For each stream, we start a goroutine to receive the DNS policies ACKs
+// The flow of the method is as follows:
+// 1. Add the stream to the map( called by the client i.e SDP)
+// 2. Start a goroutine to receive the DNS policies ACKs for that particular client.
+// 3. Send the current state of the DNS rules to the client (We store the current state fo DNS rules during the endpoint regeneration see UpdatePolicyRulesLocked)
+// 4. Wait for the context to be done
+// Note: this method is left empty on purpose and will be update with the actual implementation in the future PRs for the standalone DNS proxy
+func (s *FQDNDataServer) StreamPolicyState(stream pb.FQDNData_StreamPolicyStateServer) error {
+	// This is a temporary implementation to send the current state of the DNS rules to the client and used for testing
+	stream.Send(&pb.PolicyState{RequestId: "test"})
+	return nil
+}
+
+// NewServer creates a new FQDNDataServer which is used to handle the Standalone DNS Proxy grpc service
+func NewServer(endpointManager endpointmanager.EndpointManager, updateOnDNSMsg messagehandler.DNSMessageHandler, port int, logger *slog.Logger, listener listenConfig) *FQDNDataServer {
+	fqdnDataServer := &FQDNDataServer{
+		port:                port,
+		endpointManager:     endpointManager,
+		updateOnDNSMsg:      updateOnDNSMsg,
+		currentIdentityToIP: make(map[identity.NumericIdentity][]netip.Prefix),
+		log:                 logger,
+		prefixLengths:       counter.DefaultPrefixLengthCounter(),
+		listener:            listener,
+	}
+
+	grpcServer := grpc.NewServer(grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp))
+	fqdnDataServer.grpcServer = grpcServer
+	pb.RegisterFQDNDataServer(grpcServer, fqdnDataServer)
+	return fqdnDataServer
+}
+
+// OnIPIdentityCacheChange is a method to receive the IP identity cache change events
+func (s *FQDNDataServer) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr types.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcache.K8sMetadata, endpointFlags uint8) {
+	s.identityToIPMutex.Lock()
+	defer s.identityToIPMutex.Unlock()
+
+	if cidr.ClusterID() != 0 {
+		return
+	}
+	prefix := cidr.AsPrefix()
+	if cidr.ClusterID() == 0 {
+		switch modType {
+		case ipcache.Upsert:
+			if oldID != nil {
+				// Remove from the old identity
+				s.deleteFromIdentityToIPLocked(oldID, prefix)
+			}
+			s.currentIdentityToIP[newID.ID] = append(s.currentIdentityToIP[newID.ID], prefix)
+			s.prefixLengths.Add([]netip.Prefix{prefix})
+		case ipcache.Delete:
+			if oldID != nil {
+				s.deleteFromIdentityToIPLocked(oldID, prefix)
+			}
+		}
+	}
+}
+
+// deleteFromIdentityToIPLocked deletes the given IP from the identity to IP mapping
+// It is called when the IP identity cache changes and the IP is deleted from the mapping
+// It is also called when the IP is upserted with a new identity
+// It removes the prefix from the prefixLengths map
+// It is called with the identityToIpMutex lock held
+func (s *FQDNDataServer) deleteFromIdentityToIPLocked(identity *ipcache.Identity, prefix netip.Prefix) error {
+	if identity == nil {
+		return fmt.Errorf("identity is nil")
+	}
+
+	if ips, ok := s.currentIdentityToIP[identity.ID]; ok {
+		newIPs := slices.DeleteFunc(ips, func(existing netip.Prefix) bool {
+			if existing == prefix {
+				s.prefixLengths.Delete([]netip.Prefix{prefix})
+				return true
+			}
+			return false
+		})
+		if len(newIPs) == 0 {
+			delete(s.currentIdentityToIP, identity.ID)
+		} else {
+			s.currentIdentityToIP[identity.ID] = newIPs
+		}
+	}
+	return nil
+}
+
+// UpdatePolicyRules updates the current state of the DNS rules with the given policies and sends the current state of the DNS rules to the client
+// This method is called:
+// 1. when the DNS rules are updated during the endpoint regeneration, we store the state of the DNS rules with flag rulesUpdate as true
+// 2. when the client subscribes to DNS policies, we send the current state of the DNS rules to the client(flag rulesUpdate as false)
+// 3. when the IP identity cache changes, we update the current state of the identity to IP mapping and send the current state of the DNS rules to
+// the client(flag rulesUpdate as false)
+// Note: this method is left empty on purpose and will be updated with the actual implementation in the future PRs for the standalone DNS proxy
+func (s *FQDNDataServer) UpdatePolicyRules(policies map[identity.NumericIdentity]policy.SelectorPolicy, rulesUpdate bool) error {
+	return nil
+}
+
+// UpdateMappingRequest updates the FQDN mapping with the given data
+// SDP sends the fqdn mapping to cilium agent
+// Steps to update the mapping:
+// 1. Get the endpoint from the IP
+// 2. If the endpoint is not found, return an error
+// 3. If the IPs are not empty, update the cilium agent with the mapping
+// Note: this method is left empty on purpose and will be updated with the actual implementation in the future PRs for the standalone DNS proxy
+func (s *FQDNDataServer) UpdateMappingRequest(ctx context.Context, mappings *pb.FQDNMapping) (*pb.UpdateMappingResponse, error) {
+	return &pb.UpdateMappingResponse{
+		Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+	}, nil
+}
+
+// ListenAndServe starts the Standalone DNS Proxy gRPC server on the given port
+func (s *FQDNDataServer) ListenAndServe(ctx context.Context, health cell.Health) error {
+	listenErrs := make(chan error)
+	go func() {
+		defer close(listenErrs)
+
+		address := fmt.Sprintf("localhost:%d", s.port)
+		s.log.Info("Starting Standalone DNS Proxy server on", logfields.Address, address)
+		lis, err := s.listener.Listen(ctx, "tcp", address)
+		if err != nil {
+			s.log.Error("Failed to listen", logfields.Error, err)
+			listenErrs <- err
+			return
+		}
+
+		if err := s.grpcServer.Serve(lis); err != nil {
+			s.log.Error("Failed to serve the standalone DNS Proxy gRPC server", logfields.Error, err)
+			listenErrs <- err
+
+		}
+	}()
+
+	health.OK(fmt.Sprintf("Serving at %d", s.port))
+
+	select {
+	case err := <-listenErrs:
+		return err
+	case <-ctx.Done():
+		s.Stop()
+		<-listenErrs
+		return nil
+	}
+}
+
+func (s *FQDNDataServer) Stop() {
+	if s.grpcServer == nil {
+		return
+	}
+	// Stop the grpc server
+	s.grpcServer.GracefulStop()
+}

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
+	"github.com/cilium/cilium/pkg/fqdn/namemanager"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	"github.com/cilium/cilium/pkg/time"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+type bufconnListener struct {
+	buf *bufconn.Listener
+}
+
+func newBufconnListener(lis *bufconn.Listener) *bufconnListener {
+	return &bufconnListener{buf: lis}
+}
+
+func (b *bufconnListener) Listen(ctx context.Context, network, addr string) (net.Listener, error) {
+	return b.buf, nil
+}
+
+func TestFQDNDataServer(t *testing.T) {
+
+	test := map[string]struct {
+		port                     int
+		enableL7Proxy            bool
+		enableStandaloneDNSProxy bool
+		serverPort               int
+		err                      error
+	}{
+		"Successfully running the server": {
+			port:                     1234,
+			enableL7Proxy:            true,
+			enableStandaloneDNSProxy: true,
+			// Random port for the server should run ideally
+			// but for the test we are using bufconn
+			// which will not use the port
+			serverPort: 40045,
+			err:        nil,
+		},
+	}
+
+	buffer := 1024 * 1024
+	lis := bufconn.Listen(buffer)
+
+	for scenario, tt := range test {
+		t.Run(scenario, func(t *testing.T) {
+
+			h := hive.New(
+				cell.Module(
+					"test-fqdn-grpc-server",
+					"Test FQDN gRPC server",
+					cell.Config(defaultConfig),
+					cell.Provide(
+						func(logger *slog.Logger) endpointmanager.EndpointManager {
+							return endpointmanager.New(logger, &dummyEpSyncher{}, nil, nil, nil)
+						},
+
+						func(em endpointmanager.EndpointManager, logger *slog.Logger) *ipcache.IPCache {
+							pr := policy.NewPolicyRepository(logger, nil, nil, nil, nil, api.NewPolicyMetricsNoop())
+							return ipcache.NewIPCache(&ipcache.Configuration{
+								Context:           t.Context(),
+								IdentityAllocator: testidentity.NewMockIdentityAllocator(nil),
+								PolicyHandler:     pr.GetSelectorCache(),
+								DatapathHandler:   em,
+							})
+						},
+						func(ipc *ipcache.IPCache) namemanager.NameManager {
+							return namemanager.New(namemanager.ManagerParams{
+								Config: namemanager.NameManagerConfig{
+									MinTTL:            1,
+									DNSProxyLockCount: defaults.DNSProxyLockCount,
+									StateDir:          defaults.StateDir,
+								},
+								IPCache: ipc,
+							})
+						},
+						func(lc cell.Lifecycle, logger *slog.Logger) messagehandler.DNSMessageHandler {
+							return messagehandler.NewDNSMessageHandler(
+								messagehandler.DNSMessageHandlerParams{
+									Lifecycle:         lc,
+									Logger:            logger,
+									NameManager:       nil,
+									ProxyInstance:     nil,
+									ProxyAccessLogger: nil,
+								})
+						},
+						func() *option.DaemonConfig {
+							return &option.DaemonConfig{
+								EnableL7Proxy:    tt.enableL7Proxy,
+								ToFQDNsProxyPort: tt.port,
+							}
+						},
+						func() listenConfig {
+							return newBufconnListener(lis)
+						},
+						newServer,
+					)),
+				cell.Invoke(func(_ *FQDNDataServer) {}))
+
+			hive.AddConfigOverride(
+				h,
+				func(cfg *FQDNConfig) {
+					cfg.EnableStandaloneDNSProxy = tt.enableStandaloneDNSProxy
+					cfg.StandaloneDNSProxyServerPort = tt.serverPort
+				})
+
+			tlog := hivetest.Logger(t)
+			if err := h.Start(tlog, t.Context()); err != nil {
+				t.Fatalf("failed to start: %s", err)
+			}
+
+			// To check if the server is running, we need to create a gRPC client
+			// and try to connect to the server. If the server is not running,
+			// the client will return an error.
+			// If the server is running, we will get a response from the server.
+			conn, err := grpc.NewClient("passthrough://bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+				return lis.Dial()
+			}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			require.NoError(t, err)
+
+			c := pb.NewFQDNDataClient(conn)
+
+			connected := false
+			testutils.WaitUntil(func() bool {
+				stream, err := c.StreamPolicyState(t.Context())
+				if err != nil {
+					return false
+				}
+				response, err := stream.Recv()
+				if err != nil {
+					return false
+				}
+
+				if response.GetRequestId() == "" {
+					return false
+				} else {
+					connected = true
+					return true
+				}
+			}, 5*time.Second)
+
+			// If the server is running, we should get a response from the server
+			if !connected && tt.err == nil {
+				t.Fatalf("failed to connect to server")
+			}
+
+			t.Cleanup(func() {
+				//Stop the client
+				conn.Close()
+				// Stop the server
+				if err := h.Stop(tlog, context.TODO()); err != nil {
+					t.Fatalf("failed to stop: %s", err)
+				}
+			})
+		})
+	}
+}
+
+type dummyEpSyncher struct{}
+
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, h cell.Health) {
+}
+
+func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+}
+
+func TestHandleIPUpsert(t *testing.T) {
+	endptMgr := endpointmanager.New(hivetest.Logger(t), &dummyEpSyncher{}, nil, nil, nil)
+
+	// create a new server instance
+	server := NewServer(endptMgr, nil, 1234, hivetest.Logger(t), nil)
+
+	// Prepare a valid IPv4 (1.2.3.4/32).
+	prefix := netip.MustParsePrefix("1.2.3.4/32")
+	validCIDR := types.NewPrefixCluster(prefix, 0)
+	dummyIdentity := ipcache.Identity{ID: 1}
+
+	// Call OnIPIdentityCacheChange with identity 1 and ip: 1.2.3.4/32.
+	// Expectation: currentIdentityToIP:{1: [1.2.3.4/32]}
+	server.OnIPIdentityCacheChange(ipcache.Upsert, validCIDR, nil, nil, nil, dummyIdentity, 0, nil, 0)
+	ips := server.currentIdentityToIP[dummyIdentity.ID]
+	require.Len(t, ips, 1)
+	require.Equal(t, "1.2.3.4/32", ips[0].String())
+
+	// Call OnIPIdentityCacheChange with Upsert with identity change(1->2) for same ip: 1.2.3.4/32.
+	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32]}
+	dummyIdentity2 := ipcache.Identity{ID: 2}
+	server.OnIPIdentityCacheChange(ipcache.Upsert, validCIDR, nil, nil, &dummyIdentity, dummyIdentity2, 0, nil, 0)
+	ips = server.currentIdentityToIP[dummyIdentity2.ID]
+	require.Len(t, ips, 1)
+	require.Equal(t, "1.2.3.4/32", ips[0].String())
+	require.Empty(t, server.currentIdentityToIP[dummyIdentity.ID])
+
+	// Call OnIPIdentityCacheChange with Upsert with identity 2 for ip: 4.5.6.7/32.
+	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32, 4.5.6.7/32]}
+	prefix2 := netip.MustParsePrefix("4.5.6.7/32")
+	validCIDR2 := types.NewPrefixCluster(prefix2, 0)
+	server.OnIPIdentityCacheChange(ipcache.Upsert, validCIDR2, nil, nil, nil, dummyIdentity2, 0, nil, 0)
+	ips = server.currentIdentityToIP[dummyIdentity2.ID]
+	require.Len(t, ips, 2)
+
+	// Call OnIPIdentityCacheChange with Upsert with identity 2 for ip: 8.9.10.11/24.
+	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32, 4.5.6.7/32, 8.9.10.11/24]}
+	prefix3 := netip.MustParsePrefix("8.9.10.11/24")
+	validCIDR3 := types.NewPrefixCluster(prefix3, 0)
+	server.OnIPIdentityCacheChange(ipcache.Upsert, validCIDR3, nil, nil, nil, dummyIdentity2, 0, nil, 0)
+	ips = server.currentIdentityToIP[dummyIdentity2.ID]
+	require.Len(t, ips, 3)
+	_, ipv4 := server.prefixLengths.ToBPFData()
+	require.Len(t, ipv4, 3) // [32 24 0]
+
+	// Call OnIPIdentityCacheChange with Delete for identity 2 and ip: 10.10.10.10/24.
+	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32, 4.5.6.7/32]}
+	prefix4 := netip.MustParsePrefix("10.10.10.10/24")
+	validCIDR4 := types.NewPrefixCluster(prefix4, 0)
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR4, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	ips = server.currentIdentityToIP[dummyIdentity2.ID]
+	require.Len(t, ips, 3)
+	_, ipv4 = server.prefixLengths.ToBPFData()
+	require.Len(t, ipv4, 3) // [32 24  0]
+
+	// Call OnIPIdentityCacheChange with Delete for identity 2 and ip: 8.9.10.11/24.
+	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32, 4.5.6.7/32]}
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR3, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	ips = server.currentIdentityToIP[dummyIdentity2.ID]
+	require.Len(t, ips, 2)
+	_, ipv4 = server.prefixLengths.ToBPFData()
+	require.Len(t, ipv4, 2) // [32  0]
+
+	// Call OnIPIdentityCacheChange with Delete for identity 2 and ip: 4.5.6.7/32.
+	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32]}
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR2, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	ips = server.currentIdentityToIP[dummyIdentity2.ID]
+	require.Len(t, ips, 1)
+	require.Equal(t, "1.2.3.4/32", ips[0].String())
+
+	// Call again OnIPIdentityCacheChange with Delete for identity 2 and ip: 4.5.6.7/32.
+	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32]}
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR2, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	ips = server.currentIdentityToIP[dummyIdentity2.ID]
+	require.Len(t, ips, 1)
+	require.Equal(t, "1.2.3.4/32", ips[0].String())
+
+	// Call again OnIPIdentityCacheChange with Delete for identity 2 and ip: 1.2.3.4/32.
+	// Expectation: currentIdentityToIP:{}
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	require.Empty(t, server.currentIdentityToIP)
+	require.Empty(t, server.currentIdentityToIP[dummyIdentity2.ID])
+}

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -49,6 +49,18 @@ func (cache *policyCache) lookupOrCreate(identity *identityPkg.Identity) *cached
 	return cip
 }
 
+// GetPolicySnapshot returns a snapshot of the current policy cache.
+// The policy snapshot has the lock order as: Repository.Mutex before policyCache.Mutex.
+func (cache *policyCache) GetPolicySnapshot() map[identityPkg.NumericIdentity]SelectorPolicy {
+	cache.Lock()
+	defer cache.Unlock()
+	snapshot := make(map[identityPkg.NumericIdentity]SelectorPolicy, len(cache.policies))
+	for k, v := range cache.policies {
+		snapshot[k] = v.getPolicy()
+	}
+	return snapshot
+}
+
 // delete forgets about any cached SelectorPolicy that this endpoint uses.
 //
 // Returns true if the SelectorPolicy was removed from the cache.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -43,6 +43,8 @@ type PolicyRepository interface {
 	// calculation.
 	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error)
 
+	// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
+	GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy
 	GetRevision() uint64
 	GetRulesList() *models.Policy
 	GetSelectorCache() *SelectorCache
@@ -589,4 +591,12 @@ func (p *Repository) ReplaceByLabels(rules api.Rules, searchLabelsList []labels.
 	}
 
 	return affectedIDs, p.BumpRevision(), len(oldRules)
+}
+
+// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
+func (p *Repository) GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	return p.policyCache.GetPolicySnapshot()
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -144,7 +144,7 @@ func (p *policyContext) PolicyTrace(format string, a ...any) {
 type SelectorPolicy interface {
 	// CreateRedirects is used to ensure the endpoint has created all the needed redirects
 	// before a new EndpointPolicy is created.
-	RedirectFilters() iter.Seq2[*L4Filter, *PerSelectorPolicy]
+	RedirectFilters() iter.Seq2[*L4Filter, PerSelectorPolicyTuple]
 
 	// DistillPolicy returns the policy in terms of connectivity to peer
 	// Identities.
@@ -499,21 +499,26 @@ func (l4policy L4DirectionPolicy) toMapState(logger *slog.Logger, p *EndpointPol
 	})
 }
 
+type PerSelectorPolicyTuple struct {
+	Policy   *PerSelectorPolicy
+	Selector CachedSelector
+}
+
 // RedirectFilters returns an iterator for each L4Filter with a redirect in the policy.
-func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, *PerSelectorPolicy] {
-	return func(yield func(*L4Filter, *PerSelectorPolicy) bool) {
+func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, PerSelectorPolicyTuple] {
+	return func(yield func(*L4Filter, PerSelectorPolicyTuple) bool) {
 		if p.L4Policy.Ingress.forEachRedirectFilter(yield) {
 			p.L4Policy.Egress.forEachRedirectFilter(yield)
 		}
 	}
 }
 
-func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, *PerSelectorPolicy) bool) bool {
+func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, PerSelectorPolicyTuple) bool) bool {
 	ok := true
 	l4policy.PortRules.ForEach(func(l4 *L4Filter) bool {
-		for _, ps := range l4.PerSelectorPolicies {
+		for cs, ps := range l4.PerSelectorPolicies {
 			if ps != nil && ps.IsRedirect() {
-				ok = yield(l4, ps)
+				ok = yield(l4, PerSelectorPolicyTuple{ps, cs})
 			}
 		}
 		return ok

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -12,6 +12,7 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
+	"github.com/cilium/cilium/pkg/fqdn/service"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
@@ -116,12 +117,13 @@ func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyInt
 	}
 }
 
-func newDNSProxyIntegration(dnsProxy defaultdns.Proxy) *dnsProxyIntegration {
+func newDNSProxyIntegration(dnsProxy defaultdns.Proxy, sdpPolicyUpdater *service.FQDNDataServer) *dnsProxyIntegration {
 	if !option.Config.EnableL7Proxy {
 		return nil
 	}
 
 	return &dnsProxyIntegration{
-		dnsProxy: dnsProxy,
+		dnsProxy:         dnsProxy,
+		sdpPolicyUpdater: sdpPolicyUpdater,
 	}
 }

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
+	"github.com/cilium/cilium/pkg/fqdn/service"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
@@ -51,7 +52,8 @@ func (dr *dnsRedirect) Close() {
 }
 
 type dnsProxyIntegration struct {
-	dnsProxy defaultdns.Proxy
+	dnsProxy         defaultdns.Proxy
+	sdpPolicyUpdater service.PolicyUpdater
 }
 
 // createRedirect creates a redirect to the dns proxy. The redirect structure passed

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -163,6 +164,10 @@ func proxyTypeNotFoundError(proxyType types.ProxyType, listener string, ingress 
 		dir = "ingress"
 	}
 	return fmt.Errorf("unrecognized %s proxy type for %s: %s", dir, listener, proxyType)
+}
+
+func (p *Proxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+	p.dnsIntegration.sdpPolicyUpdater.UpdatePolicyRules(rules, true)
 }
 
 func (p *Proxy) createNewRedirect(

--- a/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
+++ b/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
@@ -1,0 +1,318 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package bufconn provides a net.Conn implemented by a buffer and related
+// dialing and listening functionality.
+package bufconn
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Listener implements a net.Listener that creates local, buffered net.Conns
+// via its Accept and Dial method.
+type Listener struct {
+	mu   sync.Mutex
+	sz   int
+	ch   chan net.Conn
+	done chan struct{}
+}
+
+// Implementation of net.Error providing timeout
+type netErrorTimeout struct {
+	error
+}
+
+func (e netErrorTimeout) Timeout() bool   { return true }
+func (e netErrorTimeout) Temporary() bool { return false }
+
+var errClosed = fmt.Errorf("closed")
+var errTimeout net.Error = netErrorTimeout{error: fmt.Errorf("i/o timeout")}
+
+// Listen returns a Listener that can only be contacted by its own Dialers and
+// creates buffered connections between the two.
+func Listen(sz int) *Listener {
+	return &Listener{sz: sz, ch: make(chan net.Conn), done: make(chan struct{})}
+}
+
+// Accept blocks until Dial is called, then returns a net.Conn for the server
+// half of the connection.
+func (l *Listener) Accept() (net.Conn, error) {
+	select {
+	case <-l.done:
+		return nil, errClosed
+	case c := <-l.ch:
+		return c, nil
+	}
+}
+
+// Close stops the listener.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	select {
+	case <-l.done:
+		// Already closed.
+		break
+	default:
+		close(l.done)
+	}
+	return nil
+}
+
+// Addr reports the address of the listener.
+func (l *Listener) Addr() net.Addr { return addr{} }
+
+// Dial creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.
+func (l *Listener) Dial() (net.Conn, error) {
+	return l.DialContext(context.Background())
+}
+
+// DialContext creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.  If ctx is Done, returns ctx.Err()
+func (l *Listener) DialContext(ctx context.Context) (net.Conn, error) {
+	p1, p2 := newPipe(l.sz), newPipe(l.sz)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-l.done:
+		return nil, errClosed
+	case l.ch <- &conn{p1, p2}:
+		return &conn{p2, p1}, nil
+	}
+}
+
+type pipe struct {
+	mu sync.Mutex
+
+	// buf contains the data in the pipe.  It is a ring buffer of fixed capacity,
+	// with r and w pointing to the offset to read and write, respectively.
+	//
+	// Data is read between [r, w) and written to [w, r), wrapping around the end
+	// of the slice if necessary.
+	//
+	// The buffer is empty if r == len(buf), otherwise if r == w, it is full.
+	//
+	// w and r are always in the range [0, cap(buf)) and [0, len(buf)].
+	buf  []byte
+	w, r int
+
+	wwait sync.Cond
+	rwait sync.Cond
+
+	// Indicate that a write/read timeout has occurred
+	wtimedout bool
+	rtimedout bool
+
+	wtimer *time.Timer
+	rtimer *time.Timer
+
+	closed      bool
+	writeClosed bool
+}
+
+func newPipe(sz int) *pipe {
+	p := &pipe{buf: make([]byte, 0, sz)}
+	p.wwait.L = &p.mu
+	p.rwait.L = &p.mu
+
+	p.wtimer = time.AfterFunc(0, func() {})
+	p.rtimer = time.AfterFunc(0, func() {})
+	return p
+}
+
+func (p *pipe) empty() bool {
+	return p.r == len(p.buf)
+}
+
+func (p *pipe) full() bool {
+	return p.r < len(p.buf) && p.r == p.w
+}
+
+func (p *pipe) Read(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Block until p has data.
+	for {
+		if p.closed {
+			return 0, io.ErrClosedPipe
+		}
+		if !p.empty() {
+			break
+		}
+		if p.writeClosed {
+			return 0, io.EOF
+		}
+		if p.rtimedout {
+			return 0, errTimeout
+		}
+
+		p.rwait.Wait()
+	}
+	wasFull := p.full()
+
+	n = copy(b, p.buf[p.r:len(p.buf)])
+	p.r += n
+	if p.r == cap(p.buf) {
+		p.r = 0
+		p.buf = p.buf[:p.w]
+	}
+
+	// Signal a blocked writer, if any
+	if wasFull {
+		p.wwait.Signal()
+	}
+
+	return n, nil
+}
+
+func (p *pipe) Write(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return 0, io.ErrClosedPipe
+	}
+	for len(b) > 0 {
+		// Block until p is not full.
+		for {
+			if p.closed || p.writeClosed {
+				return 0, io.ErrClosedPipe
+			}
+			if !p.full() {
+				break
+			}
+			if p.wtimedout {
+				return 0, errTimeout
+			}
+
+			p.wwait.Wait()
+		}
+		wasEmpty := p.empty()
+
+		end := cap(p.buf)
+		if p.w < p.r {
+			end = p.r
+		}
+		x := copy(p.buf[p.w:end], b)
+		b = b[x:]
+		n += x
+		p.w += x
+		if p.w > len(p.buf) {
+			p.buf = p.buf[:p.w]
+		}
+		if p.w == cap(p.buf) {
+			p.w = 0
+		}
+
+		// Signal a blocked reader, if any.
+		if wasEmpty {
+			p.rwait.Signal()
+		}
+	}
+	return n, nil
+}
+
+func (p *pipe) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+func (p *pipe) closeWrite() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.writeClosed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+type conn struct {
+	io.Reader
+	io.Writer
+}
+
+func (c *conn) Close() error {
+	err1 := c.Reader.(*pipe).Close()
+	err2 := c.Writer.(*pipe).closeWrite()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func (c *conn) SetDeadline(t time.Time) error {
+	c.SetReadDeadline(t)
+	c.SetWriteDeadline(t)
+	return nil
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	p := c.Reader.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rtimer.Stop()
+	p.rtimedout = false
+	if !t.IsZero() {
+		p.rtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.rtimedout = true
+			p.rwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	p := c.Writer.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.wtimer.Stop()
+	p.wtimedout = false
+	if !t.IsZero() {
+		p.wtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.wtimedout = true
+			p.wwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (*conn) LocalAddr() net.Addr  { return addr{} }
+func (*conn) RemoteAddr() net.Addr { return addr{} }
+
+type addr struct{}
+
+func (addr) Network() string { return "bufconn" }
+func (addr) String() string  { return "bufconn" }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1870,6 +1870,7 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
+google.golang.org/grpc/test/bufconn
 # google.golang.org/protobuf v1.36.6
 ## explicit; go 1.22
 google.golang.org/protobuf/encoding/protodelim


### PR DESCRIPTION
Cilium grpc server to send the policy data to the standalone dns proxy. This commit:
- Adds a server listening on ToFQDNsServerPort.
- Create a `GlobalStandaloneDNSProxy` that is used by cilium agent to communicate with the standalone dns proxy.
- During policy regeneration for an endpoint sends the policy snapshot from the repo to the `GlobalStandaloneDNSProxy` which eventually will send the data to standalone dns proxy.
- `GlobalStandaloneDNSProxy` also listens for ip cache updates and stores a map of identity to ip address to be sent to standalone dns proxy.

This PR is a subset of PR: https://github.com/cilium/cilium/pull/36213.
For overall flow, please go through the https://github.com/cilium/cilium/issues/30984#issuecomment-2505035738 and overall SDP PR: https://github.com/cilium/cilium/pull/37836

In  general the flow is:
The grpc server starts running on a default port if l7proxy and enable-standalone-dns-proxy is true
Cilium agent sends the data to SDP(standalone dns proxy) during endpoint regeneration specifically after the policy cache is updated. There is lock mechanism in the policyCache as well as the FqdnDataServer to make sure that the updates are a snapshot of the current policy state.(and in serialized manner)
StreamPolicyState is called by the client(SDP) on start and cilium agent sents it the current policy rules it has. Otherwise, it stores the stream and write the rules on the same stream for the client to receive.
UpdateMappingRequest is used by the client to send the data(DNS Response mappings) to cilium agent.

Fixes: https://github.com/cilium/cilium/issues/30984
Related PRs: https://github.com/cilium/cilium/pull/36214, https://github.com/cilium/cilium/pull/36215
CFP: https://github.com/cilium/design-cfps/pull/54

