### PR TITLE
Optimizations for IPv6 fragments

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -149,12 +149,8 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 	int l4_off;
 	int ret;
 
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
-
 	tuple.nexthdr = ip6->nexthdr;
-	ret = ipv6_hdrlen(ctx, &tuple.nexthdr);
+	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -431,15 +431,11 @@ ipv6_extract_tuple(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple)
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
-
 	tuple->nexthdr = ip6->nexthdr;
 	ipv6_addr_copy(&tuple->daddr, (union v6addr *)&ip6->daddr);
 	ipv6_addr_copy(&tuple->saddr, (union v6addr *)&ip6->saddr);
 
-	ret = ipv6_hdrlen(ctx, &tuple->nexthdr);
+	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple->nexthdr, &fraginfo);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -353,12 +353,8 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 	if (!info || !info->flag_has_tunnel_ep)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
-
 	tuple.nexthdr = ip6->nexthdr;
-	ret = ipv6_hdrlen(ctx, &tuple.nexthdr);
+	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
 	if (ret < 0)
 		return ret;
 
@@ -880,12 +876,8 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, enum ct_dir dir,
 		goto fib_lookup;
 #endif
 
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
-
 	tuple.nexthdr = ip6->nexthdr;
-	ret = ipv6_hdrlen(ctx, &tuple.nexthdr);
+	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
 	if (ret < 0)
 		return ret;
 
@@ -1164,12 +1156,8 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
-
 	tuple.nexthdr = ip6->nexthdr;
-	ret = ipv6_hdrlen(ctx, &tuple.nexthdr);
+	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
 	if (ret < 0)
 		return ret;
 
@@ -1416,12 +1404,8 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 
 	cilium_capture_in(ctx);
 
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
-
 	tuple.nexthdr = ip6->nexthdr;
-	ret = ipv6_hdrlen(ctx, &tuple.nexthdr);
+	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -67,12 +67,8 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
-
 	tuple.nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
 	if (hdrlen < 0)
 		return hdrlen;
 
@@ -169,12 +165,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, bool *snat_done,
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
-
 	tuple.nexthdr = ip6->nexthdr;
-	ret = ipv6_hdrlen(ctx, &tuple.nexthdr);
+	ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/tests/ipfrag.c
+++ b/bpf/tests/ipfrag.c
@@ -123,7 +123,8 @@ int test_ipfrag_helpers_ipv6_nofrag_check(struct __ctx_buff *ctx __maybe_unused)
 	void *data, *data_end;
 	struct ethhdr *l2;
 	struct ipv6hdr *l3;
-	fraginfo_t fraginfo;
+	fraginfo_t fraginfo, fraginfo2;
+	__u8 nexthdr;
 
 	test_init();
 
@@ -144,6 +145,12 @@ int test_ipfrag_helpers_ipv6_nofrag_check(struct __ctx_buff *ctx __maybe_unused)
 		test_fatal("ipv6_get_fraginfo failed");
 	assert(!ipfrag_is_fragment(fraginfo));
 	assert(ipfrag_has_l4_header(fraginfo));
+
+	/* ipv6_hdrlen_with_fraginfo should return the same fraginfo. */
+	nexthdr = l3->nexthdr;
+	if (ipv6_hdrlen_with_fraginfo(ctx, &nexthdr, &fraginfo2) < 0)
+		test_fatal("ipv6_hdrlen_with_fraginfo failed");
+	assert(fraginfo == fraginfo2);
 
 	test_finish();
 }
@@ -205,7 +212,8 @@ int test_ipfrag_helpers_ipv6_check(struct __ctx_buff *ctx __maybe_unused)
 	struct ethhdr *l2;
 	struct ipv6hdr *l3;
 	struct ipv6_frag_hdr *fraghdr;
-	fraginfo_t fraginfo;
+	fraginfo_t fraginfo, fraginfo2;
+	__u8 nexthdr;
 
 	test_init();
 
@@ -233,6 +241,12 @@ int test_ipfrag_helpers_ipv6_check(struct __ctx_buff *ctx __maybe_unused)
 	assert(ipfrag_get_protocol(fraginfo) == IPPROTO_UDP);
 	assert(ipfrag_get_id(fraginfo) == (__be32)(0x12345678));
 
