### PR TITLE
egress-gateway: Add IPv6 support

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -303,16 +303,19 @@ communicating via the proxy must reconnect to re-establish connections.
   to ``apiVersion: cilium.io/v2`` for all ``CiliumCIDRGroup`` resources.
 * The check for connectivity to the Kubernetes apiserver has been removed from the cilium-agent liveness probe. This can be turned back on
   by setting the helm option ``livenessProbe.requireK8sConnectivity`` to ``true``.
-* The label ``io.cilium.k8s.policy.serviceaccount`` will be included in the default label list. If you configure your own identity-relevant labels 
-  on your cluster, the number of identities will temporarily increase during the upgrade, which will result in increased drops. If you would like 
-  to disable this new behavior, you can add ``!io\.cilium\.k8s\.policy\.serviceaccount`` to your identity-relevant labels to 
+* The label ``io.cilium.k8s.policy.serviceaccount`` will be included in the default label list. If you configure your own identity-relevant labels
+  on your cluster, the number of identities will temporarily increase during the upgrade, which will result in increased drops. If you would like
+  to disable this new behavior, you can add ``!io\.cilium\.k8s\.policy\.serviceaccount`` to your identity-relevant labels to
   exclude the ``io.cilium.k8s.policy.serviceaccount`` label.
 * If using IPsec encryption the upgrade from v1.17 to v1.18 requires special attention.
   Please reference :ref:`encryption_ipsec`.
 * The Helm value of ``enableIPv4Masquerade`` in ``eni`` mode changes from ``true`` to ``false`` by default from 1.18.
   To keep the ``enableIPv4Masquerade`` enabled, explicitly set the value for
   this option to ``true``, or use a value strictly lower than 1.18 for
-  ``upgradeCompatibility``.  
+  ``upgradeCompatibility``.
+* The ``--enable-ipv4-egress-gateway`` flag has been deprecated in favor of the new ``--enable-egress-gateway`` flag.
+  The new flag enables egress gateway functionality for both IPv4 and IPv6, while the old flag only supported IPv4.
+  The old flag will continue to work for backward compatibility but will be removed in a future release.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -668,8 +668,12 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableIPMasqAgent, false, "Enable BPF ip-masq-agent")
 	option.BindEnv(vp, option.EnableIPMasqAgent)
 
-	flags.Bool(option.EnableIPv4EgressGateway, false, "Enable egress gateway for IPv4")
+	flags.Bool(option.EnableIPv4EgressGateway, false, "Enable egress gateway for IPv4 (deprecated, use enable-egress-gateway instead)")
+	flags.MarkDeprecated(option.EnableIPv4EgressGateway, fmt.Sprintf("Please use --%s instead", option.EnableEgressGateway))
 	option.BindEnv(vp, option.EnableIPv4EgressGateway)
+
+	flags.Bool(option.EnableEgressGateway, false, "Enable egress gateway for both IPv4 and IPv6")
+	option.BindEnv(vp, option.EnableEgressGateway)
 
 	flags.Bool(option.EnableEnvoyConfig, false, "Enable Envoy Config CRDs")
 	option.BindEnv(vp, option.EnableEnvoyConfig)

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -181,11 +181,18 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(logger *slog.Logger, gc 
 	case gc.egressIP.IsValid():
 		// If the gateway config specifies an egress IP, use the interface with that IP as egress
 		// interface.
-		// TODO: add ipv6 support for specifying an egress IP, currently only ipv4 is supported.
-		gwc.egressIP4 = gc.egressIP
-		gwc.ifaceName, err = netdevice.GetIfaceWithIPv4Address(gc.egressIP)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve interface with egress IP: %w", err)
+		if gc.egressIP.Is4() {
+			gwc.egressIP4 = gc.egressIP
+			gwc.ifaceName, err = netdevice.GetIfaceWithIPv4Address(gc.egressIP)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve interface with IPv4 egress IP: %w", err)
+			}
+		} else if gc.egressIP.Is6() {
+			gwc.egressIP6 = gc.egressIP
+			gwc.ifaceName, err = netdevice.GetIfaceWithIPv6Address(gc.egressIP)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve interface with IPv6 egress IP: %w", err)
+			}
 		}
 
 	default:
