### PR TITLE
gha/scale-egw: explicitly enable IPv4 masquerade

### DIFF
--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -162,6 +162,7 @@ jobs:
             --set=prometheus.enabled=true \
             --set=cluster.name=${{ env.cluster_name }} \
             ${{ matrix.test_type == 'egw' && env.EGRESS_GATEWAY_HELM_VALUES || '' }} \
+            --set=enableIPv4Masquerade=true \
             --set=bpf.masquerade=true \
             --set=kubeProxyReplacement=true \
             --set=l7Proxy=false \


### PR DESCRIPTION
10f87e67da4f modified the helm defaulting logic, disabling IPv4Masquerade by default when running in ENI mode (as we do in this workflow). However, egress gateway relies on masquerading being enabled (and performed via BPF). Hence, let's explicitly enable IPv4 masquerading.