### PR TITLE
fix(cilium-operator): add missing k8sServiceHost templating

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -142,6 +142,15 @@ spec:
               key: ALIBABA_CLOUD_ACCESS_KEY_SECRET
               optional: true
         {{- end }}
+        {{- if and .Values.k8sServiceHostRef.name .Values.k8sServiceHostRef.key }}
+        - name: KUBERNETES_SERVICE_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Values.k8sServiceHostRef.name }}
+              key: {{ .Values.k8sServiceHostRef.key }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ include "k8sServicePort" . }}
+        {{- end }}
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ include "k8sServiceHost" . }}


### PR DESCRIPTION
The `cilium-operator` was missed during the addition of the `k8sServiceHostRef` value. This amends the change.

Fixes: #37276
Fixes: 44cdfb82957c72688ba359742deb40ef2cfbd172

```release-note
Fix `k8sServiceHostRef` for `cilium-operator` in Helm chart.
```