### PR TITLE
v1.17 Backports 2025-05-07

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -195,12 +195,17 @@ jobs:
             OWNER="${OWNER//[.\/]/-}"
           fi
 
+          # We explicity set the cluster-pool Pod CIDR here to not clash with the AKS default Service CIDRs
+          # which are 10.0.0.0/16 and fd12:3456:789a:1::/108
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set cluster.name=${{ env.name }} \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \
             --helm-set=azure.resourceGroup=${{ env.name }} \
-            --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16" # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)
+            --helm-set=ipv4.enabled=true \
+            --helm-set=ipv6.enabled=true \
+            --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16 \
+            --helm-set ipam.operator.clusterPoolIPv6PodCIDRList=fd00::/104"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled \
             --hubble=false --collect-sysdump-on-failure --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
@@ -229,6 +234,7 @@ jobs:
             --kubernetes-version ${{ matrix.version }} \
             --network-plugin none \
             --node-count 2 \
+            --ip-families ipv4,ipv6 \
             ${{ env.cost_reduction }} \
             --generate-ssh-keys
 

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -61,6 +61,7 @@ concurrency:
 env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  test_concurrency: 5
 
 jobs:
   echo-inputs:
@@ -289,9 +290,20 @@ jobs:
         run: |
           mkdir -p cilium-junits
 
