### PR TITLE
Assign codeowners for no-errors-in-logs testcase

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -106,6 +108,19 @@ type noErrorsInLogs struct {
 
 	errorMsgsWithExceptions map[string][]logMatcher
 	ciliumVersion           semver.Version
+	mostCommonFailureLog    string
+	mostCommonFailureCount  int
+}
+
+func (n *noErrorsInLogs) FilePath() string {
+	extractedPath := extractPathFromLog(n.mostCommonFailureLog)
+	if extractedPath != "" {
+		return extractedPath
+	}
+	// In case log did not contain the path,
+	// we return the path of the test file.
+	return n.ScenarioBase.FilePath()
+
 }
 
 func (n *noErrorsInLogs) Name() string {
@@ -301,6 +316,12 @@ func (n *noErrorsInLogs) findUniqueFailures(logs []byte) (map[string]int, map[st
 			}
 		}
 	}
+	for f, c := range uniqueFailures {
+		if c > n.mostCommonFailureCount {
+			n.mostCommonFailureCount = c
+			n.mostCommonFailureLog = exampleLogLine[f]
+		}
+	}
 	return uniqueFailures, exampleLogLine
 }
 
@@ -318,6 +339,22 @@ func extractValueFromLog(log string, key string) string {
 	return ""
 }
 
+func extractPathFromLog(log string) string {
+	source := extractValueFromLog(log, "source")
+	parts := strings.Split(source, ":")
+	if len(parts) < 2 {
+		return ""
+	}
+	source = strings.Split(source, ":")[0]
+	_, thisPath, _, _ := runtime.Caller(0)
+	repoDir, _ := filepath.Abs(filepath.Join(thisPath, "..", "..", "..", ".."))
+	// We trim twice for cases when cilium and cilium-cli are built in a different ways.
+	// For example, when cilium is built with make kind-image in Docker, but cilium-cli is built
+	// on the local host.
+	result := strings.TrimPrefix(source, repoDir+string(filepath.Separator))
+	return strings.TrimPrefix(result, "/go/src/github.com/cilium/cilium/")
+}
+
 func (n *noErrorsInLogs) checkErrorsInLogs(id string, logs []byte, a *check.Action) {
 	uniqueFailures, exampleLogLine := n.findUniqueFailures(logs)
 	if len(uniqueFailures) > 0 {
@@ -326,6 +363,7 @@ func (n *noErrorsInLogs) checkErrorsInLogs(id string, logs []byte, a *check.Acti
 			failures.WriteRune('\n')
 			failures.WriteString(exampleLogLine[f])
 			failures.WriteString(fmt.Sprintf(" (%d occurrences)", c))
+
 		}
 		a.Failf("Found %d logs in %s matching list of errors that must be investigated:%s", len(uniqueFailures), id, failures.String())
 	}

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -50,6 +50,9 @@ func slogLevel(l logrus.Level) slog.Level {
 func initializeSlog(logOpts LogOptions, loggers []string) {
 	opts := *slogHandlerOpts
 	opts.Level = slogLevel(logOpts.GetLogLevel())
+	if opts.Level == slog.LevelDebug {
+		opts.AddSource = true
+	}
 
 	logFormat := logOpts.GetLogFormat()
 	switch logFormat {


### PR DESCRIPTION
To show how aggregation and reporting works, I've switched one log "Updating tunnel map entry" from Debug to Error.
Example run: https://github.com/cilium/cilium/actions/runs/14337153953/job/40187065813?pr=38812
```
Found 1 logs in kind-chart-testing/kube-system/cilium-ms24n (cilium-agent) matching list of errors that must be investigated:
time=2025-04-08T15:50:26Z level=error source=/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:189 msg="Updating tunnel map entry" module=agent.datapath ipAddr=172.18.0.3 allocCIDR=fd00:10:244::/64 (4 occurrences)
```
Notice that `occurrences` are calculated better now, before because of timestamps we were not aggregating them together.
Error is reported for datapath team, who is owner of file (`pkg/datapath/linux/node.go`) containing this log message:
```
check-log-errors/no-errors-in-logs/kind-chart-testing/kube-system/cilium-ms24n (cilium-agent)
    ⛑️ The following owners are responsible for reliability of the testsuite: 
        - @cilium/sig-datapath (no-errors-in-logs)
        - @cilium/sig-servicemesh (.github/workflows/conformance-kind-proxy-embedded.yaml)
        - @cilium/ci-structure (.github/workflows/conformance-kind-proxy-embedded.yaml)
```
