### PR TITLE
cilium: distributed lru map sizing roundup fixes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -632,9 +632,10 @@ Makefile* @cilium/build
 /pkg/tuple @cilium/sig-datapath
 /pkg/types/ @cilium/sig-datapath
 /pkg/u8proto/ @cilium/sig-agent
-/pkg/wireguard @cilium/wireguard
+/pkg/util/ @cilium/sig-datapath
 /pkg/version/ @cilium/sig-agent
 /pkg/versioncheck/ @cilium/sig-agent
+/pkg/wireguard @cilium/wireguard
 /pkg/xds/ @cilium/envoy
 /plugins/cilium-cni/ @cilium/sig-k8s
 /plugins/cilium-docker/ @cilium/docker

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -724,10 +724,14 @@ sizing which can be done via ``bpf.mapDynamicSizeRatio``:
 
 Note that ``bpf.distributedLRU.enabled`` is off by default in Cilium for
 legacy reasons given enabling this setting on-the-fly is disruptive for
-in-flight traffic since the BPF maps have to be recreated. It is recommended
-to use the per-node configuration to gradually phase in this setting for
-new nodes joining the cluster. Alternatively, upon initial cluster creation
-it is recommended to consider enablement.
+in-flight traffic since the BPF maps have to be recreated.
+
+It is recommended to use the per-node configuration to gradually phase in
+this setting for new nodes joining the cluster. Alternatively, upon initial
+cluster creation it is recommended to consider enablement.
+
+Also, ``bpf.distributedLRU.enabled`` is currently only supported in combination
+with ``bpf.mapDynamicSizeRatio`` as opposed to statically sized map configuration.
 
 eBPF Map Sizing
 ===============

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/util"
 	"github.com/cilium/cilium/pkg/version"
 )
 
@@ -3674,19 +3675,13 @@ func (c *DaemonConfig) calculateDynamicBPFMapSizes(vp *viper.Viper, totalMemory 
 		}
 		possibleCPUs = cpus
 	}
-	roundUp := func(x, multiple int) int {
-		return int(((x + (multiple - 1)) / multiple) * multiple)
-	}
-	roundDown := func(x, multiple int) int {
-		return int(x - (x % multiple))
-	}
 	getEntries := func(entriesDefault, min, max int) int {
 		entries := (entriesDefault * memoryAvailableForMaps) / totalMapMemoryDefault
-		entries = roundUp(entries, possibleCPUs)
+		entries = util.RoundUp(entries, possibleCPUs)
 		if entries < min {
-			entries = roundUp(min, possibleCPUs)
+			entries = util.RoundUp(min, possibleCPUs)
 		} else if entries > max {
-			entries = roundDown(max, possibleCPUs)
+			entries = util.RoundDown(max, possibleCPUs)
 		}
 		return entries
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3609,6 +3609,8 @@ func (c *DaemonConfig) calculateBPFMapSizes(vp *viper.Viper) error {
 		}
 		c.calculateDynamicBPFMapSizes(vp, vms.Total, dynamicSizeRatio)
 		c.BPFMapsDynamicSizeRatio = dynamicSizeRatio
+	} else if c.BPFDistributedLRU {
+		return fmt.Errorf("distributed LRU is only valid with a specified dynamic map size ratio")
 	} else if dynamicSizeRatio < 0.0 {
 		return fmt.Errorf("specified dynamic map size ratio %f must be > 0.0", dynamicSizeRatio)
 	} else if dynamicSizeRatio > 1.0 {

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/ebpf"
 	"github.com/google/go-cmp/cmp"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -899,6 +900,10 @@ func TestBPFMapSizeCalculation(t *testing.T) {
 		NeighMapSize      int
 		SockRevNatMapSize int
 	}
+	cpus, _ := ebpf.PossibleCPU()
+	roundUp := func(x, multiple int) int {
+		return int(((x + (multiple - 1)) / multiple) * multiple)
+	}
 	tests := []struct {
 		name        string
 		totalMemory uint64
@@ -1083,6 +1088,21 @@ func TestBPFMapSizeCalculation(t *testing.T) {
 				vp.Set(CTMapEntriesGlobalAnyName, 262144)
 			},
 		},
+		{
+			name:        "dynamic size NAT size with distributed LRU",
+			totalMemory: 3 * GiB,
+			ratio:       0.051,
+			want: sizes{
+				CTMapSizeTCP:      roundUp(580503, cpus),
+				CTMapSizeAny:      roundUp(290251, cpus),
+				NATMapSize:        roundUp(580503, cpus),
+				NeighMapSize:      roundUp(580503, cpus),
+				SockRevNatMapSize: roundUp(290251, cpus),
+			},
+			preTestRun: func(vp *viper.Viper) {
+				vp.Set(BPFDistributedLRU, true)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1098,6 +1118,7 @@ func TestBPFMapSizeCalculation(t *testing.T) {
 				NATMapEntriesGlobal:   vp.GetInt(NATMapEntriesGlobalName),
 				NeighMapEntriesGlobal: vp.GetInt(NeighMapEntriesGlobalName),
 				SockRevNatEntries:     vp.GetInt(SockRevNatEntriesName),
+				BPFDistributedLRU:     vp.GetBool(BPFDistributedLRU),
 			}
 
 			// cannot set these from the Sizeof* consts from

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/util"
 )
 
 func TestValidateIPv6ClusterAllocCIDR(t *testing.T) {
@@ -901,9 +902,6 @@ func TestBPFMapSizeCalculation(t *testing.T) {
 		SockRevNatMapSize int
 	}
 	cpus, _ := ebpf.PossibleCPU()
-	roundUp := func(x, multiple int) int {
-		return int(((x + (multiple - 1)) / multiple) * multiple)
-	}
 	tests := []struct {
 		name        string
 		totalMemory uint64
@@ -1093,11 +1091,11 @@ func TestBPFMapSizeCalculation(t *testing.T) {
 			totalMemory: 3 * GiB,
 			ratio:       0.051,
 			want: sizes{
-				CTMapSizeTCP:      roundUp(580503, cpus),
-				CTMapSizeAny:      roundUp(290251, cpus),
-				NATMapSize:        roundUp(580503, cpus),
-				NeighMapSize:      roundUp(580503, cpus),
-				SockRevNatMapSize: roundUp(290251, cpus),
+				CTMapSizeTCP:      util.RoundUp(580503, cpus),
+				CTMapSizeAny:      util.RoundUp(290251, cpus),
+				NATMapSize:        util.RoundUp(580503, cpus),
+				NeighMapSize:      util.RoundUp(580503, cpus),
+				SockRevNatMapSize: util.RoundUp(290251, cpus),
 			},
 			preTestRun: func(vp *viper.Viper) {
 				vp.Set(BPFDistributedLRU, true)

--- a/pkg/util/doc.go
+++ b/pkg/util/doc.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package util provides miscellaneous helper functions.
+package util

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package util
+
+// RoundUp rounds x up to the next specified multiple. This implementation
+// is equivalent to the kernel's roundup().
+func RoundUp(x, multiple int) int {
+	return int(((x + (multiple - 1)) / multiple) * multiple)
+}
+
+// RoundDown rounds x down to the next specified multiple. Again, this
+// implementation is equivalent to the kernel's rounddown().
+func RoundDown(x, multiple int) int {
+	return int(x - (x % multiple))
+}


### PR DESCRIPTION
(see commit msg)

Closes: https://github.com/cilium/cilium/issues/39009

```release-note
Fix map recreation loop when distributed lru setting is enabled
```
