### PR TITLE
Rnat map stale entry cleanup

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -154,6 +154,19 @@ static __always_inline int sock4_update_revnat(struct bpf_sock_addr *ctx,
 	return ret;
 }
 
+static __always_inline int sock4_delete_revnat(struct bpf_sock *ctx)
+{
+    struct ipv4_revnat_tuple key = {};
+    int ret = 0;
+
+    key.cookie = get_socket_cookie(ctx);
+    key.address = (__u32)ctx->dst_ip4;
+    key.port = (__u16)ctx->dst_port;
+
+    ret = map_delete_elem(&cilium_lb4_reverse_sk, &key);
+    return ret;
+}
+
 static __always_inline bool
 sock4_skip_xlate(struct lb4_service *svc, __be32 address)
 {
@@ -641,6 +654,32 @@ static __always_inline int sock6_update_revnat(struct bpf_sock_addr *ctx,
 		ret = map_update_elem(&cilium_lb6_reverse_sk, &key,
 				      &val, 0);
 	return ret;
+}
+
+static __always_inline void ctx_get_v6_dst_address(const struct bpf_sock *ctx,
+						   union v6addr *addr)
+{
+	addr->p1 = ctx->dst_ip6[0];
+	barrier();
+	addr->p2 = ctx->dst_ip6[1];
+	barrier();
+	addr->p3 = ctx->dst_ip6[2];
+	barrier();
+	addr->p4 = ctx->dst_ip6[3];
+	barrier();
+}
+
+static __always_inline int sock6_delete_revnat(struct bpf_sock *ctx)
+{
+    struct ipv6_revnat_tuple key = {};
+    int ret = 0;
+
+    key.cookie = get_socket_cookie(ctx);
+    ctx_get_v6_dst_address(ctx, &key.address);
+    key.port = (__u16)ctx->dst_port;
+
+    ret = map_delete_elem(&cilium_lb6_reverse_sk, &key);
+    return ret;
 }
 
 static __always_inline void ctx_get_v6_address(const struct bpf_sock_addr *ctx,
@@ -1209,6 +1248,24 @@ int cil_sock6_getpeername(struct bpf_sock_addr *ctx)
 	return SYS_PROCEED;
 }
 #endif /* ENABLE_SOCKET_LB_PEER */
+
+__section("cgroup/sock_release")
+int cil_sock_release(struct bpf_sock *ctx __maybe_unused)
+{
+# ifdef ENABLE_IPV4
+	if (ctx->family == AF_INET)
+		if (sock4_delete_revnat(ctx) == 0)
+			update_metrics(0, METRIC_EGRESS, REASON_LB_REVNAT_DELETE);
+# endif /* ENABLE_IPV4 */
+
+# ifdef ENABLE_IPV6
+	if (ctx->family == AF_INET6)
+		if (sock6_delete_revnat(ctx) == 0)
+			update_metrics(0, METRIC_EGRESS, REASON_LB_REVNAT_DELETE);
+# endif /* ENABLE_IPV6 */
+
+    return SYS_PROCEED;
+}
 
 #endif /* ENABLE_IPV6 || ENABLE_IPV4 */
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -589,6 +589,7 @@ enum {
 #define REASON_MISSED_CUSTOM_CALL	11
 #define REASON_DECRYPTING			12
 #define REASON_ENCRYPTING			13
+#define REASON_LB_REVNAT_DELETE		14
 
 /* Lookup scope for externalTrafficPolicy=Local */
 #define LB_LOOKUP_SCOPE_EXT	0

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -28,6 +28,7 @@ var errors = map[uint8]string{
 	11:  "Missed tail call to custom program",
 	12:  "Interface Decrypting",
 	13:  "Interface Encrypting",
+	14:  "LB: sock cgroup: Reverse entry delete succeeded",
 	130: "Invalid source mac",      // Unused
 	131: "Invalid destination mac", // Unused
 	132: "Invalid source ip",

--- a/pkg/socketlb/cgroup.go
+++ b/pkg/socketlb/cgroup.go
@@ -48,6 +48,7 @@ var attachTypes = map[string]ebpf.AttachType{
 	GetPeerName6: ebpf.AttachCgroupInet6GetPeername,
 	PostBind6:    ebpf.AttachCGroupInet6PostBind,
 	PreBind6:     ebpf.AttachCGroupInet6Bind,
+	SockRelease:  ebpf.AttachCgroupInetSockRelease,
 }
 
 // attachCgroup attaches a program from spec with the given name to cgroupRoot.

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -33,13 +33,15 @@ const (
 	GetPeerName6 = "cil_sock6_getpeername"
 	PostBind6    = "cil_sock6_post_bind"
 	PreBind6     = "cil_sock6_pre_bind"
+	SockRelease  = "cil_sock_release"
 )
 
 var (
 	cgroupProgs = []string{
 		Connect4, SendMsg4, RecvMsg4, GetPeerName4,
 		PostBind4, PreBind4, Connect6, SendMsg6,
-		RecvMsg6, GetPeerName6, PostBind6, PreBind6}
+		RecvMsg6, GetPeerName6, PostBind6, PreBind6,
+		SockRelease}
 )
 
 // TODO: Clean up bpffs root logic and make this a var.
@@ -124,6 +126,8 @@ func Enable(logger *slog.Logger, sysctl sysctl.Sysctl) error {
 			enabled[PreBind6] = true
 		}
 	}
+
+	enabled[SockRelease] = option.Config.EnableIPv4 || option.Config.EnableIPv6
 
 	for p, s := range enabled {
 		if s {


### PR DESCRIPTION
socketLB: cleaning up stale entries from socket-level reverse NAT map

The reverse NAT map is an LRU hashmap, so the cleaning up of stale entries is the responsibility of the LRU, which can cause performance issues due to filling up of the map to full capacity and only then the LRU kicks in. This PR aims to solve that issue by removing the entries when the socket is released by attaching a bpf program on `cgroup/sock_release`.

Fixes: #38649

Signed-off-by: ChinmayaSharma-hue <chinmaysharma1020@gmail.com>
