### PR TITLE
endpoint: execute Endpoint.writeHeaderFile under lockAlive

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -444,16 +444,15 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 		datapathRegenCtxt.regenerationLevel = regeneration.RegenerateWithDatapath
 	}
 
+	if err := e.lockAlive(); err != nil {
+		return 0, err
+	}
 	dir := datapathRegenCtxt.currentDir
 	if datapathRegenCtxt.regenerationLevel >= regeneration.RegenerateWithDatapath {
 		if err := e.writeHeaderfile(datapathRegenCtxt.nextDir); err != nil {
 			return 0, fmt.Errorf("write endpoint header file: %w", err)
 		}
 		dir = datapathRegenCtxt.nextDir
-	}
-
-	if err := e.lockAlive(); err != nil {
-		return 0, err
 	}
 	datapathRegenCtxt.epInfoCache = e.createEpInfoCache(dir)
 	e.unlock()


### PR DESCRIPTION
In af09899b1e, the call to Endpoint.writeHeaderFile was moved out of preCompilationSteps since EndpointHash takes out a read lock, which didn't work since regenerateBPF is already run under a write lock.

This patch puts writeHeaderFile under the endpoint lock once again.

Fixes: #38324 