### PR TITLE
healthserver: Add IPv6 script test case

### DIFF
--- a/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
@@ -1,0 +1,301 @@
+#! --enable-experimental-lb --enable-health-check-nodeport
+
+# Add a node address.
+db/insert node-addresses addrv6.yaml
+
+hive start
+
+env HEALTHPORT1=40000
+env HEALTHPORT2=40001
+cp service.yaml service2.yaml
+cp service.yaml service_no_health.yaml
+replace '$HEALTHPORT' $HEALTHPORT1 service.yaml
+replace '$HEALTHPORT' $HEALTHPORT2 service2.yaml
+replace '$HEALTHPORT' 0 service_no_health.yaml
+replace '$HEALTHPORT1' $HEALTHPORT1 services.table
+replace '$HEALTHPORT1' $HEALTHPORT1 health_with_service.table
+replace '$HEALTHPORT' $HEALTHPORT1 frontends.table
+replace '$HEALTHPORT' $HEALTHPORT1 backends.table
+
+# HealthServer's jobs should be reported in module health
+db/cmp --grep=^loadbalancer-healthserver health health_no_service.table
+
+# Add endpoints. This is done first to avoid non-determinismic backend
+# id allocation due to health server adding its own service and endpoints
+# which might be racy if the health server manages to go before endpoints
+# are processed.
+k8s/add endpointslice1.yaml
+db/cmp backends backends1.table
+
+# Add the service
+k8s/add service.yaml
+db/cmp --grep=^loadbalancer-healthserver health health_with_service.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+# Check the BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+
+# Validate health server response
+* http/get http://$HEALTHADDR:$HEALTHPORT1 healthserver.actual
+cmp healthserver.expected healthserver.actual
+
+# Test changing the health check port
+k8s/update service2.yaml
+
+# Check that the frontend for the health server is updated
+replace $HEALTHPORT1 $HEALTHPORT2 frontends.table
+db/cmp frontends frontends.table
+replace $HEALTHPORT1 $HEALTHPORT2 backends.table
+db/cmp backends backends.table
+
+# Check that $HEALTHPORT2 now responds and old port does not.
+* http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
+* cmp healthserver.expected healthserver.actual
+!* http/get http://$HEALTHADDR:$HEALTHPORT1 healthserver.actual
+
+# Setting the traffic policy to Cluster makes the service
+# unqualified for health server, removing it.
+cp service2.yaml service2_tpcluster.yaml
+replace 'externalTrafficPolicy: Local' 'externalTrafficPolicy: Cluster' service2_tpcluster.yaml
+replace 'internalTrafficPolicy: Local' 'internalTrafficPolicy: Cluster' service2_tpcluster.yaml
+k8s/update service2_tpcluster.yaml
+db/cmp frontends frontends_tpcluster.table
+
+# The health checker server should be down now.
+!* http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
+
+# Restore health checking for next test.
+k8s/update service2.yaml
+
+# Response should be 200
+* http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
+* cmp healthserver.expected healthserver.actual
+
+# Test without local backends
+k8s/update endpointslice2.yaml
+replace '$HEALTHPORT' $HEALTHPORT2 frontends_nobackends.table
+db/cmp frontends frontends_nobackends.table
+
+# Response should now be 503
+* http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
+* cmp healthserver-unhealthy.expected healthserver.actual
+
+# Test removing the health check port
+k8s/update service_no_health.yaml
+
+# Both ports should now stop responding
+# "!*" means expect failure and retry if needed
+!* http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
+!* http/get http://$HEALTHADDR:$HEALTHPORT1 healthserver.actual
+
+db/cmp frontends frontends_nohealthcheck.table
+db/cmp backends backends_othernode.table
+
+#####
+
+-- addrv6.yaml --
+addr: fd03::1111
+nodeport: true
+primary: true
+devicename: test
+
+-- health_no_service.table --
+Module                      Component                         Level   Message                    Error
+loadbalancer-healthserver   job-control-loop                  OK      0 health servers running
+
+-- health_with_service.table --
+Module                      Component                         Level   Message                    Error
+loadbalancer-healthserver   job-control-loop                  OK      1 health servers running
+loadbalancer-healthserver   job-listener-40000                OK      Running
+
+-- services.table --
+Name                   Source   PortNames  TrafficPolicy   Flags
+test/echo              k8s      http=80    Local           HealthCheckNodePort=$HEALTHPORT1
+test/echo:healthserver local               Local
+
+-- frontends.table --
+Address                 Type         ServiceName            PortName   Status  Backends
+[::]:30781/TCP          NodePort     test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
+[fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
+[fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
+[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP/i
+
+-- frontends_tpcluster.table --
+Address                 Type         ServiceName            PortName   Status  Backends
+[::]:30781/TCP          NodePort     test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP, [fd02::3]:80/TCP, [fd02::4]:80/TCP
+[fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP, [fd02::3]:80/TCP, [fd02::4]:80/TCP
+[fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP, [fd02::3]:80/TCP, [fd02::4]:80/TCP
+
+-- frontends_nobackends.table --
+Address                 Type         ServiceName            PortName   Status  Backends
+[::]:30781/TCP          NodePort     test/echo              http       Done    
+[fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    
+[fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    
+[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP/i
+
+-- frontends_nohealthcheck.table --
+Address                 Type         ServiceName            PortName   Status  Backends
+[::]:30781/TCP          NodePort     test/echo              http       Done    
+[fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    
+[fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    
+
+-- backends1.table --
+Instances              Address
+test/echo (http)       [fd02::1]:80/TCP
+test/echo (http)       [fd02::2]:80/TCP
+test/echo (http)       [fd02::3]:80/TCP
+test/echo (http)       [fd02::4]:80/TCP
+
+-- backends.table --
+Instances              Address
+test/echo (http)       [fd02::1]:80/TCP
+test/echo (http)       [fd02::2]:80/TCP
+test/echo (http)       [fd02::3]:80/TCP
+test/echo (http)       [fd02::4]:80/TCP
+test/echo:healthserver [fd03::1111]:$HEALTHPORT/TCP/i
+
+-- backends_othernode.table --
+Address           Instances              NodeName
+[fd02::3]:80/TCP  test/echo (http)       othernode
+[fd02::4]:80/TCP  test/echo (http)       othernode
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: "fd00::aaaa"
+  clusterIPs:
+  - "fd00::aaaa"
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Local
+  healthCheckNodePort: $HEALTHPORT
+  ipFamilies:
+  - IPv6
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: "fd01::bbbb"
+
+-- endpointslice1.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-eps
+  namespace: test
+  resourceVersion: "797"
+  uid: e1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv6
+endpoints:
+- addresses:
+  - "fd02::1"
+  nodeName: testnode
+- addresses:
+  - "fd02::2"
+  nodeName: testnode
+- addresses:
+  - "fd02::3"
+  nodeName: othernode
+- addresses:
+  - "fd02::4"
+  nodeName: othernode
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpointslice2.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-eps
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv6
+endpoints:
+- addresses:
+  - "fd02::3"
+  nodeName: othernode
+- addresses:
+  - "fd02::4"
+  nodeName: othernode
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- healthserver.expected --
+200 OK
+Content-Length=66
+Content-Type=application/json
+Date=<omitted>
+X-Content-Type-Options=nosniff
+X-Load-Balancing-Endpoint-Weight=2
+---
+{"service":{"namespace":"test","name":"echo"},"localEndpoints":2}
+-- healthserver-unhealthy.expected --
+503 Service Unavailable
+Content-Length=66
+Content-Type=application/json
+Date=<omitted>
+X-Content-Type-Options=nosniff
+X-Load-Balancing-Endpoint-Weight=0
+---
+{"service":{"namespace":"test","name":"echo"},"localEndpoints":0}
+-- lbmaps.expected --
+BE: ID=1 ADDR=[fd02::1]:80/TCP STATE=active
+BE: ID=2 ADDR=[fd02::2]:80/TCP STATE=active
+BE: ID=3 ADDR=[fd03::1111]:40000/TCP STATE=active
+REV: ID=1 ADDR=[::]:30781
+REV: ID=2 ADDR=[fd03::1111]:30781
+REV: ID=3 ADDR=[fd00::aaaa]:80
+REV: ID=4 ADDR=[fd01::bbbb]:80
+REV: ID=5 ADDR=[fd01::bbbb]:40000
+SVC: ID=1 ADDR=[::]:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal+non-routable
+SVC: ID=1 ADDR=[::]:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal+non-routable
+SVC: ID=1 ADDR=[::]:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal+non-routable
+SVC: ID=2 ADDR=[fd03::1111]:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal
+SVC: ID=2 ADDR=[fd03::1111]:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal
+SVC: ID=2 ADDR=[fd03::1111]:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal
+SVC: ID=3 ADDR=[fd00::aaaa]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
+SVC: ID=3 ADDR=[fd00::aaaa]:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
+SVC: ID=3 ADDR=[fd00::aaaa]:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
+SVC: ID=4 ADDR=[fd01::bbbb]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=4 ADDR=[fd01::bbbb]:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=4 ADDR=[fd01::bbbb]:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=5 ADDR=[fd01::bbbb]:40000/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=5 ADDR=[fd01::bbbb]:40000/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal


### PR DESCRIPTION
This commit introduces a new script-based test case, `healthserver-ipv6.txtar`, to validate the health server functionality in an IPv6 environment.

The new test case mirrors the existing IPv4 test (`healthserver.txtar`) but uses IPv6 addresses for node addresses, service IPs, endpoint IPs, and load balancer IPs.

This ensures that the health server correctly handles IPv6 configurations, including:
- Health check endpoint exposure on IPv6 addresses.
- Correct population of BPF maps with IPv6 entries.
- Accurate reporting of local IPv6 endpoints.
