### PR TITLE
show better info for histograms in cilium-dbg metrics list

### DIFF
--- a/api/v1/models/metric.go
+++ b/api/v1/models/metric.go
@@ -23,11 +23,23 @@ type Metric struct {
 	// Additional information of the metric
 	AdditionalInfo map[string]float64 `json:"additionalInfo,omitempty"`
 
+	// Buckets for histogram metrics
+	Buckets map[string]float64 `json:"buckets,omitempty"`
+
+	// Count for histogram/summary metrics
+	Count float64 `json:"count,omitempty"`
+
 	// Labels of the metric
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Name of the metric
 	Name string `json:"name,omitempty"`
+
+	// Quantiles for summary metrics
+	Quantiles map[string]float64 `json:"quantiles,omitempty"`
+
+	// Sum for histogram/summary metrics
+	Sum float64 `json:"sum,omitempty"`
 
 	// Value of the metric
 	Value float64 `json:"value,omitempty"`

--- a/api/v1/models/metric.go
+++ b/api/v1/models/metric.go
@@ -20,6 +20,9 @@ import (
 // swagger:model Metric
 type Metric struct {
 
+	// Additional information of the metric
+	AdditionalInfo map[string]float64 `json:"additionalInfo,omitempty"`
+
 	// Labels of the metric
 	Labels map[string]string `json:"labels,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3583,6 +3583,22 @@ definitions:
         type: object
         additionalProperties:
           type: number
+      buckets:
+        description: Buckets for histogram metrics
+        type: object
+        additionalProperties:
+          type: number
+      quantiles:
+        description: Quantiles for summary metrics
+        type: object
+        additionalProperties:
+          type: number
+      count:
+        description: Count for histogram/summary metrics
+        type: number
+      sum:
+        description: Sum for histogram/summary metrics
+        type: number
   Error:
     type: string
   NameManager:

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3578,6 +3578,11 @@ definitions:
         type: object
         additionalProperties:
           type: string
+      additionalInfo:
+        description: Additional information of the metric
+        type: object
+        additionalProperties:
+          type: number
   Error:
     type: string
   NameManager:

--- a/api/v1/operator/models/metric.go
+++ b/api/v1/operator/models/metric.go
@@ -20,6 +20,9 @@ import (
 // swagger:model metric
 type Metric struct {
 
+	// Additional information of the metric
+	AdditionalInfo map[string]float64 `json:"additionalInfo,omitempty"`
+
 	// Labels of the metric
 	Labels map[string]string `json:"labels,omitempty"`
 

--- a/api/v1/operator/models/metric.go
+++ b/api/v1/operator/models/metric.go
@@ -23,11 +23,23 @@ type Metric struct {
 	// Additional information of the metric
 	AdditionalInfo map[string]float64 `json:"additionalInfo,omitempty"`
 
+	// Buckets for histogram metrics
+	Buckets map[string]float64 `json:"buckets,omitempty"`
+
+	// Count for histogram/summary metrics
+	Count float64 `json:"count,omitempty"`
+
 	// Labels of the metric
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Name of the metric
 	Name string `json:"name,omitempty"`
+
+	// Quantiles for summary metrics
+	Quantiles map[string]float64 `json:"quantiles,omitempty"`
+
+	// Sum for histogram/summary metrics
+	Sum float64 `json:"sum,omitempty"`
 
 	// Value of the metric
 	Value float64 `json:"value,omitempty"`

--- a/api/v1/operator/server/embedded_spec.go
+++ b/api/v1/operator/server/embedded_spec.go
@@ -303,6 +303,17 @@ func init() {
             "type": "number"
           }
         },
+        "buckets": {
+          "description": "Buckets for histogram metrics",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "count": {
+          "description": "Count for histogram/summary metrics",
+          "type": "number"
+        },
         "labels": {
           "description": "Labels of the metric",
           "type": "object",
@@ -313,6 +324,17 @@ func init() {
         "name": {
           "description": "Name of the metric",
           "type": "string"
+        },
+        "quantiles": {
+          "description": "Quantiles for summary metrics",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "sum": {
+          "description": "Sum for histogram/summary metrics",
+          "type": "number"
         },
         "value": {
           "description": "Value of the metric",

--- a/api/v1/operator/server/embedded_spec.go
+++ b/api/v1/operator/server/embedded_spec.go
@@ -296,6 +296,13 @@ func init() {
       "description": "Metric information",
       "type": "object",
       "properties": {
+        "additionalInfo": {
+          "description": "Additional information of the metric",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
         "labels": {
           "description": "Labels of the metric",
           "type": "object",

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -4078,6 +4078,17 @@ func init() {
             "type": "number"
           }
         },
+        "buckets": {
+          "description": "Buckets for histogram metrics",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "count": {
+          "description": "Count for histogram/summary metrics",
+          "type": "number"
+        },
         "labels": {
           "description": "Labels of the metric",
           "type": "object",
@@ -4088,6 +4099,17 @@ func init() {
         "name": {
           "description": "Name of the metric",
           "type": "string"
+        },
+        "quantiles": {
+          "description": "Quantiles for summary metrics",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "sum": {
+          "description": "Sum for histogram/summary metrics",
+          "type": "number"
         },
         "value": {
           "description": "Value of the metric",
@@ -10139,6 +10161,17 @@ func init() {
             "type": "number"
           }
         },
+        "buckets": {
+          "description": "Buckets for histogram metrics",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "count": {
+          "description": "Count for histogram/summary metrics",
+          "type": "number"
+        },
         "labels": {
           "description": "Labels of the metric",
           "type": "object",
@@ -10149,6 +10182,17 @@ func init() {
         "name": {
           "description": "Name of the metric",
           "type": "string"
+        },
+        "quantiles": {
+          "description": "Quantiles for summary metrics",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "sum": {
+          "description": "Sum for histogram/summary metrics",
+          "type": "number"
         },
         "value": {
           "description": "Value of the metric",

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -4071,6 +4071,13 @@ func init() {
       "description": "Metric information",
       "type": "object",
       "properties": {
+        "additionalInfo": {
+          "description": "Additional information of the metric",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
         "labels": {
           "description": "Labels of the metric",
           "type": "object",
@@ -10125,6 +10132,13 @@ func init() {
       "description": "Metric information",
       "type": "object",
       "properties": {
+        "additionalInfo": {
+          "description": "Additional information of the metric",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
         "labels": {
           "description": "Labels of the metric",
           "type": "object",

--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -160,10 +160,10 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 
 	if err := testMetric(
 		metrics,
-		"operator_api_metrics_test_metric_a",
+		"operator_api_metrics_test_metric_a outcome=success",
 		float64(1),
 		map[string]string{
-			"outcome": "success",
+			"formatted_value": "1.000",
 		},
 	); err != nil {
 		t.Fatalf("error while inspecting metric: %s", err)
@@ -183,6 +183,18 @@ func testMetric(metrics []models.Metric, name string, value float64, labels map[
 			}
 			if !reflect.DeepEqual(metric.Labels, labels) {
 				return fmt.Errorf("expected labels map %v for %q, got %v", labels, name, metric.Labels)
+			}
+			if len(metric.Buckets) > 0 {
+				return fmt.Errorf("expected no buckets for counter metric %q, got %v", name, metric.Buckets)
+			}
+			if len(metric.Quantiles) > 0 {
+				return fmt.Errorf("expected no quantiles for counter metric %q, got %v", name, metric.Quantiles)
+			}
+			if metric.Count != 0 {
+				return fmt.Errorf("expected count 0 for counter metric %q, got %v", name, metric.Count)
+			}
+			if metric.Sum != 0 {
+				return fmt.Errorf("expected sum 0 for counter metric %q, got %v", name, metric.Sum)
 			}
 			return nil
 		}

--- a/operator/metrics/legacy.go
+++ b/operator/metrics/legacy.go
@@ -4,6 +4,9 @@
 package metrics
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
@@ -16,6 +19,15 @@ var Registry RegisterGatherer
 type RegisterGatherer interface {
 	prometheus.Registerer
 	prometheus.Gatherer
+}
+
+func formatDuration(seconds float64) string {
+	if seconds < 0.001 {
+		return fmt.Sprintf("%.3fµs", seconds*1000000)
+	} else if seconds < 1 {
+		return fmt.Sprintf("%.3fms", seconds*1000)
+	}
+	return fmt.Sprintf("%.3fs", seconds)
 }
 
 // DumpMetrics gets the current Cilium operator metrics and dumps all into a
@@ -32,7 +44,6 @@ func DumpMetrics() ([]*models.Metric, error) {
 	}
 
 	for _, val := range currentMetrics {
-
 		metricName := val.GetName()
 		metricType := val.GetType()
 
@@ -44,25 +55,62 @@ func DumpMetrics() ([]*models.Metric, error) {
 			}
 
 			var value float64
+			var additionalInfo map[string]float64
+			var formattedValue string
+
 			switch metricType {
 			case dto.MetricType_COUNTER:
 				value = metricLabel.Counter.GetValue()
+				formattedValue = fmt.Sprintf("%.3f", value)
 			case dto.MetricType_GAUGE:
 				value = metricLabel.GetGauge().GetValue()
+				formattedValue = fmt.Sprintf("%.3f", value)
 			case dto.MetricType_UNTYPED:
 				value = metricLabel.GetUntyped().GetValue()
+				formattedValue = fmt.Sprintf("%.3f", value)
 			case dto.MetricType_SUMMARY:
-				value = metricLabel.GetSummary().GetSampleSum()
+				summary := metricLabel.GetSummary()
+				value = summary.GetSampleSum()
+				additionalInfo = make(map[string]float64)
+				additionalInfo["count"] = float64(summary.GetSampleCount())
+
+				// Get quantiles and format them
+				var quantiles []string
+				for _, q := range summary.GetQuantile() {
+					additionalInfo[fmt.Sprintf("quantile_%g", q.GetQuantile())] = q.GetValue()
+					quantiles = append(quantiles, formatDuration(q.GetValue()))
+				}
+				formattedValue = strings.Join(quantiles, " / ")
 			case dto.MetricType_HISTOGRAM:
-				value = metricLabel.GetHistogram().GetSampleSum()
+				hist := metricLabel.GetHistogram()
+				value = hist.GetSampleSum()
+				additionalInfo = make(map[string]float64)
+				additionalInfo["count"] = float64(hist.GetSampleCount())
+
+				// Get buckets and format them
+				var buckets []string
+				for _, b := range hist.GetBucket() {
+					additionalInfo[fmt.Sprintf("bucket_%g", b.GetUpperBound())] = float64(b.GetCumulativeCount())
+					buckets = append(buckets, formatDuration(b.GetUpperBound()))
+				}
+				formattedValue = strings.Join(buckets, " / ")
 			default:
 				continue
 			}
 
+			var labelStrs []string
+			for k, v := range labels {
+				labelStrs = append(labelStrs, fmt.Sprintf("%s=%s", k, v))
+			}
+			labelStr := strings.Join(labelStrs, " ")
+
 			metric := &models.Metric{
-				Name:   metricName,
-				Labels: labels,
+				Name:   fmt.Sprintf("%s %s", metricName, labelStr),
 				Value:  value,
+				Labels: map[string]string{"formatted_value": formattedValue},
+			}
+			if additionalInfo != nil {
+				metric.AdditionalInfo = additionalInfo
 			}
 			result = append(result, metric)
 		}

--- a/pkg/metrics/testdata/metrics.txtar
+++ b/pkg/metrics/testdata/metrics.txtar
@@ -56,12 +56,22 @@ test_C_seconds   lbl=a    10ms / 800ms / 980ms   0s / 0s / 0s   0s / 0s / 0s   0
   }
 ]
 -- all.yaml --
-- labels: {}
+- additionalinfo: {}
+  buckets: {}
+  count: 0
+  labels: {}
   name: test_A
+  quantiles: {}
+  sum: 0
   value: 1
-- labels:
+- additionalinfo: {}
+  buckets: {}
+  count: 0
+  labels:
     lbl: a
   name: test_C_seconds
+  quantiles: {}
+  sum: 0
   value: 0.8
 -- sampled.json --
 {


### PR DESCRIPTION
Improve "cilium-dbg metrics list" output for histograms/summary metrics

Now output looks like -
```
 kubectl exec -n kube-system -it cilium-44tjx -- cilium-dbg metrics list | grep -A 5 'cilium_agent_api_process_time_seconds'
cilium_agent_api_process_time_seconds                                   method=GET path=/v1/cluster return_code=200                                                                2.523ms / 4.541ms / 4.995ms
cilium_agent_api_process_time_seconds                                   method=GET path=/v1/endpoint return_code=200                                                               5ms / 22ms / 24.7ms
cilium_agent_api_process_time_seconds                                   method=GET path=/v1/healthz return_code=200                                                                2.505ms / 4.51ms / 4.961ms
cilium_agent_bootstrap_seconds                                          outcome=success scope=bpfBase                                                                              0.000891
cilium_agent_bootstrap_seconds                                          outcome=success scope=cleanup                                                                              0.000592
cilium_agent_bootstrap_seconds                                          outcome=success scope=daemonInit                                                                           0.005052
cilium_agent_bootstrap_seconds                                          outcome=success scope=earlyInit                                                                            0.015940
cilium_agent_bootstrap_seconds                                          outcome=success scope=enableConntrack                                                                      0.000030

```

```
 kubectl exec -n kube-system -it cilium-44tjx -- cilium-dbg metrics list | grep -A 5 'cilium_identity'
cilium_identity                                                         type=reserved                                                                                              10.000000
cilium_identity_cache_timer_duration                                    name=id-alloc-update-policy-maps                                                                           2.5m / 4.5m / 4.95m
cilium_identity_cache_timer_trigger_folds                               name=id-alloc-update-policy-maps                                                                           750m / 950m / 995m
cilium_identity_cache_timer_trigger_latency                             name=id-alloc-update-policy-maps                                                                           2.5m / 4.5m / 4.95m
cilium_identity_label_sources                                           source=reserved                                                                                            10.000000
cilium_ip_addresses                                                     family=ipv4                                                                                                2.000000
cilium_ip_addresses                                                     family=ipv6                                                                                                2.000000
cilium_ipam_capacity                                                    family=ipv4                                                                                                254.000000
cilium_ipam_capacity                                                    family=ipv6                                                                                                18446744073709551616.000000
cilium_ipam_events_total                                                action=allocate family=ipv4                                                                                2.000000
```


Fixes #34521

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #34521 

```release-note
Enhanced `cilium-dbg metrics list` output with bucket counts for histograms and quantiles for summaries.
```
