### PR TITLE
identity/ipcache: extract identity restoration logic from Daemon 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -363,7 +363,6 @@ Makefile* @cilium/build
 /daemon/ @cilium/sig-agent
 /daemon/cmd/datapath.go @cilium/sig-datapath
 /daemon/cmd/endpoint* @cilium/endpoint
-/daemon/cmd/ipcache* @cilium/ipcache
 /daemon/cmd/kube_proxy* @cilium/sig-datapath
 /daemon/cmd/bootstrap_statistics.go @cilium/metrics
 /daemon/cmd/policy* @cilium/sig-policy
@@ -554,6 +553,7 @@ Makefile* @cilium/build
 /pkg/hubble/metrics @cilium/hubble-metrics
 /pkg/iana/ @cilium/sig-agent
 /pkg/identity @cilium/sig-policy
+/pkg/identity/restoration @cilium/sig-policy @cilium/ipcache
 /pkg/idpool/ @cilium/kvstore
 /pkg/ip/ @cilium/sig-agent
 /pkg/ipalloc/ @cilium/sig-ipam

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	identityrestoration "github.com/cilium/cilium/pkg/identity/restoration"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -108,7 +109,7 @@ type Daemon struct {
 	endpointInitialPolicyComplete chan struct{}
 
 	identityAllocator identitycell.CachingIdentityAllocator
-	identityRestorer  *LocalIdentityRestorer
+	identityRestorer  *identityrestoration.LocalIdentityRestorer
 	ipcache           *ipcache.IPCache
 
 	k8sWatcher  *watchers.K8sWatcher

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1449,6 +1449,7 @@ var daemonCell = cell.Module(
 		promise.New[*option.DaemonConfig],
 		newSyncHostIPs,
 	),
+	cell.Provide(NewLocalIdentityRestorer),
 	cell.Invoke(registerEndpointStateResolver),
 	cell.Invoke(func(promise.Promise[*Daemon]) {}), // Force instantiation.
 )
@@ -1481,6 +1482,7 @@ type daemonParams struct {
 	CertManager         certificatemanager.CertificateManager
 	SecretManager       certificatemanager.SecretManager
 	IdentityAllocator   identitycell.CachingIdentityAllocator
+	IdentityRestorer    *LocalIdentityRestorer
 	JobGroup            job.Group
 	Policy              policy.PolicyRepository
 	IPCache             *ipcache.IPCache
@@ -1714,7 +1716,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		// Sleep for the --identity-restore-grace-period (default: 30 seconds k8s, 10 minutes kvstore), allowing
 		// the normal allocation processes to finish, before releasing restored resources.
 		time.Sleep(option.Config.IdentityRestoreGracePeriod)
-		d.releaseRestoredIdentities()
+		d.identityRestorer.ReleaseRestoredIdentities()
 	}()
 
 	// Migrating the ENI datapath must happen before the API is served to

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -62,6 +62,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	identityrestoration "github.com/cilium/cilium/pkg/identity/restoration"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -1449,7 +1450,6 @@ var daemonCell = cell.Module(
 		promise.New[*option.DaemonConfig],
 		newSyncHostIPs,
 	),
-	cell.Provide(NewLocalIdentityRestorer),
 	cell.Invoke(registerEndpointStateResolver),
 	cell.Invoke(func(promise.Promise[*Daemon]) {}), // Force instantiation.
 )
@@ -1482,7 +1482,7 @@ type daemonParams struct {
 	CertManager         certificatemanager.CertificateManager
 	SecretManager       certificatemanager.SecretManager
 	IdentityAllocator   identitycell.CachingIdentityAllocator
-	IdentityRestorer    *LocalIdentityRestorer
+	IdentityRestorer    *identityrestoration.LocalIdentityRestorer
 	JobGroup            job.Group
 	Policy              policy.PolicyRepository
 	IPCache             *ipcache.IPCache

--- a/pkg/identity/cell/cell.go
+++ b/pkg/identity/cell/cell.go
@@ -9,6 +9,7 @@ import (
 	identityapi "github.com/cilium/cilium/pkg/identity/api"
 	identitycache "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/identity/restoration"
 )
 
 // Cell provides the identity controlplane that is responsible to allocate and manage security identities
@@ -24,4 +25,7 @@ var Cell = cell.Module(
 
 	// IdentityApiHandler provides the Identity Cilium API
 	identityapi.Cell,
+
+	// LocalIdentityRestorer restores the identities at startup
+	restoration.Cell,
 )

--- a/pkg/identity/restoration/local_identity_restorer.go
+++ b/pkg/identity/restoration/local_identity_restorer.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cmd
+package restoration
 
 import (
 	"errors"
@@ -18,10 +18,22 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/source"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "identity-restoration")
+
+// Cell provides the LocalIdentityRestorer that is responsible to restore the local identities from
+// the IPCache.
+var Cell = cell.Module(
+	"identity-restoration",
+	"Restores local identities from the ipcache map at startup",
+
+	cell.Provide(newLocalIdentityRestorer),
 )
 
 var (
@@ -48,7 +60,7 @@ type LocalIdentityRestorer struct {
 	restoredCIDRs map[netip.Prefix]identity.NumericIdentity
 }
 
-func NewLocalIdentityRestorer(params localIdentityRestorerParams) *LocalIdentityRestorer {
+func newLocalIdentityRestorer(params localIdentityRestorerParams) *LocalIdentityRestorer {
 	return &LocalIdentityRestorer{
 		params:        params,
 		restoredCIDRs: nil, // will be initialized during restoration

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -677,6 +677,8 @@ const (
 	// Count is a measure being compared to the Limit
 	Count = "count"
 
+	Total = "total"
+
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
 


### PR DESCRIPTION
This PR extracts the local identity restoration logic and state from the Daemon.

Please review the individual commits.