### PR TITLE
test: ensure the daemon shuts down cleanly

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -34,6 +34,7 @@ focus:
 - "f20-datapath-misc-3"
 include:
   ###
+  # K8sAgentChaosTest Graceful shutdown exits with a success message on SIGTERM
   # K8sAgentChaosTest Connectivity demo application Endpoint can still connect while Cilium is not running
   # K8sAgentChaosTest Restart with long lived connections L3/L4 policies still work while Cilium is restarted
   # K8sAgentChaosTest Restart with long lived connections TCP connection is not dropped when cilium restarts

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -43,6 +43,10 @@ func NewAgentCmd(hfn func() *hive.Hive) *cobra.Command {
 
 			if err := h.Run(logging.DefaultSlogLogger); err != nil {
 				logging.Fatal(daemonLogger, fmt.Sprintf("unable to run agent: %s", err))
+			} else {
+				// If h.Run() exits with no errors, it means the agent gracefully shut down.
+				// (There is a CI job that ensures this is the case)
+				daemonLogger.Info("All stop hooks executed successfully.")
 			}
 		},
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1194,6 +1194,13 @@ func (kub *Kubectl) Logs(namespace string, pod string) *CmdRes {
 		fmt.Sprintf("%s -n %s logs %s", KubectlCmd, namespace, pod))
 }
 
+// LogsPrevious returns a CmdRes with containing the resulting metadata from the
+// execution of `kubectl logs -p <pod> -n <namespace>`.
+func (kub *Kubectl) LogsPrevious(namespace string, pod string) *CmdRes {
+	return kub.Exec(
+		fmt.Sprintf("%s -n %s logs -p %s", KubectlCmd, namespace, pod))
+}
+
 // MonitorStart runs cilium-dbg monitor in the background and returns the command
 // result, CmdRes, along with a cancel function. The cancel function is used to
 // stop the monitor.


### PR DESCRIPTION
This adds a `kill 1` step to the Chaos test, and looks for the log line that indicates all stop hooks correctly executed.

Otherwise, we have a nasty habit of regressing on this.

 See: https://github.com/cilium/cilium/pull/39762 where I fixed a bunch of shutdown regressions.
