### PR TITLE
ipam/service/allocator: remove always-`nil` `Allocate{,Next}` return value

### DIFF
--- a/pkg/ipam/service/allocator/bitmap.go
+++ b/pkg/ipam/service/allocator/bitmap.go
@@ -72,31 +72,31 @@ func NewContiguousAllocationMap(max int, rangeSpec string) *AllocationBitmap {
 
 // Allocate attempts to reserve the provided item.
 // Returns true if it was allocated, false if it was already in use
-func (r *AllocationBitmap) Allocate(offset int) (bool, error) {
+func (r *AllocationBitmap) Allocate(offset int) bool {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	if r.allocated.Bit(offset) == 1 {
-		return false, nil
+		return false
 	}
 	r.allocated = r.allocated.SetBit(r.allocated, offset, 1)
 	r.count++
-	return true, nil
+	return true
 }
 
 // AllocateNext reserves one of the items from the pool.
 // (0, false, nil) may be returned if there are no items left.
-func (r *AllocationBitmap) AllocateNext() (int, bool, error) {
+func (r *AllocationBitmap) AllocateNext() (int, bool) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	next, ok := r.strategy.AllocateBit(r.allocated, r.max, r.count)
 	if !ok {
-		return 0, false, nil
+		return 0, false
 	}
 	r.count++
 	r.allocated = r.allocated.SetBit(r.allocated, next, 1)
-	return next, true, nil
+	return next, true
 }
 
 // Release releases the item back to the pool. Releasing an

--- a/pkg/ipam/service/allocator/interfaces.go
+++ b/pkg/ipam/service/allocator/interfaces.go
@@ -7,8 +7,8 @@ package allocator
 // Interface manages the allocation of items out of a range. Interface
 // should be threadsafe.
 type Interface interface {
-	Allocate(int) (bool, error)
-	AllocateNext() (int, bool, error)
+	Allocate(int) bool
+	AllocateNext() (int, bool)
 	Release(int)
 	ForEach(func(int))
 	Has(int) bool

--- a/pkg/ipam/service/ipallocator/allocator.go
+++ b/pkg/ipam/service/ipallocator/allocator.go
@@ -112,10 +112,7 @@ func (r *Range) Allocate(ip net.IP) error {
 		return &ErrNotInRange{r.net.String()}
 	}
 
-	allocated, err := r.alloc.Allocate(offset)
-	if err != nil {
-		return err
-	}
+	allocated := r.alloc.Allocate(offset)
 	if !allocated {
 		return ErrAllocated
 	}
@@ -125,10 +122,7 @@ func (r *Range) Allocate(ip net.IP) error {
 // AllocateNext reserves one of the IPs from the pool. ErrFull may
 // be returned if there are no addresses left.
 func (r *Range) AllocateNext() (net.IP, error) {
-	offset, ok, err := r.alloc.AllocateNext()
-	if err != nil {
-		return nil, err
-	}
+	offset, ok := r.alloc.AllocateNext()
 	if !ok {
 		return nil, ErrFull
 	}


### PR DESCRIPTION
`(*AllocationBitmap).Allocate{,Next}` always returns a `nil` error. Remove it and avoid some superfluous error handling in the call sites.
