### PR TITLE
envoy: log version mismatch only after failing twice

### DIFF
--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -288,14 +288,10 @@ func registerEnvoyVersionCheck(params versionCheckParams) {
 		return
 	}
 
-	checker := &envoyVersionChecker{logger: params.Logger}
-
-	envoyVersionFunc := func() (string, error) {
-		return checker.getRemoteEnvoyVersion(params.EnvoyAdminClient)
-	}
-
-	if !option.Config.ExternalEnvoyProxy {
-		envoyVersionFunc = getEmbeddedEnvoyVersion
+	checker := &envoyVersionChecker{
+		logger:        params.Logger,
+		externalEnvoy: option.Config.ExternalEnvoyProxy,
+		adminClient:   params.EnvoyAdminClient,
 	}
 
 	jobGroup := params.JobRegistry.NewGroup(
@@ -308,14 +304,24 @@ func registerEnvoyVersionCheck(params versionCheckParams) {
 	// To prevent agent restarts in case the Envoy DaemonSet isn't ready yet,
 	// version check is performed periodically and any errors are logged
 	// and reported via health reporter.
+	var previousError error
 	jobGroup.Add(job.Timer("version-check", func(_ context.Context) error {
-		if err := checker.checkEnvoyVersion(envoyVersionFunc); err != nil {
-			params.Logger.Error("Envoy: Version check failed", logfields.Error, err)
+		if err := checker.checkEnvoyVersion(); err != nil {
+			// We only log it as an error if it happens at least twice,
+			// as it is expected that during upgrade of Cilium, the Envoy version might differ
+			// for a short period of time.
+			logger := params.Logger.Info
+			if previousError != nil {
+				logger = params.Logger.Error
+			}
+			logger("Envoy: Version check failed", logfields.Error, err)
+			previousError = err
 			return err
 		}
 
+		previousError = nil
 		return nil
-	}, 5*time.Minute))
+	}, 2*time.Minute))
 }
 
 func newLocalEndpointStore() *LocalEndpointStore {

--- a/pkg/envoy/versioncheck.go
+++ b/pkg/envoy/versioncheck.go
@@ -4,13 +4,11 @@
 package envoy
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/time"
 )
 
 type envoyVersionChecker struct {
@@ -52,23 +50,9 @@ func (r *envoyVersionChecker) getEnvoyVersion() (string, error) {
 }
 
 func (r *envoyVersionChecker) getRemoteEnvoyVersion() (string, error) {
-	const versionRetryAttempts = 20
-	const versionRetryWait = 500 * time.Millisecond
-
-	// Retry is necessary because Envoy might not be ready yet
-	for i := 0; i <= versionRetryAttempts; i++ {
-		envoyVersion, err := r.adminClient.GetEnvoyVersion()
-		if err != nil {
-			if i < versionRetryAttempts {
-				r.logger.Info("Envoy: Unable to retrieve Envoy version - retry")
-				time.Sleep(versionRetryWait)
-				continue
-			}
-			return "", fmt.Errorf("failed to retrieve Envoy version: %w", err)
-		}
-
-		return envoyVersion, nil
+	envoyVersion, err := r.adminClient.GetEnvoyVersion()
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve Envoy version: %w", err)
 	}
-
-	return "", errors.New("failed to retrieve Envoy version")
+	return envoyVersion, nil
 }


### PR DESCRIPTION
Previously, we were logging version mismatch as an error each time that probe failed.
However, this does not make sense, as during regular minor or patch version upgrades, it's possible that Envoy daemonset version and Agent version do not match for brief period of time during upgrade. This can happen either when Envoy DS is upgraded first or when Agent is upgraded first on a particular node.

Now, if we log error about version mismatch, we know that mismatch has been happening for at least 5 minutes.


```release-note
envoy: Cilium does no longer report brief version mismatch of Agent and Envoy during upgrade
```
