### PR TITLE
Envoy: ignore explicit listener rules on other listeners

### DIFF
--- a/images/scripts/update-cilium-envoy-image.sh
+++ b/images/scripts/update-cilium-envoy-image.sh
@@ -18,13 +18,15 @@ latest_commit_sha="$(curl -s https://api.github.com/repos/"${github_repo}"/commi
 
 repo="cilium-envoy"
 image="quay.io/cilium/cilium-envoy"
+filter="select(.name | test(\".*-.*-.*\"))"
 if [ "${github_branch}" != "main" ] && ! [[ "${github_branch}" =~ ^v1\.[0-9]+$ ]]; then
     image="quay.io/cilium/cilium-envoy-dev"
     repo="cilium-envoy-dev"
+    filter="select(.name)"
 fi
 
 # Filter all tags that are in the format of .*-.*-.* (e.g. v1.33.2-1742995211-ca0b42f0ecdf835224a8ddfc6fe0442368d4d766)
-tags=$(curl -s "https://quay.io/api/v1/repository/cilium/${repo}/tag/?onlyActiveTags=true&filter_tag_name=like:${latest_commit_sha}" | jq -r '.tags[] | select(.name | test(".*-.*-.*"))')
+tags=$(curl -s "https://quay.io/api/v1/repository/cilium/${repo}/tag/?onlyActiveTags=true&filter_tag_name=like:${latest_commit_sha}" | jq -r ".tags[] | ${filter}")
 image_tag=$(echo "${tags}" | jq -r .name)
 image_sha256=$(echo "${tags}" | jq -r .manifest_digest)
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1631,6 +1631,10 @@ func (e *Endpoint) GetPolicyVersionHandle() *versioned.VersionHandle {
 	return nil
 }
 
+func (e *Endpoint) GetListenerProxyPort(listener string) uint16 {
+	return e.proxy.GetListenerProxyPort(listener)
+}
+
 // getProxyStatistics gets the ProxyStatistics for the flows with the
 // given characteristics, or adds a new one and returns it.
 func (e *Endpoint) getProxyStatistics(key string, l7Protocol string, port uint16, ingress bool, redirectPort uint16) *models.ProxyStatistics {

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -22,6 +22,7 @@ type EndpointProxy interface {
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
+	GetListenerProxyPort(listener string) uint16
 }
 
 func (e *Endpoint) removeNetworkPolicy() {
@@ -60,4 +61,9 @@ func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, pol
 func (f *FakeEndpointProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {}
 
 func (f *FakeEndpointProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+}
+
+// GetListenerProxyPort does nothing.
+func (f *FakeEndpointProxy) GetListenerProxyPort(listener string) uint16 {
+	return 0
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -124,6 +124,11 @@ func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
 func (r *RedirectSuiteProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
 }
 
+// GetListenerProxyPort does nothing.
+func (r *RedirectSuiteProxy) GetListenerProxyPort(listener string) uint16 {
+	return 0
+}
+
 // DummyIdentityAllocatorOwner implements
 // pkg/identity/cache/IdentityAllocatorOwner. It is used for unit testing.
 type DummyIdentityAllocatorOwner struct{}

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -533,15 +533,15 @@ func TestGetPortNetworkPolicyRule(t *testing.T) {
 	xds := testXdsServer(t)
 
 	version := versioned.Latest()
-	obtained, canShortCircuit := xds.getPortNetworkPolicyRule(version, cachedSelector1, L7Rules12, false, false, "")
+	obtained, canShortCircuit := xds.getPortNetworkPolicyRule(ep, version, cachedSelector1, L7Rules12, false, false, "")
 	require.Equal(t, ExpectedPortNetworkPolicyRule12, obtained)
 	require.True(t, canShortCircuit)
 
-	obtained, canShortCircuit = xds.getPortNetworkPolicyRule(version, cachedSelector1, L7Rules12HeaderMatch, false, false, "")
+	obtained, canShortCircuit = xds.getPortNetworkPolicyRule(ep, version, cachedSelector1, L7Rules12HeaderMatch, false, false, "")
 	require.Equal(t, ExpectedPortNetworkPolicyRule122HeaderMatch, obtained)
 	require.False(t, canShortCircuit)
 
-	obtained, canShortCircuit = xds.getPortNetworkPolicyRule(version, cachedSelector2, L7Rules1, false, false, "")
+	obtained, canShortCircuit = xds.getPortNetworkPolicyRule(ep, version, cachedSelector2, L7Rules1, false, false, "")
 	require.Equal(t, ExpectedPortNetworkPolicyRule1, obtained)
 	require.True(t, canShortCircuit)
 }

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -37,4 +37,8 @@ type EndpointUpdater interface {
 	// desired policy, if any.
 	// Must be called with Endpoint's read lock taken.
 	GetPolicyVersionHandle() *versioned.VersionHandle
+
+	// GetListenerProxyPort returns the proxy port for the given listener reference.
+	// Returns zero if the proxy port does not exist (yet).
+	GetListenerProxyPort(listener string) uint16
 }

--- a/pkg/proxy/endpoint/test/updater_mock.go
+++ b/pkg/proxy/endpoint/test/updater_mock.go
@@ -48,3 +48,7 @@ func (m *ProxyUpdaterMock) OnDNSPolicyUpdateLocked(rules restore.DNSRules) {}
 func (m *ProxyUpdaterMock) GetPolicyVersionHandle() *versioned.VersionHandle {
 	return m.VersionHandle
 }
+
+func (m *ProxyUpdaterMock) GetListenerProxyPort(listener string) uint16 {
+	return 0
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -116,6 +116,11 @@ func (p *Proxy) GetOpenLocalPorts() map[uint16]struct{} {
 	return p.proxyPorts.GetOpenLocalPorts()
 }
 
+func (p *Proxy) GetListenerProxyPort(listener string) uint16 {
+	proxyPort, _, _ := p.proxyPorts.GetProxyPort(listener)
+	return proxyPort
+}
+
 // CreateOrUpdateRedirect creates or updates a L4 redirect with corresponding
 // proxy configuration. This will allocate a proxy port as required and launch
 // a proxy instance. If the redirect is already in place, only the rules will be


### PR DESCRIPTION
Pass the proxy port of an explicit Listener reference in CNP as a proxy ID and ignore rules with non-zero proxy IDs unless the proxy ID matches the one configured for the Listener handling the connection. This scopes the policy rule containing the explicit Listener reference to only apply on the specific named listener. This way possibly stricter allow rules specified otherwise will not be bypassed due to the laxer allow rule for the specific listener.

```release-note
CNP rule redirecting to a named Listener is now ignored on other Listeners.
```
