### PR TITLE
bpf: host: respect ENABLE_IDENTITY_MARK when looking at MARK_MAGIC_IDENTITY

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1380,8 +1380,10 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 
 	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY || ctx_mark_is_wireguard(ctx))
 		src_sec_identity = HOST_ID;
+#ifdef ENABLE_IDENTITY_MARK
 	else if (magic == MARK_MAGIC_IDENTITY)
 		src_sec_identity = get_identity(ctx);
+#endif
 
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 */


### PR DESCRIPTION
For environments where option.EnableIdentityMark is not set (and thus from-container doesn't set the source identity in the skb->mark), we shouldn't attempt to retrieve the identity.

Which leaves the question whether all the *other* use of skb->mark in this program is safe. Or all those features are simply incompatible with running in a CNI-chained environment, where skb->mark is not owned by Cilium (see https://github.com/cilium/cilium/pull/12185).

```release-note
For configurations with --enable-identity-mark=false, don't attempt to retrieve the source identity from skb->mark.
```
