### PR TITLE
mtu/endpoint_updater.go: Check for unix.EINVAL not os.ErrInvalid

### DIFF
--- a/pkg/mtu/endpoint_updater.go
+++ b/pkg/mtu/endpoint_updater.go
@@ -266,7 +266,7 @@ func (emu *endpointUpdater) updateEndpoints(routeMTUs []RouteMTU) error {
 			// to do syscalls for the switching. If the netns is deleted between the time we open it and
 			// the time of calling ns.Do, we get an -EINVAL error, since the file descriptor is no longer valid.
 			// We ignore this error, since it means the netns and thus the endpoint was deleted.
-			if errors.Is(err, os.ErrInvalid) {
+			if errors.Is(err, unix.EINVAL) {
 				continue
 			}
 


### PR DESCRIPTION
Initially we checked for os.ErrInvalid, this is because it produces the same string. However, os.ErrInvalid is defined in a OS independent way in terms of an fs.ErrInvalid, so it does not actually match the -EINVAL error that we want to check for.
