### PR TITLE
Final migration of all logging.DefaultSlogLogger to their local logger instance and improvements in pkg/logging

### DIFF
--- a/Documentation/cmdref/cilium-health.md
+++ b/Documentation/cmdref/cilium-health.md
@@ -15,11 +15,9 @@ cilium-health [flags]
 ### Options
 
 ```
-  -D, --debug                Enable debug messages
-  -h, --help                 help for cilium-health
-  -H, --host string          URI to cilium-health server API
-      --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
+  -D, --debug         Enable debug messages
+  -h, --help          help for cilium-health
+  -H, --host string   URI to cilium-health server API
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion.md
+++ b/Documentation/cmdref/cilium-health_completion.md
@@ -19,10 +19,8 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
-  -D, --debug                Enable debug messages
-  -H, --host string          URI to cilium-health server API
-      --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
+  -D, --debug         Enable debug messages
+  -H, --host string   URI to cilium-health server API
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion_bash.md
+++ b/Documentation/cmdref/cilium-health_completion_bash.md
@@ -42,10 +42,8 @@ cilium-health completion bash
 ### Options inherited from parent commands
 
 ```
-  -D, --debug                Enable debug messages
-  -H, --host string          URI to cilium-health server API
-      --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
+  -D, --debug         Enable debug messages
+  -H, --host string   URI to cilium-health server API
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion_fish.md
+++ b/Documentation/cmdref/cilium-health_completion_fish.md
@@ -33,10 +33,8 @@ cilium-health completion fish [flags]
 ### Options inherited from parent commands
 
 ```
-  -D, --debug                Enable debug messages
-  -H, --host string          URI to cilium-health server API
-      --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
+  -D, --debug         Enable debug messages
+  -H, --host string   URI to cilium-health server API
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion_powershell.md
+++ b/Documentation/cmdref/cilium-health_completion_powershell.md
@@ -30,10 +30,8 @@ cilium-health completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
-  -D, --debug                Enable debug messages
-  -H, --host string          URI to cilium-health server API
-      --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
+  -D, --debug         Enable debug messages
+  -H, --host string   URI to cilium-health server API
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_completion_zsh.md
+++ b/Documentation/cmdref/cilium-health_completion_zsh.md
@@ -44,10 +44,8 @@ cilium-health completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
-  -D, --debug                Enable debug messages
-  -H, --host string          URI to cilium-health server API
-      --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
+  -D, --debug         Enable debug messages
+  -H, --host string   URI to cilium-health server API
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_get.md
+++ b/Documentation/cmdref/cilium-health_get.md
@@ -18,10 +18,8 @@ cilium-health get [flags]
 ### Options inherited from parent commands
 
 ```
-  -D, --debug                Enable debug messages
-  -H, --host string          URI to cilium-health server API
-      --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
+  -D, --debug         Enable debug messages
+  -H, --host string   URI to cilium-health server API
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_ping.md
+++ b/Documentation/cmdref/cilium-health_ping.md
@@ -17,10 +17,8 @@ cilium-health ping [flags]
 ### Options inherited from parent commands
 
 ```
-  -D, --debug                Enable debug messages
-  -H, --host string          URI to cilium-health server API
-      --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
+  -D, --debug         Enable debug messages
+  -H, --host string   URI to cilium-health server API
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_status.md
+++ b/Documentation/cmdref/cilium-health_status.md
@@ -20,10 +20,8 @@ cilium-health status [flags]
 ### Options inherited from parent commands
 
 ```
