### PR TITLE
docs: Fix BGP localPort configuration example

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -73,9 +73,9 @@ and two peers configured under this BGP instance.
       bgpInstances:
       - name: "instance-65000"
         localASN: 65000
+        localPort: 179
         peers:
         - name: "peer-65000-tor1"
-          localPort: 179
           peerASN: 65000
           peerAddress: fd00:10:0:0::1
           peerConfigRef:


### PR DESCRIPTION
LocalPort is configurable on the instance level, not on the peer level ([API ref](https://github.com/cilium/cilium/blob/2c3a60afe890d8e360538195d771713c7386bfd3/pkg/k8s/apis/cilium.io/v2/bgp_cluster_types.go#L85-L92)).

