### PR TITLE
bpf: remove unused struct tunnel_{key,value} types

### DIFF
--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -80,8 +80,6 @@ add_type(struct srv6_vrf_key6);
 add_type(struct srv6_policy_key4);
 add_type(struct srv6_policy_key6);
 add_type(struct trace_sock_notify);
-add_type(struct tunnel_key);
-add_type(struct tunnel_value);
 add_type(struct auth_key);
 add_type(struct auth_info);
 add_type(struct encrypt_config);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -224,36 +224,6 @@ struct endpoint_key {
 	__u16 cluster_id;
 } __packed;
 
-struct tunnel_key {
-	union {
-		struct {
-			__u32		ip4;
-			__u32		pad1;
-			__u32		pad2;
-			__u32		pad3;
-		};
-		union v6addr	ip6;
-	};
-	__u8 family;
-	__u8 pad;
-	__u16 cluster_id;
-} __packed;
-
-struct tunnel_value {
-	union {
-		struct {
-			__u32		ip4;
-			__u32		pad1;
-			__u32		pad2;
-			__u32		pad3;
-		};
-		union v6addr	ip6;
-	};
-	__u8 family;
-	__u8 key;
-	__u16 pad;
-} __packed;
-
 #define ENDPOINT_F_HOST			1 /* Special endpoint representing local host */
 #define ENDPOINT_F_ATHOSTNS		2 /* Endpoint located at the host networking namespace */
 #define ENDPOINT_MASK_HOST_DELIVERY	(ENDPOINT_F_HOST | ENDPOINT_F_ATHOSTNS)

--- a/pkg/datapath/alignchecker/alignchecker.go
+++ b/pkg/datapath/alignchecker/alignchecker.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/recorder"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
 	"github.com/cilium/cilium/pkg/maps/srv6map"
-	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/maps/vtep"
 )
 
@@ -121,8 +120,6 @@ func init() {
 		"srv6_vrf_key6":           {srv6map.VRFKey6{}},
 		"srv6_policy_key4":        {srv6map.PolicyKey4{}},
 		"srv6_policy_key6":        {srv6map.PolicyKey6{}},
-		"tunnel_key":              {tunnel.TunnelKey{}},
-		"tunnel_value":            {tunnel.TunnelValue{}},
 		"vtep_key":                {vtep.Key{}},
 		"vtep_value":              {vtep.VtepEndpointInfo{}},
 		"auth_key":                {authmap.AuthKey{}},


### PR DESCRIPTION
After commit 17bc606ea788 ("bpf, pkg/datapath: Remove tunnel map"), these struct types are no longer used and can be removed.