### PR TITLE
Multigateway support for Egress Gateway

### DIFF
--- a/.github/actions/cl2-modules/egw/manifests/egw-policy.yaml
+++ b/.github/actions/cl2-modules/egw/manifests/egw-policy.yaml
@@ -16,3 +16,4 @@ spec:
     nodeSelector:
       matchLabels:
         {{StructuralData .NodeSelector}}
+  egressGateways: []

--- a/Documentation/network/egress-gateway/egress-gateway.rst
+++ b/Documentation/network/egress-gateway/egress-gateway.rst
@@ -305,6 +305,43 @@ setting the ``--devices`` agent option accordingly.
    gateway node's network configuration (for example if an IP address is added or deleted). You can force a fresh selection by re-applying the
    Egress Gateway policy.
 
+Selecting multiple gateway nodes
+--------------------------------
+
+It's possible to select multiple gateway nodes in the same policy. In this case, the gateway nodes
+can be configured using the ``egressGateways`` list field. Entries on this list have the exact same
+configuration options as the ``egressGateway`` field:
+
+.. code-block:: yaml
+
+  egressGateways:
+  - nodeSelector:
+      matchLabels:
+        testLabel: testVal1
+  - nodeSelector:
+      matchLabels:
+        testLabel: testVal2
+
+.. note::
+
+    The same restrictions as with the ``egressGateway`` field apply to each item of the
+    ``egressGateways`` list.
+
+.. note::
+
+    When using multiple gateways the source endpoints matched by the policy will still egress traffic
+    through a single gateway, not all of them. The endpoints will be assigned to a gateway based on
+    its CiliumEndpoint's UID. Hence, an endpoint should use the same gateway during its lifetime
+    as long as the gateway nodes matched by the ``nodeSelector`` fields don't change. If a
+    ``nodeSelector`` field is added, removed, or modified, or if a node matching one of the
+    ``nodeSelector`` fields is added or removed, the list of gateways will change and the endpoints
+    will be reassigned.
+
+.. warning::
+
+    As with single-gateway policies, changing the gateway node will break existing egress connections.
+    Please read the following :gh-issue:`39245` which tracks this issue.
+
 Example policy
 --------------
 

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -273,6 +273,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		podToPodEncryptionV2{},
 		nodeToNodeEncryption{},
 		egressGateway{},
+		egressGatewayMultigateway{},
 		egressGatewayExcludedCidrs{},
 		egressGatewayWithL7Policy{},
 		podToNodeCidrpolicy{},

--- a/cilium-cli/connectivity/builder/egress_gateway_multigateway.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_multigateway.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type egressGatewayMultigateway struct{}
+
+func (t egressGatewayMultigateway) build(ct *check.ConnectivityTest, _ map[string]string) {
+	// Prefix the test name with `seq-` to run it sequentially.
+	newTest("seq-egress-gateway-multigateway", ct).
+		WithCiliumVersion(">=1.18.0").
+		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
+			Name:            "cegp-sample-client",
+			PodSelectorKind: "client",
+			Multigateway:    true,
+		}).
+		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
+			Name:            "cegp-sample-echo",
+			PodSelectorKind: "echo",
+			Multigateway:    true,
+		}).
+		WithIPRoutesFromOutsideToPodCIDRs().
+		WithFeatureRequirements(
+			features.RequireEnabled(features.EgressGateway),
+			features.RequireEnabled(features.NodeWithoutCilium),
+		).
+		WithScenarios(tests.EgressGatewayMultigateway())
+}

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -592,6 +592,7 @@ func newConnDisruptCEGP(ns, gwNode string) *ciliumv2.CiliumEgressGatewayPolicy {
 					},
 				},
 			},
+			EgressGateways: []ciliumv2.EgressGateway{},
 		},
 	}
 }

--- a/cilium-cli/connectivity/check/manifests/egress-gateway-policy.yaml
+++ b/cilium-cli/connectivity/check/manifests/egress-gateway-policy.yaml
@@ -15,3 +15,4 @@ spec:
     nodeSelector:
       matchLabels:
         kubernetes.io/hostname: NODE_NAME_PLACEHOLDER
+  egressGateways: [] # set by the check package in WithCiliumEgressGatewayPolicy()

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -7,7 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"net"
+	"slices"
+
+	"go4.org/netipx"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +30,86 @@ func extractClientIPFromResponse(res string) net.IP {
 	json.Unmarshal([]byte(res), &clientIP)
 
 	return net.ParseIP(clientIP.ClientIP)
+}
+
+// Test pod to host connectivity by using pings. The packet should not get masqueraded with egress
+// IP.
+func testPingHost(ctx context.Context, t *check.Test, ct *check.ConnectivityTest, s check.Scenario) {
+	i := 0
+	for _, client := range ct.ClientPods() {
+		for _, dst := range ct.HostNetNSPodsByNode() {
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
+				t.NewAction(s, fmt.Sprintf("ping-%s-%d", ipFam, i), &client, &dst, ipFam).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, ct.PingCommand(dst, ipFam))
+				})
+			})
+			i++
+		}
+	}
+}
+
+// Test pod to service connectivity by issuing DNS queries. Should not get masqueraded with egress IP
+// This test case fails for ipv6, might need to make changes for this to work with kube-dns or
+// target a different in-cluster service.
+func testDNSQuery(ctx context.Context, t *check.Test, ct *check.ConnectivityTest, s check.Scenario) {
+	i := 0
+	for _, client := range ct.ClientPods() {
+		kubeDNSService, err := ct.K8sClient().GetService(ctx, "kube-system", "kube-dns", metav1.GetOptions{})
+		if err != nil {
+			t.Fatal("Cannot get kube-dns service")
+		}
+		kubeDNSServicePeer := check.Service{Service: kubeDNSService}
+
+		t.NewAction(s, fmt.Sprintf("dig-%d", i), &client, kubeDNSServicePeer, features.IPFamilyV4).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.DigCommand(kubeDNSServicePeer, features.IPFamilyV4))
+		})
+		i++
+	}
+}
+
+// Test connecting from outside of the cluster to a nodeport service whose pods are selected by an
+// egress policy, the reply traffic should not be SNATed with the egress IP
+func testIngressNoSNAT(ctx context.Context, t *check.Test, ct *check.ConnectivityTest, s check.Scenario) {
+	i := 0
+	for _, client := range ct.ExternalEchoPods() {
+		for _, node := range ct.Nodes() {
+			for _, echo := range ct.EchoServices() {
+				// convert the service to a ServiceExternalIP as we want to access it through its external IP
+				echo := echo.ToNodeportService(node)
+
+				t.ForEachIPFamily(func(ipFam features.IPFamily) {
+					t.NewAction(s, fmt.Sprintf("curl-echo-service-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
+						a.ExecInPod(ctx, a.CurlCommand(echo))
+					})
+				})
+				i++
+			}
+		}
+	}
+}
+
+// Test connecting from outside the cluster directly to a pod which is selected by an egress
+// policy. The reply traffic should not be SNATed with the egress IP, only connections originating
+// from these pods should go through egress gateway.
+//
+// This test is executed only when Cilium is running in direct routing mode, since we can simply add a
+// route on the node that doesn't run Cilium to direct pod's traffic to the node where the pod is
+// running (while in tunneling mode we would need the external node to send the traffic over the tunnel)
+func testIngressNoSNATDirectRouting(ctx context.Context, t *check.Test, ct *check.ConnectivityTest,
+	s check.Scenario) {
+	if status, ok := ct.Feature(features.Tunnel); ok && !status.Enabled {
+		i := 0
+		for _, client := range ct.ExternalEchoPods() {
+			for _, echo := range ct.EchoPods() {
+				t.ForEachIPFamily(func(ipFam features.IPFamily) {
+					t.NewAction(s, fmt.Sprintf("curl-echo-pod-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
+						a.ExecInPod(ctx, a.CurlCommand(echo))
+					})
+				})
+				i++
+			}
+		}
+	}
 }
 
 // EgressGateway is a test case which, given the cegp-sample-client CiliumEgressGatewayPolicy targeting:
