### PR TITLE
Multi-pool IPAM with tunneling and IPSec support

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -108,8 +108,13 @@ jobs:
         include:
           - name: 'Direct Routing'
             tunnel: 'disabled'
+            encryption: 'disabled'
           - name: 'Tunnel Mode'
             tunnel: 'vxlan'
+            encryption: 'disabled'
+          - name: 'Tunnel Mode with IPSec Encryption'
+            tunnel: 'vxlan'
+            encryption: 'ipsec'
 
     name: Install and Connectivity Test
     env:
@@ -185,6 +190,11 @@ jobs:
             --helm-set=autoDirectNodeRoutes=true"
           fi
 
+          CILIUM_INSTALL_ENCRYPTION=""
+          if [ "${{ matrix.encryption }}" != "disabled" ]; then
+            CILIUM_INSTALL_ENCRYPTION="--helm-set=encryption.enabled=true --helm-set=encryption.type=${{ matrix.encryption }}"
+          fi
+
           CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
             --sysdump-output-filename \"cilium-sysdump-${{ matrix.name }}-<ts>\" \
             --junit-file \"cilium-junits/${{ env.job_name }} ${{ matrix.name }}.xml\" \
@@ -199,7 +209,7 @@ jobs:
                 \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
             }'"
 
-          echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL}" >> $GITHUB_OUTPUT
+          echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} ${CILIUM_INSTALL_ENCRYPTION}" >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
@@ -230,6 +240,12 @@ jobs:
           image-tag: ${{ steps.vars.outputs.sha }}
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
           release-version: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Create the IPSec secret
+        if: matrix.encryption == 'ipsec'
+        run: |
+          SECRET="3+ rfc4106(gcm(aes)) $(openssl rand -hex 20) 128"
+          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
 
       - name: Install Cilium
         id: install-cilium

--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -239,7 +239,8 @@ Multi-Pool IPAM is a preview feature. The following limitations apply to Cilium 
 Multi-Pool IPAM mode:
 
 .. warning::
-   - Transparent encryption is only supported with WireGuard and cannot be used with IPsec.
+   - IPsec is not supported in native routing mode. IPsec in tunnel mode and WireGuard
+     (both in native routing and tunnel mode) are supported.
    - IPAM pools with overlapping CIDRs are not supported. Each pod IP must be
      unique in the cluster due the way Cilium determines the security identity
      of endpoints by way of the IPCache.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1345,10 +1345,8 @@ func initEnv(vp *viper.Viper) {
 		log.Fatalf("Cannot specify IPAM mode %s in tunnel mode.", option.Config.IPAM)
 	}
 
-	if option.Config.IPAM == ipamOption.IPAMMultiPool {
-		if option.Config.EnableIPSec {
-			log.Fatalf("Cannot specify IPAM mode %s with %s.", option.Config.IPAM, option.EnableIPSecName)
-		}
+	if option.Config.IPAM == ipamOption.IPAMMultiPool && option.Config.EnableIPSec && !option.Config.TunnelingEnabled() {
+		log.Fatalf("IPAM mode %s with %s is supported only in tunnel mode.", option.Config.IPAM, option.EnableIPSecName)
 	}
 
 	if option.Config.InstallNoConntrackIptRules {


### PR DESCRIPTION
Thanks to the VinE support added in https://github.com/cilium/cilium/pull/37723, when in tunnel mode we encrypt the traffic after the encapsulation, at the native egress device. Therefore, the only entries (policies and states) needed for the XFRM framework to encrypt the traffic are the ones related to the remote nodes, not the ones related to the remote pod CIDRs.

As a consequence, the multi-pool IPAM mode is now supported when IPSec is enabled in tunnel mode.

Related: https://github.com/cilium/cilium/pull/38483, https://github.com/cilium/cilium/pull/37723


```release-note
Add support for Multi-Pool IPAM mode with IPSec transparent encryption in tunnel routing mode
```