### PR TITLE
helm: install ValidatingAdmissionPolicies to avoid/warn users of service account length

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-validating-admission-policy.yaml
+++ b/install/kubernetes/cilium/templates/cilium-validating-admission-policy.yaml
@@ -80,4 +80,47 @@ spec:
   validationActions:
   - Warn
 {{- end }}
+{{- if .Values.validatingAdmissionPolicies.podServiceAccountLength.enabled }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: pod-service-account-length
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - "*"
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pods
+  validations:
+  - expression: object.spec.serviceAccountName.size() < 64
+    messageExpression: "'object.spec.serviceAccountName must be no greater than 63 characters'"
+    reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: pod-service-account-length-binding
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  policyName: pod-service-account-length
+  validationActions:
+  - Warn
+{{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-validating-admission-policy.yaml
+++ b/install/kubernetes/cilium/templates/cilium-validating-admission-policy.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.validatingAdmissionPolicies.enabled }}
+{{- if .Values.validatingAdmissionPolicies.serviceAccountLength.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: service-account-length-create
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - "*"
+      operations:
+      - CREATE
+      resources:
+      - serviceaccounts
+  validations:
+  - expression: object.metadata.name.size() < 64
+    messageExpression: "'object.metadata.name must be no greater than 63 character'"
+    reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: service-account-length-create-binding
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  policyName: service-account-length-create
+  validationActions:
+  - Deny
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: service-account-length-update
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - "*"
+      operations:
+      - UPDATE
+      resources:
+      - serviceaccounts
+  validations:
+  - expression: object.metadata.name.size() < 64
+    messageExpression: "'object.metadata.name must be no greater than 63 character'"
+    reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: service-account-length-update-binding
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  policyName: service-account-length-update
+  validationActions:
+  - Warn
+{{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3953,3 +3953,7 @@ validatingAdmissionPolicies:
   serviceAccountLength:
     # -- Enable (i.e. deploy) the service-account-length policy.
     enabled: true
+  # -- Configuration for the pod-service-account-length policy
+  podServiceAccountLength:
+    # -- Enable (i.e. deploy) the pod-service-account-length policy.
+    enabled: true

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3945,3 +3945,11 @@ authentication:
 enableInternalTrafficPolicy: true
 # -- Enable LoadBalancer IP Address Management
 enableLBIPAM: true
+# Configuration for Validating Admission Policies
+validatingAdmissionPolicies:
+  # -- Global gate for Validating Admission Policies
+  enabled: true
+  # -- Configuration for service-account-length policy
+  serviceAccountLength:
+    # -- Enable (i.e. deploy) the service-account-length policy.
+    enabled: true


### PR DESCRIPTION
This change help users prevent creating service accounts with names 64 characters or greater. For users with existing services accounts that exceed this length, surface warnings to wean them off.

Related: #16579

This mitigates but does not fully fix the related issue, so only marking as related.

This installs up to 3 different policies and their respective bindings:

- deny on create for service accounts with names >63 characters:

> The serviceaccounts "qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmasdasdasdsdsadasd" is invalid: : ValidatingAdmissionPolicy 'service-account-length-create' with binding 'service-account-length-create-binding' denied request: object.metadata.name must be no greater than 63 character

- warn on update for service accounts with names >63 characters:
 
> Warning: Validation failed for ValidatingAdmissionPolicy 'service-account-length-update' with binding 'service-account-length-update-binding': object.metadata.name must be no greater than 63 character
serviceaccount/qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmasdasdasdsdsadasd configured

- warn on create/update for pods referencing service accounts with names >63 characters:

> Warning: Validation failed for ValidatingAdmissionPolicy 'pod-service-account-length' with binding 'pod-service-account-length-binding': object.spec.serviceAccountName must be no greater than 63 characters
pod/pause created

> Warning: Validation failed for ValidatingAdmissionPolicy 'pod-service-account-length' with binding 'pod-service-account-length-binding': object.spec.serviceAccountName must be no greater than 63 characters
pod/pause configured

---

```release-note
Install ValidatingAdmissionPolicies to protect and warn users against using using service accounts with names 64 characters or longer. 
```
