### PR TITLE
test: remove deprecated, ineffective provisioning flag

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -409,7 +409,6 @@ jobs:
              --skip=\"${{ matrix.cliSkip }}\" \
              --seed=1679952881 \
              -v -- \
-             -cilium.provision=false \
              -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
              -cilium.tag=${{ needs.setup-vars.outputs.SHA }}  \
              -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
@@ -424,7 +423,6 @@ jobs:
                --ginkgo.skip="${{ matrix.cliSkip }}" \
                --ginkgo.seed=1679952881 \
                --ginkgo.v -- \
-               -cilium.provision=false \
                -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
                -cilium.tag=${{ needs.setup-vars.outputs.SHA }}  \
                -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -356,7 +356,6 @@ jobs:
           --ginkgo.skip="${{ matrix.cliSkip }}" \
           --ginkgo.seed=1679952881 \
           --ginkgo.v -- \
-          -cilium.provision=false \
           -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
           -cilium.tag=${{ steps.vars.outputs.sha }}  \
           -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \

--- a/Documentation/contributing/testing/e2e_legacy.rst
+++ b/Documentation/contributing/testing/e2e_legacy.rst
@@ -238,7 +238,6 @@ usage information.
         --ginkgo.skip="" \
         --ginkgo.seed=1679952881 \
         --ginkgo.v -- \
-        -cilium.provision=false \
         -cilium.image=quay.io/${quay_org}/cilium-ci \
         -cilium.tag=${commit_sha}  \
         -cilium.operator-image=quay.io/${quay_org}/operator \
@@ -355,8 +354,6 @@ framework in the ``test/`` directory and interact with ginkgo directly:
             Specifies which tag of cilium-operator to use during tests
       -cilium.passCLIEnvironment
             Pass the environment invoking ginkgo, including PATH, to subcommands
-      -cilium.provision
-            Provision Vagrant boxes and Cilium before running test (default true)
       -cilium.showCommands
             Output which commands are ran to stdout
       -cilium.skipLogs
@@ -604,7 +601,7 @@ Example how to run ginkgo using ``dlv``:
 
 .. code-block:: shell-session
 
-	dlv test . -- --ginkgo.focus="Runtime" -ginkgo.v=true --cilium.provision=false
+	dlv test . -- --ginkgo.focus="Runtime" -ginkgo.v=true
 
 Running End-To-End Tests In Other Environments via kubeconfig
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -639,14 +636,14 @@ An example invocation is
 
 .. code-block:: shell-session
 
-  INTEGRATION_TESTS=true CNI_INTEGRATION=eks K8S_VERSION=1.16 ginkgo --focus="K8s" -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.passCLIEnvironment=true
+  INTEGRATION_TESTS=true CNI_INTEGRATION=eks K8S_VERSION=1.16 ginkgo --focus="K8s" -- -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.passCLIEnvironment=true
 
 
 To run tests with Kind, try
 
 .. code-block:: shell-session
 
-  K8S_VERSION=1.25 ginkgo --focus=K8s -- -cilium.provision=false --cilium.image=localhost:5000/cilium/cilium-dev -cilium.tag=local  --cilium.operator-image=localhost:5000/cilium/operator -cilium.operator-tag=local -cilium.kubeconfig=`echo ~/.kube/config` -cilium.testScope=K8s -cilium.operator-suffix=
+  K8S_VERSION=1.25 ginkgo --focus=K8s -- --cilium.image=localhost:5000/cilium/cilium-dev -cilium.tag=local  --cilium.operator-image=localhost:5000/cilium/operator -cilium.operator-tag=local -cilium.kubeconfig=`echo ~/.kube/config` -cilium.testScope=K8s -cilium.operator-suffix=
 
 
 Running in GKE
@@ -675,7 +672,7 @@ cluster.
   export CLUSTER_ZONE=us-west2-a
   export NATIVE_CIDR="$(gcloud container clusters describe $CLUSTER_NAME --zone $CLUSTER_ZONE --format 'value(clusterIpv4Cidr)')"
 
-  INTEGRATION_TESTS=true CNI_INTEGRATION=gke K8S_VERSION=1.17 ginkgo --focus="K8sDemo" -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.hubble-relay-image="quay.io/cilium/hubble-relay-ci" -cilium.passCLIEnvironment=true
+  INTEGRATION_TESTS=true CNI_INTEGRATION=gke K8S_VERSION=1.17 ginkgo --focus="K8sDemo" -- -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium-ci" -cilium.operator-image="quay.io/cilium/operator" -cilium.operator-suffix="-ci" -cilium.hubble-relay-image="quay.io/cilium/hubble-relay-ci" -cilium.passCLIEnvironment=true
 
 .. note:: The kubernetes version defaults to 1.23 but can be configured with
           versions between 1.16 and 1.23. Version should match the server
