### PR TITLE
chore: remove `retention-days` param in `build-images-releases.yaml`

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -173,7 +173,6 @@ jobs:
         with:
           name: image-digest ${{ matrix.name }}
           path: image-digest
-          retention-days: 10
 
   image-digests:
     name: Display Digests


### PR DESCRIPTION
This PR removes the `retention-days` param in the workflow so the retention period defaults to that of a repo-setting.