### PR TITLE
Fix node linux unit tests

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	nodemapfake "github.com/cilium/cilium/pkg/maps/nodemap/fake"
-	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
 	nodeaddressing "github.com/cilium/cilium/pkg/node/addressing"
@@ -147,10 +146,6 @@ func setupLinuxPrivilegedBaseTestSuite(tb testing.TB, addressing datapath.NodeAd
 		RoutePostEncryptMTU: s.mtuCalc.RoutePostEncryptMTU,
 	}
 
-	tunnel.SetTunnelMap(tunnel.NewTunnelMap("test_cilium_tunnel_map"))
-	err = tunnel.TunnelMap().OpenOrCreate()
-	require.NoError(tb, err)
-
 	return s
 }
 
@@ -204,8 +199,6 @@ func tearDownTest(tb testing.TB) {
 	node.UnsetTestLocalNodeStore()
 	removeDevice(dummyHostDeviceName)
 	removeDevice(dummyExternalDeviceName)
-	err := tunnel.TunnelMap().Unpin()
-	require.NoError(tb, err)
 }
 
 func setupDummyDevice(name string, ips ...net.IP) (*tables.Device, error) {

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1109,6 +1109,11 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(t *testin
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
 	log := hivetest.Logger(t)
 	linuxNodeHandler := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), new(mockEnqueuer))
+	require.NotNil(t, linuxNodeHandler)
+
+	nodeConfig := s.nodeConfigTemplate
+	nodeConfig.EnableEncapsulation = false
+	linuxNodeHandler.nodeConfig = nodeConfig
 
 	if s.enableIPv4 {
 		insertFakeRoute(t, linuxNodeHandler, ip4Alloc1)
@@ -1118,8 +1123,6 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(t *testin
 		insertFakeRoute(t, linuxNodeHandler, ip6Alloc1)
 	}
 
-	nodeConfig := s.nodeConfigTemplate
-	nodeConfig.EnableEncapsulation = false
 	err := linuxNodeHandler.NodeConfigurationChanged(nodeConfig)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Node linux tests have been updated in https://github.com/cilium/cilium/pull/38490 to remove all the assertions regarding the deprecated tunnel map. However:

-  the agent restart test was originally meant to check the update of the tunnel map entries after a node configuration change. In #38490 it has been changed to assert the update of the routes, but the linux node handler is not able (and never has been) to remove the stale routes when an address family gets disabled. Therefore, the test should be removed.
- the direct routing test lacked the correct configuration of the dummy node, specifically the CiliumInternalI{Pv4,IPv6} needed to successfully install the fake routes
- the mocked tunnel map is not useful anymore, since it has been removed altogether

All of these should have led to the tests failing in the CI, but that didn't happen because of https://github.com/cilium/cilium/pull/38172: the `node_linux_test.go` file has been tagged as `unparallel` but the `tests-privileged` target in the Makefile has not been updated to include the whole `node` package as part of the `UNPARALLELTESTPKGS` list.

The latter issue will be addressed in https://github.com/cilium/cilium/pull/39250, where a [run](https://github.com/cilium/cilium/actions/runs/14762513687/job/41446423230) of the updated tests completed successfully.