### PR TITLE
plugins/cni: set MTU on route object

### DIFF
--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -357,6 +357,7 @@ func configureIface(ipam *models.IPAMResponse, ifName string, state *CmdState) (
 func newCNIRoute(r route.Route) *cniTypes.Route {
 	rt := &cniTypes.Route{
 		Dst: r.Prefix,
+		MTU: r.MTU,
 	}
 	if r.Nexthop != nil {
 		rt.GW = *r.Nexthop


### PR DESCRIPTION
The Cilium CNI plugin outputs a [standardized](https://github.com/containernetworking/cni/blob/main/SPEC.md#section-5-result-types) JSON object. This is consumed by container runtimes (i.e. containerd / crio) or further CNI chained plugins.

CNI versions v1.1 and later include the `mtu` field on routes, where a runtime that sets route MTUs can report this to upstream callers.

As Cilium makes use of per-route MTUs, we should conform to the CNI specification and set this field.

This does not change any cilium-internal behavior. Rather, it reports to our caller what we were doing all along, in a CNI-conformant way.


```release-note
Cilium's CNI plugin now conforms to CNI v1.1 and reports per-route MTUs.
```
