### PR TITLE
bpf: node: clean up access to node-map

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -37,6 +37,7 @@
 #include "lib/local_delivery.h"
 #include "lib/drop.h"
 #include "lib/identity.h"
+#include "lib/node.h"
 #include "lib/nodeport.h"
 #include "lib/nodeport_egress.h"
 #include "lib/clustermesh.h"

--- a/bpf/lib/auth.h
+++ b/bpf/lib/auth.h
@@ -22,7 +22,6 @@ static __always_inline int
 auth_lookup(struct __ctx_buff *ctx, __u32 local_id, __u32 remote_id, __u32 remote_node_ip,
 	    __u8 auth_type)
 {
-	struct node_key node_ip = {};
 	struct node_value *node_value = NULL;
 	struct auth_info *auth;
 	struct auth_key key = {
@@ -33,9 +32,7 @@ auth_lookup(struct __ctx_buff *ctx, __u32 local_id, __u32 remote_id, __u32 remot
 	};
 
 	if (remote_node_ip) {
-		node_ip.family = ENDPOINT_KEY_IPV4;
-		node_ip.ip4 = remote_node_ip;
-		node_value = map_lookup_elem(&cilium_node_map_v2, &node_ip);
+		node_value = lookup_ip4_node(remote_node_ip);
 		if (!node_value || !node_value->id)
 			return DROP_NO_NODE_ID;
 		key.remote_node_id = node_value->id;

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -60,42 +60,6 @@ static __always_inline __u8 get_min_encrypt_key(__u8 peer_key __maybe_unused)
 }
 
 #ifdef ENABLE_IPSEC
-# ifdef ENABLE_IPV4
-static __always_inline __u16
-lookup_ip4_node_id(__u32 ip4)
-{
-	struct node_key node_ip = {};
-	struct node_value *node_value = NULL;
-
-	node_ip.family = ENDPOINT_KEY_IPV4;
-	node_ip.ip4 = ip4;
-	node_value = map_lookup_elem(&cilium_node_map_v2, &node_ip);
-	if (!node_value)
-		return 0;
-	if (!node_value->id)
-		return 0;
-	return node_value->id;
-}
-# endif /* ENABLE_IPV4 */
-
-# ifdef ENABLE_IPV6
-static __always_inline __u16
-lookup_ip6_node_id(const union v6addr *ip6)
-{
-	struct node_key node_ip = {};
-	struct node_value *node_value = NULL;
-
-	node_ip.family = ENDPOINT_KEY_IPV6;
-	node_ip.ip6 = *ip6;
-	node_value = map_lookup_elem(&cilium_node_map_v2, &node_ip);
-	if (!node_value)
-		return 0;
-	if (!node_value->id)
-		return 0;
-	return node_value->id;
-}
-# endif /* ENABLE_IPV6 */
-
 /**
  * or_encrypt_key - mask and shift key into encryption format
  */

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -93,13 +93,10 @@ set_ipsec_encrypt(struct __ctx_buff *ctx, __u8 spi, __u32 tunnel_endpoint,
 	 * bpf_host to send ctx onto tunnel for encap.
 	 */
 
-	struct node_key node_ip = {};
 	struct node_value *node_value = NULL;
 	__u32 mark;
 
-	node_ip.family = ENDPOINT_KEY_IPV4;
-	node_ip.ip4 = tunnel_endpoint;
-	node_value = map_lookup_elem(&cilium_node_map_v2, &node_ip);
+	node_value = lookup_ip4_node(tunnel_endpoint);
 	if (!node_value || !node_value->id)
 		return DROP_NO_NODE_ID;
 

--- a/bpf/lib/node.h
+++ b/bpf/lib/node.h
@@ -15,3 +15,53 @@ struct {
 	__uint(max_entries, NODE_MAP_SIZE);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } cilium_node_map_v2 __section_maps_btf;
+
+static __always_inline struct node_value *
+lookup_ip4_node(__be32 ip4)
+{
+	struct node_key key = {};
+
+	key.family = ENDPOINT_KEY_IPV4;
+	key.ip4 = ip4;
+
+	return map_lookup_elem(&cilium_node_map_v2, &key);
+}
+
+static __always_inline __u16
+lookup_ip4_node_id(__be32 ip4)
+{
+	struct node_value *node_value;
+
+	node_value = lookup_ip4_node(ip4);
+	if (!node_value)
+		return 0;
+	if (!node_value->id)
+		return 0;
+	return node_value->id;
+}
+
+# ifdef ENABLE_IPV6
+static __always_inline struct node_value *
+lookup_ip6_node(const union v6addr *ip6)
+{
+	struct node_key key = {};
+
+	key.family = ENDPOINT_KEY_IPV6;
+	key.ip6 = *ip6;
+
+	return map_lookup_elem(&cilium_node_map_v2, &key);
+}
+
+static __always_inline __u16
+lookup_ip6_node_id(const union v6addr *ip6)
+{
+	struct node_value *node_value;
+
+	node_value = lookup_ip6_node(ip6);
+	if (!node_value)
+		return 0;
+	if (!node_value->id)
+		return 0;
+	return node_value->id;
+}
+# endif /* ENABLE_IPV6 */

--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -246,27 +246,10 @@ int ipv6_not_decrypted_ipsec_from_overlay_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "ipv6_not_decrypted_ipsec_from_overlay")
 int ipv6_not_decrypted_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
 {
-	/* To be able to use memcpy, we need to ensure that the memcpy'ed field is
-	 * 8B aligned on the stack. Given the existing node_ip struct, the only way
-	 * to achieve that is to align a parent tmp struct.
-	 * We can't simply use __bpf_memcpy_builtin because that causes a
-	 * relocation error in the lib.
-	 */
-	struct tmp {
-		__u32 _;
-		struct node_key k;
-	} node_ip __align_stack_8 = {};
-	struct node_value node_value = {
-		.id = NODE_ID,
-		.spi = 0,
-	};
-
 	/* We need to populate the node ID map because we'll lookup into it on
 	 * ingress to find the node ID to use to match against XFRM IN states.
 	 */
-	node_ip.k.family = ENDPOINT_KEY_IPV6;
-	memcpy((__u8 *)&node_ip.k.ip6, (__u8 *)v6_pod_one, 16);
-	map_update_elem(&cilium_node_map_v2, &node_ip.k, &node_value, BPF_ANY);
+	node_v6_add_entry((union v6addr *)v6_pod_one, NODE_ID, 0);
 
 	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
 	return TEST_ERROR;

--- a/bpf/tests/ipsec_redirect_native.c
+++ b/bpf/tests/ipsec_redirect_native.c
@@ -6,6 +6,7 @@
 #include "node_config.h"
 #include "lib/encrypt.h"
 #include "tests/lib/ipcache.h"
+#include "tests/lib/node.h"
 
 PKTGEN("tc", "ipsec_redirect")
 int ipsec_redirect_pktgen(struct __ctx_buff *ctx)
@@ -43,15 +44,7 @@ int ipsec_redirect_check(__maybe_unused struct __ctx_buff *ctx)
 	 */
 
 	/* fill in nodemap entry */
-	struct node_key key = {
-		.family = ENDPOINT_KEY_IPV4,
-		.ip4 = DST_IP,
-	};
-	struct node_value val = {
-		.id = DST_NODE_ID,
-		.spi = TARGET_SPI, /* we should find spi 2 in mark since we use lowest */
-	};
-	map_update_elem(&cilium_node_map_v2, &key, &val, BPF_ANY);
+	node_v4_add_entry(DST_IP, DST_NODE_ID, TARGET_SPI);
 
 	/* fill encrypt map with node's current SPI 3 */
 	struct encrypt_config cfg = {

--- a/bpf/tests/lib/node.h
+++ b/bpf/tests/lib/node.h
@@ -2,16 +2,34 @@
 /* Copyright Authors of Cilium */
 
 static __always_inline void
+node_add_entry(struct node_key *key, __u16 node_id, __u8 spi)
+{
+	struct node_value value = {
+		.id = node_id,
+		.spi = spi,
+	};
+
+	map_update_elem(&cilium_node_map_v2, key, &value, BPF_ANY);
+}
+
+static __always_inline void
 node_v4_add_entry(__be32 node_ip, __u16 node_id, __u8 spi)
 {
 	struct node_key key = {
 		.family = ENDPOINT_KEY_IPV4,
 		.ip4 = node_ip,
 	};
-	struct node_value value = {
-		.id = node_id,
-		.spi = spi,
+
+	node_add_entry(&key, node_id, spi);
+}
+
+static __always_inline void
+node_v6_add_entry(const union v6addr *node_ip, __u16 node_id, __u8 spi)
+{
+	struct node_key key = {
+		.family = ENDPOINT_KEY_IPV6,
+		.ip6 = *node_ip,
 	};
 
-	map_update_elem(&cilium_node_map_v2, &key, &value, BPF_ANY);
+	node_add_entry(&key, node_id, spi);
 }


### PR DESCRIPTION
Slim down the open-coded access to the node-map, and hide the actual map name inside dedicated helpers. Also decouple the node-map and IPSec.