### PR TITLE
redirectpolicy: Add option to limit allowed addresses in AddressMatcher

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -311,6 +311,7 @@ cilium-agent [flags]
       --log-driver strings                                        Logging endpoints to use for example syslog
       --log-opt map                                               Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
       --log-system-load                                           Enable periodic logging of system load
+      --lrp-address-matcher-cidrs strings                         Limit address matches to specific CIDRs
       --max-connected-clusters uint32                             Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (beta) (default true)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -158,6 +158,7 @@ cilium-agent hive [flags]
       --kvstore-opt stringToString                                Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
       --l2-pod-announcements-interface-pattern string             Regex matching interfaces used for sending gratuitous arp messages
       --lb-state-file string                                      Synchronize load-balancing state from the specified file
+      --lrp-address-matcher-cidrs strings                         Limit address matches to specific CIDRs
       --max-connected-clusters uint32                             Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (beta) (default true)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -163,6 +163,7 @@ cilium-agent hive dot-graph [flags]
       --kvstore-opt stringToString                                Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
       --l2-pod-announcements-interface-pattern string             Regex matching interfaces used for sending gratuitous arp messages
       --lb-state-file string                                      Synchronize load-balancing state from the specified file
+      --lrp-address-matcher-cidrs strings                         Limit address matches to specific CIDRs
       --max-connected-clusters uint32                             Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (beta) (default true)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2732,8 +2732,16 @@
      - List of ports from service to be automatically redirected to above backend. Any service exposing one of these ports will be automatically redirected. Fine-grained control can be achieved by using the service annotation.
      - list
      - ``[]``
+   * - :spelling:ignore:`localRedirectPolicies.addressMatcherCIDRs`
+     - Limit the allowed addresses in Address Matcher rule of Local Redirect Policies to the given CIDRs. @schema@ type: [null, array] @schema@
+     - string
+     - ``nil``
+   * - :spelling:ignore:`localRedirectPolicies.enabled`
+     - Enable local redirect policies.
+     - bool
+     - ``false``
    * - :spelling:ignore:`localRedirectPolicy`
-     - Enable Local Redirect Policy.
+     - Enable Local Redirect Policy (deprecated, please use 'localRedirectPolicies.enabled' instead)
      - bool
      - ``false``
    * - :spelling:ignore:`logSystemLoad`

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -406,6 +406,8 @@ Helm Options
 * The ``l2NeighDiscovery.enabled`` option has been changed to default to ``false``.
 * The deprecated Helm option ``enableCiliumEndpointSlice`` has been removed. Set
   ``ciliumEndpointSlice.enabled`` instead to enable CiliumEndpointSlices.
+* ``localRedirectPolicy`` helm option has been deprecated. Set ``localRedirectPolicies.enabled`` instead.
+* The new ``localRedirectPolicies.addressMatcherCIDRs`` option can be used to limit what addresses are allowed in an address match of a CiliumLocalRedirectPolicy.
 
 Agent Options
 ~~~~~~~~~~~~~

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -79,6 +79,7 @@ Lund
 Lx
 Majkowski
 Marek
+Matcher
 Mbit
 Mediatek
 Mellanox
@@ -517,6 +518,7 @@ loadbalancer
 loadbalancers
 loadbalancing
 loadinfo
+localRedirectPolicies
 localhost
 lockdown
 lockless

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -733,7 +733,9 @@ contributors across the globe, there is almost always someone available to help.
 | loadBalancer.l7.algorithm | string | `"round_robin"` | Default LB algorithm The default LB algorithm to be used for services, which can be overridden by the service annotation (e.g. service.cilium.io/lb-l7-algorithm) Applicable values: round_robin, least_request, random |
 | loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. service.cilium.io/lb-l7, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration.  Applicable values:   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.   - disabled: Disable L7 load balancing by way of service annotation. |
 | loadBalancer.l7.ports | list | `[]` | List of ports from service to be automatically redirected to above backend. Any service exposing one of these ports will be automatically redirected. Fine-grained control can be achieved by using the service annotation. |
-| localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
+| localRedirectPolicies.addressMatcherCIDRs | string | `nil` | Limit the allowed addresses in Address Matcher rule of Local Redirect Policies to the given CIDRs. @schema@ type: [null, array] @schema@ |
+| localRedirectPolicies.enabled | bool | `false` | Enable local redirect policies. |
+| localRedirectPolicy | bool | `false` | Enable Local Redirect Policy (deprecated, please use 'localRedirectPolicies.enabled' instead) |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -727,8 +727,12 @@ data:
 {{- end }}
 {{- end }}
 
-{{- if hasKey .Values "localRedirectPolicy" }}
-  enable-local-redirect-policy: {{ .Values.localRedirectPolicy | quote }}
+{{ if or .Values.localRedirectPolicies.enabled .Values.localRedirectPolicy }}
+  enable-local-redirect-policy: "true"
+{{- end }}
+
+{{- if .Values.localRedirectPolicies.addressMatcherCIDRs }}
+  lrp-address-matcher-cidrs: {{ .Values.localRedirectPolicies.addressMatcherCIDRs | join "," | quote }}
 {{- end }}
 
 {{- if .Values.ipv4NativeRoutingCIDR }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4171,6 +4171,20 @@
       },
       "type": "object"
     },
