### PR TITLE
FQDN: preallocate identities for fqdn selectors

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -383,6 +383,7 @@ cilium-agent [flags]
       --tofqdns-max-deferred-connection-deletes int               Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
       --tofqdns-min-ttl int                                       The minimum time, in seconds, to use DNS data for toFQDNs policies
       --tofqdns-pre-cache string                                  DNS cache data at this path is preloaded on agent startup
+      --tofqdns-preallocate-identities                            Preallocate identities for ToFQDN selectors. This reduces proxied DNS response latency. Disable if you have many ToFQDN selectors. (default true)
       --tofqdns-proxy-port int                                    Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --tofqdns-proxy-response-max-delay duration                 The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
       --trace-payloadlen int                                      Length of payload to capture when tracing (default 128)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -207,6 +207,7 @@ cilium-agent hive [flags]
       --status-collector-probe-check-timeout duration             The timeout after which all probes should have finished at least once (default 5m0s)
       --status-collector-stackdump-path string                    The path where probe stackdumps should be written to (default "/run/cilium/state/agent.stack.gz")
       --status-collector-warning-threshold duration               The duration after which a probe is declared as stale (default 15s)
+      --tofqdns-preallocate-identities                            Preallocate identities for ToFQDN selectors. This reduces proxied DNS response latency. Disable if you have many ToFQDN selectors. (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -212,6 +212,7 @@ cilium-agent hive dot-graph [flags]
       --status-collector-probe-check-timeout duration             The timeout after which all probes should have finished at least once (default 5m0s)
       --status-collector-stackdump-path string                    The path where probe stackdumps should be written to (default "/run/cilium/state/agent.stack.gz")
       --status-collector-warning-threshold duration               The duration after which a probe is declared as stale (default 15s)
+      --tofqdns-preallocate-identities                            Preallocate identities for ToFQDN selectors. This reduces proxied DNS response latency. Disable if you have many ToFQDN selectors. (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1108,6 +1108,10 @@
      - The minimum time, in seconds, to use DNS data for toFQDNs policies. If the upstream DNS server returns a DNS record with a shorter TTL, Cilium overwrites the TTL with this value. Setting this value to zero means that Cilium will honor the TTLs returned by the upstream DNS server.
      - int
      - ``0``
+   * - :spelling:ignore:`dnsProxy.preAllocateIdentities`
+     - Pre-allocate ToFQDN identities. This reduces DNS proxy tail latency, at the potential cost of some unnecessary policymap entries. Disable this if you have a large (200+) number of unique ToFQDN selectors.
+     - bool
+     - ``true``
    * - :spelling:ignore:`dnsProxy.preCache`
      - DNS cache data at this path is preloaded on agent startup.
      - string

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -327,6 +327,7 @@ contributors across the globe, there is almost always someone available to help.
 | dnsProxy.idleConnectionGracePeriod | string | `"0s"` | Time during which idle but previously active connections with expired DNS lookups are still considered alive. |
 | dnsProxy.maxDeferredConnectionDeletes | int | `10000` | Maximum number of IPs to retain for expired DNS lookups with still-active connections. |
 | dnsProxy.minTtl | int | `0` | The minimum time, in seconds, to use DNS data for toFQDNs policies. If the upstream DNS server returns a DNS record with a shorter TTL, Cilium overwrites the TTL with this value. Setting this value to zero means that Cilium will honor the TTLs returned by the upstream DNS server. |
+| dnsProxy.preAllocateIdentities | bool | `true` | Pre-allocate ToFQDN identities. This reduces DNS proxy tail latency, at the potential cost of some unnecessary policymap entries. Disable this if you have a large (200+) number of unique ToFQDN selectors. |
 | dnsProxy.preCache | string | `""` | DNS cache data at this path is preloaded on agent startup. |
 | dnsProxy.proxyPort | int | `0` | Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port. |
 | dnsProxy.proxyResponseMaxDelay | string | `"100ms"` | The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1334,6 +1334,7 @@ data:
   {{- if .Values.dnsProxy.proxyResponseMaxDelay }}
   tofqdns-proxy-response-max-delay: {{ .Values.dnsProxy.proxyResponseMaxDelay | quote }}
   {{- end }}
+  tofqdns-preallocate-identities:  {{ .Values.dnsProxy.preAllocateIdentities | quote }}
 {{- end }}
 
 {{- if hasKey .Values "agentNotReadyTaintKey" }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1685,6 +1685,9 @@
         "minTtl": {
           "type": "integer"
         },
+        "preAllocateIdentities": {
+          "type": "boolean"
+        },
         "preCache": {
           "type": "string"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3769,6 +3769,9 @@ dnsProxy:
   proxyResponseMaxDelay: 100ms
   # -- DNS proxy operation mode (true/false, or unset to use version dependent defaults)
   # enableTransparentMode: true
+  # -- Pre-allocate ToFQDN identities. This reduces DNS proxy tail latency, at the potential cost of some
+  # unnecessary policymap entries. Disable this if you have a large (200+) number of unique ToFQDN selectors.
+  preAllocateIdentities: true
 # -- SCTP Configuration Values
 sctp:
   # -- Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3797,6 +3797,9 @@ dnsProxy:
   proxyResponseMaxDelay: 100ms
   # -- DNS proxy operation mode (true/false, or unset to use version dependent defaults)
   # enableTransparentMode: true
+  # -- Pre-allocate ToFQDN identities. This reduces DNS proxy tail latency, at the potential cost of some
+  # unnecessary policymap entries. Disable this if you have a large (200+) number of unique ToFQDN selectors.
+  preAllocateIdentities: true
 # -- SCTP Configuration Values
 sctp:
   # -- Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming.

--- a/pkg/fqdn/namemanager/preallocator.go
+++ b/pkg/fqdn/namemanager/preallocator.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package namemanager
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+// processSelectorChanges allocates and deallocates identities for selectors.
+//
+// This must be in a separate queue, as this involves updating policy maps
+// which may deadlock if the namemanager lock is held.
+// So, we allocate and deallocate asynchronously.
+//
+// The goal is to reduce tail latency of DNS responses. If a response comes in
+// for which an identity is already allocated, then we can write that new IP
+// to the ipcache but skip updating policy maps. This is much more efficient,
+// as updating policy maps involves synchronizing across all endpoints.
+//
+// Since we only allocate an identity per-fqdn-selector, as long as there are no
+// overlapping selectors, a given IP will not have to allocate an identity.
+func (n *manager) processSelectorChanges(ctx context.Context, change selectorChange) error {
+	if change.added {
+		lblss := labelsForSelector(n.params.Config.EnableIPv4, n.params.Config.EnableIPv6, change.sel)
+		ids := make([]identity.NumericIdentity, 0, len(lblss))
+		for _, lbls := range lblss {
+			id, _, err := n.params.Allocator.AllocateLocalIdentity(lbls, true, 0)
+			if err != nil {
+				n.logger.Error("failed to preallocate FQDN identity",
+					logfields.Error, err,
+					logfields.Labels, lbls)
+			} else {
+				n.logger.Debug("preallocated FQDN identity",
+					logfields.Identity, id)
+				ids = append(ids, id.ID)
+			}
+		}
+		n.selectorIDs[change.sel] = ids
+	} else {
+		nids := n.selectorIDs[change.sel]
+		delete(n.selectorIDs, change.sel)
+		if len(nids) == 0 { // did we, somehow, not allocate identities? Then don't release!
+			return nil
+		}
+
+		released, err := n.params.Allocator.ReleaseLocalIdentities(nids...)
+		if err != nil {
+			// this should not actually fail, given that the identities are local.
+			n.logger.Error("BUG: failed to release FQDN identities",
+				logfields.Error, err,
+				logfields.Identity, nids)
+		} else {
+			n.logger.Debug("released FQDN identity",
+				logfields.Identity, nids,
+				logfields.Released, released)
+		}
+	}
+
+	return nil
+}
+
+// labelsForSelector hard-codes what the typical set of labels for a prefix
+// that matches this selector will be.
+// This assumption is "protected" with a series of unit tests.
+func labelsForSelector(v4, v6 bool, sel api.FQDNSelector) []labels.Labels {
+	lbl := sel.IdentityLabel()
+	out := make([]labels.Labels, 0, 2)
+	if v4 && v6 {
+		l4 := labels.NewFrom(labels.LabelWorldIPv4)
+		l4[lbl.Key] = lbl
+		out = append(out, l4)
+
+		l6 := labels.NewFrom(labels.LabelWorldIPv6)
+		l6[lbl.Key] = lbl
+		out = append(out, l6)
+	} else {
+		lw := labels.NewFrom(labels.LabelWorld)
+		lw[lbl.Key] = lbl
+		out = append(out, lw)
+	}
+	return out
+}

--- a/pkg/fqdn/namemanager/preallocator_test.go
+++ b/pkg/fqdn/namemanager/preallocator_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package namemanager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+func TestLabelsForSelector(t *testing.T) {
+	selFoo := api.FQDNSelector{
+		MatchName: "foo.com",
+	}
+
+	require.Equal(t,
+		[]labels.Labels{testidentity.FQDNLabelsSingleStack},
+		labelsForSelector(true, false, selFoo),
+	)
+
+	require.Equal(t,
+		[]labels.Labels{testidentity.FQDNLabelsSingleStack},
+		labelsForSelector(false, true, selFoo),
+	)
+
+	require.Equal(t,
+		[]labels.Labels{
+			testidentity.FQDNLabelsV4,
+			testidentity.FQDNLabelsV6,
+		},
+		labelsForSelector(true, true, selFoo),
+	)
+}

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -667,6 +667,7 @@ func testCheckpointRestore(t *testing.T, testConfig testConfig) {
 	dir := t.TempDir()
 	mgr.checkpointPath = filepath.Join(dir, CheckpointFile)
 	mgr.EnableCheckpointing()
+	mgr.RestoreLocalIdentities()
 
 	for _, l := range []string{
 		"cidr:1.1.1.1/32;reserved:kube-apiserver",
@@ -697,6 +698,7 @@ func testCheckpointRestore(t *testing.T, testConfig testConfig) {
 	newMgr := NewCachingIdentityAllocator(logger, owner, NewTestAllocatorConfig())
 	defer newMgr.Close()
 	newMgr.checkpointPath = mgr.checkpointPath
+	newMgr.EnableCheckpointing()
 
 	restored, err := newMgr.RestoreLocalIdentities()
 	assert.NoError(t, err)

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -122,7 +122,10 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 
 		// Allocator: allocates local and cluster-wide security identities.
 		cacheIDAlloc := cache.NewCachingIdentityAllocator(params.Log, iao, allocatorConfig)
-		cacheIDAlloc.EnableCheckpointing()
+
+		if option.Config.RestoreState && !option.Config.DryMode {
+			cacheIDAlloc.EnableCheckpointing()
+		}
 
 		idAlloc = cacheIDAlloc
 	} else {

--- a/pkg/testutils/identity/const.go
+++ b/pkg/testutils/identity/const.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testidentity
+
+import "github.com/cilium/cilium/pkg/labels"
+
+// These constants are used in tests across two packages, to ensure that label calculation
+// for FQDN entries are consistent.
+var FQDNLabelsV4 = labels.NewLabelsFromSortedList("fqdn:foo.com;reserved:world-ipv4")
+var FQDNLabelsV6 = labels.NewLabelsFromSortedList("fqdn:foo.com;reserved:world-ipv6")
+var FQDNLabelsSingleStack = labels.NewLabelsFromSortedList("fqdn:foo.com;reserved:world")


### PR DESCRIPTION
Background: the ToFQDN policy feature works by assigning labels with source `fqdn:` to IP addresses as names are learned. For example, the IP address 1.1.1.1 may have the labels `(reserved:world, fqdn:one.one.one.one)`. (Note that IPs no longer have per-IP labels unless also selected by toCIDR policies.)

Before this change, identities were allocated when the first IP was discovered that matched a selector. Now, identities are allocated when ToFQDN policies are first created.
    
The goal is to reduce tail latency. Because allocating an identity requires a policy update, all endpoints must lock, apply incremental changes, and update envoy *before* the DNS packet can be returned to the requesting pod.
    
By pre-allocating identities, newly learned IPs require only an ipcache write, not a policymap and envoy update. This reduces DNS response latency.

```release-note
Reduces ToFQDN selector tail latency by pre-allocating selected identities. This slightly increases bpf policymap utilization.
```
