### PR TITLE
cilium-cli: Migrate from `corev1.Endpoints` to `discoveryv1.EndpointSlice`

### DIFF
--- a/cilium-cli/install/autodetect.go
+++ b/cilium-cli/install/autodetect.go
@@ -146,24 +146,24 @@ func (k *K8sInstaller) autodetectKubeProxy(ctx context.Context, helmValues map[s
 		k.Log("ℹ️  Detecting real Kubernetes API server addr and port on Kind")
 
 		// When we are using Kind, the API server addr & port is port forwarded
-		eps, err := k.client.GetEndpoints(ctx, "default", "kubernetes", metav1.GetOptions{})
+		es, err := k.client.GetEndpointSlice(ctx, "default", "kubernetes", metav1.GetOptions{})
 		if err != nil {
 			k.Log("❌ Couldn't find 'kubernetes' service endpoint on Kind")
 			return fmt.Errorf("failed to detect API server endpoint")
 		}
 
-		if len(eps.Subsets) != 0 {
-			subset := eps.Subsets[0]
+		if len(es.Endpoints) != 0 {
+			endpoint := es.Endpoints[0]
 
-			if len(subset.Addresses) != 0 {
-				apiServerHost = subset.Addresses[0].IP
+			if len(endpoint.Addresses) != 0 {
+				apiServerHost = endpoint.Addresses[0]
 			} else {
 				k.Log("❌ Couldn't find endpoint address of the 'kubernetes' service endpoint on Kind")
 				return fmt.Errorf("failed to detect API server address")
 			}
 
-			if len(subset.Ports) != 0 {
-				apiServerPort = strconv.FormatInt(int64(subset.Ports[0].Port), 10)
+			if len(es.Ports) != 0 {
+				apiServerPort = strconv.FormatInt(int64(*es.Ports[0].Port), 10)
 			} else {
 				k.Log("❌ Couldn't find endpoint port of the 'kubernetes' service endpoint on Kind")
 				return fmt.Errorf("failed to detect API server address")

--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -17,6 +17,7 @@ import (
 	"helm.sh/helm/v3/pkg/getter"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -64,7 +65,7 @@ type k8sInstallerImplementation interface {
 	ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error)
 	GetDaemonSet(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error)
 	PatchDaemonSet(ctx context.Context, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*appsv1.DaemonSet, error)
-	GetEndpoints(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Endpoints, error)
+	GetEndpointSlice(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*discoveryv1.EndpointSlice, error)
 	AutodetectFlavor(ctx context.Context) k8s.Flavor
 	ContextName() (name string)
 	ClusterName() (name string)

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -228,8 +228,8 @@ func (c *Client) GetService(ctx context.Context, namespace, name string, opts me
 	return c.Clientset.CoreV1().Services(namespace).Get(ctx, name, opts)
 }
 
-func (c *Client) GetEndpoints(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Endpoints, error) {
-	return c.Clientset.CoreV1().Endpoints(namespace).Get(ctx, name, opts)
+func (c *Client) GetEndpointSlice(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*discoveryv1.EndpointSlice, error) {
+	return c.Clientset.DiscoveryV1().EndpointSlices(namespace).Get(ctx, name, opts)
 }
 
 func (c *Client) CreateDeployment(ctx context.Context, namespace string, deployment *appsv1.Deployment, opts metav1.CreateOptions) (*appsv1.Deployment, error) {


### PR DESCRIPTION
[`corev1.Endpoints`](https://pkg.go.dev/k8s.io/api/core/v1#Endpoints) is deprecated in v1.33+
[`discoveryv1.EndpointSlice`](https://pkg.go.dev/k8s.io/api/discovery/v1#EndpointSlice) is stable since v1.21

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
cilium-cli: Migrate from `corev1.Endpoints` to `discoveryv1.EndpointSlice`
```
