### PR TITLE
operator: Attach context to logs when available

### DIFF
--- a/operator/api/server.go
+++ b/operator/api/server.go
@@ -153,7 +153,7 @@ func (s *server) Start(ctx cell.HookContext) error {
 
 	// otherwise just log any possible error and continue
 	for _, err := range errs {
-		s.logger.Error("apiserver start failed", logfields.Error, err)
+		s.logger.ErrorContext(ctx, "apiserver start failed", logfields.Error, err)
 	}
 
 	for _, srv := range s.httpSrvs {
@@ -162,7 +162,7 @@ func (s *server) Start(ctx cell.HookContext) error {
 		}
 		go func(srv httpServer) {
 			if err := srv.server.Serve(srv.listener); !errors.Is(err, http.ErrServerClosed) {
-				s.logger.Error("server stopped unexpectedly", logfields.Error, err)
+				s.logger.ErrorContext(ctx, "server stopped unexpectedly", logfields.Error, err)
 				s.shutdowner.Shutdown()
 			}
 		}(srv)

--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -139,9 +139,9 @@ func NewClient(params params, lc cell.Lifecycle, authCfg MutualAuthConfig, cfg C
 	return client
 }
 
-func (c *Client) onStart(_ cell.HookContext) error {
+func (c *Client) onStart(ctx cell.HookContext) error {
 	go func() {
-		c.log.Info("Initializing SPIRE client")
+		c.log.InfoContext(ctx, "Initializing SPIRE client")
 		attempts := 0
 		backoffTime := backoff.Exponential{Logger: c.log, Min: 100 * time.Millisecond, Max: 10 * time.Second}
 		for {
@@ -153,12 +153,13 @@ func (c *Client) onStart(_ cell.HookContext) error {
 				c.entryMutex.Unlock()
 				break
 			}
-			c.log.Warn("Unable to connect to SPIRE server",
+			c.log.WarnContext(ctx,
+				"Unable to connect to SPIRE server",
 				logfields.Attempt, attempts+1,
 				logfields.Error, err)
 			time.Sleep(backoffTime.Duration(attempts))
 		}
-		c.log.Info("Initialized SPIRE client")
+		c.log.InfoContext(ctx, "Initialized SPIRE client")
 	}()
 	return nil
 }
@@ -169,7 +170,8 @@ func (c *Client) connect(ctx context.Context) (*grpc.ClientConn, error) {
 
 	resolvedTarget, err := resolvedK8sService(ctx, c.k8sClient, c.cfg.SpireServerAddress)
 	if err != nil {
-		c.log.Warn("Unable to resolve SPIRE server address, using original value",
+		c.log.WarnContext(ctx,
+			"Unable to resolve SPIRE server address, using original value",
 			logfields.Error, err,
 			logfields.URL, c.cfg.SpireServerAddress)
 		resolvedTarget = &c.cfg.SpireServerAddress
@@ -193,7 +195,8 @@ func (c *Client) connect(ctx context.Context) (*grpc.ClientConn, error) {
 
 	tlsConfig := tlsconfig.MTLSClientConfig(source, source, tlsconfig.AuthorizeMemberOf(trustedDomain))
 
-	c.log.Info("Trying to connect to SPIRE server",
+	c.log.InfoContext(ctx,
+		"Trying to connect to SPIRE server",
 		logfields.Address, c.cfg.SpireServerAddress,
 		logfields.IPAddr, resolvedTarget)
 	conn, err := grpc.NewClient(*resolvedTarget, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
@@ -201,7 +204,8 @@ func (c *Client) connect(ctx context.Context) (*grpc.ClientConn, error) {
 		return nil, fmt.Errorf("failed to create connection to SPIRE server: %w", err)
 	}
 
-	c.log.Info("Connected to SPIRE server",
+	c.log.InfoContext(ctx,
+		"Connected to SPIRE server",
 		logfields.Address, c.cfg.SpireServerAddress,
 		logfields.IPAddr, resolvedTarget)
 	return conn, nil

--- a/operator/auth/watcher.go
+++ b/operator/auth/watcher.go
@@ -70,12 +70,14 @@ func (iw *IdentityWatcher) run(ctx context.Context) error {
 		switch e.Kind {
 		case resource.Upsert:
 			err = iw.identityClient.Upsert(ctx, e.Object.GetName())
-			iw.logger.Info("Upsert identity",
+			iw.logger.InfoContext(ctx,
+				"Upsert identity",
 				logfields.Identity, e.Object.GetName(),
 				logfields.Error, err)
 		case resource.Delete:
 			err = iw.identityClient.Delete(ctx, e.Object.GetName())
-			iw.logger.Info("Delete identity",
+			iw.logger.InfoContext(ctx,
+				"Delete identity",
 				logfields.Identity, e.Object.GetName(),
 				logfields.Error, err)
 		}

--- a/operator/cmd/ccnp_event.go
+++ b/operator/cmd/ccnp_event.go
@@ -34,7 +34,7 @@ func k8sEventMetric(scope, action string) {
 // using CiliumNetworkPolicy itself, the entire implementation uses the methods
 // associated with CiliumNetworkPolicy.
 func enableCCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGroup, clientset k8sClient.Clientset, clusterName string) {
-	logger.Info("Starting CCNP derivative handler")
+	logger.InfoContext(ctx, "Starting CCNP derivative handler")
 
 	ccnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 

--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -119,7 +119,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 		go func() {
 			defer wg.Done()
 
-			s.logger.Info("Starting to synchronize CiliumNode custom resources to KVStore")
+			s.logger.InfoContext(ctx, "Starting to synchronize CiliumNode custom resources to KVStore")
 
 			ciliumNodeKVStore, err = store.JoinSharedStore(s.logger,
 				store.Configuration{
@@ -153,7 +153,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 			}
 
 			if len(listOfCiliumNodes) == 0 && len(kvStoreNodes) != 0 {
-				s.logger.Warn("Preventing GC of nodes in the KVStore due the nonexistence of any CiliumNodes in kube-apiserver")
+				s.logger.WarnContext(ctx, "Preventing GC of nodes in the KVStore due the nonexistence of any CiliumNodes in kube-apiserver")
 				return
 			}
 
@@ -165,7 +165,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 			}
 		}()
 	} else {
-		s.logger.Info("Starting to synchronize CiliumNode custom resources")
+		s.logger.InfoContext(ctx, "Starting to synchronize CiliumNode custom resources")
 	}
 
 	if s.nodeManager != nil {
@@ -231,7 +231,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 			AddFunc: func(obj any) {
 				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				if err != nil {
-					s.logger.Warn("Unable to process CiliumNode Add event", logfields.Error, err)
+					s.logger.WarnContext(ctx, "Unable to process CiliumNode Add event", logfields.Error, err)
 					return
 				}
 				if s.nodeManager != nil {
@@ -249,7 +249,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 						}
 						key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(newObj)
 						if err != nil {
-							s.logger.Warn("Unable to process CiliumNode Update event", logfields.Error, err)
+							s.logger.WarnContext(ctx, "Unable to process CiliumNode Update event", logfields.Error, err)
 							return
 						}
 						if s.nodeManager != nil {
@@ -259,14 +259,14 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 							kvStoreQueue.Add(key)
 						}
 					} else {
-						s.logger.Warn(
+						s.logger.WarnContext(ctx,
 							"Unknown CiliumNode object type received",
 							logfields.Type, reflect.TypeOf(newNode),
 							logfields.Node, newNode,
 						)
 					}
 				} else {
-					s.logger.Warn(
+					s.logger.WarnContext(ctx,
 						"Unknown CiliumNode object type received",
 						logfields.Type, reflect.TypeOf(oldNode),
 						logfields.Node, oldNode,
@@ -276,7 +276,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 			DeleteFunc: func(obj any) {
 				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 				if err != nil {
-					s.logger.Warn("Unable to process CiliumNode Delete event", logfields.Error, err)
+					s.logger.WarnContext(ctx, "Unable to process CiliumNode Delete event", logfields.Error, err)
 					return
 				}
 				if s.nodeManager != nil {
@@ -308,7 +308,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 		cache.WaitForCacheSync(ctx.Done(), ciliumNodeInformer.HasSynced)
 		close(s.k8sCiliumNodesCacheSynced)
 		ciliumNodeManagerQueue.Add(ciliumNodeManagerQueueSyncedKey)
-		s.logger.Info("CiliumNodes caches synced with Kubernetes")
+		s.logger.InfoContext(ctx, "CiliumNodes caches synced with Kubernetes")
 		// Only handle events if nodeManagerSyncHandler is not nil. If it is nil
 		// then there isn't any event handler set for CiliumNodes events.
 		if nodeManagerSyncHandler != nil {
@@ -324,7 +324,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 		// then there isn't any event handler set for CiliumNodes events.
 		if s.withKVStore && kvStoreSyncHandler != nil {
 			<-connectedToKVStore
-			s.logger.Info("Connected to the KVStore, syncing CiliumNodes to the KVStore")
+			s.logger.InfoContext(ctx, "Connected to the KVStore, syncing CiliumNodes to the KVStore")
 			// infinite loop it will block code execution
 			for s.processNextWorkItem(kvStoreQueue, kvStoreSyncHandler) {
 			}

--- a/operator/cmd/cnp_event.go
+++ b/operator/cmd/cnp_event.go
@@ -36,7 +36,7 @@ func init() {
 // enableCNPWatcher waits for the CiliumNetworkPolicy CRD availability and then
 // garbage collects stale CiliumNetworkPolicy status field entries.
 func enableCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGroup, clientset k8sClient.Clientset, clusterName string) {
-	logger.Info("Starting CNP derivative handler")
+	logger.InfoContext(ctx, "Starting CNP derivative handler")
 	cnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	ciliumV2Controller := informer.NewInformerWithStore(

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -580,9 +580,9 @@ func (legacy *legacyOnLeader) onStop(_ cell.HookContext) error {
 	return nil
 }
 
-// OnOperatorStartLeading is the function called once the operator starts leading
+// onStart is the function called once the operator starts leading
 // in HA mode.
-func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
+func (legacy *legacyOnLeader) onStart(ctx cell.HookContext) error {
 	isLeader.Store(true)
 
 	// Restart kube-dns as soon as possible to parallelize re-initialization
@@ -592,9 +592,9 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 	// If this logic is modified, make sure the operator's clusterrole logic for
 	// pods/delete is also up-to-date.
 	if !legacy.clientset.IsEnabled() {
-		legacy.logger.Info("KubeDNS unmanaged pods controller disabled due to kubernetes support not enabled")
+		legacy.logger.InfoContext(ctx, "KubeDNS unmanaged pods controller disabled due to kubernetes support not enabled")
 	} else if option.Config.DisableCiliumEndpointCRD {
-		legacy.logger.Info(fmt.Sprintf("KubeDNS unmanaged pods controller disabled as %q option is set to 'disabled' in Cilium ConfigMap", option.DisableCiliumEndpointCRDName))
+		legacy.logger.InfoContext(ctx, fmt.Sprintf("KubeDNS unmanaged pods controller disabled as %q option is set to 'disabled' in Cilium ConfigMap", option.DisableCiliumEndpointCRDName))
 	} else if operatorOption.Config.UnmanagedPodWatcherInterval != 0 {
 		legacy.wg.Add(1)
 		go func() {
@@ -608,7 +608,7 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 		withKVStore bool
 	)
 
-	legacy.logger.Info(
+	legacy.logger.InfoContext(ctx,
 		"Initializing IPAM",
 		logfields.Mode, option.Config.IPAM,
 	)
@@ -650,7 +650,7 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 
 	if legacy.clientset.IsEnabled() &&
 		(operatorOption.Config.RemoveCiliumNodeTaints || operatorOption.Config.SetCiliumIsUpCondition) {
-		legacy.logger.Info(
+		legacy.logger.InfoContext(ctx,
 			"Managing Cilium Node Taints or Setting Cilium Is Up Condition for Kubernetes Nodes",
 			logfields.K8sNamespace, operatorOption.Config.CiliumK8sNamespace,
 			logfields.LabelSelectorFlagOption, operatorOption.Config.CiliumPodLabels,
@@ -729,7 +729,7 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 		}
 	}
 
-	legacy.logger.Info("Initialization complete")
+	legacy.logger.InfoContext(ctx, "Initialization complete")
 	return nil
 }
 

--- a/operator/doublewrite/metricreporter.go
+++ b/operator/doublewrite/metricreporter.go
@@ -85,18 +85,18 @@ func (h NoOpHandlerWithListDone) OnListDone() {
 }
 
 func (g *DoubleWriteMetricReporter) Start(ctx cell.HookContext) error {
-	g.logger.Info("Starting the Double Write Metric Reporter")
+	g.logger.InfoContext(ctx, "Starting the Double Write Metric Reporter")
 
 	kvStoreBackend, err := kvstoreallocator.NewKVStoreBackend(g.logger, kvstoreallocator.KVStoreBackendConfiguration{BasePath: cache.IdentitiesPath, Suffix: "", Typ: nil, Backend: g.kvstoreClient})
 	if err != nil {
-		g.logger.Error("Unable to initialize kvstore backend for the Double Write Metric Reporter", logfields.Error, err)
+		g.logger.ErrorContext(ctx, "Unable to initialize kvstore backend for the Double Write Metric Reporter", logfields.Error, err)
 		return err
 	}
 	g.kvStoreBackend = kvStoreBackend
 
 	crdBackend, err := identitybackend.NewCRDBackend(g.logger, identitybackend.CRDBackendConfiguration{Store: nil, StoreSet: &atomic.Bool{}, Client: g.clientset, KeyFunc: (&key.GlobalIdentity{}).PutKeyFromMap})
 	if err != nil {
-		g.logger.Error("Unable to initialize CRD backend for the Double Write Metric Reporter", logfields.Error, err)
+		g.logger.ErrorContext(ctx, "Unable to initialize CRD backend for the Double Write Metric Reporter", logfields.Error, err)
 		return err
 	}
 	g.crdBackend = crdBackend
@@ -145,14 +145,14 @@ func (g *DoubleWriteMetricReporter) compareCRDAndKVStoreIdentities(ctx context.C
 	// Get CRD identities
 	crdIdentityIds, err := g.crdBackend.ListIDs(ctx)
 	if err != nil {
-		g.logger.Error("Unable to get CRD identities", logfields.Error, err)
+		g.logger.ErrorContext(ctx, "Unable to get CRD identities", logfields.Error, err)
 		return err
 	}
 
 	// Get KVStore identities
 	kvstoreIdentityIds, err := g.kvStoreBackend.ListIDs(ctx)
 	if err != nil {
-		g.logger.Error("Unable to get KVStore identities", logfields.Error, err)
+		g.logger.ErrorContext(ctx, "Unable to get KVStore identities", logfields.Error, err)
 		return err
 	}
 
@@ -171,9 +171,9 @@ func (g *DoubleWriteMetricReporter) compareCRDAndKVStoreIdentities(ctx context.C
 	g.metrics.KVStoreOnlyIdentities.Set(float64(onlyInKVStoreCount))
 
 	if onlyInCrdCount == 0 && onlyInKVStoreCount == 0 {
-		g.logger.Info("CRD and KVStore identities are in sync")
+		g.logger.InfoContext(ctx, "CRD and KVStore identities are in sync")
 	} else {
-		g.logger.Info("Detected differences between CRD and KVStore identities",
+		g.logger.InfoContext(ctx, "Detected differences between CRD and KVStore identities",
 			logfields.CRDIdentityCount, len(crdIdentityIds),
 			logfields.KVStoreIdentityCount, len(kvstoreIdentityIds),
 			logfields.OnlyInCRDCount, onlyInCrdCount,

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -54,7 +54,7 @@ func (mm *metricsManager) Start(ctx cell.HookContext) error {
 	go func() {
 		mm.logger.Info("Starting metrics server", logfields.Address, mm.server.Addr)
 		if err := mm.server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			mm.logger.Error("Unable to start metrics server", logfields.Error, err)
+			mm.logger.ErrorContext(ctx, "Unable to start metrics server", logfields.Error, err)
 			mm.shutdowner.Shutdown()
 		}
 	}()
@@ -64,7 +64,7 @@ func (mm *metricsManager) Start(ctx cell.HookContext) error {
 
 func (mm *metricsManager) Stop(ctx cell.HookContext) error {
 	if err := mm.server.Shutdown(ctx); err != nil {
-		mm.logger.Error("Shutdown operator metrics server failed", logfields.Error, err)
+		mm.logger.ErrorContext(ctx, "Shutdown operator metrics server failed", logfields.Error, err)
 		return err
 	}
 	return nil

--- a/operator/pkg/bgpv2/cluster.go
+++ b/operator/pkg/bgpv2/cluster.go
@@ -229,7 +229,7 @@ func (b *BGPResourceManager) upsertNodeConfigs(ctx context.Context, config *v2.C
 				errs = errors.Join(errs, err)
 				continue
 			}
-			b.logger.Debug("Creating a new CiliumBGPNodeConfig",
+			b.logger.DebugContext(ctx, "Creating a new CiliumBGPNodeConfig",
 				types.BGPNodeConfigLogField, newNodeConfig.Name,
 				types.LabelClusterConfig, config.Name,
 			)
@@ -241,7 +241,7 @@ func (b *BGPResourceManager) upsertNodeConfigs(ctx context.Context, config *v2.C
 				errs = errors.Join(errs, err)
 				continue
 			}
-			b.logger.Debug("Updating an existing CiliumBGPNodeConfig",
+			b.logger.DebugContext(ctx, "Updating an existing CiliumBGPNodeConfig",
 				types.BGPNodeConfigLogField, oldNodeConfig.Name,
 				types.LabelClusterConfig, config.Name,
 			)
@@ -283,7 +283,7 @@ func (b *BGPResourceManager) deleteNodeConfigs(ctx context.Context, selectedNode
 			}
 
 		}
-		b.logger.Debug("Deleted BGP node config",
+		b.logger.DebugContext(ctx, "Deleted BGP node config",
 			types.BGPNodeConfigLogField, nodeConfig.Name,
 			types.LabelClusterConfig, config.Name,
 		)

--- a/operator/pkg/bgpv2/manager.go
+++ b/operator/pkg/bgpv2/manager.go
@@ -261,9 +261,9 @@ func (b *BGPResourceManager) Run(ctx context.Context) (err error) {
 
 			err := b.reconcileWithRetry(ctx)
 			if err != nil {
-				b.logger.Error("BGP reconciliation failed", logfields.Error, err)
+				b.logger.ErrorContext(ctx, "BGP reconciliation failed", logfields.Error, err)
 			} else {
-				b.logger.Debug("BGP reconciliation successful")
+				b.logger.DebugContext(ctx, "BGP reconciliation successful")
 			}
 		}
 	}
@@ -291,9 +291,9 @@ func (b *BGPResourceManager) reconcileWithRetry(ctx context.Context) error {
 			// log error, continue retry
 			if isRetryableError(err) && attempt%5 != 0 {
 				// for retryable error print warning only every 5th attempt
-				b.logger.Debug("Transient BGP reconciliation error", logfields.Error, TrimError(err, maxErrorLen))
+				b.logger.DebugContext(ctx, "Transient BGP reconciliation error", logfields.Error, TrimError(err, maxErrorLen))
 			} else {
-				b.logger.Warn("BGP reconciliation error", logfields.Error, TrimError(err, maxErrorLen))
+				b.logger.WarnContext(ctx, "BGP reconciliation error", logfields.Error, TrimError(err, maxErrorLen))
 			}
 			return false, nil
 		default:

--- a/operator/pkg/ciliumendpointslice/namespace.go
+++ b/operator/pkg/ciliumendpointslice/namespace.go
@@ -21,11 +21,11 @@ func (c *Controller) processNamespaceEvents(ctx context.Context) error {
 	for event := range c.namespace.Events(ctx) {
 		switch event.Kind {
 		case resource.Upsert:
-			c.logger.Debug("Got Upsert Namespace event ", logfields.K8sNamespace, event.Key)
+			c.logger.DebugContext(ctx, "Got Upsert Namespace event ", logfields.K8sNamespace, event.Key)
 
 			c.onNamespaceUpsert(event.Object)
 		case resource.Delete:
-			c.logger.Debug("Got Delete Namespace event ", logfields.K8sNamespace, event.Key)
+			c.logger.DebugContext(ctx, "Got Delete Namespace event ", logfields.K8sNamespace, event.Key)
 
 			c.onNamespaceDelete(event.Object)
 		}

--- a/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig_reconcile.go
+++ b/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig_reconcile.go
@@ -27,12 +27,12 @@ func (r *ciliumEnvoyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		logfields.Controller, "ciliumenvoyconfig",
 		logfields.Resource, req.NamespacedName,
 	)
-	scopedLog.Info("Starting reconciliation")
+	scopedLog.InfoContext(ctx, "Starting reconciliation")
 
 	svc := &corev1.Service{}
 	if err := r.client.Get(ctx, req.NamespacedName, svc); err != nil {
 		if k8serrors.IsNotFound(err) {
-			scopedLog.Debug("Unable to get service - either deleted or not yet available", logfields.Error, err)
+			scopedLog.DebugContext(ctx, "Unable to get service - either deleted or not yet available", logfields.Error, err)
 			return ctrl.Result{}, nil
 		}
 
@@ -49,7 +49,7 @@ func (r *ciliumEnvoyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	scopedLog.Info("Successfully reconciled")
+	scopedLog.InfoContext(ctx, "Successfully reconciled")
 	return ctrl.Result{}, nil
 }
 
@@ -96,7 +96,7 @@ func (r *ciliumEnvoyConfigReconciler) createOrUpdateEnvoyConfig(ctx context.Cont
 	scopedLog := r.logger.With(logfields.ServiceKey, getName(svc))
 	if exists {
 		if desired.DeepEqual(&existing) {
-			r.logger.Debug("No change for existing CiliumEnvoyConfig",
+			r.logger.DebugContext(ctx, "No change for existing CiliumEnvoyConfig",
 				logfields.CiliumEnvoyConfigName, fmt.Sprintf("%s/%s", desired.Namespace, desired.Name))
 			return nil
 		}
@@ -105,21 +105,21 @@ func (r *ciliumEnvoyConfigReconciler) createOrUpdateEnvoyConfig(ctx context.Cont
 		updated := existing.DeepCopy()
 		updated.Spec = desired.Spec
 
-		scopedLog.Debug("Updating CiliumEnvoyConfig")
+		scopedLog.DebugContext(ctx, "Updating CiliumEnvoyConfig")
 		if err := r.client.Update(ctx, updated); err != nil {
 			return fmt.Errorf("failed to update CiliumEnvoyConfig for service: %w", err)
 		}
 
-		scopedLog.Debug("Updated CiliumEnvoyConfig for service")
+		scopedLog.DebugContext(ctx, "Updated CiliumEnvoyConfig for service")
 		return nil
 	}
 
-	scopedLog.Debug("Creating CiliumEnvoyConfig")
+	scopedLog.DebugContext(ctx, "Creating CiliumEnvoyConfig")
 	if err := r.client.Create(ctx, desired); err != nil {
 		return fmt.Errorf("failed to create CiliumEnvoyConfig for service: %w", err)
 	}
 
-	scopedLog.Debug("Created CiliumEnvoyConfig for service")
+	scopedLog.DebugContext(ctx, "Created CiliumEnvoyConfig for service")
 	return nil
 }
 
@@ -132,7 +132,7 @@ func (r *ciliumEnvoyConfigReconciler) deleteEnvoyConfig(ctx context.Context, svc
 		return nil
 	}
 
-	r.logger.Debug("Deleting CiliumEnvoyConfig")
+	r.logger.DebugContext(ctx, "Deleting CiliumEnvoyConfig")
 	if err := r.client.Delete(ctx, &existing); err != nil {
 		return fmt.Errorf("failed to delete CiliumEnvoyConfig for service: %w", err)
 	}

--- a/operator/pkg/ciliumidentity/ciliumendpointslice.go
+++ b/operator/pkg/ciliumidentity/ciliumendpointslice.go
@@ -28,16 +28,16 @@ func (c *Controller) processCiliumEndpointSliceEvents(ctx context.Context, wg *s
 		case resource.Sync:
 			wg.Done()
 		case resource.Upsert:
-			c.logger.Debug("Got Upsert CES event", logfields.CESName, event.Key)
+			c.logger.DebugContext(ctx, "Got Upsert CES event", logfields.CESName, event.Key)
 			idsWithNoCESUsage = c.reconciler.cidUsageInCES.ProcessCESUpsert(event.Object.Name, event.Object.Endpoints)
 		case resource.Delete:
-			c.logger.Debug("Got Delete CES event", logfields.CESName, event.Key)
+			c.logger.DebugContext(ctx, "Got Delete CES event", logfields.CESName, event.Key)
 			idsWithNoCESUsage = c.reconciler.cidUsageInCES.ProcessCESDelete(event.Object.Name, event.Object.Endpoints)
 		}
 
 		for _, cid := range idsWithNoCESUsage {
 			cidName := strconv.Itoa(int(cid))
-			c.logger.Info("Reconciling CID as it is no longer used in CESs", logfields.CIDName, cidName)
+			c.logger.InfoContext(ctx, "Reconciling CID as it is no longer used in CESs", logfields.CIDName, cidName)
 			c.enqueueReconciliation(CIDItem{cidResourceKey(cidName)}, 0)
 		}
 

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -124,8 +124,8 @@ func registerController(p params) {
 	p.Lifecycle.Append(cidController)
 }
 
-func (c *Controller) Start(_ cell.HookContext) error {
-	c.logger.Info("Starting CID controller Operator")
+func (c *Controller) Start(ctx cell.HookContext) error {
+	c.logger.InfoContext(ctx, "Starting CID controller Operator")
 	defer utilruntime.HandleCrash()
 
 	// The Cilium Identity (CID) controller running in cilium-operator is
@@ -214,17 +214,17 @@ func (c *Controller) initReconciler(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("cid reconciler failed to init: %w", err)
 	}
-	c.logger.Info("Starting CID controller reconciler")
+	c.logger.InfoContext(ctx, "Starting CID controller reconciler")
 	return nil
 }
 
-func (c *Controller) runResourceWorker(context context.Context) error {
-	c.logger.Info("Starting resource worker")
-	defer c.logger.Info("Stopping resource worker")
+func (c *Controller) runResourceWorker(ctx context.Context) error {
+	c.logger.InfoContext(ctx, "Starting resource worker")
+	defer c.logger.InfoContext(ctx, "Stopping resource worker")
 
 	for c.processNextItem() {
 		select {
-		case <-context.Done():
+		case <-ctx.Done():
 			return nil
 		default:
 		}

--- a/operator/pkg/ciliumidentity/identity.go
+++ b/operator/pkg/ciliumidentity/identity.go
@@ -39,7 +39,8 @@ func (c *Controller) processCiliumIdentityEvents(ctx context.Context, wg *sync.W
 		}
 
 		if event.Kind == resource.Upsert || event.Kind == resource.Delete {
-			c.logger.Debug("Got CID event",
+			c.logger.DebugContext(ctx,
+				"Got CID event",
 				logfields.Type, event.Kind,
 				logfields.CIDName, event.Key,
 			)

--- a/operator/pkg/ciliumidentity/namespace.go
+++ b/operator/pkg/ciliumidentity/namespace.go
@@ -26,7 +26,8 @@ func (c *Controller) processNamespaceEvents(ctx context.Context, wg *sync.WaitGr
 		case resource.Sync:
 			wg.Done()
 		case resource.Upsert:
-			c.logger.Debug("Got Upsert Namespace event",
+			c.logger.DebugContext(ctx,
+				"Got Upsert Namespace event",
 				logfields.K8sNamespace, event.Key,
 			)
 

--- a/operator/pkg/ciliumidentity/pod.go
+++ b/operator/pkg/ciliumidentity/pod.go
@@ -40,7 +40,8 @@ func (c *Controller) processPodEvents(ctx context.Context, wg *sync.WaitGroup) e
 
 		if event.Kind == resource.Upsert || event.Kind == resource.Delete {
 			if !event.Object.Spec.HostNetwork {
-				c.logger.Debug("Got Pod event",
+				c.logger.DebugContext(ctx,
+					"Got Pod event",
 					logfields.Type, event.Kind,
 					logfields.K8sPodName, event.Key,
 				)

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -64,7 +64,7 @@ func newReconciler(
 	cesEnabled bool,
 	queueOps queueOperation,
 ) (*reconciler, error) {
-	logger.Info("Creating CID controller Operator reconciler")
+	logger.InfoContext(ctx, "Creating CID controller Operator reconciler")
 
 	minIDValue := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
 	maxIDValue := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
@@ -188,7 +188,7 @@ func (r *reconciler) createCID(cidName string, cidKey *key.GlobalIdentity) error
 		SecurityLabels: cidLabels,
 	}
 
-	r.logger.Info("Creating CID",
+	r.logger.InfoContext(r.ctx, "Creating CID",
 		logfields.Labels, cidLabels,
 		logfields.CIDName, cidName,
 	)
@@ -205,7 +205,7 @@ func (r *reconciler) updateCID(cid *cilium_api_v2.CiliumIdentity, cidKey *key.Gl
 	updatedId.Labels = selectedLabels
 	updatedId.SecurityLabels = cidLabels
 
-	r.logger.Info("Updating CID", logfields.CIDName, updatedId.Name)
+	r.logger.InfoContext(r.ctx, "Updating CID", logfields.CIDName, updatedId.Name)
 
 	_, err := r.clientset.CiliumV2().CiliumIdentities().Update(r.ctx, updatedId, metav1.UpdateOptions{})
 	return err
@@ -299,7 +299,7 @@ func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
 	prevCIDName, _ := r.cidUsageInPods.AssignCIDToPod(podName, cidName)
 
 	if cidName != prevCIDName {
-		r.logger.Info("CID allocated for pod",
+		r.logger.InfoContext(r.ctx, "CID allocated for pod",
 			logfields.K8sPodName, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
 			logfields.CIDName, cidName,
 			logfields.IdentityOld, prevCIDName,
@@ -331,7 +331,7 @@ func (r *reconciler) allocateCID(cidKey *key.GlobalIdentity) (string, bool, erro
 		// Return the assignment from the CID store, otherwise allocates a new identity
 		cidName, err = r.handleStoreCIDMatch(storeCIDs)
 		if err != nil {
-			r.logger.Error("Failed to access CID store", logfields.Error, err)
+			r.logger.ErrorContext(r.ctx, "Failed to access CID store", logfields.Error, err)
 		} else {
 			return cidName, false, nil
 		}
@@ -373,7 +373,7 @@ func (r *reconciler) handleStoreCIDMatch(storeCIDs []*cilium_api_v2.CiliumIdenti
 	cidKey := key.GetCIDKeyFromLabels(cid.SecurityLabels, "")
 
 	if err := r.upsertDesiredState(cid.Name, cidKey); err != nil {
-		r.logger.Warn("Failed to add CID to cache",
+		r.logger.WarnContext(r.ctx, "Failed to add CID to cache",
 			logfields.CIDName, cid.Name,
 			logfields.Error, err)
 		return "", err
@@ -392,7 +392,7 @@ func (r *reconciler) reconcileNamespace(nsKey resource.Key) error {
 }
 
 func (r *reconciler) updateAllPodsInNamespace(namespace string) error {
-	r.logger.Info("Reconcile all pods in namespace", logfields.K8sNamespace, namespace)
+	r.logger.InfoContext(r.ctx, "Reconcile all pods in namespace", logfields.K8sNamespace, namespace)
 
 	if r.podStore == nil {
 		return fmt.Errorf("pod store is not initialized")
@@ -406,7 +406,7 @@ func (r *reconciler) updateAllPodsInNamespace(namespace string) error {
 
 	for _, pod := range podList {
 		if !pod.Spec.HostNetwork {
-			r.logger.Debug("Reconcile Pod in namespace", logfields.K8sPodName, pod.Name)
+			r.logger.DebugContext(r.ctx, "Reconcile Pod in namespace", logfields.K8sPodName, pod.Name)
 			r.queueOps.enqueueReconciliation(PodItem{podResourceKey(pod.Name, pod.Namespace)}, 0)
 		}
 	}

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -256,7 +256,7 @@ func checkCRDs(ctx context.Context, clientset k8sClient.Clientset, logger *slog.
 
 	for _, optionalGVK := range optionalGVKs {
 		if err := checkCRD(ctx, clientset, optionalGVK); err != nil {
-			logger.Debug("CRD is not present, will not handle it", logfields.OptionalGVK, optionalGVK)
+			logger.DebugContext(ctx, "CRD is not present, will not handle it", logfields.OptionalGVK, optionalGVK)
 			continue
 		}
 		// note that the .Kind field contains the _resource_ name -

--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -47,7 +47,7 @@ func hasMatchingController(ctx context.Context, c client.Client, controllerName 
 		gwc := &gatewayv1.GatewayClass{}
 		key := types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}
 		if err := c.Get(ctx, key, gwc); err != nil {
-			scopedLog.Error("Unable to get GatewayClass", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Unable to get GatewayClass", logfields.Error, err)
 			return false
 		}
 
@@ -63,7 +63,7 @@ func getGatewaysForSecret(ctx context.Context, c client.Client, obj client.Objec
 
 	gwList := &gatewayv1.GatewayList{}
 	if err := c.List(ctx, gwList); err != nil {
-		scopedLog.Warn("Unable to list Gateways", logfields.Error, err)
+		scopedLog.WarnContext(ctx, "Unable to list Gateways", logfields.Error, err)
 		return nil
 	}
 
@@ -96,7 +96,7 @@ func getGatewaysForNamespace(ctx context.Context, c client.Client, ns client.Obj
 
 	gwList := &gatewayv1.GatewayList{}
 	if err := c.List(ctx, gwList); err != nil {
-		scopedLog.Warn("Unable to list Gateways", logfields.Error, err)
+		scopedLog.WarnContext(ctx, "Unable to list Gateways", logfields.Error, err)
 		return nil
 	}
 
@@ -124,7 +124,7 @@ func getGatewaysForNamespace(ctx context.Context, c client.Client, ns client.Obj
 				nsList := &corev1.NamespaceList{}
 				err := c.List(ctx, nsList, client.MatchingLabels(l.AllowedRoutes.Namespaces.Selector.MatchLabels))
 				if err != nil {
-					scopedLog.Warn("Unable to list Namespaces", logfields.Error, err)
+					scopedLog.WarnContext(ctx, "Unable to list Namespaces", logfields.Error, err)
 					return nil
 				}
 				for _, item := range nsList.Items {

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -132,7 +132,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 }
 
 func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx context.Context, gammaService *corev1.Service, httpRoutes *gatewayv1.HTTPRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
-	gammaLogger.Debug("Updating HTTPRoute statuses for GAMMA Service", numRoutes, len(httpRoutes.Items))
+	gammaLogger.DebugContext(ctx, "Updating HTTPRoute statuses for GAMMA Service", numRoutes, len(httpRoutes.Items))
 	for _, original := range httpRoutes.Items {
 
 		hr := original.DeepCopy()
@@ -257,7 +257,7 @@ func (r *gammaReconciler) updateHTTPRouteStatus(ctx context.Context, original *g
 	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
 		return nil
 	}
-	r.logger.Debug("Updating HTTRRoute status", httpRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
+	r.logger.DebugContext(ctx, "Updating HTTRRoute status", httpRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
 }
 

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -114,7 +114,7 @@ func (r *gatewayReconciler) enqueueRequestForOwningGatewayClass() handler.EventH
 		var reqs []reconcile.Request
 		gwList := &gatewayv1.GatewayList{}
 		if err := r.Client.List(ctx, gwList); err != nil {
-			scopedLog.Error("Unable to list Gateways")
+			scopedLog.ErrorContext(ctx, "Unable to list Gateways")
 			return nil
 		}
 
@@ -129,7 +129,8 @@ func (r *gatewayReconciler) enqueueRequestForOwningGatewayClass() handler.EventH
 				},
 			}
 			reqs = append(reqs, req)
-			scopedLog.Info("Queueing gateway",
+			scopedLog.InfoContext(ctx,
+				"Queueing gateway",
 				logfields.K8sNamespace, gw.GetNamespace(),
 				gateway, gw.GetName(),
 			)
@@ -152,7 +153,8 @@ func (r *gatewayReconciler) enqueueRequestForOwningResource() handler.EventHandl
 			return nil
 		}
 
-		scopedLog.Info("Enqueued gateway for owning service",
+		scopedLog.InfoContext(ctx,
+			"Enqueued gateway for owning service",
 			logfields.K8sNamespace, a.GetNamespace(),
 			logfields.Gateway, key,
 		)
@@ -231,17 +233,18 @@ func getReconcileRequestsForRoute(ctx context.Context, c client.Client, object m
 			Name:      string(parent.Name),
 		}, gw); err != nil {
 			if !k8serrors.IsNotFound(err) {
-				scopedLog.Error("Failed to get Gateway", logfields.Error, err)
+				scopedLog.ErrorContext(ctx, "Failed to get Gateway", logfields.Error, err)
 			}
 			continue
 		}
 
 		if !hasMatchingController(ctx, c, controllerName, logger)(gw) {
-			scopedLog.Debug("Gateway does not have matching controller, skipping")
+			scopedLog.DebugContext(ctx, "Gateway does not have matching controller, skipping")
 			continue
 		}
 
-		scopedLog.Info("Enqueued gateway for Route",
+		scopedLog.InfoContext(ctx,
+			"Enqueued gateway for Route",
 			logfields.K8sNamespace, ns,
 			logfields.ParentResource, parent.Name,
 			logfields.Route, object.GetName())
@@ -306,7 +309,7 @@ func (r *gatewayReconciler) enqueueAll() handler.MapFunc {
 		list := &gatewayv1.GatewayList{}
 
 		if err := r.Client.List(ctx, list, &client.ListOptions{}); err != nil {
-			scopedLog.Error("Failed to list Gateway", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to list Gateway", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -319,7 +322,7 @@ func (r *gatewayReconciler) enqueueAll() handler.MapFunc {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: gw,
 			})
-			scopedLog.Info("Enqueued Gateway for resource", gateway, gw)
+			scopedLog.InfoContext(ctx, "Enqueued Gateway for resource", gateway, gw)
 		}
 		return requests
 	}

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -44,7 +44,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		logfields.Controller, gateway,
 		logfields.Resource, req.NamespacedName,
 	)
-	scopedLog.Info("Reconciling Gateway")
+	scopedLog.InfoContext(ctx, "Reconciling Gateway")
 
 	// Step 1: Retrieve the Gateway
 	original := &gatewayv1.Gateway{}
@@ -59,7 +59,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Ignore deleting Gateway, this can happen when foregroundDeletion is enabled
 	// The reconciliation loop will automatically kick off for related Gateway resources.
 	if original.GetDeletionTimestamp() != nil {
-		scopedLog.Info("Gateway is being deleted, doing nothing")
+		scopedLog.InfoContext(ctx, "Gateway is being deleted, doing nothing")
 		return controllerruntime.Success()
 	}
 
@@ -76,7 +76,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if string(gwc.Spec.ControllerName) != controllerName {
-		scopedLog.Debug("GatewayClass does not have matching controller name, doing nothing")
+		scopedLog.DebugContext(ctx, "GatewayClass does not have matching controller name, doing nothing")
 		return controllerruntime.Success()
 	}
 
@@ -199,7 +199,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("failed to update Gateway status: %w", err)
 	}
 
-	scopedLog.Info("Successfully reconciled Gateway")
+	scopedLog.InfoContext(ctx, "Successfully reconciled Gateway")
 	return controllerruntime.Success()
 }
 

--- a/operator/pkg/gateway-api/gatewayclass.go
+++ b/operator/pkg/gateway-api/gatewayclass.go
@@ -75,7 +75,7 @@ func (r *gatewayClassReconciler) enqueueFromIndex(index string) handler.MapFunc 
 		if err := r.Client.List(ctx, list, &client.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector(index, client.ObjectKeyFromObject(o).String()),
 		}); err != nil {
-			scopedLog.Error("Failed to list related GatewayClass", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to list related GatewayClass", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -83,7 +83,7 @@ func (r *gatewayClassReconciler) enqueueFromIndex(index string) handler.MapFunc 
 		for _, item := range list.Items {
 			c := client.ObjectKeyFromObject(&item)
 			requests = append(requests, reconcile.Request{NamespacedName: c})
-			scopedLog.Info("Enqueued GatewayClass for resource", gatewayClass, c)
+			scopedLog.InfoContext(ctx, "Enqueued GatewayClass for resource", gatewayClass, c)
 		}
 		return requests
 	}

--- a/operator/pkg/gateway-api/gatewayclass_reconcile.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile.go
@@ -34,7 +34,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		logfields.Resource, req.NamespacedName,
 	)
 
-	scopedLog.Info("Reconciling GatewayClass")
+	scopedLog.InfoContext(ctx, "Reconciling GatewayClass")
 	original := &gatewayv1.GatewayClass{}
 	if err := r.Client.Get(ctx, req.NamespacedName, original); err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -53,7 +53,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if ref := gwc.Spec.ParametersRef; ref != nil {
 		if !isParameterRefSupported(ref) {
-			scopedLog.Error("Only CiliumGatewayClassConfig is supported for ParametersRef")
+			scopedLog.ErrorContext(ctx, "Only CiliumGatewayClassConfig is supported for ParametersRef")
 			setGatewayClassAccepted(gwc, false)
 			if err := r.ensureStatus(ctx, gwc, original); err != nil {
 				scopedLog.ErrorContext(ctx, "Failed to update GatewayClass status", logfields.Error, err)
@@ -63,7 +63,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 
 		if ref.Namespace == nil || ref.Name == "" {
-			scopedLog.Error("ParametersRef must specify namespace and name")
+			scopedLog.ErrorContext(ctx, "ParametersRef must specify namespace and name")
 			setGatewayClassAccepted(gwc, false)
 			if err := r.ensureStatus(ctx, gwc, original); err != nil {
 				scopedLog.ErrorContext(ctx, "Failed to update GatewayClass status", logfields.Error, err)
@@ -104,7 +104,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return controllerruntime.Fail(err)
 	}
 
-	scopedLog.Info("Successfully reconciled GatewayClass")
+	scopedLog.InfoContext(ctx, "Successfully reconciled GatewayClass")
 	return controllerruntime.Success()
 }
 

--- a/operator/pkg/gateway-api/gatewayclassconfig_reconcile.go
+++ b/operator/pkg/gateway-api/gatewayclassconfig_reconcile.go
@@ -24,7 +24,7 @@ func (r *gatewayClassConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		logfields.Resource, req.NamespacedName,
 	)
 
-	scopedLog.Info("Reconciling GatewayClassConfig")
+	scopedLog.InfoContext(ctx, "Reconciling GatewayClassConfig")
 	original := &v2alpha1.CiliumGatewayClassConfig{}
 	if err := r.Client.Get(ctx, req.NamespacedName, original); err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -42,7 +42,7 @@ func (r *gatewayClassConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return controllerruntime.Fail(err)
 	}
 
-	scopedLog.Info("Successfully reconciled GatewayClass")
+	scopedLog.InfoContext(ctx, "Successfully reconciled GatewayClass")
 	return controllerruntime.Success()
 }
 

--- a/operator/pkg/gateway-api/grpcroute.go
+++ b/operator/pkg/gateway-api/grpcroute.go
@@ -178,7 +178,7 @@ func (r *grpcRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
 		if err := r.Client.List(ctx, list, &client.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector(index, client.ObjectKeyFromObject(o).String()),
 		}); err != nil {
-			scopedLog.Error("Failed to get related GRPCRoutes", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get related GRPCRoutes", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -191,7 +191,7 @@ func (r *grpcRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: route,
 			})
-			scopedLog.Info("Enqueued GRPCRoute for resource", grpcRoute, route)
+			scopedLog.InfoContext(ctx, "Enqueued GRPCRoute for resource", grpcRoute, route)
 		}
 		return requests
 	}
@@ -206,7 +206,7 @@ func (r *grpcRouteReconciler) enqueueAll() handler.MapFunc {
 		list := &gatewayv1.GRPCRouteList{}
 
 		if err := r.Client.List(ctx, list, &client.ListOptions{}); err != nil {
-			scopedLog.Error("Failed to get GRPCRoutes", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get GRPCRoutes", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -219,7 +219,7 @@ func (r *grpcRouteReconciler) enqueueAll() handler.MapFunc {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: route,
 			})
-			scopedLog.Info("Enqueued GRPCRoute for resource", grpcRoute, route)
+			scopedLog.InfoContext(ctx, "Enqueued GRPCRoute for resource", grpcRoute, route)
 		}
 		return requests
 	}

--- a/operator/pkg/gateway-api/grpcroute_reconcile.go
+++ b/operator/pkg/gateway-api/grpcroute_reconcile.go
@@ -33,7 +33,7 @@ func (r *grpcRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logfields.Controller, grpcRoute,
 		logfields.ParentResource, req.NamespacedName,
 	)
-	scopedLog.Info("Reconciling GRPCRoute")
+	scopedLog.InfoContext(ctx, "Reconciling GRPCRoute")
 
 	// Fetch the GRPCRoute instance
 	original := &gatewayv1.GRPCRoute{}
@@ -119,7 +119,7 @@ func (r *grpcRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("failed to update GRPCRoute status: %w", err)
 	}
 
-	scopedLog.Info("Successfully reconciled GRPCRoute")
+	scopedLog.InfoContext(ctx, "Successfully reconciled GRPCRoute")
 	return controllerruntime.Success()
 }
 

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -79,7 +79,7 @@ func isAllowed(ctx context.Context, c client.Client, gw *gatewayv1.Gateway, rout
 			nsList := &corev1.NamespaceList{}
 			selector, _ := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
 			if err := c.List(ctx, nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
-				logger.Error("Unable to list namespaces", logfields.Error, err)
+				logger.ErrorContext(ctx, "Unable to list namespaces", logfields.Error, err)
 				return false
 			}
 

--- a/operator/pkg/gateway-api/httproute.go
+++ b/operator/pkg/gateway-api/httproute.go
@@ -220,7 +220,7 @@ func (r *httpRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
 		if err := r.Client.List(ctx, hrList, &client.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector(index, client.ObjectKeyFromObject(o).String()),
 		}); err != nil {
-			scopedLog.Error("Failed to get related HTTPRoutes", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get related HTTPRoutes", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -233,7 +233,7 @@ func (r *httpRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: route,
 			})
-			scopedLog.Info("Enqueued HTTPRoute for resource", logfields.HTTPRoute, route)
+			scopedLog.InfoContext(ctx, "Enqueued HTTPRoute for resource", logfields.HTTPRoute, route)
 		}
 		return requests
 	}
@@ -248,7 +248,7 @@ func (r *httpRouteReconciler) enqueueAll() handler.MapFunc {
 		hrList := &gatewayv1.HTTPRouteList{}
 
 		if err := r.Client.List(ctx, hrList, &client.ListOptions{}); err != nil {
-			scopedLog.Error("Failed to get HTTPRoutes", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get HTTPRoutes", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -261,7 +261,7 @@ func (r *httpRouteReconciler) enqueueAll() handler.MapFunc {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: route,
 			})
-			scopedLog.Info("Enqueued HTTPRoute for resource", logfields.HTTPRoute, route)
+			scopedLog.InfoContext(ctx, "Enqueued HTTPRoute for resource", logfields.HTTPRoute, route)
 		}
 		return requests
 	}

--- a/operator/pkg/gateway-api/httproute_reconcile.go
+++ b/operator/pkg/gateway-api/httproute_reconcile.go
@@ -30,7 +30,7 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logfields.Controller, httpRoute,
 		logfields.ParentResource, req.NamespacedName,
 	)
-	scopedLog.Info("Reconciling HTTPRoute")
+	scopedLog.InfoContext(ctx, "Reconciling HTTPRoute")
 
 	// Fetch the HTTPRoute instance
 	original := &gatewayv1.HTTPRoute{}
@@ -50,7 +50,7 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	hr := original.DeepCopy()
 
 	if !r.hasMatchingGatewayParent()(hr) {
-		scopedLog.Warn("HTTPRoute does not have a matching Gateway Parent, this should not be possible")
+		scopedLog.WarnContext(ctx, "HTTPRoute does not have a matching Gateway Parent, this should not be possible")
 		err := fmt.Errorf("Reconciliation failure: somehow selected a HTTPRoute without a matching Gateway parent")
 		return controllerruntime.Fail(err)
 	}
@@ -140,7 +140,7 @@ func (r *httpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("failed to update HTTPRoute status: %w", err)
 	}
 
-	scopedLog.Info("Successfully reconciled HTTPRoute")
+	scopedLog.InfoContext(ctx, "Successfully reconciled HTTPRoute")
 	return controllerruntime.Success()
 }
 

--- a/operator/pkg/gateway-api/secretsync.go
+++ b/operator/pkg/gateway-api/secretsync.go
@@ -49,7 +49,7 @@ func EnqueueTLSSecrets(c client.Client, logger *slog.Logger) handler.EventHandle
 					Name:      string(cert.Name),
 				}
 				reqs = append(reqs, reconcile.Request{NamespacedName: s})
-				scopedLog.Debug("Enqueued secret for gateway", logfields.Secret, s)
+				scopedLog.DebugContext(ctx, "Enqueued secret for gateway", logfields.Secret, s)
 			}
 		}
 		return reqs

--- a/operator/pkg/gateway-api/tlsroute.go
+++ b/operator/pkg/gateway-api/tlsroute.go
@@ -178,7 +178,7 @@ func (r *tlsRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
 		if err := r.Client.List(context.Background(), rList, &client.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector(index, client.ObjectKeyFromObject(o).String()),
 		}); err != nil {
-			scopedLog.Error("Failed to get related TLSRoutes", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get related TLSRoutes", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -191,7 +191,7 @@ func (r *tlsRouteReconciler) enqueueFromIndex(index string) handler.MapFunc {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: route,
 			})
-			scopedLog.Info("Enqueued TLSRoute for resource", tlsRoute, route)
+			scopedLog.InfoContext(ctx, "Enqueued TLSRoute for resource", tlsRoute, route)
 		}
 		return requests
 	}
@@ -207,7 +207,7 @@ func (r *tlsRouteReconciler) enqueueAll() handler.MapFunc {
 		trList := &gatewayv1alpha2.TLSRouteList{}
 
 		if err := r.Client.List(ctx, trList, &client.ListOptions{}); err != nil {
-			scopedLog.Error("Failed to get TLSRoutes", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get TLSRoutes", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -220,7 +220,7 @@ func (r *tlsRouteReconciler) enqueueAll() handler.MapFunc {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: route,
 			})
-			scopedLog.Info("Enqueued TLSRoute for resource", tlsRoute, route)
+			scopedLog.InfoContext(ctx, "Enqueued TLSRoute for resource", tlsRoute, route)
 		}
 		return requests
 	}

--- a/operator/pkg/gateway-api/tlsroute_reconcile.go
+++ b/operator/pkg/gateway-api/tlsroute_reconcile.go
@@ -123,7 +123,7 @@ func (r *tlsRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, fmt.Errorf("failed to update TLSRoute status: %w", err)
 	}
 
-	scopedLog.Info("Successfully reconciled TLSRoute")
+	scopedLog.InfoContext(ctx, "Successfully reconciled TLSRoute")
 	return controllerruntime.Success()
 }
 

--- a/operator/pkg/ingress/helpers.go
+++ b/operator/pkg/ingress/helpers.go
@@ -32,7 +32,7 @@ func isCiliumDefaultIngressController(ctx context.Context, c client.Client, logg
 	ciliumIngressClass := &networkingv1.IngressClass{}
 	if err := c.Get(ctx, types.NamespacedName{Name: ciliumIngressClassName}, ciliumIngressClass); err != nil {
 		if !errors.IsNotFound(err) {
-			logger.Warn("Failed to load Cilium IngressClass", logfields.Error, err)
+			logger.WarnContext(ctx, "Failed to load Cilium IngressClass", logfields.Error, err)
 		}
 
 		return false
@@ -40,7 +40,7 @@ func isCiliumDefaultIngressController(ctx context.Context, c client.Client, logg
 
 	isDefault, err := isIngressClassMarkedAsDefault(*ciliumIngressClass)
 	if err != nil {
-		logger.Warn("Failed to detect default class on IngressClass cilium", logfields.Error, err)
+		logger.WarnContext(ctx, "Failed to detect default class on IngressClass cilium", logfields.Error, err)
 		return false
 	}
 

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -124,7 +124,7 @@ func (r *ingressReconciler) enqueueSharedCiliumIngresses() handler.EventHandler 
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
 		ingressList := networkingv1.IngressList{}
 		if err := r.client.List(ctx, &ingressList); err != nil {
-			r.logger.Warn("Failed to list Ingresses", logfields.Error, err)
+			r.logger.WarnContext(ctx, "Failed to list Ingresses", logfields.Error, err)
 			return nil
 		}
 
@@ -157,7 +157,7 @@ func (r *ingressReconciler) enqueueIngressesWithoutExplicitClass() handler.Event
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
 		ingressList := networkingv1.IngressList{}
 		if err := r.client.List(ctx, &ingressList); err != nil {
-			r.logger.Warn("Failed to list Ingresses", logfields.Error, err)
+			r.logger.WarnContext(ctx, "Failed to list Ingresses", logfields.Error, err)
 			return nil
 		}
 

--- a/operator/pkg/ingress/secretsync.go
+++ b/operator/pkg/ingress/secretsync.go
@@ -45,7 +45,7 @@ func EnqueueReferencedTLSSecrets(c client.Client, logger *slog.Logger) handler.E
 				Name:      tls.SecretName,
 			}
 			reqs = append(reqs, reconcile.Request{NamespacedName: s})
-			scopedLog.Debug("Enqueued secret for Ingress", logfields.Secret, s)
+			scopedLog.DebugContext(ctx, "Enqueued secret for Ingress", logfields.Secret, s)
 		}
 		return reqs
 	})

--- a/operator/pkg/networkpolicy/cell.go
+++ b/operator/pkg/networkpolicy/cell.go
@@ -126,9 +126,9 @@ func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Ev
 	}
 
 	if errs != nil {
-		log.Error("Detected invalid CNP, setting condition", logfields.Error, errs)
+		log.ErrorContext(ctx, "Detected invalid CNP, setting condition", logfields.Error, errs)
 	} else {
-		log.Debug("CNP now valid, setting condition")
+		log.DebugContext(ctx, "CNP now valid, setting condition")
 	}
 	// Using the UpdateStatus subresource will prevent the generation from being bumped.
 	_, err = pv.params.Clientset.CiliumV2().CiliumNetworkPolicies(pol.Namespace).UpdateStatus(
@@ -140,7 +140,7 @@ func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Ev
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		log.Error("failed to update CNP status", logfields.Error, err)
+		log.ErrorContext(ctx, "failed to update CNP status", logfields.Error, err)
 	}
 
 	return err
@@ -176,9 +176,9 @@ func (pv *policyValidator) handleCCNPEvent(ctx context.Context, event resource.E
 	}
 
 	if errs != nil {
-		log.Debug("Detected invalid CCNP, setting condition", logfields.Error, errs)
+		log.DebugContext(ctx, "Detected invalid CCNP, setting condition", logfields.Error, errs)
 	} else {
-		log.Debug("CCNP now valid, setting condition")
+		log.DebugContext(ctx, "CCNP now valid, setting condition")
 	}
 	// Using the UpdateStatus subresource will prevent the generation from being bumped.
 	_, err = pv.params.Clientset.CiliumV2().CiliumClusterwideNetworkPolicies().UpdateStatus(
@@ -190,7 +190,7 @@ func (pv *policyValidator) handleCCNPEvent(ctx context.Context, event resource.E
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		log.Error("failed to update CCNP status", logfields.Error, err)
+		log.ErrorContext(ctx, "failed to update CCNP status", logfields.Error, err)
 	}
 
 	return err

--- a/operator/pkg/networkpolicy/secretsync.go
+++ b/operator/pkg/networkpolicy/secretsync.go
@@ -164,7 +164,7 @@ func IsReferencedByCiliumNetworkPolicy(ctx context.Context, c client.Client, log
 
 	cnpList := &cilium_api_v2.CiliumNetworkPolicyList{}
 	if err := c.List(ctx, cnpList); err != nil {
-		scopedLog.Warn("Unable to list CiliumNetworkPolicies", logfields.Error, err)
+		scopedLog.WarnContext(ctx, "Unable to list CiliumNetworkPolicies", logfields.Error, err)
 		return false
 	}
 
@@ -209,7 +209,7 @@ func IsReferencedByCiliumClusterwideNetworkPolicy(ctx context.Context, c client.
 
 	ccnpList := &cilium_api_v2.CiliumClusterwideNetworkPolicyList{}
 	if err := c.List(ctx, ccnpList); err != nil {
-		scopedLog.Warn("Unable to list CiliumClusterwideNetworkPolicies", logfields.Error, err)
+		scopedLog.WarnContext(ctx, "Unable to list CiliumClusterwideNetworkPolicies", logfields.Error, err)
 		return false
 	}
 

--- a/operator/pkg/nodeipam/nodesvclb.go
+++ b/operator/pkg/nodeipam/nodesvclb.go
@@ -86,7 +86,7 @@ func (r *nodeSvcLBReconciler) enqueueRequestForEndpointSlice() handler.EventHand
 			Namespace: epSlice.GetNamespace(),
 			Name:      svcName,
 		}
-		scopedLog.Info("Enqueued Service", logfields.Service, svc)
+		scopedLog.InfoContext(ctx, "Enqueued Service", logfields.Service, svc)
 		return []ctrl.Request{{NamespacedName: svc}}
 	})
 }
@@ -109,7 +109,7 @@ func (r *nodeSvcLBReconciler) enqueueRequestForNode() handler.EventHandler {
 
 		svcList := &corev1.ServiceList{}
 		if err := r.Client.List(ctx, svcList, &client.ListOptions{}); err != nil {
-			scopedLog.Error("Failed to get Services", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get Services", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 		requests := []reconcile.Request{}
@@ -122,7 +122,7 @@ func (r *nodeSvcLBReconciler) enqueueRequestForNode() handler.EventHandler {
 				Name:      item.GetName(),
 			}
 			requests = append(requests, reconcile.Request{NamespacedName: svc})
-			scopedLog.Info("Enqueued Service", logfields.Service, svc)
+			scopedLog.InfoContext(ctx, "Enqueued Service", logfields.Service, svc)
 		}
 		return requests
 	})
@@ -133,7 +133,7 @@ func (r *nodeSvcLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logfields.Controller, "node-service-lb",
 		logfields.Resource, req.NamespacedName,
 	)
-	scopedLog.Info("Reconciling Service")
+	scopedLog.InfoContext(ctx, "Reconciling Service")
 
 	svc := corev1.Service{}
 	err := r.Get(ctx, req.NamespacedName, &svc)
@@ -229,7 +229,7 @@ func (r *nodeSvcLBReconciler) getRelevantNodes(ctx context.Context, svc *corev1.
 		return []corev1.Node{}, err
 	}
 	if len(nodes.Items) == 0 {
-		scopedLog.Warn("No Nodes found with configured label selector", logfields.Labels, nodeListOptions.LabelSelector)
+		scopedLog.WarnContext(ctx, "No Nodes found with configured label selector", logfields.Labels, nodeListOptions.LabelSelector)
 	}
 
 	relevantNodes := []corev1.Node{}

--- a/operator/pkg/secretsync/secretsync_reconcile.go
+++ b/operator/pkg/secretsync/secretsync_reconcile.go
@@ -28,12 +28,12 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		logfields.Controller, "secret-syncer",
 		logfields.Resource, req.NamespacedName,
 	)
-	scopedLog.Debug("Reconciling secret")
+	scopedLog.DebugContext(ctx, "Reconciling secret")
 
 	original := &corev1.Secret{}
 	if err := r.client.Get(ctx, req.NamespacedName, original); err != nil {
 		if k8serrors.IsNotFound(err) {
-			scopedLog.Debug("Unable to get Secret - either deleted or not yet available", logfields.Error, err)
+			scopedLog.DebugContext(ctx, "Unable to get Secret - either deleted or not yet available", logfields.Error, err)
 
 			synced := false
 			// Check whether synced secret needs to be deleted from the registered secret namespaces.
@@ -47,7 +47,7 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 				synced = synced || deleted
 			}
 
-			scopedLog.Debug("Successfully reconciled Secret", logfields.Action, action(synced))
+			scopedLog.DebugContext(ctx, "Successfully reconciled Secret", logfields.Action, action(synced))
 			return controllerruntime.Success()
 		}
 
@@ -64,7 +64,7 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		if reg.RefObjectCheckFunc(ctx, r.client, r.logger, original) || reg.IsDefaultSecret(original) {
 			desiredSync := desiredSyncSecret(reg.SecretsNamespace, original)
 
-			scopedLog.Debug("Syncing secret", logfields.K8sNamespace, reg.SecretsNamespace)
+			scopedLog.DebugContext(ctx, "Syncing secret", logfields.K8sNamespace, reg.SecretsNamespace)
 			if err := r.ensureSyncedSecret(ctx, desiredSync); err != nil {
 				return controllerruntime.Fail(err)
 			}
@@ -85,7 +85,7 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		synced = synced || deleted
 	}
 
-	scopedLog.Debug("Successfully reconciled Secret", logfields.Action, action(synced))
+	scopedLog.DebugContext(ctx, "Successfully reconciled Secret", logfields.Action, action(synced))
 	return controllerruntime.Success()
 }
 
@@ -102,7 +102,7 @@ func (r *secretSyncer) cleanupSyncedSecret(ctx context.Context, req reconcile.Re
 	syncSecret := &corev1.Secret{}
 	if err := r.client.Get(ctx, types.NamespacedName{Namespace: ns, Name: req.Namespace + "-" + req.Name}, syncSecret); err == nil {
 		// Try to delete existing synced secret
-		scopedLog.Debug("Delete synced secret", logfields.K8sNamespace, ns)
+		scopedLog.DebugContext(ctx, "Delete synced secret", logfields.K8sNamespace, ns)
 		if err := r.client.Delete(ctx, syncSecret); err != nil {
 			return true, err
 		}


### PR DESCRIPTION
Since the migration to `slog`, it is possible to attach contexts to logs. This is recommended by the [`slog` docs](https://pkg.go.dev/log/slog#hdr-Contexts):

> It is recommended to pass a context to an output method if one is available.

This allows things like trace IDs to be extracted from contexts and attached to logs, allowing log/trace correlation.

This PR uses the `XxxContext()` `slog` methods when a `context.Context` is available in packages under `operator/`.


---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->


```release-note
operator: Attach context to logs when available
```
