### PR TITLE
helm: only expose envoy-admin port for agent when explicitly enabled

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -267,7 +267,7 @@ spec:
           hostPort: {{ .Values.envoy.prometheus.port }}
           protocol: TCP
         {{- end }}
-        {{- if and .Values.envoy.debug.admin.port (not $envoyDS) }}
+        {{- if and .Values.envoy.debug.admin.enabled .Values.envoy.debug.admin.port (not $envoyDS) }}
         - name: envoy-admin
           containerPort: {{ .Values.envoy.debug.admin.port }}
           hostPort: {{ .Values.envoy.debug.admin.port }}


### PR DESCRIPTION
<!-- Description of change -->

This PR improves the expose condition of the `envoy-admin` ports of the cilium-agent DaemonSet. The `envoy-admin` port should only be exposed when it is explicitly enabled. This is already the default behavior when envoy is deployed as DaemonSet: https://github.com/cilium/cilium/blob/14eccb9970de04d24dbacd41028238e94138fceb/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml#L169

```release-note
helm: only expose the envoy admin debug port for cilium-agent when it is explicitly enabled
```
