### PR TITLE
envoy: Remove single-selector wildcard assumption

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -379,7 +379,8 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 				Protocol: envoy_config_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
-						L7: &PNPAllowGETbar,
+						RemotePolicies: expectedRemotePolicies,
+						L7:             &PNPAllowGETbar,
 					},
 				},
 			},
@@ -421,7 +422,8 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 				Protocol: envoy_config_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
-						L7: &PNPAllowGETbar,
+						RemotePolicies: expectedRemotePolicies,
+						L7:             &PNPAllowGETbar,
 					},
 				},
 			},
@@ -697,7 +699,8 @@ func (ds *DaemonSuite) testL3DependentL7(t *testing.T) {
 				Protocol: envoy_config_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
-						L7: &PNPAllowGETbar,
+						RemotePolicies: []uint32{uint32(qaFooSecLblsCtx.ID)},
+						L7:             &PNPAllowGETbar,
 					},
 				},
 			},
@@ -934,21 +937,12 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 	// proxies.
 	networkPolicies := ds.getXDSNetworkPolicies(t, nil)
 	require.Len(t, networkPolicies, 2)
+
 	qaBarNetworkPolicy := networkPolicies[QAIPv4Addr.String()]
 	require.NotNil(t, qaBarNetworkPolicy)
 
-	require.Len(t, qaBarNetworkPolicy.IngressPerPortPolicies, 1)
-
-	expectedIngressPolicy := &cilium.PortNetworkPolicy{
-		Port:     80,
-		Protocol: envoy_config_core.SocketAddress_TCP,
-		Rules: []*cilium.PortNetworkPolicyRule{
-			{
-				L7: &PNPAllowGETbar,
-			},
-		},
-	}
-	require.EqualExportedValues(t, expectedIngressPolicy, qaBarNetworkPolicy.IngressPerPortPolicies[0])
+	// "foo" identity does not exist yet, so there are no ingress policies
+	require.Empty(t, qaBarNetworkPolicy.IngressPerPortPolicies)
 
 	// Allocate identities needed for this test
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
@@ -991,7 +985,8 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 				Protocol: envoy_config_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
-						L7: &PNPAllowGETbar,
+						RemotePolicies: []uint32{uint32(qaFooID.ID)},
+						L7:             &PNPAllowGETbar,
 					},
 				},
 			},

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1287,7 +1287,8 @@ func namespacedNametoSyncedSDSSecretName(namespacedName types.NamespacedName, po
 	return fmt.Sprintf("%s/%s-%s", policySecretsNamespace, namespacedName.Namespace, namespacedName.Name)
 }
 
-func (s *xdsServer) getPortNetworkPolicyRule(version *versioned.VersionHandle, sel policy.CachedSelector, wildcard bool, l7Rules *policy.PerSelectorPolicy, useFullTLSContext, useSDS bool, policySecretsNamespace string) (*cilium.PortNetworkPolicyRule, bool) {
+func (s *xdsServer) getPortNetworkPolicyRule(version *versioned.VersionHandle, sel policy.CachedSelector, l7Rules *policy.PerSelectorPolicy, useFullTLSContext, useSDS bool, policySecretsNamespace string) (*cilium.PortNetworkPolicyRule, bool) {
+	wildcard := sel.IsWildcard()
 	r := &cilium.PortNetworkPolicyRule{}
 
 	// Optimize the policy if the endpoint selector is a wildcard by
@@ -1515,14 +1516,8 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Pol
 				rules = append(rules, rule)
 			}
 		} else {
-			nSelectors := len(l4.PerSelectorPolicies)
 			for sel, l7 := range l4.PerSelectorPolicies {
-				// A single selector is effectively a wildcard, as bpf passes through
-				// only allowed l3. If there are multiple selectors for this l4-filter
-				// then the proxy may need to drop some allowed l3 due to l7 rules potentially
-				// being different between the selectors.
-				wildcard := nSelectors == 1 || sel.IsWildcard()
-				rule, cs := s.getPortNetworkPolicyRule(version, sel, wildcard, l7, useFullTLSContext, useSDS, policySecretsNamespace)
+				rule, cs := s.getPortNetworkPolicyRule(version, sel, l7, useFullTLSContext, useSDS, policySecretsNamespace)
 				if rule != nil {
 					if !cs {
 						canShortCircuit = false


### PR DESCRIPTION
We can no longer treat single-selector policies as wildcarding L3, as we no longer have bpf datapath always performing policy enforcement before cilium-envoy.

```release-note
Policy updates to Envoy no longer consider a single selector as an L3 wildcard. Cilium bpf datapath policy enforcement is not done for Cilium Ingress policy enforcement so the L3 identity needs to be enforced in all cases.
```
