### PR TITLE
Add an L7 allow-all rule when EnableDefaultDeny is false

### DIFF
--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -156,21 +156,21 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 			direction, acceptStr, acceptStr2, direction)
 	}
 
-	ing, egr, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, genCommentf(true, false))
 	require.False(t, egr, genCommentf(false, false))
 	require.Equal(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
 	_, _, err := repo.mustAdd(fooIngressDenyRule1)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, genCommentf(true, true))
 	require.False(t, egr, genCommentf(false, false))
 	require.Equal(t, fooIngressDenyRule1, matchingRules[0].Rule, "returned matching rules did not match")
 
 	_, _, err = repo.mustAdd(fooIngressDenyRule2)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, genCommentf(true, true))
 	require.False(t, egr, genCommentf(false, false))
 	require.ElementsMatch(t, matchingRules.AsPolicyRules(), api.Rules{&fooIngressDenyRule1, &fooIngressDenyRule2}, "returned matching rules did not match")
@@ -178,21 +178,21 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 	_, _, numDeleted := repo.ReplaceByLabels(nil, lal(fooIngressDenyRule1Label))
 	require.Equal(t, 1, numDeleted)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, genCommentf(true, true))
 	require.False(t, egr, genCommentf(false, false))
 	require.Equal(t, fooIngressDenyRule2, matchingRules[0].Rule, "returned matching rules did not match")
 
 	_, _, numDeleted = repo.ReplaceByLabels(nil, lal(fooIngressDenyRule2Label))
 	require.Equal(t, 1, numDeleted)
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, genCommentf(true, false))
 	require.False(t, egr, genCommentf(false, false))
 	require.Equal(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
 	_, _, err = repo.mustAdd(fooEgressDenyRule1)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, genCommentf(true, false))
 	require.True(t, egr, genCommentf(false, true))
 	require.Equal(t, fooEgressDenyRule1, matchingRules[0].Rule, "returned matching rules did not match")
@@ -201,7 +201,7 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 
 	_, _, err = repo.mustAdd(fooEgressDenyRule2)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, genCommentf(true, false))
 	require.True(t, egr, genCommentf(false, true))
 	require.Equal(t, fooEgressDenyRule2, matchingRules[0].Rule, "returned matching rules did not match")
@@ -211,7 +211,7 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 
 	_, _, err = repo.mustAdd(combinedRule)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, genCommentf(true, true))
 	require.True(t, egr, genCommentf(false, true))
 	require.Equal(t, combinedRule, matchingRules[0].Rule, "returned matching rules did not match")
@@ -220,7 +220,7 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 
 	SetPolicyEnabled(option.AlwaysEnforce)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, genCommentf(true, true))
 	require.True(t, egr, genCommentf(false, true))
 	require.Equal(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
@@ -228,7 +228,7 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 	SetPolicyEnabled(option.NeverEnforce)
 	_, _, err = repo.mustAdd(combinedRule)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, genCommentf(true, false))
 	require.False(t, egr, genCommentf(false, false))
 	require.Nil(t, matchingRules, "no rules should be returned since policy enforcement is disabled")
