### PR TITLE
bpf: fib: stream-line fib_do_redirect()

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -871,11 +871,7 @@ struct ct_entry {
 	      from_tunnel:1,	/* Connection is over tunnel */
 	      reserved3:5;
 	__u16 rev_nat_index;
-	/* In the kernel ifindex is u32, so we need to check in cilium-agent
-	 * that ifindex of a NodePort device is <= MAX(u16).
-	 * Unused when HAVE_FIB_INDEX is available.
-	 */
-	__u16 ifindex;
+	__u16 reserved4;	/* unused since v1.18 */
 
 	/* *x_flags_seen represents the OR of all TCP flags seen for the
 	 * transmit/receive direction of this entry.

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -167,7 +167,7 @@ nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
 				 struct bpf_fib_lookup_padded *fib_params,
 				 __s8 *ext_err)
 {
-	int oif = THIS_INTERFACE_IFINDEX;
+	__u32 oif;
 	int ret;
 
 	ret = (int)fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), 0);
@@ -175,10 +175,12 @@ nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
-		if ((__u32)oif == fib_params->l.ifindex)
+		oif = fib_params->l.ifindex;
+
+		if (oif == THIS_INTERFACE_IFINDEX)
 			return CTX_ACT_OK;
 
-		return fib_do_redirect(ctx, true, fib_params, true, ret, &oif, ext_err);
+		return fib_do_redirect(ctx, true, fib_params, true, ret, oif, ext_err);
 	default:
 		*ext_err = (__s8)ret;
 		return DROP_NO_FIB;

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -76,7 +76,8 @@ redirect_neigh(__u32 ifindex __maybe_unused,
 	       int plen __maybe_unused,
 	       __u32 flags __maybe_unused)
 {
-	return XDP_DROP;
+	/* Available only in TC BPF. */
+	__throw_build_bug();
 }
 
 static __always_inline __maybe_unused bool

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -71,7 +71,7 @@ redirect_self(struct xdp_md *ctx __maybe_unused)
 }
 
 static __always_inline __maybe_unused int
-redirect_neigh(int ifindex __maybe_unused,
+redirect_neigh(__u32 ifindex __maybe_unused,
 	       struct bpf_redir_neigh *params __maybe_unused,
 	       int plen __maybe_unused,
 	       __u32 flags __maybe_unused)

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -73,21 +73,17 @@ int test1_check(struct __ctx_buff *ctx)
 	test_init();
 
 	/* Simulate a successful fib lookup with an output interface.
-	 * We expect to enter ctx_redirect with the ifindex provided in the
-	 * fib params.
+	 * We expect to enter ctx_redirect with the provided ifindex.
 	 */
 	TEST("lookup_success", {
-		__u32 ifindex_bad  = 0xDEADBEEF;
 		__u32 ifindex_good = 0xAAAAAAAA;
 		int ret = -1;
 		struct bpf_fib_lookup_padded params = {0};
 		__s8 ext_err;
 
-		params.l.ifindex = ifindex_good;
-
 		ret = fib_do_redirect(ctx, false, &params, true,
 				      BPF_FIB_LKUP_RET_SUCCESS,
-				      (int *)&ifindex_bad, &ext_err);
+				      ifindex_good, &ext_err);
 		if (ret != CTX_REDIRECT_ENTERED)
 			test_fatal("did not enter ctx_redirect");
 
@@ -105,24 +101,21 @@ int test1_check(struct __ctx_buff *ctx)
 	});
 
 	/* Simulate fib lookup with no neighbor return.
-	 * We expect to enter redirect_neigh with the ifindex provided in
-	 * fib params and a non-nil bpf_redir_neigh
+	 * We expect to enter redirect_neigh with provided ifindex
+	 * and a non-nil bpf_redir_neigh.
 	 */
 	TEST("lookup_no_neigh", {
-		__u32 ifindex_bad  = 0xDEADBEEF;
 		__u32 ifindex_good = 0xAAAAAAAA;
 		int ret = -1;
 		struct bpf_fib_lookup_padded params = {0};
 		__s8 ext_err;
-
-		params.l.ifindex = ifindex_good;
 
 		if (!neigh_resolver_available())
 			test_fatal("expected neigh_resolver_available true");
 
 		ret = fib_do_redirect(ctx, false, &params, true,
 				      BPF_FIB_LKUP_RET_NO_NEIGH,
-				      (int *)&ifindex_bad, &ext_err);
+				      ifindex_good, &ext_err);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 
@@ -159,7 +152,7 @@ int test1_check(struct __ctx_buff *ctx)
 
 		ret = fib_do_redirect(ctx, false, NULL, true,
 				      BPF_FIB_LKUP_RET_NO_NEIGH,
-				      (int *)&ifindex_good, &ext_err);
+				      ifindex_good, &ext_err);
 		if (ret != REDIR_NEIGH_ENTERED)
 			test_fatal("did not enter redirect_neigh");
 

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -533,7 +533,7 @@ type CtEntry struct {
 	Flags     uint16 `align:"rx_closing"`
 	// RevNAT is in network byte order
 	RevNAT           uint16 `align:"rev_nat_index"`
-	IfIndex          uint16 `align:"ifindex"`
+	Reserved4        uint16 `align:"reserved4"`
 	TxFlagsSeen      uint8  `align:"tx_flags_seen"`
 	RxFlagsSeen      uint8  `align:"rx_flags_seen"`
 	SourceSecurityID uint32 `align:"src_sec_id"`
@@ -615,7 +615,7 @@ func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
 		timeDiff = ""
 	}
 
-	return fmt.Sprintf("expires=%d%s Packets=%d Bytes=%d RxFlagsSeen=%#02x LastRxReport=%d TxFlagsSeen=%#02x LastTxReport=%d %s RevNAT=%d SourceSecurityID=%d IfIndex=%d BackendID=%d \n",
+	return fmt.Sprintf("expires=%d%s Packets=%d Bytes=%d RxFlagsSeen=%#02x LastRxReport=%d TxFlagsSeen=%#02x LastTxReport=%d %s RevNAT=%d SourceSecurityID=%d BackendID=%d \n",
 		c.Lifetime,
 		timeDiff,
 		c.Packets,
@@ -627,7 +627,6 @@ func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
 		c.flagsString(),
 		byteorder.NetworkToHost16(c.RevNAT),
 		c.SourceSecurityID,
-		c.IfIndex,
 		c.BackendID)
 }
 


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/38308 helped to simplify the BPF-redirect logic, as we can now assume support for `HAVE_FIB_IFINDEX`. Therefore let's lift the remaining processing of the FIB result from the low-level redirect helper, and make it the caller's responsibility to select the egress interface.

While at it also free up some related space in the CT entry thanks to #38308, and clarify the use of `redirect_neigh()` in XDP context.