### PR TITLE
Add scale test for lb-ipam

### DIFF
--- a/.github/actions/cl2-modules/lbipam/config.yaml
+++ b/.github/actions/cl2-modules/lbipam/config.yaml
@@ -1,0 +1,43 @@
+{{$NumSyntheticServices := DefaultParam .CL2_LBIPAM_NUM_SYNTHETIC_SERVICES 50000}}
+{{$SyntheticServicesTimeLimit := DefaultParam .CL2_LBIPAM_SYNTHETIC_SERVICES_TIME_LIMIT "3m"}}
+
+name: LB-IPAM test
+namespace:
+  number: 1
+tuningSets:
+- name: Uniform1qps
+  qpsLoad:
+    qps: 1
+- name: TimeLimitedLoad
+  TimeLimitedLoad:
+    timeLimit: {{$SyntheticServicesTimeLimit}}
+
+steps:
+- name: Create LB-IPAM IP pool
+  phases:
+  - replicasPerNamespace: 1
+    tuningSet: Uniform1qps
+    objectBundle:
+    - basename: lbipam-lb-ip-pool
+      objectTemplatePath: manifests/lb-ip-pool.yaml
+
+- module:
+    path: ./modules/metrics.yaml
+    params:
+      action: start
+
+- name: Create synthetic Services
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: {{$NumSyntheticServices}}
+    tuningSet: TimeLimitedLoad
+    objectBundle:
+    - basename: lbipam-service-synthetic
+      objectTemplatePath: manifests/synthetic-service.yaml
+
+- module:
+    path: ./modules/metrics.yaml
+    params:
+      action: gather

--- a/.github/actions/cl2-modules/lbipam/manifests/lb-ip-pool.yaml
+++ b/.github/actions/cl2-modules/lbipam/manifests/lb-ip-pool.yaml
@@ -1,0 +1,7 @@
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: "{{.Name}}"
+spec:
+  blocks:
+  - cidr: "110.0.0.0/8"

--- a/.github/actions/cl2-modules/lbipam/manifests/synthetic-service.yaml
+++ b/.github/actions/cl2-modules/lbipam/manifests/synthetic-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{.Name}}"
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 1234
+  allocateLoadBalancerNodePorts: false

--- a/.github/actions/cl2-modules/lbipam/modules/metrics.yaml
+++ b/.github/actions/cl2-modules/lbipam/modules/metrics.yaml
@@ -1,0 +1,46 @@
+# Valid actions: "start", "gather"
+{{$action := .action}}
+
+steps:
+- name: "{{$action}}ing measurements"
+  measurements:
+  - Identifier: LBIPAMEventProcessingTime
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: LB-IPAM Event Processing Time
+      metricVersion: v1
+      unit: s
+      queries:
+      - name: Service upserts - Perc 50
+        query: histogram_quantile(0.5, sum(rate(cilium_operator_lbipam_event_processing_time_seconds_bucket{event="upsert", resource="service"}[%v])) by (le))
+      - name: Service upserts - Perc 90
+        query: histogram_quantile(0.9, sum(rate(cilium_operator_lbipam_event_processing_time_seconds_bucket{event="upsert", resource="service"}[%v])) by (le))
+      - name: Service upserts - Perc 99
+        query: histogram_quantile(0.99, sum(rate(cilium_operator_lbipam_event_processing_time_seconds_bucket{event="upsert", resource="service"}[%v])) by (le))
+      enableViolations: true
+
+
+  - Identifier: CiliumOperatorCPUUsage
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Average CPU Usage
+      metricVersion: v1
+      unit: cpu
+      enableViolations: true
+      queries:
+      - name: Max
+        query: max(avg_over_time(rate(cilium_operator_process_cpu_seconds_total[1m])[%v:]))
+
+  - Identifier: CiliumOperatorMemUsage
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Max Memory Usage
+      metricVersion: v1
+      unit: MB
+      enableViolations: true
+      queries:
+      - name: Max
+        query: max(max_over_time(cilium_operator_process_resident_memory_bytes[%v:]) / 1e6)

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -74,6 +74,9 @@ triggers:
   /scale-100:
     workflows:
     - scale-test-100-gce.yaml
+  /scale-5:
+    workflows:
+    - scale-test-5-gce.yaml
   /scale-clustermesh:
     workflows:
     - scale-test-clustermesh.yaml

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -1,8 +1,8 @@
-name: 100 Nodes Scale Test (scale-100)
+name: 5 Nodes Scale Test (scale-5)
 
 on:
   schedule:
-    - cron: '39 0 * * 1-5'
+    - cron: '22 5 * * 1-5' # Every weekday at 05:22 AM
 
   workflow_dispatch:
     inputs:
@@ -57,7 +57,9 @@ concurrency:
 env:
   # renovate: datasource=golang-version depName=go
   go_version: 1.24.3
-  test_name: scale-100
+  # Adding k8s.local to the end makes kops happy-
+  # has stricter DNS naming requirements.
+  test_name: scale-5
   cluster_name: ${{ github.run_id }}-${{ github.run_attempt }}
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 520.0.0
@@ -286,7 +288,7 @@ jobs:
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           node_size: e2-medium
-          node_count: 100
+          node_count: 5
           ig_name: workloads
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
@@ -312,7 +314,7 @@ jobs:
         id: run-cl2
         working-directory: ./perf-tests/clusterloader2
         shell: bash
