### PR TITLE
loadbalancer/maps: Use pkg/bpf instead of pkg/ebpf

### DIFF
--- a/pkg/maps/lbmap/maglev_outer_map.go
+++ b/pkg/maps/lbmap/maglev_outer_map.go
@@ -50,6 +50,9 @@ type MaglevOuterVal struct {
 	FD uint32
 }
 
+func (v *MaglevOuterVal) New() bpf.MapValue { return &MaglevOuterVal{} }
+func (k *MaglevOuterVal) String() string    { return fmt.Sprintf("%d", k.FD) }
+
 // NewMaglevOuterMap returns a new object representing a maglev outer map.
 func NewMaglevOuterMap(name string, maxEntries int, tableSize uint32, innerMap *ebpf.MapSpec) (*MaglevOuterMap, error) {
 	m := ebpf.NewMap(&ebpf.MapSpec{


### PR DESCRIPTION
The pkg/ebpf package is going away so use the pkg/bpf instead. This will also bring back the BPF map op metrics for LB maps.

This could have been also built directly on cilium/ebpf, but I'm planning to use the batch lookup to implement pressure metrics and hopefully this will also make it easier to do the BPF iterator based pressure metrics for LB maps in the future.