### PR TITLE
logging: Update klog matching regexp

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -62,9 +62,7 @@ var DefaultLogger = initializeDefaultLogger()
 
 var klogErrorOverrides = []logLevelOverride{
 	{
-		// TODO: We can drop the misspelled case here once client-go version is bumped to include:
-		//	https://github.com/kubernetes/client-go/commit/ae43527480ee9d8750fbcde3d403363873fd3d89
-		matcher:     regexp.MustCompile("Failed to update lock (optimitically|optimistically).*falling back to slow path"),
+		matcher:     regexp.MustCompile("Failed to update lock optimistically.*falling back to slow path"),
 		targetLevel: logrus.InfoLevel,
 	},
 }


### PR DESCRIPTION
[`client-go`](https://github.com/kubernetes/client-go/tree/v0.33.1) has been updated and no longer has the typo that required this fix.

See https://github.com/cilium/cilium/blob/40c6f005fb368af3010da1f218db60be521b68ca/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go#L429

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
logging: Update klog matching regexp
```
