### PR TITLE
bgp: Allow router Stop without full destroy to fix Graceful Restart

### DIFF
--- a/pkg/bgpv1/gobgp/server_test.go
+++ b/pkg/bgpv1/gobgp/server_test.go
@@ -31,7 +31,7 @@ func TestGlobalImportPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		router.Stop()
+		router.Stop(context.Background(), types.StopRequest{FullDestroy: true})
 	})
 
 	gobgpServer := router.(*GoBGPServer).server
@@ -81,7 +81,7 @@ func TestAddRemoveRoutePolicy(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				router.Stop()
+				router.Stop(context.Background(), types.StopRequest{FullDestroy: true})
 			})
 			gobgpServer := router.(*GoBGPServer).server
 

--- a/pkg/bgpv1/gobgp/state_test.go
+++ b/pkg/bgpv1/gobgp/state_test.go
@@ -257,7 +257,7 @@ func TestGetPeerState(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				testSC.Stop()
+				testSC.Stop(context.Background(), types.StopRequest{FullDestroy: true})
 			})
 
 			// add neighbours
@@ -362,7 +362,7 @@ func TestGetRoutes(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		testSC.Stop()
+		testSC.Stop(context.Background(), types.StopRequest{FullDestroy: true})
 	})
 
 	err = testSC.AddNeighbor(context.TODO(), types.ToNeighborV1(neighbor64125, ""))

--- a/pkg/bgpv1/manager/reconciler/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor_test.go
@@ -262,7 +262,7 @@ func TestNeighborReconciler(t *testing.T) {
 				t.Fatalf("failed to create test BgpServer: %v", err)
 			}
 			t.Cleanup(func() {
-				testSC.Server.Stop()
+				testSC.Server.Stop(context.Background(), types.StopRequest{FullDestroy: true})
 			})
 
 			r := NewNeighborReconciler(hivetest.Logger(t), tt.secretStore, &option.DaemonConfig{BGPSecretsNamespace: "bgp-secrets"}).Reconciler

--- a/pkg/bgpv1/manager/reconciler/preflight.go
+++ b/pkg/bgpv1/manager/reconciler/preflight.go
@@ -142,7 +142,7 @@ func (r *PreflightReconciler) Reconcile(ctx context.Context, p ReconcileParams) 
 	}
 
 	// stop the old BgpServer
-	p.CurrentServer.Server.Stop()
+	p.CurrentServer.Server.Stop(ctx, types.StopRequest{FullDestroy: true})
 
 	// create a new one via ServerWithConfig constructor
 	s, err := instance.NewServerWithConfig(ctx, r.logger, globalConfig)

