### PR TITLE
hubble: use functional options pattern for SkipUnknownCGroupIDs

### DIFF
--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -48,7 +48,6 @@ func noopParser(t *testing.T) *parser.Parser {
 		&testutils.NoopServiceGetter,
 		&testutils.NoopLinkGetter,
 		&testutils.NoopPodMetadataGetter,
-		true,
 	)
 	require.NoError(t, err)
 	return pp
@@ -787,7 +786,6 @@ func Benchmark_TrackNamespaces(b *testing.B) {
 		&testutils.NoopServiceGetter,
 		&testutils.NoopLinkGetter,
 		&testutils.NoopPodMetadataGetter,
-		true,
 	)
 	if err != nil {
 		b.Fatal(err)

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -66,7 +66,14 @@ func newPayloadParser(params payloadParserParams) (parser.Decoder, error) {
 			params.Log,
 			params.Config.EnableNetworkPolicyCorrelation,
 		))
-	return parser.New(params.Log, g, g, g, params.Ipcache, g, params.LinkCache, params.CGroupManager, params.Config.SkipUnknownCGroupIDs, parserOpts...)
+	parserOpts = append(
+		parserOpts,
+		parserOptions.WithSkipUnknownCGroupIDs(
+			params.Log,
+			params.Config.SkipUnknownCGroupIDs,
+		),
+	)
+	return parser.New(params.Log, g, g, g, params.Ipcache, g, params.LinkCache, params.CGroupManager, parserOpts...)
 }
 
 type payloadParserParams struct {

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	CacheSize                      int
 	HubbleRedactSettings           HubbleRedactSettings
 	EnableNetworkPolicyCorrelation bool
+	SkipUnknownCGroupIDs           bool
 }
 
 // HubbleRedactSettings contains all hubble redact related options
@@ -68,6 +69,16 @@ func WithNetworkPolicyCorrelation(logger *slog.Logger, enabled bool) Option {
 		opt.EnableNetworkPolicyCorrelation = enabled
 		logger.Info("configured Hubble with network policy correlation",
 			logfields.Options, opt.EnableNetworkPolicyCorrelation,
+		)
+	}
+}
+
+// WithSkipUnknownCGroupIDs configures whether Hubble will skip events with unknown CGroup IDs.
+func WithSkipUnknownCGroupIDs(logger *slog.Logger, enabled bool) Option {
+	return func(opt *Options) {
+		opt.SkipUnknownCGroupIDs = enabled
+		logger.Info("configured Hubble to skip events with unknown CGroup IDs",
+			logfields.Options, opt.SkipUnknownCGroupIDs,
 		)
 	}
 }

--- a/pkg/hubble/parser/options/options_test.go
+++ b/pkg/hubble/parser/options/options_test.go
@@ -55,3 +55,20 @@ func TestEnableNetworkPolicyCorrelation(t *testing.T) {
 	assert.True(t, opts.EnableNetworkPolicyCorrelation)
 	assert.Equal(t, want, buf.String())
 }
+
+func TestSkipUnknownCGroupIDs(t *testing.T) {
+	want := "level=info msg=\"configured Hubble to skip events with unknown CGroup IDs\" options=false\n"
+	var buf bytes.Buffer
+	logger := slog.New(
+		slog.NewTextHandler(&buf,
+			&slog.HandlerOptions{
+				ReplaceAttr: logging.ReplaceAttrFnWithoutTimestamp,
+			},
+		),
+	)
+	opt := WithSkipUnknownCGroupIDs(logger, false)
+	opts := Options{SkipUnknownCGroupIDs: true}
+	opt(&opts)
+	assert.False(t, opts.SkipUnknownCGroupIDs)
+	assert.Equal(t, want, buf.String())
+}

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -51,7 +51,6 @@ func New(
 	serviceGetter getters.ServiceGetter,
 	linkGetter getters.LinkGetter,
 	cgroupGetter getters.PodMetadataGetter,
-	skipUnknownCGroupIDs bool,
 	opts ...options.Option,
 ) (*Parser, error) {
 
@@ -70,7 +69,7 @@ func New(
 		return nil, err
 	}
 
-	sock, err := sock.New(log, endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter, cgroupGetter, skipUnknownCGroupIDs)
+	sock, err := sock.New(log, endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter, cgroupGetter, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hubble/parser/parser_test.go
+++ b/pkg/hubble/parser/parser_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Test_InvalidPayloads(t *testing.T) {
-	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil, true)
+	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	_, err = p.Decode(nil)
@@ -49,7 +49,7 @@ func Test_InvalidPayloads(t *testing.T) {
 }
 
 func Test_ParserDispatch(t *testing.T) {
-	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil, true)
+	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	// Test L3/L4 record
@@ -89,7 +89,7 @@ func Test_ParserDispatch(t *testing.T) {
 }
 
 func Test_EventType_RecordLost(t *testing.T) {
-	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil, true)
+	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	ts := time.Now()

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -42,8 +43,16 @@ func New(log *slog.Logger,
 	ipGetter getters.IPGetter,
 	serviceGetter getters.ServiceGetter,
 	cgroupGetter getters.PodMetadataGetter,
-	skipUnknownCGroupIDs bool,
+	opts ...options.Option,
 ) (*Parser, error) {
+	args := &options.Options{
+		SkipUnknownCGroupIDs: true,
+	}
+
+	for _, opt := range opts {
+		opt(args)
+	}
+
 	return &Parser{
 		log:                  log,
 		endpointGetter:       endpointGetter,
@@ -53,7 +62,7 @@ func New(log *slog.Logger,
 		serviceGetter:        serviceGetter,
 		cgroupGetter:         cgroupGetter,
 		epResolver:           common.NewEndpointResolver(log, endpointGetter, identityGetter, ipGetter),
-		skipUnknownCGroupIDs: skipUnknownCGroupIDs,
+		skipUnknownCGroupIDs: args.SkipUnknownCGroupIDs,
 	}, nil
 }
 

--- a/pkg/hubble/parser/sock/parser_test.go
+++ b/pkg/hubble/parser/sock/parser_test.go
@@ -21,6 +21,7 @@ import (
 	cgroupManager "github.com/cilium/cilium/pkg/cgroups/manager"
 	parserErrors "github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -399,7 +400,8 @@ func TestDecodeSockEvent(t *testing.T) {
 		},
 	}
 
-	p, err := New(hivetest.Logger(t), endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter, cgroupGetter, false)
+	logger := hivetest.Logger(t)
+	p, err := New(logger, endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter, cgroupGetter, options.WithSkipUnknownCGroupIDs(logger, false))
 	assert.NoError(t, err)
 
 	for _, tc := range tt {

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -63,7 +63,6 @@ func noopParser(t testing.TB) *parser.Parser {
 		&testutils.NoopServiceGetter,
 		&testutils.NoopLinkGetter,
 		&testutils.NoopPodMetadataGetter,
-		true,
 	)
 	require.NoError(t, err)
 	return pp


### PR DESCRIPTION
Like other for options in the Hubble subsystem, use the Go function options pattern to enable/disable skipping of events with unknown CGroup IDs (`SkipUnknownCGroupIDs`) instead of wiring through a `bool`.