### PR TITLE
ipcache: expose getTunnelEndpoint

### DIFF
--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -174,10 +174,10 @@ type RemoteEndpointInfo struct {
 
 func (v *RemoteEndpointInfo) String() string {
 	return fmt.Sprintf("identity=%d encryptkey=%d tunnelendpoint=%s flags=%s",
-		v.SecurityIdentity, v.Key, v.getTunnelEndpoint(), v.Flags)
+		v.SecurityIdentity, v.Key, v.GetTunnelEndpoint(), v.Flags)
 }
 
-func (v *RemoteEndpointInfo) getTunnelEndpoint() net.IP {
+func (v *RemoteEndpointInfo) GetTunnelEndpoint() net.IP {
 	if v.Flags&FlagIPv6TunnelEndpoint == 0 {
 		return v.TunnelEndpoint[:4]
 	}


### PR DESCRIPTION
In case, someone would like to access tunnel endpoint, value stored in TunnelEndpoint is no longer useful, as it combines both ipv4 and ipv6. Let's expose getTunnelEndpoint to make it possible.

Fixes: #38296 
