### PR TITLE
Fix agent graceful shutdown

### DIFF
--- a/daemon/healthz/agenthealth.go
+++ b/daemon/healthz/agenthealth.go
@@ -80,6 +80,12 @@ func registerAgentHealthHTTPService(params agentHealthParams) error {
 				Addr:    addr,
 				Handler: mux,
 			}
+
+			go func() {
+				<-ctx.Done()
+				srv.Shutdown(context.Background()) // does not use job context, as it has already been closed!
+			}()
+
 			params.Logger.Info("Starting healthz status API server", logfields.Address, addr)
 			if err := srv.Serve(ln); errors.Is(err, http.ErrServerClosed) {
 				params.Logger.Info("healthz status API server shutdown", logfields.Address, addr)

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -345,7 +345,6 @@ func newIptablesManager(p params) datapath.IptablesManager {
 
 	// init haveIp6tables argument before using it in a reconciliation loop
 	iptMgr.startDone = iptMgr.argsInit.Add()
-	p.Lifecycle.Append(iptMgr)
 
 	p.JobGroup.Add(
 		job.OneShot("iptables-reconciliation-loop", func(ctx context.Context, health cell.Health) error {
@@ -367,6 +366,10 @@ func newIptablesManager(p params) datapath.IptablesManager {
 			)
 		}),
 	)
+
+	// Add the manager after the reconciler, otherwise there is a deadlock on shutdown
+	// between closing and draining the channels.
+	p.Lifecycle.Append(iptMgr)
 
 	return iptMgr
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -942,7 +942,7 @@ func (e *Endpoint) startRegenerationFailureHandler() {
 				e.getLogger().Debug("received signal that regeneration failed")
 			case <-ctx.Done():
 				e.getLogger().Debug("exiting retrying regeneration goroutine due to endpoint being deleted")
-				return nil
+				return controller.NewExitReason("endpoint being deleted")
 			}
 
 			regenMetadata := &regeneration.ExternalRegenerationMetadata{
@@ -952,7 +952,10 @@ func (e *Endpoint) startRegenerationFailureHandler() {
 				// of the failure, simply that something failed.
 				RegenerationLevel: regeneration.RegenerateWithDatapath,
 			}
-			regen, _ := e.SetRegenerateStateIfAlive(regenMetadata)
+			regen, err := e.SetRegenerateStateIfAlive(regenMetadata)
+			if err != nil {
+				return controller.NewExitReason("endpoint being deleted")
+			}
 			if !regen {
 				// We don't need to regenerate because the endpoint is d
 				// disconnecting / is disconnected, or another regeneration has

--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -330,6 +330,9 @@ func icmpPing(logger *slog.Logger, node string, ip string, ctx context.Context, 
 }
 
 func per(nodes int, duration time.Duration) rate.Limit {
+	if nodes == 0 {
+		nodes = 1
+	}
 	return rate.Every(duration / time.Duration(nodes))
 }
 


### PR DESCRIPTION
As I was working on some other shutdown code, I noticed that the agent no longer gracefully shuts down. This was due to a few hung shutdown processes.

Please review by commit. The fixes were minor.