### PR TITLE
bpf: Fix race condition in DumpReliablyWithCallback

### DIFF
--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -261,7 +261,7 @@ func statStartGc(m *Map) gcStats {
 func doFlush4(m *Map) gcStats {
 	stats := statStartGc(m)
 	filterCallback := func(key bpf.MapKey, _ bpf.MapValue) {
-		err := (&m.Map).Delete(key)
+		err := (&m.Map).DeleteLocked(key)
 		if err != nil {
 			log.WithError(err).WithField(logfields.Key, key.String()).Error("Unable to delete NAT entry")
 		} else {
@@ -275,7 +275,7 @@ func doFlush4(m *Map) gcStats {
 func doFlush6(m *Map) gcStats {
 	stats := statStartGc(m)
 	filterCallback := func(key bpf.MapKey, _ bpf.MapValue) {
-		err := (&m.Map).Delete(key)
+		err := (&m.Map).DeleteLocked(key)
 		if err != nil {
 			log.WithError(err).WithField(logfields.Key, key.String()).Error("Unable to delete NAT entry")
 		} else {

--- a/pkg/maps/nat/nat_flush_test.go
+++ b/pkg/maps/nat/nat_flush_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+func TestFlushNat(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	numEntries := 5
+	v4NatMap := NewMap("test_nat_v4", IPv4, 1000)
+	err := v4NatMap.OpenOrCreate()
+	assert.NoError(t, err)
+	v6NatMap := NewMap("test_nat_v6", IPv6, 1000)
+	err = v6NatMap.OpenOrCreate()
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		v4NatMap.UnpinIfExists()
+		v6NatMap.UnpinIfExists()
+	})
+
+	// Populate the map with dummy entries
+	for i := 1; i <= numEntries; i++ {
+		mapKey := &NatKey4{}
+		ip := types.IPv4{192, 168, 0, byte(i)}
+		mapKey.TupleKey4.SourceAddr = ip
+		mapKey.TupleKey4.DestAddr = [4]byte{}
+		mapKey.TupleKey4.DestPort = 8000 + uint16(i)
+		err := v4NatMap.Update(mapKey, &NatEntry4{})
+		assert.NoError(t, err, "failed to insert NAT entry")
+
+		ip6 := types.IPv6{}
+		ip6[15] = byte(i)
+		mapKey6 := &NatKey6{}
+		mapKey6.TupleKey6.SourceAddr = ip6
+		mapKey6.TupleKey6.DestAddr = [16]byte{}
+		mapKey6.TupleKey6.DestPort = 8000 + uint16(i)
+		err = v6NatMap.Update(mapKey6.ToNetwork(), &NatEntry6{})
+		assert.NoError(t, err)
+	}
+
+	// Verify entry count before flush.
+	var count int
+	assert.NoError(t, v4NatMap.DumpWithCallback(func(_ bpf.MapKey, _ bpf.MapValue) { count++ }))
+	assert.Equal(t, numEntries, count)
+	// Verify entry count after flush.
+	deleted := v4NatMap.Flush()
+	assert.Equal(t, numEntries, deleted)
+	// Confirm the map is empty after flush.
+	count = 0
+	assert.NoError(t, v4NatMap.DumpWithCallback(func(_ bpf.MapKey, _ bpf.MapValue) { count++ }))
+	assert.Equal(t, 0, count)
+
+	assert.NoError(t, v6NatMap.DumpWithCallback(func(_ bpf.MapKey, _ bpf.MapValue) { count++ }))
+	assert.Equal(t, numEntries, count)
+	deleted = v6NatMap.Flush()
+	assert.Equal(t, numEntries, deleted)
+	count = 0
+	assert.NoError(t, v6NatMap.DumpWithCallback(func(_ bpf.MapKey, _ bpf.MapValue) { count++ }))
+	assert.Equal(t, 0, count)
+}


### PR DESCRIPTION
This commit fixes a race condition between DumpReliablyWithCallback and Close methods in the BPF map implementation. The race occurs when one goroutine is iterating over a map using DumpReliablyWithCallback while another goroutine closes the map by calling Close.

The fix involves:
1. Adding a write lock to DumpReliablyWithCallback to prevent the map from being closed while it's being accessed
2. Adding a DeleteLocked method that can be called when the map lock is already held
3. Updating code in ctmap.go and nat.go to use DeleteLocked instead of Delete when called from within a callback
4. Modifying PurgeOrphanNATEntries to collect entries to delete during iteration and then delete them after the iteration is complete

Added tests to verify the fix.

Fixes: #39287
Related: #37383