### PR TITLE
bpf:nodeport:wireguard: encrypt LB traffic in XDP mode

### DIFF
--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -329,13 +329,13 @@ table are not subject to encryption with WireGuard and therefore assumed to be u
 | Client outside | remote Pod via    | KPR,                 | default         |
 | cluster        | Service           | overlay routing,     |                 |
 |                |                   | without DSR,         |                 |
-|                |                   | without XDP          |                 |
+|                |                   |                      |                 |
 +----------------+-------------------+----------------------+-----------------+
 | Client outside | remote Pod via    | native routing,      | node-to-node    |
-| cluster        | Service           | without XDP          |                 |
+| cluster        | Service           |                      |                 |
 +----------------+-------------------+----------------------+-----------------+
 | Client outside | remote Pod or     | DSR in Geneve mode,  | default         |
-| cluster        | remote Node via   | without XDP          |                 |
+| cluster        | remote Node via   |                      |                 |
 |                | Service           |                      |                 |
 +----------------+-------------------+----------------------+-----------------+
 | Pod            | remote Pod via L7 | L7 Proxy / Ingress   | default         |

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1225,6 +1225,15 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 	if (flags & XFER_PKT_SNAT_DONE)
 		ctx_snat_done_set(ctx);
 #endif
+
+# if (defined(HAVE_ENCAP) && defined(ENABLE_WIREGUARD)) || \
+	(!defined(HAVE_ENCAP) && defined(ENABLE_WIREGUARD) && defined(ENABLE_NODE_ENCRYPTION))
+	if (flags & XFER_PKT_TC_EGRESS) {
+		set_identity_mark(ctx, HOST_ID, is_defined(HAVE_ENCAP) && (flags & XFER_PKT_ENCAP) ?
+				  MARK_MAGIC_OVERLAY : MARK_MAGIC_HOST);
+		return ctx_redirect(ctx, THIS_INTERFACE_IFINDEX, 0);
+	}
+# endif
 #endif
 
 	if (!validate_ethertype(ctx, &proto)) {

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -744,12 +744,12 @@ ct_recreate6:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 
-		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, false, ext_err, &oif);
-		if (fib_ok(ret))
+		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, false, ext_err, &oif, false);
+		if (fib_ok(ret, false))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV6,
 					  *dst_sec_identity, TRACE_EP_ID_UNKNOWN, oif,
 					  trace.reason, trace.monitor, bpf_htons(ETH_P_IPV6));
-		return ret;
+		return bpf_exit(ctx, ret);
 	}
 
 	goto pass_to_stack;
@@ -1298,12 +1298,12 @@ skip_vtep:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 
-		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, false, ext_err, &oif);
-		if (fib_ok(ret))
+		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, false, ext_err, &oif, false);
+		if (fib_ok(ret, false))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV4,
 					  *dst_sec_identity, TRACE_EP_ID_UNKNOWN, oif,
 					  trace.reason, trace.monitor, bpf_htons(ETH_P_IP));
-		return ret;
+		return bpf_exit(ctx, ret);
 	}
 
 	goto pass_to_stack;

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -90,15 +90,6 @@ struct {
 #endif /* CIDR6_FILTER */
 #endif /* ENABLE_PREFILTER */
 
-static __always_inline __maybe_unused int
-bpf_xdp_exit(struct __ctx_buff *ctx, const int verdict)
-{
-	if (verdict == CTX_ACT_OK)
-		ctx_move_xfer(ctx);
-
-	return verdict;
-}
-
 #ifdef ENABLE_IPV4
 #ifdef ENABLE_NODEPORT_ACCELERATION
 __declare_tail(CILIUM_CALL_IPV4_FROM_NETDEV)
@@ -204,7 +195,7 @@ out:
 		return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
 						  METRIC_INGRESS);
 
-	return bpf_xdp_exit(ctx, ret);
+	return bpf_exit(ctx, ret);
 }
 
 static __always_inline int check_v4_lb(struct __ctx_buff *ctx)
@@ -279,7 +270,7 @@ int tail_lb_ipv6(struct __ctx_buff *ctx)
 			goto drop_err;
 	}
 
-	return bpf_xdp_exit(ctx, ret);
+	return bpf_exit(ctx, ret);
 
 drop_err:
 	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err, METRIC_INGRESS);
@@ -367,7 +358,7 @@ static __always_inline int check_filters(struct __ctx_buff *ctx)
 		break;
 	}
 