--- a/pkg/bgpv1/manager/reconciler/preflight_test.go
+++ b/pkg/bgpv1/manager/reconciler/preflight_test.go
@@ -118,8 +118,8 @@ func TestPreflightReconciler(t *testing.T) {
 			// later
 			originalServer := testSC.Server
 			t.Cleanup(func() {
-				originalServer.Stop() // stop our test server
-				testSC.Server.Stop()  // stop any recreated server
+				originalServer.Stop(context.Background(), types.StopRequest{FullDestroy: true}) // stop our test server
+				testSC.Server.Stop(context.Background(), types.StopRequest{FullDestroy: true})  // stop any recreated server
 			})
 
 			// attach original config
@@ -218,8 +218,8 @@ func TestReconcileAfterServerReinit(t *testing.T) {
 
 	originalServer := testSC.Server
 	t.Cleanup(func() {
-		originalServer.Stop() // stop our test server
-		testSC.Server.Stop()  // stop any recreated server
+		originalServer.Stop(context.Background(), types.StopRequest{FullDestroy: true}) // stop our test server
+		testSC.Server.Stop(context.Background(), types.StopRequest{FullDestroy: true})  // stop any recreated server
 	})
 
 	// Validate pod CIDR and service announcements work as expected

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
@@ -355,7 +355,7 @@ func TestNeighborReconciler_StaticPeer(t *testing.T) {
 			req.NoError(err)
 
 			t.Cleanup(func() {
-				testInstance.Router.Stop()
+				testInstance.Router.Stop(context.Background(), types.StopRequest{FullDestroy: true})
 			})
 
 			params, nodeConfig := setupNeighbors(t, tt.neighbors)
@@ -521,7 +521,7 @@ func TestNeighborReconciler_DefaultGateway(t *testing.T) {
 			req.NoError(err)
 
 			t.Cleanup(func() {
-				testInstance.Router.Stop()
+				testInstance.Router.Stop(context.Background(), types.StopRequest{FullDestroy: true})
 			})
 
 			params, nodeConfig := setupNeighbors(t, tt.neighbors)

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/manager"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -243,6 +244,10 @@ func newFixture(t testing.TB, ctx context.Context, conf fixtureConfig) (*fixture
 		// local bgp state for inspection
 		cell.Invoke(func(bgp *agent.Controller) {
 			f.bgp = bgp
+		}),
+
+		cell.Invoke(func(m agent.BGPRouterManager) {
+			m.(*manager.BGPRouterManager).DestroyRouterOnStop(true) // fully destroy GoBGP server on Stop()
 		}),
 
 		metrics.Cell,

--- a/pkg/bgpv1/test/script_test.go
+++ b/pkg/bgpv1/test/script_test.go
@@ -25,6 +25,7 @@ import (
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/manager"
 	"github.com/cilium/cilium/pkg/bgpv1/test/commands"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 
@@ -139,6 +140,7 @@ func TestScript(t *testing.T) {
 			}),
 			cell.Invoke(func(m agent.BGPRouterManager) {
 				bgpMgr = m
+				m.(*manager.BGPRouterManager).DestroyRouterOnStop(true) // fully destroy GoBGP server on Stop()
 			}),
 		)
 

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -341,10 +341,18 @@ type GetRoutePoliciesResponse struct {
 	Policies []*RoutePolicy
 }
 
+// StopRequest contains parameters for stopping the underlying router
+type StopRequest struct {
+	// FullDestroy should be set to true if full destroy of the router instance should be performed.
+	// Note that this causes sending a Cease notification to BGP peers, which terminates Graceful Restart progress.
+	FullDestroy bool
+}
+
 // Router is vendor-agnostic cilium bgp configuration layer. Parameters of this layer
 // are standard BGP RFC complaint and not specific to any underlying implementation.
 type Router interface {
-	Stop()
+	// Stop stops the router
+	Stop(ctx context.Context, r StopRequest)
 
 	// AddNeighbor configures BGP peer
 	AddNeighbor(ctx context.Context, n *Neighbor) error

--- a/pkg/bgpv1/types/fake_router.go
+++ b/pkg/bgpv1/types/fake_router.go
@@ -17,7 +17,7 @@ func NewFakeRouter() Router {
 	}
 }
 
-func (f *FakeRouter) Stop() {}
+func (f *FakeRouter) Stop(ctx context.Context, r StopRequest) {}
 
 func (f *FakeRouter) AddNeighbor(ctx context.Context, n *Neighbor) error {
 	return nil


### PR DESCRIPTION
As of https://github.com/cilium/cilium/pull/38008, `BGPRouterManager.Stop()` is called when BGP CP cell is being destroyed to properly clean up all servers when the agent is stopped. This change however affected Graceful Restart behavior and should be revisited:

GoBGP sends a Cease notification to all BGP peers as part of the server `Stop()` implementation ([code ref](https://github.com/osrg/gobgp/blob/v3.37.0/pkg/server/server.go#L2089)), which makes Graceful Restart on the peered routers ineffective.

From [rfc4724, section 4](https://datatracker.ietf.org/doc/html/rfc4724#section-4) -  Graceful Restart Mechanism for BGP:

> "normal BGP procedures MUST be followed when the TCP session terminates
> due to the sending or receiving of a BGP NOTIFICATION message"

To make Graceful Restart work, we allow stopping the router without destroying GoBGP server, at least until GoBGP provides a way to not send Cease notifications upon server `Stop()` to GR-enabled peers.

The Router's `Stop()` method now takes a `StopRequest` argument, which can be used to specify whether full destroy of the Router is needed or not. Full destroy is helpful for tests, but for now it should not be used for standard Cilium agent use-case to make GR work upon agent termination.


```release-note
bgp: Fix router Stop handling to not affect Graceful Restart
```