### PR TITLE
bpf:ipsec: extend bpf tests for ipsec_maybe_redirect_to_encrypt

### DIFF
--- a/bpf/tests/ipsec_redirect_generic.h
+++ b/bpf/tests/ipsec_redirect_generic.h
@@ -24,14 +24,83 @@ int mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 #define ENABLE_IPV6
 #define ENABLE_IPSEC
 
-/* test constants */
+/*
+ * Test constants. Make sure to have a valid src/dst identity by
+ * using ids < CIDR_IDENTITY_RANGE_START.
+ */
 #define SOURCE_MAC mac_one
 #define DST_MAC mac_two
+#define SOURCE_NODE_IP v4_node_one
+#define SOURCE_NODE_IP_6 v6_node_one
 #define SOURCE_IP v4_pod_one
-#define SOURCE_IDENTITY 0xAB
+#define SOURCE_IP_6 v6_pod_one
+#define SOURCE_IDENTITY (CIDR_IDENTITY_RANGE_START - 1)
 #define DST_IP v4_pod_two
+#define DST_IP_6 v6_pod_two
 #define DST_NODE_ID 0x08b9
-#define DST_NODE_IP v4_node_one
+#define DST_NODE_IP v4_node_two
+#define DST_NODE_IP_6 v6_node_two
+#define DST_IDENTITY (CIDR_IDENTITY_RANGE_START - 2)
 #define TARGET_SPI 2
 #define BAD_SPI 3
+#define GENERAL_PORT bpf_htons(12134)
+#define VXLAN_PORT bpf_htons(8472)
 
+static __always_inline
+int generate_vxlan_packet(struct __ctx_buff *ctx, bool outer_ip4, bool inner_ip4)
+{
+	struct pktgen builder;
+	struct vxlanhdr *vxlan;
+	void *l3;
+
+	pktgen__init(&builder, ctx);
+
+	if (outer_ip4)
+		vxlan = pktgen__push_ipv4_vxlan_packet(&builder, (__u8 *)SOURCE_MAC,
+						       (__u8 *)DST_MAC, SOURCE_NODE_IP,
+						       DST_NODE_IP, GENERAL_PORT,
+						       VXLAN_PORT);
+	else
+		vxlan = pktgen__push_ipv6_vxlan_packet(&builder, (__u8 *)SOURCE_MAC,
+						       (__u8 *)DST_MAC, (__u8 *)SOURCE_NODE_IP_6,
+						       (__u8 *)DST_NODE_IP_6, GENERAL_PORT,
+						       VXLAN_PORT);
+	if (!vxlan)
+		return TEST_ERROR;
+
+	if (inner_ip4)
+		l3 = pktgen__push_ipv4_packet(&builder, (__u8 *)SOURCE_MAC, (__u8 *)DST_MAC,
+					      SOURCE_IP, DST_IP);
+	else
+		l3 = pktgen__push_ipv6_packet(&builder, (__u8 *)SOURCE_MAC, (__u8 *)DST_MAC,
+					      (__u8 *)SOURCE_IP_6, (__u8 *)DST_IP_6);
+
+	if (!l3)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+static __always_inline
+int generate_native_packet(struct __ctx_buff *ctx, bool ipv4)
+{
+	struct pktgen builder;
+	void *l3 = NULL;
+
+	pktgen__init(&builder, ctx);
+
+	if (ipv4)
+		l3 = pktgen__push_ipv4_packet(&builder, (__u8 *)SOURCE_MAC, (__u8 *)DST_MAC,
+					      SOURCE_IP, DST_IP);
+	else
+		l3 = pktgen__push_ipv6_packet(&builder, (__u8 *)SOURCE_MAC, (__u8 *)DST_MAC,
+					      (__u8 *)SOURCE_IP_6, (__u8 *)DST_IP_6);
+
+	if (!l3)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}

--- a/bpf/tests/ipsec_redirect_native.c
+++ b/bpf/tests/ipsec_redirect_native.c
@@ -46,7 +46,7 @@ int ipsec_redirect_check(__maybe_unused struct __ctx_buff *ctx)
 	map_update_elem(&cilium_encrypt_state, &ret, &cfg, BPF_ANY);
 
 	ipcache_v4_add_entry(SOURCE_IP, 0, SOURCE_IDENTITY, 0, BAD_SPI);
-	ipcache_v4_add_entry(DST_IP, 0, 0xAC, DST_NODE_IP, TARGET_SPI);
+	ipcache_v4_add_entry(DST_IP, 0, DST_IDENTITY, DST_NODE_IP, TARGET_SPI);
 
 	ret = ipsec_maybe_redirect_to_encrypt(ctx, bpf_htons(ETH_P_IP),
 					      SOURCE_IDENTITY);

--- a/bpf/tests/ipsec_redirect_native.c
+++ b/bpf/tests/ipsec_redirect_native.c
@@ -178,3 +178,15 @@ int ipsec_redirect_bad_identities_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	return bad_identities_check(ctx, true);
 }
