### PR TITLE
fix(docs): make test-docs work with SELinux enforcing

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -38,5 +38,3 @@ ENV MAKE_GIT_REPO_SAFE=1
 ## write runtime data inside a system directory.
 ## We do rely on this extension, so we cannot just drop it.
 RUN install -m 0777 -d /usr/local/lib/python3.11/site-packages/versionwarning/_static/data
-
-USER docsuser

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -3,6 +3,8 @@ FROM docker.io/library/python:3.11-alpine3.17 AS docs-base
 
 LABEL maintainer="maintainer@cilium.io"
 
+USER root
+
 RUN apk add --no-cache --virtual --update \
     aspell-en \
     nodejs \
@@ -21,6 +23,8 @@ RUN apk add --no-cache --virtual --update \
     musl-dev \
     && true
 
+RUN addgroup -S docs && adduser -S -G docs docsuser
+
 FROM docs-base AS docs-builder
 ADD ./requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
@@ -34,3 +38,5 @@ ENV MAKE_GIT_REPO_SAFE=1
 ## write runtime data inside a system directory.
 ## We do rely on this extension, so we cannot just drop it.
 RUN install -m 0777 -d /usr/local/lib/python3.11/site-packages/versionwarning/_static/data
+
+USER docsuser

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -23,8 +23,6 @@ RUN apk add --no-cache --virtual --update \
     musl-dev \
     && true
 
-RUN addgroup -S docs && adduser -S -G docs docsuser
-
 FROM docs-base AS docs-builder
 ADD ./requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt


### PR DESCRIPTION
Fix permission errors during make test-docs when SELinux is enforcing by running apk commands as root user in the Dockerfile.

Fixes: #19597

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #19597 

```release-note
Fixed make test-docs failures caused by permission errors when SELinux is set to enforcing.
```
