### PR TITLE
operator/pkg/lbipam: Add lifecycle tests for LB-IPAM

### DIFF
--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -75,6 +75,8 @@ type lbipamCellParams struct {
 
 	Config       lbipamConfig
 	SharedConfig SharedConfig
+
+	TestCounters *testCounters `optional:"true"`
 }
 
 func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
@@ -105,6 +107,7 @@ func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
 		jobGroup:     params.JobGroup,
 		config:       params.Config,
 		defaultIPAM:  params.SharedConfig.DefaultLBServiceIPAM == DefaultLBClassLBIPAM,
+		testCounters: params.TestCounters,
 	})
 
 	lbIPAM.jobGroup.Add(

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -12,10 +12,19 @@ import (
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/client"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // TestConflictResolution tests that, upon initialization, LB IPAM will detect conflicts between pools,
@@ -2359,4 +2368,149 @@ func TestRangeFromPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+// This test starts LBIPAM as part of a minimal hive to exercise the lifecycle logic.
+// LBIPAM starts in a "dormant" state, and only wakes up when at least one pool exists.
+// It can go back to sleep when that pool goes away and re-awaken.
+// We want to test that this works correctly, and that we properly shutdown in any
+// state.
+func TestLBIPAMStartupRestartShutdown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	var (
+		fakeClientset *client.FakeClientset
+		counters      *testCounters
+	)
+	testHive := hive.New(
+		// Cell under test
+		Cell,
+
+		// Dependencies
+		client.FakeClientCell,
+		cell.Provide(func() *option.DaemonConfig {
+			return &option.DaemonConfig{
+				EnableBGPControlPlane: true,
+			}
+		}),
+		cell.Config(k8s.DefaultConfig),
+		cell.Provide(
+			k8s.ServiceResource,
+			k8s.LBIPPoolsResource,
+		),
+
+		// Expose cells for testing
+		cell.Provide(func() *testCounters {
+			return &testCounters{}
+		}),
+		cell.Invoke(func(
+			tc *testCounters,
+			cf *client.FakeClientset,
+		) {
+			counters = tc
+			fakeClientset = cf
+		}),
+	)
+
+	tlog := hivetest.Logger(t)
+	err := testHive.Start(tlog, t.Context())
+	require.NoError(t, err)
+
+	// Create a service which shouldn't be processed
+	fakeK8s := fakeClientset.SlimFakeClientset.CoreV1()
+	fakePools := fakeClientset.CiliumFakeClientset.CiliumV2alpha1().CiliumLoadBalancerIPPools()
+	_, err = fakeK8s.Services("default").Create(t.Context(), &slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name: "service-a",
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type: slim_core_v1.ServiceTypeLoadBalancer,
+		},
+	}, meta_v1.CreateOptions{})
+	require.NoError(t, err)
+
+	// We should be initializing
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.Equal(collect, int64(1), counters.initializing.Load())
+	}, 5*time.Second, 100*time.Millisecond)
+	// But never finish initializing or processing any service events
+	require.Never(t, func() bool {
+		return counters.initialized.Load() != 0 || counters.serviceEvents.Load() != 0
+	}, 3*time.Second, 100*time.Millisecond)
+
+	// Create a pool, this should wake up LBIPAM
+	_, err = fakePools.Create(t.Context(), &cilium_api_v2alpha1.CiliumLoadBalancerIPPool{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "pool-a",
+		},
+		Spec: cilium_api_v2alpha1.CiliumLoadBalancerIPPoolSpec{
+			Blocks: []cilium_api_v2alpha1.CiliumLoadBalancerIPPoolIPBlock{
+				{
+					Cidr: "10.0.0.0/24",
+				},
+			},
+		},
+	}, meta_v1.CreateOptions{})
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		// We should now finish initializing
+		assert.Equal(collect, int64(1), counters.initialized.Load())
+		// Processed the pool event
+		assert.GreaterOrEqual(collect, counters.poolEvents.Load(), int64(1))
+		// And the service event
+		assert.GreaterOrEqual(collect, counters.serviceEvents.Load(), int64(1))
+	}, 5*time.Second, 100*time.Millisecond)
+
+	svc1, err := fakeK8s.Services("default").Get(t.Context(), "service-a", meta_v1.GetOptions{})
+	require.NoError(t, err)
+
+	require.Len(t, svc1.Status.LoadBalancer.Ingress, 1)
+
+	require.Equal(t, int64(0), counters.restarted.Load())
+
+	// Now delete the pool, this should cause LBIPAM to go dormant
+	err = fakePools.Delete(t.Context(), "pool-a", meta_v1.DeleteOptions{})
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		// Assert the IP has been removed from service-a
+		svc1, err := fakeK8s.Services("default").Get(t.Context(), "service-a", meta_v1.GetOptions{})
+		assert.NoError(collect, err)
+		assert.Empty(collect, svc1.Status.LoadBalancer.Ingress)
+		// Assert we restarted
+		assert.Equal(collect, int64(1), counters.restarted.Load())
+		// And are initialing again
+		assert.Equal(collect, int64(2), counters.initializing.Load())
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// But we do not initialize for a second time
+	require.Never(t, func() bool {
+		return counters.initialized.Load() > 1
+	}, 3*time.Second, 100*time.Millisecond)
+
+	curServiceEvents := counters.serviceEvents.Load()
+
+	// Create a second service
+	_, err = fakeK8s.Services("default").Create(t.Context(), &slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name: "service-b",
+		},
+	}, meta_v1.CreateOptions{})
+	require.NoError(t, err)
+
+	// We should not process the new service
+	require.Never(t, func() bool {
+		return counters.serviceEvents.Load() > curServiceEvents
+	}, 3*time.Second, 100*time.Millisecond)
+
+	err = testHive.Stop(tlog, t.Context())
+	require.NoError(t, err)
+
+	// Assert we did not process any services during shutdown
+	require.Never(t, func() bool {
+		return counters.serviceEvents.Load() > curServiceEvents
+	}, 3*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
We already have extensive tests for actual behavior. These tests are written such that we directly call into the event processing code. This is done so all code is executed synchronously which makes them very stable.

A flaw of calling directly into the event processing code is that we don't test the actual lifecycle of the LB-IPAM controller and bugs that might arise in the path between the API client and the event processing logic.

This commit adds a test to exercise the lifecycle of the LB-IPAM controller. To do so we create a hive with smallest setup which still works. LB-IPAM now increments a few atomic counters (only during testing) which we use to glean information about the lifecycle of the controller and if its processing events or not. We start the hive as we would in production. Since everything now runs in its own goroutine we do not have strong guarantees about when the controller will process events. To compensate, relatively large timeouts are used when waiting for something to happen, in an attempt to prevent flaky tests. However due to the nature of the tests, it might still happen, and we will have to keep an eye on it.

When stress testing it locally it seems stable:
```
stress -o /tmp/test- -p 100 ./lbipam.test -test.run "TestLBIPAMStartupRestartShutdown" -test.timeout=30s
5s: 0 runs so far, 0 failures, 100 active
10s: 0 runs so far, 0 failures, 100 active
15s: 100 runs so far, 0 failures, 100 active
20s: 100 runs so far, 0 failures, 100 active
25s: 103 runs so far, 0 failures, 100 active
30s: 200 runs so far, 0 failures, 100 active
35s: 200 runs so far, 0 failures, 100 active
40s: 300 runs so far, 0 failures, 100 active
45s: 300 runs so far, 0 failures, 100 active
50s: 349 runs so far, 0 failures, 100 active
55s: 400 runs so far, 0 failures, 100 active
1m0s: 400 runs so far, 0 failures, 100 active
1m5s: 500 runs so far, 0 failures, 100 active
1m10s: 500 runs so far, 0 failures, 100 active
1m15s: 586 runs so far, 0 failures, 100 active
1m20s: 600 runs so far, 0 failures, 100 active
1m25s: 600 runs so far, 0 failures, 100 active
1m30s: 700 runs so far, 0 failures, 100 active
1m35s: 700 runs so far, 0 failures, 100 active
1m40s: 800 runs so far, 0 failures, 100 active
1m45s: 800 runs so far, 0 failures, 100 active
1m50s: 800 runs so far, 0 failures, 100 active
1m55s: 900 runs so far, 0 failures, 100 active
2m0s: 900 runs so far, 0 failures, 100 active
```

This should hopefully catch regressions of https://github.com/cilium/cilium/issues/37965 or similar cases.
