### PR TITLE
operator: Use testing.T.Context added in Go 1.24 in tests

### DIFF
--- a/operator/api/health_test.go
+++ b/operator/api/health_test.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -60,7 +59,7 @@ func TestHealthHandlerK8sDisabled(t *testing.T) {
 	)
 
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
 
@@ -68,7 +67,7 @@ func TestHealthHandlerK8sDisabled(t *testing.T) {
 		t.Fatalf("expected http status code %d, got %d", http.StatusNotImplemented, rr.Result().StatusCode)
 	}
 
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }
@@ -110,7 +109,7 @@ func TestHealthHandlerK8sEnabled(t *testing.T) {
 	)
 
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
 
@@ -128,7 +127,7 @@ func TestHealthHandlerK8sEnabled(t *testing.T) {
 		t.Fatalf("expected response body %q, got: %q", "ok", string(body))
 	}
 
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }

--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -61,7 +60,7 @@ func TestMetricsHandlerWithoutMetrics(t *testing.T) {
 	)
 
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
 
@@ -84,7 +83,7 @@ func TestMetricsHandlerWithoutMetrics(t *testing.T) {
 		t.Fatalf("no metrics expected, found %v", metrics)
 	}
 
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }
@@ -140,7 +139,7 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 	hive.Viper().Set(operatorMetrics.OperatorPrometheusServeAddr, "localhost:0")
 
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
 
@@ -170,7 +169,7 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 		t.Fatalf("error while inspecting metric: %s", err)
 	}
 
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }

--- a/operator/api/server_test.go
+++ b/operator/api/server_test.go
@@ -62,7 +62,7 @@ func TestAPIServerK8sDisabled(t *testing.T) {
 	)
 
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
 
@@ -84,7 +84,7 @@ func TestAPIServerK8sDisabled(t *testing.T) {
 		t.Fatalf("failed to query endpoint: %s", err)
 	}
 
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }
@@ -127,7 +127,7 @@ func TestAPIServerK8sEnabled(t *testing.T) {
 	)
 
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
 
@@ -149,13 +149,13 @@ func TestAPIServerK8sEnabled(t *testing.T) {
 		t.Fatalf("failed to query endpoint: %s", err)
 	}
 
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }
 
 func testEndpoint(t *testing.T, port int, path string, statusCode int) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(

--- a/operator/auth/spire/client_test.go
+++ b/operator/auth/spire/client_test.go
@@ -224,7 +224,7 @@ func TestClient_Upsert(t *testing.T) {
 				cfg:   cfg,
 				entry: tt.fields.entry,
 			}
-			if err := c.Upsert(context.Background(), tt.args.id); (err != nil) != tt.wantErr {
+			if err := c.Upsert(t.Context(), tt.args.id); (err != nil) != tt.wantErr {
 				t.Errorf("Upsert() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -405,7 +405,7 @@ func TestClient_Delete(t *testing.T) {
 				cfg:   cfg,
 				entry: tt.fields.entry,
 			}
-			if err := c.Delete(context.Background(), tt.args.id); (err != nil) != tt.wantErr {
+			if err := c.Delete(t.Context(), tt.args.id); (err != nil) != tt.wantErr {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -414,7 +414,7 @@ func TestClient_Delete(t *testing.T) {
 
 func Test_resolvedK8sService(t *testing.T) {
 	_, c := client.NewFakeClientset(hivetest.Logger(t))
-	_, _ = c.CoreV1().Services("dummy-namespace").Create(context.Background(), &corev1.Service{
+	_, _ = c.CoreV1().Services("dummy-namespace").Create(t.Context(), &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "valid-service",
 		},
@@ -474,7 +474,7 @@ func Test_resolvedK8sService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolvedK8sService(context.Background(), tt.args.client, tt.args.address)
+			got, err := resolvedK8sService(t.Context(), tt.args.client, tt.args.address)
 			if tt.wantedErr != nil && (err == nil || !reflect.DeepEqual(err.Error(), tt.wantedErr.Error())) {
 				t.Errorf("resolvedK8sService() error = %v, wantErr %v", err, tt.wantedErr)
 				return

--- a/operator/cmd/allocator_test.go
+++ b/operator/cmd/allocator_test.go
@@ -41,7 +41,7 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	// Create a new CIDR allocator

--- a/operator/endpointgc/gc_test.go
+++ b/operator/endpointgc/gc_test.go
@@ -4,7 +4,6 @@
 package endpointgc
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -43,7 +42,7 @@ func TestRegisterController(t *testing.T) {
 		}),
 		metrics.Metric(NewMetrics),
 		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint]) {
-			prepareCiliumEndpoints(c)
+			prepareCiliumEndpoints(t, c)
 			ciliumEndpoint = cep
 		}),
 		cell.Invoke(func(p params) error {
@@ -53,14 +52,14 @@ func TestRegisterController(t *testing.T) {
 	)
 
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
-	cepStore, _ := ciliumEndpoint.Store(context.Background())
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	// wait for all CEPs to be deleted except for those with running pods or
 	// cilium node owner reference
 	waitForCEPs(t, cepStore, 2)
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }
@@ -82,7 +81,7 @@ func TestRegisterControllerOnce(t *testing.T) {
 		metrics.Metric(NewMetrics),
 		cell.Invoke(prepareCiliumEndpointCRD),
 		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint]) {
-			prepareCiliumEndpoints(c)
+			prepareCiliumEndpoints(t, c)
 			ciliumEndpoint = cep
 		}),
 		cell.Invoke(func(p params) error {
@@ -92,13 +91,13 @@ func TestRegisterControllerOnce(t *testing.T) {
 	)
 
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
-	cepStore, _ := ciliumEndpoint.Store(context.Background())
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	// wait for all CEPs to be deleted
 	waitForCEPs(t, cepStore, 0)
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }
@@ -119,7 +118,7 @@ func TestRegisterControllerWithCRDDisabled(t *testing.T) {
 			}
 		}),
 		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint]) {
-			prepareCiliumEndpoints(c)
+			prepareCiliumEndpoints(t, c)
 			ciliumEndpoint = cep
 		}),
 		cell.Invoke(func(p params) error {
@@ -128,15 +127,15 @@ func TestRegisterControllerWithCRDDisabled(t *testing.T) {
 		}),
 	)
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
-	cepStore, _ := ciliumEndpoint.Store(context.Background())
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	// wait for potential GC
 	time.Sleep(500 * time.Millisecond)
 	// gc is disabled so no CEPs should be deleted
 	waitForCEPs(t, cepStore, 6)
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }
@@ -148,39 +147,39 @@ func prepareCiliumEndpointCRD(c *k8sClient.FakeClientset) error {
 	return nil
 }
 
