### PR TITLE
bpf,map: Use device map instead of device macro

### DIFF
--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -85,3 +85,5 @@ add_type(struct node_key);
 add_type(struct node_value);
 add_type(struct skip_lb4_key);
 add_type(struct skip_lb6_key);
+add_type(struct device_key);
+add_type(struct device_value);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -472,6 +472,16 @@ struct node_value {
 	__u8  pad;
 };
 
+struct device_key {
+	__u32           ifindex;
+};
+
+struct device_value {
+	union macaddr   mac;
+	__u8            l3;
+	__u8		pad[7];
+};
+
 enum {
 	POLICY_INGRESS = 1,
 	POLICY_EGRESS = 2,

--- a/bpf/lib/drop_reasons.h
+++ b/bpf/lib/drop_reasons.h
@@ -86,3 +86,4 @@
 #define DROP_EP_NOT_READY	-203
 #define DROP_NO_EGRESS_IP	-204
 #define DROP_PUNT_PROXY		-205 /* Mapped as drop code, though drop not necessary. */
+#define DROP_NO_DEVICE		-206

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -8,6 +8,7 @@
 
 #include "common.h"
 #include "neigh.h"
+#include "network_device.h"
 #include "l3.h"
 
 static __always_inline bool
@@ -37,7 +38,7 @@ maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
 		 __u32 ifindex __maybe_unused,
 		 bool *l2_hdr_required __maybe_unused)
 {
-	if (IS_L3_DEV(ifindex)) {
+	if (is_l3_device(ifindex)) {
 		/* The packet is going to be redirected to L3 dev, so
 		 * skip L2 addr settings.
 		 */
@@ -127,7 +128,7 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 		if (eth_store_saddr(ctx, fib_params->l.smac, 0) < 0)
 			return DROP_WRITE_ERROR;
 	} else {
-		union macaddr smac = NATIVE_DEV_MAC_BY_IFINDEX(oif);
+		union macaddr *smac = device_mac(oif);
 		union macaddr *dmac = NULL;
 
 		if (allow_neigh_map) {
@@ -146,7 +147,7 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 		}
 		if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0)
 			return DROP_WRITE_ERROR;
-		if (eth_store_saddr_aligned(ctx, smac.addr, 0) < 0)
+		if (eth_store_saddr_aligned(ctx, smac->addr, 0) < 0)
 			return DROP_WRITE_ERROR;
 	}
 out_send:

--- a/bpf/lib/network_device.h
+++ b/bpf/lib/network_device.h
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include <linux/bpf.h>
+#include <bpf/section.h>
+#include <bpf/loader.h>
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct device_key);
+	__type(value, struct device_value);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, DEVICE_MAP_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cilium_device_map  __section_maps_btf;
+
+static __always_inline struct device_value *
+lookup_device(__u32 ifindex)
+{
+	struct device_key key = {};
+
+	key.ifindex = ifindex;
+
+	return map_lookup_elem(&cilium_device_map, &key);
+}
+
+static __always_inline bool
+is_l3_device(__u32 ifindex)
+{
+	struct device_value *device_value;
+
+	device_value = lookup_device(ifindex);
+	if (!device_value)
+		return false;
+	return device_value->l3 > 0;
+}
+
+static __always_inline union macaddr
+*device_mac(__u32 ifindex)
+{
+	struct device_value *device_value;
+
+	device_value = lookup_device(ifindex);
+	if (!device_value)
+		return NULL;
+	return &device_value->mac;
+}

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "nodeport.h"
+#include "network_device.h"
 
 #ifdef ENABLE_NODEPORT
 

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -18,7 +18,6 @@
 
 #define CILIUM_NET_IFINDEX 1
 #define CILIUM_HOST_IFINDEX 1
-#define NATIVE_DEV_MAC_BY_IFINDEX(_) { .addr = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 } }
 
 #define LRU_MEM_FLAVOR 0
 
