### PR TITLE
cli: encryption: limit tunnel filter to dst port

### DIFF
--- a/cilium-cli/connectivity/sniff/filters.go
+++ b/cilium-cli/connectivity/sniff/filters.go
@@ -28,7 +28,7 @@ func GetTunnelFilter(ct *check.ConnectivityTest) (string, error) {
 
 	switch tunnelProtocol.Mode {
 	case "vxlan", "geneve":
-		return fmt.Sprintf("(udp and port %s)", tunnelPort.Mode), nil
+		return fmt.Sprintf("(udp and dst port %s)", tunnelPort.Mode), nil
 	}
 
 	return "", fmt.Errorf("unrecognized tunnel protocol %s", tunnelProtocol.Mode)

--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -162,7 +162,7 @@ func getFilter(ctx context.Context, t *check.Test, client, clientHost *check.Pod
 	filter := fmt.Sprintf("src host %s", client.Address(ipFam))
 	dstIP := server.Address(ipFam)
 
-	if tunnelStatus, ok := t.Context().Feature(features.Tunnel); ok && tunnelStatus.Enabled {
+	if tunnelEnabled {
 		cmd := []string{
 			"/bin/sh", "-c",
 			fmt.Sprintf("ip -o route get %s | grep -oE 'src [^ ]*' | cut -d' ' -f2",


### PR DESCRIPTION
Fine-tune the tcpdump filter for Cilium's overlay traffic, so that we only match packets which have the tunnel port as **destination** port. While at it also apply a small cleanup.