### PR TITLE
kvstoremesh: lock destination etcd

### DIFF
--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -120,7 +120,19 @@ var Synchronization = cell.Module(
 		),
 		cell.Invoke(RegisterSynchronizer[*cilium_api_v2a1.CiliumEndpointSlice]),
 	),
+	cell.Invoke(registerSyncStateStop),
 )
+
+func registerSyncStateStop(lc cell.Lifecycle, ss syncstate.SyncState) {
+	lc.Append(
+		cell.Hook{
+			OnStart: func(cell.HookContext) error {
+				ss.Stop()
+				return nil
+			},
+		},
+	)
+}
 
 func registerClientsetValidator(lc cell.Lifecycle, client k8sClient.Clientset) {
 	lc.Append(cell.Hook{

--- a/clustermesh-apiserver/kvstoremesh/cells.go
+++ b/clustermesh-apiserver/kvstoremesh/cells.go
@@ -4,6 +4,7 @@
 package kvstoremesh
 
 import (
+	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/clustermesh-apiserver/option"
@@ -39,7 +40,20 @@ var Cell = cell.Module(
 	cell.Invoke(kvstoremesh.RegisterSyncWaiter),
 
 	cell.Invoke(func(*kvstoremesh.KVStoreMesh) {}),
+
+	cell.Invoke(registerSyncStateStop),
 )
+
+func registerSyncStateStop(lc cell.Lifecycle, ss syncstate.SyncState) {
+	lc.Append(
+		cell.Hook{
+			OnStart: func(cell.HookContext) error {
+				ss.Stop()
+				return nil
+			},
+		},
+	)
+}
 
 var pprofConfig = pprof.Config{
 	Pprof:        false,

--- a/clustermesh-apiserver/kvstoremesh/lifecycle.go
+++ b/clustermesh-apiserver/kvstoremesh/lifecycle.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstoremesh
+
+import (
+	"log/slog"
+	"runtime/pprof"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+)
+
+// LeaderLifecycle is the inner lifecycle of the kvstoremesh that is started when this
+// instance is elected leader. It implements cell.Lifecycle allowing cells to use it.
+type LeaderLifecycle struct {
+	cell.DefaultLifecycle
+}
+
+func WithLeaderLifecycle(cells ...cell.Cell) cell.Cell {
+	return cell.Module(
+		"leader-lifecycle",
+		"KVStoreMesh Leader Lifecycle",
+
+		cell.Provide(
+			func() *LeaderLifecycle { return &LeaderLifecycle{} },
+		),
+		cell.Decorate(
+			func(reg job.Registry, h cell.Health, logger *slog.Logger, llc *LeaderLifecycle, mid cell.ModuleID) (cell.Lifecycle, job.Group) {
+				return llc, reg.NewGroup(h, llc,
+					job.WithLogger(logger),
+					job.WithPprofLabels(pprof.Labels("cell", string(mid))))
+			},
+			cells...,
+		),
+	)
+}

--- a/clustermesh-apiserver/kvstoremesh/root.go
+++ b/clustermesh-apiserver/kvstoremesh/root.go
@@ -4,14 +4,30 @@
 package kvstoremesh
 
 import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 
+	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
+	"github.com/cilium/cilium/pkg/clustermesh/kvstoremesh"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/version"
+)
+
+var (
+	backendLockName = kvstore.BaseKeyPrefix + "/kvstoremesh-lock"
 )
 
 func NewCmd(h *hive.Hive) *cobra.Command {
@@ -43,4 +59,110 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 	rootCmd.AddCommand(h.Command())
 
 	return rootCmd
+}
+
+type params struct {
+	cell.In
+
+	// Client is the client targeting the local cluster
+	Client kvstore.Client
+
+	Metrics     kvstoremesh.Metrics
+	Shutdowner  hive.Shutdowner
+	Log         *slog.Logger
+	SyncState   syncstate.SyncState
+	JobGroup    job.Group
+	KVStoreMesh *kvstoremesh.KVStoreMesh
+	Health      cell.Health
+}
+
+func registerLeaderElectionHooks(lc cell.Lifecycle, llc *LeaderLifecycle, params params) {
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+
+	lc.Append(cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			wg.Add(1)
+			go func() {
+				runLeaderElection(ctx, llc, params)
+				wg.Done()
+			}()
+			return nil
+		},
+		OnStop: func(hctx cell.HookContext) error {
+			if err := llc.Stop(params.Log, hctx); err != nil {
+				return err
+			}
+			cancel()
+			wg.Wait()
+			return nil
+		},
+	})
+}
+
+func runLeaderElection(ctx context.Context, lc *LeaderLifecycle, params params) {
+
+	params.Client.RegisterLockLeaseExpiredObserver(backendLockName, func(string) {
+		params.Shutdowner.Shutdown(hive.ShutdownWithError(errors.New("Leader election lost")))
+	})
+
+	params.Metrics.LeaderElectionStatus.With(prometheus.Labels{metrics.LabelLeaderElectionName: "kvstoremesh"}).Set(float64(0))
+
+	// Try to win leader election with short timeout to verify if we can
+	// be immediately promoted as leader (e.g., we are the only replica).
+	// If the timeout expires, just signal readiness and try again
+	// with infinite timeout.
+	params.Log.Info("Acquiring leader election lock")
+	toCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+
+	lock, err := params.Client.LockPath(toCtx, backendLockName)
+	cancel()
+
+	if err != nil && errors.Is(err, kvstore.ErrEtcdTimeout) {
+		// signal readiness
+		params.SyncState.Stop()
+
+		// try again with infinite timeout
+		params.Log.Info("Reattempting to acquire leader election lock")
+		lock, err = params.Client.LockPath(ctx, backendLockName)
+	}
+
+	if err != nil {
+		params.Log.Error("Failed to acquire backend lock", logfields.Error, err)
+		// no need to shutdown here as it is triggered by etcd lock lease expired hook
+		return
+	}
+
+	defer func() {
+		params.Log.Info("Releasing leader election lock")
+
+		// unlock with timeout for case the etcd sidecar has already terminated
+		toCtx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		err = lock.Unlock(toCtx)
+		if err != nil {
+			params.Log.Error("Failed to release leader election lock", logfields.Error, err)
+		}
+	}()
+
+	params.Log.Info("Leader election lock acquired")
+	params.Metrics.LeaderElectionStatus.With(prometheus.Labels{metrics.LabelLeaderElectionName: "kvstoremesh"}).Set(float64(1))
+
+	kvstoremesh.RegisterSyncWaiter(kvstoremesh.SyncWaiterParams{
+		KVStoreMesh: params.KVStoreMesh,
+		SyncState:   params.SyncState,
+		Lifecycle:   lc,
+		JobGroup:    params.JobGroup,
+		Health:      params.Health,
+	})
+	params.SyncState.Stop()
+
+	err = lc.Start(params.Log, ctx)
+	if err != nil {
+		params.Log.Error("Failed to run KvStoreMesh", logfields.Error, err)
+		params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
+		return
+	}
+
+	<-ctx.Done()
 }

--- a/clustermesh-apiserver/syncstate/syncstate.go
+++ b/clustermesh-apiserver/syncstate/syncstate.go
@@ -31,14 +31,6 @@ func new(lc cell.Lifecycle, metrics Metrics, clusterInfo types.ClusterInfo) Sync
 		<-ss.WaitChannel()
 		metrics.BootstrapDuration.WithLabelValues(clusterInfo.Name).Set(syncTime.Seconds())
 	}()
-
-	lc.Append(cell.Hook{
-		OnStart: func(cell.HookContext) error {
-			ss.Stop()
-			return nil
-		},
-	})
-
 	return ss
 }
 

