### PR TITLE
Fix data races in endpointmanager tests and remove potential cause for future races

### DIFF
--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -116,15 +116,14 @@ func (ds *DaemonSuite) testEndpointAddNoLabels(t *testing.T) {
 	_, _, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	require.NoError(t, err)
 
-	expectedLabels := labels.Labels{
-		labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
-	}
+	initLbl := labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved)
+	expectedLabels := []string{initLbl.String()}
 	// Check that the endpoint has the reserved:init label.
 	v4ip, err := netip.ParseAddr(epTemplate.Addressing.IPV4)
 	require.NoError(t, err)
 	ep, err := ds.d.endpointManager.Lookup(endpointid.NewIPPrefixID(v4ip))
 	require.NoError(t, err)
-	require.Equal(t, expectedLabels, ep.OpLabels.IdentityLabels())
+	require.Equal(t, expectedLabels, ep.GetOpLabels())
 
 	secID := ep.WaitForIdentity(3 * time.Second)
 	require.NotNil(t, secID)

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -248,7 +248,7 @@ func (e *Endpoint) restoreIdentity(regenerator *Regenerator) error {
 	}
 	scopedLog := log.WithField(logfields.EndpointID, e.ID)
 	// Filter the restored labels with the new daemon's filter
-	l, _ := labelsfilter.Filter(e.OpLabels.AllLabels())
+	l, _ := labelsfilter.Filter(e.labels.AllLabels())
 	e.runlock()
 
 	// Getting the ep's identity while we are restoring should block the
@@ -414,7 +414,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		IfIndex:                  e.ifIndex,
 		ContainerIfName:          e.containerIfName,
 		DisableLegacyIdentifiers: e.disableLegacyIdentifiers,
-		OpLabels:                 e.OpLabels,
+		Labels:                   e.labels,
 		LXCMAC:                   e.mac,
 		IPv6:                     e.IPv6,
 		IPv6IPAMPool:             e.IPv6IPAMPool,
@@ -479,10 +479,8 @@ type serializableEndpoint struct {
 	// (container name, container id, pod name) for this endpoint.
 	DisableLegacyIdentifiers bool
 
-	// OpLabels is the endpoint's label configuration
-	//
-	// FIXME: Rename this field to Labels
-	OpLabels labels.OpLabels
+	// Labels is the endpoint's label configuration
+	Labels labels.OpLabels `json:"OpLabels"`
 
 	// mac is the MAC address of the endpoint
 	//
@@ -560,7 +558,7 @@ func (ep *Endpoint) UnmarshalJSON(raw []byte) error {
 	// We may have to populate structures in the Endpoint manually to do the
 	// translation from serializableEndpoint --> Endpoint.
 	restoredEp := &serializableEndpoint{
-		OpLabels:   labels.NewOpLabels(),
+		Labels:     labels.NewOpLabels(),
 		Options:    option.NewIntOptions(&EndpointMutableOptionLibrary),
 		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 		DNSZombies: fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
@@ -590,7 +588,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ifIndex = r.IfIndex
 	ep.containerIfName = r.ContainerIfName
 	ep.disableLegacyIdentifiers = r.DisableLegacyIdentifiers
-	ep.OpLabels = r.OpLabels
+	ep.labels = r.Labels
 	ep.mac = r.LXCMAC
 	ep.IPv6 = r.IPv6
 	ep.IPv6IPAMPool = r.IPv6IPAMPool

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -78,7 +78,7 @@ func (s *EndpointSuite) endpointCreator(t testing.TB, id uint16, secID identity.
 	ep.ifIndex = 1
 	ep.nodeMAC = []byte{0x02, 0xff, 0xf2, 0x12, 0x0, 0x0}
 	ep.SecurityIdentity = identity
-	ep.OpLabels = labels.NewOpLabels()
+	ep.labels = labels.NewOpLabels()
 	ep.NetNsCookie = 1234
 	return ep
 }

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -943,8 +943,8 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	mgr.localNodeStore.Update(func(ln *node.LocalNode) { ln.Labels = map[string]string{"k2": "v2"} })
 	hostEP, ok := mgr.endpoints[hostEPID]
 	require.True(t, ok)
-	got := hostEP.OpLabels.IdentityLabels().K8sStringMap()
-	require.Equal(t, map[string]string{"k2": "v2"}, got)
+	got := hostEP.GetOpLabels()
+	require.Equal(t, []string{"k8s:k2=v2"}, got)
 }
 
 func TestUpdateHostEndpointLabels(t *testing.T) {
@@ -957,7 +957,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 		oldLabels, newLabels map[string]string
 	}
 	type want struct {
-		labels      map[string]string
+		labels      []string
 		labelsCheck assert.ComparisonAssertionFunc
 	}
 	tests := []struct {
@@ -988,7 +988,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			},
 			setupWant: func() want {
 				return want{
-					labels:      map[string]string{"k1": "v1"},
+					labels:      []string{"k8s:k1=v1"},
 					labelsCheck: assert.EqualValues,
 				}
 			},
@@ -1021,7 +1021,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			},
 			setupWant: func() want {
 				return want{
-					labels:      map[string]string{"k2": "v2"},
+					labels:      []string{"k8s:k2=v2"},
 					labelsCheck: assert.EqualValues,
 				}
 			},
@@ -1054,7 +1054,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			},
 			setupWant: func() want {
 				return want{
-					labels:      map[string]string{"k1": "v1"},
+					labels:      []string{"k8s:k1=v1"},
 					labelsCheck: assert.EqualValues,
 				}
 			},
@@ -1077,7 +1077,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 
 		hostEP, ok := mgr.endpoints[hostEPID]
 		require.True(t, ok)
-		got := hostEP.OpLabels.IdentityLabels().K8sStringMap()
+		got := hostEP.GetOpLabels()
 		want.labelsCheck(t, want.labels, got, "Test Name: %s", tt.name)
 		tt.postTestRun()
 	}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/node"
@@ -1002,6 +1001,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			name: "Update labels",
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
+				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
 				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), model)
 				require.NoError(t, err)
 
@@ -1010,7 +1010,6 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 
 				ep.SetIsHost(true)
 				ep.ID = hostEPID
-				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}
 				require.NoError(t, mgr.expose(ep))
 			},
 			setupArgs: func() args {
@@ -1035,6 +1034,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			name: "Ignore labels",
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
+				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
 				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), model)
 				ep.SetIsHost(true)
 				require.NoError(t, err)
@@ -1043,7 +1043,6 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 				t.Cleanup(ep.Stop)
 
 				ep.ID = hostEPID
-				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}
 				require.NoError(t, mgr.expose(ep))
 			},
 			setupArgs: func() args {


### PR DESCRIPTION
Fix data races in endpointmanager tests and unexport and rename the `(*endpoint.Endpoint).OpLabels` field to avoid cases like these in the future.

See commits for details.