### PR TITLE
helm: add Envoy image to pre-flight

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3148,6 +3148,10 @@
      - Enable Cilium pre-flight resources (required for upgrade)
      - bool
      - ``false``
+   * - :spelling:ignore:`preflight.envoy.image`
+     - Envoy pre-flight image.
+     - object
+     - ``{"digest":"sha256:5d442079aeb87ae1aaec431f7e9cb9b3da309149521e5465fe82965d96a8ef05","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-1747631391-2d12fe781e661e30cd2c817f377c35cc6c64500e","useDigest":true}``
    * - :spelling:ignore:`preflight.extraEnv`
      - Additional preflight environment variables.
      - list

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3151,7 +3151,7 @@
    * - :spelling:ignore:`preflight.envoy.image`
      - Envoy pre-flight image.
      - object
-     - ``{"digest":"sha256:5d442079aeb87ae1aaec431f7e9cb9b3da309149521e5465fe82965d96a8ef05","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-1747631391-2d12fe781e661e30cd2c817f377c35cc6c64500e","useDigest":true}``
+     - ``{"digest":"sha256:bea4f2294e795ab1642eba912673eabba3ed1fff5124ba2e307f396810b32780","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-1749716792-9cbedf28d3f4e8d7ff482744138ac3bdf65a868c","useDigest":true}``
    * - :spelling:ignore:`preflight.extraEnv`
      - Additional preflight environment variables.
      - list

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -837,6 +837,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-preflight |
 | preflight.annotations | object | `{}` | Annotations to be added to all top-level preflight objects (resources under templates/cilium-preflight) |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
+| preflight.envoy.image | object | `{"digest":"sha256:5d442079aeb87ae1aaec431f7e9cb9b3da309149521e5465fe82965d96a8ef05","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-1747631391-2d12fe781e661e30cd2c817f377c35cc6c64500e","useDigest":true}` | Envoy pre-flight image. |
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |
 | preflight.extraVolumeMounts | list | `[]` | Additional preflight volumeMounts. |
 | preflight.extraVolumes | list | `[]` | Additional preflight volumes. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -837,7 +837,7 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-preflight |
 | preflight.annotations | object | `{}` | Annotations to be added to all top-level preflight objects (resources under templates/cilium-preflight) |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
