### PR TITLE
bpf: consistently use `BPF_F_*` constants from x/sys/unix

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -7,17 +7,12 @@ import (
 	"sync/atomic"
 
 	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
 )
 
 var (
-	preAllocateMapSetting uint32 = BPF_F_NO_PREALLOC
+	preAllocateMapSetting uint32 = unix.BPF_F_NO_PREALLOC
 	noCommonLRUMapSetting uint32 = 0
-)
-
-const (
-	// Flags for BPF_MAP_CREATE. Must match values from linux/bpf.h
-	BPF_F_NO_PREALLOC   = 1 << 0
-	BPF_F_NO_COMMON_LRU = 1 << 1
 )
 
 // EnableMapPreAllocation enables BPF map pre-allocation on map types that
@@ -32,14 +27,14 @@ func EnableMapPreAllocation() {
 // take effect in that case. Also note that this does not take effect on
 // existing map although could be recreated later when objCheck() runs.
 func DisableMapPreAllocation() {
-	atomic.StoreUint32(&preAllocateMapSetting, BPF_F_NO_PREALLOC)
+	atomic.StoreUint32(&preAllocateMapSetting, unix.BPF_F_NO_PREALLOC)
 }
 
 // EnableMapDistributedLRU enables the LRU map no-common-LRU feature which
 // splits backend memory pools among CPUs to avoid sharing a common backend
 // pool where frequent allocation/frees might content on internal spinlocks.
 func EnableMapDistributedLRU() {
-	atomic.StoreUint32(&noCommonLRUMapSetting, BPF_F_NO_COMMON_LRU)
+	atomic.StoreUint32(&noCommonLRUMapSetting, unix.BPF_F_NO_COMMON_LRU)
 }
 
 // DisableMapDistributedLRU disables the LRU map no-common-LRU feature which
@@ -54,7 +49,7 @@ func GetMapMemoryFlags(t ebpf.MapType) uint32 {
 	switch t {
 	// LPM Tries don't support preallocation.
 	case ebpf.LPMTrie:
-		return BPF_F_NO_PREALLOC
+		return unix.BPF_F_NO_PREALLOC
 	// Support disabling preallocation for these map types.
 	case ebpf.Hash, ebpf.PerCPUHash, ebpf.HashOfMaps:
 		return atomic.LoadUint32(&preAllocateMapSetting)

--- a/pkg/bpf/bpf_test.go
+++ b/pkg/bpf/bpf_test.go
@@ -8,25 +8,26 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestDefaultMapFlags(t *testing.T) {
-	require.Equal(t, uint32(BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.Hash))
+	require.Equal(t, uint32(unix.BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.Hash))
 	require.Equal(t, uint32(0), GetMapMemoryFlags(ebpf.LRUHash))
-	require.Equal(t, uint32(BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.LPMTrie))
+	require.Equal(t, uint32(unix.BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.LPMTrie))
 	require.Equal(t, uint32(0), GetMapMemoryFlags(ebpf.Array))
 
 	EnableMapPreAllocation()
 	require.Equal(t, uint32(0), GetMapMemoryFlags(ebpf.Hash))
 	require.Equal(t, uint32(0), GetMapMemoryFlags(ebpf.LRUHash))
-	require.Equal(t, uint32(BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.LPMTrie))
+	require.Equal(t, uint32(unix.BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.LPMTrie))
 	require.Equal(t, uint32(0), GetMapMemoryFlags(ebpf.Array))
 	DisableMapPreAllocation()
 
 	EnableMapDistributedLRU()
-	require.Equal(t, uint32(BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.Hash))
-	require.Equal(t, uint32(BPF_F_NO_COMMON_LRU), GetMapMemoryFlags(ebpf.LRUHash))
-	require.Equal(t, uint32(BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.LPMTrie))
+	require.Equal(t, uint32(unix.BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.Hash))
+	require.Equal(t, uint32(unix.BPF_F_NO_COMMON_LRU), GetMapMemoryFlags(ebpf.LRUHash))
+	require.Equal(t, uint32(unix.BPF_F_NO_PREALLOC), GetMapMemoryFlags(ebpf.LPMTrie))
 	require.Equal(t, uint32(0), GetMapMemoryFlags(ebpf.Array))
 	DisableMapDistributedLRU()
 }

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/option"
@@ -66,7 +67,7 @@ func setup(tb testing.TB) *Map {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	).WithCache()
 
 	err = testMap.OpenOrCreate()
@@ -129,7 +130,7 @@ func TestOpen(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC).WithCache()
+		unix.BPF_F_NO_PREALLOC).WithCache()
 	defer func() {
 		err = existingMap.Close()
 		require.NoError(t, err)
@@ -163,11 +164,11 @@ func TestOpenOrCreate(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC).WithCache()
+		unix.BPF_F_NO_PREALLOC).WithCache()
 	err := existingMap.OpenOrCreate()
 	require.NoError(t, err)
 
-	// preallocMap unsets BPF_F_NO_PREALLOC. OpenOrCreate should recreate map.
+	// preallocMap unsets unix.BPF_F_NO_PREALLOC. OpenOrCreate should recreate map.
 	EnableMapPreAllocation() // prealloc on/off is controllable in HASH map case.
 	preallocMap := NewMap("cilium_test",
 		ebpf.Hash,
@@ -193,7 +194,7 @@ func TestRecreateMap(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC).WithCache()
+		unix.BPF_F_NO_PREALLOC).WithCache()
 	err := parallelMap.Recreate()
 	defer parallelMap.Close()
 	require.NoError(t, err)
@@ -237,7 +238,7 @@ func TestBasicManipulation(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC).
+		unix.BPF_F_NO_PREALLOC).
 		WithCache().
 		WithEvents(option.BPFEventBufferConfig{Enabled: true, MaxSize: 10})
 
@@ -429,7 +430,7 @@ func TestSubscribe(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC).
+		unix.BPF_F_NO_PREALLOC).
 		WithCache().
 		WithEvents(option.BPFEventBufferConfig{Enabled: true, MaxSize: 10})
 
