### PR TITLE
Enable BBR only in host namespace

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -109,6 +109,7 @@ cilium-agent [flags]
       --enable-auto-protect-node-port-range                       Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
+      --enable-bbr-hostns-only                                    Enable BBR only in the host network namespace.
       --enable-bgp-control-plane                                  Enable the BGP control plane.
       --enable-bgp-control-plane-status-report                    Enable the BGP control plane status reporting (default true)
       --enable-bpf-clock-probe                                    Enable BPF clock source probing for more efficient tick retrieval

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -41,6 +41,7 @@ cilium-agent hive [flags]
       --enable-active-connection-tracking                         Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
+      --enable-bbr-hostns-only                                    Enable BBR only in the host network namespace.
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-drift-checker                                      Enables support for config drift checker (default true)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -47,6 +47,7 @@ cilium-agent hive dot-graph [flags]
       --enable-active-connection-tracking                         Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
+      --enable-bbr-hostns-only                                    Enable BBR only in the host network namespace.
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-drift-checker                                      Enables support for config drift checker (default true)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -259,9 +259,13 @@
    * - :spelling:ignore:`bandwidthManager`
      - Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.
      - object
-     - ``{"bbr":false,"enabled":false}``
+     - ``{"bbr":false,"bbrHostNamespaceOnly":false,"enabled":false}``
    * - :spelling:ignore:`bandwidthManager.bbr`
      - Activate BBR TCP congestion control for Pods
+     - bool
+     - ``false``
+   * - :spelling:ignore:`bandwidthManager.bbrHostNamespaceOnly`
+     - Activate BBR TCP congestion control for Pods in the host namespace only.
      - bool
      - ``false``
    * - :spelling:ignore:`bandwidthManager.enabled`

