### PR TITLE
controller: Ensure controller updates eventually apply

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -191,7 +191,7 @@ type controller struct {
 
 	// Channels written to and/or closed by the manager
 	stop    chan struct{}
-	update  chan ControllerParams
+	update  chan struct{}
 	trigger chan struct{}
 
 	// terminated is closed by the controller goroutine when it terminates
@@ -298,12 +298,14 @@ func (c *controller) GetLastErrorTimestamp() time.Time {
 	return c.lastErrorStamp
 }
 
-func (c *controller) runController(params ControllerParams) {
+func (c *controller) runController() {
+	params := c.Params()
 	errorRetries := 1
 
 	for {
 		var err error
 
+		params = c.Params()
 		interval := params.RunInterval
 
 		start := time.Now()
@@ -379,7 +381,7 @@ func (c *controller) runController(params ControllerParams) {
 		case <-c.stop:
 			goto shutdown
 
-		case params = <-c.update:
+		case <-c.update:
 			// update channel is never closed
 		case <-stdtime.After(interval):
 			// timer channel is not yet closed


### PR DESCRIPTION
Prior to this change, if multiple callers simultaneously attempted to update
the configuration of the controller, then the first one would store the
configuration then pass the configuration to the actual controller goroutine to
execute. Assuming the DoFunc logic takes long enough, the second or subsequent
callers would store the configuration and then perform a non-blocking send of
the configuration update to the internal controller goroutine. These latter
updates could be skipped due to lack of capacity in the channel, meaning the
configuration could never apply to the actual controller goroutine that is
intended to execute using the configured parameters.

Avoid this by reusing the stored copy of the configuration from the internal
goroutine. This effectively reduces a sequence of operations A, B, C during a
period where the controller runs to instead trigger once for A and once for the
final configuration C. This retains the non-blocking flow control that existing
callers of `UpdateController()` likely expect, but without losing later updates
to the configuration parameters.

Related: #29015