### PR TITLE
cilium-cli: run lrp test with per-packet LB in v1.16

### DIFF
--- a/cilium-cli/connectivity/builder/local_redirect_policy.go
+++ b/cilium-cli/connectivity/builder/local_redirect_policy.go
@@ -30,7 +30,7 @@ func (t localRedirectPolicy) build(ct *check.ConnectivityTest, _ map[string]stri
 	lrpTest := newTest("local-redirect-policy", ct).
 		WithCondition(func() bool {
 			if versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) {
-				if ct.IsSocketLBFull() || versioncheck.MustCompile(">=1.17.0")(ct.CiliumVersion) {
+				if ct.IsSocketLBFull() || versioncheck.MustCompile(">=1.16.3")(ct.CiliumVersion) {
 					return true
 				}
 			}


### PR DESCRIPTION
Currently, the local-redirect-policy test runs only under the following conditions:

- Cilium version >= 1.16.0 with socket LB fully enabled
- Cilium version >= 1.17.0 with either socket LB or per-packet LB

However, Cilium version >= 1.16.3 already supports SkipRedirectFromBackend with per-packet LB mode. Let's run the local-redirect-policy test with per-packet LB in version >= 1.16.3

Fixes: #38508

