### PR TITLE
proxy: use LocalNodeStore to retrieve local node

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -50,7 +50,6 @@ func (l *loader) writeNetdevHeader(dir string) error {
 	f, err := os.Create(headerPath)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s for writing: %w", headerPath, err)
-
 	}
 	defer f.Close()
 
@@ -519,7 +518,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfig
 
 	// Reinstall proxy rules for any running proxies if needed
 	if option.Config.EnableL7Proxy {
-		if err := p.ReinstallRoutingRules(lnc.RouteMTU); err != nil {
+		if err := p.ReinstallRoutingRules(ctx, lnc.RouteMTU); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -40,7 +40,7 @@ type PreFilter interface {
 // Proxy is any type which installs rules related to redirecting traffic to
 // a proxy.
 type Proxy interface {
-	ReinstallRoutingRules(mtu int) error
+	ReinstallRoutingRules(ctx context.Context, mtu int) error
 }
 
 // IptablesManager manages iptables rules.

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
 	"github.com/cilium/cilium/pkg/fqdn/service"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/accesslog/endpoint"
@@ -43,6 +44,7 @@ type proxyParams struct {
 
 	Lifecycle             cell.Lifecycle
 	Logger                *slog.Logger
+	LocalNodeStore        *node.LocalNodeStore
 	ProxyPorts            *proxyports.ProxyPorts
 	EnvoyProxyIntegration *envoyProxyIntegration
 	DNSProxyIntegration   *dnsProxyIntegration
@@ -57,7 +59,7 @@ func newProxy(params proxyParams) *Proxy {
 		return nil
 	}
 
-	p := createProxy(params.Logger, params.ProxyPorts, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
+	p := createProxy(params.Logger, params.LocalNodeStore, params.ProxyPorts, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
 
 	triggerDone := make(chan struct{})
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -89,8 +89,12 @@ func (p *Proxy) ReleaseProxyPort(name string) error {
 	return p.proxyPorts.ReleaseProxyPort(name)
 }
 
-func (p *Proxy) ReinstallRoutingRules(mtu int) error {
-	return ReinstallRoutingRules(p.logger, mtu)
+func (p *Proxy) ReinstallRoutingRules(ctx context.Context, mtu int) error {
+	ln, err := p.localNodeStore.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve local node: %w", err)
+	}
+	return ReinstallRoutingRules(p.logger, ln, mtu)
 }
 
 // GetProxyPort() returns the fixed listen port for a proxy, if any.

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -28,7 +28,7 @@ func proxyForTest(t *testing.T) (*Proxy, func()) {
 		RestoredProxyPortsAgeLimit: 0,
 	}
 	pp := proxyports.NewProxyPorts(hivetest.Logger(t), ppConfig, mockDatapathUpdater)
-	p := createProxy(hivetest.Logger(t), pp, nil, nil)
+	p := createProxy(hivetest.Logger(t), nil, pp, nil, nil)
 	triggerDone := make(chan struct{})
 	p.proxyPorts.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
 		MinInterval:  10 * time.Second,

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -54,7 +54,7 @@ var (
 
 // ReinstallRoutingRules ensures the presence of routing rules and tables needed
 // to route packets to and from the L7 proxy.
-func ReinstallRoutingRules(logger *slog.Logger, mtu int) error {
+func ReinstallRoutingRules(logger *slog.Logger, localNode node.LocalNode, mtu int) error {
 	fromIngressProxy, fromEgressProxy := requireFromProxyRoutes()
 
 	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
@@ -68,7 +68,7 @@ func ReinstallRoutingRules(logger *slog.Logger, mtu int) error {
 		}
 
 		if fromIngressProxy || fromEgressProxy {
-			if err := installFromProxyRoutesIPv4(logger, node.GetInternalIPv4Router(), defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
+			if err := installFromProxyRoutesIPv4(logger, localNode.GetCiliumInternalIP(false), defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
 				return err
 			}
 		} else {


### PR DESCRIPTION
This PR replaces usages of `node.GetInternalIPv4Router()` in `pkg/proxy` with `localNode.GetCiliumInternalIP(false)` (with the local node retrieved from the injected `LocalNodeStore`)

Please review the individual commits.