### PR TITLE
ci/workflows: disable github workflows on forks

### DIFF
--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   ariane-scheduled:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Run Scheduled Workflows
     strategy:
       fail-fast: false

--- a/.github/workflows/build-go-caches.yaml
+++ b/.github/workflows/build-go-caches.yaml
@@ -24,6 +24,8 @@ concurrency:
 
 jobs:
   build_go_caches:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Build Go Caches
     runs-on: ubuntu-24.04
     timeout-minutes: 20

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -28,6 +28,8 @@ jobs:
           echo '${{ tojson(inputs) }}'
 
   build-and-push:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     timeout-minutes: 45
     name: Build and Push Images
     environment: release-beta-images

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -26,6 +26,8 @@ concurrency:
 
 jobs:
   build-and-push-prs:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}

--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -21,6 +21,8 @@ concurrency:
 
 jobs:
   build-and-push:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Build and Push Image
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -13,6 +13,8 @@ permissions:
 
 jobs:
   build-and-push:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     timeout-minutes: 45
     name: Build and Push Images
     environment: release-developer-images

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   build-and-push:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     timeout-minutes: 45
     name: Build and Push Images
     environment: release

--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -11,6 +11,7 @@
     call-backport-label-updater:
       name: Update backport labels for upstream PR
       if: |
+        always() && vars.ENABLE_CILIUM_CI == 'true' &&
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.body, 'upstream-prs') &&
         contains(join(github.event.pull_request.labels.*.name, ', '), 'backport/')

--- a/.github/workflows/ci-images-cache-cleaner.yaml
+++ b/.github/workflows/ci-images-cache-cleaner.yaml
@@ -15,6 +15,8 @@ concurrency:
 
 jobs:
   cache-cleaner:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Clean Image Cache
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/ci-images-garbage-collect.yaml
+++ b/.github/workflows/ci-images-garbage-collect.yaml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   scruffy:
-    if: github.repository_owner == 'cilium'
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: scruffy
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/cilium-cli.yaml
+++ b/.github/workflows/cilium-cli.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   build-cilium-cli-binaries:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Build Cilium CLI binaries
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -65,7 +65,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -74,6 +74,8 @@ jobs:
           echo '${{ tojson(inputs) }}'
 
   commit-status-start:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Commit Status Start
     runs-on: ubuntu-24.04
     steps:
@@ -83,6 +85,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   generate-matrix:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Generate Matrix
     runs-on: ubuntu-24.04
     outputs:
@@ -147,6 +151,8 @@ jobs:
           echo "empty=$(jq '(.include | length) == 0' /tmp/result.json)" >> $GITHUB_OUTPUT
 
   wait-for-images:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -67,7 +67,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -77,6 +77,8 @@ jobs:
 
   commit-status-start:
     name: Commit Status Start
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Set initial commit status
@@ -85,6 +87,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   generate-matrix:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Generate Matrix
     runs-on: ubuntu-24.04
     outputs:
@@ -155,6 +159,8 @@ jobs:
           echo "empty=$(jq '(.include | length) == 0' /tmp/result.json)" >> $GITHUB_OUTPUT
 
   wait-for-images:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -70,7 +70,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -80,6 +80,8 @@ jobs:
 
   commit-status-start:
     name: Commit Status Start
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Set initial commit status
@@ -89,6 +91,8 @@ jobs:
 
   wait-for-images:
     name: Wait for images
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -62,7 +62,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -72,6 +72,8 @@ jobs:
 
   commit-status-start:
     name: Commit Status Start
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Set initial commit status
@@ -80,6 +82,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   delegated-ipam-conformance-test:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Install and Connectivity Test
     env:
       job_name: "Install and Connectivity Test"

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -67,7 +67,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -76,6 +76,8 @@ jobs:
           echo '${{ tojson(inputs) }}'
 
   commit-status-start:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Commit Status Start
     runs-on: ubuntu-24.04
     steps:
@@ -85,6 +87,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   wait-for-images:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -102,6 +106,8 @@ jobs:
           images: cilium-ci operator-aws-ci hubble-relay-ci cilium-cli-ci
 
   generate-matrix:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Generate Matrix
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -64,7 +64,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -73,6 +73,8 @@ jobs:
           echo '${{ tojson(inputs) }}'
 
   commit-status-start:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Commit Status Start
     runs-on: ubuntu-24.04
     steps:
@@ -82,6 +84,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   wait-for-images:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -99,6 +103,8 @@ jobs:
           images: cilium-ci operator-generic-ci
 
   gateway-api-conformance-test:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Gateway API Conformance Test
     env:
       job_name: "Gateway API Conformance Test"

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -58,7 +58,7 @@ concurrency:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -67,6 +67,8 @@ jobs:
           echo '${{ tojson(inputs) }}'
 
   setup-vars:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Setup Vars
     runs-on: ubuntu-24.04
     outputs:
