### PR TITLE
bpf: encap: let caller check whether endpoint has tunnel address

### DIFF
--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -137,9 +137,6 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx,
 		       __u32 seclabel, __u32 dstid,
 		       const struct trace_ctx *trace)
 {
-	if (!info || !info->flag_has_tunnel_ep)
-		return DROP_NO_TUNNEL_ENDPOINT;
-
 	return encap_and_redirect_with_nodeid(ctx, info, encrypt_key, seclabel,
 					      dstid, trace);
 }


### PR DESCRIPTION
encap_and_redirect_lxc() returns DROP_NO_TUNNEL_ENDPOINT as a complicated way of saying "you shouldn't even have called this function, continue as normal". Move this check into the callers, and simplify the ret-val handling.