### PR TITLE
bpf: encap: clean up tunnel_map leftovers

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -705,20 +705,6 @@ ct_recreate6:
 	/* The packet goes to a peer not managed by this agent instance */
 #ifdef TUNNEL_MODE
 	if (ct_state->from_tunnel || !skip_tunnel) {
-		struct tunnel_key key = {};
-		union v6addr *daddr = (union v6addr *)&ip6->daddr;
-
-		/* Lookup the destination prefix in the list of known
-		 * destination prefixes. If there is a match, the packet will
-		 * be encapsulated to that node and then routed by the agent on
-		 * the remote node.
-		 *
-		 * IPv6 lookup key: daddr/96
-		 */
-		ipv6_addr_copy(&key.ip6, daddr);
-		key.ip6.p4 = 0;
-		key.family = ENDPOINT_KEY_IPV6;
-
 #if !defined(ENABLE_NODEPORT) && defined(ENABLE_HOST_FIREWALL)
 		/* See comment in handle_ipv4_from_lxc(). */
 		if ((ct_status == CT_REPLY || ct_status == CT_RELATED) &&
@@ -1241,14 +1227,8 @@ skip_vtep:
 	 * destination's `skip_tunnel` flag.
 	 */
 	if (ct_state->from_tunnel || !skip_tunnel) {
-		struct tunnel_key key = {};
-
 		if (cluster_id > UINT16_MAX)
 			return DROP_INVALID_CLUSTER_ID;
-
-		key.ip4 = ip4->daddr & IPV4_MASK;
-		key.family = ENDPOINT_KEY_IPV4;
-		key.cluster_id = (__u16)cluster_id;
 
 #if !defined(ENABLE_NODEPORT) && defined(ENABLE_HOST_FIREWALL)
 		/*

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -90,19 +90,6 @@ encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 						trace);
 }
 
-/* __encap_and_redirect_lxc() is a variant of encap_and_redirect_lxc()
- * that requires a valid tunnel_endpoint.
- */
-static __always_inline int
-__encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
-			 __u8 encrypt_key, __u32 seclabel, __u32 dstid,
-			 const struct trace_ctx *trace)
-{
-	return encap_and_redirect_with_nodeid(ctx, tunnel_endpoint,
-					      encrypt_key, seclabel, dstid,
-					      trace);
-}
-
 #if defined(TUNNEL_MODE)
 /* encap_and_redirect_lxc adds IPSec metadata (if enabled) and returns the packet
  * so that it can be passed to the IP stack. Without IPSec the packet is
@@ -114,17 +101,16 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
  * CTX_ACT_REDIRECT.
  */
 static __always_inline int
-encap_and_redirect_lxc(struct __ctx_buff *ctx __maybe_unused,
-		       __be32 tunnel_endpoint, __u8 encrypt_key __maybe_unused,
-		       __u32 seclabel __maybe_unused, __u32 dstid __maybe_unused,
-		       const struct trace_ctx *trace __maybe_unused)
+encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
+		       __u8 encrypt_key, __u32 seclabel, __u32 dstid,
+		       const struct trace_ctx *trace)
 {
 	if (!tunnel_endpoint)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-	return __encap_and_redirect_lxc(ctx, tunnel_endpoint,
-					encrypt_key, seclabel, dstid,
-					trace);
+	return encap_and_redirect_with_nodeid(ctx, tunnel_endpoint,
+					      encrypt_key, seclabel, dstid,
+					      trace);
 }
 #endif /* TUNNEL_MODE */
 


### PR DESCRIPTION
Clean up the encap-related code a bit more, after the changes in https://github.com/cilium/cilium/pull/38483.