-  -D, --debug                Enable debug messages
-  -H, --host string          URI to cilium-health server API
-      --log-driver strings   Logging endpoints to use for example syslog
-      --log-opt map          Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent
+  -D, --debug         Enable debug messages
+  -H, --host string   URI to cilium-health server API
 ```
 
 ### SEE ALSO

--- a/Makefile
+++ b/Makefile
@@ -456,6 +456,8 @@ endif
 	$(QUIET) contrib/scripts/check-safenetlink.sh
 	@$(ECHO_CHECK) contrib/scripts/check-datapathconfig.sh
 	$(QUIET) contrib/scripts/check-datapathconfig.sh
+	@$(ECHO_CHECK) $(GO) run ./tools/slogloggercheck .
+	$(QUIET)$(GO) run ./tools/slogloggercheck .
 
 pprof-heap: ## Get Go pprof heap profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/heap

--- a/api/v1/health/server/server.go
+++ b/api/v1/health/server/server.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net"
 	"net/http"
@@ -21,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/hive/cell"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
@@ -29,8 +29,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/health/server/restapi"
 	"github.com/cilium/cilium/api/v1/health/server/restapi/connectivity"
-	"github.com/cilium/hive/cell"
-
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/logging"
@@ -259,7 +257,16 @@ func (s *Server) Logf(f string, args ...interface{}) {
 	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(fmt.Sprintf(f, args...))
 	} else {
-		log.Printf(f, args...)
+		slog.Info(fmt.Sprintf(f, args...))
+	}
+}
+
+// Debugf logs debug messages either via defined user logger or via system one if no user logger is defined.
+func (s *Server) Debugf(f string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Debug(fmt.Sprintf(f, args...))
+	} else {
+		slog.Debug(fmt.Sprintf(f, args...))
 	}
 }
 
@@ -272,7 +279,7 @@ func (s *Server) Fatalf(f string, args ...interface{}) {
 		s.api.Logger(f, args...)
 		os.Exit(1)
 	} else {
-		log.Fatalf(f, args...)
+		logging.Fatal(slog.Default(), fmt.Sprintf(f, args...))
 	}
 }
 
@@ -345,7 +352,7 @@ func (s *Server) Start(cell.HookContext) (err error) {
 		configureServer(domainSocket, "unix", s.SocketPath)
 
 		if os.Getuid() == 0 {
-			err := api.SetDefaultPermissions(logging.DefaultSlogLogger, s.SocketPath)
+			err := api.SetDefaultPermissions(s.Debugf, s.SocketPath)
 			if err != nil {
 				return err
 			}

--- a/api/v1/kvstoremesh/server/server.go
+++ b/api/v1/kvstoremesh/server/server.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net"
 	"net/http"
@@ -21,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/hive/cell"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
@@ -29,8 +29,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/kvstoremesh/server/restapi"
 	"github.com/cilium/cilium/api/v1/kvstoremesh/server/restapi/cluster"
-	"github.com/cilium/hive/cell"
-
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/logging"
@@ -256,7 +254,16 @@ func (s *Server) Logf(f string, args ...interface{}) {
 	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(fmt.Sprintf(f, args...))
 	} else {
-		log.Printf(f, args...)
+		slog.Info(fmt.Sprintf(f, args...))
+	}
+}
+
+// Debugf logs debug messages either via defined user logger or via system one if no user logger is defined.
+func (s *Server) Debugf(f string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Debug(fmt.Sprintf(f, args...))
+	} else {
+		slog.Debug(fmt.Sprintf(f, args...))
 	}
 }
 
@@ -269,7 +276,7 @@ func (s *Server) Fatalf(f string, args ...interface{}) {
 		s.api.Logger(f, args...)
 		os.Exit(1)
 	} else {
-		log.Fatalf(f, args...)
+		logging.Fatal(slog.Default(), fmt.Sprintf(f, args...))
 	}
 }
 
@@ -342,7 +349,7 @@ func (s *Server) Start(cell.HookContext) (err error) {
 		configureServer(domainSocket, "unix", s.SocketPath)
 
 		if os.Getuid() == 0 {
-			err := api.SetDefaultPermissions(logging.DefaultSlogLogger, s.SocketPath)
+			err := api.SetDefaultPermissions(s.Debugf, s.SocketPath)
 			if err != nil {
 				return err
 			}

--- a/api/v1/operator/server/server.go
+++ b/api/v1/operator/server/server.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net"
 	"net/http"
@@ -21,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/hive/cell"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
@@ -31,8 +31,6 @@ import (
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/cluster"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/metrics"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
-	"github.com/cilium/hive/cell"
-
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/logging"
@@ -262,7 +260,16 @@ func (s *Server) Logf(f string, args ...interface{}) {
 	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(fmt.Sprintf(f, args...))
 	} else {
-		log.Printf(f, args...)
+		slog.Info(fmt.Sprintf(f, args...))
+	}
+}
+
+// Debugf logs debug messages either via defined user logger or via system one if no user logger is defined.
+func (s *Server) Debugf(f string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Debug(fmt.Sprintf(f, args...))
+	} else {
+		slog.Debug(fmt.Sprintf(f, args...))
 	}
 }
 
@@ -275,7 +282,7 @@ func (s *Server) Fatalf(f string, args ...interface{}) {
 		s.api.Logger(f, args...)
 		os.Exit(1)
 	} else {
-		log.Fatalf(f, args...)
+		logging.Fatal(slog.Default(), fmt.Sprintf(f, args...))
 	}
 }
 
@@ -348,7 +355,7 @@ func (s *Server) Start(cell.HookContext) (err error) {
 		configureServer(domainSocket, "unix", s.SocketPath)
 
 		if os.Getuid() == 0 {
-			err := api.SetDefaultPermissions(logging.DefaultSlogLogger, s.SocketPath)
+			err := api.SetDefaultPermissions(s.Debugf, s.SocketPath)
 			if err != nil {
 				return err
 			}

--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -9,8 +9,9 @@ package {{ .APIPackage }}
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
-	"log"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -20,22 +21,18 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/hive/cell"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
-  "github.com/go-openapi/swag"
-  {{ if .UsePFlags }}flag "github.com/spf13/pflag"
-  {{ end -}}
-  {{ if .UseFlags }}"flag"
-  "strings"
-  {{ end -}}
-  "golang.org/x/net/netutil"
+	"github.com/go-openapi/swag"
+	"github.com/spf13/pflag"
+	"golang.org/x/net/netutil"
 
   {{ imports .DefaultImports }}
   {{ imports .Imports }}
-  "github.com/cilium/hive/cell"
-
-  "github.com/cilium/cilium/pkg/hive"
-  "github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/logging"
 )
 
 // Cell implements the {{ humanize .Name }} REST API server when provided
@@ -56,9 +53,9 @@ var APICell = cell.Provide(newAPI)
 type apiParams struct {
 	cell.In
 
-	Spec       *Spec
+	Spec *Spec
 
-	Logger     *slog.Logger
+	Logger *slog.Logger
 
 	Middleware middleware.Builder `name:"{{ dasherize .Name }}-middleware" optional:"true"`
 
@@ -67,7 +64,6 @@ type apiParams struct {
 		{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler {{ .PackageAlias }}.{{ pascalize .Name }}Handler
 	{{- end }}
 }
-
 
 func newAPI(p apiParams) *{{ .Package }}.{{pascalize .Name}}API {
 	api := {{ .Package }}.New{{pascalize .Name}}API(p.Spec.Document)
@@ -78,10 +74,10 @@ func newAPI(p apiParams) *{{ .Package }}.{{pascalize .Name}}API {
 	  api.{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler = p.{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler
 	{{- end }}
 
-        // Inject custom middleware if provided by Hive
+	// Inject custom middleware if provided by Hive
 	if p.Middleware != nil {
 		api.Middleware = func(builder middleware.Builder) http.Handler {
-                      return p.Middleware(api.Context().APIHandler(builder))
+			return p.Middleware(api.Context().APIHandler(builder))
 		}
 	}
 
@@ -100,7 +96,6 @@ type serverParams struct {
 	API	   *{{ .Package }}.{{pascalize .Name}}API
 }
 
-
 func newForCell(p serverParams) (*Server, error) {
 	s := NewServer(p.API)
 	s.shutdowner = p.Shutdowner
@@ -108,7 +103,6 @@ func newForCell(p serverParams) (*Server, error) {
 	p.Lifecycle.Append(s)
 	return s, nil
 }
-
 
 const (
 	schemeHTTP  = "http"
@@ -127,32 +121,32 @@ func init() {
 }
 
 var (
-  {{ if .ExcludeSpec }}
-  specFile         string
-  {{ end }}
+	{{ if .ExcludeSpec }}
+	specFile         string
+	{{ end }}
 
-  enabledListeners []string
-  gracefulTimeout  time.Duration
-  maxHeaderSize    int
+	enabledListeners []string
+	gracefulTimeout  time.Duration
+	maxHeaderSize    int
 
-  socketPath string
+	socketPath string
 
-  host         string
-  port         int
-  listenLimit  int
-  keepAlive    time.Duration
-  readTimeout  time.Duration
-  writeTimeout time.Duration
+	host         string
+	port         int
+	listenLimit  int
+	keepAlive    time.Duration
+	readTimeout  time.Duration
+	writeTimeout time.Duration
 
-  tlsHost           string
-  tlsPort           int
-  tlsListenLimit    int
-  tlsKeepAlive      time.Duration
-  tlsReadTimeout    time.Duration
-  tlsWriteTimeout   time.Duration
-  tlsCertificate    string
-  tlsCertificateKey string
-  tlsCACertificate  string
+	tlsHost           string
+	tlsPort           int
+	tlsListenLimit    int
+	tlsKeepAlive      time.Duration
+	tlsReadTimeout    time.Duration
+	tlsWriteTimeout   time.Duration
+	tlsCertificate    string
+	tlsCertificateKey string
+	tlsCACertificate  string
 )
 
 type ServerConfig struct {
@@ -195,7 +189,7 @@ func newSpec(cfg ServerConfig) (*Spec, error) {
 	deniedAPIs, err := api.AllowedFlagsToDeniedPaths(swaggerSpec, cfg.Enable{{ pascalize .Name }}ServerAccess)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse %q flag: %w",
-				       AdminEnableFlag, err)
+			AdminEnableFlag, err)
 	}
 
 	return &Spec{
@@ -213,16 +207,16 @@ func NewServer(api *{{ .Package }}.{{ pascalize .Name }}API) *Server {
 
 // ConfigureAPI configures the API and handlers.
 func (s *Server) ConfigureAPI() {
-    if s.api != nil {
-        s.handler = configureAPI(s.logger, s.api)
-    }
+	if s.api != nil {
+		s.handler = configureAPI(s.logger, s.api)
+	}
 }
 
 // ConfigureFlags configures the additional flags defined by the handlers. Needs to be called before the parser.Parse
 func (s *Server) ConfigureFlags() {
-    if s.api != nil {
-       configureFlags(s.api)
-    }
+	if s.api != nil {
+		configureFlags(s.api)
+	}
 }
 
 // Server for the {{ humanize .Name }} API
@@ -232,16 +226,16 @@ type Server struct {
 	GracefulTimeout  time.Duration
 	MaxHeaderSize    int
 
-	SocketPath string
+	SocketPath    string
 	domainSocketL *net.UnixListener
 
-	Host string
-	Port int
+	Host         string
+	Port         int
 	ListenLimit  int
 	KeepAlive    time.Duration
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
-	httpServerL   net.Listener
+	httpServerL  net.Listener
 
 	TLSHost           string
 	TLSPort           int
@@ -252,17 +246,17 @@ type Server struct {
 	TLSKeepAlive      time.Duration
 	TLSReadTimeout    time.Duration
 	TLSWriteTimeout   time.Duration
-	httpsServerL  net.Listener
+	httpsServerL      net.Listener
 
 	{{ if .ExcludeSpec }}Spec string{{ end }}
 	api               *{{ .Package }}.{{ pascalize .Name }}API
-	handler           http.Handler
-	hasListeners      bool
-	servers           []*http.Server
+	handler      http.Handler
+	hasListeners bool
+	servers      []*http.Server
 
-	wg sync.WaitGroup
-        shutdowner hive.Shutdowner
-	logger *slog.Logger
+	wg         sync.WaitGroup
+	shutdowner hive.Shutdowner
+	logger     *slog.Logger
 }
 
 // Logf logs message either via defined user logger or via system one if no user logger is defined.
@@ -272,7 +266,16 @@ func (s *Server) Logf(f string, args ...interface{}) {
 	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(fmt.Sprintf(f, args...))
 	} else {
-		log.Printf(f, args...)
+		slog.Info(fmt.Sprintf(f, args...))
+	}
+}
+
+// Debugf logs debug messages either via defined user logger or via system one if no user logger is defined.
+func (s *Server) Debugf(f string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Debug(fmt.Sprintf(f, args...))
+	} else {
+		slog.Debug(fmt.Sprintf(f, args...))
 	}
 }
 
@@ -281,11 +284,11 @@ func (s *Server) Logf(f string, args ...interface{}) {
 func (s *Server) Fatalf(f string, args ...interface{}) {
 	if s.shutdowner != nil {
 		s.shutdowner.Shutdown(hive.ShutdownWithError(fmt.Errorf(f, args...)))
-        } else if s.api != nil && s.api.Logger != nil {
+	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(f, args...)
 		os.Exit(1)
 	} else {
-		log.Fatalf(f, args...)
+		logging.Fatal(slog.Default(), fmt.Sprintf(f, args...))
 	}
 }
 
@@ -318,7 +321,7 @@ func (s *Server) hasScheme(scheme string) bool {
 
 func (s *Server) Serve() error {
 	// TODO remove when this is not needed for compatibility anymore
-        if err := s.Start(context.TODO()); err != nil {
+	if err := s.Start(context.TODO()); err != nil {
 		return err
 	}
 	s.wg.Wait()
@@ -329,7 +332,7 @@ func (s *Server) Serve() error {
 func (s *Server) Start(cell.HookContext) (err error) {
 	if !s.hasListeners {
 		if err = s.Listen(); err != nil {
-		  return err
+			return err
 		}
 	}
 
@@ -358,7 +361,7 @@ func (s *Server) Start(cell.HookContext) (err error) {
 		configureServer(domainSocket, "unix", s.SocketPath)
 
 		if os.Getuid() == 0 {
-			err := api.SetDefaultPermissions(logging.DefaultSlogLogger, s.SocketPath)
+			err := api.SetDefaultPermissions(s.Debugf, s.SocketPath)
 			if err != nil {
 				return err
 			}
@@ -505,15 +508,15 @@ func (s *Server) Start(cell.HookContext) (err error) {
 
 // Listen creates the listeners for the server
 func (s *Server) Listen() error {
-  if s.hasListeners { // already done this
-    return nil
-  }
+	if s.hasListeners { // already done this
+		return nil
+	}
 
-  if s.hasScheme(schemeHTTPS) {
-    // Use http host if https host wasn't defined
-    if s.TLSHost == "" {
-      s.TLSHost = s.Host
-    }
+	if s.hasScheme(schemeHTTPS) {
+		// Use http host if https host wasn't defined
+		if s.TLSHost == "" {
+			s.TLSHost = s.Host
+		}
 		// Use http listen limit if https listen limit wasn't defined
 		if s.TLSListenLimit == 0 {
 			s.TLSListenLimit = s.ListenLimit
@@ -530,7 +533,7 @@ func (s *Server) Listen() error {
 		if int64(s.TLSWriteTimeout) == 0 {
 			s.TLSWriteTimeout = s.WriteTimeout
 		}
-  }
+	}
 
 	if s.hasScheme(schemeUnix) {
 		addr, err := net.ResolveUnixAddr("unix", s.SocketPath)
@@ -544,37 +547,37 @@ func (s *Server) Listen() error {
 		s.domainSocketL = domSockListener
 	}
 
-  if s.hasScheme(schemeHTTP) {
-    listener, err := net.Listen("tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)))
-    if err != nil {
-      return err
-    }
+	if s.hasScheme(schemeHTTP) {
+		listener, err := net.Listen("tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)))
+		if err != nil {
+			return err
+		}
 
-    h, p, err := swag.SplitHostPort(listener.Addr().String())
-    if err != nil {
-      return err
-    }
-    s.Host = h
-    s.Port = p
-    s.httpServerL = listener
-  }
+		h, p, err := swag.SplitHostPort(listener.Addr().String())
+		if err != nil {
+			return err
+		}
+		s.Host = h
+		s.Port = p
+		s.httpServerL = listener
+	}
 
-  if s.hasScheme(schemeHTTPS) {
-    tlsListener, err := net.Listen("tcp", net.JoinHostPort(s.TLSHost, strconv.Itoa(s.TLSPort)))
-    if err != nil {
-      return err
-    }
+	if s.hasScheme(schemeHTTPS) {
+		tlsListener, err := net.Listen("tcp", net.JoinHostPort(s.TLSHost, strconv.Itoa(s.TLSPort)))
+		if err != nil {
+			return err
+		}
 
-    sh, sp, err := swag.SplitHostPort(tlsListener.Addr().String())
-    if err != nil {
-      return err
-    }
-    s.TLSHost = sh
-    s.TLSPort = sp
-    s.httpsServerL = tlsListener
-  }
+		sh, sp, err := swag.SplitHostPort(tlsListener.Addr().String())
+		if err != nil {
+			return err
+		}
+		s.TLSHost = sh
+		s.TLSPort = sp
+		s.httpsServerL = tlsListener
+	}
 
-  s.hasListeners = true
+	s.hasListeners = true
 	return nil
 }
 
@@ -662,4 +665,3 @@ func (s *Server) TLSListener() (net.Listener, error) {
 	}
 	return s.httpsServerL, nil
 }
-

--- a/api/v1/server/configure_cilium_api.go
+++ b/api/v1/server/configure_cilium_api.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/api/v1/server/restapi/recorder"
 	"github.com/cilium/cilium/api/v1/server/restapi/service"
 	"github.com/cilium/cilium/pkg/api"
-	"github.com/cilium/cilium/pkg/logging"
 	ciliumMetrics "github.com/cilium/cilium/pkg/metrics"
 )
 
@@ -313,7 +312,7 @@ func configureAPI(logger *slog.Logger, api *restapi.CiliumAPIAPI) http.Handler {
 	api.PreServerShutdown = func() {}
 
 	api.ServerShutdown = func() {
-		logging.DefaultSlogLogger.Debug("canceling server context")
+		logger.Debug("canceling server context")
 		serverCancel()
 	}
 

--- a/api/v1/server/server.go
+++ b/api/v1/server/server.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net"
 	"net/http"
@@ -21,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/hive/cell"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
@@ -36,8 +36,6 @@ import (
 	"github.com/cilium/cilium/api/v1/server/restapi/prefilter"
 	"github.com/cilium/cilium/api/v1/server/restapi/recorder"
 	"github.com/cilium/cilium/api/v1/server/restapi/service"
-	"github.com/cilium/hive/cell"
-
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/logging"
@@ -362,7 +360,16 @@ func (s *Server) Logf(f string, args ...interface{}) {
 	} else if s.api != nil && s.api.Logger != nil {
 		s.api.Logger(fmt.Sprintf(f, args...))
 	} else {
-		log.Printf(f, args...)
+		slog.Info(fmt.Sprintf(f, args...))
+	}
+}
+
+// Debugf logs debug messages either via defined user logger or via system one if no user logger is defined.
+func (s *Server) Debugf(f string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Debug(fmt.Sprintf(f, args...))
+	} else {
+		slog.Debug(fmt.Sprintf(f, args...))
 	}
 }
 
@@ -375,7 +382,7 @@ func (s *Server) Fatalf(f string, args ...interface{}) {
 		s.api.Logger(f, args...)
 		os.Exit(1)
 	} else {
-		log.Fatalf(f, args...)
+		logging.Fatal(slog.Default(), fmt.Sprintf(f, args...))
 	}
 }
 
@@ -448,7 +455,7 @@ func (s *Server) Start(cell.HookContext) (err error) {
 		configureServer(domainSocket, "unix", s.SocketPath)
 
 		if os.Getuid() == 0 {
-			err := api.SetDefaultPermissions(logging.DefaultSlogLogger, s.SocketPath)
+			err := api.SetDefaultPermissions(s.Debugf, s.SocketPath)
 			if err != nil {
 				return err
 			}

--- a/cilium-dbg/cmd/bpf_auth_flush.go
+++ b/cilium-dbg/cmd/bpf_auth_flush.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 )
 
@@ -25,7 +24,7 @@ var bpfAuthFlushCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf auth flush")
 
-		authMap, err := authmap.LoadAuthMap(logging.DefaultSlogLogger)
+		authMap, err := authmap.LoadAuthMap(log)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				fmt.Fprintln(os.Stderr, "Cannot find auth bpf map")

--- a/cilium-dbg/cmd/bpf_auth_list.go
+++ b/cilium-dbg/cmd/bpf_auth_list.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/policy"
 )
@@ -36,7 +35,7 @@ var bpfAuthListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf auth list")
 
-		authMap, err := authmap.LoadAuthMap(logging.DefaultSlogLogger)
+		authMap, err := authmap.LoadAuthMap(log)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				fmt.Fprintln(os.Stderr, "Cannot find auth bpf map")

--- a/cilium-dbg/cmd/bpf_config_list.go
+++ b/cilium-dbg/cmd/bpf_config_list.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/configmap"
 )
 
@@ -31,7 +30,7 @@ var bpfConfigListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf config list")
 
-		configMap, err := configmap.LoadMap(logging.DefaultSlogLogger)
+		configMap, err := configmap.LoadMap(log)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				fmt.Fprintln(os.Stderr, "Cannot find config bpf map")

--- a/cilium-dbg/cmd/bpf_egress_list.go
+++ b/cilium-dbg/cmd/bpf_egress_list.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/egressgateway"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 )
 
@@ -42,7 +41,7 @@ var bpfEgressListCmd = &cobra.Command{
 		bpfEgressList := []egressPolicy{}
 		var ipv4MapExists, ipv6MapExists bool
 
-		policyMap4, err := egressmap.OpenPinnedPolicyMap4(logging.DefaultSlogLogger)
+		policyMap4, err := egressmap.OpenPinnedPolicyMap4(log)
 		if err == nil {
 			ipv4MapExists = true
 			parse4 := func(key *egressmap.EgressPolicyKey4, val *egressmap.EgressPolicyVal4) {
@@ -61,7 +60,7 @@ var bpfEgressListCmd = &cobra.Command{
 			Fatalf("Cannot open IPv4 egress gateway bpf map: %s", err)
 		}
 
-		policyMap6, err := egressmap.OpenPinnedPolicyMap6(logging.DefaultSlogLogger)
+		policyMap6, err := egressmap.OpenPinnedPolicyMap6(log)
 		if err == nil {
 			ipv6MapExists = true
 			parse6 := func(key *egressmap.EgressPolicyKey6, val *egressmap.EgressPolicyVal6) {

--- a/cilium-dbg/cmd/bpf_frag_list.go
+++ b/cilium-dbg/cmd/bpf_frag_list.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/fragmap"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -33,7 +32,7 @@ var bpfFragListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf frag list")
 
-		fragMap4, err := fragmap.OpenMap4(logging.DefaultSlogLogger)
+		fragMap4, err := fragmap.OpenMap4(log)
 		if err != nil {
 			if os.IsNotExist(err) {
 				fmt.Fprintf(os.Stderr, "IPv4 map doesn't exist, skipping\n")
@@ -44,7 +43,7 @@ var bpfFragListCmd = &cobra.Command{
 			defer fragMap4.Close()
 		}
 
-		fragMap6, err := fragmap.OpenMap6(logging.DefaultSlogLogger)
+		fragMap6, err := fragmap.OpenMap6(log)
 		if err != nil {
 			if os.IsNotExist(err) {
 				fmt.Fprintf(os.Stderr, "IPv6 map doesn't exist, skipping\n")

--- a/cilium-dbg/cmd/bpf_lb_maglev_list.go
+++ b/cilium-dbg/cmd/bpf_lb_maglev_list.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	lbmaps "github.com/cilium/cilium/pkg/loadbalancer/maps"
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 // bpfMaglevListCmd represents the bpf lb maglev list command
@@ -73,7 +72,7 @@ func openMaglevOuterMap(logger *slog.Logger, name string) (*ebpf.Map, error) {
 // dumps the backend tables of all services. Returns an empty initialized
 // map if the given eBPF map does not exist.
 func dumpMaglevTable(name string, ipv6 bool) (map[string][]string, error) {
-	m, err := openMaglevOuterMap(logging.DefaultSlogLogger, name)
+	m, err := openMaglevOuterMap(log, name)
 	if errors.Is(err, os.ErrNotExist) {
 		// Map not existing is not an error.
 		// Skip dumping it and return an empty allocated map.
@@ -101,7 +100,7 @@ func dumpMaglevBackends(m *ebpf.Map, ipv6 bool) (map[string][]string, error) {
 	}
 	iter := m.Iterate()
 	for iter.Next(&key, &val) {
-		inner, err := lbmaps.MaglevInnerMapFromID(logging.DefaultSlogLogger, val.FD)
+		inner, err := lbmaps.MaglevInnerMapFromID(val.FD)
 		if err != nil {
 			return nil, fmt.Errorf("cannot open inner map with id %d: %w", val.FD, err)
 		}

--- a/cilium-dbg/cmd/bpf_metrics_list.go
+++ b/cilium-dbg/cmd/bpf_metrics_list.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -54,7 +53,7 @@ var bpfMetricsListCmd = &cobra.Command{
 	Short: "List BPF datapath traffic metrics",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf metrics list")
-		metricsmap.InitMap(logging.DefaultSlogLogger)
+		metricsmap.InitMap(log)
 		listMetrics(&metricsmap.Metrics)
 	},
 }

--- a/cilium-dbg/cmd/bpf_multicast_groups.go
+++ b/cilium-dbg/cmd/bpf_multicast_groups.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	maps_multicast "github.com/cilium/cilium/pkg/maps/multicast"
 )
 
@@ -41,7 +40,7 @@ var MulticastGroupListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf multicast group list")
 
-		groupV4Map, err := getMulticastGroupMap(logging.DefaultSlogLogger)
+		groupV4Map, err := getMulticastGroupMap(log)
 		if err != nil {
 			Fatalf("failed to get multicast bpf map: %s", err)
 		}
@@ -90,7 +89,7 @@ cilium-dbg bpf multicast group add 229.0.0.1`,
 			Fatalf("Invalid arguments: %s", err)
 		}
 
