### PR TITLE
loader: Add ability set custom constants and map renames

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -226,7 +226,7 @@ func (l *loader) reinitializeIPSec(lnc *datapath.LocalNodeConfiguration) error {
 		return fmt.Errorf("loading eBPF ELF %s: %w", networkObj, err)
 	}
 
-	co, renames := ipsecRewrites(lnc)
+	co, renames := applyProgRewrites(l.rewrites.IPsec, lnc)
 
 	var obj networkObjects
 	commit, err := bpf.LoadAndAssign(l.logger, &obj, spec, &bpf.CollectionOptions{

--- a/pkg/datapath/loader/cell.go
+++ b/pkg/datapath/loader/cell.go
@@ -15,6 +15,8 @@ var Cell = cell.Module(
 
 	cell.Provide(NewLoader),
 	cell.Provide(NewCompilationLock),
+
+	cell.ProvidePrivate(newBuiltinRewrites),
 )
 
 // NewLoader returns a new loader.

--- a/pkg/datapath/loader/rewrites.go
+++ b/pkg/datapath/loader/rewrites.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loader
+
+import (
+	"maps"
+
+	"github.com/cilium/hive/cell"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/config"
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
+)
+
+// progRewrites collects all registered hooks to rewrite a program's compile-time constants and maps
+type progRewrites struct {
+	cell.In
+
+	LXC        []datapath.EndpointProgRewriter `group:"loader-rewrite-lxc"`
+	XDP        []datapath.DeviceProgRewriter   `group:"loader-rewrite-xdp"`
+	CiliumHost []datapath.EndpointProgRewriter `group:"loader-rewrite-cilium-host"`
+	CiliumNet  []datapath.HostProgRewriter     `group:"loader-rewrite-cilium-net"`
+	Overlay    []datapath.DeviceProgRewriter   `group:"loader-rewrite-overlay"`
+	Netdev     []datapath.HostProgRewriter     `group:"loader-rewrite-netdev"`
+	IPsec      []datapath.ProgRewriter         `group:"loader-rewrite-ipsec"`
+	Wireguard  []datapath.DeviceProgRewriter   `group:"loader-rewrite-wireguard"`
+}
+
+// builtinRewrites contains the built-in standard rewrites for all loaded BPF programs.
+// See newBuiltinRewrites below for how compile-time constants and map renames are initialized.
+type builtinRewrites struct {
+	cell.Out
+
+	LXC        datapath.EndpointProgRewriter `group:"loader-rewrite-lxc"`
+	XDP        datapath.DeviceProgRewriter   `group:"loader-rewrite-xdp"`
+	CiliumHost datapath.EndpointProgRewriter `group:"loader-rewrite-cilium-host"`
+	CiliumNet  datapath.HostProgRewriter     `group:"loader-rewrite-cilium-net"`
+	Overlay    datapath.DeviceProgRewriter   `group:"loader-rewrite-overlay"`
+	Netdev     datapath.HostProgRewriter     `group:"loader-rewrite-netdev"`
+	IPsec      datapath.ProgRewriter         `group:"loader-rewrite-ipsec"`
+	Wireguard  datapath.DeviceProgRewriter   `group:"loader-rewrite-wireguard"`
+}
+
+func newBuiltinRewrites() builtinRewrites {
+	return builtinRewrites{
+		LXC:        datapath.EndpointProgRewriterFn[*config.BPFLXC](endpointRewrites),
+		XDP:        datapath.DeviceProgRewriterFn[*config.BPFXDP](xdpRewrites),
+		CiliumHost: datapath.EndpointProgRewriterFn[*config.BPFHost](ciliumHostRewrites),
+		CiliumNet:  datapath.HostProgRewriterFn[*config.BPFHost](ciliumNetRewrites),
+		Overlay:    datapath.DeviceProgRewriterFn[*config.BPFOverlay](overlayRewrite),
+		Netdev:     datapath.HostProgRewriterFn[*config.BPFHost](netdevRewrites),
+		IPsec:      datapath.ProgRewriterFn[*config.BPFNetwork](ipsecRewrites),
+		Wireguard:  datapath.DeviceProgRewriterFn[*config.BPFWireguard](wireguardRewrites),
+	}
+}
+
+func applyEndpointProgRewrites(
+	rewrites []datapath.EndpointProgRewriter,
+	ep datapath.EndpointConfiguration,
+	lnc *datapath.LocalNodeConfiguration,
+) (constants []any, mapRenames map[string]string) {
+	constants = make([]any, 0, len(rewrites))
+	mapRenames = make(map[string]string)
+
+	for _, rewriter := range rewrites {
+		c, r := rewriter.Rewrite(ep, lnc)
+		constants = append(constants, c)
+		maps.Copy(mapRenames, r)
+	}
+
+	return constants, mapRenames
+}
+
+func applyDeviceProgRewrites(
+	rewrites []datapath.DeviceProgRewriter,
+	lnc *datapath.LocalNodeConfiguration,
+	link netlink.Link,
+) (constants []any, mapRenames map[string]string) {
+	constants = make([]any, 0, len(rewrites))
+	mapRenames = make(map[string]string)
+
+	for _, rewriter := range rewrites {
+		c, r := rewriter.Rewrite(lnc, link)
+		constants = append(constants, c)
+		maps.Copy(mapRenames, r)
+	}
+
+	return constants, mapRenames
+}
+
+func applyHostProgRewrites(
+	rewrites []datapath.HostProgRewriter,
+	ep datapath.EndpointConfiguration,
+	lnc *datapath.LocalNodeConfiguration,
+	link netlink.Link,
+) (constants []any, mapRenames map[string]string) {
+	constants = make([]any, 0, len(rewrites))
+	mapRenames = make(map[string]string)
+
+	for _, rewriter := range rewrites {
+		c, r := rewriter.Rewrite(ep, lnc, link)
+		constants = append(constants, c)
+		maps.Copy(mapRenames, r)
+	}
+
+	return constants, mapRenames
+}
+
+func applyProgRewrites(
+	rewrites []datapath.ProgRewriter,
+	lnc *datapath.LocalNodeConfiguration,
+) (constants []any, mapRenames map[string]string) {
+	constants = make([]any, 0, len(rewrites))
+	mapRenames = make(map[string]string)
+
+	for _, rewriter := range rewrites {
+		c, r := rewriter.Rewrite(lnc)
+		constants = append(constants, c)
+		maps.Copy(mapRenames, r)
+	}
+
+	return constants, mapRenames
+}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -160,7 +160,7 @@ func (l *loader) compileAndLoadXDPProg(ctx context.Context, lnc *datapath.LocalN
 		return fmt.Errorf("loading eBPF ELF %s: %w", objPath, err)
 	}
 
-	co, renames := xdpRewrites(lnc, iface)
+	co, renames := applyDeviceProgRewrites(l.rewrites.XDP, lnc, iface)
 
 	var obj xdpObjects
 	commit, err := bpf.LoadAndAssign(l.logger, &obj, spec, &bpf.CollectionOptions{


### PR DESCRIPTION
This commit extends the loader infrastructure with a new mechanism to provide custom constants and map rename values when loading our BPF programs.

To achieve this, the loader now stores a list containing the rewrite logic for each BPF program type. The existing rewrite logic is provided as a built-in provider, but additional rewriters can be injected into the Hive via [value groups](https://pkg.go.dev/go.uber.org/dig#hdr-Value_Groups)

**Review per commit** : The first two commits mechanically restructure the code base so the hooks can easily be added in the third commit.