### PR TITLE
fix: Fix implicit conversion warnings in bpf_sec_to_mono macro

### DIFF
--- a/bpf/lib/mono.h
+++ b/bpf/lib/mono.h
@@ -7,7 +7,7 @@
 #if defined(ENABLE_JIFFIES) && KERNEL_HZ != 1
 # define BPF_MONO_SCALER	8
 # define bpf_mono_now()		(jiffies >> BPF_MONO_SCALER)
-# define bpf_sec_to_mono(s)	(bpf_sec_to_jiffies(s) >> BPF_MONO_SCALER)
+# define bpf_sec_to_mono(s)	((__u32)bpf_sec_to_jiffies(s) >> BPF_MONO_SCALER)
 #else
 # define bpf_mono_now()		bpf_ktime_get_sec()
 # define bpf_sec_to_mono(s)	(s)


### PR DESCRIPTION
The bpf_sec_to_mono macro was returning a __u64 value, which led to implicit conversion warnings when assigned to __u32 variables. This change adds an explicit cast to __u32 to ensure the result fits the expected data type.

Issue:
The cilium pods were in `crashloopbackoff` for the error:
```
time=2025-06-02T22:26:37Z level=error msg="Failed to compile bpf_sock.o: exit status 1" module=agent.datapath.loader compilerPID=204
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/bpf_sock.c:13:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/lib/lb.h:8:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/conntrack.h:172:5: error: implicit conversion loses integer precision: '__u64' (aka 'unsigned long long') to '__u32' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  171 |         __u32 lifetime = dir == CT_SERVICE ?" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |               ~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  172 |                          bpf_sec_to_mono(CT_SERVICE_LIFETIME_NONTCP) :" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/mono.h:10:52: note: expanded from macro 'bpf_sec_to_mono'" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="   10 | # define bpf_sec_to_mono(s)     (bpf_sec_to_jiffies(s) >> BPF_MONO_SCALER)" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/bpf_sock.c:13:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/lib/lb.h:8:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/conntrack.h:173:5: error: implicit conversion loses integer precision: '__u64' (aka 'unsigned long long') to '__u32' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  171 |         __u32 lifetime = dir == CT_SERVICE ?" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |               ~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  172 |                          bpf_sec_to_mono(CT_SERVICE_LIFETIME_NONTCP) :" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  173 |                          bpf_sec_to_mono(CT_CONNECTION_LIFETIME_NONTCP);" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/mono.h:10:52: note: expanded from macro 'bpf_sec_to_mono'" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="   10 | # define bpf_sec_to_mono(s)     (bpf_sec_to_jiffies(s) >> BPF_MONO_SCALER)" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/bpf_sock.c:13:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/lib/lb.h:8:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/conntrack.h:180:8: error: implicit conversion loses integer precision: '__u64' (aka 'unsigned long long') to '__u32' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  179 |                         lifetime = dir == CT_SERVICE ?" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  180 |                                    bpf_sec_to_mono(CT_SERVICE_LIFETIME_TCP) :" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/mono.h:10:52: note: expanded from macro 'bpf_sec_to_mono'" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="   10 | # define bpf_sec_to_mono(s)     (bpf_sec_to_jiffies(s) >> BPF_MONO_SCALER)" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/bpf_sock.c:13:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/lib/lb.h:8:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/conntrack.h:181:8: error: implicit conversion loses integer precision: '__u64' (aka 'unsigned long long') to '__u32' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  179 |                         lifetime = dir == CT_SERVICE ?" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  180 |                                    bpf_sec_to_mono(CT_SERVICE_LIFETIME_TCP) :" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  181 |                                    bpf_sec_to_mono(CT_CONNECTION_LIFETIME_TCP);" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/mono.h:10:52: note: expanded from macro 'bpf_sec_to_mono'" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="   10 | # define bpf_sec_to_mono(s)     (bpf_sec_to_jiffies(s) >> BPF_MONO_SCALER)" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/bpf_sock.c:13:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/lib/lb.h:8:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/conntrack.h:183:15: error: implicit conversion loses integer precision: '__u64' (aka 'unsigned long long') to '__u32' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  183 |                         lifetime = bpf_sec_to_mono(CT_SYN_TIMEOUT);" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/mono.h:10:52: note: expanded from macro 'bpf_sec_to_mono'" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="   10 | # define bpf_sec_to_mono(s)     (bpf_sec_to_jiffies(s) >> BPF_MONO_SCALER)" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/bpf_sock.c:13:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/lib/lb.h:8:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/conntrack.h:236:20: error: implicit conversion loses integer precision: '__u64' (aka 'unsigned long long') to '__u32' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  236 |         __u32 wait_time = bpf_sec_to_mono(CT_SERVICE_CLOSE_REBALANCE);" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |               ~~~~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/mono.h:10:52: note: expanded from macro 'bpf_sec_to_mono'" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="   10 | # define bpf_sec_to_mono(s)     (bpf_sec_to_jiffies(s) >> BPF_MONO_SCALER)" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/bpf_sock.c:13:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="In file included from /var/lib/cilium/bpf/lib/lb.h:8:" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/conntrack.h:353:31: error: implicit conversion loses integer precision: '__u64' (aka 'unsigned long long') to '__u32' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="  353 |                         __ct_update_timeout(entry, bpf_sec_to_mono(CT_CLOSE_TIMEOUT)," module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                         ~~~~~~~~~~~~~~~~~~~        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="/var/lib/cilium/bpf/lib/mono.h:10:52: note: expanded from macro 'bpf_sec_to_mono'" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="   10 | # define bpf_sec_to_mono(s)     (bpf_sec_to_jiffies(s) >> BPF_MONO_SCALER)" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="      |                                  ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~" module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=warn msg="7 errors generated." module=agent.datapath.loader
time=2025-06-02T22:26:37Z level=error msg="failed to compile bpf_sock.c" module=agent.datapath.loader error="Failed to compile bpf_sock.o: exit status 1"

```
Attaching the sysdump for reference
[cilium-sysdump-20250602-161057.zip](https://github.com/user-attachments/files/20559970/cilium-sysdump-20250602-161057.zip)
