### PR TITLE
bpf: small improvements for tail-call to policy program

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1986,7 +1986,8 @@ int handle_lxc_traffic(struct __ctx_buff *ctx __maybe_unused)
 		if (IS_ERR(ret))
 			goto drop_err;
 
-		ctx_store_meta(ctx, CB_SRC_LABEL, src_sec_identity);
+		local_delivery_fill_meta(ctx, src_sec_identity, false,
+					 true, false, 0);
 		ret = tail_call_policy(ctx, (__u16)lxc_id);
 
 drop_err:

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1975,20 +1975,23 @@ int handle_lxc_traffic(struct __ctx_buff *ctx __maybe_unused)
 {
 #ifdef ENABLE_HOST_FIREWALL
 	bool from_host = ctx_load_meta(ctx, CB_FROM_HOST);
-	__u32 lxc_id;
-	int ret;
-	__s8 ext_err = 0;
 
 	if (from_host) {
+		__u32 lxc_id = ctx_load_meta(ctx, CB_DST_ENDPOINT_ID);
+		__u32 src_sec_identity = HOST_ID;
+		__s8 ext_err = 0;
+		int ret;
+
 		ret = from_host_to_lxc(ctx, &ext_err);
 		if (IS_ERR(ret))
-			return send_drop_notify_error_ext(ctx, HOST_ID, ret, ext_err,
-							  METRIC_EGRESS);
+			goto drop_err;
 
-		lxc_id = ctx_load_meta(ctx, CB_DST_ENDPOINT_ID);
-		ctx_store_meta(ctx, CB_SRC_LABEL, HOST_ID);
+		ctx_store_meta(ctx, CB_SRC_LABEL, src_sec_identity);
 		ret = tail_call_policy(ctx, (__u16)lxc_id);
-		return send_drop_notify_error(ctx, HOST_ID, ret, METRIC_EGRESS);
+
+drop_err:
+		return send_drop_notify_error_ext(ctx, src_sec_identity,
+						  ret, ext_err, METRIC_EGRESS);
 	}
 
 	return to_host_from_lxc(ctx);

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -59,6 +59,13 @@ static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 	return CTX_ACT_OK;
 }
 
+/* Defines the calling convention for bpf_lxc's ingress policy tail-call.
+ * Note that skb->tc_index is also passed through.
+ *
+ * As the callers (from-overlay, from-netdev, ...) are re-generated independently
+ * from the policy tail-call of the inidividual endpoints, any change to this code
+ * needs to be introduced with compatibility in mind.
+ */
 static __always_inline void
 local_delivery_fill_meta(struct __ctx_buff *ctx, __u32 seclabel,
 			 bool delivery_redirect, bool from_host,


### PR DESCRIPTION
Make `local_delivery_fill_meta()` the sole way of preparing a packet for the tail-call to bpf_lxc's ingress policy program.