### PR TITLE
cilium-cli: Fix ipv6 ping regex

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -37,7 +37,8 @@ const (
 
 var (
 	// PING 10.0.0.1 (10.0.0.1) 56(84) bytes of data.
-	pingHeaderPattern = regexp.MustCompile(`^PING .* bytes of data\.`)
+	// PING 2606:4700:4700::1111(2606:4700:4700::1111) 56 data bytes
+	pingHeaderPattern = regexp.MustCompile(`^PING .*(bytes of data\.|data bytes)`)
 )
 
 // Action represents an individual action (e.g. a curl call) in a Scenario

--- a/cilium-cli/connectivity/check/action_test.go
+++ b/cilium-cli/connectivity/check/action_test.go
@@ -62,6 +62,26 @@ rtt min/avg/max/mdev = 5.780/5.895/6.010/0.115 ms`,
 			},
 			want: false,
 		},
+		{
+			name: "IPv6 ping header only",
+			args: args{
+				output: `PING 2606:4700:4700::1111(2606:4700:4700::1111) 56 data bytes`,
+			},
+			want: true,
+		},
+		{
+			name: "IPv6 full ping output",
+			args: args{
+				output: `PING 2606:4700:4700::1111(2606:4700:4700::1111) 56 data bytes
+64 bytes from 2606:4700:4700::1111: icmp_seq=1 ttl=58 time=4.57 ms
+64 bytes from 2606:4700:4700::1111: icmp_seq=2 ttl=58 time=5.42 ms
+
+--- 2606:4700:4700::1111 ping statistics ---
+2 packets transmitted, 2 received, 0% packet loss, time 1001ms
+rtt min/avg/max/mdev = 4.572/4.994/5.417/0.422 ms`,
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Fix IPv6 ping header detection in connectivity test

## Description
This PR fixes the ping header regex pattern to support both IPv4 and IPv6 formats in the connectivity test. 

Currently, when running connectivity tests with IPv6, the ping command's header has a slightly different format:
- IPv4: `PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.`
- IPv6: `PING 2606:4700:4700::1111(2606:4700:4700::1111) 56 data bytes`

The existing regex only matches the IPv4 format (`bytes of data.`), causing issues when testing with IPv6.

## Changes
- Updated the `pingHeaderPattern` regex to match both IPv4 and IPv6 ping header formats
- The new pattern: `^PING .*(bytes of data\.|data bytes)`

## Testing
I created a test program to verify the updated regex pattern works with both IPv4 and IPv6 formats:

```go
package main

import (
    "fmt"
    "regexp"
)

func main() {
    pingHeaderPattern := regexp.MustCompile(`^PING .*(bytes of data\.|data bytes)`)

    ipv4Header := "PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data."
    ipv6Header := "PING 2606:4700:4700::1111(2606:4700:4700::1111) 56 data bytes"

    fmt.Printf("IPv4 header matches: %v\n", pingHeaderPattern.MatchString(ipv4Header))
    fmt.Printf("IPv6 header matches: %v\n", pingHeaderPattern.MatchString(ipv6Header))
}
```

Output:
```bash
IPv4 header matches: true
IPv6 header matches: true
```

## Related Issues
Fixes cilium/cilium-cli#2352