### PR TITLE
daemon: Move KPR config options derivation into Cell

### DIFF
--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/gops"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/kvstore/heartbeat"
 	"github.com/cilium/cilium/pkg/pprof"
 )
@@ -47,6 +48,8 @@ var Cell = cell.Module(
 		}
 	}),
 	heartbeat.Cell,
+
+	kpr.Cell,
 
 	HealthAPIEndpointsCell,
 

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -48,6 +48,7 @@ import (
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/l2announcer"
 	loadbalancer_cell "github.com/cilium/cilium/pkg/loadbalancer/cell"
@@ -240,6 +241,9 @@ var (
 
 		// ServiceCache holds the list of known services correlated with the matching endpoints.
 		k8s.ServiceCacheCell,
+
+		// Provides KPROpts
+		kpr.Cell,
 
 		// Provides PolicyRepository (List of policy rules)
 		policy.Cell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -537,9 +537,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			return nil, nil, fmt.Errorf("unable to determine direct routing device. Use --%s to specify it",
 				option.DirectRoutingDevice)
 		}
-
-		d.logger.Warn("failed to detect devices, disabling BPF NodePort", logfields.Error, err)
-		disableNodePort()
 	} else {
 		drdName = directRoutingDevice.Name
 		d.logger.Info(

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -183,7 +183,7 @@ func (d *Daemon) initMaps() error {
 	}
 
 	ipv4Nat, ipv6Nat := nat.GlobalMaps(d.metricsRegistry, option.Config.EnableIPv4,
-		option.Config.EnableIPv6, option.Config.EnableNodePort)
+		option.Config.EnableIPv6, d.kprOpts.EnableNodePort)
 	if ipv4Nat != nil {
 		if err := ipv4Nat.Create(); err != nil {
 			return fmt.Errorf("initializing ipv4nat map: %w", err)
@@ -195,7 +195,7 @@ func (d *Daemon) initMaps() error {
 		}
 	}
 
-	if option.Config.EnableNodePort {
+	if d.kprOpts.EnableNodePort {
 		if err := neighborsmap.InitMaps(option.Config.EnableIPv4,
 			option.Config.EnableIPv6); err != nil {
 			return fmt.Errorf("initializing neighbors map: %w", err)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -230,7 +230,7 @@ func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer
 		if option.Config.EnableMKE {
 			if probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnGetCgroupClassid) != nil ||
 				probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnGetNetnsCookie) != nil {
-				logging.Fatal(logger, fmt.Sprintf("BPF kube-proxy replacement under MKE with --%s needs kernel 5.7 or newer", option.EnableMKE))
+				return fmt.Errorf("BPF kube-proxy replacement under MKE with --%s needs kernel 5.7 or newer", option.EnableMKE)
 			}
 		}
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -279,10 +279,6 @@ func finishKubeProxyReplacementInit(logger *slog.Logger, sysctl sysctl.Sysctl, d
 		return nil
 	}
 
-	if option.Config.DryMode {
-		return nil
-	}
-
 	// +-------------------------------------------------------+
 	// | After this point, BPF NodePort should not be disabled |
 	// +-------------------------------------------------------+

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -40,29 +41,29 @@ import (
 //
 // if this function cannot determine the strictness an error is returned and the boolean
 // is false. If an error is returned the boolean is of no meaning.
-func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, tunnelConfig tunnel.Config, lbConfig loadbalancer.Config) error {
-	if option.Config.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
-		option.Config.KubeProxyReplacement != option.KubeProxyReplacementFalse {
-		return fmt.Errorf("Invalid value for --%s: %s", option.KubeProxyReplacement, option.Config.KubeProxyReplacement)
+func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, tunnelConfig tunnel.Config, lbConfig loadbalancer.Config, kprOpts kpr.KPROpts) error {
+	if kprOpts.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
+		kprOpts.KubeProxyReplacement != option.KubeProxyReplacementFalse {
+		return fmt.Errorf("Invalid value for --%s: %s", option.KubeProxyReplacement, kprOpts.KubeProxyReplacement)
 	}
 
-	if option.Config.KubeProxyReplacement == option.KubeProxyReplacementTrue {
+	if kprOpts.KubeProxyReplacement == option.KubeProxyReplacementTrue {
 		logger.Info(fmt.Sprintf(
-			"Auto-enabling %q, %q, %q, %q, %q features",
-			option.EnableNodePort, option.EnableExternalIPs,
+			"Auto-enabling %q, %q, %q, %q features",
+			option.EnableExternalIPs,
 			option.EnableSocketLB, option.EnableHostPort,
 			option.EnableSessionAffinity,
 		),
 		)
 
 		option.Config.EnableHostPort = true
-		option.Config.EnableNodePort = true
+		//option.Config.EnableNodePort = true
 		option.Config.EnableExternalIPs = true
 		option.Config.EnableSocketLB = true
 		option.Config.EnableSessionAffinity = true
 	}
 
-	if !option.Config.EnableNodePort {
+	if !kprOpts.EnableNodePort {
 		// Disable features depending on NodePort
 		option.Config.EnableHostPort = false
 		option.Config.EnableExternalIPs = false
@@ -70,7 +71,7 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 		option.Config.EnableHostLegacyRouting = true
 	}
 
-	if option.Config.EnableNodePort {
+	if kprOpts.EnableNodePort {
 		if option.Config.LoadBalancerRSSv4CIDR != "" {
 			ip, cidr, err := net.ParseCIDR(option.Config.LoadBalancerRSSv4CIDR)
 			if ip.To4() == nil {
@@ -166,7 +167,8 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 		// InstallNoConntrackIptRules can only be enabled when Cilium is
 		// running in full KPR mode as otherwise conntrack would be
 		// required for NAT operations
-		if !option.Config.KubeProxyReplacementFullyEnabled() {
+		// TODO(brb) comment about session affinity
+		if !(option.Config.EnableHostPort && kprOpts.EnableNodePort && option.Config.EnableExternalIPs && option.Config.EnableSocketLB) {
 			return fmt.Errorf("%s requires the agent to run with %s=%s.",
 				option.InstallNoConntrackIptRules, option.KubeProxyReplacement, option.KubeProxyReplacementTrue)
 		}
@@ -189,13 +191,14 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 		return nil
 	}
 
-	return probeKubeProxyReplacementOptions(logger, lbConfig, sysctl)
+	return probeKubeProxyReplacementOptions(logger, lbConfig, kprOpts, sysctl)
 }
 
 // probeKubeProxyReplacementOptions checks whether the requested KPR options can be enabled with
 // the running kernel.
-func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer.Config, sysctl sysctl.Sysctl) error {
-	if option.Config.EnableNodePort {
+func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer.Config, kprOpts kpr.KPROpts, sysctl sysctl.Sysctl) error {
+
+	if kprOpts.EnableNodePort {
 		if probes.HaveProgramHelper(logger, ebpf.SchedCLS, asm.FnFibLookup) != nil {
 			return fmt.Errorf("BPF NodePort services needs kernel 4.17.0 or newer")
 		}
@@ -280,7 +283,7 @@ func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer
 
 // finishKubeProxyReplacementInit finishes initialization of kube-proxy
 // replacement after all devices are known.
-func finishKubeProxyReplacementInit(logger *slog.Logger, sysctl sysctl.Sysctl, devices []*tables.Device, directRoutingDevice string, lbConfig loadbalancer.Config) error {
+func finishKubeProxyReplacementInit(logger *slog.Logger, sysctl sysctl.Sysctl, devices []*tables.Device, directRoutingDevice string, lbConfig loadbalancer.Config, kprOpts kpr.KPROpts) error {
 	// For MKE, we only need to change/extend the socket LB behavior in case
 	// of kube-proxy replacement. Otherwise, nothing else is needed.
 	if option.Config.EnableMKE && option.Config.EnableSocketLB {
@@ -297,7 +300,7 @@ func finishKubeProxyReplacementInit(logger *slog.Logger, sysctl sysctl.Sysctl, d
 		case option.Config.IptablesMasqueradingEnabled():
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
 		// KPR=true is needed or we might rely on netfilter.
-		case option.Config.KubeProxyReplacement != option.KubeProxyReplacementTrue:
+		case kprOpts.KubeProxyReplacement != option.KubeProxyReplacementTrue:
 			msg = fmt.Sprintf("BPF host routing requires %s=%s.", option.KubeProxyReplacement, option.KubeProxyReplacementTrue)
 		}
 		if msg != "" {

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -238,7 +238,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableExternalIPs:       false,
 				enableSessionAffinity:   false,
 				enableIPSec:             false,
-				enableHostLegacyRouting: false,
+				enableHostLegacyRouting: true,
 				enableSocketLBTracing:   false,
 				expectedErrorRegex:      "",
 			},

--- a/daemon/healthz/kube_proxy_healthz.go
+++ b/daemon/healthz/kube_proxy_healthz.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer/legacy/service"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -55,6 +56,7 @@ type kubeProxyHealthParams struct {
 	Config          config
 	StatusCollector status.StatusCollector
 	ServiceManager  service.ServiceManager
+	KPROpts         kpr.KPROpts
 }
 
 type config struct {
@@ -69,7 +71,7 @@ func (r config) Flags(flags *pflag.FlagSet) {
 // status HTTP endpoint exposed on addr.
 // This endpoint reports the agent health status with the timestamp.
 func registerKubeProxyHealthzHTTPService(params kubeProxyHealthParams) error {
-	if params.Config.KubeProxyReplacementHealthzBindAddress == "" || params.AgentConfig.KubeProxyReplacement == option.KubeProxyReplacementFalse {
+	if params.Config.KubeProxyReplacementHealthzBindAddress == "" || params.KPROpts.KubeProxyReplacement == option.KubeProxyReplacementFalse {
 		return nil
 	}
 

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -272,14 +272,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
 	option.BindEnv(vp, option.KVstoreLeaseTTL)
 
-	flags.String(option.KubeProxyReplacement, "false", "Enable only selected features (will panic if any selected feature cannot be enabled) (\"false\"), or enable all features (will panic if any feature cannot be enabled) (\"true\") (default \"false\")")
-	flags.MarkHidden(option.KubeProxyReplacement)
-	option.BindEnv(vp, option.KubeProxyReplacement)
-
-	flags.Bool(option.EnableNodePort, false, "Enable NodePort type services by Cilium")
-	flags.MarkHidden(option.EnableNodePort)
-	option.BindEnv(vp, option.EnableNodePort)
-
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(vp, option.EnablePolicy)
 

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -272,6 +272,14 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
 	option.BindEnv(vp, option.KVstoreLeaseTTL)
 
+	flags.String(option.KubeProxyReplacement, "false", "Enable only selected features (will panic if an y selected feature cannot be enabled) (\"false\"), or enable all features (will panic if any feature cannot be enabled) (\"true\") (default \"false\")")
+	flags.MarkHidden(option.KubeProxyReplacement)
+	option.BindEnv(vp, option.KubeProxyReplacement)
+
+	flags.Bool(option.EnableNodePort, false, "Enable NodePort type services by Cilium")
+	flags.MarkHidden(option.EnableNodePort)
+	option.BindEnv(vp, option.EnableNodePort)
+
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(vp, option.EnablePolicy)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/apis"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/labelsfilter"
@@ -274,6 +275,8 @@ var (
 			// configuration to describe, in form of prometheus metrics, which
 			// features are enabled on the operator.
 			features.Cell,
+
+			kpr.Cell,
 		),
 	)
 
@@ -512,7 +515,7 @@ var legacyCell = cell.Module(
 	metrics.Metric(NewUnmanagedPodsMetric),
 )
 
-func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, resources operatorK8s.Resources, factory store.Factory, svcResolver *dial.ServiceResolver, cfgMCSAPI cmoperator.MCSAPIConfig, cfgClusterMeshPolicy cmtypes.PolicyConfig, metrics *UnmanagedPodsMetric, logger *slog.Logger) {
+func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, resources operatorK8s.Resources, factory store.Factory, svcResolver *dial.ServiceResolver, cfgMCSAPI cmoperator.MCSAPIConfig, cfgClusterMeshPolicy cmtypes.PolicyConfig, metrics *UnmanagedPodsMetric, logger *slog.Logger, kprOpts kpr.KPROpts) {
 	ctx, cancel := context.WithCancel(context.Background())
 	legacy := &legacyOnLeader{
 		ctx:                  ctx,
@@ -525,6 +528,7 @@ func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, re
 		cfgClusterMeshPolicy: cfgClusterMeshPolicy,
 		metrics:              metrics,
 		logger:               logger,
+		kprOpts:              kprOpts,
 	}
 	lc.Append(cell.Hook{
 		OnStart: legacy.onStart,
@@ -545,6 +549,8 @@ type legacyOnLeader struct {
 	metrics              *UnmanagedPodsMetric
 
 	logger *slog.Logger
+
+	kprOpts kpr.KPROpts
 }
 
 func (legacy *legacyOnLeader) onStop(_ cell.HookContext) error {
@@ -639,7 +645,7 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 				Endpoints:    legacy.resources.Endpoints,
 				StoreFactory: legacy.storeFactory,
 				SyncCallback: func(_ context.Context) {},
-			}, legacy.logger)
+			}, legacy.logger, legacy.kprOpts)
 			legacy.wg.Add(1)
 			go func() {
 				mcsapi.StartSynchronizingServiceExports(legacy.ctx, mcsapi.ServiceExportSyncParameters{

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -289,11 +289,6 @@ type OperatorConfig struct {
 	// IPAMAutoCreateCiliumPodIPPools contains pre-defined IP pools to be auto-created on startup.
 	IPAMAutoCreateCiliumPodIPPools map[string]string
 
-	// KubeProxyReplacement or NodePort are required to implement cluster
-	// Ingress (or equivalent Gateway API functionality)
-	KubeProxyReplacement string
-	EnableNodePort       bool
-
 	// AWS options
 
 	// ENITags are the tags that will be added to every ENI created by the AWS ENI IPAM
@@ -440,10 +435,6 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.IPAMAPIQPSLimit = vp.GetFloat64(IPAMAPIQPSLimit)
 	c.IPAMAPIBurst = vp.GetInt(IPAMAPIBurst)
 	c.ParallelAllocWorkers = vp.GetInt64(ParallelAllocWorkers)
-
-	// Gateways and Ingress
-	c.KubeProxyReplacement = vp.GetString(KubeProxyReplacement)
-	c.EnableNodePort = vp.GetBool(EnableNodePort)
 
 	// AWS options
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -289,6 +289,11 @@ type OperatorConfig struct {
 	// IPAMAutoCreateCiliumPodIPPools contains pre-defined IP pools to be auto-created on startup.
 	IPAMAutoCreateCiliumPodIPPools map[string]string
 
+	// KubeProxyReplacement or NodePort are required to implement cluster
+	// Ingress (or equivalent Gateway API functionality)
+	KubeProxyReplacement string
+	EnableNodePort       bool
+
 	// AWS options
 
 	// ENITags are the tags that will be added to every ENI created by the AWS ENI IPAM
@@ -435,6 +440,10 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.IPAMAPIQPSLimit = vp.GetFloat64(IPAMAPIQPSLimit)
 	c.IPAMAPIBurst = vp.GetInt(IPAMAPIBurst)
 	c.ParallelAllocWorkers = vp.GetInt64(ParallelAllocWorkers)
+
+	// Gateways and Ingress
+	c.KubeProxyReplacement = vp.GetString(KubeProxyReplacement)
+	c.EnableNodePort = vp.GetBool(EnableNodePort)
 
 	// AWS options
 

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -104,8 +103,6 @@ type gatewayAPIParams struct {
 	AgentConfig      *option.DaemonConfig
 	OperatorConfig   *operatorOption.OperatorConfig
 	GatewayApiConfig gatewayApiConfig
-
-	KPROpts kpr.KPROpts
 }
 
 func initGatewayAPIController(params gatewayAPIParams) error {
@@ -113,8 +110,8 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		return nil
 	}
 
-	if params.KPROpts.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
-		!params.KPROpts.EnableNodePort {
+	if params.OperatorConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
+		!params.OperatorConfig.EnableNodePort {
 		params.Logger.Warn("Gateway API support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil
 	}

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -103,6 +104,8 @@ type gatewayAPIParams struct {
 	AgentConfig      *option.DaemonConfig
 	OperatorConfig   *operatorOption.OperatorConfig
 	GatewayApiConfig gatewayApiConfig
+
+	KPROpts kpr.KPROpts
 }
 
 func initGatewayAPIController(params gatewayAPIParams) error {
@@ -110,8 +113,8 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		return nil
 	}
 
-	if params.OperatorConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
-		!params.OperatorConfig.EnableNodePort {
+	if params.KPROpts.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
+		!params.KPROpts.EnableNodePort {
 		params.Logger.Warn("Gateway API support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil
 	}

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	ingressTranslation "github.com/cilium/cilium/operator/pkg/model/translation/ingress"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
-	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -96,8 +95,6 @@ type ingressParams struct {
 	AgentConfig        *option.DaemonConfig
 	OperatorConfig     *operatorOption.OperatorConfig
 	IngressConfig      IngressConfig
-
-	KPROpts kpr.KPROpts
 }
 
 func registerReconciler(params ingressParams) error {
@@ -105,8 +102,8 @@ func registerReconciler(params ingressParams) error {
 		return nil
 	}
 
-	if params.KPROpts.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
-		!params.KPROpts.EnableNodePort {
+	if params.OperatorConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
+		!params.OperatorConfig.EnableNodePort {
 		params.Logger.Warn("Ingress Controller support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil
 	}

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	ingressTranslation "github.com/cilium/cilium/operator/pkg/model/translation/ingress"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -95,6 +96,8 @@ type ingressParams struct {
 	AgentConfig        *option.DaemonConfig
 	OperatorConfig     *operatorOption.OperatorConfig
 	IngressConfig      IngressConfig
+
+	KPROpts kpr.KPROpts
 }
 
 func registerReconciler(params ingressParams) error {
@@ -102,8 +105,8 @@ func registerReconciler(params ingressParams) error {
 		return nil
 	}
 
-	if params.OperatorConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
-		!params.OperatorConfig.EnableNodePort {
+	if params.KPROpts.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
+		!params.KPROpts.EnableNodePort {
 		params.Logger.Warn("Ingress Controller support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil
 	}

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -14,7 +14,6 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -94,8 +93,8 @@ type ServiceSyncParameters struct {
 // 'shared' specifies whether only shared services are synchronized. If 'false' then all services
 // will be synchronized. For clustermesh we only need to synchronize shared services, while for
 // VM support we need to sync all the services.
-func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, cfg ServiceSyncParameters, logger *slog.Logger, kprOpts kpr.KPROpts) {
-	k8sSvcCache := k8s.NewServiceCache(logger, loadbalancer.DefaultConfig, kprOpts, nil, nil, k8s.NewSVCMetricsNoop())
+func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, cfg ServiceSyncParameters, logger *slog.Logger, enableNodePort bool) {
+	k8sSvcCache := k8s.NewServiceCache(logger, loadbalancer.DefaultConfig, enableNodePort, nil, nil, k8s.NewSVCMetricsNoop())
 
 	kvstoreReady := make(chan struct{})
 

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -14,6 +14,7 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -93,8 +94,8 @@ type ServiceSyncParameters struct {
 // 'shared' specifies whether only shared services are synchronized. If 'false' then all services
 // will be synchronized. For clustermesh we only need to synchronize shared services, while for
 // VM support we need to sync all the services.
-func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, cfg ServiceSyncParameters, logger *slog.Logger) {
-	k8sSvcCache := k8s.NewServiceCache(logger, loadbalancer.DefaultConfig, nil, nil, k8s.NewSVCMetricsNoop())
+func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, cfg ServiceSyncParameters, logger *slog.Logger, kprOpts kpr.KPROpts) {
+	k8sSvcCache := k8s.NewServiceCache(logger, loadbalancer.DefaultConfig, kprOpts, nil, nil, k8s.NewSVCMetricsNoop())
 
 	kvstoreReady := make(chan struct{})
 

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbcell "github.com/cilium/cilium/pkg/loadbalancer/cell"
 	"github.com/cilium/cilium/pkg/lock"
@@ -87,12 +88,16 @@ func TestScript(t *testing.T) {
 				source.NewSources,
 				func() *option.DaemonConfig {
 					return &option.DaemonConfig{
-						EnableIPv4:           true,
-						EnableIPv6:           true,
-						EnableNodePort:       true,
-						EnableL7Proxy:        true,
-						EnableEnvoyConfig:    true,
+						EnableIPv4:        true,
+						EnableIPv6:        true,
+						EnableL7Proxy:     true,
+						EnableEnvoyConfig: true,
+					}
+				},
+				func() kpr.KPROpts {
+					return kpr.KPROpts{
 						KubeProxyReplacement: option.KubeProxyReplacementTrue,
+						EnableNodePort:       true,
 					}
 				},
 				func() *loadbalancer.TestConfig {

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -108,8 +109,12 @@ func TestScript(t *testing.T) {
 				func() *option.DaemonConfig {
 					// The LB control-plane still derives its configuration from DaemonConfig.
 					return &option.DaemonConfig{
-						EnableIPv4:           true,
-						EnableIPv6:           true,
+						EnableIPv4: true,
+						EnableIPv6: true,
+					}
+				},
+				func() kpr.KPROpts {
+					return kpr.KPROpts{
 						EnableNodePort:       true,
 						KubeProxyReplacement: option.KubeProxyReplacementTrue,
 					}

--- a/pkg/datapath/linux/config/cell.go
+++ b/pkg/datapath/linux/config/cell.go
@@ -11,6 +11,7 @@ import (
 	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
@@ -25,6 +26,7 @@ type WriterParams struct {
 	NodeExtraDefines   []dpdef.Map `group:"header-node-defines"`
 	NodeExtraDefineFns []dpdef.Fn  `group:"header-node-define-fns"`
 	Sysctl             sysctl.Sysctl
+	KPROpts            kpr.KPROpts
 }
 
 var Cell = cell.Module(

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/idpool"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
@@ -91,6 +92,8 @@ type linuxNodeHandler struct {
 
 	enableEncapsulation func(node *nodeTypes.Node) bool
 	nodeNeighborQueue   datapath.NodeNeighborEnqueuer
+
+	kprOpts kpr.KPROpts
 }
 
 var (
@@ -107,13 +110,14 @@ func NewNodeHandler(
 	tunnelConfig dpTunnel.Config,
 	nodeMap nodemap.MapV2,
 	nodeManager manager.NodeManager,
+	kprOpts kpr.KPROpts,
 ) (datapath.NodeHandler, datapath.NodeIDHandler, datapath.NodeNeighbors) {
 	datapathConfig := DatapathConfiguration{
 		HostDevice:   defaults.HostDevice,
 		TunnelDevice: tunnelConfig.DeviceName(),
 	}
 
-	handler := newNodeHandler(log, datapathConfig, nodeMap, nodeManager)
+	handler := newNodeHandler(log, datapathConfig, nodeMap, nodeManager, kprOpts)
 
 	nodeManager.Subscribe(handler)
 
@@ -134,6 +138,7 @@ func newNodeHandler(
 	datapathConfig DatapathConfiguration,
 	nodeMap nodemap.MapV2,
 	nbq datapath.NodeNeighborEnqueuer,
+	kprOpts kpr.KPROpts,
 ) *linuxNodeHandler {
 	return &linuxNodeHandler{
 		log:                    log,
@@ -152,6 +157,7 @@ func newNodeHandler(
 		ipsecMetricCollector:   ipsec.NewXFRMCollector(log),
 		nodeNeighborQueue:      nbq,
 		ipsecUpdateNeeded:      map[nodeTypes.Identity]bool{},
+		kprOpts:                kprOpts,
 	}
 }
 
@@ -1115,7 +1121,7 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		switch {
 		case !option.Config.EnableL2NeighDiscovery:
 			n.enableNeighDiscovery = false
-		case option.Config.DirectRoutingDeviceRequired():
+		case option.Config.DirectRoutingDeviceRequired(n.kprOpts):
 			if newConfig.DirectRoutingDevice == nil {
 				return fmt.Errorf("direct routing device is required, but not defined")
 			}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -184,7 +184,7 @@ func (l *loader) reinitializeIPSec(lnc *datapath.LocalNodeConfiguration) error {
 	// the code below, specific to EncryptInterface. Specifically, we will load
 	// bpf_host code in reloadHostDatapath onto the physical devices as selected
 	// by configuration.
-	if !option.Config.EnableIPSec || option.Config.AreDevicesRequired() {
+	if !option.Config.EnableIPSec || option.Config.AreDevicesRequired(l.kprOpts) {
 		return nil
 	}
 
@@ -470,7 +470,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfig
 		if err := compileWithOptions(ctx, l.logger, "bpf_sock.c", "bpf_sock.o", nil); err != nil {
 			logging.Fatal(l.logger, "failed to compile bpf_sock.c", logfields.Error, err)
 		}
-		if err := socketlb.Enable(l.logger, l.sysctl); err != nil {
+		if err := socketlb.Enable(l.logger, l.sysctl, l.kprOpts); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -16,6 +16,7 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/datapath/xdp"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/mtu"
@@ -48,6 +49,7 @@ func newLocalNodeConfig(
 	masqInterface string,
 	xdpConfig xdp.Config,
 	lbConfig loadbalancer.Config,
+	kprOpts kpr.KPROpts,
 	maglevConfig maglev.Config,
 	mtuTbl statedb.Table[mtu.RouteMTU],
 ) (datapath.LocalNodeConfiguration, <-chan struct{}, error) {
@@ -108,6 +110,7 @@ func newLocalNodeConfig(
 		IPv6PodSubnets:               cidr.NewCIDRSlice(config.IPv6PodSubnets),
 		XDPConfig:                    xdpConfig,
 		LBConfig:                     lbConfig,
+		KPROpts:                      kprOpts,
 		MaglevConfig:                 maglevConfig,
 	}, common.MergeChannels(devsWatch, addrsWatch, directRoutingDevWatch, mtuWatch), nil
 }

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/xdp"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
@@ -106,6 +107,7 @@ type orchestratorParams struct {
 	ConfigPromise       promise.Promise[*option.DaemonConfig]
 	XDPConfig           xdp.Config
 	LBConfig            loadbalancer.Config
+	KPROpts             kpr.KPROpts
 	MaglevConfig        maglev.Config
 }
 
@@ -203,6 +205,7 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 			o.params.Config.DeriveMasqIPAddrFromDevice,
 			o.params.XDPConfig,
 			o.params.LBConfig,
+			o.params.KPROpts,
 			o.params.MaglevConfig,
 			o.params.MTU,
 		)

--- a/pkg/datapath/tunnel/cell.go
+++ b/pkg/datapath/tunnel/cell.go
@@ -6,6 +6,7 @@ package tunnel
 import (
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -31,10 +32,10 @@ var Cell = cell.Module(
 
 		// Enable tunnel configuration when DSR Geneve is enabled (this is currently
 		// handled here, as the corresponding logic has not yet been modularized).
-		func(dcfg *option.DaemonConfig, lbcfg loadbalancer.Config) EnablerOut {
+		func(kpr kpr.KPROpts, lbcfg loadbalancer.Config) EnablerOut {
 			return NewEnabler(
-				(dcfg.EnableNodePort ||
-					dcfg.KubeProxyReplacement == option.KubeProxyReplacementTrue) &&
+				(kpr.EnableNodePort ||
+					kpr.KubeProxyReplacement == option.KubeProxyReplacementTrue) &&
 					lbcfg.LoadBalancerUsesDSR() &&
 					lbcfg.DSRDispatch == loadbalancer.DSRDispatchGeneve,
 				// The datapath logic takes care of the MTU overhead. So no need to

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/xdp"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/maglev"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -191,6 +192,8 @@ type LocalNodeConfiguration struct {
 	// Maglev configuration provides the maglev table sizes and seeds for
 	// the BPF programs.
 	MaglevConfig maglev.Config
+
+	KPROpts kpr.KPROpts
 }
 
 func (cfg *LocalNodeConfiguration) DeviceNames() []string {

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -23,7 +23,6 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	"github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -152,7 +151,7 @@ func ParseServiceID(svc *slim_corev1.Service) ServiceID {
 }
 
 // ParseService parses a Kubernetes service and returns a Service.
-func ParseService(logger *slog.Logger, cfg loadbalancer.Config, kprOpts kpr.KPROpts, svc *slim_corev1.Service, nodePortAddrs []netip.Addr) (ServiceID, *Service) {
+func ParseService(logger *slog.Logger, cfg loadbalancer.Config, enableNodePort bool, svc *slim_corev1.Service, nodePortAddrs []netip.Addr) (ServiceID, *Service) {
 	scopedLog := logger.With(
 		logfields.K8sSvcName, svc.ObjectMeta.Name,
 		logfields.K8sNamespace, svc.ObjectMeta.Namespace,
@@ -193,7 +192,7 @@ func ParseService(logger *slog.Logger, cfg loadbalancer.Config, kprOpts kpr.KPRO
 		return ServiceID{}, nil
 	}
 
-	if svc.Spec.ClusterIP == "" && (!kprOpts.EnableNodePort || len(svc.Spec.ExternalIPs) == 0) {
+	if svc.Spec.ClusterIP == "" && (!enableNodePort || len(svc.Spec.ExternalIPs) == 0) {
 		return ServiceID{}, nil
 	}
 
@@ -250,7 +249,7 @@ func ParseService(logger *slog.Logger, cfg loadbalancer.Config, kprOpts kpr.KPRO
 	svcInfo := NewService(clusterIPs, svc.Spec.ExternalIPs, loadBalancerIPs,
 		lbSrcRanges, headless, extTrafficPolicy, intTrafficPolicy,
 		uint16(svc.Spec.HealthCheckNodePort), svc.Annotations, svc.Labels, svc.Spec.Selector,
-		svc.GetNamespace(), svcType, kprOpts)
+		svc.GetNamespace(), svcType, enableNodePort)
 
 	svcInfo.SourceRangesPolicy = getAnnotationServiceSourceRangesPolicy(svc)
 	svcInfo.ProxyDelegation = getAnnotationServiceProxyDelegation(svc)
@@ -331,7 +330,7 @@ func ParseService(logger *slog.Logger, cfg loadbalancer.Config, kprOpts kpr.KPRO
 		if expType.CanExpose(slim_corev1.ServiceTypeNodePort) &&
 			(svc.Spec.Type == slim_corev1.ServiceTypeNodePort || svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer) {
 
-			if kprOpts.EnableNodePort {
+			if enableNodePort {
 				proto := loadbalancer.L4Type(port.Protocol)
 				port := uint16(port.NodePort)
 				// This can happen if the service type is NodePort/LoadBalancer but the upstream apiserver
@@ -611,7 +610,7 @@ func NewService(ips []net.IP, externalIPs, loadBalancerIPs, loadBalancerSourceRa
 	headless bool, extTrafficPolicy, intTrafficPolicy loadbalancer.SVCTrafficPolicy,
 	healthCheckNodePort uint16, annotations, labels, selector map[string]string,
 	namespace string, svcType loadbalancer.SVCType,
-	kprOpts kpr.KPROpts,
+	enableNodePort bool,
 ) *Service {
 	var (
 		k8sExternalIPs     map[string]net.IP
@@ -630,7 +629,7 @@ func NewService(ips []net.IP, externalIPs, loadBalancerIPs, loadBalancerSourceRa
 	// By omitting these IPs in the returned Service object, they
 	// are no longer considered in equality checks and thus save
 	// CPU cycles processing events Cilium will not act upon.
-	if kprOpts.EnableNodePort {
+	if enableNodePort {
 		k8sExternalIPs = parseIPs(externalIPs)
 		k8sLoadBalancerIPs = parseIPs(loadBalancerIPs)
 	}

--- a/pkg/kpr/kpr.go
+++ b/pkg/kpr/kpr.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kpr
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+)
+
+var Cell = cell.Module(
+	"kube-proxy-replacement",
+	"Provides KPR config",
+
+	cell.Config(defaultConfig),
+	cell.Provide(NewKPROpts),
+)
+
+type KPRConfig struct {
+	KubeProxyReplacement string
+	EnableNodePort       bool
+}
+
+var defaultConfig = KPRConfig{
+	KubeProxyReplacement: "false",
+	EnableNodePort:       false,
+}
+
+func (def KPRConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("enable-node-port", def.EnableNodePort, "Enable NodePort type services by Cilium")
+	flags.MarkDeprecated("enable-node-port", "The flag will be removed in v1.19. The feature will be unconditionally enabled by enabling kube-proxy-replacement")
+
+	flags.String("kube-proxy-replacement", def.KubeProxyReplacement, "Enable kube-proxy replacement")
+}
+
+type KPROpts struct {
+	KubeProxyReplacement string
+	EnableNodePort       bool
+}
+
+func NewKPROpts(cfg KPRConfig) KPROpts {
+	opts := KPROpts{
+		KubeProxyReplacement: cfg.KubeProxyReplacement,
+		EnableNodePort:       cfg.EnableNodePort,
+	}
+
+	if cfg.KubeProxyReplacement == "true" {
+		opts.EnableNodePort = true
+	}
+
+	return opts
+}

--- a/pkg/loadbalancer/cell/cell_test.go
+++ b/pkg/loadbalancer/cell/cell_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
@@ -33,6 +34,7 @@ func TestCell(t *testing.T) {
 		maglev.Cell,
 		node.LocalNodeStoreCell,
 		metrics.Cell,
+		kpr.Cell,
 		Cell,
 		cell.Provide(source.NewSources),
 		cell.Provide(

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -501,12 +502,12 @@ type ExternalConfig struct {
 }
 
 // NewExternalConfig maps the daemon config to [ExternalConfig].
-func NewExternalConfig(cfg *option.DaemonConfig) ExternalConfig {
+func NewExternalConfig(cfg *option.DaemonConfig, kprOpts kpr.KPROpts) ExternalConfig {
 	return ExternalConfig{
 		ZoneMapper:                             cfg,
 		EnableIPv4:                             cfg.EnableIPv4,
 		EnableIPv6:                             cfg.EnableIPv6,
-		KubeProxyReplacement:                   cfg.KubeProxyReplacement == option.KubeProxyReplacementTrue || cfg.EnableNodePort,
+		KubeProxyReplacement:                   kprOpts.KubeProxyReplacement == option.KubeProxyReplacementTrue || kprOpts.EnableNodePort,
 		BPFSocketLBHostnsOnly:                  cfg.BPFSocketLBHostnsOnly,
 		EnableSocketLB:                         cfg.EnableSocketLB,
 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbcell "github.com/cilium/cilium/pkg/loadbalancer/cell"
 	"github.com/cilium/cilium/pkg/loadbalancer/healthserver"
@@ -89,8 +90,12 @@ func TestScript(t *testing.T) {
 					source.NewSources,
 					func(cfg loadbalancer.TestConfig) *option.DaemonConfig {
 						return &option.DaemonConfig{
-							EnableIPv4:           true,
-							EnableIPv6:           true,
+							EnableIPv4: true,
+							EnableIPv6: true,
+						}
+					},
+					func() kpr.KPROpts {
+						return kpr.KPROpts{
 							KubeProxyReplacement: option.KubeProxyReplacementTrue,
 							EnableNodePort:       true,
 						}

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -24,6 +24,7 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/sockets"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbmaps "github.com/cilium/cilium/pkg/loadbalancer/maps"
 	"github.com/cilium/cilium/pkg/maglev"
@@ -84,6 +85,12 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 					EnableSocketLBPodConnectionTermination: true,
 					EnableIPv4:                             true,
 					EnableIPv6:                             true,
+				}
+			},
+			func() kpr.KPROpts {
+				return kpr.KPROpts{
+					KubeProxyReplacement: "true",
+					EnableNodePort:       true,
 				}
 			},
 			func() netnsOps {

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbcell "github.com/cilium/cilium/pkg/loadbalancer/cell"
 	"github.com/cilium/cilium/pkg/loadbalancer/legacy/lbmap"
@@ -84,9 +85,13 @@ func TestScript(t *testing.T) {
 						return &option.DaemonConfig{
 							EnableIPv4:                true,
 							EnableIPv6:                true,
-							EnableNodePort:            true,
 							EnableLocalRedirectPolicy: true,
-							KubeProxyReplacement:      option.KubeProxyReplacementTrue,
+						}
+					},
+					func() kpr.KPROpts {
+						return kpr.KPROpts{
+							EnableNodePort:       true,
+							KubeProxyReplacement: option.KubeProxyReplacementTrue,
 						}
 					},
 					func() redirectpolicy.TestSkipLBMap {

--- a/pkg/loadbalancer/repl/main.go
+++ b/pkg/loadbalancer/repl/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbcell "github.com/cilium/cilium/pkg/loadbalancer/cell"
 	"github.com/cilium/cilium/pkg/maglev"
@@ -84,8 +85,12 @@ func main() {
 			statedb.RWTable[tables.NodeAddress].ToTable,
 			func() *option.DaemonConfig {
 				return &option.DaemonConfig{
-					EnableIPv4:           true,
-					EnableIPv6:           true,
+					EnableIPv4: true,
+					EnableIPv6: true,
+				}
+			},
+			func() kpr.KPROpts {
+				return kpr.KPROpts{
 					KubeProxyReplacement: option.KubeProxyReplacementTrue,
 				}
 			},

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbcell "github.com/cilium/cilium/pkg/loadbalancer/cell"
 	lbreconciler "github.com/cilium/cilium/pkg/loadbalancer/reconciler"
@@ -94,8 +95,12 @@ func TestScript(t *testing.T) {
 					source.NewSources,
 					func(cfg loadbalancer.TestConfig) *option.DaemonConfig {
 						return &option.DaemonConfig{
-							EnableIPv4:           true,
-							EnableIPv6:           true,
+							EnableIPv4: true,
+							EnableIPv6: true,
+						}
+					},
+					func() kpr.KPROpts {
+						return kpr.KPROpts{
 							KubeProxyReplacement: option.KubeProxyReplacementTrue,
 							EnableNodePort:       true,
 						}

--- a/pkg/maps/nat/cell.go
+++ b/pkg/maps/nat/cell.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
@@ -28,7 +29,7 @@ var MapDisabled = fmt.Errorf("nat map is disabled")
 var Cell = cell.Module(
 	"nat-maps",
 	"NAT Maps",
-	cell.Provide(func(lc cell.Lifecycle, registry *metrics.Registry, cfgPromise promise.Promise[*option.DaemonConfig]) (promise.Promise[NatMap4], promise.Promise[NatMap6]) {
+	cell.Provide(func(lc cell.Lifecycle, registry *metrics.Registry, cfgPromise promise.Promise[*option.DaemonConfig], kprOpts kpr.KPROpts) (promise.Promise[NatMap4], promise.Promise[NatMap6]) {
 		var ipv4Nat, ipv6Nat *Map
 		res4, promise4 := promise.New[NatMap4]()
 		res6, promise6 := promise.New[NatMap6]()
@@ -41,7 +42,7 @@ var Cell = cell.Module(
 				if err != nil {
 					return fmt.Errorf("failed to wait for config promise: %w", err)
 				}
-				if !cfg.EnableNodePort {
+				if !kprOpts.EnableNodePort {
 					res4.Reject(fmt.Errorf("nat IPv4: %w", MapDisabled))
 					res6.Reject(fmt.Errorf("nat IPv6: %w", MapDisabled))
 					return nil
@@ -78,13 +79,7 @@ var Cell = cell.Module(
 				return nil
 			},
 			OnStop: func(hc cell.HookContext) error {
-				ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
-				defer cancel()
-				cfg, err := cfgPromise.Await(ctx)
-				if err != nil {
-					return err
-				}
-				if !cfg.EnableNodePort {
+				if !kprOpts.EnableNodePort {
 					return nil
 				}
 

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/dynamicconfig"
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/legacy/redirectpolicy"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -83,6 +84,7 @@ type featuresParams struct {
 	Metrics       featureMetrics
 
 	LBConfig            loadbalancer.Config
+	KPROpts             kpr.KPROpts
 	TunnelConfig        tunnel.Config
 	CNIConfigManager    cni.CNIConfigManager
 	MutualAuth          auth.MeshAuthConfig

--- a/pkg/metrics/features/features.go
+++ b/pkg/metrics/features/features.go
@@ -21,7 +21,7 @@ func updateAgentConfigMetricOnStart(jg job.Group, params featuresParams, m featu
 		if err != nil {
 			return fmt.Errorf("failed to get agent config: %w", err)
 		}
-		m.update(&params, agentConfig, params.LBConfig)
+		m.update(&params, agentConfig, params.LBConfig, params.KPROpts)
 		return nil
 	}))
 

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
@@ -943,10 +944,10 @@ func NewMetrics(withDefaults bool) Metrics {
 }
 
 type featureMetrics interface {
-	update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config)
+	update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprOpts kpr.KPROpts)
 }
 
-func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config) {
+func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprOpts kpr.KPROpts) {
 	networkMode := networkModeDirectRouting
 	if config.TunnelingEnabled() {
 		switch params.TunnelProtocol() {
@@ -1020,7 +1021,7 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 		}
 	}
 
-	if config.KubeProxyReplacement == option.KubeProxyReplacementTrue {
+	if kprOpts.KubeProxyReplacement == option.KubeProxyReplacementTrue {
 		m.ACLBKubeProxyReplacementEnabled.Add(1)
 	}
 

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -794,7 +795,9 @@ func TestUpdateKubeProxyReplacement(t *testing.T) {
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
-				KubeProxyReplacement:   tt.enableKubeProxyReplacement,
+				KPROpts: kpr.KPROpts{
+					KubeProxyReplacement: tt.enableKubeProxyReplacement,
+				},
 			}
 
 			lbConfig := loadbalancer.DefaultConfig

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -55,7 +56,7 @@ func cgroupLinkPath() string {
 // options have changed.
 // It expects bpf_sock.c to be compiled previously, so that bpf_sock.o is present
 // in the Runtime dir.
-func Enable(logger *slog.Logger, sysctl sysctl.Sysctl) error {
+func Enable(logger *slog.Logger, sysctl sysctl.Sysctl, kprOpts kpr.KPROpts) error {
 	if err := os.MkdirAll(cgroupLinkPath(), 0777); err != nil {
 		return fmt.Errorf("create bpffs link directory: %w", err)
 	}
@@ -96,7 +97,7 @@ func Enable(logger *slog.Logger, sysctl sysctl.Sysctl) error {
 			enabled[GetPeerName4] = true
 		}
 
-		if option.Config.EnableNodePort && option.Config.NodePortBindProtection {
+		if kprOpts.EnableNodePort && option.Config.NodePortBindProtection {
 			enabled[PostBind4] = true
 		}
 
@@ -118,7 +119,7 @@ func Enable(logger *slog.Logger, sysctl sysctl.Sysctl) error {
 			enabled[GetPeerName6] = true
 		}
 
-		if option.Config.EnableNodePort && option.Config.NodePortBindProtection {
+		if kprOpts.EnableNodePort && option.Config.NodePortBindProtection {
 			enabled[PostBind6] = true
 		}
 

--- a/pkg/status/cell.go
+++ b/pkg/status/cell.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipam"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
@@ -71,6 +72,7 @@ type statusParams struct {
 	Config       Config
 	DaemonConfig *option.DaemonConfig
 	LBConfig     loadbalancer.Config
+	KPROpts      kpr.KPROpts
 
 	DaemonConfigPromise promise.Promise[*option.DaemonConfig]
 

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -277,7 +277,7 @@ func (d *statusCollector) getCNIChainingStatus() *models.CNIChainingStatus {
 
 func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *models.KubeProxyReplacement {
 	var mode string
-	switch d.statusParams.DaemonConfig.KubeProxyReplacement {
+	switch d.statusParams.KPROpts.KubeProxyReplacement {
 	case option.KubeProxyReplacementTrue:
 		mode = models.KubeProxyReplacementModeTrue
 	case option.KubeProxyReplacementFalse:
@@ -307,7 +307,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		Nat46X64:              &models.KubeProxyReplacementFeaturesNat46X64{},
 		BpfSocketLBHostnsOnly: d.statusParams.DaemonConfig.BPFSocketLBHostnsOnly,
 	}
-	if d.statusParams.DaemonConfig.EnableNodePort {
+	if d.statusParams.KPROpts.EnableNodePort {
 		features.NodePort.Enabled = true
 		features.NodePort.Mode = strings.ToUpper(d.statusParams.LBConfig.LBMode)
 		switch d.statusParams.LBConfig.DSRDispatch {
@@ -367,7 +367,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		}
 		features.Nat46X64.Service = svc
 	}
-	if d.statusParams.DaemonConfig.EnableNodePort {
+	if d.statusParams.KPROpts.EnableNodePort {
 		if d.statusParams.LBConfig.AlgorithmAnnotation {
 			features.Annotations = append(features.Annotations, annotation.ServiceLoadBalancingAlgorithm)
 		}


### PR DESCRIPTION
This PR:

- Removes the unreachable `disableNodePort()` from `finishKubeProxyReplacementInit()` making the function stateless.
- Misc refactoring
- [ ] Moving initKPROpts into a cell.