@@ -152,37 +236,15 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 		t.Fatal(err)
 	}
 
-	// Ping hosts (pod to host connectivity). Should not get masqueraded with egress IP
-	i := 0
-	for _, client := range ct.ClientPods() {
-		for _, dst := range ct.HostNetNSPodsByNode() {
-			t.ForEachIPFamily(func(ipFam features.IPFamily) {
-				t.NewAction(s, fmt.Sprintf("ping-%s-%d", ipFam, i), &client, &dst, ipFam).Run(func(a *check.Action) {
-					a.ExecInPod(ctx, ct.PingCommand(dst, ipFam))
-				})
-			})
-			i++
-		}
-	}
+	// Ping hosts (pod to host connectivity). Should not get masqueraded with egress IP.
+	testPingHost(ctx, t, ct, s)
 
-	// DNS query (pod to service connectivity). Should not get masqueraded with egress IP
-	// This test case fails for ipv6, might need to make changes for this to work with kube-dns or target a different in-cluster service.
-	i = 0
-	for _, client := range ct.ClientPods() {
-		kubeDNSService, err := ct.K8sClient().GetService(ctx, "kube-system", "kube-dns", metav1.GetOptions{})
-		if err != nil {
-			t.Fatal("Cannot get kube-dns service")
-		}
-		kubeDNSServicePeer := check.Service{Service: kubeDNSService}
-
-		t.NewAction(s, fmt.Sprintf("dig-%d", i), &client, kubeDNSServicePeer, features.IPFamilyV4).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.DigCommand(kubeDNSServicePeer, features.IPFamilyV4))
-		})
-		i++
-	}
+	// Test pod to service connectivity by issuing a DNS query. Traffic should not get masqueraded
+	// with egress IP.
+	testDNSQuery(ctx, t, ct, s)
 
 	// Traffic matching an egress gateway policy should leave the cluster masqueraded with the egress IP (pod to external service using DNS)
-	i = 0
+	i := 0
 	for _, client := range ct.ClientPods() {
 		for _, externalEchoSvc := range ct.EchoExternalServices() {
 			externalEcho := externalEchoSvc.ToEchoIPService()
@@ -235,45 +297,335 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 		}
 	}
 