-		groupV4Map, err := getMulticastGroupMap(logging.DefaultSlogLogger)
+		groupV4Map, err := getMulticastGroupMap(log)
 		if err != nil {
 			Fatalf("failed to get multicast bpf map: %s", err)
 		}
@@ -118,7 +117,7 @@ cilium-dbg bpf multicast group delete 229.0.0.1`,
 			Fatalf("Invalid arguments: %s", err)
 		}
 
-		groupV4Map, err := getMulticastGroupMap(logging.DefaultSlogLogger)
+		groupV4Map, err := getMulticastGroupMap(log)
 		if err != nil {
 			Fatalf("failed to get multicast bpf map: %s", err)
 		}

--- a/cilium-dbg/cmd/bpf_multicast_subscribers.go
+++ b/cilium-dbg/cmd/bpf_multicast_subscribers.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/logging"
 	maps_multicast "github.com/cilium/cilium/pkg/maps/multicast"
 )
 
@@ -53,7 +52,7 @@ var MulticastGroupSubscriberListCmd = &cobra.Command{
 			Fatalf("invalid argument: %s", err)
 		}
 
-		groupV4Map, err := getMulticastGroupMap(logging.DefaultSlogLogger)
+		groupV4Map, err := getMulticastGroupMap(log)
 		if err != nil {
 			Fatalf("Failed to get multicast bpf map: %s", err)
 		}
@@ -221,7 +220,7 @@ func printSubscriberList(subscribers []SubscriberData) {
 }
 
 func getMulticastSubscriberMap(groupAddr netip.Addr) (maps_multicast.SubscriberV4Map, error) {
-	groupV4Map, err := getMulticastGroupMap(logging.DefaultSlogLogger)
+	groupV4Map, err := getMulticastGroupMap(log)
 	if err != nil {
 		return nil, err
 	}

--- a/cilium-dbg/cmd/bpf_nodeid_list.go
+++ b/cilium-dbg/cmd/bpf_nodeid_list.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
 
@@ -50,7 +49,7 @@ var bpfNodeIDListCmd = &cobra.Command{
 			})
 		}
 
-		nodeMap, err := nodemap.LoadNodeMapV2(logging.DefaultSlogLogger)
+		nodeMap, err := nodemap.LoadNodeMapV2(log)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				fmt.Fprintln(os.Stderr, "Cannot find node bpf map")

--- a/cilium-dbg/cmd/bpf_policy_add.go
+++ b/cilium-dbg/cmd/bpf_policy_add.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 var isDeny bool
@@ -19,7 +18,7 @@ var bpfPolicyAddCmd = &cobra.Command{
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf policy add")
-		updatePolicyKey(parsePolicyUpdateArgs(logging.DefaultSlogLogger, cmd, args, isDeny), true)
+		updatePolicyKey(parsePolicyUpdateArgs(log, cmd, args, isDeny), true)
 	},
 }
 

--- a/cilium-dbg/cmd/bpf_policy_delete.go
+++ b/cilium-dbg/cmd/bpf_policy_delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 // bpfPolicyDeleteCmd represents the bpf_policy_delete command
@@ -17,7 +16,7 @@ var bpfPolicyDeleteCmd = &cobra.Command{
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf policy delete")
-		updatePolicyKey(parsePolicyUpdateArgs(logging.DefaultSlogLogger, cmd, args, isDeny), false)
+		updatePolicyKey(parsePolicyUpdateArgs(log, cmd, args, isDeny), false)
 	},
 }
 

--- a/cilium-dbg/cmd/bpf_policy_get.go
+++ b/cilium-dbg/cmd/bpf_policy_get.go
@@ -38,11 +38,11 @@ var bpfPolicyGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf policy get")
 		if allList {
-			listAllMaps(logging.DefaultSlogLogger)
+			listAllMaps(log)
 			return
 		}
 		requireEndpointID(cmd, args)
-		listMap(logging.DefaultSlogLogger, args)
+		listMap(log, args)
 	},
 }
 

--- a/cilium-dbg/cmd/bpf_policy_list.go
+++ b/cilium-dbg/cmd/bpf_policy_list.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 // bpfPolicyListCmd represents the bpf_policy_list command
@@ -18,7 +17,7 @@ var bpfPolicyListCmd = &cobra.Command{
 	Short:   "Dump all policy maps",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf policy list")
-		listAllMaps(logging.DefaultSlogLogger)
+		listAllMaps(log)
 	},
 }
 

--- a/cilium-dbg/cmd/bpf_srv6_policy.go
+++ b/cilium-dbg/cmd/bpf_srv6_policy.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/srv6map"
 )
 
@@ -36,7 +35,7 @@ var bpfSRv6PolicyListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf srv6 policy")
 
-		m4, m6, err := srv6map.OpenPolicyMaps(logging.DefaultSlogLogger)
+		m4, m6, err := srv6map.OpenPolicyMaps(log)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				fmt.Fprintln(os.Stderr, "Cannot find SRv6 policy maps")

--- a/cilium-dbg/cmd/bpf_srv6_sid.go
+++ b/cilium-dbg/cmd/bpf_srv6_sid.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/srv6map"
 )
 
@@ -34,7 +33,7 @@ var bpfSRv6SIDListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf srv6 sid")
 
-		m, err := srv6map.OpenSIDMap(logging.DefaultSlogLogger)
+		m, err := srv6map.OpenSIDMap(log)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				fmt.Fprintln(os.Stderr, "Cannot find SRv6 SID map")

--- a/cilium-dbg/cmd/bpf_srv6_vrf.go
+++ b/cilium-dbg/cmd/bpf_srv6_vrf.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/srv6map"
 )
 
@@ -36,7 +35,7 @@ var bpfSRv6VRFListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf srv6 vrf")
 
-		m4, m6, err := srv6map.OpenVRFMaps(logging.DefaultSlogLogger)
+		m4, m6, err := srv6map.OpenVRFMaps(log)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				fmt.Fprintln(os.Stderr, "Cannot find SRv6 VRF mapping maps")

--- a/cilium-dbg/cmd/bpf_vtep_update.go
+++ b/cilium-dbg/cmd/bpf_vtep_update.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maps/vtep"
 )
@@ -45,7 +44,7 @@ var bpfVtepUpdateCmd = &cobra.Command{
 			Fatalf("Unable to parse vtep mac '%s'", args[2])
 		}
 
-		if err := vtep.UpdateVTEPMapping(logging.DefaultSlogLogger, nil, vcidr, vip, vmac); err != nil {
+		if err := vtep.UpdateVTEPMapping(log, nil, vcidr, vip, vmac); err != nil {
 			fmt.Fprintf(os.Stderr, "error updating contents of map: %s\n", err)
 			os.Exit(1)
 		}

--- a/cilium-dbg/cmd/build-config.go
+++ b/cilium-dbg/cmd/build-config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sConsts "github.com/cilium/cilium/pkg/k8s/constants"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option/resolver"
 )
 
@@ -39,7 +38,7 @@ var buildConfigCmd = &cobra.Command{
 	Short: "Resolve all of the configuration sources that apply to this node",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Info("Running")
-		if err := buildConfigHive.Run(logging.DefaultSlogLogger); err != nil {
+		if err := buildConfigHive.Run(log); err != nil {
 			Fatalf("Build config failed: %v\n", err)
 		}
 	},

--- a/cilium-dbg/cmd/encrypt_flush.go
+++ b/cilium-dbg/cmd/encrypt_flush.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/common/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
 
@@ -34,7 +33,7 @@ var encryptFlushCmd = &cobra.Command{
 	Long:  "Will cause a short connectivity disruption",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium encrypt flush")
-		runXFRMFlush(logging.DefaultSlogLogger)
+		runXFRMFlush(log)
 	},
 }
 

--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -28,7 +28,6 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/iana"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
@@ -325,7 +324,7 @@ func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 	// The map needs not to be transparently initialized here even if
 	// it's not present for some reason. Triggering map recreation with
 	// OpenOrCreate when some map attribute had changed would be much worse.
-	policyMap, err := policymap.OpenPolicyMap(logging.DefaultSlogLogger, pa.path)
+	policyMap, err := policymap.OpenPolicyMap(log, pa.path)
 	if err != nil {
 		Fatalf("Cannot open policymap %q : %s", pa.path, err)
 	}

--- a/cilium-dbg/cmd/helpers_test.go
+++ b/cilium-dbg/cmd/helpers_test.go
@@ -14,15 +14,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
-
-func init() {
-	log = logging.DefaultSlogLogger.With(logfields.LogSubsys, "cilium-dbg")
-}
 
 func TestExpandNestedJSON(t *testing.T) {
 	buf := bytes.NewBufferString("not json at all")

--- a/cilium-dbg/cmd/kvstore_delete.go
+++ b/cilium-dbg/cmd/kvstore_delete.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 var kvstoreDeleteCmd = &cobra.Command{
@@ -24,7 +22,7 @@ var kvstoreDeleteCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		client := setupKvstore(ctx, logging.DefaultSlogLogger)
+		client := setupKvstore(ctx, log)
 
 		if recursive {
 			if err := client.DeletePrefix(ctx, args[0]); err != nil {

--- a/cilium-dbg/cmd/kvstore_get.go
+++ b/cilium-dbg/cmd/kvstore_get.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/command"
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 var kvstoreGetCmd = &cobra.Command{
@@ -29,7 +28,7 @@ var kvstoreGetCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		client := setupKvstore(ctx, logging.DefaultSlogLogger)
+		client := setupKvstore(ctx, log)
 
 		if recursive {
 			pairs, err := client.ListPrefix(ctx, key)

--- a/cilium-dbg/cmd/kvstore_set.go
+++ b/cilium-dbg/cmd/kvstore_set.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 var (
@@ -29,7 +27,7 @@ var kvstoreSetCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		client := setupKvstore(ctx, logging.DefaultSlogLogger)
+		client := setupKvstore(ctx, log)
 
 		err := client.Update(ctx, key, []byte(value), false)
 		if err != nil {

--- a/cilium-dbg/cmd/policy.go
+++ b/cilium-dbg/cmd/policy.go
@@ -37,6 +37,8 @@ var (
 )
 
 func init() {
+	log = logging.DefaultSlogLogger.With(logfields.LogSubsys, "cilium-dbg")
+
 	RootCmd.AddCommand(PolicyCmd)
 
 	// Initialize LRU here because the policy subcommands (validate, import)
@@ -45,7 +47,7 @@ func init() {
 	//
 	// It's not necessary to pass a useful size here because it's not
 	// necessary to cache regexes in a short-lived binary (CLI).
-	re.InitRegexCompileLRU(logging.DefaultSlogLogger, 1)
+	re.InitRegexCompileLRU(log, 1)
 }
 
 func getContext(content []byte, offset int64) (int, string, int) {

--- a/cilium-dbg/cmd/policy.go
+++ b/cilium-dbg/cmd/policy.go
@@ -18,7 +18,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/fqdn/re"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/safeio"
@@ -37,8 +36,6 @@ var (
 )
 
 func init() {
-	log = logging.DefaultSlogLogger.With(logfields.LogSubsys, "cilium-dbg")
-
 	RootCmd.AddCommand(PolicyCmd)
 
 	// Initialize LRU here because the policy subcommands (validate, import)

--- a/cilium-dbg/cmd/policy_test.go
+++ b/cilium-dbg/cmd/policy_test.go
@@ -8,7 +8,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
+
+func init() {
+	// slogloggercheck: initialize the log variable for tests
+	log = logging.DefaultSlogLogger.With(logfields.LogSubsys, "cilium-dbg")
+}
 
 func TestLoadInvalidPolicyJSON(t *testing.T) {
 	invalidJSON := []byte(`

