### PR TITLE
bpf:trace: adjust TRACE_PAYLOAD_LEN for overlay packets

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -386,7 +386,8 @@ cilium-agent [flags]
       --tofqdns-preallocate-identities                            Preallocate identities for ToFQDN selectors. This reduces proxied DNS response latency. Disable if you have many ToFQDN selectors. (default true)
       --tofqdns-proxy-port int                                    Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --tofqdns-proxy-response-max-delay duration                 The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
-      --trace-payloadlen int                                      Length of payload to capture when tracing (default 128)
+      --trace-payloadlen int                                      Length of payload to capture when tracing native packets. (default 128)
+      --trace-payloadlen-overlay int                              Length of payload to capture when tracing overlay packets. (default 192)
       --trace-sock                                                Enable tracing for socket-based LB (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -18,5 +18,7 @@
 NODE_CONFIG(union v4addr, service_loopback_ipv4, "IPv4 source address used for SNAT when a Pod talks to itself over a Service")
 NODE_CONFIG(union v6addr, router_ipv6, "Internal IPv6 router address assigned to the cilium_host interface")
 
-NODE_CONFIG(__u32, trace_payload_len, "Length of payload to capture when tracing")
+NODE_CONFIG(__u32, trace_payload_len, "Length of payload to capture when tracing native packets.")
 #define TRACE_PAYLOAD_LEN CONFIG(trace_payload_len) /* Backwards compatibility */
+
+NODE_CONFIG(__u32, trace_payload_len_overlay, "Length of payload to capture when tracing overlay packets.")

--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -17,3 +17,6 @@
 
 NODE_CONFIG(union v4addr, service_loopback_ipv4, "IPv4 source address used for SNAT when a Pod talks to itself over a Service")
 NODE_CONFIG(union v6addr, router_ipv6, "Internal IPv6 router address assigned to the cilium_host interface")
+
+NODE_CONFIG(__u32, trace_payload_len, "Length of payload to capture when tracing")
+#define TRACE_PAYLOAD_LEN CONFIG(trace_payload_len) /* Backwards compatibility */

--- a/bpf/lib/classifiers.h
+++ b/bpf/lib/classifiers.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <bpf/config/node.h>
+
 #include "lib/common.h"
 #include "lib/ipv4.h"
 #include "lib/ipv6.h"
@@ -196,4 +198,24 @@ ctx_classify(struct __ctx_buff *ctx, __be16 proto, enum trace_point obs_point __
 
 out:
 	return flags;
+}
+
+/**
+ * compute_capture_len
+ * @ctx: socket buffer
+ * @monitor: the monitor value
+ *
+ * Compute capture length for the trace/drop notification event.
+ * Return at most `ctx_full_len` bytes.
+ * With monitor=0, use the config value `trace_payload_len`.
+ */
+static __always_inline __u64
+compute_capture_len(struct __ctx_buff *ctx, __u32 monitor)
+{
+	__u32 cap_len_default = CONFIG(trace_payload_len);
+
+	if (monitor == 0)
+		monitor = cap_len_default;
+
+	return min_t(__u64, monitor, ctx_full_len(ctx));
 }

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -475,10 +475,6 @@ enum {
 	CAPTURE_EGRESS = 2,
 };
 
-#ifndef TRACE_PAYLOAD_LEN
-#define TRACE_PAYLOAD_LEN 128ULL
-#endif
-
 #ifndef BPF_F_PSEUDO_HDR
 # define BPF_F_PSEUDO_HDR                (1ULL << 4)
 #endif

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -6,6 +6,8 @@
 #include <linux/icmpv6.h>
 #include <linux/icmp.h>
 
+#include <bpf/config/node.h>
+
 #include "common.h"
 #include "utils.h"
 #include "ipv4.h"

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -86,7 +86,7 @@ int tail_drop_notify(struct __ctx_buff *ctx)
 	}
 
 	flags = ctx_classify(ctx, 0, TRACE_POINT_UNKNOWN);
-	cap_len = compute_capture_len(ctx, 0);
+	cap_len = compute_capture_len(ctx, 0, flags, TRACE_POINT_UNKNOWN);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -64,7 +64,7 @@ int tail_drop_notify(struct __ctx_buff *ctx)
 	/* Mask needed to calm verifier. */
 	__u32 error = ctx_load_meta(ctx, 2) & 0xFFFFFFFF;
 	__u64 ctx_len = ctx_full_len(ctx);
