### PR TITLE
statedb tables: add fields to devices and route tables

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -442,6 +442,7 @@ func populateFromLink(d *tables.Device, link netlink.Link) {
 	d.RawFlags = a.RawFlags
 	d.MasterIndex = a.MasterIndex
 	d.Type = link.Type()
+	d.OperStatus = a.OperState.String()
 }
 
 // processBatch processes a batch of address, link and route updates.
@@ -494,6 +495,7 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 					LinkIndex: index,
 					Scope:     uint8(u.Scope),
 					Dst:       ipnetToPrefix(u.Family, u.Dst),
+					Priority:  u.Priority,
 				}
 				r.Src, _ = netip.AddrFromSlice(u.Src)
 				r.Gw, _ = netip.AddrFromSlice(u.Gw)

--- a/pkg/datapath/linux/testdata/device-controller-tables.txtar
+++ b/pkg/datapath/linux/testdata/device-controller-tables.txtar
@@ -44,11 +44,11 @@ db/cmp routes routes_dummy01.table
 db/cmp neighbors neighbors_dummy1.table
 
 # Exercise device table "selected" index.
-db/prefix --index=selected --columns=Name,Selected,Type,Addresses -o devices.actual devices true
+db/prefix --index=selected --columns=Name,Selected,Type,Addresses,OperStatus -o devices.actual devices true
 * cmp devices_dummy1.table devices.actual
 
 # Exercise device table "name" index.
-db/prefix --index=name --columns=Name,Selected,Type,Addresses -o devices.actual devices dummy
+db/prefix --index=name --columns=Name,Selected,Type,Addresses,OperStatus -o devices.actual devices dummy
 * cmp devices_dummy01.table devices.actual
 
 # Exercise neighbor table "IPAddr" index.
@@ -74,65 +74,65 @@ db/cmp neighbors neighbors_empty.table
 # ---------------------------------------------
 
 -- devices_empty.table --
-Name   Selected   Type     Addresses
+Name   Selected   Type     Addresses     OperStatus
 
 -- devices_dummy0.table --
-Name     Selected   Type     Addresses
-dummy0   false      dummy    192.168.0.1
+Name     Selected   Type     Addresses     OperStatus
+dummy0   false      dummy    192.168.0.1   down
 
 -- devices_dummy01.table --
-Name     Selected   Type     Addresses
-dummy0   false      dummy    192.168.0.1
-dummy1   true       dummy    192.168.1.1, 192.168.1.2
+Name     Selected   Type    Addresses                  OperStatus
+dummy0   false      dummy   192.168.0.1                down
+dummy1   true       dummy   192.168.1.1, 192.168.1.2   unknown
 
 -- devices_dummy01.table --
-Name     Selected   Type    Addresses
-dummy0   false      dummy   192.168.0.1
-dummy1   true       dummy   192.168.1.1, 192.168.1.2
+Name     Selected   Type    Addresses                  OperStatus
+dummy0   false      dummy   192.168.0.1                down
+dummy1   true       dummy   192.168.1.1, 192.168.1.2   unknown
 -- devices_dummy1.table --
-Name     Selected   Type    Addresses
-dummy1   true       dummy   192.168.1.1, 192.168.1.2
+Name     Selected   Type    Addresses                  OperStatus
+dummy1   true       dummy   192.168.1.1, 192.168.1.2   unknown
 -- devices_placeholder --
 
 
 -- routes_empty.table --
-Destination   Source   Gateway   LinkIndex   Table   Scope
+Destination   Source   Gateway   LinkIndex   Table   Scope   Priority
 
 -- routes_dummy0.table --
-Destination      Source        Gateway   Table   Scope
-192.168.0.1/32   192.168.0.1             255     254
+Destination      Source        Gateway   Table   Scope   Priority
+192.168.0.1/32   192.168.0.1             255     254     0
 
 -- routes_dummy01.table --
-Destination        Source        Gateway         Table   Scope
-0.0.0.0/0                        192.168.1.254   254     0
-192.168.1.0/24     192.168.1.1                   254     253
-192.168.1.253/32                                 254     253
-192.168.1.254/32                                 254     253
-192.168.0.1/32     192.168.0.1                   255     254
-192.168.1.1/32     192.168.1.1                   255     254
-192.168.1.2/32     192.168.1.1                   255     254
-192.168.1.255/32   192.168.1.1                   255     253
-ff00::/8                                         255     0
+Destination        Source        Gateway         Table   Scope   Priority
+0.0.0.0/0                        192.168.1.254   254     0       0
+192.168.1.0/24     192.168.1.1                   254     253     0
+192.168.1.253/32                                 254     253     0
+192.168.1.254/32                                 254     253     0
+192.168.0.1/32     192.168.0.1                   255     254     0
+192.168.1.1/32     192.168.1.1                   255     254     0
+192.168.1.2/32     192.168.1.1                   255     254     0
+192.168.1.255/32   192.168.1.1                   255     253     0
+ff00::/8                                         255     0       256
 
 -- routes_table254_link3_254.table --
-Destination        Source   Gateway   Table   Scope
+Destination        Source   Gateway   Table   Scope   Priority
 192.168.1.254/32                      254     253
 -- routes_table254_link3_all.table --
-Destination        Source        Gateway         Table   Scope
-0.0.0.0/0                        192.168.1.254   254     0
-192.168.1.0/24     192.168.1.1                   254     253
-192.168.1.253/32                                 254     253
-192.168.1.254/32                                 254     253
+Destination        Source        Gateway         Table   Scope   Priority
+0.0.0.0/0                        192.168.1.254   254     0       0
+192.168.1.0/24     192.168.1.1                   254     253     0
+192.168.1.253/32                                 254     253     0
+192.168.1.254/32                                 254     253     0
 -- routes_link3.table --