-	// When connecting from outside the cluster to a nodeport service whose pods are selected by an egress policy,
-	// the reply traffic should not be SNATed with the egress IP
+	// Test connecting from outside the cluster. Traffic should not be SNATed with the egress IP.
+	testIngressNoSNAT(ctx, t, ct, s)
+
+	// Test connecting from outside the cluster with Direct routign mode enabled. Traffic should not
+	// be SNATed with the egress IP.
+	testIngressNoSNATDirectRouting(ctx, t, ct, s)
+}
+
+// egressGatewayMultigateway is a test case similar to EgressGateway but with multiple gateways.
+// It uses the cegp-sample-client CiliumEgressGatewayPolicy targeting:
+// - The client pods (kind=client) as source
+// - The 0.0.0.0/0 destination CIDR
+// - client2 (other=client) and client3 (other=client-other-node) nodes as gateways
+//
+// and the cegp-sample-echo CiliumEgressGatewayPolicy targeting:
+// - The echo service pods (kind=echo) as source
+// - The 0.0.0.0/0 destination CIDR
+// - client2 (other=client) and client3 (other=client-other-node) nodes as gateways
+//
+// tests connectivity for:
+// - pod to host traffic
+// - pod to service traffic
+// - pod to external IP traffic
+// - reply traffic for services
+// - reply traffic for pods
+func EgressGatewayMultigateway() check.Scenario {
+	return &egressGatewayMultigateway{
+		ScenarioBase: check.NewScenarioBase(),
+	}
+}
+
+type egressGatewayMultigateway struct {
+	check.ScenarioBase
+}
+
+func (s *egressGatewayMultigateway) Name() string {
+	return "egress-gateway-multigateway"
+}
+
+type gatewayNodeInfo struct {
+	name          string
+	internalIP    net.IP
+	internalIPsv6 net.IP
+}
+
+func getSortedGatewayNodesInfo(t *check.Test, ipv6Enabled bool) []gatewayNodeInfo {
+	ct := t.Context()
+	egressGatewayNodeNames := t.EgressGatewayNodes()
+	if len(egressGatewayNodeNames) <= 1 {
+		t.Fatal("Cannot get more than 1 egress gateway node for multigateway test")
+	}
+
+	var gatewayNodes []gatewayNodeInfo
+	for _, nodeName := range egressGatewayNodeNames {
+		internalIP := ct.GetGatewayNodeInternalIP(nodeName, false)
+		if internalIP == nil {
+			t.Fatalf("Cannot get IPv4 internal IP for egress gateway node %s", nodeName)
+		}
+		var internalIPsv6 net.IP
+		if ipv6Enabled {
+			internalIPsv6 = ct.GetGatewayNodeInternalIP(nodeName, true)
+			if internalIPsv6 == nil {
+				t.Fatalf("Cannot get IPv6 internal IP for egress gateway node %s", nodeName)
+			}
+		}
+		gatewayNodes = append(gatewayNodes, gatewayNodeInfo{
+			name:          nodeName,
+			internalIP:    internalIP,
+			internalIPsv6: internalIPsv6,
+		})
+	}
+
+	// Sort gateway nodes by their IPv4 internal IP to ensure deterministic assignment
+	slices.SortFunc(gatewayNodes, func(a, b gatewayNodeInfo) int {
+		ipA, ok := netipx.FromStdIP(a.internalIP)
+		if !ok {
+			t.Fatalf("Cannot parse Gateway IP %s", a.internalIP.String())
+			return 0
+		}
+		ipB, ok := netipx.FromStdIP(b.internalIP)
+		if !ok {
+			t.Fatalf("Cannot parse Gateway IP %s", a.internalIP.String())
+			return 0
+		}
+		return ipA.Compare(ipB)
+	})
+
+	return gatewayNodes
+}
+
+// The input list of gateways nodes must be sorted.
+func assignGatewayNode(epUID string, sortedGatewayNodes []gatewayNodeInfo) *gatewayNodeInfo {
+	if len(sortedGatewayNodes) == 0 {
+		return nil
+	}
+
+	// The endpoint to gateway assignment mechanism depends on the endpoint UID. Hence, we need to
+	// calculate its hash at run time to determine the assignment using the same mechanism as Cilium
+	// uses internally.
+	h := fnv.New32a()
+	h.Write([]byte(epUID))
+	idx := h.Sum32() % uint32(len(sortedGatewayNodes))
+	return &sortedGatewayNodes[idx]
+}
+
+func (s *egressGatewayMultigateway) Run(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+
+	var ipv6Enabled bool
+	if status, ok := ct.Feature(features.IPv6); ok && status.Enabled && versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) {
+		ipv6Enabled = true
+	}
+
+	// Get sorted list of gateway nodes. The list neds to be sorted because assignGatewayNode()
+	// requires it.
+	sortedGatewayNodes := getSortedGatewayNodesInfo(t, ipv6Enabled)
+	if len(sortedGatewayNodes) <= 1 {
+		t.Fatal("Cannot get more than 1 egress gateway node for multigateway test")
+	}
+
+	// Fetch CiliumEndpoints to map Pod IPs to CiliumEndpoint UIDs
+	ciliumEndpointsList, err := ct.K8sClient().ListCiliumEndpoints(ctx, ct.Params().TestNamespace, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Failed to list CiliumEndpoints: %v", err)
+	}
+	if len(ciliumEndpointsList.Items) == 0 {
+		t.Fatalf("No CiliumEndpoints found in namespace %s", ct.Params().TestNamespace)
+	}
+
+	podIPToCepUID := make(map[string]string)
+	for _, cep := range ciliumEndpointsList.Items {
+		if cep.Status.Networking == nil {
+			t.Fatalf("CiliumEndpoint %s/%s has no networking info, skipping for egress gateway ID mapping", cep.Namespace, cep.Name)
+			continue
+		}
+		if cep.UID == "" {
+			t.Fatalf("CiliumEndpoint %s/%s has no UID, skipping for egress gateway ID mapping", cep.Namespace, cep.Name)
+			continue
+		}
+		for _, pair := range cep.Status.Networking.Addressing {
+			if pair.IPV4 != "" {
+				podIPToCepUID[pair.IPV4] = string(cep.UID)
+			}
+			if pair.IPV6 != "" {
+				podIPToCepUID[pair.IPV6] = string(cep.UID)
+			}
+		}
+	}
+
+	getGatewayForIP := func(ip string) *gatewayNodeInfo {
+		epUID, ok := podIPToCepUID[ip]
+		if !ok {
+			return nil
+		}
+		return assignGatewayNode(epUID, sortedGatewayNodes)
+	}
+
+	err = check.WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
+		var targetEntries []check.BPFEgressGatewayPolicyEntry
+
+		for _, client := range ct.ClientPods() {
+			assignedGateway := getGatewayForIP(client.Pod.Status.PodIP)
+			if assignedGateway == nil {
+				t.Fatalf("Couldn't find gateway for the client pod %s/%s with IP: %s",
+					client.Pod.Namespace, client.Pod.Name, client.Pod.Status.PodIP)
+			}
+
+			// EgressIP is null if the current node is the gateway node.
+			egressIP := "0.0.0.0"
+			if ciliumPod.Pod.Spec.NodeName == assignedGateway.name {
+				egressIP = assignedGateway.internalIP.String()
+			}
+			egressIPv6 := "::"
+			if ipv6Enabled && ciliumPod.Pod.Spec.NodeName == assignedGateway.name {
+				egressIPv6 = assignedGateway.internalIPsv6.String()
+			}
+
+			targetEntries = append(targetEntries,
+				check.BPFEgressGatewayPolicyEntry{
+					SourceIP:  client.Pod.Status.PodIP,
+					DestCIDR:  "0.0.0.0/0",
+					EgressIP:  egressIP,
+					GatewayIP: assignedGateway.internalIP.String(),
+				})
+
+			if ipv6Enabled && client.Pod.Status.PodIPs != nil {
+				for _, podIP := range client.Pod.Status.PodIPs {
+					if net.ParseIP(podIP.IP).To4() == nil {
+						targetEntries = append(targetEntries,
+							check.BPFEgressGatewayPolicyEntry{
+								SourceIP:  podIP.IP,
+								DestCIDR:  "::/0",
+								EgressIP:  egressIPv6,
+								GatewayIP: assignedGateway.internalIP.String(),
+							})
+						break
+					}
+				}
+			}
+		}
+
+		for _, echo := range ct.EchoPods() {
+			assignedGateway := getGatewayForIP(echo.Pod.Status.PodIP)
+			if assignedGateway == nil {
+				t.Fatalf("Couldn't find gateway for the client pod %s/%s with IP: %s",
+					echo.Pod.Namespace, echo.Pod.Name, echo.Pod.Status.PodIP)
+			}
+
+			// EgressIP is null if the current node is the gateway node.
+			egressIP := "0.0.0.0"
+			if ciliumPod.Pod.Spec.NodeName == assignedGateway.name {
+				egressIP = assignedGateway.internalIP.String()
+			}
+			egressIPv6 := "::"
+			if ipv6Enabled && ciliumPod.Pod.Spec.NodeName == assignedGateway.name {
+				egressIPv6 = assignedGateway.internalIPsv6.String()
+			}
+
+			targetEntries = append(targetEntries,
+				check.BPFEgressGatewayPolicyEntry{
+					SourceIP:  echo.Pod.Status.PodIP,
+					DestCIDR:  "0.0.0.0/0",
+					EgressIP:  egressIP,
+					GatewayIP: assignedGateway.internalIP.String(),
+				})
+
+			if ipv6Enabled && echo.Pod.Status.PodIPs != nil {
+				for _, podIP := range echo.Pod.Status.PodIPs {
+					if net.ParseIP(podIP.IP).To4() == nil {
+						targetEntries = append(targetEntries,
+							check.BPFEgressGatewayPolicyEntry{
+								SourceIP:  podIP.IP,
+								DestCIDR:  "::/0",
+								EgressIP:  egressIPv6,
+								GatewayIP: assignedGateway.internalIP.String(),
+							})
+						break
+					}
+				}
+			}
+		}
+
+		return targetEntries, nil
+	}, func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
+		return ct.GetConnDisruptEgressPolicyEntries(ctx, ciliumPod)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ping hosts (pod to host connectivity). Should not get masqueraded with egress IP
+	testPingHost(ctx, t, ct, s)
+
+	// Test pod to service connectivity by issuing a DNS query. Traffic should not get masqueraded
+	// with egress IP.
+	testDNSQuery(ctx, t, ct, s)
+
+	// Traffic matching an egress gateway policy should leave the cluster masqueraded with
+	// the egress IP (pod to external service using DNS)
+	i := 0
+	for _, client := range ct.ClientPods() {
+		assignedGateway := getGatewayForIP(client.Pod.Status.PodIP)
+		if assignedGateway == nil {
+			t.Fatalf("Couldn't find gateway for the client pod %s/%s with IP: %s",
+				client.Pod.Namespace, client.Pod.Name, client.Pod.Status.PodIP)
+		}
+
+		for _, externalEchoSvc := range ct.EchoExternalServices() {
+			externalEcho := externalEchoSvc.ToEchoIPService()
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
+				gatewayIP := assignedGateway.internalIP
+				if ipFam == features.IPFamilyV6 {
+					if !ipv6Enabled {
+						return
+					}
+					gatewayIP = assignedGateway.internalIPsv6
+				}
+				t.NewAction(s, fmt.Sprintf("curl-external-echo-service-%s-%d", ipFam, i), &client, externalEcho, ipFam).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
+					clientIP := extractClientIPFromResponse(a.CmdOutput())
+
+					if !clientIP.Equal(gatewayIP) {
+						a.Failf("Request reached external echo service with wrong source IP: expected: %s, actual %s", gatewayIP.String(), clientIP.String())
+					}
+				})
+			})
+			i++
+		}
+	}
+
+	// Traffic matching an egress gateway policy should leave the cluster masqueraded with the egress IP (pod to external service)
 	i = 0
