### PR TITLE
connectivity: Correct version check for Ingress test

### DIFF
--- a/cilium-cli/connectivity/builder/pod_to_ingress_service.go
+++ b/cilium-cli/connectivity/builder/pod_to_ingress_service.go
@@ -65,7 +65,7 @@ func (t podToIngressService) build(ct *check.ConnectivityTest, templates map[str
 		})
 
 	newTest("pod-to-ingress-service-deny-source-egress-other-node", ct).
-		WithCiliumVersion(">1.17.1 >1.16.7 >1.15.14").
+		WithCiliumVersion(">1.17.1 || >1.16.7 <1.17.0 || >1.15.14 <1.16.0").
 		WithFeatureRequirements(features.RequireEnabled(features.IngressController)).
 		WithCiliumPolicy(denyIngressSourceEgressOtherNodePolicyYML).
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only


### PR DESCRIPTION
The conditions should be including per minor version with OR operation. Otherwise, the test will be skipped like below

```
Skipping test [pod-to-ingress-service-deny-source-egress-other-node] [20/22] (requires Cilium version >1.17.1 >1.16.7 >1.15.14 but running 1.16.8)
```

Fixes: 212c22832589e3d3bdd973a04e9e872572cb8f53
Relates: https://github.com/cilium/cilium/pull/38053#discussion_r2032770250

Reported-by: Julian Wiedmann <jwi@isovalent.com>
Suggested-by: Simone Magnani <simone.magnani@isovalent.com>


