### PR TITLE
[v1.17] check-encryption-leak:features: backport 2025-04-04 

### DIFF
--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -41,11 +41,15 @@
 // Character literals don't appear be supported, hence this hack.
 // https://github.com/bpftrace/bpftrace/issues/3278
 #define CH_A 0x41   // 'A'
+#define CH_C 0x43   // 'C'
 #define CH_D 0x44   // 'D'
+#define CH_E 0x45   // 'E'
 #define CH_F 0x46   // 'F'
 #define CH_M 0x4D   // 'M'
+#define CH_P 0x50   // 'P'
 #define CH_R 0x52   // 'R'
 #define CH_S 0x53   // 'S'
+#define CH_U 0x55   // 'U'
 #define CH_DOT 0x2E // '.'
 
 // The value in @trace_ip4/@trace_ip6 maps for a given flow traced by the proxy is:
@@ -147,7 +151,7 @@ kprobe:br_forward
         if ($ip4h->protocol != PROTO_TCP || !$tcph->rst) {
           $time = strftime("%H:%M:%S:%f", nsecs);
 
-          printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+          printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
             $time, $skb,
             ntop($ip4h->saddr),
             ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -155,10 +159,6 @@ kprobe:br_forward
             ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->dest) : 0,
             bswap($ip4h->tot_len),
             $ip4h->protocol,
-            $ip4h->protocol == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
-            $ip4h->protocol == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
-            $ip4h->protocol == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
-            $ip4h->protocol == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
             $encap, $skb->encapsulation,
             $skb->dev->ifindex,
             $skb->dev->nd_net.net->ns.inum,
@@ -166,6 +166,16 @@ kprobe:br_forward
             $dst_is_pod, $dst_is_internal,
             !!$pod_to_pod_via_proxy,
             $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
+
+          if ($ip4h->protocol == PROTO_TCP) {
+            printf("[%s] [%p] ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
+              $time, $skb,
+              $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
+              $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
+              $tcph->psh ? CH_P : CH_DOT, $tcph->rst ? CH_R : CH_DOT,
+              $tcph->syn ? CH_S : CH_DOT, $tcph->fin ? CH_F : CH_DOT,
+              bswap($tcph->seq), bswap($tcph->ack_seq));
+          }
 
           if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
             $dns = (struct dnshdr*)($udph + 1);
@@ -228,7 +238,7 @@ kprobe:br_forward
         if ($ip6h->nexthdr != PROTO_TCP || !$tcph->rst) {
           $time = strftime("%H:%M:%S:%f", nsecs);
 
-          printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+          printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
             $time, $skb,
             ntop($ip6h->saddr.in6_u.u6_addr8),
             ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -236,10 +246,6 @@ kprobe:br_forward
             ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->dest) : 0,
             bswap($ip6h->payload_len),
             $ip6h->nexthdr,
-            $ip6h->nexthdr == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
-            $ip6h->nexthdr == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
-            $ip6h->nexthdr == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
-            $ip6h->nexthdr == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
             $encap, $skb->encapsulation,
             $skb->dev->ifindex,
             $skb->dev->nd_net.net->ns.inum,
@@ -247,6 +253,16 @@ kprobe:br_forward
             $dst_is_pod, $dst_is_internal,
             !!$pod_to_pod_via_proxy,
             $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
