### PR TITLE
ipsec: Fix key count in key rotation test

### DIFF
--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -38,9 +38,10 @@ runs:
         echo "Updating IPsec secret with $data"
         kubectl patch secret -n kube-system cilium-ipsec-keys -p="$data" -v=1
 
-        # We have two keys per node, per direction, per IP family. So a two-nodes IPv4-only cluster
-        # will have four keys.
+        # We have two keys per remote node, per direction, per IP family.
+        # So a three-nodes IPv4-only cluster will have four keys.
         exp_nb_keys=${{ inputs.nb-nodes }}
+        ((exp_nb_keys-=1))
         ((exp_nb_keys*=2))
         if [[ "${{ inputs.ipv6 }}" == "true" ]]; then
           ((exp_nb_keys*=2))

--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -17,6 +17,10 @@ inputs:
     required: true
     type: boolean
     description: "Whether IPv6 is enabled. Note IPv4 is always enabled if IPsec is enabled."
+  subnet-encryption:
+    required: true
+    type: boolean
+    description: "True if IPAM mode is ENI or Azure. In those cases, we have two keys on ingress per remote node, per IP family."
 runs:
   using: composite
   steps:
@@ -38,11 +42,16 @@ runs:
         echo "Updating IPsec secret with $data"
         kubectl patch secret -n kube-system cilium-ipsec-keys -p="$data" -v=1
 
-        # We have two keys per remote node, per direction, per IP family.
-        # So a three-nodes IPv4-only cluster will have four keys.
-        exp_nb_keys=${{ inputs.nb-nodes }}
-        ((exp_nb_keys-=1))
-        ((exp_nb_keys*=2))
+        # For each IP family, we have two keys per remote node, per direction.
+        # For subnet-encryption mode (ENI & Azure), we'll have one additional
+        # key on ingress per remote node.
+        # So a three-nodes IPv4-only ENI cluster will have six keys.
+        exp_nb_keys=$((${{ inputs.nb-nodes }} - 1))
+        if [[ "${{ inputs.subnet-encryption }}" == "true" ]]; then
+          ((exp_nb_keys*=3))
+        else
+          ((exp_nb_keys*=2))
+        fi
         if [[ "${{ inputs.ipv6 }}" == "true" ]]; then
           ((exp_nb_keys*=2))
         fi

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -370,6 +370,7 @@ jobs:
           nb-nodes: 3
           tunnel: "disabled"
           ipv6: false
+          subnet-encryption: true
 
       - name: Check conn-disrupt-test after rotating (${{ join(matrix.*, ', ') }})
         if: ${{ matrix.ipsec == true }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -344,6 +344,7 @@ jobs:
           tunnel: ${{ matrix.tunnel }}
           nb-nodes: 3 # We don't count the node without Cilium.
           ipv6: true
+          subnet-encryption: false
 
       - name: Assert that no unencrypted packets are leaked during key rotation
         uses: ./.github/actions/bpftrace/check

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -342,7 +342,7 @@ jobs:
         with:
           key-algo: ${{ matrix.key-two }}
           tunnel: ${{ matrix.tunnel }}
-          nb-nodes: 2
+          nb-nodes: 3 # We don't count the node without Cilium.
           ipv6: true
 
       - name: Assert that no unencrypted packets are leaked during key rotation


### PR DESCRIPTION
Viktor noticed that the `nb-nodes` parameter for the IPsec key rotation tests wasn't consistent with the actual number of nodes in the test clusters. This pull request fixes it. It turns out the tests were passing for the wrong reasons. See commits for details.