### PR TITLE
Fix TraceSockNotify type alignment check failure

### DIFF
--- a/bpf/lib/trace_sock.h
+++ b/bpf/lib/trace_sock.h
@@ -56,11 +56,13 @@ struct trace_sock_notify {
 	__u8 xlate_point;
 	struct ip dst_ip;
 	__u16 dst_port;
+	__u32 pad1;
 	__u64 sock_cookie;
 	__u64 cgroup_id;
 	__u8 l4_proto;
 	__u8 ipv6 : 1;
-	__u8 pad : 7;
+	__u8 pad2 : 7;
+	__u8 pad3[6];
 } __packed;
 
 #ifdef TRACE_SOCK_NOTIFY

--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -32,7 +32,7 @@ const (
 const TraceSockNotifyFlagIPv6 uint8 = 0x1
 
 const (
-	TraceSockNotifyLen = 38
+	TraceSockNotifyLen = 48
 )
 
 // TraceSockNotify is message format for socket trace notifications sent from datapath.
@@ -43,10 +43,12 @@ type TraceSockNotify struct {
 	XlatePoint uint8
 	DstIP      types.IPv6
 	DstPort    uint16
+	Pad1       uint32
 	SockCookie uint64
 	CgroupId   uint64
 	L4Proto    uint8
 	Flags      uint8
+	Pad2       [6]uint8
 }
 
 // DecodeTraceSockNotify will decode 'data' into the provided TraceSocNotify structure
@@ -63,10 +65,10 @@ func (t *TraceSockNotify) decodeTraceSockNotify(data []byte) error {
 	t.XlatePoint = data[1]
 	copy(t.DstIP[:], data[2:18])
 	t.DstPort = byteorder.Native.Uint16(data[18:20])
-	t.SockCookie = byteorder.Native.Uint64(data[20:28])
-	t.CgroupId = byteorder.Native.Uint64(data[28:36])
-	t.L4Proto = data[36]
-	t.Flags = data[37]
+	t.SockCookie = byteorder.Native.Uint64(data[24:32])
+	t.CgroupId = byteorder.Native.Uint64(data[32:40])
+	t.L4Proto = data[40]
+	t.Flags = data[41]
 
 	return nil
 }

--- a/pkg/monitor/datapath_sock_trace_test.go
+++ b/pkg/monitor/datapath_sock_trace_test.go
@@ -17,7 +17,7 @@ import (
 func TestDecodeTraceSockNotify(t *testing.T) {
 	// This check on the struct length constant is there to ensure that this
 	// test is updated when the struct changes.
-	require.Equal(t, 38, TraceSockNotifyLen)
+	require.Equal(t, 48, TraceSockNotifyLen)
 
 	input := TraceSockNotify{
 		Type:       0x00,


### PR DESCRIPTION
This change adds pads to the TraceSockNotify type and increases its size from 38 to 48.

Fixes: #38642
