### PR TITLE
cilium-cli: Export codeowners for passing testcases

### DIFF
--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -799,6 +799,17 @@ func (t *Test) NewGenericAction(s Scenario, name string) *Action {
 	return t.NewAction(s, name, nil, nil, features.IPFamilyAny)
 }
 
+// Scenarios returns a slice of all Scenarios belonging to the Test.
+func (t *Test) Scenarios() []Scenario {
+	var out []Scenario
+
+	for s := range t.scenarios {
+		out = append(out, s)
+	}
+
+	return out
+}
+
 // failedActions returns a list of failed Actions in the Test.
 func (t *Test) failedActions() []*Action {
 	var out []*Action

--- a/cilium-cli/connectivity/internal/junit/junit.go
+++ b/cilium-cli/connectivity/internal/junit/junit.go
@@ -79,6 +79,8 @@ type TestCase struct {
 	Status    string  `xml:"status,attr,omitempty"`
 	Time      float64 `xml:"time,attr"`
 
+	Properties *Properties `xml:"properties,omitempty"`
+
 	Skipped *Skipped `xml:"skipped,omitempty"`
 	Error   *Error   `xml:"error,omitempty"`
 	Failure *Failure `xml:"failure,omitempty"`


### PR DESCRIPTION
Update the junit output format to export owners for passing tests, so we
can filter by test owners and see pass/fail rates by code owner.
