### PR TITLE
bugtool:feature: accept pattern for dumping matching pinned maps

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -236,15 +236,19 @@ func bpfCgroupCommands() []string {
 	return commands
 }
 
-func bpfMapDumpCommands(mapPaths []string) []string {
+func bpfMapDumpCommands(mapPathsPatterns []string) []string {
 	bpffsMountpoint := bpffsMountpoint()
 	if bpffsMountpoint == "" {
 		return nil
 	}
 
-	commands := make([]string, 0, len(mapPaths))
-	for _, mapPath := range mapPaths {
-		commands = append(commands, "bpftool map dump pinned "+filepath.Join(bpffsMountpoint, mapPath))
+	commands := make([]string, 0, len(mapPathsPatterns))
+	for _, pattern := range mapPathsPatterns {
+		if matches, err := filepath.Glob(filepath.Join(bpffsMountpoint, pattern)); err == nil {
+			for _, match := range matches {
+				commands = append(commands, "bpftool map dump pinned "+match)
+			}
+		}
 	}
 
 	return commands

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -76,7 +76,7 @@ var bpfMapsPath = []string{
 	"tc/globals/cilium_auth_map",
 	"tc/globals/cilium_call_policy",
 	"tc/globals/cilium_calls_overlay_2",
-	"tc/globals/cilium_calls_wireguard_2",
+	"tc/globals/cilium_calls_wireguard*",
 	"tc/globals/cilium_calls_xdp*",
 	"tc/globals/cilium_capture_cache",
 	"tc/globals/cilium_runtime_config",

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -77,7 +77,7 @@ var bpfMapsPath = []string{
 	"tc/globals/cilium_call_policy",
 	"tc/globals/cilium_calls_overlay_2",
 	"tc/globals/cilium_calls_wireguard_2",
-	"tc/globals/cilium_calls_xdp",
+	"tc/globals/cilium_calls_xdp*",
 	"tc/globals/cilium_capture_cache",
 	"tc/globals/cilium_runtime_config",
 	"tc/globals/cilium_lxc",


### PR DESCRIPTION
This commit modifies the current bugtool logic to accept mapPathPattern so that bugtool can dump all pinned maps with a name matching the provided pattern. While being useful also for future extensions (ex. if we'll start/need dumping cilium_netdev, endpoints, or policies), this allows us to start re-collecting cilium_calls_xdp (whose name changed with the dynamic ifindex parameter) and cilium_calls_wireguard (same as for the xdp one). Rather than discovering interfaces and retrieving these params, let's accept patterns so that we can simply use `cilium_calls_xdp* / cilium_calls_wireguard*`.

Fixes: https://github.com/cilium/cilium/issues/39028.