### PR TITLE
[v1.17] k8s: StateDB reflector's TransformMany to return objects to delete

### DIFF
--- a/pkg/dynamicconfig/table_test.go
+++ b/pkg/dynamicconfig/table_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +31,18 @@ var (
 	dummyConfigMap = map[string]string{"key1": "value1", "key2": "value2"}
 )
 
+func startHive(t *testing.T, h *hive.Hive) {
+	tLog := hivetest.Logger(t)
+	if err := h.Start(tLog, t.Context()); err != nil {
+		t.Fatalf("starting hive encountered: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Stop(tLog, context.Background()); err != nil {
+			t.Fatalf("stopping hive encountered: %s", err)
+		}
+	})
+}
+
 func TestWatchAllKeys(t *testing.T) {
 	cSource := `[{"kind":"config-map","namespace":"kube-system","name":"a-low-priority"},{"kind":"config-map","namespace":"kube-system","name":"cilium-config"}]`
 	expected := map[string]DynamicConfig{
@@ -42,7 +55,8 @@ func TestWatchAllKeys(t *testing.T) {
 			Priority: 0,
 		},
 	}
-	_, db, dct, _ := fixture(t, cSource)
+	h, db, dct, _ := fixture(t, cSource)
+	startHive(t, h)
 
 	key := "key"
 	lowPrioritySource := "a-low-priority" // leading 'a' to test that sources that are not in priority map have lower priority
@@ -66,7 +80,8 @@ func TestWatchAllKeys(t *testing.T) {
 
 func TestWatchKey(t *testing.T) {
 	cSource := `[{"kind":"config-map","namespace":"kube-system","name":"a-low-priority"},{"kind":"config-map","namespace":"kube-system","name":"cilium-config"}]`
-	_, db, dct, _ := fixture(t, cSource)
+	h, db, dct, _ := fixture(t, cSource)
+	startHive(t, h)
 
 	key := "key"
 	lowPrioritySource := "a-low-priority" // leading 'a' to test that sources that are not in priority map have lower priority
@@ -96,7 +111,8 @@ func TestWatchKey(t *testing.T) {
 
 func TestGetKey(t *testing.T) {
 	cSource := `[{"kind":"config-map","namespace":"kube-system","name":"a-low-priority"},{"kind":"config-map","namespace":"kube-system","name":"cilium-config"}]`
-	_, db, dct, _ := fixture(t, cSource)
+	h, db, dct, _ := fixture(t, cSource)
+	startHive(t, h)
 
 	key := "key"
 	lowPrioritySource := "a-low-priority"
@@ -167,17 +183,17 @@ func TestDynamicConfigMap(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
 			configSources, _ := json.Marshal(tc.configSources)
 
-			_, db, dct, cs := fixture(t, string(configSources))
+			h, db, dct, cs := fixture(t, string(configSources))
 
 			for _, cm := range tc.cms {
-				_, err := cs.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
+				_, err := cs.CoreV1().ConfigMaps(namespace).Create(t.Context(), cm, metav1.CreateOptions{})
 				if err != nil {
-					t.Errorf("creating CofigMap: %v", err)
+					t.Fatalf("creating ConfigMap: %v", err)
 				}
 			}
+			startHive(t, h)
 
 			gotMap := map[string]string{}
 			if err := testutils.WaitUntil(func() bool {
@@ -185,18 +201,24 @@ func TestDynamicConfigMap(t *testing.T) {
 					gotMap[obj.Key.String()] = obj.Value
 				}
 				return len(gotMap) == len(tc.expectedConfig)
-			}, 2*time.Second); err != nil {
-				t.Errorf("waiting for confing table: %v", err)
+			}, 10*time.Second); err != nil {
+				t.Fatalf("waiting for config table timed out: %v", err)
 			}
 
 			if !reflect.DeepEqual(gotMap, tc.expectedConfig) {
-				t.Errorf("expectedConfig:\n%+v\ngot:\n%+v", tc.expectedConfig, gotMap)
+				t.Fatalf("expectedConfig:\n%+v\ngot:\n%+v", tc.expectedConfig, gotMap)
 			}
 
 			for _, cm := range tc.cms {
 				for k, v := range cm.Data {
-					obj, _, found := dct.Get(db.ReadTxn(), ByKey(Key{Name: k, Source: cm.Name}))
-					if !found || obj.Value != v || obj.Key.Source != cm.Name || obj.Key.Name != k {
+					txn := db.ReadTxn()
+					obj, _, found := dct.Get(txn, ByKey(Key{Name: k, Source: cm.Name}))
+					if !found {
+						for e := range dct.All(txn) {
+							t.Logf("%s\n", strings.Join(e.TableRow(), " "))
+						}
+						t.Errorf("Entry %s not found", cm.Name)
+					} else if obj.Value != v || obj.Key.Source != cm.Name || obj.Key.Name != k {
 						t.Errorf("Entry mismatch: expected (key=%v, source=%v, value=%v), but got (key=%v, source=%v, value=%v)", k, cm.Name, v, obj.Key.Name, obj.Key.Source, obj.Value)
 					}
 				}
@@ -243,17 +265,9 @@ func fixture(t *testing.T, sources string) (*hive.Hive, *statedb.DB, statedb.RWT
 			},
 		),
 	)
-
-	ctx := context.Background()
-	tLog := hivetest.Logger(t)
-	if err := h.Start(tLog, ctx); err != nil {
-		t.Fatalf("starting hive encountered: %s", err)
+	if err := h.Populate(hivetest.Logger(t)); err != nil {
+		t.Fatalf("Populate: %s", err)
 	}
-	t.Cleanup(func() {
-		if err := h.Stop(tLog, ctx); err != nil {
-			t.Fatalf("stopping hive encountered: %s", err)
-		}
-	})
 
 	return h, db, table, fakeClient
 }

--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"slices"
 	"sync"
 
 	"github.com/cilium/hive/cell"
@@ -109,10 +110,14 @@ type ReflectorConfig[Obj any] struct {
 	// Optional function to transform the objects given by the ListerWatcher. This can
 	// be used to convert into an internal model on the fly to save space and add additional
 	// fields or to for example implement TableRow/TableHeader for the "db/show" command.
+	//
+	// The object given to the transform function can be modified without copying.
 	Transform TransformFunc[Obj]
 
-	// Optional function to transform the object to a set of objects to insert into the table.
+	// Optional function to transform the object to a set of objects to insert or delete.
 	// If set, [Transform] must be nil.
+	//
+	// The object given to the transform function can be modified without copying.
 	TransformMany TransformManyFunc[Obj]
 
 	// Optional function to query all objects. Used when replacing the objects on resync.
@@ -142,17 +147,20 @@ func (cfg ReflectorConfig[Obj]) JobName() string {
 	return fmt.Sprintf("k8s-reflector-%s-%s", cfg.Table.Name(), cfg.Name)
 }
 
-// TransformFunc is an optional function to give to the Kubernetes reflector
+// TransformFunc is an optional function to give to the reflector
 // to transform the object returned by the ListerWatcher to the desired
 // target object. If the function returns false the object is silently
 // skipped.
+//
+// The object given to the transform function can be modified without copying.
 type TransformFunc[Obj any] func(statedb.ReadTxn, any) (obj Obj, ok bool)
 
-// TransformManyFunc is an optional function to give to the Kubernetes reflector
+// TransformManyFunc is an optional function to give to the reflector
 // to transform the object returned by the ListerWatcher to the desired set of
-// target objects to insert into the table. If the function returns false the object is silently
-// skipped.
-type TransformManyFunc[Obj any] func(statedb.ReadTxn, any) (objs []Obj)
+// target objects to insert or delete.
+//
+// The object given to the transform function can be modified without copying.
+type TransformManyFunc[Obj any] func(txn statedb.ReadTxn, deleted bool, obj any) (toInsert, toDelete iter.Seq[Obj])
 
 // QueryAllFunc is an optional function to give to the Kubernetes reflector
 // to query all objects in the table that are managed by the reflector.
@@ -253,18 +261,24 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 		buf := make([]Obj, 1)
 		if r.Transform != nil {
 			// Implement TransformMany with Transform.
-			transformMany = TransformManyFunc[Obj](func(txn statedb.ReadTxn, obj any) []Obj {
+			transformMany = TransformManyFunc[Obj](func(txn statedb.ReadTxn, deleted bool, obj any) (toInsert, toDelete iter.Seq[Obj]) {
 				var ok bool
 				if buf[0], ok = r.Transform(txn, obj); ok {
-					return buf
+					if deleted {
+						return nil, slices.Values(buf)
+					}
+					return slices.Values(buf), nil
 				}
-				return nil
+				return nil, nil
 			})
 		} else {
 			// No provided transform function, use the identity function instead.
-			transformMany = TransformManyFunc[Obj](func(txn statedb.ReadTxn, obj any) []Obj {
+			transformMany = TransformManyFunc[Obj](func(txn statedb.ReadTxn, deleted bool, obj any) (toInsert, toDelete iter.Seq[Obj]) {
 				buf[0] = obj.(Obj)
-				return buf
+				if deleted {
+					return nil, slices.Values(buf)
+				}
+				return slices.Values(buf), nil
 			})
 		}
 	}
@@ -334,14 +348,19 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 			inserted := sets.New[string]()
 
 			for _, item := range buf.replaceItems {
-				for _, obj := range transformMany(txn, item) {
-					if _, _, err := table.Insert(txn, obj); err != nil {
-						r.log.Error("BUG: Insert failed", logfields.Error, err)
-						continue
-					}
+				toInsert, _ := transformMany(txn, false, item)
+				// Ignoring the 'toDelete' since we're going to use queryAll below to
+				// delete everything we didn't insert here.
+				if toInsert != nil {
+					for obj := range toInsert {
+						if _, _, err := table.Insert(txn, obj); err != nil {
+							r.log.Error("BUG: Insert failed", logfields.Error, err)
+							continue
+						}
 
-					numUpserted++
-					inserted.Insert(string(indexer.ObjectToKey(obj)))
+						numUpserted++
+						inserted.Insert(string(indexer.ObjectToKey(obj)))
+					}
 				}
 			}
 
@@ -362,14 +381,18 @@ func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
 		}
 
 		for entry := range buf.entries.Values() {
-			for _, obj := range transformMany(txn, entry.obj) {
-				if !entry.deleted {
+			toInsert, toDelete := transformMany(txn, entry.deleted, entry.obj)
+			if toInsert != nil {
+				for obj := range toInsert {
 					if _, _, err := table.Modify(txn, obj, merge); err != nil {
 						r.log.Error("BUG: Modify failed", logfields.Error, err)
 					} else {
 						numUpserted++
 					}
-				} else {
+				}
+			}
+			if toDelete != nil {
+				for obj := range toDelete {
 					if _, _, err := table.Delete(txn, obj); err != nil {
 						r.log.Error("BUG: Delete failed", logfields.Error, err)
 					} else {


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/39330.

This fixes https://github.com/cilium/cilium/issues/38621 for v1.17. Marking as `release-note/misc` as the impact on v1.17 is very minor (only use of pkg/dynamicconfig that uses TransformMany is the drift checker and that would miss deleted config keys and not log a warning).