### PR TITLE
ipcache: Avoid unnecessary sorting in metadata API

### DIFF
--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -6,7 +6,10 @@ package ipcache
 import (
 	"context"
 	"fmt"
+	"maps"
+	"net"
 	"net/netip"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -14,6 +17,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
@@ -1419,4 +1424,59 @@ func BenchmarkManyResources(b *testing.B) {
 		resource := types.NewResourceID(types.ResourceKindCNP, fmt.Sprintf("namespace_%d", i), "my-policy")
 		m.upsertLocked(prefix, source.Generated, resource, lbls)
 	}
+}
+
+func BenchmarkManyCIDREntries(b *testing.B) {
+	prevRoutingMode := option.Config.RoutingMode
+	defer func() { option.Config.RoutingMode = prevRoutingMode }()
+	option.Config.RoutingMode = option.RoutingModeNative
+
+	allocator := testidentity.NewMockIdentityAllocator(nil)
+	PolicyHandler = newMockUpdater()
+	IPIdentityCache = NewIPCache(&Configuration{
+		IdentityAllocator: allocator,
+		PolicyHandler:     PolicyHandler,
+		DatapathHandler:   &mockTriggerer{},
+	})
+	IPIdentityCache.metadata = newMetadata()
+
+	cidrs := generateUniqueCIDRs(1000)
+	cidrLabels := make(map[cmtypes.PrefixCluster]labels.Labels, len(cidrs))
+	for _, v := range cidrs {
+		cidrLabels[v] = labels.GetCIDRLabels(v.AsPrefix())
+	}
+
+	var i int
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		for cidr, lbls := range cidrLabels {
+			resource := types.NewResourceID(types.ResourceKindCNP, fmt.Sprintf("namespace_%d", i), "my-policy")
+			IPIdentityCache.metadata.upsertLocked(cidr, source.Generated, resource, lbls)
+			_, _, _ = IPIdentityCache.doInjectLabels(context.TODO(), []cmtypes.PrefixCluster{cidr})
+		}
+		i++
+	}
+}
+
+// generateUniqueCIDRs generates a specified number of unique CIDRs.
+func generateUniqueCIDRs(n int) []cmtypes.PrefixCluster {
+	rand.Seed(time.Now().UnixNano())
+
+	unique := sets.New[cmtypes.PrefixCluster]()
+	for unique.Len() < n {
+		// Generate a random IP address
+		ip := net.IPv4(
+			byte(rand.Intn(256)),
+			byte(rand.Intn(256)),
+			byte(rand.Intn(256)),
+			byte(rand.Intn(256)),
+		)
+
+		// Generate a random subnet mask (between 16 and 31)
+		cidr := ip.String() + "/" + strconv.Itoa(rand.Intn(15)+17)
+		unique = unique.Insert(cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix(cidr)))
+	}
+
+	return slices.Collect(maps.Keys(unique))
 }

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -200,7 +200,7 @@ func (s prefixInfo) Source() source.Source {
 }
 
 func (s prefixInfo) EncryptKey() ipcachetypes.EncryptKey {
-	for _, rid := range s.sortedBySourceThenResourceID() {
+	for rid := range s {
 		if k := s[rid].encryptKey; k.IsValid() {
 			return k
 		}
@@ -209,7 +209,7 @@ func (s prefixInfo) EncryptKey() ipcachetypes.EncryptKey {
 }
 
 func (s prefixInfo) TunnelPeer() ipcachetypes.TunnelPeer {
-	for _, rid := range s.sortedBySourceThenResourceID() {
+	for rid := range s {
 		if t := s[rid].tunnelPeer; t.IsValid() {
 			return t
 		}


### PR DESCRIPTION
- **ipcache: Add benchmark for many CIDR ipcache entries**
- **ipcache: Avoid unnecessary sorting in metadata API**
