### PR TITLE
Switch Operator to use *metrics.Registry infra. 

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -112,6 +112,7 @@ cilium-operator-alibabacloud [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -82,6 +82,7 @@ cilium-operator-alibabacloud hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -87,6 +87,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -120,6 +120,7 @@ cilium-operator-aws [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -82,6 +82,7 @@ cilium-operator-aws hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -87,6 +87,7 @@ cilium-operator-aws hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -115,6 +115,7 @@ cilium-operator-azure [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -82,6 +82,7 @@ cilium-operator-azure hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -87,6 +87,7 @@ cilium-operator-azure hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -111,6 +111,7 @@ cilium-operator-generic [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -82,6 +82,7 @@ cilium-operator-generic hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -87,6 +87,7 @@ cilium-operator-generic hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -125,6 +125,7 @@ cilium-operator [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -82,6 +82,7 @@ cilium-operator hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -87,6 +87,7 @@ cilium-operator hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)

--- a/operator/api/metrics.go
+++ b/operator/api/metrics.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/metrics"
 	opMetrics "github.com/cilium/cilium/operator/metrics"
+	ciliumMetrics "github.com/cilium/cilium/pkg/metrics"
 )
 
 var MetricsHandlerCell = cell.Module(
@@ -18,14 +19,16 @@ var MetricsHandlerCell = cell.Module(
 	cell.Provide(newMetricsHandler),
 )
 
-type metricsHandler struct{}
+type metricsHandler struct {
+	registry *ciliumMetrics.Registry
+}
 
-func newMetricsHandler() metrics.GetMetricsHandler {
-	return &metricsHandler{}
+func newMetricsHandler(reg *ciliumMetrics.Registry) metrics.GetMetricsHandler {
+	return &metricsHandler{registry: reg}
 }
 
 func (h *metricsHandler) Handle(params metrics.GetMetricsParams) middleware.Responder {
-	m, err := opMetrics.DumpMetrics()
+	m, err := opMetrics.DumpMetrics(h.registry)
 	if err != nil {
 		return metrics.NewGetMetricsFailed()
 	}

--- a/operator/api/server_test.go
+++ b/operator/api/server_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/kvstore"
+	ciliumMetrics "github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 func TestAPIServerK8sDisabled(t *testing.T) {
@@ -32,6 +34,10 @@ func TestAPIServerK8sDisabled(t *testing.T) {
 	var testSrv Server
 
 	hive := hive.New(
+		cell.Provide(ciliumMetrics.NewRegistry),
+		cell.Provide(func() (*option.DaemonConfig, ciliumMetrics.RegistryConfig) {
+			return option.Config, ciliumMetrics.RegistryConfig{}
+		}),
 		k8sClient.FakeClientCell(),
 		cell.Invoke(func(cs *k8sClient.FakeClientset) {
 			cs.Disable()
@@ -100,6 +106,10 @@ func TestAPIServerK8sEnabled(t *testing.T) {
 	var testSrv Server
 
 	hive := hive.New(
+		cell.Provide(ciliumMetrics.NewRegistry),
+		cell.Provide(func() (*option.DaemonConfig, ciliumMetrics.RegistryConfig) {
+			return option.Config, ciliumMetrics.RegistryConfig{}
+		}),
 		k8sClient.FakeClientCell(),
 		kvstore.Cell(kvstore.DisabledBackendName),
 

--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -28,6 +28,7 @@ import (
 	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/k8s/watchers/metrics"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/logging"
@@ -93,7 +94,8 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 	)
 
 	var ciliumNodeManagerQueueConfig = workqueue.TypedRateLimitingQueueConfig[string]{
-		Name: "node_manager",
+		Name:            "node_manager",
+		MetricsProvider: metrics.MetricsProvider,
 	}
 	var kvStoreQueueConfig = workqueue.TypedRateLimitingQueueConfig[string]{
 		Name: "kvstore",

--- a/operator/metrics/legacy.go
+++ b/operator/metrics/legacy.go
@@ -4,29 +4,21 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
 	"github.com/cilium/cilium/api/v1/operator/models"
+	"github.com/cilium/cilium/pkg/metrics"
 )
-
-// Registry is the global prometheus registry for cilium-operator metrics.
-var Registry RegisterGatherer
-
-type RegisterGatherer interface {
-	prometheus.Registerer
-	prometheus.Gatherer
-}
 
 // DumpMetrics gets the current Cilium operator metrics and dumps all into a
 // Metrics structure. If metrics cannot be retrieved, returns an error.
-func DumpMetrics() ([]*models.Metric, error) {
+func DumpMetrics(reg *metrics.Registry) ([]*models.Metric, error) {
 	result := []*models.Metric{}
-	if Registry == nil {
+	if reg == nil {
 		return result, nil
 	}
 
-	currentMetrics, err := Registry.Gather()
+	currentMetrics, err := reg.Gather()
 	if err != nil {
 		return result, err
 	}

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -120,6 +120,14 @@ func registerMetricsManager(p params) {
 		metrics.APILimiterRequestsInFlight,
 		metrics.APILimiterRateLimit,
 		metrics.APILimiterProcessedRequests,
+
+		metrics.WorkQueueDepth,
+		metrics.WorkQueueAddsTotal,
+		metrics.WorkQueueLatency,
+		metrics.WorkQueueDuration,
+		metrics.WorkQueueUnfinishedWork,
+		metrics.WorkQueueLongestRunningProcessor,
+		metrics.WorkQueueRetries,
 	)
 
 	metrics.InitOperatorMetrics()

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -4,19 +4,14 @@
 package metrics
 
 import (
-	"errors"
 	"log/slog"
-	"net/http"
 	"regexp"
 
 	"github.com/cilium/hive/cell"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	controllerRuntimeMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 )
@@ -35,82 +30,28 @@ type params struct {
 	SharedCfg SharedConfig
 
 	Metrics []metric.WithMetadata `group:"hive-metrics"`
+
+	Registry *metrics.Registry
 }
 
-type metricsManager struct {
-	logger     *slog.Logger
-	shutdowner hive.Shutdowner
-
-	server http.Server
-
-	metrics []metric.WithMetadata
-}
-
-func (mm *metricsManager) Start(ctx cell.HookContext) error {
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.HandlerFor(Registry, promhttp.HandlerOpts{}))
-	mm.server.Handler = mux
-
-	go func() {
-		mm.logger.Info("Starting metrics server", logfields.Address, mm.server.Addr)
-		if err := mm.server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			mm.logger.ErrorContext(ctx, "Unable to start metrics server", logfields.Error, err)
-			mm.shutdowner.Shutdown()
-		}
-	}()
-
-	return nil
-}
-
-func (mm *metricsManager) Stop(ctx cell.HookContext) error {
-	if err := mm.server.Shutdown(ctx); err != nil {
-		mm.logger.ErrorContext(ctx, "Shutdown operator metrics server failed", logfields.Error, err)
-		return err
-	}
-	return nil
-}
-
-func registerMetricsManager(p params) {
-	if !p.SharedCfg.EnableMetrics {
-		return
-	}
-
-	mm := &metricsManager{
-		logger:     p.Logger,
-		shutdowner: p.Shutdowner,
-		server:     http.Server{Addr: p.Cfg.OperatorPrometheusServeAddr},
-		metrics:    p.Metrics,
-	}
-
-	// Use the same Registry as controller-runtime, so that we don't need
-	// to expose multiple metrics endpoints or servers.
-	//
-	// Ideally, we should use our own Registry instance, but the metrics
-	// registration is done by init() functions, which are executed before
-	// this function is called.
-	Registry = controllerRuntimeMetrics.Registry
-
-	// Unregister default Go collector that is added by default by the controller-runtime library.
-	// This is necessary to be able to register a Go collector with additional runtime metrics
-	// without any clashes with the existing Go collector.
-	Registry.Unregister(collectors.NewGoCollector())
-
-	Registry.MustRegister(collectors.NewGoCollector(
+// Note: metrics are always initialized so we have access to sampler ring buffer data
+// for debugging. However, actual prometheus server will be started depending on if
+// metrics are enabled.
+func initializeMetrics(p params) {
+	p.Registry.MustRegister(collectors.NewGoCollector(
 		collectors.WithGoCollectorRuntimeMetrics(
 			collectors.GoRuntimeMetricsRule{Matcher: goCustomCollectorsRX},
 		),
 	))
 
-	Registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{Namespace: metrics.CiliumOperatorNamespace}))
+	p.Registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{Namespace: metrics.CiliumOperatorNamespace}))
 
-	for _, metric := range mm.metrics {
-		Registry.MustRegister(metric.(prometheus.Collector))
+	for _, metric := range p.Metrics {
+		p.Registry.MustRegister(metric.(prometheus.Collector))
 	}
 
-	// Constructing the legacy metrics and register them at the metrics global variable.
-	// This is a hack until we can unify this metrics manager with the metrics.Registry.
 	metrics.NewLegacyMetrics()
-	Registry.MustRegister(
+	p.Registry.MustRegister(
 		metrics.VersionMetric,
 		metrics.KVStoreOperationsDuration,
 		metrics.KVStoreEventsQueueDuration,
@@ -131,8 +72,8 @@ func registerMetricsManager(p params) {
 	)
 
 	metrics.InitOperatorMetrics()
-	Registry.MustRegister(metrics.ErrorsWarnings)
+	p.Registry.MustRegister(metrics.ErrorsWarnings)
 	metrics.FlushLoggingMetrics()
 
-	p.Lifecycle.Append(mm)
+	p.Registry.AddServerRuntimeHooks()
 }

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -22,6 +22,7 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/watchers/metrics"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -168,7 +169,10 @@ func (c *Controller) initializeQueues() {
 
 	c.resourceQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
 		workqueue.NewTypedItemExponentialFailureRateLimiter[QueuedItem](defaultSyncBackOff, maxSyncBackOff),
-		workqueue.TypedRateLimitingQueueConfig[QueuedItem]{Name: "ciliumidentity_resource"})
+		workqueue.TypedRateLimitingQueueConfig[QueuedItem]{
+			Name:            "ciliumidentity_resource",
+			MetricsProvider: metrics.MetricsProvider,
+		})
 }
 
 // startEventProcessing starts the event processing loop for the Controller.

--- a/operator/watchers/node.go
+++ b/operator/watchers/node.go
@@ -19,6 +19,7 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	slimclientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/k8s/watchers/metrics"
 )
 
 var (
@@ -74,7 +75,10 @@ func nodesInit(wg *sync.WaitGroup, slimClient slimclientset.Interface, stopCh <-
 	nodeSyncOnce.Do(func() {
 		nodeQueue = workqueue.NewTypedRateLimitingQueueWithConfig[string](
 			workqueue.NewTypedItemExponentialFailureRateLimiter[string](1*time.Second, 120*time.Second),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "node-queue"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name:            "node-queue",
+				MetricsProvider: metrics.MetricsProvider,
+			},
 		)
 		slimNodeStore, nodeController = informer.NewInformer(
 			utils.ListerWatcherFromTyped[*slim_corev1.NodeList](slimClient.CoreV1().Nodes()),

--- a/pkg/api/metrics/metrics.go
+++ b/pkg/api/metrics/metrics.go
@@ -6,22 +6,22 @@ package metrics
 import (
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/cilium/cilium/pkg/metrics"
 
-	"github.com/cilium/cilium/operator/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // PrometheusMetrics is an implementation of Prometheus metrics for external
 // API usage
 type PrometheusMetrics struct {
-	registry    metrics.RegisterGatherer
+	registry    *metrics.Registry
 	APIDuration *prometheus.HistogramVec
 	RateLimit   *prometheus.HistogramVec
 }
 
 // NewPrometheusMetrics returns a new metrics tracking implementation to cover
 // external API usage.
-func NewPrometheusMetrics(namespace, subsystem string, registry metrics.RegisterGatherer) *PrometheusMetrics {
+func NewPrometheusMetrics(namespace, subsystem string, registry *metrics.Registry) *PrometheusMetrics {
 	m := &PrometheusMetrics{registry: registry}
 
 	m.APIDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 var Cell = cell.Module(
@@ -50,8 +51,9 @@ type mcsAPIParams struct {
 	CtrlRuntimeManager ctrlRuntime.Manager
 	Scheme             *runtime.Scheme
 
-	Logger   *slog.Logger
-	JobGroup job.Group
+	Logger          *slog.Logger
+	JobGroup        job.Group
+	MetricsRegistry *metrics.Registry
 }
 
 var requiredGVK = []schema.GroupVersionKind{
@@ -123,7 +125,7 @@ func registerMCSAPIController(params mcsAPIParams) error {
 
 	params.Logger.Info("Multi-Cluster Services API support enabled")
 
-	registerMCSAPICollector(params.Logger, params.CtrlRuntimeManager.GetClient())
+	registerMCSAPICollector(params.MetricsRegistry, params.Logger, params.CtrlRuntimeManager.GetClient())
 
 	remoteClusterServiceSource := &remoteClusterServiceExportSource{Logger: params.Logger}
 	params.ClusterMesh.RegisterClusterServiceExportUpdateHook(remoteClusterServiceSource.onClusterServiceExportEvent)

--- a/pkg/clustermesh/mcsapi/metrics.go
+++ b/pkg/clustermesh/mcsapi/metrics.go
@@ -11,13 +11,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
-	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
-func registerMCSAPICollector(logger *slog.Logger, client client.Client) {
-	operatorMetrics.Registry.MustRegister(&mcsAPICollector{
+func registerMCSAPICollector(registry *metrics.Registry, logger *slog.Logger, client client.Client) {
+	registry.MustRegister(&mcsAPICollector{
 		logger: logger,
 		client: client,
 

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -62,7 +62,14 @@ var debug = flag.Bool("debug", false, "Enable debug logging")
 func TestScript(t *testing.T) {
 	// Catch any leaked goroutines. Ignoring goroutines possibly left by other tests.
 	leakOpts := goleak.IgnoreCurrent()
-	t.Cleanup(func() { goleak.VerifyNone(t, leakOpts) })
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			leakOpts,
+			// Ignore workqueue metrics collection goroutine, this would otherwise be
+			// cleaned up shortly after the tests complete.
+			goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
+		)
+	})
 
 	version.Force(testutils.DefaultVersion)
 

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	azureAPI "github.com/cilium/cilium/pkg/azure/api"
@@ -27,14 +26,14 @@ type AllocatorAzure struct {
 }
 
 // Init in Azure implementation doesn't need to do anything
-func (a *AllocatorAzure) Init(ctx context.Context, logger *slog.Logger) error {
+func (a *AllocatorAzure) Init(ctx context.Context, logger *slog.Logger, reg *metrics.Registry) error {
 	a.rootLogger = logger
 	a.logger = a.rootLogger.With(logfields.LogSubsys, "ipam-allocator-azure")
 	return nil
 }
 
 // Start kicks of the Azure IP allocation
-func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, reg *metrics.Registry) (allocator.NodeEventHandler, error) {
 
 	var (
 		azMetrics azureAPI.MetricsAPI
@@ -72,8 +71,8 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNod
 	}
 
 	if operatorOption.Config.EnableMetrics {
-		azMetrics = apiMetrics.NewPrometheusMetrics(metrics.Namespace, "azure", operatorMetrics.Registry)
-		iMetrics = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, operatorMetrics.Registry)
+		azMetrics = apiMetrics.NewPrometheusMetrics(metrics.Namespace, "azure", reg)
+		iMetrics = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, reg)
 	} else {
 		azMetrics = &apiMetrics.NoOpMetrics{}
 		iMetrics = &ipamMetrics.NoOpMetrics{}

--- a/pkg/ipam/allocator/clusterpool/clusterpool.go
+++ b/pkg/ipam/allocator/clusterpool/clusterpool.go
@@ -31,7 +31,7 @@ type AllocatorOperator struct {
 }
 
 // Init sets up Cilium allocator based on given options
-func (a *AllocatorOperator) Init(ctx context.Context, logger *slog.Logger) error {
+func (a *AllocatorOperator) Init(ctx context.Context, logger *slog.Logger, reg *metrics.Registry) error {
 	a.rootLogger = logger
 	a.logger = logger.With(subsysLogAttr...)
 	if option.Config.EnableIPv4 {
@@ -66,7 +66,7 @@ func (a *AllocatorOperator) Init(ctx context.Context, logger *slog.Logger) error
 }
 
 // Start kicks of Operator allocation.
-func (a *AllocatorOperator) Start(ctx context.Context, updater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+func (a *AllocatorOperator) Start(ctx context.Context, updater ipam.CiliumNodeGetterUpdater, _ *metrics.Registry) (allocator.NodeEventHandler, error) {
 	a.logger.Info(
 		"Starting ClusterPool IP allocator",
 		logfields.IPv4CIDRs, operatorOption.Config.ClusterPoolIPv4CIDR,

--- a/pkg/ipam/allocator/multipool/allocator.go
+++ b/pkg/ipam/allocator/multipool/allocator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipam/allocator"
 	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 var subsysLogAttr = []any{logfields.LogSubsys, "ipam-allocator-multi-pool"}
@@ -21,13 +22,13 @@ type Allocator struct {
 	logger    *slog.Logger
 }
 
-func (a *Allocator) Init(ctx context.Context, logger *slog.Logger) error {
+func (a *Allocator) Init(ctx context.Context, logger *slog.Logger, _ *metrics.Registry) error {
 	a.poolAlloc = NewPoolAllocator(logger)
 	a.logger = logger.With(subsysLogAttr...)
 	return nil
 }
 
-func (a *Allocator) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (allocator.NodeEventHandler, error) {
+func (a *Allocator) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, _ *metrics.Registry) (allocator.NodeEventHandler, error) {
 	return NewNodeHandler(a.logger, a.poolAlloc, getterUpdater), nil
 }
 

--- a/pkg/ipam/allocator/provider.go
+++ b/pkg/ipam/allocator/provider.go
@@ -9,14 +9,15 @@ import (
 
 	"github.com/cilium/cilium/pkg/ipam"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 // AllocatorProvider defines the functions of IPAM provider front-end
 // these are implemented by e.g. pkg/ipam/allocator/{aws,azure}.
 type AllocatorProvider interface {
-	Init(ctx context.Context, logger *slog.Logger) error
-	Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater) (NodeEventHandler, error)
+	Init(ctx context.Context, logger *slog.Logger, metrics *metrics.Registry) error
+	Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, metrics *metrics.Registry) (NodeEventHandler, error)
 }
 
 // NodeEventHandler should implement the behavior to handle CiliumNode

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -6,7 +6,7 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/cilium/cilium/operator/metrics"
+	ciliumMetrics "github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
@@ -14,7 +14,7 @@ import (
 const ipamSubsystem = "ipam"
 
 type prometheusMetrics struct {
-	registry             metrics.RegisterGatherer
+	registry             *ciliumMetrics.Registry
 	Allocation           *prometheus.HistogramVec
 	Release              *prometheus.HistogramVec
 	AllocateInterfaceOps *prometheus.CounterVec
@@ -44,7 +44,7 @@ const LabelTargetNodeName = "target_node"
 
 // NewPrometheusMetrics returns a new interface metrics implementation backed by
 // Prometheus metrics.
-func NewPrometheusMetrics(namespace string, registry metrics.RegisterGatherer) *prometheusMetrics {
+func NewPrometheusMetrics(namespace string, registry *ciliumMetrics.Registry) *prometheusMetrics {
 	m := &prometheusMetrics{
 		registry: registry,
 	}
@@ -329,7 +329,7 @@ func NewTriggerMetrics(namespace, name string) *triggerMetrics {
 	}
 }
 
-func (t *triggerMetrics) Register(registry metrics.RegisterGatherer) {
+func (t *triggerMetrics) Register(registry *ciliumMetrics.Registry) {
 	registry.MustRegister(t.total)
 	registry.MustRegister(t.folds)
 	registry.MustRegister(t.callDuration)

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -24,6 +24,7 @@ import (
 
 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
 	"github.com/cilium/cilium/pkg/k8s/synced"
+	watcherMetrics "github.com/cilium/cilium/pkg/k8s/watchers/metrics"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -414,7 +415,10 @@ func (r *resource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Even
 		options:   options,
 		debugInfo: debugInfo,
 		wq: workqueue.NewTypedRateLimitingQueueWithConfig[WorkItem](options.rateLimiter,
-			workqueue.TypedRateLimitingQueueConfig[WorkItem]{Name: r.resourceName()}),
+			workqueue.TypedRateLimitingQueueConfig[WorkItem]{
+				Name:            r.resourceName(),
+				MetricsProvider: watcherMetrics.MetricsProvider,
+			}),
 	}
 
 	// Fork a goroutine to process the queued keys and pass them to the subscriber.

--- a/pkg/k8s/resource/statedb.go
+++ b/pkg/k8s/resource/statedb.go
@@ -13,6 +13,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/workqueue"
 
+	watcherMetrics "github.com/cilium/cilium/pkg/k8s/watchers/metrics"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -53,7 +54,8 @@ func (twq *tableWorkQueue[T]) Observe(ctx context.Context, next func(Event[T]), 
 	wq := workqueue.NewTypedRateLimitingQueueWithConfig[tableWorkQueueItem](
 		workqueue.DefaultTypedControllerRateLimiter[tableWorkQueueItem](),
 		workqueue.TypedRateLimitingQueueConfig[tableWorkQueueItem]{
-			Name: fmt.Sprintf("%T", zero),
+			Name:            fmt.Sprintf("%T", zero),
+			MetricsProvider: watcherMetrics.MetricsProvider,
 		},
 	)
 

--- a/pkg/k8s/watchers/metrics/metrics.go
+++ b/pkg/k8s/watchers/metrics/metrics.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package watchers
+package metrics
 
 import (
 	"context"
@@ -41,8 +41,18 @@ func init() {
 	k8s_metrics.RateLimiterLatency = registerOps.RateLimiterLatency
 	k8s_metrics.RequestResult = registerOps.RequestResult
 
-	workqueue.SetProvider(workqueueMetricsProvider{})
+	// Note: Workqueues should have the metric provider set directly
+	// via the [TypedRateLimitingQueueConfig.MetricsProvider] field.
+	// The workqueue.SetProvider call is inherently prone to breaking
+	// (see: above commment), however we will still attempt to register
+	// it for the sake of posterity.
+	workqueue.SetProvider(MetricsProvider)
 }
+
+// MetricsProvider is the global metrics provider for k8s controller runtime
+// watcher work queues. This should be set directly in TypedRateLimitingQueueConfig
+// when configuring work queues.
+var MetricsProvider = workqueueMetricsProvider{}
 
 type workqueueMetricsProvider struct{}
 

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -17,7 +17,8 @@ import (
 // Cell provides metrics registry and the 'metrics*' shell commands.
 var Cell = cell.Module("metrics", "Metrics",
 	// Provide registry to hive, but also invoke if case no cells decide to use as dependency
-	cell.Provide(NewRegistry),
+	cell.Provide(NewAgentRegistry),
+	Metric(NewLegacyMetrics),
 	cell.Config(defaultRegistryConfig),
 	cell.Config(defaultSamplerConfig),
 	cell.Provide(
@@ -31,7 +32,6 @@ var Cell = cell.Module("metrics", "Metrics",
 // and without pulling in the legacy metrics.
 var AgentCell = cell.Group(
 	Cell,
-	Metric(NewLegacyMetrics),
 	cell.Invoke(
 		func(logger *slog.Logger, reg *Registry) {
 			// Register the agent status and BPF metrics.
@@ -49,6 +49,12 @@ var AgentCell = cell.Group(
 
 		},
 	),
+)
+
+var OperatorCell = cell.Module("operator-metrics", "Operator Metrics",
+	cell.Config(defaultSamplerConfig),
+	cell.Provide(NewRegistry),
+	cell.Provide(metricsCommands, newSampler),
 )
 
 // Metric constructs a new metric cell.

--- a/pkg/metrics/cmd.go
+++ b/pkg/metrics/cmd.go
@@ -160,7 +160,7 @@ func plotCommand(dc *sampler) script.Cmd {
 				"Specify '-rate' to show the rate of change for a counter,",
 				"for example to plot how many bytes are allocated per minute:",
 				"",
-				"cilium> metrics/plot -rate go.*heap_alloc_bytes",
+				"cilium> metrics/plot --rate go.*heap_alloc_bytes",
 			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -17,7 +17,7 @@ func TestGaugeWithThreshold(t *testing.T) {
 	threshold := 1.0
 	underThreshold := threshold - 0.5
 	overThreshold := threshold + 0.5
-	reg := NewRegistry(RegistryParams{
+	reg := NewAgentRegistry(RegistryParams{
 		Logger:       logger,
 		DaemonConfig: &option.DaemonConfig{},
 	})


### PR DESCRIPTION
With the changes in https://github.com/cilium/cilium/pull/38743, the operator now has the Hive infra modules necessary to run the `shell` command.  This gives users access to a interactive shell that allows users to run included hive commands.

One thing that is missing is the `metrics` commands, which provide a buffered in-memory set of prometheus metrics.  This is because the operator still sets up its own metrics infra rather than using the `pkg/metrics.Registry` type.

This PR makes the necessary changes such that we can begin to use the Registry in the operator.


```release-note
add support for `metrics` in the cilium-operator when using the operator shell command. 
```
