### PR TITLE
LB-IPAM: Fix performance fixes

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -296,7 +296,12 @@ func (ipam *LBIPAM) poolOnUpsert(ctx context.Context, pool *cilium_api_v2alpha1.
 	pool = pool.DeepCopy()
 
 	var err error
-	if _, exists := ipam.pools[pool.GetName()]; exists {
+	if existingPool, exists := ipam.pools[pool.GetName()]; exists {
+		// Spec hasn't changed, nothing to do
+		if existingPool.Spec.DeepEqual(&pool.Spec) {
+			return nil
+		}
+
 		err = ipam.handlePoolModified(ctx, pool)
 		if err != nil {
 			return fmt.Errorf("handlePoolModified: %w", err)


### PR DESCRIPTION
This PR addresses two issues that were surfaced by scale testing as part of https://github.com/cilium/cilium/pull/39276.

Please see the individual commit messages for details.

```release-note
LB-IPAM: reduce CPU usage during service creation and release memory when no longer needed
```
