### PR TITLE
operator/watchers: Add ServiceCache for operator

### DIFF
--- a/operator/watchers/service_cache.go
+++ b/operator/watchers/service_cache.go
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"log/slog"
+	"net/netip"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/k8s"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// cacheAction is the type of action that was performed on the cache
+type cacheAction int
+
+const (
+	// UpdateService reflects that the service was updated or added
+	UpdateService cacheAction = iota
+
+	// DeleteService reflects that the service was deleted
+	DeleteService
+)
+
+// String returns the cache action as a string
+func (c cacheAction) String() string {
+	switch c {
+	case UpdateService:
+		return "service-updated"
+	case DeleteService:
+		return "service-deleted"
+	default:
+		return "unknown"
+	}
+}
+
+// serviceEvent is emitted via the Events channel of ServiceCache and describes
+// the change that occurred in the cache
+type serviceEvent struct {
+	// Action is the action that was performed in the cache
+	Action cacheAction
+
+	// ID is the identified of the service
+	ID k8s.ServiceID
+
+	// Service is the service structure
+	Service *k8s.Service
+
+	// OldService is the old service structure
+	OldService *k8s.Service
+
+	// Endpoints is the endpoints structured correlated with the service
+	Endpoints *k8s.Endpoints
+
+	// OldEndpoints is old endpoints structure.
+	OldEndpoints *k8s.Endpoints
+
+	// SWGDone marks the event as processed. The underlying StoppableWaitGroup
+	// provides a mechanism to detect if a service was synchronized with
+	// the datapath.
+	SWGDone lock.DoneFunc
+}
+
+type ServiceMutators []func(svc *slim_corev1.Service, svcInfo *k8s.Service)
+
+// serviceCache is a list of services correlated with the matching endpoints.
+// The Events member will receive events as services.
+type serviceCache struct {
+	logger *slog.Logger
+
+	// Events may only be read by single consumer. The consumer must acknowledge
+	// every event by calling Done() on the ServiceEvent.SWG.
+	events     <-chan serviceEvent
+	sendEvents chan<- serviceEvent
+
+	// mutex protects the maps below including the concurrent access of each
+	// value.
+	mutex    lock.RWMutex
+	services map[k8s.ServiceID]*k8s.Service
+	// endpoints maps a service to a map of EndpointSlices. In case the cluster
+	// is still using the v1.Endpoints, the key used in the internal map of
+	// EndpointSlices is the v1.Endpoint name.
+	endpoints map[k8s.ServiceID]*k8s.EndpointSlices
+
+	// externalEndpoints is a list of additional service backends derived from source other than the local cluster
+	externalEndpoints map[k8s.ServiceID]externalEndpoints
+
+	serviceMutators []func(svc *slim_corev1.Service, svcInfo *k8s.Service)
+}
+
+// newServiceCache returns a new ServiceCache
+func newServiceCache(logger *slog.Logger, serviceMutators ServiceMutators) *serviceCache {
+	events := make(chan serviceEvent, option.Config.K8sServiceCacheSize)
+
+	return &serviceCache{
+		logger:            logger,
+		services:          map[k8s.ServiceID]*k8s.Service{},
+		endpoints:         map[k8s.ServiceID]*k8s.EndpointSlices{},
+		externalEndpoints: map[k8s.ServiceID]externalEndpoints{},
+		events:            events,
+		sendEvents:        events,
+		serviceMutators:   serviceMutators,
+	}
+}
+
+func (sc *serviceCache) Events() <-chan serviceEvent {
+	return sc.events
+}
+
+func (s *serviceCache) emitEvent(event serviceEvent) {
+	s.sendEvents <- event
+}
+
+// UpdateService parses a Kubernetes service and adds or updates it in the
+// ServiceCache. Returns the ServiceID unless the Kubernetes service could not
+// be parsed and a bool to indicate whether the service was changed in the
+// cache or not.
+func (s *serviceCache) UpdateService(k8sSvc *slim_corev1.Service, swg *lock.StoppableWaitGroup) k8s.ServiceID {
+	var addrs []netip.Addr
+
+	svcID, newService := k8s.ParseService(s.logger, loadbalancer.DefaultConfig, k8sSvc, addrs)
+	if newService == nil {
+		return svcID
+	}
+
+	for _, mutator := range s.serviceMutators {
+		mutator(k8sSvc, newService)
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	oldService, ok := s.services[svcID]
+	if ok {
+		if oldService.DeepEqual(newService) {
+			return svcID
+		}
+	}
+
+	s.services[svcID] = newService
+
+	// Check if the corresponding Endpoints resource is already available
+	endpoints, serviceReady := s.correlateEndpoints(svcID)
+	if serviceReady {
+		s.emitEvent(serviceEvent{
+			Action:       UpdateService,
+			ID:           svcID,
+			Service:      newService,
+			OldService:   oldService,
+			Endpoints:    endpoints,
+			OldEndpoints: endpoints,
+			SWGDone:      swg.Add(),
+		})
+	}
+
+	return svcID
+}
+
+// DeleteService parses a Kubernetes service and removes it from the
+// ServiceCache
+func (s *serviceCache) DeleteService(k8sSvc *slim_corev1.Service, swg *lock.StoppableWaitGroup) {
+	svcID := k8s.ParseServiceID(k8sSvc)
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	oldService, serviceOK := s.services[svcID]
+	endpoints, _ := s.correlateEndpoints(svcID)
+	delete(s.services, svcID)
+
+	if serviceOK {
+		s.emitEvent(serviceEvent{
+			Action:    DeleteService,
+			ID:        svcID,
+			Service:   oldService,
+			Endpoints: endpoints,
+			SWGDone:   swg.Add(),
+		})
+	}
+}
+
+// UpdateEndpoints parses a Kubernetes endpoints and adds or updates it in the
+// ServiceCache. Returns the ServiceID unless the Kubernetes endpoints could not
+// be parsed and a bool to indicate whether the endpoints was changed in the
+// cache or not.
+func (s *serviceCache) UpdateEndpoints(newEndpoints *k8s.Endpoints, swg *lock.StoppableWaitGroup) (k8s.ServiceID, *k8s.Endpoints) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	esID := newEndpoints.EndpointSliceID
+
+	var oldEPs *k8s.Endpoints
+	eps, ok := s.endpoints[esID.ServiceID]
+	if ok {
+		oldEPs = eps.Get(esID.EndpointSliceName)
+		if oldEPs.DeepEqual(newEndpoints) {
+			return esID.ServiceID, newEndpoints
+		}
+	} else {
+		eps = k8s.NewEndpointsSlices()
+		s.endpoints[esID.ServiceID] = eps
+	}
+
+	eps.Upsert(esID.EndpointSliceName, newEndpoints)
+
+	// Check if the corresponding Endpoints resource is already available
+	svc, ok := s.services[esID.ServiceID]
+	endpoints, serviceReady := s.correlateEndpoints(esID.ServiceID)
+	if ok && serviceReady {
+		s.emitEvent(serviceEvent{
+			Action:       UpdateService,
+			ID:           esID.ServiceID,
+			Service:      svc,
+			Endpoints:    endpoints,
+			OldEndpoints: oldEPs,
+			SWGDone:      swg.Add(),
+		})
+	}
+
+	return esID.ServiceID, endpoints
+}
+
+// DeleteEndpoints parses a Kubernetes endpoints and removes it from the
+// ServiceCache
+func (s *serviceCache) DeleteEndpoints(svcID k8s.EndpointSliceID, swg *lock.StoppableWaitGroup) k8s.ServiceID {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	var oldEPs *k8s.Endpoints
+	svc, serviceOK := s.services[svcID.ServiceID]
+	eps, ok := s.endpoints[svcID.ServiceID]
+	if ok {
+		oldEPs = eps.Get(svcID.EndpointSliceName).DeepCopy() // copy for passing to ServiceEvent
+		isEmpty := eps.Delete(svcID.EndpointSliceName)
+		if isEmpty {
+			delete(s.endpoints, svcID.ServiceID)
+		}
+	}
+	endpoints, _ := s.correlateEndpoints(svcID.ServiceID)
+
+	if serviceOK {
+		event := serviceEvent{
+			Action:       UpdateService,
+			ID:           svcID.ServiceID,
+			Service:      svc,
+			Endpoints:    endpoints,
+			OldEndpoints: oldEPs,
+			SWGDone:      swg.Add(),
+		}
+
+		s.emitEvent(event)
+	}
+
+	return svcID.ServiceID
+}
+
+// correlateEndpoints builds a combined Endpoints of the local endpoints and
+// all external endpoints if the service is marked as a global service. Also
+// returns a boolean that indicates whether the service is ready to be plumbed,
+// this is true if:
+// A local endpoints resource is present. Regardless whether the
+//
+//	endpoints resource contains actual backends or not.
+//
+// OR Remote endpoints exist which correlate to the service.
+func (s *serviceCache) correlateEndpoints(id k8s.ServiceID) (*k8s.Endpoints, bool) {
+	endpoints := s.endpoints[id].GetEndpoints()
+	svc, svcFound := s.services[id]
+
+	hasLocalEndpoints := endpoints != nil
+	if hasLocalEndpoints {
+		for _, e := range endpoints.Backends {
+			// The endpoints returned by GetEndpoints are already deep copies,
+			// hence we can mutate them in-place without problems.
+			e.Preferred = svcFound && svc.IncludeExternal && svc.ServiceAffinity == annotation.ServiceAffinityLocal
+		}
+	} else {
+		endpoints = k8s.NewEndpoints()
+	}
+
+	var hasExternalEndpoints bool
+	if svcFound && svc.IncludeExternal {
+		externalEndpoints, ok := s.externalEndpoints[id]
+		hasExternalEndpoints = ok && len(externalEndpoints.endpoints) > 0
+		if hasExternalEndpoints {
+			// remote cluster endpoints already contain all Endpoints from all
+			// EndpointSlices so no need to search the endpoints of a particular
+			// EndpointSlice.
+			for clusterName, remoteClusterEndpoints := range externalEndpoints.endpoints {
+				for ip, e := range remoteClusterEndpoints.Backends {
+					if _, ok := endpoints.Backends[ip]; ok {
+						s.logger.Warn(
+							"Conflicting service backend IP",
+							logfields.K8sSvcName, id.Name,
+							logfields.K8sNamespace, id.Namespace,
+							logfields.IPAddr, ip,
+							logfields.ClusterName, clusterName,
+						)
+					} else {
+						e.Preferred = svc.ServiceAffinity == annotation.ServiceAffinityRemote
+						endpoints.Backends[ip] = e.DeepCopy()
+					}
+				}
+			}
+		}
+	}
+
+	// Report the service as ready if a local endpoints object exists or if
+	// external endpoints have been identified
+	return endpoints, hasLocalEndpoints || hasExternalEndpoints
+}
+
+// externalEndpoints is the collection of external endpoints in all remote
+// clusters. The map key is the name of the remote cluster.
+type externalEndpoints struct {
+	endpoints map[string]*k8s.Endpoints
+}

