### PR TITLE
bpf: service loopback for ipv6

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -283,6 +283,7 @@ cilium-agent [flags]
       --ipv6-node string                                          IPv6 address of node (default "auto")
       --ipv6-pod-subnets strings                                  List of IPv6 pod subnets to preconfigure for encryption
       --ipv6-range string                                         Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-service-loopback-address string                      IPv6 source address to use for SNAT when a Pod talks to itself over a Service. (default "fe80::1")
       --ipv6-service-range string                                 Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
       --k8s-api-server-urls strings                               Kubernetes API server URLs
       --k8s-client-burst int                                      Burst value allowed for the K8s client (default 20)

--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -992,6 +992,8 @@ These values are shared with pkg/monitor/api/datapath_debug.go and bpf/lib/dbg.h
 | DBG_SK_ASSIGN | 64 |  |
 | DBG_L7_LB | 65 |  |
 | DBG_SKIP_POLICY | 66 |  |
+| DBG_LB6_LOOPBACK_SNAT | 67 |  |
+| DBG_LB6_LOOPBACK_SNAT_REV | 68 |  |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -1215,6 +1215,8 @@ const (
 	DebugEventType_DBG_SK_ASSIGN                       DebugEventType = 64
 	DebugEventType_DBG_L7_LB                           DebugEventType = 65
 	DebugEventType_DBG_SKIP_POLICY                     DebugEventType = 66
+	DebugEventType_DBG_LB6_LOOPBACK_SNAT               DebugEventType = 67
+	DebugEventType_DBG_LB6_LOOPBACK_SNAT_REV           DebugEventType = 68
 )
 
 // Enum value maps for DebugEventType.
@@ -1287,6 +1289,8 @@ var (
 		64: "DBG_SK_ASSIGN",
 		65: "DBG_L7_LB",
 		66: "DBG_SKIP_POLICY",
+		67: "DBG_LB6_LOOPBACK_SNAT",
+		68: "DBG_LB6_LOOPBACK_SNAT_REV",
 	}
 	DebugEventType_value = map[string]int32{
 		"DBG_EVENT_UNKNOWN":                   0,
@@ -1356,6 +1360,8 @@ var (
 		"DBG_SK_ASSIGN":                       64,
 		"DBG_L7_LB":                           65,
 		"DBG_SKIP_POLICY":                     66,
+		"DBG_LB6_LOOPBACK_SNAT":               67,
+		"DBG_LB6_LOOPBACK_SNAT_REV":           68,
 	}
 )
 
@@ -5532,7 +5538,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\"SOCK_XLATE_POINT_PRE_DIRECTION_FWD\x10\x01\x12'\n" +
 	"#SOCK_XLATE_POINT_POST_DIRECTION_FWD\x10\x02\x12&\n" +
 	"\"SOCK_XLATE_POINT_PRE_DIRECTION_REV\x10\x03\x12'\n" +
-	"#SOCK_XLATE_POINT_POST_DIRECTION_REV\x10\x04*\x81\r\n" +
+	"#SOCK_XLATE_POINT_POST_DIRECTION_REV\x10\x04*\xbb\r\n" +
 	"\x0eDebugEventType\x12\x15\n" +
 	"\x11DBG_EVENT_UNKNOWN\x10\x00\x12\x0f\n" +
 	"\vDBG_GENERIC\x10\x01\x12\x16\n" +
@@ -5601,7 +5607,9 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\x0eDBG_SK_LOOKUP6\x10?\x12\x11\n" +
 	"\rDBG_SK_ASSIGN\x10@\x12\r\n" +
 	"\tDBG_L7_LB\x10A\x12\x13\n" +
-	"\x0fDBG_SKIP_POLICY\x10BB&Z$github.com/cilium/cilium/api/v1/flowb\x06proto3"
+	"\x0fDBG_SKIP_POLICY\x10B\x12\x19\n" +
+	"\x15DBG_LB6_LOOPBACK_SNAT\x10C\x12\x1d\n" +
+	"\x19DBG_LB6_LOOPBACK_SNAT_REV\x10DB&Z$github.com/cilium/cilium/api/v1/flowb\x06proto3"
 
 var (
 	file_flow_flow_proto_rawDescOnce sync.Once

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -948,4 +948,6 @@ enum DebugEventType {
     DBG_SK_ASSIGN = 64;
     DBG_L7_LB = 65;
     DBG_SKIP_POLICY = 66;
+    DBG_LB6_LOOPBACK_SNAT = 67;
+    DBG_LB6_LOOPBACK_SNAT_REV = 68;
 }

--- a/api/v1/observer/observer.pb.go
+++ b/api/v1/observer/observer.pb.go
@@ -343,6 +343,8 @@ const DebugEventType_DBG_SK_LOOKUP6 = flow.DebugEventType_DBG_SK_LOOKUP6
 const DebugEventType_DBG_SK_ASSIGN = flow.DebugEventType_DBG_SK_ASSIGN
 const DebugEventType_DBG_L7_LB = flow.DebugEventType_DBG_L7_LB
 const DebugEventType_DBG_SKIP_POLICY = flow.DebugEventType_DBG_SKIP_POLICY
+const DebugEventType_DBG_LB6_LOOPBACK_SNAT = flow.DebugEventType_DBG_LB6_LOOPBACK_SNAT
+const DebugEventType_DBG_LB6_LOOPBACK_SNAT_REV = flow.DebugEventType_DBG_LB6_LOOPBACK_SNAT_REV
 
 var DebugEventType_name = flow.DebugEventType_name
 var DebugEventType_value = flow.DebugEventType_value

--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -16,6 +16,8 @@
 #include <node_config.h>
 
 NODE_CONFIG(union v4addr, service_loopback_ipv4, "IPv4 source address used for SNAT when a Pod talks to itself over a Service")
+NODE_CONFIG(union v6addr, service_loopback_ipv6,
+	    "IPv6 source address used for SNAT when a Pod talks to itself over a Service")
 NODE_CONFIG(union v6addr, router_ipv6, "Internal IPv6 router address assigned to the cilium_host interface")
 
 NODE_CONFIG(__u32, trace_payload_len, "Length of payload to capture when tracing native packets.")

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1115,6 +1115,19 @@ ct_has_loopback_egress_entry4(const void *map, struct ipv4_ct_tuple *tuple)
 
 	return entry && entry->lb_loopback;
 }
