### PR TITLE
gh: scale-egw: run with L7 proxy enabled

### DIFF
--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -170,7 +170,6 @@ jobs:
             --set=enableIPv4Masquerade=true \
             --set=bpf.masquerade=true \
             --set=kubeProxyReplacement=true \
-            --set=l7Proxy=false \
             --set=egressMasqueradeInterfaces="" \
             --set=eni.enabled=true \
             --set=ipam.mode=eni \


### PR DESCRIPTION
The incompatibility between EGW and L7 network policies was resolved in the v1.16 release, and we'd expect users to run with L7 proxy enabled.