### PR TITLE
[v1.17] gh: e2e-upgrade: disable upgrade testing for config 12

### DIFF
--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -142,6 +142,8 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  # Temporarily disable upgrade/downgrade test
+  skip-upgrade: 'true'
 - name: '13'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: 'rhel8.6-20250415.134122'


### PR DESCRIPTION
The downgrade to v1.16 for this particular config has been broken for a few days, with no obvious culprit. Unblock CI until we understand the problem.