### PR TITLE
ipam/podcidr: fix CI flake

### DIFF
--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -281,7 +281,10 @@ func TestNodesPodCIDRManager_Resync(t *testing.T) {
 				}
 			},
 			testPostRun: func(fields *fields) {
-				time.Sleep(2 * time.Millisecond)
+				// Trigger is async, so until we have synctest testing we have
+				// to resort to Eventually.
+				require.Eventually(t, func() bool { return reSyncCalls.Load() >= 1 },
+					time.Second*2, time.Millisecond)
 				require.Equal(t, int32(1), reSyncCalls.Load())
 			},
 		},


### PR DESCRIPTION
The test was relying on `time.Sleep` for synchronisation, essentially asserting that CI could complete an async operation within two ms. Unfortunately, in CI, time is a weird soup, and hence this has the potential to fail every now and then.

Easy to reproduce by either overloading a machine or giving the process very little resources - e.g. with the following:

    go test -race -c ./pkg/ipam/allocator/podcidr
    stress -p 300 ./podcidr.test -test.v -test.run 'Resync'

Fix it with waiting longer - this would be a perfect candidate for synctest, but we'll have to do the hacky thing until that has stabilized.

Fixes: #38658 
