### PR TITLE
pkg/lb: Misc KPR subflags support

### DIFF
--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -506,7 +506,8 @@ type ExternalConfig struct {
 	EnableSocketLBPodConnectionTermination bool
 
 	// The following options will be removed in v1.19
-	EnableHostPort bool
+	EnableHostPort        bool
+	EnableSessionAffinity bool
 }
 
 // NewExternalConfig maps the daemon config to [ExternalConfig].
@@ -520,6 +521,7 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
 		EnableSocketLB:                         kprCfg.EnableSocketLB,
 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,
 		EnableHostPort:                         kprCfg.EnableHostPort,
+		EnableSessionAffinity:                  kprCfg.EnableSessionAffinity,
 	}
 }
 

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -506,9 +506,10 @@ type ExternalConfig struct {
 	EnableSocketLBPodConnectionTermination bool
 
 	// The following options will be removed in v1.19
-	EnableHostPort            bool
-	EnableSessionAffinity     bool
-	EnableSVCSourceRangeCheck bool
+	EnableHostPort              bool
+	EnableSessionAffinity       bool
+	EnableSVCSourceRangeCheck   bool
+	EnableInternalTrafficPolicy bool
 }
 
 // NewExternalConfig maps the daemon config to [ExternalConfig].
@@ -524,6 +525,7 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
 		EnableHostPort:                         kprCfg.EnableHostPort,
 		EnableSessionAffinity:                  kprCfg.EnableSessionAffinity,
 		EnableSVCSourceRangeCheck:              kprCfg.EnableSVCSourceRangeCheck,
+		EnableInternalTrafficPolicy:            cfg.EnableInternalTrafficPolicy,
 	}
 }
 

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -506,8 +506,9 @@ type ExternalConfig struct {
 	EnableSocketLBPodConnectionTermination bool
 
 	// The following options will be removed in v1.19
-	EnableHostPort        bool
-	EnableSessionAffinity bool
+	EnableHostPort            bool
+	EnableSessionAffinity     bool
+	EnableSVCSourceRangeCheck bool
 }
 
 // NewExternalConfig maps the daemon config to [ExternalConfig].
@@ -522,6 +523,7 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,
 		EnableHostPort:                         kprCfg.EnableHostPort,
 		EnableSessionAffinity:                  kprCfg.EnableSessionAffinity,
+		EnableSVCSourceRangeCheck:              kprCfg.EnableSVCSourceRangeCheck,
 	}
 }
 

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -504,6 +504,9 @@ type ExternalConfig struct {
 	BPFSocketLBHostnsOnly                  bool
 	EnableSocketLB                         bool
 	EnableSocketLBPodConnectionTermination bool
+
+	// The following options will be removed in v1.19
+	EnableHostPort bool
 }
 
 // NewExternalConfig maps the daemon config to [ExternalConfig].
@@ -516,6 +519,7 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
 		BPFSocketLBHostnsOnly:                  cfg.BPFSocketLBHostnsOnly,
 		EnableSocketLB:                         kprCfg.EnableSocketLB,
 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,
