### PR TITLE
gateway-api: Fix parentRefMatched to check Group and Kind

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -308,6 +308,11 @@ func (r *gatewayReconciler) getGatewayClassConfig(ctx context.Context, gwc *gate
 
 func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routeNamespace string, refs []gatewayv1.ParentReference) bool {
 	for _, ref := range refs {
+		// Check if the parentRef is a Gateway before checking name and namespace
+		if !helpers.IsGateway(ref) {
+			continue
+		}
+
 		if string(ref.Name) == gw.GetName() && gw.GetNamespace() == helpers.NamespaceDerefOr(ref.Namespace, routeNamespace) {
 			if ref.SectionName == nil && ref.Port == nil {
 				return true

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -801,6 +801,20 @@ func Test_sectionNameMatched(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "GAMMA Service with same name as Gateway should not match",
+			args: args{
+				listener: httpListener,
+				refs: []gatewayv1.ParentReference{
+					{
+						Kind:  (*gatewayv1.Kind)(ptr.To("Service")),
+						Group: (*gatewayv1.Group)(ptr.To("")),
+						Name:  "valid-gateway",
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes an issue where the Gateway reconciler was not checking if the parentRef was a Gateway before checking if the name and namespace match. This caused GAMMA HTTPRoutes with a Service parentRef to be incorrectly attached to Gateways with the same name.

The fix adds a check to ensure that the parentRef's Group and Kind match the Gateway API group and Gateway kind before proceeding with name and namespace matching.

## How has this been tested?

Added a new test case to verify that a GAMMA Service with the same name as a Gateway is not matched by the Gateway reconciler. All existing tests continue to pass.

Fixes: #39193

## Checklist
- [x] I have signed all my commits with DCO
- [x] I have added tests to prove my fix is effective
- [x] I have run the existing tests which continue to pass
- [x] This change requires a documentation update: No