### PR TITLE
cli: Simplify junit representation of code owners

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -104,6 +104,8 @@ func RunE(hooks api.Hooks) func(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return fmt.Errorf("❗ Failed to load code owners: %w", err)
 			}
+
+			owners = owners.WithExcludedOwners(params.ExcludeCodeOwners)
 		}
 
 		logger := check.NewConcurrentLogger(params.Writer)

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hmarr/codeowners"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -22,7 +21,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/sysdump"
-	owners_util "github.com/cilium/cilium/cilium-cli/utils/codeowners"
+	"github.com/cilium/cilium/cilium-cli/utils/codeowners"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -97,11 +96,11 @@ func RunE(hooks api.Hooks) func(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		var owners codeowners.Ruleset
+		var owners *codeowners.Ruleset
 		if params.LogCodeOwners {
 			var err error
 
-			owners, err = owners_util.Load(params.CodeOwners)
+			owners, err = codeowners.Load(params.CodeOwners)
 			if err != nil {
 				return fmt.Errorf("❗ Failed to load code owners: %w", err)
 			}
@@ -314,7 +313,7 @@ func newConnectivityTests(
 	params check.Parameters,
 	hooks api.Hooks,
 	logger *check.ConcurrentLogger,
-	owners codeowners.Ruleset,
+	owners *codeowners.Ruleset,
 ) ([]*check.ConnectivityTest, error) {
 	if params.TestConcurrency < 1 {
 		fmt.Printf("--test-concurrency parameter value is invalid [%d], using 1 instead\n", params.TestConcurrency)

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/hmarr/codeowners"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +27,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/sysdump"
+	"github.com/cilium/cilium/cilium-cli/utils/codeowners"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
@@ -52,7 +52,7 @@ type ConnectivityTest struct {
 	// Features contains the features enabled on the running Cilium cluster
 	Features features.Set
 
-	CodeOwners codeowners.Ruleset
+	CodeOwners *codeowners.Ruleset
 
 	// ClusterName is the identifier of the local cluster.
 	ClusterName string
@@ -210,7 +210,7 @@ func NewConnectivityTest(
 	p Parameters,
 	sysdumpHooks sysdump.Hooks,
 	logger *ConcurrentLogger,
-	owners codeowners.Ruleset,
+	owners *codeowners.Ruleset,
 ) (*ConnectivityTest, error) {
 	if err := p.validate(); err != nil {
 		return nil, err

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -542,7 +542,7 @@ func (ct *ConnectivityTest) report() error {
 			}
 		}
 		if len(failed) > 0 && failedActions == 0 {
-			allScenarios := make([]ownedScenario, 0, len(failed))
+			allScenarios := make([]codeowners.Scenario, 0, len(failed))
 			for _, t := range failed {
 				for scenario := range t.scenarios {
 					allScenarios = append(allScenarios, scenario)
@@ -551,7 +551,7 @@ func (ct *ConnectivityTest) report() error {
 			if len(allScenarios) == 0 {
 				// Test failure was triggered not by a specific action
 				// failing, but some other infrastructure code.
-				allScenarios = []ownedScenario{defaultTestOwners}
+				allScenarios = []codeowners.Scenario{defaultTestOwners}
 			}
 			ct.LogOwners(allScenarios...)
 		}

--- a/cilium-cli/connectivity/check/junit.go
+++ b/cilium-cli/connectivity/check/junit.go
@@ -66,7 +66,11 @@ func (j *JUnitCollector) Collect(ct *ConnectivityTest) {
 			scenarios := t.Scenarios()
 			owners := make(map[string]struct{})
 			for _, s := range scenarios {
-				for _, o := range ct.GetOwners(s) {
+				codeOwners, err := ct.CodeOwners.Owners(s)
+				if err != nil {
+					ct.Logf("Failed to find CODEOWNERS for junit test case: %s", err)
+				}
+				for _, o := range codeOwners {
 					owners[o] = struct{}{}
 				}
 			}

--- a/cilium-cli/connectivity/check/junit.go
+++ b/cilium-cli/connectivity/check/junit.go
@@ -54,7 +54,7 @@ func (j *JUnitCollector) Collect(ct *ConnectivityTest) {
 	}
 	if ct.params.LogCodeOwners {
 		props := j.testSuite.Properties.Properties
-		if workflowOwners, err := ct.CodeOwners.WorkflowOwners(); err == nil {
+		if workflowOwners, err := ct.CodeOwners.WorkflowOwners(false); err == nil {
 			for _, o := range workflowOwners {
 				props = append(props, junit.Property{Name: "owner", Value: o})
 			}
@@ -75,7 +75,7 @@ func (j *JUnitCollector) Collect(ct *ConnectivityTest) {
 			scenarios := t.Scenarios()
 			owners := make(map[string]struct{})
 			for _, s := range scenarios {
-				codeOwners, err := ct.CodeOwners.Owners(s)
+				codeOwners, err := ct.CodeOwners.Owners(false, s)
 				if err != nil {
 					ct.Logf("Failed to find CODEOWNERS for junit test case: %s", err)
 				}

--- a/cilium-cli/connectivity/check/junit.go
+++ b/cilium-cli/connectivity/check/junit.go
@@ -52,6 +52,15 @@ func (j *JUnitCollector) Collect(ct *ConnectivityTest) {
 	if j.testSuite.Timestamp == "" {
 		j.testSuite.Timestamp = ct.tests[0].startTime.Format(time.RFC3339)
 	}
+	if ct.params.LogCodeOwners {
+		props := j.testSuite.Properties.Properties
+		if workflowOwners, err := ct.CodeOwners.WorkflowOwners(); err == nil {
+			for _, o := range workflowOwners {
+				props = append(props, junit.Property{Name: "owner", Value: o})
+			}
+		}
+		j.testSuite.Properties.Properties = props
+	}
 	for _, t := range ct.tests {
 		test := &junit.TestCase{
 			Name:      t.Name(),

--- a/cilium-cli/connectivity/check/logging.go
+++ b/cilium-cli/connectivity/check/logging.go
@@ -116,6 +116,14 @@ func (ct *ConnectivityTest) LogOwners(scenarios ...codeowners.Scenario) {
 	for _, o := range owners {
 		ct.Log("        - " + o)
 	}
+
+	workflowOwners, err := ct.CodeOwners.WorkflowOwners()
+	if err != nil {
+		ct.Logf("Failed to find CODEOWNERS for github workflow: %s", err)
+	}
+	for _, o := range workflowOwners {
+		ct.Log("        - " + o)
+	}
 }
 
 // Logf logs a formatted message.

--- a/cilium-cli/connectivity/check/logging.go
+++ b/cilium-cli/connectivity/check/logging.go
@@ -10,12 +10,11 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"regexp"
 	"runtime"
 	"syscall"
 	"time"
 
-	"github.com/hmarr/codeowners"
+	"github.com/cilium/cilium/cilium-cli/utils/codeowners"
 )
 
 const (
@@ -81,16 +80,7 @@ func (ct *ConnectivityTest) Log(a ...any) {
 	fmt.Fprintln(ct.params.Writer, a...)
 }
 
-// ownedScenario represents a piece of logic in the testsuite with a
-// corresponding filepath that indicates ownership (via CODEOWNERS).
-// It is used to inform developers who they may consult in the event that a
-// test fails without a clear indication why.
-type ownedScenario interface {
-	Name() string
-	FilePath() string
-}
-
-var defaultTestOwners ownedScenario
+var defaultTestOwners codeowners.Scenario
 
 func init() {
 	// Initialize in an init func to ensure that NewScenarioBase() can look
@@ -113,69 +103,11 @@ func (s defaultScenario) Name() string {
 	return "cli-test-framework"
 }
 
-var ghWorkflowRegexp = regexp.MustCompile("^(?:.+?)/(?:.+?)/(.+?)@.*$")
-
-func (ct *ConnectivityTest) GetOwners(scenarios ...ownedScenario) []string {
-	if !ct.params.LogCodeOwners {
-		return nil
+func (ct *ConnectivityTest) LogOwners(scenarios ...codeowners.Scenario) {
+	owners, err := ct.CodeOwners.Owners(scenarios...)
+	if err != nil {
+		ct.Logf("Failed to find CODEOWNERS for test scenario: %s", err)
 	}
-
-	rules := make(map[ownedScenario]*codeowners.Rule)
-	for _, scenario := range scenarios {
-		rule, err := ct.CodeOwners.Match(scenario.FilePath())
-		if err != nil || rule == nil || rule.Owners == nil {
-			ct.Fatalf("Failed to find CODEOWNERS for test scenario. Developer BUG?"+
-				"\n\t\tname=%s path=%s err=%s", scenario.Name(), scenario.FilePath(), err)
-			return nil
-		}
-		rules[scenario] = rule
-	}
-
-	var workflowOwners []codeowners.Owner
-	var ghWorkflow string
-	// Example: cilium/cilium/.github/workflows/conformance-kind-proxy-embedded.yaml@refs/pull/37593/merge
-	ghWorkflowRef := os.Getenv("GITHUB_WORKFLOW_REF")
-	matches := ghWorkflowRegexp.FindStringSubmatch(ghWorkflowRef)
-	// here matches should either be nil (no match) or a slice with two values:
-	// the full match and the capture.
-	if len(matches) == 2 {
-		ghWorkflow = matches[1]
-	}
-	if ghWorkflow != "" {
-		workflowRule, err := ct.CodeOwners.Match(ghWorkflow)
-		if err == nil || workflowRule == nil || workflowRule.Owners == nil {
-			ct.Warnf("Failed to find CODEOWNERS for workflow %s: %s", ghWorkflow, err)
-		}
-		workflowOwners = workflowRule.Owners
-	}
-
-	excludeOwners := make(map[string]struct{})
-	for _, owner := range ct.Params().ExcludeCodeOwners {
-		excludeOwners[owner] = struct{}{}
-	}
-
-	var owners []string
-	for scenario, rule := range rules {
-		for _, o := range rule.Owners {
-			owner := o.String()
-			if _, ok := excludeOwners[owner]; ok {
-				continue
-			}
-			owners = append(owners, fmt.Sprintf("%s (%s)", owner, scenario.Name()))
-		}
-		for _, o := range workflowOwners {
-			owner := o.String()
-			if _, ok := excludeOwners[owner]; ok {
-				continue
-			}
-			owners = append(owners, fmt.Sprintf("%s (%s)", owner, ghWorkflow))
-		}
-	}
-	return owners
-}
-
-func (ct *ConnectivityTest) LogOwners(scenarios ...ownedScenario) {
-	owners := ct.GetOwners(scenarios...)
 	if len(owners) == 0 {
 		return
 	}

--- a/cilium-cli/connectivity/check/logging.go
+++ b/cilium-cli/connectivity/check/logging.go
@@ -143,7 +143,7 @@ func (ct *ConnectivityTest) GetOwners(scenarios ...ownedScenario) []string {
 	}
 	if ghWorkflow != "" {
 		workflowRule, err := ct.CodeOwners.Match(ghWorkflow)
-		if err != nil || workflowRule == nil || workflowRule.Owners == nil {
+		if err == nil || workflowRule == nil || workflowRule.Owners == nil {
 			ct.Warnf("Failed to find CODEOWNERS for workflow %s: %s", ghWorkflow, err)
 		}
 		workflowOwners = workflowRule.Owners

--- a/cilium-cli/connectivity/check/logging.go
+++ b/cilium-cli/connectivity/check/logging.go
@@ -104,7 +104,7 @@ func (s defaultScenario) Name() string {
 }
 
 func (ct *ConnectivityTest) LogOwners(scenarios ...codeowners.Scenario) {
-	owners, err := ct.CodeOwners.Owners(scenarios...)
+	owners, err := ct.CodeOwners.Owners(true, scenarios...)
 	if err != nil {
 		ct.Logf("Failed to find CODEOWNERS for test scenario: %s", err)
 	}
@@ -117,7 +117,7 @@ func (ct *ConnectivityTest) LogOwners(scenarios ...codeowners.Scenario) {
 		ct.Log("        - " + o)
 	}
 
-	workflowOwners, err := ct.CodeOwners.WorkflowOwners()
+	workflowOwners, err := ct.CodeOwners.WorkflowOwners(true)
 	if err != nil {
 		ct.Logf("Failed to find CODEOWNERS for github workflow: %s", err)
 	}

--- a/cilium-cli/utils/codeowners/codeowners.go
+++ b/cilium-cli/utils/codeowners/codeowners.go
@@ -12,6 +12,8 @@ import (
 
 type Ruleset struct {
 	codeowners.Ruleset
+
+	exclude map[string]struct{}
 }
 
 func Load(paths []string) (*Ruleset, error) {
@@ -45,4 +47,13 @@ func Load(paths []string) (*Ruleset, error) {
 	return &Ruleset{
 		Ruleset: allOwners,
 	}, nil
+}
+
+func (r *Ruleset) WithExcludedOwners(excludedOwners []string) *Ruleset {
+	excluded := make(map[string]struct{})
+	for _, o := range excludedOwners {
+		excluded[o] = struct{}{}
+	}
+	r.exclude = excluded
+	return r
 }

--- a/cilium-cli/utils/codeowners/codeowners.go
+++ b/cilium-cli/utils/codeowners/codeowners.go
@@ -10,18 +10,22 @@ import (
 	"github.com/hmarr/codeowners"
 )
 
-type Ruleset codeowners.Ruleset
+type Ruleset struct {
+	codeowners.Ruleset
+}
 
-func Load(paths []string) (codeowners.Ruleset, error) {
+func Load(paths []string) (*Ruleset, error) {
+	var (
+		allOwners codeowners.Ruleset
+		err       error
+	)
+
 	if len(paths) == 0 {
-		owners, err := codeowners.LoadFileFromStandardLocation()
+		allOwners, err = codeowners.LoadFileFromStandardLocation()
 		if err != nil {
 			return nil, fmt.Errorf("while loading: %w", err)
 		}
-		return owners, nil
 	}
-
-	var allOwners codeowners.Ruleset
 
 	for _, f := range paths {
 		coFile, err := os.Open(f)
@@ -38,5 +42,7 @@ func Load(paths []string) (codeowners.Ruleset, error) {
 		allOwners = append(allOwners, owners...)
 	}
 
-	return allOwners, nil
+	return &Ruleset{
+		Ruleset: allOwners,
+	}, nil
 }

--- a/cilium-cli/utils/codeowners/codeowners.go
+++ b/cilium-cli/utils/codeowners/codeowners.go
@@ -72,7 +72,7 @@ func (r *Ruleset) WithExcludedOwners(excludedOwners []string) *Ruleset {
 	return r
 }
 
-func (r *Ruleset) WorkflowOwners() ([]string, error) {
+func (r *Ruleset) WorkflowOwners(includeWorkflowName bool) ([]string, error) {
 	var ghWorkflow string
 	// Example: cilium/cilium/.github/workflows/conformance-kind-proxy-embedded.yaml@refs/pull/37593/merge
 	ghWorkflowRef := os.Getenv("GITHUB_WORKFLOW_REF")
@@ -99,14 +99,18 @@ func (r *Ruleset) WorkflowOwners() ([]string, error) {
 			if _, ok := r.exclude[owner]; ok {
 				continue
 			}
-			owners = append(owners, owner)
+			if includeWorkflowName {
+				owners = append(owners, fmt.Sprintf("%s (%s)", owner, ghWorkflow))
+			} else {
+				owners = append(owners, owner)
+			}
 		}
 	}
 
 	return owners, nil
 }
 
-func (r *Ruleset) Owners(scenarios ...Scenario) ([]string, error) {
+func (r *Ruleset) Owners(includeTestCase bool, scenarios ...Scenario) ([]string, error) {
 	if r == nil {
 		return nil, nil
 	}
@@ -130,7 +134,11 @@ func (r *Ruleset) Owners(scenarios ...Scenario) ([]string, error) {
 			if _, ok := r.exclude[owner]; ok {
 				continue
 			}
-			owners = append(owners, fmt.Sprintf("%s (%s)", owner, scenario.Name()))
+			if includeTestCase {
+				owners = append(owners, fmt.Sprintf("%s (%s)", owner, scenario.Name()))
+			} else {
+				owners = append(owners, owner)
+			}
 		}
 	}
 	return owners, nil


### PR DESCRIPTION
The first half of this PR is just tidying up the codeowners logic to move it
into its own package for better reuse elsewhere in the CLI.

The second half reworks the way that codeowners are emitted into the junit
files. Previously, code owners for test cases were emitted multiple times
per test case in the following form, once per owner per scenario and once
per owner of the workflow:

    @owner (test-name-or-github-workflow)

This form will continue to be used for the text output in CI runs, but it will
be changed for the junit format that is reported into the CI dashboard.
Following this PR, the workflow owners are instead injected once at the top
'test_suite' node of the junit, which avoids duplication. These are injected
without the test name, since that is available in the parent node. Furthermore,
rather than duplicating the owners properties for each scenario in a test case,
each owner is included just once.

For an alternative visualization, inspect the following example junit diff,
generated via:

    export GITHUB_WORKFLOW_REF=cilium/cilium/.github/workflows/conformance-kind-proxy-embedded.yaml@refs/pull/37593/merge
    ./cilium-cli/cilium connectivity test --log-code-owners --test no-errors-in-logs --junit-file junit_results.xml

```
--- junit_results.xml.old       2025-04-17 16:04:31.786164160 -0700
+++ junit_results.xml.new       2025-04-17 16:03:56.614366718 -0700
@@ -1,1104 +1,741 @@
 <?xml version="1.0" encoding="UTF-8"?>
   <testsuites tests="119" disabled="118" errors="0" failures="1" time="x">
       <testsuite name="connectivity test" id="0" package="cilium" tests="119" errors="0" failures="1" skipped="118" time="x" timestamp="0001-01-01T00:00:00">
           <properties>
               <property name="Args" value="--log-code-owners|--test|no-errors-in-logs|--junit-file|junit_results.xml"></property>
+              <property name="owner" value="@cilium/sig-servicemesh"></property>
+              <property name="owner" value="@cilium/github-sec"></property>
+              <property name="owner" value="@cilium/ci-structure"></property>
           </properties>
           <testcase name="no-unexpected-packet-drops" classname="connectivity test" status="skipped" time="0">
               <properties>
-                  <property name="owner" value="@cilium/ci-structure (.github/workflows/conformance-kind-proxy-embedded.yaml)"></property>
-                  <property name="owner" value="@cilium/github-sec (.github/workflows/conformance-kind-proxy-embedded.yaml)"></property>
-                  <property name="owner" value="@cilium/sig-agent (no-unexpected-packet-drops)"></property>
-                  <property name="owner" value="@cilium/sig-datapath (no-unexpected-packet-drops)"></property>
-                  <property name="owner" value="@cilium/sig-servicemesh (.github/workflows/conformance-kind-proxy-embedded.yaml)"></property>
+                  <property name="owner" value="@cilium/sig-agent"></property>
+                  <property name="owner" value="@cilium/sig-datapath"></property>
               </properties>
               <skipped message="no-unexpected-packet-drops skipped"></skipped>
           </testcase>
           ...
```

Note that this example only shows the diff for the top of the file; every test case would have the equivalent of the latter hunk applied, dropping the github owners and simplifying the individual owners for the test case.