### PR TITLE
hubble: Use `testing.T.Context` added in Go 1.24 in tests

### DIFF
--- a/hubble/cmd/observe/io_reader_observer_test.go
+++ b/hubble/cmd/observe/io_reader_observer_test.go
@@ -4,7 +4,6 @@
 package observe
 
 import (
-	"context"
 	"io"
 	"log/slog"
 	"strings"
@@ -29,7 +28,7 @@ func Test_getFlowsBasic(t *testing.T) {
 	}
 	server := NewIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
 	req := observerpb.GetFlowsRequest{}
-	client, err := server.GetFlows(context.Background(), &req)
+	client, err := server.GetFlows(t.Context(), &req)
 	require.NoError(t, err)
 	for range flows {
 		_, err = client.Recv()
@@ -65,7 +64,7 @@ func Test_getFlowsTimeRange(t *testing.T) {
 		Since: &timestamppb.Timestamp{Seconds: 50},
 		Until: &timestamppb.Timestamp{Seconds: 150},
 	}
-	client, err := server.GetFlows(context.Background(), &req)
+	client, err := server.GetFlows(t.Context(), &req)
 	require.NoError(t, err)
 	res, err := client.Recv()
 	require.NoError(t, err)
@@ -100,7 +99,7 @@ func Test_getFlowsLast(t *testing.T) {
 		Number: 2,
 		First:  false,
 	}
-	client, err := server.GetFlows(context.Background(), &req)
+	client, err := server.GetFlows(t.Context(), &req)
 	require.NoError(t, err)
 	res, err := client.Recv()
 	require.NoError(t, err)
@@ -138,7 +137,7 @@ func Test_getFlowsFirst(t *testing.T) {
 		Number: 2,
 		First:  true,
 	}
-	client, err := server.GetFlows(context.Background(), &req)
+	client, err := server.GetFlows(t.Context(), &req)
 	require.NoError(t, err)
 	res, err := client.Recv()
 	require.NoError(t, err)
@@ -179,7 +178,7 @@ func Test_getFlowsFilter(t *testing.T) {
 			},
 		},
 	}
-	client, err := server.GetFlows(context.Background(), &req)
+	client, err := server.GetFlows(t.Context(), &req)
 	require.NoError(t, err)
 	res, err := client.Recv()
 	require.NoError(t, err)
@@ -212,7 +211,7 @@ func Test_UnknownField(t *testing.T) {
 	}
 	// server and client setup.
 	server := NewIOReaderObserver(strings.NewReader(sb.String()))
