### PR TITLE
ci,gke: apply allow ESP firewall rules for GKE cluster nodes

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -300,6 +300,27 @@ jobs:
           native_cidr="$(gcloud container clusters describe ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }} --format 'value(clusterIpv4Cidr)')"
           echo native_cidr=${native_cidr} >> $GITHUB_OUTPUT
 
+      - name: Create ESP allow firewall rule
+        if: ${{ matrix.config.type == 'tunnel-ipsec' }}
+        run: |
+          cluster_name=${{ env.clusterName }}-${{ matrix.config.index }}
+          cluster_zone=${{ matrix.k8s.zone }}
+          hash=$(gcloud container clusters describe $cluster_name --zone=$cluster_zone --format="value(id)")
+          hash="${hash:0:8}"
+          echo $hash
+          cluster_node_target_tag=gke-${cluster_name}-${hash}-node
+          echo $cluster_node_target_tag
+          firewall_rule_name=gke-${cluster_name}-${hash}-allow-esp
+
+          gcloud compute firewall-rules create $firewall_rule_name \
+            --network default \
+            --direction INGRESS \
+            --action ALLOW \
+            --rules esp \
+            --priority 1000 \
+            --source-ranges 0.0.0.0/0 \
+            --target-tags $cluster_node_target_tag
+
       - name: Get cluster credentials
         run: |
           gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }}
@@ -363,6 +384,18 @@ jobs:
         with:
           artifacts_suffix: "${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }})"
           job_status: "${{ job.status }}"
+
+      - name: Clean up ESP allow firewall rule
+        if: ${{ matrix.config.type == 'tunnel-ipsec' }}
+        run: |
+          cluster_name=${{ env.clusterName }}-${{ matrix.config.index }}
+          cluster_zone=${{ matrix.k8s.zone }}
+          hash=$(gcloud container clusters describe $cluster_name --zone=$cluster_zone --format="value(id)")
+          hash="${hash:0:8}"
+          firewall_rule_name=gke-${cluster_name}-${hash}-allow-esp
+
+          gcloud compute firewall-rules delete --quiet $firewall_rule_name
+        shell: bash {0} # Disable default fail-fast behavior so that all commands run independently
 
       - name: Clean up GKE
         if: ${{ always() }}

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -309,6 +309,9 @@ communicating via the proxy must reconnect to re-establish connections.
   exclude the ``io.cilium.k8s.policy.serviceaccount`` label.
 * If using IPsec encryption the upgrade from v1.17 to v1.18 requires special attention.
   Please reference :ref:`encryption_ipsec`.
+* If using an IPsec deployment within a Google Cloud GKE cluster the default firewall rules for the cluster's subnet
+  must be updated to allow ESP traffic.
+  See :ref:`encryption_ipsec` for details.
 * The Helm value of ``enableIPv4Masquerade`` in ``eni`` mode changes from ``true`` to ``false`` by default from 1.18.
   To keep the ``enableIPv4Masquerade`` enabled, explicitly set the value for
   this option to ``true``, or use a value strictly lower than 1.18 for

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -38,6 +38,17 @@ newer v1.17 releases to support a disruption-less upgrade to v1.18.
 Once patched to the newest v1.17 stable release, a normal upgrade to v1.18 can
 be performed.
 
+.. note::
+
+   Because VXLAN is encrypted before being sent, operators see ESP
+   traffic between Kubernetes nodes.
+
+   This may result in the need to update firewall rules to allow ESP traffic
+   between nodes.
+   This is especially important in Google Cloud GKE environments.
+   The default firewall rules for the cluster's subnet may not allow ESP.
+
+
 Generate & Import the PSK
 =========================
 


### PR DESCRIPTION
In v1.18 Cilium moves to utilizing VXLAN-in-ESP traffic by default.

This means traffic between nodes is now ESP and no longer VXLAN when IPsec is enabled.

GKE, by default, does not allow ESP traffic between GKE nodes.

Therefore, create a ESP allow firewall rule which targets just the cluster nodes.

Fixes: #39337

```release-note
CI: Apply an ESP allow rule for GKE clusters to support IPsec VINE
```
