### PR TITLE
ipsec,ci: enable conn disrupt north-south for ipsec traffic

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1315,8 +1315,7 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 	return ct.params.IncludeConnDisruptTestNSTraffic &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&
 		(ct.Params().MultiCluster == "" || ct.Features[features.KPRNodePort].Enabled) &&
-		!ct.Features[features.KPRNodePortAcceleration].Enabled &&
-		(!ct.Features[features.IPsecEnabled].Enabled || !ct.Features[features.KPRNodePort].Enabled)
+		!ct.Features[features.KPRNodePortAcceleration].Enabled
 }
 
 func (ct *ConnectivityTest) ShouldRunConnDisruptEgressGateway() bool {


### PR DESCRIPTION
Enable the connection disruption tests for north-south traffic for IPsec upgrade tests.

This commit potentially introduces the flake outlined in #37540 again, for further debugging.

Fixes: #37540

```release-note
ipsec: fix connection disruption issue for ipv6 ipsec upgrade scenarios. 
```
