### PR TITLE
ciliumenvoyconfig: fix typo in hive module name

### DIFF
--- a/pkg/ciliumenvoyconfig/cell.go
+++ b/pkg/ciliumenvoyconfig/cell.go
@@ -17,7 +17,7 @@ var (
 	// Cell implements handling of the Cilium(Clusterwide)EnvoyConfig handling
 	// and backend synchronization towards Envoy.
 	Cell = cell.Module(
-		"ciliumenvoycnofig",
+		"ciliumenvoyconfig",
 		"CiliumEnvoyConfig handling",
 
 		cell.Config(CECConfig{}),


### PR DESCRIPTION
This PR fixes a typo in the hive module name of `pkg/ciliumenvoyconfig`.

`ciliumenvoycnofig` -> `ciliumenvoyconfig`

cc @joamaki 

Fixes: #39086
