### PR TITLE
daemon/helm: Deprecate --enable-svc-source-range-check

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -172,7 +172,6 @@ cilium-agent [flags]
       --enable-sctp                                               Enable SCTP support (beta)
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
-      --enable-svc-source-range-check                             Enable check of service source ranges (currently, only for LoadBalancer) (default true)
       --enable-tcx                                                Attach endpoint programs using tcx if supported by the kernel (default true)
       --enable-tracing                                            Enable tracing while determining policy (debugging)
       --enable-unreachable-routes                                 Add unreachable routes on pod deletion

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1423,16 +1423,6 @@ When accessing the service from inside a cluster, the kube-proxy replacement wil
 ignore the field regardless whether it is set. This means that any pod or any host
 process in the cluster will be able to access the ``LoadBalancer`` service internally.
 
-The load balancer source range check feature is enabled by default, and it can be
-disabled by setting ``config.svcSourceRangeCheck=false``.
-
-It makes sense to disable the check when running on some cloud providers e.g. `Amazon NLB
-<https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support>`__
-natively implements the check, so the kube-proxy replacement's feature can be disabled.
-Meanwhile `GKE internal TCP/UDP load balancer
-<https://cloud.google.com/kubernetes-engine/docs/how-to/service-parameters#lb_source_ranges>`__
-does not, so the feature must be kept enabled in order to restrict the access.
-
 By default the specified white-listed CIDRs in ``spec.loadBalancerSourceRanges``
 only apply to the ``LoadBalancer`` service, but not the corresponding ``NodePort``
 or ``ClusterIP`` service which get installed along with the ``LoadBalancer`` service.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -364,6 +364,9 @@ Deprecated Options
   The K8s Endpoint Slice feature will be unconditionally enabled.
 * The flag ``--enable-internal-traffic-policy`` has been deprecated and will be removed in Cilium 1.19. The
   ``internalTrafficPolicy`` field in a Kubernetes Service object will be unconditionally respected.
+* The flag ``--enable-svc-source-range-check`` (``svcSourceRangeCheck`` in Helm) has been deprecated
+  and will be removed in Cilium 1.19. The feature will be enabled automatically when ``--kube-proxy-replacent``
+  is set to ``true``.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -523,6 +523,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.EnableNodePort)
 
 	flags.Bool(option.EnableSVCSourceRangeCheck, true, "Enable check of service source ranges (currently, only for LoadBalancer)")
+	flags.MarkDeprecated(option.EnableSVCSourceRangeCheck, fmt.Sprintf("The flag will be removed in v1.19. The feature will be unconditionally enabled by enabling %s.", option.KubeProxyReplacement))
 	option.BindEnv(vp, option.EnableSVCSourceRangeCheck)
 
 	flags.String(option.AddressScopeMax, fmt.Sprintf("%d", defaults.AddressScopeMax), "Maximum local address scope for ipcache to consider host addresses")


### PR DESCRIPTION
In v1.19 we will enable the feature unconditionally if KPR=true.

This simplifies the KPR UX at minimal costs:

- Single test on the SVC flags in the datapath.
- The BPF maps used by the feature are of the LPM type (no pre-alloc).