### PR TITLE
make: fix golangci-lint version detection

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -111,7 +111,7 @@ endif
 # renovate: datasource=docker depName=golangci/golangci-lint
 GOLANGCILINT_WANT_VERSION = v2.1.2
 GOLANGCILINT_IMAGE_SHA = sha256:86f65772316ad8baa4bd5bb1363640fa4054a9df0ae8150b1eef893c4751533c
-GOLANGCILINT_VERSION = $(shell golangci-lint version --format short 2>/dev/null)
+GOLANGCILINT_VERSION = $(shell golangci-lint version --short 2>/dev/null)
 
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)
 VERSION_MAJOR = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION | cut -d. -f1)


### PR DESCRIPTION
Currently, the golangci-lint version detection is broken because the flag `--format short` has been replaced with `--short` with v2.

This commit fixes this by using the new flag.

Context: golangci-lint version detection is used to decide whether `make lint` should use the locally available binary (with the matching version) or whether golangci-lint should be executed with the expected version in a docker container.

Reported-by: Jussi Maki <jussi@isovalent.com>