### PR TITLE
Fix deadlock in compilation lock

### DIFF
--- a/pkg/datapath/fake/types/orchestrator.go
+++ b/pkg/datapath/fake/types/orchestrator.go
@@ -13,6 +13,12 @@ import (
 
 type FakeOrchestrator struct{}
 
+func (f *FakeOrchestrator) DatapathInitialized() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
 func (f *FakeOrchestrator) Reinitialize(ctx context.Context) error {
 	return nil
 }

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -244,6 +244,10 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 	}
 }
 
+func (o *orchestrator) DatapathInitialized() <-chan struct{} {
+	return o.dpInitialized
+}
+
 func (o *orchestrator) Reinitialize(ctx context.Context) error {
 	errChan := make(chan error)
 	o.trigger <- reinitializeRequest{

--- a/pkg/datapath/types/orchestrator.go
+++ b/pkg/datapath/types/orchestrator.go
@@ -13,6 +13,7 @@ import (
 type Orchestrator interface {
 	Reinitialize(ctx context.Context) error
 
+	DatapathInitialized() <-chan struct{}
 	ReloadDatapath(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) (string, error)
 	ReinitializeXDP(ctx context.Context, extraCArgs []string) error
 	EndpointHash(cfg EndpointConfiguration) (string, error)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -380,6 +380,13 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 
+	// Wait for the datapath to be initialized before we take the compilation read lock.
+	// If we take the read lock before the datapath is initialized, we end up blocking
+	// the datapath initialization which needs the write lock on `e.compilationLock`.
+	// Yet, we will be blocked while waiting for the initialization to finish, thus causing
+	// a deadlock.
+	<-e.orchestrator.DatapathInitialized()
+
 	// Make sure that owner is not compiling base programs while we are
 	// regenerating an endpoint.
 	e.compilationLock.RLock()


### PR DESCRIPTION
The orchestrator watches a hand full of internal state and uses this to initialize and reinitalize the datapath. Endpoints can only start compiling their programs after we have done an initial reinitialization.

To ensure this, we proxy all calls to the loader via the orchestrator which blocks on a channel which gets closed after the first call to `Reinitialize` is done.

Endpoints also cannot compile while reinitialization is going on. This is gated by a RWMutex, since if no reinitialization is going on, multiple endpoints can compile at the same time. The problem with this is that endpoints can take a read lock on the compilation lock before the  initial `Reinitialize` can take the write lock, blocking it. But the  endpoint then waits for the orchestrator to close the channel signaling `Reinitialize` is done. Thus a deadlock.

So, this commit exposes the channel and make endpoints wait until its closed before they take the read lock. This should ensure the proper ordering without the deadlock.

This is the stack trace from the endpoint goroutine:
```
goroutine 1261 [chan receive, 22 minutes]:
github.com/cilium/cilium/pkg/datapath/orchestrator.(*orchestrator).EndpointHash(0xc000a60000, {0x55d0e20, 0xc000c3f008})
        /go/src/github.com/cilium/cilium/pkg/datapath/orchestrator/orchestrator.go:323 +0x2e
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runPreCompilationSteps(0xc000c3f008, 0xc000c3f808)
        /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:758 +0xc98
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF(0xc000c3f008, 0xc000c3f808)
        /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:400 +0x1fd
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate(0xc000c3f008, 0xc000c3f808)
        /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:478 +0x991
github.com/cilium/cilium/pkg/endpoint.(*EndpointRegenerationEvent).Handle(0xc00120d8d0, 0xc0004fbc70)
        /go/src/github.com/cilium/cilium/pkg/endpoint/events.go:77 +0x25b
github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run.func1()
        /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:244 +0x131
sync.(*Once).doSlow(0x0?, 0x0?)
        /usr/local/go/src/sync/once.go:76 +0xb4
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:67
github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run(0x0?)
        /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:232 +0x36
created by github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run in goroutine 1005
        /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:228 +0x69
```

And this the stacktrace from the orchestrator:
```
goroutine 408 [sync.RWMutex.Lock, 22 minutes]:
sync.runtime_SemacquireRWMutex(0x0?, 0xa0?, 0xc002d47cb0?)
        /usr/local/go/src/runtime/sema.go:105 +0x25
sync.(*RWMutex).Lock(0x1?)
        /usr/local/go/src/sync/rwmutex.go:153 +0x6a
github.com/cilium/cilium/pkg/datapath/loader.(*loader).Reinitialize(0xc00067bd00, {0x5584238, 0xc000dc0c00}, 0xc003b22780, {{0xc000cf8d90, 0x5}, 0x2118, {0x4e5524a, 0xc}, 0x1}, ...)
        /go/src/github.com/cilium/cilium/pkg/datapath/loader/base.go:381 +0x362
```

Fixes: #38210

```release-note
Fix deadlock in compilation lock
```
