### PR TITLE
bpf: nat: don't check port range for ICMP ECHOs

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -908,6 +908,10 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 
 		ipv4_ct_tuple_swap_ports(tuple);
 		port_off = TCP_SPORT_OFF;
+
+		if (snat_v4_nat_can_skip(target, tuple))
+			return NAT_PUNT_TO_STACK;
+
 		break;
 	case IPPROTO_ICMP:
 		/* Fragmented ECHO packets are not supported currently. Drop all
@@ -951,9 +955,6 @@ nat_icmp_v4:
 	default:
 		return NAT_PUNT_TO_STACK;
 	};
-
-	if (snat_v4_nat_can_skip(target, tuple))
-		return NAT_PUNT_TO_STACK;
 
 	return __snat_v4_nat(ctx, tuple, fraginfo, off, false, target, port_off, trace, ext_err);
 }
@@ -1071,6 +1072,10 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 
 		ipv4_ct_tuple_swap_ports(&tuple);
 		port_off = TCP_DPORT_OFF;
+
+		if (snat_v4_rev_nat_can_skip(target, &tuple))
+			return NAT_PUNT_TO_STACK;
+
 		break;
 	case IPPROTO_ICMP:
 		/* Fragmented ECHOREPLY packets are not supported currently.
@@ -1119,8 +1124,6 @@ rev_nat_icmp_v4:
 		return NAT_PUNT_TO_STACK;
 	};
 
-	if (snat_v4_rev_nat_can_skip(target, &tuple))
-		return NAT_PUNT_TO_STACK;
 	ret = snat_v4_rev_nat_handle_mapping(ctx, &tuple, fraginfo, &state,
 					     (__u32)off, target, trace);
 	if (ret < 0)
@@ -1832,6 +1835,10 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 
 		ipv6_ct_tuple_swap_ports(tuple);
 		port_off = TCP_SPORT_OFF;
+
+		if (snat_v6_nat_can_skip(target, tuple))
+			return NAT_PUNT_TO_STACK;
+
 		break;
 	case IPPROTO_ICMPV6:
 		if (ipfrag_is_fragment(fraginfo))
@@ -1862,9 +1869,6 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	default:
 		return NAT_PUNT_TO_STACK;
 	};
-
-	if (snat_v6_nat_can_skip(target, tuple))
-		return NAT_PUNT_TO_STACK;
 
 	return __snat_v6_nat(ctx, tuple, fraginfo, off, false, target, port_off, trace, ext_err);
 }
@@ -1992,6 +1996,10 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 
 		ipv6_ct_tuple_swap_ports(&tuple);
 		port_off = TCP_DPORT_OFF;
+
+		if (snat_v6_rev_nat_can_skip(target, &tuple))
+			return NAT_PUNT_TO_STACK;
+
 		break;
 	case IPPROTO_ICMPV6:
 		if (ipfrag_is_fragment(fraginfo))
@@ -2028,8 +2036,6 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		return NAT_PUNT_TO_STACK;
 	};
 
-	if (snat_v6_rev_nat_can_skip(target, &tuple))
-		return NAT_PUNT_TO_STACK;
 	ret = snat_v6_rev_nat_handle_mapping(ctx, &tuple, fraginfo, &state, off, trace);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
In the case of ICMP ECHO packets, the `port` is really just an arbitrary 16-bit identifier. We can't skip SNAT based on what value this identifier has.

For completeness also do this change for ECHO_REPLY packets, even though it won't make a difference there. It will be needed once we stop clamping the ICMP identifier NAT to the nat_target's min_port / max_port range.