### PR TITLE
[v1.15] l4lb: Support environments with existing veth

### DIFF
--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -75,13 +75,17 @@ docker exec -t lb-node \
 
 IFIDX=$(docker exec -i lb-node \
     /bin/sh -c 'echo $(( $(ip -o l show eth0 | awk "{print $1}" | cut -d: -f1) ))')
-LB_VETH_HOST=$(ip -o l | grep "if$IFIDX" | awk '{print $2}' | cut -d@ -f1)
-ip l set dev $LB_VETH_HOST xdp obj bpf_xdp_veth_host.o
+LB_VETH_HOSTS=$(ip -o l | grep "if$IFIDX" | awk '{print $2}' | cut -d@ -f1)
+for veth in $LB_VETH_HOSTS; do
+    ip l set dev $veth xdp obj bpf_xdp_veth_host.o
+done
 ip l set dev l4lb-veth0 xdp obj bpf_xdp_veth_host.o
 
 # Disable TX and RX csum offloading, as veth does not support it. Otherwise,
 # the forwarded packets by the LB to the worker node will have invalid csums.
-ethtool -K $LB_VETH_HOST rx off tx off
+for veth in $LB_VETH_HOSTS; do
+    ethtool -K $veth rx off tx off
+done
 ethtool -K l4lb-veth0 rx off tx off
 
 NGINX_PID=$(docker inspect nginx -f '{{ .State.Pid }}')

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -52,8 +52,10 @@ cilium_install \
 # the forwarded packets by the LB to the worker node will have invalid csums.
 IFIDX=$(docker exec -i lb-node \
     /bin/sh -c 'echo $(( $(ip -o l show eth0 | awk "{print $1}" | cut -d: -f1) ))')
-LB_VETH_HOST=$(ip -o l | grep "if$IFIDX" | awk '{print $2}' | cut -d@ -f1)
-ethtool -K $LB_VETH_HOST rx off tx off
+LB_VETH_HOSTS=$(ip -o l | grep "if$IFIDX" | awk '{print $2}' | cut -d@ -f1)
+for veth in $LB_VETH_HOSTS; do
+    ethtool -K "$veth" rx off tx off
+done
 
 NGINX_PID=$(docker inspect nginx -f '{{ .State.Pid }}')
 WORKER_IP4=$(nsenter -t $NGINX_PID -n ip -o -4 a s eth0 | awk '{print $4}' | cut -d/ -f1 | head -n1)


### PR DESCRIPTION
GitHub environments recently started locating multiple virtual ethernet
devices as part of this lookup command, which causes the test to fail
with:

    +[21:48:53] LB_VETH_HOST='vethc63b890
    veth9368ee0'
    +[21:48:53] ip l set dev vethc63b890 veth9368ee0 xdp obj bpf_xdp_veth_host.o
    Error: either "dev" is duplicate, or "veth9368ee0" is a garbage.
    Error: Process completed with exit code 255.

Fix it by iterating through the veths.

Related: https://github.com/cilium/cilium/pull/39407