### PR TITLE
bpf: test: fix up mis-spelled HAVE_NETNS_COOKIE

### DIFF
--- a/bpf/tests/wildcard_lookup.c
+++ b/bpf/tests/wildcard_lookup.c
@@ -17,7 +17,7 @@
 
 #define ENABLE_NODEPORT 1
 
-#define BPF_HAVE_NETNS_COOKIE 1
+#define HAVE_NETNS_COOKIE 1
 
 /* Hardcode the host netns cookie to 0 */
 #define HOST_NETNS_COOKIE 0


### PR DESCRIPTION
The BPF_HAVE_NETNS_COOKIE macro doesn't exist in-tree, use the correct spelling.

Looks like the PR that introduced this test conflicted with the renaming in 17a652b7356c ("probes: remove 'BPF_' prefix from features macros").