### PR TITLE
bpf|loader: keep CFLAGS (CLANG_FLAGS) in sync between loader and BPF unit tests

### DIFF
--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -7,19 +7,15 @@ MAKEFLAGS += -r
 
 CLANG ?= clang
 
-FLAGS := -I$(ROOT_DIR)/bpf -I$(ROOT_DIR)/bpf/include -O2 -g
+FLAGS := -I$(ROOT_DIR)/bpf -I$(ROOT_DIR)/bpf/include -g
 
-CLANG_FLAGS := ${FLAGS} --target=bpf -std=gnu99 -nostdinc
-# eBPF verifier enforces unaligned access checks where necessary, so don't
-# let clang complain too early.
-CLANG_FLAGS += -Wall -Wextra -Werror -Wshadow
-CLANG_FLAGS += -Wno-address-of-packed-member
-CLANG_FLAGS += -Wno-unknown-warning-option
-CLANG_FLAGS += -Wno-gnu-variable-sized-type-not-at-end
-CLANG_FLAGS += -Wimplicit-int-conversion -Wenum-conversion
-CLANG_FLAGS += -Wimplicit-fallthrough
+# Base CFLAGS (CLANG_FLAGS) are read from pkg/datapath/loader/compile.go
+# to keep them synced with the loader
+CLANG_FLAGS := $(FLAGS) $(shell $(GO) run $(ROOT_DIR)/pkg/datapath/loader/tools/clang_cflags.go)
+
 # Create dependency files for each .o file.
 CLANG_FLAGS += -MD
+
 # Mimics the mcpu values set by cilium-agent. See GetBPFCPU().
 ifneq ($(KERNEL),54)
 CLANG_FLAGS += -mcpu=v3

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -97,7 +97,7 @@ type directoryInfo struct {
 }
 
 var (
-	standardCFlags = []string{"-O2", "--target=bpf", "-std=gnu89",
+	standardCFlags = []string{"-O2", "--target=bpf", "-std=gnu99",
 		"-nostdinc",
 		"-Wall", "-Wextra", "-Werror", "-Wshadow",
 		"-Wno-address-of-packed-member",

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -103,7 +103,6 @@ var (
 		"-Wno-address-of-packed-member",
 		"-Wno-unknown-warning-option",
 		"-Wno-gnu-variable-sized-type-not-at-end",
-		"-Wdeclaration-after-statement",
 		"-Wimplicit-int-conversion",
 		"-Wenum-conversion",
 		"-Wimplicit-fallthrough"}

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -97,7 +97,7 @@ type directoryInfo struct {
 }
 
 var (
-	standardCFlags = []string{"-O2", "--target=bpf", "-std=gnu99",
+	StandardCFlags = []string{"-O2", "--target=bpf", "-std=gnu99",
 		"-nostdinc",
 		"-Wall", "-Wextra", "-Werror", "-Wshadow",
 		"-Wno-address-of-packed-member",
@@ -172,7 +172,7 @@ func compile(ctx context.Context, logger *slog.Logger, prog *progInfo, dir *dire
 		compileArgs = append(compileArgs, "-g")
 	}
 
-	compileArgs = append(compileArgs, standardCFlags...)
+	compileArgs = append(compileArgs, StandardCFlags...)
 	compileArgs = append(compileArgs, "-mcpu="+getBPFCPU(logger))
 	compileArgs = append(compileArgs, prog.Options...)
 	compileArgs = append(compileArgs,

--- a/pkg/datapath/loader/tools/clang_cflags.go
+++ b/pkg/datapath/loader/tools/clang_cflags.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/datapath/loader"
+)
+
+func main() {
+	fmt.Println(strings.Join(loader.StandardCFlags, " "))
+}


### PR DESCRIPTION
Prior to this commit BPF unit tests ran with their own set of `CFLAGS`
(`CLANG_FLAGS`). They were manually synced to match loader's `CFLAGS`.

This commit reads the golang base `CFLAGS` definition and uses it as
base `CFLAGS` for the unit tests.

This patchset also:

* Changes loader's default to `gnu99`
* Removes `-Wdeclaration-after-statement`. See the following message within this PR for the context.