### PR TITLE
hubble: move AssertProtoEqual helper to hubble testutils

### DIFF
--- a/pkg/hubble/exporter/config_test.go
+++ b/pkg/hubble/exporter/config_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/time"
-	"github.com/cilium/cilium/test/helpers"
 )
 
 func TestCompareFlowLogConfigs(t *testing.T) {
@@ -356,7 +356,7 @@ func TestYamlConfigFileUnmarshalling(t *testing.T) {
 	for _, expected := range expectedConfigs {
 		config, ok := configs[expected.Name].(*FlowLogConfig)
 		assert.True(t, ok, "parsed config should be of type FlowLogConfig")
-		helpers.AssertProtoEqual(t, &expected, config)
+		testutils.AssertProtoEqual(t, &expected, config)
 	}
 }
 

--- a/pkg/hubble/helpers_test.go
+++ b/pkg/hubble/helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
-	"github.com/cilium/cilium/test/helpers"
+	"github.com/cilium/cilium/pkg/hubble/testutils"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -67,7 +67,7 @@ func TestParseFlowFilters(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			helpers.AssertProtoEqual(t, tc.want, got)
+			testutils.AssertProtoEqual(t, tc.want, got)
 		})
 	}
 }

--- a/pkg/hubble/testutils/proto.go
+++ b/pkg/hubble/testutils/proto.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package helpers
+package testutils
 
 import (
 	"fmt"


### PR DESCRIPTION
This commit moves the `AssertProtoEqual` test helper out of the `test/helpers` package which otherwise contains the test helpers for Ginkgo-based tests. The existing `pkg/hubble/testutils` package seems like a more appropriate place for the helper. Also this reduces initial test build time for `pkg/hubble` from ~28s to ~15s on my machine.