@@ -133,6 +132,7 @@
 #define CONFIG_MAP_SIZE 256
 #define IPCACHE_MAP_SIZE 512000
 #define NODE_MAP_SIZE 16384
+#define DEVICE_MAP_SIZE 256
 #define EGRESS_POLICY_MAP_SIZE 16384
 #define SRV6_VRF_MAP_SIZE 16384
 #define SRV6_POLICY_MAP_SIZE 16384
@@ -174,10 +174,6 @@
 #  define IPV6_RSS_PREFIX IPV6_DIRECT_ROUTING
 #  define IPV6_RSS_PREFIX_BITS 128
 # endif
-#endif
-
-#ifndef IS_L3_DEV
-# define IS_L3_DEV(ifindex) false
 #endif
 
 #define LB4_SRC_RANGE_MAP_SIZE	1000

--- a/bpf/tests/eni_nlb_symetric_routing_host.c
+++ b/bpf/tests/eni_nlb_symetric_routing_host.c
@@ -55,6 +55,7 @@ mock_redirect_neigh(int ifindex,
 
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
+#include "lib/network_device.h"
 
 ASSIGN_CONFIG(__u32, interface_ifindex, PRIMARY_IFACE)
 
@@ -126,6 +127,8 @@ int eni_nlb_symetric_routing_egress_v4_setup_setup(struct __ctx_buff *ctx)
 			      SECONDARY_IFACE, (__u8 *)LOCAL_BACKEND_MAC, (__u8 *)NODE_MAC);
 
 	ipcache_v4_add_entry(v4_pod_one, 0, SECLABEL, 0, 0);
+
+	device_add_entry(SECONDARY_IFACE, (__u8 *)NODE_MAC, 0);
 
 	ct_create4(&cilium_ct4_global, NULL, &ct, ctx, CT_INGRESS, &state, NULL);
 
@@ -237,6 +240,8 @@ int eni_nlb_symetric_routing_egress_v4_setup_icmp_setup(struct __ctx_buff *ctx)
 			      SECONDARY_IFACE, (__u8 *)LOCAL_BACKEND_MAC, (__u8 *)NODE_MAC);
 
 	ipcache_v4_add_entry(v4_pod_one, 0, SECLABEL, 0, 0);
+
+	device_add_entry(SECONDARY_IFACE, (__u8 *)NODE_MAC, 0);
 
 	ct_create4(&cilium_ct_any4_global, NULL, &ct, ctx, CT_INGRESS, &state, NULL);
 

--- a/bpf/tests/lib/network_device.h
+++ b/bpf/tests/lib/network_device.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+static __always_inline void
+device_add_entry(__u32 ifindex, const __u8 *mac, __u8 l3)
+{
+	struct device_key key = {
+		.ifindex = ifindex,
+	};
+	struct device_value value = {
+		.l3 = l3,
+	};
+
+	if (mac)
+		memcpy(&value.mac, mac, ETH_ALEN);
+
+	map_update_elem(&cilium_device_map, &key, &value, BPF_ANY);
+}

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -155,6 +155,7 @@ mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/lb.h"
+#include "lib/network_device.h"
 
 ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
 
@@ -892,6 +893,8 @@ int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 
 	if (settings)
 		settings->fail_fib = true;
+
+	device_add_entry(DEFAULT_IFACE, (__u8 *)lb_mac, 0);
 
 	return netdev_receive_packet(ctx);
 }

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -25,11 +25,14 @@
 #define BACKEND_IP		v4_pod_one
 #define BACKEND_PORT		__bpf_htons(8080)
 
+#define DEFAULT_IFACE           24
+
 #include "lib/bpf_xdp.h"
 
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/lb.h"
+#include "lib/network_device.h"
 
 static volatile const __u8 *client_mac = mac_one;
 static volatile const __u8 *lb_mac = mac_two;
