### PR TITLE
endpoint_api_manager: fix the typo for ipv6 case

### DIFF
--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -334,7 +334,7 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 		}
 		if uuid := addressing.IPV6ExpirationUUID; uuid != "" {
 			if ip := net.ParseIP(addressing.IPV6); ip != nil {
-				pool := ipam.PoolOrDefault(addressing.IPV4PoolName)
+				pool := ipam.PoolOrDefault(addressing.IPV6PoolName)
 				if err := m.ipam.StopExpirationTimer(ip, pool, uuid); err != nil {
 					return m.errorDuringCreation(ep, err)
 				}


### PR DESCRIPTION
fix the typo for ipv6 pool to get the correct pool name. we need this PR merged to resolve https://github.com/cilium/cilium/issues/38471


```release-note
Fix the typo to get the correct ipv6 pool name.
```
