### PR TITLE
ipcache: Consolidate prefixes from various resources

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -510,6 +510,7 @@ type MU struct {
 	Source   source.Source
 	Resource ipcacheTypes.ResourceID
 	Metadata []IPMetadata
+	IsCIDR   bool
 }
 
 // UpsertMetadata upserts a given IP and some corresponding information into
@@ -529,7 +530,9 @@ func (ipc *IPCache) UpsertMetadataBatch(updates ...MU) (revision uint64) {
 	prefixes := make([]cmtypes.PrefixCluster, 0, len(updates))
 	ipc.metadata.Lock()
 	for _, upd := range updates {
-		prefixes = append(prefixes, ipc.metadata.upsertLocked(upd.Prefix, upd.Source, upd.Resource, upd.Metadata...)...)
+		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Add(upd.Prefix) {
+			prefixes = append(prefixes, ipc.metadata.upsertLocked(upd.Prefix, upd.Source, upd.Resource, upd.Metadata...)...)
+		}
 	}
 	ipc.metadata.Unlock()
 	revision = ipc.metadata.enqueuePrefixUpdates(prefixes...)
@@ -558,7 +561,9 @@ func (ipc *IPCache) RemoveMetadataBatch(updates ...MU) (revision uint64) {
 	prefixes := make([]cmtypes.PrefixCluster, 0, len(updates))
 	ipc.metadata.Lock()
 	for _, upd := range updates {
-		prefixes = append(prefixes, ipc.metadata.remove(upd.Prefix, upd.Resource, upd.Metadata...)...)
+		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Delete(upd.Prefix) {
+			prefixes = append(prefixes, ipc.metadata.remove(upd.Prefix, upd.Resource, upd.Metadata...)...)
+		}
 	}
 	ipc.metadata.Unlock()
 	revision = ipc.metadata.enqueuePrefixUpdates(prefixes...)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -1475,6 +1475,7 @@ func BenchmarkManyCIDREntries(b *testing.B) {
 				Source:   source.Generated,
 				Resource: types.NewResourceID(types.ResourceKindCNP, fmt.Sprintf("namespace_%d", i), "my-policy"),
 				Metadata: []IPMetadata{lbls},
+				IsCIDR:   true,
 			})
 		}
 		revs = append(revs, IPIdentityCache.UpsertMetadataBatch(mu...))
@@ -1495,6 +1496,7 @@ func BenchmarkManyCIDREntries(b *testing.B) {
 				Source:   source.Generated,
 				Resource: types.NewResourceID(types.ResourceKindCNP, fmt.Sprintf("namespace_%d", i), "my-policy"),
 				Metadata: []IPMetadata{labels.Labels{}},
+				IsCIDR:   true,
 			})
 		}
 		revs = append(revs, IPIdentityCache.RemoveMetadataBatch(mu...))
@@ -1515,6 +1517,7 @@ func BenchmarkManyCIDREntries(b *testing.B) {
 				Source:   source.Generated,
 				Resource: types.NewResourceID(types.ResourceKindCNP, fmt.Sprintf("namespace_%d", i), "my-policy"),
 				Metadata: []IPMetadata{cidrLabels[cidr]},
+				IsCIDR:   true,
 			})
 		}
 		revs = append(revs, IPIdentityCache.UpsertMetadataBatch(mu...))

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -170,6 +170,7 @@ func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policyty
 					Source:   prefixSource[resource],
 					Resource: resource,
 					Metadata: []ipcache.IPMetadata{labels.GetCIDRLabels(prefix)},
+					IsCIDR:   true,
 				})
 			}
 			continue
@@ -202,6 +203,7 @@ func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policyty
 				Source:   prefixSource[resource],
 				Resource: resource,
 				Metadata: []ipcache.IPMetadata{labels.GetCIDRLabels(prefix)},
+				IsCIDR:   true,
 			})
 		}
 		if oldSet.Len() > 0 {
@@ -245,6 +247,7 @@ func (i *policyImporter) prunePrefixes(prunePrefixes map[ipcachetypes.ResourceID
 				Prefix:   cmtypes.NewLocalPrefixCluster(oldPrefix),
 				Resource: resource,
 				Metadata: []ipcache.IPMetadata{labels.Labels{}},
+				IsCIDR:   true,
 			})
 		}
 	}

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/netip"
 
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -23,12 +22,6 @@ func (m *MockIPCache) GetNamedPorts() types.NamedPortMultiMap {
 }
 
 func (m *MockIPCache) AddListener(listener ipcache.IPIdentityMappingListener) {}
-
-func (m *MockIPCache) AllocateCIDRs(prefixes []netip.Prefix, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
-	return nil, nil
-}
-
-func (m *MockIPCache) ReleaseCIDRIdentitiesByCIDR(prefixes []netip.Prefix) {}
 
 func (m *MockIPCache) LookupByIP(IP string) (ipcache.Identity, bool) {
 	return ipcache.Identity{}, false


### PR DESCRIPTION
Depends on https://github.com/cilium/cilium/pull/38851.

- **testutils/ipcache: Remove nonexistent methods**
  AllocateCIDRs() and ReleaseCIDRIdentitiesByCIDR() have both been removed
  from the codebase already, so remove the leftovers from this mock
  ipcache.

- **ipcache: Extend benchmark to test CIDR churn**
  Benchmark removing and re-adding CIDR prefixes as well using the batch
  metadata API, to simulate the usage from the policy importer.

- **ipcache: Consolidate prefixes from various resources**
  When many CIDRs are inserted into the ipcache via the metadata API (i.e.
  UpsertMetadataBatch() / UpsertMetadata()) and many of those CIDRs are
  present across many various resources such as CNPs (aka "duplicated"
  CIDRs across many policies), the ipcache ends up performing many
  redundant label merging operations via ToLabels() inside
  resolveIdentity(). See BenchmarkManyCIDREntries() for more context.
  
  To optimize the ipcache metadata structure and avoid storing duplicate
  instances of metadata (particularly CIDR prefixes from policies), we
  handle CIDR prefixes outside the cluster as a special case. Instead of
  tracking each CIDR by its originating policy, we consolidate them by
  treating each CIDR as originating from its own dedicated resource. This
  approach reduces duplication.
  
  The above is done by a refcount of each CIDR prefix that is destined for
  outside of the cluster.
  
  Benchmark results:
  
  ```
  $ go test -v ./pkg/ipcache -test.run '^$' -test.bench 'BenchmarkManyCIDREntries' -count 10 > old
  $ go test -v ./pkg/ipcache -test.run '^$' -test.bench 'BenchmarkManyCIDREntries' -count 10 > new
  $ benchstat old new
  name                old time/op    new time/op    delta
  ManyCIDREntries-16    35.4ms ± 4%     0.2ms ± 1%  -99.33%  (p=0.000 n=10+10)
  
  name                old alloc/op   new alloc/op   delta
  ManyCIDREntries-16    4.94MB ± 1%    0.22MB ± 0%  -95.52%  (p=0.000 n=10+10)
  
  name                old allocs/op  new allocs/op  delta
  ManyCIDREntries-16     33.4k ± 1%      4.0k ± 0%  -88.11%  (p=0.000 n=10+10)
  ```
  
  Suggested-by: Casey Callendrello <cdc@isovalent.com>
  Suggested-by: Sebastian Wicki <sebastian@isovalent.com>


  