-func prepareCiliumEndpoints(fakeClient *k8sClient.FakeClientset) {
+func prepareCiliumEndpoints(t *testing.T, fakeClient *k8sClient.FakeClientset) {
 	// Create set of Cilium Endpoints:
 	// - CEP with no owner reference and no pods
 	cep := createCiliumEndpoint("cep1", "ns")
-	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(context.Background(), cep, meta_v1.CreateOptions{})
+	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(t.Context(), cep, meta_v1.CreateOptions{})
 	// - CEP with owner reference pod that is running
 	cepWithOwnerRunningPod := createCiliumEndpoint("cep2", "ns")
 	cepWithOwnerRunningPod.OwnerReferences = []meta_v1.OwnerReference{createOwnerReference("Pod", "pod2")}
-	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(context.Background(), cepWithOwnerRunningPod, meta_v1.CreateOptions{})
+	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(t.Context(), cepWithOwnerRunningPod, meta_v1.CreateOptions{})
 	// - CEP with owner reference pod that is not running
 	cepWithOwnerNotRunningPod := createCiliumEndpoint("cep3", "ns")
 	cepWithOwnerNotRunningPod.OwnerReferences = []meta_v1.OwnerReference{createOwnerReference("Pod", "pod3")}
-	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(context.Background(), cepWithOwnerNotRunningPod, meta_v1.CreateOptions{})
+	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(t.Context(), cepWithOwnerNotRunningPod, meta_v1.CreateOptions{})
 	// - CEP with no owner reference but with pod that is running
 	cepWithLegacyRunningPod := createCiliumEndpoint("cep4", "ns")
-	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(context.Background(), cepWithLegacyRunningPod, meta_v1.CreateOptions{})
+	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(t.Context(), cepWithLegacyRunningPod, meta_v1.CreateOptions{})
 	// - CEP with no owner reference but with pod that is not running
 	cepWithLegacyNotRunningPod := createCiliumEndpoint("cep5", "ns")
-	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(context.Background(), cepWithLegacyNotRunningPod, meta_v1.CreateOptions{})
+	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(t.Context(), cepWithLegacyNotRunningPod, meta_v1.CreateOptions{})
 	// - CEP with owner reference pod that doesn't exist
 	cepWithOwnerPodDoesntExist := createCiliumEndpoint("cep6", "ns")
 	cepWithOwnerPodDoesntExist.OwnerReferences = []meta_v1.OwnerReference{createOwnerReference("Pod", "pod6")}
-	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(context.Background(), cepWithOwnerPodDoesntExist, meta_v1.CreateOptions{})
+	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(t.Context(), cepWithOwnerPodDoesntExist, meta_v1.CreateOptions{})
 
 	// Create Pods
 	// - pod that is running for cep2
-	fakeClient.Slim().CoreV1().Pods("ns").Create(context.Background(), createPod("pod2", "ns", true), meta_v1.CreateOptions{})
+	fakeClient.Slim().CoreV1().Pods("ns").Create(t.Context(), createPod("pod2", "ns", true), meta_v1.CreateOptions{})
 	// - pod that is not running for cep3
-	fakeClient.Slim().CoreV1().Pods("ns").Create(context.Background(), createPod("pod3", "ns", false), meta_v1.CreateOptions{})
+	fakeClient.Slim().CoreV1().Pods("ns").Create(t.Context(), createPod("pod3", "ns", false), meta_v1.CreateOptions{})
 	// - pod that is running for cep4
-	fakeClient.Slim().CoreV1().Pods("ns").Create(context.Background(), createPod("cep4", "ns", true), meta_v1.CreateOptions{})
+	fakeClient.Slim().CoreV1().Pods("ns").Create(t.Context(), createPod("cep4", "ns", true), meta_v1.CreateOptions{})
 	// - pod that is not running for cep5
-	fakeClient.Slim().CoreV1().Pods("ns").Create(context.Background(), createPod("cep5", "ns", false), meta_v1.CreateOptions{})
+	fakeClient.Slim().CoreV1().Pods("ns").Create(t.Context(), createPod("cep5", "ns", false), meta_v1.CreateOptions{})
 }
 
 func waitForCEPs(t *testing.T, cepStore resource.Store[*cilium_v2.CiliumEndpoint], number int) {

--- a/operator/identitygc/crd_gc_test.go
+++ b/operator/identitygc/crd_gc_test.go
@@ -4,7 +4,6 @@
 package identitygc
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -35,12 +34,12 @@ func TestUsedIdentitiesInCESs(t *testing.T) {
 		}),
 	)
 	tlog := hivetest.Logger(t)
-	err := hive.Start(tlog, context.Background())
+	err := hive.Start(tlog, t.Context())
 	if err != nil {
 		t.Fatalf("unable to start hive for the test: %s", err)
 	}
 
-	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 
 	// Empty store.
 	gotIdentities := usedIdentitiesInCESs(cesStore)