-	client, err := server.GetFlows(context.Background(), &observerpb.GetFlowsRequest{})
+	client, err := server.GetFlows(t.Context(), &observerpb.GetFlowsRequest{})
 	require.NoError(t, err)
 	// logger setup.
 	logger.Initialize(slog.NewTextHandler(&sb, nil))

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -259,7 +259,7 @@ func TestRingReader_NextFollow(t *testing.T) {
 			var timedOut bool
 			var got []*v1.Event
 			for i := range tt.count {
-				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 				got = append(got, reader.NextFollow(ctx))
 				select {
 				case <-ctx.Done():
@@ -285,7 +285,7 @@ func TestRingReader_NextFollow_WithEmptyRing(t *testing.T) {
 		goleak.IgnoreTopFunction("io.(*pipe).read"))
 	ring := NewRing(Capacity15)
 	reader := NewRingReader(ring, ring.LastWriteParallel())
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	c := make(chan *v1.Event)
 	done := make(chan struct{})
 	go func() {

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -741,7 +741,7 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	ch := make(chan *v1.Event, 30)
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -803,7 +803,7 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	// We should be able to read from a previous 'cycles' and ReadFrom will
 	// be able to catch up with the writer.
 	ch := make(chan *v1.Event, 30)
@@ -901,7 +901,7 @@ func TestRing_ReadFrom_Test_3(t *testing.T) {
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	// We should be able to read from a previous 'cycles' and ReadFrom will
 	// be able to catch up with the writer.
 	ch := make(chan *v1.Event, 30)

--- a/pkg/hubble/dropeventemitter/dropeventemitter_test.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter_test.go
@@ -4,7 +4,6 @@
 package dropeventemitter
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -183,7 +182,7 @@ func TestProcessFlow(t *testing.T) {
 				recorder:   fakeRecorder,
 				k8sWatcher: &fakeK8SWatcher{},
 			}
-			if err := e.ProcessFlow(context.Background(), tt.flow); err != nil {
+			if err := e.ProcessFlow(t.Context(), tt.flow); err != nil {
 				t.Errorf("DropEventEmitter.ProcessFlow() error = %v", err)
 			}
 			if tt.expect == "" {

--- a/pkg/hubble/exporter/config_test.go
+++ b/pkg/hubble/exporter/config_test.go
@@ -5,7 +5,6 @@ package exporter
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"testing"
 
@@ -451,7 +450,7 @@ func TestFlowLogConfigEnd(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			exporter, err := exporterFactory.Create(tc.config)
 			assert.NoError(t, err)
-			err = exporter.Export(context.Background(), &v1.Event{Event: &flow.Flow{Uuid: "1234"}})
+			err = exporter.Export(t.Context(), &v1.Event{Event: &flow.Flow{Uuid: "1234"}})
 			assert.NoError(t, err)
 			content, err := os.ReadFile(tc.config.FilePath)
 			assert.NoError(t, err)

--- a/pkg/hubble/exporter/dynamic_exporter_test.go
+++ b/pkg/hubble/exporter/dynamic_exporter_test.go
@@ -149,7 +149,7 @@ func TestEventPropagation(t *testing.T) {
 	}
 
 	// when
-	exporter.Export(context.TODO(), &v1.Event{})
+	exporter.Export(t.Context(), &v1.Event{})
 
 	// then
 	assert.Equal(t, 1, mockExporter0.events)

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -148,7 +148,7 @@ func TestExporterWithFilters(t *testing.T) {
 	exporter, err := newExporter(log, opts)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	cancelled := false
@@ -359,7 +359,7 @@ func TestExporterOnExportEvent(t *testing.T) {
 	exporter, err := newExporter(log, opts)
 	assert.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, ev := range events {
 		err := exporter.Export(ctx, ev)
 		assert.NoError(t, err)

--- a/pkg/hubble/filters/cel_expression_test.go
+++ b/pkg/hubble/filters/cel_expression_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -127,7 +126,7 @@ func TestCELExpressionFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			log := hivetest.Logger(t)
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&CELExpressionFilter{log: log}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&CELExpressionFilter{log: log}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/hubble/filters/cluster_name_test.go
+++ b/pkg/hubble/filters/cluster_name_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -176,9 +175,9 @@ func TestClusterNameFilter(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tc.f, []OnBuildFilter{&ClusterNameFilter{}})
+			fl, err := BuildFilterList(t.Context(), tc.f, []OnBuildFilter{&ClusterNameFilter{}})
 			if (err != nil) != tc.wantErr {
-				t.Errorf("BuildFilterList(context.Background(), ) error = %v, wantErr %v", err, tc.wantErr)
+				t.Errorf("BuildFilterList(t.Context(), ) error = %v, wantErr %v", err, tc.wantErr)
 				return
 			}
 			for i, ev := range tc.ev {

--- a/pkg/hubble/filters/drop_reason_desc_test.go
+++ b/pkg/hubble/filters/drop_reason_desc_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -78,7 +77,7 @@ func TestDropReasonDescFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&DropReasonDescFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&DropReasonDescFilter{}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildFilterList() with DropReasonDescFilter: error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/hubble/filters/event_type_test.go
+++ b/pkg/hubble/filters/event_type_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -152,7 +151,7 @@ func TestEventTypeFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&EventTypeFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&EventTypeFilter{}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildFilterList() with EventTypeFilter: error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/hubble/filters/filters_benchmark_test.go
+++ b/pkg/hubble/filters/filters_benchmark_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -21,7 +20,7 @@ var (
 )
 
 func runFilterBenchmark(b *testing.B, ff *flowpb.FlowFilter, events []*v1.Event) {
-	filterFuncs, err := BuildFilter(context.Background(), ff, DefaultFilters(hivetest.Logger(b)))
+	filterFuncs, err := BuildFilter(b.Context(), ff, DefaultFilters(hivetest.Logger(b)))
 	require.NoError(b, err)
 
 	for b.Loop() {
@@ -97,9 +96,9 @@ func BenchmarkCELL4ProtocolPortFlowFilterNonMatching100(b *testing.B) {
 
 func TestBenchmarkFiltersAreEquivalent(t *testing.T) {
 	log := hivetest.Logger(t)
-	basicFuncs, err := BuildFilter(context.Background(), basicL4Filter, DefaultFilters(log))
+	basicFuncs, err := BuildFilter(t.Context(), basicL4Filter, DefaultFilters(log))
 	require.NoError(t, err)
-	celFuncs, err := BuildFilter(context.Background(), celL4Filter, DefaultFilters(log))
+	celFuncs, err := BuildFilter(t.Context(), celL4Filter, DefaultFilters(log))
 	require.NoError(t, err)
 
 	gotBasic := basicFuncs.MatchOne(matchingEvent)

--- a/pkg/hubble/filters/filters_test.go
+++ b/pkg/hubble/filters/filters_test.go
@@ -83,7 +83,7 @@ func (t *testFilterFalse) OnBuildFilter(_ context.Context, ff *flowpb.FlowFilter
 }
 
 func TestOnBuildFilter(t *testing.T) {
-	fl, err := BuildFilterList(context.Background(),
+	fl, err := BuildFilterList(t.Context(),
 		[]*flowpb.FlowFilter{{SourceIdentity: []uint32{1, 2, 3}}}, // true
 		[]OnBuildFilter{&testFilterTrue{}})                        // true
 	assert.NoError(t, err)
@@ -91,7 +91,7 @@ func TestOnBuildFilter(t *testing.T) {
 		Source: &flowpb.Endpoint{Identity: 3},
 	}}))
 
-	fl, err = BuildFilterList(context.Background(),
+	fl, err = BuildFilterList(t.Context(),
 		[]*flowpb.FlowFilter{{SourceIdentity: []uint32{1, 2, 3}}}, // true
 		[]OnBuildFilter{&testFilterFalse{}})                       // false
 	assert.NoError(t, err)
@@ -99,7 +99,7 @@ func TestOnBuildFilter(t *testing.T) {
 		Source: &flowpb.Endpoint{Identity: 3},
 	}}))
 
-	fl, err = BuildFilterList(context.Background(),
+	fl, err = BuildFilterList(t.Context(),
 		[]*flowpb.FlowFilter{{SourceIdentity: []uint32{1, 2, 3}}}, // true
 		[]OnBuildFilter{
 			&testFilterFalse{}, // false

--- a/pkg/hubble/filters/fqdn_test.go
+++ b/pkg/hubble/filters/fqdn_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -202,7 +201,7 @@ func TestFQDNFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&FQDNFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&FQDNFilter{}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildFilterList() with FQDNFilter: error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -296,7 +295,7 @@ func Test_filterByDNSQuery(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&FQDNFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&FQDNFilter{}})
 			assert.Equal(t, tt.wantErr, err != nil)
 			if err == nil {
 				got := fl.MatchOne(tt.args.ev)

--- a/pkg/hubble/filters/http_test.go
+++ b/pkg/hubble/filters/http_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -554,7 +553,7 @@ func TestHTTPFilters(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&HTTPFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&HTTPFilter{}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf(`"%s" error = %v, wantErr %v`, tt.name, err, tt.wantErr)
 				return

--- a/pkg/hubble/filters/identity_test.go
+++ b/pkg/hubble/filters/identity_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,7 +82,7 @@ func TestIdentityFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&IdentityFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&IdentityFilter{}})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, fl.MatchOne(tt.args.ev))
 		})

--- a/pkg/hubble/filters/ip_test.go
+++ b/pkg/hubble/filters/ip_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -292,9 +291,9 @@ func TestIPFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&IPFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&IPFilter{}})
 			if (err != nil) != tt.wantErr {
-				t.Errorf("BuildFilterList(context.Background(), ) error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("BuildFilterList(t.Context(), ) error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			for i, ev := range tt.args.ev {
@@ -427,9 +426,9 @@ func TestIPVersionFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&IPVersionFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&IPVersionFilter{}})
 			if (err != nil) != tt.wantErr {
-				t.Errorf("BuildFilterList(context.Background(), ) error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("BuildFilterList(t.Context(), ) error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			for i, ev := range tt.args.ev {

--- a/pkg/hubble/filters/k8s_test.go
+++ b/pkg/hubble/filters/k8s_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -279,9 +278,9 @@ func TestPodFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&PodFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&PodFilter{}})
 			if (err != nil) != tt.wantErr {
-				t.Errorf("BuildFilterList(context.Background(), ) error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("BuildFilterList(t.Context(), ) error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			for i, ev := range tt.args.ev {
@@ -369,9 +368,9 @@ func TestServiceFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&ServiceFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&ServiceFilter{}})
 			if (err != nil) != tt.wantErr {
-				t.Errorf("BuildFilterList(context.Background(), ) error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("BuildFilterList(t.Context(), ) error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			for i, ev := range tt.args.ev {

--- a/pkg/hubble/filters/labels_test.go
+++ b/pkg/hubble/filters/labels_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -577,7 +576,7 @@ func TestLabelSelectorFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&LabelsFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&LabelsFilter{}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("\"%s\" error = %v, wantErr %v", tt.name, err, tt.wantErr)
 				return

--- a/pkg/hubble/filters/network_interface_test.go
+++ b/pkg/hubble/filters/network_interface_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -183,7 +182,7 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&NetworkInterfaceFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&NetworkInterfaceFilter{}})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, fl.MatchOne(tt.args.ev))
 		})

--- a/pkg/hubble/filters/nodename_test.go
+++ b/pkg/hubble/filters/nodename_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -136,7 +135,7 @@ func TestNodeFilter(t *testing.T) {
 					NodeName: tt.nodeName,
 				},
 			}
-			fl, err := BuildFilterList(context.Background(), ff, []OnBuildFilter{&NodeNameFilter{}})
+			fl, err := BuildFilterList(t.Context(), ff, []OnBuildFilter{&NodeNameFilter{}})
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErrContains)

--- a/pkg/hubble/filters/port_test.go
+++ b/pkg/hubble/filters/port_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -92,7 +91,7 @@ func TestPortFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&PortFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&PortFilter{}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("\"%s\" error = %v, wantErr %v", tt.name, err, tt.wantErr)
 				return

--- a/pkg/hubble/filters/protocol_test.go
+++ b/pkg/hubble/filters/protocol_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -84,7 +83,7 @@ func TestFlowProtocolFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&ProtocolFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&ProtocolFilter{}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("\"%s\" error = %v, wantErr %v", tt.name, err, tt.wantErr)
 				return

--- a/pkg/hubble/filters/reply_test.go
+++ b/pkg/hubble/filters/reply_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -121,7 +120,7 @@ func Test_filterByReplyField(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&ReplyFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&ReplyFilter{}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("\"%s\" error = %v, wantErr %v", tt.name, err, tt.wantErr)
 				return

--- a/pkg/hubble/filters/tcp_test.go
+++ b/pkg/hubble/filters/tcp_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -112,7 +111,7 @@ func TestFlowTCPFilter(t *testing.T) {
 		argsevent = &v1.Event{Event: &flowpb.Flow{
 			L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{Flags: tt.argsev}}}}}
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), argsfilter, []OnBuildFilter{&TCPFilter{}})
+			fl, err := BuildFilterList(t.Context(), argsfilter, []OnBuildFilter{&TCPFilter{}})
 			if err != nil {
 				t.Errorf("unexpected filter build error: %s", err)
 			} else if got := fl.MatchOne(argsevent); got != tt.want {

--- a/pkg/hubble/filters/tracing_test.go
+++ b/pkg/hubble/filters/tracing_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -120,7 +119,7 @@ func TestTraceIDFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&TraceIDFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&TraceIDFilter{}})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, fl.MatchOne(tt.args.ev))
 		})

--- a/pkg/hubble/filters/traffic_direction_test.go
+++ b/pkg/hubble/filters/traffic_direction_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,7 +66,7 @@ func TestTrafficDirectionFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&TrafficDirectionFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&TrafficDirectionFilter{}})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, fl.MatchOne(tt.args.ev))
 		})

