### PR TITLE
bpf:wireguard: reuse MARK_MAGIC_ENCRYPT for encrypted packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1672,14 +1672,14 @@ int cil_to_host(struct __ctx_buff *ctx)
 	/* Prefer ctx->mark when it is set to one of the expected values.
 	 * Also see https://github.com/cilium/cilium/issues/36329.
 	 */
-	if (((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) ||
-	    ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_TO_PROXY))
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_TO_PROXY)
 		magic = ctx->mark;
+#ifdef ENABLE_IPSEC
+	else if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT)
+		magic = ctx->mark;
+#endif
 
-	if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
-		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
-		src_id = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
-	} else if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
+	if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
 		/* Upper 16 bits may carry proxy port number */
 		__be16 port = magic >> 16;
 		/* We already traced this in the previous prog with more
@@ -1691,6 +1691,12 @@ int cil_to_host(struct __ctx_buff *ctx)
 		ret = ctx_redirect_to_proxy_first(ctx, port);
 		goto out;
 	}
+#ifdef ENABLE_IPSEC
+	else if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
+		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
+		src_id = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+	}
+#endif
 
 #ifdef ENABLE_IPSEC
 	/* Encryption stack needs this when IPSec headers are

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -27,6 +27,7 @@ int cil_from_network(struct __ctx_buff *ctx)
 
 	bpf_clear_meta(ctx);
 
+#ifdef ENABLE_IPSEC
 	/* This program should be attached to the tc-ingress of
 	 * the network-facing device. Thus, as far as Cilium
 	 * knows, no one touches to the ctx->mark before this
@@ -39,7 +40,6 @@ int cil_from_network(struct __ctx_buff *ctx)
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT)
 		obs_point_from = TRACE_FROM_STACK;
 
-#ifdef ENABLE_IPSEC
 	/* Pass unknown protocols to the stack */
 	if (!validate_ethertype(ctx, &proto))
 		goto out;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -63,7 +63,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	void *data_end, *data;
 	struct ipv6hdr *ip6;
 	struct endpoint_info *ep;
-	bool decrypted;
+	bool decrypted = false;
 	bool __maybe_unused is_dsr = false;
 	fraginfo_t fraginfo __maybe_unused;
 
@@ -107,7 +107,9 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	 */
 	info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
 
