### PR TITLE
pkg/loadbalancer/legacy: use logger directly from hive

### DIFF
--- a/pkg/loadbalancer/legacy/redirectpolicy/api.go
+++ b/pkg/loadbalancer/legacy/redirectpolicy/api.go
@@ -4,6 +4,8 @@
 package redirectpolicy
 
 import (
+	"log/slog"
+
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -12,11 +14,12 @@ import (
 )
 
 type getLrpHandler struct {
+	logger     *slog.Logger
 	lrpManager *Manager
 }
 
 func (h *getLrpHandler) Handle(params service.GetLrpParams) middleware.Responder {
-	h.lrpManager.logger.Debug("GET /lrp request", logfields.Params, params)
+	h.logger.Debug("GET /lrp request", logfields.Params, params)
 	return service.NewGetLrpOK().WithPayload(getLRPs(h.lrpManager))
 }
 

--- a/pkg/loadbalancer/legacy/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/legacy/redirectpolicy/cell.go
@@ -47,8 +47,9 @@ func newLRPManager(params lrpManagerParams) *Manager {
 	return NewRedirectPolicyManager(params.Logger, params.DB, params.Svc, params.SvcCache, params.Pods, params.Ep, params.MetricsManager)
 }
 
-func newLRPApiHandler(lrpManager *Manager) serviceapi.GetLrpHandler {
+func newLRPApiHandler(logger *slog.Logger, lrpManager *Manager) serviceapi.GetLrpHandler {
 	return &getLrpHandler{
+		logger:     logger,
 		lrpManager: lrpManager,
 	}
 }


### PR DESCRIPTION
Running Cilium with enable-experimental-lb sets the LRPManager to nil. This causes the API endpoint's logger to also be nil, leading to a panic when accessing the /lrp endpoint. This commit fixes the issue.

Fixes: 87ecc88943d4 ("legacy/redirectpolicy: migrate to slog")
