### PR TITLE
Improve error messages for unreachable Kubernetes API server

### DIFF
--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -337,6 +337,10 @@ func (c *compositeClientset) waitForConn(ctx context.Context) error {
 		c.logger.Error("Unable to contact k8s api-server",
 			logfields.IPAddr, c.restConfigManager.getConfig().Host,
 			logfields.Error, err,
+			logfields.Hint, "Please check if kube-proxy is running and if the API server is accessible",
+			logfields.Hint, "For more detailed diagnostics, check the Cilium logs",
+			logfields.Hint, fmt.Sprintf("Current connection attempt to: %s", c.restConfigManager.getConfig().Host),
+			logfields.Hint, "If using KPR=strict, verify the API server node IP is correctly specified",
 		)
 		close(stop)
 	}, connRetryInterval, stop)

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -340,7 +340,7 @@ func (c *compositeClientset) waitForConn(ctx context.Context) error {
 			logfields.Hint, "Please check if kube-proxy is running and if the API server is accessible",
 			logfields.Hint, "For more detailed diagnostics, check the Cilium logs",
 			logfields.Hint, fmt.Sprintf("Current connection attempt to: %s", c.restConfigManager.getConfig().Host),
-			logfields.Hint, "If using KPR=strict, verify the API server node IP is correctly specified",
+			logfields.Hint, "If using kubeProxyReplacement=true, verify the API server node IP is correctly specified",
 		)
 		close(stop)
 	}, connRetryInterval, stop)


### PR DESCRIPTION
This PR improves error messages when the API server is unreachable by providing more detailed diagnostics and troubleshooting steps. It specifically addresses cases where kube-proxy is crash looping and when KPR=strict mode is being used.

Fixes: #21148

```release-note
Improve error messages when API server is unreachable to help users diagnose connectivity issues, especially in cases where kube-proxy is crash looping or when KPR=strict mode is being used.
```