### PR TITLE
fix(helm): ensure the right namespace is used for agent and operator rolebindings

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -145,5 +145,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
@@ -75,5 +75,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.operator.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}


### PR DESCRIPTION
The current usage of .Release.Namespace set the namesapce to default when .namespaceOverride is used.

NOTE: These two RoleBindings are the only two places where .Release.Namespace is used in the helm chart.

```release-note
Fix two Helm resources that did not respect the namespaceOverride value.
```
