### PR TITLE
[v1.17] bpf:wireguard: reuse MARK_MAGIC_ENCRYPT for encrypted packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1606,6 +1606,9 @@ skip_egress_gateway:
 	 * bpf_host@eth0 => ...; this happens when eth0 is used to send
 	 * encrypted WireGuard UDP packets), we check whether the mark
 	 * is set before the redirect.
+	 *
+	 * NOTE: from v1.18, where we use MARK_MAGIC_ENCRYPT also for
+	 * WireGuard-encrypted traffic. This is handled in ctx_mark_is_wireguard.
 	 */
 	if (!ctx_mark_is_wireguard(ctx)) {
 		ret = host_wg_encrypt_hook(ctx, proto, src_sec_identity);

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1681,14 +1681,14 @@ int cil_to_host(struct __ctx_buff *ctx)
 	/* Prefer ctx->mark when it is set to one of the expected values.
 	 * Also see https://github.com/cilium/cilium/issues/36329.
 	 */
-	if (((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) ||
-	    ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_TO_PROXY))
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_TO_PROXY)
 		magic = ctx->mark;
+#ifdef ENABLE_IPSEC
+	else if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT)
+		magic = ctx->mark;
+#endif
 
-	if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
-		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
-		src_id = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
-	} else if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
+	if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
 		/* Upper 16 bits may carry proxy port number */
 		__be16 port = magic >> 16;
 		/* We already traced this in the previous prog with more
@@ -1700,6 +1700,12 @@ int cil_to_host(struct __ctx_buff *ctx)
 		ret = ctx_redirect_to_proxy_first(ctx, port);
 		goto out;
 	}
+#ifdef ENABLE_IPSEC
+	else if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
+		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
+		src_id = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+	}
+#endif
 
 #ifdef ENABLE_IPSEC
 	/* Encryption stack needs this when IPSec headers are

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -27,6 +27,7 @@ int cil_from_network(struct __ctx_buff *ctx)
 
 	bpf_clear_meta(ctx);
 
+#ifdef ENABLE_IPSEC
 	/* This program should be attached to the tc-ingress of
 	 * the network-facing device. Thus, as far as Cilium
 	 * knows, no one touches to the ctx->mark before this
@@ -39,7 +40,6 @@ int cil_from_network(struct __ctx_buff *ctx)
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT)
 		obs_point_from = TRACE_FROM_STACK;
 
-#ifdef ENABLE_IPSEC
 	/* Pass unknown protocols to the stack */
 	if (!validate_ethertype(ctx, &proto))
 		goto out;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -53,7 +53,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	void *data_end, *data;
 	struct ipv6hdr *ip6;
 	struct endpoint_info *ep;
-	bool decrypted;
+	bool decrypted = false;
 	bool __maybe_unused is_dsr = false;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
@@ -87,7 +87,9 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	 */
 	info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
 
+#ifdef ENABLE_IPSEC
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+#endif
 	if (decrypted) {
 		if (info)
 			*identity = info->sec_identity;
@@ -287,7 +289,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	void *data_end, *data;
 	struct iphdr *ip4;
 	struct endpoint_info *ep;
-	bool decrypted;
+	bool decrypted = false;
 	bool __maybe_unused is_dsr = false;
 	int ret;
 
@@ -340,7 +342,9 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	 */
 	info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 
+#ifdef ENABLE_IPSEC
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+#endif
 	/* If packets are decrypted the key has already been pushed into metadata. */
 	if (decrypted) {
 		if (info)
@@ -651,7 +655,7 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 {
 	__u32 src_sec_identity = 0;
 	__s8 ext_err = 0;
-	bool decrypted;
+	bool decrypted = false;
 	__u16 proto;
 	int ret;
 
@@ -686,7 +690,9 @@ int cil_from_overlay(struct __ctx_buff *ctx)
  * if the packets are ESP, because it doesn't matter for the
  * non-IPSec mode.
  */
+#ifdef ENABLE_IPSEC
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+#endif
 
 	switch (proto) {
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -181,8 +181,10 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 		*identity = get_identity(ctx);
 	} else if (magic == MARK_MAGIC_HOST) {
 		*identity = HOST_ID;
+#ifdef ENABLE_IPSEC
 	} else if (magic == MARK_MAGIC_ENCRYPT) {
 		*identity = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+#endif
 #if defined(ENABLE_L7_LB)
 	} else if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
 		*identity = get_epid(ctx); /* endpoint identity, not security identity! */

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -275,7 +275,12 @@ static __always_inline bool ctx_mark_is_wireguard(const struct __sk_buff *ctx)
 	if (!is_defined(ENABLE_WIREGUARD))
 		return false;
 
-	return (ctx->mark & MARK_MAGIC_WG_ENCRYPTED) == MARK_MAGIC_WG_ENCRYPTED;
+	/*
+	 * Handle downgrades from v1.18, where we use MARK_MAGIC_ENCRYPT also for
+	 * WireGuard-encrypted traffic.
+	 */
+	return (ctx->mark & MARK_MAGIC_WG_ENCRYPTED) == MARK_MAGIC_WG_ENCRYPTED ||
+			(ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT;
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY_COMMON


### PR DESCRIPTION
Manual backport of:

- [ ] https://github.com/cilium/cilium/pull/39651

With this patch, we protect previous usages of MARK_MAGIC_ENCRYPT which refer only to the IPSec codepath.
In v1.18, we start using that mark to signal also WireGuard encrypted packets, replacing the old MARK_MAGIC_WG_ENCRYPTED that overlaps with the k8s mark space.
This means that v1.17 needs to be able to understand that mark too in the WireGuard codepaths.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 39651
```