### PR TITLE
[v1.17] bpf: host: ipsec: check whether destination has tunnel_endpoint

### DIFF
--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -364,6 +364,9 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	if (!dst)
 		return CTX_ACT_OK;
 
+	if (!dst->tunnel_endpoint)
+		return CTX_ACT_OK;
+
 	if (!ipsec_redirect_sec_id_ok(src_sec_identity, dst->sec_identity,
 				      ip_proto))
 		return CTX_ACT_OK;


### PR DESCRIPTION
In the new IPSec encryption code @ to-netdev, check whether the destination has a valid tunnel_endpoint that we can use to select its nodeID. This matches how the encryption path in from-container behaves.