### PR TITLE
gateway-api: Remove unnecessary error

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -50,7 +50,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 	errorLogExceptions := []logMatcher{
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock,
-		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision, nilDetailsForService}
+		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision}
 	if ciliumVersion.LT(semver.MustParse("1.14.0")) {
 		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR, klogLeaderElectionFail)
 	}
@@ -328,7 +328,6 @@ const (
 	failedToReleaseLock    stringMatcher = "Failed to release lock:"
 	previouslyUsedCIDR     stringMatcher = "Unable to find identity of previously used CIDR"                           // from https://github.com/cilium/cilium/issues/26881
 	klogLeaderElectionFail stringMatcher = "error retrieving resource lock kube-system/cilium-operator-resource-lock:" // from: https://github.com/cilium/cilium/issues/31050
-	nilDetailsForService   stringMatcher = "retrieved nil details for Service"                                         // from: https://github.com/cilium/cilium/issues/35595
 
 	cantEnableJIT               stringMatcher = "bpf_jit_enable: no such file or directory"                              // Because we run tests in Kind.
 	delMissingService           stringMatcher = "Deleting no longer present service"                                     // cf. https://github.com/cilium/cilium/issues/29679

--- a/pkg/ciliumenvoyconfig/cec_manager.go
+++ b/pkg/ciliumenvoyconfig/cec_manager.go
@@ -255,7 +255,7 @@ func (r *cecManager) getK8sService(name string, namespace string) (*slim_corev1.
 		Namespace: namespace,
 	})
 	if svc == nil {
-		return nil, fmt.Errorf("retrieved nil details for Service %s/%s", namespace, name)
+		return nil, nil
 	}
 	if !exists || err != nil {
 		return nil, err


### PR DESCRIPTION
If the service is not found in the cache, we don't need to throw error
at all.

Fixes: cce40804c3ac9f564859d788faef981a697de7ac
Relates: #35595
Signed-off-by: Tam Mach <tam.mach@cilium.io>
