### PR TITLE
documentation: specify yaml for included files

### DIFF
--- a/Documentation/gettingstarted/demo.rst
+++ b/Documentation/gettingstarted/demo.rst
@@ -46,6 +46,7 @@ same TCP/UDP connection.
 We can achieve that with the following CiliumNetworkPolicy:
 
 .. literalinclude:: ../../examples/minikube/sw_l3_l4_policy.yaml
+   :language: yaml
 
 CiliumNetworkPolicies match on pod labels using an "endpointSelector" to identify the sources and destinations to which the policy applies.
 The above policy whitelists traffic sent from any pods with label (``org=empire``) to *deathstar* pods with label (``org=empire, class=deathstar``) on TCP port 80.
@@ -209,6 +210,7 @@ extends our original policy by limiting *tiefighter* to making only a POST /v1/r
 API call, but disallowing all other calls (including PUT /v1/exhaust-port).
 
 .. literalinclude:: ../../examples/minikube/sw_l3_l4_l7_policy.yaml
+   :language: yaml
 
 Update the existing rule to apply L7-aware policy to protect *deathstar* using:
 

--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -134,6 +134,7 @@ The agent uses Fsnotify to track updates to the configuration file, so the origi
 The example below shows how to configure the agent via :term:`ConfigMap` and to verify it:
 
 .. literalinclude:: ../../../examples/kubernetes-ip-masq-agent/rfc1918.yaml
+     :language: yaml
 
 .. parsed-literal::
 

--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -142,6 +142,7 @@ port and protocol fields specified in the CiliumLocalRedirectPolicy custom
 resources that will be created in the next step.
 
 .. literalinclude:: ../../../examples/kubernetes-local-redirect/backend-pod.yaml
+   :language: yaml
 
 .. parsed-literal::
 
@@ -192,6 +193,7 @@ Create a custom resource of type CiliumLocalRedirectPolicy with ``addressMatcher
 configuration.
 
 .. literalinclude:: ../../../examples/kubernetes-local-redirect/lrp-addrmatcher.yaml
+   :language: yaml
 
 .. parsed-literal::
 
@@ -282,6 +284,7 @@ policy is used to select the backend pods where traffic is redirected to.
 Deploy the Kubernetes service for which traffic needs to be redirected.
 
 .. literalinclude:: ../../../examples/kubernetes-local-redirect/k8s-svc.yaml
+   :language: yaml
 
 .. parsed-literal::
 
@@ -308,6 +311,7 @@ Create a custom resource of type CiliumLocalRedirectPolicy with ``serviceMatcher
 configuration.
 
 .. literalinclude:: ../../../examples/kubernetes-local-redirect/lrp-svcmatcher.yaml
+   :language: yaml
 
 .. parsed-literal::
 

--- a/Documentation/network/servicemesh/basic-ingress.rst
+++ b/Documentation/network/servicemesh/basic-ingress.rst
@@ -10,6 +10,7 @@ Deploy the First Ingress
 You'll find the example Ingress definition in ``basic-ingress.yaml``.
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/basic-ingress.yaml
+    :language: yaml
 
 .. parsed-literal::
 

--- a/Documentation/network/servicemesh/default-deny-ingress-policy.rst
+++ b/Documentation/network/servicemesh/default-deny-ingress-policy.rst
@@ -11,6 +11,7 @@ Default Deny Ingress Policy
 Let's apply a `CiliumClusterwideNetworkPolicy` to deny all traffic by default:
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/policy/default-deny.yaml
+     :language: yaml
 
 .. parsed-literal::
 
@@ -55,6 +56,7 @@ Now let's check if in-cluster traffic to the same endpoint is denied:
 The next step is to allow ingress traffic to the ``/details`` endpoint:
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/policy/allow-ingress-cluster.yaml
+     :language: yaml
 
 .. parsed-literal::
 

--- a/Documentation/network/servicemesh/external-ingress-policy.rst
+++ b/Documentation/network/servicemesh/external-ingress-policy.rst
@@ -11,6 +11,7 @@ External Lock-down Policy
 By default, all the external traffic is allowed. Let's apply a `CiliumNetworkPolicy` to lock down external traffic.
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/policy/external-lockdown.yaml
+     :language: yaml
 
 .. parsed-literal::
 
@@ -56,6 +57,7 @@ Another common use case is to allow only a specific set of IP addresses to acces
 the below policy
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/policy/allow-ingress-cidr.yaml
+     :language: yaml
 
 .. parsed-literal::
 

