### PR TITLE
policy/k8s: Refactor service watching to use Table[Service,Backend]

### DIFF
--- a/pkg/policy/k8s/cilium_network_policy_test.go
+++ b/pkg/policy/k8s/cilium_network_policy_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
@@ -65,10 +65,9 @@ func Test_GH33432(t *testing.T) {
 		k8sResourceSynced:  &k8sSynced.Resources{CacheStatus: make(k8sSynced.CacheStatus)},
 		k8sAPIGroups:       &k8sSynced.APIGroups{},
 		policyImporter:     policyImporter,
-		svcCache:           fakeServiceCache{},
 		cnpCache:           map[resource.Key]*types.SlimCNP{},
 		toServicesPolicies: map[resource.Key]struct{}{},
-		cnpByServiceID:     map[k8s.ServiceID]map[resource.Key]struct{}{},
+		cnpByServiceID:     map[loadbalancer.ServiceName]map[resource.Key]struct{}{},
 		metricsManager:     NewCNPMetricsNoop(),
 	}
 


### PR DESCRIPTION
As we're removing ServiceCache refactor the policy service watching to use the loadbalancer's Table[Service] and Table[Backend].

The new implementation retains the basic design of looking at the changed services and then deciding whether to recompute rules based on that.