### PR TITLE
operator: remove deprecated CES options

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -332,6 +332,8 @@ Removed Options
   The K8s terminating endpoints feature is unconditionally enabled.
 * The previously deprecated ``CONNTRACK_LOCAL`` option has been removed
 * The previously deprecated ``enableRuntimeDeviceDetection`` option has been removed
+* The previously deprecated and ignored operator flags ``ces-write-qps-limit``, ``ces-write-qps-burst``, ``ces-enable-dynamic-rate-limit``,
+  ``ces-dynamic-rate-limit-nodes``, ``ces-dynamic-rate-limit-qps-limit``, ``ces-dynamic-rate-limit-qps-burst`` have been removed.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/operator/pkg/ciliumendpointslice/cell.go
+++ b/operator/pkg/ciliumendpointslice/cell.go
@@ -4,8 +4,6 @@
 package ciliumendpointslice
 
 import (
-	"fmt"
-
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
 
@@ -19,32 +17,6 @@ const (
 
 	// CESSlicingMode instructs how CEPs are grouped in a CES.
 	CESSlicingMode = "ces-slice-mode"
-
-	// CESWriteQPSLimit is the rate limit per second for the CES work queue to
-	// process  CES events that result in CES write (Create, Update, Delete)
-	// requests to the kube-apiserver.
-	CESWriteQPSLimit = "ces-write-qps-limit"
-
-	// CESWriteQPSBurst is the burst rate per second used with CESWriteQPSLimit
-	// for the CES work queue to process CES events that result in CES write
-	// (Create, Update, Delete) requests to the kube-apiserver.
-	CESWriteQPSBurst = "ces-write-qps-burst"
-
-	// CESEnableDynamicRateLimit is used to ignore static QPS Limit and Burst
-	// and use dynamic limit, burst and nodes instead.
-	CESEnableDynamicRateLimit = "ces-enable-dynamic-rate-limit"
-
-	// CESDynamicRateLimitNodes is used to specify the list of nodes used for the
-	// dynamic rate limit steps.
-	CESDynamicRateLimitNodes = "ces-dynamic-rate-limit-nodes"
-
-	// CESDynamicRateLimitQPSLimit is used to specify the list of qps limits for the
-	// dynamic rate limit steps.
-	CESDynamicRateLimitQPSLimit = "ces-dynamic-rate-limit-qps-limit"
-
-	// CESDynamicRateLimitQPSBurst is used to specify the list of qps bursts for the
-	// dynamic rate limit steps.
-	CESDynamicRateLimitQPSBurst = "ces-dynamic-rate-limit-qps-burst"
 
 	// CESRateLimits can be used to configure a custom, stepped dynamic rate limit based on cluster size.
 	CESRateLimits = "ces-rate-limits"
@@ -62,15 +34,9 @@ var Cell = cell.Module(
 )
 
 type Config struct {
-	CESMaxCEPsInCES             int      `mapstructure:"ces-max-ciliumendpoints-per-ces"`
-	CESSlicingMode              string   `mapstructure:"ces-slice-mode"`
-	CESWriteQPSLimit            float64  `mapstructure:"ces-write-qps-limit" exhaustruct:"optional"`
-	CESWriteQPSBurst            int      `mapstructure:"ces-write-qps-burst" exhaustruct:"optional"`
-	CESEnableDynamicRateLimit   bool     `mapstructure:"ces-enable-dynamic-rate-limit" exhaustruct:"optional"`
-	CESDynamicRateLimitNodes    []string `mapstructure:"ces-dynamic-rate-limit-nodes" exhaustruct:"optional"`
-	CESDynamicRateLimitQPSLimit []string `mapstructure:"ces-dynamic-rate-limit-qps-limit" exhaustruct:"optional"`
-	CESDynamicRateLimitQPSBurst []string `mapstructure:"ces-dynamic-rate-limit-qps-burst" exhaustruct:"optional"`
-	CESDynamicRateLimitConfig   string   `mapstructure:"ces-rate-limits"`
+	CESMaxCEPsInCES           int    `mapstructure:"ces-max-ciliumendpoints-per-ces"`
+	CESSlicingMode            string `mapstructure:"ces-slice-mode"`
+	CESDynamicRateLimitConfig string `mapstructure:"ces-rate-limits"`
 }
 
 var defaultConfig = Config{
@@ -80,23 +46,9 @@ var defaultConfig = Config{
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
-	depUseDLR := fmt.Sprintf("dynamic rate limiting is now configured by default. Please use --%s to supply a custom config", CESRateLimits)
 	flags.Int(CESMaxCEPsInCES, def.CESMaxCEPsInCES, "Maximum number of CiliumEndpoints allowed in a CES")
 	flags.String(CESSlicingMode, def.CESSlicingMode, "Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity (\"identity\") or batched on a \"First Come, First Served\" basis (\"fcfs\")")
 	flags.MarkDeprecated(CESSlicingMode, "Slicing mode defaults to the FCFS mode and is now deprecated option. It does not have a functional effect")
-	flags.Float64(CESWriteQPSLimit, def.CESWriteQPSLimit, "CES work queue rate limit. Ignored when "+CESEnableDynamicRateLimit+" is set")
-	flags.MarkDeprecated(CESWriteQPSLimit, depUseDLR)
-	flags.Int(CESWriteQPSBurst, def.CESWriteQPSBurst, "CES work queue burst rate. Ignored when "+CESEnableDynamicRateLimit+" is set")
-	flags.MarkDeprecated(CESWriteQPSBurst, depUseDLR)
-
-	flags.Bool(CESEnableDynamicRateLimit, def.CESEnableDynamicRateLimit, "Flag to enable dynamic rate limit specified in separate fields instead of the static one")
-	flags.MarkDeprecated(CESEnableDynamicRateLimit, depUseDLR)
-	flags.StringSlice(CESDynamicRateLimitNodes, def.CESDynamicRateLimitNodes, "List of nodes used for the dynamic rate limit steps")
-	flags.MarkDeprecated(CESDynamicRateLimitNodes, depUseDLR)
-	flags.StringSlice(CESDynamicRateLimitQPSLimit, def.CESDynamicRateLimitQPSLimit, "List of qps limits used for the dynamic rate limit steps")
-	flags.MarkDeprecated(CESDynamicRateLimitQPSLimit, depUseDLR)
-	flags.StringSlice(CESDynamicRateLimitQPSBurst, def.CESDynamicRateLimitQPSBurst, "List of qps burst used for the dynamic rate limit steps")
-	flags.MarkDeprecated(CESDynamicRateLimitQPSBurst, depUseDLR)
 
 	flags.String(CESRateLimits, def.CESDynamicRateLimitConfig, "Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string.")
 }

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -5,7 +5,6 @@ package ciliumendpointslice
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -111,8 +110,6 @@ func registerController(p params) error {
 		return err
 	}
 
-	checkDeprecatedOpts(p.Cfg, p.Logger)
-
 	cesController := &Controller{
 		logger:              p.Logger,
 		clientset:           clientset,
@@ -131,21 +128,4 @@ func registerController(p params) error {
 	}
 	p.Lifecycle.Append(cesController)
 	return nil
-}
-
-// checkDeprecatedOpts will log an error if the user has supplied any of the
-// no-op, deprecated rate limit options.
-// TODO: Remove this function when the deprecated options are removed.
-func checkDeprecatedOpts(cfg Config, logger *slog.Logger) {
-	switch {
-	case cfg.CESWriteQPSLimit > 0:
-	case cfg.CESWriteQPSBurst > 0:
-	case cfg.CESEnableDynamicRateLimit:
-	case len(cfg.CESDynamicRateLimitNodes) > 0:
-	case len(cfg.CESDynamicRateLimitQPSLimit) > 0:
-	case len(cfg.CESDynamicRateLimitQPSBurst) > 0:
-	default:
-		return
-	}
-	logger.Error(fmt.Sprintf("You are using deprecated rate limit option(s) that have no effect. To configure custom rate limits please use --%s", CESRateLimits))
 }


### PR DESCRIPTION
In #32523 multiple flags have been deprecated and their values have been ignored since 1.16.