--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/socketlb"
@@ -379,7 +378,7 @@ func revertCNIBackup() error {
 }
 
 func removeSocketLBPrograms() error {
-	if err := socketlb.Disable(logging.DefaultSlogLogger); err != nil {
+	if err := socketlb.Disable(log); err != nil {
 		return fmt.Errorf("Failed to detach all socketlb bpf programs from %s: %w", defaults.DefaultCgroupRoot, err)
 	}
 	fmt.Println("removed all socketlb bpf programs")

--- a/cilium-dbg/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium-dbg/cmd/preflight_k8s_valid_cnp.go
@@ -46,7 +46,7 @@ has an exit code 1 is returned.`,
 	hive.RegisterFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		if err := hive.Run(logging.DefaultSlogLogger); err != nil {
+		if err := hive.Run(log); err != nil {
 			logging.Fatal(log, err.Error())
 		}
 	}

--- a/cilium-dbg/cmd/root.go
+++ b/cilium-dbg/cmd/root.go
@@ -88,13 +88,16 @@ func initConfig() {
 	logDriver := vp.GetStringSlice(option.LogDriver)
 	logOpts, err := command.GetStringMapStringE(vp, option.LogOpt)
 	if err != nil {
+		// slogloggercheck: log fatal errors using the default logger before it's initialized.
 		logging.Fatal(logging.DefaultSlogLogger, fmt.Sprintf("unable to parse %s", option.LogOpt), logfields.Error, err)
 	}
 
 	if err := logging.SetupLogging(logDriver, logOpts, "cilium-dbg", vp.GetBool(option.DebugArg)); err != nil {
+		// slogloggercheck: log fatal errors using the default logger before it's initialized.
 		logging.Fatal(logging.DefaultSlogLogger, "Unable to set up logging", logfields.Error, err)
 	}
 
+	// slogloggercheck: it has been properly initialized now.
 	log = logging.DefaultSlogLogger.With(logfields.LogSubsys, "cilium-dbg")
 
 	if cl, err := clientPkg.NewClient(vp.GetString("host")); err != nil {

--- a/cilium-health/cmd/root.go
+++ b/cilium-health/cmd/root.go
@@ -12,16 +12,12 @@ import (
 
 	"github.com/cilium/cilium/pkg/cmdref"
 	clientPkg "github.com/cilium/cilium/pkg/health/client"
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 const targetName = "cilium-health"
 
 var (
-	client  *clientPkg.Client
-	logOpts = make(map[string]string)
+	client *clientPkg.Client
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -53,9 +49,6 @@ func init() {
 	flags := rootCmd.PersistentFlags()
 	flags.BoolP("debug", "D", false, "Enable debug messages")
 	flags.StringP("host", "H", "", "URI to cilium-health server API")
-	flags.StringSlice("log-driver", []string{}, "Logging endpoints to use for example syslog")
-	flags.Var(option.NewNamedMapOptions("log-opts", &logOpts, nil),
-		"log-opt", "Log driver options for cilium-health e.g. syslog.level=info,syslog.facility=local5,syslog.tag=cilium-agent")
 	viper.BindPFlags(flags)
 
 	rootCmd.AddCommand(cmdref.NewCmd(rootCmd))
@@ -75,10 +68,5 @@ func initConfig() {
 }
 
 func run(cmd *cobra.Command, args []string) {
-	// Logging should always be bootstrapped first. Do not add any code above this!
-	if err := logging.SetupLogging(viper.GetStringSlice("log-driver"), logging.LogOptions(logOpts), "cilium-health", viper.GetBool("debug")); err != nil {
-		logging.Fatal(logging.DefaultSlogLogger, "Failed to set up logging", logfields.Error, err)
-	}
-
 	cmd.Help()
 }

--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -47,9 +47,8 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 		Use:   "clustermesh",
 		Short: "Run ClusterMesh",
 		Run: func(cmd *cobra.Command, args []string) {
-			logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, "clustermesh-apiserver")
-			if err := h.Run(logger); err != nil {
-				logging.Fatal(logger, err.Error())
+			if err := h.Run(logging.DefaultSlogLogger); err != nil {
+				logging.Fatal(logging.DefaultSlogLogger, err.Error())
 			}
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -47,7 +47,9 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 		Use:   "clustermesh",
 		Short: "Run ClusterMesh",
 		Run: func(cmd *cobra.Command, args []string) {
+			// slogloggercheck: it has been initialized in the PreRun function.
 			if err := h.Run(logging.DefaultSlogLogger); err != nil {
+				// slogloggercheck: log fatal errors using the default logger before it's initialized.
 				logging.Fatal(logging.DefaultSlogLogger, err.Error())
 			}
 		},
@@ -56,6 +58,7 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 			metrics.Namespace = metrics.CiliumClusterMeshAPIServerNamespace
 			option.Config.SetupLogging(h.Viper(), "clustermesh-apiserver")
 
+			// slogloggercheck: it has been properly initialized now.
 			logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, "clustermesh-apiserver")
 
 			option.Config.Populate(logger, h.Viper())

--- a/clustermesh-apiserver/etcdinit/root.go
+++ b/clustermesh-apiserver/etcdinit/root.go
@@ -41,14 +41,17 @@ func NewCmd() *cobra.Command {
 		Short: "Initialize an etcd data directory for use by the etcd sidecar of clustermesh-apiserver",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if err := logging.SetupLogging(nil, map[string]string{}, "etcdinit", vp.GetBool(option.DebugArg)); err != nil {
+				// slogloggercheck: log fatal errors using the default logger before it's initialized.
 				logging.Fatal(logging.DefaultSlogLogger, "Unable to set up logging", logfields.Error, err)
 			}
 
+			// slogloggercheck: the logger has been initialized in the logging.SetupLogging call above
 			log := logging.DefaultSlogLogger.With(logfields.LogSubsys, "etcdinit")
 			option.LogRegisteredSlogOptions(vp, log)
 			log.Info("Cilium ClusterMesh etcd init", logfields.Version, version.Version)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			// slogloggercheck: it has been initialized in the PreRun function.
 			log := logging.DefaultSlogLogger.With(logfields.LogSubsys, "etcdinit")
 			err := InitEtcdLocal(log)
 			// The error has already been handled and logged by InitEtcdLocal. We just use it to determine the exit code

--- a/clustermesh-apiserver/kvstoremesh/root.go
+++ b/clustermesh-apiserver/kvstoremesh/root.go
@@ -19,7 +19,9 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 		Use:   "kvstoremesh",
 		Short: "Run KVStoreMesh",
 		Run: func(cmd *cobra.Command, args []string) {
+			// slogloggercheck: it has been initialized in the PreRun function.
 			if err := h.Run(logging.DefaultSlogLogger); err != nil {
+				// slogloggercheck: log fatal errors using the default logger before it's initialized.
 				logging.Fatal(logging.DefaultSlogLogger, err.Error())
 			}
 		},
@@ -28,6 +30,7 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 			metrics.Namespace = metrics.CiliumKVStoreMeshNamespace
 			option.Config.SetupLogging(h.Viper(), "kvstoremesh")
 
+			// slogloggercheck: the logger has been initialized in the SetupLogging call above
 			log := logging.DefaultSlogLogger.With(logfields.LogSubsys, "kvstoremesh")
 
 			option.Config.Populate(log, h.Viper())

--- a/contrib/examples/statedb/main.go
+++ b/contrib/examples/statedb/main.go
@@ -51,5 +51,6 @@ func main() {
 			Cell,
 			cell.Invoke(followExamples),
 		),
+		// slogloggercheck: it's just an example, so we can use the default logger
 	).Run(logging.DefaultSlogLogger)
 }

--- a/contrib/examples/statedb_k8s/main.go
+++ b/contrib/examples/statedb_k8s/main.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/k8s/client"
-	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/logging"
 )
 
 func followPods(jg job.Group, db *statedb.DB, table statedb.Table[*v1.Pod]) {
@@ -62,5 +63,6 @@ func main() {
 	if err := pflag.CommandLine.Parse(os.Args); err != nil {
 		panic(err)
 	}
+	// slogloggercheck: it's just an example, so we can use the default logger
 	h.Run(logging.DefaultSlogLogger)
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1003,6 +1003,7 @@ func initDaemonConfigAndLogging(vp *viper.Viper) {
 
 	option.Config.SetupLogging(vp, "cilium-agent")
 
+	// slogloggercheck: using default logger for configuration initialization
 	option.Config.Populate(logging.DefaultSlogLogger, vp)
 
 	// add hooks after setting up metrics in the option.Config

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/encrypt"
@@ -269,7 +268,7 @@ func setupVTEPMapping(logger *slog.Logger, registry *metrics.Registry) error {
 			logfields.IPAddr, ep,
 		)
 
-		err := vtep.UpdateVTEPMapping(logging.DefaultSlogLogger, registry, option.Config.VtepCIDRs[i], ep, option.Config.VtepMACs[i])
+		err := vtep.UpdateVTEPMapping(logger, registry, option.Config.VtepCIDRs[i], ep, option.Config.VtepMACs[i])
 		if err != nil {
 			return fmt.Errorf("Unable to set up VTEP ipcache mappings: %w", err)
 		}

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -32,20 +32,22 @@ func NewAgentCmd(hfn func() *hive.Hive) *cobra.Command {
 				os.Exit(0)
 			}
 
-			daemonLogger := logging.DefaultSlogLogger.With(logfields.LogSubsys, daemonSubsys)
 			// Initialize working directories and validate the configuration.
-			initEnv(daemonLogger, h.Viper())
+			initEnv(logging.DefaultSlogLogger, h.Viper())
+
+			// Create a new logger for the daemon after we have initialized the
+			// configuration in initEnv().
+			daemonLogger := logging.DefaultSlogLogger.With(logfields.LogSubsys, daemonSubsys)
 
 			// Validate the daemon-specific global options.
 			if err := option.Config.Validate(h.Viper()); err != nil {
 				logging.Fatal(daemonLogger, fmt.Sprintf("invalid daemon configuration: %s", err))
 			}
 
-			// Pass the DefaultSlogLogger to the hive after being initialized
-			// with the initEnv which sets up the logging.DefaultSlogLogger with
-			// the user-options.
+			// Initialize the daemon configuration and logging with the
+			// DefaultSlogLogger without any logfields.
 			if err := h.Run(logging.DefaultSlogLogger); err != nil {
-				logging.Fatal(logging.DefaultSlogLogger, fmt.Sprintf("unable to run agent: %s", err))
+				logging.Fatal(daemonLogger, fmt.Sprintf("unable to run agent: %s", err))
 			} else {
 				// If h.Run() exits with no errors, it means the agent gracefully shut down.
 				// (There is a CI job that ensures this is the case)

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -33,10 +33,12 @@ func NewAgentCmd(hfn func() *hive.Hive) *cobra.Command {
 			}
 
 			// Initialize working directories and validate the configuration.
+			// slogloggercheck: the logger has been initialized in the cobra.OnInitialize
 			initEnv(logging.DefaultSlogLogger, h.Viper())
 
 			// Create a new logger for the daemon after we have initialized the
 			// configuration in initEnv().
+			// slogloggercheck: the logger has been initialized in the cobra.OnInitialize
 			daemonLogger := logging.DefaultSlogLogger.With(logfields.LogSubsys, daemonSubsys)
 
 			// Validate the daemon-specific global options.
@@ -46,6 +48,7 @@ func NewAgentCmd(hfn func() *hive.Hive) *cobra.Command {
 
 			// Initialize the daemon configuration and logging with the
 			// DefaultSlogLogger without any logfields.
+			// slogloggercheck: the logger has been initialized in the cobra.OnInitialize
 			if err := h.Run(logging.DefaultSlogLogger); err != nil {
 				logging.Fatal(daemonLogger, fmt.Sprintf("unable to run agent: %s", err))
 			} else {
@@ -66,9 +69,11 @@ func NewAgentCmd(hfn func() *hive.Hive) *cobra.Command {
 		h.Command(),
 	)
 
+	// slogloggercheck: using default logger for initializing global flags
 	InitGlobalFlags(logging.DefaultSlogLogger, rootCmd, h.Viper())
 
 	cobra.OnInitialize(
+		// slogloggercheck: using default logger for configuration initialization
 		option.InitConfig(logging.DefaultSlogLogger, rootCmd, "cilium-agent", "cilium", h.Viper()),
 
 		// Populate the config and initialize the logger early as these

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -20,7 +20,6 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
@@ -177,7 +176,7 @@ func (d *Daemon) fetchOldEndpoints(dir string) (*endpointRestoreState, error) {
 	}
 	eptsID := endpoint.FilterEPDir(dirFiles)
 
-	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, logging.DefaultSlogLogger, d.endpointCreator, dir, eptsID)
+	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, d.logger, d.endpointCreator, dir, eptsID)
 
 	if len(state.possible) == 0 {
 		d.logger.Info("No old endpoints found.")

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -143,7 +143,7 @@ func newConfigModifyEventHandler(params configModifyEventHandlerParams) *ConfigM
 			}
 			eventHandler.datapathRegenTrigger = rt
 
-			eventHandler.configModifyQueue = eventqueue.NewEventQueueBuffered(logging.DefaultSlogLogger, "config-modify-queue", ConfigModifyQueueSize)
+			eventHandler.configModifyQueue = eventqueue.NewEventQueueBuffered(params.Logger, "config-modify-queue", ConfigModifyQueueSize)
 			eventHandler.configModifyQueue.Run()
 
 			return nil
@@ -375,7 +375,7 @@ func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.R
 	}
 
 	status := &models.DaemonConfigurationStatus{
-		Addressing:       node.GetNodeAddressing(logging.DefaultSlogLogger),
+		Addressing:       node.GetNodeAddressing(h.logger),
 		K8sConfiguration: h.clientset.Config().K8sKubeConfigPath,
 		K8sEndpoint:      h.clientset.Config().K8sAPIServer,
 		NodeMonitor:      h.monitorAgent.State(),

--- a/hubble-relay/cmd/root.go
+++ b/hubble-relay/cmd/root.go
@@ -31,6 +31,7 @@ func New() *cobra.Command {
 		Version:      v.GetCiliumVersion().Version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := logging.SetupLogging(nil, map[string]string{}, "hubble-relay", vp.GetBool(option.DebugArg)); err != nil {
+				// slogloggercheck: log fatal errors using the default logger before it's initialized.
 				logging.Fatal(logging.DefaultSlogLogger, "Unable to set up logging", logfields.Error, err)
 			}
 			return nil
@@ -42,6 +43,7 @@ func New() *cobra.Command {
 	vp.BindPFlags(flags)
 
 	if err := vp.ReadInConfig(); err != nil {
+		// slogloggercheck: log debug errors using the default logger before it's initialized.
 		logging.DefaultSlogLogger.Debug("Failed to read config from file",
 			logfields.Error, err,
 			logfields.Path, configFilePath,

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -185,6 +185,7 @@ func New(vp *viper.Viper) *cobra.Command {
 }
 
 func runServe(vp *viper.Viper) error {
+	// slogloggercheck: the logger has been initialized with default settings
 	logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, "hubble-relay")
 
 	opts := []server.Option{

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -185,9 +185,6 @@ func New(vp *viper.Viper) *cobra.Command {
 }
 
 func runServe(vp *viper.Viper) error {
-	if vp.GetBool("debug") {
-		logging.SetLogLevelToDebug()
-	}
 	logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, "hubble-relay")
 
 	opts := []server.Option{

--- a/hubble/cmd/cli_test.go
+++ b/hubble/cmd/cli_test.go
@@ -27,6 +27,7 @@ func init() {
 	// Override the client so that it always returns an IOReaderObserver with no flows.
 	observe.GetHubbleClientFunc = func(_ context.Context, _ *viper.Viper) (client observerpb.ObserverClient, cleanup func() error, err error) {
 		cleanup = func() error { return nil }
+		// slogloggercheck: the default logger is enough for tests.
 		return observe.NewIOReaderObserver(logging.DefaultSlogLogger, new(bytes.Buffer)), cleanup, nil
 	}
 

--- a/hubble/cmd/cli_test.go
+++ b/hubble/cmd/cli_test.go
@@ -17,6 +17,7 @@ import (
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/hubble/cmd/observe"
 	"github.com/cilium/cilium/hubble/pkg/defaults"
+	"github.com/cilium/cilium/pkg/logging"
 )
 
 //go:embed observe_help.txt
@@ -26,7 +27,7 @@ func init() {
 	// Override the client so that it always returns an IOReaderObserver with no flows.
 	observe.GetHubbleClientFunc = func(_ context.Context, _ *viper.Viper) (client observerpb.ObserverClient, cleanup func() error, err error) {
 		cleanup = func() error { return nil }
-		return observe.NewIOReaderObserver(new(bytes.Buffer)), cleanup, nil
+		return observe.NewIOReaderObserver(logging.DefaultSlogLogger, new(bytes.Buffer)), cleanup, nil
 	}
 
 	expectedObserveHelp = fmt.Sprintf(expectedObserveHelp, defaults.ConfigFile)

--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -161,7 +161,7 @@ var GetHubbleClientFunc = func(ctx context.Context, vp *viper.Viper) (client obs
 			}
 			cleanup = f.Close
 		}
-		client = NewIOReaderObserver(f)
+		client = NewIOReaderObserver(logger.Logger, f)
 		return client, cleanup, nil
 	}
 	// read flows from a hubble server

--- a/hubble/cmd/observe/io_reader_observer_test.go
+++ b/hubble/cmd/observe/io_reader_observer_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -26,7 +27,7 @@ func Test_getFlowsBasic(t *testing.T) {
 		require.NoError(t, err)
 		flowStrings = append(flowStrings, string(b))
 	}
-	server := NewIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
+	server := NewIOReaderObserver(hivetest.Logger(t), strings.NewReader(strings.Join(flowStrings, "\n")+"\n"))
 	req := observerpb.GetFlowsRequest{}
 	client, err := server.GetFlows(t.Context(), &req)
 	require.NoError(t, err)
@@ -59,7 +60,7 @@ func Test_getFlowsTimeRange(t *testing.T) {
 		require.NoError(t, err)
 		flowStrings = append(flowStrings, string(b))
 	}
-	server := NewIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
+	server := NewIOReaderObserver(hivetest.Logger(t), strings.NewReader(strings.Join(flowStrings, "\n")+"\n"))
 	req := observerpb.GetFlowsRequest{
 		Since: &timestamppb.Timestamp{Seconds: 50},
 		Until: &timestamppb.Timestamp{Seconds: 150},
@@ -94,7 +95,7 @@ func Test_getFlowsLast(t *testing.T) {
 		require.NoError(t, err)
 		flowStrings = append(flowStrings, string(b))
 	}
-	server := NewIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
+	server := NewIOReaderObserver(hivetest.Logger(t), strings.NewReader(strings.Join(flowStrings, "\n")+"\n"))
 	req := observerpb.GetFlowsRequest{
 		Number: 2,
 		First:  false,
@@ -132,7 +133,7 @@ func Test_getFlowsFirst(t *testing.T) {
 		require.NoError(t, err)
 		flowStrings = append(flowStrings, string(b))
 	}
-	server := NewIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
+	server := NewIOReaderObserver(hivetest.Logger(t), strings.NewReader(strings.Join(flowStrings, "\n")+"\n"))
 	req := observerpb.GetFlowsRequest{
 		Number: 2,
 		First:  true,
@@ -170,7 +171,7 @@ func Test_getFlowsFilter(t *testing.T) {
 		require.NoError(t, err)
 		flowStrings = append(flowStrings, string(b))
 	}
-	server := NewIOReaderObserver(strings.NewReader(strings.Join(flowStrings, "\n") + "\n"))
+	server := NewIOReaderObserver(hivetest.Logger(t), strings.NewReader(strings.Join(flowStrings, "\n")+"\n"))
 	req := observerpb.GetFlowsRequest{
 		Whitelist: []*flowpb.FlowFilter{
 			{
@@ -210,7 +211,7 @@ func Test_UnknownField(t *testing.T) {
 		sb.WriteString(s + "\n")
 	}
 	// server and client setup.
-	server := NewIOReaderObserver(strings.NewReader(sb.String()))
+	server := NewIOReaderObserver(hivetest.Logger(t), strings.NewReader(sb.String()))
 	client, err := server.GetFlows(t.Context(), &observerpb.GetFlowsRequest{})
 	require.NoError(t, err)
 	// logger setup.

--- a/operator/cmd/metrics_list.go
+++ b/operator/cmd/metrics_list.go
@@ -30,6 +30,7 @@ var MetricsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all metrics for the operator",
 	Run: func(cmd *cobra.Command, args []string) {
+		// slogloggercheck: use the logger with the default settings since this ist only used for CLI output
 		logger := logging.DefaultSlogLogger
 
 		c := client.NewHTTPClientWithConfig(

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -323,6 +323,7 @@ func NewOperatorCmd(h *hive.Hive) *cobra.Command {
 		Use:   binaryName,
 		Short: "Run " + binaryName,
 		Run: func(cobraCmd *cobra.Command, args []string) {
+			// slogloggercheck: the logger has been initialized in the cobra.OnInitialize
 			logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, binaryName)
 
 			initEnv(logger, h.Viper())
@@ -330,7 +331,9 @@ func NewOperatorCmd(h *hive.Hive) *cobra.Command {
 			// Pass the DefaultSlogLogger to the hive after being initialized
 			// with the initEnv which sets up the logging.DefaultSlogLogger with
 			// the user-options.
+			// slogloggercheck: the logger has been initialized in the cobra.OnInitialize
 			if err := h.Run(logging.DefaultSlogLogger); err != nil {
+				// slogloggercheck: log fatal errors using the default logger before it's initialized.
 				logging.Fatal(logging.DefaultSlogLogger, err.Error())
 			}
 		},
@@ -354,11 +357,13 @@ func NewOperatorCmd(h *hive.Hive) *cobra.Command {
 		h.Command(),
 	)
 
+	// slogloggercheck: using default logger for configuration initialization
 	InitGlobalFlags(logging.DefaultSlogLogger, cmd, h.Viper())
 	for _, hook := range FlagsHooks {
 		hook.RegisterProviderFlag(cmd, h.Viper())
 	}
 
+	// slogloggercheck: using default logger for configuration initialization
 	cobra.OnInitialize(option.InitConfig(logging.DefaultSlogLogger, cmd, "Cilium-Operator", "cilium-operators", h.Viper()))
 
 	return cmd

--- a/pkg/api/socket.go
+++ b/pkg/api/socket.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"os/user"
 	"strconv"
@@ -26,10 +25,10 @@ func getGroupIDByName(grpName string) (int, error) {
 
 // SetDefaultPermissions sets the given socket's group to `CiliumGroupName` and
 // mode to `SocketFileMode`.
-func SetDefaultPermissions(scopedLog *slog.Logger, socketPath string) error {
+func SetDefaultPermissions(debugLogger func(msg string, args ...any), socketPath string) error {
 	gid, err := getGroupIDByName(CiliumGroupName)
 	if err != nil {
-		scopedLog.Debug("Group not found",
+		debugLogger("Group not found",
 			logfields.Error, err,
 			logfields.Path, socketPath,
 			logfields.Group, CiliumGroupName,

--- a/pkg/aws/eni/eni_gc.go
+++ b/pkg/aws/eni/eni_gc.go
@@ -6,10 +6,10 @@ package eni
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ipam/types"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -33,7 +33,7 @@ type GarbageCollectionParams struct {
 	ENITags types.Tags
 }
 
-func StartENIGarbageCollector(ctx context.Context, logger logging.FieldLogger, api EC2API, params GarbageCollectionParams) {
+func StartENIGarbageCollector(ctx context.Context, logger *slog.Logger, api EC2API, params GarbageCollectionParams) {
 	logger = logger.With(subsysLogAttr...)
 	logger.Info("Starting to garbage collect detached ENIs")
 

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -25,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/api/helpers"
 	"github.com/cilium/cilium/pkg/azure/types"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/spanstat"
 	"github.com/cilium/cilium/pkg/version"
 )
@@ -42,8 +40,6 @@ const (
 	interfacesListVirtualMachineScaleSetNetworkInterfaces   = "Interfaces.ListVirtualMachineScaleSetNetworkInterfaces"
 	interfacesListVirtualMachineScaleSetVMNetworkInterfaces = "Interfaces.ListVirtualMachineScaleSetVMNetworkInterfaces"
 )
-
-var subsysLogAttr = slog.String(logfields.LogSubsys, "azure-api")
 
 // Client represents an Azure API client
 type Client struct {

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -5,12 +5,12 @@ package ipam
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -27,7 +27,7 @@ type AzureAPI interface {
 // InstancesManager maintains the list of instances. It must be kept up to date
 // by calling Resync() regularly.
 type InstancesManager struct {
-	logger logging.FieldLogger
+	logger *slog.Logger
 	// resyncLock ensures instance incremental resync do not run at the same time as a full API resync
 	resyncLock lock.RWMutex
 
@@ -40,7 +40,7 @@ type InstancesManager struct {
 }
 
 // NewInstancesManager returns a new instances manager
-func NewInstancesManager(logger logging.FieldLogger, api AzureAPI) *InstancesManager {
+func NewInstancesManager(logger *slog.Logger, api AzureAPI) *InstancesManager {
 	return &InstancesManager{
 		logger:    logger.With(subsysLogAttr...),
 		instances: ipamTypes.NewInstanceMap(),

--- a/pkg/bgpv1/manager/reconcilerv2/paths.go
+++ b/pkg/bgpv1/manager/reconcilerv2/paths.go
@@ -6,11 +6,11 @@ package reconcilerv2
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"maps"
 
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	"github.com/cilium/cilium/pkg/k8s/resource"
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 // PathMap is a map of paths indexed by the NLRI string
@@ -32,7 +32,7 @@ type PathReference struct {
 type PathReferencesMap map[string]*PathReference
 
 type ReconcileResourceAFPathsParams struct {
-	Logger                 logging.FieldLogger
+	Logger                 *slog.Logger
 	Ctx                    context.Context
 	Router                 types.Router
 	DesiredResourceAFPaths ResourceAFPathsMap
@@ -40,7 +40,7 @@ type ReconcileResourceAFPathsParams struct {
 }
 
 type ReconcileAFPathsParams struct {
-	Logger         logging.FieldLogger
+	Logger         *slog.Logger
 	Ctx            context.Context
 	Router         types.Router
 	DesiredPaths   AFPathsMap
@@ -49,7 +49,7 @@ type ReconcileAFPathsParams struct {
 }
 
 type reconcilePathsParams struct {
-	Logger                logging.FieldLogger
+	Logger                *slog.Logger
 	Ctx                   context.Context
 	Router                types.Router
 	CurrentAdvertisements PathMap

--- a/pkg/bgpv1/manager/reconcilerv2/policies.go
+++ b/pkg/bgpv1/manager/reconcilerv2/policies.go
@@ -6,6 +6,7 @@ package reconcilerv2
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"maps"
 	"net/netip"
 	"sort"
@@ -18,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -34,7 +34,7 @@ type ResourceRoutePolicyMap map[resource.Key]RoutePolicyMap
 type RoutePolicyMap map[string]*types.RoutePolicy
 
 type ReconcileRoutePoliciesParams struct {
-	Logger          logging.FieldLogger
+	Logger          *slog.Logger
 	Ctx             context.Context
 	Router          types.Router
 	DesiredPolicies RoutePolicyMap

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -246,7 +246,7 @@ func (m *Map) updateMetrics() {
 func NewMap(name string, mapType ebpf.MapType, mapKey MapKey, mapValue MapValue,
 	maxEntries int, flags uint32) *Map {
 
-	// TODO inject the logger in a better way than this.
+	// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 	defaultSlogLogger := logging.DefaultSlogLogger
 	keySize := reflect.TypeOf(mapKey).Elem().Size()
 	valueSize := reflect.TypeOf(mapValue).Elem().Size()
@@ -275,7 +275,7 @@ func NewMap(name string, mapType ebpf.MapType, mapKey MapKey, mapValue MapValue,
 func NewMapWithInnerSpec(name string, mapType ebpf.MapType, mapKey MapKey, mapValue MapValue,
 	maxEntries int, flags uint32, innerSpec *ebpf.MapSpec) *Map {
 
-	// TODO inject the logger in a better way than this.
+	// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 	defaultSlogLogger := logging.DefaultSlogLogger
 	keySize := reflect.TypeOf(mapKey).Elem().Size()
 	valueSize := reflect.TypeOf(mapValue).Elem().Size()
@@ -492,7 +492,7 @@ func OpenMap(pinPath string, key MapKey, value MapValue) (*Map, error) {
 		return nil, err
 	}
 
-	// TODO inject the logger in a better way than this.
+	// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 	defaultSlogLogger := logging.DefaultSlogLogger
 
 	logger := defaultSlogLogger.With(

--- a/pkg/cgroups/manager/manager.go
+++ b/pkg/cgroups/manager/manager.go
@@ -4,6 +4,7 @@
 package manager
 
 import (
+	"log/slog"
 	"maps"
 	"os"
 	"slices"
@@ -12,7 +13,6 @@ import (
 	"github.com/cilium/cilium/pkg/cgroups"
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodetypes "github.com/cilium/cilium/pkg/node/types"
 )
@@ -50,7 +50,7 @@ type CGroupManager interface {
 // During initialization, the manager checks for a valid cgroup path pathProvider.
 // If it fails to find a pathProvider, it will ignore all the subsequent pod events.
 type cgroupManager struct {
-	logger logging.FieldLogger
+	logger *slog.Logger
 	// Map of pod metadata indexed by their UIDs
 	podMetadataById map[podUID]*podMetadata
 	// Map of container metadata indexed by their cgroup ids
@@ -200,7 +200,7 @@ func (c cgroupImpl) GetCgroupID(cgroupPath string) (uint64, error) {
 	return cgroups.GetCgroupID(cgroupPath)
 }
 
-func newManager(logger logging.FieldLogger, cg cgroup, pathProvider cgroupPathProvider, channelSize int) *cgroupManager {
+func newManager(logger *slog.Logger, cg cgroup, pathProvider cgroupPathProvider, channelSize int) *cgroupManager {
 	return &cgroupManager{
 		logger:                    logger,
 		podMetadataById:           make(map[string]*podMetadata),

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -96,6 +96,7 @@ func (m *Manager) createControllerLocked(name string, params ControllerParams) *
 	uuid := uuid.New().String()
 	ctrl := &managedController{
 		controller: controller{
+			// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 			logger: logging.DefaultSlogLogger.With(
 				logfields.LogSubsys, "controller",
 				fieldControllerName, name,

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -53,6 +53,7 @@ func init() {
 	var err error
 	tpl, err = tpl.Parse(content)
 	if err != nil {
+		// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 		logging.Fatal(logging.DefaultSlogLogger, "could not parse headerfile template", logfields.Error, err)
 	}
 }

--- a/pkg/datapath/prefilter/prefilter.go
+++ b/pkg/datapath/prefilter/prefilter.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/cidrmap"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -222,7 +221,7 @@ func (p *PreFilter) initOneMap(which preFilterMapType) error {
 		path = bpf.MapPath(p.logger, cidrmap.MapName+"v6_fix")
 	}
 
-	p.maps[which], err = cidrmap.OpenMapElems(logging.DefaultSlogLogger, path, prefixlen, prefixdyn, maxelems)
+	p.maps[which], err = cidrmap.OpenMapElems(p.logger, path, prefixlen, prefixdyn, maxelems)
 	if err != nil {
 		return err
 	}

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -9,6 +9,7 @@ package endpoint
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"maps"
 	"slices"
 	"sort"
@@ -62,12 +63,12 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 }
 
 // NewEndpointFromChangeModel creates a new endpoint from a request
-func NewEndpointFromChangeModel(ctx context.Context, dnsRulesAPI DNSRulesAPI, epBuildQueue EndpointBuildQueue, loader datapath.Loader, orchestrator datapath.Orchestrator, compilationLock datapath.CompilationLock, bandwidthManager datapath.BandwidthManager, ipTablesManager datapath.IptablesManager, identityManager identitymanager.IDManager, monitorAgent monitoragent.Agent, policyMapFactory policymap.Factory, policyRepo policy.PolicyRepository, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ctMapGC ctmap.GCRunner, kvstoreSyncher *ipcache.IPIdentitySynchronizer, model *models.EndpointChangeRequest) (*Endpoint, error) {
+func NewEndpointFromChangeModel(ctx context.Context, logger *slog.Logger, dnsRulesAPI DNSRulesAPI, epBuildQueue EndpointBuildQueue, loader datapath.Loader, orchestrator datapath.Orchestrator, compilationLock datapath.CompilationLock, bandwidthManager datapath.BandwidthManager, ipTablesManager datapath.IptablesManager, identityManager identitymanager.IDManager, monitorAgent monitoragent.Agent, policyMapFactory policymap.Factory, policyRepo policy.PolicyRepository, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ctMapGC ctmap.GCRunner, kvstoreSyncher *ipcache.IPIdentitySynchronizer, model *models.EndpointChangeRequest) (*Endpoint, error) {
 	if model == nil {
 		return nil, nil
 	}
 
-	ep := createEndpoint(dnsRulesAPI, epBuildQueue, loader, orchestrator, compilationLock, bandwidthManager, ipTablesManager, identityManager, monitorAgent, policyMapFactory, policyRepo, namedPortsGetter, proxy, allocator, ctMapGC, kvstoreSyncher, uint16(model.ID), model.InterfaceName)
+	ep := createEndpoint(logger, dnsRulesAPI, epBuildQueue, loader, orchestrator, compilationLock, bandwidthManager, ipTablesManager, identityManager, monitorAgent, policyMapFactory, policyRepo, namedPortsGetter, proxy, allocator, ctMapGC, kvstoreSyncher, uint16(model.ID), model.InterfaceName)
 	ep.ifIndex = int(model.InterfaceIndex)
 	ep.containerIfName = model.ContainerInterfaceName
 	ep.parentIfIndex = int(model.ParentInterfaceIndex)

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -26,7 +26,7 @@ func TestWriteInformationalComments(t *testing.T) {
 	s := setupEndpointSuite(t)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(t.Context(), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -46,7 +46,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 	s := setupEndpointSuite(b)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(b.Context(), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(b.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))

--- a/pkg/endpoint/creator/creator.go
+++ b/pkg/endpoint/creator/creator.go
@@ -5,6 +5,7 @@ package creator
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/cilium/hive/cell"
 
@@ -42,6 +43,7 @@ type EndpointCreator interface {
 }
 
 type endpointCreator struct {
+	logger           *slog.Logger
 	endpointManager  endpointmanager.EndpointManager
 	dnsRulesAPI      fqdnrules.DNSRulesService
 	epBuildQueue     endpoint.EndpointBuildQueue
@@ -68,6 +70,7 @@ var _ EndpointCreator = &endpointCreator{}
 type endpointManagerParams struct {
 	cell.In
 
+	Logger              *slog.Logger
 	EndpointManager     endpointmanager.EndpointManager
 	DNSRulesService     fqdnrules.DNSRulesService
 	EPBuildQueue        endpoint.EndpointBuildQueue
@@ -89,6 +92,7 @@ type endpointManagerParams struct {
 
 func newEndpointCreator(p endpointManagerParams) EndpointCreator {
 	return &endpointCreator{
+		logger:           p.Logger,
 		endpointManager:  p.EndpointManager,
 		dnsRulesAPI:      p.DNSRulesService,
 		epBuildQueue:     p.EPBuildQueue,
@@ -112,6 +116,7 @@ func newEndpointCreator(p endpointManagerParams) EndpointCreator {
 func (c *endpointCreator) NewEndpointFromChangeModel(ctx context.Context, base *models.EndpointChangeRequest) (*endpoint.Endpoint, error) {
 	return endpoint.NewEndpointFromChangeModel(
 		ctx,
+		c.logger,
 		c.dnsRulesAPI,
 		c.epBuildQueue,
 		c.loader,
@@ -134,6 +139,7 @@ func (c *endpointCreator) NewEndpointFromChangeModel(ctx context.Context, base *
 
 func (c *endpointCreator) ParseEndpoint(epJSON []byte) (*endpoint.Endpoint, error) {
 	return endpoint.ParseEndpoint(
+		c.logger,
 		c.dnsRulesAPI,
 		c.epBuildQueue,
 		c.loader,
@@ -156,6 +162,7 @@ func (c *endpointCreator) ParseEndpoint(epJSON []byte) (*endpoint.Endpoint, erro
 
 func (c *endpointCreator) AddIngressEndpoint(ctx context.Context) error {
 	ep, err := endpoint.CreateIngressEndpoint(
+		c.logger,
 		c.dnsRulesAPI,
 		c.epBuildQueue,
 		c.loader,
@@ -188,6 +195,7 @@ func (c *endpointCreator) AddIngressEndpoint(ctx context.Context) error {
 
 func (c *endpointCreator) AddHostEndpoint(ctx context.Context) error {
 	ep, err := endpoint.CreateHostEndpoint(
+		c.logger,
 		c.dnsRulesAPI,
 		c.epBuildQueue,
 		c.loader,

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -18,7 +19,7 @@ import (
 func TestGetCiliumEndpointStatus(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e, err := NewEndpointFromChangeModel(context.TODO(), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), nil, &models.EndpointChangeRequest{
+	e, err := NewEndpointFromChangeModel(context.TODO(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), nil, &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{
 			IPV4: "192.168.1.100",
 			IPV6: "f00d::a10:0:0:abcd",

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -190,7 +190,7 @@ func TestEndpointStatus(t *testing.T) {
 func TestEndpointDatapathOptions(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e, err := NewEndpointFromChangeModel(context.TODO(), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), nil, &models.EndpointChangeRequest{
+	e, err := NewEndpointFromChangeModel(context.TODO(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), nil, &models.EndpointChangeRequest{
 		DatapathConfiguration: &models.EndpointDatapathConfiguration{
 			DisableSipVerification: true,
 		},
@@ -204,7 +204,7 @@ func TestEndpointUpdateLabels(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(t.Context(), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -251,7 +251,7 @@ func TestEndpointState(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(t.Context(), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 	e.Start(uint16(model.ID))
 	t.Cleanup(e.Stop)
@@ -639,7 +639,7 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 	}()
 
 	model := newTestEndpointModel(12345, StateReady)
-	ep, err := NewEndpointFromChangeModel(t.Context(), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -721,7 +721,7 @@ func BenchmarkEndpointGetModel(b *testing.B) {
 	logger := hivetest.Logger(b)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(b.Context(), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(b.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))
@@ -800,8 +800,7 @@ func TestMetadataResolver(t *testing.T) {
 			t.Run(fmt.Sprintf("%s (restored=%t)", tt.name, restored), func(t *testing.T) {
 				model := newTestEndpointModel(100, StateWaitingForIdentity)
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-				ep, err := NewEndpointFromChangeModel(t.Context(), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, &fakeTypes.BandwidthManager{}, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{},
-					testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+				ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, &fakeTypes.BandwidthManager{}, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
 				require.NoError(t, err)
 
 				ep.K8sNamespace, ep.K8sPodName, ep.K8sUID = "bar", "foo", "uid"

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/linux/bandwidth"
 	"github.com/cilium/cilium/pkg/eventqueue"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -346,7 +345,7 @@ func (ev *EndpointPolicyBandwidthEvent) Handle(res chan any) {
 // so that when its metadata is resolved, events can be enqueued (such as
 // bandwidth policy).
 func (e *Endpoint) InitEventQueue() {
-	e.eventQueue = eventqueue.NewEventQueueBuffered(logging.DefaultSlogLogger, fmt.Sprintf("endpoint-%d", e.ID), option.Config.EndpointQueueSize)
+	e.eventQueue = eventqueue.NewEventQueueBuffered(e.getLogger(), fmt.Sprintf("endpoint-%d", e.ID), option.Config.EndpointQueueSize)
 }
 
 // Start assigns a Cilium Endpoint ID to the endpoint and prepares it to

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -46,10 +46,12 @@ func (e *Endpoint) PolicyDebug(msg string, attrs ...any) {
 // nil or its internal loger is not setup, it returns the default logger.
 func (e *Endpoint) Logger(subsystem string) *slog.Logger {
 	if e == nil {
+		// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 		return logging.DefaultSlogLogger.With(logfields.LogSubsys, subsystem)
 	}
 	logger := e.loggerNoSubsys.Load()
 	if logger == nil {
+		// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 		return logging.DefaultSlogLogger.With(logfields.LogSubsys, subsystem)
 	}
 
@@ -121,11 +123,13 @@ func (e *Endpoint) UpdateLogger(fields map[string]any) {
 
 	// Create a base logger without the subsys attribute for the endpoint so
 	// that we can use it in the func Logger(subsystem string) *slog.Logger
+	// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 	baseLogger := logging.DefaultSlogLogger.With(args...)
 	e.loggerNoSubsys.Store(baseLogger)
 
 	// Create a base logger with the subsys attribute.
 	args = append(args, logfields.LogSubsys, subsys)
+	// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 	baseLogger = logging.DefaultSlogLogger.With(args...)
 
 	// If this endpoint is set to debug ensure it will print debug by giving it

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -26,10 +26,10 @@ func TestPolicyLog(t *testing.T) {
 	setupEndpointSuite(t)
 	logger := hivetest.Logger(t)
 
-	do := &DummyOwner{repo: policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, api.NewPolicyMetricsNoop())}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, nil, nil, nil, nil, api.NewPolicyMetricsNoop())}
 
 	model := newTestEndpointModel(12345, StateReady)
-	ep, err := NewEndpointFromChangeModel(t.Context(), nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, do.repo, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, do.repo, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -162,7 +162,7 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 	logger := hivetest.Logger(t)
 	model := newTestEndpointModel(12345, StateRegenerating)
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-	ep, err := NewEndpointFromChangeModel(t.Context(), nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.do.repo, testipcache.NewMockIPCache(), s.rsp, s.mgr, ctmap.NewFakeGCRunner(), kvstoreSync, model)
+	ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.do.repo, testipcache.NewMockIPCache(), s.rsp, s.mgr, ctmap.NewFakeGCRunner(), kvstoreSync, model)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/node"
@@ -558,7 +557,7 @@ func (ep *Endpoint) UnmarshalJSON(raw []byte) error {
 		Labels:     labels.NewOpLabels(),
 		Options:    option.NewIntOptions(&EndpointMutableOptionLibrary),
 		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
-		DNSZombies: fqdn.NewDNSZombieMappings(logging.DefaultSlogLogger, option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
+		DNSZombies: fqdn.NewDNSZombieMappings(ep.getLogger(), option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 	}
 	if err := json.Unmarshal(raw, restoredEp); err != nil {
 		return fmt.Errorf("error unmarshaling serializableEndpoint from base64 representation: %w", err)

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -46,7 +46,7 @@ func TestMarkAndSweep(t *testing.T) {
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
 		model := newTestEndpointModel(int(id), endpoint.StateReady)
-		ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+		ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 		require.NoError(t, err)
 
 		ep.Start(uint16(model.ID))

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -390,7 +390,7 @@ func TestLookup(t *testing.T) {
 			logger := hivetest.Logger(t)
 			mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 			if tt.cm != nil {
-				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, tt.cm)
+				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, tt.cm)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
 				err = mgr.expose(ep)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
@@ -415,7 +415,7 @@ func TestLookupCiliumID(t *testing.T) {
 
 	model := newTestEndpointModel(2, endpoint.StateReady)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -490,7 +490,7 @@ func TestLookupCNIAttachmentID(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
-	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &apiv1.EndpointChangeRequest{
+	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &apiv1.EndpointChangeRequest{
 		ContainerID:            "foo",
 		ContainerInterfaceName: "bar",
 	})
@@ -513,7 +513,7 @@ func TestLookupIPv4(t *testing.T) {
 
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	model := newTestEndpointModel(4, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -666,7 +666,7 @@ func TestLookupCEPName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm)
+		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		tt.preTestRun(ep)
 		args := tt.setupArgs()
@@ -709,7 +709,7 @@ func TestUpdateReferences(t *testing.T) {
 	}
 	for _, tt := range tests {
 		var err error
-		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm)
+		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		logger := hivetest.Logger(t)
 		mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
@@ -745,7 +745,7 @@ func TestRemove(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	model := newTestEndpointModel(7, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -791,7 +791,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	model := newTestEndpointModel(1, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -834,7 +834,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -865,7 +865,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -896,7 +896,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -936,7 +936,7 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	// Create host endpoint and expose it in the endpoint manager.
 	model := newTestEndpointModel(1, endpoint.StateReady)
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -981,7 +981,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			name: "Add labels",
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -1013,7 +1013,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
-				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -1047,7 +1047,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
 				ep.SetIsHost(true)
 				require.NoError(t, err)
 

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -195,6 +195,7 @@ var (
 			labels.NewLabel("version", "v1", labels.LabelSourceK8s),
 		},
 	}
+	// slogloggercheck: the default logger is enough for tests.
 	testSelectorCache = policy.NewSelectorCache(logging.DefaultSlogLogger, IdentityCache)
 
 	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, api.WildcardEndpointSelector)

--- a/pkg/eventqueue/eventqueue.go
+++ b/pkg/eventqueue/eventqueue.go
@@ -69,7 +69,6 @@ func NewEventQueue(defaultLogger *slog.Logger) *EventQueue {
 // numBufferedEvents at a time, and all other needed fields initialized.
 func NewEventQueueBuffered(defaultLogger *slog.Logger, name string, numBufferedEvents int) *EventQueue {
 	logger := defaultLogger.With(
-		logfields.LogSubsys, "eventqueue",
 		logfields.Name, name,
 	)
 	logger.Debug("creating new EventQueue",

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -202,7 +202,9 @@ func serveDNS(w dns.ResponseWriter, r *dns.Msg) {
 
 // Setup identities, ports and endpoint IDs we will need
 var (
-	cacheAllocator          = cache.NewCachingIdentityAllocator(logging.DefaultSlogLogger, &testidentity.IdentityAllocatorOwnerMock{}, cache.NewTestAllocatorConfig())
+	// slogloggercheck: the default logger is enough for tests.
+	cacheAllocator = cache.NewCachingIdentityAllocator(logging.DefaultSlogLogger, &testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
+	// slogloggercheck: the default logger is enough for tests.
 	testSelectorCache       = policy.NewSelectorCache(logging.DefaultSlogLogger, cacheAllocator.GetIdentityCache())
 	dummySelectorCacheUser  = &testpolicy.DummySelectorCacheUser{}
 	DstID1Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst1=test"))

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -96,7 +96,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 				return nil, false, fmt.Errorf("No EPs available when restoring")
 			}
 			model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-			ep, err := endpoint.NewEndpointFromChangeModel(tb.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+			ep, err := endpoint.NewEndpointFromChangeModel(tb.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 			ep.Start(uint16(model.ID))
 			tb.Cleanup(ep.Stop)
 			return ep, false, err
@@ -853,7 +853,7 @@ func TestFullPathDependence(t *testing.T) {
 
 	// Restore rules
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))
@@ -905,7 +905,7 @@ func TestFullPathDependence(t *testing.T) {
 
 	// Restore rules for epID3
 	modelEP3 := newTestEndpointModel(int(epID3), endpoint.StateReady)
-	ep3, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, modelEP3)
+	ep3, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, modelEP3)
 	require.NoError(t, err)
 
 	ep3.Start(uint16(modelEP3.ID))
@@ -1118,7 +1118,7 @@ func TestRestoredEndpoint(t *testing.T) {
 	// restore rules, set the mock to restoring state
 	s.restoring = true
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))

--- a/pkg/health/health_connectivity_node.go
+++ b/pkg/health/health_connectivity_node.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/health/server"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -108,7 +107,7 @@ func (ch *CiliumHealth) runServer(initialized <-chan struct{}) {
 		scopedLog.Debug("Cannot find socket", logfields.Error, err)
 		time.Sleep(1 * time.Second)
 	}
-	if err := api.SetDefaultPermissions(logging.DefaultSlogLogger, defaults.SockPath); err != nil {
+	if err := api.SetDefaultPermissions(ch.logger.Debug, defaults.SockPath); err != nil {
 		scopedLog.Error("Cannot set default permissions on socket", logfields.Error, err)
 		return
 	}

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/health/probe"
 	"github.com/cilium/cilium/pkg/health/probe/responder"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
@@ -414,7 +413,7 @@ func (s *Server) newServer(logger *slog.Logger, spec *healthApi.Spec) *healthApi
 	restAPI.ConnectivityGetStatusHandler = NewGetStatusHandler(s)
 	restAPI.ConnectivityPutStatusProbeHandler = NewPutStatusProbeHandler(s)
 
-	api.DisableAPIs(logging.DefaultSlogLogger, spec.DeniedAPIs, restAPI.AddMiddlewareFor)
+	api.DisableAPIs(logger, spec.DeniedAPIs, restAPI.AddMiddlewareFor)
 	srv := healthApi.NewServer(restAPI)
 	srv.EnabledListeners = []string{"unix"}
 	srv.SocketPath = defaults.SockPath
@@ -442,7 +441,7 @@ func NewServer(logger *slog.Logger, config Config) (*Server, error) {
 	server.Client = cl
 	server.Server = *server.newServer(logger, config.HealthAPISpec)
 
-	server.httpPathServer = responder.NewServers(getAddresses(logging.DefaultSlogLogger), config.HTTPPathPort)
+	server.httpPathServer = responder.NewServers(getAddresses(logger), config.HTTPPathPort)
 
 	return server, nil
 }

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -65,6 +65,7 @@ func New(cells ...cell.Cell) *Hive {
 		// The root slog FieldLogger.
 		cell.Provide(
 			func() logging.FieldLogger {
+				// slogloggercheck: its setup has been done before hive is Ran.
 				return logging.DefaultSlogLogger
 			},
 
@@ -79,6 +80,7 @@ func New(cells ...cell.Cell) *Hive {
 	// Scope logging and health by module ID.
 	moduleDecorators := []cell.ModuleDecorator{
 		func(mid cell.ModuleID) logging.FieldLogger {
+			// slogloggercheck: its setup has been done before hive is Ran.
 			return logging.DefaultSlogLogger.With(logfields.LogSubsys, string(mid))
 		},
 		func(hp types.Provider, fmid cell.FullModuleID) cell.Health {

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -45,7 +45,6 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/loadbalancer/legacy/service"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
@@ -339,7 +338,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 	}
 	peerSvc := peer.NewService(h.nodeManager, peerServiceOptions...)
 	localSrvOpts = append(localSrvOpts,
-		serveroption.WithUnixSocketListener(logging.DefaultSlogLogger, sockPath),
+		serveroption.WithUnixSocketListener(h.log, sockPath),
 		serveroption.WithHealthService(),
 		serveroption.WithObserverService(hubbleObserver),
 		serveroption.WithPeerService(peerSvc),

--- a/pkg/hubble/metrics/metric_config_watcher.go
+++ b/pkg/hubble/metrics/metric_config_watcher.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -25,7 +24,7 @@ import (
 var metricReloadInterval = 10 * time.Second
 
 type metricConfigWatcher struct {
-	logger         logging.FieldLogger
+	logger         *slog.Logger
 	configFilePath string
 	callback       func(ctx context.Context, hash uint64, config api.Config)
 	ticker         *time.Ticker
@@ -78,7 +77,7 @@ func (c *metricConfigWatcher) reload() {
 	c.logger.Debug("Attempting reload")
 	config, isSameHash, hash, err := c.readConfig()
 	if err != nil {
-		c.logger.Error("failed reading dynamic exporter config", slog.Any(logfields.Error, err))
+		c.logger.Error("failed reading dynamic exporter config", logfields.Error, err)
 	} else {
 		if !isSameHash {
 			c.callback(context.TODO(), hash, *config)

--- a/pkg/hubble/server/serveroption/option_linux.go
+++ b/pkg/hubble/server/serveroption/option_linux.go
@@ -32,7 +32,7 @@ func WithUnixSocketListener(scopedLog *slog.Logger, path string) Option {
 			return err
 		}
 		if os.Getuid() == 0 {
-			if err := api.SetDefaultPermissions(scopedLog, socketPath); err != nil {
+			if err := api.SetDefaultPermissions(scopedLog.Debug, socketPath); err != nil {
 				socket.Close()
 				return err
 			}

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -156,9 +156,9 @@ func (iao *identityAllocatorOwner) GetNodeSuffix() string {
 
 	switch {
 	case option.Config.EnableIPv4:
-		ip = node.GetIPv4(logging.DefaultSlogLogger)
+		ip = node.GetIPv4(iao.logger)
 	case option.Config.EnableIPv6:
-		ip = node.GetIPv6(logging.DefaultSlogLogger)
+		ip = node.GetIPv6(iao.logger)
 	}
 
 	if ip == nil {

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -20,8 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
-var subsysLogAttr = []any{logfields.LogSubsys, "ipam-allocator-azure"}
-
 // AllocatorAzure is an implementation of IPAM allocator interface for Azure
 type AllocatorAzure struct {
 	rootLogger *slog.Logger
@@ -31,7 +29,7 @@ type AllocatorAzure struct {
 // Init in Azure implementation doesn't need to do anything
 func (a *AllocatorAzure) Init(ctx context.Context, logger *slog.Logger) error {
 	a.rootLogger = logger
-	a.logger = a.rootLogger.With(subsysLogAttr...)
+	a.logger = a.rootLogger.With(logfields.LogSubsys, "ipam-allocator-azure")
 	return nil
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/cec_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types.go
@@ -187,11 +187,13 @@ func (u *XDSResource) UnmarshalJSON(b []byte) (err error) {
 	if err != nil {
 		var buf bytes.Buffer
 		json.Indent(&buf, b, "", "\t")
+		// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 		logging.DefaultSlogLogger.Warn("Ignoring invalid CiliumEnvoyConfig JSON",
 			logfields.Error, err,
 			logfields.Object, buf,
 		)
 	} else if option.Config.Debug {
+		// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 		logging.DefaultSlogLogger.Debug("CEC unmarshaled XDS Resource", logfields.Resource, prototext.Format(u.Any))
 	}
 	return nil

--- a/pkg/k8s/error_helpers.go
+++ b/pkg/k8s/error_helpers.go
@@ -50,6 +50,7 @@ func K8sErrorHandler(_ context.Context, e error, _ string, _ ...any) {
 		return
 	}
 
+	// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 	logger := logging.DefaultSlogLogger
 
 	// We rate-limit certain categories of error message. These are matched

--- a/pkg/k8s/informer/informer.go
+++ b/pkg/k8s/informer/informer.go
@@ -30,6 +30,7 @@ func init() {
 				//   panicking with ErrAbortHandler also suppresses logging of a stack trace to the server's error log.
 				return
 			}
+			// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 			logging.Fatal(logging.DefaultSlogLogger, "Panic in Kubernetes runtime handler")
 		},
 	)

--- a/pkg/k8s/resource/example/main.go
+++ b/pkg/k8s/resource/example/main.go
@@ -37,6 +37,7 @@ import (
 //  kubectl run -it --rm --image=nginx  --port=80 --expose nginx
 
 var (
+	// slogloggercheck: it's just an example, so we can use the default logger
 	log = logging.DefaultSlogLogger.With(logfields.LogSubsys, "example")
 )
 

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -121,6 +121,7 @@ var (
 // registerBackend must be called by kvstore backends to register themselves
 func registerBackend(name string, module backendModule) {
 	if _, ok := registeredBackends[name]; ok {
+		// slogloggercheck: it's safe to use the default logger here since it's just to print a panic.
 		logging.Panic(logging.DefaultSlogLogger, "backend already registered", logfields.Name, name)
 	}
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -291,8 +291,10 @@ func init() {
 	}
 
 	// Initialize the etcd client logger.
+	// slogloggercheck: it's safe to use the default logger here since it's just to print a warning from etcdClientDebugLevel.
 	l, err := logutil.CreateDefaultZapLogger(etcdClientDebugLevel(logging.DefaultSlogLogger))
 	if err != nil {
+		// slogloggercheck: it's safe to use the default logger here since it's just to print a warning.
 		logging.DefaultSlogLogger.Warn("Failed to initialize etcd client logger",
 			logfields.Error, err,
 		)

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -327,6 +327,7 @@ func NewLabel(key string, value string, source string) Label {
 	if l.Source == LabelSourceCIDR {
 		c, err := LabelToPrefix(l.Key)
 		if err != nil {
+			// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 			logging.DefaultSlogLogger.Error("Failed to parse CIDR label: invalid prefix.",
 				logfields.Error, err,
 				logfields.Key, l.Key,
@@ -483,6 +484,7 @@ func (l *Label) UnmarshalJSON(data []byte) error {
 		if err == nil {
 			l.cidr = &c
 		} else {
+			// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 			logging.DefaultSlogLogger.Error("Failed to parse CIDR label: invalid prefix.",
 				logfields.Error, err,
 				logfields.Key, l.Key,
@@ -828,12 +830,14 @@ func parseLabel(str string, delim byte) (lbl Label) {
 
 	if lbl.Source == LabelSourceCIDR {
 		if lbl.Value != "" {
+			// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 			logging.DefaultSlogLogger.Error("Invalid CIDR label: labels with source cidr cannot have values.",
 				logfields.Label, lbl,
 			)
 		}
 		c, err := LabelToPrefix(lbl.Key)
 		if err != nil {
+			// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 			logging.DefaultSlogLogger.Error("Failed to parse CIDR label: invalid prefix.",
 				logfields.Label, lbl,
 			)

--- a/pkg/loadbalancer/maps/lbmaps.go
+++ b/pkg/loadbalancer/maps/lbmaps.go
@@ -662,7 +662,7 @@ func (r *BPFLBMaps) DumpMaglev(cb func(MaglevOuterKey, MaglevOuterVal, MaglevInn
 			RevNatID: byteorder.NetworkToHost16(key.(*MaglevOuterKey).RevNatID),
 		}
 		maglevValue := value.(*MaglevOuterVal)
-		inner, err := MaglevInnerMapFromID(r.Log, maglevValue.FD)
+		inner, err := MaglevInnerMapFromID(maglevValue.FD)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("cannot open inner map with fd %d: %w", maglevValue.FD, err))
 			return
@@ -757,7 +757,7 @@ func (m MaglevInnerMap) UpdateBackends(backends []loadbalancer.BackendID) error 
 
 // MaglevInnerMapFromID returns a new object representing the maglev inner map
 // identified by an ID.
-func MaglevInnerMapFromID(log *slog.Logger, id uint32) (MaglevInnerMap, error) {
+func MaglevInnerMapFromID(id uint32) (MaglevInnerMap, error) {
 	m, err := ebpf.NewMapFromID(ebpf.MapID(id))
 	return MaglevInnerMap{m}, err
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -47,6 +47,10 @@ var (
 	LevelPanic = slog.LevelError + 8
 	LevelFatal = LevelPanic + 2
 )
+var (
+	levelPanicValue = slog.AnyValue(LevelPanic)
+	levelFatalValue = slog.AnyValue(LevelFatal)
+)
 
 // LogOptions maps configuration key-value pairs related to logging.
 type LogOptions map[string]string

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -143,14 +143,14 @@ var (
 )
 
 func Fatal(logger FieldLogger, msg string, args ...any) {
-	logger.Error(msg, args...)
 	(*exitHandler.Load())()
+	logger.Error(msg, args...)
 	os.Exit(-1)
 }
 
 func Panic(logger FieldLogger, msg string, args ...any) {
-	logger.Error(msg, args...)
 	(*exitHandler.Load())()
+	logger.Error(msg, args...)
 	panic(msg)
 }
 

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -90,6 +90,18 @@ func replaceAttrFn(groups []string, a slog.Attr) slog.Attr {
 		// force slog to quote the value like logrus does...
 		return slog.String(slog.TimeKey, a.Value.Time().Format(time.RFC3339Nano))
 	case slog.LevelKey:
+		switch level := a.Value; {
+		case level.Equal(levelFatalValue):
+			return slog.Attr{
+				Key:   a.Key,
+				Value: slog.StringValue("fatal"),
+			}
+		case level.Equal(levelPanicValue):
+			return slog.Attr{
+				Key:   a.Key,
+				Value: slog.StringValue("panic"),
+			}
+		}
 		// Lower-case the log level
 		return slog.Attr{
 			Key:   a.Key,
@@ -144,13 +156,13 @@ var (
 
 func Fatal(logger FieldLogger, msg string, args ...any) {
 	(*exitHandler.Load())()
-	logger.Error(msg, args...)
+	logger.Log(context.Background(), LevelFatal, msg, args...)
 	os.Exit(-1)
 }
 
 func Panic(logger FieldLogger, msg string, args ...any) {
 	(*exitHandler.Load())()
-	logger.Error(msg, args...)
+	logger.Log(context.Background(), LevelPanic, msg, args...)
 	panic(msg)
 }
 

--- a/pkg/maps/multicast/subscribermap.go
+++ b/pkg/maps/multicast/subscribermap.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/ebpf"
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 // compile time checks
@@ -102,7 +101,7 @@ func NewGroupV4Map(in ParamsIn) ParamsOut {
 	// must have "bpf_map_for_each_elem" helper available, if not, don't
 	// initialize the map, dependent code should be checking if their map
 	// dependency is nil or not.
-	if probes.HaveProgramHelper(logging.DefaultSlogLogger, ciliumebpf.SchedCLS, asm.FnForEachMapElem) != nil {
+	if probes.HaveProgramHelper(in.Logger, ciliumebpf.SchedCLS, asm.FnForEachMapElem) != nil {
 		in.Logger.Error("Disabled support for BPF Multicast due to missing kernel support (Linux 5.13 or later)")
 		return out
 	}

--- a/pkg/monitor/agent/server.go
+++ b/pkg/monitor/agent/server.go
@@ -29,7 +29,7 @@ func buildServer(logger *slog.Logger, path string) (*net.UnixListener, error) {
 	}
 
 	if os.Getuid() == 0 {
-		err := api.SetDefaultPermissions(logger, path)
+		err := api.SetDefaultPermissions(logger.Debug, path)
 		if err != nil {
 			server.Close()
 			return nil, fmt.Errorf("cannot set default permissions on socket %s: %w", path, err)

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -54,6 +54,7 @@ var (
 // getParser must be called with dissectLock held
 func initParser() {
 	if cache == nil {
+		// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 		logging.DefaultSlogLogger.Info("Initializing dissection cache...")
 
 		cache = &parserCache{

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -6,12 +6,12 @@ package store
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path"
 
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
-	"github.com/cilium/cilium/pkg/logging"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
@@ -148,13 +148,13 @@ type NodeRegistrar struct {
 }
 
 // RegisterNode registers the local node in the cluster.
-func (nr *NodeRegistrar) RegisterNode(ctx context.Context, client kvstore.Client, n *nodeTypes.Node, manager NodeExtendedManager) error {
+func (nr *NodeRegistrar) RegisterNode(ctx context.Context, logger *slog.Logger, client kvstore.Client, n *nodeTypes.Node, manager NodeExtendedManager) error {
 	if !client.IsEnabled() {
 		return nil
 	}
 
 	// Join the shared store holding node information of entire cluster
-	nodeStore, err := store.JoinSharedStore(logging.DefaultSlogLogger, store.Configuration{
+	nodeStore, err := store.JoinSharedStore(logger, store.Configuration{
 		Context:                 ctx,
 		Backend:                 client,
 		Prefix:                  NodeStorePrefix,

--- a/pkg/node/types/nodename.go
+++ b/pkg/node/types/nodename.go
@@ -73,8 +73,10 @@ func init() {
 		return
 	}
 	if h, err := os.Hostname(); err != nil {
+		// slogloggercheck: it's safe to use the default logger as it's for a warning unlikely to happen.
 		logging.DefaultSlogLogger.Warn("Unable to retrieve local hostname", logfields.Error, err)
 	} else {
+		// slogloggercheck: it's safe to use the default logger as it's for a debug message.
 		logging.DefaultSlogLogger.Debug("os.Hostname() returned", logfields.NodeName, h)
 		nodeName = h
 	}

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -116,7 +116,7 @@ func (n *NodeDiscovery) StartDiscovery(ctx context.Context) {
 			logfields.Node, localNode.Name,
 		)
 		for {
-			if err := n.Registrar.RegisterNode(ctx, n.kvstoreClient, &localNode.Node, n.Manager); err != nil {
+			if err := n.Registrar.RegisterNode(ctx, n.logger, n.kvstoreClient, &localNode.Node, n.Manager); err != nil {
 				n.logger.Error("Unable to initialize local node. Retrying...", logfields.Error, err)
 				time.Sleep(time.Second)
 			} else {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2625,12 +2625,14 @@ func (c *DaemonConfig) SetupLogging(vp *viper.Viper, tag string) {
 	c.LogDriver = vp.GetStringSlice(LogDriver)
 
 	if m, err := command.GetStringMapStringE(vp, LogOpt); err != nil {
+		// slogloggercheck: log fatal errors using the default logger before it's initialized.
 		logging.Fatal(logging.DefaultSlogLogger, fmt.Sprintf("unable to parse %s", LogOpt), logfields.Error, err)
 	} else {
 		c.LogOpt = m
 	}
 
 	if err := logging.SetupLogging(c.LogDriver, c.LogOpt, tag, c.Debug); err != nil {
+		// slogloggercheck: log fatal errors using the default logger before it's initialized.
 		logging.Fatal(logging.DefaultSlogLogger, "Unable to set up logging", logfields.Error, err)
 	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3782,7 +3782,7 @@ func InitConfig(logger *slog.Logger, cmd *cobra.Command, programName, configName
 
 		// Check for the debug flag again now that the configuration file may has
 		// been loaded, as it might have changed.
-		if vp.GetBool("debug") {
+		if vp.GetBool(DebugArg) {
 			logging.SetLogLevelToDebug()
 		}
 	}

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -169,7 +169,7 @@ func labelSelectorToRequirements(labelSelector *slim_metav1.LabelSelector) *k8sL
 	selector, err := slim_metav1.LabelSelectorAsSelector(labelSelector)
 	if err != nil {
 		metrics.PolicyChangeTotal.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
-		// FIXME @aanm do we still need to log this error?
+		// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 		logging.DefaultSlogLogger.Error(
 			"unable to construct selector in label selector",
 			logfields.LogSubsys, "policy-api",

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -703,7 +703,6 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 	scopedLog := logger
 	if option.Config.Debug {
 		scopedLog = logger.With(
-			logfields.EndpointID, p.PolicyOwner.GetID(),
 			logfields.Port, port,
 			logfields.PortName, l4.PortName,
 			logfields.Protocol, proto,

--- a/pkg/spanstat/spanstat.go
+++ b/pkg/spanstat/spanstat.go
@@ -52,6 +52,7 @@ func (s *SpanStat) End(success bool) *SpanStat {
 // must be called with Lock() held
 func (s *SpanStat) end(success bool) *SpanStat {
 	if !s.spanStart.IsZero() {
+		// slogloggercheck: it's safe to use the default logger here as it has been initialized by the program up to this point.
 		d, _ := safetime.TimeSinceSafe(s.spanStart, logging.DefaultSlogLogger)
 		if success {
 			s.successDuration += d

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -452,6 +452,7 @@ func setupLogging(n *types.NetConf) error {
 
 	if len(n.LogFile) != 0 {
 		logging.AddHandlers(hooks.NewFileRotationLogHook(
+			// slogloggercheck: the logger has been initialized with default settings
 			logging.GetSlogLevel(logging.DefaultSlogLogger),
 			n.LogFile,
 			hooks.EnableCompression(),

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -20,6 +20,7 @@ func init() {
 }
 
 func main() {
+	// slogloggercheck: the logger has been initialized with default settings
 	logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, "cilium-cni")
 	c := cmd.NewCmd(logger)
 	skel.PluginMainFuncs(c.CNIFuncs(),

--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -41,6 +41,7 @@ connected to a Docker network of type "cilium".`,
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium-docker")
 
+		// slogloggercheck: the logger has been initialized with default settings
 		logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, "cilium-docker-driver")
 		createPluginSock(logger)
 
@@ -56,6 +57,7 @@ connected to a Docker network of type "cilium".`,
 }
 
 func main() {
+	// slogloggercheck: the logger has been initialized with default settings
 	logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, "cilium-docker-driver")
 	if err := RootCmd.Execute(); err != nil {
 		logging.Fatal(logger, err.Error())

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,7 +3,7 @@
 
 include ../Makefile.defs
 
-SUBDIRS := alignchecker mount
+SUBDIRS := alignchecker mount slogloggercheck
 
 .PHONY: all $(SUBDIRS) clean install
 

--- a/tools/mount/main.go
+++ b/tools/mount/main.go
@@ -21,5 +21,6 @@ func main() {
 	// This program is executed by an init container so we purposely don't
 	// exit with any error codes. In case of errors, the function will log warnings,
 	// but we don't block cilium agent pod from running.
+	// slogloggercheck: the logger has been initialized with default settings it's enough for a CLI tool.
 	cgroups.CheckOrMountCgrpFS(logging.DefaultSlogLogger, cgroupMountPoint)
 }

--- a/tools/slogloggercheck/.gitignore
+++ b/tools/slogloggercheck/.gitignore
@@ -1,0 +1,1 @@
+slogloggercheck

--- a/tools/slogloggercheck/Makefile
+++ b/tools/slogloggercheck/Makefile
@@ -1,0 +1,21 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+include ../../Makefile.defs
+
+TARGET := slogloggercheck
+
+.PHONY: all clean install
+
+all: $(TARGET)
+
+$(TARGET): $(wildcard *.go)
+	@$(ECHO_GO)
+	$(QUIET)CGO_ENABLED=0 $(GO) build $(GOFLAGS) -o $@
+
+clean:
+	@$(ECHO_CLEAN)
+	$(QUIET)rm -f $(TARGET)
+
+install: all
+	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)

--- a/tools/slogloggercheck/main.go
+++ b/tools/slogloggercheck/main.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	exitOK   = 0
+	exitFail = 1
+
+	// The required comment that justifies DefaultSlogLogger usage
+	requiredComment = "slogloggercheck:"
+)
+
+func main() {
+	flag.Parse()
+
+	var failed bool
+	args := flag.Args()
+
+	// If no arguments are provided, check current directory
+	if len(args) == 0 {
+		args = []string{"."}
+	}
+
+	// Check each path provided as argument
+	for _, arg := range args {
+		// Handle paths with trailing /...
+		if strings.HasSuffix(arg, "/...") {
+			arg = strings.TrimSuffix(arg, "/...")
+		}
+
+		if err := filepath.Walk(arg, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil // Skip errors
+			}
+
+			// Skip vendor directory
+			if info.IsDir() && path != arg && (info.Name() == "vendor" || strings.Contains(path, "/vendor/")) {
+				return filepath.SkipDir
+			}
+
+			if info.IsDir() {
+				return nil
+			}
+
+			if !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+
+			if !checkFile(path) {
+				failed = true
+			}
+
+			return nil
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to walk directory %s: %v\n", arg, err)
+			os.Exit(exitFail)
+		}
+	}
+
+	if failed {
+		os.Exit(exitFail)
+	}
+
+	os.Exit(exitOK)
+}
+
+// checkFile parses and checks a single file for improper DefaultSlogLogger usage.
+// It returns false if the file contains violations.
+func checkFile(path string) bool {
+	// Skip checking the file that defines DefaultSlogLogger
+	if strings.HasSuffix(path, "pkg/logging/slog.go") ||
+		strings.HasSuffix(path, "pkg/logging/logging_test.go") {
+		return true
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse file %s: %v\n", path, err)
+		return false
+	}
+
+	v := &visitor{
+		fileSet:  fset,
+		fileName: path,
+		found:    false,
+	}
+
+	ast.Walk(v, f)
+
+	return !v.found
+}
+
+// visitor implements the ast.Visitor interface to find DefaultSlogLogger usages.
+type visitor struct {
+	fileSet  *token.FileSet
+	fileName string
+	found    bool
+}
+
+// Visit checks nodes for DefaultSlogLogger usage without justification.
+func (v *visitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return nil
+	}
+
+	// Look for selector expressions (package.identifier)
+	selectorExpr, ok := node.(*ast.SelectorExpr)
+	if !ok {
+		return v
+	}
+
+	// Check if it's a reference to logging.DefaultSlogLogger
+	if ident, ok := selectorExpr.X.(*ast.Ident); ok {
+		if ident.Name == "logging" && selectorExpr.Sel.Name == "DefaultSlogLogger" {
+			// Check if there's a justification comment nearby
+			pos := v.fileSet.Position(node.Pos())
+			if !hasJustificationComment(v.fileSet, node) {
+				fmt.Printf("%s:%d: direct use of logging.DefaultSlogLogger without justification comment\n",
+					v.fileName, pos.Line)
+				fmt.Printf("  Add a comment with '%s <reason>' to justify this usage\n", requiredComment)
+				v.found = true
+			}
+		}
+	}
+
+	return v
+}
+
+// hasJustificationComment checks if there's a comment containing the required text
+// on the same line or in the line above the node.
+func hasJustificationComment(fset *token.FileSet, node ast.Node) bool {
+	// Get position info
+	pos := fset.Position(node.Pos())
+	file := pos.Filename
+	line := pos.Line
+
+	// Read the file content
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return false
+	}
+
+	lines := strings.Split(string(content), "\n")
+
+	// Check the line with the node and the line above
+	for l := line - 1; l <= line; l++ {
+		if l <= 0 || l > len(lines) {
+			continue
+		}
+
+		if strings.Contains(lines[l-1], requiredComment) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Avoid using the global logger as much as possible. Thus, we are replacing all instances with a local logger instead.

Add linter to prevent unjustified usage of DefaultSlogLogger

Print fatal or panic messages after exit handlers making sure it will be the last message being logged.

Set level keys for both panic and fatal for each message type.