### PR TITLE
cilium-cli: IPv6 connectivity tests for PodToIngress

### DIFF
--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -108,14 +108,17 @@ func (s *podToIngress) Run(ctx context.Context, t *check.Test) {
 				continue
 			}
 
-			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc, features.IPFamilyAny).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, a.CurlCommand(svc))
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
+				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &pod, svc, ipFam).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, a.CurlCommand(svc))
 
-				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
-					DNSRequired: true,
-					AltDstPort:  svc.Port(),
-				}))
+					a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
+						DNSRequired: true,
+						AltDstPort:  svc.Port(),
+					}))
+				})
 			})
+
 			i++
 		}
 	}

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -149,9 +149,10 @@ func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedRes
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Type:      serviceType,
-			ClusterIP: clusterIP,
-			Ports:     ports,
+			Type:           serviceType,
+			ClusterIP:      clusterIP,
+			Ports:          ports,
+			IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
 		},
 	}
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -66,6 +66,7 @@ func Test_getService(t *testing.T) {
 						Port:     443,
 					},
 				},
+				IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
 			},
 		}, res)
 	})
@@ -97,6 +98,7 @@ func Test_getService(t *testing.T) {
 						Port:     443,
 					},
 				},
+				IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
 			},
 		}, res)
 	})
@@ -135,6 +137,7 @@ func Test_getService(t *testing.T) {
 						Port:     443,
 					},
 				},
+				IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
 			},
 		}, res)
 	})
@@ -179,6 +182,7 @@ func Test_getService(t *testing.T) {
 						NodePort: 3001,
 					},
 				},
+				IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
 			},
 		}, res)
 	})


### PR DESCRIPTION
Test both IPv4 and IPv6 explicitly. ForEachIPFamily ensures testing those address families that are supported in the cluster.

Fixes: https://github.com/cilium/cilium/issues/37137
