### PR TITLE
renovate: Bump cilium-envoy to 1.32 for v1.15

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -580,20 +580,11 @@
         "quay.io/cilium/cilium-envoy"
       ],
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
-      "allowedVersions": "/^v1\\.31\\.([0-9]+)-([0-9]+)-.*$/",
-      "matchBaseBranches": [
-        "v1.15",
-      ]
-    },
-    {
-      "matchDepNames": [
-        "quay.io/cilium/cilium-envoy"
-      ],
-      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
       "allowedVersions": "/^v1\\.32\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "v1.17",
         "v1.16",
+        "v1.15"
       ]
     },
     {


### PR DESCRIPTION
Relates: #38449 
