### PR TITLE
identity: Allow local identity for ingress label

### DIFF
--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -632,9 +632,11 @@ func testAllocateLocally(t *testing.T, testConfig testConfig) {
 
 	cidrLbls := labels.NewLabelsFromSortedList("cidr:1.2.3.4/32")
 	podLbls := labels.NewLabelsFromSortedList("k8s:foo=bar")
+	ingressLbls := labels.NewLabelsFromSortedList("reserved:ingress;k8s:foo=bar")
 
 	assert.False(t, needsGlobalIdentity(cidrLbls))
 	assert.True(t, needsGlobalIdentity(podLbls))
+	assert.False(t, needsGlobalIdentity(ingressLbls))
 
 	id, allocated, err := mgr.AllocateLocalIdentity(cidrLbls, false, identity.IdentityScopeLocal+50)
 	assert.NoError(t, err)
@@ -645,6 +647,12 @@ func testAllocateLocally(t *testing.T, testConfig testConfig) {
 	id, _, err = mgr.AllocateLocalIdentity(podLbls, false, 0)
 	assert.ErrorIs(t, err, ErrNonLocalIdentity)
 	assert.Nil(t, id)
+
+	id, _, err = mgr.AllocateLocalIdentity(ingressLbls, false, 0)
+	assert.NoError(t, err)
+	assert.True(t, allocated)
+	assert.Equal(t, identity.IdentityScopeLocal, id.ID.Scope())
+	assert.Equal(t, identity.IdentityScopeLocal+1, id.ID)
 }
 
 func TestCheckpointRestore(t *testing.T) {

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -202,6 +202,13 @@ func ScopeForLabels(lbls labels.Labels) NumericIdentity {
 		return IdentityScopeRemoteNode
 	}
 
+	// The ingress label is for L7 LB with cilium proxy, which is running on
+	// every node. So it's not necessary to be global identity, but local
+	// identity instead.
+	if lbls.HasIngressLabel() {
+		return IdentityScopeLocal
+	}
+
 	for _, label := range lbls {
 		switch label.Source {
 		case labels.LabelSourceCIDR, labels.LabelSourceFQDN, labels.LabelSourceReserved, labels.LabelSourceCIDRGroup:


### PR DESCRIPTION
The ingress label is for L7 LB with cilium proxy, which is running on every node. So it's not necessary to be global identity, but local identity instead.


