### PR TITLE
Do not try to update CEP labels if `--disable-endpoint-crd=true`

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -403,7 +403,9 @@ func (k *K8sPodWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) er
 			}
 
 			// Synchronize Pod labels with CiliumEndpoint labels if there is a change.
-			updateCiliumEndpointLabels(k.logger, k.clientset, podEP, newK8sPod.Labels)
+			if !option.Config.DisableCiliumEndpointCRD {
+				updateCiliumEndpointLabels(k.logger, k.clientset, podEP, newK8sPod.Labels)
+			}
 		}
 
 		if annotationsChanged {


### PR DESCRIPTION
I noticed that when running 1.17.2 with `--kvstore=etcd` and `--disable-endpoint-crd=true`, the Agents will still occasionally make calls to the API Server in order to patch CEP objects. Obviously these calls end up being 404s:
<img width="733" alt="image" src="https://github.com/user-attachments/assets/eb48c2a0-fd07-4454-ab15-a360103c0665" />

Looking at the Agent which makes these calls, `cilium status` shows:
```
Controller Status:      26/27 healthy
  Name                                          Last success   Last error   Count   Message
  sync-pod-labels-with-cilium-endpoint (1665)   never          9s ago       22      ciliumendpoints.cilium.io "anton-test-58f4c8b46-74bql" not found
``` 

This PR will simply prevent the `sync-pod-labels-with-cilium-endpoint` controller from being started when CEP CRDs are disabled.

```release-note
Avoid attempting to update CiliumEndpoint CRD labels when the `--disable-endpoint-crd` option is enabled
```
