### PR TITLE
test: Update FQDN related domain and IP

### DIFF
--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -27,8 +27,8 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 		appPods map[string]string
 
 		// The IPs are updated in BeforeAll
-		worldTarget          = "vagrant-cache.ci.cilium.io"
-		worldTargetIP        = "147.75.38.95"
+		worldTarget          = "nginx-ci.cilium.rocks"
+		worldTargetIP        = "3.227.177.40"
 		worldInvalidTarget   = "cilium.io"
 		worldInvalidTargetIP = "104.198.14.52"
 	)

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -245,7 +245,7 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 
 		It("Test FQDN Policy with Relay", func() {
 			fqdnProxyPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-policy.yaml")
-			fqdnTarget := "vagrant-cache.ci.cilium.io"
+			fqdnTarget := "nginx-ci.cilium.rocks"
 
 			_, err := kubectl.CiliumPolicyAction(
 				namespaceForTest, fqdnProxyPolicy,

--- a/test/k8s/manifests/fqdn-proxy-multiple-specs-v2.yaml
+++ b/test/k8s/manifests/fqdn-proxy-multiple-specs-v2.yaml
@@ -13,7 +13,7 @@ specs:
         dns:
         - matchPattern: "*"
   - toFQDNs:
-    - matchPattern: "vagrant-cache.ci.cilium.io"
+    - matchPattern: "nginx-ci.cilium.rocks"
     - matchPattern: "www.cilium.io"
   endpointSelector:
     matchLabels:

--- a/test/k8s/manifests/fqdn-proxy-multiple-specs.yaml
+++ b/test/k8s/manifests/fqdn-proxy-multiple-specs.yaml
@@ -13,7 +13,7 @@ specs:
         dns:
         - matchPattern: "*"
   - toFQDNs:
-    - matchPattern: "vagrant-cache.ci.cilium.io"
+    - matchPattern: "nginx-ci.cilium.rocks"
   endpointSelector:
     matchLabels:
       id: app2

--- a/test/k8s/manifests/fqdn-proxy-policy.yaml
+++ b/test/k8s/manifests/fqdn-proxy-policy.yaml
@@ -16,4 +16,4 @@ spec:
         dns:
         - matchPattern: "*"
   - toFQDNs:
-    - matchPattern: "vagrant-cache.ci.cilium.io"
+    - matchPattern: "nginx-ci.cilium.rocks"


### PR DESCRIPTION
The FQDN tests use both the host and the IP to run curl. This change updates the endpoint used in this test.

Fixes: #38752


