### PR TITLE
Fix the typo in makefile help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,7 +511,7 @@ help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writin
 	$(call print_help_line,"docker-clustermesh-apiserver-image","Build docker image for Cilium clustermesh APIServer")
 	$(call print_help_line,"docker-operator-image","Build cilium-operator docker image")
 	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(alibabacloud, aws, azure, generic)")
-	$(call print_help_line,"docker-operator-*-image-debug","Build platform specific cilium-operator debug images(alibabacloud, aws, azure, generic)")
+	$(call print_help_line,"dev-docker-operator-*-image-debug","Build platform specific cilium-operator debug images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
 
 .PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-kvstoremesh-api generate-hubble-api generate-sdp-api install licenses-all veryclean run_bpf_tests run-builder


### PR DESCRIPTION
In PR https://github.com/cilium/cilium/pull/36790.

I made a mistake where I didn't add the prefix, and this iPR is to add the missing prefix.


Here is what we have in makefile 
```
$(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-opera%-image-debug,images/operator/Dockerfile,opera%,$(DOCKER_IMAGE_TAG),debug))

```

and I have the following in the help.

```
$(call print_help_line,"docker-operator-*-image-debug","Build platform specific cilium-operator debug images(alibabacloud, aws, azure, generic)")
```



Here is my test and it should be right this time.

```
(⎈|kind-kind:N/A)/Users/huangliyi/repo/liyi/cilium (pr/liyihuang/fix_make_help_typo ✔) make docker-operator-aws-image-debug
make: *** No rule to make target 'docker-operator-aws-image-debug'.  Stop.

(⎈|kind-kind:N/A)/Users/huangliyi/repo/liyi/cilium (pr/liyihuang/fix_make_help_typo ✔) make dev-docker-operator-aws-image-debug
Using Docker Buildx builder "" with build flags "--load".
: images/operator/Dockerfile quay.io/cilium/operator-aws:latest
```
