### PR TITLE
bpf: nodeport: don't track L2 addr for connection to local backend (v2)

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1377,13 +1377,14 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 			return DROP_UNKNOWN_CT;
 		}
 
-		ret = neigh_record_ip6(ctx);
-		if (ret < 0)
-			return ret;
 		if (backend_local) {
 			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 			return CTX_ACT_OK;
 		}
+
+		ret = neigh_record_ip6(ctx);
+		if (ret < 0)
+			return ret;
 	}
 
 	/* TX request to remote backend: */
@@ -2715,16 +2716,14 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 			return DROP_UNKNOWN_CT;
 		}
 
-		/* Neighbour tracking is needed for local backend until
-		 * https://github.com/cilium/cilium/issues/24062 is resolved.
-		 */
-		ret = neigh_record_ip4(ctx);
-		if (ret < 0)
-			return ret;
 		if (backend_local) {
 			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 			return CTX_ACT_OK;
 		}
+
+		ret = neigh_record_ip4(ctx);
+		if (ret < 0)
+			return ret;
 	}
 
 	/* TX request to remote backend: */


### PR DESCRIPTION
This re-introduces the optimization from
https://github.com/cilium/cilium/pull/24324.

The reasoning back then was
> Replies by a local backend either get their L2 resolution by the stack,
> or (when bpf_lxc uses bpf-host-routing) by bpf_redirect_neigh().
> But fib_redirect_*() will never fall through to the L2 neigh cache to get
> the client's MAC address.

But this was later reverted in https://github.com/cilium/cilium/pull/34303 because we had missed one case - older kernels which don't have fib_redirect_neigh(), and where Cilium thus might end up looking for the client's MAC in the neighbor map.

Now that we have bumped the minimum kernel requirement to v5.10 and *require* fib_redirect_neigh() to be available, let's bring this change back.