### PR TITLE
workflows: add RUN_AS_ROOT to build-go-caches workflow

### DIFF
--- a/.github/workflows/build-go-caches.yaml
+++ b/.github/workflows/build-go-caches.yaml
@@ -102,6 +102,7 @@ jobs:
         env:
           BUILDER_GOCACHE_DIR: "/tmp/.cache/go/.cache/go-build"
           BUILDER_GOMODCACHE_DIR: "/tmp/.cache/go/pkg"
+          RUN_AS_ROOT: "true"
         if: ${{ steps.go-cache.outputs.cache-hit != 'true' &&
               steps.check.outputs.build != ''
            }}


### PR DESCRIPTION
Since we reverse the default for running builder as root we should have
also set the correct value of the env variable in the build-go-caches
workflow as otherwise the builder does not create the golang cache in
the right directory.

Fixes: 9324f9a3ccf6 ("contrib: Reverse default for running builder as root")