### PR TITLE
test/runtime: remove already covered FQDN tests

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -190,7 +190,6 @@ jobs:
           # RuntimeAgentFQDNPolicies CNAME follow
           # RuntimeAgentFQDNPolicies DNS proxy policy works if Cilium stops
           # RuntimeAgentFQDNPolicies Enforces L3 policy even when no IPs are inserted
-          # RuntimeAgentFQDNPolicies Implements matchPattern: *
           # RuntimeAgentFQDNPolicies Interaction with other ToCIDR rules
           # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) L3-dependent L7/HTTP with toFQDN updates proxy policy
           # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) Policy addition after DNS lookup

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -189,7 +189,6 @@ jobs:
           # RuntimeAgentFQDNPolicies Can update L7 DNS policy rules
           # RuntimeAgentFQDNPolicies CNAME follow
           # RuntimeAgentFQDNPolicies DNS proxy policy works if Cilium stops
-          # RuntimeAgentFQDNPolicies Enforces L3 policy even when no IPs are inserted
           # RuntimeAgentFQDNPolicies Interaction with other ToCIDR rules
           # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) L3-dependent L7/HTTP with toFQDN updates proxy policy
           # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) Policy addition after DNS lookup

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -195,7 +195,6 @@ jobs:
           # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) L3-dependent L7/HTTP with toFQDN updates proxy policy
           # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) Policy addition after DNS lookup
           # RuntimeAgentFQDNPolicies Validate dns-proxy monitor information
-          # RuntimeAgentFQDNPolicies With verbose policy logs Validates DNSSEC responses
           # RuntimeAgentKVStoreTest KVStore tests Etcd KVStore
           # RuntimeAgentPolicies Init Policy Default Drop Test tests egress
           # RuntimeAgentPolicies Init Policy Default Drop Test tests ingress

--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -12,9 +12,6 @@ const (
 	// HttpdImage is the image used for starting an HTTP server.
 	HttpdImage = "quay.io/cilium/demo-httpd:1.0"
 
-	// DNSSECContainerImage is the image used for starting a DNSSec client.
-	DNSSECContainerImage = "docker.io/cilium/dnssec-client:v0.2"
-
 	// BindContainerImage is the image used for DNS binding testing.
 	BindContainerImage = "docker.io/cilium/docker-bind:v0.3"
 )

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -543,41 +543,6 @@ var _ = Describe("RuntimeAgentFQDNPolicies", func() {
 		res.ExpectSuccess("Container %q cannot access to %q when should work", helpers.App2, target)
 	})
 
-	It("Enforces L3 policy even when no IPs are inserted", func() {
-		By("Importing policy with toFQDNs rules")
-		fqdnPolicy := `
-[
-  {
-    "labels": [{
-	  	"key": "toFQDNs-runtime-test-policy"
-	  }],
-    "endpointSelector": {
-      "matchLabels": {
-        "container:id.app1": ""
-      }
-    },
-    "egress": [
-      {
-        "toFQDNs": [
-          {
-            "matchPattern": "notadomain.cilium.io"
-          }
-        ]
-      }
-    ]
-  }
-]`
-		_, err := vm.PolicyRenderAndImport(fqdnPolicy)
-		Expect(err).To(BeNil(), "Policy cannot be imported")
-		expectFQDNSareApplied("cilium.io", 0)
-
-		By("Denying egress to any IPs or domains")
-		for _, blockedTarget := range []string{"1.1.1.1", "cilium.io", "google.com"} {
-			res := vm.ContainerExec(helpers.App1, helpers.CurlFail(blockedTarget))
-			res.ExpectFail("Curl to %s succeeded when in deny-all due to toFQDNs" + blockedTarget)
-		}
-	})
-
 	Context("toFQDNs populates toCIDRSet (data from proxy)", func() {
 		BeforeAll(func() {
 			vm.SetUpCilium()


### PR DESCRIPTION
Remove three more tests from the runtime FQDN test suite that are either already covered by existing tests or are of limited use.

    test/runtime: remove RuntimeAgentFQDNPolicies default-deny test

    The policy used in the test doesn't have a toPorts.rules.dns rule, so
    the DNS proxy isn't covered at all in the test.
    
    This test is thus testing the default-deny behavior which is already
    covered elsewhere, e.g. various Cilium CLI connectivity tests.
---
    test/runtime: remove RuntimeAgentFQDNPolicies Implement matchPattern * test

    matchPattern * is already covered in existing Cilium CLI connectivity
    tests, though not for subdomains currently.  However, the correct
    application of the provided pattern to FQDNs is already covered in
    various unit tests in pkg/fqdn. Thus the corresponding runtime FQDN test
    case is redundant and can be removed.
---
    test/runtime: remove RuntimeAgentFQDNPolicies DNSSEC test

    The existing FQDN runtime test only checks for the existence of an
    RRSIG record in the DNS response[^1]. The Cilium DNS proxy doesn't touch
    RRSIG records at all. So it looks like the existing test is
    already of limited use and can be removed without replacement.
    
    [^1]: https://github.com/cilium/dnssec-client/blob/master/client.py#L30-L32

For #37838