### PR TITLE
agent: Deprecate --enable-internal-traffic-policy

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -138,7 +138,6 @@ cilium-agent [flags]
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format
       --enable-identity-mark                                      Enable setting identity mark for local traffic (default true)
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets
-      --enable-internal-traffic-policy                            Enable internal traffic policy (default true)
       --enable-ip-masq-agent                                      Enable BPF ip-masq-agent
       --enable-ipip-termination                                   Enable plain IPIP/IP6IP6 termination
       --enable-ipsec                                              Enable IPsec support

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -360,6 +360,8 @@ Deprecated Options
   ``--kube-proxy-replacent`` is set to ``true``.
 * The flag ``--enable-k8s-endpoint-slice`` have been deprecated and will be removed in Cilium 1.19.
   The K8s Endpoint Slice feature will be unconditionally enabled.
+* The flag ``--enable-internal-traffic-policy`` has been deprecated and will be removed in Cilium 1.19. The
+  ``internalTrafficPolicy`` field in a Kubernetes Service object will be unconditionally respected.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -962,6 +962,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.NodeLabels)
 
 	flags.Bool(option.EnableInternalTrafficPolicy, defaults.EnableInternalTrafficPolicy, "Enable internal traffic policy")
+	flags.MarkDeprecated(option.EnableInternalTrafficPolicy, "The flag will be removed in v1.19. The feature will be unconditionally enabled by default.")
 	option.BindEnv(vp, option.EnableInternalTrafficPolicy)
 
 	flags.Bool(option.EnableNonDefaultDenyPolicies, defaults.EnableNonDefaultDenyPolicies, "Enable use of non-default-deny policies")


### PR DESCRIPTION
Introduced by https://github.com/cilium/cilium/pull/34858.

It's up to a user to decide whether the policy should be enabled for a given svc.