### PR TITLE
cec: fix missing call to injectCiliumEnvoyFilters

### DIFF
--- a/pkg/ciliumenvoyconfig/legacy/cec_manager.go
+++ b/pkg/ciliumenvoyconfig/legacy/cec_manager.go
@@ -90,7 +90,7 @@ func (r *cecManager) addCiliumEnvoyConfig(cecObjectMeta metav1.ObjectMeta, cecSp
 		cecObjectMeta.GetName(),
 		cecSpec.Resources,
 		len(cecSpec.Services) > 0,
-		len(cecSpec.Services) > 0,
+		ciliumenvoyconfig.InjectCiliumEnvoyFilters(&cecObjectMeta, cecSpec),
 		ciliumenvoyconfig.UseOriginalSourceAddress(&cecObjectMeta),
 		true,
 	)


### PR DESCRIPTION
PR #37868 introduced the possibility to control Cilium Envoy filter injection via annotation.

But the PR missed one occurrence that is still only checking for `len(spec.Services) > 0` instead of calling `injectCiliumEnvoyFilters`.

This commit fixes this.