### PR TITLE
gateway-api: Fix Gateway reconciler failure when TLSRoute CRD is not installed

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -93,9 +93,11 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	tlsRouteList := &gatewayv1alpha2.TLSRouteList{}
-	if err := r.Client.List(ctx, tlsRouteList); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to list TLSRoutes", logfields.Error, err)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	if helpers.HasTLSRouteSupport(r.Client.Scheme()) {
+		if err := r.Client.List(ctx, tlsRouteList); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list TLSRoutes", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
 	}
 
 	// TODO(tam): Only list the services / ServiceImports used by accepted Routes

--- a/operator/pkg/gateway-api/helpers/tlsroute.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// HasTLSRouteSupport returns if the TLSRoute CRD is supported.
+// This checks if the Gateway API v1alpha2 group is registered in the client scheme
+// and it is expected that it is registered only if the TLSRoute
+// CRD has been installed prior to the client setup.
+func HasTLSRouteSupport(scheme *runtime.Scheme) bool {
+	return scheme.IsGroupRegistered(gatewayv1alpha2.GroupVersion.Group)
+}

--- a/operator/pkg/gateway-api/helpers/tlsroute_test.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestHasTLSRouteSupport(t *testing.T) {
+	// Create a scheme without TLSRoute registered
+	scheme := runtime.NewScheme()
+	assert.False(t, HasTLSRouteSupport(scheme))
+
+	// Register the TLSRoute group
+	err := gatewayv1alpha2.AddToScheme(scheme)
+	assert.NoError(t, err)
+	assert.True(t, HasTLSRouteSupport(scheme))
+}


### PR DESCRIPTION
## Description

This PR fixes an issue where the Gateway API reconciler fails when the experimental TLSRoute CRD is not installed. According to the documentation, the experimental Gateway API CRDs are not required if TLSRoutes are not going to be used. However, the current implementation tries to list TLSRoutes unconditionally, which fails with an error when the CRD is not installed.

The fix adds a check to determine if the TLSRoute CRD is supported in the cluster before attempting to list TLSRoutes. When the CRD is not installed, the Gateway reconciler now uses an empty TLSRouteList instead of failing with an error.

## Related issues

Fixes: #38420

## How has this been tested

I've tested this by:
1. Creating a unit test for the `HasTLSRouteSupport` helper function
2. Verifying that the Gateway reconciler works correctly when the TLSRoute CRD is not installed

## Checklist

- [x] I have read the [Documentation](https://docs.cilium.io)
- [x] I have read the [Contributing documentation](https://docs.cilium.io/en/latest/contributing/development/)
- [x] I have read the [Code of Conduct](https://docs.cilium.io/en/latest/contributing/code-of-conduct/)
- [x] I have signed the [Developer's Certificate of Origin](https://github.com/cilium/cilium/blob/main/Documentation/contributing/contributing.rst#developers-certificate-of-origin)
- [x] I have added unit tests for my changes
- [x] I have tested the changes and verified that they work and don't break existing tests