+#ifdef ENABLE_IPSEC
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+#endif
 	if (decrypted) {
 		if (info)
 			*identity = info->sec_identity;
@@ -330,7 +332,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	void *data_end, *data;
 	struct iphdr *ip4;
 	struct endpoint_info *ep;
-	bool decrypted;
+	bool decrypted = false;
 	bool __maybe_unused is_dsr = false;
 	fraginfo_t fraginfo __maybe_unused;
 	int ret;
@@ -385,7 +387,9 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	 */
 	info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 
+#ifdef ENABLE_IPSEC
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+#endif
 	/* If packets are decrypted the key has already been pushed into metadata. */
 	if (decrypted) {
 		if (info)
@@ -639,7 +643,7 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 {
 	__u32 src_sec_identity = 0;
 	__s8 ext_err = 0;
-	bool decrypted;
+	bool decrypted = false;
 	__u16 proto;
 	int ret;
 
@@ -671,7 +675,9 @@ int cil_from_overlay(struct __ctx_buff *ctx)
  * if the packets are ESP, because it doesn't matter for the
  * non-IPSec mode.
  */
+#ifdef ENABLE_IPSEC
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+#endif
 
 	switch (proto) {
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -564,6 +564,11 @@ enum metric_dir {
  * encrypting a packet. The MSB invades the Kubernetes mark "space" which is
  * fine, as it's not used by K8s. See pkg/datapath/linux/linux_defaults/mark.go
  * for more details.
+ *
+ * NOTE: from v1.18 we reuse MARK_MAGIC_ENCRYPT for WireGuard-encrypted packets,
+ * but we still need this value to handle upgrades from v1.17.
+ *
+ * TODO: can be removed in v1.19 in favor of MARK_MAGIC_ENCRYPT.
  */
 #define MARK_MAGIC_WG_ENCRYPTED		0x1E00
 

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -181,8 +181,10 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 		*identity = get_identity(ctx);
 	} else if (magic == MARK_MAGIC_HOST) {
 		*identity = HOST_ID;
+#ifdef ENABLE_IPSEC
 	} else if (magic == MARK_MAGIC_ENCRYPT) {
 		*identity = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+#endif
 	} else {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 		__u16 proto = ctx_get_protocol(ctx);

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -260,7 +260,9 @@ static __always_inline bool ctx_mark_is_wireguard(const struct __sk_buff *ctx)
 	if (!is_defined(ENABLE_WIREGUARD))
 		return false;
 
-	return (ctx->mark & MARK_MAGIC_WG_ENCRYPTED) == MARK_MAGIC_WG_ENCRYPTED;
+	/* Handle upgrades from v1.17, where we still use MARK_MAGIC_WG_ENCRYPTED. */
+	return (ctx->mark & MARK_MAGIC_WG_ENCRYPTED) == MARK_MAGIC_WG_ENCRYPTED ||
+			(ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT;
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY_COMMON

--- a/pkg/datapath/linux/linux_defaults/mark.go
+++ b/pkg/datapath/linux/linux_defaults/mark.go
@@ -20,7 +20,7 @@ package linux_defaults
 //	+-----------------------------------------------+
 //	 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4
 //
-// Kubernetes Mark (4 bits; see MagicMarkWireGuardEncrypted for usage of some of
+// Kubernetes Mark (4 bits; see MagicMarkDecryptedOverlay for usage of some of
 // K8s mark space):
 // R R R R
 // 0 1 0 0  Masquerade
@@ -100,13 +100,7 @@ const (
 	// in order to indicate that a packet has been encrypted, and that there
 	// is no need to forward it again to the WG tunnel netdev.
 	//
-	// The mark invades the K8s mark space described above. This is because
-	// some packets might carry a security identity which is indicated with
-	// MagicMarkIdentity which takes all 4 bits. The LSB bit which we take
-	// from the K8s space is not used, so this is fine). I.e., the LSB bit is
-	// 0x1000, and the K8s marks are 0x4000 and 0x8000. So both are not
-	// interfering with that bit.
-	MagicMarkWireGuardEncrypted int = 0x1E00
+	MagicMarkWireGuardEncrypted int = MagicMarkEncrypt
 
 	// MagicMarkDecrypt is the packet mark used to indicate the datapath needs
 	// to decrypt a packet.
@@ -118,6 +112,13 @@ const (
 	// When this mark is present on a packet it indicates that overlay traffic
 	// was decrypted by XFRM and should be forwarded to a tunnel device for
 	// decapsulation.
+	//
+	// The mark invades the K8s mark space described above. This is because
+	// some packets might carry a security identity which is indicated with
+	// MagicMarkIdentity which takes all 4 bits. The LSB bit which we take
+	// from the K8s space is not used, so this is fine). I.e., the LSB bit is
+	// 0x1000, and the K8s marks are 0x4000 and 0x8000. So both are not
+	// interfering with that bit.
 	MagicMarkDecryptedOverlay = 0x1D00
 
 	// MagicMarkEncrypt is the packet mark to use to indicate datapath


### PR DESCRIPTION
By protecting previous usages of MARK_MAGIC_ENCRYPT in the IPSec codepaths, we should be able to reuse such mark also to signal WG-encrypted packets. This allows us to save the bit from the k8s mark space and use our host mask.

A backport patch to v1.17 has been submitted https://github.com/cilium/cilium/pull/39652 to be able to recognize WG-encrypted packets in the previous version, which still uses MARK_MAGIC_WG_ENCRYPTED, during downgrades. As soon as it gets merged, `ci-e2e-upgrade` tests should pass.