### PR TITLE
endpoint: extract endpoint restoration logic from Daemon

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -366,7 +366,6 @@ Makefile* @cilium/build
 /daemon/cmd/kube_proxy* @cilium/sig-datapath
 /daemon/cmd/bootstrap_statistics.go @cilium/metrics
 /daemon/cmd/policy* @cilium/sig-policy
-/daemon/cmd/state.go @cilium/endpoint
 /daemon/cmd/cells*.go @cilium/sig-foundations
 /Documentation/ @cilium/docs-structure
 /Documentation/_static/ @cilium/docs-structure

--- a/pkg/endpoint/cell/cell.go
+++ b/pkg/endpoint/cell/cell.go
@@ -10,6 +10,7 @@ import (
 	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
 	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
 	endpointmetadata "github.com/cilium/cilium/pkg/endpoint/metadata"
+	"github.com/cilium/cilium/pkg/endpoint/restoration"
 	"github.com/cilium/cilium/pkg/endpoint/watchdog"
 	"github.com/cilium/cilium/pkg/endpointcleanup"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -38,4 +39,7 @@ var Cell = cell.Group(
 
 	// Cell triggers a job to ensure device tc programs remain loaded.
 	watchdog.Cell,
+
+	// Cell provides the endpoint restoration process logic
+	restoration.Cell,
 )

--- a/pkg/endpoint/restoration/cell.go
+++ b/pkg/endpoint/restoration/cell.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package restoration
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+var Cell = cell.Module(
+	"endpoint-restoration",
+	"Endpoint restoration process logic",
+
+	cell.Provide(
+		promise.New[endpointstate.EndpointsRestored],
+		promise.New[endpointstate.InitialPoliciesComputed],
+		newEndpointRestorer,
+	),
+	cell.Invoke(registerEndpointStateResolvers),
+)
+
+func registerEndpointStateResolvers(lc cell.Lifecycle, endpointRestorer *EndpointRestorer, endpointsRestoredResolver promise.Resolver[endpointstate.EndpointsRestored], initialPoliciesComputedResolver promise.Resolver[endpointstate.InitialPoliciesComputed]) {
+	var wgEndpointsRestored sync.WaitGroup
+	var wgInitialPoliciesComputed sync.WaitGroup
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	lc.Append(cell.Hook{
+		OnStart: func(_ cell.HookContext) error {
+			wgEndpointsRestored.Add(1)
+			go func() {
+				defer wgEndpointsRestored.Done()
+				if err := endpointRestorer.waitForEndpointRestore(ctx); err != nil {
+					endpointsRestoredResolver.Reject(err)
+				} else {
+					endpointsRestoredResolver.Resolve(endpointstate.EndpointsRestored{})
+				}
+			}()
+			return nil
+		},
+		OnStop: func(_ cell.HookContext) error {
+			wgEndpointsRestored.Wait()
+			return nil
+		},
+	})
+
+	lc.Append(cell.Hook{
+		OnStart: func(_ cell.HookContext) error {
+			wgInitialPoliciesComputed.Add(1)
+			go func() {
+				defer wgInitialPoliciesComputed.Done()
+				if err := endpointRestorer.waitForInitialPolicy(ctx); err != nil {
+					initialPoliciesComputedResolver.Reject(err)
+				} else {
+					initialPoliciesComputedResolver.Resolve(endpointstate.InitialPoliciesComputed{})
+				}
+			}()
+			return nil
+		},
+		OnStop: func(_ cell.HookContext) error {
+			cancelCtx()
+			wgInitialPoliciesComputed.Wait()
+			return nil
+		},
+	})
+}

--- a/pkg/endpoint/restoration/cell.go
+++ b/pkg/endpoint/restoration/cell.go
@@ -5,9 +5,9 @@ package restoration
 
 import (
 	"context"
-	"sync"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 
 	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/promise"
@@ -17,56 +17,31 @@ var Cell = cell.Module(
 	"endpoint-restoration",
 	"Endpoint restoration process logic",
 
-	cell.Provide(
-		promise.New[endpointstate.EndpointsRestored],
-		promise.New[endpointstate.InitialPoliciesComputed],
-		newEndpointRestorer,
-	),
-	cell.Invoke(registerEndpointStateResolvers),
+	cell.Provide(newEndpointRestorer),
+
+	cell.Provide(promise.New[endpointstate.EndpointsRestored]),
+	cell.Provide(promise.New[endpointstate.InitialPoliciesComputed]),
+	cell.Invoke(registerEndpointPromiseResolvers),
 )
 
-func registerEndpointStateResolvers(lc cell.Lifecycle, endpointRestorer *EndpointRestorer, endpointsRestoredResolver promise.Resolver[endpointstate.EndpointsRestored], initialPoliciesComputedResolver promise.Resolver[endpointstate.InitialPoliciesComputed]) {
-	var wgEndpointsRestored sync.WaitGroup
-	var wgInitialPoliciesComputed sync.WaitGroup
+func registerEndpointPromiseResolvers(jobGroup job.Group, endpointRestorer *EndpointRestorer, endpointsRestoredResolver promise.Resolver[endpointstate.EndpointsRestored], initialPoliciesComputedResolver promise.Resolver[endpointstate.InitialPoliciesComputed]) {
+	jobGroup.Add(job.OneShot("wait-for-endpoint-restore", func(ctx context.Context, health cell.Health) error {
+		if err := endpointRestorer.waitForEndpointRestore(ctx); err != nil {
+			endpointsRestoredResolver.Reject(err)
+			return err
+		}
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
+		endpointsRestoredResolver.Resolve(endpointstate.EndpointsRestored{})
+		return nil
+	}))
 
-	lc.Append(cell.Hook{
-		OnStart: func(_ cell.HookContext) error {
-			wgEndpointsRestored.Add(1)
-			go func() {
-				defer wgEndpointsRestored.Done()
-				if err := endpointRestorer.waitForEndpointRestore(ctx); err != nil {
-					endpointsRestoredResolver.Reject(err)
-				} else {
-					endpointsRestoredResolver.Resolve(endpointstate.EndpointsRestored{})
-				}
-			}()
-			return nil
-		},
-		OnStop: func(_ cell.HookContext) error {
-			wgEndpointsRestored.Wait()
-			return nil
-		},
-	})
+	jobGroup.Add(job.OneShot("wait-for-initial-policy-computation", func(ctx context.Context, health cell.Health) error {
+		if err := endpointRestorer.waitForInitialPolicy(ctx); err != nil {
+			initialPoliciesComputedResolver.Reject(err)
+			return err
+		}
 
-	lc.Append(cell.Hook{
-		OnStart: func(_ cell.HookContext) error {
-			wgInitialPoliciesComputed.Add(1)
-			go func() {
-				defer wgInitialPoliciesComputed.Done()
-				if err := endpointRestorer.waitForInitialPolicy(ctx); err != nil {
-					initialPoliciesComputedResolver.Reject(err)
-				} else {
-					initialPoliciesComputedResolver.Resolve(endpointstate.InitialPoliciesComputed{})
-				}
-			}()
-			return nil
-		},
-		OnStop: func(_ cell.HookContext) error {
-			cancelCtx()
-			wgInitialPoliciesComputed.Wait()
-			return nil
-		},
-	})
+		initialPoliciesComputedResolver.Resolve(endpointstate.InitialPoliciesComputed{})
+		return nil
+	}))
 }

--- a/pkg/endpoint/watchdog/ep-bpfprog-watchdog.go
+++ b/pkg/endpoint/watchdog/ep-bpfprog-watchdog.go
@@ -40,7 +40,7 @@ type epBPFProgWatchdogParams struct {
 	Logger   *slog.Logger
 	JobGroup job.Group
 
-	RestorerPromise promise.Promise[endpointstate.Restorer]
+	EndpointsRestoredPromise promise.Promise[endpointstate.EndpointsRestored]
 
 	EndpointManager endpointmanager.EndpointManager
 	Orchestrator    datapath.Orchestrator
@@ -69,7 +69,7 @@ func registerEndpointBPFProgWatchdog(p epBPFProgWatchdogParams) {
 	}
 
 	p.JobGroup.Add(job.Timer(epBPFProgWatchdog, func(ctx context.Context) error {
-		_, err := p.RestorerPromise.Await(ctx)
+		_, err := p.EndpointsRestoredPromise.Await(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/endpointstate/restorer.go
+++ b/pkg/endpointstate/restorer.go
@@ -3,15 +3,12 @@
 
 package endpointstate
 
-import "context"
+// EndpointsRestored is an empty type used for promise.Promise.
+// Waiting on that promise blocks the caller until either the context is
+// cancelled or all the endpoints have been restored from a previous run.
+type EndpointsRestored struct{}
 
-// Restorer wraps a method to wait for endpoints restoration.
-type Restorer interface {
-	// WaitForEndpointRestore blocks the caller until either the context is
-	// cancelled or all the endpoints have been restored from a previous run.
-	WaitForEndpointRestore(ctx context.Context) error
-
-	// WaitForInitialPolicy blocks the caller until either the context is
-	// cancelled or initial policies of all restored endpoints have been computed.
-	WaitForInitialPolicy(ctx context.Context) error
-}
+// InitialPoliciesComputed is an empty type used for promise.Promise.
+// Waiting on that promise blocks the caller until either the context is
+// cancelled or initial policies of all restored endpoints have been computed.
+type InitialPoliciesComputed struct{}

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -136,11 +136,11 @@ func (r secretSyncConfig) Flags(flags *pflag.FlagSet) {
 type xdsServerParams struct {
 	cell.In
 
-	Lifecycle          cell.Lifecycle
-	Logger             *slog.Logger
-	IPCache            *ipcache.IPCache
-	RestorerPromise    promise.Promise[endpointstate.Restorer]
-	LocalEndpointStore *LocalEndpointStore
+	Lifecycle                      cell.Lifecycle
+	Logger                         *slog.Logger
+	IPCache                        *ipcache.IPCache
+	InitialPoliciesComputedPromise promise.Promise[endpointstate.InitialPoliciesComputed]
+	LocalEndpointStore             *LocalEndpointStore
 
 	EnvoyProxyConfig ProxyConfig
 
@@ -164,7 +164,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 
 	xdsServer := newXDSServer(
 		params.Logger,
-		params.RestorerPromise,
+		params.InitialPoliciesComputedPromise,
 		params.IPCache,
 		params.LocalEndpointStore,
 		xdsServerConfig{

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -96,7 +96,7 @@ type ResourceTypeConfiguration struct {
 // sources.
 // types maps each supported resource type URL to its corresponding resource
 // source and ACK observer.
-func NewServer(logger *slog.Logger, resourceTypes map[string]*ResourceTypeConfiguration, restorerPromise promise.Promise[endpointstate.Restorer], metrics Metrics) *Server {
+func NewServer(logger *slog.Logger, resourceTypes map[string]*ResourceTypeConfiguration, initialPoliciesComputedPromise promise.Promise[endpointstate.InitialPoliciesComputed], metrics Metrics) *Server {
 	watchers := make(map[string]*ResourceWatcher, len(resourceTypes))
 	ackObservers := make(map[string]ResourceVersionAckObserver, len(resourceTypes))
 	for typeURL, resType := range resourceTypes {
@@ -105,7 +105,7 @@ func NewServer(logger *slog.Logger, resourceTypes map[string]*ResourceTypeConfig
 		watchers[typeURL] = w
 
 		if resType.AckObserver != nil {
-			if restorerPromise != nil {
+			if initialPoliciesComputedPromise != nil {
 				resType.AckObserver.MarkRestorePending()
 			}
 			ackObservers[typeURL] = resType.AckObserver

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -18,9 +18,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/promise"
 )
 
 const (
@@ -96,7 +94,7 @@ type ResourceTypeConfiguration struct {
 // sources.
 // types maps each supported resource type URL to its corresponding resource
 // source and ACK observer.
-func NewServer(logger *slog.Logger, resourceTypes map[string]*ResourceTypeConfiguration, initialPoliciesComputedPromise promise.Promise[endpointstate.InitialPoliciesComputed], metrics Metrics) *Server {
+func NewServer(logger *slog.Logger, resourceTypes map[string]*ResourceTypeConfiguration, metrics Metrics) *Server {
 	watchers := make(map[string]*ResourceWatcher, len(resourceTypes))
 	ackObservers := make(map[string]ResourceVersionAckObserver, len(resourceTypes))
 	for typeURL, resType := range resourceTypes {
@@ -105,9 +103,7 @@ func NewServer(logger *slog.Logger, resourceTypes map[string]*ResourceTypeConfig
 		watchers[typeURL] = w
 
 		if resType.AckObserver != nil {
-			if initialPoliciesComputedPromise != nil {
-				resType.AckObserver.MarkRestorePending()
-			}
+			resType.AckObserver.MarkRestorePending()
 			ackObservers[typeURL] = resType.AckObserver
 		}
 	}

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -28,13 +28,11 @@ const (
 	StreamTimeout = 4 * time.Second
 )
 
-var (
-	nodes = map[string]*envoy_config_core.Node{
-		node0: {Id: "node0~10.0.0.0~node0~bar"},
-		node1: {Id: "node1~10.0.0.1~node1~bar"},
-		node2: {Id: "node2~10.0.0.2~node2~bar"},
-	}
-)
+var nodes = map[string]*envoy_config_core.Node{
+	node0: {Id: "node0~10.0.0.0~node0~bar"},
+	node1: {Id: "node1~10.0.0.1~node1~bar"},
+	node2: {Id: "node2~10.0.0.2~node2~bar"},
+}
 
 var resources = []*envoy_config_route.RouteConfiguration{
 	{Name: "resource0"},
@@ -43,7 +41,8 @@ var resources = []*envoy_config_route.RouteConfiguration{
 }
 
 func responseCheck(response *envoy_service_discovery.DiscoveryResponse,
-	versionInfo string, resources []proto.Message, canary bool, typeURL string) assert.Comparison {
+	versionInfo string, resources []proto.Message, canary bool, typeURL string,
+) assert.Comparison {
 	return func() bool {
 		result := response.VersionInfo == versionInfo &&
 			len(response.Resources) == len(resources) &&
@@ -96,7 +95,8 @@ func TestRequestAllResources(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 
@@ -231,7 +231,8 @@ func TestAck(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 
@@ -354,7 +355,8 @@ func TestRequestSomeResources(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 
@@ -538,7 +540,8 @@ func TestUpdateRequestResources(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 
@@ -644,7 +647,8 @@ func TestRequestStaleNonce(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 
@@ -778,7 +782,8 @@ func TestNAck(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 
@@ -914,7 +919,8 @@ func TestNAckFromTheStart(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 
@@ -1051,7 +1057,8 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 
@@ -1122,7 +1129,8 @@ func TestTheSameVersionOnRestart(t *testing.T) {
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 
@@ -1212,7 +1220,8 @@ func TestNotAckedAfterRestart(t *testing.T) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
+	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, metrics)
+	mutator.MarkRestoreCompleted()
 
 	streamDone := make(chan struct{})
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -191,7 +191,7 @@ type xdsServer struct {
 	// them to the proxy via NPHDS in the cases described
 	ipCache IPCacheEventSource
 
-	restorerPromise promise.Promise[endpointstate.Restorer]
+	initialPoliciesComputedPromise promise.Promise[endpointstate.InitialPoliciesComputed]
 
 	localEndpointStore *LocalEndpointStore
 
@@ -227,13 +227,13 @@ type xdsServerConfig struct {
 }
 
 // newXDSServer creates a new xDS GRPC server.
-func newXDSServer(logger *slog.Logger, restorerPromise promise.Promise[endpointstate.Restorer], ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig, secretManager certificatemanager.SecretManager) *xdsServer {
+func newXDSServer(logger *slog.Logger, initialPoliciesComputedPromise promise.Promise[endpointstate.InitialPoliciesComputed], ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig, secretManager certificatemanager.SecretManager) *xdsServer {
 	xdsServer := &xdsServer{
-		logger:             logger,
-		restorerPromise:    restorerPromise,
-		listenerCount:      make(map[string]uint),
-		ipCache:            ipCache,
-		localEndpointStore: localEndpointStore,
+		logger:                         logger,
+		initialPoliciesComputedPromise: initialPoliciesComputedPromise,
+		listenerCount:                  make(map[string]uint),
+		ipCache:                        ipCache,
+		localEndpointStore:             localEndpointStore,
 
 		socketPath:    getXDSSocketPath(config.envoySocketDir),
 		accessLogPath: getAccessLogSocketPath(config.envoySocketDir),

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1692,6 +1692,8 @@ const (
 
 	Flags = "flags"
 
+	Regenerated = "regenerated"
+
 	ExitCode = "exitCode"
 
 	NumBufferedEvents = "numBufferedEvents"


### PR DESCRIPTION
This PR extracts the endpoint restoration logic and state from the `Daemon`.

Please review the individual commits.