### PR TITLE
StateDB-based K8s fake client object tracker

### DIFF
--- a/daemon/k8s/script_test.go
+++ b/daemon/k8s/script_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -32,6 +33,7 @@ func TestScript(t *testing.T) {
 	}
 	t.Cleanup(func() { time.Now = now })
 	t.Setenv("TZ", "")
+	nodeTypes.SetName("testnode")
 
 	log := hivetest.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/daemon/k8s/testdata/pod.txtar
+++ b/daemon/k8s/testdata/pod.txtar
@@ -5,18 +5,8 @@
 # api-server.
 #
 
-# Start and wait for reflector to sync up (List & Watch). This is needed
-# as the fake k8s client is dumb and would miss events between the List
-# and Watch calls.
 hive start
 db/initialized
-
-# We can also use the k8s/wait-watchers to wait for a watcher to appear.
-# This is useful when we don't have a StateDB table and thus cannot use
-# 'db/initialized'.
-# This is only here as an example for other tests. You don't need both
-# this and db/initialized!
-k8s/wait-watchers v1.pods
 
 # At the start the table is empty
 db/cmp k8s-pods empty.table 

--- a/daemon/k8s/testdata/pod.txtar
+++ b/daemon/k8s/testdata/pod.txtar
@@ -6,7 +6,6 @@
 #
 
 hive start
-db/initialized
 
 # At the start the table is empty
 db/cmp k8s-pods empty.table 
@@ -70,7 +69,7 @@ default/nginx
     "name": "nginx",
     "namespace": "default",
     "uid": "d96be1eb-51df-4383-87ab-bc29d5b42933",
-    "resourceVersion": "482057",
+    "resourceVersion": "1",
     "labels": {
       "run": "nginx"
     }
@@ -161,7 +160,7 @@ metadata:
     run: nginx
   name: nginx
   namespace: default