--- a/pkg/clustermesh/kvstoremesh/cell.go
+++ b/pkg/clustermesh/kvstoremesh/cell.go
@@ -23,4 +23,5 @@ var Cell = cell.Module(
 	cell.Config(common.DefaultConfig),
 
 	metrics.Metric(common.MetricsProvider("")),
+	metrics.Metric(MetricsProvider),
 )

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh.go
@@ -113,8 +113,6 @@ func newKVStoreMesh(lc cell.Lifecycle, params params) *KVStoreMesh {
 }
 
 type SyncWaiterParams struct {
-	cell.In
-
 	KVStoreMesh *KVStoreMesh
 	SyncState   syncstate.SyncState
 	Lifecycle   cell.Lifecycle

--- a/pkg/clustermesh/kvstoremesh/metrics.go
+++ b/pkg/clustermesh/kvstoremesh/metrics.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstoremesh
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type Metrics struct {
+	// LeaderElectionStatus indicates state of leader election
+	LeaderElectionStatus metric.Vec[metric.Gauge]
+}
+
+func MetricsProvider() Metrics {
+	return Metrics{
+		LeaderElectionStatus: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: "",
+			Name:      "leader_election_master_status",
+			Help:      "leader election status",
+		}, []string{metrics.LabelLeaderElectionName}),
+	}
+}

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -194,6 +194,11 @@ type BackendOperations interface {
 	// If the function is nil, the previous observer (if any) is unregistered.
 	RegisterLeaseExpiredObserver(prefix string, fn func(key string))
 
+	// RegisterLockLeaseExpiredObserver registers a function which is executed when
+	// the lease associated with a locked key having the given prefix is detected as expired.
+	// If the function is nil, the previous observer (if any) is unregistered.
+	RegisterLockLeaseExpiredObserver(prefix string, fn func(key string))
+
 	BackendOperationsUserMgmt
 }
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -614,11 +614,6 @@ func (e *etcdClient) newExpBackoffRateLimiter(name string) backoff.Exponential {
 }
 
 func (e *etcdClient) LockPath(ctx context.Context, path string) (locker KVLocker, err error) {
-	// Create the context first, so that the timeout also accounts for the time
-	// possibly required to acquire a new session (if not already established).
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
 	session, err := e.lockLeaseManager.GetSession(ctx, path)
 	if err != nil {
 		return nil, Hint(err)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -75,6 +75,8 @@ var ErrLockLeaseExpired = errors.New("transaction did not succeed: lock lease ex
 // aborted, and should not be logged as an error.
 var ErrOperationAbortedByInterceptor = errors.New("operation aborted")
 
+var ErrEtcdTimeout error = errors.New("etcd client timeout exceeded")
+
 type etcdModule struct {
 	opts backendOptions
 }
@@ -296,7 +298,7 @@ func etcdClientDebugLevel(logger *slog.Logger) zapcore.Level {
 // Hint tries to improve the error message displayed to te user.
 func Hint(err error) error {
 	if errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("etcd client timeout exceeded")
+		return ErrEtcdTimeout
 	}
 	return err
 }

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -128,7 +128,9 @@ func LockPath(ctx context.Context, logger *slog.Logger, backend BackendOperation
 		return nil, err
 	}
 
-	lock, err := backend.LockPath(ctx, path)
+	toCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	lock, err := backend.LockPath(toCtx, path)
 	if err != nil {
 		kvstoreLocks.unlock(path, id)
 		Trace(logger, "Failed to lock", fieldKey, path)

--- a/pkg/kvstore/memory.go
+++ b/pkg/kvstore/memory.go
@@ -205,6 +205,9 @@ func (c *inMemoryClient) LockPath(ctx context.Context, path string) (KVLocker, e
 func (c *inMemoryClient) RegisterLeaseExpiredObserver(prefix string, fn func(key string)) {
 }
 
+// RegisterLockLeaseExpiredObserver implements BackendOperations.
+func (c *inMemoryClient) RegisterLockLeaseExpiredObserver(prefix string, fn func(key string)) {}
+
 // Status implements BackendOperations.
 func (c *inMemoryClient) Status() *models.Status {
 	return &models.Status{}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -223,6 +223,9 @@ const (
 	// LabelTargetCluster is the label for target cluster name
 	LabelTargetCluster = "target_cluster"
 
+	// LabelLeaderElectionName is the name of leader election
+	LabelLeaderElectionName = "name"
+
 	// Rule label is a label for a L7 rule name.
 	LabelL7Rule = "rule"
 


### PR DESCRIPTION
Create per-cluster lock in destination etcd so that multiple instances of kvstoremesh can be used to sync data to a single etcd cluster. Every remote cluster can be synced by a single instance but each instance can sync different remote clusters.

Please ensure your pull request adheres to the following guidelines:

(https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

This PR implements local backend locking in kvstoremesh so that multiple instances can be run over a single etcd cluster. Local backend is locked on per-remote-cluster bases as kvstoremesh opens a new etcd connection for each remote cluster. This, in theory, opens ways to more creative approaches like having multiple instances of kvstoremesh syncing different set of clusters (aka sharding) but also opens questions with difficult answers - whether to drain removed cluster if there could possibly be another instance still syncing it.

This PR implements locking within remote cluster's reconnections logic just before retrieving remote configuration. The lock is locked with timeout, which, upon expiration, makes reconnection to fail and go around. It is assumed that the lock can't be lost without losing etcd connection and thus having to reconnect. This way, there is no need to implement shutdown of sync watchers.

There are also unsolved problems:
- status - status can't report that some particular cluster is waiting for lock. It just states that the cluster is ready with outdated numbers of synced resources. A new field could be added to the status indicating locking status, but it would require to change status data structures and I would rather get some commentery for the basic idea before going into this.
- metrics - metrics can indicate two states - cluster is ready or not and I think neither of them is correct for the situation when the cluster is waiting for lock. The `cilium_kvstoremesh_remote_cluster_readiness_status` metrics could be made more general by adding a new label `state` whose value could contain one of [`ready`, `disconnected`, `locked`] but this must be carefuly thought of so that potential upgrade won't trigger alerts for rules like `cilium_kvstoremesh_remote_cluster_readiness_status < 1`.
- removed cluster drainage - kvstoremesh implements cluster draining upon config file removal. The drainage must be done only when the config file was removed from the last instance of kvstoremesh HA setup but the instances are not aware of each other.

Please @giorio94, check my chages and comment. I feel I can't continue with the PR without consultation with kvstoremesh maintainers.

Fixes: #37127

```release-note
KVStoreMesh: add support for leader election, to allow running multiple replicas when Cilium operates in kvstore identity allocation mode.
```
