### PR TITLE
cilium-cli: Capture stderr from tcpdump as an error

### DIFF
--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/utils/lock"
 )
 
@@ -80,7 +81,7 @@ func Sniff(ctx context.Context, name string, target *check.Pod,
 		dbg.Debugf("Running sniffer in background on %s (%s), mode=%s: %s",
 			target.String(), target.NodeName(), mode, strings.Join(sniffer.cmd, " "))
 		err := target.K8sClient.ExecInPodWithWriters(ctx, cmdctx,
-			target.Pod.Namespace, target.Pod.Name, "", sniffer.cmd, &sniffer.stdout, io.Discard)
+			target.Pod.Namespace, target.Pod.Name, "", sniffer.cmd, &sniffer.stdout, k8s.StderrAsError)
 		if err != nil {
 			sniffer.exited <- err
 		}


### PR DESCRIPTION
tcpdump may exit with error code 14, meaning that write to stdout failed. Capture the error message it prints to stderr in that case.

Ref: https://github.com/cilium/cilium/issues/38643