+
+          if ($ip6h->nexthdr == PROTO_TCP) {
+            printf("[%s] [%p] ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
+              $time, $skb,
+              $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
+              $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
+              $tcph->psh ? CH_P : CH_DOT, $tcph->rst ? CH_R : CH_DOT,
+              $tcph->syn ? CH_S : CH_DOT, $tcph->fin ? CH_F : CH_DOT,
+              bswap($tcph->seq), bswap($tcph->ack_seq));
+          }
 
           if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
             $dns = (struct dnshdr*)($udph + 1);

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -124,8 +124,10 @@ kprobe:br_forward
           ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))
         ) {
         if ($ip4h->protocol != PROTO_TCP || !$tcph->rst) {
-          printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
-            strftime("%H:%M:%S:%f", nsecs),
+          $time = strftime("%H:%M:%S:%f", nsecs);
+
+          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
+            $time, $skb,
             ntop($ip4h->saddr),
             ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
             ntop($ip4h->daddr),
@@ -143,8 +145,8 @@ kprobe:br_forward
           if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
             $dns = (struct dnshdr*)($udph + 1);
             $query = (uint8 *)($dns + 1);
-            printf("[%s] Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
-              strftime("%H:%M:%S:%f", nsecs),
+            printf("[%s] [%p] ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+              $time, $skb,
               bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
               bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
               str(kptr($query)));
@@ -185,8 +187,10 @@ kprobe:br_forward
           ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))
         ) {
         if ($ip6h->nexthdr != PROTO_TCP || !$tcph->rst) {
-          printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
-            strftime("%H:%M:%S:%f", nsecs),
+          $time = strftime("%H:%M:%S:%f", nsecs);
+
+          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
+            $time, $skb,
             ntop($ip6h->saddr.in6_u.u6_addr8),
             ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
             ntop($ip6h->daddr.in6_u.u6_addr8),
@@ -204,8 +208,8 @@ kprobe:br_forward
           if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
             $dns = (struct dnshdr*)($udph + 1);
             $query = (uint8 *)($dns + 1);
-            printf("[%s] Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
-              strftime("%H:%M:%S:%f", nsecs),
+            printf("[%s] [%p] ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+              $time, $skb,
               bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
               bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
               str(kptr($query)));

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -1,4 +1,4 @@
-// Six parameters expected:
+// Eight parameters expected:
 // $1: IPv4 CiliumInternalIP - Node1
 // $2: IPv6 CiliumInternalIP - Node1
 // $3: IPv4 CiliumInternalIP - Node2
@@ -6,11 +6,15 @@
 // $5: IPv4 CiliumInternalIP - Node3
 // $6: IPv6 CiliumInternalIP - Node3
 // $7: Report errors if proxy traffic not found - [true|false]
-// $8: Encryption type: [wireguard|ipsec]
+// $8: Encryption type - [wireguard|ipsec]
+//
+// Notes:
+// - IPv6 addresses ($2, $4, and $6) must be "::1" in IPv4-only clusters.
+// - We assume /8 CIDRs for the provided addresses ($1-$6).
 
-#define CIDR4 (uint32)0x0A000000 // 10.0.0.0/8
 #define MASK4 (uint32)0xFF000000
-#define CIDR6 (uint32)0xfd00
+#define CIDR4 (uint32)(pton(str($1))[0]) << 24 // ex. 0x0a000000 (10.0.0.0/8)
+#define CIDR6 (uint32)(pton(str($2))[0]) << 8  // ex. 0xfd00 (fd00::/8)
 
 #define PROTO_IPV4 0x0800
 #define PROTO_IPV6 0x86DD
@@ -277,6 +281,7 @@ kprobe:tcp_connect
   }
 }
 
+// Clear traced TCP connections.
 kprobe:tcp_close
 {
   $sk = ((struct sock *) arg0);
@@ -333,7 +338,8 @@ kprobe:udpv6_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
   }
 }
 
-// Clear traced UDP connections.
+// Additionally trace traffic flows in which the source got masquerated.
+// Ignore packets w/o a socket assigned or that are not traced by the proxy.
 kprobe:udp_destroy_sock
 {
   $sk = ((struct sock *) arg0);
@@ -381,6 +387,7 @@ kprobe:__dev_queue_xmit
   delete(@trace_sk[$sk])
 }
 