@@ -239,19 +239,19 @@ func TestComputePolicyDenyEnforcementAndRules(t *testing.T) {
 	// If the mode is "default", check that the policy is always enforced for
 	// endpoints with the reserved:init label. If no policy rules match
 	// reserved:init, this drops all ingress and egress traffic.
-	ingress, egress, matchingRules := repo.computePolicyEnforcementAndRules(initIdentity)
+	ingress, egress, _, _, matchingRules := repo.computePolicyEnforcementAndRules(initIdentity)
 	require.True(t, ingress)
 	require.True(t, egress)
 	require.Equal(t, ruleSlice{}, matchingRules, "no rules should be returned since policy enforcement is disabled")
 
 	// Check that the "always" and "never" modes are not affected.
 	SetPolicyEnabled(option.AlwaysEnforce)
-	ingress, egress, _ = repo.computePolicyEnforcementAndRules(initIdentity)
+	ingress, egress, _, _, _ = repo.computePolicyEnforcementAndRules(initIdentity)
 	require.True(t, ingress)
 	require.True(t, egress)
 
 	SetPolicyEnabled(option.NeverEnforce)
-	ingress, egress, _ = repo.computePolicyEnforcementAndRules(initIdentity)
+	ingress, egress, _, _, _ = repo.computePolicyEnforcementAndRules(initIdentity)
 	require.False(t, ingress)
 	require.False(t, egress)
 

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -41,7 +41,6 @@ func (p *Repository) mustAdd(r api.Rule) (uint64, map[uint16]struct{}, error) {
 }
 
 func TestComputePolicyEnforcementAndRules(t *testing.T) {
-
 	// Cache policy enforcement value from when test was ran to avoid pollution
 	// across tests.
 	oldPolicyEnable := GetPolicyEnabled()
@@ -162,21 +161,21 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 	}
 	combinedRule.Sanitize()
 
-	ing, egr, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, "ingress policy enforcement should not apply since no rules are in repository")
 	require.False(t, egr, "egress policy enforcement should not apply since no rules are in repository")
 	require.Equal(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
 	_, _, err := repo.mustAdd(fooIngressRule1)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, "ingress policy enforcement should apply since ingress rule selects")
 	require.False(t, egr, "egress policy enforcement should not apply since no egress rules select")
 	require.Equal(t, fooIngressRule1, matchingRules[0].Rule, "returned matching rules did not match")
 
 	_, _, err = repo.mustAdd(fooIngressRule2)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, "ingress policy enforcement should apply since ingress rule selects")
 	require.False(t, egr, "egress policy enforcement should not apply since no egress rules select")
 	require.ElementsMatch(t, matchingRules.AsPolicyRules(), api.Rules{&fooIngressRule1, &fooIngressRule2})
@@ -184,7 +183,7 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 	_, _, numDeleted := repo.ReplaceByLabels(nil, lal(fooIngressRule1Label))
 	require.Equal(t, 1, numDeleted)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, "ingress policy enforcement should apply since ingress rule selects")
 	require.False(t, egr, "egress policy enforcement should not apply since no egress rules select")
 	require.Equal(t, fooIngressRule2, matchingRules[0].Rule, "returned matching rules did not match")
@@ -192,14 +191,14 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 	_, _, numDeleted = repo.ReplaceByLabels(nil, lal(fooIngressRule2Label))
 	require.Equal(t, 1, numDeleted)
 
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, "ingress policy enforcement should not apply since no rules are in repository")
 	require.False(t, egr, "egress policy enforcement should not apply since no rules are in repository")
 	require.Equal(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
 
 	_, _, err = repo.mustAdd(fooEgressRule1)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, "ingress policy enforcement should not apply since no ingress rules select")
 	require.True(t, egr, "egress policy enforcement should apply since egress rules select")
 	require.Equal(t, fooEgressRule1, matchingRules[0].Rule, "returned matching rules did not match")
@@ -208,7 +207,7 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 
 	_, _, err = repo.mustAdd(fooEgressRule2)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, "ingress policy enforcement should not apply since no ingress rules select")
 	require.True(t, egr, "egress policy enforcement should apply since egress rules select")
 	require.Equal(t, fooEgressRule2, matchingRules[0].Rule, "returned matching rules did not match")
@@ -218,7 +217,7 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 
 	_, _, err = repo.mustAdd(combinedRule)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, "ingress policy enforcement should apply since ingress rule selects")
 	require.True(t, egr, "egress policy enforcement should apply since egress rules selects")
 	require.Equal(t, combinedRule, matchingRules[0].Rule, "returned matching rules did not match")
@@ -227,7 +226,7 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 
 	SetPolicyEnabled(option.AlwaysEnforce)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.True(t, ing, "ingress policy enforcement should apply since ingress rule selects")
 	require.True(t, egr, "egress policy enforcement should apply since egress rules selects")
 	require.Equal(t, ruleSlice{}, matchingRules, "returned matching rules did not match")
