### PR TITLE
bpf: Avoid implicit conversion loses integer precision

### DIFF
--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -95,7 +95,7 @@ int icmp6_ndisc_adv_addopt(struct __ctx_buff *ctx)
 	void *data, *data_end;
 	__u64 *opt;
 
-	if (ctx_change_tail(ctx, ctx_full_len(ctx) + ICMP6_ND_OPT_LEN, 0) < 0)
+	if (ctx_change_tail(ctx, (__u32)(ctx_full_len(ctx) + ICMP6_ND_OPT_LEN), 0) < 0)
 		return DROP_INVALID;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))


### PR DESCRIPTION
This is to avoid the below error, while trying to compile with clang 20.1.2

```
./lib/icmp6.h:98:45: error: implicit conversion loses integer precision: '__u64' (aka 'unsigned long long') to '__u32' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
   98 |         if (ctx_change_tail(ctx, ctx_full_len(ctx) + ICMP6_ND_OPT_LEN, 0) < 0)
      |             ~~~~~~~~~~~~~~~      ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```