### PR TITLE
cilium: Provide a "root" job.Group

### DIFF
--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/hive/job"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +17,6 @@ import (
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/hive/health/types"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -48,10 +46,6 @@ func TestRegisterController(t *testing.T) {
 			return SharedConfig{
 				EnableCiliumEndpointSlice: true,
 			}
-		}),
-		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-			h := p.ForModule(cell.FullModuleID{"test"})
-			return jr.NewGroup(h, lc)
 		}),
 		metrics.Metric(NewMetrics),
 		cell.Invoke(func(p params) error {
@@ -105,10 +99,6 @@ func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
 			return SharedConfig{
 				EnableCiliumEndpointSlice: false,
 			}
-		}),
-		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-			h := p.ForModule(cell.FullModuleID{"test"})
-			return jr.NewGroup(h, lc)
 		}),
 		metrics.Metric(NewMetrics),
 		cell.Invoke(func(p params) error {

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/hive/job"
 	"github.com/google/go-cmp/cmp"
 	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +22,6 @@ import (
 	"github.com/cilium/cilium/operator/k8s"
 	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/hive/health/types"
 	capi_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -130,10 +128,6 @@ func initHiveTest(t *testing.T, operatorManagingCID bool) (*resource.Resource[*c
 				EnableCiliumEndpointSlice: true,
 				DisableNetworkPolicy:      false,
 			}
-		}),
-		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-			h := p.ForModule(cell.FullModuleID{"test"})
-			return jr.NewGroup(h, lc)
 		}),
 		cell.Invoke(func(p params) error {
 			registerController(p)

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
@@ -86,7 +86,7 @@ func newCRDStatusFixture(ctx context.Context, req *require.Assertions, l *slog.L
 		}
 	}
 
-	f.hive = hive.New(cell.Module("test", "test",
+	f.hive = hive.New(
 		daemon_k8s.LocalNodeCell,
 		cell.Provide(
 			func() *option.DaemonConfig {
@@ -116,7 +116,7 @@ func newCRDStatusFixture(ctx context.Context, req *require.Assertions, l *slog.L
 			f.db = db
 			f.reconcileErrTbl = table
 		}),
-	))
+	)
 
 	return f, watchersReadyFn
 }
@@ -340,7 +340,7 @@ func TestDisableStatusReport(t *testing.T) {
 	nodeTypes.SetName("node0")
 
 	var cs k8s_client.Clientset
-	hive := hive.New(cell.Module("test", "test",
+	hive := hive.New(
 		daemon_k8s.LocalNodeCell,
 		cell.Provide(
 			func() *option.DaemonConfig {
@@ -401,7 +401,7 @@ func TestDisableStatusReport(t *testing.T) {
 			}
 			jg.Add(job.OneShot("cleanup-status", r.cleanupStatus))
 		}),
-	))
+	)
 
 	require.NoError(t, hive.Start(logger, ctx))
 	t.Cleanup(func() {

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -100,31 +100,29 @@ func TestScript(t *testing.T) {
 			),
 			cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 
-			cell.Module("cec-test", "test",
-				// cecResourceParser and its friends.
-				cell.Group(
-					cell.Provide(
-						newCECResourceParser,
-						func(log *slog.Logger) PortAllocator { return staticPortAllocator{log} },
-						func() FeatureMetrics {
-							return mockFeatureMetrics{}
-						},
-					),
-					node.LocalNodeStoreCell,
-					cell.Invoke(func(lns_ *node.LocalNodeStore) { lns = lns_ }),
-				),
-				tableCells,
-				controllerCells,
-
-				cell.ProvidePrivate(
-					func() promise.Promise[synced.CRDSync] {
-						r, p := promise.New[synced.CRDSync]()
-						r.Resolve(synced.CRDSync{})
-						return p
+			// cecResourceParser and its friends.
+			cell.Group(
+				cell.Provide(
+					newCECResourceParser,
+					func(log *slog.Logger) PortAllocator { return staticPortAllocator{log} },
+					func() FeatureMetrics {
+						return mockFeatureMetrics{}
 					},
-					func() resourceMutator { return fakeEnvoy },
-					func() policyTrigger { return fakeEnvoy },
 				),
+				node.LocalNodeStoreCell,
+				cell.Invoke(func(lns_ *node.LocalNodeStore) { lns = lns_ }),
+			),
+			tableCells,
+			controllerCells,
+
+			cell.ProvidePrivate(
+				func() promise.Promise[synced.CRDSync] {
+					r, p := promise.New[synced.CRDSync]()
+					r.Resolve(synced.CRDSync{})
+					return p
+				},
+				func() resourceMutator { return fakeEnvoy },
+				func() policyTrigger { return fakeEnvoy },
 			),
 		)
 

--- a/pkg/crypto/certloader/cell_test.go
+++ b/pkg/crypto/certloader/cell_test.go
@@ -11,13 +11,11 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/hive/health/types"
 	"github.com/cilium/cilium/pkg/promise"
 )
 
@@ -42,10 +40,6 @@ func TestCell(t *testing.T) {
 	}
 
 	hive := hive.New(
-		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-			h := p.ForModule(cell.FullModuleID{"test"})
-			return jr.NewGroup(h, lc)
-		}),
 		cell.ProvidePrivate(func(cfg testConfig) Config {
 			return Config(cfg)
 		}),
@@ -99,10 +93,6 @@ func TestCellConfigError(t *testing.T) {
 	var serverConfig *WatchedServerConfig
 
 	hive := hive.New(
-		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-			h := p.ForModule(cell.FullModuleID{"test"})
-			return jr.NewGroup(h, lc)
-		}),
 		cell.ProvidePrivate(func(cfg testConfig) Config {
 			return Config(cfg)
 		}),
@@ -163,10 +153,6 @@ func TestCellShutdown(t *testing.T) {
 	}
 
 	hive := hive.New(
-		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-			h := p.ForModule(cell.FullModuleID{"test"})
-			return jr.NewGroup(h, lc)
-		}),
 		cell.ProvidePrivate(func(cfg testConfig) Config {
 			return Config(cfg)
 		}),
@@ -210,10 +196,6 @@ func TestCellDisabled(t *testing.T) {
 	var cfgPromise promise.Promise[*WatchedServerConfig]
 
 	hive := hive.New(
-		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-			h := p.ForModule(cell.FullModuleID{"test"})
-			return jr.NewGroup(h, lc)
-		}),
 		cell.ProvidePrivate(func(cfg testConfig) Config {
 			return Config(cfg)
 		}),

--- a/pkg/datapath/garp/processor_test.go
+++ b/pkg/datapath/garp/processor_test.go
@@ -93,10 +93,7 @@ func fixture(t *testing.T, c *Config) (
 		proc     *processor
 	)
 
-	h := hive.New(cell.Module(
-		"test-garp-processor-cell",
-		"TestProcessorCell",
-
+	h := hive.New(
 		cell.Config(defaultConfig),
 
 		cell.Provide(
@@ -128,7 +125,7 @@ func fixture(t *testing.T, c *Config) (
 				proc = procParam
 			},
 		),
-	))
+	)
 
 	// Apply the config so that the GARP cell will initialise.s
 	hive.AddConfigOverride(h, func(cfg *Config) {

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -42,37 +42,32 @@ func TestReconciliationLoop(t *testing.T) {
 		params  *reconcilerParams
 	)
 	h := hive.New(
-		cell.Module(
-			"iptables-reconciler-test",
-			"iptables-reconciler-test",
-
-			cell.Provide(
-				tables.NewDeviceTable,
-				statedb.RWTable[*tables.Device].ToTable,
-				func() *node.LocalNodeStore { return node.NewTestLocalNodeStore(node.LocalNode{}) },
-			),
-			cell.Invoke(func(
-				db_ *statedb.DB,
-				devices_ statedb.RWTable[*tables.Device],
-				store_ *node.LocalNodeStore,
-				health_ cell.Health,
-			) {
-				db = db_
-				devices = devices_
-				store = store_
-				db.RegisterTable(devices_)
-				health = health_.NewScope("iptables-reconciler-test")
-				params = &reconcilerParams{
-					clock:          clock,
-					localNodeStore: store_,
-					db:             db_,
-					devices:        devices_,
-					proxies:        make(chan reconciliationRequest[proxyInfo]),
-					addNoTrackPod:  make(chan reconciliationRequest[noTrackPodInfo]),
-					delNoTrackPod:  make(chan reconciliationRequest[noTrackPodInfo]),
-				}
-			}),
+		cell.Provide(
+			tables.NewDeviceTable,
+			statedb.RWTable[*tables.Device].ToTable,
+			func() *node.LocalNodeStore { return node.NewTestLocalNodeStore(node.LocalNode{}) },
 		),
+		cell.Invoke(func(
+			db_ *statedb.DB,
+			devices_ statedb.RWTable[*tables.Device],
+			store_ *node.LocalNodeStore,
+			health_ cell.Health,
+		) {
+			db = db_
+			devices = devices_
+			store = store_
+			db.RegisterTable(devices_)
+			health = health_.NewScope("iptables-reconciler-test")
+			params = &reconcilerParams{
+				clock:          clock,
+				localNodeStore: store_,
+				db:             db_,
+				devices:        devices_,
+				proxies:        make(chan reconciliationRequest[proxyInfo]),
+				addNoTrackPod:  make(chan reconciliationRequest[noTrackPodInfo]),
+				delNoTrackPod:  make(chan reconciliationRequest[noTrackPodInfo]),
+			}
+		}),
 	)
 
 	var (

--- a/pkg/datapath/l2responder/l2responder_test.go
+++ b/pkg/datapath/l2responder/l2responder_test.go
@@ -45,18 +45,13 @@ func newFixture(t testing.TB) *fixture {
 			statedb.RWTable[*tables.L2AnnounceEntry].ToTable,
 		),
 
-		cell.Module(
-			"l2responder-test",
-			"L2 responder test module",
-
-			cell.Invoke(
-				statedb.RegisterTable[*tables.L2AnnounceEntry],
-				func(d *statedb.DB, lc cell.Lifecycle, h cell.Health, t statedb.RWTable[*tables.L2AnnounceEntry], j job.Group) {
-					db = d
-					tbl = t
-					jg = j
-				}),
-		),
+		cell.Invoke(
+			statedb.RegisterTable[*tables.L2AnnounceEntry],
+			func(d *statedb.DB, lc cell.Lifecycle, h cell.Health, t statedb.RWTable[*tables.L2AnnounceEntry], j job.Group) {
+				db = d
+				tbl = t
+				jg = j
+			}),
 	).Populate(logger)
 
 	nl := &mockNeighborNetlink{}

--- a/pkg/datapath/linux/sysctl/sysctl_test.go
+++ b/pkg/datapath/linux/sysctl/sysctl_test.go
@@ -84,22 +84,17 @@ func TestWaitForReconciliation(t *testing.T) {
 	)
 
 	hive := hive.New(
-		cell.Module(
-			"sysctl-test",
-			"sysctl-test",
+		cell.Provide(func(db *statedb.DB) (statedb.RWTable[*tables.Sysctl], statedb.Index[*tables.Sysctl, reconciler.StatusKind], error) {
+			return tables.NewSysctlTable(db)
+		}),
+		cell.Invoke(func(db *statedb.DB, settings statedb.RWTable[*tables.Sysctl]) {
+			db.RegisterTable(settings)
+		}),
 
-			cell.Provide(func(db *statedb.DB) (statedb.RWTable[*tables.Sysctl], statedb.Index[*tables.Sysctl, reconciler.StatusKind], error) {
-				return tables.NewSysctlTable(db)
-			}),
-			cell.Invoke(func(db *statedb.DB, settings statedb.RWTable[*tables.Sysctl]) {
-				db.RegisterTable(settings)
-			}),
-
-			cell.Invoke(func(statedb *statedb.DB, tb statedb.RWTable[*tables.Sysctl]) {
-				db = statedb
-				settings = tb
-			}),
-		),
+		cell.Invoke(func(statedb *statedb.DB, tb statedb.RWTable[*tables.Sysctl]) {
+			db = statedb
+			settings = tb
+		}),
 	)
 
 	tlog := hivetest.Logger(t)
@@ -143,22 +138,18 @@ func TestSysctl(t *testing.T) {
 	var sysctl Sysctl
 
 	hive := hive.New(
-		cell.Module(
-			"sysctl-test",
-			"sysctl-test",
-			cell.Config(defaultConfig),
+		cell.Config(defaultConfig),
 
-			cell.Provide(
-				func() afero.Fs {
-					return afero.NewMemMapFs()
-				},
-			),
-			cell.Provide(
-				newReconcilingSysctl,
-				tables.NewSysctlTable,
-				newReconciler,
-				newOps,
-			),
+		cell.Provide(
+			func() afero.Fs {
+				return afero.NewMemMapFs()
+			},
+		),
+		cell.Provide(
+			newReconcilingSysctl,
+			tables.NewSysctlTable,
+			newReconciler,
+			newOps,
 		),
 
 		cell.Invoke(func(s Sysctl) {
@@ -242,22 +233,18 @@ func TestSysctlIgnoreErr(t *testing.T) {
 	var sysctl Sysctl
 
 	hive := hive.New(
-		cell.Module(
-			"sysctl-test",
-			"sysctl-test",
-			cell.Config(defaultConfig),
+		cell.Config(defaultConfig),
 
-			cell.Provide(
-				func() afero.Fs {
-					return afero.NewMemMapFs()
-				},
-			),
-			cell.Provide(
-				newReconcilingSysctl,
-				tables.NewSysctlTable,
-				newReconciler,
-				newOps,
-			),
+		cell.Provide(
+			func() afero.Fs {
+				return afero.NewMemMapFs()
+			},
+		),
+		cell.Provide(
+			newReconcilingSysctl,
+			tables.NewSysctlTable,
+			newReconciler,
+			newOps,
 		),
 
 		cell.Invoke(func(s Sysctl) {

--- a/pkg/dial/resolver_test.go
+++ b/pkg/dial/resolver_test.go
@@ -47,7 +47,7 @@ func TestServiceResolver(t *testing.T) {
 	h := hive.New(
 		client.FakeClientCell,
 
-		cell.Module("foo", "foo", ServiceResolverCell),
+		ServiceResolverCell,
 
 		cell.Config(k8s.DefaultConfig),
 		cell.Provide(k8s.ServiceResource),

--- a/pkg/driftchecker/checker_test.go
+++ b/pkg/driftchecker/checker_test.go
@@ -12,14 +12,12 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/dynamicconfig"
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/hive/health/types"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -185,10 +183,6 @@ func fixture(t *testing.T, cellAllSettings map[string]any) (*hive.Hive, *statedb
 			dynamicconfig.NewConfigTable,
 			func(table statedb.RWTable[dynamicconfig.DynamicConfig]) statedb.Table[dynamicconfig.DynamicConfig] {
 				return table
-			},
-			func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-				h := p.ForModule(cell.FullModuleID{"test"})
-				return jr.NewGroup(h, lc)
 			},
 			func() config {
 				return config{

--- a/pkg/dynamicconfig/table_test.go
+++ b/pkg/dynamicconfig/table_test.go
@@ -13,13 +13,11 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/hive/health/types"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/option/resolver"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -241,10 +239,6 @@ func fixture(t *testing.T, sources string) (*hive.Hive, *statedb.DB, statedb.RWT
 			NewConfigMapReflector,
 			func(table statedb.RWTable[DynamicConfig]) statedb.Table[DynamicConfig] {
 				return table
-			},
-			func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-				h := p.ForModule(cell.FullModuleID{"test"})
-				return jr.NewGroup(h, lc)
 			},
 			func() Config {
 				return Config{

--- a/pkg/dynamiclifecycle/reconciler_test.go
+++ b/pkg/dynamiclifecycle/reconciler_test.go
@@ -10,14 +10,12 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/dynamicconfig"
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/hive/health/types"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -258,10 +256,6 @@ func fixture(t *testing.T) (*hive.Hive, *statedb.DB, statedb.RWTable[dynamicconf
 			},
 			func(table statedb.RWTable[*DynamicFeature]) statedb.Table[*DynamicFeature] {
 				return table
-			},
-			func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
-				h := p.ForModule(cell.FullModuleID{"test"})
-				return jr.NewGroup(h, lc)
 			},
 			func() config {
 				return config{

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -34,8 +34,6 @@ var (
 )
 
 // New wraps the hive.New to create a hive with defaults used by cilium-agent.
-// pkg/hive should eventually go away and this code should live in e.g. daemon/cmd
-// or operator/cmd.
 func New(cells ...cell.Cell) *Hive {
 	cells = append(
 		slices.Clone(cells),
@@ -68,6 +66,12 @@ func New(cells ...cell.Cell) *Hive {
 		cell.Provide(
 			func() logging.FieldLogger {
 				return logging.DefaultSlogLogger
+			},
+
+			// Root job group. This is mostly provided for tests so that we don't need a cell.Module
+			// wrapper to get a job.Group.
+			func(reg job.Registry, h cell.Health, l *slog.Logger, lc cell.Lifecycle) job.Group {
+				return reg.NewGroup(h, lc, job.WithLogger(l))
 			},
 		),
 	)

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -56,14 +56,14 @@ func newFixture(t testing.TB) *fixture {
 
 	hive.New(
 		cell.Provide(tables.NewL2AnnounceTable),
-		cell.Module("test", "test", cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], h_ cell.Health, j job.Registry, jg_ job.Group) {
+		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], h_ cell.Health, j job.Registry, jg_ job.Group) {
 			d.RegisterTable(t)
 			db = d
 			tbl = t
 			jr = j
 			jg = jg_
 			h = h_
-		})),
+		}),
 	).Populate(logger)
 
 	fakeSvcStore := &fakeStore[*slim_corev1.Service]{}

--- a/pkg/loadbalancer/legacy/service/reconciler_test.go
+++ b/pkg/loadbalancer/legacy/service/reconciler_test.go
@@ -54,20 +54,18 @@ func TestServiceReconciler(t *testing.T) {
 	)
 
 	h := hive.New(
-		cell.Module("test", "test",
-			cell.Provide(
-				tables.NewNodeAddressTable,
-				statedb.RWTable[tables.NodeAddress].ToTable,
-				source.NewSources,
-			),
-			cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
-			cell.Provide(func() syncNodePort { return mock }),
-			cell.Invoke(registerServiceReconciler),
-			cell.Invoke(func(d *statedb.DB, na statedb.RWTable[tables.NodeAddress]) {
-				db = d
-				nodeAddrs = na
-			}),
+		cell.Provide(
+			tables.NewNodeAddressTable,
+			statedb.RWTable[tables.NodeAddress].ToTable,
+			source.NewSources,
 		),
+		cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
+		cell.Provide(func() syncNodePort { return mock }),
+		cell.Invoke(registerServiceReconciler),
+		cell.Invoke(func(d *statedb.DB, na statedb.RWTable[tables.NodeAddress]) {
+			db = d
+			nodeAddrs = na
+		}),
 	)
 
 	tlog := hivetest.Logger(t)

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -105,9 +105,7 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 				}
 			},
 		),
-		cell.Module("test", "test",
-			cell.Invoke(registerSocketTermination),
-		),
+		cell.Invoke(registerSocketTermination),
 		cell.Invoke(func(db_ *statedb.DB, backends_ statedb.RWTable[*loadbalancer.Backend]) {
 			db = db_
 			backends = backends_

--- a/pkg/maps/nat/stats/stats_test.go
+++ b/pkg/maps/nat/stats/stats_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/hive/job"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/hive"
@@ -104,9 +103,6 @@ func Test_countNat(t *testing.T) {
 	ms := make(fakeMetrics)
 	h := hive.New(
 		cell.Provide(newTables),
-		cell.Provide(func(jg job.Registry, lc cell.Lifecycle) job.Group {
-			return jg.NewGroup(nil, lc)
-		}),
 		cell.Provide(func() loadbalancer.Config { return loadbalancer.DefaultConfig }),
 		cell.Provide(func() (promise.Promise[nat.NatMap4], promise.Promise[nat.NatMap6], Config, natMetrics) {
 			r4, p4 := promise.New[nat.NatMap4]()


### PR DESCRIPTION
Provide a "root" job.Group outside a cell.Module wrapping to to make job.Group availability symmetric to loggers and to make it easier to write tests without the need to either wrap into a cell.Module or use NewGroup directly.

The second commit removes unnecessary cell.Module wrappings and NewGroup calls.