### PR TITLE
renovate: only perform etcd patch version updates in stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -687,6 +687,22 @@
       matchBaseBranches: [
         "v1.15"
       ]
+    },
+    {
+      // Do not allow any major and minor etcd updates into stable branches.
+      "enabled": false,
+      "matchDepNames": [
+        "gcr.io/etcd-development/etcd"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+      ],
+      "matchBaseBranches": [
+        "v1.17",
+        "v1.16",
+        "v1.15",
+      ]
     }
   ],
   "kubernetes": {


### PR DESCRIPTION
Let's configure renovate to perform etcd minor version updates in the main branch only, while sticking to a fixed minor version in stable branches. This ensures that we don't introduce unnecessary churn (especially in the context of the clustermesh-apiserver, which packs the etcd binary as well), and potential incompatibilities due to API differences.

The etcd project currently maintains both the current and the previous minor versions [1], so we'll still get security and important bug fixes regardless. Additionally, the etcd release cycle is also typically much longer than Cilium's (v3.5 got released in 2021), so there should be no problems from that point of view. In any case, we could still upgrade manually if need arises.

\[1]: https://etcd.io/docs/v3.6/op-guide/versioning/

Related: #39615