### PR TITLE
[v1.17] ipsec: handle tunnelled ipv6 in v1.17 leak detection

### DIFF
--- a/bpf/lib/vxlan.h
+++ b/bpf/lib/vxlan.h
@@ -52,6 +52,53 @@ vxlan_get_inner_ipv4(const void *data, const void *data_end, __u32 l4_off,
 }
 
 /*
+ * Points 'inner' to the inner IPv6 header of a IPv4 VXLan excapsulated
+ * packet.
+ *
+ * The caller should be sure the VXLan packet is encapsulating IPv6 traffic
+ * before calling this method.
+ *
+ * Returns 'true' if 'inner' now points to a bounds-checked inner IPv6 header.
+ * Returns 'false' if an error occurred.
+ */
+static __always_inline bool
+vxlan_get_inner_ipv6(const void *data, const void *data_end, __u32 l4_off,
+		     struct ipv6hdr **inner) {
+	if (data + l4_off + sizeof(struct udphdr)
+	    + sizeof(struct vxlanhdr) + sizeof(struct ethhdr) +
+	    sizeof(struct ipv6hdr) > data_end)
+		return false;
+
+	*inner = (struct ipv6hdr *)(data + l4_off  + sizeof(struct udphdr) +
+		  sizeof(struct vxlanhdr) + sizeof(struct ethhdr));
+
+	return true;
+}
+
+/*
+ * Returns the protocol number of the encapsulated packet.
+ *
+ * The caller must ensure the skb associated with these data buffers are infact
+ * a vxlan encapsulated packet before invoking this function.
+ *
+ * Returns 'ethhdr->h_proto' if the bounds-check to inner ethernet header
+ * was successful.
+ * Returns -1 otherwise.
+ */
+static __always_inline __be16
+vxlan_get_inner_proto(const void *data, const void *data_end, __u32 l4_off) {
+	struct ethhdr *eth = NULL;
+	int inner_l2_off = l4_off + sizeof(struct udphdr) + sizeof(struct vxlanhdr);
+
+	if (data + inner_l2_off + sizeof(struct ethhdr) > data_end)
+		return -1;
+
+	eth = (struct ethhdr *)(data + inner_l2_off);
+
+	return eth->h_proto;
+}
+
+/*
  * Rewrites the current VNI in the VXLan header to the provided and updates
  * the l4 checksum if necessary.
  *

--- a/bpf/tests/ipsec_redirect_generic.h
+++ b/bpf/tests/ipsec_redirect_generic.h
@@ -27,11 +27,77 @@ int mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 /* test constants */
 #define SOURCE_MAC mac_one
 #define DST_MAC mac_two
+#define SOURCE_NODE_IP v4_node_one
 #define SOURCE_IP v4_pod_one
-#define SOURCE_IDENTITY 0xAB
+#define SOURCE_IP_6 v6_pod_one
+#define SOURCE_IDENTITY 0xAB0000
+#define DST_NODE_IP v4_node_two
 #define DST_IP v4_pod_two
+#define DST_IP_6 v6_pod_two
 #define DST_NODE_ID 0x08b9
+#define DST_IDENTITY 0xAC0000
 #define TARGET_SPI 2
 #define TARGET_MARK 0x08b92e00
 #define BAD_SPI 3
