### PR TITLE
loadbalancer: Add LoadBalancerClass to Service

### DIFF
--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -81,6 +81,7 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 		Annotations:         svc.Annotations,
 		HealthCheckNodePort: uint16(svc.Spec.HealthCheckNodePort),
 		ForwardingMode:      loadbalancer.SVCForwardingModeUndef,
+		LoadBalancerClass:   svc.Spec.LoadBalancerClass,
 	}
 
 	if cfg.LBModeAnnotation {

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -59,8 +59,16 @@ type Service struct {
 	// to the backend. If undefined the default mode is used (--bpf-lb-mode).
 	ForwardingMode SVCForwardingMode
 
-	SessionAffinity        bool
+	// SessionAffinity if true will enable the client IP based session affinity.
+	SessionAffinity bool
+
+	// SessionAffinityTimeout is the duration of inactivity before the session
+	// affinity is cleared for a specific client IP.
 	SessionAffinityTimeout time.Duration
+
+	// LoadBalancerClass if set specifies the load-balancer class to be used
+	// for a LoadBalancer service. If unset the default implementation is used.
+	LoadBalancerClass *string
 
 	// ProxyRedirect if non-nil redirects the traffic going to the frontends
 	// towards a locally running proxy.
@@ -243,6 +251,10 @@ func (svc *Service) TableRow() []string {
 
 	if svc.TrafficDistribution != TrafficDistributionDefault {
 		flags = append(flags, "TrafficDistribution="+string(svc.TrafficDistribution))
+	}
+
+	if svc.LoadBalancerClass != nil {
+		flags = append(flags, "LoadBalancerClass="+*svc.LoadBalancerClass)
 	}
 
 	sort.Strings(flags)

--- a/pkg/loadbalancer/tests/testdata/loadbalancer.txtar
+++ b/pkg/loadbalancer/tests/testdata/loadbalancer.txtar
@@ -50,7 +50,7 @@ Address NodePort Primary DeviceName
 
 -- services.table --
 Name         Source   PortNames  TrafficPolicy   Flags
-test/echo    k8s      http=80    Cluster         
+test/echo    k8s      http=80    Cluster         LoadBalancerClass=test
 
 -- frontends.table --
 Address               Type         ServiceName   PortName   Status  Backends
@@ -115,6 +115,7 @@ spec:
   selector:
     name: echo
   sessionAffinity: None
+  loadBalancerClass: "test"
   type: LoadBalancer
 status:
   loadBalancer:

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -69,6 +69,7 @@ Address              Instances
   "ForwardingMode": "",
   "SessionAffinity": false,
   "SessionAffinityTimeout": 0,
+  "LoadBalancerClass": null,
   "ProxyRedirect": null,
   "HealthCheckNodePort": 0,
   "LoopbackHostPort": false,
@@ -264,6 +265,7 @@ inttrafficpolicy: Cluster
 forwardingmode: ""
 sessionaffinity: false
 sessionaffinitytimeout: 0s
+loadbalancerclass: null
 proxyredirect: null
 healthchecknodeport: 0
 loopbackhostport: false


### PR DESCRIPTION
The LoadBalancerClass is used by pkg/bgpv1 and by pkg/l2announcer. Add it so we can in the future flip them to using `Table[*lb.Service]` instead of `Resource[*corev1.Service]`.