### PR TITLE
bgpv1: Add SourceASN field to Path struct

### DIFF
--- a/pkg/bgpv1/gobgp/conversions.go
+++ b/pkg/bgpv1/gobgp/conversions.go
@@ -44,12 +44,13 @@ func ToGoBGPPath(p *types.Path) (*gobgp.Path, error) {
 	}
 
 	return &gobgp.Path{
-		Nlri:   nlri,
-		Pattrs: pattrs,
-		Age:    ageTimestamp,
-		Best:   p.Best,
-		Family: family,
-		Uuid:   p.UUID,
+		Nlri:      nlri,
+		Pattrs:    pattrs,
+		Age:       ageTimestamp,
+		Best:      p.Best,
+		Family:    family,
+		Uuid:      p.UUID,
+		SourceAsn: p.SourceASN,
 	}, nil
 }
 
@@ -78,6 +79,7 @@ func ToAgentPath(p *gobgp.Path) (*types.Path, error) {
 		AgeNanoseconds: ageNano,
 		Best:           p.Best,
 		UUID:           p.Uuid,
+		SourceASN:      p.SourceAsn,
 	}, nil
 }
 

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -58,6 +58,7 @@ type Path struct {
 	AgeNanoseconds int64 // time duration in nanoseconds since the Path was created
 	Best           bool
 	UUID           []byte // path identifier in underlying implementation
+	SourceASN      uint32
 }
 
 // Neighbor is an object representing a single BGP neighbor. It is an analogue


### PR DESCRIPTION
Added the SourceASN field to the Path struct to store the source ASN of a path. Updated ToGoBGPPath and ToAgentPath conversion functions to handle the new field. This is useful to determine whether the route is coming from eBGP or iBGP.

```release-note
bgpv1: Add SourceASN field to Path struct
```
