### PR TITLE
Renovate fixes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -761,7 +761,7 @@
         "^.github/workflows/renovate-config-validator\\.yaml$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?)\\s+RENOVATE_IMAGE=\"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\""
+        "# renovate: datasource=(?<datasource>.*?)\\s+export RENOVATE_IMAGE=\"?(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\"?"
       ]
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -474,6 +474,18 @@
         "main"
       ],
     },
+    // group updating renovate versions together (config validator/self hosted renovate)
+    {
+      "groupName": "renovate dependencies",
+      "groupSlug": "renovate-dependencies",
+      "matchDepNames": [
+        "renovatebot/renovate",
+        "ghcr.io/renovatebot/renovate",
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+    },
     {
       // Separate major minor and patch so that renovate can update the patch
       // versions of the images.

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Validate configuration
         run: |
           # renovate: datasource=docker
-          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:39.98.0@sha256:43e35242449741dab5e60510ba39704a720422f83fdaa495709bc1e0f141625d
+          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:39.259.0@sha256:9090f91e0f3f4212001a2faf2c89921d0016778c2d55e143d826c08c1bbb062e
           docker run --rm --entrypoint "renovate-config-validator" \
             -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5" \
             ${RENOVATE_IMAGE} "/renovate.json5"

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -3,7 +3,8 @@ name: Validate Renovate configuration
 on:
   pull_request:
     paths:
-      - '.github/renovate.json5'
+      # Run on any renovate.json5, not just .github/renovate.json5
+      - '**renovate.json5'
 
 jobs:
   validate:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -10,7 +10,7 @@ on:
     inputs:
       renovate_log_level_debug:
         type: boolean
-        description: "Rune Renovate With Debug Log Levels"
+        description: "Run Renovate With Debug Log Levels"
         default: true
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -535,9 +535,10 @@ run-builder: ## Drop into a shell inside a container running the cilium-builder 
 
 .PHONY: renovate-local
 renovate-local: ## Run a local linter for the renovate configuration
-	$(CONTAINER_ENGINE) run --rm -ti \
+	@echo "Running renovate --platform=local"
+	@$(CONTAINER_ENGINE) run --rm -ti \
 		-e LOG_LEVEL=debug \
-		-e GITHUB_COM_TOKEN="$(gh auth token)" \
+		-e GITHUB_COM_TOKEN="$(RENOVATE_GITHUB_COM_TOKEN)" \
 		-v /tmp:/tmp \
 		-v $(ROOT_DIR):/usr/src/app \
 		docker.io/renovate/renovate:slim \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -249,3 +249,5 @@ CURRENT_GO_MODULE = $(shell go list -m)
 define ASSERT_CILIUM_MODULE
 	$(if $(filter $(CILIUM_GO_MODULE), $(CURRENT_GO_MODULE)) ,, $(error "Could not locate Cilium's go.mod file, are you in Cilium's repository?"))
 endef
+
+RENOVATE_GITHUB_COM_TOKEN ?= $(shell gh auth token)


### PR DESCRIPTION
See individual commits for details. 

The main fixes here is to fix updating the version of renovate-config-validator works, and is syncronized with the version of renovate itself.

This PR might fail because some options in the version we're using have been changed, such as `allowedPostUpgradeCommands` has been changed to `allowedCommands`, but we'll see. If that's the case I'll update `renovate.json5` to work with the updated validator version.