-| preflight.envoy.image | object | `{"digest":"sha256:5d442079aeb87ae1aaec431f7e9cb9b3da309149521e5465fe82965d96a8ef05","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-1747631391-2d12fe781e661e30cd2c817f377c35cc6c64500e","useDigest":true}` | Envoy pre-flight image. |
+| preflight.envoy.image | object | `{"digest":"sha256:bea4f2294e795ab1642eba912673eabba3ed1fff5124ba2e307f396810b32780","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-1749716792-9cbedf28d3f4e8d7ff482744138ac3bdf65a868c","useDigest":true}` | Envoy pre-flight image. |
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |
 | preflight.extraVolumeMounts | list | `[]` | Additional preflight volumeMounts. |
 | preflight.extraVolumes | list | `[]` | Additional preflight volumes. |

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -1,3 +1,5 @@
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
+
 {{- if .Values.preflight.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -85,7 +87,7 @@ spec:
                 apiVersion: v1
                 fieldPath: spec.nodeName
           {{- with .Values.preflight.extraEnv }}
-            {{- toYaml . | trim | nindent 12 }}
+          {{- toYaml . | trim | nindent 10 }}
           {{- end }}
           volumeMounts:
           - name: cilium-run
@@ -182,6 +184,57 @@ spec:
           {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
         {{- end }}
+        {{- if $envoyDS }}
+        - name: cilium-pre-flight-envoy
+          image: {{ include "cilium.image" .Values.envoy.image | quote }}
+          imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - "touch /tmp/ready; sleep 1h"
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/ready
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          {{- with .Values.preflight.extraEnv }}
+          {{- toYaml . | trim | nindent 10 }}
+          {{- end }}
+          volumeMounts:
+          - name: envoy-sockets
+            mountPath: /var/run/cilium/envoy/sockets
+            readOnly: false
+          - name: envoy-artifacts
+            mountPath: /var/run/cilium/envoy/artifacts
+            readOnly: true
+          - name: envoy-config
+            mountPath: /var/run/cilium/envoy/
+            readOnly: true
+          {{- with .Values.preflight.resources }}
+          resources:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+          {{- with .Values.preflight.securityContext }}
+          securityContext:
+            {{- toYaml . | trim | nindent 14 }}
+          {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
+        {{- end }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
@@ -226,6 +279,24 @@ spec:
           defaultMode: 0400
           optional: true
       {{- end }}
+      {{- end }}
+      {{- if $envoyDS }}
+      - name: envoy-sockets
+        hostPath:
+          path: "{{ .Values.daemon.runPath }}/envoy/sockets"
+          type: DirectoryOrCreate
+      - name: envoy-artifacts
+        hostPath:
+          path: "{{ .Values.daemon.runPath }}/envoy/artifacts"
+          type: DirectoryOrCreate
+      - name: envoy-config
+        configMap:
+          name: {{ .Values.envoy.bootstrapConfigMap | default "cilium-envoy-config" | quote }}
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          items:
+            - key: bootstrap-config.json
+              path: bootstrap-config.json
       {{- end }}
       {{- with .Values.preflight.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -206,15 +206,6 @@ spec:
               - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
-          env:
-          - name: K8S_NODE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: spec.nodeName
-          {{- with .Values.preflight.extraEnv }}
-          {{- toYaml . | trim | nindent 10 }}
-          {{- end }}
           volumeMounts:
           - name: envoy-sockets
             mountPath: /var/run/cilium/envoy/sockets

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -186,7 +186,7 @@ spec:
         {{- end }}
         {{- if $envoyDS }}
         - name: cilium-pre-flight-envoy
-          image: {{ include "cilium.image" .Values.envoy.image | quote }}
+          image: {{ include "cilium.image" .Values.preflight.envoy.image | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4938,6 +4938,37 @@
         "enabled": {
           "type": "boolean"
         },
+        "envoy": {
+          "properties": {
+            "image": {
+              "properties": {
+                "digest": {
+                  "type": "string"
+                },
+                "override": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "pullPolicy": {
+                  "type": "string"
+                },
+                "repository": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                },
+                "useDigest": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
         "extraEnv": {
           "items": {},
           "type": "array"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3137,6 +3137,18 @@ preflight:
     digest: ""
     useDigest: false
     pullPolicy: "Always"
+  envoy:
+    # -- Envoy pre-flight image.
+    image:
+      # @schema
+      # type: [null, string]
+      # @schema
+      override: ~
+      repository: "quay.io/cilium/cilium-envoy"
+      tag: "v1.33.3-1747631391-2d12fe781e661e30cd2c817f377c35cc6c64500e"
+      pullPolicy: "Always"
+      digest: "sha256:5d442079aeb87ae1aaec431f7e9cb9b3da309149521e5465fe82965d96a8ef05"
+      useDigest: true
   # -- The priority class to use for the preflight pod.
   priorityClassName: ""
   # -- preflight update strategy

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3145,9 +3145,9 @@ preflight:
       # @schema
       override: ~
       repository: "quay.io/cilium/cilium-envoy"
-      tag: "v1.33.3-1747631391-2d12fe781e661e30cd2c817f377c35cc6c64500e"
+      tag: "v1.33.3-1749716792-9cbedf28d3f4e8d7ff482744138ac3bdf65a868c"
       pullPolicy: "Always"
-      digest: "sha256:5d442079aeb87ae1aaec431f7e9cb9b3da309149521e5465fe82965d96a8ef05"
+      digest: "sha256:bea4f2294e795ab1642eba912673eabba3ed1fff5124ba2e307f396810b32780"
       useDigest: true
   # -- The priority class to use for the preflight pod.
   priorityClassName: ""

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3158,6 +3158,18 @@ preflight:
     digest: ${CILIUM_DIGEST}
     useDigest: ${USE_DIGESTS}
     pullPolicy: "${PULL_POLICY}"
+  envoy:
+    # -- Envoy pre-flight image.
+    image:
+      # @schema
+      # type: [null, string]
+      # @schema
+      override: ~
+      repository: "${CILIUM_ENVOY_REPO}"
+      tag: "${CILIUM_ENVOY_VERSION}"
+      pullPolicy: "${PULL_POLICY}"
+      digest: "${CILIUM_ENVOY_DIGEST}"
+      useDigest: true
   # -- The priority class to use for the preflight pod.
   priorityClassName: ""
   # -- preflight update strategy


### PR DESCRIPTION
Adds the Envoy image to the pre-flight process, so that Envoy will be pre-pulled during a Cilium upgrade.

Fixes: #39374

