### PR TITLE
plugins: Don't install CNI conf in container image

### DIFF
--- a/plugins/cilium-cni/05-cilium-cni.conf
+++ b/plugins/cilium-cni/05-cilium-cni.conf
@@ -1,7 +1,0 @@
-{
-    "cniVersion": "0.3.1",
-    "name": "cilium",
-    "type": "cilium-cni",
-    "enable-debug": true,
-    "log-file": "/var/run/cilium/cilium-cni.log"
-}

--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -7,25 +7,27 @@ include $(ROOT_DIR)/../../Makefile.defs
 
 TARGET := cilium-cni
 
-.PHONY: all $(TARGET) clean install
-
+.PHONY: all
 all: $(TARGET)
 
 $(TARGET):
 	@$(ECHO_GO)
 	$(QUIET)$(GO_BUILD) -o $@
 
+.PHONY: clean
 clean:
 	@$(ECHO_CLEAN)
 	-$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO_CLEAN)
 
+.PHONY: install
 install:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CNICONFDIR)
-	$(QUIET)$(INSTALL) -m 0644 05-cilium-cni.conf $(DESTDIR)$(CNICONFDIR)
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CNIBINDIR)
 	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(CNIBINDIR)
 
+.PHONY: install-binary
 install-binary: install
 
+.PHONY: install-bash-completion
 install-bash-completion:


### PR DESCRIPTION
I noticed in local testing that when you deploy Cilium with a custom CNI                                                                                                                                                          
configuration, Cilium may report a different CNI configuration file                                                                                                                                                               
inside the Cilium container compared with the configuration on the                                                                                                                                                                
underlying host despite mapping the host filesystem into the Cilium                                                                                                                                                               
container. This appears to be due to the use of overlayfs and because                                                                                                                                                             
the 'install' target (invoked during container build) installs this                                                                                                                                                               
config file into the filesystem of the container itself. This ultimately                                                                                                                                                          
obscures the true config when inspecting it from inside the Cilium                                                                                                                                                                
container. Remove the extra unneeded config file to reduce confusion. 