### PR TITLE
api: wait with api server start until legacy daemon init finished

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
+	"github.com/cilium/cilium/daemon/cmd/legacy"
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/bpf"
@@ -1512,7 +1513,7 @@ type daemonParams struct {
 	DNSProxy            bootstrap.FQDNProxyBootstrapper
 }
 
-func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
+func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], legacy.DaemonInitialization) {
 	daemonResolver, daemonPromise := promise.New[*Daemon]()
 
 	// daemonCtx is the daemon-wide context cancelled when stopping.
@@ -1589,7 +1590,7 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 			return nil
 		},
 	})
-	return daemonPromise
+	return daemonPromise, legacy.DaemonInitialization{}
 }
 
 // startDaemon starts the old unmodular part of the cilium-agent.

--- a/daemon/cmd/legacy/daemon_init.go
+++ b/daemon/cmd/legacy/daemon_init.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package legacy
+
+// DaemonInitialization can be used to depend on the legacy daemon initialization.
+// This will make sure the Hive start hook of the "Daemon cell" runs before the start
+// hook of any dependent cell. In detail, `newDaemon` has been called, but `startDaemon`
+// is likely going to run in parallel with the start hook of the dependent cell.
+type DaemonInitialization struct{}

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	daemonapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
+	"github.com/cilium/cilium/daemon/cmd/legacy"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
@@ -57,6 +58,11 @@ type configModifyApiHandlerParams struct {
 	cell.In
 
 	Logger logrus.FieldLogger
+
+	// Depend on DaemonInitialization to wait until legacy daemon initialization is finished. This blocks the
+	// API server from starting and is required to prevent panics when accessing node globals that are
+	// initialized in that phase.
+	legacy.DaemonInitialization
 
 	DB              *statedb.DB
 	Devices         statedb.Table[*datapathTables.Device]


### PR DESCRIPTION
Currently, the API server start no longer waits until the legacy
daemon initialization finished (introduced with #39357). 
This can lead to panics from api handlers
that rely on globals that are initialized by this legacy daemon logic.

(e.g. config handler that relies on node globals (`node.GetNodeAddressing`).

Therefore, this commit modifies the configmodify api handler to wait for
the Daemon promise. This way, the start of the api server gets postponed
until IPAM has been initialized.

Note: Unfortunately, due to circular dependencies it's not possible to
depend on the Daemon promise directly. Therefore, this commit also
introduces a new marker interface `legacy.DaemonInitialization` that
can be used to depend on the daemon initialization.

Note 2: IMO it's better to introduce this new (but hopefully temporary) interface than adjust the `server.Server` template to actually wait on a promise before starting the server. Because this might have other side-effects (e.g. premature unlock of endpoint deletion queue, ...)

Note 3: Let's hope that we can delete the `Daemon` struct in the near future - to prevent re-adding state to it. Then it's even more useful to have this "marker" interface for the cases that still need to be able to depend on the legacy daemon init phase.

Fixes: #39430
Fixes: #39357