### PR TITLE
daemon: remove drymode check around monitorAgent.SendEvent

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1813,10 +1813,8 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		}
 	}
 
-	if !option.Config.DryMode {
-		if err := d.monitorAgent.SendEvent(monitorAPI.MessageTypeAgent, monitorAPI.StartMessage(time.Now())); err != nil {
-			log.WithError(err).Warn("Failed to send agent start monitor message")
-		}
+	if err := d.monitorAgent.SendEvent(monitorAPI.MessageTypeAgent, monitorAPI.StartMessage(time.Now())); err != nil {
+		log.WithError(err).Warn("Failed to send agent start monitor message")
 	}
 
 	// Watches for node neighbors link updates.


### PR DESCRIPTION
This commit removes the unnecessary check for `DryMode` when sending the agent start event to the monitor agent. The check isn't necessary because the function `startDaemon` only gets executed if drymode isn't enabled.