### PR TITLE
option: use `netip.Prefix` for `DaemonConfig.ExcludeLocalAddresses`

### DIFF
--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -143,14 +143,13 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 		if addr.DeviceName == tables.WildcardDeviceName {
 			continue
 		}
-		ip := addr.Addr.AsSlice()
 		if (!option.Config.EnableIPv4 && addr.Addr.Is4()) || (!option.Config.EnableIPv6 && addr.Addr.Is6()) {
 			continue
 		}
-		if option.Config.IsExcludedLocalAddress(ip) {
+		if option.Config.IsExcludedLocalAddress(addr.Addr) {
 			continue
 		}
-		addIdentity(ip, nil, identity.ReservedIdentityHost, labels.LabelHost)
+		addIdentity(addr.Addr.AsSlice(), nil, identity.ReservedIdentityHost, labels.LabelHost)
 	}
 
 	if option.Config.EnableIPv6 {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1886,7 +1886,7 @@ type DaemonConfig struct {
 
 	// ExcludeLocalAddresses excludes certain addresses to be recognized as
 	// a local address
-	ExcludeLocalAddresses []*net.IPNet
+	ExcludeLocalAddresses []netip.Prefix
 
 	// IPv4PodSubnets available subnets to be assign IPv4 addresses to pods from
 	IPv4PodSubnets []*net.IPNet
@@ -2206,13 +2206,12 @@ var (
 
 // IsExcludedLocalAddress returns true if the specified IP matches one of the
 // excluded local IP ranges
-func (c *DaemonConfig) IsExcludedLocalAddress(ip net.IP) bool {
-	for _, ipnet := range c.ExcludeLocalAddresses {
-		if ipnet.Contains(ip) {
+func (c *DaemonConfig) IsExcludedLocalAddress(addr netip.Addr) bool {
+	for _, prefix := range c.ExcludeLocalAddresses {
+		if prefix.Contains(addr) {
 			return true
 		}
 	}
-
 	return false
 }
 
@@ -2679,14 +2678,12 @@ func ReplaceDeprecatedFields(m map[string]any) {
 
 func (c *DaemonConfig) parseExcludedLocalAddresses(s []string) error {
 	for _, ipString := range s {
-		_, ipnet, err := net.ParseCIDR(ipString)
+		prefix, err := netip.ParsePrefix(ipString)
 		if err != nil {
 			return fmt.Errorf("unable to parse excluded local address %s: %w", ipString, err)
 		}
-
-		c.ExcludeLocalAddresses = append(c.ExcludeLocalAddresses, ipnet)
+		c.ExcludeLocalAddresses = append(c.ExcludeLocalAddresses, prefix)
 	}
-
 	return nil
 }
 

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -5,7 +5,7 @@ package option
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"testing"
@@ -252,11 +252,11 @@ func TestLocalAddressExclusion(t *testing.T) {
 	err := d.parseExcludedLocalAddresses([]string{"1.1.1.1/32", "3.3.3.0/24", "f00d::1/128"})
 	require.NoError(t, err)
 
-	require.True(t, d.IsExcludedLocalAddress(net.ParseIP("1.1.1.1")))
-	require.False(t, d.IsExcludedLocalAddress(net.ParseIP("1.1.1.2")))
-	require.True(t, d.IsExcludedLocalAddress(net.ParseIP("3.3.3.1")))
-	require.True(t, d.IsExcludedLocalAddress(net.ParseIP("f00d::1")))
-	require.False(t, d.IsExcludedLocalAddress(net.ParseIP("f00d::2")))
+	require.True(t, d.IsExcludedLocalAddress(netip.MustParseAddr("1.1.1.1")))
+	require.False(t, d.IsExcludedLocalAddress(netip.MustParseAddr("1.1.1.2")))
+	require.True(t, d.IsExcludedLocalAddress(netip.MustParseAddr("3.3.3.1")))
+	require.True(t, d.IsExcludedLocalAddress(netip.MustParseAddr("f00d::1")))
+	require.False(t, d.IsExcludedLocalAddress(netip.MustParseAddr("f00d::2")))
 }
 
 func TestCheckMapSizeLimits(t *testing.T) {


### PR DESCRIPTION
Convert `DaemonConfig.ExcludeLocalAddresses` to `[]netip.Prefix` which also simplifies `(*DaemonConfig).IsExcludedLocalAddress` and doesn't require the single caller to convert from `netip.Addr` to `net.IP` first.

For https://github.com/cilium/cilium/issues/24246