### PR TITLE
eni: Associate EIPs with ENIs instead of instance

### DIFF
--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -651,7 +651,7 @@ func (e *API) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap,
 	return &instance, nil
 }
 
-func (e *API) AssociateEIP(ctx context.Context, instanceID string, eipTags ipamTypes.Tags) (string, error) {
+func (e *API) AssociateEIP(ctx context.Context, eniID string, eipTags ipamTypes.Tags) (string, error) {
 	e.rateLimit()
 	e.delaySim.Delay(AssociateEIP)
 
@@ -664,19 +664,16 @@ func (e *API) AssociateEIP(ctx context.Context, instanceID string, eipTags ipamT
 
 	ipAddr := "192.0.2.254"
 
-	// Assign the EIP to the ENI 0 of the instance
-	for iid, enis := range e.enis {
-		if iid == instanceID {
-			for _, eni := range enis {
-				if eni.Number == 0 {
-					eni.PublicIP = ipAddr
-					return ipAddr, nil
-				}
+	for _, enis := range e.enis {
+		for id, eni := range enis {
+			if eniID == id {
+				eni.PublicIP = ipAddr
+				return ipAddr, nil
 			}
 		}
 	}
 
-	return "", fmt.Errorf("unable to find ENI 0 for instance %s", instanceID)
+	return "", fmt.Errorf("unable to find ENI %s", eniID)
 }
 
 func (e *API) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error) {

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -42,7 +42,7 @@ type EC2API interface {
 	AssignENIPrefixes(ctx context.Context, eniID string, prefixes int32) error
 	UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []string) error
 	GetInstanceTypes(context.Context) ([]ec2_types.InstanceTypeInfo, error)
-	AssociateEIP(ctx context.Context, instanceID string, eipTags ipamTypes.Tags) (string, error)
+	AssociateEIP(ctx context.Context, eniID string, eipTags ipamTypes.Tags) (string, error)
 }
 
 // InstancesManager maintains the list of instances. It must be kept up to date

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -981,7 +981,7 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	staticIP, err := ec2api.AssociateEIP(t.Context(), instanceID, make(ipamTypes.Tags))
+	staticIP, err := ec2api.AssociateEIP(t.Context(), eniID1, make(ipamTypes.Tags))
 	require.NoError(t, err)
 	instances.Resync(t.Context())
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)


### PR DESCRIPTION
Currently when associating an EIP to a node in ENI mode, the EIP is associated with the EC2 instance, but when an EC2 instance has more than one interface, this operation fails with a `operation error EC2: AssociateAddress, https response error StatusCode: 400, RequestID: XXX, api error InvalidInstanceID: There are multiple interfaces attached to instance 'i-XXX'. Please specify an interface ID for the operation instead.` error.

<img width="1839" alt="image" src="https://github.com/user-attachments/assets/d4527022-e69d-4ba3-b584-70b93c6846c0" />



This PR updates the EIP association logic to associate it with one of the instance's ENIs (by setting `NetworkInterfaceId` instead of `InstanceId` on  [`ec2.AssociateAddressInput`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2#AssociateAddressInput).

Reference: see SDK documentation:
```go
...
	// The ID of the instance. The instance must have exactly one attached network
	// interface. You can specify either the instance ID or the network interface ID,
	// but not both.
	InstanceId *string

	// The ID of the network interface. If the instance has more than one network
	// interface, you must specify a network interface ID.
	//
	// You can specify either the instance ID or the network interface ID, but not
	// both.
	NetworkInterfaceId *string
...
```

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
eni: Associate EIPs with ENIs instead of instance
```
