### PR TITLE
bpf: test: clean up dead LB_LOOKUP_SCOPE_INT service entries

### DIFF
--- a/bpf/tests/host_only_socket_lb_test.c
+++ b/bpf/tests/host_only_socket_lb_test.c
@@ -70,10 +70,8 @@ int test1_check(__maybe_unused struct xdp_md *ctx)
 		BE_KEY_VALUE(1, v4_pod_one),
 	};
 	struct { struct lb4_key key; struct lb4_service value; } services[] = {
-		SVC_KEY_VALUE(DST_PORT, 0, 0, LB_LOOKUP_SCOPE_INT),
 		SVC_KEY_VALUE(DST_PORT, 0, 0, LB_LOOKUP_SCOPE_EXT),
 		SVC_KEY_VALUE(DST_PORT, 1, 1, LB_LOOKUP_SCOPE_EXT),
-		SVC_KEY_VALUE(DST_PORT_HOSTNS, 0, 0, LB_LOOKUP_SCOPE_INT),
 		SVC_KEY_VALUE(DST_PORT_HOSTNS, 0, 0, LB_LOOKUP_SCOPE_EXT),
 		SVC_KEY_VALUE(DST_PORT_HOSTNS, 1, 1, LB_LOOKUP_SCOPE_EXT),
 	};

--- a/bpf/tests/session_affinity_test.c
+++ b/bpf/tests/session_affinity_test.c
@@ -118,7 +118,6 @@ int test1_setup(struct __ctx_buff *ctx)
 		struct lb4_key key;
 		struct lb4_service value;
 	} services[] = {
-		SVC_KEY_VALUE(0, 100 /* affinity timeout */, LB_LOOKUP_SCOPE_INT),
 		SVC_KEY_VALUE(0, 100 /* affinity timeout */, LB_LOOKUP_SCOPE_EXT),
 
 		SVC_KEY_VALUE(1, BACKEND_ID1, LB_LOOKUP_SCOPE_EXT),


### PR DESCRIPTION
If the first entry (with LB_LOOKUP_SCOPE_EXT) doesn't specify SVC_FLAG_TWO_SCOPES, then the datapath will never even look at the associated LB_LOOKUP_SCOPE_INT entry. So don't bother inserting it, this is just causing confusion.