### PR TITLE
install/kubernetes: change mapDynamicSizeRatio from number to string

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -391,7 +391,7 @@ data:
   bpf-events-default-burst-limit: {{ .Values.bpf.events.default.burstLimit | quote }}
 {{- end}}
 
-{{- if .Values.bpf.mapDynamicSizeRatio }}
+{{- if ne 0.0 ( .Values.bpf.mapDynamicSizeRatio | float64) }}
   # Specifies the ratio (0.0-1.0] of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
   bpf-map-dynamic-size-ratio: {{ .Values.bpf.mapDynamicSizeRatio | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -611,7 +611,8 @@
         "mapDynamicSizeRatio": {
           "type": [
             "null",
-            "number"
+            "number",
+            "string"
           ]
         },
         "masquerade": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -606,7 +606,7 @@ bpf:
   # @schema
   policyStatsMapMax: 65536
   # @schema
-  # type: [null, number]
+  # type: [null, number, string]
   # @schema
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -609,7 +609,7 @@ bpf:
   # @schema
   policyStatsMapMax: 65536
   # @schema
-  # type: [null, number]
+  # type: [null, number, string]
   # @schema
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/


### PR DESCRIPTION
Reverts type change from "number" to "string" for bpf.mapDynamicSizeRatio, which caused Helm schema validation to fail when setting it as a float.

This restores compatibility with the expected numeric input:
  --set bpf.mapDynamicSizeRatio=0.08

Fixes: 79733d2dafe6 ("helm: Introduce values.schema.json and tooling")

Fixes https://github.com/cilium/cilium/issues/39823