### PR TITLE
.github: Schedule go runtime,integration tests every 8h

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -24,6 +24,9 @@ on:
       - 'renovate/main-**'
     paths-ignore:
       - 'Documentation/**'
+  # Run every 8 hours
+  schedule:
+    - cron:  '0 3/8 * * *'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -24,6 +24,9 @@ on:
     - 'renovate/main-**'
     paths-ignore:
     - 'Documentation/**'
+  # Run every 8 hours
+  schedule:
+    - cron:  '0 3/8 * * *'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.


### PR DESCRIPTION
Gather the results of the "Conformance Runtime" tests every eight hours
to provide better visibility into the baseline stability of these jobs.