@@ -603,7 +604,7 @@ func TestDumpReliablyWithCallbackOverlapping(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		int(maxEntries),
-		BPF_F_NO_PREALLOC).WithCache()
+		unix.BPF_F_NO_PREALLOC).WithCache()
 	err := m.OpenOrCreate()
 	require.NoError(t, err)
 	defer func() {
@@ -691,7 +692,7 @@ func TestDumpReliablyWithCallback(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		int(maxEntries),
-		BPF_F_NO_PREALLOC).WithCache()
+		unix.BPF_F_NO_PREALLOC).WithCache()
 	err := m.OpenOrCreate()
 	require.NoError(t, err)
 	defer func() {
@@ -822,7 +823,7 @@ func TestCheckAndUpgrade(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC).WithCache()
+		unix.BPF_F_NO_PREALLOC).WithCache()
 	err := upgradeMap.OpenOrCreate()
 	require.NoError(t, err)
 	defer func() {
@@ -834,7 +835,7 @@ func TestCheckAndUpgrade(t *testing.T) {
 	upgrade := upgradeMap.CheckAndUpgrade(upgradeMap)
 	require.False(t, upgrade)
 
-	// preallocMap unsets BPF_F_NO_PREALLOC so upgrade is needed.
+	// preallocMap unsets unix.BPF_F_NO_PREALLOC so upgrade is needed.
 	EnableMapPreAllocation()
 	preallocMap := NewMap("cilium_test_upgrade",
 		ebpf.Hash,
@@ -856,7 +857,7 @@ func TestUnpin(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC).WithCache()
+		unix.BPF_F_NO_PREALLOC).WithCache()
 	err := unpinMap.OpenOrCreate()
 	require.NoError(t, err)
 	exist, err = unpinMap.exist()
@@ -894,7 +895,7 @@ func TestCreateUnpinned(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC).WithCache()
+		unix.BPF_F_NO_PREALLOC).WithCache()
 	err := m.CreateUnpinned()
 	require.NoError(t, err)
 	exist, err := m.exist()
@@ -919,7 +920,7 @@ func BenchmarkMapLookup(b *testing.B) {
 		&TestKey{},
 		&TestValue{},
 		1,
-		BPF_F_NO_PREALLOC)
+		unix.BPF_F_NO_PREALLOC)
 
 	if err := m.CreateUnpinned(); err != nil {
 		b.Fatal(err)
@@ -975,7 +976,7 @@ func TestErrorResolver(t *testing.T) {
 				&TestKey{},
 				&TestValue{},
 				1, // Only one entry, so that the second insertion will fail
-				BPF_F_NO_PREALLOC,
+				unix.BPF_F_NO_PREALLOC,
 			).WithCache()
 
 			t.Cleanup(func() {

--- a/pkg/bpf/ops_linux_test.go
+++ b/pkg/bpf/ops_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/logging"
@@ -50,7 +51,7 @@ func Test_MapOps(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	)
 
 	err := testMap.OpenOrCreate()
@@ -109,7 +110,7 @@ func Test_MapOpsPrune(t *testing.T) {
 		&TestLPMKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	)
 	err := testMap.OpenOrCreate()
 	require.NoError(t, err, "OpenOrCreate")
@@ -147,7 +148,7 @@ func Test_MapOps_ReconcilerExample(t *testing.T) {
 		&TestKey{},
 		&TestValue{},
 		maxEntries,
-		BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	)
 	err := exampleMap.OpenOrCreate()
 	require.NoError(t, err)

--- a/pkg/maps/bwmap/bwmap.go
+++ b/pkg/maps/bwmap/bwmap.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/hive/cell"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -67,7 +68,7 @@ func ThrottleMap() *bpf.Map {
 		&EdtId{},
 		&EdtInfo{},
 		MapSize,
-		bpf.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	)
 }
 

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -174,7 +175,7 @@ func OpenMapElems(logger *slog.Logger, pinPath string, prefixlen int, prefixdyn 
 		KeySize:    uint32(unsafe.Sizeof(uint32(0)) + uintptr(bytes)),
 		ValueSize:  uint32(LPM_MAP_VALUE_SIZE),
 		MaxEntries: maxelem,
-		Flags:      bpf.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC,
 		Pinning:    ebpf.PinByName,
 	}, path.Dir(pinPath))
 

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"unsafe"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ebpf"
@@ -241,7 +243,7 @@ func newIPCacheMap(name string) *bpf.Map {
 		&Key{},
 		&RemoteEndpointInfo{},
 		MaxEntries,
-		bpf.BPF_F_NO_PREALLOC)
+		unix.BPF_F_NO_PREALLOC)
 }
 
 func newIPCacheMapV1(name string) *bpf.Map {
@@ -251,7 +253,7 @@ func newIPCacheMapV1(name string) *bpf.Map {
 		&Key{},
 		&RemoteEndpointInfoV1{},
 		MaxEntries,
-		bpf.BPF_F_NO_PREALLOC)
+		unix.BPF_F_NO_PREALLOC)
 }
 
 // NewMap instantiates a Map.

