### PR TITLE
api: fix inconsistencies in policy rule marshalling behavior

### DIFF
--- a/examples/policies/l3/match-expressions/and-statement.yaml
+++ b/examples/policies/l3/match-expressions/and-statement.yaml
@@ -8,10 +8,10 @@ spec:
   - fromEndpoints:
     - matchExpressions:
       - key: "k8s:io.kubernetes.pod.namespace"
-        operator: "in"
+        operator: "In"
         values:
         - "production"
       - key: "k8s:cilium.example.com/policy"
-        operator: "in"
+        operator: "In"
         values:
         - "strict"

--- a/examples/policies/l3/match-expressions/or-statement.yaml
+++ b/examples/policies/l3/match-expressions/or-statement.yaml
@@ -8,11 +8,11 @@ spec:
   - fromEndpoints:
     - matchExpressions:
       - key: "k8s:io.kubernetes.pod.namespace"
-        operator: "in"
+        operator: "In"
         values:
         - "production"
     - matchExpressions:
       - key: "k8s:cilium.example.com/policy"
-        operator: "in"
+        operator: "In"
         values:
         - "strict"

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -286,13 +286,11 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						{
 							IngressCommonRule: api.IngressCommonRule{
 								FromEndpoints: []api.EndpointSelector{
-									{
-										LabelSelector: &slim_metav1.LabelSelector{
-											MatchLabels: map[string]string{
-												podAnyPrefixLbl: "ns-2",
-											},
+									api.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											podAnyPrefixLbl: "ns-2",
 										},
-									},
+									}),
 								},
 							},
 						},
@@ -370,13 +368,11 @@ func Test_ParseToCiliumRule(t *testing.T) {
 											MatchLabels: map[string]string{},
 										},
 									},
-									{
-										LabelSelector: &slim_metav1.LabelSelector{
-											MatchLabels: map[string]string{
-												clusterPrefixLbl: "cluster2",
-											},
+									api.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											clusterPrefixLbl: "cluster2",
 										},
-									},
+									}),
 								},
 							},
 						},
