### PR TITLE
workflows: fix feature-summary-report

### DIFF
--- a/.github/workflows/feature-summary-report.yaml
+++ b/.github/workflows/feature-summary-report.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
-          image-tag: ${{ inputs.SHA || github.sha }}
+          ci-version: ${{ inputs.SHA || github.sha }}
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 


### PR DESCRIPTION
The cilium-ci GH action changed its behavior with 0.18.1. This caused cilium-cli to run inside a container which made it to lose the ability to use environment variables passed to the executions of cilium-cli command. In order to install cilium-cli and use it as a regular binary we need to define the ci-version input.