### PR TITLE
cli: require Cilium v1.14

### DIFF
--- a/cilium-cli/cli/bgp.go
+++ b/cilium-cli/cli/bgp.go
@@ -34,7 +34,7 @@ func newCmdBgpPeers() *cobra.Command {
 		Use:     "peers",
 		Aliases: []string{"neighbors"},
 		Short:   "Lists BGP peering state",
-		Long:    "This command lists the BGP state from all nodes in the cluster - requires cilium >= v1.13.2",
+		Long:    "This command lists the BGP state from all nodes in the cluster",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			params.CiliumNamespace = namespace
 
@@ -62,7 +62,7 @@ func newCmdBgpRoutes() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "routes <available | advertised> <afi> <safi> [vrouter <asn>] [peer|neighbor <address>]",
 		Short: "Lists BGP routes",
-		Long:  "Lists BGP routes from all nodes in the cluster - requires cilium >= v1.14.6",
+		Long:  "Lists BGP routes from all nodes in the cluster",
 		Example: `  Get all IPv4 unicast routes available:
     cilium bgp routes available ipv4 unicast
 

--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -92,7 +92,7 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&params.EnableKVStoreMesh, "enable-kvstoremesh", false, "Enable kvstoremesh, an extension which caches remote cluster information in the local kvstore (Cilium >=1.14 only)")
+	cmd.Flags().BoolVar(&params.EnableKVStoreMesh, "enable-kvstoremesh", false, "Enable kvstoremesh, an extension which caches remote cluster information in the local kvstore")
 	cmd.Flags().StringVar(&params.ServiceType, "service-type", "", "Type of Kubernetes service to expose control plane { LoadBalancer | NodePort }")
 
 	return cmd

--- a/cilium-cli/connectivity/builder/check_log_errors.go
+++ b/cilium-cli/connectivity/builder/check_log_errors.go
@@ -6,16 +6,12 @@ package builder
 import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 type checkLogErrors struct{}
 
 func (t checkLogErrors) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("check-log-errors", ct).
-		WithCondition(func() bool {
-			return versioncheck.MustCompile(">=1.14.0")(ct.CiliumVersion) || ct.Params().IncludeUnsafeTests
-		}).
 		WithSysdumpPolicy(check.SysdumpPolicyOnce).
 		WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion, ct.Params().LogCheckLevels, ct.Params().ExternalTarget,
 			ct.Params().ExternalOtherTarget))

--- a/cilium-cli/connectivity/builder/egress_gateway_excluded_cidrs.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_excluded_cidrs.go
@@ -7,16 +7,12 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 type egressGatewayExcludedCidrs struct{}
 
 func (t egressGatewayExcludedCidrs) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("egress-gateway-excluded-cidrs", ct).
-		WithCondition(func() bool {
-			return versioncheck.MustCompile(">=1.14.0")(ct.CiliumVersion)
-		}).
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
 			Name:              "cegp-sample-client",
 			PodSelectorKind:   "client",

--- a/cilium-cli/connectivity/builder/north_south_loadbalancing_with_l7_policy.go
+++ b/cilium-cli/connectivity/builder/north_south_loadbalancing_with_l7_policy.go
@@ -40,7 +40,6 @@ func northSouthLoadbalancingWithL7PolicyTest(ct *check.ConnectivityTest, portRan
 				features.RequireEnabled(features.NodeWithoutCilium),
 				features.RequireEnabled(features.L7Proxy))...,
 		).
-		WithCiliumVersion(">1.13.2").
 		WithCiliumPolicy(policyYAML).
 		WithScenarios(tests.OutsideToNodePort())
 }

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 const (
@@ -1285,16 +1284,6 @@ func (ct *ConnectivityTest) KillMulticastTestSender() []string {
 
 func (ct *ConnectivityTest) ForEachIPFamily(hasNetworkPolicies bool, do func(features.IPFamily)) {
 	ipFams := features.GetIPFamilies(ct.Params().IPFamilies)
-
-	// The per-endpoint routes feature is broken with IPv6 on < v1.14 when there
-	// are any netpols installed (https://github.com/cilium/cilium/issues/23852
-	// and https://github.com/cilium/cilium/issues/23910).
-	if f, ok := ct.Feature(features.EndpointRoutes); ok &&
-		f.Enabled && hasNetworkPolicies &&
-		versioncheck.MustCompile("<1.14.0")(ct.CiliumVersion) {
-
-		ipFams = []features.IPFamily{features.IPFamilyV4}
-	}
 
 	for _, ipFam := range ipFams {
 		switch ipFam {

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1385,7 +1385,7 @@ func (ct *ConnectivityTest) createTestConnDisruptServerDeployAndSvc(ctx context.
 
 		if enabled, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.CNP)); enabled {
 			ipsec, _ := ct.Features.MatchRequirements(features.RequireMode(features.EncryptionPod, "ipsec"))
-			if ipsec && versioncheck.MustCompile(">=1.14.0 <1.16.0")(ct.CiliumVersion) {
+			if ipsec && versioncheck.MustCompile("<1.16.0")(ct.CiliumVersion) {
 				// https://github.com/cilium/cilium/issues/36681
 				continue
 			}

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 // PodToService sends an HTTP request from all client Pods
@@ -241,13 +240,6 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 				if f, ok := t.Context().Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
 					continue
 				}
-			}
-
-			//  Skip IPv6 requests when running on <1.14.0 Cilium with CNPs
-			if features.GetIPFamily(addr.Address) == features.IPFamilyV6 &&
-				versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) &&
-				t.HasNetworkPolicies() {
-				continue
 			}
 
 			// Manually construct an HTTP endpoint to override the destination IP

--- a/cilium-cli/install/autodetect.go
+++ b/cilium-cli/install/autodetect.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/cilium/cilium/cilium-cli/k8s"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 func (k *K8sInstaller) detectDatapathMode(helmValues map[string]any) error {
@@ -187,12 +186,7 @@ func (k *K8sInstaller) autodetectKubeProxy(ctx context.Context, helmValues map[s
 		}
 
 		// Use HelmOpts to set auto kube-proxy installation
-		setIfUnset("kubeProxyReplacement", func() string {
-			if versioncheck.MustCompile(">=1.14.0")(k.chartVersion) {
-				return "true"
-			}
-			return "strict"
-		}())
+		setIfUnset("kubeProxyReplacement", "true")
 
 		setIfUnset("k8sServiceHost", apiServerHost)
 		setIfUnset("k8sServicePort", apiServerPort)

--- a/cilium-cli/install/helm.go
+++ b/cilium-cli/install/helm.go
@@ -17,13 +17,13 @@ func (k *K8sInstaller) getHelmValues() (map[string]any, error) {
 	helmMapOpts := map[string]string{}
 
 	switch {
-	case versioncheck.MustCompile(">=1.12.0")(k.chartVersion):
+	case versioncheck.MustCompile(">=1.14.0")(k.chartVersion):
 		// TODO(aanm) to keep the previous behavior unchanged we will set the number
 		// of the operator replicas to 1. Ideally this should be the default in the helm chart
 		helmMapOpts["operator.replicas"] = "1"
 
 		// Set nodeinit enabled option
-		if needsNodeInit(k.flavor.Kind, k.chartVersion) {
+		if needsNodeInit(k.flavor.Kind) {
 			helmMapOpts["nodeinit.enabled"] = "true"
 		}
 
@@ -49,21 +49,13 @@ func (k *K8sInstaller) getHelmValues() (map[string]any, error) {
 		// Set Helm options specific to the detected / selected datapath mode
 		switch k.params.DatapathMode {
 		case DatapathTunnel:
-			if versioncheck.MustCompile(">=1.14.0")(k.chartVersion) {
-				helmMapOpts["routingMode"] = routingModeTunnel
-				helmMapOpts["tunnelProtocol"] = tunnelVxlan
-			} else {
-				helmMapOpts["tunnel"] = tunnelVxlan
-			}
+			helmMapOpts["routingMode"] = routingModeTunnel
+			helmMapOpts["tunnelProtocol"] = tunnelVxlan
+
 		case DatapathAwsENI:
 			helmMapOpts["ipam.mode"] = ipamENI
 			helmMapOpts["eni.enabled"] = "true"
-			if versioncheck.MustCompile(">=1.14.0")(k.chartVersion) {
-				helmMapOpts["routingMode"] = routingModeNative
-			} else {
-				// Can be removed once we drop support for <1.14.0
-				helmMapOpts["tunnel"] = tunnelDisabled
-			}
+			helmMapOpts["routingMode"] = routingModeNative
 
 		case DatapathGKE:
 			helmMapOpts["ipam.mode"] = ipamKubernetes
@@ -78,12 +70,7 @@ func (k *K8sInstaller) getHelmValues() (map[string]any, error) {
 			helmMapOpts["azure.tenantID"] = k.params.Azure.TenantID
 			helmMapOpts["azure.clientID"] = k.params.Azure.ClientID
 			helmMapOpts["azure.clientSecret"] = k.params.Azure.ClientSecret
-			if versioncheck.MustCompile(">=1.14.0")(k.chartVersion) {
-				helmMapOpts["routingMode"] = routingModeNative
-			} else {
-				// Can be removed once we drop support for <1.14.0
-				helmMapOpts["tunnel"] = tunnelDisabled
-			}
+			helmMapOpts["routingMode"] = routingModeNative
 
 			helmMapOpts["bpf.masquerade"] = "false"
 			helmMapOpts["enableIPv4Masquerade"] = "false"

--- a/cilium-cli/install/helm_test.go
+++ b/cilium-cli/install/helm_test.go
@@ -19,7 +19,7 @@ func TestK8sInstaller_getHelmValuesKind(t *testing.T) {
 	installer := K8sInstaller{
 		params:       Parameters{},
 		flavor:       k8s.Flavor{Kind: k8s.KindKind},
-		chartVersion: semver.MustParse("1.13.0"),
+		chartVersion: semver.MustParse("1.14.0"),
 	}
 	values, err := installer.getHelmValues()
 	assert.NoError(t, err)

--- a/cilium-cli/install/node_init.go
+++ b/cilium-cli/install/node_init.go
@@ -4,21 +4,9 @@
 package install
 
 import (
-	"github.com/blang/semver/v4"
-
 	"github.com/cilium/cilium/cilium-cli/k8s"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
-func needsNodeInit(k k8s.Kind, version semver.Version) bool {
-	switch k {
-
-	case k8s.KindAKS, k8s.KindGKE:
-		return true
-	case k8s.KindEKS:
-		if versioncheck.MustCompile("<=1.13.1")(version) {
-			return true
-		}
-	}
-	return false
+func needsNodeInit(k k8s.Kind) bool {
+	return k == k8s.KindAKS || k == k8s.KindGKE
 }

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	ciliumdef "github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 const sysdumpLogFile = "cilium-sysdump.log"
@@ -2386,14 +2385,7 @@ func (c *Collector) submitCiliumBugtoolTasks(pods []*corev1.Pod) error {
 			}()
 
 			// Default flags for cilium-bugtool
-			bugtoolFlags := []string{"--archiveType=gz"}
-			ciliumVersion, err := c.Client.GetCiliumVersion(ctx, p)
-			if err == nil {
-				// This flag is not available in older versions
-				if versioncheck.MustCompile(">=1.13.0")(*ciliumVersion) {
-					bugtoolFlags = append(bugtoolFlags, "--exclude-object-files")
-				}
-			}
+			bugtoolFlags := []string{"--archiveType=gz", "--exclude-object-files"}
 			// Additional flags
 			bugtoolFlags = append(bugtoolFlags, c.Options.CiliumBugtoolFlags...)
 

--- a/cilium-cli/utils/features/features_test.go
+++ b/cilium-cli/utils/features/features_test.go
@@ -6,7 +6,6 @@ package features
 import (
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -69,59 +68,39 @@ func TestFeatureSetMatchRequirements(t *testing.T) {
 
 }
 
-func TestFeatureSet_extractFromVersionedConfigMap(t *testing.T) {
+func TestFeatureSet_extractTunnelFromConfigMap(t *testing.T) {
 	tests := []struct {
-		name    string
-		version semver.Version
-		data    map[string]string
+		name string
+		data map[string]string
 
 		enabled bool
 		proto   string
 	}{
 		{
 			name:    "empty config map",
-			version: semver.Version{Major: 1, Minor: 14, Patch: 0},
 			enabled: true,
 			proto:   "vxlan",
-		},
-		{
-			name:    "legacy format, native routing",
-			version: semver.Version{Major: 1, Minor: 13, Patch: 99},
-			data:    map[string]string{"tunnel": "disabled"},
-			enabled: false,
-			proto:   "vxlan",
-		},
-		{
-			name:    "legacy format, tunnel routing",
-			version: semver.Version{Major: 1, Minor: 13, Patch: 99},
-			data:    map[string]string{"tunnel": "geneve"},
-			enabled: true,
-			proto:   "geneve",
 		},
 		{
 			name:    "native routing, default protocol",
-			version: semver.Version{Major: 1, Minor: 14, Patch: 0},
 			data:    map[string]string{"routing-mode": "native"},
 			enabled: false,
 			proto:   "vxlan",
 		},
 		{
 			name:    "native routing, geneve protocol",
-			version: semver.Version{Major: 1, Minor: 14, Patch: 0},
 			data:    map[string]string{"routing-mode": "native", "tunnel-protocol": "geneve"},
 			enabled: false,
 			proto:   "geneve",
 		},
 		{
 			name:    "tunnel routing, default protocol",
-			version: semver.Version{Major: 1, Minor: 14, Patch: 0},
 			data:    map[string]string{"routing-mode": "tunnel"},
 			enabled: true,
 			proto:   "vxlan",
 		},
 		{
 			name:    "tunnel routing, geneve protocol",
-			version: semver.Version{Major: 1, Minor: 14, Patch: 0},
 			data:    map[string]string{"routing-mode": "tunnel", "tunnel-protocol": "geneve"},
 			enabled: true,
 			proto:   "geneve",
@@ -132,7 +111,7 @@ func TestFeatureSet_extractFromVersionedConfigMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := Set{}
 			cm := corev1.ConfigMap{Data: tt.data}
-			fs.ExtractFromVersionedConfigMap(tt.version, &cm)
+			fs.ExtractFromConfigMap(&cm)
 
 			assert.Equal(t, tt.enabled, fs[Tunnel].Enabled)
 			assert.Equal(t, tt.proto, fs[Tunnel].Mode)


### PR DESCRIPTION
We currently claim compatibility for Cilium v1.15 or newer. But as the Cilium CI still downgrades into v1.14, let's keep the v1.14-specific handling around for a bit longer.