### PR TITLE
fix(installer): trim EKS cluster name from both ARN and eksctl formats

### DIFF
--- a/cilium-cli/install/autodetect_test.go
+++ b/cilium-cli/install/autodetect_test.go
@@ -32,19 +32,25 @@ func Test_getClusterName(t *testing.T) {
 	assert.Equal(t, "my-cluster", getClusterName(vals))
 }
 
-func Test_trimEKSClusterARN(t *testing.T) {
+func Test_trimEKSClusterName(t *testing.T) {
 	vals := ""
-	assert.Empty(t, trimEKSClusterARN(vals))
-
-	vals = "arn:aws:eks:eu-west-1:111111111111:cluster/my-cluster"
-	assert.Equal(t, "my-cluster", trimEKSClusterARN(vals))
-
-	vals = "cluster/my-cluster"
-	assert.Equal(t, "my-cluster", trimEKSClusterARN(vals))
-
-	vals = "arn:aws:eks:region:account-id:cluster/"
-	assert.Empty(t, trimEKSClusterARN(vals))
+	assert.Empty(t, trimEKSClusterName(vals))
 
 	vals = "invalid-arn-format"
-	assert.Equal(t, "invalid-arn-format", trimEKSClusterARN(vals))
+	assert.Equal(t, "invalid-arn-format", trimEKSClusterName(vals))
+
+	vals = "arn:aws:eks:region:account-id:cluster/"
+	assert.Empty(t, trimEKSClusterName(vals))
+
+	vals = "arn:aws:eks:eu-west-1:111111111111:cluster/my-cluster"
+	assert.Equal(t, "my-cluster", trimEKSClusterName(vals))
+
+	vals = "arn:aws:eks:us-west-1:123456789012:cluster/eks-my-cluster"
+	assert.Equal(t, "eks-my-cluster", trimEKSClusterName(vals))
+
+	vals = "my-cluster.eu-west-1.eksctl.io"
+	assert.Equal(t, "my-cluster", trimEKSClusterName(vals))
+
+	vals = "eks-cilium-test-1.ap-northeast-1.eksctl.io"
+	assert.Equal(t, "eks-cilium-test-1", trimEKSClusterName(vals))
 }


### PR DESCRIPTION
Clusters created with `eksctl` often use a kube-context like `<cluster-name>.<region>.eksctl.io`, 
which was previously not correctly trimmed during auto-detection.

This led to validation errors such as:
`cluster name must not be more than 32 characters`.

This commit introduces `trimEKSClusterName()` to correctly handle both:

- ARN format: `arn:aws:eks:<region>:<account>:cluster/<name>`

- eksctl FQDN format: `<name>.<region>.eksctl.io`

Changes include:

- Applying trimming logic in `autodetectAndValidate()` before replacing disallowed characters (`_`, `.`, `:`)

- Adding unit tests for edge cases across both formats


This ensures consistent and robust cluster name parsing across different EKS setups.


Fixes: #39482

```release-note
Improve EKS cluster name auto-detection by supporting both ARN and eksctl FQDN formats to avoid validation errors caused by overly long names.
```