-	__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
+	__u64 cap_len;
 	__u32 meta4 = ctx_load_meta(ctx, 4);
 	__u16 line = (__u16)(meta4 >> 16);
 	__u8 file = (__u8)(meta4 >> 8);
@@ -86,6 +86,7 @@ int tail_drop_notify(struct __ctx_buff *ctx)
 	}
 
 	flags = ctx_classify(ctx, 0, TRACE_POINT_UNKNOWN);
+	cap_len = compute_capture_len(ctx, 0);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -206,8 +206,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __be16 proto, __u16 line, __u8 file)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
-	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
-			      ctx_len);
+	__u64 cap_len;
 	struct ratelimit_key rkey = {
 		.usage = RATELIMIT_USAGE_EVENTS_MAP,
 	};
@@ -230,6 +229,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 	}
 
 	flags = ctx_classify(ctx, proto, obs_point);
+	cap_len = compute_capture_len(ctx, monitor);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
@@ -255,8 +255,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u16 line, __u8 file)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
-	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
-			      ctx_len);
+	__u64 cap_len;
 	struct ratelimit_key rkey = {
 		.usage = RATELIMIT_USAGE_EVENTS_MAP,
 	};
@@ -279,6 +278,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 	}
 
 	flags = ctx_classify(ctx, bpf_htons(ETH_P_IP), obs_point);
+	cap_len = compute_capture_len(ctx, monitor);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
@@ -304,8 +304,7 @@ _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 monitor, __u16 line, __u8 file)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
-	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
-			      ctx_len);
+	__u64 cap_len;
 	struct ratelimit_key rkey = {
 		.usage = RATELIMIT_USAGE_EVENTS_MAP,
 	};
@@ -328,6 +327,7 @@ _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 	}
 
 	flags = ctx_classify(ctx, bpf_htons(ETH_P_IPV6), obs_point);
+	cap_len = compute_capture_len(ctx, monitor);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -229,7 +229,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 	}
 
 	flags = ctx_classify(ctx, proto, obs_point);
-	cap_len = compute_capture_len(ctx, monitor);
+	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
@@ -278,7 +278,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 	}
 
 	flags = ctx_classify(ctx, bpf_htons(ETH_P_IP), obs_point);
-	cap_len = compute_capture_len(ctx, monitor);
+	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
@@ -327,7 +327,7 @@ _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 	}
 
 	flags = ctx_classify(ctx, bpf_htons(ETH_P_IPV6), obs_point);
-	cap_len = compute_capture_len(ctx, monitor);
+	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -24,6 +24,8 @@ static __u64 __now;
 #define REPORT_ALL_FLAGS 0xFF
 #define REPORT_NO_FLAGS 0x0
 
