### PR TITLE
cilium-cli: Reenable L7 IPv6 tests

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7.go
@@ -28,13 +28,12 @@ func clientEgressL7Test(ct *check.ConnectivityTest, templates map[string]string,
 	// Test L7 HTTP introspection using an egress policy on the clients.
 	newTest(testName, ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		WithCiliumPolicy(templates[templateName]).                    // L7 allow policy with HTTP introspection
 		WithScenarios(
 			tests.PodToPod(),
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			tests.PodToWorld(false, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
+			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.

--- a/cilium-cli/connectivity/builder/client_egress_l7_named_port.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_named_port.go
@@ -15,13 +15,12 @@ func (t clientEgressL7NamedPort) build(ct *check.ConnectivityTest, templates map
 	// Test L7 HTTP named port introspection using an egress policy on the clients.
 	newTest("client-egress-l7-named-port", ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).         // DNS resolution only
 		WithCiliumPolicy(templates["clientEgressL7HTTPNamedPortPolicyYAML"]). // L7 allow policy with HTTP introspection (named port)
 		WithScenarios(
 			tests.PodToPod(),
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			tests.PodToWorld(false, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
+			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -26,11 +26,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 	newTest(testName, ct).
 		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld(false)).
+		WithScenarios(tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -42,11 +41,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 	newTest(fmt.Sprintf("%s-denied", testName), ct).
 		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
-		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
-		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld(false)). // External Target is not allowed
+		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
+		WithCiliumPolicy(yamlFile).                                             // L7 allow policy TLS SNI enforcement for external target
+		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).           // DNS resolution only
+		WithScenarios(tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable)). // External Target is not allowed
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				// SSL error as another external target (e.g. cilium.io) SNI is not allowed
@@ -59,11 +57,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 	newTest(fmt.Sprintf("%s-wildcard", testName), ct).
 		WithCiliumVersion(">=1.18.0").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld(false)).
+		WithScenarios(tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -75,11 +72,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 	newTest(fmt.Sprintf("%s-wildcard-denied", testName), ct).
 		WithCiliumVersion(">=1.18.0").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld2(false)).
+		WithScenarios(tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				// SSL error as another external target (e.g. cilium.io) SNI is not allowed
@@ -95,11 +91,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		newTest(fmt.Sprintf("%s-double-wildcard", testName), ct).
 			WithCiliumVersion(">=1.18.0").
 			WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+			WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 			WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 			WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			WithScenarios(tests.PodToWorld(false)).
+			WithScenarios(tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable)).
 			WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 				if a.Destination().Port() == 443 {
 					return check.ResultOK, check.ResultNone
@@ -111,11 +106,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		newTest(fmt.Sprintf("%s-double-wildcard-denied", testName), ct).
 			WithCiliumVersion(">=1.18.0").
 			WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+			WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 			WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 			WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			WithScenarios(tests.PodToWorld2(false)).
+			WithScenarios(tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable)).
 			WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 				if a.Destination().Port() == 443 {
 					// SSL error as another external target (e.g. cilium.io) SNI is not allowed

--- a/cilium-cli/connectivity/builder/to_fqdns.go
+++ b/cilium-cli/connectivity/builder/to_fqdns.go
@@ -62,11 +62,10 @@ func (t toFqdnsWithProxy) build(ct *check.ConnectivityTest, templates map[string
 		WithCiliumPolicy(templates["clientEgressToFQDNsAndHTTPGetPolicyYAML"]).
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithScenarios(
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			tests.PodToWorld(false, tests.WithRetryDestPort(80)),
-			tests.PodToWorld2(false), // resolves to ExternalOtherTarget
+			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryDestPort(80)),
+			tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable), // resolves to ExternalOtherTarget
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Address(features.IPFamilyAny) == ct.Params().ExternalOtherTarget {

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/version"
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 func parseBoolStatus(s string) bool {
@@ -219,6 +221,25 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 	return nil
 }
 
+func (ct *ConnectivityTest) extractFeaturesFromUname(ctx context.Context, ciliumPod Pod, result features.Set) error {
+	stdout, err := ciliumPod.K8sClient.ExecInPod(ctx, ciliumPod.Pod.Namespace, ciliumPod.Pod.Name,
+		defaults.AgentContainerName, []string{"uname", "-r"})
+	if err != nil {
+		return fmt.Errorf("failed to fetch uname -r: %w", err)
+	}
+
+	kernelVersion, err := version.ParseKernelVersion(stdout.String())
+	if err != nil {
+		return fmt.Errorf("failed to parse kernel version: %w", err)
+	}
+
+	result[features.RHEL] = features.Status{
+		Enabled: versioncheck.MustCompile("<=4.18.0")(kernelVersion),
+	}
+
+	return nil
+}
+
 func (ct *ConnectivityTest) extractFeaturesFromK8sCluster(ctx context.Context, result features.Set) {
 	flavor := ct.client.AutodetectFlavor(ctx)
 
@@ -372,6 +393,10 @@ func (ct *ConnectivityTest) detectFeatures(ctx context.Context) error {
 			return err
 		}
 		err = ct.extractFeaturesFromCiliumStatus(ctx, ciliumPod, features)
+		if err != nil {
+			return err
+		}
+		err = ct.extractFeaturesFromUname(ctx, ciliumPod, features)
 		if err != nil {
 			return err
 		}

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -124,6 +124,8 @@ const (
 	Multicast Feature = "multicast-enabled"
 
 	L7LoadBalancer Feature = "loadbalancer-l7"
+
+	RHEL Feature = "rhel"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,9 +7,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 // CiliumVersion provides a minimal structure to the version string
@@ -69,4 +74,48 @@ func Base64() (string, error) {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(jsonBytes), nil
+}
+
+// ParseKernelVersion converts a version string to semver.Version.
+func ParseKernelVersion(ver string) (semver.Version, error) {
+	// Trim null bytes and whitespace that may come from C strings
+	ver = strings.TrimRight(ver, "\x00")
+	ver = strings.TrimSpace(ver)
+
+	verStrs := strings.Split(ver, ".")
+
+	// We are assuming the kernel version will be one of the following:
+	// 4.9.17-040917-generic or 4.9-040917-generic or 4-generic
+	// 6.15.8-200.fc42.x86_64 (newer format with additional dot-separated components)
+	// So as observed, the kernel value is N.N.N-m or N.N-m or N-m or N.N.N-m.additional.components
+	// This implies the len(verStrs) should be at least 1, but can be more than 3
+
+	if len(verStrs) < 1 {
+		return semver.Version{}, fmt.Errorf("unable to get kernel version from %q", ver)
+	}
+
+	// Take only the first 3 components for semantic version parsing
+	// If there are more than 3 components, we'll only use the first 3
+	if len(verStrs) > 3 {
+		verStrs = verStrs[:3]
+	}
+
+	// Given the observations, we use regular expression to extract
+	// the patch number from the last element of the verStrs array and
+	// append "0" to the verStrs array in case the until its length is
+	// 3 as in all cases we want to return from this function :
+	// Major.Minor.PatchNumber
+
+	patch := regexp.MustCompilePOSIX(`^[0-9]+`).FindString(verStrs[len(verStrs)-1])
+	if patch == "" {
+		verStrs[len(verStrs)-1] = "0"
+	} else {
+		verStrs[len(verStrs)-1] = patch
+	}
+
+	for len(verStrs) < 3 {
+		verStrs = append(verStrs, "0")
+	}
+
+	return versioncheck.Version(strings.Join(verStrs[:3], "."))
 }

--- a/pkg/version/version_unix.go
+++ b/pkg/version/version_unix.go
@@ -6,58 +6,9 @@
 package version
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
-
 	"github.com/blang/semver/v4"
 	"golang.org/x/sys/unix"
-
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
-
-func parseKernelVersion(ver string) (semver.Version, error) {
-	// Trim null bytes and whitespace that may come from C strings
-	ver = strings.TrimRight(ver, "\x00")
-	ver = strings.TrimSpace(ver)
-
-	verStrs := strings.Split(ver, ".")
-
-	// We are assuming the kernel version will be one of the following:
-	// 4.9.17-040917-generic or 4.9-040917-generic or 4-generic
-	// 6.15.8-200.fc42.x86_64 (newer format with additional dot-separated components)
-	// So as observed, the kernel value is N.N.N-m or N.N-m or N-m or N.N.N-m.additional.components
-	// This implies the len(verStrs) should be at least 1, but can be more than 3
-
-	if len(verStrs) < 1 {
-		return semver.Version{}, fmt.Errorf("unable to get kernel version from %q", ver)
-	}
-
-	// Take only the first 3 components for semantic version parsing
-	// If there are more than 3 components, we'll only use the first 3
-	if len(verStrs) > 3 {
-		verStrs = verStrs[:3]
-	}
-
-	// Given the observations, we use regular expression to extract
-	// the patch number from the last element of the verStrs array and
-	// append "0" to the verStrs array in case the until its length is
-	// 3 as in all cases we want to return from this function :
-	// Major.Minor.PatchNumber
-
-	patch := regexp.MustCompilePOSIX(`^[0-9]+`).FindString(verStrs[len(verStrs)-1])
-	if patch == "" {
-		verStrs[len(verStrs)-1] = "0"
-	} else {
-		verStrs[len(verStrs)-1] = patch
-	}
-
-	for len(verStrs) < 3 {
-		verStrs = append(verStrs, "0")
-	}
-
-	return versioncheck.Version(strings.Join(verStrs[:3], "."))
-}
 
 // GetKernelVersion returns the version of the Linux kernel running on this host.
 func GetKernelVersion() (semver.Version, error) {
@@ -65,5 +16,5 @@ func GetKernelVersion() (semver.Version, error) {
 	if err := unix.Uname(&unameBuf); err != nil {
 		return semver.Version{}, err
 	}
-	return parseKernelVersion(string(unameBuf.Release[:]))
+	return ParseKernelVersion(string(unameBuf.Release[:]))
 }

--- a/pkg/version/version_unix_test.go
+++ b/pkg/version/version_unix_test.go
@@ -51,7 +51,7 @@ func TestParseKernelVersion(t *testing.T) {
 		{" 6.0.0-generic ", mustHaveVersion(t, "6.0.0")},
 	}
 	for _, tt := range flagtests {
-		s, err := parseKernelVersion(tt.in)
+		s, err := ParseKernelVersion(tt.in)
 		require.NoError(t, err)
 		require.Equal(t, tt.out, s)
 	}


### PR DESCRIPTION
Our CI already runs the kernels with the fix applied:

https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/

We can reenable PodToWorld and PodToWorld2 tests that were disabled due to the bug with L7 policies. Note that they are still conditionally disabled if the fake external target is not supported.

We still, however, disable those tests on RHEL kernels, as they lack the
backport of the fix mentioned above.

Fixes: 09b3cd84748a ("cilium-cli: Disable IPv6 in PodToWorld and PodToWorld2 tests")
Fixes: https://github.com/cilium/cilium/issues/38396