### PR TITLE
hubble: don't log in parser options

### DIFF
--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -51,7 +51,6 @@ func newPayloadParser(params payloadParserParams) (parser.Decoder, error) {
 		parserOpts = append(
 			parserOpts,
 			parserOptions.WithRedact(
-				params.Log,
 				params.Config.RedactHttpURLQuery,
 				params.Config.RedactHttpUserInfo,
 				params.Config.RedactKafkaAPIKey,
@@ -63,13 +62,11 @@ func newPayloadParser(params payloadParserParams) (parser.Decoder, error) {
 	parserOpts = append(
 		parserOpts,
 		parserOptions.WithNetworkPolicyCorrelation(
-			params.Log,
 			params.Config.EnableNetworkPolicyCorrelation,
 		))
 	parserOpts = append(
 		parserOpts,
 		parserOptions.WithSkipUnknownCGroupIDs(
-			params.Log,
 			params.Config.SkipUnknownCGroupIDs,
 		),
 	)

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -3,12 +3,7 @@
 
 package options
 
-import (
-	"log/slog"
-	"strings"
-
-	"github.com/cilium/cilium/pkg/logging/logfields"
-)
+import "strings"
 
 // Option is used to configure parsers
 type Option func(*Options)
@@ -43,8 +38,8 @@ func CacheSize(size int) Option {
 	}
 }
 
-// Redact configures which data Hubble will redact.
-func WithRedact(logger *slog.Logger, httpQuery, httpUserInfo, kafkaApiKey bool, allowHeaders, denyHeaders []string) Option {
+// WithRedact configures which data Hubble will redact.
+func WithRedact(httpQuery, httpUserInfo, kafkaApiKey bool, allowHeaders, denyHeaders []string) Option {
 	return func(opt *Options) {
 		opt.HubbleRedactSettings.Enabled = true
 		opt.HubbleRedactSettings.RedactHTTPQuery = httpQuery
@@ -54,32 +49,20 @@ func WithRedact(logger *slog.Logger, httpQuery, httpUserInfo, kafkaApiKey bool, 
 			Allow: headerSliceToMap(allowHeaders),
 			Deny:  headerSliceToMap(denyHeaders),
 		}
-		if logger != nil {
-			logger.Info(
-				"configured Hubble with redact",
-				logfields.Options, opt.HubbleRedactSettings,
-			)
-		}
 	}
 }
 
 // WithNetworkPolicyCorrelation configures the Network Policy correlation of Hubble Flows.
-func WithNetworkPolicyCorrelation(logger *slog.Logger, enabled bool) Option {
+func WithNetworkPolicyCorrelation(enabled bool) Option {
 	return func(opt *Options) {
 		opt.EnableNetworkPolicyCorrelation = enabled
-		logger.Info("configured Hubble with network policy correlation",
-			logfields.Options, opt.EnableNetworkPolicyCorrelation,
-		)
 	}
 }
 
 // WithSkipUnknownCGroupIDs configures whether Hubble will skip events with unknown CGroup IDs.
-func WithSkipUnknownCGroupIDs(logger *slog.Logger, enabled bool) Option {
+func WithSkipUnknownCGroupIDs(enabled bool) Option {
 	return func(opt *Options) {
 		opt.SkipUnknownCGroupIDs = enabled
-		logger.Info("configured Hubble to skip events with unknown CGroup IDs",
-			logfields.Options, opt.SkipUnknownCGroupIDs,
-		)
 	}
 }
 

--- a/pkg/hubble/parser/options/options_test.go
+++ b/pkg/hubble/parser/options/options_test.go
@@ -4,27 +4,14 @@
 package options
 
 import (
-	"bytes"
-	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 func TestRedact(t *testing.T) {
-	want := "level=info msg=\"configured Hubble with redact\" options=\"{Enabled:true RedactHTTPQuery:false RedactHTTPUserInfo:false RedactKafkaAPIKey:false RedactHttpHeaders:{Allow:map[] Deny:map[]}}\"\n"
-	var buf bytes.Buffer
-	logger := slog.New(
-		slog.NewTextHandler(&buf,
-			&slog.HandlerOptions{
-				ReplaceAttr: logging.ReplaceAttrFnWithoutTimestamp,
-			},
-		),
-	)
-	opt := WithRedact(logger, false, false, false, nil, nil)
-	opt(&Options{
+	opt := WithRedact(true, false, false, nil, nil)
+	opts := Options{
 		HubbleRedactSettings: HubbleRedactSettings{
 			Enabled:            false,
 			RedactHTTPQuery:    false,
@@ -35,40 +22,22 @@ func TestRedact(t *testing.T) {
 				Deny:  map[string]struct{}{"tracecontent": {}},
 			},
 		},
-	})
-	assert.Equal(t, want, buf.String())
+	}
+	opt(&opts)
+	assert.True(t, opts.HubbleRedactSettings.Enabled)
+	assert.True(t, opts.HubbleRedactSettings.RedactHTTPQuery)
 }
 
 func TestEnableNetworkPolicyCorrelation(t *testing.T) {
-	want := "level=info msg=\"configured Hubble with network policy correlation\" options=true\n"
-	var buf bytes.Buffer
-	logger := slog.New(
-		slog.NewTextHandler(&buf,
-			&slog.HandlerOptions{
-				ReplaceAttr: logging.ReplaceAttrFnWithoutTimestamp,
-			},
-		),
-	)
-	opt := WithNetworkPolicyCorrelation(logger, true)
+	opt := WithNetworkPolicyCorrelation(true)
 	opts := Options{EnableNetworkPolicyCorrelation: false}
 	opt(&opts)
 	assert.True(t, opts.EnableNetworkPolicyCorrelation)
-	assert.Equal(t, want, buf.String())
 }
 
 func TestSkipUnknownCGroupIDs(t *testing.T) {
-	want := "level=info msg=\"configured Hubble to skip events with unknown CGroup IDs\" options=false\n"
-	var buf bytes.Buffer
-	logger := slog.New(
-		slog.NewTextHandler(&buf,
-			&slog.HandlerOptions{
-				ReplaceAttr: logging.ReplaceAttrFnWithoutTimestamp,
-			},
-		),
-	)
-	opt := WithSkipUnknownCGroupIDs(logger, false)
+	opt := WithSkipUnknownCGroupIDs(false)
 	opts := Options{SkipUnknownCGroupIDs: true}
 	opt(&opts)
 	assert.False(t, opts.SkipUnknownCGroupIDs)
-	assert.Equal(t, want, buf.String())
 }

--- a/pkg/hubble/parser/seven/http_test.go
+++ b/pkg/hubble/parser/seven/http_test.go
@@ -508,7 +508,7 @@ func TestDecodeL7HTTPRequestRemoveUrlQuery(t *testing.T) {
 	lr.SourceEndpoint.Port = 56789
 	lr.DestinationEndpoint.Port = 80
 
-	opts := []options.Option{options.WithRedact(nil, true, true, false, []string{}, []string{"authorization"})}
+	opts := []options.Option{options.WithRedact(true, true, false, []string{}, []string{"authorization"})}
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
@@ -556,7 +556,7 @@ func TestDecodeL7HTTPRequestHeadersRedact(t *testing.T) {
 	lr.SourceEndpoint.Port = 56789
 	lr.DestinationEndpoint.Port = 80
 
-	opts := []options.Option{options.WithRedact(nil, true, true, false, []string{"host"}, []string{})}
+	opts := []options.Option{options.WithRedact(true, true, false, []string{"host"}, []string{})}
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
@@ -574,7 +574,7 @@ func TestDecodeL7HTTPRequestHeadersRedact(t *testing.T) {
 		},
 	}, f.GetL7().GetHttp())
 
-	opts = []options.Option{options.WithRedact(nil, true, true, false, []string{}, []string{"host"})}
+	opts = []options.Option{options.WithRedact(true, true, false, []string{}, []string{"host"})}
 	parser, err = New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
@@ -694,7 +694,7 @@ func TestDecodeL7HTTPRequestPasswordRedact(t *testing.T) {
 	lr.SourceEndpoint.Port = 56789
 	lr.DestinationEndpoint.Port = 80
 
-	opts := []options.Option{options.WithRedact(nil, true, true, false, []string{}, []string{})}
+	opts := []options.Option{options.WithRedact(true, true, false, []string{}, []string{})}
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 

--- a/pkg/hubble/parser/sock/parser_test.go
+++ b/pkg/hubble/parser/sock/parser_test.go
@@ -401,7 +401,7 @@ func TestDecodeSockEvent(t *testing.T) {
 	}
 
 	logger := hivetest.Logger(t)
-	p, err := New(logger, endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter, cgroupGetter, options.WithSkipUnknownCGroupIDs(logger, false))
+	p, err := New(logger, endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter, cgroupGetter, options.WithSkipUnknownCGroupIDs(false))
 	assert.NoError(t, err)
 
 	for _, tc := range tt {

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -649,7 +649,7 @@ func TestNetworkPolicyCorrelationDisabled(t *testing.T) {
 		},
 	}
 
-	opts := []options.Option{options.WithNetworkPolicyCorrelation(hivetest.Logger(t), false)}
+	opts := []options.Option{options.WithNetworkPolicyCorrelation(false)}
 	parser, err := New(hivetest.Logger(t), endpointGetter, identityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter, opts...)
 	require.NoError(t, err)
 


### PR DESCRIPTION
The Hubble parser options are already logged as part of the Hubble cell options. There is no point in logging the values again in each `options.With*` function.

Ref. https://github.com/cilium/cilium/pull/39355#discussion_r2097838178

Suggested-by: @kaworu 