### PR TITLE
v1.17: Update Go version to 1.24 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/pkg/api/apierror.go
+++ b/pkg/api/apierror.go
@@ -42,7 +42,7 @@ func Error(code int, err error) *APIError {
 		err = errors.New("Error pointer was nil")
 	}
 
-	return New(code, err.Error()) //nolint:govet
+	return New(code, "%v", err)
 }
 
 // Error returns the API error message.

--- a/pkg/auth/spire/certificate_provider_test.go
+++ b/pkg/auth/spire/certificate_provider_test.go
@@ -274,7 +274,7 @@ func TestSpireDelegateClient_GetCertificateForIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
 	}
-	leafKey, err := rsa.GenerateKey(rand.Reader, 512)
+	leafKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		t.Fatalf("failed to generate leaf key: %v", err)
 	}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -371,7 +371,7 @@ func traceL3(ctx *SearchContext, peerEndpoints api.EndpointSelectorSlice, direct
 			result.WriteString("\n")
 		}
 	}
-	ctx.PolicyTrace(result.String()) //nolint:govet
+	ctx.PolicyTrace("%s", result.String())
 }
 
 // portRulesCoverContext determines whether L4 portions of rules cover the


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/37852.