### PR TITLE
endpoint: Add policy manager callback

### DIFF
--- a/pkg/endpointmanager/callback.go
+++ b/pkg/endpointmanager/callback.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"sync"
+
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+var _ PolicyUpdateCallbackManager = (*endpointManager)(nil)
+
+// CallBackFunc is the call back function type for policy updates.
+// Regenerated IDs are passed to the function, if this set is empty, the caller
+// needs to perform the actions for all endpoint policies.
+type CallBackFunc func(idsRegen *set.Set[identity.NumericIdentity], incremental bool) error
+
+type policyUpdateCallbackDetails struct {
+	cbMutex lock.RWMutex
+
+	// policyUpdateCallbackFuncs is the map of endpoint policy callback update functions
+	// mutex must be held to read and write.
+	policyUpdateCallbackFuncs map[string]CallBackFunc
+}
+
+func newPolicyUpdateCallbackDetails() policyUpdateCallbackDetails {
+	return policyUpdateCallbackDetails{
+		policyUpdateCallbackFuncs: make(map[string]CallBackFunc),
+	}
+}
+
+type PolicyUpdateCallbackManager interface {
+	// RegisterPolicyUpdateCallback registers the callback for policy update
+	RegisterPolicyUpdateCallback(name string, cb CallBackFunc)
+	// DeregisterPolicyUpdateCallback removes the callback for policy update
+	DeregisterPolicyUpdateCallback(name string)
+}
+
+// RegisterPolicyUpdateCallback is to satisfy the PolicyUpdateCallbackManager interface.
+func (mgr *endpointManager) RegisterPolicyUpdateCallback(name string, updateFunc CallBackFunc) {
+	mgr.cbMutex.Lock()
+	defer mgr.cbMutex.Unlock()
+
+	mgr.policyUpdateCallbackFuncs[name] = updateFunc
+}
+
+// DeregisterPolicyUpdateCallback is to satisfy the PolicyUpdateCallbackManager interface.
+func (mgr *endpointManager) DeregisterPolicyUpdateCallback(name string) {
+	mgr.cbMutex.Lock()
+	defer mgr.cbMutex.Unlock()
+	delete(mgr.policyUpdateCallbackFuncs, name)
+}
+
+// policyUpdateCallback perform the call back in separate goroutines.
+// This is non-blocking and returns immediately, the caller can wait
+// for completion by using the wait group if required.
+func (mgr *endpointManager) policyUpdateCallback(wg *sync.WaitGroup, idsToRegen *set.Set[identity.NumericIdentity], incremental bool) {
+	mgr.cbMutex.RLock()
+	defer mgr.cbMutex.RUnlock()
+	wg.Add(len(mgr.policyUpdateCallbackFuncs))
+
+	for _, fn := range mgr.policyUpdateCallbackFuncs {
+		go func(f CallBackFunc) {
+			_ = f(idsToRegen, incremental)
+			wg.Done()
+		}(fn)
+	}
+}

--- a/pkg/endpointmanager/callback_test.go
+++ b/pkg/endpointmanager/callback_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+const numberOfEndpointPolicies = 10
+
+func Test_PolicyUpdateCallback(t *testing.T) {
+	mgr := New(&dummyEpSyncher{}, nil, nil, nil, nil)
+	called := int32(0)
+	updateFunc := func(idsRegen *set.Set[identity.NumericIdentity], incremental bool) error {
+		atomic.AddInt32(&called, 1)
+		return nil
+	}
+
+	for i := range numberOfEndpointPolicies {
+		mgr.RegisterPolicyUpdateCallback(fmt.Sprintf("callback-%d", i), updateFunc)
+	}
+	wg := sync.WaitGroup{}
+	mgr.policyUpdateCallback(&wg, nil, false)
+	wg.Wait()
+	require.Equal(t, int32(10), called)
+
+	for i := range numberOfEndpointPolicies {
+		mgr.DeregisterPolicyUpdateCallback(fmt.Sprintf("callback-%d", i))
+	}
+	wg = sync.WaitGroup{}
+	mgr.policyUpdateCallback(&wg, nil, false)
+	wg.Wait()
+	require.Equal(t, int32(10), called)
+}

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -193,9 +193,10 @@ type endpointManagerParams struct {
 type endpointManagerOut struct {
 	cell.Out
 
-	Lookup  EndpointsLookup
-	Modify  EndpointsModify
-	Manager EndpointManager
+	Lookup   EndpointsLookup
+	Modify   EndpointsModify
+	Manager  EndpointManager
+	Callback PolicyUpdateCallbackManager
 }
 
 func newDefaultEndpointManager(p endpointManagerParams) endpointManagerOut {
@@ -221,9 +222,10 @@ func newDefaultEndpointManager(p endpointManagerParams) endpointManagerOut {
 	mgr.InitMetrics(p.MetricsRegistry)
 
 	return endpointManagerOut{
-		Lookup:  mgr,
-		Modify:  mgr,
-		Manager: mgr,
+		Lookup:   mgr,
+		Modify:   mgr,
+		Manager:  mgr,
+		Callback: mgr,
 	}
 }
 


### PR DESCRIPTION
This commit is to extend existing EndpointManager component to provide the callback when the policy update happens:

- All Endpoint Regeneration
- UpdatePolicyMaps function call for regen IDs
- ApplyPolicyMaps changes

The callback is non-blocking call, so that we don't hold the main processing flow.

```release-note
endpoint: Add policy manager callback
```