+
+static __always_inline bool
+ct_has_loopback_egress_entry6(const void *map, struct ipv6_ct_tuple *tuple)
+{
+	__u8 flags = tuple->flags;
+	struct ct_entry *entry;
+
+	tuple->flags = TUPLE_F_OUT;
+	entry = map_lookup_elem(map, tuple);
+	tuple->flags = flags;
+
+	return entry && entry->lb_loopback;
+}
 #endif
 
 static __always_inline bool

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -123,6 +123,8 @@ enum {
 				 * arg3: proxy port (in host byte order)
 				 */
 	DBG_SKIP_POLICY,	/**/
+	DBG_LB6_LOOPBACK_SNAT,
+	DBG_LB6_LOOPBACK_SNAT_REV,
 };
 
 /* Capture types */

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -502,7 +502,8 @@ ipv6_l4_csum_update(struct __ctx_buff *ctx, int l4_off, union v6addr *old_addr,
 static __always_inline int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 					 struct ipv6_ct_tuple *tuple,
 					 struct lb6_reverse_nat *nat,
-					 bool has_l4_header, enum ct_dir dir)
+					 bool has_l4_header, enum ct_dir dir,
+					 bool loopback __maybe_unused)
 {
 	union v6addr old_saddr __align_stack_8;
 	int ret;
@@ -511,6 +512,33 @@ static __always_inline int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 
 	ipv6_addr_copy(&old_saddr, &tuple->saddr);
 	ipv6_addr_copy(&tuple->saddr, &nat->address);
+
+#ifdef USE_LOOPBACK_LB
+	if (loopback) {
+		union v6addr old_daddr;
+
+		ipv6_addr_copy(&old_daddr, &tuple->daddr);
+		cilium_dbg_lb(ctx, DBG_LB6_LOOPBACK_SNAT_REV, old_daddr.p4, old_saddr.p4);
+
+		ret = ipv6_store_daddr(ctx, old_saddr.addr, ETH_HLEN);
+		if (IS_ERR(ret))
+			return DROP_WRITE_ERROR;
+
+		/* Update the tuple address which is representing the destination address */
+		ipv6_addr_copy(&tuple->daddr, &old_saddr);
+
+		if (has_l4_header) {
+			struct csum_offset csum_off = {};
+
+			csum_l4_offset_and_flags(tuple->nexthdr, &csum_off);
+
+			if (csum_off.offset &&
+			    ipv6_l4_csum_update(ctx, l4_off, &old_daddr, &old_saddr,
+						&csum_off, dir) < 0)
+				return DROP_CSUM_L4;
+		}
+	}
+#endif
 
 	ret = ipv6_store_saddr(ctx, nat->address.addr, ETH_HLEN);
 	if (IS_ERR(ret))
@@ -549,9 +577,11 @@ lb6_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
  * @arg ctx		packet
  * @arg l4_off		offset to L4
  * @arg index		reverse NAT index
+ * @arg loopback	loopback connection
  * @arg tuple		tuple
  */
 static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off, __u16 index,
+				       bool loopback,
 				       struct ipv6_ct_tuple *tuple, bool has_l4_header,
 				       enum ct_dir dir)
 {
@@ -561,7 +591,7 @@ static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off, __u16
 	if (nat == NULL)
 		return 0;
 
-	return __lb6_rev_nat(ctx, l4_off, tuple, nat, has_l4_header, dir);
+	return __lb6_rev_nat(ctx, l4_off, tuple, nat, has_l4_header, dir, loopback);
 }
 
 static __always_inline void