@@ -49,7 +48,7 @@ func TestUsedIdentitiesInCESs(t *testing.T) {
 
 	// 5 IDs in the store.
 	cesA := tu.CreateCESWithIDs("cesA", []int64{1, 2, 3, 4, 5})
-	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(context.Background(), cesA, meta_v1.CreateOptions{})
+	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(t.Context(), cesA, meta_v1.CreateOptions{})
 	err = testutils.WaitUntil(isCESPresent("cesA", cesStore), time.Second)
 	if err != nil {
 		t.Fatalf("cesA not present in the store after timeout: %s", err)
@@ -64,7 +63,7 @@ func TestUsedIdentitiesInCESs(t *testing.T) {
 
 	// 10 IDs in the store.
 	cesB := tu.CreateCESWithIDs("cesB", []int64{10, 20, 30, 40, 50})
-	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(context.Background(), cesB, meta_v1.CreateOptions{})
+	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(t.Context(), cesB, meta_v1.CreateOptions{})
 	err = testutils.WaitUntil(isCESPresent("cesB", cesStore), time.Second)
 	if err != nil {
 		t.Fatalf("cesB not present in the store after timeout: %s", err)
@@ -77,7 +76,7 @@ func TestUsedIdentitiesInCESs(t *testing.T) {
 	gotIdentities = usedIdentitiesInCESs(cesStore)
 	assertEqualIDs(t, wantIdentities, gotIdentities)
 
-	err = hive.Stop(tlog, context.Background())
+	err = hive.Stop(tlog, t.Context())
 	if err != nil {
 		t.Fatalf("unable to stop hive for the test: %s", err)
 	}

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -4,7 +4,6 @@
 package identitygc
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -68,16 +67,16 @@ func TestIdentitiesGC(t *testing.T) {
 		cell.Invoke(func(c k8sClient.Clientset, authClient authIdentity.Provider) error {
 			clientset = c
 			authIdentityClient = authClient
-			if err := setupK8sNodes(clientset); err != nil {
+			if err := setupK8sNodes(t, clientset); err != nil {
 				return err
 			}
-			if err := setupCiliumIdentities(clientset); err != nil {
+			if err := setupCiliumIdentities(t, clientset); err != nil {
 				return err
 			}
-			if err := setupCiliumEndpoint(clientset); err != nil {
+			if err := setupCiliumEndpoint(t, clientset); err != nil {
 				return err
 			}
-			if err := setupAuthIdentities(authIdentityClient); err != nil {
+			if err := setupAuthIdentities(t, authIdentityClient); err != nil {
 				return err
 			}
 
@@ -144,7 +143,7 @@ func TestIdentitiesGC(t *testing.T) {
 	}
 }
 
-func setupK8sNodes(clientset k8sClient.Clientset) error {
+func setupK8sNodes(t *testing.T, clientset k8sClient.Clientset) error {
 	nodes := []*corev1.Node{
 		{
 			TypeMeta: metav1.TypeMeta{
@@ -169,14 +168,14 @@ func setupK8sNodes(clientset k8sClient.Clientset) error {
 	}
 	for _, node := range nodes {
 		if _, err := clientset.CoreV1().Nodes().
-			Create(context.Background(), node, metav1.CreateOptions{}); err != nil {
+			Create(t.Context(), node, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create node %v: %w", node, err)
 		}
 	}
 	return nil
 }
 
-func setupCiliumIdentities(clientset k8sClient.Clientset) error {
+func setupCiliumIdentities(t *testing.T, clientset k8sClient.Clientset) error {
 	identities := []*v2.CiliumIdentity{
 		{
 			TypeMeta: metav1.TypeMeta{
@@ -205,24 +204,24 @@ func setupCiliumIdentities(clientset k8sClient.Clientset) error {
 	}
 	for _, identity := range identities {
 		if _, err := clientset.CiliumV2().CiliumIdentities().
-			Create(context.Background(), identity, metav1.CreateOptions{}); err != nil {
+			Create(t.Context(), identity, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create identity %v: %w", identity, err)
 		}
 	}
 	return nil
 }
 
-func setupAuthIdentities(client authIdentity.Provider) error {
-	if err := client.Upsert(context.Background(), "88888"); err != nil {
+func setupAuthIdentities(t *testing.T, client authIdentity.Provider) error {
+	if err := client.Upsert(t.Context(), "88888"); err != nil {
 		return err
 	}
-	if err := client.Upsert(context.Background(), "99999"); err != nil {
+	if err := client.Upsert(t.Context(), "99999"); err != nil {
 		return err
 	}
 	return nil
 }
 
-func setupCiliumEndpoint(clientset k8sClient.Clientset) error {
+func setupCiliumEndpoint(t *testing.T, clientset k8sClient.Clientset) error {
 	endpoint := &v2.CiliumEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-endpoint",
@@ -234,7 +233,7 @@ func setupCiliumEndpoint(clientset k8sClient.Clientset) error {
 		},
 	}
 	if _, err := clientset.CiliumV2().CiliumEndpoints("").
-		Create(context.Background(), endpoint, metav1.CreateOptions{}); err != nil {
+		Create(t.Context(), endpoint, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create endpoint %v: %w", endpoint, err)
 	}
 	return nil

--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -289,7 +289,7 @@ func Test_NodeLabels(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 	defer cancel()
 
 	for _, tt := range tests {
@@ -608,7 +608,7 @@ func Test_ClusterConfigSteps(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 	defer cancel()
 
 	f, watchersReady := newFixture(t, ctx, require.New(t), true)
@@ -831,7 +831,7 @@ func TestClusterConfigConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+			ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 			defer cancel()
 
 			f, watchersReady := newFixture(t, ctx, require.New(t), true)
@@ -1069,7 +1069,7 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+			ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 			defer cancel()
 
 			f, watchersReady := newFixture(t, ctx, require.New(t), true)
@@ -1177,7 +1177,7 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 func TestDisableClusterConfigStatusReport(t *testing.T) {
 	req := require.New(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 	defer cancel()
 
 	f, watchersReady := newFixture(t, ctx, require.New(t), false)

--- a/operator/pkg/bgpv2/peer_test.go
+++ b/operator/pkg/bgpv2/peer_test.go
@@ -186,7 +186,7 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+			ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 			t.Cleanup(func() {
 				cancel()
 			})
@@ -237,7 +237,7 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 }
 
 func TestDisablePeerConfigStatusReport(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
 	t.Cleanup(func() {
 		cancel()
 	})

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -4,7 +4,6 @@
 package ciliumendpointslice
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -73,16 +72,16 @@ func TestRegisterController(t *testing.T) {
 		}),
 	)
 	tlog := hivetest.Logger(t)
-	if err := hive.Start(tlog, context.Background()); err != nil {
+	if err := hive.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
-	cesCreated, err := createCEPandVerifyCESCreated(fakeClient, ciliumEndpoint, ciliumEndpointSlice)
+	cesCreated, err := createCEPandVerifyCESCreated(t, fakeClient, ciliumEndpoint, ciliumEndpointSlice)
 	if err != nil {
 		t.Fatalf("Couldn't verify if CES is created: %s", err)
 	}
 	// Verify CES is created when CES features is enabled
 	assert.True(t, cesCreated)
-	if err := hive.Stop(tlog, context.Background()); err != nil {
+	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }
@@ -132,30 +131,30 @@ func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
 		}),
 	)
 	tlog := hivetest.Logger(t)
-	if err := h.Start(tlog, context.Background()); err != nil {
+	if err := h.Start(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}
-	cesCreated, err := createCEPandVerifyCESCreated(fakeClient, ciliumEndpoint, ciliumEndpointSlice)
+	cesCreated, err := createCEPandVerifyCESCreated(t, fakeClient, ciliumEndpoint, ciliumEndpointSlice)
 	if err != nil {
 		t.Fatalf("Couldn't verify if CES is created: %s", err)
 	}
 	// Verify CES is NOT created when CES features is disabled
 	assert.False(t, cesCreated)
-	if err = h.Stop(tlog, context.Background()); err != nil {
+	if err = h.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
 }
 
-func createCEPandVerifyCESCreated(fakeClient k8sClient.Clientset, ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint], ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) (bool, error) {
+func createCEPandVerifyCESCreated(t *testing.T, fakeClient k8sClient.Clientset, ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint], ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) (bool, error) {
 	cep := tu.CreateStoreEndpoint("cep1", "ns", 1)
-	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(context.Background(), cep, meta_v1.CreateOptions{})
-	cepStore, _ := ciliumEndpoint.Store(context.Background())
+	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(t.Context(), cep, meta_v1.CreateOptions{})
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	if err := testutils.WaitUntil(func() bool {
 		return len(cepStore.List()) > 0
 	}, time.Second); err != nil {
 		return false, fmt.Errorf("failed to get CEP: %w", err)
 	}
-	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 
 	err := testutils.WaitUntil(func() bool {
 		return len(cesStore.List()) > 0

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -52,9 +52,9 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 		}),
 	)
 	tlog := hivetest.Logger(t)
-	hive.Start(tlog, context.Background())
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
-	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	hive.Start(tlog, t.Context())
+	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
 	cesController := &Controller{
@@ -81,7 +81,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	ces2 := tu.CreateStoreEndpointSlice("ces2", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
 	cesStore.CacheStore().Add(ces2)
 
-	cesController.syncCESsInLocalCache(context.Background())
+	cesController.syncCESsInLocalCache(t.Context())
 
 	mapping := m.mapping
 
@@ -95,7 +95,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 
 	cesController.fastQueue.ShutDown()
 	cesController.standardQueue.ShutDown()
-	hive.Stop(tlog, context.Background())
+	hive.Stop(tlog, t.Context())
 }
 
 func TestDifferentSpeedQueues(t *testing.T) {
@@ -124,9 +124,9 @@ func TestDifferentSpeedQueues(t *testing.T) {
 		}),
 	)
 	tlog := hivetest.Logger(t)
-	hive.Start(tlog, context.Background())
+	hive.Start(tlog, t.Context())
 
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 		syncDelay:           0,
 	}
 	cesController.cond = *sync.NewCond(&lock.Mutex{})
-	cesController.context, cesController.contextCancel = context.WithCancel(context.Background())
+	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.priorityNamespaces["FastNamespace"] = struct{}{}
 	cesController.initializeQueue()
 	var ns string = "NotSoImportant"
@@ -197,7 +197,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 
 	cesController.fastQueue.ShutDown()
 	cesController.standardQueue.ShutDown()
-	hive.Stop(tlog, context.Background())
+	hive.Stop(tlog, t.Context())
 }
 
 func TestCESManagement(t *testing.T) {
@@ -226,9 +226,9 @@ func TestCESManagement(t *testing.T) {
 		}),
 	)
 	tlog := hivetest.Logger(t)
-	hive.Start(tlog, context.Background())
+	hive.Start(tlog, t.Context())
 
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -246,7 +246,7 @@ func TestCESManagement(t *testing.T) {
 		syncDelay:           0,
 	}
 	cesController.cond = *sync.NewCond(&lock.Mutex{})
-	cesController.context, cesController.contextCancel = context.WithCancel(context.Background())
+	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.initializeQueue()
 	var ns string = "ns"
 
@@ -274,5 +274,5 @@ func TestCESManagement(t *testing.T) {
 
 	cesController.fastQueue.ShutDown()
 	cesController.standardQueue.ShutDown()
-	hive.Stop(tlog, context.Background())
+	hive.Stop(tlog, t.Context())
 }

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -4,7 +4,6 @@
 package ciliumendpointslice
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/cell"
@@ -48,9 +47,9 @@ func TestReconcileCreate(t *testing.T) {
 		}),
 	)
 	tlog := hivetest.Logger(t)
-	hive.Start(tlog, context.Background())
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
-	cepStore, _ := ciliumEndpoint.Store(context.Background())
+	hive.Start(tlog, t.Context())
+	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
 
 	var createdSlice *cilium_v2a1.CiliumEndpointSlice
 	fakeClient.CiliumFakeClientset.PrependReactor("create", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -79,7 +78,7 @@ func TestReconcileCreate(t *testing.T) {
 	assert.Contains(t, eps, "cep1")
 	assert.Contains(t, eps, "cep2")
 
-	hive.Stop(tlog, context.Background())
+	hive.Stop(tlog, t.Context())
 }
 
 func TestReconcileUpdate(t *testing.T) {
@@ -108,10 +107,10 @@ func TestReconcileUpdate(t *testing.T) {
 	)
 
 	tlog := hivetest.Logger(t)
-	hive.Start(tlog, context.Background())
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
-	cepStore, _ := ciliumEndpoint.Store(context.Background())
-	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	hive.Start(tlog, t.Context())
+	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 
 	var updatedSlice *cilium_v2a1.CiliumEndpointSlice
 	fakeClient.CiliumFakeClientset.PrependReactor("update", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -144,7 +143,7 @@ func TestReconcileUpdate(t *testing.T) {
 	assert.Contains(t, eps, "cep1")
 	assert.Contains(t, eps, "cep2")
 
-	hive.Stop(tlog, context.Background())
+	hive.Stop(tlog, t.Context())
 }
 
 func TestReconcileDelete(t *testing.T) {
@@ -173,10 +172,10 @@ func TestReconcileDelete(t *testing.T) {
 	)
 
 	tlog := hivetest.Logger(t)
-	hive.Start(tlog, context.Background())
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
-	cepStore, _ := ciliumEndpoint.Store(context.Background())
-	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	hive.Start(tlog, t.Context())
+	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 
 	var deletedSlice string
 	fakeClient.CiliumFakeClientset.PrependReactor("delete", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -203,7 +202,7 @@ func TestReconcileDelete(t *testing.T) {
 
 	assert.Equal(t, "ces1", deletedSlice)
 
-	hive.Stop(tlog, context.Background())
+	hive.Stop(tlog, t.Context())
 }
 
 func TestReconcileNoop(t *testing.T) {
@@ -231,9 +230,9 @@ func TestReconcileNoop(t *testing.T) {
 		}),
 	)
 	tlog := hivetest.Logger(t)
-	hive.Start(tlog, context.Background())
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
-	cepStore, _ := ciliumEndpoint.Store(context.Background())
+	hive.Start(tlog, t.Context())
+	r = newReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
 
 	noRequest := true
 	fakeClient.CiliumFakeClientset.PrependReactor("*", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -257,5 +256,5 @@ func TestReconcileNoop(t *testing.T) {
 
 	assert.True(t, noRequest)
 
-	hive.Stop(tlog, context.Background())
+	hive.Stop(tlog, t.Context())
 }

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -40,7 +40,7 @@ const (
 func TestRegisterControllerWithOperatorManagingCIDs(t *testing.T) {
 	cidResource, cesResource, fakeClient, m, h := initHiveTest(t, true)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {
 		t.Fatalf("starting hive encountered an error: %s", err)
@@ -76,7 +76,7 @@ func TestRegisterControllerWithOperatorManagingCIDs(t *testing.T) {
 func TestRegisterController(t *testing.T) {
 	cidResource, _, fakeClient, m, h := initHiveTest(t, false)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {
 		t.Fatalf("starting hive encountered an error: %s", err)
@@ -191,7 +191,7 @@ func verifyCIDUsageInCES(ctx context.Context, fakeClient *k8sClient.FakeClientse
 		return err
 	}
 
-	cesStore, _ := cesResource.Store(context.Background())
+	cesStore, _ := cesResource.Store(ctx)
 	if err := testutils.WaitUntil(func() bool {
 		return len(cesStore.List()) > 0
 	}, WaitUntilTimeout); err != nil {
@@ -226,7 +226,7 @@ func TestCreateTwoPodsWithSameLabels(t *testing.T) {
 
 	// Start test hive.
 	cidResource, _, fakeClient, _, h := initHiveTest(t, true)
-	ctx, cancelCtxFunc := context.WithCancel(context.Background())
+	ctx, cancelCtxFunc := context.WithCancel(t.Context())
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {
 		t.Fatalf("starting hive encountered an error: %s", err)
@@ -299,7 +299,7 @@ func TestUpdatePodLabels(t *testing.T) {
 
 	// Start test hive.
 	cidResource, _, fakeClient, _, h := initHiveTest(t, true)
-	ctx, cancelCtxFunc := context.WithCancel(context.Background())
+	ctx, cancelCtxFunc := context.WithCancel(t.Context())
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {
 		t.Fatalf("starting hive encountered an error: %s", err)
@@ -366,7 +366,7 @@ func TestUpdateUsedCIDIsReverted(t *testing.T) {
 
 	// Start test hive.
 	cidResource, _, fakeClient, _, h := initHiveTest(t, true)
-	ctx, cancelCtxFunc := context.WithCancel(context.Background())
+	ctx, cancelCtxFunc := context.WithCancel(t.Context())
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {
 		t.Fatalf("starting hive encountered an error: %s", err)
@@ -446,7 +446,7 @@ func TestDeleteUsedCIDIsRecreated(t *testing.T) {
 
 	// Start test hive.
 	cidResource, _, fakeClient, _, h := initHiveTest(t, true)
-	ctx, cancelCtxFunc := context.WithCancel(context.Background())
+	ctx, cancelCtxFunc := context.WithCancel(t.Context())
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {
 		t.Fatalf("starting hive encountered an error: %s", err)

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -244,7 +244,7 @@ func TestReconcileCID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
 			defer cleanupFunc()
 
@@ -423,7 +423,7 @@ func TestReconcilePod(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
 			defer cleanupFunc()
 
@@ -514,7 +514,7 @@ func TestReconcileNS(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			reconciler, queueOps, _, cleanupFunc := testNewReconciler(t, ctx, false)
 			defer cleanupFunc()
 
@@ -565,7 +565,7 @@ func TestHandleStoreCIDMatch(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			reconciler, _, _, cleanupFunc := testNewReconciler(t, ctx, false)
 			defer cleanupFunc()
 

--- a/operator/pkg/gateway-api/controller_test.go
+++ b/operator/pkg/gateway-api/controller_test.go
@@ -4,7 +4,6 @@
 package gateway_api
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -254,7 +253,7 @@ var namespaceFixtures = []client.Object{
 func Test_hasMatchingController(t *testing.T) {
 	logger := hivetest.Logger(t)
 	c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(controllerTestFixture...).Build()
-	fn := hasMatchingController(context.Background(), c, "io.cilium/gateway-controller", logger)
+	fn := hasMatchingController(t.Context(), c, "io.cilium/gateway-controller", logger)
 
 	t.Run("invalid object", func(t *testing.T) {
 		res := fn(&corev1.Pod{})
@@ -285,7 +284,7 @@ func Test_getGatewaysForSecret(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	t.Run("secret is used in gateway", func(t *testing.T) {
-		gwList := getGatewaysForSecret(context.Background(), c, &corev1.Secret{
+		gwList := getGatewaysForSecret(t.Context(), c, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "tls-secret",
 				Namespace: "default",
@@ -297,7 +296,7 @@ func Test_getGatewaysForSecret(t *testing.T) {
 	})
 
 	t.Run("secret is not used in gateway", func(t *testing.T) {
-		gwList := getGatewaysForSecret(context.Background(), c, &corev1.Secret{
+		gwList := getGatewaysForSecret(t.Context(), c, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "tls-secret-not-used",
 				Namespace: "default",
@@ -348,7 +347,7 @@ func Test_getGatewaysForNamespace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gwList := getGatewaysForNamespace(context.Background(), c, &corev1.Namespace{
+			gwList := getGatewaysForNamespace(t.Context(), c, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tt.args.namespace,
 				},

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -4,7 +4,6 @@
 package gateway_api
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -336,7 +335,7 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 	}
 
 	t.Run("non-existent gateway", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: client.ObjectKey{
 				Namespace: "default",
 				Name:      "non-existent-gateway",
@@ -352,7 +351,7 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 			Namespace: "default",
 			Name:      "gateway-with-non-existent-gateway-class",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -365,18 +364,18 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 			Namespace: "default",
 			Name:      "valid-gateway",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+		result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
 
 		// First reconcile should wait for LB status before writing addresses into Ingress status
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
 		gw := &gatewayv1.Gateway{}
-		err = c.Get(context.Background(), key, gw)
+		err = c.Get(t.Context(), key, gw)
 		require.NoError(t, err)
 
 		// Check that the gateway status has been updated
-		err = c.Get(context.Background(), key, gw)
+		err = c.Get(t.Context(), key, gw)
 		require.NoError(t, err)
 
 		require.Len(t, gw.Status.Conditions, 2)
@@ -409,20 +408,20 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 			Namespace: "long-name-test",
 			Name:      "test-long-long-long-long-long-long-long-long-long-long-long-long-name",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+		result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
 
 		// First reconcile should wait for LB status before writing addresses into Ingress status
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
 		gw := &gatewayv1.Gateway{}
-		err = c.Get(context.Background(), key, gw)
+		err = c.Get(t.Context(), key, gw)
 		require.NoError(t, err)
 		require.Empty(t, gw.Status.Addresses)
 
 		// Simulate LB service update
 		lb := &corev1.Service{}
-		err = c.Get(context.Background(), client.ObjectKey{Namespace: "long-name-test", Name: "cilium-gateway-test-long-long-long-long-long-long-lo-8tfth549c6"}, lb)
+		err = c.Get(t.Context(), client.ObjectKey{Namespace: "long-name-test", Name: "cilium-gateway-test-long-long-long-long-long-long-lo-8tfth549c6"}, lb)
 		require.NoError(t, err)
 		require.Equal(t, corev1.ServiceTypeLoadBalancer, lb.Spec.Type)
 		require.Equal(t, "test-long-long-long-long-long-long-long-long-long-lo-4bftbgh5ht", lb.Labels["io.cilium.gateway/owning-gateway"])
@@ -440,16 +439,16 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 				},
 			},
 		}
-		err = c.Status().Update(context.Background(), lb)
+		err = c.Status().Update(t.Context(), lb)
 		require.NoError(t, err)
 
 		// Perform second reconciliation
-		result, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+		result, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
 		// Check that the gateway status has been updated
-		err = c.Get(context.Background(), key, gw)
+		err = c.Get(t.Context(), key, gw)
 		require.NoError(t, err)
 
 		require.Len(t, gw.Status.Conditions, 2)
@@ -482,20 +481,20 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 			Namespace: "default",
 			Name:      "valid-tlsroute-gateway",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+		result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
 
 		// First reconcile should wait for LB status before writing addresses into Ingress status
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
 		gw := &gatewayv1.Gateway{}
-		err = c.Get(context.Background(), key, gw)
+		err = c.Get(t.Context(), key, gw)
 		require.NoError(t, err)
 		require.Empty(t, gw.Status.Addresses)
 
 		// Simulate LB service update
 		lb := &corev1.Service{}
-		err = c.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "cilium-gateway-valid-tlsroute-gateway"}, lb)
+		err = c.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "cilium-gateway-valid-tlsroute-gateway"}, lb)
 		require.NoError(t, err)
 		require.Equal(t, corev1.ServiceTypeLoadBalancer, lb.Spec.Type)
 		require.Equal(t, "valid-tlsroute-gateway", lb.Labels["io.cilium.gateway/owning-gateway"])
@@ -512,16 +511,16 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 				},
 			},
 		}
-		err = c.Status().Update(context.Background(), lb)
+		err = c.Status().Update(t.Context(), lb)
 		require.NoError(t, err)
 
 		// Perform second reconciliation
-		result, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+		result, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
 		// Check that the gateway status has been updated
-		err = c.Get(context.Background(), key, gw)
+		err = c.Get(t.Context(), key, gw)
 		require.NoError(t, err)
 
 		require.Len(t, gw.Status.Conditions, 2)

--- a/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
@@ -4,7 +4,6 @@
 package gateway_api
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -104,7 +103,7 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 	r := &gatewayClassReconciler{Client: c, logger: hivetest.Logger(t)}
 
 	t.Run("no gateway class", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Name: "non-existing-gw-class",
 			},
@@ -114,7 +113,7 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("gateway class exists but being deleted", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Name: "deleting-gw-class",
 			},
@@ -125,7 +124,7 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("gateway class exists and active", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: client.ObjectKey{
 				Name: "dummy-gw-class",
 			},
@@ -136,13 +135,13 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 		gwconformance.GWCMustHaveAcceptedConditionTrue(t, c, gwconformanceconfig.DefaultTimeoutConfig(), "dummy-gw-class")
 
 		gwc := &gatewayv1.GatewayClass{}
-		err = c.Get(context.Background(), types.NamespacedName{Name: "dummy-gw-class"}, gwc)
+		err = c.Get(t.Context(), types.NamespacedName{Name: "dummy-gw-class"}, gwc)
 		require.NoError(t, err, "Error getting gateway class")
 		require.NotZero(t, gwc.Status.SupportedFeatures)
 	})
 
 	t.Run("gateway class exists with unsupported parameter ref", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Name: "dummy-gw-class-with-unsupported-parameters-ref",
 			},
@@ -155,7 +154,7 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("gateway class exists with valid parameter ref", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: client.ObjectKey{
 				Name: "dummy-gw-class-with-valid-parameters-ref",
 			},
@@ -166,14 +165,14 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 		gwconformance.GWCMustHaveAcceptedConditionTrue(t, c, gwconformanceconfig.DefaultTimeoutConfig(), "dummy-gw-class-with-valid-parameters-ref")
 
 		gwc := &gatewayv1.GatewayClass{}
-		err = c.Get(context.Background(), types.NamespacedName{Name: "dummy-gw-class-with-valid-parameters-ref"}, gwc)
+		err = c.Get(t.Context(), types.NamespacedName{Name: "dummy-gw-class-with-valid-parameters-ref"}, gwc)
 		require.NoError(t, err, "Error getting gateway class")
 		require.NotZero(t, gwc.Status.SupportedFeatures)
 		require.Equal(t, "sha256:ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356", gwc.Annotations[configChecksumAnnotation])
 	})
 
 	t.Run("non-matching controller name", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Name: "non-matching-gw-class",
 			},
@@ -183,7 +182,7 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		gwc := &gatewayv1.GatewayClass{}
-		err = c.Get(context.Background(), types.NamespacedName{Name: "non-matching-gw-class"}, gwc)
+		err = c.Get(t.Context(), types.NamespacedName{Name: "non-matching-gw-class"}, gwc)
 
 		require.NoError(t, err, "Error getting gateway class")
 		require.Empty(t, gwc.Status.Conditions, "Gateway class should not have any conditions")

--- a/operator/pkg/gateway-api/httproute_reconcile_test.go
+++ b/operator/pkg/gateway-api/httproute_reconcile_test.go
@@ -4,7 +4,6 @@
 package gateway_api
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -1093,7 +1092,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 	r := &httpRouteReconciler{Client: c, logger: hivetest.Logger(t)}
 
 	t.Run("no http route", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      "non-existing-http-route",
 				Namespace: "default",
@@ -1104,7 +1103,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("http route exists but being deleted", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      "deleting-http-route",
 				Namespace: "default",
@@ -1121,7 +1120,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 				Name:      "valid-http-route-" + name,
 				Namespace: "default",
 			}
-			result, err := r.Reconcile(context.Background(), ctrl.Request{
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: key,
 			})
 
@@ -1129,7 +1128,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			route := &gatewayv1.HTTPRoute{}
-			err = c.Get(context.Background(), key, route)
+			err = c.Get(t.Context(), key, route)
 
 			require.NoError(t, err)
 			require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1149,7 +1148,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 				Name:      "valid-http-route-hostname-" + name,
 				Namespace: "default",
 			}
-			result, err := r.Reconcile(context.Background(), ctrl.Request{
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: key,
 			})
 
@@ -1157,7 +1156,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			route := &gatewayv1.HTTPRoute{}
-			err = c.Get(context.Background(), key, route)
+			err = c.Get(t.Context(), key, route)
 
 			require.NoError(t, err)
 			require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1178,7 +1177,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "http-route-with-hostnames-and-cross-namespace-listener",
 			Namespace: "another-namespace",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1186,7 +1185,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1207,7 +1206,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 				Name:      "http-route-with-nonexistent-" + name,
 				Namespace: "default",
 			}
-			result, err := r.Reconcile(context.Background(), ctrl.Request{
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: key,
 			})
 
@@ -1215,7 +1214,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			route := &gatewayv1.HTTPRoute{}
-			err = c.Get(context.Background(), key, route)
+			err = c.Get(t.Context(), key, route)
 
 			require.NoError(t, err)
 			require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1234,7 +1233,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "http-route-with-nonexistent-gateway",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1242,7 +1241,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Empty(t, route.Status.RouteStatus.Parents, "Should have 0 parents")
@@ -1253,7 +1252,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "gamma-parentref-only",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1261,7 +1260,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Empty(t, route.Status.RouteStatus.Parents, "Should have 0 parents")
@@ -1272,7 +1271,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "both-parentrefs",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1280,7 +1279,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1298,7 +1297,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "otherimpl-parentref",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1306,7 +1305,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Empty(t, route.Status.RouteStatus.Parents, "Should have 0 parents")
@@ -1317,7 +1316,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "oneofeach-gateway-parentrefs",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1325,7 +1324,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1343,7 +1342,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "http-route-with-not-allowed-gateway",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1351,7 +1350,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1371,7 +1370,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "http-route-with-non-matching-hostname",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1379,7 +1378,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1400,7 +1399,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 				Name:      "http-route-with-cross-namespace-" + name,
 				Namespace: "default",
 			}
-			result, err := r.Reconcile(context.Background(), ctrl.Request{
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: key,
 			})
 
@@ -1408,7 +1407,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			route := &gatewayv1.HTTPRoute{}
-			err = c.Get(context.Background(), key, route)
+			err = c.Get(t.Context(), key, route)
 
 			require.NoError(t, err)
 			require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1429,7 +1428,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "http-route-with-cross-namespace-listener",
 			Namespace: "another-namespace",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1437,7 +1436,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1455,7 +1454,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "http-route-with-cross-namespace-backend-with-grant",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1463,7 +1462,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1481,7 +1480,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			Name:      "http-route-with-unsupported-backend",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1489,7 +1488,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1510,7 +1509,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 				Name:      "http-route-missing-port-for-backend-" + name,
 				Namespace: "default",
 			}
-			result, err := r.Reconcile(context.Background(), ctrl.Request{
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: key,
 			})
 
@@ -1518,7 +1517,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			route := &gatewayv1.HTTPRoute{}
-			err = c.Get(context.Background(), key, route)
+			err = c.Get(t.Context(), key, route)
 
 			require.NoError(t, err)
 			require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1549,7 +1548,7 @@ func Test_httpRouteReconciler_Reconcile_NoServiceImportCRD(t *testing.T) {
 			Name:      "valid-http-route-service",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1557,7 +1556,7 @@ func Test_httpRouteReconciler_Reconcile_NoServiceImportCRD(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
@@ -1575,7 +1574,7 @@ func Test_httpRouteReconciler_Reconcile_NoServiceImportCRD(t *testing.T) {
 			Name:      "valid-http-route-serviceimport",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -1583,7 +1582,7 @@ func Test_httpRouteReconciler_Reconcile_NoServiceImportCRD(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		route := &gatewayv1.HTTPRoute{}
-		err = c.Get(context.Background(), key, route)
+		err = c.Get(t.Context(), key, route)
 
 		require.NoError(t, err)
 		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")

--- a/operator/pkg/ingress/helpers_test.go
+++ b/operator/pkg/ingress/helpers_test.go
@@ -4,7 +4,6 @@
 package ingress
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -243,7 +242,7 @@ func TestIsCiliumManagedIngress(t *testing.T) {
 				WithObjects(tC.fixture...).
 				Build()
 
-			isManaged := isCiliumManagedIngress(context.Background(), fakeClient, fakeLogger, tC.ingress)
+			isManaged := isCiliumManagedIngress(t.Context(), fakeClient, fakeLogger, tC.ingress)
 			require.Equal(t, tC.managed, isManaged)
 		})
 	}

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -78,7 +78,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -88,19 +88,19 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err, "Dedicated loadbalancer service should exist")
 
 		ep := corev1.Endpoints{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
 		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
 		require.NoError(t, err, "Dedicated CiliumEnvoyConfig should exist")
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
 		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
 		require.True(t, k8sApiErrors.IsNotFound(err))
 	})
@@ -134,7 +134,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -144,19 +144,19 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err, "Dedicated loadbalancer service should exist")
 
 		ep := corev1.Endpoints{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
 		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
 		require.NoError(t, err, "Dedicated CiliumEnvoyConfig should exist")
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
 		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
 		require.True(t, k8sApiErrors.IsNotFound(err))
 	})
@@ -190,7 +190,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -199,13 +199,13 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Service{})
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Service{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "Service should not be created")
 
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Endpoints{})
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Endpoints{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "Endpoints should not be created")
 
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")
 	})
 
@@ -234,7 +234,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -244,20 +244,20 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
 		require.NoError(t, err, "Shared CiliumEnvoyConfig should exist for shared Ingress")
 		require.NotEmpty(t, sharedCEC.Spec.Resources)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer service should not exist for shared Ingress")
 
 		ep := corev1.Endpoints{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer endpoints should not exist for shared Ingress")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated CiliumEnvoyConfig should not exist for shared Ingress")
 	})
 
@@ -304,7 +304,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -314,20 +314,20 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
 		require.NoError(t, err, "Shared CiliumEnvoyConfig should exist for shared Ingress")
 		require.NotEmpty(t, sharedCEC.Spec.Resources)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer service should not exist for shared Ingress")
 
 		ep := corev1.Endpoints{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer endpoints should not exist for shared Ingress")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated CiliumEnvoyConfig should not exist for shared Ingress")
 	})
 
@@ -371,7 +371,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -381,19 +381,19 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err, "Dedicated loadbalancer service should exist")
 
 		ep := corev1.Endpoints{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
 		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
 		require.NoError(t, err, "Dedicated CiliumEnvoyConfig should exist")
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
 		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
 		require.True(t, k8sApiErrors.IsNotFound(err))
 	})
@@ -425,7 +425,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -435,7 +435,7 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
 		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
 		require.True(t, k8sApiErrors.IsNotFound(err))
 	})
@@ -507,7 +507,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -517,24 +517,24 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer service should be cleaned up")
 
 		ep := corev1.Endpoints{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer endpoints should be cleaned up")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated CiliumEnvoyConfig should be cleaned up")
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
 		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
 		require.True(t, k8sApiErrors.IsNotFound(err))
 
 		ingress := networkingv1.Ingress{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &ingress)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "test"}, &ingress)
 		require.NoError(t, err)
 		require.NotEmpty(t, ingress.Status.LoadBalancer.Ingress, "Loadbalancer status of Ingress should not be changed (its up to the new owning Ingress Controller to update it accordingly)")
 	})
@@ -565,7 +565,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -575,7 +575,7 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err, "Dedicated loadbalancer service should exist")
 		require.Equal(t, "dummy", *svc.Spec.LoadBalancerClass, "Dedicated loadbalancer service should haver the specified class")
 	})
@@ -606,7 +606,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -616,12 +616,12 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
 		require.NoError(t, err, "Shared CiliumEnvoyConfig should exist for shared Ingress")
 		require.NotEmpty(t, sharedCEC.Spec.Resources)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer service should not exist for shared Ingress")
 	})
 
@@ -665,7 +665,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -675,7 +675,7 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		ingress := networkingv1.Ingress{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &ingress)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "test"}, &ingress)
 		require.NoError(t, err)
 		require.Len(t, ingress.Status.LoadBalancer.Ingress, 1, "Loadbalancer status should contain the IP of the dedicated loadbalancer service")
 		require.Equal(t, "172.21.255.202", ingress.Status.LoadBalancer.Ingress[0].IP, "Loadbalancer status should contain the IP of the dedicated loadbalancer service")
@@ -721,7 +721,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -731,7 +731,7 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		ingress := networkingv1.Ingress{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &ingress)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "test"}, &ingress)
 		require.NoError(t, err)
 		require.Len(t, ingress.Status.LoadBalancer.Ingress, 1, "Loadbalancer status should contain the IP of the shared loadbalancer service")
 		require.Equal(t, "172.21.255.200", ingress.Status.LoadBalancer.Ingress[0].IP, "Loadbalancer status should contain the IP of the shared loadbalancer service")
@@ -761,7 +761,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -802,7 +802,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -812,7 +812,7 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err)
 
 		require.Equal(t, map[string]string{"cilium.io/ingress": "true", "test.acme.io/test-label": "test"}, svc.Labels)
@@ -887,7 +887,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -897,7 +897,7 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err)
 
 		require.Contains(t, svc.Labels, "cilium.io/ingress", "Existing labels should be overwritten if they have the same key")
@@ -907,14 +907,14 @@ func TestReconcile(t *testing.T) {
 		require.Contains(t, svc.Annotations, "additional.annotation/test-annotation", "Existing annotations should not be deleted")
 
 		ep := corev1.Endpoints{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &ep)
 		require.NoError(t, err)
 
 		require.Contains(t, ep.Labels, "additional.label/test-label", "Existing labels should not be deleted")
 		require.Contains(t, ep.Annotations, "additional.annotation/test-annotation", "Existing annotations should not be deleted")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
 		require.NoError(t, err)
 
 		require.Contains(t, cec.Labels, "additional.label/test-label", "Existing labels should not be deleted")
@@ -952,7 +952,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -962,7 +962,7 @@ func TestReconcile(t *testing.T) {
 		require.NotNil(t, result)
 
 		svc := corev1.Service{}
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err)
 
 		require.Equal(t, ptr.To("service.k8s.aws/nlb"), svc.Spec.LoadBalancerClass, "LoadbalancerClass should be preserved during reconciliation")
@@ -994,7 +994,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -1003,13 +1003,13 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Service{})
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Service{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "Service should not be created")
 
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Endpoints{})
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Endpoints{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "Endpoints should not be created")
 
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")
 	})
 
@@ -1052,7 +1052,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -1061,13 +1061,13 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Service{})
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Service{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "Service should not be created")
 
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Endpoints{})
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &corev1.Endpoints{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "Endpoints should not be created")
 
-		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")
 	})
 	t.Run("Reconcile of shared Cilium Ingress with external LB support will pass the configured port via model to the CEC Translator", func(t *testing.T) {
@@ -1094,7 +1094,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, nil, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, true, 55555)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",
@@ -1134,7 +1134,7 @@ func TestReconcile(t *testing.T) {
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, true, 0)
 
-		result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "test",

--- a/operator/pkg/lbipam/lbipam_fixture_test.go
+++ b/operator/pkg/lbipam/lbipam_fixture_test.go
@@ -173,7 +173,7 @@ func (nf *newFixture) GetPool(name string) *cilium_api_v2alpha1.CiliumLoadBalanc
 func (nf *newFixture) UpsertPool(t *testing.T, pool *cilium_api_v2alpha1.CiliumLoadBalancerIPPool) {
 	key := resource.Key{Name: pool.Name}
 	nf.poolClient.resources[key] = pool
-	nf.lbipam.handlePoolEvent(context.Background(), resource.Event[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]{
+	nf.lbipam.handlePoolEvent(t.Context(), resource.Event[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]{
 		Kind:   resource.Upsert,
 		Key:    key,
 		Object: pool,
@@ -188,7 +188,7 @@ func (nf *newFixture) UpsertPool(t *testing.T, pool *cilium_api_v2alpha1.CiliumL
 func (nf *newFixture) DeletePool(t *testing.T, pool *cilium_api_v2alpha1.CiliumLoadBalancerIPPool) {
 	key := resource.Key{Name: pool.Name}
 	delete(nf.poolClient.resources, key)
-	nf.lbipam.handlePoolEvent(context.Background(), resource.Event[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]{
+	nf.lbipam.handlePoolEvent(t.Context(), resource.Event[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]{
 		Kind:   resource.Delete,
 		Key:    key,
 		Object: pool,
@@ -203,7 +203,7 @@ func (nf *newFixture) DeletePool(t *testing.T, pool *cilium_api_v2alpha1.CiliumL
 func (nf *newFixture) UpsertSvc(t *testing.T, svc *slim_core_v1.Service) {
 	key := resource.Key{Name: svc.Name, Namespace: svc.Namespace}
 	nf.svcClient.resources[key] = svc
-	nf.lbipam.handleServiceEvent(context.Background(), resource.Event[*slim_core_v1.Service]{
+	nf.lbipam.handleServiceEvent(t.Context(), resource.Event[*slim_core_v1.Service]{
 		Kind:   resource.Upsert,
 		Key:    key,
 		Object: svc,
@@ -219,7 +219,7 @@ func (nf *newFixture) UpsertSvc(t *testing.T, svc *slim_core_v1.Service) {
 func (nf *newFixture) DeleteSvc(t *testing.T, svc *slim_core_v1.Service) {
 	key := resource.Key{Name: svc.Name, Namespace: svc.Namespace}
 	delete(nf.svcClient.resources, key)
-	nf.lbipam.handleServiceEvent(context.Background(), resource.Event[*slim_core_v1.Service]{
+	nf.lbipam.handleServiceEvent(t.Context(), resource.Event[*slim_core_v1.Service]{
 		Kind:   resource.Delete,
 		Key:    key,
 		Object: svc,

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -4,7 +4,6 @@
 package lbipam
 
 import (
-	"context"
 	"net"
 	"net/netip"
 	"strings"
@@ -479,7 +478,7 @@ func TestSharingKey(t *testing.T) {
 
 	svcIP2 := svcC.Status.LoadBalancer.Ingress[0].IP
 
-	err := fixture.svcClient.Services("default").Delete(context.Background(), "service-a", meta_v1.DeleteOptions{})
+	err := fixture.svcClient.Services("default").Delete(t.Context(), "service-a", meta_v1.DeleteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/operator/pkg/nodeipam/nodesvclb_test.go
+++ b/operator/pkg/nodeipam/nodesvclb_test.go
@@ -5,7 +5,6 @@ package nodeipam
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -360,7 +359,7 @@ func Test_nodeIPAM_Reconcile(t *testing.T) {
 				Name:      name,
 				Namespace: "default",
 			}
-			result, err := r.Reconcile(context.Background(), ctrl.Request{
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: key,
 			})
 
@@ -368,7 +367,7 @@ func Test_nodeIPAM_Reconcile(t *testing.T) {
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			svc := &corev1.Service{}
-			err = c.Get(context.Background(), key, svc)
+			err = c.Get(t.Context(), key, svc)
 
 			require.NoError(t, err)
 			// It did not change the IPs already advertised
@@ -391,7 +390,7 @@ func Test_nodeIPAM_Reconcile(t *testing.T) {
 				Name:      param.name,
 				Namespace: "default",
 			}
-			result, err := r.Reconcile(context.Background(), ctrl.Request{
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: key,
 			})
 
@@ -399,7 +398,7 @@ func Test_nodeIPAM_Reconcile(t *testing.T) {
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			svc := &corev1.Service{}
-			err = c.Get(context.Background(), key, svc)
+			err = c.Get(t.Context(), key, svc)
 
 			require.NoError(t, err)
 			require.Len(t, svc.Status.LoadBalancer.Ingress, 1)
@@ -412,7 +411,7 @@ func Test_nodeIPAM_Reconcile(t *testing.T) {
 			Name:      "dualstack-external",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -420,7 +419,7 @@ func Test_nodeIPAM_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		svc := &corev1.Service{}
-		err = c.Get(context.Background(), key, svc)
+		err = c.Get(t.Context(), key, svc)
 
 		require.NoError(t, err)
 		require.Len(t, svc.Status.LoadBalancer.Ingress, 2)
@@ -433,7 +432,7 @@ func Test_nodeIPAM_Reconcile(t *testing.T) {
 			Name:      "etp-cluster",
 			Namespace: "default",
 		}
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: key,
 		})
 
@@ -441,7 +440,7 @@ func Test_nodeIPAM_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 		svc := &corev1.Service{}
-		err = c.Get(context.Background(), key, svc)
+		err = c.Get(t.Context(), key, svc)
 
 		require.NoError(t, err)
 		require.Len(t, svc.Status.LoadBalancer.Ingress, 2)
@@ -461,7 +460,7 @@ func Test_nodeIPAM_defaultIPAM_Reconcile(t *testing.T) {
 		Name:      "default-ipam",
 		Namespace: "default",
 	}
-	result, err := r.Reconcile(context.Background(), ctrl.Request{
+	result, err := r.Reconcile(t.Context(), ctrl.Request{
 		NamespacedName: key,
 	})
 
@@ -469,7 +468,7 @@ func Test_nodeIPAM_defaultIPAM_Reconcile(t *testing.T) {
 	require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 	svc := &corev1.Service{}
-	err = c.Get(context.Background(), key, svc)
+	err = c.Get(t.Context(), key, svc)
 
 	require.NoError(t, err)
 	require.Len(t, svc.Status.LoadBalancer.Ingress, 2)
@@ -490,7 +489,7 @@ func Test_nodeIPAM_CiliumResources_Reconcile(t *testing.T) {
 	}
 
 	t.Run("Managed Resource", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		result, err := r.Reconcile(ctx, ctrl.Request{
 			NamespacedName: key,
 		})
@@ -511,7 +510,7 @@ func Test_nodeIPAM_CiliumResources_Reconcile(t *testing.T) {
 	})
 
 	t.Run("Node Label Filter", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 
 		for _, param := range []struct {
 			labelFilter string
@@ -548,7 +547,7 @@ func Test_nodeIPAM_CiliumResources_Reconcile(t *testing.T) {
 	})
 
 	t.Run("Bad Node Label Filter", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		svc := &corev1.Service{}
 		_ = c.Get(ctx, key, svc)
 		// Add the label to the service which should return on the first node
@@ -567,7 +566,7 @@ func Test_nodeIPAM_CiliumResources_Reconcile(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(&buf, nil))
 		r.Logger = logger
 
-		ctx := context.Background()
+		ctx := t.Context()
 		svc := &corev1.Service{}
 		_ = c.Get(ctx, key, svc)
 		// Add the label to the service which should return on the first node

--- a/operator/pkg/secretsync/secretsync_reconcile_test.go
+++ b/operator/pkg/secretsync/secretsync_reconcile_test.go
@@ -4,7 +4,6 @@
 package secretsync_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -218,7 +217,7 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 	})
 
 	t.Run("delete synced secret if source secret doesn't exist", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "synced-secret-no-source",
@@ -228,14 +227,14 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result)
 
 		secret := &corev1.Secret{}
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-no-source"}, secret)
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-no-source"}, secret)
 
 		require.Error(t, err)
 		require.ErrorContains(t, err, "secrets \"test-synced-secret-no-source\" not found")
 	})
 
 	t.Run("delete synced secret if source secret isn't referenced by a CIlium Gateway resource", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "synced-secret-no-reference",
@@ -245,14 +244,14 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result)
 
 		secret := &corev1.Secret{}
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-no-reference"}, secret)
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-no-reference"}, secret)
 
 		require.Error(t, err)
 		require.ErrorContains(t, err, "secrets \"test-synced-secret-no-reference\" not found")
 	})
 
 	t.Run("keep synced secret if source secret exists and is referenced by a Gateway resource", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "synced-secret-with-source-and-ref",
@@ -262,12 +261,12 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result)
 
 		secret := &corev1.Secret{}
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-with-source-and-ref"}, secret)
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-with-source-and-ref"}, secret)
 		require.NoError(t, err)
 	})
 
 	t.Run("don't create synced secret for source secret that is referenced by a non Cilium Gateway resource", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "secret-with-non-cilium-ref",
@@ -277,14 +276,14 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result)
 
 		secret := &corev1.Secret{}
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-non-cilium-ref"}, secret)
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-non-cilium-ref"}, secret)
 
 		require.Error(t, err)
 		require.ErrorContains(t, err, "secrets \"test-synced-secret-non-cilium-ref\" not found")
 	})
 
 	t.Run("create synced secret for source secret that is referenced by a Cilium Gateway resource", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "secret-with-ref-not-synced",
@@ -294,12 +293,12 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result)
 
 		secret := &corev1.Secret{}
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-secret-with-ref-not-synced"}, secret)
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-secret-with-ref-not-synced"}, secret)
 		require.NoError(t, err)
 	})
 
 	t.Run("create synced secret in multiple namespaces for source secret that is referenced by a Gateway and Ingress", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "secret-shared-not-synced",
@@ -308,10 +307,10 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-secret-shared-not-synced"}, &corev1.Secret{})
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-secret-shared-not-synced"}, &corev1.Secret{})
 		require.NoError(t, err)
 
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace + "-2", Name: "test-secret-shared-not-synced"}, &corev1.Secret{})
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace + "-2", Name: "test-secret-shared-not-synced"}, &corev1.Secret{})
 		require.NoError(t, err)
 	})
 
@@ -324,10 +323,10 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		}
 
 		var err error
-		err = c.Delete(context.Background(), &ingress)
+		err = c.Delete(t.Context(), &ingress)
 		require.NoError(t, err)
 
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "secret-shared-not-synced",
@@ -336,10 +335,10 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ctrl.Result{}, result)
 
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-secret-shared-not-synced"}, &corev1.Secret{})
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-secret-shared-not-synced"}, &corev1.Secret{})
 		require.NoError(t, err)
 
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace + "-2", Name: "test-secret-shared-not-synced"}, &corev1.Secret{})
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace + "-2", Name: "test-secret-shared-not-synced"}, &corev1.Secret{})
 		require.True(t, k8sErrors.IsNotFound(err))
 	})
 }
@@ -374,7 +373,7 @@ func Test_SecretSync_Reconcile_WithDefaultSecret(t *testing.T) {
 	})
 
 	t.Run("create synced secret for source secret that is the default secret and therefore doesn't need to be referenced by any Cilium Gateway resource", func(t *testing.T) {
-		result, err := r.Reconcile(context.Background(), ctrl.Request{
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: "test",
 				Name:      "unsynced-secret-no-reference",
@@ -384,7 +383,7 @@ func Test_SecretSync_Reconcile_WithDefaultSecret(t *testing.T) {
 		require.Equal(t, ctrl.Result{}, result)
 
 		secret := &corev1.Secret{}
-		err = c.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-unsynced-secret-no-reference"}, secret)
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-unsynced-secret-no-reference"}, secret)
 		require.NoError(t, err)
 	})
 }

--- a/operator/watchers/cilium_node_gc_test.go
+++ b/operator/watchers/cilium_node_gc_test.go
@@ -4,7 +4,6 @@
 package watchers
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -66,7 +65,7 @@ func Test_performCiliumNodeGC(t *testing.T) {
 	candidateStore := newCiliumNodeGCCandidate()
 
 	// check if the invalid node is added to GC candidate
-	err := performCiliumNodeGC(context.TODO(), fcn, fCNStore, fng, interval, candidateStore, hivetest.Logger(t))
+	err := performCiliumNodeGC(t.Context(), fcn, fCNStore, fng, interval, candidateStore, hivetest.Logger(t))
 	assert.NoError(t, err)
 	assert.Len(t, candidateStore.nodesToRemove, 1)
 	_, exists := candidateStore.nodesToRemove["invalid-node"]
@@ -74,7 +73,7 @@ func Test_performCiliumNodeGC(t *testing.T) {
 
 	// check if the invalid node is actually GC-ed
 	time.Sleep(interval)
-	err = performCiliumNodeGC(context.TODO(), fcn, fCNStore, fng, interval, candidateStore, hivetest.Logger(t))
+	err = performCiliumNodeGC(t.Context(), fcn, fCNStore, fng, interval, candidateStore, hivetest.Logger(t))
 	assert.NoError(t, err)
 	assert.Empty(t, candidateStore.nodesToRemove)
 	_, exists = candidateStore.nodesToRemove["invalid-node"]


### PR DESCRIPTION
Replace usages of `context.TODO()` and `context.Background()` in operator related packages tests.

Followup of f5d5948f09e11defbc7cc8d8f6a44d0519dad942 (#38652)

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
operator: Use testing.T.Context added in Go 1.24 in tests
```