@@ -356,6 +363,28 @@ func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {
 				api.NewESFromK8sLabelSelector("", egressRule.PodSelector))
 		} else {
 			return nil, fmt.Errorf("cannot have both nil namespace selector and nil pod selector")
+		}
+	}
+
+	// Check for mismatched IP families
+	if policyGwc.egressIP.IsValid() {
+		hasIPv4Dest := false
+		hasIPv6Dest := false
+
+		for _, cidr := range dstCidrList {
+			if cidr.Addr().Is4() {
+				hasIPv4Dest = true
+			} else if cidr.Addr().Is6() {
+				hasIPv6Dest = true
+			}
+		}
+
+		if policyGwc.egressIP.Is4() && !hasIPv4Dest && hasIPv6Dest {
+			return nil, fmt.Errorf("mismatched IP families: IPv4 egress IP with IPv6 destination CIDRs")
+		}
+
+		if policyGwc.egressIP.Is6() && !hasIPv6Dest && hasIPv4Dest {
+			return nil, fmt.Errorf("mismatched IP families: IPv6 egress IP with IPv4 destination CIDRs")
 		}
 	}
 

--- a/pkg/egressgateway/policy_ipv6_test.go
+++ b/pkg/egressgateway/policy_ipv6_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package egressgateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestIPv6Support(t *testing.T) {
+	// Test that a policy with IPv6 destination CIDRs is correctly parsed
+	policy := &v2.CiliumEgressGatewayPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ipv6-policy",
+		},
+		Spec: v2.CiliumEgressGatewayPolicySpec{
+			Selectors: []v2.EgressRule{
+				{
+					PodSelector: &slimv1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+			DestinationCIDRs: []v2.CIDR{
+				"2001:db8::/32",
+			},
+			EgressGateway: &v2.EgressGateway{
+				NodeSelector: &slimv1.LabelSelector{
+					MatchLabels: map[string]string{
+						"node-role.kubernetes.io/gateway": "true",
+					},
+				},
+				Interface: "eth0",
+			},
+		},
+	}
+
+	// Parse the policy
+	config, err := ParseCEGP(policy)
+
+	// We expect no error
+	assert.NoError(t, err)
+
+	// Check that v6needed is set to true
+	assert.True(t, config.policyGwConfig.v6needed)
+
+	// Test that a policy with IPv6 egress IP is correctly parsed
+	policy = &v2.CiliumEgressGatewayPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ipv6-egress-ip-policy",
+		},
+		Spec: v2.CiliumEgressGatewayPolicySpec{
+			Selectors: []v2.EgressRule{
+				{
+					PodSelector: &slimv1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+			DestinationCIDRs: []v2.CIDR{
+				"2001:db8::/32",
+			},
+			EgressGateway: &v2.EgressGateway{
+				NodeSelector: &slimv1.LabelSelector{
+					MatchLabels: map[string]string{
+						"node-role.kubernetes.io/gateway": "true",
+					},
+				},
+				EgressIP: "2001:db8::1",
+			},
+		},
+	}
+
+	// Parse the policy
+	config, err = ParseCEGP(policy)
+
+	// We expect no error
+	assert.NoError(t, err)
+
+	// Check that v6needed is set to true
+	assert.True(t, config.policyGwConfig.v6needed)
+
+	// Check that the egress IP is correctly parsed
+	assert.True(t, config.policyGwConfig.egressIP.Is6())
+}
+
+func TestMismatchedIPFamilies(t *testing.T) {
+	// Test that a policy with mismatched IP families (IPv6 egress IP with IPv4 destination CIDRs) is rejected
+	policy := &v2.CiliumEgressGatewayPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-mismatched-policy",
+		},
+		Spec: v2.CiliumEgressGatewayPolicySpec{
+			Selectors: []v2.EgressRule{
+				{
+					PodSelector: &slimv1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+			DestinationCIDRs: []v2.CIDR{
+				"192.168.0.0/16",
+			},
+			EgressGateway: &v2.EgressGateway{
+				NodeSelector: &slimv1.LabelSelector{
+					MatchLabels: map[string]string{
+						"node-role.kubernetes.io/gateway": "true",
+					},
+				},
+				EgressIP: "2001:db8::1",
+			},
+		},
+	}
+
+	// Parse the policy
+	_, err := ParseCEGP(policy)
+
+	// We expect an error because the IP families don't match
+	assert.Error(t, err)
+
+	// The error should mention mismatched IP families
+	assert.Contains(t, err.Error(), "mismatched IP families")
+}

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
@@ -69,9 +69,9 @@ spec:
                       with IP address 192.168.1.100.
 
                       When none of the Interface or EgressIP fields is specified, the
