### PR TITLE
pkg/aws/eni: Adding support for prefix delegation in AWS bare metal

### DIFF
--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -91,6 +91,7 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 				Ipv6AddressesPerInterface: aws.Int32(10),
 			},
 			Hypervisor: ec2_types.InstanceTypeHypervisorNitro,
+			BareMetal:  aws.Bool(false),
 		},
 		{
 			InstanceType: "m5.4xlarge",
@@ -100,6 +101,7 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 				Ipv6AddressesPerInterface: aws.Int32(30),
 			},
 			Hypervisor: ec2_types.InstanceTypeHypervisorNitro,
+			BareMetal:  aws.Bool(false),
 		},
 		{
 			InstanceType: "m3.large",
@@ -109,6 +111,7 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 				Ipv6AddressesPerInterface: aws.Int32(10),
 			},
 			Hypervisor: ec2_types.InstanceTypeHypervisorXen,
+			BareMetal:  aws.Bool(false),
 		},
 		{
 			InstanceType: "m4.xlarge",
@@ -118,6 +121,7 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 				Ipv6AddressesPerInterface: aws.Int32(15),
 			},
 			Hypervisor: ec2_types.InstanceTypeHypervisorXen,
+			BareMetal:  aws.Bool(false),
 		},
 		{
 			InstanceType: "t2.xlarge",
@@ -127,6 +131,7 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 				Ipv6AddressesPerInterface: aws.Int32(15),
 			},
 			Hypervisor: ec2_types.InstanceTypeHypervisorXen,
+			BareMetal:  aws.Bool(false),
 		},
 		{
 			InstanceType: "c3.xlarge",
@@ -136,6 +141,7 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 				Ipv6AddressesPerInterface: aws.Int32(15),
 			},
 			Hypervisor: ec2_types.InstanceTypeHypervisorXen,
+			BareMetal:  aws.Bool(false),
 		},
 		{
 			InstanceType: "m4.large",
@@ -145,6 +151,17 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 				Ipv6AddressesPerInterface: aws.Int32(10),
 			},
 			Hypervisor: ec2_types.InstanceTypeHypervisorXen,
+			BareMetal:  aws.Bool(false),
+		},
+		{
+			InstanceType: "m5.metal",
+			NetworkInfo: &ec2_types.NetworkInfo{
+				MaximumNetworkInterfaces:  aws.Int32(3),
+				Ipv4AddressesPerInterface: aws.Int32(10),
+				Ipv6AddressesPerInterface: aws.Int32(10),
+			},
+			Hypervisor: "",
+			BareMetal:  aws.Bool(true),
 		},
 	}
 

--- a/pkg/aws/eni/limits/limits.go
+++ b/pkg/aws/eni/limits/limits.go
@@ -116,12 +116,14 @@ func (l *LimitsGetter) updateFromEC2API(ctx context.Context, api ec2API) error {
 		ipv4PerAdapter := aws.ToInt32(instanceTypeInfo.NetworkInfo.Ipv4AddressesPerInterface)
 		ipv6PerAdapter := aws.ToInt32(instanceTypeInfo.NetworkInfo.Ipv6AddressesPerInterface)
 		hypervisorType := instanceTypeInfo.Hypervisor
+		isBareMetal := aws.ToBool(instanceTypeInfo.BareMetal)
 
 		l.m[instanceType] = ipamTypes.Limits{
 			Adapters:       int(adapterLimit),
 			IPv4:           int(ipv4PerAdapter),
 			IPv6:           int(ipv6PerAdapter),
 			HypervisorType: string(hypervisorType),
+			IsBareMetal:    isBareMetal,
 		}
 	}
 	l.lastUpdate = time.Now()

--- a/pkg/aws/eni/limits/limits_test.go
+++ b/pkg/aws/eni/limits/limits_test.go
@@ -35,6 +35,7 @@ func TestGet(t *testing.T) {
 			Ipv6AddressesPerInterface: ptr.To[int32](6),
 		},
 		Hypervisor: ec2_types.InstanceTypeHypervisorNitro,
