### PR TITLE
pkg/{mcastmanager,multicast}: migrate to slog

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -112,7 +112,7 @@ func New(logger *slog.Logger, epSynchronizer EndpointResourceSynchronizer, lns *
 		health:                       health,
 		endpoints:                    make(map[uint16]*endpoint.Endpoint),
 		endpointsAux:                 make(map[string]*endpoint.Endpoint),
-		mcastManager:                 mcastmanager.New(option.Config.IPv6MCastDevice),
+		mcastManager:                 mcastmanager.New(logger, option.Config.IPv6MCastDevice),
 		EndpointResourceSynchronizer: epSynchronizer,
 		subscribers:                  make(map[Subscriber]struct{}),
 		controllers:                  controller.NewManager(),

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1585,6 +1585,8 @@ const (
 
 	Exists = "exists"
 
+	MulticastAddr = "multicastAddr"
+
 	IPRules = "ipRules"
 
 	Rules = "rules"

--- a/pkg/mcastmanager/mcastmanager_test.go
+++ b/pkg/mcastmanager/mcastmanager_test.go
@@ -7,11 +7,13 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 )
 
 func TestAddRemoveEndpoint(t *testing.T) {
+	logger := hivetest.Logger(t)
 	ifaces, err := netlink.LinkList()
 	require.NoError(t, err)
 
@@ -19,7 +21,7 @@ func TestAddRemoveEndpoint(t *testing.T) {
 		t.Skip("no interfaces to test")
 	}
 
-	mgr := New(ifaces[0].Attrs().Name)
+	mgr := New(logger, ifaces[0].Attrs().Name)
 
 	// Add first endpoint
 	mgr.AddAddress(netip.MustParseAddr("f00d::1234"))
@@ -49,6 +51,7 @@ func TestAddRemoveEndpoint(t *testing.T) {
 }
 
 func TestAddRemoveNil(t *testing.T) {
+	logger := hivetest.Logger(t)
 	ifaces, err := netlink.LinkList()
 	require.NoError(t, err)
 
@@ -58,7 +61,7 @@ func TestAddRemoveNil(t *testing.T) {
 
 	var (
 		iface = ifaces[0]
-		mgr   = New(iface.Attrs().Name)
+		mgr   = New(logger, iface.Attrs().Name)
 	)
 
 	mgr.AddAddress(netip.Addr{})

--- a/pkg/multicast/multicast_test.go
+++ b/pkg/multicast/multicast_test.go
@@ -8,11 +8,13 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 )
 
 func TestGroupOps(t *testing.T) {
+	logger := hivetest.Logger(t)
 	ifs, err := netlink.LinkList()
 	require.NoError(t, err)
 
@@ -24,7 +26,7 @@ func TestGroupOps(t *testing.T) {
 	maddr := randMaddr()
 
 	// Join Group
-	err = JoinGroup(ifc.Attrs().Name, maddr)
+	err = JoinGroup(logger, ifc.Attrs().Name, maddr)
 	require.NoError(t, err)
 
 	// maddr in group
@@ -33,7 +35,7 @@ func TestGroupOps(t *testing.T) {
 	require.True(t, inGroup)
 
 	// LeaveGroup
-	err = LeaveGroup(ifc.Attrs().Name, maddr)
+	err = LeaveGroup(logger, ifc.Attrs().Name, maddr)
 	require.NoError(t, err)
 
 	// maddr not in group


### PR DESCRIPTION
Migrate this package to use slog instead of logrus.