### PR TITLE
bpf: wireguard: simplify check for ICMPv6 NA

### DIFF
--- a/bpf/include/linux/icmpv6.h
+++ b/bpf/include/linux/icmpv6.h
@@ -68,6 +68,7 @@ struct icmp6hdr {
 #define icmp6_mtu		icmp6_dataun.un_data32[0]
 #define icmp6_unused		icmp6_dataun.un_data32[0]
 #define icmp6_maxdelay		icmp6_dataun.un_data16[0]
+#define icmp6_datagram_len	icmp6_dataun.un_data8[0]
 #define icmp6_router		icmp6_dataun.u_nd_advt.router
 #define icmp6_solicited		icmp6_dataun.u_nd_advt.solicited
 #define icmp6_override		icmp6_dataun.u_nd_advt.override
@@ -90,6 +91,8 @@ struct icmp6hdr {
 #define ICMPV6_TIME_EXCEED		3
 #define ICMPV6_PARAMPROB		4
 
+#define ICMPV6_ERRMSG_MAX       127
+
 #define ICMPV6_INFOMSG_MASK		0x80
 
 #define ICMPV6_ECHO_REQUEST		128
@@ -107,6 +110,11 @@ struct icmp6hdr {
 #define ICMPV6_DHAAD_REPLY		145
 #define ICMPV6_MOBILE_PREFIX_SOL	146
 #define ICMPV6_MOBILE_PREFIX_ADV	147
+
+#define ICMPV6_MRDISC_ADV		151
+#define ICMPV6_MRDISC_SOL		152
+
+#define ICMPV6_MSG_MAX          255
 
 /*
  *	Codes for Destination Unreachable
@@ -131,7 +139,11 @@ struct icmp6hdr {
 #define ICMPV6_HDR_FIELD		0
 #define ICMPV6_UNK_NEXTHDR		1
 #define ICMPV6_UNK_OPTION		2
+#define ICMPV6_HDR_INCOMP		3
 
+/* Codes for EXT_ECHO (PROBE) */
+#define ICMPV6_EXT_ECHO_REQUEST		160
+#define ICMPV6_EXT_ECHO_REPLY		161
 /*
  *	constants for (set|get)sockopt
  */

--- a/bpf/include/linux/icmpv6.h
+++ b/bpf/include/linux/icmpv6.h
@@ -101,6 +101,8 @@ struct icmp6hdr {
 #define ICMPV6_MGM_REPORT       	131
 #define ICMPV6_MGM_REDUCTION    	132
 
+#define ICMPV6_NA_MSG			136
+
 #define ICMPV6_NI_QUERY			139
 #define ICMPV6_NI_REPLY			140
 

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -520,11 +520,11 @@ icmp6_host_handle(struct __ctx_buff *ctx, int l4_off, __s8 *ext_err, bool handle
 		/* Decision is deferred to the host policies. */
 		return CTX_ACT_OK;
 
-	if ((ICMP6_UNREACH_MSG_TYPE <= type && type <= ICMP6_PARAM_ERR_MSG_TYPE) ||
-		(ICMP6_MULT_LIST_QUERY_TYPE <= type && type <= ICMP6_NA_MSG_TYPE) ||
-		(ICMP6_INV_NS_MSG_TYPE <= type && type <= ICMP6_MULT_LIST_REPORT_V2_TYPE) ||
-		(ICMP6_SEND_NS_MSG_TYPE <= type && type <= ICMP6_SEND_NA_MSG_TYPE) ||
-		(ICMP6_MULT_RA_MSG_TYPE <= type && type <= ICMP6_MULT_RT_MSG_TYPE))
+	if ((type >= ICMP6_UNREACH_MSG_TYPE && type <= ICMP6_PARAM_ERR_MSG_TYPE) ||
+	    (type >= ICMP6_MULT_LIST_QUERY_TYPE && type <= ICMP6_NA_MSG_TYPE) ||
+	    (type >= ICMP6_INV_NS_MSG_TYPE && type <= ICMP6_MULT_LIST_REPORT_V2_TYPE) ||
+	    (type >= ICMP6_SEND_NS_MSG_TYPE && type <= ICMP6_SEND_NA_MSG_TYPE) ||
+	    (type >= ICMP6_MULT_RA_MSG_TYPE && type <= ICMP6_MULT_RT_MSG_TYPE))
 		return SKIP_HOST_FIREWALL;
 	return DROP_FORBIDDEN_ICMP6;
 #else

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -17,20 +17,12 @@
 #define ICMP6_ND_OPTS (sizeof(struct ipv6hdr) + sizeof(struct icmp6hdr) + sizeof(struct in6_addr))
 #define ICMP6_ND_OPT_LEN 8
 
-#define ICMP6_UNREACH_MSG_TYPE		1
-#define ICMP6_TIME_EXCEEDED_TYPE	3
-#define ICMP6_PARAM_ERR_MSG_TYPE	4
-#define ICMP6_ECHO_REQUEST_MSG_TYPE	128
-#define ICMP6_ECHO_REPLY_MSG_TYPE	129
-#define ICMP6_MULT_LIST_QUERY_TYPE	130
 #define ICMP6_NS_MSG_TYPE		135
 #define ICMP6_NA_MSG_TYPE		136
 #define ICMP6_RR_MSG_TYPE		138
 #define ICMP6_INV_NS_MSG_TYPE		141
-#define ICMP6_MULT_LIST_REPORT_V2_TYPE	143
 #define ICMP6_SEND_NS_MSG_TYPE		148
 #define ICMP6_SEND_NA_MSG_TYPE		149
-#define ICMP6_MULT_RA_MSG_TYPE		151
 #define ICMP6_MULT_RT_MSG_TYPE		153
 
 #define SKIP_HOST_FIREWALL	-2
@@ -249,7 +241,7 @@ static __always_inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 	upper = (data + 48);
 
 	/* fill icmp6hdr */
-	icmp6hoplim->icmp6_type = ICMP6_TIME_EXCEEDED_TYPE;
+	icmp6hoplim->icmp6_type = ICMPV6_TIME_EXCEED;
 	icmp6hoplim->icmp6_code = 0;
 	icmp6hoplim->icmp6_cksum = 0;
 	icmp6hoplim->icmp6_dataun.un_data32[0] = 0;
@@ -516,15 +508,15 @@ icmp6_host_handle(struct __ctx_buff *ctx, int l4_off, __s8 *ext_err, bool handle
 	if (type == ICMP6_NS_MSG_TYPE)
 		return CTX_ACT_OK;
 
-	if (type == ICMP6_ECHO_REQUEST_MSG_TYPE || type == ICMP6_ECHO_REPLY_MSG_TYPE)
+	if (type == ICMPV6_ECHO_REQUEST || type == ICMPV6_ECHO_REPLY)
 		/* Decision is deferred to the host policies. */
 		return CTX_ACT_OK;
 
-	if ((type >= ICMP6_UNREACH_MSG_TYPE && type <= ICMP6_PARAM_ERR_MSG_TYPE) ||
-	    (type >= ICMP6_MULT_LIST_QUERY_TYPE && type <= ICMP6_NA_MSG_TYPE) ||
-	    (type >= ICMP6_INV_NS_MSG_TYPE && type <= ICMP6_MULT_LIST_REPORT_V2_TYPE) ||
+	if ((type >= ICMPV6_DEST_UNREACH && type <= ICMPV6_PARAMPROB) ||
+	    (type >= ICMPV6_MGM_QUERY && type <= ICMP6_NA_MSG_TYPE) ||
+	    (type >= ICMP6_INV_NS_MSG_TYPE && type <= ICMPV6_MLD2_REPORT) ||
 	    (type >= ICMP6_SEND_NS_MSG_TYPE && type <= ICMP6_SEND_NA_MSG_TYPE) ||
-	    (type >= ICMP6_MULT_RA_MSG_TYPE && type <= ICMP6_MULT_RT_MSG_TYPE))
+	    (type >= ICMPV6_MRDISC_ADV && type <= ICMP6_MULT_RT_MSG_TYPE))
 		return SKIP_HOST_FIREWALL;
 	return DROP_FORBIDDEN_ICMP6;
 #else

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -8,7 +8,6 @@
 #include <bpf/ctx/ctx.h>
 #include <bpf/api.h>
 
-#include "tailcall.h"
 #include "common.h"
 #include "overloadable.h"
 #include "identity.h"

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -86,17 +86,12 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 		 * by filtering out icmpv6 NA.
 		 */
 		if (ip6->nexthdr == IPPROTO_ICMPV6) {
-			__u8 icmp_type;
+			struct icmp6hdr *icmp6 = (void *)ip6 + sizeof(*ip6);
 
-			if (data + sizeof(*ip6) + ETH_HLEN +
-			    sizeof(struct icmp6hdr) > data_end)
+			if ((void *)icmp6 + sizeof(*icmp6) > data_end)
 				return DROP_INVALID;
 
-			if (icmp6_load_type(ctx, ETH_HLEN + sizeof(struct ipv6hdr),
-					    &icmp_type) < 0)
-				return DROP_INVALID;
-
-			if (icmp_type == ICMPV6_NA_MSG)
+			if (icmp6->icmp6_type == ICMPV6_NA_MSG)
 				goto out;
 		}
 #endif

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -16,6 +16,8 @@
 #include "lib/proxy.h"
 #include "lib/l4.h"
 
+#include "linux/icmpv6.h"
+
 /* ctx_is_wireguard is used to check whether ctx is a WireGuard network packet.
  * This function returns true in case all the following conditions are satisfied:
  *
@@ -95,7 +97,7 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 					    &icmp_type) < 0)
 				return DROP_INVALID;
 
-			if (icmp_type == ICMP6_NA_MSG_TYPE)
+			if (icmp_type == ICMPV6_NA_MSG)
 				goto out;
 		}
 #endif


### PR DESCRIPTION
This started as a "let's make that check for `ICMPV6_NA_MSG` a bit less obscure". But then I got distracted by all the indirection in the ICMPv6 header files ... so let's clean that up as well.