### PR TITLE
datapath/linux/probes: simplify probe functions by using sync.OnceValue

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -246,9 +246,11 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	// Check the kernel if we can make use of managed neighbor entries which
 	// simplifies and fully 'offloads' L2 resolution handling to the kernel.
 	if !option.Config.DryMode {
-		if err := probes.HaveManagedNeighbors(params.Logger); err == nil {
+		if err := probes.HaveManagedNeighbors(); err == nil {
 			params.Logger.Info("Using Managed Neighbor Kernel support")
 			option.Config.ARPPingKernelManaged = true
+		} else if !errors.Is(err, probes.ErrNotSupported) {
+			return nil, nil, fmt.Errorf("failed to probe managed neighbor support: %w", err)
 		}
 	}
 

--- a/pkg/datapath/linux/probes/attach_cgroup.go
+++ b/pkg/datapath/linux/probes/attach_cgroup.go
@@ -20,15 +20,7 @@ import (
 // It's only an approximation and doesn't execute a successful cgroup attachment
 // under the hood. If any unexpected errors are encountered, the original error
 // is returned.
-func HaveAttachCgroup() error {
-	attachCgroupOnce.Do(func() {
-		attachCgroupResult = haveAttachCgroup()
-	})
-
-	return attachCgroupResult
-}
-
-func haveAttachCgroup() error {
+var HaveAttachCgroup = sync.OnceValue(func() error {
 	// Load known-good program supported by the earliest kernels with cgroup
 	// support.
 	spec := &ebpf.ProgramSpec{
@@ -63,7 +55,4 @@ func haveAttachCgroup() error {
 	}
 
 	return errors.New("attaching prog to /dev/null did not result in error")
-}
-
-var attachCgroupOnce sync.Once
-var attachCgroupResult error
+})

--- a/pkg/datapath/linux/probes/managed_neighbors.go
+++ b/pkg/datapath/linux/probes/managed_neighbors.go
@@ -4,94 +4,71 @@
 package probes
 
 import (
-	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"sync"
 
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/netns"
-)
-
-var (
-	managedNeighborOnce   sync.Once
-	managedNeighborResult error
 )
 
 // HaveManagedNeighbors returns nil if the host supports managed neighbor entries (NTF_EXT_MANAGED).
 // On unexpected probe results this function will terminate with log.Fatal().
-func HaveManagedNeighbors(logger *slog.Logger) error {
-	managedNeighborOnce.Do(func() {
-		ns, err := netns.New()
-		if err != nil {
-			managedNeighborResult = fmt.Errorf("create netns: %w", err)
-			return
-		}
-		defer ns.Close()
-
-		// In order to call haveManagedNeighbors safely, it has to be started
-		// in a standalone netns
-		managedNeighborResult = ns.Do(func() error {
-			return haveManagedNeighbors()
-		})
-
-		// if we encounter a different error than ErrNotSupported, terminate the agent.
-		if managedNeighborResult != nil && !errors.Is(managedNeighborResult, ErrNotSupported) {
-			logging.Fatal(logger, "failed to probe managed neighbor support", logfields.Error, managedNeighborResult)
-		}
-	})
-
-	return managedNeighborResult
-}
-
-func haveManagedNeighbors() (outer error) {
-	// Use a veth device instead of a dummy to avoid the kernel having to modprobe
-	// the dummy kmod, which could potentially be compiled out. veth is currently
-	// a hard dependency for Cilium, so safe to assume the module is available if
-	// not already loaded.
-	veth := &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
-		PeerName:  "veth1",
-	}
-
-	if err := netlink.LinkAdd(veth); err != nil {
-		return fmt.Errorf("failed to add dummy veth: %w", err)
-	}
-
-	neigh := netlink.Neigh{
-		LinkIndex: veth.Index,
-		IP:        net.IPv4(0, 0, 0, 1),
-		Flags:     NTF_EXT_LEARNED,
-		FlagsExt:  NTF_EXT_MANAGED,
-	}
-
-	if err := netlink.NeighAdd(&neigh); err != nil {
-		return fmt.Errorf("failed to add neighbor: %w", err)
-	}
-
-	nl, err := safenetlink.NeighList(veth.Index, 0)
+var HaveManagedNeighbors = sync.OnceValue(func() error {
+	ns, err := netns.New()
 	if err != nil {
-		return fmt.Errorf("failed to list neighbors: %w", err)
+		return fmt.Errorf("create netns: %w", err)
 	}
+	defer ns.Close()
 
-	for _, n := range nl {
-		if !n.IP.Equal(neigh.IP) {
-			continue
-		}
-		if n.Flags != NTF_EXT_LEARNED {
-			continue
-		}
-		if n.FlagsExt != NTF_EXT_MANAGED {
-			continue
+	// In order to call haveManagedNeighbors safely, it has to be started
+	// in a standalone netns
+	return ns.Do(func() error {
+		// Use a veth device instead of a dummy to avoid the kernel having to modprobe
+		// the dummy kmod, which could potentially be compiled out. veth is currently
+		// a hard dependency for Cilium, so safe to assume the module is available if
+		// not already loaded.
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+			PeerName:  "veth1",
 		}
 
-		return nil
-	}
+		if err := netlink.LinkAdd(veth); err != nil {
+			return fmt.Errorf("failed to add dummy veth: %w", err)
+		}
 
-	return ErrNotSupported
-}
+		neigh := netlink.Neigh{
+			LinkIndex: veth.Index,
+			IP:        net.IPv4(0, 0, 0, 1),
+			Flags:     NTF_EXT_LEARNED,
+			FlagsExt:  NTF_EXT_MANAGED,
+		}
+
+		if err := netlink.NeighAdd(&neigh); err != nil {
+			return fmt.Errorf("failed to add neighbor: %w", err)
+		}
+
+		nl, err := safenetlink.NeighList(veth.Index, 0)
+		if err != nil {
+			return fmt.Errorf("failed to list neighbors: %w", err)
+		}
+
+		for _, n := range nl {
+			if !n.IP.Equal(neigh.IP) {
+				continue
+			}
+			if n.Flags != NTF_EXT_LEARNED {
+				continue
+			}
+			if n.FlagsExt != NTF_EXT_MANAGED {
+				continue
+			}
+
+			return nil
+		}
+
+		return ErrNotSupported
+	})
+})

--- a/pkg/datapath/linux/probes/managed_neighbors_test.go
+++ b/pkg/datapath/linux/probes/managed_neighbors_test.go
@@ -6,8 +6,6 @@ package probes
 import (
 	"testing"
 
-	"github.com/cilium/hive/hivetest"
-
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -15,7 +13,7 @@ func TestManagedNeighbors(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	testutils.SkipOnOldKernel(t, "5.16", "NTF_EXT_MANAGED")
 
-	if err := HaveManagedNeighbors(hivetest.Logger(t)); err != nil {
+	if err := HaveManagedNeighbors(); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Instead of manually implementing the same using `sync.Once` and an error value. Also move the fatal logging out of the probe helper into the daemon.