### PR TITLE
policy: Remove Redundant Dualstack Identity Insertion

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -825,15 +825,6 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
 				p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)
-				// If Cilium is in dual-stack mode then the "World" identity
-				// needs to be split into two identities to represent World
-				// IPv6 and IPv4 traffic distinctly from one another.
-				if id == identity.ReservedIdentityWorld && option.Config.IsDualStack() {
-					keyToAdd.Identity = identity.ReservedIdentityWorldIPv4
-					p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)
-					keyToAdd.Identity = identity.ReservedIdentityWorldIPv6
-					p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)
-				}
 			}
 		}
 	}


### PR DESCRIPTION
With #29958 the "world" entity-label automatically
encompasses the "world-ipv4" and "world-ipv6" labels.
These are automatically inserted into mapstate because
of their association with the world label, regardless
of whether Cilium is in dual-stack mode. This code is
a no-op and can be removed. The distillery tests
continued success shows that this code removal does
not matter (see `Test_EnsureDeniesPrecedeAllows`,
for world label <-> identity test examples).

Fixes: #22625

