### PR TITLE
cilium, bpf: Perform 2nd lookup also on local backends for lb-proto-diff

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -674,6 +674,7 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 				       const bool scope_switch)
 {
 	struct lb6_service *svc;
+	__u8 orig_proto = key->proto;
 
 	key->scope = LB_LOOKUP_SCOPE_EXT;
 	key->backend_slot = 0;
@@ -691,7 +692,16 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 		if (!scope_switch || !lb6_svc_is_two_scopes(svc))
 			return svc;
 		key->scope = LB_LOOKUP_SCOPE_INT;
+		key->proto = orig_proto;
 		svc = map_lookup_elem(&cilium_lb6_services_v2, key);
+
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+		/* Also check for ANY protocol for internal scope lookups */
+		if (!svc && key->proto != 0) {
+			key->proto = 0;
+			svc = map_lookup_elem(&cilium_lb6_services_v2, key);
+		}
+#endif
 	}
 
 	return svc;
@@ -1400,6 +1410,7 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 				       const bool scope_switch)
 {
 	struct lb4_service *svc;
+	__u8 orig_proto = key->proto;
 
 	key->scope = LB_LOOKUP_SCOPE_EXT;
 	key->backend_slot = 0;
@@ -1417,7 +1428,16 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 		if (!scope_switch || !lb4_svc_is_two_scopes(svc))
 			return svc;
 		key->scope = LB_LOOKUP_SCOPE_INT;
+		key->proto = orig_proto;
 		svc = map_lookup_elem(&cilium_lb4_services_v2, key);
+
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+		/* Also check for ANY protocol for internal scope lookups */
+		if (!svc && key->proto != 0) {
+			key->proto = 0;
+			svc = map_lookup_elem(&cilium_lb4_services_v2, key);
+		}
+#endif
 	}
 
 	return svc;


### PR DESCRIPTION
When performing load balancer service lookups for internal scope (`LB_LOOKUP_SCOPE_INT`), ensure protocol differentiation is considered just like it is for external scope lookups.

Fixes: https://github.com/cilium/cilium/issues/39358

```release-note
Fix a bug where services would fail to match wildcard protocols after switching to Local traffic policy with protocol differentiation enabled.
```