### PR TITLE
ci: stop using /mnt/ directory for building images

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -90,15 +90,6 @@ jobs:
           mkdir -p ../cilium-base-branch
           cp -r .github/actions/set-runtime-image ../cilium-base-branch
 
-      - name: Setup docker volumes into /mnt
-        # This allows us to make use of all available disk.
-        shell: bash
-        run: |
-          sudo systemctl stop docker
-          sudo mv /var/lib/docker/volumes /mnt/docker-volumes
-          sudo ln -s /mnt/docker-volumes /var/lib/docker/volumes
-          sudo systemctl start docker
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         # Disable GC entirely to avoid buildkit from GC caches.


### PR DESCRIPTION
In some of the runs, mnt directory is full and as a result, build fails. Usually, we were using up to ~15 GB of disk space on mnt directory, but default root has plenty of available disk space ~50 GB.

Related: #39682

Example run: https://github.com/cilium/cilium/actions/runs/15252030730/job/42890953705
Before even building images:
```
# Overview
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   17G   55G  24% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   60M  760M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G   73G     0 100% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

```release-note
ci: stop using /mnt directory for building images
```
