### PR TITLE
cilium-cli: add annotation to indicate we should wait for policy

### DIFF
--- a/cilium-cli/connectivity/check/policy.go
+++ b/cilium-cli/connectivity/check/policy.go
@@ -38,6 +38,8 @@ import (
  */
 const getPolicyRevisionRetries = 3
 
+const policyBumpAnnotation = "cli.cilium.io/bump-policy"
+
 // getCiliumPolicyRevisions returns the current policy revisions of all Cilium pods
 func (ct *ConnectivityTest) getCiliumPolicyRevisions(ctx context.Context) (map[Pod]int, error) {
 	revisions := make(map[Pod]int)
@@ -245,7 +247,13 @@ var policyApplyDeleteLock = lock.Mutex{}
 
 // isPolicy returns true if the object is a network policy, and thus
 // should bump the policy revision.
+//
+// This is true if the object is a known policy type (CNP / CCNP / KNP)
+// or if the object has the annotation cli.cilium.io/bump-policy
 func isPolicy(obj k8s.Object) bool {
+	if _, ok := obj.GetAnnotations()[policyBumpAnnotation]; ok {
+		return true
+	}
 	gk := obj.GetObjectKind().GroupVersionKind().GroupKind()
 	return (gk == schema.GroupKind{Group: ciliumv2.CustomResourceDefinitionGroup, Kind: ciliumv2.CNPKindDefinition} ||
 		gk == schema.GroupKind{Group: ciliumv2.CustomResourceDefinitionGroup, Kind: ciliumv2.CCNPKindDefinition} ||


### PR DESCRIPTION
The connectivity tests wait for policy changes to roll out; they do so by counting the number of policy resources and waiting for each agent's revision to be incremented by that number.

There are, however, other resources or actions that can cause policy revision bumps such as config changes or CiliumEnvoyConfigs. Rather than coding them all in, enable a special annotation that triggers this.
