### PR TITLE
add doc for bgp autodiscovery

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -86,6 +86,102 @@ and two peers configured under this BGP instance.
           peerConfigRef:
             name: "cilium-peer"
 
+Auto-Discovery
+--------------
+
+Cilium BGP Control Plane also supports automatic discovery of BGP peers.
+
+When enabled, the auto-discovery feature self-configures the BGP peer's IP address automatically. Selection of the specific address is dependent on the ``mode`` enabled.
+
+Cilium BGP Control Plane currently supports ``DefaultGateway`` mode for auto-discovery under ``autoDiscovery`` field in ``CiliumBGPClusterConfig``.
+
+Default Gateway Auto-Discovery
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default gateway auto-discovery mode allows Cilium to automatically discover and establish BGP session with the default gateway (typically a Top-of-Rack (ToR) switch) for a specified address family.
+
+To enable default gateway auto-discovery, configure the ``autoDiscovery`` field in the peer configuration:
+
+.. code-block:: yaml
+
+    peers:
+    - name: "tor-switch"
+      peerASN: 65000
+      autoDiscovery:
+        mode: "DefaultGateway"
+        defaultGateway:
+          addressFamily: ipv6  # Can be "ipv4" or "ipv6"
+      peerConfigRef:
+        name: "cilium-peer"
+
+Here are the ToR switch BGP configuration requirements:
+
+* ToR switches must be configured with "bgp listen range" to support dynamic BGP neighbors. This configuration enables the ToR switch to accept BGP sessions from Cilium nodes by listening for connections from a specific IP prefix range, eliminating the need to know the exact peer address of each Cilium node.
+  
+  For more details, see the `FRR documentation <https://docs.frrouting.org/en/latest/bgp.html#clicmd-bgp-listen-range-A.B.C.D-M-X-X-X-X-M-peer-group-PGNAME>`__.
+
+* Configure each ToR switch with the same local ASN (Autonomous System Number) to ensure Cilium configuration remains consistent across all cluster nodes.
+
+For example::
+
+  router bgp 65100
+    neighbor CILIUM peer-group
+    neighbor CILIUM local-as 65000 no-prepend replace-as
+    bgp listen range fd00:10:0:1::/64 peer-group CILIUM
+
+
+Once this configuration is applied:
+
+* Cilium determines the default gateway for the specified address family on each node
+* It automatically establishes a BGP session with the discovered gateway
+* It uses the peer configuration referenced by ``peerConfigRef`` for session parameters
+
+.. warning::
+
+   Link-local address as default gateway is not supported.
+
+Multi-homing with Default Gateway Auto-Discovery
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In multi-homing setups, the Cilium node connects to two different Top-of-Rack switches. It discovers both the default gateways, but it
+picks the default route with the lower metric to establish the BGP session. It's important to note that Cilium creates only one BGP session per address family
+at a time. A failure or a change of the default route with the lower metric triggers a reconciliation to establish the BGP session with the default gateway
+of the other default route.
+
+Example configuration:
+
+.. code-block:: yaml
+
+    bgpInstances:
+    - name: "65001"
+      localASN: 65001
+      peers:
+      - name: "instance-65001"
+        peerASN: 65000
+        autoDiscovery:
+          mode: "DefaultGateway"
+          defaultGateway:
+            addressFamily: ipv6
+        peerConfigRef:
+          name: "cilium-peer"
+
+Verification
+~~~~~~~~~~~~
+
+To verify that BGP sessions are established with the auto-discovered peers, use the ``cilium bgp peers`` command:
+
+.. code-block:: shell-session
+
+    $ cilium bgp peers
+    Local AS   Peer AS   Peer Address         Session       Uptime   Family         Received   Advertised
+    65001      65000     fd00:10:0:1::1:179   established   21m55s   ipv4/unicast   2          2    
+                                                                     ipv6/unicast   2          2
+
+Limitations
+~~~~~~~~~~~
+Auto Discovery with ``DefaultGateway`` mode in multi-homing setup can not be used to create multiple BGP sessions for the same address family.
+Currently, the only workaround is to configure the peer address manually for each peer.
+
 .. _bgp_peer_configuration:
 
 BGP Peer Configuration

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -123,6 +123,7 @@ Talos
 Telco
 Terraform
 Tierney
+ToR
 Triagers
 Twilio
 Uncompress


### PR DESCRIPTION
Fixes: #37315 (add documentation for bgp autodiscovery and DefaultGateway mode)

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Adding documentation for bgp peer auto-discovery and DefaultGateway mode.
bgp peer autodiscovery was added in this PR: https://github.com/cilium/cilium/pull/39416

Screenshot of documentation
![image](https://github.com/user-attachments/assets/3b69d752-a999-4bbd-bdeb-33ec405d025d)

![image](https://github.com/user-attachments/assets/ce540d74-ae2e-4a25-8bcf-8b1badad7764)



```release-note
docs: Add documentation for BGP Peer Auto-Discovery
```
