### PR TITLE
connectivity: encryption tests: filter when icmpv6.type == 136

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -80,6 +80,9 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 		 * which resulted in neigh entry not being created due to
 		 * IFF_POINTOPOINT | IFF_NOARP set on cilium_wg0. Therefore,
 		 * NA should not be sent over WG.
+		 *
+		 * Note: We account for this in connectivity tests leak checks
+		 * by filtering out icmpv6 NA.
 		 */
 		if (ip6->nexthdr == IPPROTO_ICMPV6) {
 			__u8 icmp_type;

--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -145,7 +145,12 @@ func getFilter(ctx context.Context, t *check.Test, client, clientHost *check.Pod
 		// - Any pkt client <-> server with a given proto. This might be useful
 		//   to catch any regression in the DP which makes the pkt to bypass
 		//   the VXLAN tunnel.
-		filter := fmt.Sprintf("(%s and host %s and host %s) or (host %s and host %s and %s)",
+		// - *Not* a icmpv6 neighbor broadcast packet as these are intentionally
+		//    not encrypted:
+		//    Ref[0]: https://github.com/cilium/cilium/blob/e8543eef/bpf/lib/wireguard.h#L95
+		//    See Issue: #38688
+		filter := fmt.Sprintf("((%s and host %s and host %s) or (host %s and host %s and %s))"+
+			icmpv6NAFilter,
 			tunnelFilter,
 			clientHost.Address(features.IPFamilyV4), serverHost.Address(features.IPFamilyV4),
 			client.Address(ipFam), server.Address(ipFam), protoFilter)

--- a/cilium-cli/connectivity/tests/encryption_v2.go
+++ b/cilium-cli/connectivity/tests/encryption_v2.go
@@ -297,6 +297,10 @@ func (s *podToPodEncryptionV2) resolveTCPDumpFilters4(ctx context.Context) (clie
 	return s.nativeTCPDumpFilters4(ctx)
 }
 
+// icmpv6NAFilter filters ipv6 packets with icmpv6 type 136 (neighbor advertisement).
+// These are sent unencrypted when node encryption and wireguard is enabled.
+const icmpv6NAFilter = " and not (ip6[40] = 136)"
+
 // tunnelTCPDumpFilters6 is equivalent to tunnelTCPDumpFilters4 but for IPv6.
 func (s *podToPodEncryptionV2) tunnelTCPDumpFilters6(ctx context.Context) (clientFilter string, serverFilter string, err error) {
 	if ctx.Err() != nil {
@@ -348,6 +352,15 @@ func (s *podToPodEncryptionV2) tunnelTCPDumpFilters6(ctx context.Context) (clien
 
 	clientFilter = fmt.Sprintf(fmtFilter, baseTunnelFilter, clientInnerIPv6Src, clientInnerIPv6Dst)
 	serverFilter = fmt.Sprintf(fmtFilter, baseTunnelFilter, serverInnerIPv6Dst, serverInnerIPv6Src)
+
+	// If we have node encryption enabled with wireguard, filter out icmpv6 packets
+	// that are neighbor broadcast messages as these are not sent to the WG device.
+	encNode, ok := s.ct.Feature(features.EncryptionNode)
+	if ok && encNode.Enabled && s.encryptMode.Mode == "wireguard" {
+		clientFilter += icmpv6NAFilter
+		serverFilter += icmpv6NAFilter
+	}
+
 	return clientFilter, serverFilter, nil
 }
 


### PR DESCRIPTION
Addresses: https://github.com/cilium/cilium/issues/38688

*Update*: The expression `not icmp6[1] = 136` does not appear to work. I tested `ip6[40] = 136` and that does appear to filter by the NA msg. 

Filter expression can be tested in scapy via:

```
send(IPv6(src="fe80::5055:55ff:fe24:430")/ICMPv6ND_NA(), loop=1, inter=1
```
 
```
[nix-shell:~/Code/cilium]$ sudo tcpdump -i eth0 'ip6[40] = 136'
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
09:21:25.619892 IP6 lima-vm > ip6-allnodes: ICMP6, neighbor advertisement, tgt is ::, length 24
09:21:26.620501 IP6 lima-vm > ip6-allnodes: ICMP6, neighbor advertisement, tgt is ::, length 24
09:21:27.621135 IP6 lima-vm > ip6-allnodes: ICMP6, neighbor advertisement, tgt is ::, length 24
09:21:28.621907 IP6 lima-vm > ip6-allnodes: ICMP6, neighbor advertisement, tgt is ::, length 24
```