@@ -93,6 +95,8 @@ jobs:
           echo owner=${OWNER} >> $GITHUB_OUTPUT
 
   commit-status-start:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Commit Status Start
     runs-on: ubuntu-24.04
     steps:
@@ -104,6 +108,8 @@ jobs:
   # Pre-build the ginkgo binary so that we don't have to build it for all
   # runners.
   build-ginkgo-binary:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     name: Build Ginkgo E2E
     timeout-minutes: 30

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -84,6 +84,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   generate-matrix:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Generate Matrix
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -63,7 +63,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -72,6 +72,8 @@ jobs:
           echo '${{ tojson(inputs) }}'
 
   commit-status-start:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Commit Status Start
     runs-on: ubuntu-24.04
     steps:
@@ -81,6 +83,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   wait-for-images:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -98,6 +102,8 @@ jobs:
           images: cilium-ci operator-generic-ci
 
   ingress-conformance-test:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Ingress Conformance Test
     env:
       job_name: "Ingress Conformance Test"

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -61,7 +61,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -71,6 +71,8 @@ jobs:
 
   commit-status-start:
     name: Commit Status Start
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Set initial commit status
@@ -79,6 +81,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   generate-matrix:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Generate Matrix
     runs-on: ubuntu-24.04
     outputs:
@@ -107,6 +111,8 @@ jobs:
           echo "matrix=$(jq -c . < /tmp/generated/ipsec/matrix.json)" >> $GITHUB_OUTPUT
 
   wait-for-images:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -122,6 +128,8 @@ jobs:
           SHA: ${{ inputs.SHA || github.sha }}
 
   setup-and-test:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     needs: [wait-for-images, generate-matrix]
     name: 'Setup & Test'
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -18,6 +18,8 @@ env:
 
 jobs:
   preflight-clusterrole:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Preflight Clusterrole Check
     runs-on: ubuntu-24.04
     steps:
@@ -39,6 +41,8 @@ jobs:
              cilium-preflight/clusterrole.yaml
 
   cyclonus-test:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Cyclonus Test
     env:
       job_name: "Cyclonus Test"

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -26,6 +26,8 @@ env:
 jobs:
   installation-and-connectivity:
     name: "Installation and Connectivity Test"
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -63,7 +63,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -73,6 +73,8 @@ jobs:
 
   commit-status-start:
     name: Commit Status Start
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Set initial commit status
@@ -82,6 +84,8 @@ jobs:
 
   wait-for-images:
     name: Wait for images
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -65,7 +65,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -75,6 +75,8 @@ jobs:
 
   commit-status-start:
     name: Commit Status Start
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Set initial commit status
@@ -85,6 +87,8 @@ jobs:
   # Pre-build the ginkgo binary so that we don't have to build it for all
   # runners.
   build-ginkgo-binary:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     name: Build Ginkgo Runtime
     steps:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -18,6 +18,8 @@ concurrency:
 
 jobs:
   check_changes:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Deduce required tests from code changes
     runs-on: ubuntu-24.04
     outputs:
@@ -53,7 +55,7 @@ jobs:
   # should be unaffected otherwise.
   build-html:
     needs: check_changes
-    if: ${{ needs.check_changes.outputs.docs-tree == 'true' }}
+    if: needs.check_changes.outputs.docs-tree == 'true' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Validate & Build HTML
     runs-on: ubuntu-24.04
     steps:
@@ -71,7 +73,7 @@ jobs:
 
   check-generated-documentation:
     name: Check generated documentation
-    if: ${{ github.event_name != 'merge_group' }}
+    if: github.event_name != 'merge_group' && always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/feature-summary-report.yaml
+++ b/.github/workflows/feature-summary-report.yaml
@@ -25,6 +25,8 @@ permissions:
 jobs:
   summary_report:
     name: "Summary Report"
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     env:
       job_name: "Summary Report"
     runs-on: ubuntu-24.04

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -62,7 +62,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -72,6 +72,8 @@ jobs:
 
   commit-status-start:
     name: Commit Status Start
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Set initial commit status
@@ -81,6 +83,8 @@ jobs:
 
   install-and-fqdn-perf-test:
     runs-on: ubuntu-24.04
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Install and FQDN Perf Test
     timeout-minutes: 60
     env:

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -49,7 +49,7 @@ env:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -58,6 +58,8 @@ jobs:
           echo '${{ tojson(inputs) }}'
 
   commit-status-start:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Commit Status Start
     runs-on: ubuntu-24.04
     steps:
