### PR TITLE
bpf:classifiers: add Overlay VXLAN/Geneve classifiers

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1482,7 +1482,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 __section_entry
 int cil_from_container(struct __ctx_buff *ctx)
 {
-	__u16 proto;
+	__u16 proto = 0;
 	__u32 sec_label = SECLABEL;
 	__s8 ext_err = 0;
 	int ret;

--- a/bpf/lib/classifiers.h
+++ b/bpf/lib/classifiers.h
@@ -4,6 +4,9 @@
 #pragma once
 
 #include "lib/common.h"
+#include "lib/ipv4.h"
+#include "lib/ipv6.h"
+#include "lib/l4.h"
 
 typedef __u8 cls_flags_t;
 
@@ -16,10 +19,24 @@ enum {
 	CLS_FLAG_IPV6	   = (1 << 0),
 	/* Packet originates from a L3 device (no ethernet header). */
 	CLS_FLAG_L3_DEV    = (1 << 1),
+	/* Packet uses underlay VXLAN. */
+	CLS_FLAG_VXLAN     = (1 << 2),
+	/* Packet uses underlay Geneve. */
+	CLS_FLAG_GENEVE    = (1 << 3),
 };
 
 /* Wrapper for specifying empty flags during the trace/drop event. */
 #define CLS_FLAG_NONE ((cls_flags_t)0)
+
+#ifdef HAVE_ENCAP
+/* Return the correct overlay flag CLS_FLAG_{VXLAN,GENEVE} based on the current TUNNEL_PROTOCOL. */
+#define CLS_FLAG_TUNNEL                               \
+	(__builtin_constant_p(TUNNEL_PROTOCOL) ?              \
+		((TUNNEL_PROTOCOL) == TUNNEL_PROTOCOL_VXLAN ? CLS_FLAG_VXLAN : \
+		 (TUNNEL_PROTOCOL) == TUNNEL_PROTOCOL_GENEVE ? CLS_FLAG_GENEVE : \
+		 (__throw_build_bug(), 0))                        \
+	: (__throw_build_bug(), 0))
+#endif
 
 /**
  * ctx_classify
@@ -27,12 +44,23 @@ enum {
  * @proto: the layer 3 protocol (ETH_P_IP, ETH_P_IPV6).
  *
  * Compute classifiers (CLS_FLAG_*) for the given packet to be used during
- * trace/drop notification events.
+ * trace/drop notification events. There exists two main computation methods:
+ *
+ * 1. inspecting ctx->mark for known magic values (ex. MARK_MAGIC_OVERLAY).
+ * 3. inspecting L3/L4 headers for known traffic patterns (ex. UDP+OverlayPort).
  */
 static __always_inline cls_flags_t
-ctx_classify(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
+ctx_classify(struct __ctx_buff *ctx, __be16 proto)
 {
 	cls_flags_t flags = CLS_FLAG_NONE;
+	bool parse_overlay = false;
+	void __maybe_unused *data;
+	void __maybe_unused *data_end;
+	struct ipv6hdr __maybe_unused *ip6;
+	struct iphdr __maybe_unused *ip4;
+	__be16 __maybe_unused dport;
+	__u8 __maybe_unused l4_proto;
+	int __maybe_unused l3_hdrlen;
 
 	/*
 	 * Retrieve protocol when not being provided.
@@ -49,5 +77,75 @@ ctx_classify(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
 	if (proto == bpf_htons(ETH_P_IPV6))
 		flags |= CLS_FLAG_IPV6;
 
+/* ctx->mark not available in XDP. */
+#if __ctx_is == __ctx_skb
+# ifdef HAVE_ENCAP
+	/* MARK_MAGIC_OVERLAY is used in to-{netdev,wireguard}. */
+	if ((is_defined(IS_BPF_HOST) || is_defined(IS_BPF_WIREGUARD)) &&
+	    (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_OVERLAY) {
+		flags |= CLS_FLAG_TUNNEL;
+		goto out;
+	}
+# endif /* HAVE_ENCAP */
+#endif /* __ctx_skb */
+
+#ifdef HAVE_ENCAP
+	/* Enable parsing packet headers for Overlay in from-{netdev,wireguard} and to-stack. */
+	if (is_defined(IS_BPF_HOST) || is_defined(IS_BPF_WIREGUARD))
+		parse_overlay = true;
+#endif /* HAVE_ENCAP */
+
+	/*
+	 * Skip subsequent logic that parses the packet L3/L4 headers
+	 * when not needed. For new classifiers, let's use other variables `parse_*`.
+	 */
+	if (!parse_overlay)
+		goto out;
+
+	/*
+	 * Inspect the L3 protocol, and retrieve l4_proto and l3_hdrlen.
+	 * For IPv6, let's stop at the first header.
+	 */
+	switch (proto) {
+# ifdef ENABLE_IPV6
+	case bpf_htons(ETH_P_IPV6):
+		if (!revalidate_data(ctx, &data, &data_end, &ip6))
+			goto out;
+
+		l4_proto = ip6->nexthdr;
+		l3_hdrlen = sizeof(struct ipv6hdr);
+		break;
+# endif /* ENABLE_IPV6 */
+# ifdef ENABLE_IPV4
+	case bpf_htons(ETH_P_IP):
+		if (!revalidate_data(ctx, &data, &data_end, &ip4))
+			goto out;
+
+		l4_proto = ip4->protocol;
+		l3_hdrlen = ipv4_hdrlen(ip4);
+		break;
+# endif /* ENABLE_IPV4 */
+	default:
+		goto out;
+	}
+
+	/*
+	 * Inspect the L4 protocol, looking for specific traffic patterns:
+	 * - Overlay: UDP with destination port TUNNEL_PORT.
+	 */
+	switch (l4_proto) {
+	case IPPROTO_UDP:
+		if (l4_load_port(ctx, ETH_HLEN + l3_hdrlen + UDP_DPORT_OFF, &dport) < 0)
+			goto out;
+#ifdef HAVE_ENCAP
+		if (parse_overlay && dport == bpf_htons(TUNNEL_PORT)) {
+			flags |= CLS_FLAG_TUNNEL;
+			goto out;
+		}
+#endif /* HAVE_ENCAP */
+		break;
+	}
+
+out:
 	return flags;
 }

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -85,7 +85,7 @@ int tail_drop_notify(struct __ctx_buff *ctx)
 			return exitcode;
 	}
 
-	flags = ctx_classify(ctx);
+	flags = ctx_classify(ctx, 0);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -85,7 +85,7 @@ int tail_drop_notify(struct __ctx_buff *ctx)
 			return exitcode;
 	}
 
-	flags = ctx_classify(ctx, 0);
+	flags = ctx_classify(ctx, 0, TRACE_POINT_UNKNOWN);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),

