### PR TITLE
docs: add warning about l7 policy and EnableDefaultDeny

### DIFF
--- a/Documentation/security/policy/intro.rst
+++ b/Documentation/security/policy/intro.rst
@@ -62,6 +62,11 @@ block any traffic, even if it is the first policy to apply to an endpoint. An
 administrator can safely apply this policy cluster-wide, without the risk that
 it transitions an endpoint in to default-deny and causes legitimate traffic to be dropped.
 
+.. warning::
+  ``EnableDefaultDeny`` does not apply to :ref:`layer-7 policy <l7_policy>`.
+  Adding a layer-7 rule that does not include a layer-7 allow-all will cause drops,
+  even when default-deny is explicitly disabled.
+
 .. code-block:: yaml
 
   apiVersion: cilium.io/v2

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1049,6 +1049,9 @@ latter rule will have no effect.
 .. note:: L7 policies for SNATed IPv6 traffic (e.g., pod-to-world) are `broken <https://github.com/cilium/cilium/issues/37932#issuecomment-2730287932>`__
           and waiting for the `kernel fix <https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/>`__.
 
+.. note:: :ref:`EnableDefaultDeny <policy_mode_default>` does not apply to layer-7 rules.
+   If using a layer 7 rule in concert with ``EnableDefaultDeny``, the rule should
+   allow all layer-7 traffic. See :gh-issue:`38676`. 
 
 HTTP
 ----


### PR DESCRIPTION
The layer-7 proxies do not respect EnableDefaultDeny, since L7 policy "overrides" L3, and EnableDefaultDeny is L3-only. Call this out in the documentation.

