### PR TITLE
loadbalancer: Add file-based reflector

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -313,6 +313,7 @@ cilium-agent [flags]
       --l2-pod-announcements-interface-pattern string             Regex matching interfaces used for sending gratuitous arp messages
       --label-prefix-file string                                  Valid label prefixes file path
       --labels strings                                            List of label prefixes used to determine identity of an endpoint
+      --lb-state-file string                                      Synchronize load-balancing state from the specified file
       --lib-dir string                                            Directory path to store runtime build environment (default "/var/lib/cilium")
       --local-router-ipv4 string                                  Link-local IPv4 used for Cilium's router devices
       --local-router-ipv6 string                                  Link-local IPv6 used for Cilium's router devices

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -149,6 +149,7 @@ cilium-agent hive [flags]
       --k8s-service-proxy-name string                             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement-healthz-bind-address string        The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
       --l2-pod-announcements-interface-pattern string             Regex matching interfaces used for sending gratuitous arp messages
+      --lb-state-file string                                      Synchronize load-balancing state from the specified file
       --max-connected-clusters uint32                             Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (beta) (default true)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -154,6 +154,7 @@ cilium-agent hive dot-graph [flags]
       --k8s-service-proxy-name string                             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement-healthz-bind-address string        The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
       --l2-pod-announcements-interface-pattern string             Regex matching interfaces used for sending gratuitous arp messages
+      --lb-state-file string                                      Synchronize load-balancing state from the specified file
       --max-connected-clusters uint32                             Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (beta) (default true)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)

--- a/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
@@ -105,27 +105,27 @@ primary: true
 devicename: test
 
 -- health_no_service.table --
-Module                      Component                         Level   Message                    Error
-loadbalancer-healthserver   job-control-loop                  OK      0 health servers running
-loadbalancer-reconciler     job-reconcile                     OK      OK, 0 object(s)
-loadbalancer-reconciler     job-refresh                       OK      Next refresh in 30m0s
-loadbalancer-reconciler     job-start-reconciler              Stopped Started
-loadbalancer-reflectors     job-reflect-pods                  OK      Running
-loadbalancer-reflectors     job-reflect-services-endpoints    OK      Running
-loadbalancer-writer         job-node-addr-reconciler          OK      Running
-loadbalancer-writer         job-zone-watcher                  OK      Running
+Module                                    Component                         Level   Message                    Error
+loadbalancer-healthserver                 job-control-loop                  OK      0 health servers running
+loadbalancer-reconciler                   job-reconcile                     OK      OK, 0 object(s)
+loadbalancer-reconciler                   job-refresh                       OK      Next refresh in 30m0s
+loadbalancer-reconciler                   job-start-reconciler              Stopped Started
+loadbalancer-reflectors.k8s-reflector     job-reflect-pods                  OK      Running
+loadbalancer-reflectors.k8s-reflector     job-reflect-services-endpoints    OK      Running
+loadbalancer-writer                       job-node-addr-reconciler          OK      Running
+loadbalancer-writer                       job-zone-watcher                  OK      Running
 
 -- health_with_service.table --
-Module                      Component                         Level   Message                    Error
-loadbalancer-healthserver   job-control-loop                  OK      1 health servers running
-loadbalancer-healthserver   job-listener-40000                OK      Running
-loadbalancer-reconciler     job-reconcile                     OK      OK, 4 object(s)
-loadbalancer-reconciler     job-refresh                       OK      Next refresh in 30m0s
-loadbalancer-reconciler     job-start-reconciler              Stopped Started
-loadbalancer-reflectors     job-reflect-pods                  OK      Running
-loadbalancer-reflectors     job-reflect-services-endpoints    OK      Running
-loadbalancer-writer         job-node-addr-reconciler          OK      Running
-loadbalancer-writer         job-zone-watcher                  OK      Running
+Module                                    Component                         Level   Message                    Error
+loadbalancer-healthserver                 job-control-loop                  OK      1 health servers running
+loadbalancer-healthserver                 job-listener-40000                OK      Running
+loadbalancer-reconciler                   job-reconcile                     OK      OK, 4 object(s)
+loadbalancer-reconciler                   job-refresh                       OK      Next refresh in 30m0s
+loadbalancer-reconciler                   job-start-reconciler              Stopped Started
+loadbalancer-reflectors.k8s-reflector     job-reflect-pods                  OK      Running
+loadbalancer-reflectors.k8s-reflector     job-reflect-services-endpoints    OK      Running
+loadbalancer-writer                       job-node-addr-reconciler          OK      Running
+loadbalancer-writer                       job-zone-watcher                  OK      Running
 
 -- services.table --
 Name                   Source   PortNames  TrafficPolicy   Flags

