### PR TITLE
bpf/tests: fix event map name

### DIFF
--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/datapath/link"
+	"github.com/cilium/cilium/pkg/maps/eventsmap"
 	"github.com/cilium/cilium/pkg/monitor"
 )
 
@@ -206,7 +207,7 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 
 	// Collect debug events and add them as logs of the main test
 	var globalLogReader *perf.Reader
-	if m := coll.Maps["test_cilium_events"]; m != nil {
+	if m := coll.Maps[eventsmap.MapName]; m != nil {
 		globalLogReader, err = perf.NewReader(m, os.Getpagesize()*16)
 		if err != nil {
 			t.Fatalf("new global log reader: %s", err.Error())


### PR DESCRIPTION
Fixes: bd42db2be524 ("bpf: rename EVENTS_MAP to cilium_events")

I ran the ebpf tests and noticed that Cilium events were not forwarded to userspace. This is due to a hardcoded old map name. This PR fixes it.
Not sure if we want the `Fixes` in the commit message since this is just a test fix.
I'm not familiar with the codebase, so I'm not sure if the `cilium_events` map is supposed to be always there in each `.o` used in tests. If yes, maybe we could fail

```go
m := coll.Maps[eventsmap.MapName];
if m == nil {
   t.Fatalf(...)
}
```