-        timeout-minutes: 40
+        timeout-minutes: 60
         env:
           CL2_ENABLE_PVS: "false"
           CL2_ENABLE_NETWORKPOLICIES: "true"
@@ -326,11 +328,11 @@ jobs:
           ./clusterloader \
             -v=2 \
             --testconfig=./testing/load/config.yaml \
-            --testconfig=./testing/custom/netpol/config.yaml \
+            --testconfig=./testing/custom/lbipam/config.yaml \
             --provider=gce \
             --enable-prometheus-server \
             --tear-down-prometheus-server=false \
-            --nodes=100 \
+            --nodes=5 \
             --report-dir=./report \
             --experimental-prometheus-snapshot-to-report-dir=true \
             --kubeconfig=$HOME/.kube/config \

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -292,6 +292,12 @@ func (ipam *LBIPAM) handleServiceEvent(ctx context.Context, event resource.Event
 }
 
 func (ipam *LBIPAM) poolOnUpsert(ctx context.Context, pool *cilium_api_v2.CiliumLoadBalancerIPPool) error {
+	if ipam.metrics.EventProcessingTime.IsEnabled() {
+		defer func(start time.Time) {
+			ipam.metrics.EventProcessingTime.WithLabelValues("upsert", "pool").Observe(time.Since(start).Seconds())
+		}(time.Now())
+	}
+
 	// Deep copy so we get a version we are allowed to update the status
 	pool = pool.DeepCopy()
 
@@ -325,6 +331,12 @@ func (ipam *LBIPAM) poolOnUpsert(ctx context.Context, pool *cilium_api_v2.Cilium
 }
 
 func (ipam *LBIPAM) poolOnDelete(ctx context.Context, pool *cilium_api_v2.CiliumLoadBalancerIPPool) error {
+	if ipam.metrics.EventProcessingTime.IsEnabled() {
+		defer func(start time.Time) {
+			ipam.metrics.EventProcessingTime.WithLabelValues("delete", "pool").Observe(time.Since(start).Seconds())
+		}(time.Now())
+	}
+
 	err := ipam.handlePoolDeleted(ctx, pool)
 	if err != nil {
 		return fmt.Errorf("handlePoolDeleted: %w", err)
@@ -344,6 +356,12 @@ func (ipam *LBIPAM) poolOnDelete(ctx context.Context, pool *cilium_api_v2.Cilium
 }
 
 func (ipam *LBIPAM) svcOnUpsert(ctx context.Context, svc *slim_core_v1.Service) error {
+	if ipam.metrics.EventProcessingTime.IsEnabled() {
+		defer func(start time.Time) {
+			ipam.metrics.EventProcessingTime.WithLabelValues("upsert", "service").Observe(time.Since(start).Seconds())
+		}(time.Now())
+	}
+
 	err := ipam.handleUpsertService(ctx, svc)
 	if err != nil {
 		return fmt.Errorf("handleUpsertService: %w", err)
@@ -358,6 +376,12 @@ func (ipam *LBIPAM) svcOnUpsert(ctx context.Context, svc *slim_core_v1.Service) 
 }
 
 func (ipam *LBIPAM) svcOnDelete(ctx context.Context, svc *slim_core_v1.Service) error {
+	if ipam.metrics.EventProcessingTime.IsEnabled() {
+		defer func(start time.Time) {
+			ipam.metrics.EventProcessingTime.WithLabelValues("delete", "service").Observe(time.Since(start).Seconds())
+		}(time.Now())
+	}
+
 	ipam.logger.Debug(fmt.Sprintf("Deleted service '%s/%s'", svc.GetNamespace(), svc.GetName()))
 
 	ipam.handleDeletedService(svc)

--- a/operator/pkg/lbipam/metrics.go
+++ b/operator/pkg/lbipam/metrics.go
@@ -14,6 +14,7 @@ type ipamMetrics struct {
 	UsedIPs             metric.DeletableVec[metric.Gauge]
 	MatchingServices    metric.Gauge
 	UnsatisfiedServices metric.Gauge
+	EventProcessingTime metric.Vec[metric.Observer]
 }
 
 func newMetrics() *ipamMetrics {
@@ -53,5 +54,12 @@ func newMetrics() *ipamMetrics {
 			Name:       "services_unsatisfied",
 			Help:       "The number of services which did not receive all requested IPs",
 		}),
+		EventProcessingTime: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: metrics.Namespace + "_lbipam_event_processing_time_seconds",
+			Namespace:  metrics.Namespace,
+			Subsystem:  "lbipam",
+			Name:       "event_processing_time_seconds",
+			Help:       "The time taken to process an event",
+		}, []string{"event", "resource"}),
 	}
 }


### PR DESCRIPTION
This PR adds a scale test of LB-IPAM to prove that the feature scales well event when a lot of services are created. The test is fairly simple, we create a pool and then over the course of 3 minutes (by default) add 50k services which get an IP from the pool. We record the event processing time, CPU usage and memory usage.