### PR TITLE
dynamiclifecycle: fix goroutine leak

### DIFF
--- a/pkg/dynamiclifecycle/watcher.go
+++ b/pkg/dynamiclifecycle/watcher.go
@@ -20,10 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-var (
-	limiter = rate.NewLimiter(time.Second, 1)
-)
-
 type FeatureStatus struct {
 	Feature DynamicFeatureName
 	Enabled bool
@@ -44,7 +40,6 @@ type watcherParams struct {
 
 type configWatcher struct {
 	watcherParams
-	limiter *rate.Limiter
 }
 
 // setEnabled sets the enablement flag for DynamicFeatureName
@@ -89,8 +84,10 @@ func (cw *configWatcher) processDynamicFeatures(dfcJson string) error {
 }
 
 func (cw *configWatcher) watch(ctx context.Context, health cell.Health) error {
+	limiter := rate.NewLimiter(time.Second, 1)
+	defer limiter.Stop()
 	for {
-		if err := cw.limiter.Wait(ctx); err != nil {
+		if err := limiter.Wait(ctx); err != nil {
 			return err
 		}
 
@@ -132,7 +129,7 @@ func registerWatcher(p watcherParams) error {
 		return fmt.Errorf("failed to start dynamic-lifecycle-manager with enable-dynamic-config=%t", p.DynamicConfigCellConfig.EnableDynamicConfig)
 	}
 
-	w := &configWatcher{p, limiter}
+	w := &configWatcher{p}
 	p.JobGroup.Add(job.OneShot("dynamic-config-watcher", func(ctx context.Context, health cell.Health) error {
 		return w.watch(ctx, health)
 	}))


### PR DESCRIPTION
Because NewLimiter creates a goroutine, having a global limiter causes a goroutine leak for everything that imports this package.

Move the limiter to a func-local variable.