--- a/Documentation/network/servicemesh/gateway-api/header.rst
+++ b/Documentation/network/servicemesh/gateway-api/header.rst
@@ -25,6 +25,7 @@ To add a header to a HTTP request, use a filter of the type ``RequestHeaderModif
 You can find an example Gateway and HTTPRoute definition in ``request-header.yaml``:
 
 .. literalinclude:: ../../../../examples/kubernetes/gateway/request-header.yaml
+     :language: yaml
 
 This example adds a header named ``my-header-name`` with the ``my-header-value`` value.
 

--- a/Documentation/network/servicemesh/gateway-api/http.rst
+++ b/Documentation/network/servicemesh/gateway-api/http.rst
@@ -24,6 +24,7 @@ Deploy the Cilium Gateway
 You'll find the example Gateway and HTTPRoute definition in ``basic-http.yaml``.
 
 .. literalinclude:: ../../../../examples/kubernetes/gateway/basic-http.yaml
+   :language: yaml
 
 .. parsed-literal::
 

--- a/Documentation/network/servicemesh/gateway-api/https.rst
+++ b/Documentation/network/servicemesh/gateway-api/https.rst
@@ -15,6 +15,7 @@ termination for two HTTP routes. For simplicity, the second route to ``productpa
 is omitted.
 
 .. literalinclude:: ../../../../examples/kubernetes/gateway/basic-https.yaml
+     :language: yaml
 
 .. include:: ../tls-cert.rst
 

--- a/Documentation/network/servicemesh/gateway-api/parameterized-gatewayclass.rst
+++ b/Documentation/network/servicemesh/gateway-api/parameterized-gatewayclass.rst
@@ -25,6 +25,7 @@ Deploy the Cilium Gateway with customized parameters
 In this example, we will deploy a Cilium Gateway with ``NodePort`` service instead of the default ``LoadBalancer`` type.
 
 .. literalinclude:: ../../../../examples/kubernetes/gateway/gateway-with-parameters.yaml
+     :language: yaml
 
 Apply the configuration:
 
@@ -56,3 +57,4 @@ The full list of supported parameters can be found in the ``CiliumGatewayClassCo
     in Slack.
 
 .. literalinclude:: ../../../../examples/crds/v2alpha1/ciliumgatewayclassconfigs.yaml
+     :language: yaml

--- a/Documentation/network/servicemesh/gateway-api/splitting.rst
+++ b/Documentation/network/servicemesh/gateway-api/splitting.rst
@@ -24,6 +24,7 @@ Deploy the Cilium Gateway
 You can find an example Gateway and HTTPRoute definition in ``splitting.yaml``:
 
 .. literalinclude:: ../../../../examples/kubernetes/gateway/splitting.yaml
+     :language: yaml
 
 Notice the even 50/50 split between the two Services.
 

--- a/Documentation/network/servicemesh/grpc.rst
+++ b/Documentation/network/servicemesh/grpc.rst
@@ -36,6 +36,7 @@ Deploy GRPC Ingress
 You'll find the example Ingress definition in ``examples/kubernetes/servicemesh/grpc-ingress.yaml``.
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/grpc-ingress.yaml
+     :language: yaml
 
 .. parsed-literal::
 

--- a/Documentation/network/servicemesh/ingress-to-gateway/http-migration.rst
+++ b/Documentation/network/servicemesh/ingress-to-gateway/http-migration.rst
@@ -24,6 +24,7 @@ Review Ingress Configuration
 You can find the example Ingress definition in ``basic-ingress.yaml``.
 
 .. literalinclude:: ../../../../examples/kubernetes/servicemesh/basic-ingress.yaml
+   :language: yaml
 
 This example listens for traffic on port 80, routes requests for the path ``/details`` to the ``details`` service,
 and ``/`` to the ``productpage`` service.
@@ -181,6 +182,7 @@ Review Equivalent Gateway Configuration
 You can find the equivalent final Gateway and HTTPRoute definition in ``http-migration.yaml``.
 
 .. literalinclude:: ../../../../examples/kubernetes/gateway/http-migration.yaml
+   :language: yaml
 
 The preceding example creates a Gateway named ``cilium-gateway`` that listens on port 80 for HTTP traffic.
 Two routes are defined, one for ``/details`` to the ``details`` service, and