+
+int vxlan_ipv6_packet(struct __ctx_buff *ctx) {
+	struct pktgen builder;
+	struct vxlanhdr *vxlan = NULL;
+	// struct udphdr *udp = NULL;
+	struct ipv6hdr *l3;
+	struct ethhdr *l2;
+	pktgen__init(&builder, ctx);
+
+	vxlan = pktgen__push_ipv4_vxlan_packet(&builder, (__u8 *)SOURCE_MAC,
+			                       (__u8 *)DST_MAC, SOURCE_NODE_IP,
+					       DST_NODE_IP, bpf_htons(0x1234),
+					       bpf_htons(0x8472));
+	if (!vxlan)
+		return TEST_ERROR;
+
+	/*
+	 * NOTE: there was an attempt to use the pktgen__push_ipv6_udp_packet
+	 * but this blew up the verifier's ins count and broke the tests.
+	 */
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)SOURCE_MAC, (__u8 *)DST_MAC);
+
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	ipv6hdr__set_addrs(l3, (__u8 *)SOURCE_IP_6, (__u8 *)DST_IP_6);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+int vxlan_ipv4_packet(struct __ctx_buff *ctx) {
+	struct pktgen builder;
+	struct vxlanhdr *vxlan = NULL;
+	struct iphdr *ip = NULL;
+	pktgen__init(&builder, ctx);
+
+	vxlan = pktgen__push_ipv4_vxlan_packet(&builder, (__u8 *)SOURCE_MAC,
+			                       (__u8 *)DST_MAC, SOURCE_NODE_IP,
+					       DST_NODE_IP, bpf_htons(0x1234),
+					       bpf_htons(0x8472));
+	if (!vxlan)
+		return TEST_ERROR;
+
+	ip = pktgen__push_ipv4_packet(&builder, (__u8 *)SOURCE_MAC, (__u8 *)DST_MAC,
+				 SOURCE_IP, DST_IP);
+
+	if (!ip)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
 

--- a/bpf/tests/ipsec_redirect_native.c
+++ b/bpf/tests/ipsec_redirect_native.c
@@ -55,7 +55,7 @@ int ipsec_redirect_check(__maybe_unused struct __ctx_buff *ctx)
 	 * The tunnel_endpoint is used in the IPsec hook under test below to
 	 * find the associated NodeID for an egress packet
 	 */
-	ipcache_v4_add_entry(DST_IP, 0, 0xAC, DST_IP, TARGET_SPI);
+	ipcache_v4_add_entry(DST_IP, 0, DST_IDENTITY, DST_IP, TARGET_SPI);
 
 	ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
 					      SOURCE_IDENTITY);