@@ -842,7 +872,10 @@ lb6_select_backend_id(struct __ctx_buff *ctx __maybe_unused,
 # error "Invalid load balancer backend selection algorithm!"
 #endif /* LB_SELECTION */
 
-static __always_inline int lb6_xlate(struct __ctx_buff *ctx, __u8 nexthdr,
+static __always_inline int lb6_xlate(struct __ctx_buff *ctx,
+				     const union v6addr *new_saddr __maybe_unused,
+				     const union v6addr *old_saddr __maybe_unused,
+				     __u8 nexthdr,
 				     int l3_off, int l4_off,
 				     const struct lb6_key *key,
 				     const struct lb6_backend *backend,
@@ -850,16 +883,24 @@ static __always_inline int lb6_xlate(struct __ctx_buff *ctx, __u8 nexthdr,
 {
 	const union v6addr *new_dst = &backend->address;
 	struct csum_offset csum_off = {};
+	__be32 sum;
 
 	if (has_l4_header)
 		csum_l4_offset_and_flags(nexthdr, &csum_off);
 
 	if (ipv6_store_daddr(ctx, new_dst->addr, l3_off) < 0)
 		return DROP_WRITE_ERROR;
-	if (csum_off.offset) {
-		__be32 sum = csum_diff(key->address.addr, 16, new_dst->addr,
-				       16, 0);
+	sum = csum_diff(key->address.addr, 16, new_dst->addr, 16, 0);
+#ifdef USE_LOOPBACK_LB
+	if (new_saddr && (new_saddr->d1 || new_saddr->d2)) {
+		cilium_dbg_lb(ctx, DBG_LB6_LOOPBACK_SNAT, old_saddr->p4, new_saddr->p4);
 
+		if (ipv6_store_saddr(ctx, (void *)new_saddr->addr, l3_off) < 0)
+			return DROP_WRITE_ERROR;
+		sum = csum_diff(old_saddr->addr, 16, new_saddr->addr, 16, sum);
+	}
+#endif /* USE_LOOPBACK_LB */
+	if (csum_off.offset) {
 		if (csum_l4_replace(ctx, l4_off, &csum_off, 0, sum,
 				    BPF_F_PSEUDO_HDR) < 0)
 			return DROP_CSUM_L4;
@@ -1015,9 +1056,11 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 				     __net_cookie netns_cookie __maybe_unused)
 {
 	__u32 monitor; /* Deliberately ignored; regular CT will determine monitoring. */
+	union v6addr saddr = tuple->saddr;
 	__u8 flags = tuple->flags;
 	struct lb6_backend *backend;
 	__u32 backend_id = 0;
+	union v6addr new_saddr = {};
 	int ret;
 	union lb6_affinity_client_id client_id;
 
@@ -1113,13 +1156,27 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 	if (lb6_svc_is_affinity(svc))
 		lb6_update_affinity_by_addr(svc, &client_id, backend_id);
 
-#if defined(ENABLE_LOCAL_REDIRECT_POLICY)
-	if (netns_cookie > 0 && unlikely(lb6_svc_is_localredirect(svc)) &&
-	    lb6_skip_xlate_from_ctx_to_svc(netns_cookie, tuple->daddr, tuple->sport))
-		return CTX_ACT_OK;
+#if defined(USE_LOOPBACK_LB) || defined(ENABLE_LOCAL_REDIRECT_POLICY)
+	if (ipv6_addr_equals(&saddr, &backend->address)) {
+	#if defined(ENABLE_LOCAL_REDIRECT_POLICY)
+		if (netns_cookie > 0 && unlikely(lb6_svc_is_localredirect(svc)) &&
+		    lb6_skip_xlate_from_ctx_to_svc(netns_cookie, tuple->daddr, tuple->sport))
+			return CTX_ACT_OK;
+	#endif
+
+	#ifdef USE_LOOPBACK_LB
+			union v6addr loopback_addr = CONFIG(service_loopback_ipv6);
+
+			ipv6_addr_copy(&new_saddr, &loopback_addr);
+			state->loopback = 1;
+	#endif
+	}
 #endif /* ENABLE_LOCAL_REDIRECT_POLICY */
 
-	ipv6_addr_copy(&tuple->daddr, &backend->address);
+#ifdef USE_LOOPBACK_LB
+	if (!state->loopback)
+#endif
+		ipv6_addr_copy(&tuple->daddr, &backend->address);
 
 	if (lb6_svc_is_l7_punt_proxy(svc) &&
 	    __lookup_ip6_endpoint(&backend->address)) {
@@ -1132,7 +1189,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 	if (likely(backend->port))
 		tuple->sport = backend->port;
 
-	return lb6_xlate(ctx, tuple->nexthdr, l3_off, l4_off, key,
+	return lb6_xlate(ctx, &new_saddr, &saddr, tuple->nexthdr, l3_off, l4_off, key,
 			 backend, ipfrag_has_l4_header(fraginfo));
 no_service:
 	ret = DROP_NO_SERVICE;
@@ -1153,7 +1210,12 @@ static __always_inline void lb6_ctx_store_state(struct __ctx_buff *ctx,
 					       __u16 proxy_port)
 {
 	ctx_store_meta(ctx, CB_PROXY_MAGIC, (__u32)proxy_port << 16);
-	ctx_store_meta(ctx, CB_CT_STATE, (__u32)state->rev_nat_index);
+	ctx_store_meta(ctx, CB_CT_STATE, (__u32)state->rev_nat_index << 16 |
+#ifdef USE_LOOPBACK_LB
+		state->loopback);
+#else
+		0);
+#endif /* USE_LOOPBACK_LB */
 }
 
 /* lb6_ctx_restore_state() restores per packet load balancing state from the
@@ -1166,10 +1228,14 @@ static __always_inline void lb6_ctx_restore_state(struct __ctx_buff *ctx,
 						 __u16 *proxy_port,
 						 bool clear)
 {
-	state->rev_nat_index = clear ? (__u16)ctx_load_and_clear_meta(ctx, CB_CT_STATE) :
-				       (__u16)ctx_load_meta(ctx, CB_CT_STATE);
+	__u32 meta = clear ? ctx_load_and_clear_meta(ctx, CB_CT_STATE) :
+				       ctx_load_meta(ctx, CB_CT_STATE);
 
-	/* No loopback support for IPv6, see lb6_local() above. */
+#ifdef USE_LOOPBACK_LB
+	if (meta & 1)
+		state->loopback = 1;
+#endif
+	state->rev_nat_index = meta >> 16;
 
 	*proxy_port = clear ? (ctx_load_and_clear_meta(ctx, CB_PROXY_MAGIC) >> 16) :
 			      (ctx_load_meta(ctx, CB_PROXY_MAGIC) >> 16);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -954,7 +954,7 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, enum ct_dir dir,
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
 
-		ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index,
+		ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index, false,
 				  &tuple, ipfrag_has_l4_header(fraginfo),
 				  dir);
 		if (IS_ERR(ret))

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -209,7 +209,7 @@ skip_fib:
 		trace->monitor = monitor;
 
 		ret = __lb6_rev_nat(ctx, l4_off, &tuple, nat_info,
-				    ipfrag_has_l4_header(fraginfo), CT_EGRESS);
+				    ipfrag_has_l4_header(fraginfo), CT_EGRESS, false);
 		if (IS_ERR(ret))
 			return ret;
 

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -68,6 +68,7 @@ volatile const __u8 mac_zero[] = mac_zero_addr;
 #define v4_pod_three	IPV4(192, 168, 0, 3)
 
 #define v4_svc_loopback	IPV4(10, 245, 255, 31)
+#define v6_svc_loopback {0xfd, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
 
 #define v4_all	IPV4(0, 0, 0, 0)
 

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -11,6 +11,7 @@
 
 /* Enable code paths under test*/
 #define ENABLE_IPV4
+#define ENABLE_IPV6
 
 /* Skip ingress policy checks */
 #define USE_BPF_PROG_FOR_INGRESS_POLICY
@@ -20,6 +21,11 @@
 /* Set the LXC source address to be the address of pod one */
 ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = v4_pod_one})
 ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
+ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_one_addr })
+ASSIGN_CONFIG(union v6addr, service_loopback_ipv6, { .addr = v6_svc_loopback })
+
+#define POD_IPV6 v6_pod_one
+#define SERVICE_IPV6 v6_node_three
 
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
@@ -516,6 +522,460 @@ int tc_drop_no_backend_setup(struct __ctx_buff *ctx)
 
 CHECK("tc", "tc_drop_no_backend")
 int tc_drop_no_backend_check(const struct __ctx_buff *ctx)
+{
+	__u32 expected_status = TC_ACT_SHOT;
+	__u32 *status_code;
+	void *data_end;
+	void *data;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	if (*status_code != expected_status)
+		test_fatal("status code is %lu, expected %lu", *status_code, expected_status);
+
+	test_finish();
+}
+
+static __always_inline int build_packet_v6(struct __ctx_buff *ctx, __be16 sport)
+{
+    struct pktgen builder;
+    volatile const __u8 *src = mac_one;
+    volatile const __u8 *dst = mac_two;
+    struct tcphdr *l4;
+    void *data;
+
+    pktgen__init(&builder, ctx);
+
+    l4 = pktgen__push_ipv6_tcp_packet(&builder,
+				      (__u8 *)src, (__u8 *)dst,
+				      (__u8 *)POD_IPV6, (__u8 *)SERVICE_IPV6,
+				      sport, tcp_svc_one);
+    if (!l4)
+	return TEST_ERROR;
+
+    data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+    if (!data)
+	return TEST_ERROR;
+
+    pktgen__finish(&builder);
+    return 0;
+}
+
+PKTGEN("tc", "hairpin_flow_1_forward_v6")
+int hairpin_flow_forward_pktgen_v6(struct __ctx_buff *ctx)
+{
+    return build_packet_v6(ctx, tcp_src_one);
+}
+
+SETUP("tc", "hairpin_flow_1_forward_v6")
+int hairpin_flow_forward_setup_v6(struct __ctx_buff *ctx)
+{
+    __u16 revnat_id = 1;
+
+    lb_v6_add_service((const union v6addr *)SERVICE_IPV6, tcp_svc_one, IPPROTO_TCP, 1, revnat_id);
+    lb_v6_add_backend((const union v6addr *)SERVICE_IPV6, tcp_svc_one, 1, 124,
+		      (const union v6addr *)POD_IPV6, tcp_dst_one, IPPROTO_TCP, 0);
+
+    ipcache_v6_add_entry((union v6addr *)POD_IPV6, 0, 112233, 0, 0);
+
+    endpoint_v6_add_entry((const union v6addr *)POD_IPV6, 0, 0, 0, 0, NULL, NULL);
+
+    policy_add_egress_deny_all_entry();
+    policy_add_ingress_deny_all_entry();
+
+    tail_call_static(ctx, entry_call_map, 0);
+    return TEST_ERROR;
+}
+
+CHECK("tc", "hairpin_flow_1_forward_v6")
+int hairpin_flow_forward_check_v6(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == TC_ACT_REDIRECT);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp(&l3->saddr, (const void *)&CONFIG(service_loopback_ipv6).addr,
+		   sizeof(l3->saddr)) != 0)
+		test_fatal("src IPv6 was not SNAT'ed");
+
+	if (memcmp(&l3->daddr, (const void *)POD_IPV6, sizeof(l3->daddr)) != 0)
+		test_fatal("dest IPv6 hasn't been changed to the pod IP");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_src_one)
+		test_fatal("src TCP port was changed");
+
+	if (l4->dest != tcp_dst_one)
+		test_fatal("dst TCP port incorrect");
+
+	if (l4->check != bpf_htons(0x88f8))
+		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+
+	struct ipv6_ct_tuple tuple = {};
+	struct ct_entry *ct_entry;
+
+	tuple.flags = TUPLE_F_SERVICE;
+	tuple.nexthdr = IPPROTO_TCP;
+	memcpy(&tuple.saddr, (const void *)POD_IPV6, sizeof(tuple.saddr));
+	tuple.sport = tcp_src_one;
+	memcpy(&tuple.daddr, (const void *)SERVICE_IPV6, sizeof(tuple.daddr));
+	tuple.dport = tcp_svc_one;
+
+	ipv6_ct_tuple_swap_ports(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT_SERVICE entry found");
+
+	tuple.flags = TUPLE_F_OUT;
+	tuple.nexthdr = IPPROTO_TCP;
+	memcpy(&tuple.saddr, (const void *)&CONFIG(service_loopback_ipv6).addr,
+	       sizeof(tuple.saddr));
+	tuple.sport = tcp_src_one;
+	memcpy(&tuple.daddr, (const void *)POD_IPV6, sizeof(tuple.daddr));
+	tuple.dport = tcp_dst_one;
+
+	ipv6_ct_tuple_swap_addrs(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT_EGRESS entry found");
+	if (!ct_entry->lb_loopback)
+		test_fatal("CT_EGRESS entry doesn't have loopback flag");
+
+	test_finish();
+}
+
+PKTGEN("tc", "hairpin_flow_2_forward_ingress_v6")
+int hairpin_flow_forward_ingress_pktgen_v6(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)src, (__u8 *)dst,
+					  (__u8 *)&CONFIG(service_loopback_ipv6).addr,
+					  (__u8 *)POD_IPV6, tcp_src_one, tcp_dst_one);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "hairpin_flow_2_forward_ingress_v6")
+int hairpin_flow_forward_ingress_setup_v6(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 1);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hairpin_flow_2_forward_ingress_v6")
+int hairpin_flow_forward_ingress_check_v6(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp(&l3->saddr, (const void *)&CONFIG(service_loopback_ipv6).addr,
+		   sizeof(l3->saddr)) != 0)
+		test_fatal("src IPv6 changed");
+
+	if (memcmp(&l3->daddr, (const void *)POD_IPV6, sizeof(l3->daddr)) != 0)
+		test_fatal("dest IPv6 changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_src_one)
+		test_fatal("src TCP port changed");
+
+	if (l4->dest != tcp_dst_one)
+		test_fatal("dst TCP port changed");
+
+	if (l4->check != bpf_htons(0x88f8))
+		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+
+	struct ipv6_ct_tuple tuple = {};
+	struct ct_entry *ct_entry;
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	memcpy(&tuple.saddr, (const void *)&CONFIG(service_loopback_ipv6).addr,
+	       sizeof(tuple.saddr));
+	tuple.sport = tcp_src_one;
+	memcpy(&tuple.daddr, (const void *)POD_IPV6, sizeof(tuple.daddr));
+	tuple.dport = tcp_dst_one;
+
+	ipv6_ct_tuple_swap_addrs(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT_INGRESS entry found");
+	if (!ct_entry->lb_loopback)
+		test_fatal("CT_INGRESS entry doesn't have loopback flag");
+	test_finish();
+}
+
+PKTGEN("tc", "hairpin_flow_3_reverse_v6")
+int hairpin_flow_reverse_pktgen_v6(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)src, (__u8 *)dst,
+					  (__u8 *)POD_IPV6,
+					  (__u8 *)&CONFIG(service_loopback_ipv6).addr,
+					  tcp_dst_one, tcp_src_one);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->ack = 1;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "hairpin_flow_3_reverse_v6")
+int hairpin_flow_rev_setup_v6(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 0);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hairpin_flow_3_reverse_v6")
+int hairpin_flow_rev_check_v6(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == TC_ACT_REDIRECT);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp(&l3->saddr, (const void *)POD_IPV6, sizeof(l3->saddr)) != 0)
+		test_fatal("src IPv6 changed");
+
+	if (memcmp(&l3->daddr, (const void *)&CONFIG(service_loopback_ipv6).addr,
+		   sizeof(l3->daddr)) != 0)
+		test_fatal("dest IPv6 changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_dst_one)
+		test_fatal("src TCP port changed");
+
+	if (l4->dest != tcp_src_one)
+		test_fatal("dst TCP port changed");
+
+	if (l4->check != bpf_htons(0x88e8))
+		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+
+	test_finish();
+}
+
+PKTGEN("tc", "hairpin_flow_4_reverse_ingress_v6")
+int hairpin_flow_reverse_ingress_pktgen_v6(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)src, (__u8 *)dst,
+					  (__u8 *)POD_IPV6,
+					  (__u8 *)&CONFIG(service_loopback_ipv6).addr,
+					  tcp_dst_one, tcp_src_one);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->ack = 1;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "hairpin_flow_4_reverse_ingress_v6")
+int hairpin_flow_reverse_ingress_setup_v6(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 1);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hairpin_flow_4_reverse_ingress_v6")
+int hairpin_flow_reverse_ingress_check_v6(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp(&l3->saddr, (const void *)SERVICE_IPV6, sizeof(l3->saddr)) != 0)
+		test_fatal("src IPv6 was not NAT'ed back to the svc IP");
+
+	if (memcmp(&l3->daddr, (const void *)POD_IPV6, sizeof(l3->daddr)) != 0)
+		test_fatal("dest IPv6 hasn't been NAT'ed to the original source IP");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_svc_one)
+		test_fatal("src TCP port was changed");
+
+	if (l4->dest != tcp_src_one)
+		test_fatal("dst TCP port incorrect");
+
+	if (l4->check != bpf_htons(0xdfd1))
+		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+
+	test_finish();
+}
+
+SETUP("tc", "tc_drop_no_backend_v6")
+int tc_drop_no_backend_setup_v6(struct __ctx_buff *ctx)
+{
+	int ret;
+
+	ret = build_packet_v6(ctx, tcp_src_two);
+	if (ret)
+		return ret;
+
+	lb_v6_add_service((const union v6addr *)SERVICE_IPV6, tcp_svc_one, IPPROTO_TCP, 0, 1);
+
+	/* avoid policy drop */
+	policy_add_egress_allow_all_entry();
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 0);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_drop_no_backend_v6")
+int tc_drop_no_backend_check_v6(const struct __ctx_buff *ctx)
 {
 	__u32 expected_status = TC_ACT_SHOT;
 	__u32 *status_code;

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -523,6 +523,10 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 		"when a Pod talks to itself over a Service.")
 	option.BindEnv(vp, option.ServiceLoopbackIPv4)
 
