### PR TITLE
loadbalancer/redirectpolicy: Fix API panic when LRP disabled

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/redirectpolicy/cell.go
@@ -63,8 +63,8 @@ var Cell = cell.Module(
 	cell.DecorateAll(replaceAPI),
 )
 
-func replaceAPI(enabled lrpIsEnabled, old service.GetLrpHandler, db *statedb.DB, lrps statedb.Table[*LocalRedirectPolicy]) service.GetLrpHandler {
-	if !enabled {
+func replaceAPI(cfg loadbalancer.Config, old service.GetLrpHandler, db *statedb.DB, lrps statedb.Table[*LocalRedirectPolicy]) service.GetLrpHandler {
+	if !cfg.EnableExperimentalLB {
 		return old
 	}
 	return &getLrpHandler{db, lrps}


### PR DESCRIPTION
"cilium-dbg lrp list" panic'd in the API handler when LRP was disabled, due to it delegating the call to the old implementation and nil deref'ing:

```
time=2025-05-19T10:37:10Z level=warn msg="Cilium API handler panicked" module=agent.infra.cilium-api-server url=/v1/lrp method=GET
  client=@ panicMessage="runtime error: invalid memory address or nil pointer dereference"
goroutine 23043 [running]:
runtime/debug.Stack()
        /nix/store/g29rrn8qqlg4yjqv543ryrkimr7fk43h-go-1.24.1/share/go/src/runtime/debug/stack.go:26 +0x5e
github.com/cilium/cilium/pkg/api.(*APIPanicHandler).ServeHTTP.func1()
        /home/jussi/go/src/github.com/cilium/cilium/pkg/api/apipanic.go:46 +0x30e
panic({0x46ace20?, 0x8d6f740?})
        /nix/store/g29rrn8qqlg4yjqv543ryrkimr7fk43h-go-1.24.1/share/go/src/runtime/panic.go:792 +0x132
github.com/cilium/cilium/pkg/loadbalancer/legacy/redirectpolicy.(*getLrpHandler).Handle(0xc000a21c30, {0xc003fac780?})
        /home/jussi/go/src/github.com/cilium/cilium/pkg/loadbalancer/legacy/redirectpolicy/api.go:19 +0x1d
```

Fix this by only delegating to the old implementation when new LB control-plane is disabled. Now the new handler is used when LRP is disabled which will just query against the empty policy table.

Marking as `release-note/misc` as this was unreleased code.