### PR TITLE
cilium-dbg: Fix decryption interfaces field in KPR mode

### DIFF
--- a/cilium-dbg/cmd/encrypt_status.go
+++ b/cilium-dbg/cmd/encrypt_status.go
@@ -194,8 +194,9 @@ func isDecryptionInterface(link netlink.Link) (bool, error) {
 		if bpfFilter, ok := f.(*netlink.BpfFilter); ok {
 			// We consider the interface a decryption interface if it has the
 			// BPF program we use to mark ESP packets for decryption, that is
-			// the cil_from_network BPF program.
-			if strings.Contains(bpfFilter.Name, "cil_from_network") {
+			// the cil_from_network or cil_from_netdev BPF programs.
+			if strings.Contains(bpfFilter.Name, "cil_from_network") ||
+				strings.Contains(bpfFilter.Name, "cil_from_netdev") {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
When KPR is enabled, we rely on the BPF programs in `bpf_host` for decryption rather than the programs in `bpf_network`. As a result, the programs' names change. In the `cilium-dbg encrypt status` command, we would rely on one of the program's name to detect decryption programs and the interfaces they are attached to. That command would however not handle the different name when KPR is enabled. This commit adds support for the KPR case.

Fixes: https://github.com/cilium/cilium/issues/38451.
```release-note
Fix bug that would cause the `cilium-dbg encrypt status` command to not list any decryption interfaces when KPR is enabled.
```