### PR TITLE
build: Add flag to control goexperiments

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -360,6 +360,7 @@ Makefile* @cilium/build
 /contrib/coccinelle/ @cilium/sig-datapath
 /contrib/scripts/portgen.py @cilium/sig-datapath
 /contrib/scripts/check-datapathconfig.sh @cilium/loader
+/contrib/scripts/check-fipsonly.sh @cilium/build @cilium/security
 /daemon/ @cilium/sig-agent
 /daemon/cmd/datapath.go @cilium/sig-datapath
 /daemon/cmd/endpoint* @cilium/endpoint
@@ -674,3 +675,4 @@ Makefile* @cilium/build
 /vendor/ @cilium/vendor
 /VERSION @cilium/release-managers
 /.clang-format @cilium/contributing
+/**/fipsonly.go @cilium/build @cilium/security

--- a/Makefile
+++ b/Makefile
@@ -458,6 +458,8 @@ endif
 	$(QUIET) contrib/scripts/check-datapathconfig.sh
 	@$(ECHO_CHECK) $(GO) run ./tools/slogloggercheck .
 	$(QUIET)$(GO) run ./tools/slogloggercheck .
+	@$(ECHO_CHECK) contrib/scripts/check-fipsonly.sh
+	$(QUIET) contrib/scripts/check-fipsonly.sh
 
 pprof-heap: ## Get Go pprof heap profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/heap

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -179,6 +179,9 @@ GO_CLEAN_FLAGS += -mod=vendor
 
 CGO_ENABLED ?= 0
 
+# See https://pkg.go.dev/internal/goexperiment
+GOEXPERIMENT ?=
+
 # Support CGO cross-compiling for amd64 and arm64 targets
 CGO_CC =
 CROSS_ARCH =
@@ -191,7 +194,11 @@ else ifeq ($(CROSS_ARCH),amd64)
     CGO_CC = CC=x86_64-linux-gnu-gcc
 endif
 
-GO_BUILD = CGO_ENABLED=$(CGO_ENABLED) $(CGO_CC) $(GO) build
+ifneq ($(GOEXPERIMENT),)
+    GO_BUILD = GOEXPERIMENT=$(GOEXPERIMENT) CGO_ENABLED=$(CGO_ENABLED) $(CGO_CC) $(GO) build
+else
+    GO_BUILD = CGO_ENABLED=$(CGO_ENABLED) $(CGO_CC) $(GO) build
+endif
 
 ifneq ($(RACE),)
     GO_BUILD_FLAGS += -race
@@ -209,6 +216,11 @@ endif
 
 ifneq ($(LOCKDEBUG),)
     GO_TAGS_FLAGS += lockdebug
+endif
+
+ifneq ($(findstring boringcrypto,$(GOEXPERIMENT)),)
+    CGO_ENABLED = 1
+    GO_BUILD_LDFLAGS += -linkmode external -extldflags "-static --enable-static-nss"
 endif
 
 GO_BUILD_FLAGS += -ldflags '$(GO_BUILD_LDFLAGS) $(EXTRA_GO_BUILD_LDFLAGS)' -tags=$(call join-with-comma,$(GO_TAGS_FLAGS)) $(EXTRA_GO_BUILD_FLAGS)