--- a/pkg/loadbalancer/reflectors/cell.go
+++ b/pkg/loadbalancer/reflectors/cell.go
@@ -5,41 +5,12 @@ package reflectors
 
 import (
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/stream"
-
-	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/k8s/resource"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
 var Cell = cell.Module(
 	"loadbalancer-reflectors",
 	"Reflects external state to load-balancing tables",
 
-	// Bridge Resource[XYZ] to Observable[Event[XYZ]]. Makes it easier to
-	// test [ReflectorCell].
-	cell.ProvidePrivate(resourcesToStreams),
-
-	cell.Invoke(RegisterK8sReflector),
+	// Reflects Kubernetes Services and Endpoint(Slices) to load-balancing tables
+	K8sReflectorCell,
 )
-
-type resourceIn struct {
-	cell.In
-	ServicesResource  resource.Resource[*slim_corev1.Service]
-	EndpointsResource resource.Resource[*k8s.Endpoints]
-}
-
-type StreamsOut struct {
-	cell.Out
-	ServicesStream  stream.Observable[resource.Event[*slim_corev1.Service]]
-	EndpointsStream stream.Observable[resource.Event[*k8s.Endpoints]]
-}
-
-// resourcesToStreams extracts the stream.Observable from resource.Resource.
-// This makes the reflector easier to test as its API surface is reduced.
-func resourcesToStreams(in resourceIn) StreamsOut {
-	return StreamsOut{
-		ServicesStream:  in.ServicesResource,
-		EndpointsStream: in.EndpointsResource,
-	}
-}

--- a/pkg/loadbalancer/reflectors/cell.go
+++ b/pkg/loadbalancer/reflectors/cell.go
@@ -13,4 +13,8 @@ var Cell = cell.Module(
 
 	// Reflects Kubernetes Services and Endpoint(Slices) to load-balancing tables
 	K8sReflectorCell,
+
+	// Reflects state to load-balancing tables from a local file specified with
+	// '--lb-state-file'.
+	FileReflectorCell,
 )

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflectors
+
+import (
+	"log/slog"
+	"net"
+	"net/netip"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/k8s"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var (
+	zeroV4 = cmtypes.MustParseAddrCluster("0.0.0.0")
+	zeroV6 = cmtypes.MustParseAddrCluster("::")
+
+	ingressDummyAddress = cmtypes.MustParseAddrCluster("192.192.192.192")
+	ingressDummyPort    = uint16(9999)
+)
+
+func isIngressDummyEndpoint(l3n4Addr loadbalancer.L3n4Addr) bool {
+	// The ingress and gateway-api controllers (operator/pkg/model/translation/{gateway-api,ingress}) create
+	// a dummy endpoint to force Cilium to reconcile the service. This is no longer required with this new
+	// control-plane, but due to rolling upgrades we cannot remove it immediately. Hence we have the
+	// special handling here to just ignore this endpoint to avoid populating the tables with unnecessary
+	// data.
+	return l3n4Addr.AddrCluster.Equal(ingressDummyAddress) && l3n4Addr.Port == ingressDummyPort
+}
+
+func isHeadless(svc *slim_corev1.Service) bool {
+	_, headless := svc.Labels[corev1.IsHeadlessService]
+	if strings.ToLower(svc.Spec.ClusterIP) == "none" {
+		headless = true
+	}
+	return headless
+}
+
+func convertService(cfg loadbalancer.ExternalConfig, log *slog.Logger, svc *slim_corev1.Service, source source.Source) (s *loadbalancer.Service, fes []loadbalancer.FrontendParams) {
+	name := loadbalancer.ServiceName{Namespace: svc.Namespace, Name: svc.Name}
+	s = &loadbalancer.Service{
+		Name:                name,
+		Source:              source,
+		Labels:              labels.Map2Labels(svc.Labels, string(source)),
+		Selector:            svc.Spec.Selector,
+		Annotations:         svc.Annotations,
+		HealthCheckNodePort: uint16(svc.Spec.HealthCheckNodePort),
+	}
+
+	expType, err := k8s.NewSvcExposureType(svc)
+	if err != nil {
+		log.Warn("Ignoring annotation",
+			logfields.Error, err,
+			logfields.Annotations, annotation.ServiceTypeExposure,
+			logfields.Service, svc.GetName(),
+		)
+	}
+
+	if len(svc.Spec.Ports) > 0 {
+		s.PortNames = map[string]uint16{}
+		for _, port := range svc.Spec.Ports {
+			s.PortNames[port.Name] = uint16(port.Port)
+		}
+	}
+
+	for _, srcRange := range svc.Spec.LoadBalancerSourceRanges {
+		prefix, err := netip.ParsePrefix(srcRange)
+		if err != nil {
+			continue
+		}
+		s.SourceRanges = append(s.SourceRanges, prefix)
+	}
+
+	switch svc.Spec.ExternalTrafficPolicy {
+	case slim_corev1.ServiceExternalTrafficPolicyLocal:
+		s.ExtTrafficPolicy = loadbalancer.SVCTrafficPolicyLocal
+	default:
+		s.ExtTrafficPolicy = loadbalancer.SVCTrafficPolicyCluster
+	}
+
+	if svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == slim_corev1.ServiceInternalTrafficPolicyLocal {
+		s.IntTrafficPolicy = loadbalancer.SVCTrafficPolicyLocal
+	} else {
+		s.IntTrafficPolicy = loadbalancer.SVCTrafficPolicyCluster
+	}
+	// Scopes for NodePort and LoadBalancer. Either just external (policies are the same), or
+	// both external and internal (when one policy is local)
+	scopes := []uint8{loadbalancer.ScopeExternal}
+	twoScopes := (s.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal) != (s.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal)
+	if twoScopes {
+		scopes = append(scopes, loadbalancer.ScopeInternal)
+	}
+
+	// SessionAffinity
+	if svc.Spec.SessionAffinity == slim_corev1.ServiceAffinityClientIP {
+		s.SessionAffinity = true
+
+		s.SessionAffinityTimeout = time.Duration(int(time.Second) * int(slim_corev1.DefaultClientIPServiceAffinitySeconds))
+		if cfg := svc.Spec.SessionAffinityConfig; cfg != nil && cfg.ClientIP != nil && cfg.ClientIP.TimeoutSeconds != nil && *cfg.ClientIP.TimeoutSeconds != 0 {
+			s.SessionAffinityTimeout = time.Duration(int(time.Second) * int(*cfg.ClientIP.TimeoutSeconds))
+		}
+	}
+
+	if s.IntTrafficPolicy != loadbalancer.SVCTrafficPolicyLocal && isTopologyAware(svc) {
+		s.TrafficDistribution = loadbalancer.TrafficDistributionPreferClose
+	}
+
+	// A service that is annotated as headless has no frontends, even if the service spec contains
+	// ClusterIPs etc.
+	if isHeadless(svc) {
+		return
+	}
+
+	// ClusterIP
+	if expType.CanExpose(slim_corev1.ServiceTypeClusterIP) {
+		var clusterIPs []string
+		if len(svc.Spec.ClusterIPs) > 0 {
+			clusterIPs = slices.Sorted(slices.Values(svc.Spec.ClusterIPs))
+		} else {
+			clusterIPs = []string{svc.Spec.ClusterIP}
+		}
+
+		for _, ip := range clusterIPs {
+			addr, err := cmtypes.ParseAddrCluster(ip)
+			if err != nil {
+				continue
+			}
+
+			if (!cfg.EnableIPv6 && addr.Is6()) || (!cfg.EnableIPv4 && addr.Is4()) {
+				continue
+			}
+
+			for _, port := range svc.Spec.Ports {
+				p := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
+				if p == nil {
+					continue
+				}
+				fe := loadbalancer.FrontendParams{
+					Type:        loadbalancer.SVCTypeClusterIP,
+					PortName:    loadbalancer.FEPortName(port.Name),
+					ServiceName: name,
+					ServicePort: uint16(port.Port),
+				}
+				fe.Address.AddrCluster = addr
+				fe.Address.Scope = loadbalancer.ScopeExternal
+				fe.Address.L4Addr = *p
+				fes = append(fes, fe)
+			}
+		}
+	}
+
+	// NOTE: We always want to do ClusterIP services even when full kube-proxy replacement is disabled.
+	// See https://github.com/cilium/cilium/issues/16197 for context.
+
+	if cfg.KubeProxyReplacement {
+		// NodePort
+		if (svc.Spec.Type == slim_corev1.ServiceTypeNodePort || svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer) &&
+			expType.CanExpose(slim_corev1.ServiceTypeNodePort) {
+
+			for _, scope := range scopes {
+				for _, family := range getIPFamilies(svc) {
+					if (!cfg.EnableIPv6 && family == slim_corev1.IPv6Protocol) ||
+						(!cfg.EnableIPv4 && family == slim_corev1.IPv4Protocol) {
+						continue
+					}
+					for _, port := range svc.Spec.Ports {
+						if port.NodePort == 0 {
+							continue
+						}
+
+						fe := loadbalancer.FrontendParams{
+							Type:        loadbalancer.SVCTypeNodePort,
+							PortName:    loadbalancer.FEPortName(port.Name),
+							ServiceName: name,
+							ServicePort: uint16(port.Port),
+						}
+
+						switch family {
+						case slim_corev1.IPv4Protocol:
+							fe.Address.AddrCluster = zeroV4
+						case slim_corev1.IPv6Protocol:
+							fe.Address.AddrCluster = zeroV6
+						default:
+							continue
+						}
+
+						p := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.NodePort))
+						if p == nil {
+							continue
+						}
+						fe.Address.Scope = scope
+						fe.Address.L4Addr = *p
+						fes = append(fes, fe)
+					}
+				}
+			}
+		}
+
+		// LoadBalancer
+		if svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer && expType.CanExpose(slim_corev1.ServiceTypeLoadBalancer) {
+			for _, ip := range svc.Status.LoadBalancer.Ingress {
+				if ip.IP == "" {
+					continue
+				}
+
+				addr, err := cmtypes.ParseAddrCluster(ip.IP)
+				if err != nil {
+					continue
+				}
+				if (!cfg.EnableIPv6 && addr.Is6()) || (!cfg.EnableIPv4 && addr.Is4()) {
+					continue
+				}
+
+				for _, scope := range scopes {
+					for _, port := range svc.Spec.Ports {
+						fe := loadbalancer.FrontendParams{
+							Type:        loadbalancer.SVCTypeLoadBalancer,
+							PortName:    loadbalancer.FEPortName(port.Name),
+							ServiceName: name,
+							ServicePort: uint16(port.Port),
+						}
+
+						p := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
+						if p == nil {
+							continue
+						}
+						fe.Address.AddrCluster = addr
+						fe.Address.Scope = scope
+						fe.Address.L4Addr = *p
+						fes = append(fes, fe)
+					}
+				}
+
+			}
+		}
+
+		// ExternalIP
+		for _, ip := range svc.Spec.ExternalIPs {
+			addr, err := cmtypes.ParseAddrCluster(ip)
+			if err != nil {
+				continue
+			}
+			if (!cfg.EnableIPv6 && addr.Is6()) || (!cfg.EnableIPv4 && addr.Is4()) {
+				continue
+			}
+
+			for _, port := range svc.Spec.Ports {
+				fe := loadbalancer.FrontendParams{
+					Type:        loadbalancer.SVCTypeExternalIPs,
+					PortName:    loadbalancer.FEPortName(port.Name),
+					ServiceName: name,
+					ServicePort: uint16(port.Port),
+				}
+
+				p := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
+				if p == nil {
+					continue
+				}
+
+				fe.Address.AddrCluster = addr
+				fe.Address.Scope = loadbalancer.ScopeExternal
+				fe.Address.L4Addr = *p
+				fes = append(fes, fe)
+			}
+		}
+	}
+
+	return
+}
+
+func getIPFamilies(svc *slim_corev1.Service) []slim_corev1.IPFamily {
+	if len(svc.Spec.IPFamilies) == 0 {
+		// No IP families specified, try to deduce them from the cluster IPs
+		if len(svc.Spec.ClusterIP) == 0 || svc.Spec.ClusterIP == slim_corev1.ClusterIPNone {
+			return nil
+		}
+
+		ipv4, ipv6 := false, false
+		if len(svc.Spec.ClusterIPs) > 0 {
+			for _, cip := range svc.Spec.ClusterIPs {
+				if ip.IsIPv6(net.ParseIP(cip)) {
+					ipv6 = true
+				} else {
+					ipv4 = true
+				}
+			}
+		} else {
+			ipv6 = ip.IsIPv6(net.ParseIP(svc.Spec.ClusterIP))
+			ipv4 = !ipv6
+		}
+		families := make([]slim_corev1.IPFamily, 0, 2)
+		if ipv4 {
+			families = append(families, slim_corev1.IPv4Protocol)
+		}
+		if ipv6 {
+			families = append(families, slim_corev1.IPv4Protocol)
+		}
+		return families
+	}
+	return svc.Spec.IPFamilies
+}
+
+func convertEndpoints(cfg loadbalancer.ExternalConfig, ep *k8s.Endpoints) (name loadbalancer.ServiceName, out []loadbalancer.BackendParams) {
+	name = loadbalancer.ServiceName{
+		Name:      ep.ServiceID.Name,
+		Namespace: ep.ServiceID.Namespace,
+	}
+
+	// k8s.Endpoints may have the same backend address multiple times
+	// with a different port name. Collapse them down into single
+	// entry.
+	type entry struct {
+		portNames []string
+		backend   *k8s.Backend
+	}
+	entries := map[loadbalancer.L3n4Addr]entry{}
+
+	for addrCluster, be := range ep.Backends {
+		if (!cfg.EnableIPv6 && addrCluster.Is6()) || (!cfg.EnableIPv4 && addrCluster.Is4()) {
+			continue
+		}
+		for portName, l4Addr := range be.Ports {
+			l3n4Addr := loadbalancer.L3n4Addr{
+				AddrCluster: addrCluster,
+				L4Addr:      *l4Addr,
+			}
+			if isIngressDummyEndpoint(l3n4Addr) {
+				continue
+			}
+			portNames := entries[l3n4Addr].portNames
+			if portName != "" {
+				portNames = append(portNames, portName)
+			}
+			entries[l3n4Addr] = entry{
+				portNames: portNames,
+				backend:   be,
+			}
+		}
+	}
+	for l3n4Addr, entry := range entries {
+
+		state := loadbalancer.BackendStateActive
+		if entry.backend.Terminating {
+			state = loadbalancer.BackendStateTerminating
+		}
+		be := loadbalancer.BackendParams{
+			Address:   l3n4Addr,
+			NodeName:  entry.backend.NodeName,
+			PortNames: entry.portNames,
+			Weight:    loadbalancer.DefaultBackendWeight,
+			Zone:      entry.backend.Zone,
+			ForZones:  entry.backend.HintsForZones,
+			State:     state,
+		}
+		out = append(out, be)
+	}
+	return
+}
+
+func isTopologyAware(svc *slim_corev1.Service) bool {
+	return getAnnotationTopologyAwareHints(svc) ||
+		(svc.Spec.TrafficDistribution != nil &&
+			*svc.Spec.TrafficDistribution == corev1.ServiceTrafficDistributionPreferClose)
+}
+
+func getAnnotationTopologyAwareHints(svc *slim_corev1.Service) bool {
+	// v1.DeprecatedAnnotationTopologyAwareHints has precedence over v1.AnnotationTopologyMode.
+	value, ok := svc.ObjectMeta.Annotations[corev1.DeprecatedAnnotationTopologyAwareHints]
+	if !ok {
+		value = svc.ObjectMeta.Annotations[corev1.AnnotationTopologyMode]
+	}
+	return !(value == "" || value == "disabled" || value == "Disabled")
+}

