### PR TITLE
cilium-cli: add conn tests for ipv6 egress gateway policies

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1551,7 +1551,7 @@ func (ct *ConnectivityTest) getGatewayAndNonGatewayNodes() (string, string, erro
 
 }
 
-func (ct *ConnectivityTest) GetGatewayNodeInternalIP(egressGatewayNode string) net.IP {
+func (ct *ConnectivityTest) GetGatewayNodeInternalIP(egressGatewayNode string, ipv6 bool) net.IP {
 	gatewayNode, ok := ct.Nodes()[egressGatewayNode]
 	if !ok {
 		return nil
@@ -1563,11 +1563,14 @@ func (ct *ConnectivityTest) GetGatewayNodeInternalIP(egressGatewayNode string) n
 		}
 
 		ip := net.ParseIP(addr.Address)
-		if ip == nil || ip.To4() == nil {
+		if ip == nil {
 			continue
 		}
 
-		return ip
+		isIPv6 := ip.To4() == nil
+		if isIPv6 == ipv6 {
+			return ip
+		}
 	}
 
 	return nil
@@ -1606,7 +1609,7 @@ func (ct *ConnectivityTest) GetConnDisruptEgressPolicyEntries(ctx context.Contex
 		return nil, err
 	}
 
-	gatewayIP := ct.GetGatewayNodeInternalIP(gatewayNode)
+	gatewayIP := ct.GetGatewayNodeInternalIP(gatewayNode, false)
 	if gatewayIP == nil {
 		return nil, nil
 	}

--- a/cilium-cli/connectivity/check/peer.go
+++ b/cilium-cli/connectivity/check/peer.go
@@ -282,7 +282,7 @@ func (s NodeportService) Address(family features.IPFamily) string {
 					return address.Address
 				}
 			case features.IPFamilyV6:
-				if parsedAddress.To16() != nil {
+				if parsedAddress.To16() != nil && parsedAddress.To4() == nil {
 					return address.Address
 				}
 			}

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -553,6 +553,16 @@ func (t *Test) WithCiliumEgressGatewayPolicy(params CiliumEgressGatewayPolicyPar
 
 	pl.Spec.EgressGateway.NodeSelector.MatchLabels["kubernetes.io/hostname"] = egressGatewayNode
 
+	var ipv6Enabled bool
+	if status, ok := t.ctx.Feature(features.IPv6); ok && status.Enabled && versioncheck.MustCompile(">=1.18.0")(t.ctx.CiliumVersion) {
+		ipv6Enabled = true
+	}
+
+	// If IPv6 egress policies are enabled, add the necessary destination CIDR
+	if ipv6Enabled {
+		pl.Spec.DestinationCIDRs = append(pl.Spec.DestinationCIDRs, "::/0")
+	}
+
 	// Set the excluded CIDRs
 	pl.Spec.ExcludedCIDRs = []ciliumv2.CIDR{}
 
@@ -560,6 +570,11 @@ func (t *Test) WithCiliumEgressGatewayPolicy(params CiliumEgressGatewayPolicyPar
 	case ExternalNodeExcludedCIDRs:
 		for _, nodeWithoutCiliumIP := range t.Context().params.NodesWithoutCiliumIPs {
 			if parsedIP := net.ParseIP(nodeWithoutCiliumIP.IP); parsedIP.To4() == nil {
+				// If it is an IPv6 address, add the necessary excluded CIDR
+				if ipv6Enabled {
+					cidr := ciliumv2.CIDR(fmt.Sprintf("%s/128", nodeWithoutCiliumIP.IP))
+					pl.Spec.ExcludedCIDRs = append(pl.Spec.ExcludedCIDRs, cidr)
+				}
 				continue
 			}
 

--- a/cilium-cli/connectivity/check/wait.go
+++ b/cilium-cli/connectivity/check/wait.go
@@ -402,7 +402,7 @@ func WaitForEgressGatewayBpfPolicyEntries(ctx context.Context, ciliumPods map[st
 
 			for _, entry := range entries {
 				if !slices.ContainsFunc(targetEntries, entry.matches) {
-					return fmt.Errorf("untracked entry %+v in the egress gateway policy map", entry)
+					return fmt.Errorf("untracked entry %+v in the egress gateway policy maps", entry)
 				}
 			}
 		}
@@ -413,7 +413,7 @@ func WaitForEgressGatewayBpfPolicyEntries(ctx context.Context, ciliumPods map[st
 	for {
 		if err := ensureBpfPolicyEntries(); err != nil {
 			if err := w.Retry(err); err != nil {
-				return fmt.Errorf("failed to ensure egress gateway policy map is properly populated: %w", err)
+				return fmt.Errorf("failed to ensure egress gateway policy maps are properly populated: %w", err)
 			}
 
 			continue

--- a/cilium-dbg/cmd/bpf_egress_list.go
+++ b/cilium-dbg/cmd/bpf_egress_list.go
@@ -38,28 +38,50 @@ var bpfEgressListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf egress list")
 
-		policyMap, err := egressmap.OpenPinnedPolicyMap4()
-		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				fmt.Fprintln(os.Stderr, "Cannot find egress gateway bpf maps")
-				return
+		bpfEgressList := []egressPolicy{}
+		var ipv4MapExists, ipv6MapExists bool
+
+		policyMap4, err := egressmap.OpenPinnedPolicyMap4()
+		if err == nil {
+			ipv4MapExists = true
+			parse4 := func(key *egressmap.EgressPolicyKey4, val *egressmap.EgressPolicyVal4) {
+				bpfEgressList = append(bpfEgressList, egressPolicy{
+					SourceIP:  key.GetSourceIP().String(),
+					DestCIDR:  key.GetDestCIDR().String(),
+					EgressIP:  val.GetEgressAddr().String(),
+					GatewayIP: mapGatewayIP(val.GetGatewayAddr()),
+				})
 			}
 
-			Fatalf("Cannot open egress gateway bpf maps: %s", err)
+			if err := policyMap4.IterateWithCallback(parse4); err != nil {
+				Fatalf("Error dumping contents of IPv4 egress policy map: %s\n", err)
+			}
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			Fatalf("Cannot open IPv4 egress gateway bpf map: %s", err)
 		}
 
-		bpfEgressList := []egressPolicy{}
-		parse := func(key *egressmap.EgressPolicyKey4, val *egressmap.EgressPolicyVal4) {
-			bpfEgressList = append(bpfEgressList, egressPolicy{
-				SourceIP:  key.GetSourceIP().String(),
-				DestCIDR:  key.GetDestCIDR().String(),
-				EgressIP:  val.GetEgressAddr().String(),
-				GatewayIP: mapGatewayIP(val.GetGatewayAddr()),
-			})
+		policyMap6, err := egressmap.OpenPinnedPolicyMap6()
+		if err == nil {
+			ipv6MapExists = true
+			parse6 := func(key *egressmap.EgressPolicyKey6, val *egressmap.EgressPolicyVal6) {
+				bpfEgressList = append(bpfEgressList, egressPolicy{
+					SourceIP:  key.GetSourceIP().String(),
+					DestCIDR:  key.GetDestCIDR().String(),
+					EgressIP:  val.GetEgressAddr().String(),
+					GatewayIP: mapGatewayIP(val.GetGatewayAddr()),
+				})
+			}
+
+			if err := policyMap6.IterateWithCallback(parse6); err != nil {
+				Fatalf("Error dumping contents of IPv6 egress policy map: %s\n", err)
+			}
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			Fatalf("Cannot open IPv6 egress gateway bpf map: %s", err)
 		}
 
-		if err := policyMap.IterateWithCallback(parse); err != nil {
-			Fatalf("Error dumping contents of egress policy map: %s\n", err)
+		if !ipv4MapExists && !ipv6MapExists {
+			fmt.Fprintln(os.Stderr, "Cannot find egress gateway bpf maps")
+			return
 		}
 
 		if command.OutputOption() {


### PR DESCRIPTION
As a follow up to https://github.com/cilium/cilium/pull/38452, this PR adds the ability to list IPv6 EGW policies with `cilium-dbg` and the necessary `cilium-cli` connectivity tests to enable e2e test for the IPv6 extension of EGW policies.
