### PR TITLE
k8s: fix missing service endpoints delete events

### DIFF
--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	"fmt"
 	"log/slog"
+	"reflect"
 	"sync"
 
 	"github.com/cilium/hive/cell"
@@ -393,7 +394,10 @@ func transformEndpoint(logger *slog.Logger, obj any) (any, error) {
 		return ParseEndpointSliceV1(logger, obj), nil
 	case *slim_discoveryv1beta1.EndpointSlice:
 		return ParseEndpointSliceV1Beta1(obj), nil
+	case cache.DeletedFinalStateUnknown:
+		return obj, nil
 	default:
+		logger.Error("Unknown endpoint or endpoint slice object", logfields.Name, reflect.TypeOf(obj))
 		return nil, fmt.Errorf("%T not a known endpoint or endpoint slice object", obj)
 	}
 }

--- a/pkg/k8s/resource_ctors_test.go
+++ b/pkg/k8s/resource_ctors_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestEndpointTransformPreservesThombstoneKey(t *testing.T) {
+	unknownObj := 100
+	endpoint := cache.DeletedFinalStateUnknown{
+		Key: "default/some-service",
+		Obj: unknownObj,
+	}
+
+	result, err := transformEndpoint(hivetest.Logger(t), endpoint)
+	require.NoError(t, err)
+	tombstone, ok := result.(cache.DeletedFinalStateUnknown)
+	require.True(t, ok)
+	require.Equal(t, endpoint.Key, tombstone.Key)
+}


### PR DESCRIPTION
In case of problem with k8s connectivity, Reflector performs relist operation and DeltaFIFO generates Sync events for already existing elements and Delete events for removed elements. However, we were not handling events DeletedFinalStateUnknown which resulted in stale cache for services.

```release-note
k8s: Fixed a case when delete event for service endpointslices might have been missed if connectivity to k8s apiserver was broken causing stale service cache for service.
```
