### PR TITLE
bugtool: also collect IPv6 EGW map

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -108,6 +108,7 @@ var bpfMapsPath = []string{
 	"tc/globals/cilium_throttle",
 	"tc/globals/cilium_encrypt_state",
 	"tc/globals/cilium_egress_gw_policy_v4",
+	"tc/globals/cilium_egress_gw_policy_v6",
 	"tc/globals/cilium_srv6_vrf_v4",
 	"tc/globals/cilium_srv6_vrf_v6",
 	"tc/globals/cilium_srv6_policy_v4",


### PR DESCRIPTION
The IPv6 map was added with https://github.com/cilium/cilium/pull/38452. Reflect what we currently do for the IPv4 map.