### PR TITLE
 Release IPPrefixes: Support AWS ENI IP Prefix unassignment

### DIFF
--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -377,6 +377,13 @@ func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *slog.Logger) *ipam.Rel
 	return r
 }
 
+// ReleaseIPPrefixes is a no-op on AlibabaCloud since Alibaba ENIs don't
+// support prefix delegation.
+func (n *Node) ReleaseIPPrefixes(ctx context.Context, r *ipam.ReleaseAction) error {
+	// nothing to do
+	return nil
+}
+
 // ReleaseIPs performs the ENI IP release operation
 func (n *Node) ReleaseIPs(ctx context.Context, r *ipam.ReleaseAction) error {
 	return n.manager.api.UnassignPrivateIPAddresses(ctx, r.InterfaceID, r.IPsToRelease)
@@ -415,13 +422,6 @@ func (n *Node) loggerLocked() *slog.Logger {
 
 func (n *Node) IsPrefixDelegated() bool {
 	return false
-}
-
-func (n *Node) GetUsedIPWithPrefixes() int {
-	if n.k8sObj == nil {
-		return 0
-	}
-	return len(n.k8sObj.Status.IPAM.Used)
 }
 
 // getLimits returns the interface and IP limits of this node

--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -45,23 +45,6 @@ func TestGetMaximumAllocatableIPv4(t *testing.T) {
 	require.Equal(t, 0, n.GetMaximumAllocatableIPv4())
 }
 
-// TestGetUsedIPWithPrefixes tests the logic computing used IPs on a node when prefix delegation is enabled.
-func TestGetUsedIPWithPrefixes(t *testing.T) {
-	cn := newCiliumNode("node1", withInstanceType("m5a.large"))
-	n := &Node{k8sObj: cn}
-	eniName := "eni-1"
-	prefixes := []string{"10.10.128.0/28", "10.10.128.16/28"}
-	eniMap := make(map[string]types.ENI)
-	eniMap[eniName] = types.ENI{Prefixes: prefixes}
-	cn.Status.ENI.ENIs = eniMap
-
-	allocationMap := make(ipamTypes.AllocationMap)
-	allocationMap["10.10.128.2"] = ipamTypes.AllocationIP{Resource: eniName}
-	allocationMap["10.10.128.18"] = ipamTypes.AllocationIP{Resource: eniName}
-	n.k8sObj.Status.IPAM.Used = allocationMap
-	require.Equal(t, 32, n.GetUsedIPWithPrefixes())
-}
-
 func Test_findSubnetInSameRouteTableWithNodeSubnet(t *testing.T) {
 	routeTableMap := ipamTypes.RouteTableMap{
 		"rt-1": &ipamTypes.RouteTable{

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -59,6 +59,13 @@ func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *slog.Logger) *ipam.Rel
 	return &ipam.ReleaseAction{}
 }
 
+// ReleaseIPPrefixes is a no-op on Azure since Azure ENIs don't
+// support prefix delegation.
+func (n *Node) ReleaseIPPrefixes(ctx context.Context, r *ipam.ReleaseAction) error {
+	// nothing to do
+	return nil
+}
+
 // ReleaseIPs performs the IP release operation
 func (n *Node) ReleaseIPs(ctx context.Context, r *ipam.ReleaseAction) error {
 	return fmt.Errorf("not implemented")
@@ -223,13 +230,6 @@ func (n *Node) GetMinimumAllocatableIPv4() int {
 
 func (n *Node) IsPrefixDelegated() bool {
 	return false
-}
-
-func (n *Node) GetUsedIPWithPrefixes() int {
-	if n.k8sObj == nil {
-		return 0
-	}
-	return len(n.k8sObj.Status.IPAM.Used)
 }
 
 // isAvailableInterface returns whether interface is available and the number of available IPs to allocate in interface

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -41,6 +41,7 @@ const (
 	createInterfaceAndAllocateIP = "createInterfaceAndAllocateIP"
 	allocateIP                   = "allocateIP"
 	releaseIP                    = "releaseIP"
+	releaseIPPrefixes            = "releaseIPPrefixes"
 
 	// operator status
 	success = "success"
@@ -376,7 +377,6 @@ func calculateExcessIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAbov
 	// allocated but we never want to release IPs that have been allocated
 	// because of max-above-watermark.
 	excessIPs = max(availableIPs-usedIPs-preAllocate-maxAboveWatermark, 0)
-
 	return
 }
 
@@ -482,18 +482,11 @@ func (n *Node) recalculate(ctx context.Context) {
 		n.stats.IPv4.AssignedStaticIP = stats.AssignedStaticIP
 	}
 
-	// Get used IP count with prefixes included
-	usedIPForExcessCalc := n.stats.IPv4.UsedIPs
-	if n.ops.IsPrefixDelegated() {
-		usedIPForExcessCalc = n.ops.GetUsedIPWithPrefixes()
-	}
-
 	n.stats.IPv4.AvailableIPs = len(n.ipv4Alloc.available)
 	n.stats.IPv4.NeededIPs = calculateNeededIPs(n.stats.IPv4.AvailableIPs, n.stats.IPv4.UsedIPs, n.getPreAllocate(), n.getMinAllocate(), n.getMaxAllocate())
-	n.stats.IPv4.ExcessIPs = calculateExcessIPs(n.stats.IPv4.AvailableIPs, usedIPForExcessCalc, n.getPreAllocate(), n.getMinAllocate(), n.getMaxAboveWatermark())
+	n.stats.IPv4.ExcessIPs = calculateExcessIPs(n.stats.IPv4.AvailableIPs, n.stats.IPv4.UsedIPs, n.getPreAllocate(), n.getMinAllocate(), n.getMaxAboveWatermark())
 	n.stats.IPv4.RemainingInterfaces = stats.RemainingAvailableInterfaceCount
 	n.stats.IPv4.Capacity = stats.NodeCapacity
-
 	scopedLog.Debug(
 		"Recalculated needed addresses",
 		logfields.Available, n.stats.IPv4.AvailableIPs,
@@ -645,6 +638,9 @@ type ReleaseAction struct {
 
 	// IPsToRelease is the list of IPs to release
 	IPsToRelease []string
+
+	// IPPrefixes is the list of prefixes to release
+	IPPrefixesToRelease []string
 }
 
 // maintenanceAction represents the resources available for allocation for a
@@ -662,12 +658,13 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 	a := &maintenanceAction{}
 
 	stats := n.Stats()
-
 	// Validate that the node still requires addresses to be released, the
 	// request may have been resolved in the meantime.
 	if n.manager.releaseExcessIPs && stats.IPv4.ExcessIPs > 0 {
 		a.release = n.ops.PrepareIPRelease(stats.IPv4.ExcessIPs, n.logger.Load())
-		return a, nil
+		if a.release != nil && len(a.release.IPsToRelease) > 0 {
+			return a, nil
+		}
 	}
 
 	// Validate that the node still requires addresses to be allocated, the
@@ -888,13 +885,28 @@ func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (insta
 			logfields.Releasing, ipsToRelease,
 			logfields.SelectedInterface, a.release.InterfaceID,
 			logfields.SelectedPoolID, a.release.PoolID)
-		scopedLog.Info("Releasing excess IPs from node")
 		start := time.Now()
+		// Unassign unneeded IPPrefixes
+		if len(a.release.IPPrefixesToRelease) > 0 {
+			err := n.ops.ReleaseIPPrefixes(ctx, a.release)
+			if err != nil {
+				n.manager.metricsAPI.ReleaseAttempt(releaseIPPrefixes, failed, string(a.release.PoolID), metrics.SinceInSeconds(start))
+				scopedLog.Warn(
+					"Unable to unassign ipPrefixes from interface",
+					logfields.Error, err,
+					logfields.SelectedInterface, a.release.InterfaceID,
+					logfields.ReleasingAddresses, a.release.IPPrefixesToRelease,
+				)
+				return false, err
+			}
+			n.manager.metricsAPI.ReleaseAttempt(releaseIPPrefixes, success, string(a.release.PoolID), metrics.SinceInSeconds(start))
+			n.manager.metricsAPI.AddIPRelease(string(a.release.PoolID), int64(len(a.release.IPsToRelease)))
+		}
+
 		err := n.ops.ReleaseIPs(ctx, a.release)
 		if err == nil {
 			n.manager.metricsAPI.ReleaseAttempt(releaseIP, success, string(a.release.PoolID), metrics.SinceInSeconds(start))
 			n.manager.metricsAPI.AddIPRelease(string(a.release.PoolID), int64(len(a.release.IPsToRelease)))
-
 			// Remove the IPs from ipsMarkedForRelease
 			n.mutex.Lock()
 			for _, ip := range ipsToRelease {

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -85,6 +85,10 @@ type NodeOperations interface {
 	// indicates a need to release IPs.
 	PrepareIPRelease(excessIPs int, scopedLog *slog.Logger) *ReleaseAction
 
+	// ReleaseIPPrefixes is called after invoking PrepareIPRelease and needs to
+	// perform the release of IPPrefixes.
+	ReleaseIPPrefixes(ctx context.Context, release *ReleaseAction) error
+
 	// ReleaseIPs is called after invoking PrepareIPRelease and needs to
 	// perform the release of IPs.
 	ReleaseIPs(ctx context.Context, release *ReleaseAction) error
@@ -99,10 +103,6 @@ type NodeOperations interface {
 
 	// IsPrefixDelegated helps identify if a node supports prefix delegation
 	IsPrefixDelegated() bool
-
-	// GetUsedIPWithPrefixes returns the total number of used IPs including all IPs in a prefix if at-least one of
-	// the prefix IPs is in use.
-	GetUsedIPWithPrefixes() int
 }
 
 // AllocationImplementation is the interface an implementation must provide.

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -163,6 +163,11 @@ func (n *nodeOperationsMock) releaseIP(ip string) error {
 	return fmt.Errorf("IP %s not found", ip)
 }
 
+func (n *nodeOperationsMock) ReleaseIPPrefixes(ctx context.Context, release *ReleaseAction) error {
+	// no-op stub for tests
+	return nil
+}
+
 func (n *nodeOperationsMock) ReleaseIPs(ctx context.Context, release *ReleaseAction) error {
 	for _, ipToDelete := range release.IPsToRelease {
 		if err := n.releaseIP(ipToDelete); err != nil {


### PR DESCRIPTION
Cilium currently do not support releasing IPPrefixes due to which IP starvation is happening in our Kubernetes clusters. We have to manually delete a node in order to free unused IPPrefixes. With this fix, operator will release those unused IPPrefixes to reassign them again in AWS ENI. Added no-op stub implementation in azure and alibabacloud to satisfy NodeOperations interface.

Fixes: #32209, #39904
### Without this fix, delegated prefixes won’t be released until their nodes are deleted, resulting in wasted IP space.
![Screenshot 2025-05-02 at 12 03 43 PM](https://github.com/user-attachments/assets/fb3b5652-0819-4091-9ce9-6d04159d0610)
### With the fix in place, IP Prefixes are released and can be reused again.
<img width="282" alt="Screenshot 2025-05-02 at 12 21 05 PM" src="https://github.com/user-attachments/assets/5591fedd-c161-421d-9791-210d4a08ac33" />

Non goals :

- IPv6 prefix support

```release-note
Support IPPrefix unassignment in order to reuse those IPPrefixes and prevent IP starvation.
This would require cilium-operator's AWS IAM role update to add "ec2:DescribeRouteTables" permissions.  
```