-	for _, client := range ct.ExternalEchoPods() {
-		for _, node := range ct.Nodes() {
-			for _, echo := range ct.EchoServices() {
-				// convert the service to a ServiceExternalIP as we want to access it through its external IP
-				echo := echo.ToNodeportService(node)
+	for _, client := range ct.ClientPods() {
+		assignedGateway := getGatewayForIP(client.Pod.Status.PodIP)
+		if assignedGateway == nil {
+			t.Fatalf("Couldn't find gateway for the client pod %s/%s with IP: %s",
+				client.Pod.Namespace, client.Pod.Name, client.Pod.Status.PodIP)
+		}
 
-				t.ForEachIPFamily(func(ipFam features.IPFamily) {
-					t.NewAction(s, fmt.Sprintf("curl-echo-service-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
-						a.ExecInPod(ctx, a.CurlCommand(echo))
-					})
+		for _, externalEcho := range ct.ExternalEchoPods() {
+			externalEcho := externalEcho.ToEchoIPPod()
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
+				gatewayIP := assignedGateway.internalIP
+				if ipFam == features.IPFamilyV6 {
+					if !ipv6Enabled {
+						return
+					}
+					gatewayIP = assignedGateway.internalIPsv6
+				}
+				t.NewAction(s, fmt.Sprintf("curl-external-echo-pod-%s-%d", ipFam, i), &client, externalEcho, ipFam).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
+					clientIP := extractClientIPFromResponse(a.CmdOutput())
+
+					if !clientIP.Equal(gatewayIP) {
+						a.Failf("Request reached external echo service with wrong source IP: expected: %s, actual %s", gatewayIP.String(), clientIP.String())
+					}
 				})
-				i++
-			}
+
+			})
+			i++
 		}
 	}
 
-	if status, ok := ct.Feature(features.Tunnel); ok && !status.Enabled {
-		// When connecting from outside the cluster directly to a pod which is selected by an egress policy, the
-		// reply traffic should not be SNATed with the egress IP (only connections originating from these pods
-		// should go through egress gateway).
-		//
-		// This test is executed only when Cilium is running in direct routing mode, since we can simply add a
-		// route on the node that doesn't run Cilium to direct pod's traffic to the node where the pod is
-		// running (while in tunneling mode we would need the external node to send the traffic over the tunnel)
-		i = 0
-		for _, client := range ct.ExternalEchoPods() {
-			for _, echo := range ct.EchoPods() {
-				t.ForEachIPFamily(func(ipFam features.IPFamily) {
-					t.NewAction(s, fmt.Sprintf("curl-echo-pod-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
-						a.ExecInPod(ctx, a.CurlCommand(echo))
-					})
-				})
-				i++
-			}
-		}
-	}
+	// Test connecting from outside the cluster. Traffic should not be SNATed with the egress IP.
+	testIngressNoSNAT(ctx, t, ct, s)
+
+	// Test connecting from outside the cluster with Direct routign mode enabled. Traffic should not
+	// be SNATed with the egress IP.
+	testIngressNoSNATDirectRouting(ctx, t, ct, s)
 }
 
 // EgressGatewayExcludedCIDRs is a test case which, given the cegp-sample CiliumEgressGatewayPolicy targeting:

--- a/examples/kubernetes-egress-gateway/egress-gateway-policy.yaml
+++ b/examples/kubernetes-egress-gateway/egress-gateway-policy.yaml
@@ -34,3 +34,25 @@ spec:
     # b) omit both egressIP and interface.
     # In this case the first IPv4 assigned to the interface with the default
     # route will be used as egressIP
+  egressGateways:
+    # It's possible to specify multiple egress gateways. In this case the source
+    # endpoints will egress traffic through one of the gateways listed below.
+    #
+    # If this field is used the contents of the egressGateway field above will
+    # be ignored.
+    # 
+    # Entries on this list have the exact same configuration options as the
+    # EgressGateway field above.
+  - egressGateway:
+    nodeSelector:
+      matchLabels:
+        egress-node: true
+    egressIP: "192.168.60.100"
+  - nodeSelector:
+      matchLabels:
+        egress-node-2: true
+    egressIP: "192.168.60.101"
+  - nodeSelector:
+      matchLabels:
+        egress-node-3: true
+    egressIP: "192.168.60.102"

--- a/pkg/egressgateway/helpers_test.go
+++ b/pkg/egressgateway/helpers_test.go
@@ -71,15 +71,19 @@ func addPolicy(tb testing.TB, policies fakeResource[*Policy], params *policyPara
 	})
 }
 
+type policyGatewayParams struct {
+	nodeLabels map[string]string
+	iface      string
+	egressIP   string
+}
+
 type policyParams struct {
 	name             string
 	endpointLabels   map[string]string
 	nodeSelectors    map[string]string
 	destinationCIDRs []string
 	excludedCIDRs    []string
-	nodeLabels       map[string]string
-	iface            string
-	egressIP         string
+	policyGwParams   []policyGatewayParams
 }
 
 func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig) {
@@ -95,7 +99,6 @@ func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig
 		parsedExcludedCIDRs = append(parsedExcludedCIDRs, parsedExcludedCIDR)
 	}
 
-	addr, _ := netip.ParseAddr(params.egressIP)
 	policy := &PolicyConfig{
 		id: types.NamespacedName{
 			Name: params.name,
@@ -109,10 +112,21 @@ func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig
 				},
 			},
 		},