--- a/Documentation/network/kubernetes/bandwidth-manager.rst
+++ b/Documentation/network/kubernetes/bandwidth-manager.rst
@@ -255,7 +255,23 @@ which are in the initial network namespace (hostns). BBR also needs eBPF Host-Ro
 in order to retain the network packet's socket association all the way until the
 packet hits the FQ queueing discipline on the physical device in the host namespace.
 (Without eBPF Host-Routing the packet's socket association would otherwise be orphaned
-inside the host stacks forwarding/routing layer.)
+inside the host stacks forwarding/routing layer.). By default, Cilium will not start
+up if you try to use BBR with legacy routing, but users who must use legacy routing
+can override this and enable BBR for pods in the host network namespace (``hostNetwork: true``)
+by adding the ``bandwidthManager.bbrHostNamespaceOnly`` option:
+
+.. parsed-literal::
+
+   helm upgrade cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --reuse-values \\
+     --set bandwidthManager.enabled=true \\
+     --set bandwidthManager.bbr=true
+     --set bandwidthManager.bbrHostNamespaceOnly=true
+   kubectl -n kube-system rollout restart ds/cilium
+
+With ``bandwidthManager.bbrHostNamespaceOnly``, only pods in the host network namespace
+will use BBR; others will use CUBIC.
 
 In order to verify whether the bandwidth manager with BBR has been enabled in Cilium,
 the ``cilium status`` CLI command provides visibility again through the ``BandwidthManager``

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -50,6 +50,9 @@ type DaemonConfigurationStatus struct {
 	// Configured compatibility mode for --egress-multi-home-ip-rule-compat
 	EgressMultiHomeIPRuleCompat bool `json:"egress-multi-home-ip-rule-compat,omitempty"`
 
+	// True if BBR is enabled only in the host network namespace
+	EnableBBRHostNamespaceOnly bool `json:"enableBBRHostNamespaceOnly,omitempty"`
+
 	// Enable route MTU for pod netns when CNI chaining is used
 	EnableRouteMTUForCNIChaining bool `json:"enableRouteMTUForCNIChaining,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2699,6 +2699,9 @@ definitions:
       ipLocalReservedPorts:
         description: Comma-separated list of IP ports should be reserved in the workload network namespace
         type: string
+      enableBBRHostNamespaceOnly:
+        description: True if BBR is enabled only in the host network namespace
+        type: boolean
   DatapathMode:
     description: Datapath mode
     type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2644,6 +2644,10 @@ func init() {
           "description": "Configured compatibility mode for --egress-multi-home-ip-rule-compat",
           "type": "boolean"
         },
+        "enableBBRHostNamespaceOnly": {
+          "description": "True if BBR is enabled only in the host network namespace",
+          "type": "boolean"
+        },
         "enableRouteMTUForCNIChaining": {
           "description": "Enable route MTU for pod netns when CNI chaining is used",
           "type": "boolean"
@@ -8411,6 +8415,10 @@ func init() {
         },
         "egress-multi-home-ip-rule-compat": {
           "description": "Configured compatibility mode for --egress-multi-home-ip-rule-compat",
+          "type": "boolean"
+        },
+        "enableBBRHostNamespaceOnly": {
+          "description": "True if BBR is enabled only in the host network namespace",
           "type": "boolean"
         },
         "enableRouteMTUForCNIChaining": {

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -114,8 +114,9 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.rotatedIdentitiesQueueSize | int | `1024` | Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers. |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |
 | azure.enabled | bool | `false` | Enable Azure integration. Note that this is incompatible with AKS clusters created in BYOCNI mode: use AKS BYOCNI integration (`aksbyocni.enabled`) instead. |
-| bandwidthManager | object | `{"bbr":false,"enabled":false}` | Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
+| bandwidthManager | object | `{"bbr":false,"bbrHostNamespaceOnly":false,"enabled":false}` | Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
 | bandwidthManager.bbr | bool | `false` | Activate BBR TCP congestion control for Pods |
+| bandwidthManager.bbrHostNamespaceOnly | bool | `false` | Activate BBR TCP congestion control for Pods in the host namespace only. |
 | bandwidthManager.enabled | bool | `false` | Enable bandwidth manager infrastructure (also prerequirement for BBR) |
 | bgpControlPlane | object | `{"enabled":false,"routerIDAllocation":{"mode":"default"},"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -710,6 +710,7 @@ data:
 {{- if .Values.bandwidthManager.enabled }}
   enable-bandwidth-manager: {{ .Values.bandwidthManager.enabled | quote }}
   enable-bbr: {{ .Values.bandwidthManager.bbr | quote }}
+  enable-bbr-hostns-only: {{ .Values.bandwidthManager.bbrHostNamespaceOnly | quote }}
 {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -449,6 +449,9 @@
         "bbr": {
           "type": "boolean"
         },
+        "bbrHostNamespaceOnly": {
+          "type": "boolean"
+        },
         "enabled": {
           "type": "boolean"
         }

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -444,6 +444,8 @@ bandwidthManager:
   enabled: false
   # -- Activate BBR TCP congestion control for Pods
   bbr: false
+  # -- Activate BBR TCP congestion control for Pods in the host namespace only.
+  bbrHostNamespaceOnly: false
 # -- Configure standalone NAT46/NAT64 gateway
 nat46x64Gateway:
   # -- Enable RFC6052-prefixed translation

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -447,6 +447,8 @@ bandwidthManager:
   enabled: false
   # -- Activate BBR TCP congestion control for Pods
   bbr: false
+  # -- Activate BBR TCP congestion control for Pods in the host namespace only.
+  bbrHostNamespaceOnly: false
 # -- Configure standalone NAT46/NAT64 gateway
 nat46x64Gateway:
   # -- Enable RFC6052-prefixed translation

--- a/pkg/datapath/linux/bandwidth/bandwidth.go
+++ b/pkg/datapath/linux/bandwidth/bandwidth.go
@@ -184,9 +184,13 @@ func (m *manager) probe() error {
 		}
 	}
 
+	if !m.params.Config.EnableBBR && m.params.Config.EnableBBRHostnsOnly {
+		return fmt.Errorf("cannot enable --%s without enabling --%s", types.EnableBBRHostnsOnlyFlag, types.EnableBBRFlag)
+	}
+
 	// Going via host stack will orphan skb->sk, so we do need BPF host
 	// routing for it to work properly.
-	if m.params.Config.EnableBBR && m.params.DaemonConfig.EnableHostLegacyRouting {
+	if m.params.Config.EnableBBR && m.params.DaemonConfig.EnableHostLegacyRouting && !m.params.Config.EnableBBRHostnsOnly {
 		return fmt.Errorf("BPF bandwidth manager's BBR setup requires BPF host routing.")
 	}
 

--- a/pkg/datapath/types/bandwidth.go
+++ b/pkg/datapath/types/bandwidth.go
@@ -8,6 +8,7 @@ import "github.com/spf13/pflag"
 const (
 	EnableBandwidthManagerFlag = "enable-bandwidth-manager"
 	EnableBBRFlag              = "enable-bbr"
+	EnableBBRHostnsOnlyFlag    = "enable-bbr-hostns-only"
 )
 
 type BandwidthConfig struct {
@@ -16,16 +17,21 @@ type BandwidthConfig struct {
 
 	// EnableBBR enables BBR TCP congestion control for the node including Pods
 	EnableBBR bool
+
+	// EnableBBRHostnsOnly enables BBR TCP congestion control for the node excluding Pods
+	EnableBBRHostnsOnly bool
 }
 
 func (def BandwidthConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(EnableBandwidthManagerFlag, def.EnableBandwidthManager, "Enable BPF bandwidth manager")
 	flags.Bool(EnableBBRFlag, def.EnableBBR, "Enable BBR for the bandwidth manager")
+	flags.Bool(EnableBBRHostnsOnlyFlag, def.EnableBBRHostnsOnly, "Enable BBR only in the host network namespace.")
 }
 
 var DefaultBandwidthConfig = BandwidthConfig{
 	EnableBandwidthManager: false,
 	EnableBBR:              false,
+	EnableBBRHostnsOnly:    false,
 }
 
 type BandwidthManager interface {

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -474,6 +475,17 @@ func reserveLocalIPPorts(conf *models.DaemonConfigurationStatus, sysctl sysctl.S
 	return sysctl.Write(param, reserved)
 }
 
+func configureCongestionControl(conf *models.DaemonConfigurationStatus, sysctl sysctl.Sysctl) error {
+	if !conf.EnableBBRHostNamespaceOnly {
+		return nil
+	}
+
+	// Note: This setting applies to IPv4 and IPv6
+	return sysctl.ApplySettings([]tables.Sysctl{
+		{Name: []string{"net", "ipv4", "tcp_congestion_control"}, Val: "cubic"},
+	})
+}
+
 func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 	n, err := types.LoadNetConf(args.StdinData)
 	if err != nil {
@@ -769,6 +781,11 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 				}
 			}
 			macAddrStr = newEp.Status.Networking.Mac
+		}
+		if err = ns.Do(func() error {
+			return configureCongestionControl(conf, sysctl)
+		}); err != nil {
+			return fmt.Errorf("unable to configure congestion control: %w", err)
 		}
 		res.Interfaces = append(res.Interfaces, &cniTypesV1.Interface{
 			Name:    epConf.IfName(),


### PR DESCRIPTION
Since commit fdbcbc076fc5 ("cilium: Rework BBR enablement for K8s Pods"), Cilium does not allow BBR to be enabled with host legacy routing, since without BPF redirects BBR does not work properly from inside network namespaces; without an immediate ingress->egress switch, skbs lose their socket association on ingress to the host namespace, so fq is unable to learn sk->sk_pacing_rate.

However, in some cases, legacy host routing must be used, and disallowing BBR entirely is overly restrictive. Introduce a new flag, `enable-bbr-hostns-only`, which when set alongside `enable-bbr` makes it so only pods on the host network (`hostNetwork: true`) use BBR while others use cubic like before. Just as before, `enable-bbr` sets "net.ipv4.tcp_congestion_control" to "bbr" in the host (init) network namespace, but with enable-bbr-hostns-only the Cilium CNI explicitly sets "net.ipv4.tcp_congestion_control" to "cubic" in each pods's network namespace instead of letting it inherit the default from the initial network namespace.

This gives users an escape hatch so they can at least use BBR in some contexts even if there are still some restrictions in host legacy routing mode.

```yaml
bandwidthManager:
  enabled: true
  bbr: true
  bbrHostNamespaceOnly: true
```

```bash
jordan@t14:~$ kubectl get pods ubuntu-56f8f9ffc7-lq59h -o yaml | grep -i hostNetwork
jordan@t14:~$ kubectl get pods ubuntu-host-5dc8f7848b-5pxr5 -o yaml | grep -i hostNetwork
  hostNetwork: true
jordan@t14:~$
jordan@t14:~$ kubectl exec ubuntu-56f8f9ffc7-lq59h -- sysctl net.ipv4.tcp_congestion_control
net.ipv4.tcp_congestion_control = cubic
jordan@t14:~$ kubectl exec ubuntu-host-5dc8f7848b-5pxr5 -- sysctl net.ipv4.tcp_congestion_control
net.ipv4.tcp_congestion_control = bbr
jordan@t14:~$
```

```release-note
bandwidth: Introduce bbrHostNamespaceOnly to allow limited use of BBR in legacy routing mode.
```
