### PR TITLE
Fix alignment of TraceSockNotify messages

### DIFF
--- a/bpf/lib/trace_sock.h
+++ b/bpf/lib/trace_sock.h
@@ -61,6 +61,7 @@ struct trace_sock_notify {
 	__u8 l4_proto;
 	__u8 ipv6 : 1;
 	__u8 pad : 7;
+	__u16 pad2; 
 } __packed;
 
 #ifdef TRACE_SOCK_NOTIFY

--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -32,24 +32,25 @@ const (
 const TraceSockNotifyFlagIPv6 uint8 = 0x1
 
 const (
-	TraceSockNotifyLen = 38
+	TraceSockNotifyLen = 40
 )
 
 // TraceSockNotify is message format for socket trace notifications sent from datapath.
 // Keep this in sync to the datapath structure (trace_sock_notify) defined in
 // bpf/lib/trace_sock.h
 type TraceSockNotify struct {
-	Type       uint8
-	XlatePoint uint8
-	DstIP      types.IPv6
-	DstPort    uint16
-	SockCookie uint64
-	CgroupId   uint64
-	L4Proto    uint8
-	Flags      uint8
+	Type       uint8      // 1 byte
+	XlatePoint uint8      // 1 byte
+	DstIP      types.IPv6 // 16 bytes
+	DstPort    uint16     // 2 bytes
+	L4Proto    uint8      // 1 byte
+	Flags      uint8      // 1 byte
+	_          [2]byte    // 2 bytes (explicit padding to avoid automatic padding)
+	SockCookie uint64     // 8 bytes
+	CgroupId   uint64     // 8 bytes
 }
 
-// DecodeTraceSockNotify will decode 'data' into the provided TraceSocNotify structure
+// DecodeTraceSockNotify will decode 'data' into the provided TraceSockNotify structure
 func DecodeTraceSockNotify(data []byte, sock *TraceSockNotify) error {
 	return sock.decodeTraceSockNotify(data)
 }
@@ -63,10 +64,10 @@ func (t *TraceSockNotify) decodeTraceSockNotify(data []byte) error {
 	t.XlatePoint = data[1]
 	copy(t.DstIP[:], data[2:18])
 	t.DstPort = byteorder.Native.Uint16(data[18:20])
-	t.SockCookie = byteorder.Native.Uint64(data[20:28])
-	t.CgroupId = byteorder.Native.Uint64(data[28:36])
-	t.L4Proto = data[36]
-	t.Flags = data[37]
+	t.L4Proto = data[20]
+	t.Flags = data[21]
+	t.SockCookie = byteorder.Native.Uint64(data[24:32])
+	t.CgroupId = byteorder.Native.Uint64(data[32:40])
 
 	return nil
 }

--- a/pkg/monitor/datapath_sock_trace_test.go
+++ b/pkg/monitor/datapath_sock_trace_test.go
@@ -17,7 +17,7 @@ import (
 func TestDecodeTraceSockNotify(t *testing.T) {
 	// This check on the struct length constant is there to ensure that this
 	// test is updated when the struct changes.
-	require.Equal(t, 38, TraceSockNotifyLen)
+	require.Equal(t, 40, TraceSockNotifyLen)
 
 	input := TraceSockNotify{
 		Type:       0x00,


### PR DESCRIPTION
Fixes: #38642 
![image](https://github.com/user-attachments/assets/039c9826-ecd1-4e82-ae77-f26329f07c7c)
Understanding the present memory of Go TraceSockNotify struct
```
type TraceSockNotify struct {
    Type       uint8     // 1 byte
    XlatePoint uint8     // 1 byte
    DstIP      types.IPv6 // 16 bytes (array of 16 bytes)
    DstPort    uint16    // 2 bytes
    SockCookie uint64    // 8 bytes
    CgroupId   uint64    // 8 bytes
    L4Proto    uint8     // 1 byte
    Flags      uint8     // 1 byte
}
```
Go’s memory layout adds padding to ensure fields are aligned to their type’s alignment requirements (example., uint64 fields align to 8 bytes).
The layout representation it could follow:

- Offset 0: Type (1 byte)
- Offset 1: XlatePoint (1 byte)
- Offset 2–17: DstIP (16 bytes, aligned to 1-byte boundary)
- Offset 18–19: DstPort (2 bytes)
- Offset 20–23: Padding (4 bytes to align SockCookie to 8-byte boundary)
- Offset 24–31: SockCookie (8 bytes)
- Offset 32–39: CgroupId (8 bytes)
- Offset 40: L4Proto (1 byte)
- Offset 41: Flags (1 byte)
- Offset 42–47: Padding (6 bytes to align the struct to the largest field’s alignment, which is 8 bytes for uint64)

`Total: 1 + 1 + 16 + 2 + 4 (padding) + 8 + 8 + 1 + 1 + 6 (padding) = 48 bytes`

**Solution**: **Reordered the fields and adding explicit padding to avoid automatic alignment.**
```
type TraceSockNotify struct {
    Type       uint8     // 1 byte
    XlatePoint uint8     // 1 byte
    DstIP      types.IPv6 // 16 bytes
    DstPort    uint16    // 2 bytes
    L4Proto    uint8     // 1 byte
    Flags      uint8     // 1 byte
    SockCookie uint64    // 8 bytes
    CgroupId   uint64    // 8 bytes
}
```
Reordered fields still had issue of implict adding of 2 bytes in between Flags and SockCookie due to non 8-byte boundary 

Why did I add the padding of 2 bytes?
The Go struct is subject to Go's alignment rules, where fields are aligned to their type’s natural alignment (example uint64 fields align to 8-byte boundaries)
If we see the layout representation it could follow:

- Offset 0: Type (uint8, 1 byte)
- Offset 1: XlatePoint (uint8, 1 byte)
- Offset 2–17: DstIP (types.IPv6, 16 bytes, aligned to 1-byte boundary)
- Offset 18–19: DstPort (uint16, 2 bytes)
- Offset 20: L4Proto (uint8, 1 byte)
- Offset 21: Flags (uint8, 1 byte)
- Offset 22–23: Padding (2 bytes to align SockCookie to an 8-byte boundary) 
- Offset 24–31: SockCookie (uint64, 8 bytes) //To make SockCookie offset make a multiple of 8
- Offset 32–39: CgroupId (uint64, 8 bytes)

`Total: 1 + 1 + 16 + 2 + 1 + 1 + 2 (padding) + 8 + 8 = 40 bytes`

The 2 bytes of padding are inserted before SockCookie because after Flags (offset 21), the next field (SockCookie, a uint64) requires 8-byte alignment.
The current offset (22) is not a multiple of 8, so Go adds 2 bytes of padding to move to offset 24.
