### PR TITLE
datapath: Synchronize backend with the Linux neighbor table for new LB control-plane

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -129,6 +129,9 @@ var Cell = cell.Module(
 	// DevicesController manages the devices and routes tables
 	linuxdatapath.DevicesControllerCell,
 
+	// Synchronizes load-balancing backends with the neighbor table.
+	linuxdatapath.BackendNeighborSyncCell,
+
 	// Synchronizes the userspace ipcache with the corresponding BPF map.
 	ipcache.Cell,
 

--- a/pkg/datapath/linux/backend_neighbors.go
+++ b/pkg/datapath/linux/backend_neighbors.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package linux
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// BackendNeighborSyncCell watches Table[*loadbalancer.Backend] and inserts/deletes
+// the neighbor table entries for each backend address.
+//
+// This is needed by XDP program to be able to resolve the hardware address of
+// the backend as it cannot use the neighbor sub-system to resolve it on-demand.
+var BackendNeighborSyncCell = cell.Module(
+	"backend-neighbor-sync",
+	"Synchronizes backends to Linux neighbors table",
+
+	cell.Invoke(registerBackendNeighborSync),
+)
+
+type backendNeighborSyncParams struct {
+	cell.In
+
+	JobGroup      job.Group
+	DB            *statedb.DB
+	NodeNeighbors types.NodeNeighbors
+	Backends      statedb.Table[*loadbalancer.Backend]
+}
+
+func registerBackendNeighborSync(p backendNeighborSyncParams) {
+	p.JobGroup.Add(
+		job.OneShot(
+			"backend-neighbor-sync",
+			func(ctx context.Context, _ cell.Health) error {
+				return syncBackendNeighbors(p, ctx)
+			},
+		))
+}
+
+func syncBackendNeighbors(p backendNeighborSyncParams, ctx context.Context) error {
+	wtxn := p.DB.WriteTxn(p.Backends)
+	changeIter, err := p.Backends.Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		return err
+	}
+
+	// Process the changes in batches every 50 milliseconds.
+	limiter := rate.NewLimiter(50*time.Millisecond, 1)
+	defer limiter.Stop()
+
+	addedNeighbors := map[loadbalancer.L3n4Addr]*nodeTypes.Node{}
+
+	for {
+		changes, watch := changeIter.Next(p.DB.ReadTxn())
+		for change := range changes {
+			n, found := addedNeighbors[change.Object.Address]
+			switch {
+			case change.Deleted && found:
+				delete(addedNeighbors, change.Object.Address)
+				p.NodeNeighbors.DeleteMiscNeighbor(n)
+
+			case !change.Deleted && !found:
+				n := backendToNode(change.Object)
+				addedNeighbors[change.Object.Address] = n
+				p.NodeNeighbors.InsertMiscNeighbor(n)
+			}
+		}
+
+		select {
+		case <-watch:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+func backendToNode(b *loadbalancer.Backend) *nodeTypes.Node {
+	return &nodeTypes.Node{
+		Name: fmt.Sprintf("backend-%s", b.Address.AddrCluster.AsNetIP()),
+		IPAddresses: []nodeTypes.Address{{
+			Type: addressing.NodeInternalIP,
+			IP:   b.Address.AddrCluster.AsNetIP(),
+		}},
+	}
+}

--- a/pkg/datapath/linux/backend_neighbors_test.go
+++ b/pkg/datapath/linux/backend_neighbors_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package linux_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestBackendNeighborSync(t *testing.T) {
+
+	var (
+		db       *statedb.DB
+		backends statedb.RWTable[*loadbalancer.Backend]
+	)
+	mock := &mockNodeNeighbors{
+		updates: make(chan *nodeTypes.Node),
+		deletes: make(chan *nodeTypes.Node),
+	}
+
+	h := hive.New(
+		cell.Provide(
+			loadbalancer.NewBackendsTable,
+			statedb.RWTable[*loadbalancer.Backend].ToTable,
+			func() types.NodeNeighbors { return mock },
+		),
+		linux.BackendNeighborSyncCell,
+		cell.Invoke(func(db_ *statedb.DB, backends_ statedb.RWTable[*loadbalancer.Backend]) {
+			db = db_
+			backends = backends_
+		}),
+	)
+	log := hivetest.Logger(t)
+	require.NoError(t, h.Start(log, t.Context()), "Start")
+	t.Cleanup(func() {
+		require.NoError(t, h.Stop(log, context.Background()), "Stop")
+		goleak.VerifyNone(t)
+	})
+
+	var addr1, addr2 loadbalancer.L3n4Addr
+	addr1.ParseFromString("1.0.0.1:80/TCP")
+	addr2.ParseFromString("2.0.0.2:80/TCP")
+
+	wtxn := db.WriteTxn(backends)
+	backends.Insert(wtxn, &loadbalancer.Backend{Address: addr1})
+	backends.Insert(wtxn, &loadbalancer.Backend{Address: addr2})
+	wtxn.Commit()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	t.Cleanup(cancel)
+
+	requireHasAddress := func(ch chan *nodeTypes.Node, addr loadbalancer.L3n4Addr) {
+		select {
+		case n := <-ch:
+			require.True(t, nodeHasAddress(n, addr))
+		case <-ctx.Done():
+			t.Fatalf("timeout waiting for address")
+		}
+	}
+
+	requireHasAddress(mock.updates, addr1)
+	requireHasAddress(mock.updates, addr2)
+
+	wtxn = db.WriteTxn(backends)
+	backends.DeleteAll(wtxn)
+	wtxn.Commit()
+
+	requireHasAddress(mock.deletes, addr1)
+	requireHasAddress(mock.deletes, addr2)
+}
+
+type mockNodeNeighbors struct {
+	updates chan *nodeTypes.Node
+	deletes chan *nodeTypes.Node
+}
+
+func nodeHasAddress(n *nodeTypes.Node, addr loadbalancer.L3n4Addr) bool {
+	return len(n.IPAddresses) > 0 && n.IPAddresses[0].IP.Equal(addr.AddrCluster.AsNetIP())
+}
+
+// DeleteMiscNeighbor implements types.NodeNeighbors.
+func (m *mockNodeNeighbors) DeleteMiscNeighbor(oldNode *nodeTypes.Node) {
+	m.deletes <- oldNode
+}
+
+// InsertMiscNeighbor implements types.NodeNeighbors.
+func (m *mockNodeNeighbors) InsertMiscNeighbor(newNode *nodeTypes.Node) {
+	m.updates <- newNode
+}
+
+func (m *mockNodeNeighbors) NodeCleanNeighbors(migrateOnly bool) { panic("unimplemented") }
+func (m *mockNodeNeighbors) NodeNeighDiscoveryEnabled() bool     { panic("unimplemented") }
+func (m *mockNodeNeighbors) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) error {
+	panic("unimplemented")
+}
+
+var _ types.NodeNeighbors = &mockNodeNeighbors{}

--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -276,7 +276,7 @@ var (
 	BackendByServiceName = backendServiceIndex.Query
 )
 
-func NewBackendsTable(cfg Config, db *statedb.DB) (statedb.RWTable[*Backend], error) {
+func NewBackendsTable(db *statedb.DB) (statedb.RWTable[*Backend], error) {
 	tbl, err := statedb.NewTable(
 		BackendTableName,
 		backendAddrIndex,


### PR DESCRIPTION
This implements the missing "InsertMiscNeighbor" call for when backends are added or removed to keep
the Linux neighbor table up-to-date for e.g. XDP programs.