### PR TITLE
bpf: add IPv6 mcast addr helpers and cleanup

### DIFF
--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -31,7 +31,6 @@
 #define mac_five_addr {0x15, 0x21, 0x39, 0x45, 0x4D, 0x5D}
 #define mac_six_addr {0x08, 0x14, 0x1C, 0x32, 0x52, 0x7E}
 #define mac_zero_addr {0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
-#define mac_v6mcast_base_addr {0x33, 0x33, 0x00, 0x00, 0x00, 0x00}
 
 volatile const __u8 mac_one[] = mac_one_addr;
 volatile const __u8 mac_two[] = mac_two_addr;
@@ -40,7 +39,6 @@ volatile const __u8 mac_four[] = mac_four_addr;
 volatile const __u8 mac_five[] = mac_five_addr;
 volatile const __u8 mac_six[] = mac_six_addr;
 volatile const __u8 mac_zero[] = mac_zero_addr;
-volatile const __u8 mac_v6mcast_base[] = mac_v6mcast_base_addr;
 
 /* A collection of pre-defined IP addresses, so tests can reuse them without
  *  having to come up with custom ips.
@@ -71,10 +69,6 @@ volatile const __u8 mac_v6mcast_base[] = mac_v6mcast_base_addr;
 #define v4_svc_loopback	IPV4(10, 245, 255, 31)
 
 #define v4_all	IPV4(0, 0, 0, 0)
-
-/* IPv6 mcast base address */
-#define v6_mcast_base_addr {0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0xFF, 0, 0, 0};
-volatile const __u8 v6_mcast_base[] = v6_mcast_base_addr;
 
 /* IPv6 addresses for pods in the cluster */
 #define v6_pod_one_addr {0xfd, 0x04, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}


### PR DESCRIPTION
Add IPv6 multicast helper functions that construct the multicast IPv6 and MAC addresses respectively given a unicast IPv6 address.

Cleaned up repeated and/or unnecessary code from tests and pktgen.h.

Added simple (and stupid) unit, just in case.

Please ensure your pull request adheres to the following guidelines:

---

Minor cleanup, that simplifies IPv6 L2 announcement code. No release note needed