### PR TITLE
bpf: lift L7 LB handling from inherit_identity_from_host()

### DIFF
--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -183,10 +183,6 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 		*identity = HOST_ID;
 	} else if (magic == MARK_MAGIC_ENCRYPT) {
 		*identity = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
-#if defined(ENABLE_L7_LB)
-	} else if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
-		*identity = get_epid(ctx); /* endpoint identity, not security identity! */
-#endif
 	} else {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 		__u16 proto = ctx_get_protocol(ctx);
@@ -205,13 +201,7 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 	/* Reset packet mark to avoid hitting routing rules again */
 	ctx->mark = 0;
 
-#if defined(ENABLE_L7_LB)
-	/* Caller tail calls back to source endpoint egress in this case,
-	 * do not log the (world) identity.
-	 */
-	if (magic != MARK_MAGIC_PROXY_EGRESS_EPID)
-#endif
-		cilium_dbg(ctx, DBG_INHERIT_IDENTITY, *identity, 0);
+	cilium_dbg(ctx, DBG_INHERIT_IDENTITY, *identity, 0);
 
 	return magic;
 }

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -70,9 +70,9 @@ get_identity(const struct __sk_buff *ctx)
 }
 
 /**
- * get_epid - returns source endpoint identity from the mark field
+ * get_epid - returns endpoint identifier from the mark field
  */
-static __always_inline __maybe_unused __u32
+static __always_inline __maybe_unused __u16
 get_epid(const struct __sk_buff *ctx)
 {
 	return ctx->mark >> 16;


### PR DESCRIPTION
MARK_MAGIC_PROXY_EGRESS_EPID doesn't carry an identity, and there's all sorts of hacks around inherit_identity_from_host() to handle this mismatch.

Just spell out all the needed processing in the two programs that expect a packet with this mark. It's really not that much, and clarifies the situation a lot.

No functional change intended.