### PR TITLE
endpoint: Unlock on IPIdentitySync error

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -982,6 +982,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				ID := e.SecurityIdentity.ID
 				hostIP, ok := netipx.FromStdIP(node.GetIPv4())
 				if !ok {
+					e.runlock()
 					return controller.NewExitReason("Failed to convert node IPv4 address")
 				}
 				key := node.GetEndpointEncryptKeyIndex()


### PR DESCRIPTION
Previously, if this job failed due to the host IP not being available, we would return an error but never unlock the endpoint. This would leave the system deadlocked and would be unrecoverable, even if a valid host IP was later added.

Fixes #37791

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!


```release-note
Fix a deadlock when a host has no IPv4 address.
```
