### PR TITLE
[v1.17] l4lb: Support environments with existing veth

### DIFF
--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -118,8 +118,10 @@ function initialize_docker_env {
     # the forwarded packets by the LB to the worker node will have invalid csums.
     IFIDX=$(docker exec -i lb-node \
         /bin/sh -c 'echo $(( $(ip -o l show eth0 | awk "{print $1}" | cut -d: -f1) ))')
-    LB_VETH_HOST=$(ip -o l | grep "if$IFIDX" | awk '{print $2}' | cut -d@ -f1)
-    ethtool -K "$LB_VETH_HOST" rx off tx off
+    LB_VETH_HOSTS=$(ip -o l | grep "if$IFIDX" | awk '{print $2}' | cut -d@ -f1)
+    for veth in $LB_VETH_HOSTS; do
+        ethtool -K "$veth" rx off tx off
+    done
 }
 
 function force_cleanup {


### PR DESCRIPTION
GitHub environments recently started locating multiple virtual ethernet
devices as part of this lookup command, which causes the test to fail
with:

    +[21:48:53] LB_VETH_HOST='vethc63b890
    veth9368ee0'
    +[21:48:53] ip l set dev vethc63b890 veth9368ee0 xdp obj bpf_xdp_veth_host.o
    Error: either "dev" is duplicate, or "veth9368ee0" is a garbage.
    Error: Process completed with exit code 255.

Fix it by iterating through the veths.

Related: https://github.com/cilium/cilium/issues/39407