### PR TITLE
bpf: Support IPsec over IPv6 underlay

### DIFF
--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -81,8 +81,9 @@ set_ipsec_decrypt_mark(struct __ctx_buff *ctx, __u16 node_id)
 }
 
 static __always_inline int
-set_ipsec_encrypt(struct __ctx_buff *ctx, __u8 spi, __u32 tunnel_endpoint,
-		  __u32 seclabel, bool use_meta, bool use_spi_from_map)
+set_ipsec_encrypt(struct __ctx_buff *ctx, __u8 spi,
+		  struct remote_endpoint_info *info, __u32 seclabel,
+		  bool use_meta, bool use_spi_from_map)
 {
 	/* IPSec is performed by the stack on any packets with the
 	 * MARK_MAGIC_ENCRYPT bit set. During the process though we
@@ -95,7 +96,7 @@ set_ipsec_encrypt(struct __ctx_buff *ctx, __u8 spi, __u32 tunnel_endpoint,
 	struct node_value *node_value = NULL;
 	__u32 mark;
 
-	node_value = lookup_ip4_node(tunnel_endpoint);
+	node_value = lookup_node(info);
 	if (!node_value || !node_value->id)
 		return DROP_NO_NODE_ID;
 
@@ -261,9 +262,13 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 			/* NOTE: we confirm double-encryption will not occur
 			 * above in the `ctx_is_overlay_encrypted` check
 			 */
+			struct remote_endpoint_info fake_info = {0};
+
+			fake_info.tunnel_endpoint.ip4 = ip4->daddr;
+			fake_info.flag_has_tunnel_ep = true;
 
 			/* see comment in the native-routing mode call. */
-			ret = set_ipsec_encrypt(ctx, 0, ip4->daddr,
+			ret = set_ipsec_encrypt(ctx, 0, &fake_info,
 						get_identity(ctx), true,
 						true);
 			if (ret != CTX_ACT_OK)
@@ -330,8 +335,7 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	 * supports rhel 8.6 'use_meta' can be flipped back to false and we
 	 * can rely only on the mark.
 	 */
-	ret = set_ipsec_encrypt(ctx, 0, dst->tunnel_endpoint.ip4,
-				src_sec_identity, true, true);
+	ret = set_ipsec_encrypt(ctx, 0, dst, src_sec_identity, true, true);
 	if (ret != CTX_ACT_OK)
 		return ret;
 

--- a/bpf/lib/node.h
+++ b/bpf/lib/node.h
@@ -65,3 +65,13 @@ lookup_ip6_node_id(const union v6addr *ip6)
 	return node_value->id;
 }
 # endif /* ENABLE_IPV6 */
+
+static __always_inline struct node_value *
+lookup_node(const struct remote_endpoint_info *info)
+{
+# ifdef ENABLE_IPV6
+	if (info->flag_ipv6_tunnel_ep)
+		return lookup_ip6_node(&info->tunnel_endpoint.ip6);
+# endif /* ENABLE_IPV6 */
+	return lookup_ip4_node(info->tunnel_endpoint.ip4);
+}


### PR DESCRIPTION
This pull request adds support in our datapath for IPsec over IPv6 underlays. Agent changes and CI coverage will come in a followup pull request.