### PR TITLE
healthz: Add onStop hook for healthz server

### DIFF
--- a/daemon/healthz/agenthealth.go
+++ b/daemon/healthz/agenthealth.go
@@ -64,7 +64,7 @@ func registerAgentHealthHTTPService(params agentHealthParams) error {
 		params.JobGroup.Add(job.OneShot(fmt.Sprintf("agent-healthz-server-%s", name), func(ctx context.Context, health cell.Health) error {
 			lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
 			addr := net.JoinHostPort(host, fmt.Sprintf("%d", option.Config.AgentHealthPort))
-			ln, err := lc.Listen(context.Background(), "tcp", addr)
+			ln, err := lc.Listen(ctx, "tcp", addr)
 			if errors.Is(err, unix.EADDRNOTAVAIL) {
 				params.Logger.Info("healthz status API server not available", logfields.Address, addr)
 				return fmt.Errorf("healthz status API server not available: %w", err)


### PR DESCRIPTION
This is to avoid the below issue while agent is shutting down.
```
time=2025-05-26T06:11:37Z level=info msg="Signal received" signal=terminated
time=2025-05-26T06:11:37Z level=info msg="Stopping hive"
time=2025-05-26T06:12:37Z level=error msg="Stop hook context expired before job group was done" module=enterprise-agent.agent.infra.agent-healthz
time=2025-05-26T06:12:37Z level=info msg="Stop hook executed" function="*job.group.Stop (enterprise-agent.agent.infra.agent-healthz)" duration=59.999245249s
time="2025-05-26T06:12:37.446285566Z" level=fatal msg="failed to stop: context deadline exceeded" subsys=daemon
```

Reported-By: Yusuke Suzuki <yusuke.suzuki@isovalent.com>
