### PR TITLE
connectivity: Include detailed failure messages in test report

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -84,6 +84,9 @@ type Action struct {
 	// failed is true when Fail was called on the Action
 	failed bool
 
+	// failureMessage contains the reason why the action failed
+	failureMessage string
+
 	// Output from action if there is any
 	cmdOutput string
 
@@ -1059,7 +1062,7 @@ func (a *Action) validateMetric(ctx context.Context, node string, result Metrics
 		// Collect the new metrics.
 		newMetrics, err := a.collectPrometheusMetricsForNode(result.Source, node)
 		if err != nil {
-			a.Failf("failed to collect new metrics on node %s: %w", node, err)
+			a.Failf("failed to collect new metrics on node %s: %s\n", node, err)
 			return
 		}
 

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -539,7 +539,11 @@ func (ct *ConnectivityTest) report() error {
 			ct.Logf("Test [%s]:", t.Name())
 			for _, a := range t.failedActions() {
 				failedActions++
-				ct.Log("  ❌", a)
+				if a.failureMessage != "" {
+					ct.Logf("  🟥 %s: %s", a, a.failureMessage)
+				} else {
+					ct.Log("  ❌", a)
+				}
 				ct.LogOwners(a.Scenario())
 			}
 		}

--- a/cilium-cli/connectivity/check/logging.go
+++ b/cilium-cli/connectivity/check/logging.go
@@ -414,24 +414,28 @@ func (a *Action) Infof(format string, s ...any) {
 // Fail must be called when the Action is unsuccessful.
 func (a *Action) Fail(s ...any) {
 	a.fail()
+	a.failureMessage = fmt.Sprint(s...)
 	a.test.Fail(s...)
 }
 
 // Failf must be called when the Action is unsuccessful.
 func (a *Action) Failf(format string, s ...any) {
 	a.fail()
+	a.failureMessage = fmt.Sprintf(format, s...)
 	a.test.Failf(format, s...)
 }
 
 // Fatal must be called when an irrecoverable error was encountered during the Action.
 func (a *Action) Fatal(s ...any) {
 	a.fail()
+	a.failureMessage = fmt.Sprint(s...)
 	a.test.Fatal(s...)
 }
 
 // Fatalf must be called when an irrecoverable error was encountered during the Action.
 func (a *Action) Fatalf(format string, s ...any) {
 	a.fail()
+	a.failureMessage = fmt.Sprintf(format, s...)
 	a.test.Fatalf(format, s...)
 }
 


### PR DESCRIPTION
Include the reason why a test action failed (e.g., "Pod flow was interrupted") in the final connectivity test report. This makes it easier to diagnose test failures by showing error messages like "flow was interrupted (restart count does not match 0 != 1)" directly in the report summary, rather than requiring users to search through detailed test logs.

Example: https://github.com/cilium/cilium/actions/runs/15419346198/job/43390381268

**Before**
![image](https://github.com/user-attachments/assets/4b584096-169b-4216-a548-e38705190a90)

**After**
![image](https://github.com/user-attachments/assets/78c2adec-290d-4480-89f5-efa321a151d9)
