### PR TITLE
Fix: L7 policy not working when kernel disable ipv6

### DIFF
--- a/pkg/proxy/proxyports/netstat.go
+++ b/pkg/proxy/proxyports/netstat.go
@@ -10,21 +10,18 @@ import (
 	"strconv"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
-	// procNetTCPFiles is the constant list of /proc/net files to read to get
-	// the same information about open TCP connections as output by netstat.
-	procNetTCPFiles = []string{
-		"/proc/net/tcp",
-		"/proc/net/tcp6",
-	}
-
-	// procNetUDPFiles is the constant list of /proc/net files to read to get
-	// the same information about open UDP connections as output by netstat.
-	procNetUDPFiles = []string{
-		"/proc/net/udp",
-		"/proc/net/udp6",
+	// procNetFiles is the constant map showing the correspondance of /proc/net files
+	// to the bool flag of the "do we expect them to be present based on the config"
+	// /proc/net files may be used to get the information about open connections as output by netstat.
+	procNetFiles = map[string]bool{
+		"/proc/net/tcp":  option.Config.EnableIPv4,
+		"/proc/net/udp":  option.Config.EnableIPv4,
+		"/proc/net/tcp6": option.Config.EnableIPv6,
+		"/proc/net/udp6": option.Config.EnableIPv6,
 	}
 
 	// procNetFileRegexp matches the first two columns of /proc/net/{tcp,udp}*
@@ -36,13 +33,18 @@ var (
 func (p *ProxyPorts) GetOpenLocalPorts() map[uint16]struct{} {
 	openLocalPorts := make(map[uint16]struct{}, 128)
 
-	for _, file := range append(procNetTCPFiles, procNetUDPFiles...) {
+	for file, enabled := range procNetFiles {
 		b, err := os.ReadFile(file)
 		if err != nil {
-			p.logger.Error("cannot read proc file",
-				logfields.Path, file,
-				logfields.Error, err,
-			)
+			// we only need to report this as unexpected behaviour
+			// when the ipvX is enabled in the config, but not present as a file
+			if enabled {
+				p.logger.Error("cannot read proc file",
+					logfields.Path, file,
+					logfields.Error, err,
+				)
+			}
+
 			continue
 		}
 


### PR DESCRIPTION
Prevents proxy from reporting an error while reading /proc/net/ files for the disabled ipvX version.

Fixes: #14865

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #14865

```release-note
Proxy is prevented from reporting an error reading /proc/net/ files for the disabled ipvX version.
```
