### PR TITLE
docs: Fix variable naming in EKS-to-EKS Clustermesh guide

### DIFF
--- a/Documentation/network/clustermesh/eks-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/eks-clustermesh-prep.rst
@@ -119,7 +119,7 @@ Install cluster one
 
         Cluster_1_NGW_2=$(aws ec2 create-nat-gateway \
             --subnet-id $Cluster_1_Public_Subnet_2 \
-            --allocation-id ${EIP_ALLOCATION_ID_2} \
+            --allocation-id ${Cluster_1_EIP_2} \
             --tag-specifications "ResourceType=natgateway, Tags=[{Key=Name,Value=Cluster_1_NGW_2}]" \
             --query 'NatGateway.{NatGatewayId:NatGatewayId}' \
             --output text
@@ -151,7 +151,7 @@ Install cluster one
 
         aws ec2 associate-route-table \
             --subnet-id ${Cluster_1_Public_Subnet_2} \
-            --route-table-id ${ROUTE_TABLE_ID_1}
+            --route-table-id ${Cluster_1_Public_RT}
 
         # Create private route tables
         export Cluster_1_Private_RT_1=$(aws ec2 create-route-table \


### PR DESCRIPTION
Replace inconsistent variable names like EIP_ALLOCATION_ID_2 with more descriptive and consistent names like Cluster_1_EIP_2 in the EKS-to-EKS Clustermesh Preparation documentation to improve clarity and maintain consistent naming convention.

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #35982


Replace inconsistent variable names like EIP_ALLOCATION_ID_2 with more
descriptive and consistent names like Cluster_1_EIP_2 in the EKS-to-EKS
Clustermesh Preparation documentation to improve clarity and maintain
consistent naming convention.
