### PR TITLE
hubble:monitor: align TraceNotify to DropNotify

### DIFF
--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -230,7 +230,7 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 	input := make([]*observerpb.Flow, numFlows)
 
 	for i := range numFlows {
-		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+		tn := monitor.TraceNotify{Type: byte(monitorAPI.MessageTypeTrace)}
 		macOnly := func(mac string) net.HardwareAddr {
 			m, _ := net.ParseMAC(mac)
 			return m
@@ -424,7 +424,7 @@ func TestLocalObserverServer_GetFlows_Follow_Since(t *testing.T) {
 
 	generateFlows := func(from, to int, m chan<- *observerTypes.MonitorEvent) {
 		for i := from; i < to; i++ {
-			tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+			tn := monitor.TraceNotify{Type: byte(monitorAPI.MessageTypeTrace)}
 			data := testutils.MustCreateL3L4Payload(tn)
 			m <- &observerTypes.MonitorEvent{
 				Timestamp: time.Unix(int64(i), 0),
@@ -525,7 +525,7 @@ func TestHooks(t *testing.T) {
 
 	m := s.GetEventsChannel()
 	for i := range numFlows {
-		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+		tn := monitor.TraceNotify{Type: byte(monitorAPI.MessageTypeTrace)}
 		data := testutils.MustCreateL3L4Payload(tn)
 		m <- &observerTypes.MonitorEvent{
 			Timestamp: time.Unix(int64(i), 0),
@@ -580,7 +580,7 @@ func TestLocalObserverServer_OnFlowDelivery(t *testing.T) {
 
 	m := s.GetEventsChannel()
 	for i := range numFlows {
-		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+		tn := monitor.TraceNotify{Type: byte(monitorAPI.MessageTypeTrace)}
 		data := testutils.MustCreateL3L4Payload(tn)
 		m <- &observerTypes.MonitorEvent{
 			Timestamp: time.Unix(int64(i), 0),
@@ -644,7 +644,7 @@ func TestLocalObserverServer_OnGetFlows(t *testing.T) {
 
 	m := s.GetEventsChannel()
 	for i := range numFlows {
-		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+		tn := monitor.TraceNotify{Type: byte(monitorAPI.MessageTypeTrace)}
 		data := testutils.MustCreateL3L4Payload(tn)
 		m <- &observerTypes.MonitorEvent{
 			Timestamp: time.Unix(int64(i), 0),
@@ -718,7 +718,7 @@ func TestLocalObserverServer_NodeLabels(t *testing.T) {
 
 	// simulate a new monitor event.
 	m := s.GetEventsChannel()
-	tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+	tn := monitor.TraceNotify{Type: byte(monitorAPI.MessageTypeTrace)}
 	data := testutils.MustCreateL3L4Payload(tn)
 	// NOTE: we need to send an extra event into Hubble's ring buffer to see
 	// the first one sent.

--- a/pkg/hubble/parser/parser_test.go
+++ b/pkg/hubble/parser/parser_test.go
@@ -53,7 +53,7 @@ func Test_ParserDispatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test L3/L4 record
-	tn := monitor.TraceNotifyV0{
+	tn := monitor.TraceNotify{
 		Type: byte(api.MessageTypeTrace),
 	}
 	data, err := testutils.CreateL3L4Payload(tn)

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -106,7 +106,7 @@ func newHubbleObserver(t testing.TB, nodeName string, numFlows int) *observer.Lo
 	m := s.GetEventsChannel()
 
 	for i := range numFlows {
-		tn := monitor.TraceNotifyV0{Type: byte(monitorAPI.MessageTypeTrace)}
+		tn := monitor.TraceNotify{Type: byte(monitorAPI.MessageTypeTrace)}
 		src := getRandomEndpoint()
 		dst := getRandomEndpoint()
 		srcMAC, _ := net.ParseMAC(fake.MAC())

--- a/pkg/hubble/testutils/payload.go
+++ b/pkg/hubble/testutils/payload.go
@@ -18,6 +18,7 @@ import (
 
 // CreateL3L4Payload assembles a L3/L4 payload for testing purposes
 func CreateL3L4Payload(message any, layers ...gopacket.SerializableLayer) ([]byte, error) {
+	// Serialize message.
 	buf := &bytes.Buffer{}
 	switch messageType := message.(type) {
 	case monitor.DebugCapture,
@@ -37,6 +38,16 @@ func CreateL3L4Payload(message any, layers ...gopacket.SerializableLayer) ([]byt
 	default:
 		return nil, fmt.Errorf("unsupported message type %T", messageType)
 	}
+
+	// Truncate buffer according to the event version. This allows us to serialize previous
+	// versions of events in tests, which would be otherwise serialized with the maximum size of the
+	// respective data structure (ex. DropNotifyV1 -> DropNotifyV2 + zero bytes of padding).
+	switch messageType := message.(type) {
+	case monitor.DropNotify:
+		buf.Truncate(int(messageType.DataOffset()))
+	}
+
+	// Serialize layers.
 	packet := gopacket.NewSerializeBuffer()
 	options := gopacket.SerializeOptions{
 		FixLengths: true,

--- a/pkg/hubble/testutils/payload.go
+++ b/pkg/hubble/testutils/payload.go
@@ -24,9 +24,7 @@ func CreateL3L4Payload(message any, layers ...gopacket.SerializableLayer) ([]byt
 	case monitor.DebugCapture,
 		monitor.DropNotify,
 		monitor.PolicyVerdictNotify,
-		monitor.TraceNotify,
-		monitor.TraceNotifyV0,
-		monitor.TraceNotifyV1:
+		monitor.TraceNotify:
 		if err := binary.Write(buf, byteorder.Native, message); err != nil {
 			return nil, err
 		}
@@ -43,6 +41,8 @@ func CreateL3L4Payload(message any, layers ...gopacket.SerializableLayer) ([]byt
 	// versions of events in tests, which would be otherwise serialized with the maximum size of the
 	// respective data structure (ex. DropNotifyV1 -> DropNotifyV2 + zero bytes of padding).
 	switch messageType := message.(type) {
+	case monitor.TraceNotify:
+		buf.Truncate(int(messageType.DataOffset()))
 	case monitor.DropNotify:
 		buf.Truncate(int(messageType.DataOffset()))
 	}

--- a/pkg/hubble/testutils/payload_test.go
+++ b/pkg/hubble/testutils/payload_test.go
@@ -26,11 +26,12 @@ func decodeHex(s string) []byte {
 
 func TestCreateL3L4Payload(t *testing.T) {
 	// These contain TraceNotify headers plus the ethernet header of the packet
+	// - IPv4: test with TraceNotifyVersion0
+	// - IPv6: test with TraceNotifyVersion1 (additional [16]bytes for empty OrigIP)
 	packetv4Prefix := decodeHex("0403a80b8d4598d462000000620000006800000001000000000002000000000006e9183bb275129106e2221a080045000054bfe900003f019ae2")
 	packetv4802Prefix := decodeHex("0403a80b8d4598d462000000620000006800000001000000000002000000000006e9183bb275129106e2221a81000202080045000054bfe900003f019ae2")
-	packetv6Prefix := decodeHex("0405a80b5f16f2b85600000056000000680000000000000000000000000000003333ff00b3e5129106e2221a86dd6000000000203aff")
-	packetv6802Prefix := decodeHex("0405a80b5f16f2b85600000056000000680000000000000000000000000000003333ff00b3e5129106e2221a8100020286dd6000000000203aff")
-
+	packetv6Prefix := decodeHex("0405a80b5f16f2b8560000005600010068000000000000000000000000000000000000000000000000000000000000003333ff00b3e5129106e2221a86dd6000000000203aff")
+	packetv6802Prefix := decodeHex("0405a80b5f16f2b8560000005600010068000000000000000000000000000000000000000000000000000000000000003333ff00b3e5129106e2221a8100020286dd6000000000203aff")
 	// ICMPv4/v6 packets (with reversed src/dst IPs)
 	packetICMPv4 := decodeHex("010101010a107e4000003639225700051b7b415d0000000086bf050000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637")
 	packetICMPv6Req := decodeHex("f00d0000000000000a10000000009195ff0200000000000000000001ff00b3e58700507500000000f00d0000000000000a1000000000b3e50101129106e2221a")
@@ -38,7 +39,7 @@ func TestCreateL3L4Payload(t *testing.T) {
 	packetICMPv6Rev := decodeHex("ff0200000000000000000001ff00b3e5f00d0000000000000a100000000091958700507500000000f00d0000000000000a1000000000b3e50101129106e2221a")
 
 	// The following structs are decoded pieces of the above packets
-	traceNotifyIPv4 := monitor.TraceNotifyV0{
+	traceNotifyIPv4 := monitor.TraceNotify{
 		Type:     monitorAPI.MessageTypeTrace,
 		ObsPoint: monitorAPI.TraceToStack,
 		Source:   0xba8,
@@ -48,8 +49,9 @@ func TestCreateL3L4Payload(t *testing.T) {
 		SrcLabel: 0x68,
 		DstLabel: 0x1,
 		Reason:   monitor.TraceReasonCtReply,
+		Version:  monitor.TraceNotifyVersion0,
 	}
-	traceNotifyIPv6 := monitor.TraceNotifyV0{
+	traceNotifyIPv6 := monitor.TraceNotify{
 		Type:     monitorAPI.MessageTypeTrace,
 		ObsPoint: monitorAPI.TraceFromLxc,
 		Source:   0xba8,
@@ -59,6 +61,7 @@ func TestCreateL3L4Payload(t *testing.T) {
 		SrcLabel: 0x68,
 		DstLabel: 0x0,
 		Reason:   monitor.TraceReasonPolicy,
+		Version:  monitor.TraceNotifyVersion1,
 	}
 
 	etherIPv4 := &layers.Ethernet{


### PR DESCRIPTION
This PR:

1. aligns the usage of `TraceNotify` to `DropNotify`: dropping versioning structs v0, v1, in favor of a unique structure with all fields/methods, similarly as we do for `DropNotify`.
2. Adds testing and error catching in case of unknown version numbers for both these types of events.

Fixes: https://github.com/cilium/cilium/issues/39031.