### PR TITLE
cilium-cli: add connectivity tests support for policy-default-local-cluster

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -126,6 +126,7 @@ jobs:
             cm-auth-mode-2: 'legacy'
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'enabled'
+            policy-default-local-cluster: true
 
           - name: '2'
             tunnel: 'disabled'
@@ -138,6 +139,7 @@ jobs:
             cm-auth-mode-2: 'migration'
             maxConnectedClusters: '511'
             ciliumEndpointSlice: 'disabled'
+            policy-default-local-cluster: false
 
           - name: '3'
             tunnel: 'disabled'
@@ -150,6 +152,7 @@ jobs:
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'disabled'
+            policy-default-local-cluster: true
 
           # IPsec encryption is currently not supported in case of ipv6-only clusters (#23553)
           # Wireguard encryption is currently affected by a bug in case of ipv6-only clusters (#23917)
@@ -164,6 +167,7 @@ jobs:
             cm-auth-mode-2: 'migration'
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'disabled'
+            policy-default-local-cluster: false
 
           - name: '5'
             tunnel: 'disabled'
@@ -174,6 +178,7 @@ jobs:
             tls-auto-method: helm
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'disabled'
+            policy-default-local-cluster: true
 
           - name: '6'
             tunnel: 'vxlan'
@@ -186,6 +191,7 @@ jobs:
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'enabled'
+            policy-default-local-cluster: false
 
           - name: '7'
             tunnel: 'geneve'
@@ -198,6 +204,7 @@ jobs:
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '511'
             ciliumEndpointSlice: 'disabled'
+            policy-default-local-cluster: true
 
           - name: '8'
             tunnel: 'vxlan'
@@ -210,6 +217,7 @@ jobs:
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'disabled'
+            policy-default-local-cluster: false
 
         # Tunneling is currently not supported in case of ipv6-only clusters (#17240)
         #  - name: '9'
@@ -231,6 +239,7 @@ jobs:
             tls-auto-method: helm
             maxConnectedClusters: '511'
             ciliumEndpointSlice: 'disabled'
+            policy-default-local-cluster: true
 
     steps:
       - name: Collect Workflow Telemetry
@@ -274,6 +283,7 @@ jobs:
             --helm-set=clustermesh.apiserver.tls.auto.certManagerIssuerRef.group=cert-manager.io \
             --helm-set=clustermesh.apiserver.tls.auto.certManagerIssuerRef.kind=Issuer \
             --helm-set=clustermesh.apiserver.tls.auto.certManagerIssuerRef.name=cilium \
+            --helm-set=clustermesh.policyDefaultLocalCluster=${{ matrix.policy-default-local-cluster }} \
             --helm-set=ciliumEndpointSlice.enabled=${{ matrix.ciliumEndpointSlice == 'enabled'}} \
             --helm-set=extraConfig.clustermesh-sync-timeout=5m \
             "

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -296,6 +296,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		podToK8sOnControlplane{},
 		podToControlplaneHostCidr{},
 		podToK8sOnControlplaneCidr{},
+		policyLocalCluster{},
 		localRedirectPolicy{},
 		localRedirectPolicyWithNodeDNS{},
 		noFragmentation{},

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -326,7 +326,7 @@ func finalTests(ct *check.ConnectivityTest) error {
 	}, ct)
 }
 