+// Perform sanity checks.
 END
 {
   if (str($7) == "true" && !@sanity[TYPE_PROXY_L7_IP4]) {

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -147,12 +147,13 @@ kprobe:br_forward
         if ($ip4h->protocol != PROTO_TCP || !$tcph->rst) {
           $time = strftime("%H:%M:%S:%f", nsecs);
 
-          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, proxy: %d (masqueraded: %d))\n",
+          printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
             $time, $skb,
             ntop($ip4h->saddr),
             ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
             ntop($ip4h->daddr),
             ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->dest) : 0,
+            bswap($ip4h->tot_len),
             $ip4h->protocol,
             $ip4h->protocol == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
             $ip4h->protocol == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
@@ -161,6 +162,8 @@ kprobe:br_forward
             $encap, $skb->encapsulation,
             $skb->dev->ifindex,
             $skb->dev->nd_net.net->ns.inum,
+            $src_is_pod, $src_is_internal,
+            $dst_is_pod, $dst_is_internal,
             !!$pod_to_pod_via_proxy,
             $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
 
@@ -225,12 +228,13 @@ kprobe:br_forward
         if ($ip6h->nexthdr != PROTO_TCP || !$tcph->rst) {
           $time = strftime("%H:%M:%S:%f", nsecs);
 
-          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, proxy: %d (masqueraded: %d))\n",
+          printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
             $time, $skb,
             ntop($ip6h->saddr.in6_u.u6_addr8),
             ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
             ntop($ip6h->daddr.in6_u.u6_addr8),
             ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->dest) : 0,
+            bswap($ip6h->payload_len),
             $ip6h->nexthdr,
             $ip6h->nexthdr == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
             $ip6h->nexthdr == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
@@ -239,6 +243,8 @@ kprobe:br_forward
             $encap, $skb->encapsulation,
             $skb->dev->ifindex,
             $skb->dev->nd_net.net->ns.inum,
+            $src_is_pod, $src_is_internal,
+            $dst_is_pod, $dst_is_internal,
             !!$pod_to_pod_via_proxy,
             $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
 

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -48,6 +48,15 @@
 #define CH_S 0x53   // 'S'
 #define CH_DOT 0x2E // '.'
 
+// The value in @trace_ip4/@trace_ip6 maps for a given flow traced by the proxy is:
+// 1. first set to 1 in `tcp_connect/udp_sendmsg`
+// 2. then incremented by 1 in `__dev_queue_xmit`.
+// Therefore, when checking the leak in br_forward, we should observe the value == 2.
+// However, when the packet is being source masqueraded, the map entry created in (1) would
+// differ from the entry incremented in (2) due to the different IP address. In that case,
+// the value in br_forward should be == 1.
+#define PROXY_TRACED_AND_MASQUERADED 1
+
 struct dnshdr {
   u16 id;
   u16 flags;
@@ -127,8 +136,9 @@ kprobe:br_forward
       $pod_to_pod_via_proxy =
           !($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ?
           @trace_ip4[$ip4h->saddr, 0, 0] :
-          (@trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
-            @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol]);
+          @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ?
+            @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] :
+            @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
 
       if (
           (!$pod_to_pod_via_proxy && ($src_is_pod && $dst_is_pod) && (!$src_is_internal && !$dst_is_internal)) ||
@@ -137,7 +147,7 @@ kprobe:br_forward
         if ($ip4h->protocol != PROTO_TCP || !$tcph->rst) {
           $time = strftime("%H:%M:%S:%f", nsecs);
 
-          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
+          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, proxy: %d (masqueraded: %d))\n",
             $time, $skb,
             ntop($ip4h->saddr),
             ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -151,7 +161,8 @@ kprobe:br_forward
             $encap, $skb->encapsulation,
             $skb->dev->ifindex,
             $skb->dev->nd_net.net->ns.inum,
-            $pod_to_pod_via_proxy);
+            !!$pod_to_pod_via_proxy,
+            $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
 
           if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
             $dns = (struct dnshdr*)($udph + 1);
@@ -203,8 +214,9 @@ kprobe:br_forward
       $pod_to_pod_via_proxy =
           !($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ?
           @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, 0, 0] :
