### PR TITLE
k8s/labels: Refactor `FindReserved` to return `LabelArray`

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -713,13 +713,12 @@ func (l Labels) LabelArray() LabelArray {
 
 // FindReserved locates all labels with reserved source in the labels and
 // returns a copy of them. If there are no reserved labels, returns nil.
-// TODO: return LabelArray as it is likely faster
-func (l Labels) FindReserved() Labels {
-	lbls := Labels{}
+func (l Labels) FindReserved() LabelArray {
+	lbls := make(LabelArray, 0)
 
-	for k, lbl := range l {
+	for _, lbl := range l {
 		if lbl.Source == LabelSourceReserved {
-			lbls[k] = lbl
+			lbls = append(lbls, lbl)
 		}
 	}
 


### PR DESCRIPTION
This commit addresses a TODO by modifying the `FindReserved` function to return a `LabelArray` instead of `Labels` which is a `map[string]Label`. Since the function's purpose is solely to identify reserved labels, a `LabelArray` is sufficient and more efficient than a map.

```release-note
k8s/labels: Refactor `FindReserved` to return `LabelArray`
```