-                      policy will use the first IPv4 assigned to the interface with the
+                      policy will use the first IP address (IPv4 or IPv6 depending on the destination CIDR) assigned to the interface with the
                       default route.
-                    format: ipv4
+                    format: ip
                     type: string
                   interface:
                     description: |-
@@ -80,11 +80,11 @@ spec:
 
                       Example:
                       When set to "eth1", matching egress traffic will be redirected to the
-                      node matching the NodeSelector field and SNATed with the first IPv4
-                      address assigned to the eth1 interface.
+                      node matching the NodeSelector field and SNATed with the first IP address (IPv4 or IPv6 depending on the destination CIDR)
+                      assigned to the eth1 interface.
 
                       When none of the Interface or EgressIP fields is specified, the
-                      policy will use the first IPv4 assigned to the interface with the
+                      policy will use the first IP address (IPv4 or IPv6 depending on the destination CIDR) assigned to the interface with the
                       default route.
                     type: string
                   nodeSelector:

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -364,8 +364,11 @@ const (
 	// EnableIPMasqAgent enables BPF ip-masq-agent
 	EnableIPMasqAgent = "enable-ip-masq-agent"
 
-	// EnableIPv4EgressGateway enables the IPv4 egress gateway
+	// EnableIPv4EgressGateway enables the IPv4 egress gateway (deprecated, use EnableEgressGateway instead)
 	EnableIPv4EgressGateway = "enable-ipv4-egress-gateway"
+
+	// EnableEgressGateway enables the egress gateway for both IPv4 and IPv6
+	EnableEgressGateway = "enable-egress-gateway"
 
 	// EnableEnvoyConfig enables processing of CiliumClusterwideEnvoyConfig and CiliumEnvoyConfig CRDs
 	EnableEnvoyConfig = "enable-envoy-config"
@@ -1671,6 +1674,7 @@ type DaemonConfig struct {
 
 	EnableBPFClockProbe     bool
 	EnableIPv4EgressGateway bool
+	EnableEgressGateway     bool
 	EnableEnvoyConfig       bool
 	InstallIptRules         bool
 	MonitorAggregation      string


### PR DESCRIPTION
# egress-gateway: Add IPv6 support

## Description
This PR adds IPv6 support to the egress gateway feature by introducing a new `--enable-egress-gateway` flag that enables egress gateway functionality for both IPv4 and IPv6. The existing `--enable-ipv4-egress-gateway` flag is marked as deprecated but still functional for backward compatibility.

## Changes
- Add a new `--enable-egress-gateway` flag that enables egress gateway for both IPv4 and IPv6
- Properly mark the old flag as deprecated using `flags.MarkDeprecated`
- Update the validation format for EgressIP from ipv4 to ip to support both IPv4 and IPv6 addresses
- Update documentation to remove unnecessary IPv6 examples and comments
- Update command reference documentation
- Simplify example file

## Testing
- Ran unit tests for the affected packages
- Verified that both flags can be set in the DaemonConfig struct
- Ran `make -C Documentation update-cmdref` to update the command reference

## Related Issues
Fixes #38957
Fixes #38962

```release-note
Add a new `--enable-egress-gateway` flag that enables egress gateway for both IPv4 and IPv6, deprecating the IPv4-only `--enable-ipv4-egress-gateway` flag.