### PR TITLE
feat:Add aligncheck command to bpf Makefile and to lint workflow

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -101,11 +101,22 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.24.3
       - name: Build all BPF datapath permutations
         env:
           V: 0
         run: |
           contrib/scripts/builder.sh make --quiet -C bpf build_all -j "$(nproc)" || (echo "Run 'make -C bpf build_all' locally to investigate build breakages"; exit 1)
+      - name: Run alignment checker
+        run: |
+          make -C bpf check-alignment || (echo "Run 'make -C bpf check-alignment' locally to investigate alignment mismatches"; exit 1)
+        env:
+          CLANG: clang
+          LLC: llc
 
   bpf_tests:
     needs: [check_changes]

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -172,7 +172,7 @@ endif
 
 include ./Makefile.bpf
 
-.PHONY: all bpf_all build_all subdirs install clean generate gen_compile_commands
+.PHONY: all bpf_all build_all subdirs install clean generate gen_compile_commands check-alignment
 
 all: bpf_all
 
@@ -189,6 +189,10 @@ testdata:
 
 generate: $(BPF)
 	$(GO) generate ../pkg/datapath/config
+
+check-alignment: bpf_alignchecker.o
+	@$(ECHO_CHECK) "Running alignment checker..."
+	$(QUIET) $(GO) run $(CURDIR)/../tools/alignchecker/main.go $(CURDIR)/bpf_alignchecker.o
 
 $(BPF_SIMPLE): %.o: %.c
 	@$(ECHO_CC)


### PR DESCRIPTION
Description of change:
1.Adding a dedicated make target in `bpf/Makefile `to build and run the alignment checker, allowing developers to validate alignment locally with a simple command like `make -C bpf check-alignment` 
2.Integrating the alignment checker into the existing GitHub Actions workflow `.github/workflows/lint-bpf-checks.yaml`

Fixes: #38642 and works with the PR #39396
![image](https://github.com/user-attachments/assets/9897337e-cb64-4759-8383-ec6d23e57dd8)

