### PR TITLE
hubble-helm: fixed certificates when using certmanager/autogenerate

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.hubble.enabled .Values.hubble.metrics.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") }}
-{{- $cn := list (.Values.cluster.name | replace "." "-") "hubble-metrics.cilium.io" | join "." }}
+{{- $cn := default "hubble-metrics.cilium.io" .Values.hubble.metrics.tls.server.commonName }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") .Values.hubble.relay.enabled }}
+{{- $cn := default "hubble-relay.cilium.io" .Values.hubble.relay.tls.client.commonName }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -17,9 +18,18 @@ spec:
   issuerRef:
     {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
   secretName: hubble-relay-client-certs
-  commonName: "*.hubble-relay.cilium.io"
+  commonName: {{ $cn | quote }}
   dnsNames:
-  - "*.hubble-relay.cilium.io"
+  - {{ $cn | quote }}
+  {{- range $dns := .Values.hubble.relay.tls.client.extraDnsNames }}
+  - {{ $dns | quote }}
+  {{- end }}
+  {{- if .Values.hubble.relay.tls.client.extraIpAddresses }}
+  ipAddresses:
+  {{- range $ip := .Values.hubble.relay.tls.client.extraIpAddresses }}
+  - {{ $ip | quote }}
+  {{- end }}
+  {{- end }}
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled }}
+{{- $cn := default "hubble-relay.cilium.io" .Values.hubble.relay.tls.server.commonName }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -17,9 +18,9 @@ spec:
   issuerRef:
     {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
   secretName: hubble-relay-server-certs
-  commonName: "*.hubble-relay.cilium.io"
+  commonName: {{ $cn | quote }}
   dnsNames:
-  - "*.hubble-relay.cilium.io"
+  - {{ $cn | quote }}
   {{- range $dns := .Values.hubble.relay.tls.server.extraDnsNames }}
   - {{ $dns | quote }}
   {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") }}
-{{- $cn := list "*" (.Values.cluster.name | replace "." "-") "hubble-grpc.cilium.io" | join "." }}
+{{- $cn := default "hubble-grpc.cilium.io" .Values.hubble.tls.server.commonName }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "certmanager") .Values.hubble.ui.enabled .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled }}
+{{- $cn := default "hubble-ui.cilium.io" .Values.hubble.ui.tls.client.commonName }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -17,9 +18,18 @@ spec:
   issuerRef:
     {{- toYaml .Values.hubble.tls.auto.certManagerIssuerRef | nindent 4 }}
   secretName: hubble-ui-client-certs
-  commonName: "*.hubble-ui.cilium.io"
+  commonName: {{ $cn | quote }}
   dnsNames:
-  - "*.hubble-ui.cilium.io"
+  - {{ $cn | quote }}
+  {{- range $dns := .Values.hubble.ui.tls.client.extraDnsNames }}
+  - {{ $dns | quote }}
+  {{- end }}
+  {{- if .Values.hubble.ui.tls.client.extraIpAddresses }}
+  ipAddresses:
+  {{- range $ip := .Values.hubble.ui.tls.client.extraIpAddresses }}
+  - {{ $ip | quote }}
+  {{- end }}
+  {{- end }}
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1251,6 +1251,8 @@ hubble:
         # -- base64 encoded PEM values for the Hubble metrics server key (deprecated).
         # Use existingSecret instead.
         key: ""
+        # -- DNS name to build the certificate for
+        commonName: ""
         # -- Extra DNS names added to certificate when it's auto generated
         extraDnsNames: []
         # -- Extra IP addresses added to certificate when it's auto generated
@@ -1486,6 +1488,8 @@ hubble:
       # -- base64 encoded PEM values for the Hubble server key (deprecated).
       # Use existingSecret instead.
       key: ""
+      # -- DNS name to build the certificate for
+      commonName: ""
       # -- Extra DNS names added to certificate when it's auto generated
       extraDnsNames: []
       # -- Extra IP addresses added to certificate when it's auto generated
@@ -1613,6 +1617,12 @@ hubble:
         # -- base64 encoded PEM values for the Hubble relay client key (deprecated).
         # Use existingSecret instead.
         key: ""
+        # -- DNS name to build the certificate for
+        commonName: ""
+        # -- extra DNS names added to certificate when its auto gen
+        extraDnsNames: []
+        # -- extra IP addresses added to certificate when its auto gen
+        extraIpAddresses: []
       # -- The hubble-relay server certificate and private key
       server:
         # When set to true, enable TLS on for Hubble Relay server
@@ -1631,6 +1641,8 @@ hubble:
         # -- base64 encoded PEM values for the Hubble relay server key (deprecated).
         # Use existingSecret instead.
         key: ""
+        # -- DNS name to build the certificate for
+        commonName: ""
         # -- extra DNS names added to certificate when its auto gen
         extraDnsNames: []
         # -- extra IP addresses added to certificate when its auto gen
@@ -1746,6 +1758,12 @@ hubble:
         # -- base64 encoded PEM values for the Hubble UI client key (deprecated).
         # Use existingSecret instead.
         key: ""
+        # -- DNS name to build the certificate for
+        commonName: ""
+        # -- extra DNS names added to certificate when its auto gen
+        extraDnsNames: []
+        # -- extra IP addresses added to certificate when its auto gen
+        extraIpAddresses: []
     backend:
       # -- Hubble-ui backend image.
       image:


### PR DESCRIPTION
If you enabled autogeneration of the certificates for hubble using certmanager some of the Certificate crd's were generated wrong.

Some of them contained hardcoded cilium.io domains and there was no trivial way to configure the commonName and dnsNames field.

With this commit this is fixed and unified over all certificates for hubble.

Tested using v1.32.1+k0s kubernetes version with different versions of the **values.yaml** file.

Fixes: #38563

```release-note
Fix incorrect generation of Hubble certificates with cert-manager, where some Certificate CRDs had hardcoded `cilium.io` domains and lacked configurable `commonName` and `dnsNames` fields.
```

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!


