### PR TITLE
cli: default to SPDY connection for exec

### DIFF
--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -840,7 +840,8 @@ func (c *Client) createDialer(url *url.URL) (httpstream.Dialer, error) {
 		return nil, fmt.Errorf("Error while creating k8s dialer: (websocket) %w, (spdy) %w", errWebsocket, errSPDY)
 	}
 
-	dialerFallback := portforward.NewFallbackDialer(dialerWebsocket, dialerSPDY, func(err error) bool {
+	// Default to the SPDY connection
+	dialerFallback := portforward.NewFallbackDialer(dialerSPDY, dialerWebsocket, func(err error) bool {
 		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
 	})
 	return dialerFallback, nil

--- a/cilium-cli/k8s/exec.go
+++ b/cilium-cli/k8s/exec.go
@@ -51,7 +51,8 @@ func newExecutor(config *rest.Config, url *url.URL) (remotecommand.Executor, err
 		return nil, fmt.Errorf("Error while creating k8s executor: (websocket) %w, (spdy) %w", errWebsocket, errSPDY)
 	}
 
-	execFallback, errFallback := remotecommand.NewFallbackExecutor(execWebsocket, execSPDY, func(err error) bool {
+	// Default to the SPDY connection
+	execFallback, errFallback := remotecommand.NewFallbackExecutor(execSPDY, execWebsocket, func(err error) bool {
 		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
 	})
 	if errFallback != nil {


### PR DESCRIPTION
The upstream websocket executor implementation has a variety of issues due to hardcoded timeouts, and [continues to cause flakes](https://github.com/cilium/cilium/issues/38643) in our test suites which use a remote executor.

See https://github.com/kubernetes/kubernetes/commit/1d4be7527f8b2d2c4eb6dcc7ef58b4c3133f6f19 (upstream timeout bumped from 2 seconds to 30 seconds)
See https://github.com/kubernetes/kubernetes/commit/b04d1177efb0cfc84b76732848eef8f0ea89b25b (upstream timeout bumped from 30 seconds to 60 seconds)
See also https://github.com/kubernetes/kubernetes/commits/master/staging/src/k8s.io/client-go/tools/remotecommand

We continue to use the fallback mechanism here to allow Websocket connections in cases where SPDY is not available. SPDY is not available when there is an HTTP-only proxy in front of the Kubernetes API server.

To properly fix this issue, we could make upstream contributions to improve the websocket executor to rely less on hardcoded timeouts and also expose a mechanism for indicating to both sides of the connection when the `io.Writers` for fd 0, 1, and 2 are ready for writes.

### Additional context

We introduced the use of the Websocket executor with https://github.com/cilium/cilium/pull/37538 in order to address the `"Upgrade request required"` error which users see when they use the `cilium sysdump` subcommand and their Kubernetes API Server is behind a proxy which does not support SPDY. As described in the PR description there, SPDY as a protocol has been deprecated since 2015, and Kubernetes has used websocket by default since v1.29.

In this implementation, we included a fallback mechanism to SPDY, in the case that Websocket is not available.

After introducing websockets, we began to see at least two related errors crop up in our CI:

https://github.com/cilium/cilium/issues/37784

```
websocket: close 1006 (abnormal closure): unexpected EOF
```

```
command terminated with exit code 14
```

A change which resolved most, but not all of these errors was https://github.com/cilium/cilium/pull/37984. See the PR description there for additional details. Unfortunately, this change did not resolve the flakes that we see in CI for the cases where tcpdump writes to the stdout `io.Writer` before the websocket connection is fully established.

This PR should eliminate those flakes, and also allows users to continue using `cilium sysdump` in cases where SPDY is not available.

Fixes: #38643
