### PR TITLE
clustermesh: policy: add --policy-default-local-cluster

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -342,6 +342,7 @@ cilium-agent [flags]
       --policy-accounting                                         Enable policy accounting (default true)
       --policy-audit-mode                                         Enable policy audit (non-drop) mode
       --policy-cidr-match-mode strings                            The entities that can be selected by CIDR policy. Supported values: 'nodes'
+      --policy-default-local-cluster                              Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-queue-size uint                                    Size of queue for policy-related events (default 100)
       --policy-secrets-namespace string                           PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP
       --policy-secrets-only-from-secrets-namespace                Configures the agent to only read policy Secrets from the policy-secrets-namespace

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -167,6 +167,7 @@ cilium-agent hive [flags]
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
+      --policy-default-local-cluster                              Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-queue-size uint                                    Size of queue for policy-related events (default 100)
       --policy-secrets-namespace string                           PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP
       --policy-secrets-only-from-secrets-namespace                Configures the agent to only read policy Secrets from the policy-secrets-namespace

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -172,6 +172,7 @@ cilium-agent hive dot-graph [flags]
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
+      --policy-default-local-cluster                              Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-queue-size uint                                    Size of queue for policy-related events (default 100)
       --policy-secrets-namespace string                           PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP
       --policy-secrets-only-from-secrets-namespace                Configures the agent to only read policy Secrets from the policy-secrets-namespace

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -123,6 +123,7 @@ cilium-operator-alibabacloud [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -86,6 +86,7 @@ cilium-operator-alibabacloud hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -91,6 +91,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -130,6 +130,7 @@ cilium-operator-aws [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -86,6 +86,7 @@ cilium-operator-aws hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -91,6 +91,7 @@ cilium-operator-aws hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -126,6 +126,7 @@ cilium-operator-azure [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -86,6 +86,7 @@ cilium-operator-azure hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -91,6 +91,7 @@ cilium-operator-azure hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -122,6 +122,7 @@ cilium-operator-generic [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -86,6 +86,7 @@ cilium-operator-generic hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -91,6 +91,7 @@ cilium-operator-generic hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -135,6 +135,7 @@ cilium-operator [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -86,6 +86,7 @@ cilium-operator hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -91,6 +91,7 @@ cilium-operator hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -932,6 +932,10 @@
      - The maximum number of clusters to support in a ClusterMesh. This value cannot be changed on running clusters, and all clusters in a ClusterMesh must be configured with the same value. Values > 255 will decrease the maximum allocatable cluster-local identities. Supported values are 255 and 511.
      - int
      - ``255``
+   * - :spelling:ignore:`clustermesh.policyDefaultLocalCluster`
+     - Control whether policy rules assume by default the local cluster if not explicitly selected
+     - bool
+     - ``false``
    * - :spelling:ignore:`clustermesh.useAPIServer`
      - Deploy clustermesh-apiserver for clustermesh
      - bool

--- a/Documentation/network/clustermesh/policy.rst
+++ b/Documentation/network/clustermesh/policy.rst
@@ -35,13 +35,38 @@ between two clusters. The cluster name refers to the name given via the
     metadata:
       name: "allow-cross-cluster"
     spec:
-      description: "Allow x-wing in cluster1 to contact rebel-base in cluster2"
+      description: "Allow x-wing to be deployed in the local cluster to contact rebel-base in cluster2"
       endpointSelector:
         matchLabels:
           name: x-wing
-          io.cilium.k8s.policy.cluster: cluster1
       egress:
       - toEndpoints:
         - matchLabels:
             name: rebel-base
             io.cilium.k8s.policy.cluster: cluster2
+
+
+Note that by default policies automatically select endpoints from all the clusters unless it is explicitly specified.
+To restrict endpoint selection to the local cluster by default you can enable the option ``--policy-default-local-cluster``
+via the ConfigMap option ``policy-default-local-cluster`` or the Helm value ``clustermesh.policyDefaultLocalCluster``.
+
+The following policy illustrates how to explicitly allow pods to communicate to all clusters.
+
+.. code-block:: yaml
+
+    apiVersion: "cilium.io/v2"
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: "allow-cross-cluster-any"
+    spec:
+      description: "Allow x-wing to be deployed in the local cluster to contact rebel-base in any cluster"
+      endpointSelector:
+        matchLabels:
+          name: x-wing
+      egress:
+      - toEndpoints:
+        - matchLabels:
+            name: rebel-base
+          matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: Exists

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -260,6 +260,7 @@ var (
 
 		// ClusterMesh is the Cilium's multicluster implementation.
 		cell.Config(cmtypes.DefaultClusterInfo),
+		cell.Config(cmtypes.DefaultPolicyConfig),
 		clustermesh.Cell,
 
 		// L2announcer resolves l2announcement policies, services, node labels and devices into a list of IPs+netdevs

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -283,6 +283,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.enableEndpointSliceSynchronization | bool | `false` | Enable the synchronization of Kubernetes EndpointSlices corresponding to the remote endpoints of appropriately-annotated global services through ClusterMesh |
 | clustermesh.enableMCSAPISupport | bool | `false` | Enable Multi-Cluster Services API support |
 | clustermesh.maxConnectedClusters | int | `255` | The maximum number of clusters to support in a ClusterMesh. This value cannot be changed on running clusters, and all clusters in a ClusterMesh must be configured with the same value. Values > 255 will decrease the maximum allocatable cluster-local identities. Supported values are 255 and 511. |
+| clustermesh.policyDefaultLocalCluster | bool | `false` | Control whether policy rules assume by default the local cluster if not explicitly selected |
 | clustermesh.useAPIServer | bool | `false` | Deploy clustermesh-apiserver for clustermesh |
 | cni.binPath | string | `"/opt/cni/bin"` | Configure the path to the CNI binary directory on the host. |
 | cni.chainingMode | string | `nil` | Configure chaining on top of other CNI plugins. Possible values:  - none  - aws-cni  - flannel  - generic-veth  - portmap |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1415,6 +1415,7 @@ data:
 {{- end }}
   clustermesh-enable-endpoint-sync: {{ .Values.clustermesh.enableEndpointSliceSynchronization | quote }}
   clustermesh-enable-mcs-api: {{ .Values.clustermesh.enableMCSAPISupport | quote }}
+  policy-default-local-cluster: {{ .Values.clustermesh.policyDefaultLocalCluster | quote }}
 
   nat-map-stats-entries: {{ .Values.nat.mapStatsEntries | quote }}
   nat-map-stats-interval: {{ .Values.nat.mapStatsInterval | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1467,6 +1467,9 @@
         "maxConnectedClusters": {
           "type": "integer"
         },
+        "policyDefaultLocalCluster": {
+          "type": "boolean"
+        },
         "useAPIServer": {
           "type": "boolean"
         }

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3263,6 +3263,8 @@ clustermesh:
   enableEndpointSliceSynchronization: false
   # -- Enable Multi-Cluster Services API support
   enableMCSAPISupport: false
+  # -- Control whether policy rules assume by default the local cluster if not explicitly selected
+  policyDefaultLocalCluster: false
   # -- Annotations to be added to all top-level clustermesh objects (resources under templates/clustermesh-apiserver and templates/clustermesh-config)
   annotations: {}
   # -- Clustermesh explicit configuration.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3285,6 +3285,8 @@ clustermesh:
   enableEndpointSliceSynchronization: false
   # -- Enable Multi-Cluster Services API support
   enableMCSAPISupport: false
+  # -- Control whether policy rules assume by default the local cluster if not explicitly selected
+  policyDefaultLocalCluster: false
 
   # -- Annotations to be added to all top-level clustermesh objects (resources under templates/clustermesh-apiserver and templates/clustermesh-config)
   annotations: {}

--- a/operator/cmd/ccnp_event.go
+++ b/operator/cmd/ccnp_event.go
@@ -32,8 +32,8 @@ func k8sEventMetric(scope, action string) {
 // enableCCNPWatcher is similar to enableCNPWatcher but handles the watch events for
 // clusterwide policies. Since, internally Clusterwide policies are implemented
 // using CiliumNetworkPolicy itself, the entire implementation uses the methods
-// associcated with CiliumNetworkPolicy.
-func enableCCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGroup, clientset k8sClient.Clientset) {
+// associated with CiliumNetworkPolicy.
+func enableCCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGroup, clientset k8sClient.Clientset, clusterName string) {
 	logger.Info("Starting CCNP derivative handler")
 
 	ccnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
@@ -51,7 +51,7 @@ func enableCCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGr
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
 					cnpCpy := cnp.DeepCopy()
 
-					groups.AddDerivativePolicyIfNeeded(logger, clientset, cnpCpy.CiliumNetworkPolicy, true)
+					groups.AddDerivativePolicyIfNeeded(logger, clientset, clusterName, cnpCpy.CiliumNetworkPolicy, true)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj any) {
@@ -68,7 +68,7 @@ func enableCCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGr
 						newCNPCpy := newCNP.DeepCopy()
 						oldCNPCpy := oldCNP.DeepCopy()
 
-						groups.UpdateDerivativePolicyIfNeeded(logger, clientset, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, true)
+						groups.UpdateDerivativePolicyIfNeeded(logger, clientset, clusterName, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, true)
 					}
 				}
 			},
@@ -100,7 +100,7 @@ func enableCCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGr
 		controller.ControllerParams{
 			Group: ccnpToGroupsControllerGroup,
 			DoFunc: func(ctx context.Context) error {
-				groups.UpdateCNPInformation(logger, clientset)
+				groups.UpdateCNPInformation(logger, clientset, clusterName)
 				return nil
 			},
 			RunInterval: 5 * time.Minute,

--- a/operator/cmd/cnp_event.go
+++ b/operator/cmd/cnp_event.go
@@ -35,7 +35,7 @@ func init() {
 
 // enableCNPWatcher waits for the CiliumNetworkPolicy CRD availability and then
 // garbage collects stale CiliumNetworkPolicy status field entries.
-func enableCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGroup, clientset k8sClient.Clientset) {
+func enableCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGroup, clientset k8sClient.Clientset, clusterName string) {
 	logger.Info("Starting CNP derivative handler")
 	cnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
@@ -52,7 +52,7 @@ func enableCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGro
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
 					cnpCpy := cnp.DeepCopy()
 
-					groups.AddDerivativePolicyIfNeeded(logger, clientset, cnpCpy.CiliumNetworkPolicy, false)
+					groups.AddDerivativePolicyIfNeeded(logger, clientset, clusterName, cnpCpy.CiliumNetworkPolicy, false)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj any) {
@@ -69,7 +69,7 @@ func enableCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGro
 						newCNPCpy := newCNP.DeepCopy()
 						oldCNPCpy := oldCNP.DeepCopy()
 
-						groups.UpdateDerivativePolicyIfNeeded(logger, clientset, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, false)
+						groups.UpdateDerivativePolicyIfNeeded(logger, clientset, clusterName, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, false)
 					}
 				}
 			},
@@ -101,7 +101,7 @@ func enableCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGro
 		controller.ControllerParams{
 			Group: cnpToGroupsControllerGroup,
 			DoFunc: func(ctx context.Context) error {
-				groups.UpdateCNPInformation(logger, clientset)
+				groups.UpdateCNPInformation(logger, clientset, clusterName)
 				return nil
 			},
 			RunInterval: 5 * time.Minute,

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -134,6 +134,7 @@ var (
 		"Operator Control Plane",
 
 		cell.Config(cmtypes.DefaultClusterInfo),
+		cell.Config(cmtypes.DefaultPolicyConfig),
 		cell.Invoke(cmtypes.ClusterInfo.InitClusterIDMax),
 		cell.Invoke(cmtypes.ClusterInfo.Validate),
 
@@ -508,18 +509,19 @@ var legacyCell = cell.Module(
 	metrics.Metric(NewUnmanagedPodsMetric),
 )
 
-func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, resources operatorK8s.Resources, factory store.Factory, svcResolver *dial.ServiceResolver, cfgMCSAPI cmoperator.MCSAPIConfig, metrics *UnmanagedPodsMetric, logger *slog.Logger) {
+func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, resources operatorK8s.Resources, factory store.Factory, svcResolver *dial.ServiceResolver, cfgMCSAPI cmoperator.MCSAPIConfig, cfgClusterMeshPolicy cmtypes.PolicyConfig, metrics *UnmanagedPodsMetric, logger *slog.Logger) {
 	ctx, cancel := context.WithCancel(context.Background())
 	legacy := &legacyOnLeader{
-		ctx:          ctx,
-		cancel:       cancel,
-		clientset:    clientset,
-		resources:    resources,
-		storeFactory: factory,
-		svcResolver:  svcResolver,
-		cfgMCSAPI:    cfgMCSAPI,
-		metrics:      metrics,
-		logger:       logger,
+		ctx:                  ctx,
+		cancel:               cancel,
+		clientset:            clientset,
+		resources:            resources,
+		storeFactory:         factory,
+		svcResolver:          svcResolver,
+		cfgMCSAPI:            cfgMCSAPI,
+		cfgClusterMeshPolicy: cfgClusterMeshPolicy,
+		metrics:              metrics,
+		logger:               logger,
 	}
 	lc.Append(cell.Hook{
 		OnStart: legacy.onStart,
@@ -528,15 +530,16 @@ func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, re
 }
 
 type legacyOnLeader struct {
-	ctx          context.Context
-	cancel       context.CancelFunc
-	clientset    k8sClient.Clientset
-	wg           sync.WaitGroup
-	resources    operatorK8s.Resources
-	storeFactory store.Factory
-	svcResolver  *dial.ServiceResolver
-	cfgMCSAPI    cmoperator.MCSAPIConfig
-	metrics      *UnmanagedPodsMetric
+	ctx                  context.Context
+	cancel               context.CancelFunc
+	clientset            k8sClient.Clientset
+	wg                   sync.WaitGroup
+	resources            operatorK8s.Resources
+	storeFactory         store.Factory
+	svcResolver          *dial.ServiceResolver
+	cfgMCSAPI            cmoperator.MCSAPIConfig
+	cfgClusterMeshPolicy cmtypes.PolicyConfig
+	metrics              *UnmanagedPodsMetric
 
 	logger *slog.Logger
 }
@@ -739,12 +742,14 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 		}
 	}
 
+	clusterNamePolicy := cmtypes.LocalClusterNameForPolicies(legacy.cfgClusterMeshPolicy, option.Config.ClusterName)
+
 	if legacy.clientset.IsEnabled() && option.Config.EnableCiliumNetworkPolicy {
-		enableCNPWatcher(legacy.ctx, legacy.logger, &legacy.wg, legacy.clientset)
+		enableCNPWatcher(legacy.ctx, legacy.logger, &legacy.wg, legacy.clientset, clusterNamePolicy)
 	}
 
 	if legacy.clientset.IsEnabled() && option.Config.EnableCiliumClusterwideNetworkPolicy {
-		enableCCNPWatcher(legacy.ctx, legacy.logger, &legacy.wg, legacy.clientset)
+		enableCCNPWatcher(legacy.ctx, legacy.logger, &legacy.wg, legacy.clientset, clusterNamePolicy)
 	}
 
 	if legacy.clientset.IsEnabled() {

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -135,3 +135,33 @@ func (_ QuirksConfig) Flags(flags *pflag.FlagSet) {
 			"policy both within and across clusters")
 	flags.MarkHidden("allow-unsafe-policy-skb-usage")
 }
+
+const PolicyAnyCluster = ""
+
+// PolicyConfig allows the user to configure config related to ClusterMesh and policies
+type PolicyConfig struct {
+	// PolicyDefaultLocalCluster control whether policy rules assume
+	// by default the local cluster if not explicitly selected
+	PolicyDefaultLocalCluster bool
+}
+
+var DefaultPolicyConfig = PolicyConfig{
+	PolicyDefaultLocalCluster: false,
+}
+
+func (p PolicyConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool(
+		"policy-default-local-cluster", p.PolicyDefaultLocalCluster,
+		"Control whether policy rules assume by default the local cluster if not explicitly selected",
+	)
+}
+
+// LocalClusterNameForPolicies returns what should be considered the local cluster
+// name in network policies
+func LocalClusterNameForPolicies(cfg PolicyConfig, localClusterName string) string {
+	if cfg.PolicyDefaultLocalCluster {
+		return localClusterName
+	} else {
+		return PolicyAnyCluster
+	}
+}

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
@@ -29,6 +30,13 @@ const (
 	// podAnyNamespaceLabelsPrefix is the prefix use in the label selector for namespace labels
 	// for any source type.
 	podAnyNamespaceLabelsPrefix = labels.LabelSourceAnyKeyPrefix + k8sConst.PodNamespaceMetaLabelsPrefix
+
+	// clusterPrefixLbl is the prefix use in the label selector for cluster name.
+	clusterPrefixLbl = labels.LabelSourceK8sKeyPrefix + k8sConst.PolicyLabelCluster
+
+	// clusterAnyPrefixLbl is the prefix use in the label selector for cluster name
+	// for any source type.
+	clusterAnyPrefixLbl = labels.LabelSourceAnyKeyPrefix + k8sConst.PolicyLabelCluster
 
 	// podInitLbl is the label used in a label selector to match on
 	// initializing pods.
@@ -62,10 +70,12 @@ func GetPolicyLabels(ns, name string, uid types.UID, derivedFrom string) labels.
 }
 
 // getEndpointSelector converts the provided labelSelector into an EndpointSelector,
-// adding the relevant matches for namespaces based on the provided options.
+// adding the relevant matches for namespaces and clusters based on the provided options.
 // If no namespace is provided then it is assumed that the selector is global to the cluster
 // this is when translating selectors for CiliumClusterwideNetworkPolicy.
-func getEndpointSelector(namespace string, labelSelector *slim_metav1.LabelSelector, addK8sPrefix, matchesInit bool) api.EndpointSelector {
+// If a clusterName is provided then is is assumed that the selector is scoped to the local
+// cluster by default in a ClusterMesh environment.
+func getEndpointSelector(clusterName, namespace string, labelSelector *slim_metav1.LabelSelector, addK8sPrefix, matchesInit bool) api.EndpointSelector {
 	es := api.NewESFromK8sLabelSelector("", labelSelector)
 
 	// The k8s prefix must not be added to reserved labels.
@@ -96,17 +106,24 @@ func getEndpointSelector(namespace string, labelSelector *slim_metav1.LabelSelec
 		}
 	}
 
+	// Similarly to namespace, the user can explicitly specify the cluster in the
+	// FromEndpoints selector. If omitted, we limit the
+	// scope to the cluster the policy lives in.
+	if clusterName != cmtypes.PolicyAnyCluster && !es.HasKey(clusterPrefixLbl) && !es.HasKey(clusterAnyPrefixLbl) {
+		es.AddMatch(clusterPrefixLbl, clusterName)
+	}
+
 	return es
 }
 
-func parseToCiliumIngressCommonRule(namespace string, es api.EndpointSelector, ing api.IngressCommonRule) api.IngressCommonRule {
+func parseToCiliumIngressCommonRule(clusterName, namespace string, es api.EndpointSelector, ing api.IngressCommonRule) api.IngressCommonRule {
 	matchesInit := matchesPodInit(es)
 	var retRule api.IngressCommonRule
 
 	if ing.FromEndpoints != nil {
 		retRule.FromEndpoints = make([]api.EndpointSelector, len(ing.FromEndpoints))
 		for j, ep := range ing.FromEndpoints {
-			retRule.FromEndpoints[j] = getEndpointSelector(namespace, ep.LabelSelector, true, matchesInit)
+			retRule.FromEndpoints[j] = getEndpointSelector(clusterName, namespace, ep.LabelSelector, true, matchesInit)
 		}
 	}
 
@@ -132,7 +149,7 @@ func parseToCiliumIngressCommonRule(namespace string, es api.EndpointSelector, i
 	if ing.FromRequires != nil {
 		retRule.FromRequires = make([]api.EndpointSelector, len(ing.FromRequires))
 		for j, ep := range ing.FromRequires {
-			retRule.FromRequires[j] = getEndpointSelector(namespace, ep.LabelSelector, false, matchesInit)
+			retRule.FromRequires[j] = getEndpointSelector(clusterName, namespace, ep.LabelSelector, false, matchesInit)
 		}
 	}
 
@@ -149,7 +166,7 @@ func parseToCiliumIngressCommonRule(namespace string, es api.EndpointSelector, i
 	return retRule
 }
 
-func parseToCiliumIngressRule(namespace string, es api.EndpointSelector, inRules []api.IngressRule) []api.IngressRule {
+func parseToCiliumIngressRule(clusterName, namespace string, es api.EndpointSelector, inRules []api.IngressRule) []api.IngressRule {
 	var retRules []api.IngressRule
 
 	if inRules != nil {
@@ -163,7 +180,7 @@ func parseToCiliumIngressRule(namespace string, es api.EndpointSelector, inRules
 				retRules[i].ICMPs = make(api.ICMPRules, len(ing.ICMPs))
 				copy(retRules[i].ICMPs, ing.ICMPs)
 			}
-			retRules[i].IngressCommonRule = parseToCiliumIngressCommonRule(namespace, es, ing.IngressCommonRule)
+			retRules[i].IngressCommonRule = parseToCiliumIngressCommonRule(clusterName, namespace, es, ing.IngressCommonRule)
 			retRules[i].Authentication = ing.Authentication.DeepCopy()
 			retRules[i].SetAggregatedSelectors()
 		}
@@ -171,7 +188,7 @@ func parseToCiliumIngressRule(namespace string, es api.EndpointSelector, inRules
 	return retRules
 }
 
-func parseToCiliumIngressDenyRule(namespace string, es api.EndpointSelector, inRules []api.IngressDenyRule) []api.IngressDenyRule {
+func parseToCiliumIngressDenyRule(clusterName, namespace string, es api.EndpointSelector, inRules []api.IngressDenyRule) []api.IngressDenyRule {
 	var retRules []api.IngressDenyRule
 
 	if inRules != nil {
@@ -185,20 +202,20 @@ func parseToCiliumIngressDenyRule(namespace string, es api.EndpointSelector, inR
 				retRules[i].ICMPs = make(api.ICMPRules, len(ing.ICMPs))
 				copy(retRules[i].ICMPs, ing.ICMPs)
 			}
-			retRules[i].IngressCommonRule = parseToCiliumIngressCommonRule(namespace, es, ing.IngressCommonRule)
+			retRules[i].IngressCommonRule = parseToCiliumIngressCommonRule(clusterName, namespace, es, ing.IngressCommonRule)
 			retRules[i].SetAggregatedSelectors()
 		}
 	}
 	return retRules
 }
 
-func parseToCiliumEgressCommonRule(namespace string, es api.EndpointSelector, egr api.EgressCommonRule) api.EgressCommonRule {
+func parseToCiliumEgressCommonRule(clusterName, namespace string, es api.EndpointSelector, egr api.EgressCommonRule) api.EgressCommonRule {
 	matchesInit := matchesPodInit(es)
 	var retRule api.EgressCommonRule
 	if egr.ToEndpoints != nil {
 		retRule.ToEndpoints = make([]api.EndpointSelector, len(egr.ToEndpoints))
 		for j, ep := range egr.ToEndpoints {
-			endpointSelector := getEndpointSelector(namespace, ep.LabelSelector, true, matchesInit)
+			endpointSelector := getEndpointSelector(clusterName, namespace, ep.LabelSelector, true, matchesInit)
 			endpointSelector.Generated = ep.Generated
 			retRule.ToEndpoints[j] = endpointSelector
 		}
@@ -217,7 +234,7 @@ func parseToCiliumEgressCommonRule(namespace string, es api.EndpointSelector, eg
 	if egr.ToRequires != nil {
 		retRule.ToRequires = make([]api.EndpointSelector, len(egr.ToRequires))
 		for j, ep := range egr.ToRequires {
-			retRule.ToRequires[j] = getEndpointSelector(namespace, ep.LabelSelector, false, matchesInit)
+			retRule.ToRequires[j] = getEndpointSelector(clusterName, namespace, ep.LabelSelector, false, matchesInit)
 		}
 	}
 
@@ -248,7 +265,7 @@ func parseToCiliumEgressCommonRule(namespace string, es api.EndpointSelector, eg
 	return retRule
 }
 
-func parseToCiliumEgressRule(namespace string, es api.EndpointSelector, inRules []api.EgressRule) []api.EgressRule {
+func parseToCiliumEgressRule(clusterName, namespace string, es api.EndpointSelector, inRules []api.EgressRule) []api.EgressRule {
 	var retRules []api.EgressRule
 
 	if inRules != nil {
@@ -269,7 +286,7 @@ func parseToCiliumEgressRule(namespace string, es api.EndpointSelector, inRules 
 				copy(retRules[i].ToFQDNs, egr.ToFQDNs)
 			}
 
-			retRules[i].EgressCommonRule = parseToCiliumEgressCommonRule(namespace, es, egr.EgressCommonRule)
+			retRules[i].EgressCommonRule = parseToCiliumEgressCommonRule(clusterName, namespace, es, egr.EgressCommonRule)
 			retRules[i].Authentication = egr.Authentication
 			retRules[i].SetAggregatedSelectors()
 		}
@@ -277,7 +294,7 @@ func parseToCiliumEgressRule(namespace string, es api.EndpointSelector, inRules 
 	return retRules
 }
 
-func parseToCiliumEgressDenyRule(namespace string, es api.EndpointSelector, inRules []api.EgressDenyRule) []api.EgressDenyRule {
+func parseToCiliumEgressDenyRule(clusterName, namespace string, es api.EndpointSelector, inRules []api.EgressDenyRule) []api.EgressDenyRule {
 	var retRules []api.EgressDenyRule
 
 	if inRules != nil {
@@ -293,7 +310,7 @@ func parseToCiliumEgressDenyRule(namespace string, es api.EndpointSelector, inRu
 				copy(retRules[i].ICMPs, egr.ICMPs)
 			}
 
-			retRules[i].EgressCommonRule = parseToCiliumEgressCommonRule(namespace, es, egr.EgressCommonRule)
+			retRules[i].EgressCommonRule = parseToCiliumEgressCommonRule(clusterName, namespace, es, egr.EgressCommonRule)
 			retRules[i].SetAggregatedSelectors()
 		}
 	}
@@ -318,8 +335,9 @@ func namespacesAreValid(namespace string, userNamespaces []string) bool {
 // ParseToCiliumRule returns an api.Rule with all the labels parsed into cilium
 // labels. If the namespace provided is empty then the rule is cluster scoped, this
 // might happen in case of CiliumClusterwideNetworkPolicy which enforces a policy on the cluster
-// instead of the particular namespace.
-func ParseToCiliumRule(logger *slog.Logger, namespace, name string, uid types.UID, r *api.Rule) *api.Rule {
+// instead of the particular namespace. If the clusterName is provided then the
+// policy is scoped to the local cluster in a ClusterMesh environment.
+func ParseToCiliumRule(logger *slog.Logger, clusterName, namespace, name string, uid types.UID, r *api.Rule) *api.Rule {
 	retRule := &api.Rule{}
 	if r.EndpointSelector.LabelSelector != nil {
 		retRule.EndpointSelector = api.NewESFromK8sLabelSelector("", r.EndpointSelector.LabelSelector)
@@ -349,10 +367,10 @@ func ParseToCiliumRule(logger *slog.Logger, namespace, name string, uid types.UI
 		retRule.NodeSelector = api.NewESFromK8sLabelSelector("", r.NodeSelector.LabelSelector)
 	}
 
-	retRule.Ingress = parseToCiliumIngressRule(namespace, r.EndpointSelector, r.Ingress)
-	retRule.IngressDeny = parseToCiliumIngressDenyRule(namespace, r.EndpointSelector, r.IngressDeny)
-	retRule.Egress = parseToCiliumEgressRule(namespace, r.EndpointSelector, r.Egress)
-	retRule.EgressDeny = parseToCiliumEgressDenyRule(namespace, r.EndpointSelector, r.EgressDeny)
+	retRule.Ingress = parseToCiliumIngressRule(clusterName, namespace, r.EndpointSelector, r.Ingress)
+	retRule.IngressDeny = parseToCiliumIngressDenyRule(clusterName, namespace, r.EndpointSelector, r.IngressDeny)
+	retRule.Egress = parseToCiliumEgressRule(clusterName, namespace, r.EndpointSelector, r.Egress)
+	retRule.EgressDeny = parseToCiliumEgressDenyRule(clusterName, namespace, r.EndpointSelector, r.EgressDeny)
 
 	retRule.Labels = ParseToCiliumLabels(namespace, name, uid, r.Labels)
 

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -31,6 +31,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 	uuid := types.UID("11bba160-ddca-11e8-b697-0800273b04ff")
 	type args struct {
 		namespace      string
+		clusterName    string
 		rule           *api.Rule
 		uid            types.UID
 		overrideConfig func()
@@ -348,6 +349,99 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			),
 		},
 		{
+			name: "set-cluster-by-default",
+			args: args{
+				clusterName: "cluster1",
+				namespace:   slim_metav1.NamespaceDefault,
+				uid:         uuid,
+				rule: &api.Rule{
+					EndpointSelector: api.NewESFromMatchRequirements(
+						map[string]string{
+							role: "backend",
+						},
+						nil,
+					),
+					Ingress: []api.IngressRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{
+								FromEndpoints: []api.EndpointSelector{
+									{
+										LabelSelector: &slim_metav1.LabelSelector{
+											MatchLabels: map[string]string{},
+										},
+									},
+									{
+										LabelSelector: &slim_metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												clusterPrefixLbl: "cluster2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: api.NewRule().WithEndpointSelector(
+				api.NewESFromMatchRequirements(
+					map[string]string{
+						role:      "backend",
+						namespace: "default",
+					},
+					nil,
+				),
+			).WithIngressRules(
+				[]api.IngressRule{
+					{
+						IngressCommonRule: api.IngressCommonRule{
+							FromEndpoints: []api.EndpointSelector{
+								api.NewESFromK8sLabelSelector(
+									labels.LabelSourceK8sKeyPrefix,
+									&slim_metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											k8sConst.PodNamespaceLabel:  "default",
+											k8sConst.PolicyLabelCluster: "cluster1",
+										},
+									}),
+								api.NewESFromK8sLabelSelector(
+									labels.LabelSourceK8sKeyPrefix,
+									&slim_metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											k8sConst.PodNamespaceLabel:  "default",
+											k8sConst.PolicyLabelCluster: "cluster2",
+										},
+									}),
+							},
+						},
+					},
+				},
+			).WithLabels(
+				labels.LabelArray{
+					{
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "set-cluster-by-default",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.namespace",
+						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.uid",
+						Value:  string(uuid),
+						Source: labels.LabelSourceK8s,
+					},
+				},
+			),
+		},
+		{
 			// When the rule specifies namespace labels, namespace label is not added
 			// by the namespace where the rule was inserted.
 			name: "parse-in-namespace-with-ns-labels-selector",
@@ -595,7 +689,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			} else {
 				option.Config.EnableNodeSelectorLabels = false
 			}
-			got := ParseToCiliumRule(hivetest.Logger(t), tt.args.namespace, tt.name, tt.args.uid, tt.args.rule)
+			got := ParseToCiliumRule(hivetest.Logger(t), tt.args.clusterName, tt.args.namespace, tt.name, tt.args.uid, tt.args.rule)
 
 			// Sanitize to set AggregatedSelectors field.
 			tt.want.Sanitize()

--- a/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
@@ -78,7 +78,7 @@ type CiliumClusterwideNetworkPolicyList struct {
 
 // Parse parses a CiliumClusterwideNetworkPolicy and returns a list of cilium
 // policy rules.
-func (r *CiliumClusterwideNetworkPolicy) Parse(logger *slog.Logger) (api.Rules, error) {
+func (r *CiliumClusterwideNetworkPolicy) Parse(logger *slog.Logger, clusterName string) (api.Rules, error) {
 	if r.ObjectMeta.Name == "" {
 		return nil, NewErrParse("CiliumClusterwideNetworkPolicy must have name")
 	}
@@ -96,16 +96,15 @@ func (r *CiliumClusterwideNetworkPolicy) Parse(logger *slog.Logger) (api.Rules, 
 		if err := r.Spec.Sanitize(); err != nil {
 			return nil, NewErrParse(fmt.Sprintf("Invalid CiliumClusterwideNetworkPolicy spec: %s", err))
 		}
-		cr := k8sCiliumUtils.ParseToCiliumRule(logger, "", name, uid, r.Spec)
+		cr := k8sCiliumUtils.ParseToCiliumRule(logger, clusterName, "", name, uid, r.Spec)
 		retRules = append(retRules, cr)
 	}
 	if r.Specs != nil {
 		for _, rule := range r.Specs {
 			if err := rule.Sanitize(); err != nil {
 				return nil, NewErrParse(fmt.Sprintf("Invalid CiliumClusterwideNetworkPolicy specs: %s", err))
-
 			}
-			cr := k8sCiliumUtils.ParseToCiliumRule(logger, "", name, uid, rule)
+			cr := k8sCiliumUtils.ParseToCiliumRule(logger, clusterName, "", name, uid, rule)
 			retRules = append(retRules, cr)
 		}
 	}

--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -160,7 +160,7 @@ func (r *CiliumNetworkPolicy) SetDerivedPolicyStatus(derivativePolicyName string
 
 // Parse parses a CiliumNetworkPolicy and returns a list of cilium policy
 // rules.
-func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger) (api.Rules, error) {
+func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger, clusterName string) (api.Rules, error) {
 	if r.ObjectMeta.Name == "" {
 		return nil, NewErrParse("CiliumNetworkPolicy must have name")
 	}
@@ -177,7 +177,7 @@ func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger) (api.Rules, error) {
 			Specs:      r.Specs,
 			Status:     r.Status,
 		}
-		return ccnp.Parse(logger)
+		return ccnp.Parse(logger, clusterName)
 	}
 	name := r.ObjectMeta.Name
 	uid := r.ObjectMeta.UID
@@ -195,16 +195,15 @@ func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger) (api.Rules, error) {
 		if r.Spec.NodeSelector.LabelSelector != nil {
 			return nil, NewErrParse("Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector")
 		}
-		cr := k8sCiliumUtils.ParseToCiliumRule(logger, namespace, name, uid, r.Spec)
+		cr := k8sCiliumUtils.ParseToCiliumRule(logger, clusterName, namespace, name, uid, r.Spec)
 		retRules = append(retRules, cr)
 	}
 	if r.Specs != nil {
 		for _, rule := range r.Specs {
 			if err := rule.Sanitize(); err != nil {
 				return nil, NewErrParse(fmt.Sprintf("Invalid CiliumNetworkPolicy specs: %s", err))
-
 			}
-			cr := k8sCiliumUtils.ParseToCiliumRule(logger, namespace, name, uid, rule)
+			cr := k8sCiliumUtils.ParseToCiliumRule(logger, clusterName, namespace, name, uid, rule)
 			retRules = append(retRules, cr)
 		}
 	}

--- a/pkg/k8s/apis/cilium.io/v2/fuzz_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/fuzz_test.go
@@ -15,7 +15,8 @@ func FuzzCiliumNetworkPolicyParse(f *testing.F) {
 		ff := fuzz.NewConsumer(data)
 		r := &CiliumNetworkPolicy{}
 		ff.GenerateStruct(r)
-		_, _ = r.Parse(hivetest.Logger(t))
+		clusterName, _ := ff.GetString()
+		_, _ = r.Parse(hivetest.Logger(t), clusterName)
 	})
 }
 
@@ -24,6 +25,7 @@ func FuzzCiliumClusterwideNetworkPolicyParse(f *testing.F) {
 		ff := fuzz.NewConsumer(data)
 		r := &CiliumClusterwideNetworkPolicy{}
 		ff.GenerateStruct(r)
-		_, _ = r.Parse(hivetest.Logger(t))
+		clusterName, _ := ff.GetString()
+		_, _ = r.Parse(hivetest.Logger(t), clusterName)
 	})
 }

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -313,7 +314,7 @@ func TestParseSpec(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 
-	rules, err := expectedPolicyRule.Parse(logger)
+	rules, err := expectedPolicyRule.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.NoError(t, err)
 	require.Len(t, rules, 1)
 	require.Equal(t, *expectedSpecRule, *rules[0])
@@ -323,7 +324,7 @@ func TestParseSpec(t *testing.T) {
 	var expectedPolicyRuleUnmarshalled CiliumNetworkPolicy
 	err = json.Unmarshal(b, &expectedPolicyRuleUnmarshalled)
 	require.NoError(t, err)
-	expectedPolicyRuleUnmarshalled.Parse(logger)
+	expectedPolicyRuleUnmarshalled.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.Equal(t, *expectedPolicyRule, expectedPolicyRuleUnmarshalled)
 
 	cnpl := CiliumNetworkPolicy{}
@@ -338,7 +339,7 @@ func TestParseSpec(t *testing.T) {
 			UID:       uuidRule,
 		},
 	}
-	_, err = empty.Parse(logger)
+	_, err = empty.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.EqualValues(t, ErrEmptyCNP, err)
 
 	emptyCCNP := &CiliumClusterwideNetworkPolicy{
@@ -347,7 +348,7 @@ func TestParseSpec(t *testing.T) {
 			UID:  uuidRule,
 		},
 	}
-	_, err = emptyCCNP.Parse(logger)
+	_, err = emptyCCNP.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.EqualValues(t, ErrEmptyCCNP, err)
 }
 
@@ -405,7 +406,7 @@ func TestParseRules(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 
-	rules, err := expectedPolicyRuleList.Parse(logger)
+	rules, err := expectedPolicyRuleList.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.NoError(t, err)
 	require.Len(t, rules, 2)
 	for i, rule := range rules {
@@ -417,7 +418,7 @@ func TestParseRules(t *testing.T) {
 	var expectedPolicyRuleUnmarshalled CiliumNetworkPolicy
 	err = json.Unmarshal(b, &expectedPolicyRuleUnmarshalled)
 	require.NoError(t, err)
-	expectedPolicyRuleUnmarshalled.Parse(logger)
+	expectedPolicyRuleUnmarshalled.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.Equal(t, *expectedPolicyRuleList, expectedPolicyRuleUnmarshalled)
 
 	cnpl := CiliumNetworkPolicy{}
@@ -488,7 +489,7 @@ func TestParseWithNodeSelector(t *testing.T) {
 		},
 		Spec: &rule,
 	}
-	_, err := cnpl.Parse(logger)
+	_, err := cnpl.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.ErrorContains(t, err, "Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector")
 
 	// CCNP parse is allowed to have a NodeSelector.
@@ -500,7 +501,7 @@ func TestParseWithNodeSelector(t *testing.T) {
 		},
 		Spec: cnpl.Spec,
 	}
-	_, err = ccnpl.Parse(logger)
+	_, err = ccnpl.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.NoError(t, err)
 
 	// CCNPs are received as CNP and initially parsed as CNP. Create a CNP with
@@ -513,7 +514,7 @@ func TestParseWithNodeSelector(t *testing.T) {
 		},
 		Spec: &rule,
 	}
-	_, err = ccnplAsCNP.Parse(logger)
+	_, err = ccnplAsCNP.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.NoError(t, err)
 
 	// Now test a CNP and CCNP with an EndpointSelector only.
@@ -521,11 +522,11 @@ func TestParseWithNodeSelector(t *testing.T) {
 	rule.NodeSelector = emptySelector
 
 	// CNP and CCNP parse is allowed to have an EndpointSelector.
-	_, err = cnpl.Parse(logger)
+	_, err = cnpl.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.NoError(t, err)
-	_, err = ccnpl.Parse(logger)
+	_, err = ccnpl.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.NoError(t, err)
-	_, err = ccnplAsCNP.Parse(logger)
+	_, err = ccnplAsCNP.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.NoError(t, err)
 }
 

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -510,7 +511,7 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 			args.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 			want.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 
-			rules, policyImportErr := args.cnp.Parse(hivetest.Logger(t))
+			rules, policyImportErr := args.cnp.Parse(hivetest.Logger(t), cmtypes.PolicyAnyCluster)
 			require.Equal(t, want.err, policyImportErr)
 
 			// Only add policies if we have successfully parsed them. Otherwise, if

--- a/pkg/policy/directory/cell.go
+++ b/pkg/policy/directory/cell.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	policycell "github.com/cilium/cilium/pkg/policy/cell"
 )
@@ -33,9 +34,11 @@ type DirectoryWatcherReadStatus interface {
 type PolicyWatcherParams struct {
 	cell.In
 
-	Lifecycle cell.Lifecycle
-	Logger    *slog.Logger
-	Importer  policycell.PolicyImporter
+	Lifecycle               cell.Lifecycle
+	Logger                  *slog.Logger
+	Importer                policycell.PolicyImporter
+	ClusterInfo             cmtypes.ClusterInfo
+	ClusterMeshPolicyConfig cmtypes.PolicyConfig
 }
 
 type Config struct {
@@ -83,6 +86,7 @@ func newPolicyWatcher(p PolicyWatcherParams, cfg Config) *policyWatcher {
 		log:                p.Logger,
 		policyImporter:     p.Importer,
 		config:             cfg,
+		clusterName:        cmtypes.LocalClusterNameForPolicies(p.ClusterMeshPolicyConfig, p.ClusterInfo.Name),
 		fileNameToCnpCache: make(map[string]*cilium_v2.CiliumNetworkPolicy),
 	}
 	w.synced.Add(1)

--- a/pkg/policy/directory/watcher.go
+++ b/pkg/policy/directory/watcher.go
@@ -34,6 +34,7 @@ type policyWatcher struct {
 	log            *slog.Logger
 	config         Config
 	policyImporter policycell.PolicyImporter
+	clusterName    string
 	synced         sync.WaitGroup
 	// maps cnp file name to cnp object. this is required to retrieve data during delete.
 	fileNameToCnpCache map[string]*cilium_v2.CiliumNetworkPolicy
@@ -96,7 +97,7 @@ func (p *policyWatcher) addToPolicyEngine(cnp *cilium_v2.CiliumNetworkPolicy, cn
 	)
 
 	// convert to rules
-	rules, err := cnp.Parse(p.log)
+	rules, err := cnp.Parse(p.log, p.clusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/policy/groups/controllers.go
+++ b/pkg/policy/groups/controllers.go
@@ -20,7 +20,7 @@ const (
 // from providers.  To avoid issues with rate-limiting this function will
 // execute the addDerivative function with a max number of concurrent calls,
 // defined on maxConcurrentUpdates.
-func UpdateCNPInformation(logger *slog.Logger, clientset client.Clientset) {
+func UpdateCNPInformation(logger *slog.Logger, clientset client.Clientset, clusterName string) {
 	cnpToUpdate := groupsCNPCache.GetAllCNP()
 	sem := make(chan bool, maxConcurrentUpdates)
 	for _, cnp := range cnpToUpdate {
@@ -29,11 +29,10 @@ func UpdateCNPInformation(logger *slog.Logger, clientset client.Clientset) {
 			defer func() { <-sem }()
 			// We use the same cache for Clusterwide and Namespaced cilium policies
 			if cnp.ObjectMeta.Namespace == "" {
-				addDerivativePolicy(context.TODO(), logger, clientset, cnp, true)
+				addDerivativePolicy(context.TODO(), logger, clientset, clusterName, cnp, true)
 			} else {
-				addDerivativePolicy(context.TODO(), logger, clientset, cnp, false)
+				addDerivativePolicy(context.TODO(), logger, clientset, clusterName, cnp, false)
 			}
-
 		}(cnp)
 	}
 }

--- a/pkg/policy/groups/helpers.go
+++ b/pkg/policy/groups/helpers.go
@@ -27,7 +27,7 @@ func getDerivativeName(obj v1.Object) string {
 }
 
 // createDerivativeCNP will return a new CNP based on the given rule.
-func createDerivativeCNP(ctx context.Context, logger *slog.Logger, cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumNetworkPolicy, error) {
+func createDerivativeCNP(ctx context.Context, logger *slog.Logger, clusterName string, cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumNetworkPolicy, error) {
 	// CNP informer may provide a CNP object without APIVersion or Kind.
 	// Setting manually to make sure that the derivative policy works ok.
 	derivativeCNP := &cilium_v2.CiliumNetworkPolicy{
@@ -52,8 +52,7 @@ func createDerivativeCNP(ctx context.Context, logger *slog.Logger, cnp *cilium_v
 		err   error
 	)
 
-	rules, err = cnp.Parse(logger)
-
+	rules, err = cnp.Parse(logger, clusterName)
 	if err != nil {
 		// We return a valid pointer for derivative policy here instead of nil.
 		// This object is used to get generated name for the derivative policy
@@ -67,7 +66,7 @@ func createDerivativeCNP(ctx context.Context, logger *slog.Logger, cnp *cilium_v
 }
 
 // createDerivativeCCNP will return a new CCNP based on the given rule.
-func createDerivativeCCNP(ctx context.Context, logger *slog.Logger, cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumClusterwideNetworkPolicy, error) {
+func createDerivativeCCNP(ctx context.Context, logger *slog.Logger, clusterName string, cnp *cilium_v2.CiliumNetworkPolicy) (*cilium_v2.CiliumClusterwideNetworkPolicy, error) {
 	ccnp := &cilium_v2.CiliumClusterwideNetworkPolicy{
 		TypeMeta:   cnp.TypeMeta,
 		ObjectMeta: cnp.ObjectMeta,
@@ -100,8 +99,7 @@ func createDerivativeCCNP(ctx context.Context, logger *slog.Logger, cnp *cilium_
 		err   error
 	)
 
-	rules, err = ccnp.Parse(logger)
-
+	rules, err = ccnp.Parse(logger, clusterName)
 	if err != nil {
 		// We return a valid pointer for derivative policy here instead of nil.
 		// This object is used to get generated name for the derivative policy

--- a/pkg/policy/groups/helpers_test.go
+++ b/pkg/policy/groups/helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -42,14 +43,14 @@ func TestCorrectDerivativeName(t *testing.T) {
 	name := "test"
 	cnp := getSamplePolicy(name, "testns")
 	logger := hivetest.Logger(t)
-	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), logger, cnp)
+	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), logger, cmtypes.PolicyAnyCluster, cnp)
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%s-groups-%s", name, cnp.ObjectMeta.UID), cnpDerivedPolicy.ObjectMeta.Name)
 
 	// Test clusterwide policy helper functions
 	ccnpName := "ccnp-test"
 	ccnp := getSamplePolicy(ccnpName, "")
-	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), logger, ccnp)
+	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), logger, cmtypes.PolicyAnyCluster, ccnp)
 
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%s-groups-%s", ccnpName, ccnp.ObjectMeta.UID), ccnpDerivedPolicy.ObjectMeta.Name)
@@ -74,7 +75,7 @@ func TestDerivativePoliciesAreDeletedIfNogroups(t *testing.T) {
 	cnp.Spec.Egress = egressRule
 
 	logger := hivetest.Logger(t)
-	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), logger, cnp)
+	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), logger, cmtypes.PolicyAnyCluster, cnp)
 	require.NoError(t, err)
 	require.Equal(t, cnp.Spec.Egress, cnpDerivedPolicy.Specs[0].Egress)
 	require.Len(t, cnpDerivedPolicy.Specs, 1)
@@ -84,7 +85,7 @@ func TestDerivativePoliciesAreDeletedIfNogroups(t *testing.T) {
 	ccnp := getSamplePolicy(ccnpName, "")
 	ccnp.Spec.Egress = egressRule
 
-	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), logger, ccnp)
+	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), logger, cmtypes.PolicyAnyCluster, ccnp)
 	require.NoError(t, err)
 	require.Equal(t, ccnp.Spec.Egress, ccnpDerivedPolicy.Specs[0].Egress)
 	require.Len(t, ccnpDerivedPolicy.Specs, 1)
@@ -125,7 +126,7 @@ func TestDerivativePoliciesAreInheritCorrectly(t *testing.T) {
 
 	cnp.Spec.Egress = egressRule
 
-	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), hivetest.Logger(t), cnp)
+	cnpDerivedPolicy, err := createDerivativeCNP(context.TODO(), hivetest.Logger(t), cmtypes.PolicyAnyCluster, cnp)
 	require.NoError(t, err)
 	require.Nil(t, cnpDerivedPolicy.Spec)
 	require.Len(t, cnpDerivedPolicy.Specs, 1)
@@ -137,7 +138,7 @@ func TestDerivativePoliciesAreInheritCorrectly(t *testing.T) {
 	ccnp := getSamplePolicy(ccnpName, "")
 	ccnp.Spec.Egress = egressRule
 
-	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), hivetest.Logger(t), ccnp)
+	ccnpDerivedPolicy, err := createDerivativeCCNP(context.TODO(), hivetest.Logger(t), cmtypes.PolicyAnyCluster, ccnp)
 	require.NoError(t, err)
 	require.Nil(t, ccnpDerivedPolicy.Spec)
 	require.Len(t, ccnpDerivedPolicy.Specs, 1)

--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -65,9 +66,10 @@ type PolicyWatcherParams struct {
 
 	Lifecycle cell.Lifecycle
 
-	ClientSet client.Clientset
-	Config    *option.DaemonConfig
-	Logger    *slog.Logger
+	ClientSet               client.Clientset
+	Config                  *option.DaemonConfig
+	ClusterMeshPolicyConfig cmtypes.PolicyConfig
+	Logger                  *slog.Logger
 
 	K8sResourceSynced *synced.Resources
 	K8sAPIGroups      *synced.APIGroups
@@ -96,6 +98,7 @@ func startK8sPolicyWatcher(params PolicyWatcherParams) {
 	p := &policyWatcher{
 		log:                              params.Logger,
 		config:                           params.Config,
+		clusterMeshPolicyConfig:          params.ClusterMeshPolicyConfig,
 		policyImporter:                   params.PolicyImporter,
 		k8sResourceSynced:                params.K8sResourceSynced,
 		k8sAPIGroups:                     params.K8sAPIGroups,

--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/types"
@@ -139,7 +140,7 @@ func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialR
 		p.metricsManager.AddCNP(cnp.CiliumNetworkPolicy)
 	}
 
-	rules, err := cnp.Parse(scopedLog)
+	rules, err := cnp.Parse(scopedLog, cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.config.ClusterName))
 	if err != nil {
 		scopedLog.Warn(
 			"Unable to add CiliumNetworkPolicy",

--- a/pkg/policy/k8s/network_policy.go
+++ b/pkg/policy/k8s/network_policy.go
@@ -14,12 +14,12 @@ import (
 	"github.com/cilium/cilium/pkg/source"
 )
 
-func (p *policyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string, dc chan uint64) error {
+func (p *policyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string, dc chan uint64, clusterName string) error {
 	defer func() {
 		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
 	}()
 
-	rules, err := k8s.ParseNetworkPolicy(p.log, k8sNP)
+	rules, err := k8s.ParseNetworkPolicy(p.log, clusterName, k8sNP)
 	if err != nil {
 		metrics.PolicyChangeTotal.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
 		p.log.Error(

--- a/pkg/policy/k8s/watcher.go
+++ b/pkg/policy/k8s/watcher.go
@@ -11,6 +11,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -23,8 +24,9 @@ import (
 )
 
 type policyWatcher struct {
-	log    *slog.Logger
-	config *option.DaemonConfig
+	log                     *slog.Logger
+	config                  *option.DaemonConfig
+	clusterMeshPolicyConfig cmtypes.PolicyConfig
 
 	k8sResourceSynced *k8sSynced.Resources
 	k8sAPIGroups      *k8sSynced.APIGroups
@@ -156,7 +158,10 @@ func (p *policyWatcher) watchResources(ctx context.Context) {
 				var err error
 				switch event.Kind {
 				case resource.Upsert:
-					err = p.addK8sNetworkPolicyV1(event.Object, k8sAPIGroupNetworkingV1Core, knpDone)
+					err = p.addK8sNetworkPolicyV1(
+						event.Object, k8sAPIGroupNetworkingV1Core, knpDone,
+						cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.config.ClusterName),
+					)
 				case resource.Delete:
 					err = p.deleteK8sNetworkPolicyV1(event.Object, k8sAPIGroupNetworkingV1Core, knpDone)
 				}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Add a new option to select endpoint rules from the local cluster by default  for CNP, CCNP and k8s NP. It works in a similar way as namespaced NP (k8s NP and CNP). Enabling this new option will make sure that users do not add too wide network rules in ClusterMesh environments.

This new option is for now opt-in but meant to be a future new default once ready, that we provide proper tooling to identify (CC)NP that will be changed as a result and after a transition period.

Related to #36194 / https://github.com/cilium/cilium/issues/36194#issuecomment-2802430595

The main remaining point is about the tooling to identify which (CC)NP behavior will be changed when enabling this option. This could probably be added in a preflight container.

```release-note
policy: add a new option enable-default-restrict-local-cluster-policy to restrict policies rules to the local cluster in ClusterMesh environment
```