-		policyGwConfig: &policyGatewayConfig{
-			iface:    params.iface,
+	}
+	for _, gwParams := range params.policyGwParams {
+		addr, _ := netip.ParseAddr(gwParams.egressIP)
+		pwc := policyGatewayConfig{
+			iface:    gwParams.iface,
 			egressIP: addr,
-		},
+		}
+		if len(gwParams.nodeLabels) != 0 {
+			pwc.nodeSelector = api.EndpointSelector{
+				LabelSelector: &slimv1.LabelSelector{
+					MatchLabels: gwParams.nodeLabels,
+				},
+			}
+		}
+		policy.policyGwConfigs = append(policy.policyGwConfigs, pwc)
 	}
 	if len(params.nodeSelectors) != 0 {
 		policy.nodeSelectors = []api.EndpointSelector{
@@ -129,14 +143,6 @@ func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig
 				LabelSelector: &slimv1.LabelSelector{
 					MatchLabels: params.endpointLabels,
 				},
-			},
-		}
-	}
-
-	if len(params.nodeLabels) != 0 {
-		policy.policyGwConfig.nodeSelector = api.EndpointSelector{
-			LabelSelector: &slimv1.LabelSelector{
-				MatchLabels: params.nodeLabels,
 			},
 		}
 	}
@@ -169,12 +175,27 @@ func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig
 			ExcludedCIDRs:    excludedCIDRs,
 			EgressGateway: &v2.EgressGateway{
 				NodeSelector: &slimv1.LabelSelector{
-					MatchLabels: params.nodeLabels,
+					MatchLabels: params.policyGwParams[0].nodeLabels,
 				},
-				Interface: params.iface,
-				EgressIP:  params.egressIP,
+				Interface: params.policyGwParams[0].iface,
+				EgressIP:  params.policyGwParams[0].egressIP,
 			},
 		},
+	}
+
+	// Only populate the list if there is more than one gateway.
+	if len(params.policyGwParams) > 1 {
+		// EgressGateways contains all the gateways.
+		for _, gwParams := range params.policyGwParams {
+			gateway := v2.EgressGateway{
+				NodeSelector: &slimv1.LabelSelector{
+					MatchLabels: gwParams.nodeLabels,
+				},
+				Interface: gwParams.iface,
+				EgressIP:  gwParams.egressIP,
+			}
+			cegp.Spec.EgressGateways = append(cegp.Spec.EgressGateways, gateway)
+		}
 	}
 
 	if len(params.nodeSelectors) != 0 {

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -573,18 +573,20 @@ func (manager *Manager) relaxRPFilter() error {
 	ifSet := make(map[string]struct{})
 
 	for _, pc := range manager.policyConfigs {
-		if !pc.gatewayConfig.localNodeConfiguredAsGateway {
-			continue
-		}
+		for _, gatewayConfig := range pc.gatewayConfigs {
+			if !gatewayConfig.localNodeConfiguredAsGateway {
+				continue
+			}
 
-		ifaceName := pc.gatewayConfig.ifaceName
-		if _, ok := ifSet[ifaceName]; !ok {
-			ifSet[ifaceName] = struct{}{}
-			sysSettings = append(sysSettings, tables.Sysctl{
-				Name:      []string{"net", "ipv4", "conf", ifaceName, "rp_filter"},
-				Val:       "2",
-				IgnoreErr: false,
-			})
+			ifaceName := gatewayConfig.ifaceName
+			if _, ok := ifSet[ifaceName]; !ok {
+				ifSet[ifaceName] = struct{}{}
+				sysSettings = append(sysSettings, tables.Sysctl{
+					Name:      []string{"net", "ipv4", "conf", ifaceName, "rp_filter"},
+					Val:       "2",
+					IgnoreErr: false,
+				})
+			}
 		}
 	}
 

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -175,7 +175,11 @@ func TestEgressGatewayCEGPParser(t *testing.T) {
 	policy := policyParams{
 		name:             "",
 		destinationCIDRs: []string{destCIDR},
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				iface: testInterface1,
+			},
+		},
 	}
 
 	cegp, _ := newCEGP(&policy)
@@ -184,8 +188,12 @@ func TestEgressGatewayCEGPParser(t *testing.T) {
 
 	// catch nil DestinationCIDR field
 	policy = policyParams{
-		name:  "policy-1",
-		iface: testInterface1,
+		name: "policy-1",
+		policyGwParams: []policyGatewayParams{
+			{
+				iface: testInterface1,
+			},
+		},
 	}
 
 	cegp, _ = newCEGP(&policy)
@@ -195,8 +203,12 @@ func TestEgressGatewayCEGPParser(t *testing.T) {
 
 	// must specify at least one DestinationCIDR
 	policy = policyParams{
-		name:  "policy-1",
-		iface: testInterface1,
+		name: "policy-1",
+		policyGwParams: []policyGatewayParams{
+			{
+				iface: testInterface1,
+			},
+		},
 	}
 
 	cegp, _ = newCEGP(&policy)
@@ -207,10 +219,34 @@ func TestEgressGatewayCEGPParser(t *testing.T) {
 	policy = policyParams{
 		name:             "policy-1",
 		destinationCIDRs: []string{destCIDR},
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				iface: testInterface1,
+			},
+		},
 	}
 
 	cegp, _ = newCEGP(&policy)
+	cegp.Spec.EgressGateway = nil
+	_, err = ParseCEGP(cegp)
+	require.Error(t, err)
+
+	// Catch EgressGateways that don't contain EgressGateway or EgressGateways fields.
+	policy = policyParams{
+		name:             "policy-1",
+		destinationCIDRs: []string{destCIDR},
+		policyGwParams: []policyGatewayParams{
+			{
+				iface: testInterface1,
+			},
+			{
+				iface: testInterface2,
+			},
+		},
+	}
+
+	cegp, _ = newCEGP(&policy)
+	cegp.Spec.EgressGateways = nil
 	cegp.Spec.EgressGateway = nil
 	_, err = ParseCEGP(cegp)
 	require.Error(t, err)
@@ -219,7 +255,11 @@ func TestEgressGatewayCEGPParser(t *testing.T) {
 	policy = policyParams{
 		name:             "policy-1",
 		destinationCIDRs: []string{destCIDR},
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				iface: testInterface1,
+			},
+		},
 	}
 
 	cegp, _ = newCEGP(&policy)
@@ -232,8 +272,16 @@ func TestEgressGatewayCEGPParser(t *testing.T) {
 	policy = policyParams{
 		name:             "policy-1",
 		destinationCIDRs: []string{destCIDR},
-		iface:            testInterface1,
-		egressIP:         egressIP1,
+		policyGwParams: []policyGatewayParams{
+			{
+				iface:    testInterface1,
+				egressIP: egressIP1,
+			},
+			{
+				iface:    testInterface2,
+				egressIP: egressIP2,
+			},
+		},
 	}
 
 	cegp, _ = newCEGP(&policy)
@@ -277,8 +325,12 @@ func TestEgressGatewayManager(t *testing.T) {
 		name:             "policy-1",
 		endpointLabels:   ep1Labels,
 		destinationCIDRs: []string{destCIDR, destCIDRv6},
-		nodeLabels:       nodeGroup1Labels,
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
 	}
 
 	addPolicy(t, k.policies, &policy1)
@@ -345,8 +397,12 @@ func TestEgressGatewayManager(t *testing.T) {
 		name:             "policy-2",
 		endpointLabels:   ep2Labels,
 		destinationCIDRs: []string{destCIDR, destCIDRv6},
-		nodeLabels:       nodeGroup2Labels,
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup2Labels,
+				iface:      testInterface1,
+			},
+		},
 	})
 	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