@@ -67,6 +69,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   integration-test:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     env:
       job_name: "Integration Test"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -61,7 +61,7 @@ concurrency:
 
 jobs:
   echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch' && always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Echo Workflow Dispatch Inputs
     runs-on: ubuntu-24.04
     steps:
@@ -70,6 +70,8 @@ jobs:
           echo '${{ tojson(inputs) }}'
 
   commit-status-start:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Commit Status Start
     runs-on: ubuntu-24.04
     steps:
@@ -79,6 +81,8 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   integration-test:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Integration Test
     env:
       # GitHub doesn't provide a way to retrieve the name of a job, so we have

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -25,6 +25,8 @@ env:
 
 jobs:
   kubernetes-e2e:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: K8s Network E2E tests
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     timeout-minutes: 60

--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -25,6 +25,8 @@ env:
 
 jobs:
   kubernetes-e2e-net:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: K8s Network Policy E2E tests
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -18,6 +18,8 @@ concurrency:
 
 jobs:
   check_changes:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Deduce required tests from code changes
     runs-on: ubuntu-24.04
     outputs:
@@ -55,6 +57,8 @@ jobs:
               - '.github/workflows/lint-bpf-checks.yaml'
 
   checkpatch:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Check Patch
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -26,6 +26,8 @@ concurrency:
 
 jobs:
   compute-vars:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Compute variables
     runs-on: ubuntu-22.04
     outputs:
@@ -82,6 +84,8 @@ jobs:
               - 'test/**'
 
   build-commits-cilium:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Check if cilium builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]
@@ -168,6 +172,8 @@ jobs:
         run: git --no-pager log --format=%B -n 1
 
   build-commits-hubble-cli:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Check if hubble-cli builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]
@@ -260,6 +266,8 @@ jobs:
         run: git --no-pager log --format=%B -n 1
 
   build-commits-bpf:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Check if bpf builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]
@@ -353,6 +361,8 @@ jobs:
         run: git --no-pager log --format=%B -n 1
 
   build-commits-test:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Check if test builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]

--- a/.github/workflows/push-chart-ci.yaml
+++ b/.github/workflows/push-chart-ci.yaml
@@ -30,6 +30,8 @@ concurrency:
 
 jobs:
   setup-charts:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Setup Charts
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,8 @@ concurrency:
 
 jobs:
   release:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Release
     environment: release-tool
     timeout-minutes: 40

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   validate:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Validate Renovate configuration
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   renovate:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     name: Run self-hosted Renovate
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/scale-cleanup-kops.yaml
+++ b/.github/workflows/scale-cleanup-kops.yaml
@@ -30,6 +30,8 @@ env:
 
 jobs:
   cleanup-kops-clusters:
+    # Skip running workflow on forks using variable Kill Switch
+    if: always() && vars.ENABLE_CILIUM_CI == 'true'
     runs-on: ubuntu-24.04
     name: Cleanup kops clusters
     timeout-minutes: 30


### PR DESCRIPTION
```release-note
Disable GitHub workflows on forks
```

## Disable GitHub Workflows on Forks by Default

### Problem Statement

Currently, GitHub workflows are triggered on forked repositories, resulting in:

- Unnecessary workflow runs on forks.
- Unwanted GitHub email notifications for fork owners.

While GitHub provides an option to [completely or selectively disable Actions](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow) on forks, this approach is restrictive and prevents users from using workflows on their forks for legitimate use cases. 

## Proposed Solution (Explicit Deny over Allow All)

This PR proposes changes to the GitHub workflows to explicitly configure them to run only when the project owner is cilium. By adding this condition, workflows will:

Run only on the cilium/cilium repository by default.
Prevent triggering workflows on forks, saving unnecessary usage and avoiding email spam.
If a fork owner wishes to run workflows, they can still modify the workflow configurations on their fork as needed.

### Benefits
- Reduces unnecessary workflow run usage.
- Prevents unwanted email notifications for fork owners.
- Provides a better default behavior while still allowing flexibility for fork owners.

## Additional Context

Attached below are screenshots of the email notifications and workflow runs triggered on my fork to illustrate the problem being addressed by this PR.

- 
![Screenshot 2025-04-07 at 21 06 15](https://github.com/user-attachments/assets/55a07fcc-a02d-4fe0-a709-0cc403649f1b)

- 
![Screenshot 2025-04-07 at 21 07 19](https://github.com/user-attachments/assets/d6407607-c35e-4c7f-a342-849125b8adcd)


- https://github.com/orgs/community/discussions/26704