### PR TITLE
docs: Remove references to Vagrant

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -404,8 +404,7 @@ Minor version
 ~~~~~~~~~~~~~
 
 #. Check if it is possible to remove the last supported Kubernetes version from
-   :ref:`k8scompatibility`, :ref:`k8s_requirements`, :ref:`test_matrix`,
-   :ref:`running_k8s_tests`, :ref:`gsg_istio` and add the new Kubernetes
+   :ref:`k8scompatibility`, :ref:`k8s_requirements` and add the new Kubernetes
    version to that list.
 
 #. If the minimal supported version changed, leave a note in the upgrade guide


### PR DESCRIPTION
The legacy e2e tests still exist, but the files needed to operate Vagrant are now gone. Remove references to Vagrant so that these instructions are a bit simpler and closer to reality. When we complete https://github.com/cilium/cilium/issues/37837 we can get rid of the rest.
