### PR TITLE
envoy: Sync deny policies for Ingress policy enforcement

### DIFF
--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1313,7 +1313,7 @@ func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, versio
 		return r, true
 	}
 
-	if l7Rules.IsDeny {
+	if l7Rules.GetDeny() {
 		r.Deny = true
 		return r, false
 	}

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -504,7 +504,7 @@ var PortRuleHeaderMatchSecretLogOnMismatch = &api.PortRuleHTTP{
 	},
 }
 
-func Test_getWildcardNetworkPolicyRule(t *testing.T) {
+func Test_getWildcardNetworkPolicyRules(t *testing.T) {
 	version := versioned.Latest()
 	perSelectorPoliciesWithWildcard := policy.L7DataMap{
 		cachedSelector1:           nil,
@@ -514,8 +514,8 @@ func Test_getWildcardNetworkPolicyRule(t *testing.T) {
 
 	xds := testXdsServer(t)
 
-	obtained := xds.getWildcardNetworkPolicyRule(version, perSelectorPoliciesWithWildcard)
-	require.Equal(t, &cilium.PortNetworkPolicyRule{}, obtained)
+	obtained := xds.getWildcardNetworkPolicyRules(version, perSelectorPoliciesWithWildcard)
+	require.Equal(t, []*cilium.PortNetworkPolicyRule{{}}, obtained)
 
 	// both cachedSelector2 and cachedSelector2 select identity 1001, but duplicates must have been removed
 	perSelectorPolicies := policy.L7DataMap{
@@ -524,10 +524,10 @@ func Test_getWildcardNetworkPolicyRule(t *testing.T) {
 		cachedRequiresV2Selector1: nil,
 	}
 
-	obtained = xds.getWildcardNetworkPolicyRule(version, perSelectorPolicies)
-	require.Equal(t, &cilium.PortNetworkPolicyRule{
+	obtained = xds.getWildcardNetworkPolicyRules(version, perSelectorPolicies)
+	require.Equal(t, []*cilium.PortNetworkPolicyRule{{
 		RemotePolicies: []uint32{1001, 1002, 1003},
-	}, obtained)
+	}}, obtained)
 }
 
 func TestGetPortNetworkPolicyRule(t *testing.T) {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -135,6 +135,9 @@ const (
 	// PolicyID is the identifier of a L3, L4 or L7 Policy. Ideally the .NumericIdentity
 	PolicyID = "policyID"
 
+	// IsDeny is 'true' for a deny rule
+	IsDeny = "isDeny"
+
 	// AddedPolicyID is the .NumericIdentity, or set or them
 	AddedPolicyID = "policyID.Added"
 

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -187,11 +187,11 @@ func mergePortProto(policyCtx PolicyContext, existingFilter, filterToMerge *L4Fi
 			}
 
 			// Merge two non-identical sets of non-nil rules
-			if l7Rules != nil && l7Rules.IsDeny {
+			if l7Rules.GetDeny() {
 				// If existing rule is deny then it's a no-op
 				// Denies takes priority over any rule.
 				continue
-			} else if newL7Rules != nil && newL7Rules.IsDeny {
+			} else if newL7Rules.GetDeny() {
 				// Overwrite existing filter if the new rule is a deny case
 				// Denies takes priority over any rule.
 				existingFilter.PerSelectorPolicies[cs] = newL7Rules


### PR DESCRIPTION
Now that endpoint policies with east/west Ingress are enforced completely in Envoy we must sync the full deny policy to Envoy, as we can not rely on the bpf datapath doing it prior to Envoy.

Fixes: #39730

```release-note
Deny policies are now synced to Envoy so that they can be enforced for Ingress policies.
```
