### PR TITLE
gateway-api: Fix GRPCRoute status not being displayed correctly

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -541,7 +541,17 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 		}
 
 		if !isValid {
-			conds = append(conds, gatewayListenerInvalidRouteKinds(gw, "Invalid Route Kinds"))
+			conds = append(conds,
+				gatewayListenerProgrammedCondition(gw, false, "Listener not valid"),
+				gatewayListenerAcceptedCondition(gw, false, "Listener not valid"),
+				metav1.Condition{
+					Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+					Status:             metav1.ConditionFalse,
+					Reason:             "InvalidRouteKinds",
+					Message:            "Invalid Route Kinds",
+					ObservedGeneration: gw.GetGeneration(),
+					LastTransitionTime: metav1.Now(),
+				})
 		} else {
 			conds = append(conds,
 				gatewayListenerProgrammedCondition(gw, true, "Listener Programmed"),

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -471,7 +471,7 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 
 	for _, l := range gw.Spec.Listeners {
 		allSupported := getSupportedRouteKinds(l.Protocol)
-		supportedKinds := []gatewayv1.RouteGroupKind{}
+		var supportedKinds []gatewayv1.RouteGroupKind
 		isValid := true
 
 		if l.AllowedRoutes != nil && len(l.AllowedRoutes.Kinds) > 0 {
@@ -551,6 +551,7 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 					Status:             metav1.ConditionTrue,
 					Reason:             string(gatewayv1.ListenerReasonResolvedRefs),
 					Message:            "Resolved Refs",
+					ObservedGeneration: gw.GetGeneration(),
 					LastTransitionTime: metav1.Now(),
 				})
 		}

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -542,7 +542,7 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 
 		if !isValid {
 			conds = append(conds,
-				gatewayListenerProgrammedCondition(gw, false, "Listener not valid"),
+				gatewayListenerInvalidRouteKinds(gw, "Invalid Route Kinds"),
 				gatewayListenerAcceptedCondition(gw, false, "Listener not valid"),
 				metav1.Condition{
 					Type:               string(gatewayv1.ListenerConditionResolvedRefs),

--- a/operator/pkg/gateway-api/gateway_status.go
+++ b/operator/pkg/gateway-api/gateway_status.go
@@ -101,7 +101,7 @@ func gatewayListenerProgrammedCondition(gw *gatewayv1.Gateway, ready bool, msg s
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: gw.GetGeneration(),
 			LastTransitionTime: metav1.NewTime(time.Now()),
-			Reason:             string(gatewayv1.ListenerConditionProgrammed),
+			Reason:             string(gatewayv1.ListenerReasonProgrammed),
 			Message:            msg,
 		}
 	default:
@@ -124,7 +124,7 @@ func gatewayListenerAcceptedCondition(gw *gatewayv1.Gateway, ready bool, msg str
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: gw.GetGeneration(),
 			LastTransitionTime: metav1.NewTime(time.Now()),
-			Reason:             string(gatewayv1.ListenerConditionAccepted),
+			Reason:             string(gatewayv1.ListenerReasonAccepted),
 			Message:            msg,
 		}
 	default:

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -48,13 +48,6 @@ func ObjectNamePtr(name string) *gatewayv1.ObjectName {
 	return &objectName
 }
 
-func groupDerefOr(group *gatewayv1.Group, defaultGroup string) string {
-	if group != nil && *group != "" {
-		return string(*group)
-	}
-	return defaultGroup
-}
-
 // isAllowed returns true if the provided Route is allowed to attach to given gateway
 func isAllowed(ctx context.Context, c client.Client, gw *gatewayv1.Gateway, route metav1.Object, logger *slog.Logger) bool {
 	for _, listener := range gw.Spec.Listeners {
@@ -172,7 +165,7 @@ func getSupportedRouteKinds(protocol gatewayv1.ProtocolType) []gatewayv1.RouteGr
 			},
 		}
 	default:
-		return []gatewayv1.RouteGroupKind{}
+		return nil
 	}
 }
 

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -48,6 +48,13 @@ func ObjectNamePtr(name string) *gatewayv1.ObjectName {
 	return &objectName
 }
 
+func groupDerefOr(group *gatewayv1.Group, defaultGroup string) string {
+	if group != nil && *group != "" {
+		return string(*group)
+	}
+	return defaultGroup
+}
+
 // isAllowed returns true if the provided Route is allowed to attach to given gateway
 func isAllowed(ctx context.Context, c client.Client, gw *gatewayv1.Gateway, route metav1.Object, logger *slog.Logger) bool {
 	for _, listener := range gw.Spec.Listeners {


### PR DESCRIPTION
## Summary

This PR enables support for `GRPCRoute` attachment to `Gateway` listeners using the `HTTP` or `HTTPS` protocol in Cilium's Gateway API implementation.

## Description

Previously, Cilium did not properly support `GRPCRoute` resources — while traffic could be routed if configured manually, listeners on a `Gateway` would not register these routes as attached, and `kubectl describe gateway` would not show them under `Supported Kinds` or `Attached Routes`.

This change introduces the necessary wiring to support `GRPCRoute`:

- Registers `GRPCRoute` into the runtime scheme
- Updates the controller logic to support `GRPCRoute` as a valid kind for `HTTP` and `HTTPS` protocols
- Adds filtering and route attachment logic for `GRPCRoute`
- Ensures listener status is correctly populated with GRPCRoute data

## Problem

Even though `GRPCRoute` is a valid Gateway API object and often used with Envoy-based L7 load balancing, Cilium’s Gateway controller did not consider it for attachment or status reflection, causing:

- `Attached Routes: 0` when a `GRPCRoute` was attached
- `Supported Kinds` only showing `HTTPRoute`
- Inconsistent observability and diagnostics

## Solution

This PR includes:

- `gatewayv1.AddToScheme()` to explicitly register `GRPCRoute`
- Modifications in `setListenerStatus()` to:
  - Include GRPCRoutes in `supportedKinds`
  - Count attached GRPCRoutes
- Addition of `filterGRPCRoutesByListener()` to select matching GRPCRoutes for each listener
- Enhanced `getSupportedRouteKinds()` to return both `HTTPRoute` and `GRPCRoute` for HTTP/HTTPS listeners

## How to test

1. Deploy the patched operator image.
2. Create a `Gateway` with a listener of protocol `HTTP` or `HTTPS`.
3. Create a valid `GRPCRoute` that attaches to the Gateway.
4. Run:

   ```bash
   kubectl describe gateway <your-gateway-name>
   ```

5. Confirm:
   - `Attached Routes` is incremented
   - `Supported Kinds` includes `GRPCRoute`
   - gRPC traffic is routed correctly

## Notes

- This implementation is compatible with the current Gateway API spec
- Backward compatible with existing `HTTPRoute`, `TLSRoute`, etc.
- Further testing in CI environments may be warranted

## Related Issues

Fixes: https://github.com/cilium/cilium/issues/39021

