### PR TITLE
pkg/endpoint: Store and restore parentIfIndex

### DIFF
--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -420,6 +420,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		DockerEndpointID:         e.dockerEndpointID,
 		IfName:                   e.ifName,
 		IfIndex:                  e.ifIndex,
+		ParentIfIndex:            e.parentIfIndex,
 		ContainerIfName:          e.containerIfName,
 		DisableLegacyIdentifiers: e.disableLegacyIdentifiers,
 		Labels:                   e.labels,
@@ -479,6 +480,11 @@ type serializableEndpoint struct {
 
 	// ifIndex is the interface index of the host face interface (veth pair)
 	IfIndex int
+
+	// parentIfIndex is the interface index of the interface with which the endpoint
+	// IP is associated. In some scenarios, the network will expect traffic with
+	// the endpoint IP to be sent via the parent interface.
+	ParentIfIndex int
 
 	// ContainerIfName is the name of the container facing interface (veth pair).
 	ContainerIfName string
@@ -594,6 +600,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.dockerEndpointID = r.DockerEndpointID
 	ep.ifName = r.IfName
 	ep.ifIndex = r.IfIndex
+	ep.parentIfIndex = r.ParentIfIndex
 	ep.containerIfName = r.ContainerIfName
 	ep.disableLegacyIdentifiers = r.DisableLegacyIdentifiers
 	ep.labels = r.Labels

--- a/plugins/cilium-cni/cmd/endpoint.go
+++ b/plugins/cilium-cni/cmd/endpoint.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
@@ -97,6 +98,8 @@ func (c *defaultEndpointConfiguration) PrepareEndpoint(ipam *models.IPAMResponse
 		ifindex, err := ifindexFromMac(ipam.IPV4.MasterMac)
 		if err == nil {
 			ep.ParentInterfaceIndex = ifindex
+		} else {
+			c.Log.Error("Unable to get interface index from MAC address", logfields.Error, err)
 		}
 	}
 


### PR DESCRIPTION
In #35298 endpoints got the parentIfIndex field to store the parent interface index, which is used to ensure endpoint traffic is routed out of the parent interface when set.

This interface index is given to the agent by the CNI plugin and stored in the endpoint object. However, when the agent is restarted, it has to restore endpoint state from disk. The parentIfIndex field was not being stored or restored, so after a restart the parentIfIndex would be set to 0, which would cause the agent to not route traffic out of the parent interface.

This commit adds the parentIfIndex field to the endpoint state serialization and deserialization process, so that it is stored and restored correctly.

```release-note
Persist parent interface index of endpoint across agent restarts
```
