### PR TITLE
feat(hubble): add optional CiliumNetworkPolicy for UI ↔ relay connect…

### DIFF
--- a/examples/hubble/hubble-network-policy.yaml
+++ b/examples/hubble/hubble-network-policy.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  egress:
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "4244"
+              protocol: TCP
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s-app: hubble-ui
+            k8s:io.kubernetes.pod.namespace: kube-system
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: hubble-relay
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "4244"
+              protocol: TCP
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "wildcard-from-endpoints"
+spec:
+  description: "Policy for ingress allow to kube-dns from all Cilium managed endpoints in the cluster"
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: kube-system
+      k8s-app: kube-dns
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP

--- a/examples/hubble/hubble-network-policy.yaml
+++ b/examples/hubble/hubble-network-policy.yaml
@@ -16,11 +16,27 @@ spec:
         - ports:
             - port: "4244"
               protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            "k8s:io.kubernetes.pod.namespace": kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
   ingress:
     - fromEndpoints:
         - matchLabels:
             k8s-app: hubble-ui
-            k8s:io.kubernetes.pod.namespace: kube-system
+            "k8s:io.kubernetes.pod.namespace": kube-system
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -35,28 +51,28 @@ spec:
     - toEndpoints:
         - matchLabels:
             k8s-app: hubble-relay
-            k8s:io.kubernetes.pod.namespace: kube-system
+            "k8s:io.kubernetes.pod.namespace": kube-system
       toPorts:
         - ports:
-            - port: "4244"
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            "k8s:io.kubernetes.pod.namespace": kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
               protocol: TCP
     - toEntities:
         - kube-apiserver
----
-apiVersion: "cilium.io/v2"
-kind: CiliumClusterwideNetworkPolicy
-metadata:
-  name: "wildcard-from-endpoints"
-spec:
-  description: "Policy for ingress allow to kube-dns from all Cilium managed endpoints in the cluster"
-  endpointSelector:
-    matchLabels:
-      k8s:io.kubernetes.pod.namespace: kube-system
-      k8s-app: kube-dns
   ingress:
-  - fromEndpoints:
-    - {}
-    toPorts:
-    - ports:
-      - port: "53"
-        protocol: UDP
+    - toPorts:
+        - ports:
+            - port: "8081"
+              protocol: TCP
+


### PR DESCRIPTION
Add optional CiliumNetworkPolicy to allow connectivity between hubble-ui and hubble-relay.

Fixes #35348

```release-note
Add example CiliumNetworkPolicy resources in `examples/hubble/hubble-network-policy.yaml` for Hubble component connectivity
```