--- a/Documentation/network/servicemesh/ingress-to-gateway/tls-migration.rst
+++ b/Documentation/network/servicemesh/ingress-to-gateway/tls-migration.rst
@@ -20,6 +20,7 @@ Review Ingress Configuration
 You can find the example Ingress definition in ``tls-ingress.yaml``.
 
 .. literalinclude:: ../../../../examples/kubernetes/servicemesh/tls-ingress.yaml
+   :language: yaml
 
 This example:
 
@@ -155,6 +156,7 @@ Review Equivalent Gateway Configuration
 You can find the equivalent final Gateway and HTTPRoute definition in ``tls-migration.yaml``.
 
 .. literalinclude:: ../../../../examples/kubernetes/gateway/tls-migration.yaml
+   :language: yaml
 
 Deploy the resources and verify that HTTPS requests are routed successfully to the services.
 For more information, consult the Gateway API :ref:`gs_gateway_https`.

--- a/Documentation/network/servicemesh/istio.rst
+++ b/Documentation/network/servicemesh/istio.rst
@@ -279,6 +279,7 @@ Istio's mTLS-based HTTPs connections:
 To solve the problem and allow Cilium to manage L7 policy, you must disable Istio's mTLS authentication by configuring a new policy:
 
 .. literalinclude:: ../../../examples/kubernetes-istio/authn.yaml
+     :language: yaml
 
 You must apply this policy to the same namespace where you implement the HTTP-based network policy:
 

--- a/Documentation/network/servicemesh/path-types.rst
+++ b/Documentation/network/servicemesh/path-types.rst
@@ -36,6 +36,7 @@ Review the Ingress
 Here is the Ingress used:
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/ingress-path-types-ingress.yaml
+     :language: yaml
 
 You can see here that there are five matches, one for each of our deployments.
 

--- a/Documentation/network/servicemesh/tls-termination.rst
+++ b/Documentation/network/servicemesh/tls-termination.rst
@@ -14,6 +14,7 @@ This example builds on the HTTP and gRPC ingress examples, adding TLS
 termination.
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/tls-ingress.yaml
+     :language: yaml
 
 .. include:: tls-cert.rst
 

--- a/Documentation/security/dns.rst
+++ b/Documentation/security/dns.rst
@@ -49,10 +49,12 @@ The following Cilium network policy allows ``mediabot`` pods to only access ``ap
    .. group-tab:: Generic
 
       .. literalinclude:: ../../examples/kubernetes-dns/dns-matchname.yaml
+          :language: yaml
 
    .. group-tab:: OpenShift
 
       .. literalinclude:: ../../examples/kubernetes-dns/dns-matchname-openshift.yaml
+          :language: yaml
 
 .. note::
 
@@ -104,6 +106,7 @@ e.g., the pattern ``*.github.com``. We can achieve this easily by changing the
 ``toFQDN`` rule to use ``matchPattern`` instead of ``matchName``.
 
 .. literalinclude:: ../../examples/kubernetes-dns/dns-pattern.yaml
+    :language: yaml
 
 .. parsed-literal::
 
@@ -138,6 +141,7 @@ policy below achieves the port-based restrictions along with the DNS-based
 policies.
 
 .. literalinclude:: ../../examples/kubernetes-dns/dns-port.yaml
+    :language: yaml
 
 .. parsed-literal::
 

--- a/Documentation/security/elasticsearch.rst
+++ b/Documentation/security/elasticsearch.rst
@@ -148,6 +148,7 @@ In the policy file below, you will see the following rules for controlling the i
 * ``fromEndpoints`` with labels ``app:empire`` only ``HTTP`` ``GET`` is allowed on paths matching regex ``^/spaceship_diagnostics/_search/??.*$`` and ``^/troop_logs/search/??.*$``
 
 .. literalinclude:: ../../examples/kubernetes-es/es-sw-policy.yaml
+     :language: yaml
 
 Apply this Elasticsearch-aware network security policy using ``kubectl``:
 

--- a/Documentation/security/host-firewall.rst
+++ b/Documentation/security/host-firewall.rst
@@ -108,6 +108,7 @@ It allows communications from outside the cluster only for TCP/22 and for ICMP
 allowed.
 
 .. literalinclude:: ../../examples/policies/host/demo-host-policy.yaml
+     :language: yaml
 
 To apply this policy, run:
 

--- a/Documentation/security/policy-creation.rst
+++ b/Documentation/security/policy-creation.rst
@@ -117,6 +117,7 @@ to allow that traffic.
 Apply a default-deny policy:
 
 .. literalinclude:: ../../examples/minikube/sw_deny_policy.yaml
