### PR TITLE
stop panic when CHECK name is different from SETUP or PKTGEN

### DIFF
--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -194,13 +194,22 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 		testNameToPrograms[match[1]] = progs
 	}
 
-	for progName, set := range testNameToPrograms {
+	for testName, set := range testNameToPrograms {
 		if set.checkProg == nil {
-			t.Fatalf(
-				"File '%s' contains a setup program in section '%s' but no check program.",
-				elfPath,
-				spec.Programs[progName].SectionName,
-			)
+			var missingChecks []string
+			if set.setupProg != nil {
+				missingChecks = append(missingChecks, "setup")
+			}
+			if set.pktgenProg != nil {
+				missingChecks = append(missingChecks, "pktgen")
+			}
+			if len(missingChecks) > 0 {
+				t.Fatalf(
+					"Test '%s' has %s program(s) but no matching check program. Make sure the CHECK program name matches the SETUP/PKTGEN program name.",
+					testName,
+					strings.Join(missingChecks, " and "),
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION


If the CHECK program name is not the same as the `SETUP` or `PKTGEN` name, the test crashes with a confusing error. This fix checks the names first and shows a clear error instead of panicking.

Fixes: #39840

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #39840 

```release-note
Fix BPF tests to prevent panics caused by mismatched CHECK program names by properly handling naming errors.
```
