### PR TITLE
hive: Start the module job groups last

### DIFF
--- a/vendor/github.com/cilium/hive/cell/lifecycle.go
+++ b/vendor/github.com/cilium/hive/cell/lifecycle.go
@@ -96,6 +96,13 @@ func (lc *DefaultLifecycle) Append(hook HookInterface) {
 	lc.hooks = append(lc.hooks, augmentedHook{hook, nil})
 }
 
+func (lc *DefaultLifecycle) AppendWithModuleID(hook HookInterface, moduleID FullModuleID) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+
+	lc.hooks = append(lc.hooks, augmentedHook{hook, moduleID})
+}
+
 func (lc *DefaultLifecycle) Start(log *slog.Logger, ctx context.Context) error {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()


### PR DESCRIPTION
The job groups were provided for each module and its lifecycle hooks appended when constructed. This is problematic when the job group is used multiple times as then the dependencies of the later uses won't influence the order in which start hooks run, e.g. if a later job depends on X it might happen that the job is started before X is started.

For example:
```
  cell.Module(...,
    cell.Provide(newX),

    // First use of the job.Group will construct it and append hooks to
    // lifecycle.
    cell.Invoke(func(jg job.Group, ...) { jg.Add( ... )}),

    // This second use will construct X and append its hooks, but these
    // are now *after* the job.Group's hooks and hence we might start the
    // job after X has been constructed.
    cell.Invoke(func(jg job.Group, x *X) { jg.Add( ... )}),
  )
```

To fix this, we'll make the job groups start as the very last thing in the lifecycle which ensures all the start hooks of provided objects are run.

This will mean that Start hooks cannot block on work done from jobs, e.g. await on a promise resolved by a job etc. Instead in these cases a job must be used instead. This is a good thing though as it'll increase parallelism at start and avoid temptations to block in start hooks.

---

TODO:
- Add 'Fixes' to commit messages
- Merge https://github.com/cilium/hive/pull/50 and bump cilium/hive
- Review uses of module-scoped `job.Group` and see if any released version of Cilium could potentially hit this. If so add release notes.