@@ -76,6 +79,8 @@ int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 	endpoint_v4_add_entry(BACKEND_IP, 0, 0, 0, 0, 0, NULL, NULL);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
+
+	device_add_entry(DEFAULT_IFACE, (__u8 *)client_mac, 0);
 
 	return xdp_receive_packet(ctx);
 }

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -28,6 +28,8 @@
 #define BACKEND_IP_REMOTE	v4_pod_two
 #define BACKEND_PORT		__bpf_htons(8080)
 
+#define DEFAULT_IFACE           24
+
 #define fib_lookup mock_fib_lookup
 
 static volatile const __u8 *client_mac = mac_one;
@@ -62,8 +64,10 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 	__u32 key = 0;
 	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
 
-	if (settings && settings->fail_fib)
+	if (settings && settings->fail_fib) {
+		params->ifindex = DEFAULT_IFACE;
 		return BPF_FIB_LKUP_RET_NO_NEIGH;
+	}
 
 	params->ifindex = 0;
 
@@ -83,6 +87,7 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/lb.h"
+#include "lib/network_device.h"
 
 /* Test that a SVC request to a local backend
  * - gets DNATed (but not SNATed)
@@ -535,6 +540,8 @@ int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 
 	if (settings)
 		settings->fail_fib = true;
+
+	device_add_entry(DEFAULT_IFACE, (__u8 *)lb_mac, 0);
 
 	return xdp_receive_packet(ctx);
 }

--- a/pkg/datapath/alignchecker/alignchecker.go
+++ b/pkg/datapath/alignchecker/alignchecker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/devicemap"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/maps/eventsmap"
 	"github.com/cilium/cilium/pkg/maps/fragmap"
@@ -125,6 +126,8 @@ func init() {
 		"ratelimit_value":         {ratelimitmap.Value{}},
 		"ratelimit_metrics_key":   {ratelimitmap.MetricsKey{}},
 		"ratelimit_metrics_value": {ratelimitmap.MetricsValue{}},
+		"device_key":              {devicemap.DeviceKey{}},
+		"device_value":            {devicemap.DeviceValue{}},
 	})
 
 	registerToCheckSizes(map[string][]any{

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -432,13 +432,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["LB4_SRC_RANGE_MAP_SIZE"] = fmt.Sprintf("%d", cfg.LBConfig.LBSourceRangeMapEntries)
 	cDefinesMap["LB6_SRC_RANGE_MAP_SIZE"] = fmt.Sprintf("%d", cfg.LBConfig.LBSourceRangeMapEntries)
 
-	macByIfIndexMacro, isL3DevMacro, err := devMacros(nativeDevices)
-	if err != nil {
-		return fmt.Errorf("generating device macros: %w", err)
-	}
-	cDefinesMap["NATIVE_DEV_MAC_BY_IFINDEX(IFINDEX)"] = macByIfIndexMacro
-	cDefinesMap["IS_L3_DEV(ifindex)"] = isL3DevMacro
-
 	// --- WARNING: THIS CONFIGURATION METHOD IS DEPRECATED, SEE FUNCTION DOC ---
 
 	const (
@@ -773,54 +766,6 @@ return false;`))
 
 		return vlanFilterMacro.String(), nil
 	}
-}
-
-// devMacros generates NATIVE_DEV_MAC_BY_IFINDEX and IS_L3_DEV macros which
-// are written to node_config.h.
-func devMacros(devs []*tables.Device) (string, string, error) {
-	var (
-		macByIfIndexMacro, isL3DevMacroBuf bytes.Buffer
-		isL3DevMacro                       string
-	)
-	macByIfIndex := make(map[int]string)
-	l3DevIfIndices := make([]int, 0)
-
-	for _, dev := range devs {
-		if len(dev.HardwareAddr) != 6 {
-			l3DevIfIndices = append(l3DevIfIndices, dev.Index)
-		}
-		macByIfIndex[dev.Index] = mac.CArrayString(net.HardwareAddr(dev.HardwareAddr))
-	}
-
-	macByIfindexTmpl := template.Must(template.New("macByIfIndex").Parse(
-		`({ \
-union macaddr __mac = {.addr = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0}}; \
-switch (IFINDEX) { \
-{{range $idx,$mac := .}} case {{$idx}}: {union macaddr __tmp = {.addr = {{$mac}}}; __mac=__tmp;} break; \
-{{end}}} \
-__mac; })`))
-
-	if err := macByIfindexTmpl.Execute(&macByIfIndexMacro, macByIfIndex); err != nil {
-		return "", "", fmt.Errorf("failed to execute template: %w", err)
-	}
-
-	if len(l3DevIfIndices) == 0 {
-		isL3DevMacro = "false"
-	} else {
-		isL3DevTmpl := template.Must(template.New("isL3Dev").Parse(
-			`({ \
-bool is_l3 = false; \
-switch (ifindex) { \
-{{range $idx := .}} case {{$idx}}: is_l3 = true; break; \
-{{end}}} \
-is_l3; })`))
-		if err := isL3DevTmpl.Execute(&isL3DevMacroBuf, l3DevIfIndices); err != nil {
-			return "", "", fmt.Errorf("failed to execute template: %w", err)
-		}
-		isL3DevMacro = isL3DevMacroBuf.String()
-	}
-
-	return macByIfIndexMacro.String(), isL3DevMacro, nil
 }
 
 func (h *HeaderfileWriter) writeNetdevConfig(w io.Writer, opts *option.IntOptions) {

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -27,7 +27,9 @@ import (
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/maps/devicemap"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/nodediscovery"
@@ -114,6 +116,7 @@ type orchestratorParams struct {
 	MaglevConfig        maglev.Config
 	WgAgent             wgTypes.WireguardAgent
 	IPsecConfig         datapath.IPsecConfig
+	DeviceMap           *devicemap.DeviceMap
 }
 
 func newOrchestrator(params orchestratorParams) *orchestrator {
@@ -281,6 +284,10 @@ func (o *orchestrator) reinitialize(ctx context.Context, req reinitializeRequest
 	}
 
 	var errs []error
+	if err := o.reinitializeDeviceMap(localNodeConfig); err != nil {
+		errs = append(errs, err)
+	}
+
 	if err := o.params.Loader.Reinitialize(
 		ctx,
 		localNodeConfig,
@@ -357,4 +364,49 @@ func (o *orchestrator) Unload(ep datapath.Endpoint) {
 func (o *orchestrator) WriteEndpointConfig(w io.Writer, cfg datapath.EndpointConfiguration) error {
 	<-o.dpInitialized
 	return o.params.Loader.WriteEndpointConfig(w, cfg, o.latestLocalNodeConfig.Load())
+}
+
+func (o *orchestrator) reinitializeDeviceMap(lnc *datapath.LocalNodeConfiguration) error {
+	deviceCache := map[uint32]*tables.Device{}
+	// Create or update devices in the device bpf map
+	for _, dev := range lnc.Devices {
+		deviceCache[uint32(dev.Index)] = dev
+		isL3Dev := uint8(0)
+		parsedMAC, _ := mac.ParseMAC(dev.HardwareAddr.String())
+		uint64MAC, err := parsedMAC.Uint64()
+		if err != nil {
+			o.params.Log.Warn("Failed to parse device mac",
+				logfields.Error, err,
+				logfields.Device, dev,
+			)
+			isL3Dev = uint8(1)
+		}
+
+		key := &devicemap.DeviceKey{IfIndex: uint32(dev.Index)}
+		val := &devicemap.DeviceValue{MAC: uint64MAC, L3: isL3Dev}
+		err = o.params.DeviceMap.Update(key, val)
+		if err != nil {
+			o.params.Log.Warn("Failed to update entry for device bpf map",
+				logfields.Error, err,
+				logfields.Device, dev,
+			)
+			return err
+		}
+	}
+
+	// Remove non-existent devices in the device bpf map
+	o.params.DeviceMap.IterateWithCallback(
+		func(key *devicemap.DeviceKey, val *devicemap.DeviceValue) {
+			if dev, found := deviceCache[key.IfIndex]; !found {
+				err := o.params.DeviceMap.Delete(key)
+				if err != nil {
+					o.params.Log.Warn("Failed to delete entry from device bpf map",
+						logfields.Error, err,
+						logfields.Device, dev,
+					)
+				}
+			}
+		})
+
+	return nil
 }

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/bwmap"
 	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap/gc"
+	"github.com/cilium/cilium/pkg/maps/devicemap"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/maps/encrypt"
 	"github.com/cilium/cilium/pkg/maps/l2respondermap"
@@ -81,6 +82,9 @@ var Cell = cell.Module(
 
 	// Provides access to the vtep map.
 	vtep.Cell,
+
+	// Provides the device map which contains information about ifindexes and macs.
+	devicemap.Cell,
 )
 
 type mapApiHandlerOut struct {

--- a/pkg/maps/devicemap/cell.go
+++ b/pkg/maps/devicemap/cell.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package devicemap
+
+import (
+	"fmt"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
+)
+
+// Cell provides the devicemap.Map which contains information about device ifindexes and their macs.
+var Cell = cell.Module(
+	"device-map",
+	"eBPF map which contains information about device ifindexes and their macs",
+
+	cell.Provide(newDeviceMap),
+)
+
+func newDeviceMap(lifecycle cell.Lifecycle) (bpf.MapOut[*DeviceMap], defines.NodeOut) {
+	deviceMap := newMap()
+
+	lifecycle.Append(cell.Hook{
+		OnStart: func(context cell.HookContext) error {
+			return deviceMap.init()
+		},
+		OnStop: func(context cell.HookContext) error {
+			return deviceMap.close()
+		},
+	})
+
+	nodeOut := defines.NodeOut{
+		NodeDefines: defines.Map{
+			"DEVICE_MAP_SIZE": fmt.Sprint(MaxEntries),
+		},
+	}
+
+	return bpf.NewMapOut(deviceMap), nodeOut
+}

--- a/pkg/maps/devicemap/device_map_privileged_test.go
+++ b/pkg/maps/devicemap/device_map_privileged_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package devicemap
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func setup(tb testing.TB) *DeviceMap {
+	testutils.PrivilegedTest(tb)
+
+	bpf.CheckOrMountFS(hivetest.Logger(tb), "")
+	err := rlimit.RemoveMemlock()
+	require.NoError(tb, err)
+
+	deviceMap := newMap()
+	err = deviceMap.init()
+	require.NoError(tb, err)
+
+	tb.Cleanup(func() {
+		err := deviceMap.close()
+		require.NoError(tb, err)
+	})
+
+	return deviceMap
+}
+
+func TestPrivilegedDeviceMap(t *testing.T) {
+	deviceMap := setup(t)
+
+	randMAC01, _ := mac.GenerateRandMAC()
+	mac01, err := randMAC01.Uint64()
+	require.NoError(t, err)
+	randMAC02, _ := mac.GenerateRandMAC()
+	mac02, err := randMAC02.Uint64()
+	require.NoError(t, err)
+	ifIndex := uint32(10)
+	key := DeviceKey{IfIndex: ifIndex}
+	val01 := DeviceValue{MAC: mac01, L3: uint8(0)}
+	val02 := DeviceValue{MAC: mac02, L3: uint8(1)}
+
+	value, err := deviceMap.Lookup(&key)
+	require.Error(t, err)
+	require.Nil(t, value)
+
+	err = deviceMap.Update(&key, &val01)
+	require.NoError(t, err)
+
+	value, err = deviceMap.Lookup(&key)
+	dv := value.(*DeviceValue)
+	require.NoError(t, err)
+	require.Equal(t, mac01, dv.MAC)
+	require.Equal(t, uint8(0), dv.L3)
+
+	err = deviceMap.Update(&key, &val02)
+	require.NoError(t, err)
+
+	value, err = deviceMap.Lookup(&key)
+	dv = value.(*DeviceValue)
+	require.NoError(t, err)
+	require.Equal(t, mac02, dv.MAC)
+	require.Equal(t, uint8(1), dv.L3)
+
+	err = deviceMap.Delete(&key)
+	require.NoError(t, err)
+
+	value, err = deviceMap.Lookup(&key)
+	require.Error(t, err)
+	require.Nil(t, value)
+}

--- a/pkg/maps/devicemap/devicemap.go
+++ b/pkg/maps/devicemap/devicemap.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package devicemap
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/mac"
+)
+
+const (
+	MapName    = "cilium_device_map"
+	MaxEntries = 256
+)
+
+type DeviceMap struct {
+	*bpf.Map
+}
+
+func newMap() *DeviceMap {
+	return &DeviceMap{
+		bpf.NewMap(
+			MapName,
+			ebpf.Hash,
+			&DeviceKey{},
+			&DeviceValue{},
+			MaxEntries,
+			unix.BPF_F_NO_PREALLOC,
+		),
+	}
+}
+
+type DeviceKey struct {
+	IfIndex uint32 `align:"ifindex"`
+}
+
+func (k *DeviceKey) String() string {
+	return fmt.Sprintf("%d", k.IfIndex)
+}
+
+func (k *DeviceKey) New() bpf.MapKey { return &DeviceKey{} }
+
+type DeviceValue struct {
+	MAC mac.Uint64MAC `align:"mac"`
+	L3  uint8         `align:"l3"`
+	Pad [7]uint8      `align:"pad"`
+}
+
+func (v *DeviceValue) String() string {
+	return fmt.Sprintf("mac=%s is_l3_dev=%d", v.MAC, v.L3)
+}
+
+func (v *DeviceValue) New() bpf.MapValue { return &DeviceValue{} }
+
+// DeviceIterateCallback represents the signature of the callback function
+// expected by the IterateWithCallback method, which in turn is used to iterate
+// all the keys/values of a device map.
+type DeviceIterateCallback func(*DeviceKey, *DeviceValue)
+
+// IterateWithCallback iterates through all the keys/values of a device map,
+// passing each key/value pair to the cb callback.
+func (m *DeviceMap) IterateWithCallback(cb DeviceIterateCallback) error {
+	return m.DumpWithCallback(func(k bpf.MapKey, v bpf.MapValue) {
+		key := k.(*DeviceKey)
+		value := v.(*DeviceValue)
+
+		cb(key, value)
+	})
+}
+
+func (m *DeviceMap) init() error {
+	if err := m.OpenOrCreate(); err != nil {
+		return fmt.Errorf("failed to init bpf map: %w", err)
+	}
+
+	return nil
+}
+
+func (m *DeviceMap) close() error {
+	if err := m.Close(); err != nil {
+		return fmt.Errorf("failed to close bpf map: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/maps/devicemap/doc.go
+++ b/pkg/maps/devicemap/doc.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// +groupName=maps
+package devicemap


### PR DESCRIPTION
This patch reimplements IS_L3_DEV and NATIVE_DEV_MAC_BY_IFINDEX using bpf map, including the following changes:

1.Define a cilium_device_map, this new map will map device ifindexes to their MACs and check if they are L3 devices.
2.Orchestrator manages device entries in the above map.
3.Use is_l3_device() and device_mac() methods to replace IS_L3_DEV and
  NATIVE_DEV_MAC_BY_IFINDEX

Fixes: #39116

```release-note
Reimplement device macros using a new device bpf map
```
