### PR TITLE
docs: Native routing Masquerading in the cloud

### DIFF
--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -31,6 +31,16 @@ Setting the routable CIDR
   10.0.0.0/8`` (or ``ipv6-native-routing-cidr: fd00::/100`` for IPv6 addresses)
   in which case all destinations within that CIDR will **not** be masqueraded.
 
+  In the public cloud environment, if you don't configure ``ipv4-native-routing-cidr``, 
+  Cilium will automatically detect the VPC CIDR range as the native routing range. 
+  Cilium does not masquerade the source address for traffic that is natively
+  routable in the network, because it is possible for the endpoints to
+  communicate directly without NAT.
+  As a result, if masquerading is enabled, traffic from pods to other 
+  non-cluster resources within the same VPC (e.g., virtual machines) will be 
+  routed directly without masquerading the source IP address.
+
+
 Setting the masquerading interface
   See :ref:`masq_modes` for configuring the masquerading interfaces.
 


### PR DESCRIPTION
Add a section to talk about the native routing masquerading in the cloud environment based on discussion
https://github.com/cilium/cilium/pull/39156#discussion_r2061990449.


This is the PR can be applied to all branches.


Things are a bit different between clouds where I didn't reveal all details in the doc, but the behavior is the same across the clouds.


```release-note
Add a section to talk about the native routing masquerading in the cloud environment.
```