-      - name: Run connectivity test (${{ join(matrix.*, ', ') }})
+      - name: Run sequential connectivity test (${{ join(matrix.*, ', ') }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --log-code-owners \
+          --test "seq-.*" \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
+          --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
+
+      - name: Run concurrent connectivity test (${{ join(matrix.*, ', ') }})
+        run: |
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --log-code-owners \
+          --test-concurrency=${{ env.test_concurrency }} \
+          --test "!seq-.*" \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
@@ -323,9 +335,18 @@ jobs:
         run: |
           cilium status --wait --interactive=false --wait-duration=10m
 
-      - name: Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})
+      - name: Run sequential connectivity test with IPSec (${{ join(matrix.*, ', ') }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --log-code-owners \
+          --test "seq-.*" \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 2.xml" \
+          --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
+
+      - name: Run concurrent connectivity test with IPSec (${{ join(matrix.*, ', ') }})
+        run: |
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --log-code-owners \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 2.xml" \
           --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
 

--- a/Documentation/installation/k8s-install-openshift-okd.rst
+++ b/Documentation/installation/k8s-install-openshift-okd.rst
@@ -10,12 +10,13 @@
 Installation on OpenShift OKD
 *****************************
 
-Cilium can be installed on OpenShift by using vendor maintained OLM images.
+There is currently no community-maintained installation of Cilium on OpenShift.
+However, Cilium can be installed on OpenShift by using vendor-maintained OLM images.
 These images, and the relevant installation instructions for them, can be
 found on the Red Hat Ecosystem Catalog:
 
-* `Cilium Software Page <https://catalog.redhat.com/software/container-stacks/detail/60423ec2c00b1279ffe35a68>`__
-* `Certified Cilium OLM container images <https://catalog.redhat.com/software/containers/search?gs&q=cilium%20olm>`__
+* `Isovalent Enterprise for Cilium Software Page <https://catalog.redhat.com/software/container-stacks/detail/61a80a18b1610a914eccb3c2>`__
+* `Certified Isovalent Enterprise for Cilium OLM container images <https://catalog.redhat.com/search?q=isovalent&searchType=containers&partnerName=Isovalent&p=1&product_listings_names=Isovalent%20Enterprise%20for%20Cilium>`__
 
 .. admonition:: Video
   :class: attention

--- a/Documentation/observability/visibility.rst
+++ b/Documentation/observability/visibility.rst
@@ -106,4 +106,4 @@ Limitations
 -----------
 
 * DNS visibility is available on egress only.
-* L7 policies for SNATed IPv6 traffic (e.g., pod-to-world) are `broken <https://github.com/cilium/cilium/issues/37932#issuecomment-2730287932>`__ and waiting for the `kernel fix <https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/>`__.
+* L7 policies for SNATed IPv6 traffic (e.g., pod-to-world) require a kernel with the `fix <https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/>`__ applied. The stable kernel versions with the fix are 6.14.1, 6.12.22, 6.6.86, 6.1.133, 5.15.180, 5.10.236, 5.4.292. See :gh-issue:`37932` for the reference.

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1031,8 +1031,8 @@ latter rule will have no effect.
           When Envoy is embedded in the agent pod, Layer 7 traffic targeted by policies
           will therefore depend on the availability of the Cilium agent pod.
 
-.. note:: L7 policies for SNATed IPv6 traffic (e.g., pod-to-world) are `broken <https://github.com/cilium/cilium/issues/37932#issuecomment-2730287932>`__
-          and waiting for the `kernel fix <https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/>`__.
+.. note:: L7 policies for SNATed IPv6 traffic (e.g., pod-to-world) require a kernel with the `fix <https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/>`__ applied.
+          The stable kernel versions with the fix are 6.14.1, 6.12.22, 6.6.86, 6.1.133, 5.15.180, 5.10.236, 5.4.292. See :gh-issue:`37932` for the reference.
 
 .. note:: :ref:`EnableDefaultDeny <policy_mode_default>` does not apply to layer-7 rules.
    If using a layer 7 rule in concert with ``EnableDefaultDeny``, the rule should

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -30,7 +30,7 @@ can talk to each other. Layer 3 policies can be specified using the following me
   the cluster.
 
 * `Node based`: This is an extension of ``remote-node`` entity. Optionally nodes
-   can have unique identity that can be used to allow/block access only from specific ones.
+  can have unique identity that can be used to allow/block access only from specific ones.
 
 * `CIDR based`: This is used to describe the relationship to or from external
   services if the remote peer is not an endpoint. This requires to hardcode either
@@ -44,7 +44,7 @@ can talk to each other. Layer 3 policies can be specified using the following me
 
 .. _Endpoints based:
 
-Endpoints Based
+Endpoints based
 ---------------
 
 Endpoints-based L3 policy is used to establish rules between endpoints inside
@@ -283,7 +283,7 @@ as an :ref:`endpoint selector <endpoints based>` within the policy.
 
 
 This example shows how to allow all endpoints with the label ``id=app2``
-to talk to all endpoints of kubernetes service ``myservice`` in kubernetes
+to talk to all endpoints of Kubernetes Service ``myservice`` in kubernetes
 namespace ``default`` as well as all services with label ``env=staging`` in
 namespace ``another-namespace``.
 
@@ -304,7 +304,7 @@ namespace ``another-namespace``.
 
 .. _Entities based:
 
-Entities Based
+Entities based
 --------------
 
 ``fromEntities`` is used to describe the entities that can access the selected
@@ -655,7 +655,7 @@ IPs to be allowed are selected via:
 
 The example below allows all DNS traffic on port 53 to the DNS service and
 intercepts it via the `DNS Proxy`_. If using a non-standard DNS port for
-a DNS application behind a Kubernetes service, the port must match the backend
+a DNS application behind a Kubernetes Service, the port must match the backend
 port. When the application makes a request for my-remote-service.com, Cilium
 learns the IP address and will allow traffic due to the match on the name under
 the ``toFQDNs.matchName`` rule.

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -88,7 +88,7 @@ v4_prefix_secondary="192.168.0.0/16"
 v4_range_secondary="192.168.0.0/24"
 v6_prefix="fc00:c111::/64"
 v6_prefix_secondary="fc00:c112::/64"
-CILIUM_ROOT="$(git rev-parse --show-toplevel)"
+CILIUM_ROOT="$(realpath $(dirname ${BASH_SOURCE[0]:-$0})/../..)"
 
 have_kind() {
     [[ -n "$(command -v kind)" ]]

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -89,9 +89,11 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	tlsRouteList := &gatewayv1alpha2.TLSRouteList{}
-	if err := r.Client.List(ctx, tlsRouteList); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to list TLSRoutes", logfields.Error, err)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	if helpers.HasTLSRouteSupport(r.Client.Scheme()) {
+		if err := r.Client.List(ctx, tlsRouteList); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list TLSRoutes", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
 	}
 
 	// TODO(tam): Only list the services / ServiceImports used by accepted Routes

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -279,6 +279,11 @@ func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *
 
 func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routeNamespace string, refs []gatewayv1.ParentReference) bool {
 	for _, ref := range refs {
+		// Check if the parentRef is a Gateway before checking name and namespace
+		if !helpers.IsGateway(ref) {
+			continue
+		}
+
 		if string(ref.Name) == gw.GetName() && gw.GetNamespace() == helpers.NamespaceDerefOr(ref.Namespace, routeNamespace) {
 			if ref.SectionName == nil && ref.Port == nil {
 				return true

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -785,6 +785,20 @@ func Test_sectionNameMatched(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "GAMMA Service with same name as Gateway should not match",
+			args: args{
+				listener: httpListener,
+				refs: []gatewayv1.ParentReference{
+					{
+						Kind:  (*gatewayv1.Kind)(ptr.To("Service")),
+						Group: (*gatewayv1.Group)(ptr.To("")),
+						Name:  "valid-gateway",
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/operator/pkg/gateway-api/helpers/serviceimport.go
+++ b/operator/pkg/gateway-api/helpers/serviceimport.go
@@ -12,11 +12,11 @@ import (
 )
 
 // HasServiceImportSupport return if the ServiceImport CRD is supported.
-// This checks if the MCS API group is registered in the client scheme
+// This checks if the MCS API group ServiceImport CRD is registered in the client scheme
 // and it is expected that it is registered only if the ServiceImport
 // CRD has been installed prior to the client setup.
 func HasServiceImportSupport(scheme *runtime.Scheme) bool {
-	return scheme.IsGroupRegistered(mcsapiv1alpha1.GroupVersion.Group)
+	return scheme.Recognizes(mcsapiv1alpha1.SchemeGroupVersion.WithKind("ServiceImport"))
 }
 
 func GetServiceName(svcImport *mcsapiv1alpha1.ServiceImport) (string, error) {

--- a/operator/pkg/gateway-api/helpers/tlsroute.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// HasTLSRouteSupport returns if the TLSRoute CRD is supported.
+// This checks if the Gateway API v1alpha2 group is registered in the client scheme
+// and it is expected that it is registered only if the TLSRoute
+// CRD has been installed prior to the client setup.
+func HasTLSRouteSupport(scheme *runtime.Scheme) bool {
+	return scheme.IsGroupRegistered(gatewayv1alpha2.GroupVersion.Group)
+}

--- a/operator/pkg/gateway-api/helpers/tlsroute.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute.go
@@ -9,9 +9,9 @@ import (
 )
 
 // HasTLSRouteSupport returns if the TLSRoute CRD is supported.
-// This checks if the Gateway API v1alpha2 group is registered in the client scheme
+// This checks if the Gateway API v1alpha2 TLSRoute CRD is registered in the client scheme
 // and it is expected that it is registered only if the TLSRoute
 // CRD has been installed prior to the client setup.
 func HasTLSRouteSupport(scheme *runtime.Scheme) bool {
-	return scheme.IsGroupRegistered(gatewayv1alpha2.GroupVersion.Group)
+	return scheme.Recognizes(gatewayv1alpha2.SchemeGroupVersion.WithKind("TLSRoute"))
 }

--- a/operator/pkg/gateway-api/helpers/tlsroute_test.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestHasTLSRouteSupport(t *testing.T) {
+	// Create a scheme without TLSRoute registered
+	scheme := runtime.NewScheme()
+	assert.False(t, HasTLSRouteSupport(scheme))
+
+	// Register the TLSRoute group
+	err := gatewayv1alpha2.AddToScheme(scheme)
+	assert.NoError(t, err)
+	assert.True(t, HasTLSRouteSupport(scheme))
+}

--- a/operator/pkg/gateway-api/helpers/tlsroute_test.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute_test.go
@@ -12,12 +12,15 @@ import (
 )
 
 func TestHasTLSRouteSupport(t *testing.T) {
-	// Create a scheme without TLSRoute registered
-	scheme := runtime.NewScheme()
-	assert.False(t, HasTLSRouteSupport(scheme))
+	scheme1 := runtime.NewScheme()
+	assert.False(t, HasTLSRouteSupport(scheme1), "Should be false when group is not registered")
 
-	// Register the TLSRoute group
-	err := gatewayv1alpha2.AddToScheme(scheme)
+	scheme2 := runtime.NewScheme()
+	scheme2.AddKnownTypes(gatewayv1alpha2.SchemeGroupVersion, &gatewayv1alpha2.TCPRoute{})
+	assert.False(t, HasTLSRouteSupport(scheme2), "Should be false when group is registered but TLSRoute kind is not")
+
+	scheme3 := runtime.NewScheme()
+	err := gatewayv1alpha2.AddToScheme(scheme3)
 	assert.NoError(t, err)
-	assert.True(t, HasTLSRouteSupport(scheme))
+	assert.True(t, HasTLSRouteSupport(scheme3), "Should be true when TLSRoute kind is registered")
 }


### PR DESCRIPTION
 * [ ] ~#36398 (@dylandreimerink).~ This is not required as v1.17 already has the change.
 * [x] #37704 (@gandro) :warning: resolved conflicts
 * [x] #38874 (@syedazeez337)
 * [x] #39122 (@liyihuang)
 * [ ] #39065 (@mikejoh)
 * [ ] #39212 (@gentoo-root)
 * [x] #39154 (@joestringer)
 * [ ] #38886 (@auriaave)
 * [x] #39275 (@syedazeez337) assigned to the reviewer @youngnick 

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 36398 37704 38874 39122 39065 39212 39154 38886 39275
```