+    "localRedirectPolicies": {
+      "properties": {
+        "addressMatcherCIDRs": {
+          "type": [
+            "null",
+            "array"
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "localRedirectPolicy": {
       "type": "boolean"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2112,8 +2112,17 @@ l2NeighDiscovery:
   enabled: false
 # -- Enable Layer 7 network policy.
 l7Proxy: true
-# -- Enable Local Redirect Policy.
+# -- Enable Local Redirect Policy (deprecated, please use 'localRedirectPolicies.enabled' instead)
 localRedirectPolicy: false
+localRedirectPolicies:
+  # -- Enable local redirect policies.
+  enabled: false
+  # -- Limit the allowed addresses in Address Matcher rule of
+  # Local Redirect Policies to the given CIDRs.
+  # @schema@
+  # type: [null, array]
+  # @schema@
+  addressMatcherCIDRs: ~
 # To include or exclude matched resources from cilium identity evaluation
 # labels: ""
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2125,8 +2125,21 @@ l2NeighDiscovery:
   enabled: false
 # -- Enable Layer 7 network policy.
 l7Proxy: true
-# -- Enable Local Redirect Policy.
+
+# -- Enable Local Redirect Policy (deprecated, please use 'localRedirectPolicies.enabled' instead)
 localRedirectPolicy: false
+
+localRedirectPolicies:
+  # -- Enable local redirect policies.
+  enabled: false
+  
+  # -- Limit the allowed addresses in Address Matcher rule of
+  # Local Redirect Policies to the given CIDRs.
+  # @schema@
+  # type: [null, array]
+  # @schema@
+  addressMatcherCIDRs: ~
+
 # To include or exclude matched resources from cilium identity evaluation
 # labels: ""
 

--- a/pkg/loadbalancer/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/redirectpolicy/cell.go
@@ -24,6 +24,8 @@ var Cell = cell.Module(
 	"local-redirect-policies",
 	"Controller for CiliumLocalRedirectPolicy",
 
+	cell.Config(DefaultConfig),
+
 	cell.Provide(
 		// Provide Table[*LocalRedirectPolicy]. Used from replaceAPI.
 		statedb.RWTable[*LocalRedirectPolicy].ToTable,

--- a/pkg/loadbalancer/redirectpolicy/config.go
+++ b/pkg/loadbalancer/redirectpolicy/config.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"net/netip"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	AddressMatcherCIDRsName = "lrp-address-matcher-cidrs"
+)
+
+type Config struct {
+	// AddressMatcherCIDRs limits which addresses can be used in a
+	// AddressMatcher rule to specific CIDRs. This allows global control over
+	// what addresses can be matched over the namespaced CiliumLocalRedirectPolicies.
+	AddressMatcherCIDRs []netip.Prefix `mapstructure:"lrp-address-matcher-cidrs"`
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.StringSlice(AddressMatcherCIDRsName, []string{}, "Limit address matches to specific CIDRs")
+}
+
+func (cfg Config) addressAllowed(addr netip.Addr) bool {
+	if len(cfg.AddressMatcherCIDRs) == 0 {
+		return true
+	}
+	for _, prefix := range cfg.AddressMatcherCIDRs {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+var DefaultConfig = Config{
+	AddressMatcherCIDRs: nil,
+}

--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -310,6 +310,9 @@ func (c *lrpController) processRedirectPolicy(wtxn writer.WriteTxn, lrpID k8s.Se
 					logfields.Error, err)
 			}
 		}
+	case lrpConfigTypeNone:
+		cleanup(wtxn)
+		return ws, func(writer.WriteTxn) {}
 	}
 
 	// For each matching pod create a backend and associate it with the LocalRedirect

--- a/pkg/loadbalancer/redirectpolicy/table.go
+++ b/pkg/loadbalancer/redirectpolicy/table.go
@@ -4,6 +4,9 @@
 package redirectpolicy
 
 import (
+	"iter"
+	"log/slog"
+
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
@@ -14,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -79,7 +83,7 @@ func newLRPListerWatcher(cs client.Clientset) lrpListerWatcher {
 	return k8sUtils.ListerWatcherFromTyped(cs.CiliumV2().CiliumLocalRedirectPolicies("" /* all namespaces */))
 }
 
-func registerLRPReflector(enabled lrpIsEnabled, db *statedb.DB, jg job.Group, lw lrpListerWatcher, lrps statedb.RWTable[*LocalRedirectPolicy]) {
+func registerLRPReflector(enabled lrpIsEnabled, cfg Config, db *statedb.DB, log *slog.Logger, jg job.Group, lw lrpListerWatcher, lrps statedb.RWTable[*LocalRedirectPolicy]) {
 	if !enabled || lw == nil {
 		return
 	}
@@ -90,13 +94,35 @@ func registerLRPReflector(enabled lrpIsEnabled, db *statedb.DB, jg job.Group, lw
 			Table:         lrps,
 			ListerWatcher: lw,
 			MetricScope:   "CiliumLocalRedirectPolicy",
-			Transform: func(_ statedb.ReadTxn, obj any) (*LocalRedirectPolicy, bool) {
-				clrp, ok := obj.(*ciliumv2.CiliumLocalRedirectPolicy)
-				if !ok {
-					return nil, false
+			TransformMany: func(_ statedb.ReadTxn, deleted bool, obj any) (toInsert, toDelete iter.Seq[*LocalRedirectPolicy]) {
+				clrp := obj.(*ciliumv2.CiliumLocalRedirectPolicy)
+				rp, err := parseLRP(cfg, log, clrp)
+				if err != nil {
+					log.Warn("Rejecting malformed CiliumLocalRedirectPolicy",
+						logfields.K8sNamespace, clrp.Namespace,
+						logfields.Name, clrp.Name,
+						logfields.Error, err)
+					toDelete = func(yield func(*LocalRedirectPolicy) bool) {
+						yield(&LocalRedirectPolicy{
+							ID: k8s.ServiceID{
+								Cluster:   "",
+								Name:      clrp.Name,
+								Namespace: clrp.Namespace,
+							},
+							UID: clrp.UID,
+						})
+					}
+				} else {
+					it := func(yield func(*LocalRedirectPolicy) bool) {
+						yield(rp)
+					}
+					if deleted {
+						toDelete = it
+					} else {
+						toInsert = it
+					}
 				}
-				rp, err := parseLRP(clrp, true)
-				return rp, err == nil
+				return
 			},
 		})
 }

--- a/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
@@ -1,3 +1,5 @@
+#! --lrp-address-matcher-cidrs=169.254.169.0/24,2001::/64
+
 hive start
 
 # Add a pod and an address-based redirection. Add IPv4 first then
@@ -21,17 +23,45 @@ db/cmp backends backends.table
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.actual maps.expected
 
-# Deleting the LRP cleans up the tables.
-k8s/delete lrp-addr.yaml lrp-addr-ipv6.yaml
+# Remove the IPv6 redirect
+k8s/delete lrp-addr-ipv6.yaml
+
+# Change the redirection to a non-allowed address.
+replace '169.254.169.254' '10.1.1.1' lrp-addr.yaml
+k8s/update lrp-addr.yaml
+
+# Entries and map should be empty
+# The entry should now have type none and maps should be empty
+db/show localredirectpolicies
+* db/empty localredirectpolicies
+* lb/maps-empty
+
+# Changing back to an allowed address reverts
+replace '10.1.1.1' '169.254.169.253' lrp-addr.yaml
+k8s/update lrp-addr.yaml
+db/cmp localredirectpolicies lrp-fixed.table
+
+# Check the BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-v4.expected
+
+# Remove the remaining policy
+k8s/delete lrp-addr.yaml
 
 # Tables and maps should now be empty.
 * db/empty services frontends backends localredirectpolicies
 * lb/maps-empty
 
+# ---
+
 -- lrp.table --
 Name               Type     FrontendType      Frontends
 test/lrp-addr      address  addr-single-port  169.254.169.254:8080/TCP
 test/lrp-addr-ipv6 address  addr-single-port  [2001::1]:8080/TCP
+
+-- lrp-fixed.table --
+Name               Type     FrontendType      Frontends
+test/lrp-addr      address  addr-single-port  169.254.169.253:8080/TCP
 
 -- services.table --
 Name                              Source
@@ -133,3 +163,8 @@ SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 
 SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=2 ADDR=[2001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=2 ADDR=[2001::1]:8080/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- maps-v4.expected --
+BE: ID=3 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=3 ADDR=169.254.169.253:8080
+SVC: ID=3 ADDR=169.254.169.253:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=169.254.169.253:8080/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect


### PR DESCRIPTION
This adds the `--lrp-address-matcher-cidrs` flag to limit which IP addresses can be used in an AddressMatcher. The corresponding helm option is `localRedirectPolicies.addressMatcherCIDRs`.

The `localRedirectPolicy` helm option is marked deprecated and `localRedirectPolicies.enabled` is introduced instead to unify LRP related configuration under one prefix.

If an LRP is created with an AddressMatcher containing a disallowed IP address then a log message is emitted ("Ignoring IP in AddressMatcher") and the LRP parses to an empty one with type "none" which will undo any prior reconciled configuration.

```release-note
LocalRedirectPolicy: Helm option 'localRedirectPolicy' is now deprecated and 'localRedirectPolicies.enabled' should be used instead. The new helm option localRedirectPolicies.addressMatcherCIDRs can be used to limit which addresses are allowed in an AddressMatcher.
```