### PR TITLE
,github/workflows: remove duplicate yaml keys

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -267,12 +267,11 @@ jobs:
 
   build-commits-bpf:
     # Skip running workflow on forks using variable Kill Switch
-    if: always() && vars.ENABLE_CILIUM_CI == 'true'
+    if: always() && needs.compute-vars.outputs.build-bpf == 'true' && vars.ENABLE_CILIUM_CI == 'true'
     name: Check if bpf builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     # Runs only if code under bpf/ is changed.
-    if: needs.compute-vars.outputs.build-bpf == 'true'
     timeout-minutes: 180
     steps:
       - name: Collect Workflow Telemetry
@@ -362,12 +361,11 @@ jobs:
 
   build-commits-test:
     # Skip running workflow on forks using variable Kill Switch
-    if: always() && vars.ENABLE_CILIUM_CI == 'true'
+    if: always() && needs.compute-vars.outputs.build-test == 'true' && vars.ENABLE_CILIUM_CI == 'true'
     name: Check if test builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     # Runs only if code under test/ is changed.
-    if: needs.compute-vars.outputs.build-test == 'true'
     timeout-minutes: 180
     steps:
       - name: Collect Workflow Telemetry


### PR DESCRIPTION
Having duplicate yaml keys broke running those workflows.

Fixes: a4b295c7cb57 ("ci/workflows: disable github workflows on forks using GH variable kill switch")