### PR TITLE
Fix bug where Cilium incorrectly configures externalTrafficPolicy for ClusterIP services in Gateway API

### DIFF
--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_clusterip/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_clusterip/cec-output.yaml
@@ -1,0 +1,117 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    cilium.io/use-original-source-address: "false"
+    gateway.networking.k8s.io/gateway-name: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  backendServices:
+  - name: my-service
+    namespace: default
+    number:
+    - "8080"
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 10.0.0.0
+              prefixLen: 8
+            - addressPrefix: 172.16.0.0
+              prefixLen: 12
+            - addressPrefix: 192.168.0.0
+              prefixLen: 16
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          pathSeparatedPrefix: /bar
+        route:
+          cluster: default:my-service:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    edsClusterConfig:
+      serviceName: default/my-service:8080
+    name: default:my-service:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  services:
+  - listener: ""
+    name: cilium-gateway-my-gateway
+    namespace: default
+    ports:
+    - 80

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_clusterip/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_clusterip/config-input.yaml
@@ -1,0 +1,14 @@
+cluster_config:
+  idle_timeout_seconds: 60
+host_network_config: {}
+ip_config:
+  ipv4_enabled: true
+  ipv6_enabled: true
+listener_config:
+  stream_idle_timeout_seconds: 300
+original_ip_detection_config: {}
+route_config:
+  host_name_suffix_match: true
+secrets_namespace: cilium-secrets
+service_config:
+  type: ClusterIP

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_clusterip/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_clusterip/input.yaml
@@ -1,0 +1,21 @@
+http:
+- hostname: '*'
+  name: prod-web-gw
+  port: 80
+  routes:
+  - backends:
+    - name: my-service
+      namespace: default
+      port:
+        port: 8080
+    path_match:
+      prefix: /bar
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1
+service:
+  type: ClusterIP

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_clusterip/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_clusterip/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -203,8 +203,15 @@ func (t *gatewayAPITranslator) toServiceType(params *model.Service) corev1.Servi
 // toExternalTrafficPolicy returns the ExternalTrafficPolicy from the given Service object.
 // If hostNetwork is enabled, no external traffic policy is return.
 // The default value is the one from the configuration flag.
+// ExternalTrafficPolicy is only valid for LoadBalancer and NodePort service types.
 func (t *gatewayAPITranslator) toExternalTrafficPolicy(params *model.Service) corev1.ServiceExternalTrafficPolicy {
 	if t.cfg.HostNetworkConfig.Enabled {
+		return corev1.ServiceExternalTrafficPolicy("")
+	}
+
+	// Only set ExternalTrafficPolicy for LoadBalancer and NodePort service types
+	serviceType := t.toServiceType(params)
+	if serviceType != corev1.ServiceTypeLoadBalancer && serviceType != corev1.ServiceTypeNodePort {
 		return corev1.ServiceExternalTrafficPolicy("")
 	}
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the gateway controller was setting `externalTrafficPolicy` for ClusterIP services, which is invalid according to Kubernetes validation. The fix ensures that `externalTrafficPolicy` is only set for LoadBalancer and NodePort service types.

## How has this been tested?

- Added unit tests for the `toExternalTrafficPolicy` function to verify it returns an empty string for ClusterIP services
- Added a test case for a ClusterIP service to ensure the fix works correctly
- Manually tested with a Kind cluster by creating a Gateway with a `CiliumGatewayClassConfig` that specifies `spec.service.type: ClusterIP`

## Related issues

Fixes: #38852

## Checklist

- [x] I have read the [Cilium contributing guide](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/)
- [x] I have added unit tests to verify the fix
- [x] I have tested the changes on a Kind cluster
- [x] I have updated the documentation if necessary