### PR TITLE
ipsec: Cover IPv6-only clusters in CI

### DIFF
--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -10,6 +10,7 @@
 //
 // Notes:
 // - IPv6 addresses ($2, $4, and $6) must be "::1" in IPv4-only clusters.
+// - IPv4 addresses ($1, $3, and $5) must be "0.0.0.1" in IPv6-only clusters.
 // - We assume /8 CIDRs for the provided addresses ($1-$6).
 
 #define MASK4 (uint32)0xFF000000
@@ -485,7 +486,7 @@ BEGIN
 // Perform sanity checks.
 END
 {
-  if (str($7) == "true" && !@sanity[TYPE_PROXY_L7_IP4]) {
+  if (str($7) == "true" && !@sanity[TYPE_PROXY_L7_IP4] && str($1) != "0.0.0.1") {
     printf("Sanity check failed: detected no IPv4 connections from the L7 proxy. Is the filter correct?\n")
   }
 

--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -13,10 +13,10 @@ inputs:
     required: true
     type: string
     description: "Number of nodes in the cluster or clustermesh"
-  ipv6:
+  dual-stack:
     required: true
     type: boolean
-    description: "Whether IPv6 is enabled. Note IPv4 is always enabled if IPsec is enabled."
+    description: "Whether both IPV4 and IPv6 are enabled."
   subnet-encryption:
     required: true
     type: boolean
@@ -52,7 +52,7 @@ runs:
         else
           ((exp_nb_keys*=2))
         fi
-        if [[ "${{ inputs.ipv6 }}" == "true" ]]; then
+        if [[ "${{ inputs.dual-stack }}" == "true" ]]; then
           ((exp_nb_keys*=2))
         fi
         # If running in tunneling mode, then we have twice the amount of states

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -370,7 +370,7 @@ jobs:
           key-algo: "gcm(aes)"
           nb-nodes: 3
           tunnel: "disabled"
-          ipv6: false
+          dual-stack: false
           subnet-encryption: true
 
       - name: Check conn-disrupt-test after rotating (${{ join(matrix.*, ', ') }})

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -306,22 +306,32 @@ jobs:
         run: |
           mkdir -p cilium-junits
 
+          TEST='"seq-.*"'
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            TEST='"seq-.*,!pod-to-world.*"'
+          fi
+
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }}-sequential-pre-rotate (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --test 'seq-.*'
+            --test $TEST
 
       - name: Run concurrent tests (${{ join(matrix.*, ', ') }})
         shell: bash
         run: |
           mkdir -p cilium-junits
 
+          TEST='"!seq-.*"'
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            TEST='"!(seq-.*|pod-to-world.*|pod-to-cidr)"'
+          fi
+
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }}-concurrent-pre-rotate (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --test '!seq-.*' \
+            --test $TEST \
             --test-concurrency=${{ env.test_concurrency }}
 
       - name: Features tested
@@ -372,21 +382,32 @@ jobs:
         run: |
           mkdir -p cilium-junits
 
+          TEST='"seq-.*"'
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            TEST='"seq-.*,!pod-to-world.*"'
+          fi
+
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }}-sequential-post-rotate (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --test 'seq-.*'
+            --test $TEST
 
       - name: Run concurrent tests (${{ join(matrix.*, ', ') }})
         shell: bash
         run: |
           mkdir -p cilium-junits
+
+          TEST='"!seq-.*"'
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            TEST='"!(seq-.*|pod-to-world.*|pod-to-cidr)"'
+          fi
+
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }}-concurrent-post-rotate (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --test "!seq-.*" \
+            --test $TEST \
             --test-concurrency=${{ env.test_concurrency }}
 
       - name: Features tested

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -289,6 +289,9 @@ jobs:
           if [[ "${{ matrix.ipv6 }}" == "false" ]]; then
             CILIUM_INTERNAL_IPS="${CILIUM_INTERNAL_IPS// / ::1 } ::1"
           fi
+          if [[ "${{ matrix.ipv4 }}" == "false" ]]; then
+            CILIUM_INTERNAL_IPS="0.0.0.1 ${CILIUM_INTERNAL_IPS// / 0.0.0.1 }"
+          fi
 
           echo "params=$CILIUM_INTERNAL_IPS" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -183,6 +183,7 @@ jobs:
           tunnel: ${{ matrix.tunnel }}
           devices: ${{ matrix.devices }}
           endpoint-routes: ${{ matrix.endpoint-routes }}
+          ipv4: ${{ matrix.ipv4 }}
           ipv6: ${{ matrix.ipv6 }}
           kpr: ${{ matrix.kpr }}
           lb-mode: ${{ matrix.lb-mode }}
@@ -202,6 +203,9 @@ jobs:
           IP_FAM="dual"
           if [ "${{ matrix.ipv6 }}" == "false" ]; then
             IP_FAM="ipv4"
+          fi
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            IP_FAM="ipv6"
           fi
           echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
 
@@ -343,7 +347,7 @@ jobs:
           key-algo: ${{ matrix.key-two }}
           tunnel: ${{ matrix.tunnel }}
           nb-nodes: 3 # We don't count the node without Cilium.
-          dual-stack: true
+          dual-stack: ${{ matrix.ipv4 != 'false' && matrix.ipv6 != 'false' }}
           subnet-encryption: false
 
       - name: Assert that no unencrypted packets are leaked during key rotation

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -343,7 +343,7 @@ jobs:
           key-algo: ${{ matrix.key-two }}
           tunnel: ${{ matrix.tunnel }}
           nb-nodes: 3 # We don't count the node without Cilium.
-          ipv6: true
+          dual-stack: true
           subnet-encryption: false
 
       - name: Assert that no unencrypted packets are leaked during key rotation

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -298,8 +298,10 @@ jobs:
       - name: Start unencrypted packets check
         uses: ./.github/actions/bpftrace/start
         with:
+          # Only check for DNS proxy traffic if IPv4 is enabled.
+          # If it isn't, we will skip the proxy tests and won't have any such traffic.
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
-          args: ${{ steps.bpftrace-params.outputs.params }} "true" "ipsec"
+          args: ${{ steps.bpftrace-params.outputs.params }} "${{ matrix.ipv4 != 'false' }}" "ipsec"
 
       - name: Run sequential tests (${{ join(matrix.*, ', ') }})
         shell: bash
@@ -375,7 +377,7 @@ jobs:
         uses: ./.github/actions/bpftrace/start
         with:
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
-          args: ${{ steps.bpftrace-params.outputs.params }} "true" "ipsec"
+          args: ${{ steps.bpftrace-params.outputs.params }} "${{ matrix.ipv4 != 'false' }}" "ipsec"
 
       - name: Run sequential tests (${{ join(matrix.*, ', ') }})
         shell: bash

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -129,7 +129,7 @@ jobs:
       job_name: 'Setup & Test'
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 100
       matrix:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -403,9 +403,10 @@ jobs:
         if: ${{ matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/start
         with:
-          # enable the check for proxy traffic.
+          # Enable the check for proxy traffic only if IPv4 is enabled.
+          # Otherwise we will be skipping proxy tests and won't have DNS proxy traffic.
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
-          args: ${{ steps.bpftrace-params.outputs.params }} "true" "${{ matrix.encryption }}"
+          args: ${{ steps.bpftrace-params.outputs.params }} "${{ matrix.ipv4 != 'false' }}" "${{ matrix.encryption }}"
 
       - name: Run sequential Cilium tests
         uses: ./.github/actions/conn-disrupt-test-check

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -132,7 +132,7 @@ jobs:
       job_name: 'Setup & Test'
     strategy:
       fail-fast: false
-      max-parallel: 41
+      max-parallel: 100
       matrix:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -358,6 +358,9 @@ jobs:
           if [[ "${{ matrix.ipv6 }}" == "false" ]]; then
             CILIUM_INTERNAL_IPS="${CILIUM_INTERNAL_IPS// / ::1 } ::1"
           fi
+          if [[ "${{ matrix.ipv4 }}" == "false" ]]; then
+            CILIUM_INTERNAL_IPS="0.0.0.1 ${CILIUM_INTERNAL_IPS// / 0.0.0.1 }"
+          fi
 
           echo "params=$CILIUM_INTERNAL_IPS" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -207,6 +207,7 @@ jobs:
           chart-dir: './untrusted/cilium-downgrade/install/kubernetes/cilium'
           tunnel: ${{ matrix.tunnel }}
           endpoint-routes: ${{ matrix.endpoint-routes }}
+          ipv4: ${{ matrix.ipv4 }}
           ipv6: ${{ matrix.ipv6 }}
           kpr: ${{ matrix.kpr }}
           lb-mode: ${{ matrix.lb-mode }}
@@ -228,6 +229,7 @@ jobs:
           chart-dir: './untrusted/cilium-newest/install/kubernetes/cilium'
           tunnel: ${{ matrix.tunnel }}
           endpoint-routes: ${{ matrix.endpoint-routes }}
+          ipv4: ${{ matrix.ipv4 }}
           ipv6: ${{ matrix.ipv6 }}
           kpr: ${{ matrix.kpr }}
           lb-mode: ${{ matrix.lb-mode }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -192,6 +192,12 @@ jobs:
           echo downgrade_version=${CILIUM_DOWNGRADE_VERSION} >> $GITHUB_OUTPUT
           echo image_tag=${IMAGE_TAG} >> $GITHUB_OUTPUT
 
+          CONCURRENT_CONNECTIVITY_TESTS="!seq-.*"
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            CONCURRENT_CONNECTIVITY_TESTS="!(seq-.*|pod-to-world.*|pod-to-cidr)"
+          fi
+          echo concurrent_connectivity_tests=${CONCURRENT_CONNECTIVITY_TESTS} >> $GITHUB_OUTPUT
+
       - name: Checkout pull request branch (NOT TRUSTED)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -347,7 +353,7 @@ jobs:
             CILIUM_INTERNAL_IPS="${CILIUM_INTERNAL_IPS// / ::1 } ::1"
           fi
           if [[ "${{ matrix.ipv4 }}" == "false" ]]; then
-            CILIUM_INTERNAL_IPS="0.0.0.1 ${CILIUM_INTERNAL_IPS// / 0.0.0.1 }"
+            CILIUM_INTERNAL_IPS=" 0.0.0.1 ${CILIUM_INTERNAL_IPS// / 0.0.0.1 }"
           fi
           echo "params=$CILIUM_INTERNAL_IPS" >> $GITHUB_OUTPUT
 
@@ -394,7 +400,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-concurrent
-          tests: '!seq-.*'
+          tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
           test-concurrency: ${{ env.test_concurrency }}
 
       - name: Assert that no unencrypted packets are leaked during Cilium upgrade
@@ -451,7 +457,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-concurrent
-          tests: '!seq-.*'
+          tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
           test-concurrency: ${{ env.test_concurrency }}
 
       - name: Assert that no unencrypted packets are leaked during Cilium downgrade

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -130,7 +130,7 @@ jobs:
       job_name: 'Setup & Test'
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 100
       matrix:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -346,6 +346,9 @@ jobs:
           if [[ "${{ matrix.ipv6 }}" == "false" ]]; then
             CILIUM_INTERNAL_IPS="${CILIUM_INTERNAL_IPS// / ::1 } ::1"
           fi
+          if [[ "${{ matrix.ipv4 }}" == "false" ]]; then
+            CILIUM_INTERNAL_IPS="0.0.0.1 ${CILIUM_INTERNAL_IPS// / 0.0.0.1 }"
+          fi
           echo "params=$CILIUM_INTERNAL_IPS" >> $GITHUB_OUTPUT
 
       - name: Start unencrypted packets check for Cilium upgrade


### PR DESCRIPTION
This pull request adds coverage for IPv6-only configurations in the IPsec workflows, in preparation for IPsec + IPv6 underlay coverage. See commits for details.