### PR TITLE
.github: Reduce builder workflow by one job

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -40,26 +40,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  has-credentials:
-    name: Check for Quay secrets
-    runs-on: ubuntu-24.04
-    environment: ${{ inputs.environment || 'release-base-images' }}
-    timeout-minutes: 2
-    outputs:
-      present: ${{ steps.secrets.outputs.present }}
-    steps:
-      - name: Check for secrets
-        id: secrets
-        env:
-          has_credentials: ${{ secrets.QUAY_BASE_RELEASE_USERNAME_202411 && secrets.QUAY_BASE_RELEASE_PASSWORD_202411 && 1 }}
-        if: ${{ env.has_credentials }}
-        run:
-          echo 'present=1' >> "$GITHUB_OUTPUT"
-
   build-and-push:
-    needs: has-credentials
     # Skip this workflow for repositories without credentials and branches that are created by renovate where the event type is pull_request_target
-    if: ${{ needs.has-credentials.outputs.present && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
+    if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 45
     environment: ${{ inputs.environment || 'release-base-images' }}
@@ -334,13 +317,7 @@ jobs:
           git diff HEAD^
           git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:$ref
 
-  image-digests:
-    name: Display Digests
-    runs-on: ubuntu-24.04
-    environment: ${{ inputs.environment || 'release-base-images' }}
-    needs: build-and-push
-    steps:
-      - name: Downloading Image Digests
+      - name: Prepare for Image Digests
         shell: bash
         run: |
           mkdir -p image-digest/


### PR DESCRIPTION
Previously this workflow had a job to check if credentials exist
and a second job to actually do the build. This is a bit inefficient for
scheduling by requiring another GitHub runner to run the extra trivial
step for an secret check, and it also required approvers to approve
the builder workflow twice - once for each job.

We can replace this with a simpler check on a repository variable
which is also only configured in the upstream cilium repository. This
way the original intent is retained for commit af7ba9aa9953
("ci: fix build-images-base to not die in forks") while simplifying the
way that developers interact with the workflow.

Related: https://github.com/cilium/cilium/pull/34950
CC: @jsoref
