### PR TITLE
Remove remaining references to consul

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -680,10 +680,6 @@ The "Double Write" Identity Allocation Mode allows Cilium to allocate identities
 same time. This mode also has two versions: one where the source of truth comes from the kvstore (``--identity-allocation-mode=doublewrite-readkvstore``),
 and one where the source of truth comes from CRDs (``--identity-allocation-mode=doublewrite-readcrd``).
 
-.. note::
-
-    "Double Write" mode is not compatible with Consul as the KVStore
-
 The high-level migration plan looks as follows:
 
 #. Starting state: Cilium is running in KVStore mode.

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -66,7 +66,6 @@ const (
 //	2.1 Create a new slave key. This operation is potentially racy as the master
 //	    key can be removed in the meantime.
 //	    - etcd: Create is made conditional on existence of master key
-//	    - consul: locking
 //
 // ... match not found:
 //


### PR DESCRIPTION
Cilium no longer supports Consul since commit f323ffc16d79
("kvstore: Remove Consul support"), so there's no need to have
references to it in docs or code comments.
