### PR TITLE
iptables/ipset: Fix ipset ops panic

### DIFF
--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -439,6 +439,82 @@ func TestOpsPruneEnabled(t *testing.T) {
 	assert.True(t, nCalled.Load())
 }
 
+func TestOpsRetry(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var (
+		db    *statedb.DB
+		table statedb.RWTable[*tables.IPSetEntry]
+	)
+
+	shouldFail := true
+
+	hive := hive.New(
+		cell.Provide(func() config {
+			return config{NodeIPSetNeeded: true}
+		}),
+
+		cell.Provide(
+			tables.NewIPSetTable,
+			newOps,
+			newReconciler,
+		),
+		cell.Provide(func(logger *slog.Logger) *ipset {
+			return &ipset{
+				executable: funcExecutable(func(ctx context.Context, command string, stdin string, arg ...string) ([]byte, error) {
+					// fail the operation at the first attempt
+					if shouldFail {
+						shouldFail = false
+						return nil, errors.New("test error")
+					}
+					return nil, nil
+				}),
+				log: logger,
+			}
+		}),
+
+		cell.Invoke(
+			func(db_ *statedb.DB, table_ statedb.RWTable[*tables.IPSetEntry], reconciler_ reconciler.Reconciler[*tables.IPSetEntry]) {
+				db = db_
+				table = table_
+				_ = reconciler_ // to start the reconciler
+			},
+		),
+	)
+
+	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+
+	require.NoError(t, hive.Start(log, t.Context()))
+
+	obj := &tables.IPSetEntry{
+		Name:   CiliumNodeIPSetV4,
+		Family: string(INetFamily),
+		Addr:   netip.MustParseAddr("1.1.1.1"),
+		Status: reconciler.StatusPending(),
+	}
+
+	txn := db.WriteTxn(table)
+	_, _, err := table.Insert(txn, obj)
+	require.NoError(t, err)
+	txn.Commit()
+
+	for {
+		queryObj, _, watch, found := table.GetWatch(db.ReadTxn(), tables.IPSetEntryIndex.QueryFromObject(obj))
+		require.True(t, found)
+
+		if queryObj.Status.Kind == reconciler.StatusKindDone {
+			require.Equal(t, CiliumNodeIPSetV4, queryObj.Name)
+			require.Equal(t, netip.MustParseAddr("1.1.1.1"), queryObj.Addr)
+			require.Equal(t, string(INetFamily), queryObj.Family)
+			break
+		}
+
+		<-watch
+	}
+
+	require.NoError(t, hive.Stop(log, t.Context()))
+}
+
 func TestIPSetList(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/pkg/datapath/iptables/ipset/ops.go
+++ b/pkg/datapath/iptables/ipset/ops.go
@@ -74,11 +74,21 @@ var _ reconciler.Operations[*tables.IPSetEntry] = &ops{}
 var _ reconciler.BatchOperations[*tables.IPSetEntry] = &ops{}
 
 func (ops *ops) Update(ctx context.Context, _ statedb.ReadTxn, entry *tables.IPSetEntry) error {
-	panic("Unexpectedly Update() called for reconciliation")
+	if !ops.enabled {
+		return nil
+	}
+
+	addrsByName := map[string][]netip.Addr{entry.Name: {entry.Addr}}
+	return ops.ipset.addBatch(ctx, addrsByName)
 }
 
 func (ops *ops) Delete(ctx context.Context, _ statedb.ReadTxn, entry *tables.IPSetEntry) error {
-	panic("Unexpectedly Delete() called for reconciliation")
+	if !ops.enabled {
+		return nil
+	}
+
+	addrsByName := map[string][]netip.Addr{entry.Name: {entry.Addr}}
+	return ops.ipset.delBatch(ctx, addrsByName)
 }
 
 func (ops *ops) Prune(ctx context.Context, _ statedb.ReadTxn, objs iter.Seq2[*tables.IPSetEntry, statedb.Revision]) error {


### PR DESCRIPTION
When a cilium/statedb reconciler relies on batched operations and a failure happens, the subsequent retry calls the non-batched operations (e.g: `Update` instead of `UpdateBatch`). Therefore, to avoid a panic in case of a retry, we need to define the non-batched operations too for the ipset reconciler.

Though this should be fixed upstream, this PR aims to prevent the panic before an updated version of cilium/statedb is vendored in the codebase.

```release-note
Fix a panic happening in the ipset reconciler when a previous reconciliation failed.
```