### PR TITLE
Update vagrant-cache IP

### DIFF
--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -28,7 +28,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 
 		// The IPs are updated in BeforeAll
 		worldTarget          = "vagrant-cache.ci.cilium.io"
-		worldTargetIP        = "147.75.38.95"
+		worldTargetIP        = "3.227.177.40"
 		worldInvalidTarget   = "cilium.io"
 		worldInvalidTargetIP = "104.198.14.52"
 	)


### PR DESCRIPTION
The FQDN tests use both the host and the IP to run curl. This change updates the endpoint used in this test.

Fixes: #38752
