### PR TITLE
gh: network-e2e: hard-code number of nodes

### DIFF
--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -229,6 +229,7 @@ jobs:
             --                                            \
             --kubeconfig=${PWD}/_artifacts/kubeconfig.conf     \
             --provider=local                              \
+            --num-nodes=2                                 \
             --dump-logs-on-failure=true                   \
             --report-dir=${E2E_REPORT_DIR}                \
             --disable-log-dump=true


### PR DESCRIPTION
For some reason the test suite doesn't correctly detect the number of nodes in the cluster [0]. Specify it through a config option instead.

[0] https://github.com/cilium/cilium/issues/25135#issuecomment-2835405608

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
