### PR TITLE
cli: De-duplicate workflow owners results in junit

### DIFF
--- a/cilium-cli/connectivity/suite.go
+++ b/cilium-cli/connectivity/suite.go
@@ -30,7 +30,7 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 	if err != nil {
 		return err
 	}
-	junitCollector := check.NewJUnitCollector(connTests[0].Params().JunitProperties, connTests[0].Params().JunitFile)
+	junitCollector := check.NewJUnitCollector(connTests[0].Params().JunitProperties, connTests[0].Params().JunitFile, connTests[0].CodeOwners)
 	for i := range suiteBuilders {
 		if e := suiteBuilders[i](connTests, extra.AddConnectivityTests); e != nil {
 			return e


### PR DESCRIPTION
Collect is called for each test, so the same workflow owners could be
collected from different tests multiple times. Avoid this by adding them
once during the junit collector creation.