### PR TITLE
k8s: StateDB reflector's TransformMany to return objects to delete

### DIFF
--- a/pkg/dynamicconfig/script_test.go
+++ b/pkg/dynamicconfig/script_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dynamicconfig
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"maps"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
+func TestScript(t *testing.T) {
+	// Catch any leaked goroutines.
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	version.Force(testutils.DefaultVersion)
+	setup := func(t testing.TB, args []string) *script.Engine {
+		h := hive.New(
+			client.FakeClientCell,
+			Cell,
+		)
+
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		h.RegisterFlags(flags)
+		require.NoError(t, flags.Parse(args), "parse args")
+
+		var opts []hivetest.LogOption
+		if *debug {
+			opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+		}
+		log := hivetest.Logger(t, opts...)
+
+		t.Cleanup(func() {
+			assert.NoError(t, h.Stop(log, context.TODO()))
+		})
+		cmds, err := h.ScriptCommands(log)
+		require.NoError(t, err, "ScriptCommands")
+		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+
+		return &script.Engine{
+			Cmds:             cmds,
+			RetryInterval:    100 * time.Millisecond,
+			MaxRetryInterval: time.Second,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	scripttest.Test(t,
+		ctx,
+		setup,
+		[]string{},
+		"testdata/*.txtar")
+}

--- a/pkg/dynamicconfig/table_test.go
+++ b/pkg/dynamicconfig/table_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +31,18 @@ var (
 	dummyConfigMap = map[string]string{"key1": "value1", "key2": "value2"}
 )
 
+func startHive(t *testing.T, h *hive.Hive) {
+	tLog := hivetest.Logger(t)
+	if err := h.Start(tLog, t.Context()); err != nil {
+		t.Fatalf("starting hive encountered: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Stop(tLog, context.Background()); err != nil {
+			t.Fatalf("stopping hive encountered: %s", err)
+		}
+	})
+}
+
 func TestWatchAllKeys(t *testing.T) {
 	cSource := `[{"kind":"config-map","namespace":"kube-system","name":"a-low-priority"},{"kind":"config-map","namespace":"kube-system","name":"cilium-config"}]`
 	expected := map[string]DynamicConfig{
@@ -42,7 +55,8 @@ func TestWatchAllKeys(t *testing.T) {
 			Priority: 0,
 		},
 	}
-	_, db, dct, _ := fixture(t, cSource)
+	h, db, dct, _ := fixture(t, cSource)
+	startHive(t, h)
 
 	key := "key"
 	lowPrioritySource := "a-low-priority" // leading 'a' to test that sources that are not in priority map have lower priority
@@ -66,7 +80,8 @@ func TestWatchAllKeys(t *testing.T) {
 
 func TestWatchKey(t *testing.T) {
 	cSource := `[{"kind":"config-map","namespace":"kube-system","name":"a-low-priority"},{"kind":"config-map","namespace":"kube-system","name":"cilium-config"}]`
-	_, db, dct, _ := fixture(t, cSource)
+	h, db, dct, _ := fixture(t, cSource)
+	startHive(t, h)
 
 	key := "key"
 	lowPrioritySource := "a-low-priority" // leading 'a' to test that sources that are not in priority map have lower priority
@@ -96,7 +111,8 @@ func TestWatchKey(t *testing.T) {
 
 func TestGetKey(t *testing.T) {
 	cSource := `[{"kind":"config-map","namespace":"kube-system","name":"a-low-priority"},{"kind":"config-map","namespace":"kube-system","name":"cilium-config"}]`
-	_, db, dct, _ := fixture(t, cSource)
+	h, db, dct, _ := fixture(t, cSource)
+	startHive(t, h)
 
 	key := "key"
 	lowPrioritySource := "a-low-priority"
@@ -167,17 +183,17 @@ func TestDynamicConfigMap(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
 			configSources, _ := json.Marshal(tc.configSources)
 
-			_, db, dct, cs := fixture(t, string(configSources))
+			h, db, dct, cs := fixture(t, string(configSources))
 
 			for _, cm := range tc.cms {
-				_, err := cs.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
+				_, err := cs.CoreV1().ConfigMaps(namespace).Create(t.Context(), cm, metav1.CreateOptions{})
 				if err != nil {
-					t.Errorf("creating CofigMap: %v", err)
+					t.Fatalf("creating ConfigMap: %v", err)
 				}
 			}
+			startHive(t, h)
 
 			gotMap := map[string]string{}
 			if err := testutils.WaitUntil(func() bool {
@@ -185,18 +201,24 @@ func TestDynamicConfigMap(t *testing.T) {
 					gotMap[obj.Key.String()] = obj.Value
 				}
 				return len(gotMap) == len(tc.expectedConfig)
-			}, 2*time.Second); err != nil {
-				t.Errorf("waiting for confing table: %v", err)
+			}, 10*time.Second); err != nil {
+				t.Fatalf("waiting for config table timed out: %v", err)
 			}
 
 			if !reflect.DeepEqual(gotMap, tc.expectedConfig) {
-				t.Errorf("expectedConfig:\n%+v\ngot:\n%+v", tc.expectedConfig, gotMap)
+				t.Fatalf("expectedConfig:\n%+v\ngot:\n%+v", tc.expectedConfig, gotMap)
 			}
 
 			for _, cm := range tc.cms {
 				for k, v := range cm.Data {
-					obj, _, found := dct.Get(db.ReadTxn(), ByKey(Key{Name: k, Source: cm.Name}))
-					if !found || obj.Value != v || obj.Key.Source != cm.Name || obj.Key.Name != k {
+					txn := db.ReadTxn()
+					obj, _, found := dct.Get(txn, ByKey(Key{Name: k, Source: cm.Name}))
+					if !found {
+						for e := range dct.All(txn) {
+							t.Logf("%s\n", strings.Join(e.TableRow(), " "))
+						}
+						t.Errorf("Entry %s not found", cm.Name)
+					} else if obj.Value != v || obj.Key.Source != cm.Name || obj.Key.Name != k {
 						t.Errorf("Entry mismatch: expected (key=%v, source=%v, value=%v), but got (key=%v, source=%v, value=%v)", k, cm.Name, v, obj.Key.Name, obj.Key.Source, obj.Value)
 					}
 				}
@@ -243,17 +265,9 @@ func fixture(t *testing.T, sources string) (*hive.Hive, *statedb.DB, statedb.RWT
 			},
 		),
 	)
-
-	ctx := context.Background()
-	tLog := hivetest.Logger(t)
-	if err := h.Start(tLog, ctx); err != nil {
-		t.Fatalf("starting hive encountered: %s", err)
+	if err := h.Populate(hivetest.Logger(t)); err != nil {
+		t.Fatalf("Populate: %s", err)
 	}
-	t.Cleanup(func() {
-		if err := h.Stop(tLog, ctx); err != nil {
-			t.Fatalf("stopping hive encountered: %s", err)
-		}
-	})
 
 	return h, db, table, fakeClient
 }

--- a/pkg/dynamicconfig/testdata/configmap.txtar
+++ b/pkg/dynamicconfig/testdata/configmap.txtar
@@ -1,0 +1,61 @@
+# Test the reflection of the cilium-config ConfigMap
+
+hive/start
+db/initialized
+
+# Add cilium-config with keys foo and baz
+k8s/add cilium-config.yaml
+db/cmp cilium-configs configs1.table
+
+# Removing it removes all keys from the "cilium-config" source
+k8s/delete cilium-config.yaml
+
+# Table should be empty now
+* db/empty cilium-configs
+
+# Add the entries back
+k8s/add cilium-config.yaml
+db/cmp cilium-configs configs1.table
+
+# Update baz=quux to baz=baz
+replace 'quux' 'baz' cilium-config.yaml
+replace 'quux' 'baz' configs1.table
+k8s/update cilium-config.yaml
+db/cmp cilium-configs configs1.table
+
+# Remove the 'baz' key
+sed '^\s+baz:.*' '' cilium-config.yaml
+k8s/update cilium-config.yaml
+db/cmp cilium-configs configs2.table
+
+# Cleanup
+k8s/delete cilium-config.yaml
+
+# Table should be empty now
+* db/empty cilium-configs
+
+####
+
+-- configs1.table --
+Key   Source          Priority   Value
+baz   cilium-config   1          quux
+foo   cilium-config   1          bar
+
+-- configs2.table --
+Key   Source          Priority   Value
+foo   cilium-config   1          bar
+
+-- cilium-config.yaml --
+# Produced with:
+# kubectl get -n kube-system configmaps/cilium-config -o yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: cilium-config
+  namespace: kube-system
+data:
+  foo: bar
+  baz: quux
+ 

--- a/pkg/dynamicconfig/testdata/node-config.txtar
+++ b/pkg/dynamicconfig/testdata/node-config.txtar
@@ -1,0 +1,61 @@
+#! --config-sources=[{"kind":"cilium-node-config","namespace":"kube-system","name":"foo"}]
+
+# Test the reflection of the CiliumNodeConfig
+hive/start
+db/initialized
+
+# Add cilium-config with keys foo and baz
+k8s/add cilium-node-config.yaml
+db/cmp cilium-configs configs1.table
+
+# Removing it removes all keys from the "cilium-config" source
+k8s/delete cilium-node-config.yaml
+
+# Table should be empty now
+* db/empty cilium-configs
+
+# Add the entries back
+k8s/add cilium-node-config.yaml
+db/cmp cilium-configs configs1.table
+
+# Update baz=quux to baz=baz
+replace 'quux' 'baz' cilium-node-config.yaml
+replace 'quux' 'baz' configs1.table
+k8s/update cilium-node-config.yaml
+db/cmp cilium-configs configs1.table
+
+# Remove the 'baz' key
+sed '^\s+baz:.*' '' cilium-node-config.yaml
+k8s/update cilium-node-config.yaml
+db/cmp cilium-configs configs2.table
+
+# Cleanup
+k8s/delete cilium-node-config.yaml
+
+# Table should be empty now
+* db/empty cilium-configs
+
+####
+
+-- configs1.table --
+Key   Source          Priority   Value
+baz   cnc-foo         1          quux
+foo   cnc-foo         1          bar
+
+-- configs2.table --
+Key   Source          Priority   Value
+foo   cnc-foo         1          bar
+
+-- cilium-node-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNodeConfig
+metadata:
+  namespace: kube-system
+  name: cnc-foo
+spec:
+  nodeSelector:
+    matchLabels:
+      foo: "bar"
+  defaults:
+    foo: bar
+    baz: quux

--- a/pkg/dynamicconfig/testdata/node.txtar
+++ b/pkg/dynamicconfig/testdata/node.txtar
@@ -1,0 +1,64 @@
+#! --config-sources=[{"kind":"node","namespace":"kube-system","name":"foo"}]
+
+# Test the reflection of the configs as annotations in the Node
+# object.
+hive/start
+db/initialized
+
+# Add node with keys foo and baz as annotations
+k8s/add node.yaml
+db/cmp cilium-configs configs1.table
+
+stop
+
+# Removing it removes all keys from the "cilium-config" source
+k8s/delete cilium-node-config.yaml
+
+# Table should be empty now
+* db/empty cilium-configs
+
+# Add the entries back
+k8s/add cilium-node-config.yaml
+db/cmp cilium-configs configs1.table
+
+# Update baz=quux to baz=baz
+replace 'quux' 'baz' cilium-node-config.yaml
+replace 'quux' 'baz' configs1.table
+k8s/update cilium-node-config.yaml
+db/cmp cilium-configs configs1.table
+
+# Remove the 'baz' key
+sed '^\s+baz:.*' '' cilium-node-config.yaml
+k8s/update cilium-node-config.yaml
+db/cmp cilium-configs configs2.table
+
+# Cleanup
+k8s/delete cilium-node-config.yaml
+
+# Table should be empty now
+* db/empty cilium-configs
+
+####
+
+-- configs1.table --
+Key   Source          Priority   Value
+baz   node-foo        1          quux
+foo   node-foo        1          bar
+
+-- configs2.table --
+Key   Source          Priority   Value
+foo   node-foo        1          bar
+
+-- node.yaml --
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    config.cilium.io/foo: bar
+    config.cilium.io/baz: quux
+
+  labels:
+    # Labels not relevant
+  name: node-foo
+spec:
+  # Not relevant for this test

--- a/pkg/k8s/client/fake.go
+++ b/pkg/k8s/client/fake.go
@@ -184,12 +184,6 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 			if err != nil {
 				return fmt.Errorf("decode: %w", err)
 			}
-
-			// Also try decoding using the kubernetes schema instead
-			// of the slim schema so that we get an object that the "kubernetes"
-			// tracker accepts.
-			kobj, _ := testutils.DecodeKubernetesObject(b)
-
 			gvr, _ := meta.UnsafeGuessKindToResource(*gvk)
 			objMeta, err := meta.Accessor(obj)
 			if err != nil {
@@ -212,14 +206,8 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 				switch action {
 				case "add":
 					trackerErr = tracker.Add(obj)
-					if trackerErr != nil && kobj != nil {
-						trackerErr = tracker.Add(kobj)
-					}
 				case "update":
 					trackerErr = tracker.Update(gvr, obj, ns)
-					if trackerErr != nil && kobj != nil {
-						trackerErr = tracker.Update(gvr, kobj, ns)
-					}
 				case "delete":
 					trackerErr = tracker.Delete(gvr, ns, name)
 				}

--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"slices"
 	"sync"
 
 	"github.com/cilium/hive/cell"
@@ -109,10 +110,14 @@ type ReflectorConfig[Obj any] struct {
 	// Optional function to transform the objects given by the ListerWatcher. This can
 	// be used to convert into an internal model on the fly to save space and add additional
 	// fields or to for example implement TableRow/TableHeader for the "db/show" command.
+	//
+	// The object given to the transform function can be modified without copying.
 	Transform TransformFunc[Obj]
 
-	// Optional function to transform the object to a set of objects to insert into the table.
+	// Optional function to transform the object to a set of objects to insert or delete.
 	// If set, [Transform] must be nil.
+	//
+	// The object given to the transform function can be modified without copying.
 	TransformMany TransformManyFunc[Obj]
 
 	// Optional function to query all objects. Used when replacing the objects on resync.
@@ -142,17 +147,20 @@ func (cfg ReflectorConfig[Obj]) JobName() string {
 	return fmt.Sprintf("k8s-reflector-%s-%s", cfg.Table.Name(), cfg.Name)
 }
 
-// TransformFunc is an optional function to give to the Kubernetes reflector
+// TransformFunc is an optional function to give to the reflector
 // to transform the object returned by the ListerWatcher to the desired
 // target object. If the function returns false the object is silently
 // skipped.
+//
+// The object given to the transform function can be modified without copying.
 type TransformFunc[Obj any] func(statedb.ReadTxn, any) (obj Obj, ok bool)
 
-// TransformManyFunc is an optional function to give to the Kubernetes reflector
+// TransformManyFunc is an optional function to give to the reflector
 // to transform the object returned by the ListerWatcher to the desired set of
-// target objects to insert into the table. If the function returns false the object is silently
-// skipped.
-type TransformManyFunc[Obj any] func(statedb.ReadTxn, any) (objs []Obj)
+// target objects to insert or delete.
+//
+// The object given to the transform function can be modified without copying.
+type TransformManyFunc[Obj any] func(txn statedb.ReadTxn, deleted bool, obj any) (toInsert, toDelete iter.Seq[Obj])
 
 // QueryAllFunc is an optional function to give to the Kubernetes reflector
 // to query all objects in the table that are managed by the reflector.
@@ -253,18 +261,24 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 		buf := make([]Obj, 1)
 		if r.Transform != nil {
 			// Implement TransformMany with Transform.
-			transformMany = TransformManyFunc[Obj](func(txn statedb.ReadTxn, obj any) []Obj {
+			transformMany = TransformManyFunc[Obj](func(txn statedb.ReadTxn, deleted bool, obj any) (toInsert, toDelete iter.Seq[Obj]) {
 				var ok bool
 				if buf[0], ok = r.Transform(txn, obj); ok {
-					return buf
+					if deleted {
+						return nil, slices.Values(buf)
+					}
+					return slices.Values(buf), nil
 				}
-				return nil
+				return nil, nil
 			})
 		} else {
 			// No provided transform function, use the identity function instead.
-			transformMany = TransformManyFunc[Obj](func(txn statedb.ReadTxn, obj any) []Obj {
+			transformMany = TransformManyFunc[Obj](func(txn statedb.ReadTxn, deleted bool, obj any) (toInsert, toDelete iter.Seq[Obj]) {
 				buf[0] = obj.(Obj)
-				return buf
+				if deleted {
+					return nil, slices.Values(buf)
+				}
+				return slices.Values(buf), nil
 			})
 		}
 	}
@@ -334,14 +348,19 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 			inserted := sets.New[string]()
 
 			for _, item := range buf.replaceItems {
-				for _, obj := range transformMany(txn, item) {
-					if _, _, err := table.Insert(txn, obj); err != nil {
-						r.log.Error("BUG: Insert failed", logfields.Error, err)
-						continue
-					}
+				toInsert, _ := transformMany(txn, false, item)
+				// Ignoring the 'toDelete' since we're going to use queryAll below to
+				// delete everything we didn't insert here.
+				if toInsert != nil {
+					for obj := range toInsert {
+						if _, _, err := table.Insert(txn, obj); err != nil {
+							r.log.Error("BUG: Insert failed", logfields.Error, err)
+							continue
+						}
 
-					numUpserted++
-					inserted.Insert(string(indexer.ObjectToKey(obj)))
+						numUpserted++
+						inserted.Insert(string(indexer.ObjectToKey(obj)))
+					}
 				}
 			}
 
@@ -362,14 +381,18 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 		}
 
 		for entry := range buf.entries.Values() {
-			for _, obj := range transformMany(txn, entry.obj) {
-				if !entry.deleted {
+			toInsert, toDelete := transformMany(txn, entry.deleted, entry.obj)
+			if toInsert != nil {
+				for obj := range toInsert {
 					if _, _, err := table.Modify(txn, obj, merge); err != nil {
 						r.log.Error("BUG: Modify failed", logfields.Error, err)
 					} else {
 						numUpserted++
 					}
-				} else {
+				}
+			}
+			if toDelete != nil {
+				for obj := range toDelete {
 					if _, _, err := table.Delete(txn, obj); err != nil {
 						r.log.Error("BUG: Delete failed", logfields.Error, err)
 					} else {

--- a/pkg/k8s/testutils/decoder.go
+++ b/pkg/k8s/testutils/decoder.go
@@ -72,17 +72,19 @@ func DecodeObject(bytes []byte) (runtime.Object, error) {
 
 func DecodeObjectGVK(bytes []byte) (runtime.Object, *schema.GroupVersionKind, error) {
 	obj, gvk, err := Decoder().Decode(bytes, nil, nil)
-	return obj, gvk, err
+	if err == nil {
+		return obj, gvk, err
+	}
+	return DecodeKubernetesObject(bytes)
 }
 
-func DecodeKubernetesObject(bytes []byte) (runtime.Object, error) {
+func DecodeKubernetesObject(bytes []byte) (runtime.Object, *schema.GroupVersionKind, error) {
 	kubernetesDecoderOnce.Do(func() {
 		scheme := runtime.NewScheme()
 		fake.AddToScheme(scheme)
 		kubernetesDecoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
 	})
-	obj, _, err := kubernetesDecoder.Decode(bytes, nil, nil)
-	return obj, err
+	return kubernetesDecoder.Decode(bytes, nil, nil)
 }
 
 func DecodeFile(path string) (runtime.Object, error) {


### PR DESCRIPTION
This fixes the issue https://github.com/cilium/cilium/issues/38621 by changing the `TransformMany` in the StateDB reflector to also return the objects that should be deleted.

Additionally adding a script test suite to pkg/dynamicconfig to verify that the issue has been solved and lsolving a flaky test that I encountered.