### PR TITLE
bpf: optimize map and program metrics collection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/cilium/charts v0.0.0-20250515220554-50a217da63ae
 	github.com/cilium/coverbee v0.3.3-0.20240723084546-664438750fce
 	github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
-	github.com/cilium/ebpf v0.18.1-0.20250521101936-dd4d949f2f7b
+	github.com/cilium/ebpf v0.18.1-0.20250603151700-df9ebe841740
 	github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c
 	github.com/cilium/fake v0.7.0
 	github.com/cilium/hive v0.0.0-20250523125409-7cbbf5e0d9f5

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62 h1:MOWY9eqnrr
 github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62/go.mod h1:9EU8oWNwEP6f98xJz/YjWw7yOLHK7p90MKmaPu1wBcE=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a h1:PRGN7B+72mj3OtLL2DM3F/9jp+ItgqgNS7mecgCmwsQ=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
-github.com/cilium/ebpf v0.18.1-0.20250521101936-dd4d949f2f7b h1:SUv4wmxx/A64oTZp2xVpHRSnQSGLtji696jzd3jP21c=
-github.com/cilium/ebpf v0.18.1-0.20250521101936-dd4d949f2f7b/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
+github.com/cilium/ebpf v0.18.1-0.20250603151700-df9ebe841740 h1:u9M4mYNNcKmtwvUARzv8WHkU82t/0RCpGPaM84hkpr0=
+github.com/cilium/ebpf v0.18.1-0.20250603151700-df9ebe841740/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba h1:Ddc5e+pz0/nY0XiAEW/UcIlvnaHACSuF77ePyMNX510=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba/go.mod h1:9MPoeojWVEBLFnioKXTvRoqGWTs9Dt252r1ACFsi8K8=
 github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c h1:+/SPdDam5Mha4QzOByEoBE7hfq8aUxnioItyKM48U6M=

