### PR TITLE
loadbalancer: use `netip.Prefix` for `Service.SourceRanges`

### DIFF
--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"maps"
 	"net"
+	"net/netip"
 	"slices"
 	"strings"
 	"sync"
@@ -27,7 +28,6 @@ import (
 
 	daemonK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/annotation"
-	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container"
 	"github.com/cilium/cilium/pkg/ip"
@@ -423,11 +423,11 @@ func convertService(cfg loadbalancer.ExternalConfig, log *slog.Logger, svc *slim
 	}
 
 	for _, srcRange := range svc.Spec.LoadBalancerSourceRanges {
-		cidr, err := cidr.ParseCIDR(srcRange)
+		prefix, err := netip.ParsePrefix(srcRange)
 		if err != nil {
 			continue
 		}
-		s.SourceRanges = append(s.SourceRanges, *cidr)
+		s.SourceRanges = append(s.SourceRanges, prefix)
 	}
 
 	switch svc.Spec.ExternalTrafficPolicy {

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -6,6 +6,7 @@ package loadbalancer
 import (
 	"fmt"
 	"maps"
+	"net/netip"
 	"slices"
 	"sort"
 	"strconv"
@@ -16,7 +17,6 @@ import (
 	"github.com/cilium/statedb/part"
 
 	"github.com/cilium/cilium/pkg/annotation"
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
@@ -74,7 +74,7 @@ type Service struct {
 
 	// SourceRanges if non-empty will restrict access to the service to the specified
 	// client addresses.
-	SourceRanges []cidr.CIDR
+	SourceRanges []netip.Prefix
 
 	// PortNames maps a port name to a port number.
 	PortNames map[string]uint16


### PR DESCRIPTION
There are no users requiring this to be a `cidr.CIDR`. Avoid unnecessary conversion to `netip.Prefix` for `UpdateSourceRange` by storing as `netip.Prefix` right away.

For https://github.com/cilium/cilium/issues/24246