-func renderTemplates(clusterName string, param check.Parameters) (map[string]string, error) {
+func renderTemplates(clusterNameLocal, clusterNameRemote string, param check.Parameters) (map[string]string, error) {
 	templates := map[string]string{
 		"clientEgressToCIDRExternalPolicyYAML":               clientEgressToCIDRExternalPolicyYAML,
 		"clientEgressToCIDRExternalPolicyKNPYAML":            clientEgressToCIDRExternalPolicyKNPYAML,
@@ -364,10 +364,12 @@ func renderTemplates(clusterName string, param check.Parameters) (map[string]str
 	for key, temp := range templates {
 		val, err := template.Render(temp, struct {
 			check.Parameters
-			ClusterName string
+			ClusterNameLocal  string
+			ClusterNameRemote string
 		}{
-			Parameters:  param,
-			ClusterName: clusterName,
+			Parameters:        param,
+			ClusterNameLocal:  clusterNameLocal,
+			ClusterNameRemote: clusterNameRemote,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to render template %s: %w", key, err)
@@ -384,7 +386,10 @@ func injectTests(tests []testBuilder, connTests ...*check.ConnectivityTest) erro
 	id := 0
 	for i := range tests {
 		if _, ok := templates[connTests[id].Params().TestNamespace]; !ok {
-			nsTemplates, err := renderTemplates(connTests[id].ClusterName, connTests[id].Params())
+			nsTemplates, err := renderTemplates(
+				connTests[id].ClusterNameLocal, connTests[id].ClusterNameRemote,
+				connTests[id].Params(),
+			)
 			if err != nil {
 				return err
 			}

--- a/cilium-cli/connectivity/builder/manifests/allow-all-egress.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-all-egress.yaml
@@ -6,7 +6,8 @@ spec:
   endpointSelector: {}
   egress:
   - toEndpoints:
-    - {}
+    - matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
   - toCIDR:
     - 0.0.0.0/0
     - ::/0

--- a/cilium-cli/connectivity/builder/manifests/allow-all-except-world.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-all-except-world.yaml
@@ -13,7 +13,8 @@ spec:
     - health
     - kube-apiserver
   - toEndpoints:
-      - {}
+    - matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
   # When node-local-dns is deployed with local IP,
   # Cilium labels its ip as world.
   # This change prevents failing the connectivity
@@ -35,4 +36,5 @@ spec:
     - health
     - kube-apiserver
   - fromEndpoints:
-    - {}
+    - matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/allow-all-ingress.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-all-ingress.yaml
@@ -6,4 +6,5 @@ spec:
   endpointSelector: {}
   ingress:
   - fromEndpoints:
-    - {}
+    - matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-from-any.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-from-any.yaml
@@ -11,6 +11,8 @@ spec:
   - toEndpoints:
     - matchLabels:
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "8080"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-matchheader-secret-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-matchheader-secret-port-range.yaml
@@ -16,6 +16,8 @@ spec:
   - toEndpoints:
     - matchLabels:
         kind: echo
+      matchExpressions:
+      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}", "{{.ClusterNameRemote}}" ] }
     toPorts:
     - ports:
       - port: "4096"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-matchheader-secret.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-matchheader-secret.yaml
@@ -16,6 +16,8 @@ spec:
   - toEndpoints:
     - matchLabels:
         kind: echo
+      matchExpressions:
+      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}", "{{.ClusterNameRemote}}" ] }
     toPorts:
     - ports:
       - port: "8080"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-method-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-method-port-range.yaml
@@ -17,6 +17,8 @@ spec:
   - toEndpoints:
     - matchLabels:
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "4096"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-method.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-method.yaml
@@ -17,6 +17,8 @@ spec:
   - toEndpoints:
     - matchLabels:
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "8080"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-named-port.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-named-port.yaml
@@ -17,6 +17,8 @@ spec:
   - toEndpoints:
     - matchLabels:
         kind: echo
+      matchExpressions:
+      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}", "{{.ClusterNameRemote}}" ] }
     toPorts:
     - ports:
       - port: "http-8080"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-port-range.yaml
@@ -17,6 +17,8 @@ spec:
   - toEndpoints:
     - matchLabels:
         kind: echo
+      matchExpressions:
+      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}", "{{.ClusterNameRemote}}" ] }
     toPorts:
     - ports:
       - port: "4096"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http.yaml
@@ -17,6 +17,8 @@ spec:
   - toEndpoints:
     - matchLabels:
         kind: echo
+      matchExpressions:
+      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}", "{{.ClusterNameRemote}}" ] }
     toPorts:
     - ports:
       - port: "8080"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-node-local-dns.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-node-local-dns.yaml
@@ -20,7 +20,7 @@ spec:
         - matchLabels:
             k8s-app: node-local-dns
             io.kubernetes.pod.namespace: kube-system
-            io.cilium.k8s.policy.cluster: {{.ClusterName}}
+            io.cilium.k8s.policy.cluster: {{.ClusterNameLocal}}
     - toFQDNs:
       - matchName: "echo-external-node.{{.TestNamespace}}.svc.cluster.local"
       toPorts:

--- a/cilium-cli/connectivity/builder/manifests/client-egress-only-dns.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-only-dns.yaml
@@ -20,7 +20,7 @@ spec:
       - matchExpressions:
           - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
           - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
-          - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterName}}" ] }
+          - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}" ] }
 # OpenShift  runs coreDNS in openshift-dns namespace and uses port 5353
   - toPorts:
     - ports:
@@ -35,7 +35,7 @@ spec:
     - matchExpressions:
       - { key: 'dns.operator.openshift.io/daemonset-dns', operator: Exists }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "openshift-dns" ] }
-      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterName}}" ] }
+      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}" ] }
   # When node-local-dns is deployed with local IP,
   # Cilium labels its ip as world.
   # This change prevents failing the connectivity

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-deny-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-deny-port-range.yaml
@@ -16,3 +16,5 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-deny.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-deny.yaml
@@ -15,3 +15,5 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-deny-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-deny-port-range.yaml
@@ -15,3 +15,4 @@ spec:
     toEndpoints:
     - matchExpressions:
       - { key: 'kind', operator: In, values: [ "echo" ] }
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-deny.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-deny.yaml
@@ -14,3 +14,4 @@ spec:
     toEndpoints:
     - matchExpressions:
       - { key: 'kind', operator: In, values: [ "echo" ] }
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-knp-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-knp-port-range.yaml
@@ -13,6 +13,8 @@ spec:
         - podSelector:
             matchLabels:
               kind: echo
