### PR TITLE
docs: clarify node IPAM LB behavior with node labels and taints

### DIFF
--- a/Documentation/network/node-ipam.rst
+++ b/Documentation/network/node-ipam.rst
@@ -39,6 +39,12 @@ all the Pods selected by the Service (via their EndpointSlices) as candidates.
     If they don't, check if the matching EndpointSlices look correct and/or
     try setting ``.spec.externalTrafficPolicy`` to ``Cluster``.
 
+Node IPAM honors the Node label ``node.kubernetes.io/exclude-from-external-load-balancers``
+and the Node taint ``ToBeDeletedByClusterAutoscaler``. Node IPAM **doesn't**
+consider a node as a candidate for load balancing if the label
+``node.kubernetes.io/exclude-from-external-load-balancers`` or the taint
+``ToBeDeletedByClusterAutoscaler`` is present.
+
 To restrict the Nodes that should listen for incoming traffic, add annotation
 ``io.cilium.nodeipam/match-node-labels`` to the Service. The value of the
 annotation is a


### PR DESCRIPTION
Add a section explaining how Node label `node.kubernetes.io/exclude-from-external-load-balancers` and Node taint `ToBeDeletedByClusterAutoscaler` influence which nodes are selected for load balancing.

Motivation: Currently this check made by Node IPAM LB isn't explained in the docs, which could potentially mislead users (for example, when deploying 3 control plane nodes with kubeadm and making the nodes schedulable by removing all taints). By adding this section, users can check for themselves whether their nodes are valid candidates for load balancing.

Fixes: #38793

```release-note
docs: clarify node IPAM LB behavior with node labels and taints
```