### PR TITLE
cli: sysdump: collect logs from restarted test pods.

### DIFF
--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -642,10 +642,12 @@ func (c *Collector) Run() error {
 
 					p, err := c.Client.ListPods(ctx, namespace.Name, metav1.ListOptions{})
 					if err != nil {
-						return fmt.Errorf("failed to get logs from Hubble certgen pods")
+						return fmt.Errorf("failed to get logs from crashloop/restarted pods: %w", err)
 					}
-					if err := c.SubmitLogsTasks(filterCrashedPods(p, 0), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
-						return fmt.Errorf("failed to collect logs from Hubble certgen pods")
+					if err := c.SubmitLogsTasks(append(
+						filterCrashedPods(p, 0),
+						filterRestartedContainersPods(p, 0)...), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+						return fmt.Errorf("failed to collect logs from crashloop/restarted pods: %w", err)
 					}
 				}
 				return nil


### PR DESCRIPTION
Currently only crash-loop pods are included in the test pod crash log sysdump task.
However, we are also interested in test pods crashing once, such as in the case of a uncommon panic bug, that may not trigger a crash loop.
This change will also get logs for Pods that have
been restarted to be included in the sysdump task.

