### PR TITLE
ciliumenvoyconfig: Add job to mark CEC resources synced

### DIFF
--- a/pkg/ciliumenvoyconfig/cell.go
+++ b/pkg/ciliumenvoyconfig/cell.go
@@ -39,7 +39,10 @@ var (
 	)
 
 	controllerCells = cell.Group(
-		cell.Invoke(registerCECController),
+		cell.Invoke(
+			registerCECController,
+			registerCachesSyncedJob,
+		),
 		metrics.Metric(newMetrics),
 	)
 

--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"slices"
 	"strconv"
+	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -23,8 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -35,6 +38,7 @@ type cecControllerParams struct {
 	DB             *statedb.DB
 	JobGroup       job.Group
 	ExpConfig      loadbalancer.Config
+	DaemonConfig   *option.DaemonConfig
 	Metrics        Metrics
 	CECs           statedb.Table[*CEC]
 	EnvoyResources statedb.RWTable[*EnvoyResource]
@@ -64,6 +68,9 @@ type cecController struct {
 
 func registerCECController(params cecControllerParams) {
 	if !params.ExpConfig.EnableExperimentalLB {
+		return
+	}
+	if !params.DaemonConfig.EnableL7Proxy || !params.DaemonConfig.EnableEnvoyConfig {
 		return
 	}
 
@@ -518,4 +525,74 @@ func computeLoadAssignments(
 		}
 	}
 	return
+}
+
+// maxSyncWaitTime is the amount of time to wait for CECs to be synced to Envoy before
+// marking the (C)CEC resources as synced. This is the maximum delay introduced by the
+// CEC processing to the initial endpoint generation.
+const maxSyncWaitTime = time.Minute
+
+// registerCachesSyncedJob registers a job to wait for Table[EnvoyResource] to
+// be initialized and all entries to have been reconciled to Envoy. This will block
+// the initial endpoint generation to reduce churn.
+func registerCachesSyncedJob(p cecControllerParams, res *synced.Resources) {
+	if !p.DaemonConfig.EnableL7Proxy || !p.DaemonConfig.EnableEnvoyConfig {
+		return
+	}
+
+	var synced atomic.Bool
+
+	res.BlockWaitGroupToSyncResources(
+		nil, /* Use nil stop channel as we'll eventually mark synced as true */
+		nil, /* SWG */
+		synced.Load,
+		k8sAPIGroupCiliumEnvoyConfigV2,
+	)
+
+	res.BlockWaitGroupToSyncResources(
+		nil, /* Use nil stop channel as we'll eventually mark synced as true */
+		nil, /* SWG */
+		synced.Load,
+		k8sAPIGroupCiliumClusterwideEnvoyConfigV2,
+	)
+
+	p.JobGroup.Add(
+		job.OneShot(
+			"mark-caches-synced",
+			func(ctx context.Context, health cell.Health) error {
+				defer synced.Store(true)
+
+				ctx, cancel := context.WithTimeout(ctx, maxSyncWaitTime)
+				defer cancel()
+
+				// Wait until the table has been populated.
+				_, initWatch := p.EnvoyResources.Initialized(p.DB.ReadTxn())
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-initWatch:
+				}
+
+				// Wait for all initial resources to have been synced to Envoy.
+				for {
+					ers, watch := p.EnvoyResources.AllWatch(p.DB.ReadTxn())
+					done := true
+					for er := range ers {
+						if er.Status.Kind != reconciler.StatusKindDone {
+							done = false
+							break
+						}
+					}
+					if done {
+						break
+					}
+
+					select {
+					case <-ctx.Done():
+						return nil
+					case <-watch:
+					}
+				}
+				return nil
+			}))
 }

--- a/pkg/ciliumenvoyconfig/k8s_reflector.go
+++ b/pkg/ciliumenvoyconfig/k8s_reflector.go
@@ -54,6 +54,11 @@ func cecListerWatchers(cs client.Clientset) (out struct {
 	return
 }
 
+const (
+	k8sAPIGroupCiliumEnvoyConfigV2            = "cilium/v2::CiliumEnvoyConfig"
+	k8sAPIGroupCiliumClusterwideEnvoyConfigV2 = "cilium/v2::CiliumClusterwideEnvoyConfig"
+)
+
 // registerCECK8sReflector registers reflectors to Table[CEC] from CiliumEnvoyConfig and
 // CiliumClusterwideEnvoyConfig.
 func registerCECK8sReflector(
@@ -61,6 +66,7 @@ func registerCECK8sReflector(
 	ecfg loadbalancer.Config,
 	p *CECResourceParser,
 	crdSync promise.Promise[synced.CRDSync],
+	apiGroups *synced.APIGroups,
 	nodeLabels *nodeLabels,
 	log *slog.Logger,
 	lws listerWatchers,
@@ -74,6 +80,10 @@ func registerCECK8sReflector(
 	if lws.cec == nil || !ecfg.EnableExperimentalLB {
 		return nil
 	}
+
+	apiGroups.AddAPI(k8sAPIGroupCiliumEnvoyConfigV2)
+	apiGroups.AddAPI(k8sAPIGroupCiliumClusterwideEnvoyConfigV2)
+
 	transform := func(txn statedb.ReadTxn, obj any) (*CEC, bool) {
 		var (
 			objMeta *metav1.ObjectMeta


### PR DESCRIPTION
The commit c929bef70dd7f051a78a211e7670ab2b7299a79f introduced waiting for CiliumEnvoyConfig and CiliumClusterwideEnvoyConfig to be processed before doing the initial endpoint generation.

This implements the syncing for the new implementation by waiting for the Table[EnvoyResource] to be initialized and that all entries have been synced to Envoy.
