### PR TITLE
gh: aws-cni: set --enable-identity-mark=false option

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -226,6 +226,7 @@ jobs:
             --helm-set=ipam.mode=cluster-pool \
             --helm-set=routingMode=native \
             --helm-set=bandwidthManager.enabled=false \
+            --helm-set=extraArgs={--enable-identity-mark=false} \
             --wait=false"
 
           if [ "${{ matrix.wireguard }}" == "true" ]; then


### PR DESCRIPTION
When AWS-CNI is in control of orchestrating the connectivity on the node, we shouldn't assume that usage of skb->mark for Cilium is safe.

https://github.com/cilium/cilium/pull/12185 introduced the `--enable-identity-mark` option for this scenario, so that Cilium doesn't use the skb->mark for identity propagation. Set this flag in the AWS-CNI workflow accordingly.