### PR TITLE
bpf: egressgw: modernize the FIB-driven redirect path 

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -182,14 +182,9 @@ not_esp:
 			set_identity_mark(ctx, *identity, MARK_MAGIC_EGW_DONE);
 
 			/* to-netdev@bpf_host handles SNAT, so no need to do it here. */
-			ret = egress_gw_fib_lookup_and_redirect_v6(ctx, &snat_addr,
-								   &daddr, egress_ifindex,
-								   ext_err);
-			if (ret != CTX_ACT_OK)
-				return ret;
-
-			if (!revalidate_data(ctx, &data, &data_end, &ip6))
-				return DROP_INVALID;
+			return egress_gw_fib_lookup_and_redirect_v6(ctx, &snat_addr,
+								    &daddr, egress_ifindex,
+								    ext_err);
 		}
 	}
 #endif /* ENABLE_EGRESS_GATEWAY_COMMON */
@@ -492,14 +487,9 @@ not_esp:
 			set_identity_mark(ctx, *identity, MARK_MAGIC_EGW_DONE);
 
 			/* to-netdev@bpf_host handles SNAT, so no need to do it here. */
-			ret = egress_gw_fib_lookup_and_redirect(ctx, snat_addr,
-								daddr, egress_ifindex,
-								ext_err);
-			if (ret != CTX_ACT_OK)
-				return ret;
-
-			if (!revalidate_data(ctx, &data, &data_end, &ip4))
-				return DROP_INVALID;
+			return egress_gw_fib_lookup_and_redirect(ctx, snat_addr,
+								 daddr, egress_ifindex,
+								 ext_err);
 		}
 	}
 #endif /* ENABLE_EGRESS_GATEWAY_COMMON */

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -42,22 +42,14 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 	__u32 oif;
 	int ret;
 
-	/* Immediate redirect to egress_ifindex requires L2 resolution.
-	 * Fall back to FIB lookup on older kernels.
-	 */
-	if (egress_ifindex && neigh_resolver_available())
+	if (egress_ifindex)
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr, 0);
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
-		break;
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
-		/* Don't redirect if we can't update the L2 DMAC: */
-		if (!neigh_resolver_available())
-			return CTX_ACT_OK;
-
 		break;
 	default:
 		*ext_err = (__s8)ret;
@@ -404,7 +396,7 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 	__u32 oif;
 	int ret;
 
-	if (egress_ifindex && neigh_resolver_available())
+	if (egress_ifindex)
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	ret = (__s8)fib_lookup_v6(ctx, &fib_params,
@@ -413,10 +405,7 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
-		break;
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
-		if (!neigh_resolver_available())
-			return CTX_ACT_OK;
 		break;
 	default:
 		*ext_err = (__s8)ret;


### PR DESCRIPTION
Now that we can require that the neigh-resolver is available in this code path (since the `egress_gw_fib_lookup_and_redirect()` helper is only called from TC context), there's potential to remove some unused fallback code & handling in bpf_overlay.