### PR TITLE
operator/networkpolicy: don't log invalid CNPs as errors

### DIFF
--- a/operator/pkg/networkpolicy/cell.go
+++ b/operator/pkg/networkpolicy/cell.go
@@ -134,7 +134,7 @@ func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Ev
 	}
 
 	if errs != nil {
-		log.Error("Detected invalid CNP, setting condition", logfields.Error, errs)
+		log.Debug("Detected invalid CNP, setting condition", logfields.Error, errs)
 	} else {
 		log.Debug("CNP now valid, setting condition")
 	}


### PR DESCRIPTION
Change the log message severity to Debug (like for CCNPs). An invalid CNP is not an error of the networkpolicy validator cell. The error will be reported on the CNPs status.