### PR TITLE
renovate: Bump allowed Go version for stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -336,7 +336,7 @@
         "docker.io/library/golang",
         "go"
       ],
-      "allowedVersions": "<1.24",
+      "allowedVersions": "<1.25",
       "matchBaseBranches": [
         "v1.17",
         "v1.16",


### PR DESCRIPTION
Golang v1.23 will be EOL in August so we will need to update all stable branches to v1.24. I also need a standard package that is only available in Go v1.24 so we might as well update now.