### PR TITLE
service: notify health observers about deleted service

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -2088,6 +2088,8 @@ func (s *Service) deleteServiceLocked(svc *svcInfo) error {
 	metrics.ServicesEventsCount.WithLabelValues("delete").Inc()
 	s.notifyMonitorServiceDelete(svc.frontend.ID)
 
+	s.notifyHealthCheckUpdateSubscribersServiceDelete(svc)
+
 	return nil
 }
 


### PR DESCRIPTION
Currently, deleting a Service from a node (while still keeping it as K8s Service - e.g. via selective node exposure) doesn't notify health subscribers about the deletion of the Service.

Therefore, this commit adds explicit notification for this case.