### PR TITLE
bgp: Component tests enhancements

### DIFF
--- a/pkg/bgpv1/test/testdata/peering-ipv6.txtar
+++ b/pkg/bgpv1/test/testdata/peering-ipv6.txtar
@@ -1,35 +1,30 @@
-#! --probe-tcp-md5 --test-peering-ips=fd00::aa:bb:cc:101,fd00::aa:bb:cc:102
+#! --test-peering-ips=fd00::aa:bb:cc:111,fd00::aa:bb:cc:112
 
-# Tests IPv6 peering with authentication.
+# Tests IPv6-only peering and advertisement.
 
 # Start the hive
 hive start
 
 # Wait for k8s watchers to be initialized
 k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-k8s/wait-watchers v1.services v1.secrets
 
 # Configure gobgp server
-gobgp/add-server --router-id=1.2.3.4 65001 fd00::aa:bb:cc:101 1790
-gobgp/add-peer --password=Cilium123 fd00::aa:bb:cc:102 65001
+gobgp/add-server --router-id=1.2.3.4 65001 fd00::aa:bb:cc:111 1790
+gobgp/add-peer fd00::aa:bb:cc:112 65001
 
 # Configure BGP on Cilium
-k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml auth-secret.yaml
+k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
 
 # Wait for peering to be established
-gobgp/wait-state fd00::aa:bb:cc:102 ESTABLISHED
+gobgp/wait-state fd00::aa:bb:cc:112 ESTABLISHED
 
 # Validate peering state
 gobgp/peers -o peers.actual
 * cmp gobgp-peers.expected peers.actual
 
-# Validate IPv4 routes
-gobgp/routes -o routes.actual ipv4 unicast
-* cmp gobgp-routes-ipv4.expected routes.actual
-
-# Validate IPv6 routes
+# Validate routes
 gobgp/routes -o routes.actual ipv6 unicast
-* cmp gobgp-routes-ipv6.expected routes.actual
+* cmp gobgp-routes.expected routes.actual
 
 #####
 
@@ -40,11 +35,10 @@ metadata:
   name: test-node
 spec:
   addresses:
-  - ip: fd00::aa:bb:cc:102
+  - ip: fd00::aa:bb:cc:112
     type: InternalIP
   ipam:
     podCIDRs:
-    - 10.244.0.0/24
     - fd00:11:22::/64
 
 -- bgp-node-config.yaml --
@@ -60,8 +54,8 @@ spec:
     peers:
     - name: gobgp-peer
       peerASN: 65001
-      peerAddress: fd00::aa:bb:cc:101
-      localAddress: fd00::aa:bb:cc:102
+      peerAddress: fd00::aa:bb:cc:111
+      localAddress: fd00::aa:bb:cc:112
       peerConfigRef:
         name: gobgp-peer-config
 
@@ -73,15 +67,9 @@ metadata:
 spec:
   transport:
     peerPort: 1790
-  authSecretRef: bgp-auth-secret
   timers:
     connectRetryTimeSeconds: 1
   families:
-  - afi: ipv4
-    safi: unicast
-    advertisements:
-      matchLabels:
-        advertise: bgp
   - afi: ipv6
     safi: unicast
     advertisements:
@@ -99,22 +87,9 @@ spec:
   advertisements:
   - advertisementType: PodCIDR
 
--- auth-secret.yaml --
-apiVersion: v1
-kind: Secret
-type: string
-metadata:
-  name: bgp-auth-secret
-  namespace: kube-system
-data:
-  password: Q2lsaXVtMTIz
-
 -- gobgp-peers.expected --
 PeerAddress          RouterID   PeerASN   SessionState   KeepAlive   HoldTime   GracefulRestartTime
-fd00::aa:bb:cc:102   5.6.7.8    65001     ESTABLISHED    30          90         0
--- gobgp-routes-ipv4.expected --
-Prefix          NextHop              Attrs
-10.244.0.0/24   fd00::aa:bb:cc:102   [{Origin: i} {AsPath: } {LocalPref: 100} {MpReach(ipv4-unicast): {Nexthop: fd00::aa:bb:cc:102, NLRIs: [10.244.0.0/24]}}]
--- gobgp-routes-ipv6.expected --
+fd00::aa:bb:cc:112   5.6.7.8    65001     ESTABLISHED    30          90         0
+-- gobgp-routes.expected --
 Prefix            NextHop              Attrs
-fd00:11:22::/64   fd00::aa:bb:cc:102   [{Origin: i} {AsPath: } {LocalPref: 100} {MpReach(ipv6-unicast): {Nexthop: fd00::aa:bb:cc:102, NLRIs: [fd00:11:22::/64]}}]
+fd00:11:22::/64   fd00::aa:bb:cc:112   [{Origin: i} {AsPath: } {LocalPref: 100} {MpReach(ipv6-unicast): {Nexthop: fd00::aa:bb:cc:112, NLRIs: [fd00:11:22::/64]}}]

--- a/pkg/bgpv1/test/testdata/svc-path-attributes.txtar
+++ b/pkg/bgpv1/test/testdata/svc-path-attributes.txtar
@@ -31,33 +31,33 @@ gobgp/wait-state fd00::bb:cc:dd:102 ESTABLISHED
 gobgp/peers -o peers.actual
 * cmp gobgp-peers.expected peers.actual
 
-# Validate IPv4 PodCIDR routes
+# Validate IPv4 service routes
 gobgp/routes -o routes.actual ipv4 unicast
 * cmp gobgp-routes-99-ipv4.expected routes.actual
 
-# Validate IPv6 PodCIDR routes
+# Validate IPv6 service routes
 gobgp/routes -o routes.actual ipv6 unicast
 * cmp gobgp-routes-99-ipv6.expected routes.actual
 
 # Configure advertisement with communities ending with 101
 k8s/update bgp-advertisement-101.yaml
 
-# Validate IPv4 PodCIDR routes
+# Validate IPv4 service routes
 gobgp/routes -o routes.actual ipv4 unicast
 * cmp gobgp-routes-101-ipv4.expected routes.actual
 
-# Validate IPv6 PodCIDR routes
+# Validate IPv6 service routes
 gobgp/routes -o routes.actual ipv6 unicast
 * cmp gobgp-routes-101-ipv6.expected routes.actual
 
 # Configure advertisement with overlapping advertisements
 k8s/update bgp-advertisement-overlapping.yaml
 
-# Validate IPv4 PodCIDR routes
+# Validate IPv4 service routes
 gobgp/routes -o routes.actual ipv4 unicast
 * cmp gobgp-routes-overlapping-ipv4.expected routes.actual
 
-# Validate IPv6 PodCIDR routes
+# Validate IPv6 service routes
 gobgp/routes -o routes.actual ipv6 unicast
 * cmp gobgp-routes-overlapping-ipv6.expected routes.actual
 


### PR DESCRIPTION
Adds a test that peers IPv6-only peering and IPv6-only advertisement.
Enhances existing auth test to validate advertised routes.
Fixes comments in svc-path-attributes test.
