### PR TITLE
bpf:trace: refactor L2/L3 packet check into classifiers

### DIFF
--- a/bpf/lib/classifiers.h
+++ b/bpf/lib/classifiers.h
@@ -31,12 +31,11 @@ enum {
 static __always_inline cls_flags_t
 ctx_classify(const struct __ctx_buff *ctx __maybe_unused)
 {
-#if defined(IS_BPF_WIREGUARD)
+	if (ETH_HLEN != 0)
+		return CLS_FLAG_NONE;
+
 	if (ctx_get_protocol(ctx) == bpf_htons(ETH_P_IPV6))
 		return CLS_FLAG_L3_DEV | CLS_FLAG_IPV6;
 
 	return CLS_FLAG_L3_DEV;
-#else
-	return CLS_FLAG_NONE;
-#endif
 }

--- a/bpf/lib/classifiers.h
+++ b/bpf/lib/classifiers.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include "lib/common.h"
+
+typedef __u8 cls_flags_t;
+
+/* Classification flags used to enrich trace/drop notifications events. */
+enum {
+	/* Packet uses IPv6. This flag is only needed/set in trace event:
+	 * - carrying the orig_ip IPv6 info from send_trace_notify6, or
+	 * - with L3 IPv6 packets, to instruct Hubble to use the right decoder.
+	 */
+	CLS_FLAG_IPV6	   = (1 << 0),
+	/* Packet originates from a L3 device (no ethernet header). */
+	CLS_FLAG_L3_DEV    = (1 << 1),
+};
+
+/* Wrapper for specifying empty flags during the trace/drop event. */
+#define CLS_FLAG_NONE ((cls_flags_t)0)
+
+/**
+ * ctx_classify
+ * @ctx: socket buffer
+ *
+ * Compute classifiers (CLS_FLAG_*) for the given packet to be used during
+ * trace/drop notification events.
+ */
+static __always_inline cls_flags_t
+ctx_classify(const struct __ctx_buff *ctx __maybe_unused)
+{
+#if defined(IS_BPF_WIREGUARD)
+	if (ctx_get_protocol(ctx) == bpf_htons(ETH_P_IPV6))
+		return CLS_FLAG_L3_DEV | CLS_FLAG_IPV6;
+
+	return CLS_FLAG_L3_DEV;
+#else
+	return CLS_FLAG_NONE;
+#endif
+}

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -20,6 +20,7 @@
 #include "metrics.h"
 #include "ratelimit.h"
 #include "tailcall.h"
+#include "classifiers.h"
 
 #define NOTIFY_DROP_VER 2
 
@@ -32,9 +33,10 @@ struct drop_notify {
 	__u8		file;
 	__s8		ext_error;
 	__u32		ifindex;
-	__u8		ipv6:1;
-	__u8		l3_dev:1;
-	__u8		pad1:6;
+	__u8		flags; /* __u8 instead of cls_flags_t so that it will error
+				* when cls_flags_t grows (either borrow bits from pad2 or
+				* move to flags_lower/flags_upper).
+				*/
 	__u8		pad2[3];
 };
 
@@ -59,7 +61,6 @@ struct drop_notify {
 __declare_tail(CILIUM_CALL_DROP_NOTIFY)
 int __send_drop_notify(struct __ctx_buff *ctx)
 {
-	bool l3_dev = false, ipv6 = false;
 	/* Mask needed to calm verifier. */
 	__u32 error = ctx_load_meta(ctx, 2) & 0xFFFFFFFF;
 	__u64 ctx_len = ctx_full_len(ctx);
@@ -68,6 +69,7 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 	__u16 line = (__u16)(meta4 >> 16);
 	__u8 file = (__u8)(meta4 >> 8);
 	__u8 exitcode = (__u8)meta4;
+	cls_flags_t flags = CLS_FLAG_NONE;
 	struct ratelimit_key rkey = {
 		.usage = RATELIMIT_USAGE_EVENTS_MAP,
 	};
@@ -83,10 +85,7 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 			return exitcode;
 	}
 
-#ifdef IS_BPF_WIREGUARD
-	l3_dev = true;
-	ipv6 = ctx->protocol == bpf_htons(ETH_P_IPV6);
-#endif
+	flags = ctx_classify(ctx);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),
@@ -98,8 +97,7 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 		.file           = file,
 		.ext_error      = (__s8)(__u8)(error >> 8),
 		.ifindex        = ctx_get_ifindex(ctx),
-		.ipv6           = ipv6,
-		.l3_dev         = l3_dev,
+		.flags          = flags,
 	};
 
 	ctx_event_output(ctx, &cilium_events,

--- a/bpf/lib/source_info.h
+++ b/bpf/lib/source_info.h
@@ -58,6 +58,7 @@ __id_for_file(const char *const header_name)
 	_strcase_(114, "host_firewall.h");
 	_strcase_(115, "nodeport_egress.h");
 	_strcase_(116, "ipv6.h");
+	_strcase_(117, "classifiers.h");
 
 	/* @@ source files list end */
 

--- a/bpf/tests/classifiers_common.h
+++ b/bpf/tests/classifiers_common.h
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+/* For testing L2/L3 devices, we make use of ETH_HLEN:
+ * IS_BPF_WIREGUARD -> 0
+ * IS_BPF_HOST      -> 14 by default
+ */
+#if defined(IS_BPF_WIREGUARD)
+# undef IS_BPF_WIREGUARD
+# include "bpf_wireguard.c"
+#elif defined(IS_BPF_HOST)
+# undef IS_BPF_HOST
+# include "bpf_host.c"
+#else
+# error "this file supports inclusion only from files with IS_BPF_HOST or IS_BPF_WIREGUARD defined"
+#endif
+
+#include "common.h"
+#include "pktgen.h"
+
+/* Remove the L2 layer to simulate packet in an L3 device. */
+static __always_inline void
+adjust_l2(struct __ctx_buff *ctx)
+{
+	if (!is_defined(IS_BPF_WIREGUARD))
+		return;
+
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
+
+	if ((void *)data + __ETH_HLEN + __ETH_HLEN <= data_end)
+		memcpy(data, data + __ETH_HLEN, __ETH_HLEN);
+
+	skb_adjust_room(ctx, -__ETH_HLEN, BPF_ADJ_ROOM_MAC, flags);
+}
+
+static __always_inline int
+pktgen(struct __ctx_buff *ctx, bool is_ipv4)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	if (is_ipv4)
+		l4 = pktgen__push_ipv4_udp_packet(&builder,
+						  (__u8 *)mac_one,
+						  (__u8 *)mac_two,
+						  v4_node_one,
+						  v4_node_two,
+						  tcp_src_one,
+						  tcp_src_two);
+	else
+		l4 = pktgen__push_ipv6_udp_packet(&builder,
+						  (__u8 *)mac_one,
+						  (__u8 *)mac_two,
+						  (__u8 *)v6_node_one,
+						  (__u8 *)v6_node_two,
+						  tcp_src_one,
+						  tcp_src_two);
+
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+PKTGEN("tc", "ctx_classify4")
+static __always_inline int
+ctx_classify4_pktgen(struct __ctx_buff *ctx) {
+	return pktgen(ctx, true);
+}
+
+CHECK("tc", "ctx_classify4")
+int ctx_classify4_check(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	adjust_l2(ctx);
+
+	cls_flags_t flags = ctx_classify(ctx);
+
+	/* L3 flag set only from bpf_wireguard */
+	assert(((flags & CLS_FLAG_L3_DEV) != 0) == is_defined(IS_BPF_WIREGUARD));
+
+	/* IPv6 flag not set. */
+	assert((flags & CLS_FLAG_IPV6) == 0);
+
+	test_finish();
+}
+
+PKTGEN("tc", "ctx_classify6")
+static __always_inline int
+ctx_classify6_pktgen(struct __ctx_buff *ctx) {
+	return pktgen(ctx, false);
+}
+
+CHECK("tc", "ctx_classify6")
+int ctx_classify6_check(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	adjust_l2(ctx);
+
+	cls_flags_t flags = ctx_classify(ctx);
+
+	/* L3 flag set only from bpf_wireguard */
+	assert(((flags & CLS_FLAG_L3_DEV) != 0) == is_defined(IS_BPF_WIREGUARD));
+
+	/* IPv6 flag set from bpf_wireguard, given it is a L3 packet. */
+	assert(((flags & CLS_FLAG_IPV6) != 0) == is_defined(IS_BPF_WIREGUARD));
+
+	test_finish();
+}

--- a/bpf/tests/classifiers_common.h
+++ b/bpf/tests/classifiers_common.h
@@ -22,7 +22,7 @@
 static __always_inline void
 adjust_l2(struct __ctx_buff *ctx)
 {
-	if (!is_defined(IS_BPF_WIREGUARD))
+	if (ETH_HLEN != 0)
 		return;
 
 	void *data = (void *)(long)ctx->data;
@@ -83,8 +83,8 @@ int ctx_classify4_check(struct __ctx_buff *ctx)
 
 	cls_flags_t flags = ctx_classify(ctx);
 
-	/* L3 flag set only from bpf_wireguard */
-	assert(((flags & CLS_FLAG_L3_DEV) != 0) == is_defined(IS_BPF_WIREGUARD));
+	/* L3 flag set only when ETH_HLEN is 0. */
+	assert(((flags & CLS_FLAG_L3_DEV) != 0) == (ETH_HLEN == 0));
 
 	/* IPv6 flag not set. */
 	assert((flags & CLS_FLAG_IPV6) == 0);
@@ -107,11 +107,11 @@ int ctx_classify6_check(struct __ctx_buff *ctx)
 
 	cls_flags_t flags = ctx_classify(ctx);
 
-	/* L3 flag set only from bpf_wireguard */
-	assert(((flags & CLS_FLAG_L3_DEV) != 0) == is_defined(IS_BPF_WIREGUARD));
+	/* L3 flag set only when ETH_HLEN is 0. */
+	assert(((flags & CLS_FLAG_L3_DEV) != 0) == (ETH_HLEN == 0));
 
-	/* IPv6 flag set from bpf_wireguard, given it is a L3 packet. */
-	assert(((flags & CLS_FLAG_IPV6) != 0) == is_defined(IS_BPF_WIREGUARD));
+	/* IPv6 flag set with a L3 packet. */
+	assert(((flags & CLS_FLAG_IPV6) != 0) == (ETH_HLEN == 0));
 
 	test_finish();
 }

--- a/bpf/tests/classifiers_l2_dev.c
+++ b/bpf/tests/classifiers_l2_dev.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define IS_BPF_HOST 1
+
+#include "classifiers_common.h"

--- a/bpf/tests/classifiers_l3_dev.c
+++ b/bpf/tests/classifiers_l3_dev.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define IS_BPF_WIREGUARD 1
+
+#include "classifiers_common.h"

--- a/pkg/monitor/api/files.go
+++ b/pkg/monitor/api/files.go
@@ -35,6 +35,7 @@ var files = map[uint8]string{
 	114: "host_firewall.h",
 	115: "nodeport_egress.h",
 	116: "ipv6.h",
+	117: "classifiers.h",
 
 	// @@ source files list end
 }


### PR DESCRIPTION
* Refactor current identical check in {trace,drop}.h for packets from L2/L3 devices into a new classifiers.h file.
* Moving also from using bits in `struct {trace,drop}_notify` to a new `__u8 flags` fields. This will help us in subsequent patches where we introduce additional classifiers.

Please refer to commit messages for further details.
