### PR TITLE
disk-cleanup: Gather more info about usage

### DIFF
--- a/.github/actions/disk-cleanup/action.yaml
+++ b/.github/actions/disk-cleanup/action.yaml
@@ -3,11 +3,23 @@ description: "Cleanup disk space"
 runs:
   using: composite
   steps:
+    - name: Assess disk usage before cleanup
+      shell: bash
+      run: |
+        echo "# Overview"
+        df -h
+        echo "# Usage for /mnt"
+        sudo du --human-readable \
+                --threshold 50m \
+                -- /mnt
+        echo "# Usage for /var/lib/docker/volumes"
+        sudo du --human-readable \
+                --dereference \
+                --threshold 50m \
+                -- /var/lib/docker/volumes/
     - name: Free up disk space
       shell: bash
       run: |
-        echo "Disk space before cleanup..."
-        df -h /
         echo "Removing unnecessary files to free up disk space..."
         # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832
         sudo rm -rf \
@@ -26,5 +38,17 @@ runs:
           /usr/local/share/powershell \
           /usr/share/dotnet \
           /usr/share/swift
-        echo "Disk space after cleanup..."
-        df -h /
+    - name: Assess disk usage after cleanup
+      shell: bash
+      run: |
+        echo "# Overview"
+        df -h
+        echo "# Usage for /mnt"
+        sudo du --human-readable \
+                --threshold 50m \
+                -- /mnt
+        echo "# Usage for /var/lib/docker/volumes"
+        sudo du --human-readable \
+                --dereference \
+                --threshold 50m \
+                -- /var/lib/docker/volumes/


### PR DESCRIPTION
Split the steps for gathering info about the disk usage into dedicated
steps before and after the cleanup, and also print the usage of /mnt
which is currently causing problems in Cilium testing infrastructure.

Related: https://github.com/cilium/cilium/issues/39682
