### PR TITLE
cilium-dbg: don't emit logs on flush

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -317,7 +317,7 @@ func newMap(mapName string, m mapType) *Map {
 
 // doGCForFamily iterates through a CTv6 map and drops entries based on the given
 // filter.
-func doGCForFamily(m *Map, filter GCFilter, next4, next6 func(GCEvent), ipv6 bool) gcStats {
+func doGCForFamily(m *Map, filter GCFilter, next4, next6 func(GCEvent), ipv6 bool, logResults bool) gcStats {
 	family := nat.IPv4
 	if ipv6 {
 		family = nat.IPv6
@@ -343,7 +343,7 @@ func doGCForFamily(m *Map, filter GCFilter, next4, next6 func(GCEvent), ipv6 boo
 		}
 	}
 
-	stats := statStartGc(m)
+	stats := statStartGc(m, logResults)
 	defer stats.finish()
 
 	if natMap != nil {
@@ -499,8 +499,8 @@ func (f GCFilter) doFiltering(srcIP, dstIP netip.Addr, srcPort, dstPort uint16, 
 	return noAction
 }
 
-func doGC(m *Map, filter GCFilter, next4, next6 func(GCEvent)) (int, error) {
-	stats := doGCForFamily(m, filter, next4, next6, m.mapType.isIPv6())
+func doGC(m *Map, filter GCFilter, next4, next6 func(GCEvent), logResults bool) (int, error) {
+	stats := doGCForFamily(m, filter, next4, next6, m.mapType.isIPv6(), logResults)
 	return int(stats.deleted), stats.dumpError
 }
 
@@ -512,7 +512,7 @@ func GC(m *Map, filter GCFilter, next4, next6 func(GCEvent)) (int, error) {
 		filter.Time = uint32(t)
 	}
 
-	return doGC(m, filter, next4, next6)
+	return doGC(m, filter, next4, next6, false)
 }
 
 // PurgeOrphanNATEntries removes orphan SNAT entries. We call an SNAT entry
@@ -615,7 +615,7 @@ func (m *Map) Flush(next4, next6 func(GCEvent)) int {
 	d, _ := doGC(m, GCFilter{
 		RemoveExpired: true,
 		Time:          MaxTime,
-	}, next4, next6)
+	}, next4, next6, false)
 
 	return d
 }

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -222,7 +222,7 @@ func TestCtGcIcmp(t *testing.T) {
 	}
 	mcast, next, complete := stream.Multicast[GCEvent]()
 	mcast.Observe(context.Background(), NatMapNext4, func(err error) {})
-	stats := doGCForFamily(ctMap, filter, next, nil, false)
+	stats := doGCForFamily(ctMap, filter, next, nil, false, false)
 	complete(nil)
 	require.Equal(t, uint32(0), stats.aliveEntries)
 	require.Equal(t, uint32(1), stats.deleted)
@@ -336,7 +336,7 @@ func TestCtGcTcp(t *testing.T) {
 	}
 	mcast, next, complete := stream.Multicast[GCEvent]()
 	mcast.Observe(context.Background(), NatMapNext4, func(err error) {})
-	stats := doGCForFamily(ctMap, filter, next, nil, false)
+	stats := doGCForFamily(ctMap, filter, next, nil, false, false)
 	complete(nil)
 	require.Equal(t, uint32(0), stats.aliveEntries)
 	require.Equal(t, uint32(1), stats.deleted)
@@ -430,7 +430,7 @@ func TestCtGcDsr(t *testing.T) {
 	}
 	mcast, next, complete := stream.Multicast[GCEvent]()
 	mcast.Observe(context.Background(), NatMapNext4, func(err error) {})
-	stats := doGCForFamily(ctMap, filter, next, nil, false)
+	stats := doGCForFamily(ctMap, filter, next, nil, false, false)
 	complete(nil)
 	require.Equal(t, uint32(0), stats.aliveEntries)
 	require.Equal(t, uint32(1), stats.deleted)
@@ -912,6 +912,6 @@ func benchmarkCtGc(t *testing.B, size int) {
 		t.Logf("starting gc")
 		defer t.Logf("done gc pass!")
 		t.StartTimer()
-		doGCForFamily(ctMap, filter, func(g GCEvent) {}, nil, false)
+		doGCForFamily(ctMap, filter, func(g GCEvent) {}, nil, false, false)
 	}
 }


### PR DESCRIPTION
This was breaking CI as that wasn't emitting the expected output when running commands such as:

```
root@kind-worker:/home/cilium# cilium bpf ct flush global
Flushed 61 entries from /sys/fs/bpf/tc/globals/cilium_ct4_global
Flushed 6 entries from /sys/fs/bpf/tc/globals/cilium_ct_any4_global
Flushed 4 entries from /sys/fs/bpf/tc/globals/cilium_ct6_global
Flushed 6 entries from /sys/fs/bpf/tc/globals/cilium_ct_any6_global
```

This behavior was added in 694213c64ec903c49a1c421e9a32c4741027faa7 to add visibility following the decision to not emit error logs when we had a gc map delete "miss".

Fixes: #38989

