### PR TITLE
crd: fix double registration of ciliumnodeconfigs

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -177,11 +177,6 @@ func CustomResourceDefinitionList() map[string]*CRDList {
 			Name:     LBIPPoolCRDName,
 			FullName: k8sconstv2.LBIPPoolName,
 		},
-		// TODO remove me when CNC v2alpha 1 will be deprecated
-		synced.CRDResourceName(k8sconstv2alpha1.CNCName): {
-			Name:     CNCCRDNameAlpha,
-			FullName: k8sconstv2alpha1.CNCName,
-		},
 		synced.CRDResourceName(k8sconstv2.CCGName): {
 			Name:     CCGCRDName,
 			FullName: k8sconstv2.CCGName,
@@ -336,9 +331,8 @@ func GetPregeneratedCRD(logger *slog.Logger, crdName string) apiextensionsv1.Cus
 		crdBytes = crdsv2Ciliumbgpnodeconfigoverrides
 	case LBIPPoolCRDName:
 		crdBytes = crdsv2Ciliumloadbalancerippools
-	case CNCCRDNameAlpha:
-		crdBytes = crdsv2CiliumNodeConfigs
 	case CNCCRDName:
+		// Contains both v2 and v2alpha1 versions
 		crdBytes = crdsv2CiliumNodeConfigs
 	case CCGCRDName:
 		crdBytes = crdsv2CiliumCIDRGroups

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -126,7 +126,6 @@ func AllCiliumCRDResourceNames() []string {
 	res := append(AgentCRDResourceNames(), GatewayAPIResourceNames()...)
 	res = append(res,
 		CRDResourceName(v2.CNCName),
-		CRDResourceName(v2alpha1.CNCName), // TODO depreciate CNC on v2alpha1 https://github.com/cilium/cilium/issues/31982
 	)
 	return res
 }


### PR DESCRIPTION
Before, ciliumnodeconfigs were registered twice, causing conflict error on k8s apiserver. Example log:
```verb="POST" URI="/apis/apiextensions.k8s.io/v1/customresourcedefinitions" resp=409```
Based on cilium-operator logs, we can see that we tried to create ciliumnodeconfigs CRD twice:
```
Creating CRD [...] name=ciliumnodeconfigs.cilium.io 
...
Creating CRD [...] name=ciliumnodeconfigs.cilium.io
```

Fixes: #31721
