### PR TITLE
health: fix health endpoint cleanup

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1797,7 +1797,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 
 	bootstrapStats.healthCheck.Start()
 	if option.Config.EnableHealthChecking {
-		if err := d.ciliumHealth.Init(d.ctx, d.healthEndpointRouting); err != nil {
+		if err := d.ciliumHealth.Init(d.ctx, d.healthEndpointRouting, cleaner.cleanupFuncs.Add); err != nil {
 			return fmt.Errorf("failed to initialize cilium health: %w", err)
 		}
 	}

--- a/pkg/health/health_manager.go
+++ b/pkg/health/health_manager.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	controllerInterval    = 60 * time.Second
-	successfulPingTimeout = 3 * time.Minute
+	successfulPingTimeout = 5 * time.Minute
 )
 
 // Cell provides the Cilium health infrastructure that is responsible for


### PR DESCRIPTION
With PR #38847 the healthmanager cell uses a Hive Lifecycle stop hook to cleanup the health endpoint when the agent shuts down. Having this no longer triggered by the daemon cleanup funcs, leads to the following warning at shutdown.

```
time=2025-04-18T05:16:27Z level=warn source=/go/src/github.com/cilium/cilium/pkg/health/health_manager.go:203 msg="Ignoring error while deleting Cilium health endpoint" module=agent.controlplane.cilium-health error="Unable to delete key 10.244.0.155:0 from /sys/fs/bpf/tc/globals/cilium_lxc: unable to delete element 10.244.0.155:0 from map cilium_lxc: delete: key does not exist" (2 occurrences)
```

To prevent this warning, this commit temporarily reverts this specific change and uses the daemon cleanupfuncs again - instead of reverting the complete (and follow up) PRs.