--- a/pkg/loadbalancer/reflectors/file.go
+++ b/pkg/loadbalancer/reflectors/file.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/pflag"
+	"sigs.k8s.io/yaml"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_discoveryv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// StateFile defines the format for the state file used with --lb-state-file.
+type StateFile struct {
+	Services  []slim_corev1.Service            `json:"services"`
+	Endpoints []slim_discoveryv1.EndpointSlice `json:"endpoints"`
+}
+
+// FileReflectorCell synchronizes the load-balancing state from a file specified with --lb-state-file.
+// The file format is specified by [StateFile] and consists of Kubernetes services and endpoint slices.
+//
+// The Kubernetes definitions are used to avoid having a new format and conversions from that format
+// and it is also familiar to users.
+//
+// The implementation is tested by 'pkg/loadbalancer/tests/testdata/file.txtar' which also shows
+// an example of the file format.
+var FileReflectorCell = cell.Module(
+	"file-reflector",
+	"Synchronizes load-balancing state from a file",
+
+	cell.Config(fileReflectorConfig{}),
+	cell.Invoke(registerFileReflector),
+)
+
+const (
+	logfieldServiceCount  = "serviceCount"
+	logfieldFrontendCount = "frontendCount"
+	logfieldBackendCount  = "backendCount"
+)
+
+type fileReflectorConfig struct {
+	LBStateFile         string        `mapstructure:"lb-state-file"`
+	LBStateFileInterval time.Duration `mapstructure:"lb-state-file-interval"`
+}
+
+func (_ fileReflectorConfig) Flags(flags *pflag.FlagSet) {
+	flags.String("lb-state-file", "", "Synchronize load-balancing state from the specified file")
+	flags.Duration("lb-state-file-interval", time.Second, "Amount of time to wait for load-balancing state file to settle before processing it")
+	flags.MarkHidden("lb-state-file-interval")
+}
+
+func registerFileReflector(log *slog.Logger, jg job.Group, lbcfg loadbalancer.Config, extcfg loadbalancer.ExternalConfig, cfg fileReflectorConfig, w *writer.Writer) error {
+	if cfg.LBStateFile == "" || !lbcfg.EnableExperimentalLB {
+		return nil
+	}
+
+	file := cfg.LBStateFile
+	isYAML := false
+	switch {
+	case strings.HasSuffix(file, ".yaml"), strings.HasSuffix(file, ".yml"):
+		isYAML = true
+	case strings.HasSuffix(file, ".json"):
+		isYAML = false
+	default:
+		return fmt.Errorf("could not deduce file format from %q, expected .json or .yaml suffix", file)
+	}
+	ls := fileReflector{
+		log:       log,
+		cfg:       cfg,
+		extConfig: extcfg,
+		file:      file,
+		isYAML:    isYAML,
+		w:         w,
+	}
+	jg.Add(job.OneShot(
+		"sync",
+		ls.syncLoop,
+		job.WithRetry(-1, &job.ExponentialBackoff{
+			Min: time.Minute,
+			Max: 5 * time.Minute,
+		}),
+	))
+	return nil
+}
+
+// fileReflector syncs Source=LocalAPI state from a file containing a
+// [structs.LoadBalancerState].
+type fileReflector struct {
+	log       *slog.Logger
+	cfg       fileReflectorConfig
+	extConfig loadbalancer.ExternalConfig
+	file      string
+	isYAML    bool
+	w         *writer.Writer
+}
+
+func (s *fileReflector) syncLoop(ctx context.Context, health cell.Health) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create file watcher: %w", err)
+	}
+	defer watcher.Close()
+
+	// Watch the parent directory for changes and react to events on the specified
+	// file.
+	watchDir := "."
+	if path.IsAbs(s.file) {
+		watchDir = path.Dir(s.file)
+	}
+	if err := watcher.Add(watchDir); err != nil {
+		return fmt.Errorf("failed to watch %q: %w", s.file, err)
+	}
+
+	settleTimer := time.NewTimer(s.cfg.LBStateFileInterval)
+	defer settleTimer.Stop()
+
+	for {
+		if state, err := s.load(); err != nil {
+			s.log.Error("Failed to synchronize",
+				logfields.File, s.file,
+				logfields.Error, err)
+		} else {
+			txn := s.w.WriteTxn()
+			if numServices, numFrontends, numBackends, err := s.synchronize(txn, state); err == nil {
+				txn.Commit()
+				s.log.Info("Synchronized from local state",
+					logfields.File, s.file,
+					logfieldServiceCount, numServices,
+					logfieldFrontendCount, numFrontends,
+					logfieldBackendCount, numBackends)
+			} else {
+				s.log.Error("Failed to synchronize",
+					logfields.File, s.file,
+					logfields.Error, err)
+				txn.Abort()
+			}
+		}
+
+		// Wait for the state file to change. After the first change we'll wait
+		// for [fileReflectorConfig.LBStateFileInterval] before processing it.
+		var timeout <-chan time.Time
+		ready := false
+		for !ready {
+			select {
+			case ev := <-watcher.Events:
+				if path.Base(ev.Name) != path.Base(s.file) {
+					// Not the file we're looking for.
+					continue
+				}
+				if ev.Op == fsnotify.Remove {
+					// Ignore removals. To clear out the local state an empty file is expected.
+					continue
+				}
+				// Reset the timer. Each subsequent modification to the file pushes the
+				// processing time back by [LBStateFileInterval].
+				settleTimer.Reset(s.cfg.LBStateFileInterval)
+				timeout = settleTimer.C
+			case <-ctx.Done():
+				return nil
+			case <-timeout:
+				ready = true
+			}
+		}
+	}
+}
+
+func (s *fileReflector) load() (*StateFile, error) {
+	b, err := os.ReadFile(s.file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+
+	}
+	var state StateFile
+
+	if s.isYAML {
+		err = yaml.Unmarshal(b, &state)
+	} else {
+		err = json.Unmarshal(b, &state)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &state, nil
+
+}
+
+func (s *fileReflector) synchronize(txn writer.WriteTxn, state *StateFile) (numServices, numFrontends, numBackends int, err error) {
+	// Delete all existing source=LocalAPI services/frontends/backends.
+	err = s.w.DeleteServicesBySource(txn, source.LocalAPI)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to delete services: %w", err)
+	}
+	err = s.w.DeleteBackendsBySource(txn, source.LocalAPI)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to delete backends: %w", err)
+	}
+	for i := range state.Services {
+		svc, fes := convertService(s.extConfig, s.log, &state.Services[i], source.LocalAPI)
+		if err := s.w.UpsertServiceAndFrontends(txn, svc, fes...); err != nil {
+			return 0, 0, 0, fmt.Errorf("failed to upsert services and frontends: %w", err)
+		}
+		numServices++
+		numFrontends += len(fes)
+	}
+	for i := range state.Endpoints {
+		eps := k8s.ParseEndpointSliceV1(s.log, &state.Endpoints[i])
+		svcName, bes := convertEndpoints(s.extConfig, eps)
+		if err := s.w.UpsertBackends(txn, svcName, source.LocalAPI, bes...); err != nil {
+			return 0, 0, 0, fmt.Errorf("failed to upsert backends: %w", err)
+		}
+		numBackends++
+	}
+	return
+}

