### PR TITLE
fqdn/namemanager: Pre-allocate Identities for FQDN Selectors

### DIFF
--- a/pkg/fqdn/namemanager/cell.go
+++ b/pkg/fqdn/namemanager/cell.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/fqdn"
+	identityCell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -58,6 +59,8 @@ type ManagerParams struct {
 	Config  NameManagerConfig
 	IPCache ipc
 	EPMgr   endpoints
+	// To be able to pre-allocate locally-scoped identities for FQDN selectors.
+	IdentityAllocator identityCell.CachingIdentityAllocator
 }
 
 func adaptors(ipcache *ipcache.IPCache, epLookup endpointmanager.EndpointsLookup) (ipc, endpoints) {

--- a/pkg/fqdn/namemanager/manager.go
+++ b/pkg/fqdn/namemanager/manager.go
@@ -516,7 +516,10 @@ func (n *manager) allocateIdentity(_ []string) {
 		for _, ls := range lbls {
 			_, _, err := n.params.IdentityAllocator.AllocateIdentity(ctx, ls, true, identity.InvalidIdentity)
 			if err != nil {
-				log.WithError(err).WithField(logfields.Selector, sel).Error("Failed to pre-allocate identity for FQDN selector.")
+				n.logger.Error("Failed to pre-allocate identity for FQDN selector",
+					logfields.Error, err,
+					logfields.Selector, sel,
+				)
 			}
 		}
 	}


### PR DESCRIPTION
This is a performance improvement for DNS lookups.
Critical path latency for DNS lookups is reduced
by pre-allocating a matching identity whenever
the policy engine adds a new ToFQDN selector,
because no policy maps need to be updated when 
the first DNS lookup occurs.