--- a/bpf/lib/notify.h
+++ b/bpf/lib/notify.h
@@ -46,6 +46,7 @@ enum {
 
 /* Available observation points. */
 enum trace_point {
+	TRACE_POINT_UNKNOWN = -1,
 	TRACE_TO_LXC,
 	TRACE_TO_PROXY,
 	TRACE_TO_HOST,

--- a/bpf/lib/notify.h
+++ b/bpf/lib/notify.h
@@ -44,3 +44,20 @@ enum {
 	.len_cap	= (c),		\
 	.version	= (v)
 
+/* Available observation points. */
+enum trace_point {
+	TRACE_TO_LXC,
+	TRACE_TO_PROXY,
+	TRACE_TO_HOST,
+	TRACE_TO_STACK,
+	TRACE_TO_OVERLAY,
+	TRACE_FROM_LXC,
+	TRACE_FROM_PROXY,
+	TRACE_FROM_HOST,
+	TRACE_FROM_STACK,
+	TRACE_FROM_OVERLAY,
+	TRACE_FROM_NETWORK,
+	TRACE_TO_NETWORK,
+	TRACE_FROM_CRYPTO,
+	TRACE_TO_CRYPTO,
+} __packed;

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -218,7 +218,7 @@ static __always_inline void
 _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src, __u32 dst, __u16 dst_id, __u32 ifindex,
 		   enum trace_reason reason, __u32 monitor,
-		   __be16 proto __maybe_unused, __u16 line, __u8 file)
+		   __be16 proto, __u16 line, __u8 file)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
@@ -244,7 +244,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 			return;
 	}
 
