### PR TITLE
helm/hubble: Fix wrong value for metrics server tls existingSecret

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -1034,7 +1034,7 @@ spec:
           defaultMode: 0400
           sources:
           - secret:
-              name: {{ .Values.hubble.tls.server.existingSecret | default "hubble-metrics-server-certs" }}
+              name: {{ .Values.hubble.metrics.tls.server.existingSecret | default "hubble-metrics-server-certs" }}
               optional: true
               items:
               - key: tls.crt


### PR DESCRIPTION
Use `hubble.metrics.tls` instead of `hubble.tls` when setting the hubble-metrics-tls projected secret source name in daemonset helm template.

Option added in: 5339161bfdcccf1bcb8d3ef3a5b9db803208ef81 ([PR](https://github.com/cilium/cilium/pull/34114))

We should label for backport in 1.17.
Thanks!