### PR TITLE
tls: Remove mock TLS config GetCertificate method

### DIFF
--- a/pkg/crypto/certloader/server.go
+++ b/pkg/crypto/certloader/server.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"log/slog"
 	"slices"
 
@@ -130,13 +129,6 @@ func (c *WatchedServerConfig) ServerConfig(base *tls.Config) *tls.Config {
 				)
 			}
 			return tlsConfig, nil
-		},
-		// Same issue as https://github.com/golang/go/issues/29139 but for
-		// http.Server.ServeTLS.
-		// Can be removed after https://github.com/golang/go/pull/66795 is merged
-		// and included in a release.
-		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-			return nil, fmt.Errorf("all certificates configured via GetConfigForClient")
 		},
 		// NOTE: this MinVersion is not used as this tls.Config will be
 		// overridden by the one returned by GetConfigForClient. The effective


### PR DESCRIPTION
This is no longer needed since https://github.com/golang/go/pull/66795 shipped in go 1.23 and cilium builds with go 1.24.


See https://github.com/golang/go/blob/go1.23.0/src/net/http/server.go#L3390

Related to #31973

---


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->


```release-note
tls: Remove mock TLS config GetCertificate method
```
