### PR TITLE
endpoint: move ep bpfprog watchdog from daemon to pkg/endpoint/watchdog

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -138,7 +138,6 @@ type Daemon struct {
 	bwManager datapath.BandwidthManager
 
 	wireguardAgent *wireguard.Agent
-	orchestrator   datapath.Orchestrator
 
 	lrpManager   *redirectpolicy.Manager
 	maglevConfig maglev.Config
@@ -323,7 +322,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		k8sSvcCache:       params.K8sSvcCache,
 		ipam:              params.IPAM,
 		wireguardAgent:    params.WGAgent,
-		orchestrator:      params.Orchestrator,
 		lrpManager:        params.LRPManager,
 		maglevConfig:      params.MaglevConfig,
 		lbConfig:          params.LBConfig,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1448,7 +1448,6 @@ var daemonCell = cell.Module(
 	cell.ProvidePrivate(daemonSettings),
 	cell.Invoke(registerEndpointStateResolver),
 	cell.Invoke(func(promise.Promise[*Daemon]) {}), // Force instantiation.
-	endpointBPFrogWatchdogCell,
 )
 
 type daemonParams struct {
@@ -1512,7 +1511,6 @@ type daemonParams struct {
 	IPAM                *ipam.IPAM
 	CRDSyncPromise      promise.Promise[k8sSynced.CRDSync]
 	IdentityManager     identitymanager.IDManager
-	Orchestrator        datapath.Orchestrator
 	LRPManager          *redirectpolicy.Manager
 	MaglevConfig        maglev.Config
 	LBConfig            loadbalancer.Config

--- a/pkg/endpoint/cell/cell.go
+++ b/pkg/endpoint/cell/cell.go
@@ -10,6 +10,7 @@ import (
 	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
 	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
 	endpointmetadata "github.com/cilium/cilium/pkg/endpoint/metadata"
+	"github.com/cilium/cilium/pkg/endpoint/watchdog"
 	"github.com/cilium/cilium/pkg/endpointcleanup"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 )
@@ -34,4 +35,7 @@ var Cell = cell.Group(
 
 	// RegeneratorCell provides extra options and utilities for endpoints regeneration.
 	endpoint.RegeneratorCell,
+
+	// Cell triggers a job to ensure device tc programs remain loaded.
+	watchdog.Cell,
 )


### PR DESCRIPTION
This commit moves the endpoint bpf program watchdag from the daemon to
`pkg/endpoint/watchdog`. The watchdog can directly depend on the Orchestrator.
By doing this we can get rid of the dependency to the `Daemon` struct.

Please review the individual commits.