--- a/pkg/loadbalancer/reflectors/file.go
+++ b/pkg/loadbalancer/reflectors/file.go
@@ -224,7 +224,7 @@ func (s *fileReflector) synchronize(txn writer.WriteTxn, state *StateFile) (numS
 	}
 	for i := range state.Endpoints {
 		eps := k8s.ParseEndpointSliceV1(s.log, &state.Endpoints[i])
-		svcName, bes := convertEndpoints(s.extConfig, eps)
+		svcName, bes := convertEndpoints(s.log, s.extConfig, eps)
 		if err := s.w.UpsertBackends(txn, svcName, source.LocalAPI, bes...); err != nil {
 			return 0, 0, 0, fmt.Errorf("failed to upsert backends: %w", err)
 		}

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -252,7 +252,7 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 			initEndpoints(txn)
 
 		case resource.Upsert:
-			name, backends := convertEndpoints(p.ExtConfig, obj)
+			name, backends := convertEndpoints(p.Log, p.ExtConfig, obj)
 
 			if len(backends) > 0 {
 				err := p.Writer.UpsertBackends(

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -12,30 +12,24 @@ import (
 	"log/slog"
 	"maps"
 	"net"
-	"net/netip"
 	"slices"
-	"strings"
 	"sync"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/cilium/stream"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	daemonK8s "github.com/cilium/cilium/daemon/k8s"
-	"github.com/cilium/cilium/pkg/annotation"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbmaps "github.com/cilium/cilium/pkg/loadbalancer/maps"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
@@ -57,7 +51,7 @@ const (
 	reflectorWaitTime = 100 * time.Millisecond
 )
 
-// ReflectorCell reflects Kubernetes Service and EndpointSlice objects to the
+// K8sReflectorCell reflects Kubernetes Service and EndpointSlice objects to the
 // load-balancing tables.
 //
 // Note that this implementation uses Resource[*Service] and Resource[*Endpoints],
@@ -65,12 +59,36 @@ const (
 // times. We should instead have a reflector that is built directly on the client-go
 // reflector (k8s.RegisterReflector) and not populate an intermediate cache.Store.
 // But as we're still experimenting it's easier to build on what already exists.
-var ReflectorCell = cell.Module(
-	"reflector",
+var K8sReflectorCell = cell.Module(
+	"k8s-reflector",
 	"Reflects load-balancing state from Kubernetes",
 
+	// Bridge Resource[XYZ] to Observable[Event[XYZ]]. Makes it easier to
+	// test [ReflectorCell].
+	cell.ProvidePrivate(resourcesToStreams),
 	cell.Invoke(RegisterK8sReflector),
 )
+
+type resourceIn struct {
+	cell.In
+	ServicesResource  resource.Resource[*slim_corev1.Service]
+	EndpointsResource resource.Resource[*k8s.Endpoints]
+}
+
+type StreamsOut struct {
+	cell.Out
+	ServicesStream  stream.Observable[resource.Event[*slim_corev1.Service]]
+	EndpointsStream stream.Observable[resource.Event[*k8s.Endpoints]]
+}
+
+// resourcesToStreams extracts the stream.Observable from resource.Resource.
+// This makes the reflector easier to test as its API surface is reduced.
+func resourcesToStreams(in resourceIn) StreamsOut {
+	return StreamsOut{
+		ServicesStream:  in.ServicesResource,
+		EndpointsStream: in.EndpointsResource,
+	}
+}
 
 type reflectorParams struct {
 	cell.In
@@ -202,7 +220,7 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 			initServices(txn)
 
 		case resource.Upsert:
-			svc, fes := convertService(p.ExtConfig, p.Log, obj)
+			svc, fes := convertService(p.ExtConfig, p.Log, obj, source.Kubernetes)
 			if svc == nil {
 				return
 			}
@@ -368,352 +386,6 @@ func (rh *reflectorHealth) report() {
 		}
 	}
 	rh.prevError = processingError
-}
-
-var (
-	zeroV4 = cmtypes.MustParseAddrCluster("0.0.0.0")
-	zeroV6 = cmtypes.MustParseAddrCluster("::")
-
-	ingressDummyAddress = cmtypes.MustParseAddrCluster("192.192.192.192")
-	ingressDummyPort    = uint16(9999)
-)
-
-func isIngressDummyEndpoint(l3n4Addr loadbalancer.L3n4Addr) bool {
-	// The ingress and gateway-api controllers (operator/pkg/model/translation/{gateway-api,ingress}) create
-	// a dummy endpoint to force Cilium to reconcile the service. This is no longer required with this new
-	// control-plane, but due to rolling upgrades we cannot remove it immediately. Hence we have the
-	// special handlind here to just ignore this endpoint to avoid populating the tables with unnecessary
-	// data.
-	return l3n4Addr.AddrCluster.Equal(ingressDummyAddress) && l3n4Addr.Port == ingressDummyPort
-}
-
-func isHeadless(svc *slim_corev1.Service) bool {
-	_, headless := svc.Labels[corev1.IsHeadlessService]
-	if strings.ToLower(svc.Spec.ClusterIP) == "none" {
-		headless = true
-	}
-	return headless
-}
-
-func convertService(cfg loadbalancer.ExternalConfig, log *slog.Logger, svc *slim_corev1.Service) (s *loadbalancer.Service, fes []loadbalancer.FrontendParams) {
-	name := loadbalancer.ServiceName{Namespace: svc.Namespace, Name: svc.Name}
-	s = &loadbalancer.Service{
-		Name:                name,
-		Source:              source.Kubernetes,
-		Labels:              labels.Map2Labels(svc.Labels, string(source.Kubernetes)),
-		Selector:            svc.Spec.Selector,
-		Annotations:         svc.Annotations,
-		HealthCheckNodePort: uint16(svc.Spec.HealthCheckNodePort),
-	}
-
-	expType, err := k8s.NewSvcExposureType(svc)
-	if err != nil {
-		log.Warn("Ignoring annotation",
-			logfields.Error, err,
-			logfields.Annotations, annotation.ServiceTypeExposure,
-			logfields.Service, svc.GetName(),
-		)
-	}
-
-	if len(svc.Spec.Ports) > 0 {
-		s.PortNames = map[string]uint16{}
-		for _, port := range svc.Spec.Ports {
-			s.PortNames[port.Name] = uint16(port.Port)
-		}
-	}
-
-	for _, srcRange := range svc.Spec.LoadBalancerSourceRanges {
-		prefix, err := netip.ParsePrefix(srcRange)
-		if err != nil {
-			continue
-		}
-		s.SourceRanges = append(s.SourceRanges, prefix)
-	}
-
-	switch svc.Spec.ExternalTrafficPolicy {
-	case slim_corev1.ServiceExternalTrafficPolicyLocal:
-		s.ExtTrafficPolicy = loadbalancer.SVCTrafficPolicyLocal
-	default:
-		s.ExtTrafficPolicy = loadbalancer.SVCTrafficPolicyCluster
-	}
-
-	if svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == slim_corev1.ServiceInternalTrafficPolicyLocal {
-		s.IntTrafficPolicy = loadbalancer.SVCTrafficPolicyLocal
-	} else {
-		s.IntTrafficPolicy = loadbalancer.SVCTrafficPolicyCluster
-	}
-	// Scopes for NodePort and LoadBalancer. Either just external (policies are the same), or
-	// both external and internal (when one policy is local)
-	scopes := []uint8{loadbalancer.ScopeExternal}
-	twoScopes := (s.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal) != (s.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal)
-	if twoScopes {
-		scopes = append(scopes, loadbalancer.ScopeInternal)
-	}
-
-	// SessionAffinity
-	if svc.Spec.SessionAffinity == slim_corev1.ServiceAffinityClientIP {
-		s.SessionAffinity = true
-
-		s.SessionAffinityTimeout = time.Duration(int(time.Second) * int(slim_corev1.DefaultClientIPServiceAffinitySeconds))
-		if cfg := svc.Spec.SessionAffinityConfig; cfg != nil && cfg.ClientIP != nil && cfg.ClientIP.TimeoutSeconds != nil && *cfg.ClientIP.TimeoutSeconds != 0 {
-			s.SessionAffinityTimeout = time.Duration(int(time.Second) * int(*cfg.ClientIP.TimeoutSeconds))
-		}
-	}
-
-	if s.IntTrafficPolicy != loadbalancer.SVCTrafficPolicyLocal && isTopologyAware(svc) {
-		s.TrafficDistribution = loadbalancer.TrafficDistributionPreferClose
-	}
-
-	// A service that is annotated as headless has no frontends, even if the service spec contains
-	// ClusterIPs etc.
-	if isHeadless(svc) {
-		return
-	}
-
-	// ClusterIP
-	if expType.CanExpose(slim_corev1.ServiceTypeClusterIP) {
-		var clusterIPs []string
-		if len(svc.Spec.ClusterIPs) > 0 {
-			clusterIPs = slices.Sorted(slices.Values(svc.Spec.ClusterIPs))
-		} else {
-			clusterIPs = []string{svc.Spec.ClusterIP}
-		}
-
-		for _, ip := range clusterIPs {
-			addr, err := cmtypes.ParseAddrCluster(ip)
-			if err != nil {
-				continue
-			}
-
-			if (!cfg.EnableIPv6 && addr.Is6()) || (!cfg.EnableIPv4 && addr.Is4()) {
-				continue
-			}
-
-			for _, port := range svc.Spec.Ports {
-				p := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
-				if p == nil {
-					continue
-				}
-				fe := loadbalancer.FrontendParams{
-					Type:        loadbalancer.SVCTypeClusterIP,
-					PortName:    loadbalancer.FEPortName(port.Name),
-					ServiceName: name,
-					ServicePort: uint16(port.Port),
-				}
-				fe.Address.AddrCluster = addr
-				fe.Address.Scope = loadbalancer.ScopeExternal
-				fe.Address.L4Addr = *p
-				fes = append(fes, fe)
-			}
-		}
-	}
-
-	// NOTE: We always want to do ClusterIP services even when full kube-proxy replacement is disabled.
-	// See https://github.com/cilium/cilium/issues/16197 for context.
-
-	if cfg.KubeProxyReplacement {
-		// NodePort
-		if (svc.Spec.Type == slim_corev1.ServiceTypeNodePort || svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer) &&
-			expType.CanExpose(slim_corev1.ServiceTypeNodePort) {
-
-			for _, scope := range scopes {
-				for _, family := range getIPFamilies(svc) {
-					if (!cfg.EnableIPv6 && family == slim_corev1.IPv6Protocol) ||
-						(!cfg.EnableIPv4 && family == slim_corev1.IPv4Protocol) {
-						continue
-					}
-					for _, port := range svc.Spec.Ports {
-						if port.NodePort == 0 {
-							continue
-						}
-
-						fe := loadbalancer.FrontendParams{
-							Type:        loadbalancer.SVCTypeNodePort,
-							PortName:    loadbalancer.FEPortName(port.Name),
-							ServiceName: name,
-							ServicePort: uint16(port.Port),
-						}
-
-						switch family {
-						case slim_corev1.IPv4Protocol:
-							fe.Address.AddrCluster = zeroV4
-						case slim_corev1.IPv6Protocol:
-							fe.Address.AddrCluster = zeroV6
-						default:
-							continue
-						}
-
-						p := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.NodePort))
-						if p == nil {
-							continue
-						}
-						fe.Address.Scope = scope
-						fe.Address.L4Addr = *p
-						fes = append(fes, fe)
-					}
-				}
-			}
-		}
-
-		// LoadBalancer
-		if svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer && expType.CanExpose(slim_corev1.ServiceTypeLoadBalancer) {
-			for _, ip := range svc.Status.LoadBalancer.Ingress {
-				if ip.IP == "" {
-					continue
-				}
-
-				addr, err := cmtypes.ParseAddrCluster(ip.IP)
-				if err != nil {
-					continue
-				}
-				if (!cfg.EnableIPv6 && addr.Is6()) || (!cfg.EnableIPv4 && addr.Is4()) {
-					continue
-				}
-
-				for _, scope := range scopes {
-					for _, port := range svc.Spec.Ports {
-						fe := loadbalancer.FrontendParams{
-							Type:        loadbalancer.SVCTypeLoadBalancer,
-							PortName:    loadbalancer.FEPortName(port.Name),
-							ServiceName: name,
-							ServicePort: uint16(port.Port),
-						}
-
-						p := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
-						if p == nil {
-							continue
-						}
-						fe.Address.AddrCluster = addr
-						fe.Address.Scope = scope
-						fe.Address.L4Addr = *p
-						fes = append(fes, fe)
-					}
-				}
-
-			}
-		}
-
-		// ExternalIP
-		for _, ip := range svc.Spec.ExternalIPs {
-			addr, err := cmtypes.ParseAddrCluster(ip)
-			if err != nil {
-				continue
-			}
-			if (!cfg.EnableIPv6 && addr.Is6()) || (!cfg.EnableIPv4 && addr.Is4()) {
-				continue
-			}
-
-			for _, port := range svc.Spec.Ports {
-				fe := loadbalancer.FrontendParams{
-					Type:        loadbalancer.SVCTypeExternalIPs,
-					PortName:    loadbalancer.FEPortName(port.Name),
-					ServiceName: name,
-					ServicePort: uint16(port.Port),
-				}
-
-				p := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
-				if p == nil {
-					continue
-				}
-
-				fe.Address.AddrCluster = addr
-				fe.Address.Scope = loadbalancer.ScopeExternal
-				fe.Address.L4Addr = *p
-				fes = append(fes, fe)
-			}
-		}
-	}
-
-	return
-}
-
-func getIPFamilies(svc *slim_corev1.Service) []slim_corev1.IPFamily {
-	if len(svc.Spec.IPFamilies) == 0 {
-		// No IP families specified, try to deduce them from the cluster IPs
-		if len(svc.Spec.ClusterIP) == 0 || svc.Spec.ClusterIP == slim_corev1.ClusterIPNone {
-			return nil
-		}
-
-		ipv4, ipv6 := false, false
-		if len(svc.Spec.ClusterIPs) > 0 {
-			for _, cip := range svc.Spec.ClusterIPs {
-				if ip.IsIPv6(net.ParseIP(cip)) {
-					ipv6 = true
-				} else {
-					ipv4 = true
-				}
-			}
-		} else {
-			ipv6 = ip.IsIPv6(net.ParseIP(svc.Spec.ClusterIP))
-			ipv4 = !ipv6
-		}
-		families := make([]slim_corev1.IPFamily, 0, 2)
-		if ipv4 {
-			families = append(families, slim_corev1.IPv4Protocol)
-		}
-		if ipv6 {
-			families = append(families, slim_corev1.IPv4Protocol)
-		}
-		return families
-	}
-	return svc.Spec.IPFamilies
-}
-
-func convertEndpoints(cfg loadbalancer.ExternalConfig, ep *k8s.Endpoints) (name loadbalancer.ServiceName, out []loadbalancer.BackendParams) {
-	name = loadbalancer.ServiceName{
-		Name:      ep.ServiceID.Name,
-		Namespace: ep.ServiceID.Namespace,
-	}
-
-	// k8s.Endpoints may have the same backend address multiple times
-	// with a different port name. Collapse them down into single
-	// entry.
-	type entry struct {
-		portNames []string
-		backend   *k8s.Backend
-	}
-	entries := map[loadbalancer.L3n4Addr]entry{}
-
-	for addrCluster, be := range ep.Backends {
-		if (!cfg.EnableIPv6 && addrCluster.Is6()) || (!cfg.EnableIPv4 && addrCluster.Is4()) {
-			continue
-		}
-		for portName, l4Addr := range be.Ports {
-			l3n4Addr := loadbalancer.L3n4Addr{
-				AddrCluster: addrCluster,
-				L4Addr:      *l4Addr,
-			}
-			if isIngressDummyEndpoint(l3n4Addr) {
-				continue
-			}
-			portNames := entries[l3n4Addr].portNames
-			if portName != "" {
-				portNames = append(portNames, portName)
-			}
-			entries[l3n4Addr] = entry{
-				portNames: portNames,
-				backend:   be,
-			}
-		}
-	}
-	for l3n4Addr, entry := range entries {
-
-		state := loadbalancer.BackendStateActive
-		if entry.backend.Terminating {
-			state = loadbalancer.BackendStateTerminating
-		}
-		be := loadbalancer.BackendParams{
-			Address:   l3n4Addr,
-			NodeName:  entry.backend.NodeName,
-			PortNames: entry.portNames,
-			Weight:    loadbalancer.DefaultBackendWeight,
-			Zone:      entry.backend.Zone,
-			ForZones:  entry.backend.HintsForZones,
-			State:     state,
-		}
-		out = append(out, be)
-	}
-	return
 }
 
 // hostPortServiceNamePrefix returns the common prefix for synthetic HostPort services
@@ -945,19 +617,4 @@ func joinObservables[T any](src stream.Observable[T], srcs ...stream.Observable[
 				src.Observe(ctx, emit, comp)
 			}
 		})
-}
-
-func isTopologyAware(svc *slim_corev1.Service) bool {
-	return getAnnotationTopologyAwareHints(svc) ||
-		(svc.Spec.TrafficDistribution != nil &&
-			*svc.Spec.TrafficDistribution == corev1.ServiceTrafficDistributionPreferClose)
-}
-
-func getAnnotationTopologyAwareHints(svc *slim_corev1.Service) bool {
-	// v1.DeprecatedAnnotationTopologyAwareHints has precedence over v1.AnnotationTopologyMode.
-	value, ok := svc.ObjectMeta.Annotations[corev1.DeprecatedAnnotationTopologyAwareHints]
-	if !ok {
-		value = svc.ObjectMeta.Annotations[corev1.AnnotationTopologyMode]
-	}
-	return !(value == "" || value == "disabled" || value == "Disabled")
 }

--- a/pkg/loadbalancer/reflectors/k8s_test.go
+++ b/pkg/loadbalancer/reflectors/k8s_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 func BenchmarkConvertService(b *testing.B) {
-	obj, err := testutils.DecodeFile("../experimental/benchmark/testdata/service.yaml")
+	obj, err := testutils.DecodeFile("../benchmark/testdata/service.yaml")
 	if err != nil {
 		panic(err)
 	}
@@ -39,7 +39,7 @@ func BenchmarkConvertService(b *testing.B) {
 }
 
 func BenchmarkParseEndpointSlice(b *testing.B) {
-	obj, err := testutils.DecodeFile("../experimental/benchmark/testdata/endpointslice.yaml")
+	obj, err := testutils.DecodeFile("../benchmark/testdata/endpointslice.yaml")
 	if err != nil {
 		panic(err)
 	}
@@ -53,7 +53,7 @@ func BenchmarkParseEndpointSlice(b *testing.B) {
 }
 
 func BenchmarkConvertEndpoints(b *testing.B) {
-	obj, err := testutils.DecodeFile("../experimental/benchmark/testdata/endpointslice.yaml")
+	obj, err := testutils.DecodeFile("../benchmark/testdata/endpointslice.yaml")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/loadbalancer/reflectors/k8s_test.go
+++ b/pkg/loadbalancer/reflectors/k8s_test.go
@@ -14,6 +14,7 @@ import (
 	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/source"
 )
 
 var (
@@ -32,7 +33,7 @@ func BenchmarkConvertService(b *testing.B) {
 	svc := obj.(*slim_corev1.Service)
 
 	for b.Loop() {
-		convertService(benchmarkExternalConfig, slog.New(slog.DiscardHandler), svc)
+		convertService(benchmarkExternalConfig, slog.New(slog.DiscardHandler), svc, source.Kubernetes)
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "services/sec")
 }

--- a/pkg/loadbalancer/reflectors/k8s_test.go
+++ b/pkg/loadbalancer/reflectors/k8s_test.go
@@ -62,7 +62,7 @@ func BenchmarkConvertEndpoints(b *testing.B) {
 	eps := k8s.ParseEndpointSliceV1(logger, epSlice)
 
 	for b.Loop() {
-		convertEndpoints(benchmarkExternalConfig, eps)
+		convertEndpoints(logger, benchmarkExternalConfig, eps)
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpoints/sec")
 }

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"path"
 	"strconv"
 	"strings"
 	"testing"
@@ -110,6 +111,14 @@ func TestScript(t *testing.T) {
 			flags.Set("lb-retry-backoff-min", "10ms") // as we're doing fault injection we want
 			flags.Set("lb-retry-backoff-max", "10ms") // tiny backoffs
 			flags.Set("bpf-lb-maglev-table-size", "1021")
+
+			// Expand $WORK in args. Used by testdata/file.txtar.
+			// This works by creating a new temporary directory for this test (e.g. /tmp/<tempdir/002)
+			// and replacing the directory with /001 which is the temp directory that scripttest created.
+			tempDir := path.Join(path.Dir(t.TempDir()), "001")
+			for i := range args {
+				args[i] = strings.ReplaceAll(args[i], "$WORK", tempDir)
+			}
 
 			// Parse the shebang arguments in the script.
 			require.NoError(t, flags.Parse(args), "flags.Parse")

--- a/pkg/loadbalancer/tests/testdata/file.txtar
+++ b/pkg/loadbalancer/tests/testdata/file.txtar
@@ -1,0 +1,96 @@
+#! --lb-state-file=$WORK/state.yaml --lb-state-file-interval=10ms
+#
+# Tests the --lb-state-file mechanism to populate the load-balancing state from a file on disk.
+#
+
+hive/start
+db/initialized
+
+# Starting with a missing state file. Tables should be empty
+db/empty services backends frontends
+
+# Switch to state with 1 service and 1 backend
+# Using 'mv' to atomically swap the file so we won't read partial files. This is what
+# a production implementation using this facility must do as well.
+mv state1.yaml state.yaml
+
+# Wait for synchronization
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+# Check BPF maps
+lb/maps-dump maps.actual
+* cmp maps.actual maps.expected
+
+# Drop the endpoints
+sed '^endpoints' '^not-endpoints' state.yaml
+
+# Backend table should be empty now
+* db/empty backends
+
+# Empty file will clear everything
+mv state_empty.yaml state.yaml
+
+# Everything is empty
+* db/empty services frontends backends
+lb/maps-dump maps.actual
+* empty maps.actual
+
+###
+
+-- services.table --
+Name        Source   PortNames   TrafficPolicy   Flags
+test/echo   api      http=80     Cluster
+
+-- frontends.table --
+Address            Type          ServiceName   PortName   Backends         RedirectTo   Status    Error
+172.16.1.1:80/TCP  LoadBalancer  test/echo     http       2.2.2.2:80/TCP                Done
+
+-- backends.table --
+Address          Instances          Shadows   NodeName
+2.2.2.2:80/TCP   test/echo (http)
+
+-- state_empty.yaml --
+-- state1.yaml --
+services:
+  # Since we don't rely on the k8s api machinery, the definition can be quite minimal:
+  - metadata:
+      name: echo
+      namespace: test
+    spec:
+      ports:
+      - name: http
+        port: 80
+        protocol: TCP
+        targetPort: 80
+      type: LoadBalancer
+    status:
+      loadBalancer:
+        ingress:
+        - ip: 172.16.1.1
+
+endpoints:
+  - metadata:
+      labels:
+        kubernetes.io/service-name: echo
+      name: echo-ep1
+      namespace: test
+    addressType: IPv4
+    endpoints:
+    - addresses:
+      - 2.2.2.2
+      conditions:
+        ready: true
+        serving: true
+        terminating: false
+    ports:
+    - name: http
+      port: 80
+      protocol: TCP
+
+-- maps.expected --
+BE: ID=1 ADDR=2.2.2.2:80/TCP STATE=active
+REV: ID=1 ADDR=172.16.1.1:80
+SVC: ID=1 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=1 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer


### PR DESCRIPTION
As the `cilium-dbg service update` is being removed (https://github.com/cilium/cilium/pull/39084) we need a different mechanism for serving the use-case. 

This implements a file-based synchronization for the load-balancing state by using the Kubernetes Service and EndpointSlice formats, which makes for a simple implementation that is also familiar to users.