### PR TITLE
bpf: Use long-term solution for IPv6 tunneling checksum bug

### DIFF
--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -195,7 +195,7 @@ l4_csum_replace(const struct xdp_md *ctx, __u64 off, __u32 from, __u32 to,
 	int ret;
 
 	if (unlikely(flags & ~(BPF_F_MARK_MANGLED_0 | BPF_F_PSEUDO_HDR |
-			       BPF_F_HDR_FIELD_MASK)))
+			       BPF_F_HDR_FIELD_MASK | BPF_F_IPV6)))
 		return -EINVAL;
 	if (unlikely(size != 0 && size != 2))
 		return -EINVAL;

--- a/bpf/include/linux/bpf.h
+++ b/bpf/include/linux/bpf.h
@@ -5895,6 +5895,7 @@ enum {
 	BPF_F_PSEUDO_HDR		= (1ULL << 4),
 	BPF_F_MARK_MANGLED_0		= (1ULL << 5),
 	BPF_F_MARK_ENFORCE		= (1ULL << 6),
+	BPF_F_IPV6			= (1ULL << 7),
 };
 
 /* BPF_FUNC_clone_redirect and BPF_FUNC_redirect flags. */


### PR DESCRIPTION
This pull request implements the long term fix for the kernel bug described (and worked around) in https://github.com/cilium/cilium/pull/39279. For older kernels, we'll continue falling back to the workaround. See commits for details.

This pull request isn't a fix per-se, but I'd still like to backport it to v1.18. The risk seems low given the amount of code and we know the workaround is more fragile than the long-term solution.