### PR TITLE
bpf: lb: remove compatibility support for CT entries without rev_nat_index

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -303,12 +303,6 @@ __ct_lookup(const void *map, struct __ctx_buff *ctx, const void *tuple,
 		if (ct_entry_alive(entry))
 			*monitor = ct_update_timeout(entry, is_tcp, dir, seen_flags);
 
-		/* For backward-compatibility we need to update reverse NAT
-		 * index in the CT_SERVICE entry for old connections.
-		 */
-		if (dir == CT_SERVICE && entry->rev_nat_index == 0)
-			entry->rev_nat_index = ct_state->rev_nat_index;
-
 #ifdef CONNTRACK_ACCOUNTING
 		__sync_fetch_and_add(&entry->packets, 1);
 		__sync_fetch_and_add(&entry->bytes, ctx_full_len(ctx));


### PR DESCRIPTION
The CT lookup for CT_SERVICE entries currently carries some compatibility support for CT entries that don't have the .rev_nat_index field populated. This was added a long time ago (in v1.6) with commit 872b7f032ea3 ("datapath: Redo backend selection if stale CT_SERVICE entry is found"),

But nowadays the CT lookup itself already enforces that SVC entry and CT entry have the same rev_nat_index - otherwise ct_entry_matches_types() causes us to return CT_NEW from __ct_lookup(), and the caller simply re-creates the CT entry.

Therefore we can safely delete this compatibility code, it should never get used.