+	/* ipv6_hdrlen_with_fraginfo should return the same fraginfo. */
+	nexthdr = l3->nexthdr;
+	if (ipv6_hdrlen_with_fraginfo(ctx, &nexthdr, &fraginfo2) < 0)
+		test_fatal("ipv6_hdrlen_with_fraginfo failed");
+	assert(fraginfo == fraginfo2);
+
 	/* Non-first fragment */
 	fraghdr->frag_off = bpf_htons((0x100 << 3) | 1);
 	fraginfo = ipv6_get_fraginfo(ctx, l3);
@@ -243,6 +257,12 @@ int test_ipfrag_helpers_ipv6_check(struct __ctx_buff *ctx __maybe_unused)
 	assert(ipfrag_get_protocol(fraginfo) == IPPROTO_UDP);
 	assert(ipfrag_get_id(fraginfo) == (__be32)(0x12345678));
 
+	/* ipv6_hdrlen_with_fraginfo should return the same fraginfo. */
+	nexthdr = l3->nexthdr;
+	if (ipv6_hdrlen_with_fraginfo(ctx, &nexthdr, &fraginfo2) < 0)
+		test_fatal("ipv6_hdrlen_with_fraginfo failed");
+	assert(fraginfo == fraginfo2);
+
 	/* Last fragment */
 	fraghdr->frag_off = bpf_htons(0x200 << 3);
 	fraginfo = ipv6_get_fraginfo(ctx, l3);
@@ -252,6 +272,12 @@ int test_ipfrag_helpers_ipv6_check(struct __ctx_buff *ctx __maybe_unused)
 	assert(!ipfrag_has_l4_header(fraginfo));
 	assert(ipfrag_get_protocol(fraginfo) == IPPROTO_UDP);
 	assert(ipfrag_get_id(fraginfo) == (__be32)(0x12345678));
+
+	/* ipv6_hdrlen_with_fraginfo should return the same fraginfo. */
+	nexthdr = l3->nexthdr;
+	if (ipv6_hdrlen_with_fraginfo(ctx, &nexthdr, &fraginfo2) < 0)
+		test_fatal("ipv6_hdrlen_with_fraginfo failed");
+	assert(fraginfo == fraginfo2);
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -267,10 +267,12 @@ int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 
 	struct ipv4_ct_tuple tuple;
 	struct ct_entry *ct_entry;
-	int l4_off, ret;
+	int l3_off, l4_off, ret;
 
-	ret = lb4_extract_tuple(ctx, l3, sizeof(*status_code) + ETH_HLEN,
-				ipfrag_encode_ipv4(l3), &l4_off, &tuple);
+	l3_off = sizeof(*status_code) + ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(l3);
+
+	ret = lb4_extract_tuple(ctx, l3, ipfrag_encode_ipv4(l3), l4_off, &tuple);
 	assert(!IS_ERR(ret));
 
 	tuple.flags = TUPLE_F_IN;
@@ -542,10 +544,12 @@ int nodeport_dsr_backend_redirect_check(struct __ctx_buff *ctx)
 
 	struct ipv4_ct_tuple tuple;
 	struct ct_entry *ct_entry;
-	int l4_off, ret;
+	int l3_off, l4_off, ret;
 
-	ret = lb4_extract_tuple(ctx, l3, sizeof(*status_code) + ETH_HLEN,
-				ipfrag_encode_ipv4(l3), &l4_off, &tuple);
+	l3_off = sizeof(*status_code) + ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(l3);
+
+	ret = lb4_extract_tuple(ctx, l3, ipfrag_encode_ipv4(l3), l4_off, &tuple);
 	assert(!IS_ERR(ret));
 
 	tuple.flags = TUPLE_F_IN;


### PR DESCRIPTION
IPv6 fragments were implemented in https://github.com/cilium/cilium/pull/38110. Follow-up with some optimizations, aimed to reduce the verification complexity.

```release-note
Optimize the implementation of IPv6 fragments.
```