+ASSIGN_CONFIG(__u32, trace_payload_len, 128UL);
+
 /* Advance global (fake) time by one unit. */
 void advance_time(void)
 {
@@ -45,7 +47,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		struct ct_entry entry = {};
 		union tcp_flags flags = {};
 		__u32 then;
-		int monitor;
+		int monitor = 0;
 
 		/* No update initially; mostly just because __now is less than the
 		 * default report interval.
@@ -106,7 +108,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 			test_fatal("ct entry lookup failed");
 
 		union tcp_flags seen_flags = {0};
-		__u32 monitor;
+		__u32 monitor = 0;
 
 		seen_flags.value |= TCP_FLAG_SYN;
 
@@ -218,7 +220,7 @@ int svc_test(__maybe_unused struct __sk_buff *sctx)
 		struct ipv4_ct_tuple tuple = {};
 		struct ct_state ct_state = {};
 		union tcp_flags seen_flags = {0};
-		__u32 monitor;
+		__u32 monitor = 0;
 
 		tuple.nexthdr = IPPROTO_TCP;
 		tuple.flags = CT_SERVICE;

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -636,7 +636,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.ServiceNoBackendResponse, defaults.ServiceNoBackendResponse, "Response to traffic for a service without backends")
 	option.BindEnv(vp, option.ServiceNoBackendResponse)
 
-	flags.Int(option.TracePayloadlen, 128, "Length of payload to capture when tracing")
+	flags.Int(option.TracePayloadlen, defaults.TracePayloadLen, "Length of payload to capture when tracing")
 	option.BindEnv(vp, option.TracePayloadlen)
 
 	flags.Bool(option.Version, false, "Print version information")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -636,8 +636,11 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.ServiceNoBackendResponse, defaults.ServiceNoBackendResponse, "Response to traffic for a service without backends")
 	option.BindEnv(vp, option.ServiceNoBackendResponse)
 
-	flags.Int(option.TracePayloadlen, defaults.TracePayloadLen, "Length of payload to capture when tracing")
+	flags.Int(option.TracePayloadlen, defaults.TracePayloadLen, "Length of payload to capture when tracing native packets.")
 	option.BindEnv(vp, option.TracePayloadlen)
+
+	flags.Int(option.TracePayloadlenOverlay, defaults.TracePayloadLenOverlay, "Length of payload to capture when tracing overlay packets.")
+	option.BindEnv(vp, option.TracePayloadlenOverlay)
 
 	flags.Bool(option.Version, false, "Print version information")
 	option.BindEnv(vp, option.Version)

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -13,11 +13,13 @@ type Node struct {
 	RouterIPv6 [16]byte `config:"router_ipv6"`
 	// IPv4 source address used for SNAT when a Pod talks to itself over a Service.
 	ServiceLoopbackIPv4 [4]byte `config:"service_loopback_ipv4"`
-	// Length of payload to capture when tracing.
+	// Length of payload to capture when tracing native packets.
 	TracePayloadLen uint32 `config:"trace_payload_len"`
+	// Length of payload to capture when tracing overlay packets.
+	TracePayloadLenOverlay uint32 `config:"trace_payload_len_overlay"`
 }
 
 func NewNode() *Node {
 	return &Node{[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-		[4]byte{0x0, 0x0, 0x0, 0x0}, 0x0}
+		[4]byte{0x0, 0x0, 0x0, 0x0}, 0x0, 0x0}
 }

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -13,9 +13,11 @@ type Node struct {
 	RouterIPv6 [16]byte `config:"router_ipv6"`
 	// IPv4 source address used for SNAT when a Pod talks to itself over a Service.
 	ServiceLoopbackIPv4 [4]byte `config:"service_loopback_ipv4"`
+	// Length of payload to capture when tracing.
+	TracePayloadLen uint32 `config:"trace_payload_len"`
 }
 
 func NewNode() *Node {
 	return &Node{[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-		[4]byte{0x0, 0x0, 0x0, 0x0}}
+		[4]byte{0x0, 0x0, 0x0, 0x0}, 0x0}
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -218,7 +218,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_SESSION_AFFINITY"] = "1"
 	}
 
-	cDefinesMap["TRACE_PAYLOAD_LEN"] = fmt.Sprintf("%dULL", option.Config.TracePayloadlen)
 	cDefinesMap["MTU"] = fmt.Sprintf("%d", cfg.DeviceMTU)
 
 	// --- WARNING: THIS CONFIGURATION METHOD IS DEPRECATED, SEE FUNCTION DOC ---

--- a/pkg/datapath/loader/config.go
+++ b/pkg/datapath/loader/config.go
@@ -6,6 +6,7 @@ package loader
 import (
 	"github.com/cilium/cilium/pkg/datapath/config"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 func nodeConfig(lnc *datapath.LocalNodeConfiguration) config.Node {
@@ -18,6 +19,8 @@ func nodeConfig(lnc *datapath.LocalNodeConfiguration) config.Node {
 	if lnc.CiliumInternalIPv6 != nil {
 		node.RouterIPv6 = ([16]byte)(lnc.CiliumInternalIPv6.To16())
 	}
+
+	node.TracePayloadLen = uint32(option.Config.TracePayloadlen)
 
 	return node
 }

--- a/pkg/datapath/loader/config.go
+++ b/pkg/datapath/loader/config.go
@@ -21,6 +21,7 @@ func nodeConfig(lnc *datapath.LocalNodeConfiguration) config.Node {
 	}
 
 	node.TracePayloadLen = uint32(option.Config.TracePayloadlen)
+	node.TracePayloadLenOverlay = uint32(option.Config.TracePayloadlenOverlay)
 
 	return node
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -488,6 +488,12 @@ const (
 	// ServiceNoBackendResponse is the default response for services without backends
 	ServiceNoBackendResponse = "reject"
 
+	// TracePayloadLen is the default length of payload to capture when tracing.
+	// The value is aligned to 2 cache-lines (64B each):
+	// - decreasing below 64B would not be enough for decoding typical headers
+	// - any value between 64B-128B would still require access to 2 cache-lines
+	TracePayloadLen = 128
+
 	// Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation.
 	UseCiliumInternalIPForIPsec = false
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -488,11 +488,19 @@ const (
 	// ServiceNoBackendResponse is the default response for services without backends
 	ServiceNoBackendResponse = "reject"
 
-	// TracePayloadLen is the default length of payload to capture when tracing.
+	// TracePayloadLen is the default length of payload to capture when tracing native packets.
 	// The value is aligned to 2 cache-lines (64B each):
 	// - decreasing below 64B would not be enough for decoding typical headers
 	// - any value between 64B-128B would still require access to 2 cache-lines
 	TracePayloadLen = 128
+
+	// TracePayloadLenOverlay is the default length of payload to capture when tracing overlay packets.
+	// The above TracePayloadLen might not be enough, resulting in a decode error for packets:
+	// - TCPv6 with options over VXLANv4 (>=134B) -- decode error
+	// - TCPv6 with SRv6 segments (>=136B) -- decode error
+	// - {ICMP,UDP,TCP}v6 over (future) VXLANv6 (>=132B) -- decode error
+	// The value is aligned to 3 cache-lines, see above comment in TracePayloadLen.
+	TracePayloadLenOverlay = 192
 
 	// Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation.
 	UseCiliumInternalIPForIPsec = false

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -354,8 +354,11 @@ const (
 	// StateDir is the directory path to store runtime state
 	StateDir = "state-dir"
 
-	// TracePayloadlen length of payload to capture when tracing
+	// TracePayloadlen length of payload to capture when tracing native packets.
 	TracePayloadlen = "trace-payloadlen"
+
+	// TracePayloadlenOverlay length of payload to capture when tracing overlay packets.
+	TracePayloadlenOverlay = "trace-payloadlen-overlay"
 
 	// Version prints the version information
 	Version = "version"
@@ -1547,19 +1550,20 @@ type DaemonConfig struct {
 	EnableIPMasqAgent           bool
 	IPMasqAgentConfigPath       string
 
-	EnableBPFClockProbe bool
-	EnableEgressGateway bool
-	EnableEnvoyConfig   bool
-	InstallIptRules     bool
-	MonitorAggregation  string
-	PreAllocateMaps     bool
-	IPv6NodeAddr        string
-	IPv4NodeAddr        string
-	SocketPath          string
-	TracePayloadlen     int
-	Version             string
-	PrometheusServeAddr string
-	ToFQDNsMinTTL       int
+	EnableBPFClockProbe    bool
+	EnableEgressGateway    bool
+	EnableEnvoyConfig      bool
+	InstallIptRules        bool
+	MonitorAggregation     string
+	PreAllocateMaps        bool
+	IPv6NodeAddr           string
+	IPv4NodeAddr           string
+	SocketPath             string
+	TracePayloadlen        int
+	TracePayloadlenOverlay int
+	Version                string
+	PrometheusServeAddr    string
+	ToFQDNsMinTTL          int
 
 	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
 	// for each FQDN selector in endpoint's restored DNS rules
@@ -2712,6 +2716,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.ExternalEnvoyProxy = vp.GetBool(ExternalEnvoyProxy)
 	c.SocketPath = vp.GetString(SocketPath)
 	c.TracePayloadlen = vp.GetInt(TracePayloadlen)
+	c.TracePayloadlenOverlay = vp.GetInt(TracePayloadlenOverlay)
 	c.Version = vp.GetString(Version)
 	c.PolicyTriggerInterval = vp.GetDuration(PolicyTriggerInterval)
 	c.CTMapEntriesTimeoutTCP = vp.GetDuration(CTMapEntriesTimeoutTCPName)


### PR DESCRIPTION
~Blocked by https://github.com/cilium/cilium/pull/39650.~ Good to have (non-blocking) for https://github.com/cilium/cilium/pull/37634.

As described in commit messages, when tracing overlay packets the default TRACE_PAYLOAD_LEN might not be enough. An example would be an Overlay IPv4 packet carrying an IPv6 TCP packet with Options (MSS, etc., such as a SYN packet). In that case, Hubble would fail decoding such packet due to missing bytes. Same problems would arise in case of IPv6 underlay.

For this reason:
1. move `TRACE_PAYLOAD_LEN` to `CONFIG(trace_payload_len)` for coherency with the new datapath config, and use it to trace native packets
2. introduce `CONFIG(trace_payload_len_overlay)` and use it for tracing overlay packets
3. postpone the computation of capture_length when tracing to only when the trace needs to be omitted
4. add an helper to accomplish (3) based on the current classifier flags: use (2) when CLS_FLAG_{VXLAN,GENEVE} is set, (1) otherwise.

Fixes: https://github.com/cilium/cilium/issues/39030.