### PR TITLE
[v1.16] ci: bump lvh kind image version in conformance-runtime to 6.6-20250415.134122

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -272,7 +272,7 @@ jobs:
           test-name: runtime-tests
           install-dependencies: true
           # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          image-version: "6.6-20241218.004849"
+          image-version: "6.6-20250415.134122"
           host-mount: ./
           images-folder-parent: "/tmp"
           cpu: 4


### PR DESCRIPTION
Manually bump the image version to check whether tests are passing on the latest version.

For #38058