### PR TITLE
bpf/tests: Add __FINE__:__LINE__ prefix for test_log

### DIFF
--- a/bpf/tests/builtins.c
+++ b/bpf/tests/builtins.c
@@ -36,7 +36,7 @@ int test_builtin_memcmp(__maybe_unused struct __ctx_buff *ctx)
 
 	int i;
 
-	for (i = 0; i < 100; i++) {
+	for (i = 0; i < 70; i++) {
 		/* ./builtin_gen memcmp 32 > builtin_memcmp.h */
 		#include "builtin_memcmp.h"
 	}


### PR DESCRIPTION
I noticed that the `test_log` macro in the current BPF unit test framework does not record the source file and line number information in logs, making it difficult to locate problematic code positions. Therefore, I modified the `test_log` macro by adding `__FILE__:__LINE__` prefixes.

**Before modification:**
```
=== RUN   TestBPF/host_only_socket_lb_test.o/sock4_xlate_fwd_test
    bpf_test.go:444: xlate_fwd: 0
    bpf_test.go:444: ip 0100a8c0
    bpf_test.go:444: port 7000
    bpf_test.go:444: ret: 0
```

**After modification:**
```
=== RUN   TestBPF/host_only_socket_lb_test.o/sock4_xlate_fwd_test
    bpf_test.go:444: host_only_socket_lb_test.c:105: xlate_fwd: 0
    bpf_test.go:444: host_only_socket_lb_test.c:106: ip 0100a8c0
    bpf_test.go:444: host_only_socket_lb_test.c:107: port 7000
    bpf_test.go:444: host_only_socket_lb_test.c:108: ret: 0
```

However, after these changes, the verifier rejected the `bpf/tests/builtins.c` unit test file with the error: **"BPF program is too large. Processed 1000001 insn"**. This occurred because the addition of file/line metadata increased the program size beyond the verifier's instruction limit (1,000,000 instructions). To resolve this, I reduced the scale of the `builtin_memcmp` test cases in `builtins.c`, ensuring compliance with the verifier's constraints while retaining essential test coverage.

This adjustment aligns with BPF verifier practices that enforce strict program size limits to prevent resource exhaustion and ensure safe execution.


```release-note
bpf/tests: Add __FILE__:__LINE__ prefix for test_log
```
