### PR TITLE
legacy/redirectpolicy: migrate to slog

### DIFF
--- a/pkg/loadbalancer/legacy/redirectpolicy/api.go
+++ b/pkg/loadbalancer/legacy/redirectpolicy/api.go
@@ -16,7 +16,7 @@ type getLrpHandler struct {
 }
 
 func (h *getLrpHandler) Handle(params service.GetLrpParams) middleware.Responder {
-	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /lrp request")
+	h.lrpManager.logger.Debug("GET /lrp request", logfields.Params, params)
 	return service.NewGetLrpOK().WithPayload(getLRPs(h.lrpManager))
 }
 

--- a/pkg/loadbalancer/legacy/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/legacy/redirectpolicy/cell.go
@@ -4,6 +4,8 @@
 package redirectpolicy
 
 import (
+	"log/slog"
+
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 
@@ -27,6 +29,7 @@ var Cell = cell.Module(
 type lrpManagerParams struct {
 	cell.In
 
+	Logger         *slog.Logger
 	DB             *statedb.DB
 	Svc            service.ServiceManager
 	SvcCache       k8s.ServiceCache
@@ -41,7 +44,7 @@ func newLRPManager(params lrpManagerParams) *Manager {
 		// The experimental implementation is enabled, do nothing here.
 		return nil
 	}
-	return NewRedirectPolicyManager(params.DB, params.Svc, params.SvcCache, params.Pods, params.Ep, params.MetricsManager)
+	return NewRedirectPolicyManager(params.Logger, params.DB, params.Svc, params.SvcCache, params.Pods, params.Ep, params.MetricsManager)
 }
 
 func newLRPApiHandler(lrpManager *Manager) serviceapi.GetLrpHandler {


### PR DESCRIPTION
Migrate this package to use slog instead of logrus.