### PR TITLE
operator/networkpolicy: consider all rules when validating policy

### DIFF
--- a/operator/pkg/networkpolicy/cell.go
+++ b/operator/pkg/networkpolicy/cell.go
@@ -121,10 +121,10 @@ func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Ev
 
 	var errs error
 	if pol.Spec != nil {
-		errs = errors.Join(pol.Spec.Sanitize())
+		errs = errors.Join(errs, pol.Spec.Sanitize())
 	}
 	for _, r := range pol.Specs {
-		errs = errors.Join(r.Sanitize())
+		errs = errors.Join(errs, r.Sanitize())
 	}
 
 	newPol := pol.DeepCopy()
@@ -171,10 +171,10 @@ func (pv *policyValidator) handleCCNPEvent(ctx context.Context, event resource.E
 
 	var errs error
 	if pol.Spec != nil {
-		errs = errors.Join(pol.Spec.Sanitize())
+		errs = errors.Join(errs, pol.Spec.Sanitize())
 	}
 	for _, r := range pol.Specs {
-		errs = errors.Join(r.Sanitize())
+		errs = errors.Join(errs, r.Sanitize())
 	}
 
 	newPol := pol.DeepCopy()


### PR DESCRIPTION
Currently, only the validation result of the last policy rule is propagated to the `CiliumNetworkPolicy`/`CiliumClusterwideNetworkPolicy` status field. Fix this by joining all sanitization errors instead of just the last one in a list of rules.

Fixes #38795

```release-note
Fix a bug where a `CiliumNetworkPolicy`/`CiliumClusterwideNetworkPolicy` containing invalid rules would not be reported with invalid status.
```
