### PR TITLE
Support KPR with IPv6 underlay

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -19,6 +19,9 @@ inputs:
   ipv6:
     description: 'Enable IPv6'
     default: 'true'
+  underlay:
+    description: 'Underlay protocol for the VXLAN or GENEVE tunnels'
+    default: 'ipv4'
   kpr:
     description: 'Enable kube-proxy replacement'
     default: 'false'
@@ -137,6 +140,9 @@ runs:
           IPV6=""
           if [ "${{ inputs.ipv6 }}" != "false" ]; then
             IPV6="--helm-set=ipv6.enabled=true"
+            if [ "${{ inputs.underlay }}" == "ipv6" ]; then
+              IPV6+=" --helm-set=underlayProtocol=ipv6"
+            fi
           fi
 
           MASQ=""

--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -363,5 +363,6 @@
   kpr: 'false'
   ipv6: 'true'
   ipv4: 'false'
-  tunnel: 'disabled'
+  tunnel: 'vxlan'
+  underlay: 'ipv6'
   skip-upgrade: 'true'

--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -359,8 +359,8 @@
 - name: '32'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.15-20250424.080122'
-  kube-proxy: 'iptables'
-  kpr: 'false'
+  kube-proxy: 'none'
+  kpr: 'true'
   ipv6: 'true'
   ipv4: 'false'
   tunnel: 'vxlan'

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -199,6 +199,7 @@ jobs:
           endpoint-routes: ${{ matrix.endpoint-routes }}
           ipv4: ${{ matrix.ipv4 }}
           ipv6: ${{ matrix.ipv6 }}
+          underlay: ${{ matrix.underlay }}
           kpr: ${{ matrix.kpr }}
           lb-mode: ${{ matrix.lb-mode }}
           lb-acceleration: ${{ matrix.lb-acceleration }}
@@ -225,6 +226,7 @@ jobs:
           endpoint-routes: ${{ matrix.endpoint-routes }}
           ipv4: ${{ matrix.ipv4 }}
           ipv6: ${{ matrix.ipv6 }}
+          underlay: ${{ matrix.underlay }}
           kpr: ${{ matrix.kpr }}
           lb-mode: ${{ matrix.lb-mode }}
           lb-acceleration: ${{ matrix.lb-acceleration }}

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -433,19 +433,17 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 }
 
 static __always_inline
-bool egress_gw_reply_needs_redirect_hook_v6(struct ipv6hdr *ip6, __u32 *tunnel_endpoint,
-					    __u32 *dst_sec_identity)
+bool egress_gw_reply_needs_redirect_hook_v6(struct ipv6hdr *ip6,
+					    struct remote_endpoint_info **info)
 {
 	if (egress_gw_reply_matches_policy_v6(ip6)) {
-		struct remote_endpoint_info *info;
+		struct remote_endpoint_info *egw_info;
 
-		info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
-		if (!info || info->tunnel_endpoint.ip4 == 0)
+		egw_info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
+		if (!egw_info || egw_info->tunnel_endpoint.ip4 == 0)
 			return false;
 
-		*tunnel_endpoint = info->tunnel_endpoint.ip4;
-		*dst_sec_identity = info->sec_identity;
-
+		*info = egw_info;
 		return true;
 	}
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -125,9 +125,9 @@ nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_p
 			return ret;
 	}
 
-	return __encap_with_nodeid_opt(ctx, src_ip, src_port, dst_ip,
-				       src_sec_identity, dst_sec_identity, NOT_VTEP_DST,
-				       opt, opt_len, ct_reason, monitor, ifindex);
+	return __encap_with_nodeid_opt4(ctx, src_ip, src_port, dst_ip,
+					src_sec_identity, dst_sec_identity, NOT_VTEP_DST,
+					opt, opt_len, ct_reason, monitor, ifindex);
 }
 # endif
 #endif /* HAVE_ENCAP */

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -310,7 +310,7 @@ ctx_set_encap_info4(struct __sk_buff *ctx, __u32 src_ip,
 
 static __always_inline __maybe_unused int
 ctx_set_encap_info6(struct __sk_buff *ctx, const union v6addr *tunnel_endpoint,
-		    __u32 seclabel)
+		    __u32 seclabel, void *opt, __u32 opt_len)
 {
 	struct bpf_tunnel_key key = {};
 	__u32 key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
@@ -326,6 +326,12 @@ ctx_set_encap_info6(struct __sk_buff *ctx, const union v6addr *tunnel_endpoint,
 	ret = ctx_set_tunnel_key(ctx, &key, key_size, BPF_F_TUNINFO_IPV6);
 	if (unlikely(ret < 0))
 		return DROP_WRITE_ERROR;
+
+	if (opt && opt_len > 0) {
+		ret = ctx_set_tunnel_opt(ctx, opt, opt_len);
+		if (unlikely(ret < 0))
+			return DROP_WRITE_ERROR;
+	}
 
 	return CTX_ACT_REDIRECT;
 }

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -253,7 +253,8 @@ ctx_set_encap_info4(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 static __always_inline __maybe_unused int
 ctx_set_encap_info6(struct xdp_md *ctx __maybe_unused,
 		    const union v6addr *tunnel_endpoint __maybe_unused,
-		    __u32 seclabel __maybe_unused)
+		    __u32 seclabel __maybe_unused, void *opt __maybe_unused,
+		    __u32 opt_len __maybe_unused)
 {
 	return 0;
 }

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -150,8 +150,9 @@ func initKubeProxyReplacementOptions(sysctl sysctl.Sysctl, tunnelConfig tunnel.C
 			log.Warning("NodePort BPF configured without bind(2) protection against service ports")
 		}
 
-		if option.Config.TunnelingEnabled() && tunnelConfig.UnderlayProtocol() == tunnel.IPv6 {
-			return fmt.Errorf("BPF NodePort cannot be used over an IPv6 underlay")
+		if option.Config.TunnelingEnabled() && tunnelConfig.UnderlayProtocol() == tunnel.IPv6 &&
+			option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
+			return fmt.Errorf("XDP acceleration cannot be used with an IPv6 underlay")
 		}
 
 		if option.Config.TunnelingEnabled() && tunnelConfig.EncapProtocol() == tunnel.VXLAN &&


### PR DESCRIPTION
This pull request adds support for KPR when running with an IPv6 underlay. The first commit introduces an IPv6 version of the encapsulation function. The second commit performs some refactoring to ease readability of subsequent commits. The third commit removes a function argument that became unnecessary thanks to the previous commit. The fourth commit adds the support in the datapath. Fifth and last commit enable this in the agent and cover it in the CI.

```release-note
Add support for kube-proxy replacement with IPv6 underlay
```