### PR TITLE
bugtool: include human-readable ttl for ct entries

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -403,7 +403,7 @@ func ciliumDbgCommands(cmdDir string) []string {
 		"cilium-dbg bpf egress list",
 		"cilium-dbg bpf vtep list",
 		"cilium-dbg bpf endpoint list",
-		"cilium-dbg bpf ct list global",
+		"cilium-dbg bpf ct list global --time-diff",
 		"cilium-dbg bpf nat list",
 		"cilium-dbg bpf nat retries list",
 		"cilium-dbg bpf ipmasq list",


### PR DESCRIPTION
the `--time-diff` option for ct list commands provides improved readability for the conntrack entry lifetime.

Example diff:

```
# sdiff -w 201 <(cilium bpf ct list global | head -1) <( cilium bpf ct list global --time-diff | head -1)
TCP IN 10.104.4.1:48022 -> 10.104.4.3:19090 expires=16997807 Packets=10 Bytes=954 RxFlagsSeen=0x1   |   TCP IN 10.104.4.1:48022 -> 10.104.4.3:19090 expires=16997807 (remaining: -9699 sec(s)) Packets=10
```

```release-note
bugtool: Include human-readable TTL for conntrack entries.
```
