### PR TITLE
Feature: Add Option to disable Namespace Creation

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -741,6 +741,7 @@ contributors across the globe, there is almost always someone available to help.
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |
 | monitor.enabled | bool | `false` | Enable the cilium-monitor sidecar. |
 | name | string | `"cilium"` | Agent daemonset name. |
+| namespaceCreate | bool | `true` | namespaceCreate allows to override the creation of the default namespace This property allows to create a Namespace for Cillium through external tools. |
 | namespaceOverride | string | `""` | namespaceOverride allows to override the destination namespace for Cilium resources. This property allows to use Cilium as part of an Umbrella Chart with different targets. |
 | nat.mapStatsEntries | int | `32` | Number of the top-k SNAT map connections to track in Cilium statedb. |
 | nat.mapStatsInterval | string | `"30s"` | Interval between how often SNAT map is counted for stats. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -741,7 +741,7 @@ contributors across the globe, there is almost always someone available to help.
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |
 | monitor.enabled | bool | `false` | Enable the cilium-monitor sidecar. |
 | name | string | `"cilium"` | Agent daemonset name. |
-| namespaceCreate | bool | `true` | namespaceCreate allows to override the creation of the default namespace This property allows to create a Namespace for Cillium through external tools. |
+| namespaceCreate | bool | `true` | namespaceCreate allows to override the creation of the default namespace This property allows to create a Namespace for Cillium through external tools. WARNING: enabling this and _not_ creating the namespace correctly will cause the installation to fail to apply. |
 | namespaceOverride | string | `""` | namespaceOverride allows to override the destination namespace for Cilium resources. This property allows to use Cilium as part of an Umbrella Chart with different targets. |
 | nat.mapStatsEntries | int | `32` | Number of the top-k SNAT map connections to track in Cilium statedb. |
 | nat.mapStatsInterval | string | `"30s"` | Interval between how often SNAT map is counted for stats. |

--- a/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
+++ b/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.namespaceCreate }}
 {{- $secretNamespaces := dict -}}
 {{- range $cfg := tuple .Values.ingressController .Values.gatewayAPI .Values.envoyConfig .Values.bgpControlPlane -}}
 {{- if and $cfg.enabled $cfg.secretsNamespace.create $cfg.secretsNamespace.name -}}
@@ -24,4 +25,5 @@ metadata:
     {{- with $.Values.secretsNamespaceAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end}}
 {{- end}}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4212,6 +4212,12 @@
     "name": {
       "type": "string"
     },
+    "namespaceCreate": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
     "namespaceOverride": {
       "type": [
         "null",

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -13,6 +13,8 @@ namespaceOverride: ""
 # @schema
 # -- namespaceCreate allows to override the creation of the default namespace
 # This property allows to create a Namespace for Cillium through external tools.
+# WARNING: enabling this and _not_ creating the namespace correctly will cause
+# the installation to fail to apply.
 namespaceCreate: true
 # @schema
 # type: [null, object]

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -9,6 +9,12 @@
 # This property allows to use Cilium as part of an Umbrella Chart with different targets.
 namespaceOverride: ""
 # @schema
+# type: [null, boolean]
+# @schema
+# -- namespaceCreate allows to override the creation of the default namespace
+# This property allows to create a Namespace for Cillium through external tools.
+namespaceCreate: true
+# @schema
 # type: [null, object]
 # @schema
 # -- commonLabels allows users to add common labels for all Cilium resources.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -11,6 +11,8 @@ namespaceOverride: ""
 # @schema
 # -- namespaceCreate allows to override the creation of the default namespace
 # This property allows to create a Namespace for Cillium through external tools.
+# WARNING: enabling this and _not_ creating the namespace correctly will cause
+# the installation to fail to apply.
 namespaceCreate: true
 
 # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -5,6 +5,14 @@
 # -- namespaceOverride allows to override the destination namespace for Cilium resources.
 # This property allows to use Cilium as part of an Umbrella Chart with different targets.
 namespaceOverride: ""
+
+# @schema
+# type: [null, boolean]
+# @schema
+# -- namespaceCreate allows to override the creation of the default namespace
+# This property allows to create a Namespace for Cillium through external tools.
+namespaceCreate: true
+
 # @schema
 # type: [null, object]
 # @schema


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Add Option to disable Namespace Creation.

For my Case, i create all my Namespaces in the Cluster with a helm chart to allow to add different options.

Since Cilium is now in charge of the namespace, I'm having problems changing labels or annotations because the helm chart overrides them and lacks an annotation addition or modification feature.

Like this annotations:

`pod-security.kubernetes.io/enforce=privileged` which is required for running [Talos](https://www.talos.dev/v1.10/kubernetes-guides/network/deploying-cilium/) with cilium.

```release-note
Add Option to disable the creation of the Namespace via the cilium helm chart
```

