### PR TITLE
LB-IPAM: Deprecate CiliumLoadBalancerIPPool v2alpha1

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -293,6 +293,8 @@ communicating via the proxy must reconnect to re-establish connections.
 1.19 Upgrade Notes
 ------------------
 * MCS-API CoreDNS configuration recommendation has been updated. See :ref:`clustermesh_mcsapi_prereqs` for more details.
+* The ``v2alpha1`` version of ``CiliumLoadBalancerIPPool`` CRD has been deprecated in favor of the ``v2`` version. Please change ``apiVersion: cilium.io/v2alpha1``
+  to ``apiVersion: cilium.io/v2`` in your manifests for all ``CiliumLoadBalancerIPPool`` resources.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumloadbalancerippools.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumloadbalancerippools.yaml
@@ -241,6 +241,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/k8s/apis/cilium.io/v2alpha1/lbipam_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/lbipam_types.go
@@ -18,6 +18,7 @@ import (
 // +kubebuilder:printcolumn:name="IPs Available",type=string,JSONPath=`.status.conditions[?(@.type=="cilium.io/IPsAvailable")].message`
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
 
 // CiliumLoadBalancerIPPool is a Kubernetes third-party resource which
 // is used to defined pools of IPs which the operator can use to to allocate


### PR DESCRIPTION
After promoting the `CiliumLoadBalancerIPPool` CRD to v2 version, deprecate the previous v2alpha1 version.

Fixes: https://github.com/cilium/cilium/issues/39110

```release-note
Deprecate `v2alpha1` version of `CiliumLoadBalancerIPPool` CRD in favor of the `v2` version
```

~Blocked on https://github.com/cilium/cilium/pull/39090~