+		EnableHostPort:                         kprCfg.EnableHostPort,
 	}
 }
 

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -504,6 +504,7 @@ type ExternalConfig struct {
 	BPFSocketLBHostnsOnly                  bool
 	EnableSocketLB                         bool
 	EnableSocketLBPodConnectionTermination bool
+	EnableHealthCheckLoadBalancerIP        bool
 
 	// The following options will be removed in v1.19
 	EnableHostPort              bool
@@ -522,6 +523,7 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
 		BPFSocketLBHostnsOnly:                  cfg.BPFSocketLBHostnsOnly,
 		EnableSocketLB:                         kprCfg.EnableSocketLB,
 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,
+		EnableHealthCheckLoadBalancerIP:        cfg.EnableHealthCheckLoadBalancerIP,
 		EnableHostPort:                         kprCfg.EnableHostPort,
 		EnableSessionAffinity:                  kprCfg.EnableSessionAffinity,
 		EnableSVCSourceRangeCheck:              kprCfg.EnableSVCSourceRangeCheck,

--- a/pkg/loadbalancer/healthserver/healthserver.go
+++ b/pkg/loadbalancer/healthserver/healthserver.go
@@ -169,7 +169,7 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 					s.params.Writer.DeleteBackendsOfService(wtxn, healthServiceName, source.Local)
 					s.params.Writer.DeleteServiceAndFrontends(wtxn, healthServiceName)
 					wtxn.Commit()
-				} else {
+				} else if extCfg.EnableHealthCheckLoadBalancerIP {
 					// Create a LoadBalancer service to expose the health server on the $LB_VIP.
 					// For NodePort we don't need anything as the HealthServer is already listening on
 					// all node addresses.

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -90,8 +90,9 @@ func TestScript(t *testing.T) {
 					source.NewSources,
 					func(cfg loadbalancer.TestConfig) *option.DaemonConfig {
 						return &option.DaemonConfig{
-							EnableIPv4: true,
-							EnableIPv6: true,
+							EnableIPv4:                  true,
+							EnableIPv6:                  true,
+							EnableInternalTrafficPolicy: true,
 						}
 					},
 					func() kpr.KPRConfig {

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -90,9 +90,10 @@ func TestScript(t *testing.T) {
 					source.NewSources,
 					func(cfg loadbalancer.TestConfig) *option.DaemonConfig {
 						return &option.DaemonConfig{
-							EnableIPv4:                  true,
-							EnableIPv6:                  true,
-							EnableInternalTrafficPolicy: true,
+							EnableIPv4:                      true,
+							EnableIPv6:                      true,
+							EnableInternalTrafficPolicy:     true,
+							EnableHealthCheckLoadBalancerIP: true,
 						}
 					},
 					func() kpr.KPRConfig {

--- a/pkg/loadbalancer/maps/lbmaps.go
+++ b/pkg/loadbalancer/maps/lbmaps.go
@@ -333,10 +333,17 @@ func (r *BPFLBMaps) allMaps() ([]mapDesc, []mapDesc) {
 		{&r.sockRevNat6Map, NewSockRevNat6Map, r.Cfg.LBSockRevNatEntries},
 		{&r.affinity6Map, newAffinity6Map, r.Cfg.LBAffinityMapEntries},
 	}
-	mapsToCreate := []mapDesc{
-		{&r.affinityMatchMap, NewAffinityMatchMap, r.Cfg.LBAffinityMapEntries},
-	}
+	affinityMap := mapDesc{&r.affinityMatchMap, NewAffinityMatchMap, r.Cfg.LBAffinityMapEntries}
+
+	mapsToCreate := []mapDesc{}
 	mapsToDelete := []mapDesc{}
+
+	if r.ExtCfg.EnableSessionAffinity {
+		mapsToCreate = append(mapsToCreate, affinityMap)
+	} else {
+		mapsToDelete = append(mapsToDelete, affinityMap)
+	}
+
 	if r.ExtCfg.EnableIPv4 {
 		mapsToCreate = append(mapsToCreate, v4Maps...)
 	} else {

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -369,13 +369,15 @@ func (ops *BPFOps) deleteFrontend(fe *loadbalancer.Frontend) error {
 		}
 	}
 
-	// Clean up any potential affinity match entries. We do this regardless of
-	// whether or not SessionAffinity is enabled as it might've been toggled by
-	// the user. Could optimize this by holding some more state if needed.
-	for addr := range ops.backendReferences[fe.Address] {
-		err := ops.deleteAffinityMatch(feID, ops.backendStates[addr].id)
-		if err != nil {
-			return fmt.Errorf("delete affinity match %d: %w", feID, err)
+	if ops.extCfg.EnableSessionAffinity {
+		// Clean up any potential affinity match entries. We do this regardless of
+		// whether or not SessionAffinity is enabled as it might've been toggled by
+		// the user. Could optimize this by holding some more state if needed.
+		for addr := range ops.backendReferences[fe.Address] {
+			err := ops.deleteAffinityMatch(feID, ops.backendStates[addr].id)
+			if err != nil {
+				return fmt.Errorf("delete affinity match %d: %w", feID, err)
+			}
 		}
 	}
 
@@ -792,8 +794,10 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 		if err := ops.deleteBackend(orphanState.addr.IsIPv6(), orphanState.id); err != nil {
 			return fmt.Errorf("delete backend: %w", err)
 		}
-		if err := ops.deleteAffinityMatch(feID, orphanState.id); err != nil {
-			return fmt.Errorf("delete affinity match: %w", err)
+		if ops.extCfg.EnableSessionAffinity {
+			if err := ops.deleteAffinityMatch(feID, orphanState.id); err != nil {
+				return fmt.Errorf("delete affinity match: %w", err)
+			}
 		}
 		ops.releaseBackend(orphanState.id, orphanState.addr)
 	}
@@ -844,22 +848,24 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 			return fmt.Errorf("upsert service: %w", err)
 		}
 
-		// TODO: Most likely we'll just need to keep some state on the reconciled SessionAffinity
-		// state to avoid the extra syscalls when session affinity is not enabled.
-		// For now we update these regardless so that we handle properly the SessionAffinity being
-		// flipped on and then off.
-		if svc.SessionAffinity && be.State == loadbalancer.BackendStateActive {
-			ops.log.Debug("Update affinity",
-				logfields.ID, feID,
-				logfields.BackendID, beID)
-			if err := ops.upsertAffinityMatch(feID, beID); err != nil {
-				return fmt.Errorf("upsert affinity match: %w", err)
-			}
-		} else {
-			// SessionAffinity either disabled or backend not active, no matter which
-			// clean up any affinity match that might exist.
-			if err := ops.deleteAffinityMatch(feID, beID); err != nil {
-				return fmt.Errorf("delete affinity match: %w", err)
+		if ops.extCfg.EnableSessionAffinity {
+			// TODO: Most likely we'll just need to keep some state on the reconciled SessionAffinity
+			// state to avoid the extra syscalls when session affinity is not enabled.
+			// For now we update these regardless so that we handle properly the SessionAffinity being
+			// flipped on and then off.
+			if svc.SessionAffinity && be.State == loadbalancer.BackendStateActive {
+				ops.log.Debug("Update affinity",
+					logfields.ID, feID,
+					logfields.BackendID, beID)
+				if err := ops.upsertAffinityMatch(feID, beID); err != nil {
+					return fmt.Errorf("upsert affinity match: %w", err)
+				}
+			} else {
+				// SessionAffinity either disabled or backend not active, no matter which
+				// clean up any affinity match that might exist.
+				if err := ops.deleteAffinityMatch(feID, beID); err != nil {
+					return fmt.Errorf("delete affinity match: %w", err)
+				}
 			}
 		}
 
@@ -1049,7 +1055,7 @@ func (ops *BPFOps) upsertMaster(svcKey maps.ServiceKey, svcVal maps.ServiceValue
 	svc := fe.Service
 
 	// Set the SessionAffinity/L7ProxyPort. These re-use the "backend ID".
-	if svc.SessionAffinity {
+	if svc.SessionAffinity && ops.extCfg.EnableSessionAffinity {
 		if err := svcVal.SetSessionAffinityTimeoutSec(uint32(svc.SessionAffinityTimeout.Seconds())); err != nil {
 			return err
 		}

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1055,6 +1055,7 @@ func TestBPFOps(t *testing.T) {
 		EnableIPv4:           true,
 		EnableIPv6:           true,
 		KubeProxyReplacement: true,
+		EnableHostPort:       true,
 	}
 
 	cfg, _ := loadbalancer.NewConfig(log, loadbalancer.DefaultUserConfig, loadbalancer.DeprecatedConfig{}, &option.DaemonConfig{})

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1051,11 +1051,12 @@ func TestBPFOps(t *testing.T) {
 
 	// Enable features.
 	extCfg := loadbalancer.ExternalConfig{
-		ZoneMapper:           &option.DaemonConfig{},
-		EnableIPv4:           true,
-		EnableIPv6:           true,
-		KubeProxyReplacement: true,
-		EnableHostPort:       true,
+		ZoneMapper:            &option.DaemonConfig{},
+		EnableIPv4:            true,
+		EnableIPv6:            true,
+		KubeProxyReplacement:  true,
+		EnableHostPort:        true,
+		EnableSessionAffinity: true,
 	}
 
 	cfg, _ := loadbalancer.NewConfig(log, loadbalancer.DefaultUserConfig, loadbalancer.DeprecatedConfig{}, &option.DaemonConfig{})

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -95,8 +95,9 @@ func TestScript(t *testing.T) {
 					source.NewSources,
 					func(cfg loadbalancer.TestConfig) *option.DaemonConfig {
 						return &option.DaemonConfig{
-							EnableIPv4: true,
-							EnableIPv6: true,
+							EnableIPv4:                  true,
+							EnableIPv6:                  true,
+							EnableInternalTrafficPolicy: true,
 						}
 					},
 					func() kpr.KPRConfig {

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -101,9 +101,10 @@ func TestScript(t *testing.T) {
 					},
 					func() kpr.KPRConfig {
 						return kpr.KPRConfig{
-							KubeProxyReplacement: option.KubeProxyReplacementTrue,
-							EnableNodePort:       true,
-							EnableHostPort:       true,
+							KubeProxyReplacement:  option.KubeProxyReplacementTrue,
+							EnableNodePort:        true,
+							EnableHostPort:        true,
+							EnableSessionAffinity: true,
 						}
 					},
 					func(ops *lbreconciler.BPFOps, lns *node.LocalNodeStore, w *writer.Writer, waitFn loadbalancer.InitWaitFunc) uhive.ScriptCmdsOut {

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -103,6 +103,7 @@ func TestScript(t *testing.T) {
 						return kpr.KPRConfig{
 							KubeProxyReplacement: option.KubeProxyReplacementTrue,
 							EnableNodePort:       true,
+							EnableHostPort:       true,
 						}
 					},
 					func(ops *lbreconciler.BPFOps, lns *node.LocalNodeStore, w *writer.Writer, waitFn loadbalancer.InitWaitFunc) uhive.ScriptCmdsOut {

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -101,10 +101,11 @@ func TestScript(t *testing.T) {
 					},
 					func() kpr.KPRConfig {
 						return kpr.KPRConfig{
-							KubeProxyReplacement:  option.KubeProxyReplacementTrue,
-							EnableNodePort:        true,
-							EnableHostPort:        true,
-							EnableSessionAffinity: true,
+							KubeProxyReplacement:      option.KubeProxyReplacementTrue,
+							EnableNodePort:            true,
+							EnableHostPort:            true,
+							EnableSessionAffinity:     true,
+							EnableSVCSourceRangeCheck: true,
 						}
 					},
 					func(ops *lbreconciler.BPFOps, lns *node.LocalNodeStore, w *writer.Writer, waitFn loadbalancer.InitWaitFunc) uhive.ScriptCmdsOut {

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -45,6 +45,8 @@ type Writer struct {
 	sourcePriorities map[source.Source]uint8 // The smaller the int, the more preferred the source. Use via sourcePriority().
 
 	selectBackendsFunc SelectBackendsFunc
+
+	extCfg *loadbalancer.ExternalConfig
 }
 
 type SelectBackendsFunc = func(iter.Seq2[loadbalancer.BackendParams, statedb.Revision], *loadbalancer.Service, *loadbalancer.Frontend) iter.Seq2[loadbalancer.BackendParams, statedb.Revision]
@@ -66,6 +68,8 @@ type writerParams struct {
 	ServiceHooks []ServiceHook `group:"service-hooks"`
 
 	SourcePriorities source.Sources
+
+	ExtCfg loadbalancer.ExternalConfig
 }
 
 func init() {
@@ -84,6 +88,7 @@ func NewWriter(p writerParams) (*Writer, error) {
 		nodeAddrs:        p.NodeAddresses,
 		svcHooks:         p.ServiceHooks,
 		sourcePriorities: priorityMapFromSlice(p.SourcePriorities),
+		extCfg:           &p.ExtCfg,
 	}
 	w.selectBackendsFunc = w.DefaultSelectBackends
 	return w, nil
@@ -370,7 +375,7 @@ func (w *Writer) DefaultSelectBackends(bes iter.Seq2[loadbalancer.BackendParams,
 	ipv4, ipv6 := true, true
 	isLocalProxyDelegation := func(loadbalancer.L3n4Addr) bool { return true }
 	if fe != nil {
-		onlyLocal = shouldUseLocalBackends(fe)
+		onlyLocal = shouldUseLocalBackends(w.extCfg, fe)
 		if fe.Address.IsIPv6() {
 			ipv4, ipv6 = false, true
 		} else {
@@ -696,10 +701,11 @@ func isExtLocal(fe *loadbalancer.Frontend) bool {
 	}
 }
 
-func isIntLocal(fe *loadbalancer.Frontend) bool {
-	/* FIXME if !option.Config.EnableInternalTrafficPolicy {
+func isIntLocal(extCfg *loadbalancer.ExternalConfig, fe *loadbalancer.Frontend) bool {
+	if !extCfg.EnableInternalTrafficPolicy {
 		return false
-	}*/
+	}
+
 	switch fe.Type {
 	case loadbalancer.SVCTypeClusterIP, loadbalancer.SVCTypeNodePort, loadbalancer.SVCTypeLoadBalancer, loadbalancer.SVCTypeExternalIPs:
 		return fe.Service.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal
@@ -708,7 +714,7 @@ func isIntLocal(fe *loadbalancer.Frontend) bool {
 	}
 }
 
-func shouldUseLocalBackends(fe *loadbalancer.Frontend) bool {
+func shouldUseLocalBackends(extCfg *loadbalancer.ExternalConfig, fe *loadbalancer.Frontend) bool {
 	// When both traffic policies are Local, there is only the external scope, which
 	// should contain node-local backends only. Checking isExtLocal is still enough.
 	switch fe.Address.Scope {
@@ -717,11 +723,11 @@ func shouldUseLocalBackends(fe *loadbalancer.Frontend) bool {
 			// ClusterIP doesn't support externalTrafficPolicy and has only the
 			// external scope, which contains only node-local backends when
 			// internalTrafficPolicy=Local.
-			return isIntLocal(fe)
+			return isIntLocal(extCfg, fe)
 		}
 		return isExtLocal(fe)
 	case loadbalancer.ScopeInternal:
-		return isIntLocal(fe)
+		return isIntLocal(extCfg, fe)
 	default:
 		return false
 	}

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -57,6 +58,7 @@ func fixture(t testing.TB, hooks ...ServiceHook) (p testParams) {
 			tables.NewNodeAddressTable,
 			statedb.RWTable[tables.NodeAddress].ToTable,
 			source.NewSources,
+			func() kpr.KPRConfig { return kpr.KPRConfig{} },
 		),
 		cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 		cell.Invoke(func(p_ testParams) { p = p_ }),


### PR DESCRIPTION
See commit msgs. TL;DR the following flag support has been added to the pkg/lb:

- `EnableHostPort` (to-be removed in v1.19)
- `EnableSessionAffinity` (to-be removed in v1.19)
- `EnableSVCSourceRangeCheck` (to-be removed in v1.19)
- `EnableInternalTrafficPolicy` (to-be removed in v1.19)
- `EnableHealthCheckLoadBalancerIP` (need to ping Google folks whether their external LB HC can do HC using a node IP instead of LB IP. if yes, then we can remove the flag and the code)

Blocked by https://github.com/cilium/cilium/pull/40026.