+
+PKTGEN("tc", "ipsec_redirect_bad_identities6")
+int ipsec_redirect_bad_identities6_pktgen(struct __ctx_buff *ctx)
+{
+	return generate_native_packet(ctx, false);
+}
+
+CHECK("tc", "ipsec_redirect_bad_identities6")
+int ipsec_redirect_bad_identities6_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	return bad_identities_check(ctx, false);
+}

--- a/bpf/tests/ipsec_redirect_native.c
+++ b/bpf/tests/ipsec_redirect_native.c
@@ -83,3 +83,15 @@ int ipsec_redirect_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, true);
 }
+
+PKTGEN("tc", "ipsec_redirect6")
+int ipsec_redirect6_pktgen(struct __ctx_buff *ctx)
+{
+	return generate_native_packet(ctx, false);
+}
+
+CHECK("tc", "ipsec_redirect6")
+int ipsec_redirect6_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	return ipsec_redirect_checks(ctx, false);
+}

--- a/bpf/tests/ipsec_redirect_tunnel.c
+++ b/bpf/tests/ipsec_redirect_tunnel.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define TUNNEL_MODE
+
+#include "ipsec_redirect_generic.h"
+
+#include "node_config.h"
+
+/* must define `HAVE_ENCAP 1` before including 'lib/encrypt.h'.
+ * lib/encrypt.h eventually imports overloadable_skb.h which exposes
+ * ctx_is_overlay and ctx_is_overlay_encrypted, utilized within
+ * 'ipsec_maybe_redirect_to_encrypt'
+ */
+#define HAVE_ENCAP 1
+#include "lib/encrypt.h"
+#include "lib/node.h"
+#include "tests/lib/ipcache.h"
+
+static __always_inline
+int ipsec_redirect_checks(__maybe_unused struct __ctx_buff *ctx, bool outer_ipv4)
+{
+	test_init();
+
+	int ret = 0;
+	__be16 proto = outer_ipv4 ? bpf_htons(ETH_P_IP) : bpf_htons(ETH_P_IPV6);
+
+	if (outer_ipv4)
+		node_v4_add_entry(DST_NODE_IP, DST_NODE_ID, TARGET_SPI);
+	else
+		node_v6_add_entry((const union v6addr *)DST_NODE_IP_6, DST_NODE_ID, TARGET_SPI);
+
+	struct encrypt_config cfg = {
+		.encrypt_key = BAD_SPI,
+	};
+	map_update_elem(&cilium_encrypt_state, &ret, &cfg, BPF_ANY);
+
+	/* Ensure we simply return from 'ipsec_maybe_redirect_to_encrypt' if
+	 * the 'MARK_MAGIC_OVERLAY_ENCRYPTED' mark is set.
+	 */
+	TEST("overlay-encrypted-mark-set", {
+		ctx->mark = MARK_MAGIC_OVERLAY_ENCRYPTED;
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, proto, SOURCE_IDENTITY);
+		assert(ret == CTX_ACT_OK);
+	})
+
+	/*
+	 * Ensure encryption mark is set for overlay traffic with source
+	 * identity pod SOURCE_IDENTITY and CTX_ACT_REDIRECT is set.
+	 *
+	 * NOTE: with MARK_MAGIC_OVERLAY, any source identity in the ctx->mark
+	 * would make `ipsec_maybe_redirect_to_encrypt` returning CTX_ACT_REDIRECT
+	 * with also the encryption mark set.
+	 */
+	TEST("overlay-mark-set", {
+		set_identity_mark(ctx, SOURCE_IDENTITY, MARK_MAGIC_OVERLAY);
+		ret = ipsec_maybe_redirect_to_encrypt(ctx, proto, SOURCE_IDENTITY);
+		assert(ctx->mark == ipsec_encode_encryption_mark(TARGET_SPI, DST_NODE_ID));
+		assert(ret == CTX_ACT_REDIRECT);
+	})
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipsec_redirect_tunnel4_v4")
+int ipsec_redirect_tunnel4_v4_pktgen(struct __ctx_buff *ctx)
+{
+	return generate_vxlan_packet(ctx, true, true);
+}
+
+CHECK("tc", "ipsec_redirect_tunnel4_v4")
+int ipsec_redirect_tunnel4_v4_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	return ipsec_redirect_checks(ctx, true);
+}

