### PR TITLE
[v1.16] bpf: wireguard: avoid ipcache lookup for source's security identity

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -208,6 +208,7 @@ jobs:
             --helm-set=ipam.mode=cluster-pool \
             --helm-set=routingMode=native \
             --helm-set=bandwidthManager.enabled=false \
+            --helm-set=extraArgs={--enable-identity-mark=false} \
             --wait=false"
 
           if [ "${{ matrix.wireguard }}" == "true" ]; then

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1372,8 +1372,10 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 
 	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY || ctx_mark_is_wireguard(ctx))
 		src_sec_identity = HOST_ID;
+#ifdef ENABLE_IDENTITY_MARK
 	else if (magic == MARK_MAGIC_IDENTITY)
 		src_sec_identity = get_identity(ctx);
+#endif
 
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 */

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1499,7 +1499,7 @@ skip_host_firewall:
 	 * is set before the redirect.
 	 */
 	if (!ctx_mark_is_wireguard(ctx)) {
-		ret = wg_maybe_redirect_to_encrypt(ctx, proto);
+		ret = wg_maybe_redirect_to_encrypt(ctx, proto, src_sec_identity);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 		else if (IS_ERR(ret))

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1370,7 +1370,7 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 
 	bpf_clear_meta(ctx);
 
-	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY)
+	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY || ctx_mark_is_wireguard(ctx))
 		src_sec_identity = HOST_ID;
 	else if (magic == MARK_MAGIC_IDENTITY)
 		src_sec_identity = get_identity(ctx);

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1592,7 +1592,7 @@ skip_egress_gateway:
 #endif
 
 #ifdef ENABLE_NODEPORT