--- a/pkg/maps/ipmasq/ipmasq.go
+++ b/pkg/maps/ipmasq/ipmasq.go
@@ -7,6 +7,8 @@ import (
 	"net/netip"
 	"sync"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/ebpf"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -59,7 +61,7 @@ func IPMasq4Map(registry *metrics.Registry) *bpf.Map {
 			&Key4{},
 			&Value{},
 			MaxEntriesIPv4,
-			bpf.BPF_F_NO_PREALLOC,
+			unix.BPF_F_NO_PREALLOC,
 		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(MapNameIPv4))
 	})
@@ -74,7 +76,7 @@ func IPMasq6Map(registry *metrics.Registry) *bpf.Map {
 			&Key6{},
 			&Value{},
 			MaxEntriesIPv6,
-			bpf.BPF_F_NO_PREALLOC,
+			unix.BPF_F_NO_PREALLOC,
 		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(MapNameIPv6))
 	})

--- a/pkg/maps/lbmap/skip_lb_map.go
+++ b/pkg/maps/lbmap/skip_lb_map.go
@@ -11,6 +11,8 @@ import (
 	"net"
 	"unsafe"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/ebpf"
@@ -63,7 +65,7 @@ func NewSkipLBMap(logger *slog.Logger) (SkipLBMap, error) {
 			KeySize:    uint32(unsafe.Sizeof(SkipLB4Key{})),
 			ValueSize:  uint32(unsafe.Sizeof(SkipLB4Value{})),
 			MaxEntries: SkipLBMapMaxEntries,
-			Flags:      bpf.BPF_F_NO_PREALLOC,
+			Flags:      unix.BPF_F_NO_PREALLOC,
 			Pinning:    pinning,
 		})
 	}
