### PR TITLE
Corrections to IP Pools Example Documentation

### DIFF
--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -44,10 +44,9 @@ A basic IP Pools with both an IPv4 and IPv6 range looks like this:
     spec:
       blocks:
       - cidr: "10.0.10.0/24"
-      - cidr: "2004::0/64"
+      - cidr: "2004::0/112"
       - start: "20.0.20.100"
         stop: "20.0.20.200"
-      - start: "1.2.3.4"
 
 After adding the pool to the cluster, it appears like so.
 
@@ -55,7 +54,7 @@ After adding the pool to the cluster, it appears like so.
 
     $ kubectl get ippools                           
     NAME        DISABLED   CONFLICTING   IPS AVAILABLE   AGE
-    blue-pool   false      False         65788           2s
+    blue-pool   false      False         65892           2s
 
 CIDRs, Ranges and reserved IPs
 ------------------------------


### PR DESCRIPTION
## Corrections to IP Pools Example Documentation

1.  Deleted the line in configuration example that I believe was a placeholder  start: "1.2.3.4" with no end range.

2.  Change the ipv6 example to have a smaller CIDR range of /112 and correct the example output to match the real output with this change.  The current example does not match what you actually will see if you copy the example.  You would see "IPS AVAILABLE" of a crazy large number of 18446744073709551974.  The change will make a more comprehensible example.

3.  Correct the example output of "kubectl get ippools" to match the example.


```release-note
docs: Bring minor corrections to IP Pools example documentation
```

Signed-off-by: Adam Langmeyer <adamlangmeyer@fastmail.com>