--- a/bpf/tests/ipsec_redirect_tunnel.c
+++ b/bpf/tests/ipsec_redirect_tunnel.c
@@ -73,3 +73,15 @@ int ipsec_redirect_tunnel4_v4_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, true);
 }
+
+PKTGEN("tc", "ipsec_redirect_tunnel4_v6")
+int ipsec_redirect_tunnel4_v6_pktgen(struct __ctx_buff *ctx)
+{
+	return generate_vxlan_packet(ctx, true, false);
+}
+
+CHECK("tc", "ipsec_redirect_tunnel4_v6")
+int ipsec_redirect_tunnel4_v6_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	return ipsec_redirect_checks(ctx, true);
+}

--- a/bpf/tests/ipsec_redirect_tunnel.c
+++ b/bpf/tests/ipsec_redirect_tunnel.c
@@ -85,3 +85,15 @@ int ipsec_redirect_tunnel4_v6_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, true);
 }
+
+PKTGEN("tc", "ipsec_redirect_tunnel6_v4")
+int ipsec_redirect_tunnel6_v4_pktgen(struct __ctx_buff *ctx)
+{
+	return generate_vxlan_packet(ctx, false, true);
+}
+
+CHECK("tc", "ipsec_redirect_tunnel6_v4")
+int ipsec_redirect_tunnel6_v4_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	return ipsec_redirect_checks(ctx, false);
+}

--- a/bpf/tests/ipsec_redirect_tunnel.c
+++ b/bpf/tests/ipsec_redirect_tunnel.c
@@ -97,3 +97,15 @@ int ipsec_redirect_tunnel6_v4_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, false);
 }
+
+PKTGEN("tc", "ipsec_redirect_tunnel6_v6")
+int ipsec_redirect_tunnel6_v6_pktgen(struct __ctx_buff *ctx)
+{
+	return generate_vxlan_packet(ctx, false, true);
+}
+
+CHECK("tc", "ipsec_redirect_tunnel6_v6")
+int ipsec_redirect_tunnel6_v6_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	return ipsec_redirect_checks(ctx, false);
+}

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -648,6 +648,29 @@ pktgen__push_ipv4_packet(struct pktgen *builder,
 	return l3;
 }
 
+static __always_inline struct ipv6hdr *
+pktgen__push_ipv6_packet(struct pktgen *builder,
+			 __u8 *smac, __u8 *dmac,
+			 __u8 *saddr, __u8 *daddr)
+{
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	l2 = pktgen__push_ethhdr(builder);
+	if (!l2)
+		return NULL;
+
+	ethhdr__set_macs(l2, smac, dmac);
+
+	l3 = pktgen__push_default_ipv6hdr(builder);
+	if (!l3)
+		return NULL;
+
+	ipv6hdr__set_addrs(l3, saddr, daddr);
+
+	return l3;
+}
+
 static __always_inline struct tcphdr *
 pktgen__push_ipv4_tcp_packet(struct pktgen *builder,
 			     __u8 *smac, __u8 *dmac,
@@ -806,6 +829,22 @@ pktgen__push_ipv6_udp_packet(struct pktgen *builder,
 	l4->dest = dport;
 
 	return l4;
+}
+
+static __always_inline struct vxlanhdr *
+pktgen__push_ipv6_vxlan_packet(struct pktgen *builder,
+			       __u8 *smac, __u8 *dmac,
+			       __u8 *saddr, __u8 *daddr,
+			       __be16 sport, __be16 dport)
+{
+	struct udphdr *l4;
+
+	l4 = pktgen__push_ipv6_udp_packet(builder, smac, dmac, saddr, daddr,
+					  sport, dport);
+	if (!l4)
+		return NULL;
+
+	return pktgen__push_default_vxlanhdr(builder);
 }
 
 static __always_inline struct icmp6hdr *


### PR DESCRIPTION
Being hugely inspired by https://github.com/cilium/cilium/commit/b824305182d9ce13adcd28cd94ad287f3e38178a, especially for infrastructure and subset of tests to run. Had to refactor a lot of stuff though, and tried to modify the infra so that we just have 2 files, `native` and `tunnel`. Inside each of them, they now test both IPv4 and IPv6.

In brief, this patch covers tests for `ipsec_maybe_redirect_to_encrypt()` with:
1. Native IPv4 packet
2. Native IPv6 packet
3. VXLANv4-InnerIPv4 packet
4. VXLANv4-InnerIPv6 packet

In addition, this patch lands the infra for the following tests, which cannot be enabled yet (MBOI for/after https://github.com/cilium/cilium/pull/39620):
1. VXLANv6-InnerIPV4
2. VXLANv6-InnerIPV6
