### PR TITLE
feat(sdp): Hive cmd for standalone dns proxy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -653,6 +653,7 @@ Makefile* @cilium/build
 /SECURITY.md @cilium/contributing
 /SECURITY-INSIGHTS.yml @cilium/security
 /stable.txt @cilium/release-managers
+/standalone-dns-proxy/ @cilium/fqdn
 /test/ @cilium/ci-structure
 /test/Makefile* @cilium/ci-structure @cilium/build
 # Service handling tests

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -45,6 +45,8 @@ cilium-agent hive [flags]
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-envoy-version-check                               Do not perform Envoy version check
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
+      --dns-max-ips-per-restored-rule int                         Maximum number of IPs to maintain for each restored DNS rule (default 1000)
+      --dnsproxy-concurrency-processing-grace-period duration     Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
       --dynamic-lifecycle-config string                           List of dynamic lifecycle features and their configuration including the dependencies (default "[]")
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
@@ -212,6 +214,7 @@ cilium-agent hive [flags]
       --status-collector-probe-check-timeout duration             The timeout after which all probes should have finished at least once (default 5m0s)
       --status-collector-stackdump-path string                    The path where probe stackdumps should be written to (default "/run/cilium/state/agent.stack.gz")
       --status-collector-warning-threshold duration               The duration after which a probe is declared as stale (default 15s)
