### PR TITLE
chore(hubble-ui): Silence access log produced by readinessProbe

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/_nginx.tpl
+++ b/install/kubernetes/cilium/templates/hubble-ui/_nginx.tpl
@@ -31,6 +31,7 @@ server {
         sub_filter '<base href="/"/>' '<base href="{{ .Values.hubble.ui.baseUrl }}"/>';
         {{- end }}
         location {{ .Values.hubble.ui.baseUrl }} {
+            if ($http_user_agent ~* "kube-probe") { access_log off; }
             {{- if not (eq .Values.hubble.ui.baseUrl "/") }}
             rewrite ^{{ (trimSuffix "/" .Values.hubble.ui.baseUrl) }}(/.*)$ $1 break;
             {{- end }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This is a little follow-up of my contribution ~2years ago:
- https://github.com/cilium/cilium/pull/27028

Without this change, you see a lot of those lines inside the log:
```log
(..)
10.42.1.32 - - [03/Apr/2025:19:23:37 +0000] "GET / HTTP/1.1" 200 702 "-" "kube-probe/1.31" "-"
10.42.1.32 - - [03/Apr/2025:19:23:45 +0000] "GET / HTTP/1.1" 200 702 "-" "kube-probe/1.31" "-"
(..)
```

With the change, these lines will not appear since we silence them based on the kubelet's User-Agent.

**Release note entry:**
```release-note
ReadinessProbe of Hubble-ui no longer produces unnecessary access log entries inside the frontend container.
```
