### PR TITLE
ctmap: on delete error, use host byte order.

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -461,7 +461,8 @@ func cleanup(m *Map, filter GCFilter, natMap *nat.Map, stats *gcStats, next func
 		case deleteEntry:
 			err := purgeCtEntry(m, ctKey, entry, natMap, next, countFailedFn)
 			if err != nil {
-				log.WithError(err).WithField(logfields.Key, ctKey.String()).Error("Unable to delete CT entry")
+				log.WithError(err).WithField(logfields.Key, ctKey.ToHost().String()).
+					Error("Unable to delete CT entry")
 			} else {
 				stats.deleted++
 			}


### PR DESCRIPTION
When a ctmap delete happens, we see somewhat confusing tuples being logged, for example from cli tests:

```
delete: key does not exist" key="[fd00:10:244:3::fb3f]:13568 --> [fd00:10:96::a]:49104
```
On further inspection, these ports are just network byte order as is in the map. To clear things up a bit let's make sure the byte order is host to log these correctly.

Addresses: #38498

