### PR TITLE
l2announcer: explicitly start l2announcer in hive cell via cell.Invoke

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -74,7 +74,6 @@ import (
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/l2announcer"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
@@ -1547,7 +1546,6 @@ type daemonParams struct {
 	ServiceCache        k8s.ServiceCache
 	ClusterMesh         *clustermesh.ClusterMesh
 	MonitorAgent        monitorAgent.Agent
-	L2Announcer         *l2announcer.L2Announcer
 	ServiceManager      service.ServiceManager
 	L7Proxy             *proxy.Proxy
 	DB                  *statedb.DB

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -47,6 +47,7 @@ var Cell = cell.Module(
 
 	cell.Provide(NewL2Announcer),
 	cell.Provide(l2AnnouncementPolicyResource),
+	cell.Invoke(func(*L2Announcer) {}), // register and start L2 announcer
 )
 
 func l2AnnouncementPolicyResource(lc cell.Lifecycle, cs k8sClient.Clientset) (resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy], error) {
@@ -62,9 +63,7 @@ func l2AnnouncementPolicyResource(lc cell.Lifecycle, cs k8sClient.Clientset) (re
 type l2AnnouncerParams struct {
 	cell.In
 
-	Lifecycle cell.Lifecycle
-	Logger    logrus.FieldLogger
-	Health    cell.Health
+	Logger logrus.FieldLogger
 
 	DaemonConfig         *option.DaemonConfig
 	Clientset            k8sClient.Clientset

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -70,9 +70,7 @@ func newFixture(t testing.TB) *fixture {
 	fakePolicyStore := &fakeStore[*v2alpha1.CiliumL2AnnouncementPolicy]{}
 
 	params := l2AnnouncerParams{
-		Logger:    logrus.New(),
-		Lifecycle: &cell.DefaultLifecycle{},
-		Health:    h,
+		Logger: logrus.New(),
 		DaemonConfig: &option.DaemonConfig{
 			K8sNamespace:             "kube_system",
 			EnableL2Announcements:    true,
@@ -114,21 +112,27 @@ type fakeStore[T runtime.Object] struct {
 func (fs *fakeStore[T]) List() []T {
 	return fs.slice
 }
+
 func (fs *fakeStore[T]) IterKeys() resource.KeyIter { return nil }
+
 func (fs *fakeStore[T]) Get(obj T) (item T, exists bool, err error) {
 	var def T
 	return def, false, nil
 }
+
 func (fs *fakeStore[T]) GetByKey(key resource.Key) (item T, exists bool, err error) {
 	var def T
 	return def, false, nil
 }
+
 func (fs *fakeStore[T]) IndexKeys(indexName, indexedValue string) ([]string, error) {
 	return nil, nil
 }
+
 func (fs *fakeStore[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
 	return nil, nil
 }
+
 func (fs *fakeStore[T]) CacheStore() cache.Store { return nil }
 
 var _ resource.Resource[runtime.Object] = (*fakeResource[runtime.Object])(nil)
@@ -138,7 +142,6 @@ type fakeResource[T runtime.Object] struct {
 }
 
 func (fr *fakeResource[T]) Observe(ctx context.Context, next func(event resource.Event[T]), complete func(error)) {
-
 }
 
 func (fr *fakeResource[T]) Events(ctx context.Context, opts ...resource.EventsOpt) <-chan resource.Event[T] {
@@ -880,7 +883,6 @@ func TestPolicySelection(t *testing.T) {
 
 	assert.Len(t, fix.announcer.selectedPolicies, 1)
 	assert.Empty(t, fix.announcer.selectedServices)
-
 }
 
 // Test that when the selected IP types in the policy changes, that proxy neighbor table is updated properly.


### PR DESCRIPTION
Currently, the L2 announcer gets implicitly started due to the dependency from the daemon to the `L2Announcer`.

To remove the otherwise unused dependency from the daemon, this commit adds an explicit registration and start of the L2Announcer by using `cell.Invoke` in the respective hive cell.

Note: In addition, the unused L2Announcer dependencies `Livecycle` & `Health` have been removed.

cc @dylandreimerink (not sure whether this was an intentional decision and I might miss some ordering aspect that the announcer needs to start before the daemon initialization)