### PR TITLE
build: fix image dir on make image tag script

### DIFF
--- a/images/scripts/update-cilium-runtime-image.sh
+++ b/images/scripts/update-cilium-runtime-image.sh
@@ -19,7 +19,7 @@ image=${1}
 image_dir=${2}
 image="${image%%:*}"
 
-image_tag="$(WITHOUT_SUFFIX=1 "${script_dir}/make-image-tag.sh" images/runtime)"
+image_tag="$(WITHOUT_SUFFIX=1 "${script_dir}/make-image-tag.sh" "${image_dir}")"
 
 image_full="${image}:${image_tag}"
 sha256=$("${script_dir}/get-image-digest.sh" "${image_full}" || echo "")


### PR DESCRIPTION
This commit fixes the usage of the hardcoded image directory by using the image_dir parameter instead.