### PR TITLE
loadbalancer: Port forwarding mode to new control-plane

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -16,6 +16,7 @@ cilium-agent hive [flags]
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --bpf-lb-algorithm string                                   BPF load balancing algorithm ("random", "maglev") (default "random")
       --bpf-lb-algorithm-annotation                               Enable service-level annotation for configuring BPF load balancing algorithm
+      --bpf-lb-dsr-dispatch string                                BPF load balancing DSR dispatch method ("opt", "ipip", "geneve") (default "opt")
       --bpf-lb-external-clusterip                                 Enable external access to ClusterIP services (default false)
       --bpf-lb-maglev-hash-seed string                            Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
       --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M, one of: [251 509 1021 2039 4093 8191 16381 32749 65521 131071]) (default 16381)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -20,6 +20,8 @@ cilium-agent hive [flags]
       --bpf-lb-maglev-hash-seed string                            Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
       --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M, one of: [251 509 1021 2039 4093 8191 16381 32749 65521 131071]) (default 16381)
       --bpf-lb-map-max int                                        Maximum number of entries in Cilium BPF lbmap (default 65536)
+      --bpf-lb-mode string                                        BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
+      --bpf-lb-mode-annotation                                    Enable service-level annotation for configuring BPF load balancing mode
       --bpf-lb-source-range-all-types                             Propagate loadbalancerSourceRanges to all corresponding service types
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -26,6 +26,8 @@ cilium-agent hive dot-graph [flags]
       --bpf-lb-maglev-hash-seed string                            Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
       --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M, one of: [251 509 1021 2039 4093 8191 16381 32749 65521 131071]) (default 16381)
       --bpf-lb-map-max int                                        Maximum number of entries in Cilium BPF lbmap (default 65536)
+      --bpf-lb-mode string                                        BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
+      --bpf-lb-mode-annotation                                    Enable service-level annotation for configuring BPF load balancing mode
       --bpf-lb-source-range-all-types                             Propagate loadbalancerSourceRanges to all corresponding service types
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -22,6 +22,7 @@ cilium-agent hive dot-graph [flags]
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --bpf-lb-algorithm string                                   BPF load balancing algorithm ("random", "maglev") (default "random")
       --bpf-lb-algorithm-annotation                               Enable service-level annotation for configuring BPF load balancing algorithm
+      --bpf-lb-dsr-dispatch string                                BPF load balancing DSR dispatch method ("opt", "ipip", "geneve") (default "opt")
       --bpf-lb-external-clusterip                                 Enable external access to ClusterIP services (default false)
       --bpf-lb-maglev-hash-seed string                            Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
       --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M, one of: [251 509 1021 2039 4093 8191 16381 32749 65521 131071]) (default 16381)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -545,7 +545,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	nativeDevices, _ := datapathTables.SelectedDevices(d.devices, rxn)
-	if err := finishKubeProxyReplacementInit(params.Logger, params.Sysctl, nativeDevices, drdName); err != nil {
+	if err := finishKubeProxyReplacementInit(params.Logger, params.Sysctl, nativeDevices, drdName, d.lbConfig); err != nil {
 		d.logger.Error("failed to finalise LB initialization", logfields.Error, err)
 		return nil, nil, fmt.Errorf("failed to finalise LB initialization: %w", err)
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -549,21 +549,11 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.CgroupPathMKE)
 	option.BindEnv(vp, option.CgroupPathMKE)
 
-	flags.String(option.NodePortMode, option.NodePortModeSNAT, "BPF NodePort mode (\"snat\", \"dsr\", \"hybrid\")")
-	flags.MarkHidden(option.NodePortMode)
-	option.BindEnv(vp, option.NodePortMode)
-
 	flags.String(option.NodePortAcceleration, option.NodePortAccelerationDisabled, fmt.Sprintf(
 		"BPF NodePort acceleration via XDP (\"%s\", \"%s\")",
 		option.NodePortAccelerationNative, option.NodePortAccelerationDisabled))
 	flags.MarkHidden(option.NodePortAcceleration)
 	option.BindEnv(vp, option.NodePortAcceleration)
-
-	flags.Bool(option.LoadBalancerModeAnnotation, false, "Enable service-level annotation for configuring BPF load balancing mode")
-	option.BindEnv(vp, option.LoadBalancerModeAnnotation)
-
-	flags.String(option.LoadBalancerMode, option.NodePortModeSNAT, "BPF load balancing mode (\"snat\", \"dsr\", \"hybrid\")")
-	option.BindEnv(vp, option.LoadBalancerMode)
 
 	flags.String(option.LoadBalancerDSRDispatch, option.DSRDispatchOption, "BPF load balancing DSR dispatch method (\"opt\", \"ipip\", \"geneve\")")
 	option.BindEnv(vp, option.LoadBalancerDSRDispatch)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -555,9 +555,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.NodePortAcceleration)
 	option.BindEnv(vp, option.NodePortAcceleration)
 
