### PR TITLE
egressgw: reserve space in IPv6 policy entry

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -406,6 +406,8 @@ struct egress_gw_policy_entry6 {
 	union v6addr egress_ip;
 	__u32 gateway_ip;
 	__u32 reserved[3]; /* reserved for future extension, e.g. v6 gateway_ip */
+	__u32 egress_ifindex;
+	__u32 reserved2; /* for even more future extension */
 };
 
 struct srv6_vrf_key4 {

--- a/pkg/maps/egressmap/policy.go
+++ b/pkg/maps/egressmap/policy.go
@@ -56,9 +56,11 @@ type EgressPolicyKey6 struct {
 
 // EgressPolicyVal6 is the value of an egress policy map.
 type EgressPolicyVal6 struct {
-	EgressIP  types.IPv6 `align:"egress_ip"`
-	GatewayIP types.IPv4 `align:"gateway_ip"`
-	Reserved  [3]uint32  `align:"reserved"`
+	EgressIP      types.IPv6 `align:"egress_ip"`
+	GatewayIP     types.IPv4 `align:"gateway_ip"`
+	Reserved      [3]uint32  `align:"reserved"`
+	EgressIfindex uint32     `align:"egress_ifindex"`
+	Reserved2     uint32     `align:"reserved2"`
 }
 
 type PolicyConfig struct {


### PR DESCRIPTION
Plan for the future and add a few bytes for future work. It's much easier to do this now, when we haven't cut a release yet that contains this map.