+	flags.String(option.ServiceLoopbackIPv6, defaults.ServiceLoopbackIPv6, "IPv6 source address to use for SNAT "+
+		"when a Pod talks to itself over a Service.")
+	option.BindEnv(vp, option.ServiceLoopbackIPv6)
+
 	flags.Bool(option.EnableIPv4Masquerade, true, "Masquerade IPv4 traffic from endpoints leaving the host")
 	option.BindEnv(vp, option.EnableIPv4Masquerade)
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -482,6 +482,14 @@ func (d *Daemon) allocateIPs(ctx context.Context, router restoredIPs) error {
 
 		d.logger.Info(fmt.Sprintf("  IPv6 router address: %s", node.GetIPv6Router(d.logger)))
 
+		// Allocate IPv6 service loopback IP
+		loopbackIPv6 := net.ParseIP(option.Config.ServiceLoopbackIPv6)
+		if loopbackIPv6 == nil {
+			return fmt.Errorf("Invalid IPv6 loopback address %s", option.Config.ServiceLoopbackIPv6)
+		}
+		node.SetServiceLoopbackIPv6(loopbackIPv6)
+		d.logger.Info(fmt.Sprintf("  Loopback IPv6: %s", node.GetServiceLoopbackIPv6(d.logger).String()))
+
 		d.logger.Info("  Local IPv6 addresses:")
 		for _, addr := range addrs {
 			if addr.Addr.Is6() {

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -15,6 +15,8 @@ type Node struct {
 	RouterIPv6 [16]byte `config:"router_ipv6"`
 	// IPv4 source address used for SNAT when a Pod talks to itself over a Service.
 	ServiceLoopbackIPv4 [4]byte `config:"service_loopback_ipv4"`
+	// IPv6 source address used for SNAT when a Pod talks to itself over a Service.
+	ServiceLoopbackIPv6 [16]byte `config:"service_loopback_ipv6"`
 	// Whether or not BPF_FIB_LOOKUP_SKIP_NEIGH is supported.
 	SupportsFibLookupSkipNeigh bool `config:"supports_fib_lookup_skip_neigh"`
 	// Length of payload to capture when tracing native packets.
@@ -26,5 +28,7 @@ type Node struct {
 func NewNode() *Node {
 	return &Node{0x0,
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-		[4]byte{0x0, 0x0, 0x0, 0x0}, false, 0x0, 0x0}
+		[4]byte{0x0, 0x0, 0x0, 0x0},
+		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+		false, 0x0, 0x0}
 }

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -44,6 +44,7 @@ var (
 		CiliumInternalIPv6:  ipv6DummyAddr.AsSlice(),
 		AllocCIDRIPv4:       cidr.MustParseCIDR("10.147.0.0/16"),
 		ServiceLoopbackIPv4: ipv4DummyAddr.AsSlice(),
+		ServiceLoopbackIPv6: ipv6DummyAddr.AsSlice(),
 		Devices:             []*tables.Device{},
 		NodeAddresses:       []tables.NodeAddress{},
 		HostEndpointID:      1,

--- a/pkg/datapath/loader/config.go
+++ b/pkg/datapath/loader/config.go
@@ -17,6 +17,10 @@ func nodeConfig(lnc *datapath.LocalNodeConfiguration) config.Node {
 		node.ServiceLoopbackIPv4 = [4]byte(lnc.ServiceLoopbackIPv4.To4())
 	}
 
+	if lnc.ServiceLoopbackIPv6 != nil {
+		node.ServiceLoopbackIPv6 = [16]byte(lnc.ServiceLoopbackIPv6.To16())
+	}
+
 	if lnc.CiliumInternalIPv6 != nil {
 		node.RouterIPv6 = ([16]byte)(lnc.CiliumInternalIPv6.To16())
 	}

--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -23,6 +23,7 @@ var (
 		CiliumInternalIPv4:  templateIPv4[:],
 		AllocCIDRIPv4:       cidr.MustParseCIDR("10.147.0.0/16"),
 		ServiceLoopbackIPv4: templateIPv4[:],
+		ServiceLoopbackIPv6: templateIPv6[:],
 		HostEndpointID:      1,
 		EnableIPv4:          true,
 	}

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -103,6 +103,7 @@ func newLocalNodeConfig(
 		NativeRoutingCIDRIPv4:        datapath.RemoteSNATDstAddrExclusionCIDRv4(localNode),
 		NativeRoutingCIDRIPv6:        datapath.RemoteSNATDstAddrExclusionCIDRv6(localNode),
 		ServiceLoopbackIPv4:          node.GetServiceLoopbackIPv4(logger),
+		ServiceLoopbackIPv6:          node.GetServiceLoopbackIPv6(logger),
 		Devices:                      nativeDevices,
 		NodeAddresses:                statedb.Collect(nodeAddrsIter),
 		DirectRoutingDevice:          directRoutingDevice,

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -176,8 +176,9 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 					}
 				}
 				if agentConfig.EnableIPv6 {
+					loopback := n.Local.ServiceLoopbackIPv6 != nil
 					ipv6GW := n.GetCiliumInternalIP(true) != nil
-					if !ipv6GW {
+					if !ipv6GW || !loopback {
 						return false
 					}
 				}

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -70,6 +70,11 @@ type LocalNodeConfiguration struct {
 	// Immutable at runtime.
 	ServiceLoopbackIPv4 net.IP
 
+	// ServiceLoopbackIPv6 is the source address used for SNAT when a Pod talks to itself
+	// over a Service.
+	// Immutable at runtime.
+	ServiceLoopbackIPv6 net.IP
+
 	// Devices is the native network devices selected for datapath use.
 	// Mutable at runtime.
 	Devices []*tables.Device

--- a/pkg/datapath/types/zz_generated.deepequal.go
+++ b/pkg/datapath/types/zz_generated.deepequal.go
@@ -132,6 +132,23 @@ func (in *LocalNodeConfiguration) DeepEqual(other *LocalNodeConfiguration) bool 
 		}
 	}
 
+	if ((in.ServiceLoopbackIPv6 != nil) && (other.ServiceLoopbackIPv6 != nil)) || ((in.ServiceLoopbackIPv6 == nil) != (other.ServiceLoopbackIPv6 == nil)) {
+		in, other := &in.ServiceLoopbackIPv6, &other.ServiceLoopbackIPv6
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	if ((in.Devices != nil) && (other.Devices != nil)) || ((in.Devices == nil) != (other.Devices == nil)) {
 		in, other := &in.Devices, &other.Devices
 		if other == nil {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -290,6 +290,9 @@ const (
 	// ServiceLoopbackIPv4 is the default address for service loopback
 	ServiceLoopbackIPv4 = "169.254.42.1"
 
+	// ServiceLoopbackIPv6 is the default address for service loopback
+	ServiceLoopbackIPv6 = "fe80::1"
+
 	// EnableEndpointRoutes is the value for option.EnableEndpointRoutes.
 	// It is disabled by default for backwards compatibility.
 	EnableEndpointRoutes = false

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -102,6 +102,8 @@ const (
 	DbgSkLookup6
 	DbgSkAssign
 	DbgL7LB
+	DbgLb6LoopbackSnat
+	DbgLb6LoopbackSnatRev
 )
 
 // must be in sync with <bpf/lib/conntrack.h>
@@ -348,6 +350,10 @@ func (n *DebugMsg) Message(linkMonitor getters.LinkGetter) string {
 		return fmt.Sprintf("Reverse NAT lookup, index=%d", byteorder.NetworkToHost16(uint16(n.Arg1)))
 	case DbgLb6ReverseNat:
 		return fmt.Sprintf("Performing reverse NAT, address.p4=%x port=%d", n.Arg1, byteorder.NetworkToHost16(uint16(n.Arg2)))
+	case DbgLb6LoopbackSnat:
+		return fmt.Sprintf("Loopback SNAT from.p4=%x to.p4=%x", n.Arg1, n.Arg2)
+	case DbgLb6LoopbackSnatRev:
+		return fmt.Sprintf("Loopback reverse SNAT from.p4=%x to.p4=%x", n.Arg1, n.Arg2)
 	case DbgLb4LookupFrontend:
 		return fmt.Sprintf("Frontend service lookup, addr=%s key.dport=%d", ip4Str(n.Arg1), byteorder.NetworkToHost16(uint16(n.Arg2)))
 	case DbgLb4LookupFrontendFail:

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -197,10 +197,22 @@ func GetServiceLoopbackIPv4(logger *slog.Logger) net.IP {
 	return getLocalNode(logger).Local.ServiceLoopbackIPv4
 }
 
+// GetServiceLoopbackIPv6 returns the service loopback IPv6 address of this node.
+func GetServiceLoopbackIPv6(logger *slog.Logger) net.IP {
+	return getLocalNode(logger).Local.ServiceLoopbackIPv6
+}
+
 // SetIPv4Loopback sets the service loopback IPv4 address of this node.
 func SetServiceLoopbackIPv4(ip net.IP) {
 	localNode.Update(func(n *LocalNode) {
 		n.Local.ServiceLoopbackIPv4 = ip
+	})
+}
+
+// SetServiceLoopbackIPv6 sets the service loopback IPv6 address of this node.
+func SetServiceLoopbackIPv6(ip net.IP) {
+	localNode.Update(func(n *LocalNode) {
+		n.Local.ServiceLoopbackIPv6 = ip
 	})
 }
 

--- a/pkg/node/table.go
+++ b/pkg/node/table.go
@@ -75,6 +75,9 @@ type LocalNodeInfo struct {
 	// ServiceLoopbackIPv4 is the source address used for SNAT when a Pod talks to
 	// itself through a Service.
 	ServiceLoopbackIPv4 net.IP
+	// ServiceLoopbackIPv6 is the source address used for SNAT when a Pod talks to
+	// itself through a Service.
+	ServiceLoopbackIPv6 net.IP
 	// IsBeingDeleted indicates that the local node is being deleted.
 	IsBeingDeleted bool
 	// UnderlayProtocol is the IP family of our underlay.

--- a/pkg/node/zz_generated.deepcopy.go
+++ b/pkg/node/zz_generated.deepcopy.go
@@ -50,6 +50,11 @@ func (in *LocalNodeInfo) DeepCopyInto(out *LocalNodeInfo) {
 		*out = make(net.IP, len(*in))
 		copy(*out, *in)
 	}
+	if in.ServiceLoopbackIPv6 != nil {
+		in, out := &in.ServiceLoopbackIPv6, &out.ServiceLoopbackIPv6
+		*out = make(net.IP, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/node/zz_generated.deepequal.go
+++ b/pkg/node/zz_generated.deepequal.go
@@ -79,6 +79,23 @@ func (in *LocalNodeInfo) DeepEqual(other *LocalNodeInfo) bool {
 		}
 	}
 
+	if ((in.ServiceLoopbackIPv6 != nil) && (other.ServiceLoopbackIPv6 != nil)) || ((in.ServiceLoopbackIPv6 == nil) != (other.ServiceLoopbackIPv6 == nil)) {
+		in, other := &in.ServiceLoopbackIPv6, &other.ServiceLoopbackIPv6
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	if in.IsBeingDeleted != other.IsBeingDeleted {
 		return false
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -743,6 +743,9 @@ const (
 	// ServiceLoopbackIPv4 is the address to use for service loopback SNAT
 	ServiceLoopbackIPv4 = "ipv4-service-loopback-address"
 
+	// ServiceLoopbackIPv6 is the address to use for service loopback SNAT
+	ServiceLoopbackIPv6 = "ipv6-service-loopback-address"
+
 	// LocalRouterIPv4 is the link-local IPv4 address to use for Cilium router device
 	LocalRouterIPv4 = "local-router-ipv4"
 
@@ -1555,6 +1558,9 @@ type DaemonConfig struct {
 	// ServiceLoopbackIPv4 is the address to use for service loopback SNAT
 	ServiceLoopbackIPv4 string
 
+	// ServiceLoopbackIPv6 is the address to use for service loopback SNAT
+	ServiceLoopbackIPv6 string
+
 	// LocalRouterIPv4 is the link-local IPv4 address used for Cilium's router device
 	LocalRouterIPv4 string
 
@@ -1910,6 +1916,7 @@ var (
 		FixedIdentityMapping:            make(map[string]string),
 		LogOpt:                          make(map[string]string),
 		ServiceLoopbackIPv4:             defaults.ServiceLoopbackIPv4,
+		ServiceLoopbackIPv6:             defaults.ServiceLoopbackIPv6,
 		EnableEndpointRoutes:            defaults.EnableEndpointRoutes,
 		AnnotateK8sNode:                 defaults.AnnotateK8sNode,
 		AutoCreateCiliumNodeResource:    defaults.AutoCreateCiliumNodeResource,
@@ -2515,6 +2522,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.LibDir = vp.GetString(LibDir)
 	c.LogSystemLoadConfig = vp.GetBool(LogSystemLoadConfigName)
 	c.ServiceLoopbackIPv4 = vp.GetString(ServiceLoopbackIPv4)
+	c.ServiceLoopbackIPv6 = vp.GetString(ServiceLoopbackIPv6)
 	c.LocalRouterIPv4 = vp.GetString(LocalRouterIPv4)
 	c.LocalRouterIPv6 = vp.GetString(LocalRouterIPv6)
 	c.EnableBPFClockProbe = vp.GetBool(EnableBPFClockProbe)


### PR DESCRIPTION
Service Loopback IPv6

Fixes: #26733 

```release-note
IPv6 support for pods connecting to themselves via a k8s service ("service loopback").
```

