### PR TITLE
connectivity: Fix flow validation for wildcard tls sni

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -73,6 +73,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		WithScenarios(tests.PodToWorld2()).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().Port() == 443 {
+				// SSL error as another external target (e.g. cilium.io) SNI is not allowed
+				return check.ResultCurlSSLError, check.ResultNone
+			}
 			return check.ResultDefaultDenyEgressDrop, check.ResultNone
 		})
 
@@ -101,6 +105,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 			WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 			WithScenarios(tests.PodToWorld2()).
 			WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+				if a.Destination().Port() == 443 {
+					// SSL error as another external target (e.g. cilium.io) SNI is not allowed
+					return check.ResultCurlSSLError, check.ResultNone
+				}
 				return check.ResultDefaultDenyEgressDrop, check.ResultNone
 			})
 	}


### PR DESCRIPTION
This commit is to update the expectation to fix the flow validation failure in cilium/proxy CI.

Relates: https://github.com/cilium/proxy/actions/runs/14384792950/job/40337349500
Fixes: f6369099d053607330eaaea790ed792d3d784c6e

