### PR TITLE
maglev: Move seeds into maglev.Config

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -281,7 +281,7 @@ func (d *Daemon) initMaps() error {
 	if !d.lbConfig.EnableExperimentalLB &&
 		(d.lbConfig.LBAlgorithm == loadbalancer.LBAlgorithmMaglev ||
 			d.lbConfig.AlgorithmAnnotation) {
-		if err := lbmap.InitMaglevMaps(option.Config.EnableIPv4, option.Config.EnableIPv6, uint32(d.maglevConfig.MaglevTableSize)); err != nil {
+		if err := lbmap.InitMaglevMaps(option.Config.EnableIPv4, option.Config.EnableIPv6, uint32(d.maglevConfig.TableSize)); err != nil {
 			return fmt.Errorf("initializing maglev maps: %w", err)
 		}
 	}

--- a/pkg/datapath/linux/config/cell.go
+++ b/pkg/datapath/linux/config/cell.go
@@ -11,7 +11,6 @@ import (
 	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
 
@@ -24,7 +23,6 @@ type WriterParams struct {
 	NodeExtraDefines   []dpdef.Map `group:"header-node-defines"`
 	NodeExtraDefineFns []dpdef.Fn  `group:"header-node-define-fns"`
 	Sysctl             sysctl.Sysctl
-	Maglev             *maglev.Maglev
 }
 
 var Cell = cell.Module(

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/mac"
-	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
@@ -62,7 +61,6 @@ type HeaderfileWriter struct {
 	log                *slog.Logger
 	nodeMap            nodemap.MapV2
 	nodeAddressing     datapath.NodeAddressing
-	maglev             *maglev.Maglev
 	nodeExtraDefines   dpdef.Map
 	nodeExtraDefineFns []dpdef.Fn
 	sysctl             sysctl.Sysctl
@@ -82,7 +80,6 @@ func NewHeaderfileWriter(p WriterParams) (datapath.ConfigWriter, error) {
 		nodeExtraDefineFns: p.NodeExtraDefineFns,
 		log:                p.Log,
 		sysctl:             p.Sysctl,
-		maglev:             p.Maglev,
 	}, nil
 }
 
@@ -499,10 +496,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	// be set by the Service annotation
 	if cfg.LBConfig.AlgorithmAnnotation ||
 		cfg.LBConfig.LBAlgorithm == loadbalancer.LBAlgorithmMaglev {
-		cDefinesMap["LB_MAGLEV_LUT_SIZE"] = fmt.Sprintf("%d", h.maglev.Config.TableSize)
+		cDefinesMap["LB_MAGLEV_LUT_SIZE"] = fmt.Sprintf("%d", cfg.MaglevConfig.TableSize)
 	}
-	cDefinesMap["HASH_INIT4_SEED"] = fmt.Sprintf("%d", h.maglev.SeedJhash0)
-	cDefinesMap["HASH_INIT6_SEED"] = fmt.Sprintf("%d", h.maglev.SeedJhash1)
+	cDefinesMap["HASH_INIT4_SEED"] = fmt.Sprintf("%d", cfg.MaglevConfig.SeedJhash0)
+	cDefinesMap["HASH_INIT6_SEED"] = fmt.Sprintf("%d", cfg.MaglevConfig.SeedJhash1)
 
 	if option.Config.DirectRoutingDeviceRequired() {
 		drd := cfg.DirectRoutingDevice

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -499,7 +499,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	// be set by the Service annotation
 	if cfg.LBConfig.AlgorithmAnnotation ||
 		cfg.LBConfig.LBAlgorithm == loadbalancer.LBAlgorithmMaglev {
-		cDefinesMap["LB_MAGLEV_LUT_SIZE"] = fmt.Sprintf("%d", h.maglev.Config.MaglevTableSize)
+		cDefinesMap["LB_MAGLEV_LUT_SIZE"] = fmt.Sprintf("%d", h.maglev.Config.TableSize)
 	}
 	cDefinesMap["HASH_INIT4_SEED"] = fmt.Sprintf("%d", h.maglev.SeedJhash0)
 	cDefinesMap["HASH_INIT6_SEED"] = fmt.Sprintf("%d", h.maglev.SeedJhash1)

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -47,6 +47,7 @@ var (
 		Devices:            []*tables.Device{},
 		NodeAddresses:      []tables.NodeAddress{},
 		HostEndpointID:     1,
+		MaglevConfig:       maglev.DefaultConfig,
 	}
 	dummyDevCfg   testutils.TestEndpoint
 	ipv4DummyAddr = netip.MustParseAddr("192.0.2.3")
@@ -237,8 +238,7 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 	setupConfigSuite(t)
 
 	var (
-		na   datapath.NodeAddressing
-		magl *maglev.Maglev
+		na datapath.NodeAddressing
 	)
 	h := hive.New(
 		cell.Provide(
@@ -247,10 +247,8 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 		maglev.Cell,
 		cell.Invoke(func(
 			nodeaddressing datapath.NodeAddressing,
-			ml *maglev.Maglev,
 		) {
 			na = nodeaddressing
-			magl = ml
 		}),
 	)
 
@@ -270,7 +268,6 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 		},
 		Sysctl:  sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
 		NodeMap: fake.NewFakeNodeMapV2(),
-		Maglev:  magl,
 	})
 	require.NoError(t, err)
 
@@ -291,7 +288,6 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 		},
 		Sysctl:  sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
 		NodeMap: fake.NewFakeNodeMapV2(),
-		Maglev:  magl,
 	})
 	require.NoError(t, err)
 