+            matchExpressions:
+              - { key: io.cilium.k8s.policy.cluster, operator: Exists }
       ports:
         - protocol: TCP
           port: 4096

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-knp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-knp.yaml
@@ -13,6 +13,8 @@ spec:
         - podSelector:
             matchLabels:
               kind: echo
+            matchExpressions:
+              - { key: io.cilium.k8s.policy.cluster, operator: Exists }
       ports:
         - protocol: TCP
           port: 8080

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-port-range.yaml
@@ -16,3 +16,5 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression.yaml
@@ -15,3 +15,5 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-knp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-knp.yaml
@@ -11,6 +11,8 @@ spec:
         - podSelector:
             matchLabels:
               kind: echo
+            matchExpressions:
+              - { key: io.cilium.k8s.policy.cluster, operator: Exists }
       ports:
         - port: 8080
           protocol: TCP

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-named-port-deny.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-named-port-deny.yaml
@@ -15,3 +15,5 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         name: client
+      matchExpressions:
+        - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-no-cluster-policy.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-no-cluster-policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-echo-no-cluster-policy
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-port-range.yaml
@@ -16,6 +16,8 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
   - toPorts:
     - ports:
       - port: "53"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo.yaml
@@ -15,6 +15,8 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
   - toPorts:
     - ports:
       - port: "53"

--- a/cilium-cli/connectivity/builder/manifests/client-ingress-from-client2-knp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-ingress-from-client2-knp.yaml
@@ -11,3 +11,5 @@ spec:
         - podSelector:
             matchLabels:
               other: client
+            matchExpressions:
+            - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-ingress-from-client2.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-ingress-from-client2.yaml
@@ -10,3 +10,5 @@ spec:
   - fromEndpoints:
     - matchLabels:
         other: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-deny-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-deny-port-range.yaml
@@ -17,3 +17,5 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-deny.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-deny.yaml
@@ -16,3 +16,5 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-port-range.yaml
@@ -17,3 +17,5 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo.yaml
@@ -16,3 +16,5 @@ spec:
     - matchLabels:
         io.kubernetes.pod.namespace: cilium-test
         kind: echo
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/deny-ingress-backend.yaml
+++ b/cilium-cli/connectivity/builder/manifests/deny-ingress-backend.yaml
@@ -8,3 +8,5 @@ spec:
     - toEndpoints:
         - matchLabels:
             kind: echo
+          matchExpressions:
+          - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client-deny.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client-deny.yaml
@@ -11,3 +11,5 @@ spec:
   - fromEndpoints:
     - matchLabels:
         other: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client-knp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client-knp.yaml
@@ -12,3 +12,5 @@ spec:
         - podSelector:
             matchLabels:
               other: client
+            matchExpressions:
+            - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client.yaml
@@ -11,3 +11,5 @@ spec:
   - fromEndpoints:
     - matchLabels:
         other: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp-deny.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp-deny.yaml
@@ -11,6 +11,8 @@ spec:
   - fromEndpoints:
     - matchLabels:
         other: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     icmps:
     - fields:
       - family: IPv4

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp.yaml
@@ -11,6 +11,8 @@ spec:
   - fromEndpoints:
     - matchLabels:
         other: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     icmps:
     - fields:
       - family: IPv4

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-l7-http-named-port.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-l7-http-named-port.yaml
@@ -15,6 +15,8 @@ spec:
   - fromEndpoints:
     - matchLabels:
         other: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "http-8080"

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-l7-http-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-l7-http-port-range.yaml
@@ -15,6 +15,8 @@ spec:
   - fromEndpoints:
     - matchLabels:
         other: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "4096"

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-l7-http.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-l7-http.yaml
@@ -15,6 +15,8 @@ spec:
   - fromEndpoints:
     - matchLabels:
         other: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "8080"

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-mutual-authentication-fail-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-mutual-authentication-fail-port-range.yaml
@@ -11,6 +11,8 @@ spec:
   - fromEndpoints:
     - matchLabels:
         kind: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "4096"

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-mutual-authentication-fail.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-mutual-authentication-fail.yaml
@@ -11,6 +11,8 @@ spec:
   - fromEndpoints:
     - matchLabels:
         kind: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "8080"

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-mutual-authentication-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-mutual-authentication-port-range.yaml
@@ -11,6 +11,8 @@ spec:
   - fromEndpoints:
     - matchLabels:
         kind: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "4096"

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-mutual-authentication.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-mutual-authentication.yaml
@@ -11,6 +11,8 @@ spec:
   - fromEndpoints:
     - matchLabels:
         kind: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
     toPorts:
     - ports:
       - port: "8080"

