### PR TITLE
IPAM: Use testing.T.Context added in Go 1.24 in tests

### DIFF
--- a/pkg/alibabacloud/eni/node_stat_test.go
+++ b/pkg/alibabacloud/eni/node_stat_test.go
@@ -4,7 +4,6 @@
 package eni
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -51,7 +50,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 			},
 		},
 	}
-	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), n.logger)
+	_, stats, err := n.ResyncInterfacesAndIPs(t.Context(), n.logger)
 	assert.NoError(err)
 	// 3 ENIs, 10 IPs per ENI, 1 primary IP and one ENI is primary.
 	assert.Equal(19, stats.NodeCapacity)

--- a/pkg/alibabacloud/eni/node_test.go
+++ b/pkg/alibabacloud/eni/node_test.go
@@ -4,7 +4,6 @@
 package eni
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -66,7 +65,7 @@ func TestCreateInterface(t *testing.T) {
 	setup(t)
 
 	alibabaAPI.UpdateENIs(primaryENIs)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
@@ -96,7 +95,7 @@ func TestCreateInterface(t *testing.T) {
 		return nil
 	})
 
-	toAlloc, _, err := mngr.Get("node1").Ops().CreateInterface(context.Background(), &ipam.AllocationAction{
+	toAlloc, _, err := mngr.Get("node1").Ops().CreateInterface(t.Context(), &ipam.AllocationAction{
 		IPv4: ipam.IPAllocationAction{
 			MaxIPsToAllocate: 10,
 		},
@@ -105,7 +104,7 @@ func TestCreateInterface(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 10, toAlloc)
 
-	toAlloc, _, err = mngr.Get("node1").Ops().CreateInterface(context.Background(), &ipam.AllocationAction{
+	toAlloc, _, err = mngr.Get("node1").Ops().CreateInterface(t.Context(), &ipam.AllocationAction{
 		IPv4: ipam.IPAllocationAction{
 			MaxIPsToAllocate: 11,
 		},
@@ -119,7 +118,7 @@ func TestCandidateAndEmptyInterfaces(t *testing.T) {
 	setup(t)
 
 	alibabaAPI.UpdateENIs(primaryENIs)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
@@ -150,7 +149,7 @@ func TestPrepareIPAllocation(t *testing.T) {
 	setup(t)
 
 	alibabaAPI.UpdateENIs(primaryENIs)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
@@ -163,7 +162,7 @@ func TestPrepareIPAllocation(t *testing.T) {
 	require.Equal(t, 2, a.EmptyInterfaceSlots+a.IPv4.InterfaceCandidates, "empty: %v, candidates: %v", a.EmptyInterfaceSlots, a.IPv4.InterfaceCandidates)
 
 	// create one eni
-	toAlloc, _, err := mngr.Get("node1").Ops().CreateInterface(context.Background(), &ipam.AllocationAction{
+	toAlloc, _, err := mngr.Get("node1").Ops().CreateInterface(t.Context(), &ipam.AllocationAction{
 		IPv4: ipam.IPAllocationAction{
 			MaxIPsToAllocate: 10,
 		},

--- a/pkg/aws/ec2/mock/mock_test.go
+++ b/pkg/aws/ec2/mock/mock_test.go
@@ -4,7 +4,6 @@
 package mock
 
 import (
-	"context"
 	"errors"
 	"net"
 	"testing"
@@ -21,19 +20,19 @@ func TestMock(t *testing.T) {
 	api := NewAPI([]*ipamTypes.Subnet{{ID: "s-1", AvailableAddresses: 100}}, []*ipamTypes.VirtualNetwork{{ID: "v-1"}}, []*types.SecurityGroup{{ID: "sg-1"}}, []*ipamTypes.RouteTable{})
 	require.NotNil(t, api)
 
-	eniID1, _, err := api.CreateNetworkInterface(context.TODO(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 
-	eniID2, _, err := api.CreateNetworkInterface(context.TODO(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID2, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 
-	_, err = api.AttachNetworkInterface(context.TODO(), 0, "i-1", eniID1)
+	_, err = api.AttachNetworkInterface(t.Context(), 0, "i-1", eniID1)
 	require.NoError(t, err)
 
 	_, ok := api.enis["i-1"][eniID1]
 	require.True(t, ok)
 
-	_, err = api.AttachNetworkInterface(context.TODO(), 1, "i-1", eniID2)
+	_, err = api.AttachNetworkInterface(t.Context(), 1, "i-1", eniID2)
 	require.NoError(t, err)
 
 	_, ok = api.enis["i-1"][eniID1]
@@ -42,23 +41,23 @@ func TestMock(t *testing.T) {
 	require.True(t, ok)
 
 	// Attached ENIs cannot be deleted
-	err = api.DeleteNetworkInterface(context.TODO(), eniID1)
+	err = api.DeleteNetworkInterface(t.Context(), eniID1)
 	require.Error(t, err)
 
 	// Detach and delete ENI
-	err = api.DetachNetworkInterface(context.TODO(), "i-1", eniID1)
+	err = api.DetachNetworkInterface(t.Context(), "i-1", eniID1)
 	require.NoError(t, err)
-	err = api.DeleteNetworkInterface(context.TODO(), eniID1)
+	err = api.DeleteNetworkInterface(t.Context(), eniID1)
 	require.NoError(t, err)
 
 	// ENIs cannot be deleted twice
-	err = api.DeleteNetworkInterface(context.TODO(), eniID1)
+	err = api.DeleteNetworkInterface(t.Context(), eniID1)
 	require.Error(t, err)
 
 	// Detach and delete ENI
-	err = api.DetachNetworkInterface(context.TODO(), "i-1", eniID2)
+	err = api.DetachNetworkInterface(t.Context(), "i-1", eniID2)
 	require.NoError(t, err)
-	err = api.DeleteNetworkInterface(context.TODO(), eniID2)
+	err = api.DeleteNetworkInterface(t.Context(), eniID2)
 	require.NoError(t, err)
 
 	_, ok = api.enis["i-1"][eniID1]
@@ -78,7 +77,7 @@ func TestMock(t *testing.T) {
 	}
 	api.UpdateSecurityGroups([]*types.SecurityGroup{sg1, sg2})
 
-	sgMap, err := api.GetSecurityGroups(context.TODO())
+	sgMap, err := api.GetSecurityGroups(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, types.SecurityGroupMap{"sg1": sg1, "sg2": sg2}, sgMap)
 }
@@ -90,27 +89,27 @@ func TestSetMockError(t *testing.T) {
 	mockError := errors.New("error")
 
 	api.SetMockError(CreateNetworkInterface, mockError)
-	_, _, err := api.CreateNetworkInterface(context.TODO(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	_, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(AttachNetworkInterface, mockError)
-	_, err = api.AttachNetworkInterface(context.TODO(), 0, "i-1", "e-1")
+	_, err = api.AttachNetworkInterface(t.Context(), 0, "i-1", "e-1")
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(DeleteNetworkInterface, mockError)
-	err = api.DeleteNetworkInterface(context.TODO(), "e-1")
+	err = api.DeleteNetworkInterface(t.Context(), "e-1")
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(AssignPrivateIpAddresses, mockError)
-	_, err = api.AssignPrivateIpAddresses(context.TODO(), "e-1", 10)
+	_, err = api.AssignPrivateIpAddresses(t.Context(), "e-1", 10)
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(UnassignPrivateIpAddresses, mockError)
-	err = api.UnassignPrivateIpAddresses(context.TODO(), "e-1", []string{"10.0.0.10", "10.0.0.11"})
+	err = api.UnassignPrivateIpAddresses(t.Context(), "e-1", []string{"10.0.0.10", "10.0.0.11"})
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(ModifyNetworkInterface, mockError)
-	err = api.ModifyNetworkInterface(context.TODO(), "e-1", "a-1", true)
+	err = api.ModifyNetworkInterface(t.Context(), "e-1", "a-1", true)
 	require.Equal(t, mockError, err)
 }
 
@@ -119,7 +118,7 @@ func TestSetLimiter(t *testing.T) {
 	require.NotNil(t, api)
 
 	api.SetLimiter(10.0, 2)
-	_, _, err := api.CreateNetworkInterface(context.TODO(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	_, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
 }
 
@@ -180,7 +179,7 @@ func TestGetRouteTables(t *testing.T) {
 		routeTables,
 	)
 
-	tables, err := api.GetRouteTables(context.Background())
+	tables, err := api.GetRouteTables(t.Context())
 	require.NoError(t, err)
 	require.Len(t, tables, 2)
 

--- a/pkg/aws/eni/instances_test.go
+++ b/pkg/aws/eni/instances_test.go
@@ -4,7 +4,6 @@
 package eni
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -193,16 +192,16 @@ var (
 	}
 )
 
-func iteration1(api *ec2mock.API, mngr *InstancesManager) {
+func iteration1(t *testing.T, api *ec2mock.API, mngr *InstancesManager) {
 	api.UpdateENIs(enis)
-	mngr.Resync(context.TODO())
+	mngr.Resync(t.Context())
 }
 
-func iteration2(api *ec2mock.API, mngr *InstancesManager) {
+func iteration2(t *testing.T, api *ec2mock.API, mngr *InstancesManager) {
 	api.UpdateSubnets(subnets2)
 	api.UpdateSecurityGroups(securityGroups2)
 	api.UpdateENIs(enis2)
-	mngr.Resync(context.TODO())
+	mngr.Resync(t.Context())
 }
 
 func TestGetSubnet(t *testing.T) {
@@ -217,7 +216,7 @@ func TestGetSubnet(t *testing.T) {
 	require.Nil(t, mngr.GetSubnet("subnet-2"))
 	require.Nil(t, mngr.GetSubnet("subnet-3"))
 
-	iteration1(api, mngr)
+	iteration1(t, api, mngr)
 
 	subnet1 := mngr.GetSubnet("subnet-1")
 	require.NotNil(t, subnet1)
@@ -229,7 +228,7 @@ func TestGetSubnet(t *testing.T) {
 
 	require.Nil(t, mngr.GetSubnet("subnet-3"))
 
-	iteration2(api, mngr)
+	iteration2(t, api, mngr)
 
 	subnet1 = mngr.GetSubnet("subnet-1")
 	require.NotNil(t, subnet1)
@@ -252,8 +251,8 @@ func TestFindSubnetByIDs(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
-	iteration1(api, mngr)
-	iteration2(api, mngr)
+	iteration1(t, api, mngr)
+	iteration2(t, api, mngr)
 
 	// exact match subnet-1
 	s := mngr.FindSubnetByIDs("vpc-1", "us-west-1", []string{"subnet-1"})
@@ -292,8 +291,8 @@ func TestFindSubnetByTags(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
-	iteration1(api, mngr)
-	iteration2(api, mngr)
+	iteration1(t, api, mngr)
+	iteration2(t, api, mngr)
 
 	// exact match subnet-1
 	s := mngr.FindSubnetByTags("vpc-1", "us-west-1", ipamTypes.Tags{"tag1": "tag1"})
@@ -334,7 +333,7 @@ func TestGetSecurityGroupByTags(t *testing.T) {
 	})
 	require.Empty(t, sgGroups)
 
-	iteration1(api, mngr)
+	iteration1(t, api, mngr)
 	reqTags := ipamTypes.Tags{
 		"k1": "v1",
 	}
@@ -342,7 +341,7 @@ func TestGetSecurityGroupByTags(t *testing.T) {
 	require.Len(t, sgGroups, 1)
 	require.Equal(t, reqTags, sgGroups[0].Tags)
 
-	iteration2(api, mngr)
+	iteration2(t, api, mngr)
 	reqTags = ipamTypes.Tags{
 		"k2": "v2",
 	}
@@ -351,7 +350,7 @@ func TestGetSecurityGroupByTags(t *testing.T) {
 	require.Equal(t, reqTags, sgGroups[0].Tags)
 
 	// iteration 3
-	mngr.Resync(context.TODO())
+	mngr.Resync(t.Context())
 	reqTags = ipamTypes.Tags{
 		"k3": "v3",
 	}

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -4,7 +4,6 @@
 package eni
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -149,11 +148,11 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -195,11 +194,11 @@ func TestNodeManagerPrefixDelegation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, true)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, true)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, true)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -266,11 +265,11 @@ func TestNodeManagerENIWithSGTags(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -328,11 +327,11 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -386,11 +385,11 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -416,8 +415,8 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 
 	// Use 10 out of 10 IPs, PreAllocate 1 must kick in and allocate an additional IP
 	mngr.Upsert(updateCiliumNode(cn, 10, 10))
-	syncTime := instances.Resync(context.TODO())
-	mngr.Resync(context.TODO(), syncTime)
+	syncTime := instances.Resync(t.Context())
+	mngr.Resync(t.Context(), syncTime)
 	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second))
 	node = mngr.Get("node2")
 	require.NotNil(t, node)
@@ -453,11 +452,11 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, true, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -513,23 +512,23 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	node.UpdatedResource(obj)
 
 	// Excess timestamps should be registered after this
-	syncTime := instances.Resync(context.TODO())
-	mngr.Resync(context.TODO(), syncTime)
+	syncTime := instances.Resync(t.Context())
+	mngr.Resync(t.Context(), syncTime)
 
 	// Acknowledge release IPs after 3 secs
 	time.AfterFunc(3*time.Second, func() {
 		// Excess delay duration should have elapsed by now, trigger resync again.
 		// IPs should be marked as excess
-		syncTime := instances.Resync(context.TODO())
-		mngr.Resync(context.TODO(), syncTime)
+		syncTime := instances.Resync(t.Context())
+		mngr.Resync(t.Context(), syncTime)
 		time.Sleep(1 * time.Second)
 		node.PopulateIPReleaseStatus(obj)
 		// Fake acknowledge IPs for release like agent would.
 		testipam.FakeAcknowledgeReleaseIps(obj)
 		node.UpdatedResource(obj)
 		// Resync one more time to process acknowledgements.
-		syncTime = instances.Resync(context.TODO())
-		mngr.Resync(context.TODO(), syncTime)
+		syncTime = instances.Resync(t.Context())
+		mngr.Resync(t.Context(), syncTime)
 	})
 
 	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second))
@@ -557,16 +556,16 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	err = ec2api.TagENI(context.TODO(), eniID1, map[string]string{
+	err = ec2api.TagENI(t.Context(), eniID1, map[string]string{
 		"foo":                 "bar",
 		"cilium.io/no_manage": "true",
 	})
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -594,7 +593,7 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 
 	// Use 7 out of 8 IPs
 	mngr.Upsert(updateCiliumNode(cn, 8, 7))
-	mngr.Resync(context.TODO(), instances.Resync(context.TODO()))
+	mngr.Resync(t.Context(), instances.Resync(t.Context()))
 	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
 
 	node = mngr.Get("node1")
@@ -627,11 +626,11 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -651,8 +650,8 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	// assigned the remaining 3 that the t2.xlarge instance type supports
 	// (3x15 - 3 = 42 max)
 	mngr.Upsert(updateCiliumNode(cn, 42, 40))
-	syncTime := instances.Resync(context.TODO())
-	mngr.Resync(context.TODO(), syncTime)
+	syncTime := instances.Resync(t.Context())
+	mngr.Resync(t.Context(), syncTime)
 	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second))
 
 	node = mngr.Get("node2")
@@ -687,11 +686,11 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, testSubnet.ID, "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, testSubnet.ID, "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -759,11 +758,11 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	state := make([]*nodeState, numNodes)
 
 	for i := range state {
-		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "mgmt-1", "desc", []string{"sg1", "sg2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "mgmt-1", "desc", []string{"sg1", "sg2"}, false)
 		require.NoError(t, err)
-		_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, fmt.Sprintf("i-testNodeManagerManyNodes-%d", i), eniID)
+		_, err = ec2api.AttachNetworkInterface(t.Context(), 0, fmt.Sprintf("i-testNodeManagerManyNodes-%d", i), eniID)
 		require.NoError(t, err)
-		instancesManager.Resync(context.TODO())
+		instancesManager.Resync(t.Context())
 		s := &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("i-testNodeManagerManyNodes-%d", i)}
 		s.cn = newCiliumNode(s.name, withTestDefaults(), withInstanceID(s.instanceName), withInstanceType("c3.xlarge"),
 			withFirstInterfaceIndex(1), withIPAMPreAllocate(1), withIPAMMinAllocate(minAllocate))
@@ -786,7 +785,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	// The above check returns as soon as the address requirements are met.
 	// The metrics may still be oudated, resync all nodes to update
 	// metrics.
-	mngr.Resync(context.TODO(), time.Now())
+	mngr.Resync(t.Context(), time.Now())
 
 	require.Equal(t, numNodes, metricsapi.Nodes("total"))
 	require.Equal(t, 0, metricsapi.Nodes("in-deficit"))
@@ -824,11 +823,11 @@ func TestNodeManagerInstanceNotRunning(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	ec2api.SetMockError(ec2mock.AttachNetworkInterface, errors.New("foo is not 'running' foo"))
 	require.NoError(t, err)
@@ -871,15 +870,15 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	eniID2, _, err := ec2api.CreateNetworkInterface(context.TODO(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID2, _, err := ec2api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 1, instanceID, eniID2)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, instanceID, eniID2)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -895,16 +894,16 @@ func TestInstanceBeenDeleted(t *testing.T) {
 
 	// Delete all enis attached to instance, this mocks the operation of
 	// deleting the instance. The deletion should be detected.
-	err = ec2api.DetachNetworkInterface(context.TODO(), instanceID, eniID1)
+	err = ec2api.DetachNetworkInterface(t.Context(), instanceID, eniID1)
 	require.NoError(t, err)
-	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID1)
+	err = ec2api.DeleteNetworkInterface(t.Context(), eniID1)
 	require.NoError(t, err)
-	err = ec2api.DetachNetworkInterface(context.TODO(), instanceID, eniID2)
+	err = ec2api.DetachNetworkInterface(t.Context(), instanceID, eniID2)
 	require.NoError(t, err)
-	err = ec2api.DeleteNetworkInterface(context.TODO(), eniID2)
+	err = ec2api.DeleteNetworkInterface(t.Context(), eniID2)
 	require.NoError(t, err)
 	// Resync instances from mocked AWS
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	// Use 2 out of 9 IPs
 	mngr.Upsert(updateCiliumNode(cn, 9, 2))
 
@@ -932,11 +931,11 @@ func TestNodeManagerStaticIP(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -978,13 +977,13 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 	require.NoError(t, err)
-	_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, instanceID, eniID1)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	staticIP, err := ec2api.AssociateEIP(context.TODO(), instanceID, make(ipamTypes.Tags))
+	staticIP, err := ec2api.AssociateEIP(t.Context(), instanceID, make(ipamTypes.Tags))
 	require.NoError(t, err)
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -1020,11 +1019,11 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 
 	b.ResetTimer()
 	for i := range state {
-		eniID, _, err := ec2api.CreateNetworkInterface(context.TODO(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(b.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
 		require.NoError(b, err)
-		_, err = ec2api.AttachNetworkInterface(context.TODO(), 0, fmt.Sprintf("i-benchmarkAllocWorker-%d", i), eniID)
+		_, err = ec2api.AttachNetworkInterface(b.Context(), 0, fmt.Sprintf("i-benchmarkAllocWorker-%d", i), eniID)
 		require.NoError(b, err)
-		instances.Resync(context.TODO())
+		instances.Resync(b.Context())
 		s := &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("i-benchmarkAllocWorker-%d", i)}
 		s.cn = newCiliumNode(s.name, withTestDefaults(), withInstanceID(s.instanceName), withInstanceType("m4.large"),
 			withIPAMPreAllocate(1), withIPAMMinAllocate(10))

--- a/pkg/aws/eni/node_stat_test.go
+++ b/pkg/aws/eni/node_stat_test.go
@@ -4,7 +4,6 @@
 package eni
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -54,7 +53,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 	ipamNode.SetPoolMaintainer(&mockMaintainer{})
 	n.node = ipamNode
 
-	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), hivetest.Logger(t))
+	_, stats, err := n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
 	assert.NoError(err)
 	// m5.large = 10 IPs per ENI, 3 ENIs.
 	// Accounting for primary ENI IPs, we should be able to allocate (10-1)*3=27 IPs.
@@ -62,7 +61,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 
 	cn.Spec.ENI.UsePrimaryAddress = new(bool)
 	*cn.Spec.ENI.UsePrimaryAddress = true
-	_, stats, err = n.ResyncInterfacesAndIPs(context.Background(), hivetest.Logger(t))
+	_, stats, err = n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
 	assert.NoError(err)
 	// In this case, we disable using allocated primary IP,
 	// so we should be able to allocate 10*3=30 IPs.
@@ -70,7 +69,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 
 	ipamNode.prefixDelegation = true
 	// Note: m5a.large is a nitro instance, so it supports prefix delegation.
-	_, stats, err = n.ResyncInterfacesAndIPs(context.Background(), hivetest.Logger(t))
+	_, stats, err = n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
 	assert.NoError(err)
 	// m5.large = 10 IPs per ENI, 3 ENIs.
 	// Accounting for primary ENI IPs, we should be able to allocate (10-1)*3=27 IPs.
@@ -81,7 +80,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 
 	// Lets turn off UsePrimaryAddress.
 	*cn.Spec.ENI.UsePrimaryAddress = false
-	_, stats, err = n.ResyncInterfacesAndIPs(context.Background(), hivetest.Logger(t))
+	_, stats, err = n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
 	assert.NoError(err)
 	// In this case, we have prefix delegation enabled.
 	// Thus we have 16 addr * 9 addr * 3 ENIs = 432 IPs.
@@ -103,7 +102,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 
 	// Finally, we have the case where an eni has a leftover prefix available.
 	// Thus, we add an additional 16 IPs to the capacity.
-	_, stats, err = n.ResyncInterfacesAndIPs(context.Background(), hivetest.Logger(t))
+	_, stats, err = n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
 	assert.NoError(err)
 	assert.Equal(27+16-1, stats.NodeCapacity)
 }

--- a/pkg/azure/api/mock/mock_test.go
+++ b/pkg/azure/api/mock/mock_test.go
@@ -4,7 +4,6 @@
 package mock
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -20,11 +19,11 @@ func TestMock(t *testing.T) {
 	api := NewAPI([]*ipamTypes.Subnet{subnet}, []*ipamTypes.VirtualNetwork{{ID: "v-1"}})
 	require.NotNil(t, api)
 
-	instances, err := api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
+	instances, err := api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
 	require.NoError(t, err)
 	require.Equal(t, 0, instances.NumInstances())
 
-	vnets, subnets, err := api.GetVpcsAndSubnets(context.Background())
+	vnets, subnets, err := api.GetVpcsAndSubnets(t.Context())
 	require.NoError(t, err)
 	require.Len(t, vnets, 1)
 	require.Equal(t, &ipamTypes.VirtualNetwork{ID: "v-1"}, vnets["v-1"])
@@ -39,7 +38,7 @@ func TestMock(t *testing.T) {
 		Resource: resource.DeepCopy(),
 	})
 	api.UpdateInstances(instances)
-	instances, err = api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
+	instances, err = api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
 	require.NoError(t, err)
 	require.Equal(t, 1, instances.NumInstances())
 	instances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.InterfaceRevision) error {
@@ -48,9 +47,9 @@ func TestMock(t *testing.T) {
 		return nil
 	})
 
-	err = api.AssignPrivateIpAddressesVMSS(context.Background(), "vm1", "vmss1", "s-1", "eth0", 2)
+	err = api.AssignPrivateIpAddressesVMSS(t.Context(), "vm1", "vmss1", "s-1", "eth0", 2)
 	require.NoError(t, err)
-	instances, err = api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
+	instances, err = api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
 	require.NoError(t, err)
 	require.Equal(t, 1, instances.NumInstances())
 	instances.ForeachInterface("", func(instanceID, interfaceID string, revision ipamTypes.InterfaceRevision) error {
@@ -87,15 +86,15 @@ func TestSetMockError(t *testing.T) {
 	mockError := errors.New("error")
 
 	api.SetMockError(GetInstances, mockError)
-	_, err := api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
+	_, err := api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
 	require.ErrorIs(t, err, mockError)
 
 	api.SetMockError(GetVpcsAndSubnets, mockError)
-	_, _, err = api.GetVpcsAndSubnets(context.Background())
+	_, _, err = api.GetVpcsAndSubnets(t.Context())
 	require.ErrorIs(t, err, mockError)
 
 	api.SetMockError(AssignPrivateIpAddressesVMSS, mockError)
-	err = api.AssignPrivateIpAddressesVMSS(context.Background(), "vmss1", "i-1", "s-1", "eth0", 0)
+	err = api.AssignPrivateIpAddressesVMSS(t.Context(), "vmss1", "i-1", "s-1", "eth0", 0)
 	require.ErrorIs(t, err, mockError)
 }
 
@@ -105,6 +104,6 @@ func TestSetLimiter(t *testing.T) {
 	require.NotNil(t, api)
 
 	api.SetLimiter(10.0, 2)
-	_, err := api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
+	_, err := api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
 	require.NoError(t, err)
 }

--- a/pkg/azure/ipam/instances_test.go
+++ b/pkg/azure/ipam/instances_test.go
@@ -4,7 +4,6 @@
 package ipam
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -69,7 +68,7 @@ var (
 	}
 )
 
-func iteration1(api *apimock.API, mngr *InstancesManager) {
+func iteration1(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 	instances := ipamTypes.NewInstanceMap()
 
 	resource := &types.AzureInterface{
@@ -105,10 +104,10 @@ func iteration1(api *apimock.API, mngr *InstancesManager) {
 	})
 
 	api.UpdateInstances(instances)
-	mngr.Resync(context.Background())
+	mngr.Resync(t.Context())
 }
 
-func iteration2(api *apimock.API, mngr *InstancesManager) {
+func iteration2(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 	api.UpdateSubnets(subnets2)
 
 	instances := ipamTypes.NewInstanceMap()
@@ -162,7 +161,7 @@ func iteration2(api *apimock.API, mngr *InstancesManager) {
 	})
 
 	api.UpdateInstances(instances)
-	mngr.Resync(context.TODO())
+	mngr.Resync(t.Context())
 }
 
 func TestGetVpcsAndSubnets(t *testing.T) {
@@ -176,13 +175,13 @@ func TestGetVpcsAndSubnets(t *testing.T) {
 	require.Nil(t, mngr.subnets["subnet-2"])
 	require.Nil(t, mngr.subnets["subnet-3"])
 
-	iteration1(api, mngr)
+	iteration1(t, api, mngr)
 
 	require.NotNil(t, mngr.subnets["subnet-1"])
 	require.NotNil(t, mngr.subnets["subnet-2"])
 	require.Nil(t, mngr.subnets["subnet-3"])
 
-	iteration2(api, mngr)
+	iteration2(t, api, mngr)
 
 	require.NotNil(t, mngr.subnets["subnet-1"])
 	require.NotNil(t, mngr.subnets["subnet-2"])

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -4,7 +4,6 @@
 package ipam
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -172,7 +171,7 @@ func TestIpamPreAllocate8(t *testing.T) {
 	})
 	api.UpdateInstances(m)
 
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 
 	k8sapi := newK8sMock()
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
@@ -235,7 +234,7 @@ func TestIpamMinAllocate10(t *testing.T) {
 	})
 	api.UpdateInstances(m)
 
-	instances.Resync(context.TODO())
+	instances.Resync(t.Context())
 
 	k8sapi := newK8sMock()
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, false)
@@ -322,7 +321,7 @@ func TestIpamManyNodes(t *testing.T) {
 			}
 
 			api.UpdateInstances(allInstances)
-			instances.Resync(context.TODO())
+			instances.Resync(t.Context())
 
 			for i := range state {
 				state[i] = &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i)}
@@ -345,7 +344,7 @@ func TestIpamManyNodes(t *testing.T) {
 			// The above check returns as soon as the address requirements are met.
 			// The metrics may still be outdated, resync all nodes to update
 			// metrics.
-			mngr.Resync(context.TODO(), time.Now())
+			mngr.Resync(t.Context(), time.Now())
 			require.Equal(t, numNodes, metrics.Nodes("total"))
 			require.Equal(t, 0, metrics.Nodes("in-deficit"))
 			require.Equal(t, 0, metrics.Nodes("at-capacity"))
@@ -399,7 +398,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 	}
 
 	api.UpdateInstances(allInstances)
-	instances.Resync(context.Background())
+	instances.Resync(b.Context())
 
 	for i := range state {
 		state[i] = &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i)}

--- a/pkg/azure/ipam/node_stats_test.go
+++ b/pkg/azure/ipam/node_stats_test.go
@@ -4,7 +4,6 @@
 package ipam
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -48,7 +47,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 			},
 		},
 	}
-	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), hivetest.Logger(t))
+	_, stats, err := n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
 	assert.NoError(err)
 	assert.Equal(255, stats.NodeCapacity)
 }

--- a/pkg/ipam/allocator/multipool/node_handler_test.go
+++ b/pkg/ipam/allocator/multipool/node_handler_test.go
@@ -4,7 +4,6 @@
 package multipool
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -123,7 +122,7 @@ func TestNodeHandler(t *testing.T) {
 		t.Fatal("Update should not have be called before Resync")
 	default:
 	}
-	nh.Resync(context.TODO(), time.Time{})
+	nh.Resync(t.Context(), time.Time{})
 
 	node1Update := <-onUpdateArgs
 	assert.Equal(t, "node1", node1Update.newNode.Name)

--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -4,7 +4,6 @@
 package podcidr
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/netip"
@@ -294,7 +293,7 @@ func TestNodesPodCIDRManager_Resync(t *testing.T) {
 			logger:    hivetest.Logger(t),
 			k8sReSync: tt.fields.k8sReSync,
 		}
-		n.Resync(context.Background(), time.Time{})
+		n.Resync(t.Context(), time.Time{})
 
 		if tt.testPostRun != nil {
 			tt.testPostRun(tt.fields)

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -215,8 +215,8 @@ func Test_MultiPoolManager(t *testing.T) {
 	fakeK8sCiliumNodeAPI.updateNode(currentNode)
 	assert.Equal(t, "upsert", <-events)
 
-	c.waitForPool(context.TODO(), IPv4, "jupiter")
-	c.waitForPool(context.TODO(), IPv6, "jupiter")
+	c.waitForPool(t.Context(), IPv4, "jupiter")
+	c.waitForPool(t.Context(), IPv6, "jupiter")
 
 	// Allocations should now succeed
 	jupiterIP0 := net.ParseIP("192.168.1.1")

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -241,7 +241,7 @@ func TestNodeManagerDelete(t *testing.T) {
 	require.NotNil(t, mngr.Get("node-foo"))
 	require.Nil(t, mngr.Get("node2"))
 
-	mngr.Resync(context.Background(), time.Now())
+	mngr.Resync(t.Context(), time.Now())
 	avail, used, needed := metrics.GetPerNodeMetrics("node-foo")
 	require.NotNil(t, avail)
 	require.NotNil(t, used)
@@ -636,7 +636,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	// The above check returns as soon as the address requirements are met.
 	// The metrics may still be oudated, resync all nodes to update
 	// metrics.
-	mngr.Resync(context.TODO(), time.Now())
+	mngr.Resync(t.Context(), time.Now())
 
 	require.Equal(t, numNodes, metricsapi.Nodes("total"))
 	require.Equal(t, 0, metricsapi.Nodes("in-deficit"))


### PR DESCRIPTION
Replace usages of `context.TODO()` and `context.Background()` in IPAM related packages tests:

* `pkg/alibabacloud`
* `pkg/aws`
* `pkg/azure`
* `pkg/ipam`

Followup of f5d5948f09e11defbc7cc8d8f6a44d0519dad942 (#38652)

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
IPAM: Use testing.T.Context added in Go 1.24 in tests
```