--- a/bpf/tests/ipsec_redirect_tunnel.c
+++ b/bpf/tests/ipsec_redirect_tunnel.c
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define TUNNEL_MODE
+
+#include "ipsec_redirect_generic.h"
+
+#include "node_config.h"
+
+/* must define `HAVE_ENCAP 1` before including 'lib/encrypt.h'.
+ * lib/encrypt.h eventually imports overloadable_skb.h which exposes
+ * ctx_is_overlay and ctx_is_overlay_encrypted, utilized within
+ * 'ipsec_maybe_redirect_to_encrypt'
+ */
+#define HAVE_ENCAP 1
+#include "lib/encrypt.h"
+
+#include "tests/lib/ipcache.h"
+
+PKTGEN("tc", "ipsec_redirect_tunnel_v4_overlay_checks")
+int ipsec_redirect_pktgen_v4_overlay_checks(struct __ctx_buff *ctx)
+{
+	return vxlan_ipv4_packet(ctx);
+}
+
+CHECK("tc", "ipsec_redirect_tunnel_v4_overlay_checks")
+int ipsec_redirect_check_v4_overlay_checks(__maybe_unused struct __ctx_buff *ctx) {
+	test_init();
+
+	int ret = 0;
+
+	/* Ensure we simply return from 'ipsec_maybe_redirect_to_encrypt' if
+	 * the 'MARK_MAGIC_OVERLAY_ENCRYPTED' mark is set.
+	 */
+	TEST("overlay-encrypted-mark-set", {
+		ctx->mark = MARK_MAGIC_OVERLAY_ENCRYPTED;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure packet from overlay that is not OVERLAY_ENCRYPTED and does not
+	 * have a dst ipcache entry returns CTX_ACT_OK
+	 */
+	TEST("overlay-no-dst", {
+		ctx->mark = MARK_MAGIC_OVERLAY;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	test_finish();
+}
+
+
+PKTGEN("tc", "ipsec_redirect_tunnel_v4_pod_to_pod")
+int ipsec_redirect_pktgen_v4_pod_to_pod(struct __ctx_buff *ctx)
+{
+	return vxlan_ipv4_packet(ctx);
+}
+
+CHECK("tc", "ipsec_redirect_tunnel_v4_pod_to_pod")
+int ipsec_redirect_check_v4_pod_to_pod(__maybe_unused struct __ctx_buff *ctx) {
+	test_init();
+
+	int ret = 0;
+
+	/*
+	 * Fill the nodemap with the destination node's ID keyed by the
+	 * destination node's IP. This is the case for VXLAN traffic where
+	 * the outer ipv4.dst == DST_NODE_IP
+	 */
+	struct node_key key = {
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = DST_NODE_IP,
+	};
+	struct node_value val = {
+		.id = DST_NODE_ID,
+		.spi = TARGET_SPI,
+	};
+
+	map_update_elem(&NODE_MAP_V2, &key, &val, BPF_ANY);
+
+	struct encrypt_config cfg = {
+		.encrypt_key = BAD_SPI,
+	};
+	map_update_elem(&ENCRYPT_MAP, &ret, &cfg, BPF_ANY);
+
+	/*
+	 * Ensure encryption mark is set for pod-to-pod traffic and
+	 * CTX_ACT_REDIRECT is set.
+	 */
+	TEST("overlay-pod-to-pod", {
+		/* add dst ipcache entry mapping to inner dst ipv4 */
+		ipcache_v4_add_entry(DST_IP, 0, DST_IDENTITY, DST_IP, TARGET_SPI);
+
+		ctx->mark = SOURCE_IDENTITY | MARK_MAGIC_OVERLAY;
+		/*
+		 * NOTE: the passedin SOURCE_IDENTITY does not matter here,
+		 * once the function determines the packet is MARK_MAGIC_OVERLAY
+		 * it will pull the identity directly from ctx.
+		 */
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+
+		assert(ctx->mark == TARGET_MARK);
+		assert(ret == CTX_ACT_REDIRECT);
+	})
+
+	test_finish();
+}
+
+
+PKTGEN("tc", "ipsec_redirect_tunnel_v4_bad_identities")
+int ipsec_redirect_pktgen_v4_bad_identites(struct __ctx_buff *ctx)
+{
+	return vxlan_ipv4_packet(ctx);
+}
+
+CHECK("tc", "ipsec_redirect_tunnel_v4_bad_identities")
+int ipsec_redirect_check_v4_bad_identities(__maybe_unused struct __ctx_buff *ctx) {
+	test_init();
+
+	int ret = 0;
+
+	/*
+	 * Ensure if source identity is HOST_ID encryption does not occur
+	 */
+	TEST("overlay-host-to-pod", {
+		__u32 mark = MARK_MAGIC_OVERLAY | (HOST_ID << 16);
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if source identity is WORLD_ID encryption does not occur
+	 */
+	TEST("overlay-world-to-pod", {
+		__u32 mark = MARK_MAGIC_OVERLAY | (WORLD_ID << 16);
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if source identity is REMOTE_NODE_ID encryption does not occur
+	 */
+	TEST("overlay-remote-node-to-pod", {
+		__u32 mark = MARK_MAGIC_OVERLAY | (REMOTE_NODE_ID << 16);
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if dst identity is HOST_ID encryption does not occur
+	 */
+	TEST("overlay-pod-to-host", {
+		__u32 mark = MARK_MAGIC_OVERLAY | SOURCE_IDENTITY;
+		ipcache_v4_add_entry(DST_IP, 0, HOST_ID, DST_IP, TARGET_SPI);
+
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if dst identity is WORLD_ID encryption does not occur
+	 */
+	TEST("overlay-pod-to-world", {
+		__u32 mark = MARK_MAGIC_OVERLAY | SOURCE_IDENTITY;
+		ipcache_v4_add_entry(DST_IP, 0, WORLD_ID, DST_IP, TARGET_SPI);
+
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if dst identity is REMOTE_NODE_ID encryption does not occur
+	 */
+	TEST("overlay-pod-to-remote_node", {
+		__u32 mark = MARK_MAGIC_OVERLAY | SOURCE_IDENTITY;
+		ipcache_v4_add_entry(DST_IP, 0, REMOTE_NODE_ID, DST_IP, TARGET_SPI);
+
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	test_finish();
+}

--- a/bpf/tests/ipsec_redirect_tunnel_v6.c
+++ b/bpf/tests/ipsec_redirect_tunnel_v6.c
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define TUNNEL_MODE
+
+#include "ipsec_redirect_generic.h"
+
+#include "node_config.h"
+
+/* must define `HAVE_ENCAP 1` before including 'lib/encrypt.h'.
+ * lib/encrypt.h eventually imports overloadable_skb.h which exposes
+ * ctx_is_overlay and ctx_is_overlay_encrypted, utilized within
+ * 'ipsec_maybe_redirect_to_encrypt'
+ */
+#define HAVE_ENCAP 1
+#include "lib/encrypt.h"
+
+#include "tests/lib/ipcache.h"
+
+PKTGEN("tc", "ipsec_redirect_tunnel_v6_pod_to_pod")
+int ipsec_redirect_pktgen_v6_pod_to_pod(struct __ctx_buff *ctx)
+{
+	return vxlan_ipv6_packet(ctx);
+}
+
+CHECK("tc", "ipsec_redirect_tunnel_v6_pod_to_pod")
+int ipsec_redirect_check_v6_pod_to_pod(__maybe_unused struct __ctx_buff *ctx) {
+	test_init();
+
+	int ret = 0;
+
+	struct node_key key = {
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = DST_NODE_IP,
+	};
+	struct node_value val = {
+		.id = DST_NODE_ID,
+		.spi = TARGET_SPI,
+	};
+
+	map_update_elem(&NODE_MAP_V2, &key, &val, BPF_ANY);
+
+	struct encrypt_config cfg = {
+		.encrypt_key = BAD_SPI,
+	};
+	map_update_elem(&ENCRYPT_MAP, &ret, &cfg, BPF_ANY);
+
+	/*
+	 * Ensure encryption mark is set for pod-to-pod traffic and
+	 * CTX_ACT_REDIRECT is set.
+	 */
+	TEST("overlay-pod-to-pod", {
+		/* add dst ipcache entry mapping to inner dst ipv4 */
+		ipcache_v6_add_entry((union v6addr *)DST_IP_6,
+				     0, DST_IDENTITY, DST_IP, TARGET_SPI);
+
+		ctx->mark = SOURCE_IDENTITY | MARK_MAGIC_OVERLAY;
+		/*
+		 * NOTE: the passedin SOURCE_IDENTITY does not matter here,
+		 * once the function determines the packet is MARK_MAGIC_OVERLAY
+		 * it will pull the identity directly from ctx.
+		 */
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+
+		assert(ctx->mark == TARGET_MARK);
+		assert(ret == CTX_ACT_REDIRECT);
+	})
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipsec_redirect_tunnel_v6_bad_identities")
+int ipsec_redirect_pktgen_v6_bad_identites(struct __ctx_buff *ctx)
+{
+	return vxlan_ipv6_packet(ctx);
+}
+
+CHECK("tc", "ipsec_redirect_tunnel_v6_bad_identities")
+int ipsec_redirect_check_v6_bad_identities(__maybe_unused struct __ctx_buff *ctx) {
+	test_init();
+
+	int ret = 0;
+
+	/*
+	 * Ensure if source identity is HOST_ID encryption does not occur
+	 */
+	TEST("overlay-host-to-pod", {
+		__u32 mark = MARK_MAGIC_OVERLAY | (HOST_ID << 16);
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if source identity is WORLD_ID encryption does not occur
+	 */
+	TEST("overlay-world-to-pod", {
+		__u32 mark = MARK_MAGIC_OVERLAY | (WORLD_ID << 16);
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if source identity is REMOTE_NODE_ID encryption does not occur
+	 */
+	TEST("overlay-remote-node-to-pod", {
+		__u32 mark = MARK_MAGIC_OVERLAY | (REMOTE_NODE_ID << 16);
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if dst identity is HOST_ID encryption does not occur
+	 */
+	TEST("overlay-pod-to-host", {
+		__u32 mark = MARK_MAGIC_OVERLAY | SOURCE_IDENTITY;
+		ipcache_v6_add_entry((union v6addr *)DST_IP_6, 0, HOST_ID,
+				     DST_IP, TARGET_SPI);
+
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if dst identity is WORLD_ID encryption does not occur
+	 */
+	TEST("overlay-pod-to-world", {
+		__u32 mark = MARK_MAGIC_OVERLAY | SOURCE_IDENTITY;
+		ipcache_v6_add_entry((union v6addr *)DST_IP_6, 0, WORLD_ID,
+				     DST_IP, TARGET_SPI);
+
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure if dst identity is REMOTE_NODE_ID encryption does not occur
+	 */
+	TEST("overlay-pod-to-remote_node", {
+		__u32 mark = MARK_MAGIC_OVERLAY | SOURCE_IDENTITY;
+		ipcache_v6_add_entry((union v6addr *)DST_IP_6, 0, REMOTE_NODE_ID,
+				     DST_IP, TARGET_SPI);
+
+		ctx->mark = mark;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
+						      SOURCE_IDENTITY);
+
+		assert(ctx->mark == mark);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	test_finish();
+}


### PR DESCRIPTION
In 38bfecaeddfd249bea0019c91047a1c5b7f02b16 code was backported to v1.17 to ensure no leaked packets would slip through when upgrading/downgrading from v1.17 to v1.18.

The leak detection mechanism failed to include checking for encapsulated IPv6 packets.

Update the leak detection bits to parse out the inner MAC header, determine the IP version, and check the inner IP protocol accordingly.

This will now ensure leaked tunnelled IPv6 traffic is encapsulated during v1.17<->v1.18 upgrade/downgrade.

```release-note
ipsec: include ipv6 in v1.18 upgrade leak detection
```
