### PR TITLE
[v1.17] agent: Exclude apiserver connectivity as part of liveness probe

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2600,6 +2600,10 @@
      - interval between checks of the liveness probe
      - int
      - ``30``
+   * - :spelling:ignore:`livenessProbe.requireK8sConnectivity`
+     - whether to require k8s connectivity as part of the check.
+     - bool
+     - ``false``
    * - :spelling:ignore:`loadBalancer`
      - Configure service load balancing
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -290,6 +290,13 @@ communicating via the proxy must reconnect to re-establish connections.
 
 .. _1.17_upgrade_notes:
 
+
+1.17.4 Upgrade Notes
+--------------------
+
+* The check for connectivity to the Kubernetes apiserver has been removed from the cilium-agent liveness probe.
+  This can be turned back on by setting the helm option ``livenessProbe.requireK8sConnectivity`` to ``true``.
+
 1.17 Upgrade Notes
 ------------------
 
@@ -354,7 +361,6 @@ communicating via the proxy must reconnect to re-establish connections.
     and ``tls.secretSync.enabled: true``
   * The defaults for **upgraded** clusters (where ``upgradeCompatibility`` is ``v1.16``) do not enable 
     SDS. They are: ``tls.readSecretsOnlyFromSecretsNamespace: true`` and ``tls.secretSync.enabled: false``
-
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -700,6 +700,7 @@ contributors across the globe, there is almost always someone available to help.
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
+| livenessProbe.requireK8sConnectivity | bool | `false` | whether to require k8s connectivity as part of the check. |
 | loadBalancer | object | `{"acceleration":"disabled","experimental":false,"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
 | loadBalancer.acceleration | string | `"disabled"` | acceleration is the option to accelerate service handling via XDP Applicable values can be: disabled (do not use XDP), native (XDP BPF program is run directly out of the networking driver's early receive path), or best-effort (use native mode XDP acceleration on devices that support it). |
 | loadBalancer.experimental | bool | `false` | experimental enables support for the experimental load-balancing control-plane. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -158,6 +158,8 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
+            - name: "require-k8s-connectivity"
+              value: {{ .Values.livenessProbe.requireK8sConnectivity | quote }}
           {{- end }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: 1

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4003,6 +4003,9 @@
         },
         "periodSeconds": {
           "type": "integer"
+        },
+        "requireK8sConnectivity": {
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2011,6 +2011,8 @@ livenessProbe:
   failureThreshold: 10
   # -- interval between checks of the liveness probe
   periodSeconds: 30
+  # -- whether to require k8s connectivity as part of the check.
+  requireK8sConnectivity: false
 readinessProbe:
   # -- failure threshold of readiness probe
   failureThreshold: 3

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2022,6 +2022,8 @@ livenessProbe:
   failureThreshold: 10
   # -- interval between checks of the liveness probe
   periodSeconds: 30
+  # -- whether to require k8s connectivity as part of the check.
+  requireK8sConnectivity: false
 readinessProbe:
   # -- failure threshold of readiness probe
   failureThreshold: 3


### PR DESCRIPTION
[ upstream commit ee24e3f53e1dae35411ead4b0a413c7013c6ec40 ]

Exclude the k8s apiserver connectivity check from the liveness probe.

With this change cilium-agent will no longer be restarted due to failed liveness probing if it cannot reach the Kubernetes apiserver.

The old behavior can be turned back on with the helm option 'livenessProbe.requireK8sConnectivity':
```
$ helm template ./install/kubernetes/cilium|grep -A1 require-k8s
            - name: "require-k8s-connectivity"
              value: false

$ helm template ./install/kubernetes/cilium --set livenessProbe.requireK8sConnectivity=true |grep -A1 require-k8s
            - name: "require-k8s-connectivity"
              value: true
```

```release-note
The connectivity to Kubernetes apiserver is no longer checked as part of the liveness probe. This avoids restarting the cilium-agent when the apiserver cannot be reached.
```

```upstream-prs
38458
```