### PR TITLE
test: Use slog.DiscardHandler

### DIFF
--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io"
 	"log/slog"
 	"net/netip"
 	"strings"
@@ -386,7 +385,7 @@ func withLocked(m *lock.Mutex, f func()) {
 }
 
 func TestOpsPruneEnabled(t *testing.T) {
-	fakeLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	fakeLogger := slog.New(slog.DiscardHandler)
 
 	db := statedb.New()
 	table, _ := statedb.NewTable("ipsets", tables.IPSetEntryIndex)


### PR DESCRIPTION
This is to pave the way for new golangci-lint version e.g. 2.1.1

```
[lint] $ ~/go/src/github.com/cilium/cilium/mise-tasks/lint
pkg/datapath/iptables/ipset/ipset_test.go:389:25: use slog.DiscardHandler instead (sloglint)
        fakeLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
                               ^
1 issues:
* sloglint: 1
```


