### PR TITLE
agent: deprecate --bpf-lb-proto-diff

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -50,7 +50,6 @@ cilium-agent [flags]
       --bpf-lb-map-max int                                        Maximum number of entries in Cilium BPF lbmap (default 65536)
       --bpf-lb-mode string                                        BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
       --bpf-lb-mode-annotation                                    Enable service-level annotation for configuring BPF load balancing mode
-      --bpf-lb-proto-diff                                         Enable support for service protocol differentiation (TCP, UDP, SCTP) (default true)
       --bpf-lb-rss-ipv4-src-cidr string                           BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP
       --bpf-lb-rss-ipv6-src-cidr string                           BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
       --bpf-lb-sock                                               Enable socket-based LB for E/W traffic

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -345,6 +345,8 @@ Deprecated Options
   feature is enabled by default.
 * The custom calls feature (``--enable-custom-calls``) has been deprecated, and will
   be removed in Cilium 1.19.
+* The flag ``--bpf-lb-proto-diff`` has been deprecated and will be removed in Cilium 1.19.
+  Service protocol differentiation will be unconditionally enabled.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -601,6 +601,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.LoadBalancerAcceleration)
 
 	flags.Bool(option.LoadBalancerProtocolDifferentiation, true, "Enable support for service protocol differentiation (TCP, UDP, SCTP)")
+	flags.MarkDeprecated(option.LoadBalancerProtocolDifferentiation, "The flag to control service protocol differentiation has been deprecated, and it will be removed in v1.19. The feature will be unconditionally enabled.")
 	option.BindEnv(vp, option.LoadBalancerProtocolDifferentiation)
 
 	flags.Bool(option.EnableAutoProtectNodePortRange, true,


### PR DESCRIPTION
As per https://github.com/cilium/cilium/issues/39249 we deprecate this option flag and stage it for removal in v1.19.

Fixes: #39249