### PR TITLE
bugtool: include find /sys/fs/bpf output in sysdump artifact

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -219,6 +219,7 @@ func miscSystemCommands() []string {
 		// tc
 		"tc qdisc show",
 		"tc -d -s qdisc show", // Show statistics on queuing disciplines
+		"find /sys/fs/bpf -ls",
 	}
 }
 


### PR DESCRIPTION
This is useful output to have when troubleshooting loader-related issues. Long overdue. :(

```release-note
Include the results of `find /sys/fs/bpf` in bugtool output
```
