### PR TITLE
hubble: allow to enable/disable network policy correlation option again

### DIFF
--- a/pkg/hubble/cell/config.go
+++ b/pkg/hubble/cell/config.go
@@ -94,8 +94,6 @@ type config struct {
 	K8sDropEventsInterval time.Duration `mapstructure:"hubble-drop-events-interval"`
 	// K8sDropEventsReasons controls which drop reasons to emit events for.
 	K8sDropEventsReasons []string `mapstructure:"hubble-drop-events-reasons"`
-	// EnableNetworkPolicyCorrelation controls whether to enable network policy correlation of Hubble flows
-	EnableNetworkPolicyCorrelation bool `mapstructure:"hubble-network-policy-correlation-enabled"`
 }
 
 var defaultConfig = config{
@@ -129,10 +127,9 @@ var defaultConfig = config{
 	RecorderStoragePath:   hubbleDefaults.RecorderStoragePath,
 	RecorderSinkQueueSize: 1024,
 	// Hubble k8s v1.Events integration configuration.
-	EnableK8sDropEvents:            false,
-	K8sDropEventsInterval:          2 * time.Minute,
-	K8sDropEventsReasons:           []string{"auth_required", "policy_denied"},
-	EnableNetworkPolicyCorrelation: true,
+	EnableK8sDropEvents:   false,
+	K8sDropEventsInterval: 2 * time.Minute,
+	K8sDropEventsReasons:  []string{"auth_required", "policy_denied"},
 }
 
 func (def config) Flags(flags *pflag.FlagSet) {
@@ -173,7 +170,6 @@ func (def config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("hubble-drop-events", def.EnableK8sDropEvents, "Emit packet drop Events related to pods (alpha)")
 	flags.Duration("hubble-drop-events-interval", def.K8sDropEventsInterval, "Minimum time between emitting same events")
 	flags.StringSlice("hubble-drop-events-reasons", def.K8sDropEventsReasons, "Drop reasons to emit events for")
-	flags.Bool("hubble-network-policy-correlation-enabled", def.EnableNetworkPolicyCorrelation, "Enable network policy correlation of Hubble flows")
 }
 
 func (cfg *config) normalize() {

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -60,6 +60,12 @@ func newPayloadParser(params payloadParserParams) (parser.Decoder, error) {
 			),
 		)
 	}
+	parserOpts = append(
+		parserOpts,
+		parserOptions.WithNetworkPolicyCorrelation(
+			params.Log,
+			params.Config.EnableNetworkPolicyCorrelation,
+		))
 	return parser.New(params.Log, g, g, g, params.Ipcache, g, params.LinkCache, params.CGroupManager, params.Config.SkipUnknownCGroupIDs, parserOpts...)
 }
 

--- a/pkg/hubble/parser/cell/config.go
+++ b/pkg/hubble/parser/cell/config.go
@@ -14,6 +14,9 @@ type config struct {
 	// be skipped.
 	SkipUnknownCGroupIDs bool `mapstructure:"hubble-skip-unknown-cgroup-ids"`
 
+	// EnableNetworkPolicyCorrelation controls whether to enable network policy correlation of Hubble flows
+	EnableNetworkPolicyCorrelation bool `mapstructure:"hubble-network-policy-correlation-enabled"`
+
 	// EnableRedact controls if sensitive information will be redacted from L7
 	// flows.
 	EnableRedact bool `mapstructure:"hubble-redact-enabled"`
@@ -32,13 +35,14 @@ type config struct {
 }
 
 var defaultConfig = config{
-	SkipUnknownCGroupIDs:   true,
-	EnableRedact:           false,
-	RedactHttpURLQuery:     false,
-	RedactHttpUserInfo:     true,
-	RedactHttpHeadersAllow: []string{},
-	RedactHttpHeadersDeny:  []string{},
-	RedactKafkaAPIKey:      false,
+	SkipUnknownCGroupIDs:           true,
+	EnableNetworkPolicyCorrelation: true,
+	EnableRedact:                   false,
+	RedactHttpURLQuery:             false,
+	RedactHttpUserInfo:             true,
+	RedactHttpHeadersAllow:         []string{},
+	RedactHttpHeadersDeny:          []string{},
+	RedactKafkaAPIKey:              false,
 }
 
 func (cfg config) validate() error {
@@ -57,4 +61,5 @@ func (def config) Flags(flags *pflag.FlagSet) {
 	flags.StringSlice("hubble-redact-http-headers-allow", def.RedactHttpHeadersAllow, "HTTP headers to keep visible in flows")
 	flags.StringSlice("hubble-redact-http-headers-deny", def.RedactHttpHeadersDeny, "HTTP headers to redact from flows")
 	flags.Bool("hubble-redact-kafka-apikey", def.RedactKafkaAPIKey, "Hubble redact Kafka API key from flows")
+	flags.Bool("hubble-network-policy-correlation-enabled", def.EnableNetworkPolicyCorrelation, "Enable network policy correlation of Hubble flows")
 }

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -62,7 +62,7 @@ func WithRedact(logger *slog.Logger, httpQuery, httpUserInfo, kafkaApiKey bool, 
 	}
 }
 
-// EnableL3L4PolicyCorrelation configures the Network Policy correlation of Hubble Flows.
+// WithNetworkPolicyCorrelation configures the Network Policy correlation of Hubble Flows.
 func WithNetworkPolicyCorrelation(logger *slog.Logger, enabled bool) Option {
 	return func(opt *Options) {
 		opt.EnableNetworkPolicyCorrelation = enabled

--- a/pkg/hubble/parser/options/options_test.go
+++ b/pkg/hubble/parser/options/options_test.go
@@ -50,8 +50,8 @@ func TestEnableNetworkPolicyCorrelation(t *testing.T) {
 		),
 	)
 	opt := WithNetworkPolicyCorrelation(logger, true)
-	opt(&Options{
-		EnableNetworkPolicyCorrelation: true,
-	})
+	opts := Options{EnableNetworkPolicyCorrelation: false}
+	opt(&opts)
+	assert.True(t, opts.EnableNetworkPolicyCorrelation)
 	assert.Equal(t, want, buf.String())
 }


### PR DESCRIPTION
The referenced commit caused the Hubble network policy correlation to be always enabled, i.e. setting `--hubble-network-policy-correlation-enabled` no longer had any effect.

Fix this by correctly wiring up the config again and translating it into a parser option in newPayloadParser.

Fixes: 5df6f520eb8f ("feat(hubble): decouple the payloadparser from hubble control plane.")
Fixes: #38368

No need to backport because 5df6f520eb8f/#38368 didn't make it into a released version yet.