@@ -697,7 +694,7 @@ AKS (experimental)
 .. code-block:: shell-session
 
     export NATIVE_CIDR="10.241.0.0/16"
-    INTEGRATION_TESTS=true CNI_INTEGRATION=aks K8S_VERSION=1.17 ginkgo --focus="K8s" -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.passCLIEnvironment=true -cilium.image="mcr.microsoft.com/oss/cilium/cilium" -cilium.tag="1.12.1" -cilium.operator-image="mcr.microsoft.com/oss/cilium/operator" -cilium.operator-suffix=""  -cilium.operator-tag="1.12.1"
+    INTEGRATION_TESTS=true CNI_INTEGRATION=aks K8S_VERSION=1.17 ginkgo --focus="K8s" -- -cilium.kubeconfig=`echo ~/.kube/config` -cilium.passCLIEnvironment=true -cilium.image="mcr.microsoft.com/oss/cilium/cilium" -cilium.tag="1.12.1" -cilium.operator-image="mcr.microsoft.com/oss/cilium/operator" -cilium.operator-suffix=""  -cilium.operator-tag="1.12.1"
 
 AWS EKS (experimental)
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -782,7 +779,7 @@ To run this you can use the following command:
 
 .. code-block:: shell-session
 
-    ginkgo -- --cilium.provision=false --cilium.SSHConfig="cat ssh-config"
+    ginkgo -- --cilium.SSHConfig="cat ssh-config"
 
 
 Environment variables

--- a/contrib/scripts/run-gh-ginkgo-workflow.sh
+++ b/contrib/scripts/run-gh-ginkgo-workflow.sh
@@ -196,7 +196,6 @@ run_tests() {
             --ginkgo.skip= \
             --ginkgo.seed=1679952881 \
             --ginkgo.v -- \
-            -cilium.provision=false \
             -cilium.image=quay.io/${quay_org}/cilium-ci \
             -cilium.tag=${commit_sha}  \
             -cilium.operator-image=quay.io/${quay_org}/operator \

--- a/contrib/testing/integrations.sh
+++ b/contrib/testing/integrations.sh
@@ -48,7 +48,6 @@ gct()
         HUBBLE_RELAY_IMAGE_TAG="${HUBBLE_RELAY_IMAGE_TAG:-"latest"}" \
         K8S_VERSION="$(kubectl version -o json |  jq -r '(.serverVersion.major + "." + (.serverVersion.minor | scan("[0-9]+")))' | sed 's/"//g')" \
         INTEGRATION_TESTS=true ginkgo -v "$FOCUS" -- \
-            -cilium.provision=false \
             -cilium.kubeconfig=$HOME/.kube/config \
             -cilium.passCLIEnvironment=true \
             -cilium.testScope=k8s \

--- a/test/Makefile
+++ b/test/Makefile
@@ -57,7 +57,6 @@ k8s-kind:
 		NO_CILIUM_ON_NODES="$(NO_CILIUM_ON_NODES)" \
 		INTEGRATION_TESTS=true ginkgo --focus "$(FOCUS)" -v -- \
 			-cilium.testScope=k8s \
-			-cilium.provision=false \
 			-cilium.kubeconfig=$$(echo ~/.kube/config) \
 			-cilium.passCLIEnvironment=true \
 			-cilium.image="$(DOCKER_REGISTRY)/cilium/cilium-dev" \

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -17,7 +17,6 @@ const (
 
 // CiliumTestConfigType holds all of the configurable elements of the testsuite
 type CiliumTestConfigType struct {
-	Reprovision bool
 	// HoldEnvironment leaves the test infrastructure in place on failure
 	HoldEnvironment bool
 	// PassCLIEnvironment passes through the environment invoking the gingko
@@ -55,7 +54,6 @@ var CiliumTestConfig = CiliumTestConfigType{}
 // ParseFlags parses commandline flags relevant to testing.
 func (c *CiliumTestConfigType) ParseFlags() {
 	flagset := flag.NewFlagSet("cilium", flag.ExitOnError)
-	flagset.BoolVar(&c.Reprovision, "cilium.provision", false, "(deprecated)")
 	flagset.BoolVar(&c.HoldEnvironment, "cilium.holdEnvironment", false,
 		"On failure, hold the environment in its current state")
 	flagset.BoolVar(&c.PassCLIEnvironment, "cilium.passCLIEnvironment", false,


### PR DESCRIPTION
Remove the -cilium.provision flag to the test suite that was already deprecated in commit 2eb8a1859a74 ("test: Remove Vagrant VM provisioning logic").