@@ -377,8 +433,12 @@ func TestEgressGatewayManager(t *testing.T) {
 		endpointLabels:   ep1Labels,
 		destinationCIDRs: []string{destCIDR, destCIDRv6},
 		excludedCIDRs:    []string{excludedCIDR1, excludedCIDR1v6},
-		nodeLabels:       nodeGroup1Labels,
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
 	})
 	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
@@ -399,8 +459,12 @@ func TestEgressGatewayManager(t *testing.T) {
 		endpointLabels:   ep1Labels,
 		destinationCIDRs: []string{destCIDR, destCIDRv6},
 		excludedCIDRs:    []string{excludedCIDR1, excludedCIDR2, excludedCIDR1v6, excludedCIDR2v6},
-		nodeLabels:       nodeGroup1Labels,
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
 	})
 	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
@@ -423,8 +487,12 @@ func TestEgressGatewayManager(t *testing.T) {
 		endpointLabels:   ep1Labels,
 		destinationCIDRs: []string{destCIDR, destCIDRv6},
 		excludedCIDRs:    []string{excludedCIDR2, excludedCIDR2v6},
-		nodeLabels:       nodeGroup1Labels,
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
 	})
 	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
@@ -444,8 +512,12 @@ func TestEgressGatewayManager(t *testing.T) {
 		name:             "policy-1",
 		endpointLabels:   ep1Labels,
 		destinationCIDRs: []string{destCIDR, destCIDRv6},
-		nodeLabels:       nodeGroup1Labels,
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
 	})
 	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
@@ -463,8 +535,12 @@ func TestEgressGatewayManager(t *testing.T) {
 		name:             "policy-1",
 		endpointLabels:   ep1Labels,
 		destinationCIDRs: []string{destCIDR, destCIDRv6},
-		nodeLabels:       nodeGroupNotFoundLabels,
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroupNotFoundLabels,
+				iface:      testInterface1,
+			},
+		},
 	})
 	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
@@ -482,8 +558,12 @@ func TestEgressGatewayManager(t *testing.T) {
 		name:             "policy-3",
 		endpointLabels:   ep1Labels,
 		destinationCIDRs: []string{destCIDR3, destCIDR3v6},
-		nodeLabels:       nodeGroup1Labels,
-		iface:            "no_interface",
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      "no_interface",
+			},
+		},
 	})
 	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
@@ -544,9 +624,13 @@ func TestNodeSelector(t *testing.T) {
 		name:             "policy-1",
 		endpointLabels:   ep1Labels,
 		destinationCIDRs: []string{destCIDR, destCIDRv6},
-		nodeLabels:       nodeGroup1Labels,
-		iface:            testInterface1,
-		nodeSelectors:    nodeGroup2Labels,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
+		nodeSelectors: nodeGroup2Labels,
 	}
 
 	addPolicy(t, k.policies, &policy1)
@@ -620,8 +704,12 @@ func TestEndpointDataStore(t *testing.T) {
 		name:             "policy-1",
 		endpointLabels:   ep1Labels,
 		destinationCIDRs: []string{destCIDR, destCIDRv6},
-		nodeLabels:       nodeGroup1Labels,
-		iface:            testInterface1,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
 	}
 
 	addPolicy(t, k.policies, &policy1)

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"slices"
 	"testing"
 	"time"
 