+      --tofqdns-enable-dns-compression                            Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
       --tofqdns-preallocate-identities                            Preallocate identities for ToFQDN selectors. This reduces proxied DNS response latency. Disable if you have many ToFQDN selectors. (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -51,6 +51,8 @@ cilium-agent hive dot-graph [flags]
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-envoy-version-check                               Do not perform Envoy version check
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
+      --dns-max-ips-per-restored-rule int                         Maximum number of IPs to maintain for each restored DNS rule (default 1000)
+      --dnsproxy-concurrency-processing-grace-period duration     Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
       --dynamic-lifecycle-config string                           List of dynamic lifecycle features and their configuration including the dependencies (default "[]")
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
@@ -217,6 +219,7 @@ cilium-agent hive dot-graph [flags]
       --status-collector-probe-check-timeout duration             The timeout after which all probes should have finished at least once (default 5m0s)
       --status-collector-stackdump-path string                    The path where probe stackdumps should be written to (default "/run/cilium/state/agent.stack.gz")
       --status-collector-warning-threshold duration               The duration after which a probe is declared as stale (default 15s)
+      --tofqdns-enable-dns-compression                            Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
       --tofqdns-preallocate-identities                            Preallocate identities for ToFQDN selectors. This reduces proxied DNS response latency. Disable if you have many ToFQDN selectors. (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -694,9 +694,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(vp, option.ToFQDNsMaxIPsPerHost)
 
-	flags.Int(option.DNSMaxIPsPerRestoredRule, defaults.DNSMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored DNS rule")
-	option.BindEnv(vp, option.DNSMaxIPsPerRestoredRule)
-
 	flags.Bool(option.DNSPolicyUnloadOnShutdown, false, "Unload DNS policy rules on graceful shutdown")
 	option.BindEnv(vp, option.DNSPolicyUnloadOnShutdown)
 
@@ -716,14 +713,8 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.ToFQDNsPreCache, defaults.ToFQDNsPreCache, "DNS cache data at this path is preloaded on agent startup")
 	option.BindEnv(vp, option.ToFQDNsPreCache)
 
-	flags.Bool(option.ToFQDNsEnableDNSCompression, defaults.ToFQDNsEnableDNSCompression, "Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present")
-	option.BindEnv(vp, option.ToFQDNsEnableDNSCompression)
-
 	flags.Int(option.DNSProxyConcurrencyLimit, 0, "Limit concurrency of DNS message processing")
 	option.BindEnv(vp, option.DNSProxyConcurrencyLimit)
-
-	flags.Duration(option.DNSProxyConcurrencyProcessingGracePeriod, 0, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
-	option.BindEnv(vp, option.DNSProxyConcurrencyProcessingGracePeriod)
 
 	flags.Int(option.DNSProxyLockCount, defaults.DNSProxyLockCount, "Array size containing mutexes which protect against parallel handling of DNS response names. Preferably use prime numbers")
 	flags.MarkHidden(option.DNSProxyLockCount)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -108,10 +108,6 @@ const (
 	// DefaultCgroupRoot is the default path where cilium cgroup2 should be mounted
 	DefaultCgroupRoot = "/run/cilium/cgroupv2"
 
-	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored DNS rules.
-	DNSMaxIPsPerRestoredRule = 1000
-
 	// FQDNRegexCompileLRUSize defines the maximum size for the FQDN regex
 	// compilation LRU used by the DNS proxy and policy validation.
 	FQDNRegexCompileLRUSize = 1024
@@ -142,10 +138,6 @@ const (
 	// global cache on startup.
 	// The file is not re-read after agent start.
 	ToFQDNsPreCache = ""
-
-	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
-	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
-	ToFQDNsEnableDNSCompression = true
 
 	// DNSProxyEnableTransparentMode enables transparent mode for the DNS proxy.
 	DNSProxyEnableTransparentMode = false

--- a/pkg/fqdn/bootstrap/dns_proxy.go
+++ b/pkg/fqdn/bootstrap/dns_proxy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
 	"github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/fqdn/re"
+	"github.com/cilium/cilium/pkg/fqdn/service"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -41,6 +42,7 @@ type dnsProxyParams struct {
 	EndpointManager   endpointmanager.EndpointManager
 	IPCache           *ipcache.IPCache
 	LocalNodeStore    *node.LocalNodeStore
+	FQDNConfig        service.FQDNConfig
 }
 
 // newDNSProxy initializes the DNS l7 proxy.
@@ -59,10 +61,10 @@ func newDNSProxy(params dnsProxyParams) (proxy.DNSProxier, error) {
 		Address:                "",
 		IPv4:                   option.Config.EnableIPv4,
 		IPv6:                   option.Config.EnableIPv6,
-		EnableDNSCompression:   option.Config.ToFQDNsEnableDNSCompression,
-		MaxRestoreDNSIPs:       option.Config.DNSMaxIPsPerRestoredRule,
+		EnableDNSCompression:   params.FQDNConfig.ToFQDNsEnableDNSCompression,
+		MaxRestoreDNSIPs:       params.FQDNConfig.DNSMaxIPsPerRestoredRule,
 		ConcurrencyLimit:       option.Config.DNSProxyConcurrencyLimit,
-		ConcurrencyGracePeriod: option.Config.DNSProxyConcurrencyProcessingGracePeriod,
+		ConcurrencyGracePeriod: params.FQDNConfig.DNSProxyConcurrencyProcessingGracePeriod,
 		RejectReply:            option.Config.FQDNRejectResponse,
 	}
 

--- a/pkg/fqdn/service/cell.go
+++ b/pkg/fqdn/service/cell.go
@@ -83,6 +83,19 @@ const (
 
 	// StandaloneDNSProxyServerPort is the port on which the standalone DNS proxy gRPC server should listen.
 	StandaloneDNSProxyServerPort = "standalone-dns-proxy-server-port"
+
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules
+	DNSMaxIPsPerRestoredRule = "dns-max-ips-per-restored-rule"
+
+	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
+	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
+	ToFQDNsEnableDNSCompression = "tofqdns-enable-dns-compression"
+
+	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
+	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
+	// been reached.
+	DNSProxyConcurrencyProcessingGracePeriod = "dnsproxy-concurrency-processing-grace-period"
 )
 
 type FQDNConfig struct {
@@ -91,14 +104,33 @@ type FQDNConfig struct {
 
 	// StandaloneDNSProxyServerPort is the user-configured global, Standalone DNS proxy gRPC server port
 	StandaloneDNSProxyServerPort int
+
+	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
+	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
+	ToFQDNsEnableDNSCompression bool
+
+	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
+	// for each FQDN selector in endpoint's restored DNS rules
+	DNSMaxIPsPerRestoredRule int
+
+	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
+	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
+	// been reached.
+	DNSProxyConcurrencyProcessingGracePeriod time.Duration
 }
 
 var DefaultConfig = FQDNConfig{
-	EnableStandaloneDNSProxy:     false,
-	StandaloneDNSProxyServerPort: 40045,
+	EnableStandaloneDNSProxy:                 false,
+	StandaloneDNSProxyServerPort:             40045,
+	ToFQDNsEnableDNSCompression:              true,
+	DNSMaxIPsPerRestoredRule:                 1000,
+	DNSProxyConcurrencyProcessingGracePeriod: 0,
 }
 
 func (def FQDNConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(EnableStandaloneDNSProxy, def.EnableStandaloneDNSProxy, "Enables standalone DNS proxy")
 	flags.Int(StandaloneDNSProxyServerPort, def.StandaloneDNSProxyServerPort, "Global port on which the gRPC server for standalone DNS proxy should listen")
+	flags.Bool(ToFQDNsEnableDNSCompression, def.ToFQDNsEnableDNSCompression, "Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present")
+	flags.Int(DNSMaxIPsPerRestoredRule, def.DNSMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored DNS rule")
+	flags.Duration(DNSProxyConcurrencyProcessingGracePeriod, def.DNSProxyConcurrencyProcessingGracePeriod, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
 }

--- a/pkg/fqdn/service/cell.go
+++ b/pkg/fqdn/service/cell.go
@@ -28,7 +28,7 @@ var Cell = cell.Module(
 	"sdp-grpc-server",
 	"Provides the standalone DNS proxy gRPC server",
 
-	cell.Config(defaultConfig),
+	cell.Config(DefaultConfig),
 	cell.Provide(newDefaultListener),
 	cell.ProvidePrivate(newPolicyRulesTable),
 	cell.ProvidePrivate(newIdentityToIPsTable),
@@ -93,7 +93,7 @@ type FQDNConfig struct {
 	StandaloneDNSProxyServerPort int
 }
 
-var defaultConfig = FQDNConfig{
+var DefaultConfig = FQDNConfig{
 	EnableStandaloneDNSProxy:     false,
 	StandaloneDNSProxyServerPort: 40045,
 }

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -83,7 +83,7 @@ func TestFQDNDataServer(t *testing.T) {
 		t.Run(scenario, func(t *testing.T) {
 
 			h := hive.New(
-				cell.Config(defaultConfig),
+				cell.Config(DefaultConfig),
 				cell.Provide(
 					func(logger *slog.Logger) endpointmanager.EndpointManager {
 						return endpointmanager.New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
@@ -198,7 +198,7 @@ func setupServer(t *testing.T, port int, enableL7Proxy bool, enableStandaloneDNS
 		cell.Module(
 			"test-fqdn-grpc-server",
 			"Test FQDN gRPC server",
-			cell.Config(defaultConfig),
+			cell.Config(DefaultConfig),
 			cell.Provide(
 				func(logger *slog.Logger) endpointmanager.EndpointManager {
 					return endpointmanager.New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -372,10 +372,6 @@ const (
 	// CMDRef is the path to cmdref output directory
 	CMDRef = "cmdref"
 
-	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored DNS rules
-	DNSMaxIPsPerRestoredRule = "dns-max-ips-per-restored-rule"
-
 	// DNSPolicyUnloadOnShutdown is the name of the dns-policy-unload-on-shutdown option.
 	DNSPolicyUnloadOnShutdown = "dns-policy-unload-on-shutdown"
 
@@ -402,18 +398,9 @@ const (
 	// The file is not re-read after agent start.
 	ToFQDNsPreCache = "tofqdns-pre-cache"
 
-	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
-	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
-	ToFQDNsEnableDNSCompression = "tofqdns-enable-dns-compression"
-
 	// DNSProxyConcurrencyLimit limits parallel processing of DNS messages in
 	// DNS proxy at any given point in time.
 	DNSProxyConcurrencyLimit = "dnsproxy-concurrency-limit"
-
-	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
-	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
-	// been reached.
-	DNSProxyConcurrencyProcessingGracePeriod = "dnsproxy-concurrency-processing-grace-period"
 
 	// DNSProxyLockCount is the array size containing mutexes which protect
 	// against parallel handling of DNS response IPs.
@@ -1505,10 +1492,6 @@ type DaemonConfig struct {
 	Version                string
 	ToFQDNsMinTTL          int
 
-	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
-	// for each FQDN selector in endpoint's restored DNS rules
-	DNSMaxIPsPerRestoredRule int
-
 	// DNSPolicyUnloadOnShutdown defines whether DNS policy rules should be unloaded on
 	// graceful shutdown.
 	DNSPolicyUnloadOnShutdown bool
@@ -1547,18 +1530,9 @@ type DaemonConfig struct {
 	// Path to a file with DNS cache data to preload on startup
 	ToFQDNsPreCache string
 
-	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
-	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
-	ToFQDNsEnableDNSCompression bool
-
 	// DNSProxyConcurrencyLimit limits parallel processing of DNS messages in
 	// DNS proxy at any given point in time.
 	DNSProxyConcurrencyLimit int
-
-	// DNSProxyConcurrencyProcessingGracePeriod is the amount of grace time to
-	// wait while processing DNS messages when the DNSProxyConcurrencyLimit has
-	// been reached.
-	DNSProxyConcurrencyProcessingGracePeriod time.Duration
 
 	// DNSProxyEnableTransparentMode enables transparent mode for the DNS proxy.
 	DNSProxyEnableTransparentMode bool
@@ -2003,7 +1977,6 @@ var (
 		EnableIPv6NDP:                   defaults.EnableIPv6NDP,
 		EnableSCTP:                      defaults.EnableSCTP,
 		EnableL7Proxy:                   defaults.EnableL7Proxy,
-		DNSMaxIPsPerRestoredRule:        defaults.DNSMaxIPsPerRestoredRule,
 		ToFQDNsMaxIPsPerHost:            defaults.ToFQDNsMaxIPsPerHost,
 		IdentityChangeGracePeriod:       defaults.IdentityChangeGracePeriod,
 		CiliumIdentityMaxJitter:         defaults.CiliumIdentityMaxJitter,
@@ -2792,7 +2765,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.EnableIdentityMark = vp.GetBool(EnableIdentityMark)
 
 	// toFQDNs options
-	c.DNSMaxIPsPerRestoredRule = vp.GetInt(DNSMaxIPsPerRestoredRule)
 	c.DNSPolicyUnloadOnShutdown = vp.GetBool(DNSPolicyUnloadOnShutdown)
 	c.FQDNRegexCompileLRUSize = vp.GetUint(FQDNRegexCompileLRUSize)
 	c.ToFQDNsMaxIPsPerHost = vp.GetInt(ToFQDNsMaxIPsPerHost)
@@ -2810,11 +2782,9 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	}
 	c.ToFQDNsProxyPort = vp.GetInt(ToFQDNsProxyPort)
 	c.ToFQDNsPreCache = vp.GetString(ToFQDNsPreCache)
-	c.ToFQDNsEnableDNSCompression = vp.GetBool(ToFQDNsEnableDNSCompression)
 	c.ToFQDNsIdleConnectionGracePeriod = vp.GetDuration(ToFQDNsIdleConnectionGracePeriod)
 	c.FQDNProxyResponseMaxDelay = vp.GetDuration(FQDNProxyResponseMaxDelay)
 	c.DNSProxyConcurrencyLimit = vp.GetInt(DNSProxyConcurrencyLimit)
-	c.DNSProxyConcurrencyProcessingGracePeriod = vp.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
 	c.DNSProxyEnableTransparentMode = vp.GetBool(DNSProxyEnableTransparentMode)
 	c.DNSProxyInsecureSkipTransparentModeCheck = vp.GetBool(DNSProxyInsecureSkipTransparentModeCheck)
 	c.DNSProxyLockCount = vp.GetInt(DNSProxyLockCount)

--- a/standalone-dns-proxy/cmd/root.go
+++ b/standalone-dns-proxy/cmd/root.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/cilium/cilium/pkg/fqdn/service"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var (
+	// StandaloneDNSProxyCell provides the standalone DNS proxy functionality
+	// It is responsible for starting and stopping the standalone DNS proxy
+	// based on the configuration provided in the config. It connects to the
+	// cilium agent via gRPC to receive DNS rules and send DNS responses.
+	StandaloneDNSProxyCell = cell.Module(
+		"standalone-dns-proxy",
+		"Provides the standalone DNS proxy functionality",
+
+		cell.Provide(func() *option.DaemonConfig {
+			return option.Config
+		}),
+		cell.Config(service.DefaultConfig),
+		cell.Invoke(registerStandaloneDNSProxyHooks),
+	)
+
+	binaryName = "standalone-dns-proxy"
+)
+
+func NewDNSProxyCmd(h *hive.Hive) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   binaryName,
+		Short: "Run " + binaryName,
+		Run: func(cobraCmd *cobra.Command, args []string) {
+			// slogloggercheck: the logger has been initialized in the cobra.OnInitialize
+			initEnv(logging.DefaultSlogLogger, h.Viper())
+
+			// slogloggercheck: the logger has been initialized in the cobra.OnInitialize
+			if err := h.Run(logging.DefaultSlogLogger); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+	h.RegisterFlags(cmd.Flags())
+
+	cmd.AddCommand(
+		h.Command(),
+	)
+
+	// slogloggercheck: using default logger for configuration initialization
+	cobra.OnInitialize(option.InitConfig(logging.DefaultSlogLogger, cmd, "Standalone-DNS-Proxy", "standalone-dns-proxy", h.Viper()))
+
+	return cmd
+}
+
+func initEnv(logger *slog.Logger, vp *viper.Viper) {
+	option.Config.Populate(logger, vp)
+	option.LogRegisteredSlogOptions(vp, logger)
+}
+
+func Execute(cmd *cobra.Command) {
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+type standaloneDNSProxyParams struct {
+	cell.In
+
+	Logger      *slog.Logger
+	AgentConfig *option.DaemonConfig
+	FQDNConfig  service.FQDNConfig
+	Lifecycle   cell.Lifecycle
+}
+
+func registerStandaloneDNSProxyHooks(params standaloneDNSProxyParams) error {
+	sdp := NewStandaloneDNSProxy(params.Logger, params.AgentConfig, params.FQDNConfig)
+
+	if params.AgentConfig.EnableL7Proxy && params.FQDNConfig.EnableStandaloneDNSProxy {
+		sdp.logger.Info("Standalone DNS proxy is enabled")
+	} else {
+		return fmt.Errorf("standalone DNS proxy requires L7 proxy and standalone DNS proxy to be enabled in the configuration")
+	}
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			return sdp.StartStandaloneDNSProxy()
+		},
+		OnStop: func(cell.HookContext) error {
+			return sdp.StopStandaloneDNSProxy()
+		},
+	})
+	return nil
+}

--- a/standalone-dns-proxy/cmd/standalonednsproxy.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/fqdn/service"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type StandaloneDNSProxy struct {
+	logger *slog.Logger
+
+	standaloneDNSProxyServerPort uint16
+	enableL7Proxy                bool
+	enableStandaloneDNSProxy     bool
+}
+
+// NewStandaloneDNSProxy creates a new standalone DNS proxy
+func NewStandaloneDNSProxy(logger *slog.Logger, agentCfg *option.DaemonConfig, fqdnCfg service.FQDNConfig) *StandaloneDNSProxy {
+	return &StandaloneDNSProxy{
+		logger:                       logger,
+		enableL7Proxy:                agentCfg.EnableL7Proxy,
+		enableStandaloneDNSProxy:     fqdnCfg.EnableStandaloneDNSProxy,
+		standaloneDNSProxyServerPort: uint16(fqdnCfg.StandaloneDNSProxyServerPort),
+	}
+}
+
+// Note: This is intentionally left blank. The actual implementation will be added in a future commit.
+func (sdp *StandaloneDNSProxy) StopStandaloneDNSProxy() error {
+	return nil
+}
+
+// Note: This is intentionally left blank. The actual implementation will be added in a future commit.
+func (sdp *StandaloneDNSProxy) StartStandaloneDNSProxy() error {
+	return nil
+}

--- a/standalone-dns-proxy/cmd/standalonednsproxy_test.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/fqdn/service"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func TestStandaloneDNSProxy(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreCurrent(),
+	)
+
+	// Enable L7 proxy for the standalone DNS proxy
+	option.Config.EnableL7Proxy = true
+	h := hive.New(StandaloneDNSProxyCell)
+
+	hive.AddConfigOverride(
+		h,
+		func(cfg *service.FQDNConfig) {
+			cfg.EnableStandaloneDNSProxy = true
+		})
+
+	err := h.Populate(hivetest.Logger(t))
+	assert.NoError(t, err, "Populate()")
+}

--- a/standalone-dns-proxy/fipsonly.go
+++ b/standalone-dns-proxy/fipsonly.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/standalone-dns-proxy/main.go
+++ b/standalone-dns-proxy/main.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/standalone-dns-proxy/cmd"
+)
+
+func main() {
+	standaloneDNSProxyHive := hive.New(cmd.StandaloneDNSProxyCell)
+
+	cmd.Execute(cmd.NewDNSProxyCmd(standaloneDNSProxyHive))
+}


### PR DESCRIPTION
This pull request introduces a new standalone DNS proxy feature to the Cilium project. Key changes include the addition of a new module for the standalone DNS proxy, updates to configuration management, and the creation of supporting files for the proxy's functionality and testing.

### Standalone DNS Proxy Implementation:
* Added a new module `StandaloneDNSProxyCell` in `standalone-dns-proxy/cmd/root.go` to provide the standalone DNS proxy functionality, including hooks for starting and stopping the proxy based on configuration.
* Introduced the `StandaloneDNSProxy` struct and its associated methods (`StartStandaloneDNSProxy` and `StopStandaloneDNSProxy`) in `standalone-dns-proxy/cmd/standalonednsproxy.go`. These methods are placeholders for future implementation.
* Created the entry point for the standalone DNS proxy in `standalone-dns-proxy/main.go`. This file initializes the proxy and executes the command.

### Configuration and Code Refactoring:
* Renamed `defaultConfig` to `DefaultConfig` in `pkg/fqdn/service/cell.go` to align with Go naming conventions for exported variables.

### Testing:
* Added a test case in `standalone-dns-proxy/cmd/standalonednsproxy_test.go` to verify that the standalone DNS proxy module can be populated without errors.

### Code Ownership:
* Updated the `CODEOWNERS` file to assign ownership of the `standalone-dns-proxy/` directory to the `@cilium/proxy` and `@cilium/fqdn` teams.

Fixes: https://github.com/cilium/cilium/issues/30984
CFP: https://github.com/cilium/design-cfps/pull/54


```release-note
Added initial scaffolding for a standalone DNS proxy component in Cilium. This includes a new module to manage the proxy lifecycle, configuration updates, and basic test coverage. The proxy functionality is currently a placeholder and will be expanded in future releases.
```