### PR TITLE
docs: masquerade notes for eni mode with eks mode

### DIFF
--- a/Documentation/installation/k8s-install-helm.rst
+++ b/Documentation/installation/k8s-install-helm.rst
@@ -166,6 +166,11 @@ Install Cilium
          remember to replace ``eth+`` with the proper interface name. For
          reference, Amazon Linux 2 uses ``eth+``, whereas Amazon Linux 2023 uses
          ``ens+``. Mixed node clusters are not supported currently.
+         
+         Even if ``enableIPv4Masquerade`` is set to ``true`` in the ENI environment 
+         the pod traffic to its VPC will not be masqueraded, since Cilium treats
+         the entire VPC CIDR as the cluster range.
+
 
     .. group-tab:: OpenShift
 


### PR DESCRIPTION
While we have the https://github.com/cilium/cilium/pull/38663 merged and change the behavior from 1.18. It's still worthy to note this special beahvior in the doc in previous and current version so people can know even they enable masquerading using ENI mode. The pod IP will not get masqueraded when pods trying to access the other IP address within the VPC.


@joestringer I will add more why I raise this PR and why I'm doing this way. You can guide me if that's reasonable and what the best way to do it.  I had some explaination in https://github.com/cilium/cilium/pull/38663 and thought it's enough.


After I raised https://github.com/cilium/cilium/pull/38663, I have found there are still some gaps. Before 1.18. we have the EKS install doc(https://docs.cilium.io/en/stable/installation/k8s-install-helm/#k8s-install-helm) asking the users to configure something like.
```
helm install cilium cilium/cilium --version 1.17.3 \
  --namespace kube-system \
  --set eni.enabled=true \
  --set ipam.mode=eni \
  --set egressMasqueradeInterfaces=eth+ \
  --set routingMode=native
```
Anyone read this configure and found IPv4Masquerade is enabled by default. I think they would expect that the traffic going outside of cluster will get masqueraded. The reality is it depends where the destination is. In the ENI mode, we generate the following iptable rule. 
```
-A CILIUM_POST_nat ! -d 192.168.0.0/16 -o eth+ -m comment --comment "cilium masquerade non-cluster" -j MASQUERADE
```

However, `192.168.0.0/16` is the whole VPC range, that means anything on that VPC(RDS, other EC2, AWS load balancer) will not get masqueraded. users could configure some subnets as the dedicated subnets just for pods, but cilium doesn't have that granularity to generate the iptables rules only for "pods" subnets.


That's why I think it's worthy to note it since people can get confused very easily if they enable IPv4Masquerade in EKS environment and expect any non-cluster traffic will get masqueraded.

Why I put it here not masquerade page?

Because this is the confusing part realted to AWS since we have the iptables rules for whole VPC and we have `egressMasqueradeInterfaces` config here. that's the best place that I can find for AWS users since we dont have a dedicated AWS page(the current deticated AWS page is more for the ipam)

Why not put it Cilium Quick Installation?

on Cilium Quick Installation page, we just use the cilium CLI install and hide all the details dont have other notes. To me, serious cilium users will read the helm doc.

why I have this PR to main than 1.17, 1.16, 1.15 branches?

Because we have https://github.com/cilium/cilium/pull/38663 merged, it's disabled by default. I could raise the PR to 1.17 and backport to 1.15 and 1.16. That was something I was trying to do from the beginning, but I realized this behavior doesn't change between versions. People could still enable this feature in 1.18 and expect the masquerade working as they expect. that's why I think the note is worhty for AWS users no matter the feature itself is enabled or disabled. 

Maybe I should have one PR for main to cover v1.18 and another PR to v1.17 backport v1.17 notes to the version we currently support.


Hope I made it clear this time and address all your concerns.


```release-note
docs: Document that traffic to the VPC in ENI mode is not masqueraded
```