@@ -74,7 +76,7 @@ func NewSkipLBMap(logger *slog.Logger) (SkipLBMap, error) {
 			KeySize:    uint32(unsafe.Sizeof(SkipLB6Key{})),
 			ValueSize:  uint32(unsafe.Sizeof(SkipLB6Value{})),
 			MaxEntries: SkipLBMapMaxEntries,
-			Flags:      bpf.BPF_F_NO_PREALLOC,
+			Flags:      unix.BPF_F_NO_PREALLOC,
 			Pinning:    pinning,
 		})
 	}

--- a/pkg/maps/lbmap/source_range.go
+++ b/pkg/maps/lbmap/source_range.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -154,7 +156,7 @@ func initSourceRange(registry *metrics.Registry, params InitParams) {
 			&SourceRangeKey4{},
 			&SourceRangeValue{},
 			SourceRangeMapMaxEntries,
-			bpf.BPF_F_NO_PREALLOC,
+			unix.BPF_F_NO_PREALLOC,
 		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(SourceRange4MapName))
 	}
@@ -166,7 +168,7 @@ func initSourceRange(registry *metrics.Registry, params InitParams) {
 			&SourceRangeKey6{},
 			&SourceRangeValue{},
 			SourceRangeMapMaxEntries,
-			bpf.BPF_F_NO_PREALLOC,
+			unix.BPF_F_NO_PREALLOC,
 		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(SourceRange6MapName))
 	}

--- a/pkg/maps/recorder/ipv4.go
+++ b/pkg/maps/recorder/ipv4.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/ebpf"
@@ -89,7 +91,7 @@ func CaptureMap4() *Map {
 				&CaptureWcard4{},
 				&CaptureRule4{},
 				MapSize,
-				bpf.BPF_F_NO_PREALLOC,
+				unix.BPF_F_NO_PREALLOC,
 			).WithCache().WithEvents(option.Config.GetEventBufferConfig(MapNameWcard4)),
 			v4: true,
 		}

--- a/pkg/maps/recorder/ipv6.go
+++ b/pkg/maps/recorder/ipv6.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/ebpf"
@@ -89,7 +91,7 @@ func CaptureMap6() *Map {
 				&CaptureWcard6{},
 				&CaptureRule6{},
 				MapSize,
-				bpf.BPF_F_NO_PREALLOC,
+				unix.BPF_F_NO_PREALLOC,
 			).WithCache().WithEvents(option.Config.GetEventBufferConfig(MapNameWcard6)),
 			v4: false,
 		}

--- a/pkg/maps/srv6map/policy.go
+++ b/pkg/maps/srv6map/policy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/hive/cell"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -147,7 +148,7 @@ func newPolicyMaps(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*Poli
 		&PolicyKey4{},
 		&PolicyValue{},
 		maxPolicyEntries,
-		bpf.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	)
 
 	m6 := bpf.NewMap(
@@ -156,7 +157,7 @@ func newPolicyMaps(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*Poli
 		&PolicyKey6{},
 		&PolicyValue{},
 		maxPolicyEntries,
-		bpf.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	)
 
 	lc.Append(cell.Hook{

--- a/pkg/maps/srv6map/sid.go
+++ b/pkg/maps/srv6map/sid.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/hive/cell"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -79,7 +80,7 @@ func newSIDMap(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*SIDMap],
 		&SIDKey{},
 		&SIDValue{},
 		maxSIDEntries,
-		bpf.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	)
 
 	lc.Append(cell.Hook{

--- a/pkg/maps/srv6map/vrf.go
+++ b/pkg/maps/srv6map/vrf.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/hive/cell"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -151,7 +152,7 @@ func newVRFMaps(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*VRFMap4
 		&VRFKey4{},
 		&VRFValue{},
 		maxVRFEntries,
-		bpf.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	)
 
 	m6 := bpf.NewMap(
@@ -160,7 +161,7 @@ func newVRFMaps(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*VRFMap4
 		&VRFKey6{},
 		&VRFValue{},
 		maxVRFEntries,
-		bpf.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC,
 	)
 
 	lc.Append(cell.Hook{


### PR DESCRIPTION
Rather than duplicating them in the bpf package. Some maps already use the auto-generated constants from x/sys/unix, so make the usage consistent.
