### PR TITLE
[1.17] bpf: always mark decrypted wireguard traffic

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -671,6 +671,14 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 		goto out;
 	}
 
+#if defined(ENABLE_WIREGUARD)
+	/* If cilium sets MARK_MAGIC_DECRYPT the mark is only needed until
+	 * we reach this program. To not cause any further collision with the
+	 * `decrypted` variable, clear the mark.
+	 */
+	ctx->mark = 0;
+#endif
+
 /* We need to handle following possible packets come to this program
  *
  * 1. ESP packets coming from overlay (encrypted and not marked)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -1062,7 +1062,7 @@ func (h *HeaderfileWriter) WriteEndpointConfig(w io.Writer, cfg *datapath.LocalN
 	deviceNames := cfg.DeviceNames()
 
 	// Add cilium_wg0 if necessary.
-	if option.Config.NeedBPFHostOnWireGuardDevice() {
+	if option.Config.EnableWireguard {
 		deviceNames = append(slices.Clone(deviceNames), wgtypes.IfaceName)
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2387,35 +2387,6 @@ func (c *DaemonConfig) AreDevicesRequired() bool {
 		c.EnableIPSec
 }
 
-// NeedBPFHostOnWireGuardDevice returns true if the agent needs to attach
-// cil_from_netdev on the Ingress of Cilium's WireGuard device
-func (c *DaemonConfig) NeedBPFHostOnWireGuardDevice() bool {
-	if !c.EnableWireguard {
-		return false
-	}
-
-	// In native routing mode we want to deliver packets to local endpoints
-	// straight from BPF, without passing through the stack.
-	// This matches overlay mode (where bpf_overlay would handle the delivery)
-	// and native routing mode without encryption (where bpf_host at the native
-	// device would handle the delivery).
-	if !c.TunnelingEnabled() {
-		return true
-	}
-
-	// When WG & encrypt-node are on, a NodePort BPF to-be forwarded request
-	// to a remote node running a selected service endpoint must be encrypted.
-	// To make the NodePort's rev-{S,D}NAT translations to happen for a reply
-	// from the remote node, we need to attach bpf_host to the Cilium's WG
-	// netdev (otherwise, the WG netdev after decrypting the reply will pass
-	// it to the stack which drops the packet).
-	if c.EnableNodePort && c.EncryptNode {
-		return true
-	}
-
-	return false
-}
-
 // NeedEgressOnWireGuardDevice returns true if the agent needs to attach
 // cil_to_wireguard on the Egress of Cilium's WireGuard device
 func (c *DaemonConfig) NeedEgressOnWireGuardDevice() bool {


### PR DESCRIPTION
This PR is a manual backport needed for #39239. This is needed for upgrade scenarios, where a future version of cilium (1.18) expects this mark to be there. To achieve this, we always need to attach `cil_from_netdev` to the wireguard device. As `NeedBPFHostOnWireGuardDevice` then becomes obsolete, we remove it entirely from the code base.