-	flags = ctx_classify(ctx);
+	flags = ctx_classify(ctx, proto);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
@@ -293,8 +293,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 			return;
 	}
 
-	flags = ctx_classify(ctx);
-
+	flags = ctx_classify(ctx, bpf_htons(ETH_P_IP));
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
@@ -343,7 +342,7 @@ _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 			return;
 	}
 
-	flags = ctx_classify(ctx) | CLS_FLAG_IPV6;
+	flags = ctx_classify(ctx, bpf_htons(ETH_P_IPV6));
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -229,7 +229,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 			return;
 	}
 
-	flags = ctx_classify(ctx, proto);
+	flags = ctx_classify(ctx, proto, obs_point);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
@@ -278,7 +278,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 			return;
 	}
 
-	flags = ctx_classify(ctx, bpf_htons(ETH_P_IP));
+	flags = ctx_classify(ctx, bpf_htons(ETH_P_IP), obs_point);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
@@ -327,7 +327,7 @@ _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 			return;
 	}
 
-	flags = ctx_classify(ctx, bpf_htons(ETH_P_IPV6));
+	flags = ctx_classify(ctx, bpf_htons(ETH_P_IPV6), obs_point);
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -30,24 +30,6 @@
 #include "ratelimit.h"
 #include "classifiers.h"
 
-/* Available observation points. */
-enum trace_point {
-	TRACE_TO_LXC,
-	TRACE_TO_PROXY,
-	TRACE_TO_HOST,
-	TRACE_TO_STACK,
-	TRACE_TO_OVERLAY,
-	TRACE_FROM_LXC,
-	TRACE_FROM_PROXY,
-	TRACE_FROM_HOST,
-	TRACE_FROM_STACK,
-	TRACE_FROM_OVERLAY,
-	TRACE_FROM_NETWORK,
-	TRACE_TO_NETWORK,
-	TRACE_FROM_CRYPTO,
-	TRACE_TO_CRYPTO,
-} __packed;
-
 /* Reasons for forwarding a packet, keep in sync with pkg/monitor/datapath_trace.go */
 enum trace_reason {
 	TRACE_REASON_POLICY = CT_NEW,

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -133,6 +133,9 @@ _update_trace_metrics(struct __ctx_buff *ctx, enum trace_point obs_point,
 		__throw_build_bug();
 		break;
 #endif
+	case TRACE_POINT_UNKNOWN:
+		__throw_build_bug();
+		break;
 	}
 }
 


### PR DESCRIPTION
With this patch, the datapath is now able to signal Overlay packets during Trace/Drop notification events.
This is useful for two main reasons (treated in separate upcoming PRs):

1. Hubble/Monitor do not need to rely on fixed ports to decode overlay packets, they simply check this flag;
2. Datapath can then send more bytes during such events in case of Overlay packets when not needed

These new flags are solely used for tracing events and they do not interfere with bpf metrics computation.
The VXLAN/GENEVE flags can be computed either:

1. via ctx->mark (SKB only): we do set MARK_MAGIC_OVERLAY on the egress path of a packet.
2. via parsing L2/L3/L4 headers: matching for UDP with TUNNEL_PORT.

Please do refer to commit messages for a detailed description and considerations of the introduced changes.

Fixes: #39032

```release-note
 Introduce traffic classifiers CLS_FLAG_{VXLAN,GENEVE} for tracing overlay traffic.
```