--- a/cilium-cli/connectivity/builder/manifests/host-firewall-egress.yaml
+++ b/cilium-cli/connectivity/builder/manifests/host-firewall-egress.yaml
@@ -16,3 +16,4 @@ spec:
         operator: NotIn
         values:
         - echo-other-node
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/manifests/host-firewall-ingress.yaml
+++ b/cilium-cli/connectivity/builder/manifests/host-firewall-ingress.yaml
@@ -16,3 +16,4 @@ spec:
         operator: NotIn
         values:
         - client
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }

--- a/cilium-cli/connectivity/builder/policy_local_cluster.go
+++ b/cilium-cli/connectivity/builder/policy_local_cluster.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-egress-to-echo-no-cluster-policy.yaml
+var clientEgressToEchoNoClusterPolicyYAML string
+
+type policyLocalCluster struct{}
+
+func (t policyLocalCluster) build(ct *check.ConnectivityTest, templates map[string]string) {
+	newTest("policy-local-cluster-egress", ct).
+		WithCiliumPolicy(clientEgressToEchoNoClusterPolicyYAML).
+		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).
+		WithScenarios(tests.PodToPod()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if !ct.Features[features.PolicyDefaultLocalCLuster].Enabled {
+				return check.ResultOK, check.ResultOK
+			}
+			if ct.Params().MultiCluster == "" {
+				return check.ResultOK, check.ResultOK
+			}
+			if a.Destination().HasLabel("name", "echo-same-node") {
+				return check.ResultOK, check.ResultOK
+			}
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -53,8 +53,10 @@ type ConnectivityTest struct {
 
 	CodeOwners *codeowners.Ruleset
 
-	// ClusterName is the identifier of the local cluster.
-	ClusterName string
+	// ClusterNameLocal is the identifier of the local cluster.
+	ClusterNameLocal string
+	// ClusterNameRemote is the identifier of the destination cluster.
+	ClusterNameRemote string
 
 	// Parameters to the test suite, specified by the CLI user.
 	params Parameters

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -440,6 +440,12 @@ func newConnDisruptCNP(ns string) *ciliumv2.CiliumNetworkPolicy {
 	selector := policyapi.EndpointSelector{
 		LabelSelector: &slimmetav1.LabelSelector{
 			MatchLabels: map[string]string{"kind": KindTestConnDisrupt},
+			MatchExpressions: []slimmetav1.LabelSelectorRequirement{
+				{
+					Key:      "io.cilium.k8s.policy.cluster",
+					Operator: slimmetav1.LabelSelectorOpExists,
+				},
+			},
 		},
 	}
 

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -352,7 +352,15 @@ func (ct *ConnectivityTest) detectFeatures(ctx context.Context) error {
 		}
 	}
 
-	ct.ClusterName = cmp.Or(cm.Data["cluster-name"], "default")
+	ct.ClusterNameLocal = cmp.Or(cm.Data["cluster-name"], "default")
+	ct.ClusterNameRemote = ct.ClusterNameLocal
+	if ct.params.MultiCluster != "" {
+		cmDst, err := ct.clients.dst.GetConfigMap(ctx, ct.params.CiliumNamespace, defaults.ConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to retrieve dst cluster ConfigMap %q: %w", defaults.ConfigMapName, err)
+		}
+		ct.ClusterNameRemote = cmp.Or(cmDst.Data["cluster-name"], "default")
+	}
 
 	return nil
 }

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -113,6 +113,8 @@ const (
 	IPsecEnabled                  Feature = "enable-ipsec"
 	ClusterMeshEnableEndpointSync Feature = "clustermesh-enable-endpoint-sync"
 
+	PolicyDefaultLocalCLuster Feature = "policy-default-local-cluster"
+
 	LocalRedirectPolicy Feature = "enable-local-redirect-policy"
 
 	BGPControlPlane Feature = "enable-bgp-control-plane"
@@ -373,6 +375,10 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[ClusterMeshEnableEndpointSync] = Status{
 		Enabled: cm.Data[string(ClusterMeshEnableEndpointSync)] == "true",
+	}
+
+	fs[PolicyDefaultLocalCLuster] = Status{
+		Enabled: cm.Data[string(PolicyDefaultLocalCLuster)] == "true",
 	}
 
 	fs[LocalRedirectPolicy] = Status{


### PR DESCRIPTION
Followup to #39338 adding support for connectivity test for this new mode.

Also this draft PR #39731 contains the same cli commits but with the new option enabled to have a full CI test run with this turned on by default

```release-note
cli: add suport for policy-default-local-cluster in connectivity tests
```
