### PR TITLE
hive/health: Remove info logging when stopping

### DIFF
--- a/pkg/hive/health/provider.go
+++ b/pkg/hive/health/provider.go
@@ -52,10 +52,6 @@ func (p *provider) Start(ctx cell.HookContext) error {
 
 func (p *provider) Stop(ctx cell.HookContext) error {
 	p.stopped.Store(true)
-	tx := p.db.ReadTxn()
-	for s, rev := range p.statusTable.All(tx) {
-		p.logger.Info(fmt.Sprintf("%s (rev=%d)", s.ID.String(), rev))
-	}
 	return nil
 }
 


### PR DESCRIPTION
The health provider logs every health entry when it stops at INFO level:
```
  time=2025-06-04T12:05:16.740Z level=INFO msg="agent.some-module (rev=35)" module=health
  time=2025-06-04T12:05:16.740Z level=INFO msg="agent.some-other-module (rev=39)" module=health
  ...
```
This isn't useful and makes for example logs in tests unnecessarily verbose. Remove this logging.
