### PR TITLE
Upload junit results for Go unit test runs

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -382,7 +382,8 @@ jobs:
             go install golang.org/dl/go${{ env.go-version }}@latest
             go${{ env.go-version }} download
             go${{ env.go-version}} install github.com/mfridman/tparse@baf229e8494613f134bc0e1f4cb9dc9b12f66442
-            make SKIP_COVERAGE=1 LOG_CODEOWNERS=1 tests-privileged GO=go${{ env.go-version }}
+            go${{ env.go-version}} install github.com/cilium/go-junit-report/v2/cmd/go-junit-report@cc2d3acf69eeefab6f9a23ad61b175cd1d570623 # v2.3.0
+            make SKIP_COVERAGE=1 LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml" tests-privileged GO=go${{ env.go-version }}
 
       - name: Copy tested features
         if: ${{ matrix.focus == 'agent' || matrix.focus == 'datapath' }}
@@ -426,7 +427,6 @@ jobs:
             test_results-*.tar.gz
 
       - name: Fetch JUnits
-        if: ${{ always() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
         shell: bash
         run: |
           mkdir -p cilium-junits
@@ -439,7 +439,6 @@ jobs:
           for filename in *.xml; do cp "${filename}" "../cilium-junits/${junit_filename}"; done;
 
       - name: Upload JUnits [junit]
-        if: ${{ always() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cilium-junits-${{ matrix.focus }}
@@ -453,7 +452,6 @@ jobs:
           path: ${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary
-        if: ${{ always() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
         with:
           junit-directory: "cilium-junits"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -77,6 +77,10 @@ jobs:
 
   integration-test:
     name: Integration Test
+    env:
+      # GitHub doesn't provide a way to retrieve the name of a job, so we have
+      # to repeated it here.
+      job_name: "Integration Test (${{matrix.arch}})"
     strategy:
       fail-fast: false
       matrix:
@@ -166,6 +170,7 @@ jobs:
         timeout-minutes: 15
         run: |
           go install github.com/mfridman/tparse@baf229e8494613f134bc0e1f4cb9dc9b12f66442 # v0.14.0
+          go install github.com/cilium/go-junit-report/v2/cmd/go-junit-report@cc2d3acf69eeefab6f9a23ad61b175cd1d570623 # v2.3.0
 
       - name: Run integration tests
         timeout-minutes: 60
@@ -173,7 +178,49 @@ jobs:
           export V=0
           export DOCKER_BUILD_FLAGS=--quiet
           export CFLAGS="-Werror"
-          make integration-tests LOG_CODEOWNERS=1
+          make integration-tests LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml"
+
+      - name: Fetch JUnits
+        shell: bash
+        run: |
+          mkdir -p cilium-junits
+          cd test/
+          # junit_filename needs to be the same as the Job Name presented on the
+          # GH web UI - In the Summary page of a workflow run, left column
+          # "Jobs" - so that we can map the junit file to the right job - step
+          # pair on datastudio.
+          junit_filename="${{ env.job_name }}.xml"
+          for filename in *.xml; do cp "${filename}" "../cilium-junits/${junit_filename}"; done;
+
+      - name: Upload JUnits [junit]
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cilium-junits-${{ env.job_name }}
+          path: cilium-junits/*.xml
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() && runner.arch != 'ARM64' }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
+
+  merge-upload:
+    if: ${{ always() }}
+    name: Merge and Upload Artifacts
+    runs-on: ubuntu-24.04
+    needs: integration-test
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+      - name: Merge JUnits
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: cilium-junits
+          pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:
     if: ${{ always() }}

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -102,7 +102,12 @@ ifneq ($(V),0)
 	GOTEST_FORMATTER_FLAGS += -follow
 endif
 ifneq ($(LOG_CODEOWNERS),)
+ifneq ($(shell command -v go-junit-report),)
+	JUNIT_PATH ?= junit_results.xml
+	GOTEST_FORMATTER = tee >(go-junit-report -parser gojson -code-owners=$(CODEOWNERS_PATH) -code-owners-prefix github.com/cilium/cilium/ >"$(JUNIT_PATH)") >($(GO) run ./tools/testowners --code-owners=$(CODEOWNERS_PATH)) >(tparse $(GOTEST_FORMATTER_FLAGS)) >/dev/null
+else
 	GOTEST_FORMATTER = tee >($(GO) run ./tools/testowners --code-owners=$(CODEOWNERS_PATH)) >(tparse $(GOTEST_FORMATTER_FLAGS)) >/dev/null
+endif
 else
 	GOTEST_FORMATTER = tparse $(GOTEST_FORMATTER_FLAGS)
 endif


### PR DESCRIPTION
Use https://github.com/cilium/go-junit-report to publish Junit results for
Cilium unit / integration tests (ie direct Golang tests) so these can be
included in testing dashboards.

Tested in https://github.com/cilium/cilium/pull/39016 .
