### PR TITLE
ci: fix conn-disrupt-test-check action

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -22,7 +22,7 @@ inputs:
     description: 'Select which connectivity tests to run'
   test-concurrency:
     required: false
-    default: 1
+    default: '1'
     description: 'Concurrency level to run tests'
 
 runs:
@@ -53,6 +53,6 @@ runs:
           --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
           --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
           --test "$TEST_ARG" \
-          --test-concurrency ${{ inputs.test-concurrency }} \
+          --test-concurrency=${{ inputs.test-concurrency }} \
           --expected-xfrm-errors "+inbound_no_state" \
           ${EXTRA_ARG}


### PR DESCRIPTION
The commit fixes Cilium CLI  param in the conn-disrupt-test-check action.
