### PR TITLE
gh: e2e-upgrade: check for unexpected drops from connectivity tests

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -417,6 +417,13 @@ jobs:
           test-concurrency: ${{ env.test_concurrency }}
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
+      - name: Check for unexpected packet drops during connectivity tests
+        uses: ./.github/actions/conn-disrupt-test-check
+        with:
+          job-name: cilium-upgrade-${{ matrix.name }}
+          tests: 'no-unexpected-packet-drops'
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
+
       - name: Assert that no unencrypted packets are leaked during connectivity tests after upgrade
         if: ${{ matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/check
@@ -487,6 +494,14 @@ jobs:
           job-name: cilium-downgrade-${{ matrix.name }}
           tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
           test-concurrency: ${{ env.test_concurrency }}
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
+
+      - name: Check for unexpected packet drops during connectivity tests
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        uses: ./.github/actions/conn-disrupt-test-check
+        with:
+          job-name: cilium-upgrade-${{ matrix.name }}
+          tests: 'no-unexpected-packet-drops'
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after downgrade


### PR DESCRIPTION
By checking for no-unexpected-packet-drops right after running the whole connectivity test suite, we catch unexpected drops straight away.

Otherwise this check only happens on the *next* run of the connectivity tests - which might either not happen at all, or is after a up/downgrade and therefore way too late to capture related debug info in the sysdump.

Fixes: https://github.com/cilium/cilium/issues/39103