### PR TITLE
docs(examples): fix local-redirect-policy example

### DIFF
--- a/examples/kubernetes-local-redirect/node-local-dns-lrp.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns-lrp.yaml
@@ -8,6 +8,13 @@ spec:
     serviceMatcher:
       serviceName: kube-dns
       namespace: kube-system
+      toPorts:
+        - port: "53"
+          name: dns
+          protocol: UDP
+        - port: "53"
+          name: dns-tcp
+          protocol: TCP
   redirectBackend:
     localEndpointSelector:
       matchLabels:


### PR DESCRIPTION
# Description
Adds ports to `redirectFrontend` section of `CiliumLocalRedirectPolicy` used as example to deploying `node-local-dns` with `kubeProxyReplacement`. The reason to add the ports is that the example as it is doesn't work with `node-local-dns`, and after to fix the example, it started to cache DNS requests.

# Troubleshooting

## Before fix `CiliumLocalRedirectPolicy`
* Metrics of `node-local-dns`:
```
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="."} 1
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="in-addr.arpa."} 1
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="ip6.arpa."} 1
```
* Response time of DNS Requests:
```
root@my-app-6bb458975d-g7qt7:/# dig google.com                

; <<>> DiG 9.10.3-P4-Ubuntu <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 39772
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;google.com.			IN	A

;; ANSWER SECTION:
google.com.		30	IN	A	172.217.29.142

;; Query time: 7 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Fri May 23 15:22:55 UTC 2025
;; MSG SIZE  rcvd: 65
```

## After fix `CiliumLocalRedirectPolicy`
* Metrics of `node-local-dns`:
```
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="A",view="",zone="."} 5
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="."} 1
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="in-addr.arpa."} 1
coredns_dns_requests_total{family="1",proto="udp",server="dns://0.0.0.0:53",type="other",view="",zone="ip6.arpa."} 1
```

* Response time of DNS Requests:
```
root@my-app-6bb458975d-g7qt7:/# dig google.com

; <<>> DiG 9.10.3-P4-Ubuntu <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 2381
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;google.com.			IN	A

;; ANSWER SECTION:
google.com.		28	IN	A	172.217.29.78

;; Query time: 0 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Fri May 23 15:31:53 UTC 2025
;; MSG SIZE  rcvd: 65
```

Signed-off-by: Lucas de Farias Teixeira <farias.lucasteixeira@gmail.com>