### PR TITLE
operator/pkg/gateway-api: Update ServiceImport and TLSRoute support c…

### DIFF
--- a/operator/pkg/gateway-api/helpers/serviceimport.go
+++ b/operator/pkg/gateway-api/helpers/serviceimport.go
@@ -12,11 +12,11 @@ import (
 )
 
 // HasServiceImportSupport return if the ServiceImport CRD is supported.
-// This checks if the MCS API group is registered in the client scheme
+// This checks if the MCS API group ServiceImport CRD is registered in the client scheme
 // and it is expected that it is registered only if the ServiceImport
 // CRD has been installed prior to the client setup.
 func HasServiceImportSupport(scheme *runtime.Scheme) bool {
-	return scheme.IsGroupRegistered(mcsapiv1alpha1.GroupVersion.Group)
+	return scheme.Recognizes(mcsapiv1alpha1.SchemeGroupVersion.WithKind("ServiceImport"))
 }
 
 func GetServiceName(svcImport *mcsapiv1alpha1.ServiceImport) (string, error) {

--- a/operator/pkg/gateway-api/helpers/tlsroute.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute.go
@@ -9,9 +9,9 @@ import (
 )
 
 // HasTLSRouteSupport returns if the TLSRoute CRD is supported.
-// This checks if the Gateway API v1alpha2 group is registered in the client scheme
+// This checks if the Gateway API v1alpha2 TLSRoute CRD is registered in the client scheme
 // and it is expected that it is registered only if the TLSRoute
 // CRD has been installed prior to the client setup.
 func HasTLSRouteSupport(scheme *runtime.Scheme) bool {
-	return scheme.IsGroupRegistered(gatewayv1alpha2.GroupVersion.Group)
+	return scheme.Recognizes(gatewayv1alpha2.SchemeGroupVersion.WithKind("TLSRoute"))
 }

--- a/operator/pkg/gateway-api/helpers/tlsroute_test.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute_test.go
@@ -12,12 +12,15 @@ import (
 )
 
 func TestHasTLSRouteSupport(t *testing.T) {
-	// Create a scheme without TLSRoute registered
-	scheme := runtime.NewScheme()
-	assert.False(t, HasTLSRouteSupport(scheme))
+	scheme1 := runtime.NewScheme()
+	assert.False(t, HasTLSRouteSupport(scheme1), "Should be false when group is not registered")
 
-	// Register the TLSRoute group
-	err := gatewayv1alpha2.AddToScheme(scheme)
+	scheme2 := runtime.NewScheme()
+	scheme2.AddKnownTypes(gatewayv1alpha2.SchemeGroupVersion, &gatewayv1alpha2.TCPRoute{})
+	assert.False(t, HasTLSRouteSupport(scheme2), "Should be false when group is registered but TLSRoute kind is not")
+
+	scheme3 := runtime.NewScheme()
+	err := gatewayv1alpha2.AddToScheme(scheme3)
 	assert.NoError(t, err)
-	assert.True(t, HasTLSRouteSupport(scheme))
+	assert.True(t, HasTLSRouteSupport(scheme3), "Should be true when TLSRoute kind is registered")
 }


### PR DESCRIPTION
- Currently, if we dont have TLSRoute CRD installed, the operator will still try to list TLSRoute CRD that's because we validate the TLSRoute through IsGroupRegistered.

- This commit refactors the HasServiceImportSupport and HasTLSRouteSupport functions to check for the registration of the ServiceImport and TLSRoute CRDs instead of IsGroupRegistered. so the optinal CRD will not just pass when the Group is registered.

- Update the UT to test the TLSRoute properly

Fixes: https://github.com/cilium/cilium/issues/38420

```release-note
Check the TLSRoute and HasServiceImportSupport through the CRD. 
```
