### PR TITLE
cilium-cli:  Format TestNamespace based on TestConcurrency

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -329,7 +329,9 @@ func newConnectivityTests(
 	connTests := make([]*check.ConnectivityTest, 0, params.TestConcurrency)
 	for i := range params.TestConcurrency {
 		params := params
-		params.TestNamespace = fmt.Sprintf("%s-%d", params.TestNamespace, i+1)
+		if params.TestConcurrency > 1 {
+			params.TestNamespace = fmt.Sprintf("%s-%d", params.TestNamespace, i+1)
+		}
 		params.TestNamespaceIndex = i
 		if params.ExternalTargetCANamespace == "" {
 			params.ExternalTargetCANamespace = params.TestNamespace

--- a/cilium-cli/cli/connectivity_test.go
+++ b/cilium-cli/cli/connectivity_test.go
@@ -29,8 +29,8 @@ func TestNewConnectivityTests(t *testing.T) {
 				ExternalTargetCANamespace: "",
 			},
 			expectedCount:                     1,
-			expectedTestNamespaces:            []string{"cilium-test-1"},
-			expectedExternalTargetCANamespace: []string{"cilium-test-1"},
+			expectedTestNamespaces:            []string{"cilium-test"},
+			expectedExternalTargetCANamespace: []string{"cilium-test"},
 		},
 		{
 			params: check.Parameters{
@@ -39,7 +39,7 @@ func TestNewConnectivityTests(t *testing.T) {
 				ExternalTargetCANamespace: "cilium-test",
 			},
 			expectedCount:                     1,
-			expectedTestNamespaces:            []string{"cilium-test-1"},
+			expectedTestNamespaces:            []string{"cilium-test"},
 			expectedExternalTargetCANamespace: []string{"cilium-test"},
 		},
 		{
@@ -50,7 +50,7 @@ func TestNewConnectivityTests(t *testing.T) {
 				TestConcurrency:           -1,
 			},
 			expectedCount:                     1,
-			expectedTestNamespaces:            []string{"cilium-test-1"},
+			expectedTestNamespaces:            []string{"cilium-test"},
 			expectedExternalTargetCANamespace: []string{"cilium-test"},
 		},
 		{


### PR DESCRIPTION
Currently, we can't really run the cilium connectivity test to a target namespace, because we always add the index based on TestConcurrency. 

This PR will skip adding the index when the TestConcurrency is 1, so people can run the `cilium connectivity test --test-namespace cilium-test-abc` in `cilium-test-abc` NS not `cilium-test-abc-1` NS



```release-note
cilium connectivity test will not add suffix to test-namespace when the concurrency is 1.
```
