### PR TITLE
doc: using helm install for gateway api install doc

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -55,7 +55,7 @@ Installation
 
         .. parsed-literal::
 
-            $ helm upgrade cilium |CHART_RELEASE| \\
+            $ helm install cilium |CHART_RELEASE| \\
                 --namespace kube-system \\
                 --reuse-values \\
                 --set kubeProxyReplacement=true \\


### PR DESCRIPTION
- fix the helm upgrade since it can't perform the install for helm
- use helm install for gateway api so it's consistent with other places in the doc.



```release-note
Change the helm upgrade to helm install in the gateway api install doc
```