-          (@trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
-            @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr]);
+          @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ?
+            @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] :
+            @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
 
       if (
           (!$pod_to_pod_via_proxy && ($src_is_pod && $dst_is_pod) && (!$src_is_internal && !$dst_is_internal)) ||
@@ -213,7 +225,7 @@ kprobe:br_forward
         if ($ip6h->nexthdr != PROTO_TCP || !$tcph->rst) {
           $time = strftime("%H:%M:%S:%f", nsecs);
 
-          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, override: %d)\n",
+          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d (skb: %d), ifindex: %d, netns: %x, proxy: %d (masqueraded: %d))\n",
             $time, $skb,
             ntop($ip6h->saddr.in6_u.u6_addr8),
             ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -227,7 +239,8 @@ kprobe:br_forward
             $encap, $skb->encapsulation,
             $skb->dev->ifindex,
             $skb->dev->nd_net.net->ns.inum,
-            $pod_to_pod_via_proxy);
+            !!$pod_to_pod_via_proxy,
+            $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
 
           if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
             $dns = (struct dnshdr*)($udph + 1);
@@ -293,7 +306,7 @@ kprobe:tcp_connect
         $sk->__sk_common.skc_daddr == (uint32)pton(str($5));
 
     if ($dst_is_pod && !(str($8) == "ipsec" && ($src_is_internal || $dst_is_internal))) {
-      @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_TCP] = true;
+      @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_TCP] = 1;
       @trace_sk[$sk] = true;
       @sanity[TYPE_PROXY_L7_IP4] = true;
     }
@@ -313,7 +326,7 @@ kprobe:tcp_connect
         $sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8 == pton(str($6));
 
     if ($dst_is_pod && !(str($8) == "ipsec" && ($src_is_internal || $dst_is_internal))) {
-      @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_TCP] = true;
+      @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_TCP] = 1;
       @trace_sk[$sk] = true;
       @sanity[TYPE_PROXY_L7_IP6] = true;
     }
@@ -349,7 +362,7 @@ kprobe:udp_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
         $sk->__sk_common.skc_rcv_saddr == (uint32)pton(str($5));
 
     if (!(str($8) == "ipsec" && $src_is_internal)) {
-      @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_UDP] = true;
+      @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_UDP] = 1;
       @trace_sk[$sk] = true;
       @sanity[TYPE_PROXY_DNS_IP4] = true;
     }
@@ -370,7 +383,7 @@ kprobe:udpv6_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
         $sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8 == pton(str($6));
 
     if (!(str($8) == "ipsec" && $src_is_internal)) {
-      @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_UDP] = true;
+      @trace_ip6[$sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8, bswap($sk->__sk_common.skc_num), PROTO_UDP] = 1;
       @trace_sk[$sk] = true;
       @sanity[TYPE_PROXY_DNS_IP6] = true;
     }
@@ -418,9 +431,9 @@ kprobe:__dev_queue_xmit
   }
 
   if ($proto == PROTO_IPV4) {
-    @trace_ip4[$ip4h->saddr, $udph->source, $l4proto] = true;
+    @trace_ip4[$ip4h->saddr, $udph->source, $l4proto]++;
   } else {
-    @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $l4proto] = true;
+    @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $l4proto]++;
   }
 
   delete(@trace_sk[$sk])

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -387,6 +387,27 @@ kprobe:__dev_queue_xmit
   delete(@trace_sk[$sk])
 }
 
