### PR TITLE
hubble-cli: add option to print policy names for flow verdict events

### DIFF
--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -715,6 +715,9 @@ func handleFlowArgs(writer io.Writer, ofilter *flowFilter, debug bool) (err erro
 	if formattingOpts.nodeName {
 		opts = append(opts, hubprinter.WithNodeName())
 	}
+	if formattingOpts.policyNames {
+		opts = append(opts, hubprinter.WithPolicyNames())
+	}
 	printer = hubprinter.New(opts...)
 	return nil
 }

--- a/hubble/cmd/observe/observe.go
+++ b/hubble/cmd/observe/observe.go
@@ -33,6 +33,7 @@ var (
 
 		enableIPTranslation bool
 		nodeName            bool
+		policyNames         bool
 		numeric             bool
 		color               string
 	}
@@ -122,6 +123,7 @@ func init() {
   table:    Tab-aligned columns
 `)
 	formattingFlags.BoolVarP(&formattingOpts.nodeName, "print-node-name", "", false, "Print node name in output")
+	formattingFlags.BoolVarP(&formattingOpts.policyNames, "print-policy-names", "", false, "Print policy names in output")
 	formattingFlags.StringVar(
 		&formattingOpts.timeFormat, "time-format", "StampMilli",
 		fmt.Sprintf(`Specify the time format for printing. This option does not apply to the json and jsonpb output type. One of:

--- a/hubble/cmd/observe_help.txt
+++ b/hubble/cmd/observe_help.txt
@@ -127,6 +127,7 @@ Formatting Flags:
                                table:    Tab-aligned columns
                               (default "compact")
       --print-node-name      Print node name in output
+      --print-policy-names   Print policy names in output
       --time-format string   Specify the time format for printing. This option does not apply to the json and jsonpb output type. One of:
                                StampMilli:             Jan _2 15:04:05.000
                                YearMonthDay:           2006-01-02

--- a/hubble/pkg/printer/options.go
+++ b/hubble/pkg/printer/options.go
@@ -32,6 +32,7 @@ type Options struct {
 	enableDebug         bool
 	enableIPTranslation bool
 	nodeName            bool
+	policyNames         bool
 	timeFormat          string
 	color               string
 }
@@ -121,6 +122,13 @@ func WithIPTranslation() Option {
 func WithNodeName() Option {
 	return func(opts *Options) {
 		opts.nodeName = true
+	}
+}
+
+// WithPolicyNames enables printing the names of policies which allow / deny traffic
+func WithPolicyNames() Option {
+	return func(opts *Options) {
+		opts.policyNames = true
 	}
 }
 

--- a/hubble/pkg/printer/printer_test.go
+++ b/hubble/pkg/printer/printer_test.go
@@ -130,16 +130,30 @@ func TestPrinter_AllFieldsInMask(t *testing.T) {
 
 func TestPrinter_WriteProtoFlow(t *testing.T) {
 	buf := bytes.Buffer{}
+
 	reply := proto.Clone(&f).(*flowpb.Flow)
 	reply.IsReply = &wrapperspb.BoolValue{Value: true}
+
 	unknown := proto.Clone(&f).(*flowpb.Flow)
 	unknown.IsReply = nil
+
 	policyDenied := proto.Clone(&f).(*flowpb.Flow)
 	policyDenied.EventType = &flowpb.CiliumEventType{
 		Type: monitorAPI.MessageTypePolicyVerdict,
 	}
 	policyDenied.IsReply = nil
 	policyDenied.TrafficDirection = flowpb.TrafficDirection_EGRESS
+	policyDenied.EgressDeniedBy = []*flowpb.Policy{{Name: "my-policy", Namespace: "my-policy-namespace", Kind: "CiliumNetworkPolicy"}}
+
+	policyAllowed := proto.Clone(&f).(*flowpb.Flow)
+	policyAllowed.EventType = &flowpb.CiliumEventType{
+		Type: monitorAPI.MessageTypePolicyVerdict,
+	}
+	policyAllowed.Verdict = flowpb.Verdict_FORWARDED
+	policyAllowed.IsReply = nil
+	policyAllowed.TrafficDirection = flowpb.TrafficDirection_INGRESS
+	policyAllowed.IngressAllowedBy = []*flowpb.Policy{{Name: "my-policy", Namespace: "my-policy-namespace", Kind: "CiliumNetworkPolicy"}, {Name: "my-policy-2", Kind: "CiliumClusterwideNetworkPolicy"}}
+
 	type args struct {
 		f *flowpb.Flow
 	}
@@ -252,6 +266,40 @@ Jan  1 00:20:34.567   1.1.1.1:31793   2.2.2.2:8080   kafka-request   DROPPED   K
 			expected: "Jan  1 00:20:34.567 [k8s1]: " +
 				"1.1.1.1:31793 (health) <> 2.2.2.2:8080 (ID:12345) " +
 				"policy-verdict:none EGRESS DENIED (TCP Flags: SYN)\n",
+		},
+		{
+			name: "compact-policy-verdict-denied-with-policy-name",
+			options: []Option{
+				Compact(),
+				WithColor("never"),
+				WithNodeName(),
+				WithPolicyNames(),
+				Writer(&buf),
+			},
+			args: args{
+				f: policyDenied,
+			},
+			wantErr: false,
+			expected: "Jan  1 00:20:34.567 [k8s1]: " +
+				"1.1.1.1:31793 (health) <> 2.2.2.2:8080 (ID:12345) " +
+				"policy-verdict:none EGRESS DENIED BY my-policy (CiliumNetworkPolicy) (TCP Flags: SYN)\n",
+		},
+		{
+			name: "compact-policy-verdict-allowed-with-policy-name",
+			options: []Option{
+				Compact(),
+				WithColor("never"),
+				WithNodeName(),
+				WithPolicyNames(),
+				Writer(&buf),
+			},
+			args: args{
+				f: policyAllowed,
+			},
+			wantErr: false,
+			expected: "Jan  1 00:20:34.567 [k8s1]: " +
+				"1.1.1.1:31793 (health) <> 2.2.2.2:8080 (ID:12345) " +
+				"policy-verdict:none INGRESS ALLOWED BY my-policy (CiliumNetworkPolicy), my-policy-2 (CiliumClusterwideNetworkPolicy) (TCP Flags: SYN)\n",
 		},
 		{
 			name: "compact-direction-unknown",
@@ -396,6 +444,25 @@ DESTINATION: 2.2.2.2:8080
 DESTINATION: 2.2.2.2:8080
        TYPE: Policy denied
     VERDICT: DROPPED
+    SUMMARY: TCP Flags: SYN`,
+		},
+		{
+			name: "dict-with-policy-name",
+			options: []Option{
+				Dict(),
+				WithColor("never"),
+				WithPolicyNames(),
+				Writer(&buf),
+			},
+			args: args{
+				f: policyDenied,
+			},
+			wantErr: false,
+			expected: `  TIMESTAMP: Jan  1 00:20:34.567
+     SOURCE: 1.1.1.1:31793
+DESTINATION: 2.2.2.2:8080
+       TYPE: policy-verdict:none EGRESS
+    VERDICT: DENIED BY my-policy (CiliumNetworkPolicy)
     SUMMARY: TCP Flags: SYN`,
 		},
 		{
@@ -1626,6 +1693,67 @@ EVENTS LOST: HUBBLE_RING_BUFFER CPU(5) 1`,
 			}
 			require.NoError(t, p.Close())
 			require.Equal(t, strings.TrimSpace(tt.expected), strings.TrimSpace(buf.String()))
+		})
+	}
+}
+
+func TestFormatPolicyNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		policies []*flowpb.Policy
+		expected string
+	}{
+		{
+			name:     "No policies",
+			policies: []*flowpb.Policy{},
+			expected: "",
+		},
+		{
+			name: "Single policy with kind and name",
+			policies: []*flowpb.Policy{
+				{Kind: "CiliumNetworkPolicy", Name: "AllowHTTP"},
+			},
+			expected: " BY AllowHTTP (CiliumNetworkPolicy)",
+		},
+		{
+			name: "Multiple policies with kind and name",
+			policies: []*flowpb.Policy{
+				{Kind: "CiliumNetworkPolicy", Name: "AllowHTTP"},
+				{Kind: "CiliumClusterwideNetworkPolicy", Name: "AllowDNS"},
+			},
+			expected: " BY AllowHTTP (CiliumNetworkPolicy), AllowDNS (CiliumClusterwideNetworkPolicy)",
+		},
+		{
+			name: "Policy with missing kind",
+			policies: []*flowpb.Policy{
+				{Kind: "", Name: "AllowAll"},
+			},
+			expected: "",
+		},
+		{
+			name: "Policy with missing name",
+			policies: []*flowpb.Policy{
+				{Kind: "CiliumNetworkPolicy", Name: ""},
+			},
+			expected: "",
+		},
+		{
+			name: "Mixed valid and invalid policies",
+			policies: []*flowpb.Policy{
+				{Kind: "CiliumNetworkPolicy", Name: "AllowHTTP"},
+				{Kind: "", Name: "InvalidPolicy"},
+				{Kind: "CiliumClusterwideNetworkPolicy", Name: "AllowDNS"},
+			},
+			expected: " BY AllowHTTP (CiliumNetworkPolicy), AllowDNS (CiliumClusterwideNetworkPolicy)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatPolicyNames(tt.policies)
+			if result != tt.expected {
+				t.Errorf("formatPolicyNames() = %q, want %q", result, tt.expected)
+			}
 		})
 	}
 }


