### PR TITLE
policy: extract namespace only once on repository insert/delete

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -171,10 +171,11 @@ func (p *Repository) addListLocked(rules api.Rules) (ruleSlice, uint64) {
 func (p *Repository) insert(r *rule) {
 	p.rules[r.key] = r
 	p.metricsManager.AddRule(r.Rule)
-	if _, ok := p.rulesByNamespace[r.key.resource.Namespace()]; !ok {
-		p.rulesByNamespace[r.key.resource.Namespace()] = sets.New[ruleKey]()
+	namespace := r.key.resource.Namespace()
+	if _, ok := p.rulesByNamespace[namespace]; !ok {
+		p.rulesByNamespace[namespace] = sets.New[ruleKey]()
 	}
-	p.rulesByNamespace[r.key.resource.Namespace()].Insert(r.key)
+	p.rulesByNamespace[namespace].Insert(r.key)
 	rid := r.key.resource
 	if len(rid) > 0 {
 		if p.rulesByResource[rid] == nil {
@@ -193,9 +194,10 @@ func (p *Repository) del(key ruleKey) {
 	}
 	p.metricsManager.DelRule(r.Rule)
 	delete(p.rules, key)
-	p.rulesByNamespace[key.resource.Namespace()].Delete(key)
-	if len(p.rulesByNamespace[key.resource.Namespace()]) == 0 {
-		delete(p.rulesByNamespace, key.resource.Namespace())
+	namespace := r.key.resource.Namespace()
+	p.rulesByNamespace[namespace].Delete(key)
+	if len(p.rulesByNamespace[namespace]) == 0 {
+		delete(p.rulesByNamespace, namespace)
 	}
 
 	rid := key.resource


### PR DESCRIPTION
The `(*rule).key.resource.Namespace` method used to get the namespace for accessing `(*Repository).rulesByNamespace` implies `strings.Cut` on the `ResourceID` for each call.

Cache the namespace value to improve repository insert/delete time a bit by avoiding these repeated `strings.Cut` calls.