### PR TITLE
iptables: Don't track tunneling traffic

### DIFF
--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -24,9 +25,11 @@ var Cell = cell.Module(
 	cell.Config(defaultConfig),
 	cell.ProvidePrivate(func(
 		cfg *option.DaemonConfig,
+		tunnelCfg tunnel.Config,
 	) SharedConfig {
 		return SharedConfig{
 			TunnelingEnabled:                cfg.TunnelingEnabled(),
+			TunnelPort:                      tunnelCfg.Port(),
 			NodeIpsetNeeded:                 cfg.NodeIpsetNeeded(),
 			IptablesMasqueradingIPv4Enabled: cfg.IptablesMasqueradingIPv4Enabled(),
 			IptablesMasqueradingIPv6Enabled: cfg.IptablesMasqueradingIPv6Enabled(),
@@ -86,6 +89,7 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 
 type SharedConfig struct {
 	TunnelingEnabled                bool
+	TunnelPort                      uint16
 	NodeIpsetNeeded                 bool
 	IptablesMasqueradingIPv4Enabled bool
 	IptablesMasqueradingIPv6Enabled bool


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

VXLAN traffic tends to create a lot of `conntrack` entries (> 100k), because each node needs to open connections to every node in the cluster.

Also, VXLAN doesn't operate with stateful flows (i.e. nodes send traffic to port 8472, they don't "reply" to packets based on the other node's source port), so each entry is in the `UNREPLIED` state, making them useless in the context of a stateful firewall.

This commit adds `iptables` rules to prevent VXLAN traffic from being added to `conntrack`. This doesn't remove any functionality, but avoids overflowing `conntrack` with useless entries.

For what it's worth, Calico is doing the same in
projectcalico/calico#8977.

```release-note
Avoid VXLAN/Geneve connections filling up `conntrack` when tunneling is enabled
```
