### PR TITLE
Run preflight checks before cilium update

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -370,6 +370,50 @@ jobs:
       - name: Start conn-disrupt-test
         uses: ./.github/actions/conn-disrupt-test-setup
 
+      - name: Running pre-flight check
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        shell: bash
+        run: |
+          # Running pre-flight check
+          helm template './untrusted/cilium-newest/install/kubernetes/cilium' \
+            --namespace=kube-system \
+            --set preflight.enabled=true \
+            --set agent=false \
+            --set operator.enabled=false \
+            > cilium-preflight.yaml
+          kubectl create -f cilium-preflight.yaml
+          # After applying the cilium-preflight.yaml,
+          # ensure that the number of READY pods is the same number of Cilium pods running.
+          daemonsetPreflight="fail"
+          iterations=0
+          while [ $iterations -lt 300 ]; do
+              readyNum=$(kubectl get daemonset cilium -n kube-system -o jsonpath={.status.numberReady})
+              preflightNum=$(kubectl get daemonset cilium-pre-flight-check -n kube-system -o jsonpath={.status.numberReady})
+              if [[ "$readyNum" == "$preflightNum" ]]; then
+                  daemonsetPreflight="success"
+                  break
+              fi
+              let iterations++
+              sleep 0.3
+          done
+          # Once the number of READY pods are equal,
+          # make sure the Cilium pre-flight deployment is also marked as READY 1/1.
+          deploymentPreflight="fail"
+          iterations=0
+          while [ $iterations -lt 300 ]; do
+              availNum=$(kubectl get deployment cilium-pre-flight-check -n kube-system -o jsonpath={.status.availableReplicas})
+              readyNum=$(kubectl get deployment cilium-pre-flight-check -n kube-system -o jsonpath={.status.readyReplicas})
+              if [[ "$availNum" == "$readyNum" ]]; then
+                  deploymentPreflight="success"
+                  break
+              fi
+              let iterations++
+              sleep 0.3
+          done
+          # Clean up pre-flight check
+          kubectl delete -f cilium-preflight.yaml
+          [[ "$daemonsetPreflight" == "success" && "$deploymentPreflight" == "success"]]
+
       - name: Upgrade Cilium
         if: ${{ matrix.skip-upgrade != 'true' }}
         shell: bash

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -5,11 +5,11 @@ metadata:
   name: cilium-pre-flight-check
   namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.preflight.annotations }}
-  {{- with .Values.commonLabels }}
-  labels:
+  annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  annotations:
+  {{- with .Values.commonLabels }}
+  labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -19,11 +19,11 @@ spec:
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      {{- with .Values.preflight.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
         kubectl.kubernetes.io/default-container: cilium-pre-flight-check
+        {{- with .Values.preflight.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         app.kubernetes.io/part-of: cilium
         k8s-app: cilium-pre-flight-check


### PR DESCRIPTION
Fix preflight yaml template.
The annotations: field is always present; this fix avoids broken indentation.


<!-- Description of change -->

Fixes: #38418

```release-note
Run preflight checks before cilium update,
The annotations: field is always present; this fix avoids broken indentation.
```