@@ -235,7 +234,7 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 	SetPolicyEnabled(option.NeverEnforce)
 	_, _, err = repo.mustAdd(combinedRule)
 	require.NoError(t, err, "unable to add rule to policy repository")
-	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
+	ing, egr, _, _, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	require.False(t, ing, "ingress policy enforcement should not apply since policy enforcement is disabled ")
 	require.False(t, egr, "egress policy enforcement should not apply since policy enforcement is disabled")
 	require.Nil(t, matchingRules, "no rules should be returned since policy enforcement is disabled")
@@ -246,19 +245,19 @@ func TestComputePolicyEnforcementAndRules(t *testing.T) {
 	// If the mode is "default", check that the policy is always enforced for
 	// endpoints with the reserved:init label. If no policy rules match
 	// reserved:init, this drops all ingress and egress traffic.
-	ingress, egress, matchingRules := repo.computePolicyEnforcementAndRules(initIdentity)
+	ingress, egress, _, _, matchingRules := repo.computePolicyEnforcementAndRules(initIdentity)
 	require.True(t, ingress)
 	require.True(t, egress)
 	require.Equal(t, ruleSlice{}, matchingRules, "no rules should be returned since policy enforcement is disabled")
 
 	// Check that the "always" and "never" modes are not affected.
 	SetPolicyEnabled(option.AlwaysEnforce)
-	ingress, egress, _ = repo.computePolicyEnforcementAndRules(initIdentity)
+	ingress, egress, _, _, _ = repo.computePolicyEnforcementAndRules(initIdentity)
 	require.True(t, ingress)
 	require.True(t, egress)
 
 	SetPolicyEnabled(option.NeverEnforce)
-	ingress, egress, _ = repo.computePolicyEnforcementAndRules(initIdentity)
+	ingress, egress, _, _, _ = repo.computePolicyEnforcementAndRules(initIdentity)
 	require.False(t, ingress)
 	require.False(t, egress)
 }
@@ -1627,7 +1626,7 @@ func TestDefaultAllow(t *testing.T) {
 			require.NoError(t, err, "unable to add rule to policy repository")
 		}
 
-		ing, egr, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
+		ing, egr, _, _, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
 		require.Equal(t, tc.ingress, ing, "case %d: ingress should match", i)
 		require.Equal(t, tc.egress, egr, "case %d: egress should match", i)
 		require.Len(t, matchingRules, tc.ruleC, "case %d: rule count should match", i)
@@ -1643,7 +1642,7 @@ func TestDefaultAllow(t *testing.T) {
 			require.NoError(t, err, "unable to add rule to policy repository")
 		}
 
-		ing, egr, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
+		ing, egr, _, _, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
 		require.Equal(t, tc.ingress, ing, "case %d: ingress should match", i)
 		require.Equal(t, tc.egress, egr, "case %d: egress should match", i)
 		require.Len(t, matchingRules, tc.ruleC, "case %d: rule count should match", i)
@@ -1666,7 +1665,7 @@ func TestDefaultAllow(t *testing.T) {
 				require.NoError(t, err, "unable to add rule to policy repository")
 			}
 
