### PR TITLE
bpf: lb: simplify punt-to-proxy path

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1110,12 +1110,10 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 
 	ipv6_addr_copy(&tuple->daddr, &backend->address);
 
-	if (lb6_svc_is_l7_punt_proxy(svc)) {
-		if (__lookup_ip6_endpoint(&backend->address)) {
-			ctx_skip_nodeport_set(ctx);
-			ret = LB_PUNT_TO_STACK;
-			goto drop_err;
-		}
+	if (lb6_svc_is_l7_punt_proxy(svc) &&
+	    __lookup_ip6_endpoint(&backend->address)) {
+		ctx_skip_nodeport_set(ctx);
+		return LB_PUNT_TO_STACK;
 	}
 	if (skip_xlate)
 		return CTX_ACT_OK;
@@ -1899,12 +1897,10 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 #endif
 		tuple->daddr = backend->address;
 
-	if (lb4_svc_is_l7_punt_proxy(svc)) {
-		if (__lookup_ip4_endpoint(backend->address)) {
-			ctx_skip_nodeport_set(ctx);
-			ret = LB_PUNT_TO_STACK;
-			goto drop_err;
-		}
+	if (lb4_svc_is_l7_punt_proxy(svc) &&
+	    __lookup_ip4_endpoint(backend->address)) {
+		ctx_skip_nodeport_set(ctx);
+		return LB_PUNT_TO_STACK;
 	}
 	if (skip_xlate)
 		return CTX_ACT_OK;


### PR DESCRIPTION
No need to exit via the `drop_err` path, the tuple->flags have already been restored at this point. This matches the `return` statement right below.

Also reduce the indentation by one level.