### PR TITLE
routing: Delete stale ingress and egress rules

### DIFF
--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -153,16 +153,18 @@ func TestDelete(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Log("Test: " + tt.name)
-		ns := netns.NewNetNS(t)
-		ns.Do(func() error {
-			ifaceCleanup := createDummyDevice(t, masterMAC)
-			defer ifaceCleanup()
+		t.Run(tt.name, func(t *testing.T) {
+			ns := netns.NewNetNS(t)
+			ns.Do(func() error {
+				ifaceCleanup := createDummyDevice(t, masterMAC)
+				defer ifaceCleanup()
 
-			ip := tt.preRun()
-			err := Delete(hivetest.Logger(t), ip, false)
-			require.Equal(t, tt.wantErr, (err != nil))
-			return nil
+				ip := tt.preRun()
+				err := Delete(hivetest.Logger(t), ip, false)
+				require.Equalf(t, tt.wantErr, (err != nil), "got error: %v", err)
+
+				return nil
+			})
 		})
 	}
 }

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -97,7 +97,7 @@ func TestDelete(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "valid IP addr matching rules",
+			name: "valid IP addr matching a single rule",
 			preRun: func() netip.Addr {
 				runConfigure(t, fakeRoutingInfo, fakeIP, 1500)
 				return fakeIP
@@ -105,7 +105,7 @@ func TestDelete(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "IP addr doesn't match rules",
+			name: "IP addr doesn't match any rule",
 			preRun: func() netip.Addr {
 				ip := netip.MustParseAddr("192.168.2.233")
 
@@ -115,7 +115,7 @@ func TestDelete(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "IP addr matches more than number expected",
+			name: "IP addr matches multiple rules",
 			preRun: func() netip.Addr {
 				ip := netip.MustParseAddr("192.168.2.233")
 
@@ -130,7 +130,7 @@ func TestDelete(t *testing.T) {
 				require.NotEmpty(t, rules)
 
 				// Insert almost duplicate rule; the reason for this is to
-				// trigger an error while trying to delete the ingress rule. We
+				// trigger the deletion of all the matching rules. We
 				// are setting the Src because ingress rules don't have
 				// one (only Dst), thus we set Src to create a near-duplicate.
 				r := rules[0]
@@ -139,17 +139,16 @@ func TestDelete(t *testing.T) {
 
 				return ip
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
-			name: "fails to delete rules due to masquerade misconfiguration",
+			name: "delete rules with dest CIDR after masquerade is disabled",
 			preRun: func() netip.Addr {
 				runConfigure(t, fakeRoutingInfo, fakeIP, 1500)
-				// inconsistency with fakeRoutingInfo.Masquerade should lead to failure
 				option.Config.EnableIPv4Masquerade = false
 				return fakeIP
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2537,8 +2537,7 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 
 		// This is a best-effort attempt to cleanup. We expect there to be one
 		// ingress rule and multiple egress rules. If we find more rules than
-		// expected, then the rules will be left as-is because there was
-		// likely manual intervention.
+		// expected, we delete all rules referring to a per-ENI routing table ID.
 		if e.IPv4.IsValid() {
 			if err := linuxrouting.Delete(e.getLogger(), e.IPv4, option.Config.EgressMultiHomeIPRuleCompat); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %w", err))


### PR DESCRIPTION
```
    routing: Delete all stale egress and ingress rules
    
    The current rule deletion logic skips the removal in case more than one
    rule that matches the requested template is found. Therefore, if a stale
    rule is not garbage collected properly and another rule for the same
    address is installed, Cilium stops removing the installed rules,
    accumulating them indefinitely.
    
    The change addresses this issue deleting all the stale ingress and
    egress rules matching the specified template, even when more than one
    occurrence is found. In order to do so, a more generic
    deleteRulesFiltered is added, where all the installed rules matching a
    given template are then evaluated by a series of filter to decide if it
    should be removed or not.
    
    In case of egress rules, the new logic skips the deletion of those that
    refers to a table ID not managed by Cilium, that is, a table ID outside
    of the per ENI routing table range.
    
    The unit tests are changed accordingly, therefore expecting a success
    instead of an error when more than one rule is found.
```

Among the others, the result of the last `TestDelete` sub-test in `pkg/datapath/linux/routing/routing_test.go`, added in https://github.com/cilium/cilium/pull/24933, is altered by this PR.
The subtest was meant to verify that a change in the masquerading option generates an error when trying to remove the previously installed rules. Specifically, the workflow simulated in the test was:

1) the agent is started with masquerading enabled
2) as a consequence, egress routing rules are installed with a non-nil destination CIDR (see `Configure`)
3) the agent is restarted with masquerade disabled
4) the removal of the egress rules should now fail because the template is expecting a nil destination CIDR

But the test was actually failing due to the fact that in the test setup two rules where installed:

```
logger.go:256: time=2025-05-27T11:22:30.161+02:00 level=WARN source=/home/pippolo/cilium/cilium-tmp/pkg/datapath/linux/routing/routing.go:391 msg="Found too many rules matching, skipping deletion" candidates="[ip rule 111: from 192.168.2.123/32 to 192.168.0.0/16 table 11  ip rule 111: from 192.168.2.123/32 to 192.170.0.0/16 table 11 ]" rule="111: from 192.168.2.123/32 to all lookup 0 proto unspec"
```

In other words, the previous logic was not logging any error when a single stale egress rule with a non-nil destination CIDR was found. The error seen in the test was just a consequence of the limitation related to the multiple rules found.

With the changes in this PR, we remove all stale egress rules with a non-nil destination CIDR, since the template rule passed to `deleteRulesFiltered` has a nil dst CIDR, corresponding to a `0.0.0.0/0` CIDR. Therefore, all the previous rules are selected by `route.ListRules` and removed.
Note that the opposite (that is, restarting the agent after enabling masquerading) still leaves stale rules behind. This was not solved by the previous approach either, but requires https://github.com/cilium/cilium/issues/38285 instead.

Notes to reviewer: please review each commit individually

```release-note
Remove stale ingress and egress routing rules after the deletion of an endpoint.
```
