### PR TITLE
cilium-cli: IPv6 connectivity tests for PodToHostPort

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1324,3 +1324,12 @@ func (ct *ConnectivityTest) IsSocketLBFull() bool {
 	}
 	return false
 }
+
+func (ct *ConnectivityTest) GetPodHostIPByFamily(pod Pod, ipFam features.IPFamily) (string, error) {
+	for _, addr := range pod.Pod.Status.HostIPs {
+		if features.GetIPFamily(addr.IP) == ipFam {
+			return addr.IP, nil
+		}
+	}
+	return "", fmt.Errorf("pod doesn't have HostIP of family %s", ipFam)
+}


### PR DESCRIPTION
Test both IPv4 and IPv6 explicitly. ForEachIPFamily ensures testing those address families that are supported in the cluster.

Fixes: https://github.com/cilium/cilium/issues/37134