### PR TITLE
egressgw: set ifindex for egress interface in IPv6 policy entry

### DIFF
--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -307,9 +307,7 @@ bool egress_gw_snat_needed_v6(union v6addr *saddr __maybe_unused,
 		return false;
 
 	*snat_addr = egress_gw_policy->egress_ip;
-# ifdef EGRESS_IFINDEX
-	*egress_ifindex = EGRESS_IFINDEX;
-# endif
+	*egress_ifindex = egress_gw_policy->egress_ifindex;
 
 	return true;
 #else

--- a/bpf/tests/lib/egressgw_policy.h
+++ b/bpf/tests/lib/egressgw_policy.h
@@ -35,7 +35,8 @@ static __always_inline void add_egressgw_policy_entry_v6(const union v6addr *sad
 							 const union v6addr *daddr,
 							 __u8 cidr,
 							 __be32 gateway_ip,
-							 const union v6addr *egress_ip)
+							 const union v6addr *egress_ip,
+							 __u32 egress_ifindex)
 {
 	struct egress_gw_policy_key6 in_key = {
 		.lpm_key = { EGRESS_PREFIX_LEN_V6(cidr), {} },
@@ -46,6 +47,7 @@ static __always_inline void add_egressgw_policy_entry_v6(const union v6addr *sad
 	struct egress_gw_policy_entry6 in_val = {
 		.egress_ip  = *egress_ip,
 		.gateway_ip = gateway_ip,
+		.egress_ifindex = egress_ifindex,
 	};
 
 	map_update_elem(&cilium_egress_gw_policy_v6, &in_key, &in_val, 0);

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -230,7 +230,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	return netdev_send_packet(ctx);
 }
@@ -271,9 +271,9 @@ int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT_EXCL_CIDR));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip);
+				     &egress_ip, 0);
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_EXCLUDED_CIDR,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	return netdev_send_packet(ctx);
 }
@@ -321,7 +321,7 @@ int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_NO_GATEWAY,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	return netdev_send_packet(ctx);
 }
@@ -385,7 +385,7 @@ int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 
 	create_ct_entry_v6(ctx, client_port(TEST_DROP_NO_EGRESS_IP));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, GATEWAY_NODE_IP,
-				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6);
+				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6, 0);
 
 	return netdev_send_packet(ctx);
 }

--- a/bpf/tests/tc_egressgw_redirect_from_overlay.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay.c
@@ -212,7 +212,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr egress_ip = EGRESS_IP_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	return overlay_receive_packet(ctx);
 }
@@ -251,9 +251,9 @@ int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr egress_ip = EGRESS_IP_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip);
+				     &egress_ip, 0);
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_EXCLUDED_CIDR,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	return overlay_receive_packet(ctx);
 }
@@ -293,7 +293,7 @@ int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr egress_ip = EGRESS_IP_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_NO_GATEWAY,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	return overlay_receive_packet(ctx);
 }
@@ -332,7 +332,7 @@ int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 	union v6addr no_egress_ip = EGRESS_GATEWAY_NO_EGRESS_IP_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, GATEWAY_NODE_IP,
-				     &no_egress_ip);
+				     &no_egress_ip, 0);
 
 	return overlay_receive_packet(ctx);
 }

--- a/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
@@ -110,7 +110,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr egress_ip = EGRESS_IP_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip);
+				     &egress_ip, EGRESS_IFINDEX);
 
 	return overlay_receive_packet(ctx);
 }

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -410,7 +410,7 @@ int egressgw_snat1_setup_v6(struct __ctx_buff *ctx)
 	union v6addr egress_ip = EGRESS_IP_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -514,7 +514,7 @@ int egressgw_tuple_collision1_setup_v6(struct __ctx_buff *ctx)
 	union v6addr egress_ip = EGRESS_IP_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -554,7 +554,7 @@ int egressgw_tuple_collision2_setup_v6(struct __ctx_buff *ctx)
 	union v6addr egress_ip = EGRESS_IP3_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -633,9 +633,9 @@ int egressgw_skip_excluded_cidr_snat_setup_v6(struct __ctx_buff *ctx)
 	union v6addr client_ip = CLIENT_IP_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6);
+				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6, 0);
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_EXCLUDED_CIDR,
-				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6);
+				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -717,7 +717,7 @@ int egressgw_fib_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr egress_ip = EGRESS_IP2_V6;
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip);
+				     &egress_ip, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 

