### PR TITLE
[v1.15] .github: provide correct env variables to api/v1 Makefile

### DIFF
--- a/api/v1/Makefile
+++ b/api/v1/Makefile
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 include ../../Makefile.defs
 
+VOLUME ?= $(CURDIR)
+CONTAINER_IMAGE ?= $(CILIUM_BUILDER_IMAGE)
+
 .PHONY: proto
 proto:
 	$(QUIET)$(CONTAINER_ENGINE) container run --rm \
-		--volume $(CURDIR):/src \
+		--volume $(VOLUME):/src \
 		--user "$(shell id -u):$(shell id -g)" \
-		$(CILIUM_BUILDER_IMAGE) \
+		$(CONTAINER_IMAGE) \
 		make -C /src -f Makefile.protoc


### PR DESCRIPTION
The base image build GitHub workflow calling the Makefile sets CONTAINER_IMAGE, not CILIUM_BUILDER_IMAGE. This change also uses the VOLUME environment variable which is set in the calling workflow.

I was doing a bit of digging into why base image builds are failing on v1.15 (see [here](https://github.com/cilium/cilium/pull/39224) and [here](https://github.com/cilium/cilium/pull/39252) for examples).

@joestringer had looked into some of the errors [here](https://github.com/cilium/cilium/pull/38423#issuecomment-2748620815) but I noticed that a lot of these were also occurring on the successful run on v1.16 [here](https://github.com/cilium/cilium/actions/runs/14637899121/job/41073205842).

The only difference in output was in the `docker container run` command:

v1.16:
```
docker container run --rm \
	--volume /home/runner/work/cilium/cilium/api/v1:/src \
	--user "1001:118" \
	quay.io/cilium/cilium-builder:29d9d5b71a7bb78c72be70ab12124a18eb7308cf@sha256:6d50a55d3e4085276c3235e999bc68a9682df4edb048211b077f1e9f9cd4e268 \
	make -C /src -f Makefile.protoc
```

v1.15:
```
docker container run --rm \
	--volume /home/runner/work/cilium/cilium-base-branch/api/v1:/src \
	--user "1001:118" \
	 \
	make -C /src -f Makefile.protoc
bash: line 1: go: command not found
```

v1.15 is missing the actual builder image to run. This appears to be because the base image build GitHub workflow calling the Makefile sets CONTAINER_IMAGE, not CILIUM_BUILDER_IMAGE.