### PR TITLE
test/runtime: replace RuntimeAgentFQDNPolicies CNAME follow by unit test

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -188,7 +188,6 @@ jobs:
         include:
           ###
           # RuntimeAgentFQDNPolicies Can update L7 DNS policy rules
-          # RuntimeAgentFQDNPolicies CNAME follow
           # RuntimeAgentFQDNPolicies DNS proxy policy works if Cilium stops
           # RuntimeAgentFQDNPolicies Interaction with other ToCIDR rules
           # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) L3-dependent L7/HTTP with toFQDN updates proxy policy

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1319,7 +1319,16 @@ func (p *DNSProxy) GetBindPort() uint16 {
 // the lowest applicable TTL, rcode, anwer rr types and question types
 // When a CNAME is returned the chain is collapsed down, keeping the lowest TTL,
 // and CNAME targets are returned.
-func ExtractMsgDetails(msg *dns.Msg) (qname string, responseIPs []netip.Addr, TTL uint32, CNAMEs []string, rcode int, answerTypes []uint16, qTypes []uint16, err error) {
+func ExtractMsgDetails(msg *dns.Msg) (
+	qname string,
+	responseIPs []netip.Addr,
+	TTL uint32,
+	CNAMEs []string,
+	rcode int,
+	answerTypes []uint16,
+	qTypes []uint16,
+	err error,
+) {
 	if len(msg.Question) == 0 {
 		return "", nil, 0, nil, 0, nil, nil, errors.New("Invalid DNS message")
 	}


### PR DESCRIPTION
Replace the CNAME follow test in the runtime FQDN suite by a unit test exercising the core of what the existing runtime test is about. This has a lot less overhead and is one step closer to getting rid of the runtime FQDN tests.

For #37838