### PR TITLE
Re-optimize CI build process

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -79,9 +79,6 @@ jobs:
           ref: ${{ github.base_ref || github.event.repository.default_branch }}
           persist-credentials: false
 
-      - name: Cleanup Disk space in runner
-        uses: ./.github/actions/disk-cleanup
-
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -87,6 +87,18 @@ jobs:
           mkdir -p ../cilium-base-branch
           cp -r .github/actions/set-runtime-image ../cilium-base-branch
 
+      - name: Check for disk usage and cleanup /mnt
+        shell: bash
+        run: |
+          echo "# Disk usage"
+          df -h
+          echo "# Usage for /mnt"
+          sudo du --human-readable \
+                --threshold 50m \
+                -- /mnt
+          echo "# Removing /mnt/tmp-pv.img"
+          sudo rm -f '/mnt/tmp-pv.img'
+
       - name: Setup docker volumes into /mnt
         # This allows us to make use of all available disk.
         shell: bash

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -87,6 +87,15 @@ jobs:
           mkdir -p ../cilium-base-branch
           cp -r .github/actions/set-runtime-image ../cilium-base-branch
 
+      - name: Setup docker volumes into /mnt
+        # This allows us to make use of all available disk.
+        shell: bash
+        run: |
+          sudo systemctl stop docker
+          sudo mv /var/lib/docker/volumes /mnt/docker-volumes
+          sudo ln -s /mnt/docker-volumes /var/lib/docker/volumes
+          sudo systemctl start docker
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         # Disable GC entirely to avoid buildkit from GC caches.


### PR DESCRIPTION
Cleaning the disk on a GitHub runner can take up to 2 minutes, which adds unnecessary delay when building CI images. However, skipping the cleanup step causes build failures due to the Go cache filling up the disk.

After some investigation, we identified that the /mnt directory was full because of a large file: /mnt/tmp-pv.img. There's no documentation explaining the purpose of this file, but we've confirmed that other disk cleanup GitHub Actions also remove it.

Following this approach, we now remove /mnt/tmp-pv.img to quickly free up space and ensure the /mnt directory is usable again for building CI images.