@@ -41,13 +42,16 @@ const (
 
 	node1 = "k8s1"
 	node2 = "k8s2"
+	node3 = "k8s3"
 
 	node1IP = "192.168.1.1"
 	node2IP = "192.168.1.2"
+	node3IP = "192.168.1.3"
 
 	ep1IP = "10.0.0.1"
 	ep2IP = "10.0.0.2"
 	ep3IP = "10.0.0.3"
+	ep4IP = "10.0.0.4"
 
 	destCIDR        = "1.1.1.0/24"
 	destCIDR3       = "1.1.3.0/24"
@@ -73,6 +77,7 @@ const (
 	ep1IPv6 = "fd00::1"
 	ep2IPv6 = "fd00::2"
 	ep3IPv6 = "fd00::3"
+	ep4IPv6 = "fd00::4"
 
 	destCIDRv6        = "2001:db8::/64"
 	destCIDR3v6       = "2001:db8:3::/64"
@@ -100,6 +105,7 @@ var (
 	nodeGroupNotFoundLabels = map[string]string{"label1": "notfound"}
 	nodeGroup1Labels        = map[string]string{"label1": "1"}
 	nodeGroup2Labels        = map[string]string{"label2": "2"}
+	nodeGroup3Labels        = map[string]string{"label3": "3"}
 )
 
 type egressRule struct {
@@ -114,6 +120,11 @@ type parsedEgressRule struct {
 	destCIDR  netip.Prefix
 	egressIP  netip.Addr
 	gatewayIP netip.Addr
+}
+
+func (v *parsedEgressRule) String() string {
+	return fmt.Sprintf("sourceIP: %s, destCIDR: %s, egressIP: %s, gatewayIP: %s",
+		v.sourceIP.String(), v.destCIDR.String(), v.gatewayIP.String(), v.egressIP.String())
 }
 
 type rpFilterSetting struct {
@@ -766,6 +777,191 @@ func TestEndpointDataStore(t *testing.T) {
 	})
 }
 
+func TestMultigatewayPolicy(t *testing.T) {
+	k := setupEgressGatewayTestSuite(t)
+	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1, egressCIDR1v6})
+
+	policyMap4 := k.manager.policyMap4
+	policyMap6 := k.manager.policyMap6
+
+	egressGatewayManager := k.manager
+	reconciliationEventsCount := egressGatewayManager.reconciliationEventsCount.Load()
+
+	k.policies.sync(t)
+	k.nodes.sync(t)
+	k.endpoints.sync(t)
+
+	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
+
+	// Create a couple gateway nodes with different labels
+	type testNodes struct {
+		name   string
+		ip     string
+		labels map[string]string
+		node   *nodeTypes.Node
+	}
+	// List of nodes is already organized by the node IP.
+	nodes := []testNodes{
+		{node1, node1IP, nodeGroup1Labels, nil},
+		{node2, node2IP, nodeGroup2Labels, nil},
+	}
+	for i, node := range nodes {
+		newNode := newCiliumNode(node.name, node.ip, node.labels)
+		k.nodes.process(t, resource.Event[*cilium_api_v2.CiliumNode]{
+			Kind:   resource.Upsert,
+			Object: newNode.ToCiliumNode(),
+		})
+		nodes[i].node = &newNode
+		reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager,
+			reconciliationEventsCount)
+	}
+	// Sort the list of nodes by node IP
+	slices.SortFunc(nodes, func(a, b testNodes) int {
+		return netip.MustParseAddr(a.ip).Compare(netip.MustParseAddr(b.ip))
+	})
+
+	// Create endpoints with the same set of labels.
+	type testEndpoints struct {
+		name string
+		ipv4 string
+		ipv6 string
+		ep   *k8sTypes.CiliumEndpoint
+		id   *identity.Identity
+	}
+	eps := []testEndpoints{
+		{"ep-1", ep1IP, ep1IPv6, nil, nil},
+		{"ep-2", ep2IP, ep2IPv6, nil, nil},
+		{"ep-3", ep3IP, ep3IPv6, nil, nil},
+		{"ep-4", ep4IP, ep4IPv6, nil, nil},
+	}
+	for i, ep := range eps {
+		newEP, newID := newEndpointAndIdentity(ep.name, ep.ipv4, ep.ipv6, ep1Labels)
+		addEndpoint(t, k.endpoints, &newEP)
+		eps[i].ep = &newEP
+		eps[i].id = newID
+		reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
+	}
+
+	// Function to generate the correct assignments for endpoints.
+	// List of nodes is expected to be sorted.
+	assignEndpoints := func(endpoints []testEndpoints, gateways []testNodes, ipv4 bool) []egressRule {
+		var rules []egressRule
+
+		for _, endpoint := range endpoints {
+			h := computeEndpointHash(endpoint.ep.UID)
+			gw := gateways[h%uint32(len(gateways))]
+
+			var sourceIP, cidr, egressIP string
+			if ipv4 {
+				sourceIP = endpoint.ipv4
+				cidr = destCIDR
+				// Egress IP is zero for nodes that are not the current node.
+				if gw.name == node1 {
+					egressIP = egressIP1
+				} else {
+					egressIP = zeroIP4
+				}
+			} else {
+				sourceIP = endpoint.ipv6
+				cidr = destCIDRv6
+				// Egress IP is zero for nodes that are not the current node.
+				if gw.name == node1 {
+					egressIP = egressIP1v6
+				} else {
+					egressIP = zeroIP6
+				}
+			}
+
+			rules = append(rules, egressRule{
+				sourceIP:  sourceIP,
+				destCIDR:  cidr,
+				egressIP:  egressIP,
+				gatewayIP: gw.ip,
+			})
+		}
+		return rules
+	}
+
+	// Create a new policy
+	policy1 := policyParams{
+		name:             "policy-1",
+		endpointLabels:   ep1Labels,
+		destinationCIDRs: []string{destCIDR, destCIDRv6},
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+			{
+				nodeLabels: nodeGroup2Labels,
+				iface:      testInterface2,
+			},
+		},
+	}
+
+	addPolicy(t, k.policies, &policy1)
+	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
+
+	// Check that the Egress rules are correctly created. Endpoints should have been assigned to
+	// gateways in round-robin way.
+	// Note that this is evaluated from the node1 perspective, so the entries for other nodes will
+	// have a zeroIP as EgressIP.
+	ipV4ExpectedpolicyMap := assignEndpoints(eps, nodes, true)
+	ipV6ExpectedpolicyMap := assignEndpoints(eps, nodes, false)
+	assertEgressRules4(t, policyMap4, ipV4ExpectedpolicyMap)
+	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap)
+
+	// Remove one endpoint and check that the remaining endpoints have not changed gateways.
+	deleteEndpoint(t, k.endpoints, eps[0].ep)
+	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
+	assertEgressRules4(t, policyMap4, ipV4ExpectedpolicyMap[1:])
+	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap[1:])
+
+	// Add one endpoint and check the configuration went back to the previous state.
+	addEndpoint(t, k.endpoints, eps[0].ep)
+	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
+	assertEgressRules4(t, policyMap4, ipV4ExpectedpolicyMap)
+	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap)
+
+	// Add a new gateway and check that the endpoints get redistributed.
+	nodes = append(nodes, testNodes{
+		name:   node3,
+		ip:     node3IP,
+		labels: nodeGroup3Labels,
+	})
+	newNode := newCiliumNode(node3, node3IP, nodeGroup3Labels)
+	k.nodes.process(t, resource.Event[*cilium_api_v2.CiliumNode]{
+		Kind:   resource.Upsert,
+		Object: newNode.ToCiliumNode(),
+	})
+	nodes[2].node = &newNode
+	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
+
+	policy1.policyGwParams = append(policy1.policyGwParams, policyGatewayParams{
+		nodeLabels: nodeGroup3Labels,
+		iface:      testInterface2,
+	})
+	addPolicy(t, k.policies, &policy1)
+	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
+	ipV4ExpectedpolicyMap = assignEndpoints(eps, nodes, true)
+	ipV6ExpectedpolicyMap = assignEndpoints(eps, nodes, false)
+	assertEgressRules4(t, policyMap4, assignEndpoints(eps, nodes, true))
+	assertEgressRules6(t, policyMap6, assignEndpoints(eps, nodes, false))
+
+	// Remove two gateways to ensure the endpoints are migrated to the single gateway left.
+	policy1.policyGwParams = policy1.policyGwParams[:1]
+	addPolicy(t, k.policies, &policy1)
+	waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
+	for i := range ipV4ExpectedpolicyMap {
+		ipV4ExpectedpolicyMap[i].egressIP = egressIP1
+		ipV4ExpectedpolicyMap[i].gatewayIP = nodes[0].ip
+		ipV6ExpectedpolicyMap[i].egressIP = egressIP1
+		ipV6ExpectedpolicyMap[i].gatewayIP = nodes[0].ip
+	}
+	assertEgressRules4(t, policyMap4, assignEndpoints(eps, nodes[:1], true))
+	assertEgressRules6(t, policyMap6, assignEndpoints(eps, nodes[:1], false))
+}
+
 func TestCell(t *testing.T) {
 	err := hive.New(Cell).Populate(hivetest.Logger(t))
 	if err != nil {
@@ -947,11 +1143,11 @@ func tryAssertEgressRules4(policyMap *egressmap.PolicyMap4, rules []egressRule) 
 		}
 
 		if policyVal.GetEgressAddr() != r.egressIP {
-			return fmt.Errorf("mismatched egress IP")
+			return fmt.Errorf("mismatched egress IP. Expected: %s, Got: %s", r.String(), policyVal.String())
 		}
 
 		if policyVal.GetGatewayAddr() != r.gatewayIP {
-			return fmt.Errorf("mismatched gateway IP")
+			return fmt.Errorf("mismatched gateway IP. Expected: %s, Got: %s", r.String(), policyVal.String())
 		}
 	}
 
