### PR TITLE
cli: Emit target package for error in logs failure

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -112,10 +112,10 @@ func (a *Action) String() string {
 	sn := a.test.scenarioName(a.scenario)
 	p := a.Peers()
 	if p != "" {
-		return fmt.Sprintf("%s/%s: %s", sn, a.name, p)
+		return fmt.Sprintf("%s:%s: %s", sn, a.name, p)
 	}
 
-	return fmt.Sprintf("%s/%s", sn, a.name)
+	return fmt.Sprintf("%s:%s", sn, a.name)
 }
 
 // Peers returns the name and addr:port of the peers involved in the Action.

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -120,11 +120,16 @@ func (n *noErrorsInLogs) FilePath() string {
 	// In case log did not contain the path,
 	// we return the path of the test file.
 	return n.ScenarioBase.FilePath()
-
 }
 
 func (n *noErrorsInLogs) Name() string {
-	return "no-errors-in-logs"
+	result := "no-errors-in-logs"
+	extractedPath := extractPackageFromLog(n.mostCommonFailureLog)
+	if extractedPath != "" {
+		result = result + ":" + extractedPath
+	}
+
+	return result
 }
 
 type podID struct{ Cluster, Namespace, Name string }
@@ -353,6 +358,15 @@ func extractPathFromLog(log string) string {
 	// on the local host.
 	result := strings.TrimPrefix(source, repoDir+string(filepath.Separator))
 	return strings.TrimPrefix(result, "/go/src/github.com/cilium/cilium/")
+}
+
+func extractPackageFromLog(log string) string {
+	result := extractPathFromLog(log)
+	if result == "" {
+		return ""
+	}
+	result, _ = filepath.Split(result)
+	return filepath.Clean(result)
 }
 
 func (n *noErrorsInLogs) checkErrorsInLogs(id string, logs []byte, a *check.Action) {


### PR DESCRIPTION
When the "no-errors-in-logs" test fails, report the package with the
error as part of the action name so that it's easier for developers to
understand which area of the codebase is emitting the error log.

Example test output:

    ...
    .  [.] Action [check-log-errors/no-errors-in-logs:vendor/github.com/cilium/hive/job:kind-kind/kube-system/cilium-znv6v (install-cni-binaries)]
    .
    📋 Test Report [cilium-test-1]
    ❌ 1/1 tests failed (4/17 actions), 118 tests skipped, 0 scenarios skipped:
    Test [check-log-errors]:
      ❌ check-log-errors/no-errors-in-logs:vendor/github.com/cilium/hive/job:kind-kind/kube-system/cilium-d6vf2 (cilium-agent)
        ⛑️ The following owners are responsible for reliability of the testsuite:
            - @cilium/vendor (no-errors-in-logs:vendor/github.com/cilium/hive/job)

