### PR TITLE
loadbalancer: Remove Service.Properties

### DIFF
--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
-	"github.com/cilium/statedb/part"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/labels"
@@ -86,10 +85,6 @@ type Service struct {
 	// TrafficDistribution if not default will influence how backends are chosen for
 	// frontends associated with this service.
 	TrafficDistribution TrafficDistribution
-
-	// Properties are additional untyped properties that can carry feature
-	// specific metadata about the service.
-	Properties part.Map[string, any]
 }
 
 type TrafficDistribution string
@@ -230,15 +225,6 @@ func (svc *Service) TableRow() []string {
 
 	if svc.ForwardingMode != SVCForwardingModeUndef {
 		flags = append(flags, "ForwardingMode="+string(svc.ForwardingMode))
-	}
-
-	if svc.Properties.Len() != 0 {
-		// Since the property is an "any", we'll just show the keys.
-		propKeys := make([]string, 0, svc.Properties.Len())
-		for k := range svc.Properties.All() {
-			propKeys = append(propKeys, k)
-		}
-		flags = append(flags, "Properties="+strings.Join(propKeys, ", "))
 	}
 
 	if svc.TrafficDistribution != TrafficDistributionDefault {

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -76,8 +76,7 @@ Address              Instances
   "PortNames": {
     "http": 80
   },
-  "TrafficDistribution": "",
-  "Properties": []
+  "TrafficDistribution": ""
 }
 -- frontends-expected.json --
 {
@@ -271,7 +270,6 @@ sourceranges: []
 portnames:
     http: 80
 trafficdistribution: ""
-properties: []
 -- frontends-expected.yaml --
 frontendparams:
     address: 10.96.50.104:80/TCP


### PR DESCRIPTION
Remove the [Properties] field from [Service]. This was added prematurely to potentially allow features to piggyback on the [Service] object to carry state. This isn't well thought out and we don't have similar facilities for [Frontend] or [Backend].