### PR TITLE
.github/workflows: remove cilium-cli from build-go-caches

### DIFF
--- a/.github/workflows/build-go-caches.yaml
+++ b/.github/workflows/build-go-caches.yaml
@@ -33,10 +33,6 @@ jobs:
           - name: cilium
             make-target: build-container
 
-          - name: cilium-cli
-            make-target: -C cilium-cli
-            require-dir: cilium-cli
-
           - name: operator-aws
             make-target: build-container-operator-aws
 


### PR DESCRIPTION
The cilium-cli was removed from the v1.17 thus, we don't need to build the golang caches for it.

Fixes: b0fef92e1c10 ("cleanup: Remove cilium-cli related files")