### PR TITLE
gh: ariane: don't trigger ipsec-upgrade on /test

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -18,7 +18,6 @@ triggers:
     - tests-clustermesh-upgrade.yaml
     - tests-datapath-verifier.yaml
     - tests-e2e-upgrade.yaml
-    - tests-ipsec-upgrade.yaml
     - hubble-cli-integration-test.yaml
   /ci-aks:
     workflows:


### PR DESCRIPTION
With the changes from https://github.com/cilium/cilium/pull/38757, the ipsec-upgrade workflow is only testing patch-version upgrades. These only get tested for release branches, but not on the main branch.

Therefore we don't need to run this no-op workflow on the main branch.