### PR TITLE
bpf: nat: fine-tune snat_v*_nat_handle_mapping()

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -306,8 +306,6 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 	if (!map)
 		return DROP_SNAT_NO_MAP_FOUND;
 
-	*state = __snat_lookup(map, tuple);
-
 	if (needs_ct) {
 		struct ipv4_ct_tuple tuple_snat;
 		int ret;
@@ -332,6 +330,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 		}
 	}
 
+	*state = __snat_lookup(map, tuple);
 	if (*state) {
 		int ret;
 		struct ipv4_ct_tuple rtuple = {};
@@ -1345,8 +1344,6 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 {
 	bool needs_ct = target->needs_ct;
 
-	*state = snat_v6_lookup(tuple);
-
 	if (needs_ct) {
 		struct ipv6_ct_tuple tuple_snat;
 		int ret;
@@ -1371,6 +1368,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 		}
 	}
 
+	*state = snat_v6_lookup(tuple);
 	if (*state) {
 		int ret;
 		struct ipv6_ct_tuple rtuple = {};


### PR DESCRIPTION
Delay the lookup for the SNAT state until we've processed the CT lookup. This eases readability, and seems to help with reducing complexity.