--- a/pkg/metrics/bpf_test.go
+++ b/pkg/metrics/bpf_test.go
@@ -48,6 +48,7 @@ func TestGetBPFUsage(t *testing.T) {
 
 func BenchmarkGetBPFUsage(b *testing.B) {
 	testutils.PrivilegedTest(b)
+	b.ReportAllocs()
 
 	prefix := "_ciltest_"
 	for range 1000 {

--- a/vendor/github.com/cilium/ebpf/info.go
+++ b/vendor/github.com/cilium/ebpf/info.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/cilium/ebpf/asm"
@@ -58,6 +57,36 @@ type MapInfo struct {
 	mapExtra uint64
 	memlock  uint64
 	frozen   bool
+}
+
+// minimalMapInfoFromFd queries the minimum information needed to create a Map
+// based on a file descriptor. This requires the map type, key/value sizes,
+// maxentries and flags.
+//
+// Does not fall back to fdinfo since the version gap between fdinfo (4.10) and
+// [sys.ObjInfo] (4.13) is small and both kernels are EOL since at least Nov
+// 2017.
+//
+// Requires at least Linux 4.13.
+func minimalMapInfoFromFd(fd *sys.FD) (*MapInfo, error) {
+	var info sys.MapInfo
+	if err := sys.ObjInfo(fd, &info); err != nil {
+		return nil, fmt.Errorf("getting object info: %w", err)
+	}
+
+	typ, err := MapTypeForPlatform(platform.Native, info.Type)
+	if err != nil {
+		return nil, fmt.Errorf("map type: %w", err)
+	}
+
+	return &MapInfo{
+		Type:       typ,
+		KeySize:    info.KeySize,
+		ValueSize:  info.ValueSize,
+		MaxEntries: info.MaxEntries,
+		Flags:      uint32(info.MapFlags),
+		Name:       unix.ByteSliceToString(info.Name[:]),
+	}, nil
 }
 
 // newMapInfoFromFd queries map information about the given fd. [sys.ObjInfo] is
@@ -186,15 +215,41 @@ func (mi *MapInfo) Frozen() bool {
 	return mi.frozen
 }
 
-// programStats holds statistics of a program.
-type programStats struct {
-	// Total accumulated runtime of the program ins ns.
-	runtime time.Duration
-	// Total number of times the program was called.
-	runCount uint64
-	// Total number of times the programm was NOT called.
-	// Added in commit 9ed9e9ba2337 ("bpf: Count the number of times recursion was prevented").
-	recursionMisses uint64
+// ProgramStats contains runtime statistics for a single [Program], returned by
+// [Program.Stats].
+//
+// Will contain mostly zero values if the collection of statistics is not
+// enabled, see [EnableStats].
+type ProgramStats struct {
+	// Total accumulated runtime of the Program.
+	//
+	// Requires at least Linux 5.8.
+	Runtime time.Duration
+
+	// Total number of times the Program has executed.
+	//
+	// Requires at least Linux 5.8.
+	RunCount uint64
+
+	// Total number of times the program was not executed due to recursion. This
+	// can happen when another bpf program is already running on the cpu, when bpf
+	// program execution is interrupted, for example.
+	//
+	// Requires at least Linux 5.12.
+	RecursionMisses uint64
+}
+
+func newProgramStatsFromFd(fd *sys.FD) (*ProgramStats, error) {
+	var info sys.ProgInfo
+	if err := sys.ObjInfo(fd, &info); err != nil {
+		return nil, fmt.Errorf("getting program info: %w", err)
+	}
+
+	return &ProgramStats{
+		Runtime:         time.Duration(info.RunTimeNs),
+		RunCount:        info.RunCnt,
+		RecursionMisses: info.RecursionMisses,
+	}, nil
 }
 
 // programJitedInfo holds information about JITed info of a program.
@@ -231,7 +286,8 @@ type programJitedInfo struct {
 	numFuncLens uint32
 }
 
-// ProgramInfo describes a program.
+// ProgramInfo describes a Program's immutable metadata. For runtime statistics,
+// see [ProgramStats].
 type ProgramInfo struct {
 	Type ProgramType
 	id   ProgramID
@@ -243,7 +299,6 @@ type ProgramInfo struct {
 	createdByUID     uint32
 	haveCreatedByUID bool
 	btf              btf.ID
-	stats            *programStats
 	loadTime         time.Duration
 
 	maps                 []MapID
@@ -261,6 +316,37 @@ type ProgramInfo struct {
 	memlock uint64
 }
 
+// minimalProgramFromFd queries the minimum information needed to create a
+// Program based on a file descriptor, requiring at least the program type.
+//
+// Does not fall back to fdinfo since the version gap between fdinfo (4.10) and
+// [sys.ObjInfo] (4.13) is small and both kernels are EOL since at least Nov
+// 2017.
+//
+// Requires at least Linux 4.13.
+func minimalProgramInfoFromFd(fd *sys.FD) (*ProgramInfo, error) {
+	var info sys.ProgInfo
+	if err := sys.ObjInfo(fd, &info); err != nil {
+		return nil, fmt.Errorf("getting object info: %w", err)
+	}
+
+	typ, err := ProgramTypeForPlatform(platform.Native, info.Type)
+	if err != nil {
+		return nil, fmt.Errorf("program type: %w", err)
+	}
+
+	return &ProgramInfo{
+		Type: typ,
+		Name: unix.ByteSliceToString(info.Name[:]),
+	}, nil
+}
+
+// newProgramInfoFromFd queries program information about the given fd.
+//
+// [sys.ObjInfo] is attempted first, supplementing any missing values with
+// information from /proc/self/fdinfo. Ignores EINVAL from ObjInfo as well as
+// ErrNotSupported from reading fdinfo (indicating the file exists, but no
+// fields of interest were found). If both fail, an error is always returned.
 func newProgramInfoFromFd(fd *sys.FD) (*ProgramInfo, error) {
 	var info sys.ProgInfo
 	err1 := sys.ObjInfo(fd, &info)
@@ -276,16 +362,11 @@ func newProgramInfoFromFd(fd *sys.FD) (*ProgramInfo, error) {
 	}
 
 	pi := ProgramInfo{
-		Type: typ,
-		id:   ProgramID(info.Id),
-		Tag:  hex.EncodeToString(info.Tag[:]),
-		Name: unix.ByteSliceToString(info.Name[:]),
-		btf:  btf.ID(info.BtfId),
-		stats: &programStats{
-			runtime:         time.Duration(info.RunTimeNs),
-			runCount:        info.RunCnt,
-			recursionMisses: info.RecursionMisses,
-		},
+		Type:                 typ,
+		id:                   ProgramID(info.Id),
+		Tag:                  hex.EncodeToString(info.Tag[:]),
+		Name:                 unix.ByteSliceToString(info.Name[:]),
+		btf:                  btf.ID(info.BtfId),
 		jitedSize:            info.JitedProgLen,
 		loadTime:             time.Duration(info.LoadTime),
 		verifiedInstructions: info.VerifiedInsns,
@@ -452,38 +533,6 @@ func (pi *ProgramInfo) CreatedByUID() (uint32, bool) {
 // supports the field but the program was loaded without BTF information.)
 func (pi *ProgramInfo) BTFID() (btf.ID, bool) {
 	return pi.btf, pi.btf > 0
-}
-
-// RunCount returns the total number of times the program was called.
-//
-// Can return 0 if the collection of statistics is not enabled. See EnableStats().
-// The bool return value indicates whether this optional field is available.
-func (pi *ProgramInfo) RunCount() (uint64, bool) {
-	if pi.stats != nil {
-		return pi.stats.runCount, true
-	}
-	return 0, false
-}
-
-// Runtime returns the total accumulated runtime of the program.
-//
-// Can return 0 if the collection of statistics is not enabled. See EnableStats().
-// The bool return value indicates whether this optional field is available.
-func (pi *ProgramInfo) Runtime() (time.Duration, bool) {
-	if pi.stats != nil {
-		return pi.stats.runtime, true
-	}
-	return time.Duration(0), false
-}
-
-// RecursionMisses returns the total number of times the program was NOT called.
-// This can happen when another bpf program is already running on the cpu, which
-// is likely to happen for example when you interrupt bpf program execution.
-func (pi *ProgramInfo) RecursionMisses() (uint64, bool) {
-	if pi.stats != nil {
-		return pi.stats.recursionMisses, true
-	}
-	return 0, false
 }
 
 // btfSpec returns the BTF spec associated with the program.
@@ -784,25 +833,31 @@ func scanFdInfoReader(r io.Reader, fields map[string]interface{}) error {
 	var (
 		scanner = bufio.NewScanner(r)
 		scanned int
+		reader  bytes.Reader
 	)
 
 	for scanner.Scan() {
-		parts := strings.SplitN(scanner.Text(), "\t", 2)
-		if len(parts) != 2 {
+		key, rest, found := bytes.Cut(scanner.Bytes(), []byte(":"))
+		if !found {
+			// Line doesn't contain a colon, skip.
 			continue
 		}
-
-		name := strings.TrimSuffix(parts[0], ":")
-		field, ok := fields[string(name)]
+		field, ok := fields[string(key)]
 		if !ok {
 			continue
 		}
-
 		// If field already contains a non-zero value, don't overwrite it with fdinfo.
-		if zero(field) {
-			if n, err := fmt.Sscanln(parts[1], field); err != nil || n != 1 {
-				return fmt.Errorf("can't parse field %s: %v", name, err)
-			}
+		if !zero(field) {
+			scanned++
+			continue
+		}
+
+		// Cut the \t following the : as well as any potential trailing whitespace.
+		rest = bytes.TrimSpace(rest)
+
+		reader.Reset(rest)
+		if n, err := fmt.Fscan(&reader, field); err != nil || n != 1 {
+			return fmt.Errorf("can't parse field %s: %v", key, err)
 		}
 
 		scanned++
@@ -831,12 +886,16 @@ func zero(arg any) bool {
 	return v.IsZero()
 }
 
-// EnableStats starts the measuring of the runtime
-// and run counts of eBPF programs.
+// EnableStats starts collecting runtime statistics of eBPF programs, like the
+// amount of program executions and the cumulative runtime.
 //
-// Collecting statistics can have an impact on the performance.
+// Specify a BPF_STATS_* constant to select which statistics to collect, like
+// [unix.BPF_STATS_RUN_TIME]. Closing the returned [io.Closer] will stop
+// collecting statistics.
 //
-// Requires at least 5.8.
+// Collecting statistics may have a performance impact.
+//
+// Requires at least Linux 5.8.
 func EnableStats(which uint32) (io.Closer, error) {
 	fd, err := sys.EnableStats(&sys.EnableStatsAttr{
 		Type: which,

--- a/vendor/github.com/cilium/ebpf/internal/efw/object.go
+++ b/vendor/github.com/cilium/ebpf/internal/efw/object.go
@@ -87,3 +87,31 @@ func EbpfGetNextPinnedObjectPath(startPath string, objectType ObjectType) (strin
 	))
 	return windows.ByteSliceToString(tmp), objectType, err
 }
+
+/*
+Canonicalize a path using filesystem canonicalization rules.
+
+	_Must_inspect_result_ ebpf_result_t
+		ebpf_canonicalize_pin_path(_Out_writes_(output_size) char* output, size_t output_size, _In_z_ const char* input)
+*/
+var ebpfCanonicalizePinPath = newProc("ebpf_canonicalize_pin_path")
+
+func EbpfCanonicalizePinPath(input string) (string, error) {
+	addr, err := ebpfCanonicalizePinPath.Find()
+	if err != nil {
+		return "", err
+	}
+
+	inputBytes, err := windows.ByteSliceFromString(input)
+	if err != nil {
+		return "", err
+	}
+
+	output := make([]byte, _EBPF_MAX_PIN_PATH_LENGTH)
+	err = errorResult(syscall.SyscallN(addr,
+		uintptr(unsafe.Pointer(&output[0])),
+		uintptr(len(output)),
+		uintptr(unsafe.Pointer(&inputBytes[0])),
+	))
+	return windows.ByteSliceToString(output), err
+}

--- a/vendor/github.com/cilium/ebpf/internal/kallsyms/kallsyms.go
+++ b/vendor/github.com/cilium/ebpf/internal/kallsyms/kallsyms.go
@@ -1,13 +1,13 @@
 package kallsyms
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"slices"
 	"strconv"
-	"strings"
 
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/platform"
@@ -114,11 +114,11 @@ func assignModules(f io.Reader, symbols map[string]string) error {
 			continue
 		}
 
-		if _, requested := symbols[s.name]; !requested {
+		if _, requested := symbols[string(s.name)]; !requested {
 			continue
 		}
 
-		if _, ok := found[s.name]; ok {
+		if _, ok := found[string(s.name)]; ok {
 			// We've already seen this symbol. Return an error to avoid silently
 			// attaching to a symbol in the wrong module. libbpf also rejects
 			// referring to ambiguous symbols.
@@ -129,8 +129,8 @@ func assignModules(f io.Reader, symbols map[string]string) error {
 				s.name, s.addr, s.mod, errAmbiguousKsym)
 		}
 
-		symbols[s.name] = s.mod
-		found[s.name] = struct{}{}
+		symbols[string(s.name)] = string(s.mod)
+		found[string(s.name)] = struct{}{}
 	}
 	if err := r.Err(); err != nil {
 		return fmt.Errorf("reading kallsyms: %w", err)
@@ -230,7 +230,7 @@ func assignAddresses(f io.Reader, symbols map[string]uint64) error {
 			continue
 		}
 
-		existing, requested := symbols[s.name]
+		existing, requested := symbols[string(s.name)]
 		if existing != 0 {
 			// Multiple addresses for a symbol have been found. Return a friendly
 			// error to avoid silently attaching to the wrong symbol. libbpf also
@@ -238,7 +238,7 @@ func assignAddresses(f io.Reader, symbols map[string]uint64) error {
 			return fmt.Errorf("symbol %s(0x%x): duplicate found at address 0x%x: %w", s.name, existing, s.addr, errAmbiguousKsym)
 		}
 		if requested {
-			symbols[s.name] = s.addr
+			symbols[string(s.name)] = s.addr
 		}
 	}
 	if err := r.Err(); err != nil {
@@ -250,15 +250,18 @@ func assignAddresses(f io.Reader, symbols map[string]uint64) error {
 
 type ksym struct {
 	addr uint64
-	name string
-	mod  string
+	name []byte
+	mod  []byte
 }
 
 // parseSymbol parses a line from /proc/kallsyms into an address, type, name and
 // module. Skip will be true if the symbol doesn't match any of the given symbol
 // types. See `man 1 nm` for all available types.
 //
-// Example line: `ffffffffc1682010 T nf_nat_init  [nf_nat]`
+// Only yields symbols whose type is contained in types. An empty value for types
+// disables this filtering.
+//
+// Example line: `ffffffffc1682010 T nf_nat_init\t[nf_nat]`
 func parseSymbol(r *reader, types []rune) (s ksym, err error, skip bool) {
 	for i := 0; r.Word(); i++ {
 		switch i {
@@ -276,10 +279,10 @@ func parseSymbol(r *reader, types []rune) (s ksym, err error, skip bool) {
 			}
 		// Name of the symbol.
 		case 2:
-			s.name = r.Text()
+			s.name = r.Bytes()
 		// Kernel module the symbol is provided by.
 		case 3:
-			s.mod = strings.Trim(r.Text(), "[]")
+			s.mod = bytes.Trim(r.Bytes(), "[]")
 		// Ignore any future fields.
 		default:
 			return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/cilium/deepequal-gen/generators
 # github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
 ## explicit; go 1.18
 github.com/cilium/dns
-# github.com/cilium/ebpf v0.18.1-0.20250521101936-dd4d949f2f7b
+# github.com/cilium/ebpf v0.18.1-0.20250603151700-df9ebe841740
 ## explicit; go 1.23.0
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm


### PR DESCRIPTION
https://github.com/cilium/ebpf/pull/1791 optimized opening bpf objects and calling obj_info, since it was allocating quite heavily before.

This is the effect on the GetBPFUsage benchmark:

```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/metrics
cpu: AMD Ryzen 7 3700X 8-Core Processor
               │   old.txt    │              new.txt               │
               │    sec/op    │   sec/op     vs base               │
GetBPFUsage-16   145.43m ± 1%   77.51m ± 1%  -46.70% (p=0.002 n=6)

               │   old.txt    │               new.txt               │
               │     B/op     │     B/op      vs base               │
GetBPFUsage-16   50.38Mi ± 0%   24.24Mi ± 0%  -51.89% (p=0.002 n=6)

               │   old.txt    │              new.txt               │
               │  allocs/op   │  allocs/op   vs base               │
GetBPFUsage-16   358.11k ± 0%   82.67k ± 0%  -76.92% (p=0.002 n=6)
```

This should make the /metrics endpoint even more responsive and reduce the amount of garbage it creates.

@marseel 