### PR TITLE
Makefile: Improve tparse,junit output handling

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -80,6 +80,7 @@ SWAGGER := $(CONTAINER_ENGINE) run -u $(shell id -u):$(shell id -g) --rm -v $(RO
 # as non-immediate variables
 GO_BUILD_FLAGS ?=
 GO_TEST_FLAGS ?=
+GO_TEST_OUT ?= /dev/null
 GO_CLEAN_FLAGS ?=
 GO_BUILD_LDFLAGS ?=
 # go build/test -tags values
@@ -111,13 +112,13 @@ ifneq ($(shell command -v go-junit-report),)
 		>($(GO) run $(ROOT_DIR)/tools/testowners \
 			--code-owners=$(CODEOWNERS_PATH)) \
 		>(tparse $(GOTEST_FORMATTER_FLAGS)) \
-		>/dev/null
+		>$(GO_TEST_OUT)
 else
 	GOTEST_FORMATTER = tee \
 		>($(GO) run $(ROOT_DIR)/tools/testowners \
 			--code-owners=$(CODEOWNERS_PATH)) \
 		>(tparse $(GOTEST_FORMATTER_FLAGS)) \
-		>/dev/null
+		>$(GO_TEST_OUT)
 endif
 else
 	GOTEST_FORMATTER = tparse $(GOTEST_FORMATTER_FLAGS)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -104,9 +104,21 @@ endif
 ifneq ($(LOG_CODEOWNERS),)
 ifneq ($(shell command -v go-junit-report),)
 	JUNIT_PATH ?= junit_results.xml
-	GOTEST_FORMATTER = tee >(go-junit-report -parser gojson -code-owners=$(CODEOWNERS_PATH) -code-owners-prefix github.com/cilium/cilium/ >"$(JUNIT_PATH)") >($(GO) run ./tools/testowners --code-owners=$(CODEOWNERS_PATH)) >(tparse $(GOTEST_FORMATTER_FLAGS)) >/dev/null
+	GOTEST_FORMATTER = tee \
+		>(go-junit-report -parser gojson \
+			-code-owners=$(CODEOWNERS_PATH) \
+			-code-owners-prefix github.com/cilium/cilium/ \
+			>"$(JUNIT_PATH)") \
+		>($(GO) run $(ROOT_DIR)/tools/testowners \
+			--code-owners=$(CODEOWNERS_PATH)) \
+		>(tparse $(GOTEST_FORMATTER_FLAGS)) \
+		>/dev/null
 else
-	GOTEST_FORMATTER = tee >($(GO) run ./tools/testowners --code-owners=$(CODEOWNERS_PATH)) >(tparse $(GOTEST_FORMATTER_FLAGS)) >/dev/null
+	GOTEST_FORMATTER = tee \
+		>($(GO) run $(ROOT_DIR)/tools/testowners \
+			--code-owners=$(CODEOWNERS_PATH)) \
+		>(tparse $(GOTEST_FORMATTER_FLAGS)) \
+		>/dev/null
 endif
 else
 	GOTEST_FORMATTER = tparse $(GOTEST_FORMATTER_FLAGS)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -108,17 +108,19 @@ ifneq ($(shell command -v go-junit-report),)
 		>(go-junit-report -parser gojson \
 			-code-owners=$(CODEOWNERS_PATH) \
 			-code-owners-prefix github.com/cilium/cilium/ \
-			>"$(JUNIT_PATH)") \
+			-out "$(JUNIT_PATH)") \
 		>($(GO) run $(ROOT_DIR)/tools/testowners \
 			--code-owners=$(CODEOWNERS_PATH)) \
 		>(tparse $(GOTEST_FORMATTER_FLAGS)) \
-		>$(GO_TEST_OUT)
+		>$(GO_TEST_OUT) \
+		| cat
 else
 	GOTEST_FORMATTER = tee \
 		>($(GO) run $(ROOT_DIR)/tools/testowners \
 			--code-owners=$(CODEOWNERS_PATH)) \
 		>(tparse $(GOTEST_FORMATTER_FLAGS)) \
-		>$(GO_TEST_OUT)
+		>$(GO_TEST_OUT) \
+		| cat
 endif
 else
 	GOTEST_FORMATTER = tparse $(GOTEST_FORMATTER_FLAGS)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -96,7 +96,6 @@ CODEOWNERS_PATH ?= CODEOWNERS
 # as the latter is too verbose for most of the test suite.
 GOTEST_FORMATTER ?= cat
 ifneq ($(shell command -v tparse),)
-	GOTEST_COVER_OPTS += -json
 	GOTEST_FORMATTER_FLAGS :=
 ifneq ($(V),0)
 	GOTEST_FORMATTER_FLAGS += -follow
@@ -123,6 +122,9 @@ endif
 else
 	GOTEST_FORMATTER = tparse $(GOTEST_FORMATTER_FLAGS)
 endif
+endif
+ifneq ($(GOTEST_FORMATTER),cat)
+	GO_TEST_FLAGS += -json
 endif
 
 # renovate: datasource=docker depName=golangci/golangci-lint


### PR DESCRIPTION
Review commit by commit:
- **Makefile: Tidy GOTEST_FORMATTER declarations**
- **Makefile: Move -json go flag to GO_TEST_FLAGS**
- **Makefile: Add GO_TEST_OUT variable**
- **Makefile: Ensure junit output is flushed**

The main goal of this PR is to make output to different test formatters more
reliable (the last commit). On the way, I tidied a few things and added a new
optional variable `GO_TEST_OUT` which can be specified on the make command line
in order to output go test results as JSON to a file (default: `/dev/null`).