@@ -459,13 +455,11 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						{
 							IngressCommonRule: api.IngressCommonRule{
 								FromEndpoints: []api.EndpointSelector{
-									{
-										LabelSelector: &slim_metav1.LabelSelector{
-											MatchLabels: map[string]string{
-												podAnyNamespaceLabelsPrefix + "team": "team-a",
-											},
+									api.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											podAnyNamespaceLabelsPrefix + "team": "team-a",
 										},
-									},
+									}),
 								},
 							},
 						},

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -262,6 +262,24 @@ var (
 }`)...)
 )
 
+func sanitizeCNPRules(cnp *CiliumNetworkPolicy) error {
+	if cnp.Spec != nil {
+		if err := cnp.Spec.Sanitize(); err != nil {
+			return err
+		}
+	}
+
+	if cnp.Specs != nil {
+		for _, rule := range cnp.Specs {
+			if err := rule.Sanitize(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 func TestParseSpec(t *testing.T) {
 	es := api.NewESFromMatchRequirements(
 		map[string]string{
@@ -330,6 +348,12 @@ func TestParseSpec(t *testing.T) {
 	cnpl := CiliumNetworkPolicy{}
 	err = json.Unmarshal(ciliumRule, &cnpl)
 	require.NoError(t, err)
+
+	err = sanitizeCNPRules(&cnpl)
+	require.NoError(t, err)
+	err = sanitizeCNPRules(expectedPolicyRuleWithLabel)
+	require.NoError(t, err)
+
 	require.Equal(t, *expectedPolicyRuleWithLabel, cnpl)
 
 	empty := &CiliumNetworkPolicy{
@@ -424,6 +448,12 @@ func TestParseRules(t *testing.T) {
 	cnpl := CiliumNetworkPolicy{}
 	err = json.Unmarshal(ciliumRuleList, &cnpl)
 	require.NoError(t, err)
+
+	err = sanitizeCNPRules(&cnpl)
+	require.NoError(t, err)
+	err = sanitizeCNPRules(expectedPolicyRuleListWithLabel)
+	require.NoError(t, err)
+
 	require.Equal(t, *expectedPolicyRuleListWithLabel, cnpl)
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -152,6 +152,10 @@ func checkInitLabelsPolicy(logger *slog.Logger, cnp *unstructured.Unstructured) 
 			continue
 		}
 		podInitLbl := labels.LabelSourceReservedKeyPrefix + labels.IDNameInit
+
+		if err := spec.EndpointSelector.Sanitize(); err != nil {
+			return err
+		}
 		if spec.EndpointSelector.HasKey(podInitLbl) {
 			logOnce.Do(func() {
 				logger.Error(

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -526,6 +526,16 @@ func GetExtendedKeyFrom(str string) string {
 	return src + PathDelimiter + next
 }
 
+type KeyExtender func(string) string
+
+var DefaultKeyExtender KeyExtender = GetExtendedKeyFrom
+
+func GetSourcePrefixKeyExtender(srcPrefix string) KeyExtender {
+	return func(str string) string {
+		return srcPrefix + str
+	}
+}
+
 // Map2Labels transforms in the form: map[key(string)]value(string) into Labels. The
 // source argument will overwrite the source written in the key of the given map.
 // Example:

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -528,6 +528,9 @@ func GetExtendedKeyFrom(str string) string {
 
 type KeyExtender func(string) string
 
+// Extender to convert label keys from Cilium representation to kubernetes representation.
+// Key passed to this extender is converted to format `<source>.<key>`.
+// The extender is not idempotent, caller needs to make sure its only called once for a key.
 var DefaultKeyExtender KeyExtender = GetExtendedKeyFrom
 
 func GetSourcePrefixKeyExtender(srcPrefix string) KeyExtender {

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -71,14 +71,14 @@ func (r *Rule) Sanitize() error {
 	}
 
 	if r.EndpointSelector.LabelSelector != nil {
-		if err := r.EndpointSelector.sanitize(); err != nil {
+		if err := r.EndpointSelector.Sanitize(); err != nil {
 			return err
 		}
 	}
 
 	var hostPolicy bool
 	if r.NodeSelector.LabelSelector != nil {
-		if err := r.NodeSelector.sanitize(); err != nil {
+		if err := r.NodeSelector.Sanitize(); err != nil {
 			return err
 		}
 		hostPolicy = true
@@ -228,19 +228,19 @@ func (i *IngressCommonRule) sanitize() error {
 	}
 
 	for n := range i.FromEndpoints {
-		if err := i.FromEndpoints[n].sanitize(); err != nil {
+		if err := i.FromEndpoints[n].Sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for n := range i.FromRequires {
-		if err := i.FromRequires[n].sanitize(); err != nil {
+		if err := i.FromRequires[n].Sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for n := range i.FromNodes {
-		if err := i.FromNodes[n].sanitize(); err != nil {
+		if err := i.FromNodes[n].Sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
@@ -441,19 +441,19 @@ func (e *EgressCommonRule) sanitize(l3Members map[string]int) error {
 	}
 
 	for i := range e.ToEndpoints {
-		if err := e.ToEndpoints[i].sanitize(); err != nil {
+		if err := e.ToEndpoints[i].Sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for i := range e.ToRequires {
-		if err := e.ToRequires[i].sanitize(); err != nil {
+		if err := e.ToRequires[i].Sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for i := range e.ToNodes {
-		if err := e.ToNodes[i].sanitize(); err != nil {
+		if err := e.ToNodes[i].Sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
@@ -716,7 +716,7 @@ func (c *CIDRRule) sanitize() error {
 	if c.CIDRGroupSelector != nil {
 		cnt++
 		es := NewESFromK8sLabelSelector(labels.LabelSourceCIDRGroupKeyPrefix, c.CIDRGroupSelector)
-		if err := es.sanitize(); err != nil {
+		if err := es.Sanitize(); err != nil {
 			return fmt.Errorf("failed to parse cidrGroupSelector %v: %w", c.CIDRGroupSelector.String(), err)
 		}
 	}

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -30,9 +30,12 @@ var (
 	enableDefaultDenyDefault = true
 )
 
-// Sanitize validates and sanitizes a policy rule. Minor edits such as
-// capitalization of the protocol name are automatically fixed up. More
-// fundamental violations will cause an error to be returned.
+// Sanitize validates and sanitizes a policy rule. Minor edits such as capitalization
+// of the protocol name are automatically fixed up.
+// As part of `EndpointSelector` sanitization we also convert the label keys to internal
+// representation prefixed with the source information. Check `EndpointSelector.sanitize()`
+// method for more details.
+// More fundamental violations will cause an error to be returned.
 //
 // Note: this function is called from both the operator and the agent;
 // make sure any configuration flags are bound in **both** binaries.
@@ -224,20 +227,20 @@ func (i *IngressCommonRule) sanitize() error {
 		retErr = ErrFromToNodesRequiresNodeSelectorOption
 	}
 
-	for _, es := range i.FromEndpoints {
-		if err := es.sanitize(); err != nil {
+	for n := range i.FromEndpoints {
+		if err := i.FromEndpoints[n].sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
-	for _, es := range i.FromRequires {
-		if err := es.sanitize(); err != nil {
+	for n := range i.FromRequires {
+		if err := i.FromRequires[n].sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
-	for _, ns := range i.FromNodes {
-		if err := ns.sanitize(); err != nil {
+	for n := range i.FromNodes {
+		if err := i.FromNodes[n].sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
@@ -437,20 +440,20 @@ func (e *EgressCommonRule) sanitize(l3Members map[string]int) error {
 		retErr = ErrFromToNodesRequiresNodeSelectorOption
 	}
 
-	for _, es := range e.ToEndpoints {
-		if err := es.sanitize(); err != nil {
+	for i := range e.ToEndpoints {
+		if err := e.ToEndpoints[i].sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
-	for _, es := range e.ToRequires {
-		if err := es.sanitize(); err != nil {
+	for i := range e.ToRequires {
+		if err := e.ToRequires[i].sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
-	for _, ns := range e.ToNodes {
-		if err := ns.sanitize(); err != nil {
+	for i := range e.ToNodes {
+		if err := e.ToNodes[i].sanitize(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}

--- a/pkg/policy/api/rules_test.go
+++ b/pkg/policy/api/rules_test.go
@@ -4,9 +4,15 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	k8sLbls "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/selection"
 )
 
 // TestRulesDeepEqual tests that individual rules (via Rule.DeepEqual()) and
@@ -54,4 +60,234 @@ func TestRulesDeepEqual(t *testing.T) {
 	validPortRulesClone[0].EndpointSelector = wcSelector2
 
 	require.True(t, validPortRules.DeepEqual(&validPortRulesClone))
+}
+
+func TestRuleMarshalling(t *testing.T) {
+	// EndpointSelector marshalling unit test covers more specific scenarios.
+	// Check selector_test.go
+	testSelectors := map[string]struct {
+		jsonStr       string
+		expected      EndpointSelector
+		sanitized     EndpointSelector
+		sanitizedJSON string
+	}{
+		"empty": {
+			jsonStr: `{}`,
+			expected: EndpointSelector{
+				LabelSelector: &slim_metav1.LabelSelector{},
+			},
+			sanitized: EndpointSelector{
+				LabelSelector:             &slim_metav1.LabelSelector{},
+				requirements:              &k8sLbls.Requirements{},
+				cachedLabelSelectorString: "&LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{},}",
+				Generated:                 false,
+				sanitized:                 true,
+			},
+			sanitizedJSON: `{}`,
+		},
+		"matchLabels": {
+			jsonStr: `{"matchLabels":{"app":"frontend"}}`,
+			expected: EndpointSelector{
+				LabelSelector: &slim_metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "frontend"},
+				},
+			},
+			sanitized: EndpointSelector{
+				LabelSelector: &slim_metav1.LabelSelector{
+					MatchLabels: map[string]string{"any.app": "frontend"},
+				},
+				requirements: &k8sLbls.Requirements{
+					selectorRequirementsConverter(t, "any.app", selection.Equals, []string{"frontend"}),
+				},
+				cachedLabelSelectorString: "&LabelSelector{MatchLabels:map[string]string{any.app: frontend,},MatchExpressions:[]LabelSelectorRequirement{},}",
+				Generated:                 false,
+				sanitized:                 true,
+			},
+			sanitizedJSON: `{"matchLabels":{"any:app":"frontend"}}`,
+		},
+	}
+
+	dummyRule := struct {
+		jsonStr       string
+		expected      []IngressRule
+		sanitized     []IngressRule
+		sanitizedJSON string
+	}{
+		jsonStr: `[{"fromEndpoints":[{}]}]`,
+		expected: []IngressRule{{IngressCommonRule: IngressCommonRule{
+			FromEndpoints: []EndpointSelector{testSelectors["empty"].expected},
+		}}},
+		sanitized: []IngressRule{{IngressCommonRule: IngressCommonRule{
+			FromEndpoints:       []EndpointSelector{testSelectors["empty"].sanitized},
+			aggregatedSelectors: []EndpointSelector{},
+		}}},
+		sanitizedJSON: `[{"fromEndpoints":[{}]}]`,
+	}
+	enableDefaultDenySanitized := `"enableDefaultDeny":{"ingress":true,"egress":false}`
+
+	defaultDenyEnabled := func(ret bool) *bool { return &ret }
+	defaultDenyConfig := DefaultDenyConfig{
+		Egress:  defaultDenyEnabled(false),
+		Ingress: defaultDenyEnabled(true),
+	}
+
+	type errorType int
+	const (
+		noError errorType = iota
+		inputUnmarshalError
+		sanitizeError
+	)
+
+	tests := []struct {
+		name                string
+		inputJSON           string
+		expected            Rule
+		sanitizedExepected  Rule
+		sanitizedOutputJSON string
+		expectedErr         errorType
+	}{
+		{
+			name:                "Empty JSON",
+			inputJSON:           `{}`,
+			expected:            Rule{},
+			sanitizedExepected:  Rule{},
+			sanitizedOutputJSON: `{}`,
+			expectedErr:         sanitizeError,
+		},
+		{
+			name:                "Invalid JSON",
+			inputJSON:           `{"endpointSelector"`,
+			expected:            Rule{},
+			sanitizedExepected:  Rule{},
+			sanitizedOutputJSON: `{}`,
+			expectedErr:         inputUnmarshalError,
+		},
+		{
+			name:      "With valid EndpointSelector and no Rules",
+			inputJSON: fmt.Sprintf(`{"endpointSelector":%s}`, testSelectors["empty"].jsonStr),
+			expected: Rule{
+				EndpointSelector: testSelectors["empty"].expected,
+			},
+			sanitizedExepected:  Rule{},
+			sanitizedOutputJSON: `{}`,
+			expectedErr:         sanitizeError,
+		},
+		{
+			name:      "With empty EndpointSelector and no NodeSelector",
+			inputJSON: fmt.Sprintf(`{"endpointSelector":%s,"ingress":%s}`, testSelectors["empty"].jsonStr, dummyRule.jsonStr),
+			expected: Rule{
+				EndpointSelector: testSelectors["empty"].expected,
+				Ingress:          dummyRule.expected,
+			},
+			sanitizedExepected: Rule{
+				EndpointSelector:  testSelectors["empty"].sanitized,
+				Ingress:           dummyRule.sanitized,
+				EnableDefaultDeny: defaultDenyConfig,
+			},
+			sanitizedOutputJSON: fmt.Sprintf(
+				`{"endpointSelector":%s,"ingress":%s,%s}`,
+				testSelectors["empty"].sanitizedJSON, dummyRule.sanitizedJSON, enableDefaultDenySanitized,
+			),
+			expectedErr: noError,
+		},
+		{
+			name:      "With empty NodeSelector and no EndpointSelector",
+			inputJSON: fmt.Sprintf(`{"nodeSelector":%s,"ingress":%s}`, testSelectors["empty"].jsonStr, dummyRule.jsonStr),
+			expected: Rule{
+				NodeSelector: testSelectors["empty"].expected,
+				Ingress:      dummyRule.expected,
+			},
+			sanitizedExepected: Rule{
+				NodeSelector:      testSelectors["empty"].sanitized,
+				Ingress:           dummyRule.sanitized,
+				EnableDefaultDeny: defaultDenyConfig,
+			},
+			sanitizedOutputJSON: fmt.Sprintf(`{"nodeSelector":%s,"ingress":%s,%s}`, testSelectors["empty"].sanitizedJSON, dummyRule.sanitizedJSON, enableDefaultDenySanitized),
+			expectedErr:         noError,
+		},
+		{
+			name: "With empty EndpointSelector and NodeSelector",
+			inputJSON: fmt.Sprintf(
+				`{"endpointSelector":%s,"nodeSelector":%s,"ingress":%s}`,
+				testSelectors["empty"].jsonStr,
+				testSelectors["empty"].jsonStr,
+				dummyRule.jsonStr,
+			),
+			expected: Rule{
+				EndpointSelector: testSelectors["empty"].expected,
+				NodeSelector:     testSelectors["empty"].expected,
+				Ingress:          dummyRule.expected,
+			},
+			sanitizedExepected:  Rule{},
+			sanitizedOutputJSON: `{}`,
+			expectedErr:         sanitizeError,
+		},
+		{
+			name:      "With matchLabels EndpointSelector",
+			inputJSON: fmt.Sprintf(`{"endpointSelector":%s,"ingress":%s}`, testSelectors["matchLabels"].jsonStr, dummyRule.jsonStr),
+			expected: Rule{
+				EndpointSelector: testSelectors["matchLabels"].expected,
+				Ingress:          dummyRule.expected,
+			},
+			sanitizedExepected: Rule{
+				EndpointSelector:  testSelectors["matchLabels"].sanitized,
+				Ingress:           dummyRule.sanitized,
+				EnableDefaultDeny: defaultDenyConfig,
+			},
+			sanitizedOutputJSON: fmt.Sprintf(
+				`{"endpointSelector":%s,"ingress":%s,%s}`,
+				testSelectors["matchLabels"].sanitizedJSON, dummyRule.sanitizedJSON, enableDefaultDenySanitized,
+			),
+			expectedErr: noError,
+		},
+		{
+			name:      "With matchLabels NodeSelector",
+			inputJSON: fmt.Sprintf(`{"nodeSelector":%s,"ingress":%s}`, testSelectors["matchLabels"].jsonStr, dummyRule.jsonStr),
+			expected: Rule{
+				NodeSelector: testSelectors["matchLabels"].expected,
+				Ingress:      dummyRule.expected,
+			},
+			sanitizedExepected: Rule{
+				NodeSelector:      testSelectors["matchLabels"].sanitized,
+				Ingress:           dummyRule.sanitized,
+				EnableDefaultDeny: defaultDenyConfig,
+			},
+			sanitizedOutputJSON: fmt.Sprintf(
+				`{"nodeSelector":%s,"ingress":%s,%s}`,
+				testSelectors["matchLabels"].sanitizedJSON, dummyRule.sanitizedJSON, enableDefaultDenySanitized,
+			),
+			expectedErr: noError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := Rule{}
+
+			err := json.Unmarshal([]byte(tt.inputJSON), &rule)
+			if tt.expectedErr == inputUnmarshalError {
+				require.ErrorContains(t, err, "unexpected end of JSON input")
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, rule, "UnMarshalled Rule")
+
+			ruleMarshalled, err := json.Marshal(&rule)
+			require.NoError(t, err)
+			require.Equalf(t, tt.inputJSON, string(ruleMarshalled), "Marshalled Rule")
+
+			err = rule.Sanitize()
+			if tt.expectedErr == sanitizeError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.sanitizedExepected, rule, "Sanitized Rule")
+
+			ruleSanitizedMarshalled, err := json.Marshal(&rule)
+			require.NoError(t, err)
+			require.Equalf(t, tt.sanitizedOutputJSON, string(ruleSanitizedMarshalled), "Marshalled Sanitized Rule")
+		})
+	}
 }

--- a/pkg/policy/api/zz_generated.deepequal.go
+++ b/pkg/policy/api/zz_generated.deepequal.go
@@ -425,6 +425,9 @@ func (in *EndpointSelector) DeepEqual(other *EndpointSelector) bool {
 	if in.Generated != other.Generated {
 		return false
 	}
+	if in.sanitized != other.sanitized {
+		return false
+	}
 
 	return true
 }
@@ -1389,6 +1392,9 @@ func (in *ServiceSelector) DeepEqual(other *ServiceSelector) bool {
 		return false
 	}
 	if in.Generated != other.Generated {
+		return false
+	}
+	if in.sanitized != other.sanitized {
 		return false
 	}
 

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -232,13 +232,13 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 								UID:       uuid,
 							},
 							Spec: &policyapi.Rule{
-								EndpointSelector: policyapi.EndpointSelector{
-									LabelSelector: &slim_metav1.LabelSelector{
+								EndpointSelector: policyapi.NewESFromK8sLabelSelector("",
+									&slim_metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"env": "cluster-1",
 										},
 									},
-								},
+								),
 								Ingress: []policyapi.IngressRule{{}},
 								Egress:  nil,
 							},
@@ -251,14 +251,14 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 				r := policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, policyapi.NewPolicyMetricsNoop())
 				r.MustAddList(policyapi.Rules{
 					policyapi.NewRule().
-						WithEndpointSelector(policyapi.EndpointSelector{
-							LabelSelector: &slim_metav1.LabelSelector{
+						WithEndpointSelector(
+							policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"env": "cluster-1",
 									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 								},
-							},
-						}).
+							}),
+						).
 						WithIngressRules([]policyapi.IngressRule{{}}).
 						WithEgressRules(nil).
 						WithLabels(utils.GetPolicyLabels(
@@ -282,14 +282,12 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.MustAddList(policyapi.Rules{
 					{
-						EndpointSelector: policyapi.EndpointSelector{
-							LabelSelector: &slim_metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"env": "cluster-1",
-									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
-								},
+						EndpointSelector: policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"env": "cluster-1",
+								labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 							},
-						},
+						}),
 						Ingress:     []policyapi.IngressRule{{}},
 						Egress:      []policyapi.EgressRule{{}},
 						Labels:      lbls,
@@ -305,13 +303,11 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 								UID:       uuid,
 							},
 							Spec: &policyapi.Rule{
-								EndpointSelector: policyapi.EndpointSelector{
-									LabelSelector: &slim_metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"env": "cluster-1",
-										},
+								EndpointSelector: policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"env": "cluster-1",
 									},
-								},
+								}),
 								Ingress: []policyapi.IngressRule{{}},
 								Egress:  nil,
 							},
@@ -324,14 +320,14 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 				r := policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, policyapi.NewPolicyMetricsNoop())
 				r.MustAddList(policyapi.Rules{
 					policyapi.NewRule().
-						WithEndpointSelector(policyapi.EndpointSelector{
-							LabelSelector: &slim_metav1.LabelSelector{
+						WithEndpointSelector(
+							policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"env": "cluster-1",
 									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 								},
-							},
-						}).
+							}),
+						).
 						WithIngressRules([]policyapi.IngressRule{{}}).
 						WithEgressRules(nil).
 						WithLabels(utils.GetPolicyLabels(
@@ -353,14 +349,12 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 				r := policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, policyapi.NewPolicyMetricsNoop())
 				r.MustAddList(policyapi.Rules{
 					{
-						EndpointSelector: policyapi.EndpointSelector{
-							LabelSelector: &slim_metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"env": "cluster-1",
-									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
-								},
+						EndpointSelector: policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"env": "cluster-1",
+								labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 							},
-						},
+						}),
 						Ingress:     []policyapi.IngressRule{{}},
 						Egress:      []policyapi.EgressRule{{}},
 						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
@@ -376,13 +370,11 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 								UID:       uuid,
 							},
 							Spec: &policyapi.Rule{
-								EndpointSelector: policyapi.EndpointSelector{
-									LabelSelector: &slim_metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"env": "cluster-1",
-										},
+								EndpointSelector: policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"env": "cluster-1",
 									},
-								},
+								}),
 								Labels:  labels.ParseLabelArray("foo=bar"),
 								Ingress: []policyapi.IngressRule{{}},
 							},
@@ -397,14 +389,12 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.MustAddList(policyapi.Rules{
 					policyapi.NewRule().
-						WithEndpointSelector(policyapi.EndpointSelector{
-							LabelSelector: &slim_metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"env": "cluster-1",
-									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
-								},
+						WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"env": "cluster-1",
+								labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 							},
-						}).
+						})).
 						WithIngressRules([]policyapi.IngressRule{{}}).
 						WithEgressRules(nil).
 						WithLabels(lbls),
@@ -421,26 +411,22 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 				r := policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, policyapi.NewPolicyMetricsNoop())
 				r.MustAddList(policyapi.Rules{
 					{
-						EndpointSelector: policyapi.EndpointSelector{
-							LabelSelector: &slim_metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"env": "cluster-1",
-									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
-								},
+						EndpointSelector: policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"env": "cluster-1",
+								labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 							},
-						},
+						}),
 						Ingress: []policyapi.IngressRule{
 							{
 								IngressCommonRule: policyapi.IngressCommonRule{
 									FromEndpoints: []policyapi.EndpointSelector{
-										{
-											LabelSelector: &slim_metav1.LabelSelector{
-												MatchLabels: map[string]string{
-													"env": "cluster-1",
-													labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
-												},
+										policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"env": "cluster-1",
+												labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 											},
-										},
+										}),
 									},
 								},
 							},
@@ -467,26 +453,22 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 				r := policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, policyapi.NewPolicyMetricsNoop())
 				r.MustAddList(policyapi.Rules{
 					{
-						EndpointSelector: policyapi.EndpointSelector{
-							LabelSelector: &slim_metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"env": "cluster-1",
-									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
-								},
+						EndpointSelector: policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"env": "cluster-1",
+								labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 							},
-						},
+						}),
 						Ingress: []policyapi.IngressRule{
 							{
 								IngressCommonRule: policyapi.IngressCommonRule{
 									FromEndpoints: []policyapi.EndpointSelector{
-										{
-											LabelSelector: &slim_metav1.LabelSelector{
-												MatchLabels: map[string]string{
-													"env": "cluster-1",
-													labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
-												},
+										policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"env": "cluster-1",
+												labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 											},
-										},
+										}),
 									},
 								},
 							},


### PR DESCRIPTION
See commit message for details.

EndpointSelector marshalling behavior:
**Before**

![image](https://github.com/user-attachments/assets/a6a6fdc2-ecc4-4424-965a-66a4829a2fb4)

**After**

![image](https://github.com/user-attachments/assets/6325e62e-4fc0-4502-8fc5-07bdf065433b)

Fixes: #38010

```release-note
api: fix inconsistencies in policy rule marshalling behavior
```