### PR TITLE
Emit junit output from BPF unit tests

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -111,6 +111,10 @@ jobs:
     needs: [check_changes]
     if: ${{ needs.check_changes.outputs.bpf-tree == 'true' || needs.check_changes.outputs.bpf-tests-runner == 'true' || needs.check_changes.outputs.workflow-description == 'true' }}
     name: BPF unit/integration Tests
+    env:
+      # GitHub doesn't provide a way to retrieve the name of a job, so we have
+      # to repeated it here.
+      job_name: "bpf_tests"
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -120,4 +124,27 @@ jobs:
           fetch-depth: 0
       - name: Run BPF tests
         run: |
-          make run_bpf_tests || (echo "Run 'make run_bpf_tests' locally to investigate failures"; exit 1)
+          make run_bpf_tests \
+              LOG_CODEOWNERS=1 \
+              JUNIT_PATH="../../test/${{ env.job_name }}.xml" \
+          || (echo "Run 'make run_bpf_tests' locally to investigate failures"; exit 1)
+      - name: Fetch JUnits
+        shell: bash
+        run: |
+          mkdir -p cilium-junits
+          cd test/
+          # junit_filename needs to be the same as the Job Name presented on the
+          # GH web UI - In the Summary page of a workflow run, left column
+          # "Jobs" - so that we can map the junit file to the right job - step
+          # pair on datastudio.
+          junit_filename="${{ env.job_name }}.xml"
+          for filename in *.xml; do cp "${filename}" "../cilium-junits/${junit_filename}"; done;
+      - name: Upload JUnits [junit]
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+      - name: Publish Test Results As GitHub Summary
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"

--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,12 @@ BPF_TEST_VERBOSE ?= 0
 
 run_bpf_tests: ## Build and run the BPF unit tests using the cilium-builder container image.
 	DOCKER_ARGS=--privileged RUN_AS_ROOT=1 contrib/scripts/builder.sh \
-		"make" "-j$(shell nproc)" "-C" "bpf/tests/" "run" "BPF_TEST_FILE=$(BPF_TEST_FILE)" "BPF_TEST_DUMP_CTX=$(BPF_TEST_DUMP_CTX)" "V=$(BPF_TEST_VERBOSE)"
+		$(MAKE) $(SUBMAKEOPTS) -j$(shell nproc) -C bpf/tests/ run \
+			"BPF_TEST_FILE=$(BPF_TEST_FILE)" \
+			"BPF_TEST_DUMP_CTX=$(BPF_TEST_DUMP_CTX)" \
+			"LOG_CODEOWNERS=$(LOG_CODEOWNERS)" \
+			"JUNIT_PATH=$(JUNIT_PATH)" \
+			"V=$(BPF_TEST_VERBOSE)"
 
 run-builder: ## Drop into a shell inside a container running the cilium-builder image.
 	DOCKER_ARGS=-it contrib/scripts/builder.sh bash

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -90,7 +90,7 @@ GO_TAGS_FLAGS += osusergo
 # RACE is specified.
 GOTEST_COVER_OPTS =
 
-CODEOWNERS_PATH ?= CODEOWNERS
+CODEOWNERS_PATH ?= $(ROOT_DIR)/CODEOWNERS
 
 # By default, just print go test output immediately to the terminal. If tparse
 # is installed, use it to format the output. Use -progress instead of -follow,

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -53,7 +53,7 @@ clean:
 	rm -f $(wildcard *.i)
 	rm -f $(wildcard *.d)
 
-BPF_TEST_FLAGS:=
+BPF_TEST_FLAGS:= $(GO_TEST_FLAGS)
 ifneq ($(shell id -u), 0)
 		BPF_TEST_FLAGS += -exec "sudo -E"
 endif
@@ -83,6 +83,9 @@ ifdef BPF_TEST_FILE
 endif
 
 run: $(TEST_OBJECTS)
-	$(QUIET)$(GO) test ./bpftest -bpf-test-path $(ROOT_DIR)/bpf/tests $(BPF_TEST_FLAGS)
+	$(QUIET)$(GO) test ./bpftest \
+		-bpf-test-path $(ROOT_DIR)/bpf/tests \
+		$(BPF_TEST_FLAGS) \
+	| $(GOTEST_FORMATTER)
 
 -include $(TEST_OBJECTS:.o=.d)


### PR DESCRIPTION
Based on PRs https://github.com/cilium/cilium/pull/39092, https://github.com/cilium/cilium/pull/39098

Update the BPF unit test makefiles and workflows to emit junit output so that
we can consume these test results in the Cilium CI dashboards.
