### PR TITLE
bpf: test: install deny-all network policy for LB hairpin tests

### DIFF
--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -24,6 +24,12 @@ policy_add_ingress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 }
 
 static __always_inline void
+policy_add_ingress_deny_all_entry(void)
+{
+	policy_add_entry(false, 0, 0, 0, true);
+}
+
+static __always_inline void
 policy_add_egress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
 	policy_add_entry(true, sec_label, protocol, dport, false);

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -106,6 +106,10 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 
 	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, 0, NULL, NULL);
 
+	/* Hairpin should over-rule any installed network policy: */
+	policy_add_egress_deny_all_entry();
+	policy_add_ingress_deny_all_entry();
+
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, 0);
 	/* Fail if we didn't jump */


### PR DESCRIPTION
A hairpinned connection is meant to ignore egress & ingress network policy. Confirm that this works as expected.