@@ -993,11 +1189,11 @@ func tryAssertEgressRules6(policyMap *egressmap.PolicyMap6, rules []egressRule) 
 		}
 
 		if policyVal.GetEgressAddr() != r.egressIP {
-			return fmt.Errorf("mismatched egress IP")
+			return fmt.Errorf("mismatched egress IP. Expected: %s, Got: %s", r.String(), policyVal.String())
 		}
 
 		if policyVal.GetGatewayAddr() != r.gatewayIP {
-			return fmt.Errorf("mismatched gateway IP")
+			return fmt.Errorf("mismatched gateway IP. Expected: %s, Got: %s", r.String(), policyVal.String())
 		}
 	}
 

--- a/pkg/egressgateway/policy_test.go
+++ b/pkg/egressgateway/policy_test.go
@@ -21,9 +21,9 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 		nodeSelectors     []api.EndpointSelector
 		dstCIDRs          []netip.Prefix
 		excludedCIDRs     []netip.Prefix
-		policyGwConfig    *policyGatewayConfig
+		policyGwConfigs   []policyGatewayConfig
 		matchedEndpoints  map[endpointID]*endpointMetadata
-		gatewayConfig     gatewayConfig
+		gatewayConfigs    []gatewayConfig
 	}
 	type args struct {
 		epDataStore           map[endpointID]*endpointMetadata
@@ -177,9 +177,9 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 				nodeSelectors:     tt.fields.nodeSelectors,
 				dstCIDRs:          tt.fields.dstCIDRs,
 				excludedCIDRs:     tt.fields.excludedCIDRs,
-				policyGwConfig:    tt.fields.policyGwConfig,
+				policyGwConfigs:   tt.fields.policyGwConfigs,
 				matchedEndpoints:  tt.fields.matchedEndpoints,
-				gatewayConfig:     tt.fields.gatewayConfig,
+				gatewayConfigs:    tt.fields.gatewayConfigs,
 			}
 			config.updateMatchedEndpointIDs(tt.args.epDataStore, tt.args.nodesAddresses2Labels)
 			assert.Len(t, config.matchedEndpoints, tt.want)

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
@@ -55,8 +55,10 @@ spec:
                   type: string
                 type: array
               egressGateway:
-                description: EgressGateway is the gateway node responsible for SNATing
-                  traffic.
+                description: |-
+                  EgressGateway is the gateway node responsible for SNATing traffic.
+                  In case multiple nodes are a match for the given set of labels, the first node
+                  in lexical ordering based on their name will be selected.
                 properties:
                   egressIP:
                     description: |-
@@ -150,6 +152,113 @@ spec:
                 required:
                 - nodeSelector
                 type: object
+              egressGateways:
+                default: []
+                description: |-
+                  Optional list of gateway nodes responsible for SNATing traffic.
+                  If this field has any entries the contents of the egressGateway field will be ignored.
+                  In case multiple nodes are a match for the given set of labels in each entry,
+                  the first node in lexical ordering based on their name will be selected for each entry.
+                items:
+                  description: |-
+                    EgressGateway identifies the node that should act as egress gateway for a
+                    given egress Gateway policy. In addition to that it also specifies the
+                    configuration of said node (which egress IP or network interface should be
+                    used to SNAT traffic).
+                  properties:
+                    egressIP:
+                      description: |-
+                        EgressIP is the source IP address that the egress traffic is SNATed
+                        with.
+
+                        Example:
+                        When set to "192.168.1.100", matching egress traffic will be
+                        redirected to the node matching the NodeSelector field and SNATed
+                        with IP address 192.168.1.100.
+
+                        When none of the Interface or EgressIP fields is specified, the
+                        policy will use the first IPv4 assigned to the interface with the
+                        default route.
+                      format: ipv4
+                      type: string
+                    interface:
+                      description: |-
+                        Interface is the network interface to which the egress IP address
+                        that the traffic is SNATed with is assigned.
+
+                        Example:
+                        When set to "eth1", matching egress traffic will be redirected to the
+                        node matching the NodeSelector field and SNATed with the first IPv4
+                        address assigned to the eth1 interface.
+
+                        When none of the Interface or EgressIP fields is specified, the
+                        policy will use the first IPv4 assigned to the interface with the
+                        default route.
+                      type: string
+                    nodeSelector:
+                      description: |-
+                        This is a label selector which selects the node that should act as
+                        egress gateway for the given policy.
+                        In case multiple nodes are selected, only the first one in the
+                        lexical ordering over the node names will be used.
+                        This field follows standard label selector semantics.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            description: MatchLabelsValue represents the value from
+                              the MatchLabels {key,value} pair.
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - nodeSelector
+                  type: object
+                type: array
               excludedCIDRs:
                 description: |-
                   ExcludedCIDRs is a list of destination CIDRs that will be excluded

--- a/pkg/k8s/apis/cilium.io/v2/cegp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cegp_types.go
@@ -63,7 +63,18 @@ type CiliumEgressGatewayPolicySpec struct {
 	ExcludedCIDRs []CIDR `json:"excludedCIDRs"`
 
 	// EgressGateway is the gateway node responsible for SNATing traffic.
+	// In case multiple nodes are a match for the given set of labels, the first node
+	// in lexical ordering based on their name will be selected.
 	EgressGateway *EgressGateway `json:"egressGateway"`
+
+	// Optional list of gateway nodes responsible for SNATing traffic.
+	// If this field has any entries the contents of the egressGateway field will be ignored.
+	// In case multiple nodes are a match for the given set of labels in each entry,
+	// the first node in lexical ordering based on their name will be selected for each entry.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
+	EgressGateways []EgressGateway `json:"egressGateways,omitempty"`
 }
 
 // EgressGateway identifies the node that should act as egress gateway for a

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
@@ -1428,6 +1428,13 @@ func (in *CiliumEgressGatewayPolicySpec) DeepCopyInto(out *CiliumEgressGatewayPo
 		*out = new(EgressGateway)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.EgressGateways != nil {
+		in, out := &in.EgressGateways, &out.EgressGateways
+		*out = make([]EgressGateway, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -1269,6 +1269,23 @@ func (in *CiliumEgressGatewayPolicySpec) DeepEqual(other *CiliumEgressGatewayPol
 		}
 	}
 
+	if ((in.EgressGateways != nil) && (other.EgressGateways != nil)) || ((in.EgressGateways == nil) != (other.EgressGateways == nil)) {
+		in, other := &in.EgressGateways, &other.EgressGateways
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if !inElement.DeepEqual(&(*other)[i]) {
+					return false
+				}
+			}
+		}
+	}
+
 	return true
 }
 


### PR DESCRIPTION
Add Multigateway support to egress gateway. 

[Link to the CFP](https://github.com/cilium/design-cfps/blob/main/cilium/CFP-38341-multigateway-egress-gateway-policy.md)

Fixes: #38341

```release-note
Add support for multiple gateways to Cilium Egress Gateway.
```
