### PR TITLE
contrib/scripts: Fix IndexError in stacktrace script

### DIFF
--- a/contrib/scripts/consolidate_go_stacktrace.py
+++ b/contrib/scripts/consolidate_go_stacktrace.py
@@ -182,14 +182,14 @@ if __name__ == "__main__":
                 '{} ({} goroutines)'.format(
                     s.replace(
                         cilium_source,
-                        args.source_dir[0]),
+                        args.source_dir),
                     skipped[s]),
                 file=sys.stderr)
         print(file=sys.stderr)
     if len(blocked) > 0:
         print('The following packages are blocked:')
         for s in blocked:
-            print(s.replace(cilium_source, args.source_dir[0]))
+            print(s.replace(cilium_source, args.source_dir))
 
     if f != sys.stdin:
         f.close()


### PR DESCRIPTION
Since the below mentioned commit, it seems that other usages of
`source_dir` were not fixed up when it became a string var instead of an
slice var. Fix the remaining usages. Now the script outputs the full
output.

```
$ ./consolidate_go_stacktrace.py --filter lock ...
...
Stacktraces from the following packages were skipped as they do not match ['lock', 'Lock(', 'RLock(', 'Semacquire(']:
Traceback (most recent call last):
  File "/home/chris/code/cilium/cilium/contrib/scripts/consolidate_go_stacktrace.py", line 185, in <module>
    args.source_dir[0]),
    ~~~~~~~~~~~~~~~^^^
IndexError: string index out of range
```

Fixes: bafbfb8452d ("consolidate_go_stacktrace.py: Use relative paths by default")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
