### PR TITLE
ratelimitmap: init maps before metrics collection

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
-	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/maps/vtep"
 	"github.com/cilium/cilium/pkg/mtu"
@@ -153,10 +152,6 @@ func (d *Daemon) initMaps() error {
 
 	if err := metricsmap.Metrics.OpenOrCreate(); err != nil {
 		return fmt.Errorf("initializing metrics map: %w", err)
-	}
-
-	if err := ratelimitmap.InitMaps(); err != nil {
-		return fmt.Errorf("initializing ratelimit maps: %w", err)
 	}
 
 	// Tunnel map is no longer used, not even in tunnel routing mode.


### PR DESCRIPTION
Currently, starting the Cilium Agent can result in the following
warning when collecting metrics on the ratelimit metrics map starts
before the daemon initialized the ratelimit metrics map.

```
2025-05-06T10:17:39.944482772Z time="2025-05-06T10:17:39.941569631Z" level=warning msg="Failed to read ratelimit metrics from BPF map" source="/go/src/github.com/cilium/cilium/pkg/maps/ratelimitmap/ratelimitmap.go:203" error="loading pinned map /sys/fs/bpf/tc/globals/cilium_ratelimit_metrics: no such file or directory" subsys=ratelimit-map
```

The reason is that the map gets initialized via the daemon init logic
(that calls `ratelimitmap.InitMaps` - while the metrics collector
gets registered via Hive lifecycle.

Therefore, this commit initializes the ratelimit metrics map
with a Hive lifecycle hook and lets the metrics registration depend
on the map. This way it's ensured that the map is created when
the metrics collection starts.

---

Seen on https://github.com/cilium/cilium/pull/39357 in the ci-ginkgo tests (e.g.  https://github.com/cilium/cilium/actions/runs/14856075257/job/41713009262). It's likely that the change of Daemon dependencies in that PR lead to exposing this issue. But the actual issue exists in the current codebase.

Agent logs from a sysdump

```
2025-05-06T10:17:36.972737837Z time=2025-05-06T10:17:36Z level=debug source=/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/oneshot.go:134 msg="Starting one-shot job" module=agent.infra.metrics name=collect func=metrics.(*sampler).collectLoop
2025-05-06T10:17:36.972752705Z time=2025-05-06T10:17:36Z level=debug source=/go/src/github.com/cilium/cilium/pkg/hive/health/provider.go:93 msg="upserting health status" module=health lastLevel=none reporter-id=agent.infra.metrics.job-collect status="agent.infra.metrics.job-collect: [OK] Running"
2025-05-06T10:17:36.972894950Z time="2025-05-06T10:17:36.972734997Z" level=warning msg="Failed to read ratelimit metrics from BPF map" source="/go/src/github.com/cilium/cilium/pkg/maps/ratelimitmap/ratelimitmap.go:203" error="loading pinned map /sys/fs/bpf/tc/globals/cilium_ratelimit_metrics: no such file or directory" subsys=ratelimit-map
...
2025-05-06T10:17:38.575349928Z time="2025-05-06T10:17:38.575265248Z" level=info msg="Initializing daemon" source="/go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1546" subsys=daemon
```

-> daemon init starts after ratelimit metrics collection