-  resourceVersion: "482057"
+  resourceVersion: "1"
   uid: d96be1eb-51df-4383-87ab-bc29d5b42933
 spec:
   containers:

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
@@ -258,7 +258,7 @@ func TestCRDConditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
-			logger := hivetest.Logger(t)
+			logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
 			f, watcherReadyFn := newCRDStatusFixture(ctx, require.New(t), logger)
 

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
@@ -28,6 +28,7 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8s_client "github.com/cilium/cilium/pkg/k8s/client"
 	cilium_client_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -336,6 +337,7 @@ func TestCRDConditions(t *testing.T) {
 func TestDisableStatusReport(t *testing.T) {
 	ctx := context.TODO()
 	logger := hivetest.Logger(t)
+	nodeTypes.SetName("node0")
 
 	var cs k8s_client.Clientset
 	hive := hive.New(cell.Module("test", "test",

--- a/pkg/bgpv1/test/testdata/peering-auth.txtar
+++ b/pkg/bgpv1/test/testdata/peering-auth.txtar
@@ -5,10 +5,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-k8s/wait-watchers v1.services v1.secrets
-
 # Configure gobgp server
 gobgp/add-server --router-id=1.2.3.4 65001 fd00::aa:bb:cc:101 1790
 gobgp/add-peer --password=Cilium123 fd00::aa:bb:cc:102 65001

--- a/pkg/bgpv1/test/testdata/peering-changes.txtar
+++ b/pkg/bgpv1/test/testdata/peering-changes.txtar
@@ -5,10 +5,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-k8s/wait-watchers v1.services
-
 # Add a LoadBalancer service
 k8s/add service-lb.yaml
 

--- a/pkg/bgpv1/test/testdata/peering-ipv6.txtar
+++ b/pkg/bgpv1/test/testdata/peering-ipv6.txtar
@@ -5,9 +5,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-
 # Configure gobgp server
 gobgp/add-server --router-id=1.2.3.4 65001 fd00::aa:bb:cc:111 1790
 gobgp/add-peer fd00::aa:bb:cc:112 65001

--- a/pkg/bgpv1/test/testdata/peering-multi-instance.txtar
+++ b/pkg/bgpv1/test/testdata/peering-multi-instance.txtar
@@ -5,10 +5,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-k8s/wait-watchers v1.services
-
 # Configure gobgp servers
 gobgp/add-server 65010 10.99.0.101 1790
 gobgp/add-server 65011 10.99.0.102 1790

--- a/pkg/bgpv1/test/testdata/pod-cidr.txtar
+++ b/pkg/bgpv1/test/testdata/pod-cidr.txtar
@@ -5,9 +5,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-
 # Configure gobgp server
 gobgp/add-server --router-id=1.2.3.4 65001 fd00::aa:bb:dd:101 1790
 gobgp/add-peer fd00::aa:bb:dd:102 65001

--- a/pkg/bgpv1/test/testdata/pod-ip-pool.txtar
+++ b/pkg/bgpv1/test/testdata/pod-ip-pool.txtar
@@ -5,9 +5,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-
 # Configure GoBGP server
 gobgp/add-server 65010 10.99.2.1 1790
 gobgp/add-peer 10.99.2.2 65001

--- a/pkg/bgpv1/test/testdata/svc-adverts.txtar
+++ b/pkg/bgpv1/test/testdata/svc-adverts.txtar
@@ -6,10 +6,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-k8s/wait-watchers v1.services
-
 # Configure gobgp server
 gobgp/add-server --router-id=1.2.3.4 65010 fd00::bb:cc:dd:1 1790
 gobgp/add-server --router-id=5.6.7.8 65011 fd00::bb:cc:dd:2 1790

--- a/pkg/bgpv1/test/testdata/svc-aggregation.txtar
+++ b/pkg/bgpv1/test/testdata/svc-aggregation.txtar
@@ -6,10 +6,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-k8s/wait-watchers v1.services
-
 # Configure gobgp server
 gobgp/add-server 65010 10.99.4.211 1790
 

--- a/pkg/bgpv1/test/testdata/svc-path-attributes.txtar
+++ b/pkg/bgpv1/test/testdata/svc-path-attributes.txtar
@@ -7,10 +7,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-k8s/wait-watchers v1.services
-
 # Configure gobgp server
 gobgp/add-server --router-id=1.2.3.4 65001 fd00::bb:cc:dd:101 1790
 gobgp/add-peer fd00::bb:cc:dd:102 65001

--- a/pkg/bgpv1/test/testdata/svc-sharing.txtar
+++ b/pkg/bgpv1/test/testdata/svc-sharing.txtar
@@ -6,10 +6,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-k8s/wait-watchers v1.services
-
 # Configure gobgp server
 gobgp/add-server 65010 10.99.4.201 1790
 

--- a/pkg/bgpv1/test/testdata/svc-traffic-policy.txtar
+++ b/pkg/bgpv1/test/testdata/svc-traffic-policy.txtar
@@ -6,10 +6,6 @@
 # Start the hive
 hive start
 
-# Wait for k8s watchers to be initialized
-k8s/wait-watchers cilium.io.v2.ciliumnodes cilium.io.v2.ciliumbgpnodeconfigs cilium.io.v2.ciliumbgppeerconfigs cilium.io.v2.ciliumbgpadvertisements
-k8s/wait-watchers v1.services v1.endpoints
-
 # Configure gobgp server
 gobgp/add-server 65010 10.99.4.101 1790
 

--- a/pkg/ciliumenvoyconfig/testdata/anyport.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/anyport.txtar
@@ -1,8 +1,6 @@
 # Test handling of CiliumEnvoyConfig, without specifying service ports
 
-# Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db/initialized
 
 # Set up the services and endpoints
 k8s/add service.yaml

--- a/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
@@ -1,8 +1,6 @@
 # Test handling of CiliumEnvoyConfig with backend services.
 
-# Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db/initialized
 
 # Set up the services and endpoints. Add the test/frontend first and wait for it
 # to reconcile.

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -1,8 +1,6 @@
 # Test handling of CiliumClusterwideEnvoyConfig
 
-# Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db/initialized
 
 # Set up the services and endpoints
 k8s/add service.yaml endpointslice.yaml

--- a/pkg/ciliumenvoyconfig/testdata/headless.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/headless.txtar
@@ -1,8 +1,6 @@
 # Test handling of headless services
 
-# Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db/initialized
 
 # Set up the services and endpoints
 k8s/add service.yaml endpointslice.yaml

--- a/pkg/ciliumenvoyconfig/testdata/ingress.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/ingress.txtar
@@ -6,7 +6,6 @@
 # dumped using e.g. "kubectl get svc/details -o yaml".
 
 hive/start
-db/initialized
 
 # Add the objects
 k8s/add svc-ingress.yaml eps-ingress.yaml cec.yaml

--- a/pkg/ciliumenvoyconfig/testdata/labels.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/labels.txtar
@@ -2,7 +2,6 @@
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db/initialized
 
 set-node-labels foo=a
 

--- a/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
@@ -2,7 +2,6 @@
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db/initialized
 
 # Add the objects and wait for it to be ingested.
 k8s/add service.yaml endpointslice.yaml cec.yaml

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -5,7 +5,6 @@ db/insert node-addresses addrv4.yaml
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db/initialized
 
 # Set up the services and endpoints
 k8s/add service.yaml

--- a/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
@@ -5,7 +5,6 @@ db/insert node-addresses addrv4.yaml
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db/initialized
 
 # Set up the services and endpoints
 k8s/add service.yaml

--- a/pkg/clustermesh/testdata/clusterservice.txtar
+++ b/pkg/clustermesh/testdata/clusterservice.txtar
@@ -1,7 +1,6 @@
 #! --cluster-id=1 --cluster-name=cluster1
 
 hive/start
-db/initialized
 
 # Create a service to which to add the external backends.
 k8s/add service.yaml endpointslice.yaml

--- a/pkg/clustermesh/testdata/service-affinity.txtar
+++ b/pkg/clustermesh/testdata/service-affinity.txtar
@@ -1,7 +1,6 @@
 #! --cluster-id=1 --cluster-name=cluster1
 
 hive/start
-db/initialized
 
 # Create a service with affinity set to local.
 k8s/add service.yaml endpointslice.yaml

--- a/pkg/datapath/linux/testdata/device-controller-tables.txtar
+++ b/pkg/datapath/linux/testdata/device-controller-tables.txtar
@@ -7,9 +7,8 @@
 # - Because of the above, we can not rely on assignment of particular interface indexes to the newly created interfaces.
 #   Therefore we always omit the Index / DeviceIndex columns in all tables.
 
-# Start the hive and wait for tables to be synchronized.
+# Start the hive
 hive start
-db/initialized
 
 # Start with clean state.
 db/cmp devices --grep dummy devices_empty.table

--- a/pkg/datapath/linux/testdata/device-detection-force.txtar
+++ b/pkg/datapath/linux/testdata/device-detection-force.txtar
@@ -2,9 +2,8 @@
 
 # Tests the behavior of device detection when forced detection is enabled.
 
-# Start the hive and wait for tables to be synchronized.
+# Start the hive
 hive start
-db/initialized
 
 # Add dummy0 interface - matches devices wildcard, should be selected.
 exec ip link add dummy0 type dummy

--- a/pkg/datapath/linux/testdata/device-detection-wildcard.txtar
+++ b/pkg/datapath/linux/testdata/device-detection-wildcard.txtar
@@ -3,9 +3,8 @@
 # Test that if the user specifies a device wildcard, then all devices not matching the wildcard
 # will be marked as non-selected.
 
-# Start the hive and wait for tables to be synchronized.
+# Start the hive
 hive start
-db/initialized
 
 # Add dummy0 interface - matches devices wildcard.
 exec ip link add dummy0 type dummy

--- a/pkg/datapath/linux/testdata/device-detection.txtar
+++ b/pkg/datapath/linux/testdata/device-detection.txtar
@@ -1,8 +1,7 @@
 # Tests the behavior of device detection without providing explicit --devices option.
 
-# Start the hive and wait for tables to be synchronized.
+# Start the hive
 hive start
-db/initialized
 
 # Create veth0 + veth1 interfaces without default route - should not be selected.
 exec ip link add veth0 type veth peer name veth1

--- a/pkg/dynamicconfig/script_test.go
+++ b/pkg/dynamicconfig/script_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -30,6 +31,8 @@ var debug = flag.Bool("debug", false, "Enable debug logging")
 func TestScript(t *testing.T) {
 	// Catch any leaked goroutines.
 	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	nodeTypes.SetName("testnode")
 
 	version.Force(testutils.DefaultVersion)
 	setup := func(t testing.TB, args []string) *script.Engine {

--- a/pkg/dynamicconfig/testdata/configmap.txtar
+++ b/pkg/dynamicconfig/testdata/configmap.txtar
@@ -1,7 +1,6 @@
 # Test the reflection of the cilium-config ConfigMap
 
 hive/start
-db/initialized
 
 # Add cilium-config with keys foo and baz
 k8s/add cilium-config.yaml

--- a/pkg/dynamicconfig/testdata/node-config.txtar
+++ b/pkg/dynamicconfig/testdata/node-config.txtar
@@ -2,7 +2,6 @@
 
 # Test the reflection of the CiliumNodeConfig
 hive/start
-db/initialized
 
 # Add cilium-config with keys foo and baz
 k8s/add cilium-node-config.yaml
@@ -38,20 +37,20 @@ k8s/delete cilium-node-config.yaml
 ####
 
 -- configs1.table --
-Key   Source          Priority   Value
-baz   cnc-foo         1          quux
-foo   cnc-foo         1          bar
+Key   Source      Priority   Value
+baz   foo         1          quux
+foo   foo         1          bar
 
 -- configs2.table --
-Key   Source          Priority   Value
-foo   cnc-foo         1          bar
+Key   Source      Priority   Value
+foo   foo         1          bar
 
 -- cilium-node-config.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNodeConfig
 metadata:
   namespace: kube-system
-  name: cnc-foo
+  name: foo
 spec:
   nodeSelector:
     matchLabels:

--- a/pkg/dynamicconfig/testdata/node.txtar
+++ b/pkg/dynamicconfig/testdata/node.txtar
@@ -1,9 +1,8 @@
-#! --config-sources=[{"kind":"node","namespace":"kube-system","name":"foo"}]
+#! --config-sources=[{"kind":"node","name":"testnode"}]
 
 # Test the reflection of the configs as annotations in the Node
 # object.
 hive/start
-db/initialized
 
 # Add node with keys foo and baz as annotations
 k8s/add node.yaml
@@ -42,12 +41,12 @@ k8s/delete cilium-node-config.yaml
 
 -- configs1.table --
 Key   Source          Priority   Value
-baz   node-foo        1          quux
-foo   node-foo        1          bar
+baz   testnode        1          quux
+foo   testnode        1          bar
 
 -- configs2.table --
 Key   Source          Priority   Value
-foo   node-foo        1          bar
+foo   testnode        1          bar
 
 -- node.yaml --
 apiVersion: v1
@@ -59,6 +58,6 @@ metadata:
 
   labels:
     # Labels not relevant
-  name: node-foo
+  name: testnode
 spec:
   # Not relevant for this test

--- a/pkg/k8s/client/object_tracker.go
+++ b/pkg/k8s/client/object_tracker.go
@@ -1,0 +1,652 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
+	"k8s.io/client-go/util/jsonpath"
+
+	"github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	logfieldGVR             = "gvr" //  GroupVersIonResource
+	logfieldClientset       = "clientset"
+	logfieldResourceVersion = "resourceVersion"
+	logfieldFieldSelector   = "fieldSelector"
+)
+
+// statedbObjectTracker implements [testing.ObjectTracker] using a StateDB table.
+// This allows for proper implementation of Watch() that respects the ResourceVersion
+// allowing multiple Watch() calls in parallel.
+//
+// This object tracker is prepended to the reactor chain and will process the objects
+// and short-circuit the chain before the fake client's own object tracker.
+//
+// https://pkg.go.dev/k8s.io/client-go/testing#ObjectTracker
+type statedbObjectTracker struct {
+	domain  string
+	log     *slog.Logger
+	db      *statedb.DB
+	scheme  testing.ObjectScheme
+	decoder runtime.Decoder
+	tbl     statedb.RWTable[object]
+}
+
+func newStateDBObjectTracker(db *statedb.DB, log *slog.Logger) (*statedbObjectTracker, error) {
+	tbl, err := statedb.NewTable("k8s-object-tracker", objectIndex)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.RegisterTable(tbl); err != nil {
+		return nil, err
+	}
+	return &statedbObjectTracker{
+		log:     log,
+		db:      db,
+		tbl:     tbl,
+		scheme:  testutils.Scheme,
+		decoder: testutils.Decoder(),
+	}, nil
+}
+
+type object struct {
+	objectId
+	o runtime.Object
+}
+
+func (o object) TableHeader() []string {
+	return []string{
+		"ID",
+		"Type",
+	}
+}
+
+func (o object) TableRow() []string {
+	return []string{
+		o.objectId.String(),
+		fmt.Sprintf("%T", o.o),
+	}
+}
+
+type objectId struct {
+	types.NamespacedName
+	gvr schema.GroupVersionResource
+
+	// domain to which this objects belongs, e.g. this is used
+	// to differentiate between the slim and kubernetes clientsets
+	// and avoid mixing them up since they have the same [gvr]
+	domain string
+}
+
+func newObjectId(clientset string, gvr schema.GroupVersionResource, namespace, name string) (o objectId) {
+	o.domain = clientset
+	o.gvr = gvr
+	o.Namespace = namespace
+	o.Name = name
+	return
+}
+
+func (oid objectId) String() string {
+	return oid.domain + ";" + oid.gvr.String() + ";" + oid.NamespacedName.String()
+}
+
+func (oid objectId) Key() index.Key {
+	return index.Stringer(oid)
+}
+
+var (
+	objectIndex = statedb.Index[object, objectId]{
+		Name: "id",
+		FromObject: func(obj object) index.KeySet {
+			return index.NewKeySet(obj.Key())
+		},
+		FromKey: index.Stringer[objectId],
+		FromString: func(key string) (index.Key, error) {
+			return index.String(key), nil
+		},
+		Unique: true,
+	}
+)
+
+// For returns a object tracker for a specific use-case (domain) that is separate from others.
+func (s *statedbObjectTracker) For(domain string, scheme *runtime.Scheme, decoder runtime.Decoder) *statedbObjectTracker {
+	o := *s
+	o.domain = domain
+	o.scheme = scheme
+	o.decoder = decoder
+	return &o
+}
+
+func (s *statedbObjectTracker) ObjectReaction() testing.ReactionFunc {
+	return testing.ObjectReaction(s)
+}
+
+func (s *statedbObjectTracker) addList(obj runtime.Object) error {
+	list, err := meta.ExtractList(obj)
+	if err != nil {
+		return err
+	}
+	errs := runtime.DecodeList(list, s.decoder)
+	if len(errs) > 0 {
+		return errs[0]
+	}
+	for _, obj := range list {
+		if err := s.Add(obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Add adds an object to the tracker. If object being added
+// is a list, its items are added separately.
+func (s *statedbObjectTracker) Add(obj runtime.Object) error {
+	if meta.IsListType(obj) {
+		return s.addList(obj)
+	}
+
+	wtxn := s.db.WriteTxn(s.tbl)
+	defer wtxn.Commit()
+
+	obj = obj.DeepCopyObject()
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		s.log.Debug("Add", logfields.Error, err)
+		return err
+	}
+
+	version := s.tbl.Revision(wtxn) + 1
+	objMeta.SetResourceVersion(strconv.FormatUint(version, 10))
+
+	gvks, _, err := s.scheme.ObjectKinds(obj)
+	if err != nil {
+		s.log.Debug("Add", logfields.Error, err)
+		return err
+	}
+
+	if partial, ok := obj.(*metav1.PartialObjectMetadata); ok && len(partial.TypeMeta.APIVersion) > 0 {
+		gvks = []schema.GroupVersionKind{partial.TypeMeta.GroupVersionKind()}
+	}
+
+	if len(gvks) == 0 {
+		err := fmt.Errorf("no registered kinds for %v", obj)
+		s.log.Debug("Add", logfields.Error, err)
+		return err
+	}
+	for _, gvk := range gvks {
+		// NOTE: UnsafeGuessKindToResource is a heuristic and default match. The
+		// actual registration in apiserver can specify arbitrary route for a
+		// gvk. If a test uses such objects, it cannot preset the tracker with
+		// objects via Add(). Instead, it should trigger the Create() function
+		// of the tracker, where an arbitrary gvr can be specified.
+		gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+		// Resource doesn't have the concept of "__internal" version, just set it to "".
+		if gvr.Version == runtime.APIVersionInternal {
+			gvr.Version = ""
+		}
+
+		s.log.Debug(
+			"Add",
+			logfieldClientset, s.domain,
+			logfieldGVR, gvr,
+			logfields.K8sNamespace, objMeta.GetNamespace(),
+			logfields.Name, objMeta.GetName(),
+		)
+
+		s.tbl.Insert(wtxn, object{
+			objectId: newObjectId(s.domain, gvr, objMeta.GetNamespace(), objMeta.GetName()),
+			o:        obj})
+	}
+	return nil
+}
+
+// Apply applies an object in the tracker in the specified namespace.
+func (s *statedbObjectTracker) Apply(gvr schema.GroupVersionResource, applyConfiguration runtime.Object, ns string, opts ...metav1.PatchOptions) error {
+	log := s.log.With(
+		logfieldClientset, s.domain,
+		logfields.Object, applyConfiguration)
+
+	applyConfigurationMeta, err := meta.Accessor(applyConfiguration)
+	if err != nil {
+		log.Debug("Apply", logfields.Error, err)
+		return err
+	}
+
+	obj, err := s.Get(gvr, ns, applyConfigurationMeta.GetName(), metav1.GetOptions{})
+	if err != nil {
+		log.Debug("Apply", logfields.Error, err)
+		return err
+	}
+
+	old, err := json.Marshal(obj)
+	if err != nil {
+		log.Debug("Apply", logfields.Error, err)
+		return err
+	}
+
+	// reset the object in preparation to unmarshal, since unmarshal does not guarantee that fields
+	// in obj that are removed by patch are cleared
+	value := reflect.ValueOf(obj)
+	value.Elem().Set(reflect.New(value.Type().Elem()).Elem())
+
+	// For backward compatibility with behavior 1.30 and earlier, continue to handle apply
+	// via strategic merge patch (clients may use fake.NewClientset and ManagedFieldObjectTracker
+	// for full field manager support).
+	patch, err := json.Marshal(applyConfiguration)
+	if err != nil {
+		log.Debug("Apply", logfields.Error, err)
+		return err
+	}
+	mergedByte, err := strategicpatch.StrategicMergePatch(old, patch, obj)
+	if err != nil {
+		log.Debug("Apply", logfields.Error, err)
+		return err
+	}
+	if err = json.Unmarshal(mergedByte, obj); err != nil {
+		log.Debug("Apply", logfields.Error, err)
+		return err
+	}
+
+	err = s.Update(gvr, obj, ns)
+	s.log.Debug("Apply", logfields.Error, err)
+	return err
+}
+
+// Create adds an object to the tracker in the specified namespace. If the object exists an error is returned.
+func (s *statedbObjectTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.CreateOptions) error {
+	log := s.log.With(
+		logfieldClientset, s.domain,
+		logfields.Object, obj)
+
+	obj = obj.DeepCopyObject()
+	newMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	if len(newMeta.GetNamespace()) == 0 {
+		newMeta.SetNamespace(ns)
+	}
+	wtxn := s.db.WriteTxn(s.tbl)
+	_, found, _ := s.tbl.Insert(wtxn, object{
+		objectId: newObjectId(s.domain, gvr, ns, newMeta.GetName()),
+		o:        obj})
+	if found {
+		wtxn.Abort()
+		gr := gvr.GroupResource()
+		err := apierrors.NewAlreadyExists(gr, newMeta.GetName())
+		log.Debug("Create", logfields.Error, err)
+	}
+	log.Debug("Create")
+	wtxn.Commit()
+	return nil
+}
+
+// Delete deletes an existing object from the tracker. If object
+// didn't exist in the tracker prior to deletion, Delete returns
+// no error.
+func (s *statedbObjectTracker) Delete(gvr schema.GroupVersionResource, ns string, name string, opts ...metav1.DeleteOptions) error {
+	log := s.log.With(
+		logfieldClientset, s.domain,
+		logfields.K8sNamespace, ns,
+		logfields.Name, name)
+
+	wtxn := s.db.WriteTxn(s.tbl)
+	_, found, _ := s.tbl.Delete(wtxn, object{objectId: newObjectId(s.domain, gvr, ns, name)})
+	if !found {
+		wtxn.Abort()
+		err := apierrors.NewNotFound(gvr.GroupResource(), name)
+		log.Debug("Delete", logfields.Error, err)
+		return err
+	}
+	wtxn.Commit()
+	log.Debug("Delete")
+	return nil
+}
+
+// Get retrieves the object by its kind, namespace and name.
+// Returns an error if object is not found.
+func (s *statedbObjectTracker) Get(gvr schema.GroupVersionResource, ns string, name string, opts ...metav1.GetOptions) (runtime.Object, error) {
+	log := s.log.With(
+		logfieldClientset, s.domain,
+		logfieldGVR, gvr,
+		logfields.K8sNamespace, ns,
+		logfields.Name, name)
+
+	txn := s.db.ReadTxn()
+	obj, rev, found := s.tbl.Get(txn, objectIndex.Query(newObjectId(s.domain, gvr, ns, name)))
+	if !found {
+		err := apierrors.NewNotFound(gvr.GroupResource(), name)
+		log.Debug("Get", logfields.Error, err)
+		return nil, err
+	}
+	log.Debug("Get", logfieldResourceVersion, rev)
+	return obj.o.DeepCopyObject(), nil
+}
+
+// List retrieves all objects of a given kind in the given
+// namespace. Only non-List kinds are accepted.
+func (s *statedbObjectTracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, ns string, opts ...metav1.ListOptions) (runtime.Object, error) {
+	// Heuristic for list kind: original kind + List suffix. Might
+	// not always be true but this tracker has a pretty limited
+	// understanding of the actual API model.
+	listGVK := gvk
+	listGVK.Kind = listGVK.Kind + "List"
+	// GVK does have the concept of "internal version". The scheme recognizes
+	// the runtime.APIVersionInternal, but not the empty string.
+	if listGVK.Version == "" {
+		listGVK.Version = runtime.APIVersionInternal
+	}
+
+	list, err := s.scheme.New(listGVK)
+	if err != nil {
+		return nil, err
+	}
+
+	if !meta.IsListType(list) {
+		return nil, fmt.Errorf("%q is not a list type", listGVK.Kind)
+	}
+
+	var fieldSelector fields.Selector
+	if len(opts) > 0 {
+		opt := opts[0]
+		if opt.FieldSelector != "" {
+			fieldSelector, err = fields.ParseSelector(opt.FieldSelector)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	matchingObjects := []runtime.Object{}
+	txn := s.db.ReadTxn()
+
+	for obj, rev := range s.tbl.All(txn) {
+		if obj.domain != s.domain || obj.gvr != gvr ||
+			(ns != "" && obj.Namespace != ns) {
+			continue
+		}
+
+		if fieldSelector != nil {
+			if !objectMatchesFieldSelector(obj.o, fieldSelector) {
+				s.log.Debug("List: Skipping object due to FieldSelector mismatch",
+					logfields.K8sNamespace, ns,
+					logfields.Name, obj.Name,
+					logfieldFieldSelector, fieldSelector)
+				continue
+			}
+		}
+
+		o := obj.o.DeepCopyObject()
+		m, _ := meta.Accessor(o)
+		m.SetResourceVersion(strconv.FormatUint(rev, 10))
+		matchingObjects = append(matchingObjects, o)
+	}
+	m, _ := meta.ListAccessor(list)
+	m.SetResourceVersion(strconv.FormatUint(s.tbl.Revision(txn), 10))
+
+	if err := meta.SetList(list, matchingObjects); err != nil {
+		return nil, err
+	}
+
+	s.log.Debug(
+		"List",
+		logfieldClientset, s.domain,
+		logfieldGVR, gvr,
+		logfields.K8sNamespace, ns,
+		logfields.Count, len(matchingObjects),
+	)
+	return list, nil
+}
+
+// Patch patches an existing object in the tracker in the specified namespace.
+//
+// The reactor functions take care of actually processing the patch
+// (objectTrackerReact.Patch in client-go/testing/fixture.go).
+func (s *statedbObjectTracker) Patch(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.PatchOptions) error {
+	return s.updateOrPatch("Patch", gvr, obj, ns)
+}
+
+// Update updates an existing object in the tracker in the specified namespace.
+// If the object does not exist an error is returned.
+func (s *statedbObjectTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.UpdateOptions) error {
+	return s.updateOrPatch("Update", gvr, obj, ns)
+}
+
+func (s *statedbObjectTracker) updateOrPatch(what string, gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.UpdateOptions) error {
+	obj = obj.DeepCopyObject()
+	newMeta, err := meta.Accessor(obj)
+	if err != nil {
+		s.log.Debug(what, logfields.Error, err)
+		return err
+	}
+	if len(newMeta.GetNamespace()) == 0 {
+		newMeta.SetNamespace(ns)
+	}
+	wtxn := s.db.WriteTxn(s.tbl)
+	version := s.tbl.Revision(wtxn) + 1
+	newMeta.SetResourceVersion(strconv.FormatUint(version, 10))
+
+	log := s.log.With(
+		logfieldClientset, s.domain,
+		logfields.Object, obj,
+		logfieldResourceVersion, version)
+
+	_, found, _ := s.tbl.Insert(wtxn, object{objectId: newObjectId(s.domain, gvr, ns, newMeta.GetName()), o: obj})
+	if !found {
+		wtxn.Abort()
+		gr := gvr.GroupResource()
+		err := apierrors.NewNotFound(gr, newMeta.GetName())
+		log.Debug(what, logfields.Error, err)
+		return err
+	}
+	wtxn.Commit()
+	log.Debug(what)
+	return nil
+}
+
+// Watch watches objects from the tracker. Watch returns a channel
+// which will push added / modified / deleted object.
+func (s *statedbObjectTracker) Watch(gvr schema.GroupVersionResource, ns string, opts ...metav1.ListOptions) (watch.Interface, error) {
+	wtxn := s.db.WriteTxn(s.tbl)
+	changeIter, err := s.tbl.Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		// Impossible
+		panic(err)
+	}
+
+	var fieldSelector fields.Selector
+	version := uint64(0)
+	if len(opts) > 0 && opts[0].ResourceVersion != "" {
+		opt := opts[0]
+		version, err = strconv.ParseUint(opt.ResourceVersion, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		if opt.FieldSelector != "" {
+			fieldSelector, err = fields.ParseSelector(opt.FieldSelector)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	s.log.Debug("Watch",
+		logfieldClientset, s.domain,
+		logfieldGVR, gvr,
+		logfields.K8sNamespace, ns,
+		logfieldResourceVersion, version)
+
+	w := &statedbWatch{
+		clientset:     s.domain,
+		log:           s.log,
+		version:       version,
+		gvr:           gvr,
+		ns:            ns,
+		db:            s.db,
+		iter:          changeIter,
+		stop:          make(chan struct{}),
+		stopped:       make(chan struct{}),
+		events:        make(chan watch.Event, 1),
+		fieldSelector: fieldSelector,
+	}
+	go w.feed()
+
+	return w, nil
+}
+
+type statedbWatch struct {
+	clientset     string
+	log           *slog.Logger
+	gvr           schema.GroupVersionResource
+	ns            string
+	version       statedb.Revision
+	db            *statedb.DB
+	iter          statedb.ChangeIterator[object]
+	stop          chan struct{}
+	stopOnce      sync.Once
+	stopped       chan struct{}
+	events        chan watch.Event
+	fieldSelector fields.Selector
+}
+
+// ResultChan implements watch.Interface.
+func (w *statedbWatch) ResultChan() <-chan watch.Event {
+	return w.events
+}
+
+func (w *statedbWatch) feed() {
+	defer close(w.stopped)
+	defer close(w.events)
+	seen := sets.New[string]()
+	for {
+		changes, changesWatch := w.iter.Next(w.db.ReadTxn())
+		for change := range changes {
+			if change.Revision <= w.version {
+				continue
+			}
+			obj := change.Object
+			if obj.domain != w.clientset {
+				continue
+			}
+			if (w.ns != "" && obj.Namespace != w.ns) || obj.gvr != w.gvr {
+				continue
+			}
+
+			if w.fieldSelector != nil {
+				if !objectMatchesFieldSelector(obj.o, w.fieldSelector) {
+					w.log.Debug("Watch: Skipping event due to FieldSelector mismatch",
+						logfieldFieldSelector, w.fieldSelector)
+					continue
+				}
+			}
+
+			var ev watch.Event
+			ev.Object = obj.o.DeepCopyObject()
+
+			switch {
+			case change.Deleted:
+				ev.Type = watch.Deleted
+				seen.Delete(obj.Name)
+			case seen.Has(obj.Name):
+				ev.Type = watch.Modified
+			default:
+				ev.Type = watch.Added
+				seen.Insert(obj.Name)
+			}
+			w.log.Debug(
+				"Event",
+				logfieldGVR, obj.gvr,
+				logfields.K8sNamespace, obj.Namespace,
+				logfields.Name, obj.Name,
+				logfields.Type, ev.Type,
+				logfieldResourceVersion, change.Revision,
+				logfields.Object, ev.Object,
+			)
+			select {
+			case w.events <- ev:
+			case <-w.stop:
+				return
+			}
+		}
+		select {
+		case <-w.stop:
+			return
+		case <-changesWatch:
+		}
+
+	}
+}
+
+// Stop implements watch.Interface.
+func (w *statedbWatch) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.stop)
+	})
+	<-w.stopped
+}
+
+var _ watch.Interface = &statedbWatch{}
+
+var _ testing.ObjectTracker = &statedbObjectTracker{}
+
+func objectMatchesFieldSelector(obj runtime.Object, sel fields.Selector) bool {
+	for _, req := range sel.Requirements() {
+		value, err := getFieldPathValue(obj, req.Field)
+		if err != nil {
+			return false
+		}
+		// https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/#supported-operators
+		// Only =, == and != are supported.
+		switch req.Operator {
+		case selection.DoubleEquals, selection.Equals:
+			if value != req.Value {
+				return false
+			}
+		case selection.NotEquals:
+			if value == req.Value {
+				return false
+			}
+		default:
+			panic(fmt.Sprintf("unsupported operator: %q", req.Operator))
+		}
+	}
+	return true
+}
+
+func getFieldPathValue(obj interface{}, fieldPath string) (string, error) {
+	p := jsonpath.New("").AllowMissingKeys(false)
+	if err := p.Parse("{$." + fieldPath + "}"); err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	if err := p.Execute(&b, obj); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}

--- a/pkg/k8s/client/script_test.go
+++ b/pkg/k8s/client/script_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package client
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// TestScript runs all the testdata/*.txtar script tests. The tests are
+// run in parallel. If you need to update the expected files inside the txtar
+// files you can run 'go test . -scripttest.update' to update the files.
+func TestScript(t *testing.T) {
+	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	scripttest.Test(t,
+		ctx,
+		func(t testing.TB, args []string) *script.Engine {
+			h := hive.New(
+				FakeClientCell,
+			)
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			h.RegisterFlags(flags)
+			t.Cleanup(func() {
+				assert.NoError(t, h.Stop(log, context.TODO()))
+			})
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+			maps.Insert(cmds, maps.All(script.DefaultCmds()))
+			return &script.Engine{
+				Cmds: cmds,
+			}
+		}, []string{}, "testdata/*.txtar")
+}

--- a/pkg/k8s/client/testdata/fake.txtar
+++ b/pkg/k8s/client/testdata/fake.txtar
@@ -1,0 +1,137 @@
+# Tests for the fake k8s client and our custom object tracker.
+#
+# This adds+updates an object from each of the clientsets and checks that
+# they get correctly indexed and we can retrieve them via the k8s script commands.
+
+hive/start
+
+# Add object for the Kubernetes and Slim clientsets
+k8s/add service.yaml
+k8s/update service.yaml
+
+# Add object just for the Kubernetes clientset (has no slim counterpart)
+k8s/add limitrange.yaml
+k8s/update limitrange.yaml
+
+# Add object for the Cilium clientset
+k8s/add ciliumenvoyconfig.yaml
+k8s/update ciliumenvoyconfig.yaml
+
+# Add object for the apiext clientset
+k8s/add apiext_crd.yaml
+k8s/update apiext_crd.yaml
+
+# Add object for the MCSAPI clientset
+k8s/add mcs_svcexport.yaml
+k8s/update mcs_svcexport.yaml
+
+# Validate the summary to see that we've indexed everything
+k8s/summary summary.actual
+cmp summary.expected summary.actual
+
+# Verify that we can retrieve the service (this will prefer slim)
+k8s/get v1.services test/echo -o actual.yaml
+grep 'kind: Service' actual.yaml
+grep 'name: echo' actual.yaml
+
+# Verify that we can retrieve the limitrange from the Kubernetes clientset
+k8s/get v1.limitranges bar/foo -o actual.yaml
+grep 'kind: LimitRange' actual.yaml
+grep 'name: foo' actual.yaml
+
+# Verify that we can retrieve the service export from the MCS clientset
+k8s/get multicluster.x-k8s.io.v1alpha1.serviceexports test -o actual.yaml
+grep 'kind: ServiceExport' actual.yaml
+grep 'name: test' actual.yaml
+
+# Validate the table output of 'k8s-object-tracker'
+db/cmp k8s-object-tracker object-tracker.table
+
+# Delete objects from each clientset
+k8s/delete service.yaml limitrange.yaml ciliumenvoyconfig.yaml apiext_crd.yaml mcs_svcexport.yaml
+k8s/summary summary.actual
+cmp summary.empty summary.actual
+db/empty k8s-object-tracker
+
+###
+
+-- object-tracker.table --
+ID                                                                                           Type
+*;/v1, Resource=services;test/echo                                                           *v1.Service
+*;apiextensions.k8s.io/v1, Resource=customresourcedefinitions;/ciliumenvoyconfigs.cilium.io  *v1.CustomResourceDefinition
+*;cilium.io/v2, Resource=ciliumenvoyconfigs;default/cec                                      *v2.CiliumEnvoyConfig
+*;multicluster.x-k8s.io/v1alpha1, Resource=serviceexports;/test                              *v1alpha1.ServiceExport
+k8s;/v1, Resource=limitranges;bar/foo                                                        *v1.LimitRange
+k8s;/v1, Resource=services;test/echo                                                         *v1.Service
+
+-- summary.expected --
+*:
+- v1.services: 1
+- cilium.io.v2.ciliumenvoyconfigs: 1
+- apiextensions.k8s.io.v1.customresourcedefinitions: 1
+- multicluster.x-k8s.io.v1alpha1.serviceexports: 1
+k8s:
+- v1.services: 1
+- v1.limitranges: 1
+-- summary.empty --
+*:
+- v1.services: 0
+- cilium.io.v2.ciliumenvoyconfigs: 0
+- apiextensions.k8s.io.v1.customresourcedefinitions: 0
+- multicluster.x-k8s.io.v1alpha1.serviceexports: 0
+k8s:
+- v1.services: 0
+- v1.limitranges: 0
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  resourceVersion: "12345" # Will be ignored
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+
+-- limitrange.yaml --
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: foo
+  namespace: bar
+
+-- ciliumenvoyconfig.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: cec
+  namespace: default
+  resourceVersion: "12345" # Will be ignored
+  uid: 094b684c-6a6a-4313-b07b-c7c124da8d1f
+spec:
+  backendServices:
+  - name: foo
+
+-- apiext_crd.yaml --
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumenvoyconfigs.cilium.io
+spec:
+  group: cilium.io
+  names:
+    categories:
+    - cilium
+    kind: CiliumEnvoyConfig
+    listKind: CiliumEnvoyConfigList
+    plural: ciliumenvoyconfigs
+    shortNames:
+    - cec
+    singular: ciliumenvoyconfig
+  scope: Namespaced
+
+-- mcs_svcexport.yaml --
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: test

--- a/pkg/k8s/testutils/decoder.go
+++ b/pkg/k8s/testutils/decoder.go
@@ -29,6 +29,9 @@ var (
 	// lazily constructed.
 	Scheme = runtime.NewScheme()
 
+	// KubernetesScheme is the core Kubernetes scheme.
+	KubernetesScheme = runtime.NewScheme()
+
 	decoderOnce sync.Once
 	decoder     runtime.Decoder
 
@@ -44,6 +47,13 @@ func Decoder() runtime.Decoder {
 		decoder = serializer.NewCodecFactory(Scheme).UniversalDeserializer()
 	})
 	return decoder
+}
+
+func KubernetesDecoder() runtime.Decoder {
+	kubernetesDecoderOnce.Do(func() {
+		kubernetesDecoder = serializer.NewCodecFactory(KubernetesScheme).UniversalDeserializer()
+	})
+	return kubernetesDecoder
 }
 
 func init() {
@@ -63,6 +73,8 @@ func init() {
 
 	// Add multiclusterv1alpha1
 	mcsapi_fake.AddToScheme(Scheme)
+
+	fake.AddToScheme(KubernetesScheme)
 }
 
 func DecodeObject(bytes []byte) (runtime.Object, error) {
@@ -79,12 +91,7 @@ func DecodeObjectGVK(bytes []byte) (runtime.Object, *schema.GroupVersionKind, er
 }
 
 func DecodeKubernetesObject(bytes []byte) (runtime.Object, *schema.GroupVersionKind, error) {
-	kubernetesDecoderOnce.Do(func() {
-		scheme := runtime.NewScheme()
-		fake.AddToScheme(scheme)
-		kubernetesDecoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
-	})
-	return kubernetesDecoder.Decode(bytes, nil, nil)
+	return KubernetesDecoder().Decode(bytes, nil, nil)
 }
 
 func DecodeFile(path string) (runtime.Object, error) {

--- a/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
@@ -3,9 +3,7 @@
 # Add a node address.
 db/insert node-addresses addrv4.yaml
 
-# Start and wait for initialization.
 hive start
-db/initialized
 
 env HEALTHPORT1=40000
 env HEALTHPORT2=40001

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -49,6 +50,7 @@ func TestScript(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	version.Force(k8sTestutils.DefaultVersion)
+	nodeTypes.SetName("testnode")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)

--- a/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
@@ -1,5 +1,4 @@
 hive start
-db/initialized
 
 # Add a pod and an address-based redirection. Add IPv4 first then
 # IPv6 for consistent ordering.

--- a/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
@@ -106,6 +106,7 @@ spec:
         - containerPort: 80
           name: tcp
           protocol: TCP
+  nodeName: testnode
 status:
   hostIP: 172.19.0.3
   hostIPs:

--- a/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns.txtar
@@ -179,14 +179,14 @@ endpoints:
     ready: true
     serving: true
     terminating: false
-  nodeName: kind-worker
+  nodeName: testnode
 - addresses:
   - 10.244.1.51
   conditions:
     ready: true
     serving: true
     terminating: false
-  nodeName: kind-worker
+  nodeName: testnode
 kind: EndpointSlice
 metadata:
   labels:
@@ -254,7 +254,7 @@ spec:
     - containerPort: 9253
       name: metrics
       protocol: TCP
-  nodeName: kind-control-plane
+  nodeName: testnode
 status:
   conditions:
   - lastProbeTime: null
@@ -300,7 +300,7 @@ spec:
     - containerPort: 9253
       name: metrics
       protocol: TCP
-  nodeName: kind-control-plane
+  nodeName: testnode
 status:
   conditions:
   - lastProbeTime: null

--- a/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns.txtar
@@ -4,7 +4,6 @@
 
 # Start and wait for reflectors to catch up.
 hive start
-db/initialized
 
 # Add the kubedns service and endpoints
 k8s/add svc-kubedns.yaml eps-kubedns.yaml

--- a/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
@@ -1,11 +1,9 @@
 hive start
-db/initialized
 
 # Add pods, services and endpoints.
 k8s/add pod.yaml service.yaml endpointslice.yaml
 db/cmp services services-before.table
 db/cmp frontends frontends-before.table
-
 
 # Compare maps
 lb/maps-dump lbmaps.actual

--- a/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
@@ -198,6 +198,7 @@ spec:
         - containerPort: 70
           name: udp
           protocol: UDP
+  nodeName: testnode
 status:
   hostIP: 172.19.0.3
   hostIPs:

--- a/pkg/loadbalancer/redirectpolicy/testdata/skiplb-addr.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/skiplb-addr.txtar
@@ -220,6 +220,7 @@ spec:
         - containerPort: 80
           name: tcp
           protocol: TCP
+  nodeName: testnode
 status:
   hostIP: 172.19.0.3
   hostIPs:

--- a/pkg/loadbalancer/redirectpolicy/testdata/skiplb-addr.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/skiplb-addr.txtar
@@ -3,7 +3,6 @@
 # the load-balancing in datapath for packets originating from the backend.
 
 hive start
-db/initialized
 
 ### Case 1: 1) cookie, 2) pod 3) LRP
 

--- a/pkg/loadbalancer/redirectpolicy/testdata/skiplb.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/skiplb.txtar
@@ -3,7 +3,6 @@
 # the load-balancing in datapath for packets originating from the backend.
 
 hive start
-db/initialized
 
 ### Case 1: 1) cookie, 2) pod,service,eps, 3) LRP
 

--- a/pkg/loadbalancer/redirectpolicy/testdata/skiplb.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/skiplb.txtar
@@ -11,17 +11,23 @@ hive start
 # coming from the EndpointManager.
 db/insert desired-skiplbmap pod-cookie.yaml
 
-# Add pods, services and endpoints.
-k8s/add endpointslice.yaml
+# Add services and endpoints.
+k8s/add service.yaml endpointslice.yaml
 db/cmp backends backends.table
 
-k8s/add pod.yaml service.yaml lrp-svc.yaml
+# Compare LB maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-case1-pre.expected
+
+# Add the override
+k8s/add pod.yaml lrp-svc.yaml
 db/cmp localredirectpolicies lrp.table
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp desired-skiplbmap skiplbmap.table
 
-# Compare LB maps
+# Compare LB maps. The original backends become orphans and
+# are removed a new backend is created for the pod.
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.actual maps-case1.expected
 
@@ -160,6 +166,15 @@ Address                    Type        ServiceName   PortName   Backends        
 169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                     Done
 [1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:8080/TCP                      Done
 
+-- maps-case1-pre.expected --
+BE: ID=1 ADDR=10.244.1.1:8080/TCP STATE=active
+BE: ID=2 ADDR=[2001::1]:8080/TCP STATE=active
+REV: ID=1 ADDR=169.254.169.254:8080
+REV: ID=2 ADDR=[1001::1]:8080
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:8080/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 -- maps-case1.expected --
 BE: ID=3 ADDR=10.244.2.1:80/TCP STATE=active
 BE: ID=4 ADDR=[2002::2]:80/TCP STATE=active
@@ -215,6 +230,7 @@ spec:
         - containerPort: 80
           name: tcp
           protocol: TCP
+  nodeName: testnode
 status:
   hostIP: 172.19.0.3
   hostIPs:

--- a/pkg/loadbalancer/tests/main_test.go
+++ b/pkg/loadbalancer/tests/main_test.go
@@ -16,5 +16,9 @@ func TestMain(m *testing.M) {
 		// and the agent specifics.
 		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
 		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+
+		// Unfortunately we don't have a way for waiting for the DelayingWorkQueue's background goroutine
+		// to exit (used by pkg/k8s/resource), so we'll just need to ignore it.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType[...]).waitingLoop"),
 	)
 }

--- a/pkg/loadbalancer/tests/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/tests/testdata/clusterip.txtar
@@ -3,9 +3,6 @@
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 # Add the service and then endpoints
 k8s/add service.yaml
 db/cmp services services.table

--- a/pkg/loadbalancer/tests/testdata/dualstack-maglev.txtar
+++ b/pkg/loadbalancer/tests/testdata/dualstack-maglev.txtar
@@ -10,9 +10,6 @@ db/cmp node-addresses nodeaddrs.table
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 # For determinism, add the endpoints first and then services.
 k8s/add endpointslice-ipv4.yaml endpointslice-ipv6.yaml
 db/cmp backends backends.table

--- a/pkg/loadbalancer/tests/testdata/dualstack.txtar
+++ b/pkg/loadbalancer/tests/testdata/dualstack.txtar
@@ -9,9 +9,6 @@ db/cmp node-addresses nodeaddrs.table
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 # For determinism, add the endpoints first.
 k8s/add endpointslice-ipv4.yaml endpointslice-ipv6.yaml
 db/cmp backends backends.table 

--- a/pkg/loadbalancer/tests/testdata/external-clusterip.txtar
+++ b/pkg/loadbalancer/tests/testdata/external-clusterip.txtar
@@ -4,9 +4,6 @@
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 k8s/add service.yaml endpointslice.yaml
 
 # Check the BPF maps. The service should not be marked as "non-routable"

--- a/pkg/loadbalancer/tests/testdata/file.txtar
+++ b/pkg/loadbalancer/tests/testdata/file.txtar
@@ -4,7 +4,6 @@
 #
 
 hive/start
-db/initialized
 
 # Starting with a missing state file. Tables should be empty
 db/empty services backends frontends

--- a/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
@@ -6,9 +6,6 @@
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 # Start with two backends that are both active.
 cp endpointslice.yaml.tmpl endpointslice.yaml
 replace '$TERM1' 'false' endpointslice.yaml

--- a/pkg/loadbalancer/tests/testdata/headless.txtar
+++ b/pkg/loadbalancer/tests/testdata/headless.txtar
@@ -3,9 +3,6 @@
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 # Add a headless service with backends.
 k8s/add service_clusterip_none.yaml endpointslice.yaml
 

--- a/pkg/loadbalancer/tests/testdata/hostport.txtar
+++ b/pkg/loadbalancer/tests/testdata/hostport.txtar
@@ -13,7 +13,6 @@ db/cmp node-addresses nodeaddrs.table
 
 # Start the test application
 hive start
-db/initialized
 
 # Add a pod with 'hostPort'. A synthetic service, frontend and backend will
 # be created for it.
@@ -173,7 +172,7 @@ spec:
       hostPort: 4444
       protocol: TCP
     resources: {}
-  nodeName: kind-worker
+  nodeName: testnode
   restartPolicy: Always
   schedulerName: default-scheduler
   securityContext: {}

--- a/pkg/loadbalancer/tests/testdata/ingress.txtar
+++ b/pkg/loadbalancer/tests/testdata/ingress.txtar
@@ -7,7 +7,6 @@
 # Based on https://docs.cilium.io/en/stable/network/servicemesh/http/
 
 hive/start
-db/initialized
 
 # Add the service and endpoints
 k8s/add svc-ingress.yaml eps-ingress.yaml

--- a/pkg/loadbalancer/tests/testdata/loadbalancer.txtar
+++ b/pkg/loadbalancer/tests/testdata/loadbalancer.txtar
@@ -7,11 +7,6 @@ db/cmp node-addresses nodeaddrs.table
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-# (otherwise might miss events due to List() vs Watch() race in fake client).
-# NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
-db/initialized
-
 # Add the endpoints and service
 k8s/add endpointslice.yaml
 db/cmp backends backends.table

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -7,7 +7,6 @@
 #
 
 hive/start
-db/initialized
 
 # Add our test service and backends. To avoid undeterministic ID allocation
 # add the IPv4 endpoints first.

--- a/pkg/loadbalancer/tests/testdata/multiport.txtar
+++ b/pkg/loadbalancer/tests/testdata/multiport.txtar
@@ -3,9 +3,6 @@
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table

--- a/pkg/loadbalancer/tests/testdata/nodeport-addr.txtar
+++ b/pkg/loadbalancer/tests/testdata/nodeport-addr.txtar
@@ -8,7 +8,6 @@ db/cmp node-addresses nodeaddrs.table
 
 # Start the test application
 hive start
-db/initialized
 
 # Add the first service and endpoints
 k8s/add endpointslice.yaml

--- a/pkg/loadbalancer/tests/testdata/nodeport-explicit-maglev.txtar
+++ b/pkg/loadbalancer/tests/testdata/nodeport-explicit-maglev.txtar
@@ -7,11 +7,6 @@ db/cmp node-addresses nodeaddrs.table
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-# (otherwise might miss events due to List() vs Watch() race in fake client).
-# NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
-db/initialized
-
 # Add the first service and endpoints
 k8s/add endpointslice.yaml
 db/cmp backends backends1.table

--- a/pkg/loadbalancer/tests/testdata/nodeport-explicit-random.txtar
+++ b/pkg/loadbalancer/tests/testdata/nodeport-explicit-random.txtar
@@ -7,11 +7,6 @@ db/cmp node-addresses nodeaddrs.table
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-# (otherwise might miss events due to List() vs Watch() race in fake client).
-# NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
-db/initialized
-
 # Add the first service and endpoints
 k8s/add endpointslice.yaml
 db/cmp backends backends1.table

--- a/pkg/loadbalancer/tests/testdata/nodeport-maglev.txtar
+++ b/pkg/loadbalancer/tests/testdata/nodeport-maglev.txtar
@@ -8,11 +8,6 @@ db/cmp node-addresses nodeaddrs.table
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-# (otherwise might miss events due to List() vs Watch() race in fake client).
-# NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
-db/initialized
-
 # Add the first service and endpoints
 k8s/add endpointslice.yaml
 db/cmp backends backends1.table

--- a/pkg/loadbalancer/tests/testdata/nodeport.txtar
+++ b/pkg/loadbalancer/tests/testdata/nodeport.txtar
@@ -8,11 +8,6 @@ db/cmp node-addresses nodeaddrs.table
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-# (otherwise might miss events due to List() vs Watch() race in fake client).
-# NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
-db/initialized
-
 # Add the first service and endpoints
 k8s/add endpointslice.yaml
 db/cmp backends backends_only1.table

--- a/pkg/loadbalancer/tests/testdata/proxy-delegation.txtar
+++ b/pkg/loadbalancer/tests/testdata/proxy-delegation.txtar
@@ -2,7 +2,6 @@
 
 # Start the test application
 hive start
-db/initialized
 
 # Set the local node IP address. This is used when filtering for local backends
 # when proxy delegation is set.

--- a/pkg/loadbalancer/tests/testdata/pruning.txtar
+++ b/pkg/loadbalancer/tests/testdata/pruning.txtar
@@ -3,9 +3,6 @@
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table

--- a/pkg/loadbalancer/tests/testdata/quarantined.txtar
+++ b/pkg/loadbalancer/tests/testdata/quarantined.txtar
@@ -4,7 +4,6 @@
 # of quarantined backends.
 
 hive/start
-db/initialized
 
 # Add our test service and backends.
 k8s/add service.yaml endpointslice.yaml

--- a/pkg/loadbalancer/tests/testdata/queries.txtar
+++ b/pkg/loadbalancer/tests/testdata/queries.txtar
@@ -5,7 +5,6 @@
 
 # Start and wait for sync against the k8s fake client.
 hive start
-db/initialized
 
 # Show the registered tables and indexes
 db

--- a/pkg/loadbalancer/tests/testdata/reuse.txtar
+++ b/pkg/loadbalancer/tests/testdata/reuse.txtar
@@ -18,7 +18,6 @@
 #
 
 hive start
-db/initialized
 
 # Make a copy of service.yaml with a different name
 cp service.yaml service2.yaml

--- a/pkg/loadbalancer/tests/testdata/source-ranges.txtar
+++ b/pkg/loadbalancer/tests/testdata/source-ranges.txtar
@@ -3,9 +3,6 @@
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table

--- a/pkg/loadbalancer/tests/testdata/svc-forwarding-mode-annotation.txtar
+++ b/pkg/loadbalancer/tests/testdata/svc-forwarding-mode-annotation.txtar
@@ -2,7 +2,6 @@
 
 # Start the test application
 hive start
-db/initialized
 
 # Add service w/o "service.cilium.io/forwarding-mode"
 k8s/add service.yaml endpointslice.yaml

--- a/pkg/loadbalancer/tests/testdata/svc-node-exposure.txtar
+++ b/pkg/loadbalancer/tests/testdata/svc-node-exposure.txtar
@@ -3,9 +3,7 @@
 # Test service node exposure
 #
 
-# Start and wait for watchers
 hive start
-db/initialized
 
 # Add the endpoints and service
 k8s/add endpointslice.yaml

--- a/pkg/loadbalancer/tests/testdata/svc-type-annotation.txtar
+++ b/pkg/loadbalancer/tests/testdata/svc-type-annotation.txtar
@@ -3,11 +3,6 @@
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-# (otherwise might miss events due to List() vs Watch() race in fake client).
-# NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
-db/initialized
-
 # Add the endpoints and service
 k8s/add endpointslice.yaml
 db/cmp backends backends.table

--- a/pkg/loadbalancer/tests/testdata/topology-aware.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware.txtar
@@ -8,7 +8,6 @@ test/set-node-labels topology.kubernetes.io/zone=foo
 
 # Start and wait for watchers
 hive start
-db/initialized
 
 # Add the service (with topology-mode=auto) and endpoints
 # 10.244.1.1 (for zones foo & bar), 10.244.2.1 (for zone quux).

--- a/pkg/loadbalancer/tests/testdata/trafficpolicy.txtar
+++ b/pkg/loadbalancer/tests/testdata/trafficpolicy.txtar
@@ -3,9 +3,6 @@
 # Start the test application
 hive start
 
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db/initialized
-
 # Create a LoadBalancer service with Local traffic policies and associate two backends 
 # to it, one of them on this node ("testnode") and one on another node.
 k8s/add service_tp_local.yaml endpointslice.yaml


### PR DESCRIPTION
This implements a new `testing.ObjectTracker` on top of StateDB that fixes the long-standing pain point with the k8s fake client, namely that its `Watch` implementation does not support multiple watchers and it will miss events that happen between `List` and `Watch`. This new implementation understands `ResourceVersion` and allows starting to watch from older versions without missing events.

This will also help doing more complicated integration tests where we would e.g. run the agent and the operator hives in the same process with a single fake client & tracker and we would be able to have both watching the same resources.

An extra bonus is that we now have debug logging for every k8s action that is done: 
```
logger.go:256: time=2025-05-08T18:35:43.964+02:00 level=DEBUG source=/home/jussi/go/src/github.com/cilium/cilium/pkg/k8s/client/object_tracker.go:324 msg=Get module=k8s-fake-client clientset=* gvr="cilium.io/v2, Resource=ciliumloadbalancerippools" k8sNamespace="" name=pool-a resourceVersion=9
logger.go:256: time=2025-05-08T18:35:43.964+02:00 level=DEBUG source=/home/jussi/go/src/github.com/cilium/cilium/pkg/k8s/client/object_tracker.go:436 msg=Update module=k8s-fake-client clientset=* obj="&{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:pool-a GenerateName: Namespace: SelfLink: UID: ResourceVersion:9 Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[]} Spec:{ServiceSelector:nil AllowFirstLastIPs: Blocks:[{Cidr:10.0.0.0/24 Start: Stop:}] Disabled:false} Status:{Conditions:[{Type:cilium.io/PoolConflict Status:False ObservedGeneration:0 LastTransitionTime:2025-05-08 18:35:43 +0200 CEST Reason:resolved Message:} {Type:cilium.io/IPsTotal Status:Unknown ObservedGeneration:0 LastTransitionTime:2025-05-08 18:35:43 +0200 CEST Reason:noreason Message:256} {Type:cilium.io/IPsAvailable Status:Unknown ObservedGeneration:0 LastTransitionTime:2025-05-08 18:35:43 +0200 CEST Reason:noreason Message:255}]}}" resourceVersion=9
etc.
```