+     :language: yaml
 
 CiliumNetworkPolicies match on pod labels using an ``endpointSelector`` to identify
 the sources and destinations to which the policy applies. The above policy denies
@@ -175,6 +176,7 @@ expect this traffic to arrive at the deathstar, we can form a policy to match
 the traffic:
 
 .. literalinclude:: ../../examples/minikube/sw_l3_l4_policy.yaml
+     :language: yaml
 
 To apply this L3/L4 policy, run:
 

--- a/Documentation/security/policy/kubernetes.rst
+++ b/Documentation/security/policy/kubernetes.rst
@@ -56,6 +56,7 @@ namespace.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/kubernetes/namespace/isolate-namespaces.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/kubernetes/namespace/isolate-namespaces.json
@@ -90,6 +91,7 @@ for a fully functional example including pods deployed to different namespaces.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/kubernetes/namespace/namespace-policy.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/kubernetes/namespace/namespace-policy.json
@@ -125,6 +127,7 @@ namespace.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/kubernetes/namespace/kubedns-policy.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/kubernetes/namespace/kubedns-policy.json
@@ -165,6 +168,7 @@ that achieves a logical OR between the keys and its values.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/match-expressions/or-statement.yaml
+          :language: yaml
 
      .. group-tab:: JSON
 
@@ -183,6 +187,7 @@ The following example shows a logical AND using a single ``matchExpression``.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/match-expressions/and-statement.yaml
+          :language: yaml
 
      .. group-tab:: JSON
 
@@ -232,6 +237,7 @@ resources.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/kubernetes/serviceaccount/serviceaccount-policy.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/kubernetes/serviceaccount/serviceaccount-policy.json
@@ -253,10 +259,12 @@ policies to a particular cluster.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+          :language: yaml
 
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+          :language: yaml
 
 Note the ``io.kubernetes.pod.namespace: default`` in the policy
 rule. It makes sure the policy applies to ``rebel-base`` in the
@@ -274,10 +282,12 @@ combined with an ``Exists`` operator.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clustermesh/cross-cluster-any-namespace-policy.yaml
+          :language: yaml
 
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clustermesh/cross-cluster-any-namespace-policy.yaml
+          :language: yaml
 
 Clusterwide Policies
 ~~~~~~~~~~~~~~~~~~~~
@@ -296,10 +306,12 @@ namespace to pods matching the labels ``name=leia`` in any namespace.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clusterwide/clusterscope-policy.yaml
+          :language: yaml
 
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clusterwide/clusterscope-policy.yaml
+          :language: yaml
 
 Allow All Cilium Managed Endpoints To Communicate With Kube-dns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -313,10 +325,12 @@ with kube-dns on port 53/UDP in the ``kube-system`` namespace.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
+          :language: yaml
 
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clusterwide/wildcard-from-endpoints.yaml
+          :language: yaml
 
 .. _health_endpoint: 
 
