### PR TITLE
bpf: Fix incorrect checksum when rewriting VXLAN VNI

### DIFF
--- a/bpf/lib/vxlan.h
+++ b/bpf/lib/vxlan.h
@@ -85,7 +85,7 @@ vxlan_rewrite_vni(void *ctx, const void *data, const void *data_end,
 	if (udp->check) {
 		csum_l4_offset_and_flags(IPPROTO_UDP, &csum);
 		if (csum_l4_replace(ctx, l4_off, &csum, old_vni, vx->vx_vni,
-				    BPF_F_PSEUDO_HDR | sizeof(__u16)) < 0)
+				    sizeof(__u16)) < 0)
 			return false;
 	}
 


### PR DESCRIPTION
For the multicast feature, we may need to rewrite the VXLAN VNI field. After doing that, we of course need to update the checksum. We use the `bpf_l4_csum_update` helper to that end.

When using that helper, we however shouldn't pass the `BPF_F_PSEUDO_HDR` flag because the VNI isn't part of the pseudo-header. If we pass that flag, then [it will also update `skb->csum`](https://elixir.bootlin.com/linux/v6.13.7/source/net/core/utils.c#L431-L433). In the problematic case, `skb->csum` holds a checksum over the whole packet, including its L3 and L4 checksum fields. In that checksum, the changes we just made to the VNI field and to the L4 checksum field null each other so `skb->csum` should stay unchanged.

If the modified field had been part of the pseudo-header, then the L3 checksum would have been updated as well and `skb->csum` would need to be updated to reflect that.

Not marking as bug because (1) multicast isn't really exposed to users and (2) it doesn't seem to have any practical impact on TX where we use this code.

```release-note
Fix bug in multicast feature that may cause packets to be dropped due to an incorrect checksum when hardware offload is enabled.
```