### PR TITLE
cilium-cli: Use v2alpha1 version of CCG for Cilium versions below v1.18

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -61,8 +61,14 @@ var (
 	//go:embed manifests/client-egress-to-cidrgroup-external-deny.yaml
 	clientEgressToCIDRGroupExternalDenyPolicyYAML string
 
+	//go:embed manifests/client-egress-to-cidrgroup-external-deny-v2alpha1.yaml
+	clientEgressToCIDRGroupExternalDenyPolicyV2Alpha1YAML string
+
 	//go:embed manifests/client-egress-to-cidrgroup-external-deny-label.yaml
 	clientEgressToCIDRGroupExternalDenyLabelPolicyYAML string
+
+	//go:embed manifests/client-egress-to-cidrgroup-external-deny-label-v2alpha1.yaml
+	clientEgressToCIDRGroupExternalDenyLabelPolicyV2Alpha1YAML string
 
 	//go:embed manifests/client-egress-l7-http.yaml
 	clientEgressL7HTTPPolicyYAML string
@@ -327,32 +333,34 @@ func finalTests(ct *check.ConnectivityTest) error {
 
 func renderTemplates(clusterName string, param check.Parameters) (map[string]string, error) {
 	templates := map[string]string{
-		"clientEgressToCIDRExternalPolicyYAML":               clientEgressToCIDRExternalPolicyYAML,
-		"clientEgressToCIDRExternalPolicyKNPYAML":            clientEgressToCIDRExternalPolicyKNPYAML,
-		"clientEgressToCIDRNodeKNPYAML":                      clientEgressToCIDRNodeKNPYAML,
-		"clientEgressToCIDRExternalDenyPolicyYAML":           clientEgressToCIDRExternalDenyPolicyYAML,
-		"clientEgressToCIDRGroupExternalDenyPolicyYAML":      clientEgressToCIDRGroupExternalDenyPolicyYAML,
-		"clientEgressToCIDRGroupExternalDenyLabelPolicyYAML": clientEgressToCIDRGroupExternalDenyLabelPolicyYAML,
-		"clientEgressL7HTTPPolicyYAML":                       clientEgressL7HTTPPolicyYAML,
-		"clientEgressL7HTTPPolicyPortRangeYAML":              clientEgressL7HTTPPolicyPortRangeYAML,
-		"clientEgressL7HTTPNamedPortPolicyYAML":              clientEgressL7HTTPNamedPortPolicyYAML,
-		"clientEgressToFQDNsPolicyYAML":                      clientEgressToFQDNsPolicyYAML,
-		"clientEgressToFQDNsAndHTTPGetPolicyYAML":            clientEgressToFQDNsAndHTTPGetPolicyYAML,
-		"clientEgressTLSSNIPolicyYAML":                       clientEgressTLSSNIPolicyYAML,
-		"clientEgressTLSSNIWildcardPolicyYAML":               clientEgressTLSSNIWildcardPolicyYAML,
-		"clientEgressTLSSNIDoubleWildcardPolicyYAML":         clientEgressTLSSNIDoubleWildcardPolicyYAML,
-		"clientEgressTLSSNIOtherPolicyYAML":                  clientEgressTLSSNIOtherPolicyYAML,
-		"clientEgressL7TLSSNIPolicyYAML":                     clientEgressL7TLSSNIPolicyYAML,
-		"clientEgressL7TLSOtherSNIPolicyYAML":                clientEgressL7TLSOtherSNIPolicyYAML,
-		"clientEgressL7TLSPolicyYAML":                        clientEgressL7TLSPolicyYAML,
-		"clientEgressL7TLSPolicyPortRangeYAML":               clientEgressL7TLSPolicyPortRangeYAML,
-		"clientEgressL7HTTPMatchheaderSecretYAML":            clientEgressL7HTTPMatchheaderSecretYAML,
-		"clientEgressL7HTTPMatchheaderSecretPortRangeYAML":   clientEgressL7HTTPMatchheaderSecretPortRangeYAML,
-		"clientEgressL7HTTPExternalYAML":                     clientEgressL7HTTPExternalYAML,
-		"clientEgressNodeLocalDNSYAML":                       clientEgressNodeLocalDNSYAML,
-		"clientEgressOnlyDNSPolicyYAML":                      clientEgressOnlyDNSPolicyYAML,
-		"echoIngressFromCIDRYAML":                            echoIngressFromCIDRYAML,
-		"denyCIDRPolicyYAML":                                 denyCIDRPolicyYAML,
+		"clientEgressToCIDRExternalPolicyYAML":                       clientEgressToCIDRExternalPolicyYAML,
+		"clientEgressToCIDRExternalPolicyKNPYAML":                    clientEgressToCIDRExternalPolicyKNPYAML,
+		"clientEgressToCIDRNodeKNPYAML":                              clientEgressToCIDRNodeKNPYAML,
+		"clientEgressToCIDRExternalDenyPolicyYAML":                   clientEgressToCIDRExternalDenyPolicyYAML,
+		"clientEgressToCIDRGroupExternalDenyPolicyYAML":              clientEgressToCIDRGroupExternalDenyPolicyYAML,
+		"clientEgressToCIDRGroupExternalDenyPolicyV2Alpha1YAML":      clientEgressToCIDRGroupExternalDenyPolicyV2Alpha1YAML,
+		"clientEgressToCIDRGroupExternalDenyLabelPolicyYAML":         clientEgressToCIDRGroupExternalDenyLabelPolicyYAML,
+		"clientEgressToCIDRGroupExternalDenyLabelPolicyV2Alpha1YAML": clientEgressToCIDRGroupExternalDenyLabelPolicyV2Alpha1YAML,
+		"clientEgressL7HTTPPolicyYAML":                               clientEgressL7HTTPPolicyYAML,
+		"clientEgressL7HTTPPolicyPortRangeYAML":                      clientEgressL7HTTPPolicyPortRangeYAML,
+		"clientEgressL7HTTPNamedPortPolicyYAML":                      clientEgressL7HTTPNamedPortPolicyYAML,
+		"clientEgressToFQDNsPolicyYAML":                              clientEgressToFQDNsPolicyYAML,
+		"clientEgressToFQDNsAndHTTPGetPolicyYAML":                    clientEgressToFQDNsAndHTTPGetPolicyYAML,
+		"clientEgressTLSSNIPolicyYAML":                               clientEgressTLSSNIPolicyYAML,
+		"clientEgressTLSSNIWildcardPolicyYAML":                       clientEgressTLSSNIWildcardPolicyYAML,
+		"clientEgressTLSSNIDoubleWildcardPolicyYAML":                 clientEgressTLSSNIDoubleWildcardPolicyYAML,
+		"clientEgressTLSSNIOtherPolicyYAML":                          clientEgressTLSSNIOtherPolicyYAML,
+		"clientEgressL7TLSSNIPolicyYAML":                             clientEgressL7TLSSNIPolicyYAML,
+		"clientEgressL7TLSOtherSNIPolicyYAML":                        clientEgressL7TLSOtherSNIPolicyYAML,
+		"clientEgressL7TLSPolicyYAML":                                clientEgressL7TLSPolicyYAML,
+		"clientEgressL7TLSPolicyPortRangeYAML":                       clientEgressL7TLSPolicyPortRangeYAML,
+		"clientEgressL7HTTPMatchheaderSecretYAML":                    clientEgressL7HTTPMatchheaderSecretYAML,
+		"clientEgressL7HTTPMatchheaderSecretPortRangeYAML":           clientEgressL7HTTPMatchheaderSecretPortRangeYAML,
+		"clientEgressL7HTTPExternalYAML":                             clientEgressL7HTTPExternalYAML,
+		"clientEgressNodeLocalDNSYAML":                               clientEgressNodeLocalDNSYAML,
+		"clientEgressOnlyDNSPolicyYAML":                              clientEgressOnlyDNSPolicyYAML,
+		"echoIngressFromCIDRYAML":                                    echoIngressFromCIDRYAML,
+		"denyCIDRPolicyYAML":                                         denyCIDRPolicyYAML,
 	}
 	if param.K8sLocalHostTest {
 		templates["clientEgressToCIDRCPHostPolicyYAML"] = clientEgressToCIDRCPHostPolicyYAML

--- a/cilium-cli/connectivity/builder/client_egress_to_cidrgroup_deny.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_cidrgroup_deny.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 type clientEgressToCidrgroupDeny struct{}
@@ -14,10 +15,14 @@ type clientEgressToCidrgroupDeny struct{}
 func (t clientEgressToCidrgroupDeny) build(ct *check.ConnectivityTest, templates map[string]string) {
 	// This policy denies L3 traffic to ExternalCIDR except ExternalIP/32
 	// It does so using a CiliumCIDRGroup
+	policy := templates["clientEgressToCIDRGroupExternalDenyPolicyYAML"]
+	if !versioncheck.MustCompile("<=1.17.0")(ct.CiliumVersion) {
+		policy = templates["clientEgressToCIDRGroupExternalDenyPolicyV2Alpha1YAML"]
+	}
 	newTest("client-egress-to-cidrgroup-deny", ct).
 		WithCiliumVersion(">=1.17.0").
 		WithCiliumPolicy(allowAllEgressPolicyYAML). // Allow all egress traffic
-		WithCiliumPolicy(templates["clientEgressToCIDRGroupExternalDenyPolicyYAML"]).
+		WithCiliumPolicy(policy).
 		WithScenarios(
 			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIPv4)), // Denies all traffic to ExternalOtherIP, but allow ExternalIP
 		).
@@ -40,10 +45,14 @@ type clientEgressToCidrgroupDenyByLabel struct{}
 func (t clientEgressToCidrgroupDenyByLabel) build(ct *check.ConnectivityTest, templates map[string]string) {
 	// This policy denies L3 traffic to ExternalCIDR except ExternalIP/32
 	// It does so using a CiliumCIDRGroup
+	policy := templates["clientEgressToCIDRGroupExternalDenyLabelPolicyYAML"]
+	if !versioncheck.MustCompile("<=1.17.0")(ct.CiliumVersion) {
+		policy = templates["clientEgressToCIDRGroupExternalDenyLabelPolicyV2Alpha1YAML"]
+	}
 	newTest("client-egress-to-cidrgroup-deny-by-label", ct).
 		WithCiliumVersion(">=1.17.0").
 		WithCiliumPolicy(allowAllEgressPolicyYAML). // Allow all egress traffic
-		WithCiliumPolicy(templates["clientEgressToCIDRGroupExternalDenyLabelPolicyYAML"]).
+		WithCiliumPolicy(policy).
 		WithScenarios(
 			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIPv4)), // Denies all traffic to ExternalOtherIP, but allow ExternalIP
 		).

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-cidrgroup-external-deny-label-v2alpha1.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-cidrgroup-external-deny-label-v2alpha1.yaml
@@ -1,0 +1,34 @@
+# This policy denies packets towards {{.ExternalOtherIPv4}} and {{.ExternalOtherIPv6}}, but
+# not {{.ExternalIPv4}} and {{.ExternalIPv6}}
+# Please note that if there is no other allowed rule, the policy
+# will be automatically denied {{.ExternalIPv4}} and {{.ExternalIPv6}} as well.
+
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumCIDRGroup
+metadata:
+  name: cilium-test-external-cidr-label
+  labels:
+    destination: external
+spec:
+  externalCIDRs:
+    - "{{.ExternalCIDRv4}}"
+    - "{{.ExternalCIDRv6}}"
+
+---
+
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-cidrgroup-deny-label
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toCIDRSet:
+    - cidrGroupSelector:
+        matchLabels:
+          destination: external
+      except:
+        - "{{.ExternalIPv4}}/32"
+        - "{{.ExternalIPv6}}/128"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-cidrgroup-external-deny-v2alpha1.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-cidrgroup-external-deny-v2alpha1.yaml
@@ -1,0 +1,30 @@
+# This policy denies packets towards {{.ExternalOtherIPv4}} and {{.ExternalOtherIPv6}}, but
+# not {{.ExternalIPv4}} and {{.ExternalIPv6}}
+# Please note that if there is no other allowed rule, the policy
+# will be automatically denied {{.ExternalIPv4}} and {{.ExternalIPv6}} as well.
+
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumCIDRGroup
+metadata:
+  name: cilium-test-external-cidr
+spec:
+  externalCIDRs:
+    - "{{.ExternalCIDRv4}}"
+    - "{{.ExternalCIDRv6}}"
+
+---
+
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-cidrgroup-deny
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toCIDRSet:
+    - cidrGroupRef: cilium-test-external-cidr
+      except:
+        - "{{ .ExternalIPv4 | ipToCIDR }}"
+        - "{{ .ExternalIPv6 | ipToCIDR }}"


### PR DESCRIPTION
This was causing issues in CI [1].

[1]: https://github.com/cilium/cilium-cli/actions/runs/15278380967/job/42970668457?pr=3039

Signed-off-by: Chris Tarazi <chris@isovalent.com>

---

Fixes: https://github.com/cilium/cilium/pull/38940
