### PR TITLE
treewide: Remove references to cilium-etcd-operator

### DIFF
--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -302,9 +302,6 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 		}
 		// Start handling events for KVStore **after** nodeManagerSyncHandler
 		// otherwise Cilium Operator will block until the KVStore is available.
-		// This might be problematic in clusters that have etcd-operator with
-		// cluster-pool ipam mode because they depend on Cilium Operator to be
-		// running and handling IP Addresses with nodeManagerSyncHandler.
 		// Only handle events if kvStoreSyncHandler is not nil. If it is nil
 		// then there isn't any event handler set for CiliumNodes events.
 		if s.withKVStore && kvStoreSyncHandler != nil {

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -550,8 +550,9 @@ func (legacy *legacyOnLeader) onStop(_ cell.HookContext) error {
 func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 	isLeader.Store(true)
 
-	// Restart kube-dns as soon as possible since it helps etcd-operator to be
-	// properly setup. If kube-dns is not managed by Cilium it can prevent
+	// Restart kube-dns as soon as possible to parallelize re-initialization
+	// of DNS with other operation functions.
+	// If kube-dns is not managed by Cilium it can prevent
 	// etcd from reaching out kube-dns in EKS.
 	// If this logic is modified, make sure the operator's clusterrole logic for
 	// pods/delete is also up-to-date.

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -243,30 +243,6 @@ func testEventWatcherBatching(t *testing.T) {
 	require.NotEqual(t, 0, owner.WaitUntilID(2057))
 }
 
-func TestGetIdentityCache(t *testing.T) {
-	testutils.IntegrationTest(t)
-	kvstore.SetupDummy(t, "etcd")
-
-	for _, testConfig := range testConfigs {
-		t.Run(testConfig.name, func(t *testing.T) {
-			testGetIdentityCache(t, testConfig)
-		})
-	}
-}
-
-func testGetIdentityCache(t *testing.T, testConfig testConfig) {
-	identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
-	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := NewCachingIdentityAllocator(newDummyOwner(), testConfig.allocatorConfig)
-	<-mgr.InitIdentityAllocator(nil)
-	defer mgr.Close()
-	defer mgr.IdentityAllocator.DeleteAllKeys()
-
-	cache := mgr.GetIdentityCache()
-	_, ok := cache[identity.ReservedCiliumKVStore]
-	require.True(t, ok)
-}
-
 func TestAllocator(t *testing.T) {
 	testutils.IntegrationTest(t)
 	cl := kvstore.SetupDummy(t, "etcd")

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -15,17 +15,6 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-var (
-	kvstoreLabels = labels.NewLabelsFromModel([]string{
-		"k8s:app=etcd",
-		"k8s:etcd_cluster=cilium-etcd",
-		"k8s:io.cilium/app=etcd-operator",
-		"k8s:io.kubernetes.pod.namespace=kube-system",
-		"k8s:io.cilium.k8s.policy.serviceaccount=default",
-		"k8s:io.cilium.k8s.policy.cluster=default",
-	})
-)
-
 func TestLookupReservedIdentity(t *testing.T) {
 	testutils.IntegrationTest(t)
 
@@ -55,10 +44,6 @@ func testLookupReservedIdentity(t *testing.T, testConfig testConfig) {
 	require.Equal(t, worldID, id.ID)
 
 	identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
-
-	id = mgr.LookupIdentity(context.TODO(), kvstoreLabels)
-	require.NotNil(t, id)
-	require.Equal(t, identity.ReservedCiliumKVStore, id.ID)
 }
 
 func TestLookupReservedIdentityByLabels(t *testing.T) {
@@ -131,13 +116,6 @@ func TestLookupReservedIdentityByLabels(t *testing.T) {
 				"id.foo":          labels.ParseLabel("id.foo"),
 			},
 			),
-		},
-		{
-			name: "well-known-kvstore",
-			args: args{
-				lbls: kvstoreLabels,
-			},
-			want: identity.NewIdentity(identity.ReservedCiliumKVStore, kvstoreLabels),
 		},
 		{
 			name: "no fixed and reserved identities returns nil",


### PR DESCRIPTION
Remove remaining tree references to the cilium-etcd-operator and its
corresponding special well known identities, as we no longer attempt to
ensure that environments with a podnetworked etcd can be used as the basis
for bootstrapping a Cilium environment for managing pod networks.