+		BareMetal:  ptr.To(false),
 	}})
 	newLimitsGetter, err := NewLimitsGetter(hivetest.Logger(t), api, testTriggerMinInterval, testEC2apiTimeout, testEC2apiRetryCount)
 	require.NoError(t, err)
@@ -51,6 +52,7 @@ func TestGet(t *testing.T) {
 		IPv4:           5,
 		IPv6:           6,
 		HypervisorType: "nitro",
+		IsBareMetal:    false,
 	}, limit)
 
 	// Test 3: EC2 API call and update limits but trigger can't be triggered
@@ -62,6 +64,7 @@ func TestGet(t *testing.T) {
 			Ipv6AddressesPerInterface: ptr.To[int32](15),
 		},
 		Hypervisor: ec2_types.InstanceTypeHypervisorNitro,
+		BareMetal:  ptr.To(false),
 	}})
 
 	limit, ok = newLimitsGetter.Get("newtype")
@@ -75,6 +78,7 @@ func TestGet(t *testing.T) {
 			IPv4:           15,
 			IPv6:           15,
 			HypervisorType: "nitro",
+			IsBareMetal:    false,
 		}
 	}, 2*testTriggerMinInterval, time.Millisecond)
 }
@@ -91,6 +95,7 @@ func TestInitEC2APIUpdateTrigger(t *testing.T) {
 				Ipv6AddressesPerInterface: ptr.To[int32](10),
 			},
 			Hypervisor: ec2_types.InstanceTypeHypervisorNitro,
+			BareMetal:  ptr.To(false),
 		},
 	})
 
@@ -113,5 +118,6 @@ func TestInitEC2APIUpdateTrigger(t *testing.T) {
 		IPv4:           10,
 		IPv6:           10,
 		HypervisorType: "nitro",
+		IsBareMetal:    false,
 	}, limits)
 }

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -789,8 +789,8 @@ func (n *Node) IsPrefixDelegated() bool {
 	if !limitsAvailable {
 		return false
 	}
-	// Allocating prefixes is supported only on nitro instances
-	if limits.HypervisorType != "nitro" {
+	// Allocating prefixes is supported only on nitro and bare metal instances
+	if limits.HypervisorType != "nitro" && !limits.IsBareMetal {
 		return false
 	}
 	// Check if this node is allowed to use prefix delegation

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -25,6 +25,9 @@ type Limits struct {
 	// HypervisorType tracks the instance's hypervisor type if available. Used to determine if features like prefix
 	// delegation are supported on an instance. Bare metal instances would have empty string.
 	HypervisorType string
+
+	// IsBareMetal tracks whether an instance is a bare metal instance or not
+	IsBareMetal bool
 }
 
 // AllocationIP is an IP which is available for allocation, or already

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -335,6 +335,9 @@ func (in *Limits) DeepEqual(other *Limits) bool {
 	if in.HypervisorType != other.HypervisorType {
 		return false
 	}
+	if in.IsBareMetal != other.IsBareMetal {
+		return false
+	}
 
 	return true
 }


### PR DESCRIPTION
# What does this do

This PR aims to add the possibility of prefix delegation on AWS instances of type `bare metal`. The original idea was to allow this feature only on instances of Hypervisor type `nitro` (PR #18463). However, this also works on nitro based instances of type bare metal. The only instances that don't support this feature are those of Hypervisor type `xen`.

This feature is also available on AWS's own CNI [ENABLE_PREFIX_DELEGATION](https://github.com/aws/amazon-vpc-cni-k8s?tab=readme-ov-file#enable_prefix_delegation-v190).

# How was it tested

This change was successfully tested on our clusters. Having noticed a problem with AWS nitro based bare metal instances not being assigned IP prefixes, this fix solved our issue.

```release-note
AWS ENI IPAM Mode: Added support for prefix delegation on AWS bare metal instances
```