+// Check arguments number and values.
+// No need to check IPs ($1-$6) as the script would return
+// a compile error when using pton() with an incorrect address.
+BEGIN
+{
+  if (str($8) == "" || str($9) != "") {
+    printf("Incorrect number of arguments, expected 8.\n");
+    exit();
+  }
+
+  if (str($7) != "false" && str($7) != "true") {
+    printf("Incorrect sanity value, expected [true|false].\n");
+    exit();
+  }
+
+  if (str($8) != "ipsec" && str($8) != "wireguard") {
+    printf("Incorrect encryption type, expected [wireguard|ipsec].\n");
+    exit();
+  }
+}
+
 // Perform sanity checks.
 END
 {

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -21,6 +21,9 @@
 #define PROTO_TCP 6
 #define PROTO_UDP 17
 #define PROTO_ESP 50
+#define PROTO_ICMP_IPV4 1
+#define PROTO_ICMP_IPV6 58
+#define PROTO_FRAGMENT_IPV6 44
 
 #define AF_INET	2
 #define AF_INET6 10
@@ -38,7 +41,9 @@
 // Character literals don't appear be supported, hence this hack.
 // https://github.com/bpftrace/bpftrace/issues/3278
 #define CH_A 0x41   // 'A'
+#define CH_D 0x44   // 'D'
 #define CH_F 0x46   // 'F'
+#define CH_M 0x4D   // 'M'
 #define CH_R 0x52   // 'R'
 #define CH_S 0x53   // 'S'
 #define CH_DOT 0x2E // '.'
@@ -79,6 +84,7 @@ kprobe:br_forward
   $ip6h = ((struct ipv6hdr *) ($skb->head + $skb->network_header));
   $udph = ((struct udphdr*) ($skb->head + $skb->transport_header));
   $tcph = ((struct tcphdr*) ($skb->head + $skb->transport_header));
+  $icmph = ((struct icmphdr*) ($skb->head + $skb->transport_header));
 
   // $skb->encapsulation might be unset when encap headers are manually pushed,
   // despite $skb->inner references being correct.
@@ -95,6 +101,7 @@ kprobe:br_forward
     $ip6h = ((struct ipv6hdr*) ($skb->head + $skb->inner_network_header));
     $udph = ((struct udphdr*) ($skb->head + $skb->inner_transport_header));
     $tcph = ((struct tcphdr*) ($skb->head + $skb->inner_transport_header));
+    $icmph = ((struct icmphdr*) ($skb->head + $skb->inner_transport_header));
   }
 
   if ($proto == PROTO_IPV4) {
@@ -154,6 +161,19 @@ kprobe:br_forward
               bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
               bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
               str(kptr($query)));
+          }
+
+          if ($ip4h->protocol == PROTO_ICMP_IPV4) {
+            $frag_off = bswap($ip4h->frag_off);
+
+            printf("[%s] [%p] ↳ Detected ICMP message, IPFlags: .%c%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
+              $time, $skb,
+              ($frag_off & 0x4000) >> 14 ? CH_D : CH_DOT,
+              ($frag_off & 0x2000) >> 13 ? CH_M : CH_DOT,
+              $icmph->type,
+              $icmph->code,
+              $frag_off & 0x1FFF,
+              bswap($ip4h->id));
           }
         }
       }
@@ -217,6 +237,25 @@ kprobe:br_forward
               bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
               bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
               str(kptr($query)));
+          }
+
+          if ($ip6h->nexthdr == PROTO_ICMP_IPV6 || $ip6h->nexthdr == PROTO_FRAGMENT_IPV6) {
+            $frag_id = 0;
+            $frag_off_res_m = 0;
+
+            if ($ip6h->nexthdr == PROTO_FRAGMENT_IPV6) {
+              $frag_hdr = (struct frag_hdr *)($ip6h + 1);
+              $frag_id = bswap($frag_hdr->identification);
+              $frag_off_res_m = bswap($frag_hdr->frag_off);
+            }
+
+            printf("[%s] [%p] ↳ Detected ICMP message, IPFlags: ..%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
+              $time, $skb,
+              $frag_off_res_m & 0x0001 ? CH_M : CH_DOT,
+              $icmph->type,
+              $icmph->code,
+              $frag_off_res_m >> 3,
+              $frag_id);
           }
         }
       }


### PR DESCRIPTION
Manual backport of:

* https://github.com/cilium/cilium/pull/38266
* https://github.com/cilium/cilium/pull/38263
* https://github.com/cilium/cilium/pull/38278
* https://github.com/cilium/cilium/pull/38297
* https://github.com/cilium/cilium/pull/38281
* https://github.com/cilium/cilium/pull/38268

Doing to soften the pain for future fixes/changes to the script.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 38266 38263 38278 38297 38281 38268
```