--- a/pkg/hubble/filters/uuid_test.go
+++ b/pkg/hubble/filters/uuid_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,7 +71,7 @@ func TestUUIDFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&UUIDFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&UUIDFilter{}})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, fl.MatchOne(tt.args.ev))
 		})

--- a/pkg/hubble/filters/workload_test.go
+++ b/pkg/hubble/filters/workload_test.go
@@ -4,7 +4,6 @@
 package filters
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -512,7 +511,7 @@ func TestWorkloadFilterInclude(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&WorkloadFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&WorkloadFilter{}})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, fl.MatchOne(tt.args.ev))
 		})
@@ -620,7 +619,7 @@ func TestWorkloadFilterExclude(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fl, err := BuildFilterList(context.Background(), tt.args.f, []OnBuildFilter{&WorkloadFilter{}})
+			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&WorkloadFilter{}})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, fl.MatchNone(tt.args.ev))
 		})

--- a/pkg/hubble/metrics/api/registry_test.go
+++ b/pkg/hubble/metrics/api/registry_test.go
@@ -144,8 +144,8 @@ func TestRegister(t *testing.T) {
 		opts, _ := ParseContextOptions(options)
 		handlers := initHandlers(t, opts, promRegistry, log)
 
-		ExecuteAllProcessFlow(context.TODO(), flow1, *handlers)
-		ExecuteAllProcessFlow(context.TODO(), flow2, *handlers)
+		ExecuteAllProcessFlow(t.Context(), flow1, *handlers)
+		ExecuteAllProcessFlow(t.Context(), flow2, *handlers)
 		assert.Equal(t, 2, (*handlers)[0].Handler.(*testHandler).ProcessCalled)
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
@@ -187,8 +187,8 @@ func TestRegister(t *testing.T) {
 		opts, _ := ParseContextOptions(options)
 		handlers := initHandlers(t, opts, promRegistry, log)
 
-		ExecuteAllProcessFlow(context.TODO(), flow1, *handlers)
-		ExecuteAllProcessFlow(context.TODO(), flow2, *handlers)
+		ExecuteAllProcessFlow(t.Context(), flow1, *handlers)
+		ExecuteAllProcessFlow(t.Context(), flow2, *handlers)
 		assert.Equal(t, 2, (*handlers)[0].Handler.(*testHandler).ProcessCalled)
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
@@ -226,8 +226,8 @@ func TestRegister(t *testing.T) {
 		opts, _ := ParseContextOptions(options)
 		handlers := initHandlers(t, opts, promRegistry, log)
 
-		ExecuteAllProcessFlow(context.TODO(), flow1, *handlers)
-		ExecuteAllProcessFlow(context.TODO(), flow2, *handlers)
+		ExecuteAllProcessFlow(t.Context(), flow1, *handlers)
+		ExecuteAllProcessFlow(t.Context(), flow2, *handlers)
 		assert.Equal(t, 2, (*handlers)[0].Handler.(*testHandler).ProcessCalled)
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
@@ -265,8 +265,8 @@ func TestRegister(t *testing.T) {
 		opts, _ := ParseContextOptions(options)
 		handlers := initHandlers(t, opts, promRegistry, log)
 
-		ExecuteAllProcessFlow(context.TODO(), flow1, *handlers)
-		ExecuteAllProcessFlow(context.TODO(), flow2, *handlers)
+		ExecuteAllProcessFlow(t.Context(), flow1, *handlers)
+		ExecuteAllProcessFlow(t.Context(), flow2, *handlers)
 		assert.Equal(t, 2, (*handlers)[0].Handler.(*testHandler).ProcessCalled)
 
 		verifyMetricSeriesExists(t, promRegistry, 2)

--- a/pkg/hubble/metrics/drop/handler_test.go
+++ b/pkg/hubble/metrics/drop/handler_test.go
@@ -4,7 +4,6 @@
 package drop
 
 import (
-	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -56,7 +55,7 @@ func TestDropHandler(t *testing.T) {
 			Destination: &pb.Endpoint{Namespace: "bar"},
 			Verdict:     pb.Verdict_FORWARDED,
 		}
-		dropHandler.ProcessFlow(context.TODO(), flow)
+		dropHandler.ProcessFlow(t.Context(), flow)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
@@ -91,8 +90,8 @@ func TestDropHandler(t *testing.T) {
 			DropReason:     uint32(pb.DropReason_POLICY_DENIED),
 			DropReasonDesc: pb.DropReason_POLICY_DENIED,
 		}
-		dropHandler.ProcessFlow(context.TODO(), flow1)
-		dropHandler.ProcessFlow(context.TODO(), flow2)
+		dropHandler.ProcessFlow(t.Context(), flow1)
+		dropHandler.ProcessFlow(t.Context(), flow2)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
@@ -116,7 +115,7 @@ func TestDropHandler(t *testing.T) {
 		assert.Equal(t, 1., *metric.Counter.Value)
 
 		//send another flow with same labels
-		dropHandler.ProcessFlow(context.TODO(), flow1)
+		dropHandler.ProcessFlow(t.Context(), flow1)
 		metricFamilies, _ = registry.Gather()
 		metric = metricFamilies[0].Metric[0]
 		assert.Equal(t, 2., *metric.Counter.Value)

--- a/pkg/hubble/metrics/flow/handler_test.go
+++ b/pkg/hubble/metrics/flow/handler_test.go
@@ -4,7 +4,6 @@
 package flow
 
 import (
-	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -63,8 +62,8 @@ func TestFlowHandler(t *testing.T) {
 			Destination: &pb.Endpoint{Namespace: "bar"},
 			Verdict:     pb.Verdict_FORWARDED,
 		}
-		h.ProcessFlow(context.TODO(), flow0)
-		h.ProcessFlow(context.TODO(), flow1)
+		h.ProcessFlow(t.Context(), flow0)
+		h.ProcessFlow(t.Context(), flow1)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
@@ -100,7 +99,7 @@ func TestFlowHandler(t *testing.T) {
 			Source: &pb.Endpoint{Namespace: "allowNs"},
 		}
 
-		h.ProcessFlow(context.TODO(), flow2)
+		h.ProcessFlow(t.Context(), flow2)
 
 		metricFamilies, err = registry.Gather()
 		require.NoError(t, err)
@@ -132,7 +131,7 @@ func TestFlowHandler(t *testing.T) {
 			Source:  &pb.Endpoint{Namespace: "allowNs"},
 		}
 
-		h.ProcessFlow(context.TODO(), flow3)
+		h.ProcessFlow(t.Context(), flow3)
 
 		metricFamilies, err = registry.Gather()
 		require.NoError(t, err)

--- a/pkg/hubble/metrics/flows-to-world/handler_test.go
+++ b/pkg/hubble/metrics/flows-to-world/handler_test.go
@@ -4,7 +4,6 @@
 package flows_to_world
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -52,19 +51,19 @@ func TestFlowsToWorldHandler_MatchingFlow(t *testing.T) {
 		DestinationNames: []string{"cilium.io"},
 	}
 
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 	flow.L4 = &flowpb.Layer4{
 		Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 53}},
 	}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 	flow.L4 = &flowpb.Layer4{
 		Protocol: &flowpb.Layer4_ICMPv4{ICMPv4: &flowpb.ICMPv4{}},
 	}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 	flow.L4 = &flowpb.Layer4{
 		Protocol: &flowpb.Layer4_ICMPv6{ICMPv6: &flowpb.ICMPv6{}},
 	}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
 # TYPE hubble_flows_to_world_total counter
 hubble_flows_to_world_total{destination="cilium.io",protocol="ICMPv4",source="src-a",verdict="DROPPED"} 1
@@ -93,12 +92,12 @@ func TestFlowsToWorldHandler_NonMatchingFlows(t *testing.T) {
 	assert.NoError(t, h.Init(registry, opts))
 
 	// destination is missing.
-	h.ProcessFlow(context.Background(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &flowpb.Flow{
 		Verdict: flowpb.Verdict_FORWARDED,
 		Source:  &flowpb.Endpoint{Namespace: "src-a"},
 	})
 	// destination is not reserved:world
-	h.ProcessFlow(context.Background(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &flowpb.Flow{
 		Verdict: flowpb.Verdict_FORWARDED,
 		Source:  &flowpb.Endpoint{Namespace: "src-a"},
 		Destination: &flowpb.Endpoint{
@@ -106,7 +105,7 @@ func TestFlowsToWorldHandler_NonMatchingFlows(t *testing.T) {
 		},
 	})
 	// L4 information is missing.
-	h.ProcessFlow(context.Background(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &flowpb.Flow{
 		Verdict: flowpb.Verdict_FORWARDED,
 		Source:  &flowpb.Endpoint{Namespace: "src-a"},
 		Destination: &flowpb.Endpoint{
@@ -114,7 +113,7 @@ func TestFlowsToWorldHandler_NonMatchingFlows(t *testing.T) {
 		},
 	})
 	// EventType is missing.
-	h.ProcessFlow(context.Background(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &flowpb.Flow{
 		Verdict: flowpb.Verdict_FORWARDED,
 		Source:  &flowpb.Endpoint{Namespace: "src-a"},
 		Destination: &flowpb.Endpoint{
@@ -127,7 +126,7 @@ func TestFlowsToWorldHandler_NonMatchingFlows(t *testing.T) {
 		},
 	})
 	// Drop reason is not "Policy denied".
-	h.ProcessFlow(context.Background(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &flowpb.Flow{
 		Verdict:        flowpb.Verdict_DROPPED,
 		EventType:      &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
 		DropReasonDesc: flowpb.DropReason_STALE_OR_UNROUTABLE_IP,
@@ -143,7 +142,7 @@ func TestFlowsToWorldHandler_NonMatchingFlows(t *testing.T) {
 		DestinationNames: []string{"cilium.io"},
 	})
 	// Flow is a reply.
-	h.ProcessFlow(context.Background(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &flowpb.Flow{
 		Verdict:   flowpb.Verdict_FORWARDED,
 		EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeTrace},
 		L4: &flowpb.Layer4{
@@ -197,7 +196,7 @@ func TestFlowsToWorldHandler_AnyDrop(t *testing.T) {
 		},
 		DestinationNames: []string{"cilium.io"},
 	}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
 # TYPE hubble_flows_to_world_total counter
 hubble_flows_to_world_total{destination="cilium.io",protocol="TCP",source="src-a",verdict="DROPPED"} 1
@@ -241,19 +240,19 @@ func TestFlowsToWorldHandler_IncludePort(t *testing.T) {
 		DestinationNames: []string{"cilium.io"},
 		IsReply:          wrapperspb.Bool(false),
 	}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 	flow.L4 = &flowpb.Layer4{
 		Protocol: &flowpb.Layer4_UDP{
 			UDP: &flowpb.UDP{DestinationPort: 53},
 		},
 	}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 	flow.L4 = &flowpb.Layer4{
 		Protocol: &flowpb.Layer4_SCTP{
 			SCTP: &flowpb.SCTP{DestinationPort: 2905},
 		},
 	}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
 # TYPE hubble_flows_to_world_total counter
 hubble_flows_to_world_total{destination="cilium.io",port="2905",protocol="SCTP",source="src-a",verdict="FORWARDED"} 1
@@ -300,20 +299,20 @@ func TestFlowsToWorldHandler_SynOnly(t *testing.T) {
 		DestinationNames: []string{"cilium.io"},
 		IsReply:          wrapperspb.Bool(false),
 	}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 
 	// flows without is_reply field should be counted.
 	flow.IsReply = nil
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 
 	// reply flows should not be counted
 	flow.IsReply = wrapperspb.Bool(true)
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 
 	// Non-SYN should not be counted
 	flow.IsReply = wrapperspb.Bool(false)
 	flow.L4.GetTCP().Flags = &flowpb.TCPFlags{ACK: true}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 
 	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
 # TYPE hubble_flows_to_world_total counter

--- a/pkg/hubble/metrics/http/handler_test.go
+++ b/pkg/hubble/metrics/http/handler_test.go
@@ -4,7 +4,6 @@
 package http
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -38,7 +37,7 @@ func Test_httpHandler_Status(t *testing.T) {
 }
 
 func Test_httpHandler_ProcessFlow(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	plugin := httpPlugin{}
 	handler := plugin.NewHandler()
 	options := &api.MetricConfig{
@@ -116,7 +115,7 @@ func Test_httpHandler_ProcessFlow(t *testing.T) {
 }
 
 func Test_httpHandlerV2_ProcessFlow(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	plugin := httpV2Plugin{}
 	handler := plugin.NewHandler()
 	options := &api.MetricConfig{

--- a/pkg/hubble/metrics/kafka/handler_test.go
+++ b/pkg/hubble/metrics/kafka/handler_test.go
@@ -4,7 +4,6 @@
 package kafka
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -38,7 +37,7 @@ func Test_kafkaHandler_Status(t *testing.T) {
 }
 
 func Test_kafkaHandler_ProcessFlow(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	plugin := kafkaPlugin{}
 	handler := plugin.NewHandler()
 	options := &api.MetricConfig{

--- a/pkg/hubble/metrics/policy/handler_test.go
+++ b/pkg/hubble/metrics/policy/handler_test.go
@@ -4,7 +4,6 @@
 package policy
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -30,16 +29,16 @@ func TestPolicyHandler(t *testing.T) {
 		Verdict:          flowpb.Verdict_DROPPED,
 	}
 
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 	flow.TrafficDirection = flowpb.TrafficDirection_INGRESS
 	flow.PolicyMatchType = monitorAPI.PolicyMatchL3L4
 	flow.Verdict = flowpb.Verdict_REDIRECTED
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 
 	// Policy verdicts from host shouldn't be counted.
 	flow.PolicyMatchType = monitorAPI.PolicyMatchAll
 	flow.Source = &flowpb.Endpoint{Identity: uint32(identity.ReservedIdentityHost)}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 
 	// l7/http
 	flow.EventType = &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog}
@@ -51,7 +50,7 @@ func TestPolicyHandler(t *testing.T) {
 			Url:      "http://myhost/some/path",
 			Protocol: "http/1.1",
 		}}}
-	h.ProcessFlow(context.Background(), &flow)
+	h.ProcessFlow(t.Context(), &flow)
 
 	expected := strings.NewReader(`# HELP hubble_policy_verdicts_total Total number of Cilium network policy verdicts
 # TYPE hubble_policy_verdicts_total counter

--- a/pkg/hubble/metrics/port-distribution/handler_test.go
+++ b/pkg/hubble/metrics/port-distribution/handler_test.go
@@ -4,7 +4,6 @@
 package portdistribution
 
 import (
-	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,7 +43,7 @@ func TestPortDistributionHandler(t *testing.T) {
 
 	t.Run("ProcessFlow_SkipReply", func(t *testing.T) {
 		flow := buildFlow(8080, pb.Verdict_FORWARDED, true)
-		portHandler.ProcessFlow(context.TODO(), flow)
+		portHandler.ProcessFlow(t.Context(), flow)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
@@ -54,7 +53,7 @@ func TestPortDistributionHandler(t *testing.T) {
 
 	t.Run("ProcessFlow_SkipDropped", func(t *testing.T) {
 		flow := buildFlow(8080, pb.Verdict_DROPPED, false)
-		portHandler.ProcessFlow(context.TODO(), flow)
+		portHandler.ProcessFlow(t.Context(), flow)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
@@ -64,7 +63,7 @@ func TestPortDistributionHandler(t *testing.T) {
 
 	t.Run("ProcessFlow", func(t *testing.T) {
 		flow := buildFlow(8080, pb.Verdict_FORWARDED, false)
-		portHandler.ProcessFlow(context.TODO(), flow)
+		portHandler.ProcessFlow(t.Context(), flow)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
@@ -88,7 +87,7 @@ func TestPortDistributionHandler(t *testing.T) {
 		assert.Equal(t, 1., *metric.Counter.Value)
 
 		//send another flow with same labels
-		portHandler.ProcessFlow(context.TODO(), flow)
+		portHandler.ProcessFlow(t.Context(), flow)
 		metricFamilies, _ = registry.Gather()
 		metric = metricFamilies[0].Metric[0]
 		assert.Equal(t, 2., *metric.Counter.Value)
@@ -113,11 +112,11 @@ func TestPortDistributionHandler(t *testing.T) {
 		require.NoError(t, portHandler.Init(registry, opts))
 
 		flow1 := buildFlow(8081, pb.Verdict_FORWARDED, false)
-		portHandler.ProcessFlow(context.TODO(), flow1)
+		portHandler.ProcessFlow(t.Context(), flow1)
 
 		flow2 := buildFlow(8082, pb.Verdict_FORWARDED, false)
-		portHandler.ProcessFlow(context.TODO(), flow2)
-		portHandler.ProcessFlow(context.TODO(), flow2)
+		portHandler.ProcessFlow(t.Context(), flow2)
+		portHandler.ProcessFlow(t.Context(), flow2)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)

--- a/pkg/hubble/metrics/tcp/handler_test.go
+++ b/pkg/hubble/metrics/tcp/handler_test.go
@@ -4,7 +4,6 @@
 package tcp
 
 import (
-	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -76,7 +75,7 @@ func TestTcpHandler(t *testing.T) {
 
 		t.Run("ProcessSupportedFlagsFlow_"+tc.name, func(t *testing.T) {
 			flow := buildFlow(tc.flags)
-			_ = tcpHandler.ProcessFlow(context.TODO(), flow)
+			_ = tcpHandler.ProcessFlow(t.Context(), flow)
 
 			metricFamilies, err := registry.Gather()
 			require.NoError(t, err)
@@ -99,7 +98,7 @@ func TestTcpHandler(t *testing.T) {
 			assert.Equal(t, 1., *metric.Counter.Value)
 
 			//send another flow with same labels
-			tcpHandler.ProcessFlow(context.TODO(), flow)
+			tcpHandler.ProcessFlow(t.Context(), flow)
 			metricFamilies, _ = registry.Gather()
 			metric = metricFamilies[0].Metric[0]
 			assert.Equal(t, 2., *metric.Counter.Value)
@@ -140,7 +139,7 @@ func TestTcpHandler(t *testing.T) {
 
 		t.Run("ProcessUnsupportedFlagsFlow_"+tc.name, func(t *testing.T) {
 			flow := buildFlow(tc.flags)
-			_ = tcpHandler.ProcessFlow(context.TODO(), flow)
+			_ = tcpHandler.ProcessFlow(t.Context(), flow)
 
 			metricFamilies, err := registry.Gather()
 			require.NoError(t, err)

--- a/pkg/hubble/monitor/filter_test.go
+++ b/pkg/hubble/monitor/filter_test.go
@@ -5,7 +5,6 @@ package monitor
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -497,7 +496,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 			assert.NoError(t, err)
 
 			for _, event := range tc.events {
-				stop, err := mf.OnMonitorEvent(context.Background(), event.event)
+				stop, err := mf.OnMonitorEvent(t.Context(), event.event)
 				assert.Equal(t, event.expectedErr, err)
 				assert.Equal(t, event.stop, stop)
 			}

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -68,7 +68,7 @@ func TestLocalObserverServer_ServerStatus(t *testing.T) {
 	pp := noopParser(t)
 	s, err := NewLocalServer(pp, nsManager, hivetest.Logger(t), observeroption.WithMaxFlows(container.Capacity1))
 	require.NoError(t, err)
-	res, err := s.ServerStatus(context.Background(), &observerpb.ServerStatusRequest{})
+	res, err := s.ServerStatus(t.Context(), &observerpb.ServerStatusRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), res.SeenFlows)
 	assert.Equal(t, uint64(0), res.NumFlows)
@@ -212,7 +212,7 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 		},
 		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
 			OnContext: func() context.Context {
-				return context.Background()
+				return t.Context()
 			},
 		},
 	}
@@ -357,7 +357,7 @@ func TestLocalObserverServer_GetAgentEvents(t *testing.T) {
 		},
 		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
 			OnContext: func() context.Context {
-				return context.Background()
+				return t.Context()
 			},
 		},
 	}
@@ -471,7 +471,7 @@ func TestLocalObserverServer_GetFlows_Follow_Since(t *testing.T) {
 		},
 		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
 			OnContext: func() context.Context {
-				return context.Background()
+				return t.Context()
 			},
 		},
 	}
@@ -552,7 +552,7 @@ func TestLocalObserverServer_OnFlowDelivery(t *testing.T) {
 		},
 		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
 			OnContext: func() context.Context {
-				return context.Background()
+				return t.Context()
 			},
 		},
 	}
@@ -610,7 +610,7 @@ func TestLocalObserverServer_OnGetFlows(t *testing.T) {
 		},
 		FakeGRPCServerStream: &testutils.FakeGRPCServerStream{
 			OnContext: func() context.Context {
-				return context.Background()
+				return t.Context()
 			},
 		},
 	}
@@ -754,7 +754,7 @@ func TestLocalObserverServer_GetNamespaces(t *testing.T) {
 	})
 	s, err := NewLocalServer(pp, nsManager, hivetest.Logger(t), observeroption.WithMaxFlows(container.Capacity1))
 	require.NoError(t, err)
-	res, err := s.GetNamespaces(context.Background(), &observerpb.GetNamespacesRequest{})
+	res, err := s.GetNamespaces(t.Context(), &observerpb.GetNamespacesRequest{})
 	require.NoError(t, err)
 	expected := &observerpb.GetNamespacesResponse{
 		Namespaces: []*observerpb.Namespace{

--- a/pkg/hubble/relay/observer/server_test.go
+++ b/pkg/hubble/relay/observer/server_test.go
@@ -948,7 +948,7 @@ func TestGetNodes(t *testing.T) {
 				withObserverClientBuilder(tt.ocb),
 			)
 			assert.NoError(t, err)
-			got, err := srv.GetNodes(context.Background(), tt.req)
+			got, err := srv.GetNodes(t.Context(), tt.req)
 			assert.Equal(t, tt.want.err, err)
 			assert.Equal(t, tt.want.resp, got)
 			out := buf.String()
@@ -1149,7 +1149,7 @@ func TestGetNamespaces(t *testing.T) {
 				withObserverClientBuilder(tt.ocb),
 			)
 			assert.NoError(t, err)
-			got, err := srv.GetNamespaces(context.Background(), tt.req)
+			got, err := srv.GetNamespaces(t.Context(), tt.req)
 			assert.Equal(t, tt.want.err, err)
 			assert.Equal(t, tt.want.resp, got)
 			out := buf.String()
@@ -1430,7 +1430,7 @@ func TestServerStatus(t *testing.T) {
 				withObserverClientBuilder(tt.ocb),
 			)
 			assert.NoError(t, err)
-			got, err := srv.ServerStatus(context.Background(), tt.req)
+			got, err := srv.ServerStatus(t.Context(), tt.req)
 			assert.Equal(t, tt.want.err, err)
 			assert.Equal(t, tt.want.resp, got)
 			out := buf.String()

--- a/pkg/hubble/relay/pool/client_test.go
+++ b/pkg/hubble/relay/pool/client_test.go
@@ -5,7 +5,6 @@ package pool
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -59,7 +58,7 @@ func TestGRPCClientConnBuilder_CertificateChange(t *testing.T) {
 	clientConn, err := cb.ClientConn(fmt.Sprintf("unix://%s", list.Addr().String()), "foo.test.cilium.io")
 	require.NoError(t, err)
 	hc := healthpb.NewHealthClient(clientConn)
-	_, err = hc.Check(context.TODO(), nil)
+	_, err = hc.Check(t.Context(), nil)
 	require.NoError(t, err)
 
 	cert, ca = newTestCAandCert(t)
@@ -76,7 +75,7 @@ func TestGRPCClientConnBuilder_CertificateChange(t *testing.T) {
 	fTLSb.set(&cert, ca)
 
 	require.Eventually(t, func() bool {
-		_, err = hc.Check(context.TODO(), nil)
+		_, err = hc.Check(t.Context(), nil)
 		if err != nil {
 			t.Logf("Error %q conn state %q", err.Error(), clientConn.GetState().String())
 		}

--- a/pkg/hubble/relay/server/health_test.go
+++ b/pkg/hubble/relay/server/health_test.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -59,13 +58,13 @@ func TestHealthServer(t *testing.T) {
 func eventuallServingStatus(t *testing.T, svc healthpb.HealthServer, status healthpb.HealthCheckResponse_ServingStatus) {
 	t.Helper()
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		res, err := svc.Check(context.TODO(), &healthpb.HealthCheckRequest{
+		res, err := svc.Check(t.Context(), &healthpb.HealthCheckRequest{
 			Service: "",
 		})
 		assert.NoError(c, err)
 		assert.Equal(c, status, res.Status)
 
-		res, err = svc.Check(context.TODO(), &healthpb.HealthCheckRequest{
+		res, err = svc.Check(t.Context(), &healthpb.HealthCheckRequest{
 			Service: v1.ObserverServiceName,
 		})
 		assert.NoError(c, err)

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -169,7 +169,7 @@ func newHubblePeer(t testing.TB, ctx context.Context, address string, hubbleObse
 func benchmarkRelayGetFlows(b *testing.B, withFieldMask bool) {
 	tmp := b.TempDir()
 	root := "unix://" + filepath.Join(tmp, "peer-")
-	ctx := context.Background()
+	ctx := b.Context()
 	numFlows := b.N
 	numPeers := 2
 


### PR DESCRIPTION
Replace usages of `context.TODO()` and `context.Background()` in hubble related packages tests.

Followup of f5d5948f09e11defbc7cc8d8f6a44d0519dad942 (#38652)

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->


```release-note
hubble: Use testing.T.Context added in Go 1.24 in tests
```