-	flags.String(option.LoadBalancerDSRDispatch, option.DSRDispatchOption, "BPF load balancing DSR dispatch method (\"opt\", \"ipip\", \"geneve\")")
-	option.BindEnv(vp, option.LoadBalancerDSRDispatch)
-
 	flags.Bool(option.LoadBalancerNat46X64, false, "BPF load balancing support for NAT46 and NAT64")
 	flags.MarkHidden(option.LoadBalancerNat46X64)
 	option.BindEnv(vp, option.LoadBalancerNat46X64)

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -44,9 +44,13 @@ type kprConfig struct {
 	tunnelProtocol tunnel.EncapProtocol
 	nodePortMode   string
 	dispatchMode   string
+
+	lbConfig loadbalancer.Config
 }
 
 func (cfg *kprConfig) set() {
+	cfg.lbConfig = loadbalancer.DefaultConfig
+
 	option.Config.KubeProxyReplacement = cfg.kubeProxyReplacement
 	option.Config.EnableSocketLB = cfg.enableSocketLB
 	option.Config.EnableNodePort = cfg.enableNodePort
@@ -62,8 +66,8 @@ func (cfg *kprConfig) set() {
 	option.Config.RoutingMode = cfg.routingMode
 	option.Config.LoadBalancerDSRDispatch = cfg.dispatchMode
 
-	if cfg.nodePortMode == option.NodePortModeDSR || cfg.nodePortMode == option.NodePortModeHybrid {
-		option.Config.NodePortMode = cfg.nodePortMode
+	if cfg.nodePortMode == loadbalancer.LBModeDSR || cfg.nodePortMode == loadbalancer.LBModeHybrid {
+		cfg.lbConfig.LBMode = cfg.nodePortMode
 	}
 }
 
@@ -83,7 +87,7 @@ func errorMatch(err error, regex string) assert.Comparison {
 
 func (cfg *kprConfig) verify(t *testing.T, tc tunnel.Config) {
 	logger := hivetest.Logger(t)
-	err := initKubeProxyReplacementOptions(logger, sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"), tc, loadbalancer.DefaultConfig)
+	err := initKubeProxyReplacementOptions(logger, sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"), tc, cfg.lbConfig)
 	if err != nil || cfg.expectedErrorRegex != "" {
 		require.Condition(t, errorMatch(err, cfg.expectedErrorRegex))
 		if strings.Contains(cfg.expectedErrorRegex, "Invalid") {
@@ -265,7 +269,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.VXLAN
-				cfg.nodePortMode = option.NodePortModeDSR
+				cfg.nodePortMode = loadbalancer.LBModeDSR
 				cfg.dispatchMode = option.DSRDispatchOption
 			},
 			kprConfig{
@@ -287,7 +291,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
 				cfg.routingMode = option.RoutingModeNative
 				cfg.tunnelProtocol = tunnel.Geneve
-				cfg.nodePortMode = option.NodePortModeDSR
+				cfg.nodePortMode = loadbalancer.LBModeDSR
 				cfg.dispatchMode = option.DSRDispatchGeneve
 			},
 			kprConfig{
@@ -307,7 +311,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.Geneve
-				cfg.nodePortMode = option.NodePortModeDSR
+				cfg.nodePortMode = loadbalancer.LBModeDSR
 				cfg.dispatchMode = option.DSRDispatchGeneve
 			},
 			kprConfig{
@@ -327,7 +331,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.VXLAN
-				cfg.nodePortMode = option.NodePortModeDSR
+				cfg.nodePortMode = loadbalancer.LBModeDSR
 				cfg.dispatchMode = option.DSRDispatchGeneve
 			},
 			kprConfig{
@@ -349,7 +353,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
 				cfg.routingMode = option.RoutingModeNative
 				cfg.tunnelProtocol = tunnel.Geneve
-				cfg.nodePortMode = option.NodePortModeHybrid
+				cfg.nodePortMode = loadbalancer.LBModeHybrid
 				cfg.dispatchMode = option.DSRDispatchGeneve
 			},
 			kprConfig{
@@ -369,7 +373,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.Geneve
-				cfg.nodePortMode = option.NodePortModeHybrid
+				cfg.nodePortMode = loadbalancer.LBModeHybrid
 				cfg.dispatchMode = option.DSRDispatchGeneve
 			},
 			kprConfig{
@@ -389,7 +393,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.VXLAN
-				cfg.nodePortMode = option.NodePortModeHybrid
+				cfg.nodePortMode = loadbalancer.LBModeHybrid
 				cfg.dispatchMode = option.DSRDispatchGeneve
 			},
 			kprConfig{

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -410,11 +410,11 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["ENABLE_DSR_HYBRID"] = "1"
 				cDefinesMap["ENABLE_DSR_BYUSER"] = "1"
 			}
-			if option.Config.LoadBalancerDSRDispatch == option.DSRDispatchOption {
+			if cfg.LBConfig.DSRDispatch == loadbalancer.DSRDispatchOption {
 				cDefinesMap["DSR_ENCAP_MODE"] = fmt.Sprintf("%d", dsrEncapNone)
-			} else if option.Config.LoadBalancerDSRDispatch == option.DSRDispatchIPIP {
+			} else if cfg.LBConfig.DSRDispatch == loadbalancer.DSRDispatchIPIP {
 				cDefinesMap["DSR_ENCAP_MODE"] = fmt.Sprintf("%d", dsrEncapIPIP)
-			} else if option.Config.LoadBalancerDSRDispatch == option.DSRDispatchGeneve {
+			} else if cfg.LBConfig.DSRDispatch == loadbalancer.DSRDispatchGeneve {
 				cDefinesMap["DSR_ENCAP_MODE"] = fmt.Sprintf("%d", dsrEncapGeneve)
 			}
 		} else {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -399,14 +399,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["DSR_ENCAP_IPIP"] = fmt.Sprintf("%d", dsrEncapIPIP)
 		cDefinesMap["DSR_ENCAP_GENEVE"] = fmt.Sprintf("%d", dsrEncapGeneve)
 		cDefinesMap["DSR_ENCAP_NONE"] = fmt.Sprintf("%d", dsrEncapNone)
-		if option.Config.LoadBalancerUsesDSR() {
+		if cfg.LBConfig.LoadBalancerUsesDSR() {
 			cDefinesMap["ENABLE_DSR"] = "1"
 			if option.Config.EnablePMTUDiscovery {
 				cDefinesMap["ENABLE_DSR_ICMP_ERRORS"] = "1"
 			}
-			if option.Config.NodePortMode == option.NodePortModeHybrid {
+			if cfg.LBConfig.LBMode == loadbalancer.LBModeHybrid {
 				cDefinesMap["ENABLE_DSR_HYBRID"] = "1"
-			} else if option.Config.LoadBalancerModeAnnotation {
+			} else if cfg.LBConfig.LBModeAnnotation {
 				cDefinesMap["ENABLE_DSR_HYBRID"] = "1"
 				cDefinesMap["ENABLE_DSR_BYUSER"] = "1"
 			}

--- a/pkg/datapath/tunnel/cell.go
+++ b/pkg/datapath/tunnel/cell.go
@@ -6,6 +6,7 @@ package tunnel
 import (
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -30,11 +31,11 @@ var Cell = cell.Module(
 
 		// Enable tunnel configuration when DSR Geneve is enabled (this is currently
 		// handled here, as the corresponding logic has not yet been modularized).
-		func(dcfg *option.DaemonConfig) EnablerOut {
+		func(dcfg *option.DaemonConfig, lbcfg loadbalancer.Config) EnablerOut {
 			return NewEnabler(
 				(dcfg.EnableNodePort ||
 					dcfg.KubeProxyReplacement == option.KubeProxyReplacementTrue) &&
-					dcfg.LoadBalancerUsesDSR() &&
+					lbcfg.LoadBalancerUsesDSR() &&
 					dcfg.LoadBalancerDSRDispatch == option.DSRDispatchGeneve,
 				// The datapath logic takes care of the MTU overhead. So no need to
 				// take it into account here.

--- a/pkg/datapath/tunnel/cell.go
+++ b/pkg/datapath/tunnel/cell.go
@@ -36,7 +36,7 @@ var Cell = cell.Module(
 				(dcfg.EnableNodePort ||
 					dcfg.KubeProxyReplacement == option.KubeProxyReplacementTrue) &&
 					lbcfg.LoadBalancerUsesDSR() &&
-					dcfg.LoadBalancerDSRDispatch == option.DSRDispatchGeneve,
+					lbcfg.DSRDispatch == loadbalancer.DSRDispatchGeneve,
 				// The datapath logic takes care of the MTU overhead. So no need to
 				// take it into account here.
 				// See encap_geneve_dsr_opt[4,6] in nodeport.h

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -344,15 +344,13 @@ func Test_ParseNodeAddressType(t *testing.T) {
 
 func TestParseNodeWithService(t *testing.T) {
 	oldAnnotateK8sNode := option.Config.AnnotateK8sNode
-	oldDefaultLbMode := option.Config.NodePortMode
 
 	var lbConfig loadbalancer.Config
 	option.Config.AnnotateK8sNode = false
-	option.Config.NodePortMode = option.NodePortModeSNAT
+	lbConfig.LBMode = loadbalancer.LBModeSNAT
 	lbConfig.LBAlgorithm = loadbalancer.LBAlgorithmRandom
 	defer func() {
 		option.Config.AnnotateK8sNode = oldAnnotateK8sNode
-		option.Config.NodePortMode = oldDefaultLbMode
 	}()
 
 	k8sNode := &slim_corev1.Node{

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -29,15 +29,15 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-func getAnnotationServiceForwardingMode(svc *slim_corev1.Service) (loadbalancer.SVCForwardingMode, error) {
+func getAnnotationServiceForwardingMode(cfg loadbalancer.Config, svc *slim_corev1.Service) (loadbalancer.SVCForwardingMode, error) {
 	if value, ok := annotation.Get(svc, annotation.ServiceForwardingMode); ok {
 		val := loadbalancer.ToSVCForwardingMode(strings.ToLower(value))
 		if val != loadbalancer.SVCForwardingModeUndef {
 			return val, nil
 		}
-		return loadbalancer.ToSVCForwardingMode(option.Config.NodePortMode), fmt.Errorf("Value %q is not supported for %q", val, annotation.ServiceForwardingMode)
+		return loadbalancer.ToSVCForwardingMode(cfg.LBMode), fmt.Errorf("Value %q is not supported for %q", val, annotation.ServiceForwardingMode)
 	}
-	return loadbalancer.ToSVCForwardingMode(option.Config.NodePortMode), nil
+	return loadbalancer.ToSVCForwardingMode(cfg.LBMode), nil
 }
 
 func getAnnotationServiceLoadBalancingAlgorithm(cfg loadbalancer.Config, svc *slim_corev1.Service) (loadbalancer.SVCLoadBalancingAlgorithm, error) {
@@ -257,11 +257,11 @@ func ParseService(logger *slog.Logger, cfg loadbalancer.Config, svc *slim_corev1
 	svcInfo.ServiceAffinity = annotation.GetAnnotationServiceAffinity(svc)
 	svcInfo.Shared = annotation.GetAnnotationShared(svc)
 
-	svcInfo.ForwardingMode = loadbalancer.ToSVCForwardingMode(option.Config.NodePortMode)
+	svcInfo.ForwardingMode = loadbalancer.ToSVCForwardingMode(cfg.LBMode)
 	if cfg.AlgorithmAnnotation {
 		var err error
 
-		svcInfo.ForwardingMode, err = getAnnotationServiceForwardingMode(svc)
+		svcInfo.ForwardingMode, err = getAnnotationServiceForwardingMode(cfg, svc)
 		if err != nil {
 			scopedLog.Warn(
 				"Ignoring annotation, applying global configuration",

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -271,11 +271,9 @@ func TestParseServiceWithServiceTypeExposure(t *testing.T) {
 }
 
 func TestParseService(t *testing.T) {
-	oldDefaultLbMode := option.Config.NodePortMode
-	option.Config.NodePortMode = option.NodePortModeSNAT
-	defer func() {
-		option.Config.NodePortMode = oldDefaultLbMode
-	}()
+	lbcfg := loadbalancer.DefaultConfig
+	lbcfg.LBMode = loadbalancer.LBModeSNAT
+
 	objMeta := slim_metav1.ObjectMeta{
 		Name:      "foo",
 		Namespace: "bar",
@@ -294,8 +292,6 @@ func TestParseService(t *testing.T) {
 			Type: slim_corev1.ServiceTypeClusterIP,
 		},
 	}
-
-	lbcfg := loadbalancer.DefaultConfig
 
 	id, svc := ParseService(hivetest.Logger(t), lbcfg, k8sSvc, nil)
 	require.Equal(t, ServiceID{Namespace: "bar", Name: "foo"}, id)

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -63,7 +63,7 @@ const (
 type SVCForwardingMode string
 
 const (
-	SVCForwardingModeUndef = SVCForwardingMode("undef")
+	SVCForwardingModeUndef = SVCForwardingMode("")
 	SVCForwardingModeDSR   = SVCForwardingMode("dsr")
 	SVCForwardingModeSNAT  = SVCForwardingMode("snat")
 )

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -70,13 +69,14 @@ const (
 )
 
 func ToSVCForwardingMode(s string) SVCForwardingMode {
-	if s == option.NodePortModeDSR {
+	switch s {
+	case LBModeDSR:
 		return SVCForwardingModeDSR
-	}
-	if s == option.NodePortModeSNAT {
+	case LBModeSNAT:
 		return SVCForwardingModeSNAT
+	default:
+		return SVCForwardingModeUndef
 	}
-	return SVCForwardingModeUndef
 }
 
 type SVCLoadBalancingAlgorithm uint8

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -732,9 +732,16 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 	// isRoutable denotes whether this service can be accessed from outside the cluster.
 	isRoutable := !svcKey.IsSurrogate() &&
 		(svcType != loadbalancer.SVCTypeClusterIP || ops.cfg.ExternalClusterIP)
+
+	forwardingMode := loadbalancer.ToSVCForwardingMode(ops.cfg.LBMode)
+	if ops.cfg.LBModeAnnotation && svc.ForwardingMode != loadbalancer.SVCForwardingModeUndef {
+		forwardingMode = svc.ForwardingMode
+	}
+
 	flag := loadbalancer.NewSvcFlag(&loadbalancer.SvcFlagParam{
 		SvcType:          svcType,
 		SvcNatPolicy:     svc.NatPolicy,
+		SvcFwdModeDSR:    forwardingMode == loadbalancer.SVCForwardingModeDSR,
 		SvcExtLocal:      svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal,
 		SvcIntLocal:      svc.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal,
 		SessionAffinity:  svc.SessionAffinity,

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -4,6 +4,7 @@
 package reflectors
 
 import (
+	"fmt"
 	"log/slog"
 	"net"
 	"net/netip"
@@ -43,6 +44,17 @@ func isIngressDummyEndpoint(l3n4Addr loadbalancer.L3n4Addr) bool {
 	return l3n4Addr.AddrCluster.Equal(ingressDummyAddress) && l3n4Addr.Port == ingressDummyPort
 }
 
+func getAnnotationServiceForwardingMode(cfg loadbalancer.Config, svc *slim_corev1.Service) (loadbalancer.SVCForwardingMode, error) {
+	if value, ok := annotation.Get(svc, annotation.ServiceForwardingMode); ok {
+		val := loadbalancer.ToSVCForwardingMode(strings.ToLower(value))
+		if val != loadbalancer.SVCForwardingModeUndef {
+			return val, nil
+		}
+		return loadbalancer.ToSVCForwardingMode(cfg.LBMode), fmt.Errorf("value %q is not supported for %q", val, annotation.ServiceForwardingMode)
+	}
+	return loadbalancer.SVCForwardingModeUndef, nil
+}
+
 func isHeadless(svc *slim_corev1.Service) bool {
 	_, headless := svc.Labels[corev1.IsHeadlessService]
 	if strings.ToLower(svc.Spec.ClusterIP) == "none" {
@@ -51,7 +63,7 @@ func isHeadless(svc *slim_corev1.Service) bool {
 	return headless
 }
 
-func convertService(cfg loadbalancer.ExternalConfig, rawlog *slog.Logger, localNodeStore *node.LocalNodeStore, svc *slim_corev1.Service, source source.Source) (s *loadbalancer.Service, fes []loadbalancer.FrontendParams) {
+func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig, rawlog *slog.Logger, localNodeStore *node.LocalNodeStore, svc *slim_corev1.Service, source source.Source) (s *loadbalancer.Service, fes []loadbalancer.FrontendParams) {
 	// Lazily construct the augmented logger as we very rarely log here. This improves throughput by 20% and avoids an allocation.
 	log := sync.OnceValue(func() *slog.Logger {
 		return rawlog.With(
@@ -68,6 +80,19 @@ func convertService(cfg loadbalancer.ExternalConfig, rawlog *slog.Logger, localN
 		Selector:            svc.Spec.Selector,
 		Annotations:         svc.Annotations,
 		HealthCheckNodePort: uint16(svc.Spec.HealthCheckNodePort),
+		ForwardingMode:      loadbalancer.SVCForwardingModeUndef,
+	}
+
+	if cfg.LBModeAnnotation {
+		fwdMode, err := getAnnotationServiceForwardingMode(cfg, svc)
+		if err == nil {
+			s.ForwardingMode = fwdMode
+		} else {
+			log().Warn("Ignoring annotation",
+				logfields.Error, err,
+				logfields.Annotations, annotation.ServiceForwardingMode,
+			)
+		}
 	}
 
 	if localNodeStore != nil {
@@ -164,11 +189,11 @@ func convertService(cfg loadbalancer.ExternalConfig, rawlog *slog.Logger, localN
 				continue
 			}
 
-			if (!cfg.EnableIPv6 && addr.Is6()) || (!cfg.EnableIPv4 && addr.Is4()) {
+			if (!extCfg.EnableIPv6 && addr.Is6()) || (!extCfg.EnableIPv4 && addr.Is4()) {
 				log().Debug(
 					"Skipping ClusterIP due to disabled IP family",
-					logfields.IPv4, cfg.EnableIPv4,
-					logfields.IPv6, cfg.EnableIPv6,
+					logfields.IPv4, extCfg.EnableIPv4,
+					logfields.IPv6, extCfg.EnableIPv6,
 					logfields.Address, addr,
 				)
 				continue
@@ -198,19 +223,19 @@ func convertService(cfg loadbalancer.ExternalConfig, rawlog *slog.Logger, localN
 	// NOTE: We always want to do ClusterIP services even when full kube-proxy replacement is disabled.
 	// See https://github.com/cilium/cilium/issues/16197 for context.
 
-	if cfg.KubeProxyReplacement {
+	if extCfg.KubeProxyReplacement {
 		// NodePort
 		if (svc.Spec.Type == slim_corev1.ServiceTypeNodePort || svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer) &&
 			expType.CanExpose(slim_corev1.ServiceTypeNodePort) {
 
 			for _, scope := range scopes {
 				for _, family := range getIPFamilies(svc) {
-					if (!cfg.EnableIPv6 && family == slim_corev1.IPv6Protocol) ||
-						(!cfg.EnableIPv4 && family == slim_corev1.IPv4Protocol) {
+					if (!extCfg.EnableIPv6 && family == slim_corev1.IPv6Protocol) ||
+						(!extCfg.EnableIPv4 && family == slim_corev1.IPv4Protocol) {
 						log().Debug(
 							"Skipping NodePort due to disabled IP family",
-							logfields.IPv4, cfg.EnableIPv4,
-							logfields.IPv6, cfg.EnableIPv6,
+							logfields.IPv4, extCfg.EnableIPv4,
+							logfields.IPv6, extCfg.EnableIPv6,
 							logfields.Family, family,
 						)
 						continue
@@ -259,11 +284,11 @@ func convertService(cfg loadbalancer.ExternalConfig, rawlog *slog.Logger, localN
 				if err != nil {
 					continue
 				}
-				if (!cfg.EnableIPv6 && addr.Is6()) || (!cfg.EnableIPv4 && addr.Is4()) {
+				if (!extCfg.EnableIPv6 && addr.Is6()) || (!extCfg.EnableIPv4 && addr.Is4()) {
 					log().Debug(
 						"Skipping LoadBalancer due to disabled IP family",
-						logfields.IPv4, cfg.EnableIPv4,
-						logfields.IPv6, cfg.EnableIPv6,
+						logfields.IPv4, extCfg.EnableIPv4,
+						logfields.IPv6, extCfg.EnableIPv6,
 						logfields.Address, addr,
 					)
 					continue
@@ -300,11 +325,11 @@ func convertService(cfg loadbalancer.ExternalConfig, rawlog *slog.Logger, localN
 			if err != nil {
 				continue
 			}
-			if (!cfg.EnableIPv6 && addr.Is6()) || (!cfg.EnableIPv4 && addr.Is4()) {
+			if (!extCfg.EnableIPv6 && addr.Is6()) || (!extCfg.EnableIPv4 && addr.Is4()) {
 				log().Debug(
 					"Skipping ExternalIP due to disabled IP family",
-					logfields.IPv4, cfg.EnableIPv4,
-					logfields.IPv6, cfg.EnableIPv6,
+					logfields.IPv4, extCfg.EnableIPv4,
+					logfields.IPv6, extCfg.EnableIPv6,
 					logfields.Address, addr,
 				)
 				continue

--- a/pkg/loadbalancer/reflectors/file.go
+++ b/pkg/loadbalancer/reflectors/file.go
@@ -85,6 +85,7 @@ func registerFileReflector(log *slog.Logger, jg job.Group, lbcfg loadbalancer.Co
 	ls := fileReflector{
 		log:       log,
 		cfg:       cfg,
+		lbConfig:  lbcfg,
 		extConfig: extcfg,
 		file:      file,
 		isYAML:    isYAML,
@@ -106,6 +107,7 @@ func registerFileReflector(log *slog.Logger, jg job.Group, lbcfg loadbalancer.Co
 type fileReflector struct {
 	log       *slog.Logger
 	cfg       fileReflectorConfig
+	lbConfig  loadbalancer.Config
 	extConfig loadbalancer.ExternalConfig
 	file      string
 	isYAML    bool
@@ -215,7 +217,7 @@ func (s *fileReflector) synchronize(txn writer.WriteTxn, state *StateFile) (numS
 		return 0, 0, 0, fmt.Errorf("failed to delete backends: %w", err)
 	}
 	for i := range state.Services {
-		svc, fes := convertService(s.extConfig, s.log, nil, &state.Services[i], source.LocalAPI)
+		svc, fes := convertService(s.lbConfig, s.extConfig, s.log, nil, &state.Services[i], source.LocalAPI)
 		if err := s.w.UpsertServiceAndFrontends(txn, svc, fes...); err != nil {
 			return 0, 0, 0, fmt.Errorf("failed to upsert services and frontends: %w", err)
 		}

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -222,7 +222,7 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 			initServices(txn)
 
 		case resource.Upsert:
-			svc, fes := convertService(p.ExtConfig, p.Log, p.LocalNodeStore, obj, source.Kubernetes)
+			svc, fes := convertService(p.Config, p.ExtConfig, p.Log, p.LocalNodeStore, obj, source.Kubernetes)
 			if svc == nil {
 				// The service should not be provisioned on this agent. Try to delete if it was previously.
 				name := loadbalancer.ServiceName{Namespace: obj.Namespace, Name: obj.Name}

--- a/pkg/loadbalancer/reflectors/k8s_test.go
+++ b/pkg/loadbalancer/reflectors/k8s_test.go
@@ -33,7 +33,7 @@ func BenchmarkConvertService(b *testing.B) {
 	svc := obj.(*slim_corev1.Service)
 
 	for b.Loop() {
-		convertService(benchmarkExternalConfig, slog.New(slog.DiscardHandler), nil, svc, source.Kubernetes)
+		convertService(loadbalancer.DefaultConfig, benchmarkExternalConfig, slog.New(slog.DiscardHandler), nil, svc, source.Kubernetes)
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "services/sec")
 }

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -55,6 +55,10 @@ type Service struct {
 	// If set to "Local", only node-local backends are chosen.
 	IntTrafficPolicy SVCTrafficPolicy
 
+	// ForwardingMode controls whether DSR or SNAT should be used for the dispatch
+	// to the backend. If undefined the default mode is used (--bpf-lb-mode).
+	ForwardingMode SVCForwardingMode
+
 	SessionAffinity        bool
 	SessionAffinityTimeout time.Duration
 
@@ -209,6 +213,10 @@ func (svc *Service) TableRow() []string {
 
 	if alg := svc.GetLBAlgorithmAnnotation(); alg != SVCLoadBalancingAlgorithmUndef {
 		flags = append(flags, "ExplicitLBAlgorithm="+alg.String())
+	}
+
+	if svc.ForwardingMode != SVCForwardingModeUndef {
+		flags = append(flags, "ForwardingMode="+string(svc.ForwardingMode))
 	}
 
 	if svc.Properties.Len() != 0 {

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -66,6 +66,7 @@ Address              Instances
   "NatPolicy": "",
   "ExtTrafficPolicy": "Cluster",
   "IntTrafficPolicy": "Cluster",
+  "ForwardingMode": "",
   "SessionAffinity": false,
   "SessionAffinityTimeout": 0,
   "ProxyRedirect": null,
@@ -260,6 +261,7 @@ selector:
 natpolicy: ""
 exttrafficpolicy: Cluster
 inttrafficpolicy: Cluster
+forwardingmode: ""
 sessionaffinity: false
 sessionaffinitytimeout: 0s
 proxyredirect: null

--- a/pkg/loadbalancer/tests/testdata/svc-forwarding-mode-annotation.txtar
+++ b/pkg/loadbalancer/tests/testdata/svc-forwarding-mode-annotation.txtar
@@ -1,0 +1,107 @@
+#! --lb-test-fault-probability=0.0 --bpf-lb-mode-annotation
+
+# Start the test application
+hive start
+db/initialized
+
+# Add service w/o "service.cilium.io/forwarding-mode"
+k8s/add service.yaml endpointslice.yaml
+db/cmp frontends frontends.table
+db/cmp services services.table
+
+# Check maps
+lb/maps-dump maps.actual
+* cmp maps.actual maps_snat.expected
+
+# Set the forwarding mode to DSR
+sed 'placeholder: placeholder' 'service.cilium.io/forwarding-mode: dsr' service.yaml
+k8s/update service.yaml
+db/cmp services services.table
+
+# Check maps
+lb/maps-dump maps.actual
+* cmp maps.actual maps_dsr.expected
+
+#####
+
+-- services.table --
+Name         Source   TrafficPolicy   Flags
+test/echo    k8s      Cluster
+
+-- services_dsr.table --
+Name         Source   TrafficPolicy   Flags
+test/echo    k8s      Cluster         ForwardingMode=dsr
+
+-- frontends.table --
+Address               Type         ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort     test/echo     http       Done    10.244.1.1:80/TCP
+10.96.50.104:80/TCP   ClusterIP    test/echo     http       Done    10.244.1.1:80/TCP
+172.16.1.1:80/TCP     LoadBalancer test/echo     http       Done    10.244.1.1:80/TCP
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  annotations:
+    placeholder: placeholder
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- maps_snat.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=2 ADDR=10.96.50.104:80
+REV: ID=3 ADDR=172.16.1.1:80
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=3 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+-- maps_dsr.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=2 ADDR=10.96.50.104:80
+REV: ID=3 ADDR=172.16.1.1:80
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable+dsr
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable+dsr
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+dsr
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+dsr
+SVC: ID=3 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+dsr
+SVC: ID=3 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+dsr

--- a/pkg/loadbalancer/zz_generated.deepequal.go
+++ b/pkg/loadbalancer/zz_generated.deepequal.go
@@ -155,6 +155,9 @@ func (in *UserConfig) DeepEqual(other *UserConfig) bool {
 	if in.LBAlgorithm != other.LBAlgorithm {
 		return false
 	}
+	if in.DSRDispatch != other.DSRDispatch {
+		return false
+	}
 	if in.ExternalClusterIP != other.ExternalClusterIP {
 		return false
 	}

--- a/pkg/loadbalancer/zz_generated.deepequal.go
+++ b/pkg/loadbalancer/zz_generated.deepequal.go
@@ -146,6 +146,12 @@ func (in *UserConfig) DeepEqual(other *UserConfig) bool {
 		}
 	}
 
+	if in.LBMode != other.LBMode {
+		return false
+	}
+	if in.LBModeAnnotation != other.LBModeAnnotation {
+		return false
+	}
 	if in.LBAlgorithm != other.LBAlgorithm {
 		return false
 	}

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -178,9 +178,9 @@ var (
 	}
 
 	defaultNodePortModes = []string{
-		option.NodePortModeSNAT,
-		option.NodePortModeDSR,
-		option.NodePortModeHybrid,
+		loadbalancer.LBModeSNAT,
+		loadbalancer.LBModeDSR,
+		loadbalancer.LBModeHybrid,
 	}
 
 	defaultNodePortModeAlgorithms = []string{
@@ -1022,7 +1022,7 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 		m.ACLBKubeProxyReplacementEnabled.Add(1)
 	}
 
-	m.ACLBNodePortConfig.WithLabelValues(config.NodePortMode, lbConfig.LBAlgorithm, config.NodePortAcceleration).Add(1)
+	m.ACLBNodePortConfig.WithLabelValues(lbConfig.LBMode, lbConfig.LBAlgorithm, config.NodePortAcceleration).Add(1)
 
 	if config.EnableBGPControlPlane {
 		m.ACLBBGPEnabled.Add(1)

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -100,13 +100,13 @@ func TestUpdateNetworkMode(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				RoutingMode:            tt.tunnelMode,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				TunnelConfig:    tt.tunnelProto,
@@ -153,13 +153,13 @@ func TestUpdateIPAMMode(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				IPAM:                   tt.IPAMMode,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -206,12 +206,12 @@ func TestUpdateCNIChainingMode(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: tt.chainingMode,
@@ -267,13 +267,13 @@ func TestUpdateInternetProtocol(t *testing.T) {
 				IPAM:                   defaultIPAMModes[0],
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				EnableIPv4:             tt.enableIPv4,
 				EnableIPv6:             tt.enableIPv6,
 			}
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -318,13 +318,13 @@ func TestUpdateIdentityAllocationMode(t *testing.T) {
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				DatapathMode:           defaultDeviceModes[0],
 				IdentityAllocationMode: tt.identityAllocationMode,
 			}
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -374,13 +374,13 @@ func TestUpdateCiliumEndpointSlices(t *testing.T) {
 				EnableIPv4:                true,
 				IdentityAllocationMode:    defaultIdentityAllocationModes[0],
 				DatapathMode:              defaultDeviceModes[0],
-				NodePortMode:              defaultNodePortModes[0],
 				NodePortAcceleration:      defaultNodePortModeAccelerations[0],
 				EnableCiliumEndpointSlice: tt.enableCES,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -417,12 +417,12 @@ func TestUpdateDeviceMode(t *testing.T) {
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				DatapathMode:           tt.deviceMode,
 			}
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -472,12 +472,12 @@ func TestUpdateHostFirewall(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				EnableHostFirewall:     tt.enableHostFirewall,
 			}
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -517,12 +517,12 @@ func TestUpdateLocalRedirectPolicies(t *testing.T) {
 				EnableIPv4:                true,
 				IdentityAllocationMode:    defaultIdentityAllocationModes[0],
 				DatapathMode:              defaultDeviceModes[0],
-				NodePortMode:              defaultNodePortModes[0],
 				NodePortAcceleration:      defaultNodePortModeAccelerations[0],
 				EnableLocalRedirectPolicy: tt.enableLRP,
 			}
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -562,12 +562,12 @@ func TestUpdateMutualAuth(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -608,13 +608,13 @@ func TestUpdateNonDefaultDeny(t *testing.T) {
 				EnableIPv4:                   true,
 				IdentityAllocationMode:       defaultIdentityAllocationModes[0],
 				DatapathMode:                 defaultDeviceModes[0],
-				NodePortMode:                 defaultNodePortModes[0],
 				NodePortAcceleration:         defaultNodePortModeAccelerations[0],
 				EnableNonDefaultDenyPolicies: tt.enableNonDefaultDeny,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -651,13 +651,13 @@ func TestUpdateCIDRPolicyModeToNode(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				PolicyCIDRMatchMode:    []string{tt.policyMode},
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -733,7 +733,6 @@ func TestUpdateEncryptionMode(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				EnableIPSec:            tt.enableIPSec,
 				EnableWireguard:        tt.enableWireguard,
@@ -742,6 +741,7 @@ func TestUpdateEncryptionMode(t *testing.T) {
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -793,13 +793,13 @@ func TestUpdateKubeProxyReplacement(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				KubeProxyReplacement:   tt.enableKubeProxyReplacement,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -850,12 +850,12 @@ func TestUpdateNodePortConfig(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           tt.portMode,
 				NodePortAcceleration:   tt.accelerationMode,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = tt.algoMode
+			lbConfig.LBMode = tt.portMode
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -910,13 +910,13 @@ func TestUpdateBGP(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				EnableBGPControlPlane:  tt.bgpControlPlane,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -956,13 +956,13 @@ func TestUpdateIPv4EgressGateway(t *testing.T) {
 				EnableIPv4:              true,
 				IdentityAllocationMode:  defaultIdentityAllocationModes[0],
 				DatapathMode:            defaultDeviceModes[0],
-				NodePortMode:            defaultNodePortModes[0],
 				NodePortAcceleration:    defaultNodePortModeAccelerations[0],
 				EnableIPv4EgressGateway: tt.enableEGW,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -1003,12 +1003,12 @@ func TestUpdateBandwidthManager(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode:  defaultChainingModes[0],
@@ -1050,12 +1050,12 @@ func TestUpdateSCTP(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -1096,12 +1096,12 @@ func TestUpdateInternalTrafficPolicy(t *testing.T) {
 				EnableIPv4:                  true,
 				IdentityAllocationMode:      defaultIdentityAllocationModes[0],
 				DatapathMode:                defaultDeviceModes[0],
-				NodePortMode:                defaultNodePortModes[0],
 				NodePortAcceleration:        defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -1142,12 +1142,12 @@ func TestUpdateVTEP(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -1188,12 +1188,12 @@ func TestUpdateEnvoyConfig(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -1239,13 +1239,13 @@ func TestUpdateBigTCPProtocol(t *testing.T) {
 				IPAM:                   defaultIPAMModes[0],
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				EnableIPv4:             true,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -1300,12 +1300,12 @@ func TestUpdateL2Announcements(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -1345,12 +1345,12 @@ func TestUpdateL2PodAnnouncements(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode:   defaultChainingModes[0],
@@ -1392,12 +1392,12 @@ func TestUpdateExtEnvoyProxyMode(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
@@ -1447,12 +1447,12 @@ func TestUpdateDynamicNodeConfig(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
-				NodePortMode:           defaultNodePortModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
 			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
 
 			params := mockFeaturesParams{
 				CNIChainingMode:                     defaultChainingModes[0],

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -249,9 +249,6 @@ const (
 	// via XDP ("none", "generic", "native", or "best-effort")
 	NodePortAcceleration = "node-port-acceleration"
 
-	// Alias to DSR dispatch method
-	LoadBalancerDSRDispatch = "bpf-lb-dsr-dispatch"
-
 	// Alias to DSR/IPIP IPv4 source CIDR
 	LoadBalancerRSSv4CIDR = "bpf-lb-rss-ipv4-src-cidr"
 
@@ -1140,15 +1137,6 @@ const (
 )
 
 const (
-	// DSR dispatch mode to encode service into IP option or extension header
-	DSRDispatchOption = "opt"
-
-	// DSR dispatch mode to encapsulate to IPIP
-	DSRDispatchIPIP = "ipip"
-
-	// DSR dispatch mode to encapsulate to Geneve
-	DSRDispatchGeneve = "geneve"
-
 	// NodePortAccelerationDisabled means we do not accelerate NodePort via XDP
 	NodePortAccelerationDisabled = XDPModeDisabled
 
@@ -1793,10 +1781,6 @@ type DaemonConfig struct {
 
 	// LoadBalancerIPIPSockMark enables sock-lb logic to force service traffic via IPIP
 	LoadBalancerIPIPSockMark bool
-
-	// LoadBalancerDSRDispatch indicates the method for pushing packets to
-	// backends under DSR ("opt" or "ipip")
-	LoadBalancerDSRDispatch string
 
 	// LoadBalancerRSSv4CIDR defines the outer source IPv4 prefix for DSR/IPIP
 	LoadBalancerRSSv4CIDR string
@@ -2840,7 +2824,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.EnableIPv4FragmentsTracking = vp.GetBool(EnableIPv4FragmentsTrackingName)
 	c.EnableIPv6FragmentsTracking = vp.GetBool(EnableIPv6FragmentsTrackingName)
 	c.FragmentsMapEntries = vp.GetInt(FragmentsMapEntriesName)
-	c.LoadBalancerDSRDispatch = vp.GetString(LoadBalancerDSRDispatch)
 	c.LoadBalancerRSSv4CIDR = vp.GetString(LoadBalancerRSSv4CIDR)
 	c.LoadBalancerRSSv6CIDR = vp.GetString(LoadBalancerRSSv6CIDR)
 	c.LoadBalancerIPIPSockMark = vp.GetBool(LoadBalancerIPIPSockMark)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -245,20 +245,9 @@ const (
 	// EnableSVCSourceRangeCheck enables check of service source range checks
 	EnableSVCSourceRangeCheck = "enable-svc-source-range-check"
 
-	// NodePortMode indicates in which mode NodePort implementation should run
-	// ("snat", "dsr" or "hybrid")
-	NodePortMode = "node-port-mode"
-
 	// NodePortAcceleration indicates whether NodePort should be accelerated
 	// via XDP ("none", "generic", "native", or "best-effort")
 	NodePortAcceleration = "node-port-acceleration"
-
-	// Alias to NodePortMode
-	LoadBalancerMode = "bpf-lb-mode"
-
-	// LoadBalancerModeAnnotation tells whether controller should check service
-	// level annotation for configuring bpf loadbalancing method (snat vs dsr).
-	LoadBalancerModeAnnotation = "bpf-lb-mode-annotation"
 
 	// Alias to DSR dispatch method
 	LoadBalancerDSRDispatch = "bpf-lb-dsr-dispatch"
@@ -1151,15 +1140,6 @@ const (
 )
 
 const (
-	// NodePortModeSNAT is for SNATing requests to remote nodes
-	NodePortModeSNAT = "snat"
-
-	// NodePortModeDSR is for performing DSR for requests to remote nodes
-	NodePortModeDSR = "dsr"
-
-	// NodePortModeHybrid is a dual mode of the above, that is, DSR for TCP and SNAT for UDP
-	NodePortModeHybrid = "hybrid"
-
 	// DSR dispatch mode to encode service into IP option or extension header
 	DSRDispatchOption = "opt"
 
@@ -1810,14 +1790,6 @@ type DaemonConfig struct {
 
 	// NodePortNat46X64 indicates whether NAT46 / NAT64 can be used.
 	NodePortNat46X64 bool
-
-	// NodePortMode indicates in which mode NodePort implementation should run
-	// ("snat", "dsr" or "hybrid")
-	NodePortMode string
-
-	// LoadBalancerModeAnnotation tells whether controller should check service
-	// level annotation for configuring bpf load balancing algorithm.
-	LoadBalancerModeAnnotation bool
 
 	// LoadBalancerIPIPSockMark enables sock-lb logic to force service traffic via IPIP
 	LoadBalancerIPIPSockMark bool
@@ -2471,12 +2443,6 @@ func (c *DaemonConfig) DirectRoutingDeviceRequired() bool {
 	}
 
 	return c.EnableNodePort || BPFHostRoutingEnabled || Config.EnableWireguard
-}
-
-func (c *DaemonConfig) LoadBalancerUsesDSR() bool {
-	return c.NodePortMode == NodePortModeDSR ||
-		c.NodePortMode == NodePortModeHybrid ||
-		c.LoadBalancerModeAnnotation
 }
 
 // KVstoreEnabled returns whether Cilium is configured to connect to an external KVStore.
@@ -3251,8 +3217,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 
 func (c *DaemonConfig) populateLoadBalancerSettings(logger *slog.Logger, vp *viper.Viper) {
 	c.NodePortAcceleration = vp.GetString(LoadBalancerAcceleration)
-	c.NodePortMode = vp.GetString(LoadBalancerMode)
-	c.LoadBalancerModeAnnotation = vp.GetBool(LoadBalancerModeAnnotation)
 	// If old settings were explicitly set by the user, then have them
 	// override the new ones in order to not break existing setups.
 	if vp.IsSet(NodePortAcceleration) {
@@ -3261,14 +3225,6 @@ func (c *DaemonConfig) populateLoadBalancerSettings(logger *slog.Logger, vp *vip
 		if vp.IsSet(LoadBalancerAcceleration) && prior != c.NodePortAcceleration {
 			logging.Fatal(logger, fmt.Sprintf("Both --%s and --%s were set. Only use --%s instead.",
 				LoadBalancerAcceleration, NodePortAcceleration, LoadBalancerAcceleration))
-		}
-	}
-	if vp.IsSet(NodePortMode) {
-		prior := c.NodePortMode
-		c.NodePortMode = vp.GetString(NodePortMode)
-		if vp.IsSet(LoadBalancerMode) && prior != c.NodePortMode {
-			logging.Fatal(logger, fmt.Sprintf("Both --%s and --%s were set. Only use --%s instead.",
-				LoadBalancerMode, NodePortMode, LoadBalancerMode))
 		}
 	}
 }

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -311,12 +311,12 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 	if d.statusParams.DaemonConfig.EnableNodePort {
 		features.NodePort.Enabled = true
 		features.NodePort.Mode = strings.ToUpper(d.statusParams.LBConfig.LBMode)
-		switch d.statusParams.DaemonConfig.LoadBalancerDSRDispatch {
-		case option.DSRDispatchIPIP:
+		switch d.statusParams.LBConfig.DSRDispatch {
+		case loadbalancer.DSRDispatchIPIP:
 			features.NodePort.DsrMode = models.KubeProxyReplacementFeaturesNodePortDsrModeIPIP
-		case option.DSRDispatchOption:
+		case loadbalancer.DSRDispatchOption:
 			features.NodePort.DsrMode = models.KubeProxyReplacementFeaturesNodePortDsrModeIPOptionExtension
-		case option.DSRDispatchGeneve:
+		case loadbalancer.DSRDispatchGeneve:
 			features.NodePort.DsrMode = models.KubeProxyReplacementFeaturesNodePortDsrModeGeneve
 		}
 		if d.statusParams.LBConfig.LBMode == loadbalancer.LBModeHybrid {

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -310,7 +310,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 	}
 	if d.statusParams.DaemonConfig.EnableNodePort {
 		features.NodePort.Enabled = true
-		features.NodePort.Mode = strings.ToUpper(d.statusParams.DaemonConfig.NodePortMode)
+		features.NodePort.Mode = strings.ToUpper(d.statusParams.LBConfig.LBMode)
 		switch d.statusParams.DaemonConfig.LoadBalancerDSRDispatch {
 		case option.DSRDispatchIPIP:
 			features.NodePort.DsrMode = models.KubeProxyReplacementFeaturesNodePortDsrModeIPIP
@@ -319,9 +319,9 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		case option.DSRDispatchGeneve:
 			features.NodePort.DsrMode = models.KubeProxyReplacementFeaturesNodePortDsrModeGeneve
 		}
-		if d.statusParams.DaemonConfig.NodePortMode == option.NodePortModeHybrid {
+		if d.statusParams.LBConfig.LBMode == loadbalancer.LBModeHybrid {
 			//nolint:staticcheck
-			features.NodePort.Mode = strings.Title(d.statusParams.DaemonConfig.NodePortMode)
+			features.NodePort.Mode = strings.Title(d.statusParams.LBConfig.LBMode)
 		}
 		features.NodePort.Algorithm = models.KubeProxyReplacementFeaturesNodePortAlgorithmRandom
 		if d.statusParams.LBConfig.LBAlgorithm == loadbalancer.LBAlgorithmMaglev {
@@ -372,7 +372,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		if d.statusParams.LBConfig.AlgorithmAnnotation {
 			features.Annotations = append(features.Annotations, annotation.ServiceLoadBalancingAlgorithm)
 		}
-		if d.statusParams.DaemonConfig.LoadBalancerModeAnnotation {
+		if d.statusParams.LBConfig.LBModeAnnotation {
 			features.Annotations = append(features.Annotations, annotation.ServiceForwardingMode)
 		}
 		features.Annotations = append(features.Annotations, annotation.ServiceNodeExposure)


### PR DESCRIPTION
This ports the service forwarding mode annotation to the new control-plane (https://github.com/cilium/cilium/pull/35064).

To simplify the implementation and testing I'm first moving the related configuration options to `loadbalancer.Config`.