-	if (!ctx_snat_done(ctx) && !ctx_is_overlay(ctx)) {
+	if (!ctx_snat_done(ctx) && !ctx_is_overlay(ctx) && !ctx_mark_is_wireguard(ctx)) {
 		/*
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1498,7 +1498,7 @@ skip_host_firewall:
 	 * encrypted WireGuard UDP packets), we check whether the mark
 	 * is set before the redirect.
 	 */
-	if ((ctx->mark & MARK_MAGIC_WG_ENCRYPTED) != MARK_MAGIC_WG_ENCRYPTED) {
+	if (!ctx_mark_is_wireguard(ctx)) {
 		ret = wg_maybe_redirect_to_encrypt(ctx, proto);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -431,7 +431,7 @@ not_esp:
 			if (unlikely(ret != CTX_ACT_OK))
 				return ret;
 
-			ctx_egw_done_set(ctx);
+			set_identity_mark(ctx, *identity, MARK_MAGIC_EGW_DONE);
 
 			/* to-netdev@bpf_host handles SNAT, so no need to do it here. */
 			ret = egress_gw_fib_lookup_and_redirect(ctx, snat_addr,

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -728,8 +728,8 @@ enum metric_dir {
 #define MARK_MAGIC_IDENTITY		0x0F00 /* mark carries identity */
 #define MARK_MAGIC_TO_PROXY		0x0200
 #define MARK_MAGIC_SNAT_DONE		0x0300
-#define MARK_MAGIC_OVERLAY		0x0400
-#define MARK_MAGIC_EGW_DONE		0x0500
+#define MARK_MAGIC_OVERLAY		0x0400 /* mark carries identity */
+#define MARK_MAGIC_EGW_DONE		0x0500 /* mark carries identity */
 
 #define MARK_MAGIC_KEY_MASK		0xFF00
 

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -253,12 +253,6 @@ static __always_inline bool ctx_mark_is_wireguard(const struct __sk_buff *ctx)
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY_COMMON
-static __always_inline void ctx_egw_done_set(struct __sk_buff *ctx)
-{
-	ctx->mark &= ~MARK_MAGIC_HOST_MASK;
-	ctx->mark |= MARK_MAGIC_EGW_DONE;
-}
-
 static __always_inline bool ctx_egw_done(const struct __sk_buff *ctx)
 {
 	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_EGW_DONE;

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -244,6 +244,14 @@ static __always_inline bool ctx_is_overlay(const struct __sk_buff *ctx)
 	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_OVERLAY;
 }
 
+static __always_inline bool ctx_mark_is_wireguard(const struct __sk_buff *ctx)
+{
+	if (!is_defined(ENABLE_WIREGUARD))
+		return false;
+
+	return (ctx->mark & MARK_MAGIC_WG_ENCRYPTED) == MARK_MAGIC_WG_ENCRYPTED;
+}
+
 #ifdef ENABLE_EGRESS_GATEWAY_COMMON
 static __always_inline void ctx_egw_done_set(struct __sk_buff *ctx)
 {

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -16,7 +16,8 @@
 #include "lib/proxy.h"
 
 static __always_inline int
-wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
+wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
+			     __u32 src_sec_identity)
 {
 	struct remote_endpoint_info *dst = NULL;
 	struct remote_endpoint_info __maybe_unused *src = NULL;
@@ -55,7 +56,14 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 		}
 #endif
 		dst = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
-		src = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
+
+		if (src_sec_identity == UNKNOWN_ID) {
+			src = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
+			if (!src)
+				return CTX_ACT_OK;
+
+			src_sec_identity = src->sec_identity;
+		}
 		break;
 #endif
 #ifdef ENABLE_IPV4
@@ -89,7 +97,14 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 		}
 # endif /* HAVE_ENCAP */
 		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-		src = lookup_ip4_remote_endpoint(ip4->saddr, 0);
+
+		if (src_sec_identity == UNKNOWN_ID) {
+			src = lookup_ip4_remote_endpoint(ip4->saddr, 0);
+			if (!src)
+				return CTX_ACT_OK;
+
+			src_sec_identity = src->sec_identity;
+		}
 		break;
 #endif
 	default:
@@ -120,7 +135,7 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 	 * This means that the packet won't be encrypted. This is fine,
 	 * as with --encrypt-node=false we encrypt only pod-to-pod packets.
 	 */
-	if (!src || src->sec_identity == HOST_ID)
+	if (src_sec_identity == HOST_ID)
 		goto out;
 #endif /* !ENABLE_NODE_ENCRYPTION */
 
@@ -130,13 +145,13 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 	 * reply traffic arrives from the cluster-external server and goes to
 	 * the client pod.
 	 */
-	if (!src || !identity_is_cluster(src->sec_identity))
+	if (!identity_is_cluster(src_sec_identity))
 		goto out;
 
 	/* If source is remote node we should treat it like outside traffic.
 	 * This is possible when connection is done from pod to load balancer with DSR enabled.
 	 */
-	if (identity_is_remote_node(src->sec_identity))
+	if (identity_is_remote_node(src_sec_identity))
 		goto out;
 
 maybe_encrypt: __maybe_unused
@@ -144,8 +159,7 @@ maybe_encrypt: __maybe_unused
 	 * required.
 	 */
 	if (dst && dst->key) {
-		if (src)
-			set_identity_mark(ctx, src->sec_identity, MARK_MAGIC_IDENTITY);
+		set_identity_mark(ctx, src_sec_identity, MARK_MAGIC_IDENTITY);
 overlay_encrypt: __maybe_unused
 		return ctx_redirect(ctx, WG_IFINDEX, 0);
 	}

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -4,6 +4,7 @@
 #define CLIENT_IP		v4_pod_one
 #define CLIENT_PORT		__bpf_htons(111)
 #define CLIENT_NODE_IP		v4_node_one
+#define CLIENT_IDENTITY		123456
 
 #define GATEWAY_NODE_IP		v4_node_two
 

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -89,7 +89,7 @@ int egressgw_snat1_setup(struct __ctx_buff *ctx)
 				  GATEWAY_NODE_IP, EGRESS_IP);
 
 	/* Jump into the entrypoint */
-	ctx_egw_done_set(ctx);
+	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	/* Fail if we didn't jump */
 	return TEST_ERROR;
@@ -152,7 +152,7 @@ SETUP("tc", "tc_egressgw_snat2")
 int egressgw_snat2_setup(struct __ctx_buff *ctx)
 {
 	/* Jump into the entrypoint */
-	ctx_egw_done_set(ctx);
+	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	/* Fail if we didn't jump */
 	return TEST_ERROR;
@@ -191,7 +191,7 @@ int egressgw_tuple_collision1_setup(struct __ctx_buff *ctx)
 				  GATEWAY_NODE_IP, EGRESS_IP);
 
 	/* Jump into the entrypoint */
-	ctx_egw_done_set(ctx);
+	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	/* Fail if we didn't jump */
 	return TEST_ERROR;
@@ -226,7 +226,7 @@ int egressgw_tuple_collision2_setup(struct __ctx_buff *ctx)
 				  GATEWAY_NODE_IP, EGRESS_IP3);
 
 	/* Jump into the entrypoint */
-	ctx_egw_done_set(ctx);
+	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	/* Fail if we didn't jump */
 	return TEST_ERROR;
@@ -303,7 +303,7 @@ int egressgw_skip_excluded_cidr_snat_setup(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_EXCLUDED_CIDR, 0);
 
 	/* Jump into the entrypoint */
-	ctx_egw_done_set(ctx);
+	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	/* Fail if we didn't jump */
 	return TEST_ERROR;
@@ -383,7 +383,7 @@ int egressgw_fib_redirect_setup(struct __ctx_buff *ctx)
 				  GATEWAY_NODE_IP, EGRESS_IP2);
 
 	/* Jump into the entrypoint */
-	ctx_egw_done_set(ctx);
+	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	/* Fail if we didn't jump */
 	return TEST_ERROR;
@@ -403,4 +403,3 @@ int egressgw_fib_redirect_check(const struct __ctx_buff *ctx __maybe_unused)
 
 	return ret;
 }
-


### PR DESCRIPTION
Backport of

* [ ] https://github.com/cilium/cilium/pull/33543 (partial)
* [x] https://github.com/cilium/cilium/pull/35900
* [ ] https://github.com/cilium/cilium/pull/37956
* [ ] https://github.com/cilium/cilium/pull/38430
* [ ] https://github.com/cilium/cilium/pull/38592
* [ ] https://github.com/cilium/cilium/pull/38737
* [ ] https://github.com/cilium/cilium/pull/38738

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
  35900 37956 38430 38592 38737 38738
```