### PR DESCRIPTION
# Description
This is a small UX improvement which allows users to print the names of (C)CNPs which allowed or denied their traffic when using `hubble observe`. 

We already had this information in the `Flow` protobuf objects, so this PR simply makes it accessible to users.

# Testing
Example of new behaviour:
```
$ hubble observe --from-pod anton-test/anton-test-c5bb98d5-l47bv --print-policy-names

May  7 13:18:01.952: 100.120.143.6:45980 (ID:8534524) -> 100.120.55.189:3002 (ID:8568632) policy-verdict:L3-Only EGRESS ALLOWED BY allow-egress-test-cnp (CiliumNetworkPolicy) (TCP Flags: SYN)

May  7 13:18:04.812: 100.120.143.6:60220 (ID:8534524) -> 100.120.55.189:3002 (ID:8568632) policy-verdict:L3-Only EGRESS ALLOWED BY allow-egress-test-cnp (CiliumNetworkPolicy) (TCP Flags: SYN)
```

Compared with old behaviour:
```
$ hubble observe --from-pod anton-test/anton-test-c5bb98d5-l47bv

May  7 13:17:23.135: 100.120.143.6:41384 (ID:8534524) -> 100.120.55.189:3002 (ID:8568632) policy-verdict:L3-Only EGRESS ALLOWED (TCP Flags: SYN)

May  7 13:17:26.905: 100.120.143.6:54036 (ID:8534524) -> 100.120.55.189:3002 (ID:8568632) policy-verdict:L3-Only EGRESS ALLOWED (TCP Flags: SYN)
```


```release-note
hubble-cli: new `--print-policy-names` option to show the names of (C)CNPs that allowed or denied traffic
```
