### PR TITLE
bpf: lxc: detect L7 LB hairpin connections

### DIFF
--- a/bpf/tests/lb_tests.c
+++ b/bpf/tests/lb_tests.c
@@ -59,7 +59,7 @@ int test_lb4_tcp_dual_scope(__maybe_unused struct __ctx_buff *ctx)
 
 	lb_v4_add_service_with_flags(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP,
 				     BACKEND_COUNT, REVNAT_INDEX,
-				     0, SVC_FLAG_TWO_SCOPES);
+				     0, SVC_FLAG_TWO_SCOPES, 0);
 
 	service = lb4_lookup_service(&key, true);
 	assert(service);
@@ -110,7 +110,7 @@ int test_lb4_any_proto_dual_scope(__maybe_unused struct __ctx_buff *ctx)
 
 	lb_v4_add_service_with_flags(FRONTEND_IP, FRONTEND_PORT,
 				     IPPROTO_ANY, BACKEND_COUNT,
-				     REVNAT_INDEX, 0, SVC_FLAG_TWO_SCOPES);
+				     REVNAT_INDEX, 0, SVC_FLAG_TWO_SCOPES, 0);
 
 	service = lb4_lookup_service(&key, true);
 	assert(service);

--- a/bpf/tests/session_affinity_maglev_test.c
+++ b/bpf/tests/session_affinity_maglev_test.c
@@ -170,7 +170,7 @@ static __always_inline void setup_test(void)
 
 	__lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, IPPROTO_TCP,
 			    LB_MAGLEV_LUT_SIZE, TEST_REVNAT, SVC_FLAG_ROUTABLE, 0,
-			    true, affinity_timeout);
+			    true, affinity_timeout, 0);
 
 	/* Backend ID and slot must start by 1 */
 	__u32 backends[LB_MAGLEV_LUT_SIZE];

--- a/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
+++ b/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
@@ -66,7 +66,7 @@ SETUP("tc", "v4_local_redirect")
 int v4_local_backend_to_service_setup(struct __ctx_buff *ctx)
 {
 	lb_v4_add_service_with_flags(V4_SERVICE_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1,
-				     SVC_FLAG_ROUTABLE, SVC_FLAG_LOCALREDIRECT);
+				     SVC_FLAG_ROUTABLE, SVC_FLAG_LOCALREDIRECT, 0);
 	lb_v4_add_backend(V4_SERVICE_IP, SERVICE_PORT, 1, 124,
 			  V4_BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/skip_lb_xlate_socket_lb.c
+++ b/bpf/tests/skip_lb_xlate_socket_lb.c
@@ -70,9 +70,9 @@ int test_sock4_xlate_fwd_skip_lb(__maybe_unused struct xdp_md *ctx)
 	__u8 val = 0;
 
 	lb_v4_add_service_with_flags(v4_svc_one, tcp_svc_one, IPPROTO_TCP, 1, revnat_id,
-				     0, SVC_FLAG_LOCALREDIRECT);
+				     0, SVC_FLAG_LOCALREDIRECT, 0);
 	lb_v4_add_service_with_flags(v4_svc_two, tcp_svc_two, IPPROTO_TCP, 1, revnat_id2,
-				     0, SVC_FLAG_LOCALREDIRECT);
+				     0, SVC_FLAG_LOCALREDIRECT, 0);
 	lb_v4_add_backend(v4_svc_one, tcp_svc_one, 1, 124,
 			  v4_pod_one, tcp_dst_one, IPPROTO_TCP, 0);
 	lb_v4_add_backend(v4_svc_two, tcp_svc_two, 1, 124,


### PR DESCRIPTION
L7 LB traffic is handled by from-container matching the L7 service entry, and punting the request to the proxy. The proxy then LBs the request and pushes it back up into from-container for L3/L4 network policy and local delivery.

In case the upstream connection is to the client itself (= hairpin), we want to skip L3/L4 Egress & Ingress network policy. Flag the upstream connection's CT entry accordingly.