### PR TITLE
clustermesh: Move command to subdirectory

### DIFF
--- a/clustermesh-apiserver/cmd/root.go
+++ b/clustermesh-apiserver/cmd/root.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cilium/cilium/clustermesh-apiserver/clustermesh"
+	clustermeshdbg "github.com/cilium/cilium/clustermesh-apiserver/clustermesh-dbg"
+	"github.com/cilium/cilium/clustermesh-apiserver/common"
+	"github.com/cilium/cilium/clustermesh-apiserver/etcdinit"
+	"github.com/cilium/cilium/clustermesh-apiserver/kvstoremesh"
+	kvstoremeshdbg "github.com/cilium/cilium/clustermesh-apiserver/kvstoremesh-dbg"
+	"github.com/cilium/cilium/clustermesh-apiserver/version"
+	"github.com/cilium/cilium/pkg/cmdref"
+	"github.com/cilium/cilium/pkg/hive"
+)
+
+var RootCmd = &cobra.Command{
+	Use:   "clustermesh-apiserver",
+	Short: "Run the ClusterMesh apiserver",
+}
+
+func init() {
+	RootCmd.AddCommand(
+		cmdref.NewCmd(RootCmd),
+		version.NewCmd(),
+		// etcd init does not use the Hive framework, because it's a "one and done" process that doesn't spawn a service
+		// or server, or perform any waiting for connections.
+		etcdinit.NewCmd(),
+		clustermesh.NewCmd(hive.New(common.Cell, clustermesh.Cell)),
+		kvstoremesh.NewCmd(hive.New(common.Cell, kvstoremesh.Cell)),
+		clustermeshdbg.RootCmd,
+		kvstoremeshdbg.RootCmd,
+	)
+}
+
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -4,42 +4,9 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/spf13/cobra"
-
-	"github.com/cilium/cilium/clustermesh-apiserver/clustermesh"
-	clustermeshdbg "github.com/cilium/cilium/clustermesh-apiserver/clustermesh-dbg"
-	"github.com/cilium/cilium/clustermesh-apiserver/common"
-	"github.com/cilium/cilium/clustermesh-apiserver/etcdinit"
-	"github.com/cilium/cilium/clustermesh-apiserver/kvstoremesh"
-	kvstoremeshdbg "github.com/cilium/cilium/clustermesh-apiserver/kvstoremesh-dbg"
-	"github.com/cilium/cilium/clustermesh-apiserver/version"
-	"github.com/cilium/cilium/pkg/cmdref"
-	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/clustermesh-apiserver/cmd"
 )
 
 func main() {
-	cmd := &cobra.Command{
-		Use:   "clustermesh-apiserver",
-		Short: "Run the ClusterMesh apiserver",
-	}
-
-	cmd.AddCommand(
-		cmdref.NewCmd(cmd),
-		version.NewCmd(),
-		// etcd init does not use the Hive framework, because it's a "one and done" process that doesn't spawn a service
-		// or server, or perform any waiting for connections.
-		etcdinit.NewCmd(),
-		clustermesh.NewCmd(hive.New(common.Cell, clustermesh.Cell)),
-		kvstoremesh.NewCmd(hive.New(common.Cell, kvstoremesh.Cell)),
-		clustermeshdbg.RootCmd,
-		kvstoremeshdbg.RootCmd,
-	)
-
-	if err := cmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	cmd.Execute()
 }


### PR DESCRIPTION
Most of the binaries in the tree are structured with a cmd/ directory
that is invoked from the main.go in the main subdirectory for the
binary. Make clustermesh-apiserver follow the same common pattern.
No functional changes intended in this commit.
