### PR TITLE
docs: add kubespray instructions for cluster creation

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -153,6 +153,46 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
           - It might be necessary to add ``--host-dns-resolver=false`` if using the Virtualbox provider,
             otherwise DNS resolution may not work after Cilium installation.
 
+    .. group-tab:: Kubespray
+
+       `Kubespray <https://github.com/kubernetes-sigs/kubespray>`_ requires Python ≥ 3.10 for recent versions. 
+       For environment setup and dependencies installation, see the `Kubespray Ansible documentation <https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ansible/ansible.md#installing-ansible>`_.
+
+       **Configure cluster:**
+
+       .. code-block:: bash
+
+           # Enter the already cloned kubespray directory
+           cd kubespray/
+           
+           # Copy sample inventory
+           cp -rfp inventory/sample inventory/mycluster
+           
+           # Configure your inventory
+           vi inventory/mycluster/inventory.ini
+           
+           # Configure Kubernetes networking:
+           # Use CNI without any network plugin
+           sed -e 's/^kube_network_plugin:.*$/kube_network_plugin: cni/' \
+               -e 's/^kube_owner:.*$/kube_owner: root/' \
+               inventory/mycluster/group_vars/k8s_cluster/k8s-cluster.yml > k8s-cluster.tmp
+           mv k8s-cluster.tmp inventory/mycluster/group_vars/k8s_cluster/k8s-cluster.yml
+
+       Setting ``kube_network_plugin: cni`` ensures the cluster deploys without any network plugin, allowing Cilium to be installed separately afterward.
+
+       **Deploy cluster:**
+
+       .. code-block:: bash
+
+           ansible-playbook -i inventory/mycluster/inventory.ini cluster.yml -b -v \
+             --private-key=~/.ssh/private_key
+
+       (Adjust the path to your private SSH key.)
+
+       .. note::
+
+          For more detailed configuration options, refer to the `Kubespray documentation <https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ansible/vars.md>`_.
+
     .. group-tab:: Rancher Desktop
 
        Install Rancher Desktop >= v1.1.0 as per Rancher Desktop documentation:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

This PR adds documentation explaining how to create a Kubernetes cluster 
using Kubespray with the proper configuration to install Cilium.
The instructions cover:

- Basic Kubespray setup requirements
- Creating a cluster without network plugin (CNI only mode)
- Applying the necessary configuration changes
- Deployment steps

This helps users who prefer using Kubespray for cluster provisioning
before installing Cilium.

Signed-off-by: bo.jiang <bo.jiang@daocloud.io>

```release-note
docs: Add Kubespray cluster creation instructions to the quick installation guide
```