-Destination        Source        Gateway         Table   Scope
-192.168.1.254/32                                 254     253
-192.168.1.253/32                                 254     253
-192.168.1.0/24     192.168.1.1                   254     253
-0.0.0.0/0                        192.168.1.254   254     0
-192.168.1.1/32     192.168.1.1                   255     254
-192.168.1.2/32     192.168.1.1                   255     254
-192.168.1.255/32   192.168.1.1                   255     253
-ff00::/8                                         255     0
+Destination        Source        Gateway         Table   Scope   Priority
+192.168.1.254/32                                 254     253     0
+192.168.1.253/32                                 254     253     0
+192.168.1.0/24     192.168.1.1                   254     253     0
+0.0.0.0/0                        192.168.1.254   254     0       0
+192.168.1.1/32     192.168.1.1                   255     254     0
+192.168.1.2/32     192.168.1.1                   255     254     0
+192.168.1.255/32   192.168.1.1                   255     253     0
+ff00::/8                                         255     0       0
 -- routes_placeholder --
 
 

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -97,6 +97,7 @@ type Device struct {
 	RawFlags     uint32          // Raw interface flags
 	Type         string          // Device type, e.g. "veth" etc.
 	MasterIndex  int             // Index of the master device (e.g. bridge or bonding device)
+	OperStatus   string          // Operational status, e.g. "up", "lower-layer-down"
 
 	Selected          bool   // True if this is an external facing device
 	NotSelectedReason string // Reason why this device was not selected
@@ -127,6 +128,7 @@ func (*Device) TableHeader() []string {
 		"HWAddr",
 		"Flags",
 		"Addresses",
+		"OperStatus",
 	}
 }
 
@@ -144,6 +146,7 @@ func (d *Device) TableRow() []string {
 		d.HardwareAddr.String(),
 		d.Flags.String(),
 		strings.Join(addrs, ", "),
+		d.OperStatus,
 	}
 }
 

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -94,10 +94,11 @@ type Route struct {
 	Table     RouteTable
 	LinkIndex int
 
-	Scope uint8
-	Dst   netip.Prefix
-	Src   netip.Addr
-	Gw    netip.Addr
+	Scope    uint8
+	Dst      netip.Prefix
+	Src      netip.Addr
+	Gw       netip.Addr
+	Priority int
 }
 
 func (r *Route) DeepCopy() *Route {
@@ -106,8 +107,8 @@ func (r *Route) DeepCopy() *Route {
 }
 
 func (r *Route) String() string {
-	return fmt.Sprintf("Route{Dst: %s, Src: %s, Table: %d, LinkIndex: %d}",
-		r.Dst, r.Src, r.Table, r.LinkIndex)
+	return fmt.Sprintf("Route{Dst: %s, Src: %s, Table: %d, LinkIndex: %d, Priority: %d}",
+		r.Dst, r.Src, r.Table, r.LinkIndex, r.Priority)
 }
 
 func (*Route) TableHeader() []string {
@@ -118,6 +119,7 @@ func (*Route) TableHeader() []string {
 		"LinkIndex",
 		"Table",
 		"Scope",
+		"Priority",
 	}
 }
 
@@ -138,6 +140,7 @@ func (r *Route) TableRow() []string {
 		fmt.Sprintf("%d", r.LinkIndex),
 		fmt.Sprintf("%d", r.Table),
 		fmt.Sprintf("%d", r.Scope),
+		fmt.Sprintf("%d", r.Priority),
 	}
 }
 

--- a/pkg/datapath/tables/zz_generated.deepequal.go
+++ b/pkg/datapath/tables/zz_generated.deepequal.go
@@ -70,6 +70,9 @@ func (in *Device) DeepEqual(other *Device) bool {
 	if in.MasterIndex != other.MasterIndex {
 		return false
 	}
+	if in.OperStatus != other.OperStatus {
+		return false
+	}
 	if in.Selected != other.Selected {
 		return false
 	}


### PR DESCRIPTION
adding operational status to devices table and priority to route table. it is pre-requisite for adding auto-discovery of bgp peers feature to bgp control plane

Please ensure your pull request adheres to the following guidelines:

- [ X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X ] All code is covered by unit and/or runtime tests where feasible.
- [ X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!


This PR is a pre-requisite to fix github issue #37315 
for adding auto-discovery of bgp peers (proposal: https://github.com/cilium/design-cfps/blob/main/cilium/CFP-37315-bgp-auto-discovery.md), we need access to operational state of links and priority of routes.
route priority will be used to create bgp sessions with the default gateway of lowest priority default route
operational state of the link will be used to check if the link through which default gateway is reachable is up or not

Steps used to test:
1. make kind-bgp-v4
2. KIND_CLUSTER_NAME=bgp-cplane-dev-v4 make kind-image
3.  cilium install --chart-directory install/kubernetes/cilium -f contrib/containerlab/bgp-cplane-dev-v4/values.yaml --set image.override="localhost:5000/cilium/cilium-dev:local" --set image.pullPolicy=Never --set operator.image.override="localhost:5000/cilium/operator-generic:local" --set operator.image.pullPolicy=Never
4. kubectl exec -it [cilium pod id] -n kube-system -- bash
5. cilium-dbg shell
6. db/show routes, db/show devices



```release-note
datapath: update route and device statedb tables
```
