### PR TITLE
fqdn: optimize ForceExpireByNameIP

### DIFF
--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -975,8 +975,7 @@ func TestZombiesForceExpire(t *testing.T) {
 	zombies.Upsert(now, netip.MustParseAddr("2.2.2.2"), "test.com")
 
 	// Don't expire if the IP doesn't match
-	err = zombies.ForceExpireByNameIP(time.Time{}, "somethingelse.com", netip.MustParseAddr("1.1.1.1"))
-	require.NoError(t, err)
+	zombies.ForceExpireByNameIP(time.Time{}, "somethingelse.com", netip.MustParseAddr("1.1.1.1"))
 	alive, dead = zombies.GC()
 	require.Empty(t, dead)
 	assertZombiesContain(t, alive, map[string][]string{
@@ -984,8 +983,7 @@ func TestZombiesForceExpire(t *testing.T) {
 	})
 
 	// Expire 1 name for this IP but leave other names
-	err = zombies.ForceExpireByNameIP(time.Time{}, "somethingelse.com", netip.MustParseAddr("2.2.2.2"))
-	require.NoError(t, err)
+	zombies.ForceExpireByNameIP(time.Time{}, "somethingelse.com", netip.MustParseAddr("2.2.2.2"))
 	alive, dead = zombies.GC()
 	require.Empty(t, dead)
 	assertZombiesContain(t, alive, map[string][]string{
@@ -993,8 +991,7 @@ func TestZombiesForceExpire(t *testing.T) {
 	})
 
 	// Don't remove if the name doesn't match
-	err = zombies.ForceExpireByNameIP(time.Time{}, "blarg.com", netip.MustParseAddr("2.2.2.2"))
-	require.NoError(t, err)
+	zombies.ForceExpireByNameIP(time.Time{}, "blarg.com", netip.MustParseAddr("2.2.2.2"))
 	alive, dead = zombies.GC()
 	require.Empty(t, dead)
 	assertZombiesContain(t, alive, map[string][]string{
@@ -1002,8 +999,7 @@ func TestZombiesForceExpire(t *testing.T) {
 	})
 
 	// Clear everything
-	err = zombies.ForceExpireByNameIP(time.Time{}, "test.com", netip.MustParseAddr("2.2.2.2"))
-	require.NoError(t, err)
+	zombies.ForceExpireByNameIP(time.Time{}, "test.com", netip.MustParseAddr("2.2.2.2"))
 	alive, dead = zombies.GC()
 	require.Empty(t, dead)
 	require.Empty(t, alive)


### PR DESCRIPTION
This function is called in the FQDN critical path -- that is to say, while we are holding on to the intercepted DNS packet. It was pretty sub-optimal, scanning through a large map... especially since we have the key to the map!

So, stop the sequential scan and just use the index. Also, don't re-allocate arrays that we're unlikely to change.


```release-note
Improves performance of the DNS proxy when large numbers of IPs are being cached.
```


