### PR TITLE
dnsproxy: don't verify names of answers

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1225,19 +1225,10 @@ func ExtractMsgDetails(msg *dns.Msg) (
 	}
 	qname = strings.ToLower(string(msg.Question[0].Name))
 
-	// rrName is the name the next RR should include.
-	// This will change when we see CNAMEs.
-	rrName := strings.ToLower(qname)
-
 	TTL = math.MaxUint32 // a TTL must exist in the RRs
 
 	answerTypes = make([]uint16, 0, len(msg.Answer))
 	for _, ans := range msg.Answer {
-		// Ensure we have records for DNS names we expect
-		if strings.ToLower(ans.Header().Name) != rrName {
-			return qname, nil, 0, nil, 0, nil, nil, fmt.Errorf("Unexpected name (%s) in RRs for %s (query for %s)", ans, rrName, qname)
-		}
-
 		// Handle A, AAAA and CNAME records by accumulating IPs and lowest TTL
 		switch ans := ans.(type) {
 		case *dns.A:
@@ -1264,7 +1255,6 @@ func ExtractMsgDetails(msg *dns.Msg) (
 			if TTL > ans.Hdr.Ttl {
 				TTL = ans.Hdr.Ttl
 			}
-			rrName = strings.ToLower(ans.Target)
 			CNAMEs = append(CNAMEs, ans.Target)
 		}
 		answerTypes = append(answerTypes, ans.Header().Rrtype)


### PR DESCRIPTION
Make it such that all we care about is that the question section matches what we asked. Other clients, such as the Go stdlib resolver[1] also assume the server is right.

Dropping the message on the floor because we're more strict than other clients doesn't help people trying to use toFQDN policies, so let's not. Note that there is no security gain from checking that the name matches what we asked. We trust the DNS server, if it gives us this arguably malformed response, we just pass it on and let the client deal with it.

[1] https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/net/dnsclient_unix.go;l=696


```release-note
Cilium's DNS proxy no longer overzealously validates that DNS response answers match the query exactly, to work around questionable DNS server implementations.
```
