### PR TITLE
.github: Notify teams as part of filing a CFP

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -18,6 +18,14 @@ If so, please describe the problem
 
 Include any specific requirements you need
 
+**Notify relevant community channels**
+
+Notify the members of any relevant code owners below from the [teams] list in the following form:
+
+- @cilium/example
+
+If you don't know which team to include or you haven't gotten feedback, consider raising this topic on [Slack] in the #development channel or during a [community meeting] for awareness.
+
 **(Optional) Describe your proposed solution**
 
 Please complete this section if you have ideas / suggestions on how to implement the feature. We strongly recommend discussing your approach with Cilium committers before spending lots of time implementing a change.
@@ -25,3 +33,7 @@ Please complete this section if you have ideas / suggestions on how to implement
 For longer proposals, you are welcome to link to an external doc (e.g. a Google doc). We have a [Cilium Feature Proposal template](https://docs.google.com/document/d/1vtE82JExQHw8_-pX2Uhq5acN1BMPxNlS6cMQUezRTWg/edit) to help you structure your proposal - if you would like to use it, please make a copy and ensure it's publicly visible, and then add the link here.
 
 Once the CFP is close to being finalized, please add it as a PR to the [design-cfps](https://github.com/cilium/design-cfps) repo for final approval.
+
+[community meeting]: https://docs.cilium.io/en/stable/community/community/#community-meetings
+[Slack]: https://docs.cilium.io/en/stable/community/community/#slack
+[teams]: https://github.com/cilium/community/tree/main/ladder/teams


### PR DESCRIPTION
Improve the issue template for filing new feature issues to CC the
relevant teams. This should improve the awareness of ongoing proposals
in different areas of Cilium.
