### PR TITLE
helm: uniform hubble and clustermesh certgen job security posture

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -9,10 +9,18 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: certgen
           image: {{ include "cilium.image" .Values.certgen.image | quote }}
           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            allowPrivilegeEscalation: false
           {{- with .Values.certgen.resources }}
           resources:
           {{- toYaml . | nindent 10 }}
@@ -84,7 +92,7 @@ spec:
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-      hostNetwork: true
+      hostNetwork: false
       {{- with .Values.certgen.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
3790121f747a ("add securityContext for cronjob & disable hostNetwork") updated the hubble certgen job definition configuring a restrictive security context, and disabling host network. However, it missed updating the definition of the clustermesh one. Let's get that fixed, so that they are aligned.

<!-- Description of change -->

Fixes: #issue-number

```release-note
Add securityContext & disable hostNetwork in clustermesh-apiserver cronjob helm template
```
