### PR TITLE
aws/ENI: Only use pagination when not specifying IDs

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -348,10 +348,12 @@ func (c *Client) describeNetworkInterfacesFromInstances(ctx context.Context) ([]
 				Values: []string{"*"},
 			},
 		},
-		MaxResults: aws.Int32(defaults.ENIMaxResultsPerApiCall),
 	}
 	if len(enisListFromInstances) > 0 {
 		ENIAttrs.NetworkInterfaceIds = enisListFromInstances
+	} else {
+		// MaxResults is incompatible with NetworkInterfaceIds
+		ENIAttrs.MaxResults = aws.Int32(defaults.ENIMaxResultsPerApiCall)
 	}
 
 	var result []ec2_types.NetworkInterface


### PR DESCRIPTION
Setting both IDs and a maxresult parameter in a describe call input is not possible, see [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Query-Requests.html#api-pagination):

> If you call a describe API action with both a list of IDs and MaxResults, the request fails with the error InvalidParameterCombination.

Fixes #39106

See also #37983

Will need to be backported to 1.17

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
aws/ENI: Only use pagination when not specifying IDs
```
