### PR TITLE
[v1.17] bpf: nat: add various ICMPv6 bits

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -2063,7 +2063,7 @@ int tail_no_service_ipv4(struct __ctx_buff *ctx)
 		/* Redirect ICMP to the interface we received it on. */
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
 				   ctx_get_ifindex(ctx));
-		ret = ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+		ret = redirect_self(ctx);
 	}
 
 	if (IS_ERR(ret))
@@ -2243,7 +2243,7 @@ int tail_no_service_ipv6(struct __ctx_buff *ctx)
 		/* Redirect ICMP to the interface we received it on. */
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
 				   ctx_get_ifindex(ctx));
-		ret = ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+		ret = redirect_self(ctx);
 	}
 
 drop_err:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1582,6 +1582,8 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off)
 
 		port_off = TCP_DPORT_OFF;
 		break;
+	case IPPROTO_ICMPV6:
+		return DROP_UNKNOWN_ICMP6_CODE;
 	default:
 		return DROP_UNKNOWN_L4;
 	}

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1678,6 +1678,19 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 			if (icmp6hdr.icmp6_code > ICMPV6_REJECT_ROUTE)
 				return DROP_UNKNOWN_ICMP6_CODE;
 
+			goto nat_icmp_v6;
+		case ICMPV6_PKT_TOOBIG:
+			goto nat_icmp_v6;
+		case ICMPV6_TIME_EXCEED:
+			switch (icmp6hdr.icmp6_code) {
+			case ICMPV6_EXC_HOPLIMIT:
+			case ICMPV6_EXC_FRAGTIME:
+				break;
+			default:
+				return DROP_UNKNOWN_ICMP6_CODE;
+			}
+
+nat_icmp_v6:
 			return snat_v6_nat_handle_icmp_error(ctx, off);
 		default:
 			return DROP_NAT_UNSUPP_PROTO;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1544,6 +1544,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off)
 	__u16 port_off;
 	__u32 icmpoff;
 	int hdrlen;
+	__u8 type;
 	int ret;
 
 	/* According to the RFC 5508, any networking equipment that is
@@ -1583,7 +1584,15 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off)
 		port_off = TCP_DPORT_OFF;
 		break;
 	case IPPROTO_ICMPV6:
-		return DROP_UNKNOWN_ICMP6_CODE;
+		if (icmp6_load_type(ctx, icmpoff, &type) < 0)
+			return DROP_INVALID;
+
+		switch (type) {
+		case ICMPV6_ECHO_REQUEST:
+			return NAT_PUNT_TO_STACK;
+		default:
+			return DROP_UNKNOWN_ICMP6_CODE;
+		}
 	default:
 		return DROP_UNKNOWN_L4;
 	}

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1590,9 +1590,17 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off)
 		switch (type) {
 		case ICMPV6_ECHO_REQUEST:
 			return NAT_PUNT_TO_STACK;
+		case ICMPV6_ECHO_REPLY:
+			port_off = offsetof(struct icmp6hdr, icmp6_dataun.u_echo.identifier);
+			break;
 		default:
 			return DROP_UNKNOWN_ICMP6_CODE;
 		}
+
+		if (ctx_load_bytes(ctx, icmpoff + port_off,
+				   &tuple.sport, sizeof(tuple.sport)) < 0)
+			return DROP_INVALID;
+		break;
 	default:
 		return DROP_UNKNOWN_L4;
 	}


### PR DESCRIPTION
Backport of
* [ ] #37766
* [ ] #38068
* [ ] #39505
* [ ] #39661

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 37766 38068 39505 39661
```
