### PR TITLE
don't require k8s connectivity in kube_proxy_healthz

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -319,6 +319,7 @@ communicating via the proxy must reconnect to re-establish connections.
 * This Cilium version now requires a v5.10 Linux kernel or newer.
 * CiliumIdentity CRD does not contain Security Labels in metadata anymore except for the namespace label.
 * The support for Envoy Go Extensions (proxylib) is deprecated, and will be removed in a future release.
+* The kube_proxy_healthz endpoint no longer requires Kubernetes control plane connectivity to succeed.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/daemon/healthz/kube_proxy_healthz.go
+++ b/daemon/healthz/kube_proxy_healthz.go
@@ -127,7 +127,7 @@ func (h kubeproxyHealthzHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	lastUpdateTs := currentTs
 	// We piggy back here on Cilium daemon health. If Cilium is healthy, we can
 	// reasonably assume that the node networking is ready.
-	sr := h.statusCollector.GetStatus(true, true)
+	sr := h.statusCollector.GetStatus(true, false)
 	if isUnhealthy(&sr) {
 		statusCode = http.StatusServiceUnavailable
 		lastUpdateTs = h.svc.GetLastUpdatedTs()


### PR DESCRIPTION
Don't report unhealthy in kube_proxy_healthz when cilium can't connect to k8s-apiserver. This is because:

* This follows the same behavior of kube-proxy
* kube_proxy_healthz is used by load balancers to healthcheck nodes. Do this avoids data plane disruptions on control plane outrage.

Fixes: #39778

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #39778

```release-note
The kube_proxy_healthz endpoint no longer requires Kubernetes control plane connectivity to succeed
```
