### PR TITLE
cilium-cli: Allow BINDIR environment variable to be dynamically configured for install path

### DIFF
--- a/cilium-cli/Makefile
+++ b/cilium-cli/Makefile
@@ -10,7 +10,7 @@ all: $(TARGET)
 .PHONY: all $(TARGET) local-release install clean test bench clean-tags tags
 
 
-BINDIR = /usr/local/bin
+PREFIX=/usr/local
 CLI_VERSION=$(shell git describe --tags --always)
 CLI_MAIN_DIR?=./cmd/cilium
 GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(CLI_VERSION)"


### PR DESCRIPTION
Added ?= to BINDIR variable to assign only if it's not set/doesn't have a value.

Fixes: #38786

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
