### PR TITLE
bpf: nat: handle egressing ICMPv6 error messages with embedded ECHO / ECHO_REPLY

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1764,9 +1764,17 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off, bool has_l4_hea
 		switch (type) {
 		case ICMPV6_ECHO_REQUEST:
 			return NAT_PUNT_TO_STACK;
+		case ICMPV6_ECHO_REPLY:
+			port_off = offsetof(struct icmp6hdr, icmp6_dataun.u_echo.identifier);
+			break;
 		default:
 			return DROP_UNKNOWN_ICMP6_CODE;
 		}
+
+		if (ctx_load_bytes(ctx, icmpoff + port_off,
+				   &tuple.sport, sizeof(tuple.sport)) < 0)
+			return DROP_INVALID;
+		break;
 	default:
 		return DROP_UNKNOWN_L4;
 	}

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1718,6 +1718,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off, bool has_l4_hea
 	__u16 port_off;
 	__u32 icmpoff;
 	int hdrlen;
+	__u8 type;
 	int ret;
 
 	/* According to the RFC 5508, any networking equipment that is
@@ -1757,7 +1758,15 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off, bool has_l4_hea
 		port_off = TCP_DPORT_OFF;
 		break;
 	case IPPROTO_ICMPV6:
-		return DROP_UNKNOWN_ICMP6_CODE;
+		if (icmp6_load_type(ctx, icmpoff, &type) < 0)
+			return DROP_INVALID;
+
+		switch (type) {
+		case ICMPV6_ECHO_REQUEST:
+			return NAT_PUNT_TO_STACK;
+		default:
+			return DROP_UNKNOWN_ICMP6_CODE;
+		}
 	default:
 		return DROP_UNKNOWN_L4;
 	}


### PR DESCRIPTION
Following on to https://github.com/cilium/cilium/pull/38068, this adds support for `ECHO` / `ECHO_REPLY` in egressing ICMPv6 error messages.

One relevant scenario is an `DEST_UNREACH` response for an inbound `ECHO`.