### PR TITLE
contrib: Remove kind.sh dependency on git

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -88,7 +88,7 @@ v4_prefix_secondary="192.168.0.0/16"
 v4_range_secondary="192.168.0.0/24"
 v6_prefix="fc00:c111::/64"
 v6_prefix_secondary="fc00:c112::/64"
-CILIUM_ROOT="$(git rev-parse --show-toplevel)"
+CILIUM_ROOT="$(realpath $(dirname ${BASH_SOURCE[0]:-$0})/../..)"
 
 have_kind() {
     [[ -n "$(command -v kind)" ]]


### PR DESCRIPTION
This script was relying on git to find the root of the Cilium repository
in order to expose the source tree into the container. This could cause
problems in some scenarios like when mounting a git worktree copy of the
source into an lvh-kind environment. Specifically, after launching the
VM, I would attempt to use "make kind" from the /host directory with the
git worktree copy of the source mounted, and the kind startup would fail
because the git worktree links could not be followed.

There's various ways to solve this problem including mounting additional
paths into the container or only mounting the original source tree.
However, all this step is trying to do is find the path to the source
tree two levels up from the path of the script itself. We can do this in
a cross-platform way with "realpath".

Related: cbf08c55d28e ("contrib: Support contrib/scripts/kind.sh on macOS")
