### PR TITLE
operator: skip node taint retry when node not found

### DIFF
--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -73,6 +74,11 @@ func checkTaintForNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err := checkAndMarkNode(ctx, c, nodeGetter, key, mno, logger)
+	// Do not requeue on node not found errors
+	if err != nil && k8serrors.IsNotFound(err) {
+		workQueue.Forget(key)
+		return true
+	}
 	handleErr(err, key, workQueue, logger)
 	return true
 }
@@ -80,7 +86,7 @@ func checkTaintForNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter
 func handleErr(err error, key string, workQueue workqueue.TypedRateLimitingInterface[string], logger *slog.Logger) {
 	if err == nil {
 		if workQueue.NumRequeues(key) >= maxSilentRetries {
-			logger.Info("Successfully updated tains and conditions for the node", logfields.NodeName, key)
+			logger.Info("Successfully updated taints and conditions for the node", logfields.NodeName, key)
 		}
 		workQueue.Forget(key)
 		return


### PR DESCRIPTION
The Cilium Operator logs are filled with attempts to retry updating taints/conditions on nodes even if we can't get the node from the local store due to node deletion. Skip retry in this case.

<!-- Description of change -->

Fixes: #38059

```release-note
operator: skip retry of node taint update when node not found
```