--- a/bugtool/fipsonly.go
+++ b/bugtool/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/cilium-cli/cmd/cilium/fipsonly.go
+++ b/cilium-cli/cmd/cilium/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/cilium-dbg/fipsonly.go
+++ b/cilium-dbg/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/cilium-health/fipsonly.go
+++ b/cilium-health/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/clustermesh-apiserver/fipsonly.go
+++ b/clustermesh-apiserver/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/contrib/scripts/check-fipsonly.sh
+++ b/contrib/scripts/check-fipsonly.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of Cilium
+
+set -eu
+
+EXCLUDED_DIRS=(
+    "cilium-health/responder"
+    "contrib/examples/statedb"
+    "contrib/examples/statedb_k8s"
+    "images/builder"
+    "pkg/datapath/loader/tools"
+    "pkg/k8s/resource/example"
+    "pkg/loadbalancer/benchmark/cmd"
+    "pkg/loadbalancer/repl"
+    "tools/alignchecker"
+    "tools/api-flaggen"
+    "tools/crdcheck"
+    "tools/crdlistgen"
+    "tools/dev-doctor"
+    "tools/dpgen"
+    "tools/feature-helm-generator"
+    "tools/legacyhguardcheck"
+    "tools/licensecheck"
+    "tools/licensegen"
+    "tools/mount"
+    "tools/slogloggercheck"
+    "tools/spdxconv"
+    "tools/sysctlfix"
+    "tools/testowners"
+)
+
+FIPSONLY_EXAMPLE=$(
+    cat <<EOT
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"
+EOT
+)
+
+REQUIRED_LINES=(
+    "//go:build boringcrypto"
+    "import _ \"crypto/tls/fipsonly\""
+)
+
+main_packages() {
+    grep -lr --include="*.go" --exclude-dir="vendor" "package main" |
+        xargs dirname |
+        sort -u
+}
+
+has_error=0
+
+for package in $(main_packages); do
+    # Skip excluded directories
+    for excluded in "${EXCLUDED_DIRS[@]}"; do
+        if [[ "${package}" == "${excluded}" ]]; then
+            echo "Skipping excluded package ${package}"
+            continue 2
+        fi
+    done
+
+    echo "Inspecting package ${package}"
+    if [[ -f "${package}/fipsonly.go" ]]; then
+        # check if the file contains the required lines
+        for line in "${REQUIRED_LINES[@]}"; do
+            if ! grep -q "${line}" "${package}/fipsonly.go"; then
+                echo >&2 "::error file=${package}/fipsonly.go,line=1,col=1::File ${package}/fipsonly.go is missing required line: '${line}'"
+                has_error=1
+                continue 2
+            fi
+        done
+        echo "File ${package}/fipsonly.go is valid"
+    else
+        echo >&2 "::error::File ${package}/fipsonly.go is missing"
+        has_error=1
+        continue 2
+    fi
+done
+
+if [ $has_error -eq 1 ]; then
+    echo >&2 "::error::FIPSONLY check failed. Please ensure that all main packages either have a 'fipsonly.go' file or are added to the exclusion list in ./contrib/scripts/check-fipsonly.sh"
+    echo >&2 "Example fipsonly.go file content:"
+    echo >&2 "$FIPSONLY_EXAMPLE"
+    exit 1
+else
+    echo "FIPSONLY check passed"
+fi

--- a/daemon/fipsonly.go
+++ b/daemon/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/hubble-relay/fipsonly.go
+++ b/hubble-relay/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/hubble/fipsonly.go
+++ b/hubble/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/operator/fipsonly.go
+++ b/operator/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/plugins/cilium-cni/fipsonly.go
+++ b/plugins/cilium-cni/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/plugins/cilium-docker/fipsonly.go
+++ b/plugins/cilium-docker/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Related issue: #23919 

```release-note
build: Add flag to control goexperiments and add configuration to use fipsonly package when the boringcrypto goexperiment is used
```

---

This PR makes it easier to use [go experiments](https://pkg.go.dev/internal/goexperiment) by passing down the `GOEXPERIMENT` environment variable to the `go build` commands.

It also adds config for the `boringcrypto` goexperiment:
* Enable CGO when boringcrypto is enabled
* Enable the fipsonly package when boringcrypto is enabled


Notes on the boringcrypto goexperiment and FIPS compliance:
* the boringcrypto goexperiment is FIPS validated and hence can be relied on to achieve FIPS compliance. ([ref](https://boringssl.googlesource.com/boringssl/+/master/crypto/fipsmodule/FIPS.md))
* go 1.24 ships with a pure go implementation of fips140 approved algorithms, but this implementation is currently still pending approval by a CMVP-accredited laboratory. Hence as of today, this can not be relied on to achieve FIPS compliance. ([ref](https://go.dev/doc/security/fips140))
* the cilium contributors and maintainers do not provide any guarantees with regards to the FIPS compliance status of the cilium projects and tools. Interested users will have to evaluate for themselves whether the code is useful for their own purposes. As such, this PR does not update cilium release processes to provide any artifacts marked as "FIPS enabled/compliant". parties interested in achieving FIPS compliance when using cilium are responsible to build themselves compliant artifacts and ensure their configuration covers all the required regulatory requirements to achieve FIPS compliance.


Example of using the boringcrypto goexperiment:
```sh
$ NOSTRIP=1 GOEXPERIMENT=boringcrypto make -C operator cilium-operator-aws
make: Entering directory '/home/hadrien/go/src/github.com/cilium/cilium/operator'
GOEXPERIMENT=boringcrypto CGO_ENABLED=1  go build  -mod=vendor -ldflags ' -X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.18.0-dev 82b43c379d 2025-03-24T12:29:50+01:00" -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=0de0009734b0b9e9481369813a047e69d6d7915b" -linkmode external -extldflags "-static --enable-static-nss" ' -tags=osusergo,ipam_provider_aws  -o cilium-operator-aws
make: Leaving directory '/home/hadrien/go/src/github.com/cilium/cilium/operator'

$ go tool nm operator/cilium-operator-aws | grep -E 'sig.FIPSOnly|sig.BoringCrypto'
  489a20 t crypto/internal/boring/sig.BoringCrypto.abi0
  489a40 t crypto/internal/boring/sig.FIPSOnly.abi0
```
Note: in the example above, `NOSTRIP` is only used to preserve the debug symbols table and show that both the `BoringCrypto` and `FIPSOnly` [signatures](https://pkg.go.dev/crypto/internal/boring/sig) are present in the resulting binary.