### PR TITLE
proxy/endpoint: Add GetPolicyNames interface method

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -448,6 +448,19 @@ type Endpoint struct {
 	ctMapGC ctmap.GCRunner
 }
 
+// GetPolicyNames returns the policy names for this endpoint.
+// For Endpoint, the policy names are the IP addresses of the endpoint.
+func (e *Endpoint) GetPolicyNames() []string {
+	var ips []string
+	if ipv6 := e.GetIPv6Address(); ipv6 != "" {
+		ips = append(ips, ipv6)
+	}
+	if ipv4 := e.GetIPv4Address(); ipv4 != "" {
+		ips = append(ips, ipv4)
+	}
+	return ips
+}
+
 func (e *Endpoint) GetReporter(name string) cell.Health {
 	if e.reporterScope == nil {
 		_, h := cell.NewSimpleHealth()

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -12,6 +12,7 @@ import (
 // EndpointInfoSource returns information about an endpoint being proxied.
 // The read lock must be held when calling any method.
 type EndpointInfoSource interface {
+	GetPolicyNames() []string
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string

--- a/pkg/proxy/endpoint/test/updater_mock.go
+++ b/pkg/proxy/endpoint/test/updater_mock.go
@@ -17,6 +17,18 @@ type ProxyUpdaterMock struct {
 	VersionHandle *versioned.VersionHandle
 }
 
+func (m *ProxyUpdaterMock) GetPolicyNames() []string {
+	var res []string
+	if len(m.Ipv4) != 0 {
+		res = append(res, m.Ipv4)
+	}
+
+	if len(m.Ipv6) != 0 {
+		res = append(res, m.Ipv6)
+	}
+	return res
+}
+
 func (m *ProxyUpdaterMock) GetID() uint64 { return m.Id }
 
 func (m *ProxyUpdaterMock) GetIPv4Address() string { return m.Ipv4 }


### PR DESCRIPTION
This is to support the use case, in which Policy Updater didn't have any IP but referenced by name.

Relates: https://github.com/cilium/proxy/pull/1193

