### PR TITLE
cli: encryption: improve ICMPv6 NA detection

### DIFF
--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -188,6 +188,11 @@ func getFilter(ctx context.Context, t *check.Test, client, clientHost *check.Pod
 	// make tcpdump to capture the pkts (false positive).
 	filter = fmt.Sprintf("%s and dst host %s", filter, dstIP)
 
+	// Exclude icmpv6 neighbor broadcast packets, as these are intentionally not encrypted:
+	// Ref[0]: https://github.com/cilium/cilium/blob/e8543eef/bpf/lib/wireguard.h#L95
+	// See Issue: #38688
+	filter = fmt.Sprintf("(%s) and (%s)", filter, icmpv6NAFilter)
+
 	return filter
 }
 

--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -145,15 +145,15 @@ func getFilter(ctx context.Context, t *check.Test, client, clientHost *check.Pod
 		// - Any pkt client <-> server with a given proto. This might be useful
 		//   to catch any regression in the DP which makes the pkt to bypass
 		//   the VXLAN tunnel.
-		// - *Not* a icmpv6 neighbor broadcast packet as these are intentionally
-		//    not encrypted:
-		//    Ref[0]: https://github.com/cilium/cilium/blob/e8543eef/bpf/lib/wireguard.h#L95
-		//    See Issue: #38688
-		filter := fmt.Sprintf("((%s and host %s and host %s) or (host %s and host %s and %s))"+
-			icmpv6NAFilter,
+		filter := fmt.Sprintf("((%s and host %s and host %s) or (host %s and host %s and %s))",
 			tunnelFilter,
 			clientHost.Address(features.IPFamilyV4), serverHost.Address(features.IPFamilyV4),
 			client.Address(ipFam), server.Address(ipFam), protoFilter)
+
+		// Exclude icmpv6 neighbor broadcast packets, as these are intentionally not encrypted:
+		// Ref[0]: https://github.com/cilium/cilium/blob/e8543eef/bpf/lib/wireguard.h#L95
+		// See Issue: #38688
+		filter = fmt.Sprintf("(%s) and (%s)", filter, icmpv6NAFilter)
 
 		return filter
 

--- a/cilium-cli/connectivity/tests/encryption_v2.go
+++ b/cilium-cli/connectivity/tests/encryption_v2.go
@@ -299,7 +299,7 @@ func (s *podToPodEncryptionV2) resolveTCPDumpFilters4(ctx context.Context) (clie
 
 // icmpv6NAFilter filters ipv6 packets with icmpv6 type 136 (neighbor advertisement).
 // These are sent unencrypted when node encryption and wireguard is enabled.
-const icmpv6NAFilter = "not (ip6[40] = 136)"
+const icmpv6NAFilter = "not (icmp6 and ip6[40] = 136)"
 
 // tunnelTCPDumpFilters6 is equivalent to tunnelTCPDumpFilters4 but for IPv6.
 func (s *podToPodEncryptionV2) tunnelTCPDumpFilters6(ctx context.Context) (clientFilter string, serverFilter string, err error) {

--- a/cilium-cli/connectivity/tests/encryption_v2.go
+++ b/cilium-cli/connectivity/tests/encryption_v2.go
@@ -299,7 +299,7 @@ func (s *podToPodEncryptionV2) resolveTCPDumpFilters4(ctx context.Context) (clie
 
 // icmpv6NAFilter filters ipv6 packets with icmpv6 type 136 (neighbor advertisement).
 // These are sent unencrypted when node encryption and wireguard is enabled.
-const icmpv6NAFilter = " and not (ip6[40] = 136)"
+const icmpv6NAFilter = "not (ip6[40] = 136)"
 
 // tunnelTCPDumpFilters6 is equivalent to tunnelTCPDumpFilters4 but for IPv6.
 func (s *podToPodEncryptionV2) tunnelTCPDumpFilters6(ctx context.Context) (clientFilter string, serverFilter string, err error) {
@@ -357,8 +357,8 @@ func (s *podToPodEncryptionV2) tunnelTCPDumpFilters6(ctx context.Context) (clien
 	// that are neighbor broadcast messages as these are not sent to the WG device.
 	encNode, ok := s.ct.Feature(features.EncryptionNode)
 	if ok && encNode.Enabled && s.encryptMode.Mode == "wireguard" {
-		clientFilter += icmpv6NAFilter
-		serverFilter += icmpv6NAFilter
+		clientFilter = fmt.Sprintf("(%s) and (%s)", clientFilter, icmpv6NAFilter)
+		serverFilter = fmt.Sprintf("(%s) and (%s)", serverFilter, icmpv6NAFilter)
 	}
 
 	return clientFilter, serverFilter, nil


### PR DESCRIPTION
Also plug the ICMPv6 NA filtering from https://github.com/cilium/cilium/pull/38798 into the native-routing paths, so that we avoid false-positives like [this one](https://github.com/cilium/cilium/actions/runs/14438246021/job/40483140950) in CI.
