### PR TITLE
k8s/client: Properly return AlreadyExists in Create

### DIFF
--- a/pkg/k8s/client/object_tracker.go
+++ b/pkg/k8s/client/object_tracker.go
@@ -302,6 +302,7 @@ func (s *statedbObjectTracker) Create(gvr schema.GroupVersionResource, obj runti
 		gr := gvr.GroupResource()
 		err := apierrors.NewAlreadyExists(gr, newMeta.GetName())
 		log.Debug("Create", logfields.Error, err)
+		return err
 	}
 	log.Debug("Create")
 	wtxn.Commit()


### PR DESCRIPTION
The error was only logged instead of returned. This caused flakyness in tests as they didn't know to retry.

Fixes: 3f50ccb355c ("k8s/client: StateDB-based ObjectTracker")
