### PR TITLE
helm: possibility to use kvstoremesh in kvstore identity allocation mode

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -210,3 +210,10 @@ Return user specify tls.secretSync.enabled or default value based on the upgrade
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{/*
+Determine if CRDs are used for identity allocation
+*/}}
+{{- define "identityAllocationCRD" }}
+  {{- list "crd" "doublewrite-readkvstore" "doublewrite-readcrd" | has .Values.identityAllocationMode }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
+{{- if and .Values.clustermesh.useAPIServer .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") (eq "true" (include "identityAllocationCRD" .)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
+{{- if and .Values.clustermesh.useAPIServer .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") (eq "true" (include "identityAllocationCRD" .)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -181,6 +181,8 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- end }}
+      {{- if eq "true" (include "identityAllocationCRD" .) }}
       - name: apiserver
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
@@ -308,6 +310,7 @@ spec:
         - --prometheus-serve-addr=:{{ .Values.clustermesh.apiserver.metrics.kvstoremesh.port }}
         - --controller-group-metrics=all
         {{- end }}
+        - --enable-heartbeat={{ eq "true" (include "identityAllocationCRD" .) | ternary "false" "true" }}
         {{- with .Values.clustermesh.apiserver.kvstoremesh.extraArgs }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
@@ -24,7 +24,7 @@ spec:
   clusterIP: None
   type: ClusterIP
   ports:
-  {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal" }}
+  {{- if and (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") (eq "true" (include "identityAllocationCRD" .)) }}
     {{- if .Values.clustermesh.apiserver.metrics.enabled }}
   - name: apiserv-metrics
     port: {{ .Values.clustermesh.apiserver.metrics.port }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -35,7 +35,7 @@ spec:
     matchNames:
     - {{ include "cilium.namespace" . }}
   endpoints:
-  {{- if and .Values.clustermesh.apiserver.metrics.enabled (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
+  {{- if and .Values.clustermesh.apiserver.metrics.enabled (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") (eq "true" (include "identityAllocationCRD" .)) }}
   - port: apiserv-metrics
     interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.interval | quote }}
     {{- if .Values.clustermesh.apiserver.metrics.serviceMonitor.scrapeTimeout }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -1,5 +1,5 @@
 {{- if and
-  (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal"))
+  (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") (eq "true" (include "identityAllocationCRD" .)))
   (ne .Values.clustermesh.apiserver.tls.authMode "legacy")
 }}
 ---

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -166,12 +166,17 @@
 {{- fail ".Values.clustermesh.apiserver.kvstoremesh.kvstoreMode must have the value of external or internal" -}}
 {{- end -}}
 
-{{- if and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
-  {{- if and (ne .Values.identityAllocationMode "crd") (ne .Values.identityAllocationMode "doublewrite-readkvstore") (ne .Values.identityAllocationMode "doublewrite-readcrd") }}
-    {{ fail (printf "The clustermesh-apiserver cannot be enabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstore through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
-  {{- end }}
-  {{- if .Values.disableEndpointCRD }}
-    {{ fail "The clustermesh-apiserver cannot be enabled in combination with .Values.disableEndpointCRD=true" }}
+{{- if .Values.clustermesh.useAPIServer }}
+  {{- if eq "true" (include "identityAllocationCRD" .) }}
+    {{/* CRDs are used */}}
+    {{- if and .Values.disableEndpointCRD }}
+      {{ fail "The clustermesh-apiserver cannot be enabled in combination with .Values.disableEndpointCRD=true" }}
+    {{- end }}
+  {{- else }}
+    {{/* kvstore is used */}}
+    {{- if not .Values.clustermesh.apiserver.kvstoremesh.enabled }}
+      {{ fail (printf "The kvstoremesh container cannot be disabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstores through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
+    {{- end}}
   {{- end }}
 {{- end }}
 {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}


### PR DESCRIPTION
This PR implements possibility to run `clustermesh-apiserver` with `kvstore` identity allocation mode.  In this scenario, the `clustermesh-apiserver` deployment omits `apiserver` container but retains `kvstoremesh` and `etcd` containers. Resulting combo than acts as a cache for the data of other clusters in the mesh.

`clustermesh-apiserver` deployment implements a scalable, high availability etcd storage without need to set up and maintain an external etcd cluster. This PR implements easy way to use it for clusters with `kvstore` identity allocation mode.

This setup was allowed by [implementing (optional) heartbeat in `kvstoremesh`](https://github.com/cilium/cilium/issues/39356) container.


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.

<!-- Description of change -->

```release-note
Implemented optional etcd cache for remote cluster's data in `kvstore` identity allocation mode.
```
