### PR TITLE
[v1.16] hubble: fix flowfilter flag parsing allowing only one filter

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -957,8 +957,8 @@ data:
 {{- if .Values.hubble.export.static.enabled }}
   hubble-export-file-path: {{ .Values.hubble.export.static.filePath | quote }}
   hubble-export-fieldmask: {{ .Values.hubble.export.static.fieldMask | join " " | quote }}
-  hubble-export-allowlist: {{ .Values.hubble.export.static.allowList | join "," | quote }}
-  hubble-export-denylist: {{ .Values.hubble.export.static.denyList | join "," | quote }}
+  hubble-export-allowlist: {{ .Values.hubble.export.static.allowList | join "" | quote }}
+  hubble-export-denylist: {{ .Values.hubble.export.static.denyList | join "" | quote }}
 {{- end }}
 {{- if .Values.hubble.export.dynamic.enabled }}
   hubble-flowlogs-config-path: /flowlog-config/flowlogs.yaml

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3478,26 +3478,30 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 
 	for _, enc := range vp.GetStringSlice(HubbleExportAllowlist) {
 		dec := json.NewDecoder(strings.NewReader(enc))
-		var result flowpb.FlowFilter
-		if err := dec.Decode(&result); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
+		for {
+			var result flowpb.FlowFilter
+			if err := dec.Decode(&result); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				log.Fatalf("failed to decode hubble-export-allowlist '%v': %s", enc, err)
 			}
-			log.Fatalf("failed to decode hubble-export-allowlist '%v': %s", enc, err)
+			c.HubbleExportAllowlist = append(c.HubbleExportAllowlist, &result)
 		}
-		c.HubbleExportAllowlist = append(c.HubbleExportAllowlist, &result)
 	}
 
 	for _, enc := range vp.GetStringSlice(HubbleExportDenylist) {
 		dec := json.NewDecoder(strings.NewReader(enc))
-		var result flowpb.FlowFilter
-		if err := dec.Decode(&result); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
+		for {
+			var result flowpb.FlowFilter
+			if err := dec.Decode(&result); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				log.Fatalf("failed to decode hubble-export-denylist '%v': %s", enc, err)
 			}
-			log.Fatalf("failed to decode hubble-export-denylist '%v': %s", enc, err)
+			c.HubbleExportDenylist = append(c.HubbleExportDenylist, &result)
 		}
-		c.HubbleExportDenylist = append(c.HubbleExportDenylist, &result)
 	}
 
 	if fm := vp.GetStringSlice(HubbleExportFieldmask); len(fm) > 0 {


### PR DESCRIPTION
### Description

This PR fixes the flag parsing of `hubble-export-allowlist` and `hubble-export-denylist` that currently only considers one JSON object from the Helm chart `allowList` and `denyList` options.

### Details

The parsing logic for the Hubble flowfilter flags does not exhaust the JSON decoder, resulting in only the first filter to be considered.

Using the following Helm values:
```yaml
  export:
    static:
      enabled: true
      filePath: /var/run/cilium/hubble/events.log
      allowList: []
      denyList:
        - '{"source_pod":["kube-system/"],"destination_ip":["1.1.1.1/32"]}'
        - '{"destination_pod":["kube-system/"],"source_ip":["1.1.1.1/32"]}'
```

Which will be used generate the cilium configmap:
```yaml
{{- if .Values.hubble.export.static.enabled }}
  ...
  hubble-export-allowlist: {{ .Values.hubble.export.static.allowList | join "," | quote }}
  hubble-export-denylist: {{ .Values.hubble.export.static.denyList | join "," | quote }}
{{- end }}
```

It seems we assume that the flag parsing done by viper when using stringSlice will return a list of JSON objects, but it actually returns one string with all JSON objects joined with a comma. Adding a log statement confirms the latter:
```
time="2025-04-07T19:43:20Z" level=info msg="decoding denylist argument from flag: hubble-export-denylist" filter-string="{\"source_pod\":[\"kube-system/\"],\"destination_ip\":[\"1.1.1.1/32\"]},{\"destination_pod\":[\"kube-system/\"],\"source_ip\":[\"1.1.1.1/32\"]}" idx=0 subsys=config type=deny
```

The JSON decoder is able to decode the first object, and on the next iteration would error out on the comma which it does not understand when outside an object, but since we don't continue iterating after the first result, no errors are raised, and consequently we also silently ignore the remaining objects.

To fix, join with an empty separator and wrap the decoding in a for loop to ensure we exhaust the content of the reader passed in the decoder.

This has already been fixed in 1.17+ following the migration of the exporter codebase to a hive cell and using a different flag parsing method.

### Testing

Add a log statement when building the filter list and notice that Hubble only parses the first filter it sees:
```
time="2025-04-07T19:27:47Z" level=info msg="  --hubble-export-allowlist=''" subsys=daemon
time="2025-04-07T19:27:47Z" level=info msg="  --hubble-export-denylist='{\"source_pod\":[\"kube-system/\"],\"destination_ip\":[\"1.1.1.1/32\"]}{\"destination_pod\":[\"kube-system/\"],\"source_ip\":[\"1.1.1.1/32\"]}'" subsys=daemon
time="2025-04-07T19:27:52Z" level=info msg="building filter list for allowlist" filters="[]" subsys=daemon
time="2025-04-07T19:27:52Z" level=info msg="building filter list for denylist" filters="[source_pod:\"kube-system/\" destination_ip:\"1.1.1.1/32\"]" subsys=daemon
```

Then apply the fix described above and confirm we see both filters in the filter list:
```
time="2025-04-07T19:30:13Z" level=info msg="  --hubble-export-allowlist=''" subsys=daemon
time="2025-04-07T19:30:13Z" level=info msg="  --hubble-export-denylist='{\"source_pod\":[\"kube-system/\"],\"destination_ip\":[\"1.1.1.1/32\"]}{\"destination_pod\":[\"kube-system/\"],\"source_ip\":[\"1.1.1.1/32\"]}'" subsys=daemon
time="2025-04-07T19:30:18Z" level=info msg="building filter list for allowlist" filters="[]" subsys=daemon
time="2025-04-07T19:30:18Z" level=info msg="building filter list for denylist" filters="[source_pod:\"kube-system/\" destination_ip:\"1.1.1.1/32\" source_ip:\"1.1.1.1/32\" destination_pod:\"kube-system/\"]" subsys=daemon
```