@@ -308,7 +304,6 @@ func TestWriteNodeConfigExtraDefines(t *testing.T) {
 		},
 		Sysctl:  sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
 		NodeMap: fake.NewFakeNodeMapV2(),
-		Maglev:  magl,
 	})
 	require.NoError(t, err)
 
@@ -391,9 +386,6 @@ func TestNewHeaderfileWriter(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	setupConfigSuite(t)
 
-	lc := hivetest.Lifecycle(t)
-	magl := maglev.New(maglev.DefaultConfig, lc)
-
 	a := dpdef.Map{"A": "1"}
 	var buffer bytes.Buffer
 
@@ -403,7 +395,6 @@ func TestNewHeaderfileWriter(t *testing.T) {
 		NodeExtraDefineFns: nil,
 		Sysctl:             sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
 		NodeMap:            fake.NewFakeNodeMapV2(),
-		Maglev:             magl,
 	})
 
 	require.Error(t, err, "duplicate keys should be rejected")
@@ -414,7 +405,6 @@ func TestNewHeaderfileWriter(t *testing.T) {
 		NodeExtraDefineFns: nil,
 		Sysctl:             sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
 		NodeMap:            fake.NewFakeNodeMapV2(),
-		Maglev:             magl,
 	})
 	require.NoError(t, err)
 	require.NoError(t, cfg.WriteNodeConfig(&buffer, &dummyNodeCfg))

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -392,13 +392,12 @@ func TestNewHeaderfileWriter(t *testing.T) {
 	setupConfigSuite(t)
 
 	lc := hivetest.Lifecycle(t)
-	magl, err := maglev.New(maglev.DefaultConfig, lc)
-	require.NoError(t, err, "maglev.New")
+	magl := maglev.New(maglev.DefaultConfig, lc)
 
 	a := dpdef.Map{"A": "1"}
 	var buffer bytes.Buffer
 
-	_, err = NewHeaderfileWriter(WriterParams{
+	_, err := NewHeaderfileWriter(WriterParams{
 		NodeAddressing:     fakeTypes.NewNodeAddressing(),
 		NodeExtraDefines:   []dpdef.Map{a, a},
 		NodeExtraDefineFns: nil,

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/xdp"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -45,6 +46,7 @@ func newLocalNodeConfig(
 	masqInterface string,
 	xdpConfig xdp.Config,
 	lbConfig loadbalancer.Config,
+	maglevConfig maglev.Config,
 	mtuTbl statedb.Table[mtu.RouteMTU],
 ) (datapath.LocalNodeConfiguration, <-chan struct{}, error) {
 	auxPrefixes := []*cidr.CIDR{}
@@ -104,5 +106,6 @@ func newLocalNodeConfig(
 		IPv6PodSubnets:               cidr.NewCIDRSlice(config.IPv6PodSubnets),
 		XDPConfig:                    xdpConfig,
 		LBConfig:                     lbConfig,
+		MaglevConfig:                 maglevConfig,
 	}, common.MergeChannels(devsWatch, addrsWatch, directRoutingDevWatch, mtuWatch), nil
 }

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/nodediscovery"
@@ -105,6 +106,7 @@ type orchestratorParams struct {
 	ConfigPromise       promise.Promise[*option.DaemonConfig]
 	XDPConfig           xdp.Config
 	LBConfig            loadbalancer.Config
+	MaglevConfig        maglev.Config
 }
 
 func newOrchestrator(params orchestratorParams) *orchestrator {
@@ -201,6 +203,7 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 			o.params.Config.DeriveMasqIPAddrFromDevice,
 			o.params.XDPConfig,
 			o.params.LBConfig,
+			o.params.MaglevConfig,
 			o.params.MTU,
 		)
 		if err != nil {

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/xdp"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maglev"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
 
@@ -184,6 +185,10 @@ type LocalNodeConfiguration struct {
 
 	// LBConfig holds the configuration options for load-balancing
 	LBConfig loadbalancer.Config
+
+	// Maglev configuration provides the maglev table sizes and seeds for
+	// the BPF programs.
+	MaglevConfig maglev.Config
 }
 
 func (cfg *LocalNodeConfiguration) DeviceNames() []string {

--- a/pkg/datapath/types/zz_generated.deepequal.go
+++ b/pkg/datapath/types/zz_generated.deepequal.go
@@ -275,5 +275,9 @@ func (in *LocalNodeConfiguration) DeepEqual(other *LocalNodeConfiguration) bool 
 		return false
 	}
 
+	if in.MaglevConfig != other.MaglevConfig {
+		return false
+	}
+
 	return true
 }

--- a/pkg/loadbalancer/benchmark/benchmark.go
+++ b/pkg/loadbalancer/benchmark/benchmark.go
@@ -54,10 +54,10 @@ var (
 	//go:embed testdata/endpointslice.yaml
 	endpointSliceYaml []byte
 
-	maglevConfig = maglev.Config{
-		MaglevTableSize: 1021,
-		MaglevHashSeed:  maglev.DefaultHashSeed,
-	}
+	maglevConfig, _ = maglev.UserConfig{
+		TableSize: 1021,
+		HashSeed:  maglev.DefaultHashSeed,
+	}.ToConfig()
 )
 
 func RunBenchmark(testSize int, iterations int, loglevel slog.Level, validate bool) {
@@ -564,9 +564,9 @@ func testHive(maps lbmaps.LBMaps,
 					return maps
 				},
 
-				func(lc cell.Lifecycle) (*maglev.Maglev, maglev.Config, error) {
-					m, err := maglev.New(maglevConfig, lc)
-					return m, maglevConfig, err
+				func(lc cell.Lifecycle) (*maglev.Maglev, maglev.Config) {
+					m := maglev.New(maglevConfig, lc)
+					return m, maglevConfig
 				},
 			),
 

--- a/pkg/loadbalancer/maps/lbmaps.go
+++ b/pkg/loadbalancer/maps/lbmaps.go
@@ -301,7 +301,7 @@ func (r *BPFLBMaps) Start(ctx cell.HookContext) (err error) {
 		Type:       ebpf.Array,
 		KeySize:    uint32(unsafe.Sizeof(lbmap.MaglevInnerKey{})),
 		MaxEntries: 1,
-		ValueSize:  lbmap.MaglevBackendLen * uint32(r.MaglevCfg.MaglevTableSize),
+		ValueSize:  lbmap.MaglevBackendLen * uint32(r.MaglevCfg.TableSize),
 	}
 
 	mapsToCreate, mapsToDelete := r.allMaps()

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1042,12 +1042,12 @@ func TestBPFOps(t *testing.T) {
 	lc := hivetest.Lifecycle(t)
 	log := hivetest.Logger(t)
 
-	maglevCfg := maglev.Config{
-		MaglevTableSize: 1021,
-		MaglevHashSeed:  maglev.DefaultHashSeed,
-	}
-	maglev, err := maglev.New(maglevCfg, lc)
-	require.NoError(t, err, "maglev.New")
+	maglevCfg, err := maglev.UserConfig{
+		TableSize: 1021,
+		HashSeed:  maglev.DefaultHashSeed,
+	}.ToConfig()
+	require.NoError(t, err, "ToConfig")
+	maglev := maglev.New(maglevCfg, lc)
 
 	// Enable features.
 	extCfg := loadbalancer.ExternalConfig{

--- a/pkg/maps/lbmap/maglev_test.go
+++ b/pkg/maps/lbmap/maglev_test.go
@@ -65,11 +65,12 @@ func TestInitMaps(t *testing.T) {
 	// Now insert the entry, so that the map should not be removed
 	err = InitMaglevMaps(true, false, uint32(maglevTableSize))
 	require.NoError(t, err)
-	ml, err := maglev.New(maglev.Config{
-		MaglevTableSize: maglevTableSize,
-		MaglevHashSeed:  maglev.DefaultHashSeed,
-	}, hivetest.Lifecycle(t))
-	require.NoError(t, err, "maglev.New")
+	cfg, err := maglev.UserConfig{
+		TableSize: maglevTableSize,
+		HashSeed:  maglev.DefaultHashSeed,
+	}.ToConfig()
+	require.NoError(t, err, "ToConfig")
+	ml := maglev.New(cfg, hivetest.Lifecycle(t))
 	lbm := New(loadbalancer.DefaultConfig, ml)
 	params := &datapathTypes.UpsertServiceParams{
 		ID:   1,

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -326,10 +326,10 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		features.NodePort.Algorithm = models.KubeProxyReplacementFeaturesNodePortAlgorithmRandom
 		if d.statusParams.LBConfig.LBAlgorithm == loadbalancer.LBAlgorithmMaglev {
 			features.NodePort.Algorithm = models.KubeProxyReplacementFeaturesNodePortAlgorithmMaglev
-			features.NodePort.LutSize = int64(d.statusParams.MaglevConfig.MaglevTableSize)
+			features.NodePort.LutSize = int64(d.statusParams.MaglevConfig.TableSize)
 		}
 		if d.statusParams.LBConfig.AlgorithmAnnotation {
-			features.NodePort.LutSize = int64(d.statusParams.MaglevConfig.MaglevTableSize)
+			features.NodePort.LutSize = int64(d.statusParams.MaglevConfig.TableSize)
 		}
 		if d.statusParams.DaemonConfig.NodePortAcceleration == option.NodePortAccelerationGeneric {
 			features.NodePort.Acceleration = models.KubeProxyReplacementFeaturesNodePortAccelerationGeneric


### PR DESCRIPTION
The maglev seeds are used by the HeaderFileWriter and as such are more akin to configuration data.
Move the user configurable flags into `maglev.UserConfig` and from that construct the `maglev.Config` with the computed seeds.

So let's simplify HeaderFileWriter dependencies and feed in these seeds via the LocalNodeConfiguration
so that more of its inputs are just plain-old-data rather than stateful objects.