### PR TITLE
Makefile: Fix creating docker builders

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -13,7 +13,7 @@ export DOCKER_BUILDKIT=1
 ifdef ARCH
   # Default to multi-arch builds, always create the builder for all the platforms we support
   DOCKER_PLATFORMS := linux/arm64,linux/amd64
-  DOCKER_BUILDER := $(shell docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1)
+  DOCKER_BUILDER := $(shell docker buildx ls --format '{{ .Name }}' | head -n1)
   ifneq (,$(filter $(DOCKER_BUILDER),default desktop-linux))
     DOCKER_BUILDKIT_DRIVER :=
     ifdef DOCKER_BUILDKIT_IMAGE
@@ -36,7 +36,7 @@ else
 endif
 DOCKER_EXISTS := $(shell command -v docker 2>/dev/null)
 ifdef DOCKER_EXISTS
-DOCKER_BUILDER := $(shell docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1)
+DOCKER_BUILDER := $(shell docker buildx ls --format '{{ .Name }}' | head -n1)
 endif
 
 ##@ Docker Images


### PR DESCRIPTION
It seems that the output of `docker buildx ls` doesn't match the expectation of the command that we use:

    docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1

With the current versions of Docker (28.1.1) and buildx (0.23.0), the output of `docker buildx ls` looks like this:

    NAME/NODE            DRIVER/ENDPOINT                   STATUS    BUILDKIT   PLATFORMS
    naughty_mayer*       docker-container
     \_ naughty_mayer0    \_ unix:///var/run/docker.sock   running   v0.21.1    linux/amd64* (+4), linux/arm64*, linux/386
    default              docker
     \_ default           \_ default                       running   v0.21.0    linux/amd64 (+4), linux/386

...and the above command's output is empty.

Change the command to the following:

    docker buildx ls --format '{{ .Name }}' | head -n1

...assuming that the idea is to get the name of the first builder, check if it's default (or default-linux), and if it is, create an actual one that would use the docker-container driver and be able to build multi-arch images.

This fix resolves the following error message on machines that don't have a suitable builder in advance:

    ERROR: Multi-platform build is not supported for the docker driver.
    Switch to a different driver, or turn on the containerd image store, and try again.
    Learn more at https://docs.docker.com/go/build-multi-platform/