--- a/operator/watchers/service_cache_test.go
+++ b/operator/watchers/service_cache_test.go
@@ -1,0 +1,776 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"fmt"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/k8s"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestServiceCacheEndpoints(t *testing.T) {
+	endpoints := k8s.ParseEndpoints(&slim_corev1.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+		Subsets: []slim_corev1.EndpointSubset{
+			{
+				Addresses: []slim_corev1.EndpointAddress{{IP: "2.2.2.2"}},
+				Ports: []slim_corev1.EndpointPort{
+					{
+						Name:     "http-test-svc",
+						Port:     8080,
+						Protocol: slim_corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	})
+
+	updateEndpoints := func(svcCache *serviceCache, swgEps *lock.StoppableWaitGroup) {
+		svcCache.UpdateEndpoints(endpoints, swgEps)
+	}
+	deleteEndpoints := func(svcCache *serviceCache, swgEps *lock.StoppableWaitGroup) {
+		svcCache.DeleteEndpoints(endpoints.EndpointSliceID, swgEps)
+	}
+
+	testServiceCache(t, updateEndpoints, deleteEndpoints)
+}
+
+func TestServiceCacheEndpointSlice(t *testing.T) {
+	endpoints := k8s.ParseEndpointSliceV1(hivetest.Logger(t), &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo-afbh9",
+			Namespace: "bar",
+			Labels: map[string]string{
+				slim_discovery_v1.LabelServiceName: "foo",
+			},
+		},
+		Endpoints: []slim_discovery_v1.Endpoint{
+			{
+				Addresses: []string{
+					"2.2.2.2",
+				},
+			},
+		},
+		Ports: []slim_discovery_v1.EndpointPort{
+			{
+				Name:     func() *string { a := "http-test-svc"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(8080); return &a }(),
+			},
+		},
+	})
+
+	updateEndpoints := func(svcCache *serviceCache, swgEps *lock.StoppableWaitGroup) {
+		svcCache.UpdateEndpoints(endpoints, swgEps)
+	}
+	deleteEndpoints := func(svcCache *serviceCache, swgEps *lock.StoppableWaitGroup) {
+		svcCache.DeleteEndpoints(endpoints.EndpointSliceID, swgEps)
+	}
+
+	testServiceCache(t, updateEndpoints, deleteEndpoints)
+}
+
+func testServiceCache(t *testing.T,
+	updateEndpointsCB, deleteEndpointsCB func(svcCache *serviceCache, swgEps *lock.StoppableWaitGroup)) {
+
+	svcCache := newServiceCache(hivetest.Logger(t), nil)
+
+	k8sSvc := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: slim_corev1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+			Type: slim_corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	swgSvcs := lock.NewStoppableWaitGroup()
+	svcID := svcCache.UpdateService(k8sSvc, swgSvcs)
+
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service event received before endpoints have been imported")
+	default:
+	}
+
+	swgEps := lock.NewStoppableWaitGroup()
+	updateEndpointsCB(svcCache, swgEps)
+
+	// The service should be ready as both service and endpoints have been
+	// imported
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	endpoints, ready := svcCache.correlateEndpoints(svcID)
+	require.True(t, ready)
+	require.Equal(t, "2.2.2.2:8080/TCP", endpoints.String())
+
+	// Updating the service without chaning it should not result in an event
+	svcCache.UpdateService(k8sSvc, swgSvcs)
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service event received for unchanged service object")
+	default:
+	}
+
+	// Deleting the service will result in a service delete event
+	svcCache.DeleteService(k8sSvc, swgSvcs)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, DeleteService, event.Action)
+		require.Equal(t, svcID, event.ID)
+
+		return true
+	}, 2*time.Second))
+
+	// Reinserting the service should re-match with the still existing endpoints
+	svcCache.UpdateService(k8sSvc, swgSvcs)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+
+		return true
+	}, 2*time.Second))
+
+	// Deleting the endpoints will result in a service update event
+	deleteEndpointsCB(svcCache, swgEps)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+
+		return true
+	}, 2*time.Second))
+
+	endpoints, serviceReady := svcCache.correlateEndpoints(svcID)
+	require.False(t, serviceReady)
+	require.Empty(t, endpoints.String())
+
+	// Reinserting the endpoints should re-match with the still existing service
+	updateEndpointsCB(svcCache, swgEps)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	endpoints, serviceReady = svcCache.correlateEndpoints(svcID)
+	require.True(t, serviceReady)
+	require.Equal(t, "2.2.2.2:8080/TCP", endpoints.String())
+
+	// Deleting the service will result in a service delete event
+	svcCache.DeleteService(k8sSvc, swgSvcs)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, DeleteService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	// Deleting the endpoints will not emit an event as the notification
+	// was sent out when the service was deleted.
+	deleteEndpointsCB(svcCache, swgEps)
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service delete event received")
+	default:
+	}
+
+	swgSvcs.Stop()
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		swgSvcs.Wait()
+		return true
+	}, 2*time.Second))
+
+	swgEps.Stop()
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		swgEps.Wait()
+		return true
+	}, 2*time.Second))
+}
+
+func TestCacheActionString(t *testing.T) {
+	require.Equal(t, "service-updated", UpdateService.String())
+	require.Equal(t, "service-deleted", DeleteService.String())
+}
+
+func TestServiceMutators(t *testing.T) {
+	var m1, m2 int
+
+	svcCache := newServiceCache(hivetest.Logger(t), nil)
+
+	svcCache.serviceMutators = append(svcCache.serviceMutators,
+		func(svc *slim_corev1.Service, svcInfo *k8s.Service) { m1++ },
+		func(svc *slim_corev1.Service, svcInfo *k8s.Service) { m2++ },
+	)
+	swg := lock.NewStoppableWaitGroup()
+	svcCache.UpdateService(&slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
+		Spec: slim_corev1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Selector:  map[string]string{"foo": "bar"},
+			Type:      slim_corev1.ServiceTypeClusterIP,
+		},
+	}, swg)
+
+	// Assert that the service mutators configured have been executed.
+	require.Equal(t, 1, m1)
+	require.Equal(t, 1, m2)
+}
+
+func TestServiceCacheWith2EndpointSlice(t *testing.T) {
+	k8sEndpointSlice1 := k8s.ParseEndpointSliceV1(hivetest.Logger(t), &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo-yyyyy",
+			Namespace: "bar",
+			Labels: map[string]string{
+				slim_discovery_v1.LabelServiceName: "foo",
+			},
+		},
+		Endpoints: []slim_discovery_v1.Endpoint{
+			{
+				Addresses: []string{
+					"2.2.2.2",
+				},
+			},
+		},
+		Ports: []slim_discovery_v1.EndpointPort{
+			{
+				Name:     func() *string { a := "http-test-svc"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(8080); return &a }(),
+			},
+		},
+	})
+
+	k8sEndpointSlice2 := k8s.ParseEndpointSliceV1(hivetest.Logger(t), &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo-xxxxx",
+			Namespace: "bar",
+			Labels: map[string]string{
+				slim_discovery_v1.LabelServiceName: "foo",
+			},
+		},
+		Endpoints: []slim_discovery_v1.Endpoint{
+			{
+				Addresses: []string{
+					"2.2.2.3",
+				},
+			},
+		},
+		Ports: []slim_discovery_v1.EndpointPort{
+			{
+				Name:     func() *string { a := "http-test-svc"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(8080); return &a }(),
+			},
+		},
+	})
+
+	k8sEndpointSlice3 := k8s.ParseEndpointSliceV1(hivetest.Logger(t), &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo-xxxxx",
+			Namespace: "baz",
+			Labels: map[string]string{
+				slim_discovery_v1.LabelServiceName: "foo",
+			},
+		},
+		Endpoints: []slim_discovery_v1.Endpoint{
+			{
+				Addresses: []string{
+					"2.2.2.4",
+				},
+			},
+		},
+		Ports: []slim_discovery_v1.EndpointPort{
+			{
+				Name:     func() *string { a := "http-test-svc"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(8080); return &a }(),
+			},
+		},
+	})
+
+	svcCache := newServiceCache(hivetest.Logger(t), nil)
+
+	k8sSvc := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: slim_corev1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+			Type: slim_corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	swgSvcs := lock.NewStoppableWaitGroup()
+	svcID := svcCache.UpdateService(k8sSvc, swgSvcs)
+
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service event received before endpoints have been imported")
+	default:
+	}
+
+	swgEps := lock.NewStoppableWaitGroup()
+	svcCache.UpdateEndpoints(k8sEndpointSlice1, swgEps)
+	svcCache.UpdateEndpoints(k8sEndpointSlice2, swgEps)
+	svcCache.UpdateEndpoints(k8sEndpointSlice3, swgEps)
+
+	// The service should be ready as both service and endpoints have been
+	// imported for k8sEndpointSlice1
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	// The service should be ready as both service and endpoints have been
+	// imported for k8sEndpointSlice2
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service event received when endpoints not selected by a service have been imported")
+	default:
+	}
+	endpoints, ready := svcCache.correlateEndpoints(svcID)
+	require.True(t, ready)
+	require.Equal(t, "2.2.2.2:8080/TCP,2.2.2.3:8080/TCP", endpoints.String())
+
+	// Updating the service without changing it should not result in an event
+	svcCache.UpdateService(k8sSvc, swgSvcs)
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service event received for unchanged service object")
+	default:
+	}
+
+	// Deleting the service will result in a service delete event
+	svcCache.DeleteService(k8sSvc, swgSvcs)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, DeleteService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	// Reinserting the service should re-match with the still existing endpoints
+	svcCache.UpdateService(k8sSvc, swgSvcs)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	// Deleting the k8sEndpointSlice2 will result in a service update event
+	svcCache.DeleteEndpoints(k8sEndpointSlice2.EndpointSliceID, swgEps)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	endpoints, ready = svcCache.correlateEndpoints(svcID)
+	require.True(t, ready)
+	require.Equal(t, "2.2.2.2:8080/TCP", endpoints.String())
+
+	svcCache.DeleteEndpoints(k8sEndpointSlice1.EndpointSliceID, swgEps)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	endpoints, serviceReady := svcCache.correlateEndpoints(svcID)
+	require.False(t, serviceReady)
+	require.Empty(t, endpoints.String())
+
+	// Reinserting the endpoints should re-match with the still existing service
+	svcCache.UpdateEndpoints(k8sEndpointSlice1, swgEps)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	endpoints, serviceReady = svcCache.correlateEndpoints(svcID)
+	require.True(t, serviceReady)
+	require.Equal(t, "2.2.2.2:8080/TCP", endpoints.String())
+
+	// Deleting the service will result in a service delete event
+	svcCache.DeleteService(k8sSvc, swgSvcs)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, DeleteService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	// Deleting the endpoints will not emit an event as the notification
+	// was sent out when the service was deleted.
+	svcCache.DeleteEndpoints(k8sEndpointSlice1.EndpointSliceID, swgEps)
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service delete event received")
+	default:
+	}
+
+	swgSvcs.Stop()
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		swgSvcs.Wait()
+		return true
+	}, 2*time.Second))
+
+	swgEps.Stop()
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		swgEps.Wait()
+		return true
+	}, 2*time.Second))
+}
+
+func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
+	k8sEndpointSlice1 := k8s.ParseEndpointSliceV1(hivetest.Logger(t), &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo-yyyyy",
+			Namespace: "bar",
+			Labels: map[string]string{
+				slim_discovery_v1.LabelServiceName: "foo",
+			},
+		},
+		Endpoints: []slim_discovery_v1.Endpoint{
+			{
+				Addresses: []string{
+					"2.2.2.2",
+				},
+			},
+		},
+		Ports: []slim_discovery_v1.EndpointPort{
+			{
+				Name:     func() *string { a := "http-test-svc"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(8080); return &a }(),
+			},
+		},
+	})
+
+	k8sEndpointSlice2 := k8s.ParseEndpointSliceV1(hivetest.Logger(t), &slim_discovery_v1.EndpointSlice{
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo-xxxxx",
+			Namespace: "bar",
+			Labels: map[string]string{
+				slim_discovery_v1.LabelServiceName: "foo",
+			},
+		},
+		Endpoints: []slim_discovery_v1.Endpoint{
+			{
+				Addresses: []string{
+					"2.2.2.2",
+				},
+			},
+		},
+		Ports: []slim_discovery_v1.EndpointPort{
+			{
+				Name:     func() *string { a := "http-test-svc2"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(8081); return &a }(),
+			},
+		},
+	})
+
+	svcCache := newServiceCache(hivetest.Logger(t), nil)
+
+	k8sSvc := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: slim_corev1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Selector: map[string]string{
+				"foo": "bar",
+			},
+			Type: slim_corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	swgSvcs := lock.NewStoppableWaitGroup()
+	svcID := svcCache.UpdateService(k8sSvc, swgSvcs)
+
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service event received before endpoints have been imported")
+	default:
+	}
+
+	swgEps := lock.NewStoppableWaitGroup()
+	svcCache.UpdateEndpoints(k8sEndpointSlice1, swgEps)
+	svcCache.UpdateEndpoints(k8sEndpointSlice2, swgEps)
+
+	// The service should be ready as both service and endpoints have been
+	// imported for k8sEndpointSlice1
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	// The service should be ready as both service and endpoints have been
+	// imported for k8sEndpointSlice2
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service event received when endpoints not selected by a service have been imported")
+	default:
+	}
+	endpoints, ready := svcCache.correlateEndpoints(svcID)
+	require.True(t, ready)
+	require.Equal(t, "2.2.2.2:8080/TCP,2.2.2.2:8081/TCP", endpoints.String())
+
+	// Updating the service without changing it should not result in an event
+	svcCache.UpdateService(k8sSvc, swgSvcs)
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service event received for unchanged service object")
+	default:
+	}
+
+	// Deleting the service will result in a service delete event
+	svcCache.DeleteService(k8sSvc, swgSvcs)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, DeleteService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	// Reinserting the service should re-match with the still existing endpoints
+	svcCache.UpdateService(k8sSvc, swgSvcs)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	// Deleting the k8sEndpointSlice2 will result in a service update event
+	svcCache.DeleteEndpoints(k8sEndpointSlice2.EndpointSliceID, swgEps)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	endpoints, ready = svcCache.correlateEndpoints(svcID)
+	require.True(t, ready)
+	require.Equal(t, "2.2.2.2:8080/TCP", endpoints.String())
+
+	svcCache.DeleteEndpoints(k8sEndpointSlice1.EndpointSliceID, swgEps)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	endpoints, serviceReady := svcCache.correlateEndpoints(svcID)
+	require.False(t, serviceReady)
+	require.Empty(t, endpoints.String())
+
+	// Reinserting the endpoints should re-match with the still existing service
+	svcCache.UpdateEndpoints(k8sEndpointSlice1, swgEps)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, UpdateService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	endpoints, serviceReady = svcCache.correlateEndpoints(svcID)
+	require.True(t, serviceReady)
+	require.Equal(t, "2.2.2.2:8080/TCP", endpoints.String())
+
+	// Deleting the service will result in a service delete event
+	svcCache.DeleteService(k8sSvc, swgSvcs)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		event := <-svcCache.events
+		defer event.SWGDone()
+		require.Equal(t, DeleteService, event.Action)
+		require.Equal(t, svcID, event.ID)
+		return true
+	}, 2*time.Second))
+
+	// Deleting the endpoints will not emit an event as the notification
+	// was sent out when the service was deleted.
+	svcCache.DeleteEndpoints(k8sEndpointSlice1.EndpointSliceID, swgEps)
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-svcCache.events:
+		t.Error("Unexpected service delete event received")
+	default:
+	}
+
+	swgSvcs.Stop()
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		swgSvcs.Wait()
+		return true
+	}, 2*time.Second))
+
+	swgEps.Stop()
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		swgEps.Wait()
+		return true
+	}, 2*time.Second))
+}
+
+func BenchmarkCorrelateEndpoints(b *testing.B) {
+	const epslices = 10
+	const epsPerSlice = 100
+
+	cache := newServiceCache(hivetest.Logger(b), nil)
+
+	var swg lock.StoppableWaitGroup
+	id := k8s.ServiceID{Name: "foo", Namespace: "bar"}
+	cache.UpdateService(&slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
+		Spec: slim_corev1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Selector:  map[string]string{"foo": "bar"},
+			Type:      slim_corev1.ServiceTypeClusterIP,
+		},
+	}, &swg)
+
+	ip := netip.MustParseAddr("192.168.0.0")
+	for i := range epslices {
+		cache.UpdateEndpoints(func(i int) *k8s.Endpoints {
+			return &k8s.Endpoints{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:      fmt.Sprintf("foo-%04d", i),
+					Namespace: "bar",
+				},
+				EndpointSliceID: k8s.EndpointSliceID{
+					ServiceID:         id,
+					EndpointSliceName: fmt.Sprintf("foo-%05d", i),
+				},
+				Backends: func() map[cmtypes.AddrCluster]*k8s.Backend {
+					be := make(map[cmtypes.AddrCluster]*k8s.Backend)
+					for range epsPerSlice {
+						ip = ip.Next()
+						be[cmtypes.AddrClusterFrom(ip, 0)] = &k8s.Backend{
+							Ports: serviceStore.PortConfiguration{
+								"http":     &loadbalancer.L4Addr{Port: 80, Protocol: "TCP"},
+								"http-alt": &loadbalancer.L4Addr{Port: 8080, Protocol: "TCP"},
+							},
+						}
+					}
+					return be
+				}(),
+			}
+		}(i), &swg)
+	}
+
+	for b.Loop() {
+		eps, ready := cache.correlateEndpoints(id)
+		assert.True(b, ready)
+		assert.Len(b, eps.Backends, epslices*epsPerSlice)
+	}
+}

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -127,8 +127,8 @@ func (e *Endpoints) String() string {
 	return strings.Join(backends, ",")
 }
 
