### PR TITLE
bpf: host: use MARK_MAGIC_EGW_DONE-embedded identity in to-netdev

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1386,6 +1386,10 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 	else if (magic == MARK_MAGIC_IDENTITY)
 		src_sec_identity = get_identity(ctx);
 #endif
+#ifdef ENABLE_EGRESS_GATEWAY_COMMON
+	else if (magic == MARK_MAGIC_EGW_DONE)
+		src_sec_identity = get_identity(ctx);
+#endif
 
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 */


### PR DESCRIPTION
Now that https://github.com/cilium/cilium/pull/38430 has landed in the n-1 release, we can trust that skbs with the MARK_MAGIC_EGW_DONE mark carry the source identity. Use it.