### PR TITLE
doc:ipsec:kvstore: explicit limitations that could lead to staling XFRM states and no connectivity

### DIFF
--- a/Documentation/kvstore.rst
+++ b/Documentation/kvstore.rst
@@ -116,6 +116,7 @@ Key                    Value
 ``cilium/.heartbeat``  Current time and date
 ====================== ======================
 
+.. _kvstore_leases:
 
 Leases
 ======
@@ -149,6 +150,14 @@ Key                                                             Lease Timeout   
 
 .. _LockLeaseTTL: https://pkg.go.dev/github.com/cilium/cilium/pkg/defaults?tab=doc#LockLeaseTTL
 .. _KVstoreLeaseTTL: https://pkg.go.dev/github.com/cilium/cilium/pkg/defaults?tab=doc#KVstoreLeaseTTL
+
+Caveats and Limitations
+=======================
+
+If you manually remove and recreate kvstore state when IPSec transparent
+encryption is enabled, then that may cause permanent connectivity disruption
+for pods managed by Cilium. Refer to :ref:`xfrm_state_staling_in_cilium` for
+further details.
 
 Debugging
 =========

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -398,6 +398,42 @@ errors.
    yet, so Cilium drops the packets at the source. These drops will stop once
    the CiliumNode information is propagated across the cluster.
 
+.. _xfrm_state_staling_in_cilium:
+
+XFRM State Staling in Cilium
+============================
+
+Control plane disruptions can lead to connectivity issues due to stale XFRM
+states with out-of-sync IPsec anti-replay counters. This typically results in
+permanent connectivity disruptions between pods managed by Cilium. This section
+explains how these issues occur and what you can do about them.
+
+Identified Causes
+-----------------
+
+In KVStore Mode (e.g., etcd), you might encounter stale XFRM states:
+
+  * If a Cilium agent is down for prolonged time, the corresponding node entry
+    in the kvstore will be deleted due to lease expiration (see
+    :ref:`kvstore_leases`), resulting in stale XFRM states.
+
+  * If you manually recreate your key-value store, a Cilium agent might connect
+    too late to the new instance. This delay can cause the agent to miss crucial
+    node delete and create events, leading Cilium to retain outdated XFRM states
+    for those nodes.
+
+In CRD Mode, stale XFRM states can occur if you delete a CiliumNode resource and
+restart the Cilium agent DaemonSet. While other agents create fresh XFRM states
+for the new CiliumNode, the agent on that new node may retain obsolete XFRM
+states for all the other peer nodes.
+
+Mitigation
+----------
+
+To restore connectivity in those cases, perform a key rotation (see
+:ref:`ipsec_key_rotation`). This action ensures new consistent and valid XFRM
+states across all your nodes.
+
 Disabling Encryption
 ====================
 


### PR DESCRIPTION
IPSec relies on XFRM states and policies to ensure encrypted pod-to-pod connectivity. In the XFRM state:
    
* seq is the incoming sequence number counter. It is used by the kernel
      to track and validate received packets. When a packet arrives, its
      sequence number is compared to the expected range to detect replays
      or out-of-order packets. Together this the oseq value, it helps implement
      the anti-replay window to prevent attackers from resending previously captured packets.
* oseq is the outgoing sequence number counter. It is used when sending
      packets protected by IPsec. Each outbound IPsec packet is assigned an
      incrementing oseq value. The oseq ensures unique sequence numbers for
      each packet, which the receiver uses to validate the order and detect replays.
    
In a SA between two nodes A and B, the seq/oseq values in the XFRM state A must match the oseq/seq values in node B, and vice versa. If that is not the case, users would experience the `XfrmInStateProtoError` error, with no IPSec connectivity between the two nodes.
    
We noticed that a Cilium user might end up in this situation in both the following cases, as stated in the doc changes:
    
1. KVStore Mode (e.g., etcd): When a Cilium agent connects too late to the
       newly created KVStore, it may miss the node delete and create events
       for entries that were restored or reinitialized. This results in staling
       XFRM state, causing permanent network disruption. Please do note that
       operations such as etcd removal and recreation are not supported.
2. CRD Mode: a similar issue may occur when a CiliumNode resource is deleted
       and the Cilium agent DaemonSet is restarted. While other agents will
       recreate fresh XFRM states for the new CiliumNode, the restarted agent
       may continue to hold obsolete XFRM states referencing all peer nodes.
    
The identified mitigation strategy for these scenario is a proper IPSec key rotation, which would cause all the states to be consistently recreated in all Cilium agents.