### PR TITLE
policy: add policy-default-local-cluster support for node identities

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -502,6 +502,12 @@ This example shows how to allow all endpoints with the label ``env=prod`` to rec
 traffic **only** from control plane (labeled
 ``node-role.kubernetes.io/control-plane=""``) nodes in the cluster (or clustermesh).
 
+Note that by default policies automatically select nodes from all the clusters in
+a Cluster Mesh environment unless it is explicitly specified. To restrict node
+selection to the local cluster by default you can enable the option
+``--policy-default-local-cluster`` via the ConfigMap option ``policy-default-local-cluster``
+or the Helm value ``clustermesh.policyDefaultLocalCluster``.
+
 .. only:: html
 
    .. tabs::

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -602,6 +602,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			// for reserved:remote-node to allow only nodes and not endpoints
 			name: "parse-from-to-nodes-rule",
 			args: args{
+				clusterName: "cluster1",
 				overrideConfig: func() {
 					option.Config.EnableNodeSelectorLabels = true
 				},
@@ -649,6 +650,11 @@ func Test_ParseToCiliumRule(t *testing.T) {
 												Operator: slim_metav1.LabelSelectorOpExists,
 												Values:   []string{},
 											},
+										},
+									},
+									&slim_metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											clusterPrefixLbl: "cluster1",
 										},
 									}),
 							},

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
@@ -778,6 +779,8 @@ func (m *manager) nodeIdentityLabels(n nodeTypes.Node) (nodeLabels labels.Labels
 		hasOverride = true
 	} else if !n.IsLocal() && option.Config.PerNodeLabelsEnabled() {
 		lbls := labels.Map2Labels(n.Labels, labels.LabelSourceNode)
+		clusterLabel := labels.NewLabel(k8sConst.PolicyLabelCluster, n.Cluster, labels.LabelSourceK8s)
+		lbls[clusterLabel.Key] = clusterLabel
 		filteredLbls, _ := labelsfilter.FilterNodeLabels(lbls)
 		nodeLabels.MergeLabels(filteredLbls)
 	}


### PR DESCRIPTION
Followup to https://github.com/cilium/cilium/pull/39338 to also add support for nodes.

First commit add the cluster label to node identities and second commit add support for `policy-default-local-cluster` with the same logic as other endpoint selectors (if the flag is turned on and no clusters are explicitly defined).

```release-note
identity: policy: add cluster label to node identities and add policy-default-local-cluster support for node identities
```

Related to https://github.com/cilium/cilium/issues/36194 / https://github.com/cilium/cilium/issues/36194#issuecomment-2802430595