-			ing, egr, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
+			ing, egr, _, _, matchingRules := repo.computePolicyEnforcementAndRules(fooIdentity)
 			require.Equal(t, itc.ingress, ing, "case ingress %d + egress %d: ingress should match", i, e)
 			require.Equal(t, etc.egress, egr, "case ingress %d + egress %d: egress should match", i, e)
 			require.Len(t, matchingRules, itc.ruleC+etc.ruleC, "case ingress %d + egress %d: rule count should match", i, e)

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -55,6 +55,12 @@ type PolicyContext interface {
 	// value stored.
 	SetDeny(newValue bool) (oldValue bool)
 
+	// DefaultDenyIngress returns true if default deny is enabled for ingress
+	DefaultDenyIngress() bool
+
+	// DefaultDenyEgress returns true if default deny is enabled for egress
+	DefaultDenyEgress() bool
+
 	GetLogger() *slog.Logger
 
 	PolicyTrace(format string, a ...any)
@@ -65,7 +71,9 @@ type policyContext struct {
 	ns   string
 	// isDeny this field is set to true if the given policy computation should
 	// be done for the policy deny.
-	isDeny bool
+	isDeny             bool
+	defaultDenyIngress bool
+	defaultDenyEgress  bool
 
 	logger       *slog.Logger
 	traceEnabled bool
@@ -108,6 +116,16 @@ func (p *policyContext) SetDeny(deny bool) bool {
 	oldDeny := p.isDeny
 	p.isDeny = deny
 	return oldDeny
+}
+
+// DefaultDenyIngress returns true if default deny is enabled for ingress
+func (p *policyContext) DefaultDenyIngress() bool {
+	return p.defaultDenyIngress
+}
+
+// DefaultDenyEgress returns true if default deny is enabled for egress
+func (p *policyContext) DefaultDenyEgress() bool {
+	return p.defaultDenyEgress
 }
 
 func (p *policyContext) GetLogger() *slog.Logger {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Fixes: https://github.com/cilium/cilium/issues/38676

When EnableDefaultDeny is false, the policy should allow everything outside of the selected subject, but because there is no blanket allow-all for the L7 policy, all peers except the selected ones get denied even when they should not.
This PR fixes that by adding a blanket allow-all L7 rule as a part of the wildcard rule that gets added.

```release-note
Fixes a bug where layer-7 rules would override enableDefaultDeny: false, incorrectly dropping traffic.
```


TESTING:

POLICY 1 -
```
spec:
  endpointSelector: {}
  enableDefaultDeny:
    egress: false
  egress:
  - toPorts:
    - ports:
      - port: "53"
        protocol: ANY
      rules:
        dns:
        - matchPattern: "amazon.com"
```

```
➜  ~ k exec -it iperf3-client-c8mmw -- nslookup google.com
Server:		10.96.0.10
Address:	10.96.0.10:53

Non-authoritative answer:
Name:	google.com
Address: 142.251.33.78

Non-authoritative answer:
Name:	google.com
Address: 2607:f8b0:400a:800::200e
```

With `enableDefaultDeny.egress: true`:
```
➜  ~ k exec -it iperf3-client-c8mmw -- nslookup google.com
Server:		10.96.0.10
Address:	10.96.0.10:53

** server can't find google.com: REFUSED

** server can't find google.com: REFUSED

command terminated with exit code 1
➜  ~
➜  ~
➜  ~ k exec -it iperf3-client-c8mmw -- nslookup amazon.com
Server:		10.96.0.10
Address:	10.96.0.10:53

Non-authoritative answer:
Name:	amazon.com
Address: 205.251.242.103
Name:	amazon.com
Address: 52.94.236.248
Name:	amazon.com
Address: 54.239.28.85

Non-authoritative answer:
```

POLICY 2 - 
```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "http-policy-test"
spec:
  endpointSelector:
    matchLabels:
      app: nginx
  enableDefaultDeny:
    egress: false
  ingress:
    - fromEndpoints:
        - matchLabels:
            app: client
      toPorts:
        - ports:
            - port: "80"
              protocol: TCP
          rules:
            http:
              - method: "GET"
                path: "/api"
```

```
➜  ~ k exec -it client -- curl http://nginx-service/
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
html { color-scheme: light dark; }
body { width: 35em; margin: 0 auto;
font-family: Tahoma, Verdana, Arial, sans-serif; }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>
```

With `enableDefaultDeny.egress: true`:

```
➜  ~ k exec -it client -- curl http://nginx-service/
Access denied
➜  ~ k exec -it client -- curl http://nginx-service/api
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx/1.27.4</center>
</body>
</html>
```