@@ -332,7 +346,9 @@ cluster connectivity health.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clusterwide/health.yaml
+          :language: yaml
 
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/kubernetes/clusterwide/health.yaml
+          :language: yaml

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -79,6 +79,7 @@ the label ``role=backend``.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/simple/l3.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/simple/l3.json
@@ -100,6 +101,7 @@ all ingress traffic to an endpoint may be done as follows:
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/ingress-allow-all/ingress-allow-all.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/ingress-allow-all/ingress-allow-all.json
@@ -134,6 +136,7 @@ the label ``role=frontend``.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/simple/l3_egress.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/simple/l3_egress.json
@@ -157,6 +160,7 @@ following rule allows all egress traffic from endpoints with the label
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/egress-allow-all/egress-allow-all.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/egress-allow-all/egress-allow-all.json
@@ -187,6 +191,7 @@ egress.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/egress-default-deny/egress-default-deny.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/egress-default-deny/egress-default-deny.json
@@ -243,6 +248,7 @@ be only accessible if the source endpoint also has the label ``env=prod``.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/requires/requires.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/requires/requires.json
@@ -263,6 +269,7 @@ accessible from endpoints that have both labels ``env=prod`` and
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/requires/endpoints.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/requires/endpoints.json
@@ -308,6 +315,7 @@ namespace ``another-namespace``.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/service/service.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/service/service.json
@@ -391,6 +399,7 @@ Allow all endpoints with the label ``env=dev`` to access the kube-apiserver.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/entities/apiserver.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/entities/apiserver.json
@@ -416,6 +425,7 @@ serving the particular endpoint.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/entities/host.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/entities/host.json
@@ -438,6 +448,7 @@ in the cluster that Cilium is running on.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/entities/nodes.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/entities/nodes.json
@@ -458,6 +469,7 @@ endpoints that have the label ``role=public``.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/entities/world.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/entities/world.json
@@ -496,6 +508,7 @@ traffic **only** from control plane (labeled
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/entities/customnodes.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/entities/customnodes.json
@@ -576,6 +589,7 @@ but not CIDR prefix ``10.96.0.0/12``
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/cidr/cidr.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/cidr/cidr.json
@@ -684,6 +698,7 @@ Example
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/fqdn/fqdn.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l3/fqdn/fqdn.json
@@ -766,6 +781,7 @@ only be able to emit packets using TCP on port 80, to any layer 3 destination:
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l4/l4.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l4/l4.json
@@ -786,6 +802,7 @@ only be able to emit packets using TCP on ports 80-444, to any layer 3 destinati
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l4/l4_port_range.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l4/l4_port_range.json
@@ -814,6 +831,7 @@ endpoints with the label ``role=frontend`` will not be able to communicate with
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l4/l3_l4_combined.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l4/l3_l4_combined.json
@@ -839,6 +857,7 @@ ports other than port 80.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l4/cidr_l4_combined.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l4/cidr_l4_combined.json
@@ -1097,6 +1116,7 @@ be rejected. Requests on ports other than port 80 will be dropped.
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l7/http/simple/l7.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l7/http/simple/l7.json
@@ -1120,6 +1140,7 @@ While communicating on this port, the only API endpoints allowed will be ``GET
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l7/http/http.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l7/http/http.json
@@ -1204,6 +1225,7 @@ Allow producing to topic empire-announce using Role
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l7/kafka/kafka-role.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l7/kafka/kafka-role.json
@@ -1221,6 +1243,7 @@ Allow producing to topic empire-announce using apiKeys
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l7/kafka/kafka.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l7/kafka/kafka.json
@@ -1284,6 +1307,7 @@ allowed but connections to the returned IPs are not, as there is no L3
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l7/dns/dns.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l7/dns/dns.json
@@ -1341,6 +1365,7 @@ DNS Proxy
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l7/dns/dns-visibility.yaml
+          :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l7/dns/dns-visibility.json
@@ -1435,10 +1460,12 @@ as this policy is allowing traffic from everywhere except from "world".
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l3/entities/from_world_deny.yaml
+          :language: yaml
 
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/l3/entities/from_world_deny.yaml
+          :language: yaml
 
 Deny policies do not support: policy enforcement at L7, i.e., specifically
 denying an URL and ``toFQDNs``, i.e., specifically denying traffic to a specific
@@ -1519,10 +1546,12 @@ the label ``type=ingress-worker`` on TCP ports 22, 6443 (kube-apiserver), 2379
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/host/lock-down-ingress.yaml
+          :language: yaml
 
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/host/lock-down-ingress.yaml
+          :language: yaml
 
 To reuse this policy, replace the ``port:`` values with ports used in your
 environment.

--- a/Documentation/security/policy/lifecycle.rst
+++ b/Documentation/security/policy/lifecycle.rst
@@ -78,6 +78,7 @@ done as follows:
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l4/init.yaml
+           :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l4/init.json
@@ -95,6 +96,7 @@ queries from initializing endpoints may be done as follows:
      .. group-tab:: k8s YAML
 
         .. literalinclude:: ../../../examples/policies/l4/from_init.yaml
+           :language: yaml
      .. group-tab:: JSON
 
         .. literalinclude:: ../../../examples/policies/l4/from_init.json

--- a/Documentation/security/tls-visibility.rst
+++ b/Documentation/security/tls-visibility.rst
@@ -391,6 +391,7 @@ The following Cilium network policy indicates that Cilium should perform HTTP-aw
 of communication between the ``mediabot`` pod to ``httpbin.org``.
 
 .. literalinclude:: ../../examples/kubernetes-tls-inspection/l7-visibility-tls.yaml
+   :language: yaml
 
 Let's take a closer look at the policy:
 


### PR DESCRIPTION
The documentation makes extensive use of embedding example YAML files, which is nice because they can be referenced in a `kubectl` command (etc). The `literalinclude` directive also supports a `:language:` argument that enables syntax highlighting. Enable that.