-// newEndpoints returns a new Endpoints
-func newEndpoints() *Endpoints {
+// NewEndpoints returns a new Endpoints
+func NewEndpoints() *Endpoints {
 	return &Endpoints{
 		Backends: map[cmtypes.AddrCluster]*Backend{},
 	}
@@ -157,7 +157,7 @@ func ParseEndpointsID(ep *slim_corev1.Endpoints) EndpointSliceID {
 
 // ParseEndpoints parses a Kubernetes Endpoints resource
 func ParseEndpoints(ep *slim_corev1.Endpoints) *Endpoints {
-	endpoints := newEndpoints()
+	endpoints := NewEndpoints()
 	endpoints.ObjectMeta = ep.ObjectMeta
 
 	for _, sub := range ep.Subsets {
@@ -211,7 +211,7 @@ func ParseEndpointSliceID(es endpointSlice) EndpointSliceID {
 // It reads ready and terminating state of endpoints in the EndpointSlice to
 // return an EndpointSlice ID and a filtered list of Endpoints for service load-balancing.
 func ParseEndpointSliceV1Beta1(ep *slim_discovery_v1beta1.EndpointSlice) *Endpoints {
-	endpoints := newEndpoints()
+	endpoints := NewEndpoints()
 	endpoints.ObjectMeta = ep.ObjectMeta
 	endpoints.EndpointSliceID = ParseEndpointSliceID(ep)
 
@@ -309,7 +309,7 @@ func parseEndpointPortV1Beta1(port slim_discovery_v1beta1.EndpointPort) (string,
 // It reads ready and terminating state of endpoints in the EndpointSlice to
 // return an EndpointSlice ID and a filtered list of Endpoints for service load-balancing.
 func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSlice) *Endpoints {
-	endpoints := newEndpoints()
+	endpoints := NewEndpoints()
 	endpoints.ObjectMeta = ep.ObjectMeta
 	endpoints.EndpointSliceID = ParseEndpointSliceID(ep)
 
@@ -475,7 +475,7 @@ func (es *EndpointSlices) GetEndpoints() *Endpoints {
 	if es == nil || len(es.epSlices) == 0 {
 		return nil
 	}
-	allEps := newEndpoints()
+	allEps := NewEndpoints()
 	for _, eps := range es.epSlices {
 		for backend, ep := range eps.Backends {
 			// EndpointSlices may have duplicate addresses on different slices.
@@ -494,6 +494,10 @@ func (es *EndpointSlices) GetEndpoints() *Endpoints {
 		}
 	}
 	return allEps
+}
+
+func (es *EndpointSlices) Get(name string) *Endpoints {
+	return es.epSlices[name]
 }
 
 // Upsert maps the 'esname' to 'e'.

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -267,7 +267,7 @@ func Test_parseK8sEPv1(t *testing.T) {
 		EndpointSliceName: "foo",
 	}
 	newEmptyEndpoints := func() *Endpoints {
-		eps := newEndpoints()
+		eps := NewEndpoints()
 		eps.ObjectMeta = meta
 		eps.EndpointSliceID = sliceID
 		return eps
@@ -583,7 +583,7 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 	}
 
 	newEmptyEndpoints := func() *Endpoints {
-		eps := newEndpoints()
+		eps := NewEndpoints()
 		eps.ObjectMeta = meta
 		eps.EndpointSliceID = sliceID
 		return eps
@@ -1146,7 +1146,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 	}
 
 	newEmptyEndpoints := func() *Endpoints {
-		eps := newEndpoints()
+		eps := NewEndpoints()
 		eps.ObjectMeta = meta
 		eps.EndpointSliceID = sliceID
 		return eps

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -685,7 +685,7 @@ func (s *ServiceCacheImpl) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 			e.Preferred = svcFound && svc.IncludeExternal && svc.ServiceAffinity == annotation.ServiceAffinityLocal
 		}
 	} else {
-		endpoints = newEndpoints()
+		endpoints = NewEndpoints()
 	}
 
 	var hasExternalEndpoints bool

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -937,7 +937,7 @@ func TestExternalServiceDeletion(t *testing.T) {
 	createEndpoints := func(clusters ...string) externalEndpoints {
 		eeps := newExternalEndpoints()
 		for i, cluster := range clusters {
-			eps := newEndpoints()
+			eps := NewEndpoints()
 			eps.Backends[cmtypes.MustParseAddrCluster(fmt.Sprintf("1.1.1.%d", i))] = &Backend{}
 			eeps.endpoints[cluster] = eps
 		}


### PR DESCRIPTION
The pkg/k8s/service_cache.go is used by both the old load-balancing control-plane implementation and by the operator. As we want to remove the old code, make a stripped down copy of the service_cache.go for the operator for use in the k8s-to-kvstore sync.