--- a/bpf/tests/xdp_egressgw_reply.c
+++ b/bpf/tests/xdp_egressgw_reply.c
@@ -263,7 +263,7 @@ int egressgw_reply_setup_v6(struct __ctx_buff *ctx)
 
 	/* install EgressGW policy for the connection: */
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6);
+				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6, 0);
 
 	/* install RevSNAT entry */
 	struct ipv6_ct_tuple snat_tuple = {

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -737,11 +737,11 @@ func (manager *Manager) updateEgressRules6() {
 			gatewayIP = ExcludedCIDRIPv4
 		}
 
-		if policyPresent && policyVal.Match(gwc.egressIP6, gatewayIP) {
+		if policyPresent && policyVal.Match(gwc.egressIP6, gatewayIP, 0) {
 			return
 		}
 
-		if err := manager.policyMap6.Update(endpointIP, dstCIDR, gwc.egressIP6, gatewayIP); err != nil {
+		if err := manager.policyMap6.Update(endpointIP, dstCIDR, gwc.egressIP6, gatewayIP, 0); err != nil {
 			manager.logger.Error(
 				"Error applying IPv6 egress gateway policy",
 				logfields.Error, err,

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -737,17 +737,18 @@ func (manager *Manager) updateEgressRules6() {
 			gatewayIP = ExcludedCIDRIPv4
 		}
 
-		if policyPresent && policyVal.Match(gwc.egressIP6, gatewayIP, 0) {
+		if policyPresent && policyVal.Match(gwc.egressIP6, gatewayIP, gwc.egressIfindex) {
 			return
 		}
 
-		if err := manager.policyMap6.Update(endpointIP, dstCIDR, gwc.egressIP6, gatewayIP, 0); err != nil {
+		if err := manager.policyMap6.Update(endpointIP, dstCIDR, gwc.egressIP6, gatewayIP, gwc.egressIfindex); err != nil {
 			manager.logger.Error(
 				"Error applying IPv6 egress gateway policy",
 				logfields.Error, err,
 				logfields.SourceIP, endpointIP,
 				logfields.DestinationCIDR, dstCIDR,
 				logfields.EgressIP, gwc.egressIP6,
+				logfields.LinkIndex, gwc.egressIfindex,
 				logfields.GatewayIP, gatewayIP,
 			)
 		} else {

--- a/pkg/maps/egressmap/policy_test.go
+++ b/pkg/maps/egressmap/policy_test.go
@@ -81,10 +81,13 @@ func TestPrivilegedPolicyMap(t *testing.T) {
 		gatewayIP1 := netip.MustParseAddr("3.3.3.1")
 		gatewayIP2 := netip.MustParseAddr("3.3.3.2")
 
-		err := egressPolicyMap.Update(sourceIP1, destCIDR1, egressIP1, gatewayIP1)
+		ifIndex1 := uint32(1)
+		ifIndex2 := uint32(2)
+
+		err := egressPolicyMap.Update(sourceIP1, destCIDR1, egressIP1, gatewayIP1, ifIndex1)
 		assert.NoError(t, err)
 
-		err = egressPolicyMap.Update(sourceIP2, destCIDR2, egressIP2, gatewayIP2)
+		err = egressPolicyMap.Update(sourceIP2, destCIDR2, egressIP2, gatewayIP2, ifIndex2)
 		assert.NoError(t, err)
 
 		val, err := egressPolicyMap.Lookup(sourceIP1, destCIDR1)
@@ -92,12 +95,14 @@ func TestPrivilegedPolicyMap(t *testing.T) {
 
 		assert.Equal(t, val.EgressIP.Addr(), egressIP1)
 		assert.Equal(t, val.GatewayIP.Addr(), gatewayIP1)
+		assert.Equal(t, val.EgressIfindex, ifIndex1)
 
 		val, err = egressPolicyMap.Lookup(sourceIP2, destCIDR2)
 		assert.NoError(t, err)
 
 		assert.Equal(t, val.EgressIP.Addr(), egressIP2)
 		assert.Equal(t, val.GatewayIP.Addr(), gatewayIP2)
+		assert.Equal(t, val.EgressIfindex, ifIndex2)
 
 		err = egressPolicyMap.Delete(sourceIP2, destCIDR2)
 		assert.NoError(t, err)
@@ -107,6 +112,7 @@ func TestPrivilegedPolicyMap(t *testing.T) {
 
 		assert.Equal(t, val.EgressIP.Addr(), egressIP1)
 		assert.Equal(t, val.GatewayIP.Addr(), gatewayIP1)
+		assert.Equal(t, val.EgressIfindex, ifIndex1)
 
 		_, err = egressPolicyMap.Lookup(sourceIP2, destCIDR2)
 		assert.ErrorIs(t, err, ebpf.ErrKeyNotExist)


### PR DESCRIPTION
Add support for pushing down the ifindex of the egress interface (https://github.com/cilium/cilium/pull/36151).

This avoids the usability annoyance of adding custom routes on the gateway node, as described in https://github.com/cilium/cilium/pull/30488.


```release-note
The egress interface for IPv6 traffic matched by an Egress Gateway policy is entirely determined by the `egressGateway` section in the policy, using either the selected `interface` or the interface with the default route. When an `egressIP` is specified, the interface continues to be selected according to the configured IP routing on the node.
```