### PR TITLE
remove Cilium node annotations during uninstall when clean-cilium-state is true

### DIFF
--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -72,6 +72,8 @@ type k8sInstallerImplementation interface {
 	GetNamespace(ctx context.Context, namespace string, options metav1.GetOptions) (*corev1.Namespace, error)
 	DeleteNamespace(ctx context.Context, namespace string, opts metav1.DeleteOptions) error
 	DeletePodCollection(ctx context.Context, namespace string, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
+
+	PatchNode(ctx context.Context, name string, pt types.PatchType, data []byte) (*corev1.Node, error)
 }
 
 type K8sInstaller struct {


### PR DESCRIPTION
Deletes Cilium-related annotations from K8s nodes as part of the uninstall process.

Fixes #22306

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #22306 

```release-note
Cilium uninstall now removes annotations from Kubernetes nodes when clean-cilium-state: true
```