### PR TITLE
k8s: respect daemon context in WaitForCacheSyncWithTimeout

### DIFF
--- a/pkg/k8s/synced/resources_test.go
+++ b/pkg/k8s/synced/resources_test.go
@@ -122,7 +122,7 @@ func TestWaitForCacheSyncWithTimeout(t *testing.T) {
 					})
 				}
 
-				err := r.WaitForCacheSyncWithTimeout(test.timeout, test.resourceNames...)
+				err := r.WaitForCacheSyncWithTimeout(t.Context(), test.timeout, test.resourceNames...)
 				if test.expectErr == nil {
 					assert.NoError(err)
 				} else {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -270,7 +270,7 @@ func (k *K8sWatcher) InitK8sSubsystem(ctx context.Context, cachesSynced chan str
 	go func() {
 		k.logger.Info("Waiting until all pre-existing resources have been received")
 		allResources := append(resources, cachesOnly...)
-		if err := k.k8sResourceSynced.WaitForCacheSyncWithTimeout(option.Config.K8sSyncTimeout, allResources...); err != nil {
+		if err := k.k8sResourceSynced.WaitForCacheSyncWithTimeout(ctx, option.Config.K8sSyncTimeout, allResources...); err != nil {
 			logging.Fatal(k.logger, "Timed out waiting for pre-existing resources to be received; exiting", logfields.Error, err)
 		}
 		close(cachesSynced)


### PR DESCRIPTION
Currently, while initializing the k8s subsystem in the Cilium Agent, the function `WaitForCacheSyncWithTimeout` might waits for the passed timeout and results in a panic (`logging.Fatal`) even if the agent initialization already failed for other reasons.

Therefore, this commit adds an `context.Context` as additional parameter to the function - and the logic will also respect the cancellation of this context.