### PR TITLE
ci: do not run north-south conn disrupt for 5.4 kernel

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -24,6 +24,10 @@ inputs:
     required: false
     default: 1
     description: 'Concurrency level to run tests'
+  kernel:
+    required: false
+    default: ''
+    description: 'Do not run NS conn distrupt tests for kernel 5.4'
 
 runs:
   using: composite
@@ -31,15 +35,25 @@ runs:
     - name: Perform Conn Disrupt Test
       shell: bash
       run: |
+        # extract kernel version prefix
+        version=${{ inputs.kernel }}
+        version=${version%%-*}
+
         if [[ -n "${{ inputs.tests }}" ]]; then
           TEST_ARG="${{ inputs.tests }}"
         else
           TEST_ARG="no-interrupted-connections"
-          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic --include-conn-disrupt-test-egw"
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw"
+          if [[ "${version}" != "5.4" ]]; then
+            EXTRA_ARG="$EXTRA_ARG --include-conn-disrupt-test-ns-traffic"
+          fi
         fi
         if [[ "${{ inputs.full-test }}" == "true" ]]; then
           TEST_ARG=""
-          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic --include-conn-disrupt-test-egw"
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw"
+          if [[ "${version}" != "5.4" ]]; then
+            EXTRA_ARG="$EXTRA_ARG --include-conn-disrupt-test-ns-traffic"
+          fi
         fi
         ${{ inputs.cilium-cli }} connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \

--- a/.github/actions/conn-disrupt-test-setup/action.yaml
+++ b/.github/actions/conn-disrupt-test-setup/action.yaml
@@ -6,6 +6,10 @@ inputs:
     required: false
     default: "/usr/local/bin/cilium"
     description: 'Path to the Cilium CLI binary'
+  kernel:
+    required: false
+    default: ''
+    description: 'Do not run NS conn distrupt tests for kernel 5.4'
 
 runs:
   using: composite
@@ -13,15 +17,23 @@ runs:
     - name: Setup Conn Disrupt Test
       shell: bash
       run: |
+        # extract kernel version prefix
+        version=${{ inputs.kernel }}
+        version="${version%%-*}"
+
+        include_ns_test=""
+        if [[ "${version}" != "5.4" ]]; then
+          include_ns_test="--include-conn-disrupt-test-ns-traffic"
+        fi
+
         # Create pods which establish long lived connections. It will be used by
         # subsequent connectivity tests with --include-conn-disrupt-test to catch any
         # interruption in such flows.
         ${{ inputs.cilium-cli }} connectivity test --include-conn-disrupt-test \
-          --include-conn-disrupt-test-ns-traffic \
           --include-conn-disrupt-test-egw \
           --include-unsafe-tests \
           --conn-disrupt-test-setup \
           --conn-disrupt-dispatch-interval 0ms \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
           --conn-disrupt-test-xfrm-errors-path "./cilium-conn-disrupt-xfrm-errors" \
-          --expected-xfrm-errors "+inbound_no_state"
+          --expected-xfrm-errors "+inbound_no_state" $include_ns_test

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -346,6 +346,8 @@ jobs:
 
       - name: Start conn-disrupt-test
         uses: ./.github/actions/conn-disrupt-test-setup
+        with:
+          kernel: ${{ matrix.kernel }}
 
       - name: Upgrade Cilium
         if: ${{ matrix.skip-upgrade != 'true' }}
@@ -368,6 +370,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}
+          kernel: ${{ matrix.kernel }}
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Start unencrypted packets check for connectivity tests after upgrade
@@ -444,6 +447,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}
+          kernel: ${{ matrix.kernel }}
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Start unencrypted packets check for connectivity tests after downgrade

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -342,6 +342,8 @@ jobs:
       - name: Setup conn-disrupt-test before upgrading (${{ join(matrix.*, ', ') }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: ./.github/actions/conn-disrupt-test-setup
+        with:
+          kernel: ${{ matrix.kernel }}
 
       - name: Upgrade Cilium (${{ join(matrix.*, ', ') }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -361,6 +363,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}
+          kernel: ${{ matrix.kernel }}
 
       - name: Run sequential tests after upgrading (${{ join(matrix.*, ', ') }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -417,6 +420,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}
+          kernel: ${{ matrix.kernel }}
 
       - name: Run sequential tests after downgrading (${{ join(matrix.*, ', ') }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}


### PR DESCRIPTION
Upstream cilium CLI now runs north-south conn disruptions more liberally.

This was made possible by EoL'ing the 5.4 kernel tests.

However, stable branches will still test 5.4 kernel.

Therefore, we need to ensure north-south conn disrupt tests do not run for stable branches which still place the 5.4 kernel under test.

```release-note
ci: do not run north-south conn disrupt tests for 5.4 kernels
```