-	return bpf_xdp_exit(ctx, ret);
+	return bpf_exit(ctx, ret);
 }
 
 __section_entry

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -66,8 +66,9 @@
 /* XFER_FLAGS that get transferred from XDP to SKB */
 enum {
 	XFER_PKT_NO_SVC		= (1 << 0),  /* Skip upper service handling. */
-	XFER_UNUSED		= (1 << 1),
+	XFER_PKT_TC_EGRESS	= (1 << 1),  /* Packets needs TC egress hook. */
 	XFER_PKT_SNAT_DONE	= (1 << 2),  /* SNAT is done */
+	XFER_PKT_ENCAP		= (1 << 3),  /* Packets has been encapsulated. */
 };
 
 /* For use in ctx_get_xfer(), after XDP called ctx_move_xfer(). */

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -62,7 +62,7 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 	if (is_defined(IS_BPF_HOST) && oif == ctx_get_ifindex(ctx))
 		return CTX_ACT_OK;
 
-	return fib_do_redirect(ctx, true, &fib_params, false, ret, oif, ext_err);
+	return fib_do_redirect(ctx, true, &fib_params, false, ret, oif, ext_err, false);
 }
 
 # ifdef ENABLE_EGRESS_GATEWAY
@@ -417,7 +417,7 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 	if (is_defined(IS_BPF_HOST) && oif == ctx_get_ifindex(ctx))
 		return CTX_ACT_OK;
 
-	return fib_do_redirect(ctx, true, &fib_params, false, ret, oif, ext_err);
+	return fib_do_redirect(ctx, true, &fib_params, false, ret, oif, ext_err, false);
 }
 
 static __always_inline

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -336,3 +336,9 @@ ctx_set_encap_info6(struct __sk_buff *ctx, const union v6addr *tunnel_endpoint,
 	return CTX_ACT_REDIRECT;
 }
 #endif /* HAVE_ENCAP */
+
+static __always_inline __maybe_unused int
+bpf_exit(struct __ctx_buff *ctx __maybe_unused, const int verdict)
+{
+	return verdict;
+}

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -286,3 +286,12 @@ ctx_set_tunnel_opt(struct xdp_md *ctx, void *opt, __u32 opt_len)
 	return 0;
 }
 #endif /* HAVE_ENCAP */
+
+static __always_inline __maybe_unused int
+bpf_exit(struct __ctx_buff *ctx, const int verdict)
+{
+	if (verdict == CTX_ACT_OK)
+		ctx_move_xfer(ctx);
+
+	return verdict;
+}

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -82,7 +82,7 @@ int test1_check(struct __ctx_buff *ctx)
 
 		ret = fib_do_redirect(ctx, false, &params, true,
 				      BPF_FIB_LKUP_RET_SUCCESS,
-				      ifindex_good, &ext_err);
+				      ifindex_good, &ext_err, false);
 		if (ret != CTX_REDIRECT_ENTERED)
 			test_fatal("did not enter ctx_redirect");
 
@@ -114,7 +114,7 @@ int test1_check(struct __ctx_buff *ctx)
 
 		ret = fib_do_redirect(ctx, false, &params, true,
 				      BPF_FIB_LKUP_RET_NO_NEIGH,
-				      ifindex_good, &ext_err);
+				      ifindex_good, &ext_err, false);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 
@@ -151,7 +151,7 @@ int test1_check(struct __ctx_buff *ctx)
 
 		ret = fib_do_redirect(ctx, false, NULL, true,
 				      BPF_FIB_LKUP_RET_NO_NEIGH,
-				      ifindex_good, &ext_err);
+				      ifindex_good, &ext_err, false);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 

--- a/bpf/tests/session_affinity_maglev_test.c
+++ b/bpf/tests/session_affinity_maglev_test.c
@@ -213,7 +213,7 @@ check_packet(const struct __ctx_buff *ctx, int backend_id)
 
 	status_code = data;
 
-	assert(fib_ok(*status_code));
+	assert(fib_ok(*status_code, false));
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)

--- a/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
@@ -136,7 +136,7 @@ int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	assert(fib_ok(*status_code));
+	assert(fib_ok(*status_code, false));
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -280,7 +280,7 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	assert(fib_ok(*status_code));
+	assert(fib_ok(*status_code, false));
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
@@ -373,7 +373,7 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	assert(fib_ok(*status_code));
+	assert(fib_ok(*status_code, false));
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)

--- a/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
@@ -143,7 +143,7 @@ int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	assert(fib_ok(*status_code));
+	assert(fib_ok(*status_code, false));
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)


### PR DESCRIPTION
In TC, the to-netdev hook for Wireguard encrypts all overlay traffic, including all LB-to-remote-backend traffic we generate straight away in the nodeport codepath.
In XDP, we don't traverse egress program that would apply encryption policy, and we cannot redirect the packet to the TC to-netdev right away.

This commit adds the capability to encrypt this LB traffic when WireGuard and NodeEncryption are enabled. The proposed approach acts in the nodeport tailcalls: the backed is remote, and we operate right at the `fib_redirect` level. We do finish setup the packet in XDP, but we instead push it up to TC to run the egress hook, specifically to get the encryption feature.

The two flags introduced to do the XDP->TC redirection are as generic as possible and can be reused.

TODO: add tests.

Fixes: #38477.