### PR TITLE
Add support for IPv6-only kind cluster creation

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -36,6 +36,10 @@ kind-clustermesh-ready: ## Check if both kind clustermesh clusters exist
 	@kind get clusters 2>&1 | grep "clustermesh2" \
 		&& exit 0 || exit 1
 
+.PHONY: kind-ipv6
+kind-ipv6: ## Create an ipv6 only kind cluster for Cilium development.
+	$(QUIET)SED=$(SED) ./contrib/scripts/kind.sh  "" "" "" "" "" "ipv6" "::1"
+
 .PHONY: kind-bgp-v4
 kind-bgp-v4:
 	$(QUIET) $(MAKE) -C contrib/containerlab/bgp-cplane-dev-v4 deploy


### PR DESCRIPTION
Introduces a new Makefile target `kind-ipv6` to create of an IPv6-only kind cluster for Cilium development. This doesn't resolve the issue that the container on KIND can't access the Internet.

I have run the test and can see only the external tests are failing. I dont think there is an easy way to fix it. Maybe we need to include some "external" container as the external in the future.

```
❌ 14/72 tests failed (60/524 actions), 43 tests skipped, 2 scenarios skipped:
Test [no-policies]:
  ❌ no-policies/pod-to-cidr/external-1111-0: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1111 (1.1.1.1:443)
  ❌ no-policies/pod-to-cidr/external-1111-1: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1111 (1.1.1.1:443)
  ❌ no-policies/pod-to-cidr/external-1111-2: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1111 (1.1.1.1:443)
  ❌ no-policies/pod-to-cidr/external-1001-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1001 (1.0.0.1:443)
  ❌ no-policies/pod-to-cidr/external-1001-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1001 (1.0.0.1:443)
  ❌ no-policies/pod-to-cidr/external-1001-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1001 (1.0.0.1:443)
Test [all-ingress-deny]:
  ❌ all-ingress-deny/pod-to-cidr/external-1111-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1111 (1.1.1.1:443)
  ❌ all-ingress-deny/pod-to-cidr/external-1111-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1111 (1.1.1.1:443)
  ❌ all-ingress-deny/pod-to-cidr/external-1111-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1111 (1.1.1.1:443)
  ❌ all-ingress-deny/pod-to-cidr/external-1001-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1001 (1.0.0.1:443)
  ❌ all-ingress-deny/pod-to-cidr/external-1001-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1001 (1.0.0.1:443)
  ❌ all-ingress-deny/pod-to-cidr/external-1001-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1001 (1.0.0.1:443)
Test [all-ingress-deny-knp]:
  ❌ all-ingress-deny-knp/pod-to-cidr/external-1111-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1111 (1.1.1.1:443)
  ❌ all-ingress-deny-knp/pod-to-cidr/external-1111-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1111 (1.1.1.1:443)
  ❌ all-ingress-deny-knp/pod-to-cidr/external-1111-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1111 (1.1.1.1:443)
  ❌ all-ingress-deny-knp/pod-to-cidr/external-1001-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1001 (1.0.0.1:443)
  ❌ all-ingress-deny-knp/pod-to-cidr/external-1001-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1001 (1.0.0.1:443)
  ❌ all-ingress-deny-knp/pod-to-cidr/external-1001-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1001 (1.0.0.1:443)
Test [to-cidr-external]:
  ❌ to-cidr-external/pod-to-cidr/external-1111-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1111 (1.1.1.1:443)
  ❌ to-cidr-external/pod-to-cidr/external-1111-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1111 (1.1.1.1:443)
  ❌ to-cidr-external/pod-to-cidr/external-1111-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1111 (1.1.1.1:443)
  ❌ to-cidr-external/pod-to-cidr/external-1001-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1001 (1.0.0.1:443)
  ❌ to-cidr-external/pod-to-cidr/external-1001-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1001 (1.0.0.1:443)
  ❌ to-cidr-external/pod-to-cidr/external-1001-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1001 (1.0.0.1:443)
Test [to-cidr-external-knp]:
  ❌ to-cidr-external-knp/pod-to-cidr/external-1111-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1111 (1.1.1.1:443)
  ❌ to-cidr-external-knp/pod-to-cidr/external-1111-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1111 (1.1.1.1:443)
  ❌ to-cidr-external-knp/pod-to-cidr/external-1111-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1111 (1.1.1.1:443)
  ❌ to-cidr-external-knp/pod-to-cidr/external-1001-0: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1001 (1.0.0.1:443)
  ❌ to-cidr-external-knp/pod-to-cidr/external-1001-1: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1001 (1.0.0.1:443)
  ❌ to-cidr-external-knp/pod-to-cidr/external-1001-2: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1001 (1.0.0.1:443)
Test [client-egress-to-cidr-deny]:
  ❌ client-egress-to-cidr-deny/pod-to-cidr/external-1111-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1111 (1.1.1.1:443)
  ❌ client-egress-to-cidr-deny/pod-to-cidr/external-1111-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1111 (1.1.1.1:443)
  ❌ client-egress-to-cidr-deny/pod-to-cidr/external-1111-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1111 (1.1.1.1:443)
Test [client-egress-to-cidrgroup-deny]:
  ❌ client-egress-to-cidrgroup-deny/pod-to-cidr/external-1111-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1111 (1.1.1.1:443)
  ❌ client-egress-to-cidrgroup-deny/pod-to-cidr/external-1111-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1111 (1.1.1.1:443)
  ❌ client-egress-to-cidrgroup-deny/pod-to-cidr/external-1111-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1111 (1.1.1.1:443)
Test [client-egress-to-cidrgroup-deny-by-label]:
  ❌ client-egress-to-cidrgroup-deny-by-label/pod-to-cidr/external-1111-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> external-1111 (1.1.1.1:443)
  ❌ client-egress-to-cidrgroup-deny-by-label/pod-to-cidr/external-1111-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> external-1111 (1.1.1.1:443)
  ❌ client-egress-to-cidrgroup-deny-by-label/pod-to-cidr/external-1111-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> external-1111 (1.1.1.1:443)
Test [client-egress-l7-tls-headers-sni]:
  ❌ client-egress-l7-tls-headers-sni/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ client-egress-l7-tls-headers-sni/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ client-egress-l7-tls-headers-sni/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> one.one.one.one.-https (one.one.one.one.:443)
Test [client-egress-l7-tls-headers-other-sni]:
  ❌ client-egress-l7-tls-headers-other-sni/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ client-egress-l7-tls-headers-other-sni/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ client-egress-l7-tls-headers-other-sni/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> one.one.one.one.-https (one.one.one.one.:443)
Test [seq-client-egress-l7-tls-deny-without-headers]:
  ❌ seq-client-egress-l7-tls-deny-without-headers/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ seq-client-egress-l7-tls-deny-without-headers/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ seq-client-egress-l7-tls-deny-without-headers/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> one.one.one.one.-https (one.one.one.one.:443)
Test [seq-client-egress-l7-tls-headers]:
  ❌ seq-client-egress-l7-tls-headers/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-0: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ seq-client-egress-l7-tls-headers/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-1: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ seq-client-egress-l7-tls-headers/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-2: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> one.one.one.one.-https (one.one.one.one.:443)
Test [seq-client-egress-l7-extra-tls-headers]:
  ❌ seq-client-egress-l7-extra-tls-headers/pod-to-world-with-extra-tls-intercept/https-to-one.one.one.one.-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ seq-client-egress-l7-extra-tls-headers/pod-to-world-with-extra-tls-intercept/https-to-k8s.io.-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> k8s.io.-https (k8s.io.:443)
  ❌ seq-client-egress-l7-extra-tls-headers/pod-to-world-with-extra-tls-intercept/https-to-one.one.one.one.-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ seq-client-egress-l7-extra-tls-headers/pod-to-world-with-extra-tls-intercept/https-to-k8s.io.-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> k8s.io.-https (k8s.io.:443)
  ❌ seq-client-egress-l7-extra-tls-headers/pod-to-world-with-extra-tls-intercept/https-to-one.one.one.one.-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ seq-client-egress-l7-extra-tls-headers/pod-to-world-with-extra-tls-intercept/https-to-k8s.io.-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> k8s.io.-https (k8s.io.:443)
Test [seq-client-egress-l7-tls-headers-port-range]:
  ❌ seq-client-egress-l7-tls-headers-port-range/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-0: cilium-test-1/client-645b68dcf7-fhcjh (fd00::27) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ seq-client-egress-l7-tls-headers-port-range/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-1: cilium-test-1/client2-66475877c6-xtqw7 (fd00::f1) -> one.one.one.one.-https (one.one.one.one.:443)
  ❌ seq-client-egress-l7-tls-headers-port-range/pod-to-world-with-tls-intercept/https-to-one.one.one.one.-2: cilium-test-1/client3-795488bf5-xhmkv (fd00::1f1) -> one.one.one.one.-https (one.one.one.one.:443)
[cilium-test-1] 14 tests failed
```



```release-note
introduces a new Makefile target `kind-ipv6` to create of an IPv6-only kind cluster for Cilium development
```
