### PR TITLE
pkg/k8s: Synchronize heartbeat goroutine

### DIFF
--- a/pkg/k8s/client/client_test.go
+++ b/pkg/k8s/client/client_test.go
@@ -227,7 +227,9 @@ func Test_client(t *testing.T) {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	hive.RegisterFlags(flags)
 	flags.Set(option.K8sAPIServerURLs, srv.URL)
-	flags.Set(option.K8sHeartbeatTimeout, "5ms")
+	flags.Set(option.K8sHeartbeatTimeout, "150ms")
+	// Set a higher QPS limit as the test exercises timing aspects.
+	flags.Set(option.K8sClientQPSLimit, "500")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -311,7 +313,9 @@ func Test_clientMultipleAPIServers(t *testing.T) {
 	hive.RegisterFlags(flags)
 	urls := []string{servers[0].URL, servers[1].URL, servers[2].URL}
 	flags.Set(option.K8sAPIServerURLs, strings.Join(urls, ","))
-	flags.Set(option.K8sHeartbeatTimeout, "5ms")
+	flags.Set(option.K8sHeartbeatTimeout, "150ms")
+	// Set a higher QPS limit as the test exercises timing aspects.
+	flags.Set(option.K8sClientQPSLimit, "500")
 	// 2/3 servers are stopped in order to validate that the agent connects to an active server.
 	servers[1].Close()
 	servers[2].Close()


### PR DESCRIPTION
When the heartbeat timeout is set to a low value (e.g., in tests), there's a risk that the goroutine responsible for sending heartbeat probes may not start before the timeout expires. To address this, introduce a channel to synchronize goroutine startup.

A WaitGroup could also be used, but it risks blocking the controller indefinitely if the goroutine fails to start or blocks on I/O.

Fixes: https://github.com/cilium/cilium/issues/39428