### PR TITLE
policymap: always remove egress policy program along with endpoint

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -112,7 +112,7 @@ type EndpointMapManager struct {
 // packets that arrive on this node from being forwarded to the endpoint that
 // used to exist with the specified ID.
 func (e *EndpointMapManager) RemoveDatapathMapping(endpointID uint16) error {
-	return policymap.RemoveGlobalMapping(logging.DefaultSlogLogger, uint32(endpointID), option.Config.EnableEnvoyConfig)
+	return policymap.RemoveGlobalMapping(logging.DefaultSlogLogger, uint32(endpointID))
 }
 
 // RemoveMapPath removes the specified path from the filesystem.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -885,7 +885,7 @@ func (e *Endpoint) deleteMaps() []error {
 	// Remove the policy tail call entry for the endpoint. This will disable
 	// policy evaluation for the endpoint and will result in missing tail calls if
 	// e.g. bpf_host or bpf_overlay call into the endpoint's policy program.
-	if err := policymap.RemoveGlobalMapping(logging.DefaultSlogLogger, uint32(e.ID), option.Config.EnableEnvoyConfig); err != nil {
+	if err := policymap.RemoveGlobalMapping(logging.DefaultSlogLogger, uint32(e.ID)); err != nil {
 		errors = append(errors, fmt.Errorf("removing endpoint program from global policy map: %w", err))
 	}
 


### PR DESCRIPTION
Since 7b92700b6d and e9438c20e7, egress policy programs are inserted unconditionally, even when the L7 proxy is disabled. Unfortunately, the teardown logic only runs when the proxy is enabled, causing all handle_policy_egress programs to leak.

Double unfortunately, since this program doesn't reference any Cilium maps in its attached-but-disabled state (it's an empty program), it doesn't show up in Cilium's maps metrics, making the issue hard to spot. The latter is being addressed in https://github.com/cilium/cilium/pull/39557.

This commit makes the removal unconditional, since the attachment is also unconditional. I've decided against making both attachment and detachment conditional, since that would still cause orphaned programs if the l7 proxy was disabled on a running cluster. Endpoint teardown should always attempt to remove all known policy programs for robustness.

```release-note
Fix handle_policy_egress programs not being cleaned up during endpoint teardown
```
