### PR TITLE
monitor/format: use `MonitorFormatter` to print on any `bufio.Writer` and not just on Stdout

### DIFF
--- a/cilium-dbg/cmd/monitor.go
+++ b/cilium-dbg/cmd/monitor.go
@@ -54,7 +54,7 @@ programs attached to endpoints and devices. This includes:
 		},
 	}
 	linkCache  = link.NewLinkCache()
-	printer    = format.NewMonitorFormatter(api.INFO, linkCache)
+	printer    = format.NewMonitorFormatter(api.INFO, linkCache, os.Stdout)
 	socketPath = ""
 	verbosity  = []bool{}
 )

--- a/cilium-dbg/cmd/monitor.go
+++ b/cilium-dbg/cmd/monitor.go
@@ -147,7 +147,6 @@ func consumeMonitorEvents(ctx context.Context, conn net.Conn, version listener.V
 				logfields.Error, err,
 				logfields.Type, pl.Type,
 			)
-			format.LostEvent(pl.Lost, pl.CPU)
 		}
 	}
 }

--- a/cilium-dbg/cmd/monitor.go
+++ b/cilium-dbg/cmd/monitor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/monitor"
 	"github.com/cilium/cilium/pkg/monitor/agent/listener"
+	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/monitor/format"
 	"github.com/cilium/cilium/pkg/monitor/payload"
 	"github.com/cilium/cilium/pkg/time"
@@ -53,7 +54,7 @@ programs attached to endpoints and devices. This includes:
 		},
 	}
 	linkCache  = link.NewLinkCache()
-	printer    = format.NewMonitorFormatter(format.INFO, linkCache)
+	printer    = format.NewMonitorFormatter(api.INFO, linkCache)
 	socketPath = ""
 	verbosity  = []bool{}
 )
@@ -76,15 +77,15 @@ func init() {
 
 func setVerbosity() {
 	if printer.JSONOutput {
-		printer.Verbosity = format.JSON
+		printer.Verbosity = api.JSON
 	} else {
 		switch len(verbosity) {
 		case 1:
-			printer.Verbosity = format.DEBUG
+			printer.Verbosity = api.DEBUG
 		case 2:
-			printer.Verbosity = format.VERBOSE
+			printer.Verbosity = api.VERBOSE
 		default:
-			printer.Verbosity = format.INFO
+			printer.Verbosity = api.INFO
 		}
 	}
 }

--- a/pkg/hubble/parser/debug/parser.go
+++ b/pkg/hubble/parser/debug/parser.go
@@ -46,7 +46,7 @@ func (p *Parser) Decode(data []byte, cpu int) (*flowpb.DebugEvent, error) {
 	}
 
 	dbg := &monitor.DebugMsg{}
-	if err := monitor.DecodeDebugMsg(data, dbg); err != nil {
+	if err := dbg.Decode(data); err != nil {
 		return nil, fmt.Errorf("failed to parse debug event: %w", err)
 	}
 

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -79,7 +79,7 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	}
 
 	sock := &monitor.TraceSockNotify{}
-	if err := monitor.DecodeTraceSockNotify(data, sock); err != nil {
+	if err := sock.Decode(data); err != nil {
 		return fmt.Errorf("failed to parse sock trace event: %w", err)
 	}
 

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -163,14 +163,14 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	switch eventType {
 	case monitorAPI.MessageTypeDrop:
 		dn = &monitor.DropNotify{}
-		if err := monitor.DecodeDropNotify(data, dn); err != nil {
+		if err := dn.Decode(data); err != nil {
 			return fmt.Errorf("failed to parse drop: %w", err)
 		}
 		eventSubType = dn.SubType
 		packetOffset = (int)(dn.DataOffset())
 	case monitorAPI.MessageTypeTrace:
 		tn = &monitor.TraceNotify{}
-		if err := monitor.DecodeTraceNotify(data, tn); err != nil {
+		if err := tn.Decode(data); err != nil {
 			return fmt.Errorf("failed to parse trace: %w", err)
 		}
 		eventSubType = tn.ObsPoint
@@ -186,7 +186,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		packetOffset = (int)(tn.DataOffset())
 	case monitorAPI.MessageTypePolicyVerdict:
 		pvn = &monitor.PolicyVerdictNotify{}
-		if err := monitor.DecodePolicyVerdictNotify(data, pvn); err != nil {
+		if err := pvn.Decode(data); err != nil {
 			return fmt.Errorf("failed to parse policy verdict: %w", err)
 		}
 		eventSubType = pvn.SubType
@@ -194,7 +194,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		authType = pb.AuthType(pvn.GetAuthType())
 	case monitorAPI.MessageTypeCapture:
 		dbg = &monitor.DebugCapture{}
-		if err := monitor.DecodeDebugCapture(data, dbg); err != nil {
+		if err := dbg.Decode(data); err != nil {
 			return fmt.Errorf("failed to parse debug capture: %w", err)
 		}
 		eventSubType = dbg.SubType

--- a/pkg/monitor/api/agent_notify_linux.go
+++ b/pkg/monitor/api/agent_notify_linux.go
@@ -3,6 +3,11 @@
 
 package api
 
+import (
+	"bytes"
+	"encoding/gob"
+)
+
 // Methods in this file are only used on Linux paired with the MonitorEvent interface.
 
 // Dump prints the message according to the verbosity level specified
@@ -12,4 +17,21 @@ func (n *AgentNotify) Dump(args *DumpArgs) {
 	} else {
 		n.DumpInfo()
 	}
+}
+
+// Decode decodes the message in 'data' into the struct.
+func (a *AgentNotify) Decode(data []byte) error {
+	buf := bytes.NewBuffer(data[1:])
+	dec := gob.NewDecoder(buf)
+	return dec.Decode(a)
+}
+
+// GetSrc retrieves the source endpoint for the message
+func (n *AgentNotify) GetSrc() (src uint16) {
+	return 0
+}
+
+// GetDst retrieves the destination endpoint for the message.
+func (n *AgentNotify) GetDst() (dst uint16) {
+	return 0
 }

--- a/pkg/monitor/api/agent_notify_linux.go
+++ b/pkg/monitor/api/agent_notify_linux.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+// Methods in this file are only used on Linux paired with the MonitorEvent interface.
+
+// Dump prints the message according to the verbosity level specified
+func (n *AgentNotify) Dump(args *DumpArgs) {
+	if args.Verbosity == JSON {
+		n.DumpJSON()
+	} else {
+		n.DumpInfo()
+	}
+}

--- a/pkg/monitor/api/agent_notify_linux.go
+++ b/pkg/monitor/api/agent_notify_linux.go
@@ -6,6 +6,7 @@ package api
 import (
 	"bytes"
 	"encoding/gob"
+	"fmt"
 )
 
 // Methods in this file are only used on Linux paired with the MonitorEvent interface.
@@ -13,9 +14,9 @@ import (
 // Dump prints the message according to the verbosity level specified
 func (n *AgentNotify) Dump(args *DumpArgs) {
 	if args.Verbosity == JSON {
-		n.DumpJSON()
+		fmt.Fprintln(args.Buf, n.getJSON())
 	} else {
-		n.DumpInfo()
+		fmt.Fprintf(args.Buf, ">> %s: %s\n", resolveAgentType(n.Type), n.Text)
 	}
 }
 

--- a/pkg/monitor/api/monitor_event_interface_linux.go
+++ b/pkg/monitor/api/monitor_event_interface_linux.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 
@@ -46,6 +47,7 @@ type DumpArgs struct {
 	LinkMonitor getters.LinkGetter
 	Dissect     bool
 	Verbosity   Verbosity
+	Buf         *bufio.Writer
 }
 
 // MonitorEvent is the interface that all monitor events must implement to be dumped

--- a/pkg/monitor/api/monitor_event_interface_linux.go
+++ b/pkg/monitor/api/monitor_event_interface_linux.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+)
+
+// Verbosity levels for formatting output.
+type Verbosity uint8
+
+const (
+	// INFO is the level of verbosity in which summaries of Drop and Capture
+	// messages are printed out when the monitor is invoked
+	INFO Verbosity = iota + 1
+	// DEBUG is the level of verbosity in which more information about packets
+	// is printed than in INFO mode. Debug, Drop, and Capture messages are printed.
+	DEBUG
+	// VERBOSE is the level of verbosity in which the most information possible
+	// about packets is printed out. Currently is not utilized.
+	VERBOSE
+	// JSON is the level of verbosity in which event information is printed out in json format
+	JSON
+)
+
+// DisplayFormat is used to determine how to display the endpoint
+type DisplayFormat bool
+
+const (
+	// DisplayLabel is used to display the endpoint as a label
+	DisplayLabel DisplayFormat = false
+	// DisplayHex is used to display the endpoint as a number
+	DisplayNumeric DisplayFormat = true
+)
+
+// DumpArgs is used to pass arguments to the Dump method
+type DumpArgs struct {
+	Data        []byte
+	CpuPrefix   string
+	Format      DisplayFormat
+	LinkMonitor getters.LinkGetter
+	Dissect     bool
+	Verbosity   Verbosity
+}
+
+// MonitorEvent is the interface that all monitor events must implement to be dumped
+type MonitorEvent interface {
+	// Decode decodes the message in 'data' into the struct.
+	Decode(data []byte) error
+	// GetSrc retrieves the source endpoint for the message
+	GetSrc() (src uint16)
+	// GetDst retrieves the destination endpoint for the message.
+	GetDst() (dst uint16)
+	// Dump prints the message according to the verbosity level specified
+	Dump(args *DumpArgs)
+}
+
+// DefaultDecoder is a default implementation of the Decode method
+type DefaultDecoder struct{}
+
+// Decode decodes the message in 'data' into the struct.
+func (d *DefaultDecoder) Decode(data []byte) error {
+	return binary.Read(bytes.NewReader(data), byteorder.Native, d)
+}
+
+// DefaultSrcDstGetter is a default implementation of the GetSrc and GetDst methods
+type DefaultSrcDstGetter struct{}
+
+// GetSrc retrieves the source endpoint for the message
+func (d *DefaultSrcDstGetter) GetSrc() (src uint16) {
+	return 0
+}
+
+// GetDst retrieves the destination endpoint for the message.
+func (d *DefaultSrcDstGetter) GetDst() (dst uint16) {
+	return 0
+}

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -253,18 +253,8 @@ func resolveAgentType(t AgentNotification) string {
 	return fmt.Sprintf("%d", t)
 }
 
-// DumpInfo dumps an agent notification
-func (n *AgentNotify) DumpInfo() {
-	fmt.Printf(">> %s: %s\n", resolveAgentType(n.Type), n.Text)
-}
-
 func (n *AgentNotify) getJSON() string {
 	return fmt.Sprintf(`{"type":"agent","subtype":"%s","message":%s}`, resolveAgentType(n.Type), n.Text)
-}
-
-// DumpJSON prints notification in json format
-func (n *AgentNotify) DumpJSON() {
-	fmt.Println(n.getJSON())
 }
 
 // PolicyUpdateNotification structures update notification

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -239,6 +239,18 @@ type DebugMsg struct {
 	Arg3    uint32
 }
 
+// Dump prints the message according to the verbosity level specified
+func (n *DebugMsg) Dump(args *api.DumpArgs) {
+	switch args.Verbosity {
+	case api.INFO:
+		n.DumpInfo(args.Data)
+	case api.JSON:
+		n.DumpJSON(args.CpuPrefix, args.LinkMonitor)
+	default:
+		n.DumpVerbose(args.CpuPrefix, args.LinkMonitor)
+	}
+}
+
 // DecodeDebugMsg will decode 'data' into the provided DebugMsg structure
 func DecodeDebugMsg(data []byte, dbg *DebugMsg) error {
 	return dbg.decodeDebugMsg(data)
@@ -265,8 +277,8 @@ func (n *DebugMsg) decodeDebugMsg(data []byte) error {
 func (n *DebugMsg) DumpInfo(data []byte) {
 }
 
-// Dump prints the debug message in a human readable format.
-func (n *DebugMsg) Dump(prefix string, linkMonitor getters.LinkGetter) {
+// DumpVerbose prints the debug message in a human readable format.
+func (n *DebugMsg) DumpVerbose(prefix string, linkMonitor getters.LinkGetter) {
 	fmt.Printf("%s MARK %#x FROM %d DEBUG: %s\n", prefix, n.Hash, n.Source, n.Message(linkMonitor))
 }
 
@@ -437,6 +449,19 @@ type DebugCapture struct {
 	Arg1    uint32
 	Arg2    uint32
 	// data
+}
+
+// Dump prints the message according to the verbosity level specified
+func (n *DebugCapture) Dump(args *api.DumpArgs) {
+	switch args.Verbosity {
+	case api.INFO, api.DEBUG:
+		n.DumpInfo(args.Data, args.LinkMonitor)
+	case api.JSON:
+		n.DumpJSON(args.Data, args.CpuPrefix, args.LinkMonitor)
+	default:
+		fmt.Println(msgSeparator)
+		n.DumpVerbose(args.Dissect, args.Data, args.CpuPrefix)
+	}
 }
 
 // DecodeDebugCapture will decode 'data' into the provided DebugCapture structure

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -252,11 +252,6 @@ func (n *DebugMsg) Dump(args *api.DumpArgs) {
 	}
 }
 
-// DecodeDebugMsg will decode 'data' into the provided DebugMsg structure
-func DecodeDebugMsg(data []byte, dbg *DebugMsg) error {
-	return dbg.Decode(data)
-}
-
 // GetSrc retrieves the source endpoint for the message.
 func (n *DebugMsg) GetSrc() uint16 {
 	return n.Source
@@ -475,11 +470,6 @@ func (n *DebugCapture) Dump(args *api.DumpArgs) {
 // GetSrc retrieves the source endpoint for the message.
 func (n *DebugCapture) GetSrc() uint16 {
 	return n.Source
-}
-
-// DecodeDebugCapture will decode 'data' into the provided DebugCapture structure
-func DecodeDebugCapture(data []byte, dbg *DebugCapture) error {
-	return dbg.Decode(data)
 }
 
 // Decode decodes the message in 'data' into the struct.

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -230,6 +230,7 @@ const (
 
 // DebugMsg is the message format of the debug message found in the BPF ring buffer
 type DebugMsg struct {
+	api.DefaultSrcDstGetter
 	Type    uint8
 	SubType uint8
 	Source  uint16
@@ -253,10 +254,16 @@ func (n *DebugMsg) Dump(args *api.DumpArgs) {
 
 // DecodeDebugMsg will decode 'data' into the provided DebugMsg structure
 func DecodeDebugMsg(data []byte, dbg *DebugMsg) error {
-	return dbg.decodeDebugMsg(data)
+	return dbg.Decode(data)
 }
 
-func (n *DebugMsg) decodeDebugMsg(data []byte) error {
+// GetSrc retrieves the source endpoint for the message.
+func (n *DebugMsg) GetSrc() uint16 {
+	return n.Source
+}
+
+// Decode decodes the message in 'data' into the struct.
+func (n *DebugMsg) Decode(data []byte) error {
 	if l := len(data); l < DebugMsgLen {
 		return fmt.Errorf("unexpected DebugMsg data length, expected %d but got %d", DebugMsgLen, l)
 	}
@@ -439,6 +446,7 @@ const (
 
 // DebugCapture is the metadata sent along with a captured packet frame
 type DebugCapture struct {
+	api.DefaultSrcDstGetter
 	Type    uint8
 	SubType uint8
 	// Source, if populated, is the ID of the source endpoint.
@@ -464,12 +472,18 @@ func (n *DebugCapture) Dump(args *api.DumpArgs) {
 	}
 }
 
-// DecodeDebugCapture will decode 'data' into the provided DebugCapture structure
-func DecodeDebugCapture(data []byte, dbg *DebugCapture) error {
-	return dbg.decodeDebugCapture(data)
+// GetSrc retrieves the source endpoint for the message.
+func (n *DebugCapture) GetSrc() uint16 {
+	return n.Source
 }
 
-func (n *DebugCapture) decodeDebugCapture(data []byte) error {
+// DecodeDebugCapture will decode 'data' into the provided DebugCapture structure
+func DecodeDebugCapture(data []byte, dbg *DebugCapture) error {
+	return dbg.Decode(data)
+}
+
+// Decode decodes the message in 'data' into the struct.
+func (n *DebugCapture) Decode(data []byte) error {
 	if l := len(data); l < DebugCaptureLen {
 		return fmt.Errorf("unexpected DebugCapture data length, expected %d but got %d", DebugCaptureLen, l)
 	}

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -4,6 +4,7 @@
 package monitor
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -244,11 +245,12 @@ type DebugMsg struct {
 func (n *DebugMsg) Dump(args *api.DumpArgs) {
 	switch args.Verbosity {
 	case api.INFO:
-		n.DumpInfo(args.Data)
+		// We don't print messages at INFO level
+		return
 	case api.JSON:
-		n.DumpJSON(args.CpuPrefix, args.LinkMonitor)
+		fmt.Fprintln(args.Buf, n.getJSON(args.CpuPrefix, args.LinkMonitor))
 	default:
-		n.DumpVerbose(args.CpuPrefix, args.LinkMonitor)
+		fmt.Fprintf(args.Buf, "%s MARK %#x FROM %d DEBUG: %s\n", args.CpuPrefix, n.Hash, n.Source, n.Message(args.LinkMonitor))
 	}
 }
 
@@ -272,16 +274,6 @@ func (n *DebugMsg) Decode(data []byte) error {
 	n.Arg3 = byteorder.Native.Uint32(data[16:20])
 
 	return nil
-}
-
-// DumpInfo prints a summary of a subset of the debug messages which are related
-// to sending, not processing, of packets.
-func (n *DebugMsg) DumpInfo(data []byte) {
-}
-
-// DumpVerbose prints the debug message in a human readable format.
-func (n *DebugMsg) DumpVerbose(prefix string, linkMonitor getters.LinkGetter) {
-	fmt.Printf("%s MARK %#x FROM %d DEBUG: %s\n", prefix, n.Hash, n.Source, n.Message(linkMonitor))
 }
 
 // Message returns the debug message in a human-readable format
@@ -429,11 +421,6 @@ func (n *DebugMsg) getJSON(cpuPrefix string, linkMonitor getters.LinkGetter) str
 		cpuPrefix, n.Message(linkMonitor))
 }
 
-// DumpJSON prints notification in json format
-func (n *DebugMsg) DumpJSON(cpuPrefix string, linkMonitor getters.LinkGetter) {
-	fmt.Println(n.getJSON(cpuPrefix, linkMonitor))
-}
-
 const (
 	// DebugCaptureLen is the amount of packet data in a packet capture message
 	DebugCaptureLen = 24
@@ -458,12 +445,12 @@ type DebugCapture struct {
 func (n *DebugCapture) Dump(args *api.DumpArgs) {
 	switch args.Verbosity {
 	case api.INFO, api.DEBUG:
-		n.DumpInfo(args.Data, args.LinkMonitor)
+		n.DumpInfo(args.Buf, args.Data, args.LinkMonitor)
 	case api.JSON:
-		n.DumpJSON(args.Data, args.CpuPrefix, args.LinkMonitor)
+		n.DumpJSON(args.Buf, args.Data, args.CpuPrefix, args.LinkMonitor)
 	default:
-		fmt.Println(msgSeparator)
-		n.DumpVerbose(args.Dissect, args.Data, args.CpuPrefix)
+		fmt.Fprintln(args.Buf, msgSeparator)
+		n.DumpVerbose(args.Buf, args.Dissect, args.Data, args.CpuPrefix)
 	}
 }
 
@@ -491,11 +478,11 @@ func (n *DebugCapture) Decode(data []byte) error {
 }
 
 // DumpInfo prints a summary of the capture messages.
-func (n *DebugCapture) DumpInfo(data []byte, linkMonitor getters.LinkGetter) {
+func (n *DebugCapture) DumpInfo(buf *bufio.Writer, data []byte, linkMonitor getters.LinkGetter) {
 	prefix := n.infoPrefix(linkMonitor)
 
 	if len(prefix) > 0 {
-		fmt.Printf("%s: %s\n", prefix, GetConnectionSummary(data[DebugCaptureLen:], nil))
+		fmt.Fprintf(buf, "%s: %s\n", prefix, GetConnectionSummary(data[DebugCaptureLen:], nil))
 	}
 }
 
@@ -523,12 +510,11 @@ func (n *DebugCapture) infoPrefix(linkMonitor getters.LinkGetter) string {
 }
 
 // DumpVerbose prints the captured packet in human readable format
-func (n *DebugCapture) DumpVerbose(dissect bool, data []byte, prefix string) {
-	fmt.Printf("%s MARK %#x FROM %d DEBUG: %d bytes, ", prefix, n.Hash, n.Source, n.Len)
-	fmt.Println(n.subTypeString())
+func (n *DebugCapture) DumpVerbose(buf *bufio.Writer, dissect bool, data []byte, prefix string) {
+	fmt.Fprintf(buf, "%s MARK %#x FROM %d DEBUG: %d bytes, %s", prefix, n.Hash, n.Source, n.Len, n.subTypeString())
 
 	if n.Len > 0 && len(data) > DebugCaptureLen {
-		Dissect(dissect, data[DebugCaptureLen:])
+		Dissect(buf, dissect, data[DebugCaptureLen:])
 	}
 }
 
@@ -566,13 +552,13 @@ func (n *DebugCapture) getJSON(data []byte, cpuPrefix string, linkMonitor getter
 }
 
 // DumpJSON prints notification in json format
-func (n *DebugCapture) DumpJSON(data []byte, cpuPrefix string, linkMonitor getters.LinkGetter) {
+func (n *DebugCapture) DumpJSON(buf *bufio.Writer, data []byte, cpuPrefix string, linkMonitor getters.LinkGetter) {
 	resp, err := n.getJSON(data, cpuPrefix, linkMonitor)
 	if err != nil {
-		fmt.Printf(`{"type":"debug_capture_error","message":%q}`+"\n", err.Error())
+		fmt.Fprintf(buf, `{"type":"debug_capture_error","message":%q}`+"\n", err.Error())
 		return
 	}
-	fmt.Println(resp)
+	fmt.Fprintln(buf, resp)
 }
 
 // DebugCaptureVerbose represents a json notification printed by monitor

--- a/pkg/monitor/datapath_debug_test.go
+++ b/pkg/monitor/datapath_debug_test.go
@@ -33,7 +33,7 @@ func TestDecodeDebugCapture(t *testing.T) {
 	require.NoError(t, err)
 
 	output := &DebugCapture{}
-	err = DecodeDebugCapture(buf.Bytes(), output)
+	err = output.Decode(buf.Bytes())
 	require.NoError(t, err)
 
 	require.Equal(t, input.Type, output.Type)
@@ -57,7 +57,7 @@ func BenchmarkNewDecodeDebugCapture(b *testing.B) {
 
 	for b.Loop() {
 		dbg := &DebugCapture{}
-		if err := DecodeDebugCapture(buf.Bytes(), dbg); err != nil {
+		if err := dbg.Decode(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -101,7 +101,7 @@ func TestDecodeDebugMsg(t *testing.T) {
 	require.NoError(t, err)
 
 	output := &DebugMsg{}
-	err = DecodeDebugMsg(buf.Bytes(), output)
+	err = output.Decode(buf.Bytes())
 	require.NoError(t, err)
 
 	require.Equal(t, input.Type, output.Type)
@@ -125,7 +125,7 @@ func BenchmarkNewDecodeDebugMsg(b *testing.B) {
 
 	for b.Loop() {
 		dbg := &DebugMsg{}
-		if err := DecodeDebugMsg(buf.Bytes(), dbg); err != nil {
+		if err := dbg.Decode(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -100,11 +100,6 @@ func (n *DropNotify) dumpIdentity(buf *bufio.Writer, numeric api.DisplayFormat) 
 	}
 }
 
-// DecodeDropNotify will decode 'data' into the provided DropNotify structure
-func DecodeDropNotify(data []byte, dn *DropNotify) error {
-	return dn.Decode(data)
-}
-
 // Decode decodes the message in 'data' into the struct.
 func (n *DropNotify) Decode(data []byte) error {
 	if l := len(data); l < dropNotifyV1Len {

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -80,6 +80,16 @@ func (dn *DropNotify) Dump(args *api.DumpArgs) {
 	}
 }
 
+// GetSrc retrieves the source endpoint for the message.
+func (n *DropNotify) GetSrc() uint16 {
+	return n.Source
+}
+
+// GetDst retrieves the destination endpoint for the message.
+func (n *DropNotify) GetDst() uint16 {
+	return uint16(n.DstID)
+}
+
 // dumpIdentity dumps the source and destination identities in numeric or
 // human-readable format.
 func (n *DropNotify) dumpIdentity(buf *bufio.Writer, numeric api.DisplayFormat) {
@@ -92,10 +102,11 @@ func (n *DropNotify) dumpIdentity(buf *bufio.Writer, numeric api.DisplayFormat) 
 
 // DecodeDropNotify will decode 'data' into the provided DropNotify structure
 func DecodeDropNotify(data []byte, dn *DropNotify) error {
-	return dn.decodeDropNotify(data)
+	return dn.Decode(data)
 }
 
-func (n *DropNotify) decodeDropNotify(data []byte) error {
+// Decode decodes the message in 'data' into the struct.
+func (n *DropNotify) Decode(data []byte) error {
 	if l := len(data); l < dropNotifyV1Len {
 		return fmt.Errorf("unexpected DropNotify data length, expected at least %d but got %d", dropNotifyV1Len, l)
 	}

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/identity"
@@ -71,12 +70,12 @@ type DropNotify struct {
 func (dn *DropNotify) Dump(args *api.DumpArgs) {
 	switch args.Verbosity {
 	case api.INFO, api.DEBUG:
-		dn.DumpInfo(args.Data, args.Format)
+		dn.DumpInfo(args.Buf, args.Data, args.Format)
 	case api.JSON:
-		dn.DumpJSON(args.Data, args.CpuPrefix)
+		dn.DumpJSON(args.Buf, args.Data, args.CpuPrefix)
 	default:
-		fmt.Println(msgSeparator)
-		dn.DumpVerbose(!args.Dissect, args.Data, args.CpuPrefix, args.Format)
+		fmt.Fprintln(args.Buf, msgSeparator)
+		dn.DumpVerbose(args.Buf, !args.Dissect, args.Data, args.CpuPrefix, args.Format)
 	}
 }
 
@@ -169,18 +168,15 @@ func (n *DropNotify) DataOffset() uint {
 }
 
 // DumpInfo prints a summary of the drop messages.
-func (n *DropNotify) DumpInfo(data []byte, numeric api.DisplayFormat) {
-	buf := bufio.NewWriter(os.Stdout)
+func (n *DropNotify) DumpInfo(buf *bufio.Writer, data []byte, numeric api.DisplayFormat) {
 	fmt.Fprintf(buf, "xx drop (%s) flow %#x to endpoint %d, ifindex %d, file %s:%d, ",
 		api.DropReasonExt(n.SubType, n.ExtError), n.Hash, n.DstID, n.Ifindex, api.BPFFileName(n.File), int(n.Line))
 	n.dumpIdentity(buf, numeric)
 	fmt.Fprintf(buf, ": %s\n", GetConnectionSummary(data[n.DataOffset():], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()}))
-	buf.Flush()
 }
 
 // DumpVerbose prints the drop notification in human readable form
-func (n *DropNotify) DumpVerbose(dissect bool, data []byte, prefix string, numeric api.DisplayFormat) {
-	buf := bufio.NewWriter(os.Stdout)
+func (n *DropNotify) DumpVerbose(buf *bufio.Writer, dissect bool, data []byte, prefix string, numeric api.DisplayFormat) {
 	fmt.Fprintf(buf, "%s MARK %#x FROM %d DROP: %d bytes, reason %s",
 		prefix, n.Hash, n.Source, n.OrigLen, api.DropReasonExt(n.SubType, n.ExtError))
 
@@ -195,9 +191,8 @@ func (n *DropNotify) DumpVerbose(dissect bool, data []byte, prefix string, numer
 	}
 
 	if offset := int(n.DataOffset()); n.CapLen > 0 && len(data) > offset {
-		Dissect(dissect, data[offset:])
+		Dissect(buf, dissect, data[offset:])
 	}
-	buf.Flush()
 }
 
 func (n *DropNotify) getJSON(data []byte, cpuPrefix string) (string, error) {
@@ -213,10 +208,10 @@ func (n *DropNotify) getJSON(data []byte, cpuPrefix string) (string, error) {
 }
 
 // DumpJSON prints notification in json format
-func (n *DropNotify) DumpJSON(data []byte, cpuPrefix string) {
+func (n *DropNotify) DumpJSON(buf *bufio.Writer, data []byte, cpuPrefix string) {
 	resp, err := n.getJSON(data, cpuPrefix)
 	if err == nil {
-		fmt.Println(resp)
+		fmt.Fprintln(buf, resp)
 	}
 }
 

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -67,9 +67,22 @@ type DropNotify struct {
 	// data
 }
 
+// Dump prints the message according to the verbosity level specified
+func (dn *DropNotify) Dump(args *api.DumpArgs) {
+	switch args.Verbosity {
+	case api.INFO, api.DEBUG:
+		dn.DumpInfo(args.Data, args.Format)
+	case api.JSON:
+		dn.DumpJSON(args.Data, args.CpuPrefix)
+	default:
+		fmt.Println(msgSeparator)
+		dn.DumpVerbose(!args.Dissect, args.Data, args.CpuPrefix, args.Format)
+	}
+}
+
 // dumpIdentity dumps the source and destination identities in numeric or
 // human-readable format.
-func (n *DropNotify) dumpIdentity(buf *bufio.Writer, numeric DisplayFormat) {
+func (n *DropNotify) dumpIdentity(buf *bufio.Writer, numeric api.DisplayFormat) {
 	if numeric {
 		fmt.Fprintf(buf, ", identity %d->%d", n.SrcLabel, n.DstLabel)
 	} else {
@@ -150,7 +163,7 @@ func (n *DropNotify) DataOffset() uint {
 }
 
 // DumpInfo prints a summary of the drop messages.
-func (n *DropNotify) DumpInfo(data []byte, numeric DisplayFormat) {
+func (n *DropNotify) DumpInfo(data []byte, numeric api.DisplayFormat) {
 	buf := bufio.NewWriter(os.Stdout)
 	fmt.Fprintf(buf, "xx drop (%s) flow %#x to endpoint %d, ifindex %d, file %s:%d, ",
 		api.DropReasonExt(n.SubType, n.ExtError), n.Hash, n.DstID, n.Ifindex, api.BPFFileName(n.File), int(n.Line))
@@ -160,7 +173,7 @@ func (n *DropNotify) DumpInfo(data []byte, numeric DisplayFormat) {
 }
 
 // DumpVerbose prints the drop notification in human readable form
-func (n *DropNotify) DumpVerbose(dissect bool, data []byte, prefix string, numeric DisplayFormat) {
+func (n *DropNotify) DumpVerbose(dissect bool, data []byte, prefix string, numeric api.DisplayFormat) {
 	buf := bufio.NewWriter(os.Stdout)
 	fmt.Fprintf(buf, "%s MARK %#x FROM %d DROP: %d bytes, reason %s",
 		prefix, n.Hash, n.Source, n.OrigLen, api.DropReasonExt(n.SubType, n.ExtError))

--- a/pkg/monitor/datapath_drop_test.go
+++ b/pkg/monitor/datapath_drop_test.go
@@ -40,7 +40,7 @@ func TestDecodeDropNotify(t *testing.T) {
 	require.NoError(t, err)
 
 	output := &DropNotify{}
-	err = DecodeDropNotify(buf.Bytes(), output)
+	err = output.Decode(buf.Bytes())
 	require.NoError(t, err)
 
 	require.Equal(t, input.Type, output.Type)
@@ -65,14 +65,14 @@ func TestDecodeDropNotify(t *testing.T) {
 
 func TestDecodeDropNotifyErrors(t *testing.T) {
 	n := DropNotify{}
-	err := DecodeDropNotify([]byte{}, &n)
+	err := n.Decode([]byte{})
 	require.Error(t, err)
 	require.Equal(t, "unexpected DropNotify data length, expected at least 36 but got 0", err.Error())
 
 	// invalid version
 	ev := make([]byte, dropNotifyV2Len)
 	ev[14] = 0xff
-	err = DecodeDropNotify(ev, &n)
+	err = n.Decode(ev)
 	require.Error(t, err)
 	require.Equal(t, "Unrecognized drop event (version 255)", err.Error())
 }
@@ -89,7 +89,7 @@ func BenchmarkDecodeDropNotifyV1(b *testing.B) {
 
 	for b.Loop() {
 		dn := &DropNotify{}
-		if err := DecodeDropNotify(buf.Bytes(), dn); err != nil {
+		if err := dn.Decode(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -107,7 +107,7 @@ func BenchmarkDecodeDropNotifyV2(b *testing.B) {
 
 	for b.Loop() {
 		dn := &DropNotify{}
-		if err := DecodeDropNotify(buf.Bytes(), dn); err != nil {
+		if err := dn.Decode(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -62,6 +62,11 @@ type PolicyVerdictNotify struct {
 	// data
 }
 
+// Dump prints the message according to the verbosity level specified
+func (pn *PolicyVerdictNotify) Dump(args *api.DumpArgs) {
+	pn.DumpInfo(args.Data, args.Format)
+}
+
 // DecodePolicyVerdictNotify will decode 'data' into the provided PolicyVerdictNotify structure
 func DecodePolicyVerdictNotify(data []byte, pvn *PolicyVerdictNotify) error {
 	return pvn.decodePolicyVerdictNotify(data)
@@ -134,7 +139,7 @@ func (n *PolicyVerdictNotify) GetAuthType() policy.AuthType {
 }
 
 // DumpInfo prints a summary of the policy notify messages.
-func (n *PolicyVerdictNotify) DumpInfo(data []byte, numeric DisplayFormat) {
+func (n *PolicyVerdictNotify) DumpInfo(data []byte, numeric api.DisplayFormat) {
 	buf := bufio.NewWriter(os.Stdout)
 	dir := "egress"
 	if n.IsTrafficIngress() {

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -67,12 +67,25 @@ func (pn *PolicyVerdictNotify) Dump(args *api.DumpArgs) {
 	pn.DumpInfo(args.Data, args.Format)
 }
 
-// DecodePolicyVerdictNotify will decode 'data' into the provided PolicyVerdictNotify structure
-func DecodePolicyVerdictNotify(data []byte, pvn *PolicyVerdictNotify) error {
-	return pvn.decodePolicyVerdictNotify(data)
+// GetSrc retrieves the source endpoint for the message.
+func (n *PolicyVerdictNotify) GetSrc() uint16 {
+	return n.Source
 }
 
-func (n *PolicyVerdictNotify) decodePolicyVerdictNotify(data []byte) error {
+// GetDst retrieves the security identity for the message.
+// `POLICY_INGRESS` -> `RemoteLabel` is the src security identity.
+// `POLICY_EGRESS` -> `RemoteLabel` is the dst security identity.
+func (n *PolicyVerdictNotify) GetDst() uint16 {
+	return uint16(n.RemoteLabel)
+}
+
+// DecodePolicyVerdictNotify will decode 'data' into the provided PolicyVerdictNotify structure
+func DecodePolicyVerdictNotify(data []byte, pvn *PolicyVerdictNotify) error {
+	return pvn.Decode(data)
+}
+
+// Decode decodes the message in 'data' into the struct.
+func (n *PolicyVerdictNotify) Decode(data []byte) error {
 	if l := len(data); l < PolicyVerdictNotifyLen {
 		return fmt.Errorf("unexpected PolicyVerdictNotify data length, expected %d but got %d", PolicyVerdictNotifyLen, l)
 	}

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -79,11 +79,6 @@ func (n *PolicyVerdictNotify) GetDst() uint16 {
 	return uint16(n.RemoteLabel)
 }
 
-// DecodePolicyVerdictNotify will decode 'data' into the provided PolicyVerdictNotify structure
-func DecodePolicyVerdictNotify(data []byte, pvn *PolicyVerdictNotify) error {
-	return pvn.Decode(data)
-}
-
 // Decode decodes the message in 'data' into the struct.
 func (n *PolicyVerdictNotify) Decode(data []byte) error {
 	if l := len(data); l < PolicyVerdictNotifyLen {

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -6,7 +6,6 @@ package monitor
 import (
 	"bufio"
 	"fmt"
-	"os"
 
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/identity"
@@ -64,7 +63,7 @@ type PolicyVerdictNotify struct {
 
 // Dump prints the message according to the verbosity level specified
 func (pn *PolicyVerdictNotify) Dump(args *api.DumpArgs) {
-	pn.DumpInfo(args.Data, args.Format)
+	pn.DumpInfo(args.Buf, args.Data, args.Format)
 }
 
 // GetSrc retrieves the source endpoint for the message.
@@ -147,8 +146,7 @@ func (n *PolicyVerdictNotify) GetAuthType() policy.AuthType {
 }
 
 // DumpInfo prints a summary of the policy notify messages.
-func (n *PolicyVerdictNotify) DumpInfo(data []byte, numeric api.DisplayFormat) {
-	buf := bufio.NewWriter(os.Stdout)
+func (n *PolicyVerdictNotify) DumpInfo(buf *bufio.Writer, data []byte, numeric api.DisplayFormat) {
 	dir := "egress"
 	if n.IsTrafficIngress() {
 		dir = "ingress"
@@ -163,5 +161,4 @@ func (n *PolicyVerdictNotify) DumpInfo(data []byte, numeric api.DisplayFormat) {
 		GetPolicyActionString(n.Verdict, n.IsTrafficAudited()),
 		n.GetAuthType(), n.GetPolicyMatchType(),
 		GetConnectionSummary(data[PolicyVerdictNotifyLen:], nil))
-	buf.Flush()
 }

--- a/pkg/monitor/datapath_policy_test.go
+++ b/pkg/monitor/datapath_policy_test.go
@@ -40,7 +40,7 @@ func TestDecodePolicyVerdicyNotify(t *testing.T) {
 	require.NoError(t, err)
 
 	output := &PolicyVerdictNotify{}
-	err = DecodePolicyVerdictNotify(buf.Bytes(), output)
+	err = output.Decode(buf.Bytes())
 	require.NoError(t, err)
 
 	require.Equal(t, input.Type, output.Type)
@@ -72,7 +72,7 @@ func BenchmarkNewDecodePolicyVerdictNotify(b *testing.B) {
 
 	for b.Loop() {
 		pvn := &PolicyVerdictNotify{}
-		if err := DecodePolicyVerdictNotify(buf.Bytes(), pvn); err != nil {
+		if err := pvn.Decode(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/monitor/datapath_recorder.go
+++ b/pkg/monitor/datapath_recorder.go
@@ -18,6 +18,9 @@ const (
 
 // RecorderCapture is the message format of a pcap capture in the bpf ring buffer
 type RecorderCapture struct {
+	api.DefaultSrcDstGetter
+	api.DefaultDecoder
+
 	Type     uint8
 	SubType  uint8
 	RuleID   uint16

--- a/pkg/monitor/datapath_recorder.go
+++ b/pkg/monitor/datapath_recorder.go
@@ -7,6 +7,8 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+
+	"github.com/cilium/cilium/pkg/monitor/api"
 )
 
 const (
@@ -24,6 +26,11 @@ type RecorderCapture struct {
 	CapLen   uint32
 	Len      uint32
 	// data
+}
+
+// Dump prints the message according to the verbosity level specified
+func (n *RecorderCapture) Dump(args *api.DumpArgs) {
+	n.DumpInfo(args.Data)
 }
 
 // DumpInfo prints a summary of the recorder notify messages.

--- a/pkg/monitor/datapath_recorder.go
+++ b/pkg/monitor/datapath_recorder.go
@@ -6,7 +6,6 @@ package monitor
 import (
 	"bufio"
 	"fmt"
-	"os"
 
 	"github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -33,20 +32,17 @@ type RecorderCapture struct {
 
 // Dump prints the message according to the verbosity level specified
 func (n *RecorderCapture) Dump(args *api.DumpArgs) {
-	n.DumpInfo(args.Data)
+	n.DumpInfo(args.Buf, args.Data)
 }
 
 // DumpInfo prints a summary of the recorder notify messages.
-func (n *RecorderCapture) DumpInfo(data []byte) {
-	buf := bufio.NewWriter(os.Stdout)
+func (n *RecorderCapture) DumpInfo(buf *bufio.Writer, data []byte) {
 	dir := "egress"
 	if n.SubType == 1 {
 		dir = "ingress"
 	}
 	fmt.Fprintf(buf, "Recorder capture: dir:%s rule:%d ts:%d caplen:%d len:%d\n",
 		dir, int(n.RuleID), int(n.TimeBoot), int(n.CapLen), int(n.Len))
-	buf.Flush()
-	Dissect(true, data[RecorderCaptureLen:])
+	Dissect(buf, true, data[RecorderCaptureLen:])
 	fmt.Fprintf(buf, "----\n")
-	buf.Flush()
 }

--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -61,11 +61,6 @@ func (t *TraceSockNotify) Dump(args *api.DumpArgs) {
 	}
 }
 
-// DecodeTraceSockNotify will decode 'data' into the provided TraceSocNotify structure
-func DecodeTraceSockNotify(data []byte, sock *TraceSockNotify) error {
-	return sock.Decode(data)
-}
-
 // Decode decodes the message in 'data' into the struct.
 func (t *TraceSockNotify) Decode(data []byte) error {
 	if l := len(data); l < TraceSockNotifyLen {

--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -4,10 +4,8 @@
 package monitor
 
 import (
-	"bufio"
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/monitor/api"
@@ -57,7 +55,8 @@ func (t *TraceSockNotify) Dump(args *api.DumpArgs) {
 	// Currently only printed with the debug option. Extend it to info and json.
 	// GH issue: https://github.com/cilium/cilium/issues/21510
 	if args.Verbosity == api.DEBUG {
-		t.DumpDebug(args.CpuPrefix)
+		fmt.Fprintf(args.Buf, "%s [%s] cgroup_id: %d sock_cookie: %d, dst [%s]:%d %s \n",
+			args.CpuPrefix, t.XlatePointStr(), t.CgroupId, t.SockCookie, t.IP(), t.DstPort, t.L4ProtoStr())
 	}
 }
 
@@ -77,14 +76,6 @@ func (t *TraceSockNotify) Decode(data []byte) error {
 	t.Flags = data[37]
 
 	return nil
-}
-
-func (t *TraceSockNotify) DumpDebug(prefix string) {
-	buf := bufio.NewWriter(os.Stdout)
-
-	fmt.Fprintf(buf, "%s [%s] cgroup_id: %d sock_cookie: %d, dst [%s]:%d %s \n",
-		prefix, t.XlatePointStr(), t.CgroupId, t.SockCookie, t.IP(), t.DstPort, t.L4ProtoStr())
-	buf.Flush()
 }
 
 func (t *TraceSockNotify) XlatePointStr() string {

--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/types"
 )
 
@@ -47,6 +48,15 @@ type TraceSockNotify struct {
 	CgroupId   uint64
 	L4Proto    uint8
 	Flags      uint8
+}
+
+// Dump prints the message according to the verbosity level specified
+func (t *TraceSockNotify) Dump(args *api.DumpArgs) {
+	// Currently only printed with the debug option. Extend it to info and json.
+	// GH issue: https://github.com/cilium/cilium/issues/21510
+	if args.Verbosity == api.DEBUG {
+		t.DumpDebug(args.CpuPrefix)
+	}
 }
 
 // DecodeTraceSockNotify will decode 'data' into the provided TraceSocNotify structure

--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -40,6 +40,8 @@ const (
 // Keep this in sync to the datapath structure (trace_sock_notify) defined in
 // bpf/lib/trace_sock.h
 type TraceSockNotify struct {
+	api.DefaultSrcDstGetter
+
 	Type       uint8
 	XlatePoint uint8
 	DstIP      types.IPv6
@@ -61,10 +63,11 @@ func (t *TraceSockNotify) Dump(args *api.DumpArgs) {
 
 // DecodeTraceSockNotify will decode 'data' into the provided TraceSocNotify structure
 func DecodeTraceSockNotify(data []byte, sock *TraceSockNotify) error {
-	return sock.decodeTraceSockNotify(data)
+	return sock.Decode(data)
 }
 
-func (t *TraceSockNotify) decodeTraceSockNotify(data []byte) error {
+// Decode decodes the message in 'data' into the struct.
+func (t *TraceSockNotify) Decode(data []byte) error {
 	if l := len(data); l < TraceSockNotifyLen {
 		return fmt.Errorf("unexpected TraceSockNotify data length, expected %d but got %d", TraceSockNotifyLen, l)
 	}

--- a/pkg/monitor/datapath_sock_trace_test.go
+++ b/pkg/monitor/datapath_sock_trace_test.go
@@ -43,7 +43,7 @@ func TestDecodeTraceSockNotify(t *testing.T) {
 	require.NoError(t, err)
 
 	output := &TraceSockNotify{}
-	err = DecodeTraceSockNotify(buf.Bytes(), output)
+	err = output.Decode(buf.Bytes())
 	require.NoError(t, err)
 
 	require.Equal(t, input.Type, output.Type)
@@ -67,7 +67,7 @@ func BenchmarkNewDecodeTraceSockNotify(b *testing.B) {
 
 	for b.Loop() {
 		tsn := &TraceSockNotify{}
-		if err := DecodeTraceSockNotify(buf.Bytes(), tsn); err != nil {
+		if err := tsn.Decode(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -63,6 +63,19 @@ type TraceNotify struct {
 	// data
 }
 
+// Dump prints the message according to the verbosity level specified
+func (tn *TraceNotify) Dump(args *api.DumpArgs) {
+	switch args.Verbosity {
+	case api.INFO, api.DEBUG:
+		tn.DumpInfo(args.Data, args.Format, args.LinkMonitor)
+	case api.JSON:
+		tn.DumpJSON(args.Data, args.CpuPrefix, args.LinkMonitor)
+	default:
+		fmt.Println(msgSeparator)
+		tn.DumpVerbose(args.Dissect, args.Data, args.CpuPrefix, args.Format, args.LinkMonitor)
+	}
+}
+
 // decodeTraceNotify decodes the trace notify message in 'data' into the struct.
 func (tn *TraceNotify) decodeTraceNotify(data []byte) error {
 	if l := len(data); l < traceNotifyV0Len {
@@ -188,7 +201,7 @@ func DecodeTraceNotify(data []byte, tn *TraceNotify) error {
 
 // dumpIdentity dumps the source and destination identities in numeric or
 // human-readable format.
-func (n *TraceNotify) dumpIdentity(buf *bufio.Writer, numeric DisplayFormat) {
+func (n *TraceNotify) dumpIdentity(buf *bufio.Writer, numeric api.DisplayFormat) {
 	if numeric {
 		fmt.Fprintf(buf, ", identity %d->%d", n.SrcLabel, n.DstLabel)
 	} else {
@@ -289,7 +302,7 @@ func (n *TraceNotify) DataOffset() uint {
 }
 
 // DumpInfo prints a summary of the trace messages.
-func (n *TraceNotify) DumpInfo(data []byte, numeric DisplayFormat, linkMonitor getters.LinkGetter) {
+func (n *TraceNotify) DumpInfo(data []byte, numeric api.DisplayFormat, linkMonitor getters.LinkGetter) {
 	buf := bufio.NewWriter(os.Stdout)
 	hdrLen := n.DataOffset()
 	if enc := n.encryptReasonString(); enc != "" {
@@ -306,7 +319,7 @@ func (n *TraceNotify) DumpInfo(data []byte, numeric DisplayFormat, linkMonitor g
 }
 
 // DumpVerbose prints the trace notification in human readable form
-func (n *TraceNotify) DumpVerbose(dissect bool, data []byte, prefix string, numeric DisplayFormat, linkMonitor getters.LinkGetter) {
+func (n *TraceNotify) DumpVerbose(dissect bool, data []byte, prefix string, numeric api.DisplayFormat, linkMonitor getters.LinkGetter) {
 	buf := bufio.NewWriter(os.Stdout)
 	fmt.Fprintf(buf, "%s MARK %#x FROM %d %s: %d bytes (%d captured), state %s",
 		prefix, n.Hash, n.Source, api.TraceObservationPoint(n.ObsPoint), n.OrigLen, n.CapLen, n.traceReasonString())

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -204,11 +204,6 @@ var traceReasons = map[uint8]string{
 	TraceReasonEncryptOverlay:       "encrypt-overlay",
 }
 
-// DecodeTraceNotify will decode 'data' into the provided TraceNotify structure
-func DecodeTraceNotify(data []byte, tn *TraceNotify) error {
-	return tn.Decode(data)
-}
-
 // dumpIdentity dumps the source and destination identities in numeric or
 // human-readable format.
 func (n *TraceNotify) dumpIdentity(buf *bufio.Writer, numeric api.DisplayFormat) {

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -76,8 +76,18 @@ func (tn *TraceNotify) Dump(args *api.DumpArgs) {
 	}
 }
 
-// decodeTraceNotify decodes the trace notify message in 'data' into the struct.
-func (tn *TraceNotify) decodeTraceNotify(data []byte) error {
+// GetSrc retrieves the source endpoint for the message.
+func (tn *TraceNotify) GetSrc() uint16 {
+	return tn.Source
+}
+
+// GetDst retrieves the destination endpoint or proxy destination port according to the message subtype.
+func (tn *TraceNotify) GetDst() uint16 {
+	return tn.DstID
+}
+
+// Decode decodes the message in 'data' into the struct.
+func (tn *TraceNotify) Decode(data []byte) error {
 	if l := len(data); l < traceNotifyV0Len {
 		return fmt.Errorf("unexpected TraceNotify data length, expected at least %d but got %d", traceNotifyV0Len, l)
 	}
@@ -196,7 +206,7 @@ var traceReasons = map[uint8]string{
 
 // DecodeTraceNotify will decode 'data' into the provided TraceNotify structure
 func DecodeTraceNotify(data []byte, tn *TraceNotify) error {
-	return tn.decodeTraceNotify(data)
+	return tn.Decode(data)
 }
 
 // dumpIdentity dumps the source and destination identities in numeric or

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -67,12 +66,12 @@ type TraceNotify struct {
 func (tn *TraceNotify) Dump(args *api.DumpArgs) {
 	switch args.Verbosity {
 	case api.INFO, api.DEBUG:
-		tn.DumpInfo(args.Data, args.Format, args.LinkMonitor)
+		tn.DumpInfo(args.Buf, args.Data, args.Format, args.LinkMonitor)
 	case api.JSON:
-		tn.DumpJSON(args.Data, args.CpuPrefix, args.LinkMonitor)
+		tn.DumpJSON(args.Buf, args.Data, args.CpuPrefix, args.LinkMonitor)
 	default:
-		fmt.Println(msgSeparator)
-		tn.DumpVerbose(args.Dissect, args.Data, args.CpuPrefix, args.Format, args.LinkMonitor)
+		fmt.Fprintln(args.Buf, msgSeparator)
+		tn.DumpVerbose(args.Buf, args.Dissect, args.Data, args.CpuPrefix, args.Format, args.LinkMonitor)
 	}
 }
 
@@ -307,8 +306,7 @@ func (n *TraceNotify) DataOffset() uint {
 }
 
 // DumpInfo prints a summary of the trace messages.
-func (n *TraceNotify) DumpInfo(data []byte, numeric api.DisplayFormat, linkMonitor getters.LinkGetter) {
-	buf := bufio.NewWriter(os.Stdout)
+func (n *TraceNotify) DumpInfo(buf *bufio.Writer, data []byte, numeric api.DisplayFormat, linkMonitor getters.LinkGetter) {
 	hdrLen := n.DataOffset()
 	if enc := n.encryptReasonString(); enc != "" {
 		fmt.Fprintf(buf, "%s %s flow %#x ",
@@ -320,12 +318,10 @@ func (n *TraceNotify) DumpInfo(data []byte, numeric api.DisplayFormat, linkMonit
 	ifname := linkMonitor.Name(n.Ifindex)
 	fmt.Fprintf(buf, " state %s ifindex %s orig-ip %s: %s\n", n.traceReasonString(),
 		ifname, n.OriginalIP().String(), GetConnectionSummary(data[hdrLen:], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()}))
-	buf.Flush()
 }
 
 // DumpVerbose prints the trace notification in human readable form
-func (n *TraceNotify) DumpVerbose(dissect bool, data []byte, prefix string, numeric api.DisplayFormat, linkMonitor getters.LinkGetter) {
-	buf := bufio.NewWriter(os.Stdout)
+func (n *TraceNotify) DumpVerbose(buf *bufio.Writer, dissect bool, data []byte, prefix string, numeric api.DisplayFormat, linkMonitor getters.LinkGetter) {
 	fmt.Fprintf(buf, "%s MARK %#x FROM %d %s: %d bytes (%d captured), state %s",
 		prefix, n.Hash, n.Source, api.TraceObservationPoint(n.ObsPoint), n.OrigLen, n.CapLen, n.traceReasonString())
 
@@ -353,9 +349,8 @@ func (n *TraceNotify) DumpVerbose(dissect bool, data []byte, prefix string, nume
 
 	hdrLen := n.DataOffset()
 	if n.CapLen > 0 && len(data) > int(hdrLen) {
-		Dissect(dissect, data[hdrLen:])
+		Dissect(buf, dissect, data[hdrLen:])
 	}
-	buf.Flush()
 }
 
 func (n *TraceNotify) getJSON(data []byte, cpuPrefix string, linkMonitor getters.LinkGetter) (string, error) {
@@ -371,10 +366,10 @@ func (n *TraceNotify) getJSON(data []byte, cpuPrefix string, linkMonitor getters
 }
 
 // DumpJSON prints notification in json format
-func (n *TraceNotify) DumpJSON(data []byte, cpuPrefix string, linkMonitor getters.LinkGetter) {
+func (n *TraceNotify) DumpJSON(buf *bufio.Writer, data []byte, cpuPrefix string, linkMonitor getters.LinkGetter) {
 	resp, err := n.getJSON(data, cpuPrefix, linkMonitor)
 	if err == nil {
-		fmt.Println(resp)
+		fmt.Fprintln(buf, resp)
 	}
 }
 

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -47,7 +47,7 @@ func TestDecodeTraceNotify(t *testing.T) {
 	require.NoError(t, err)
 
 	out := TraceNotify{}
-	err = DecodeTraceNotify(buf.Bytes(), &out)
+	err = out.Decode(buf.Bytes())
 	require.NoError(t, err)
 	require.Equal(t, in.Type, out.Type)
 	require.Equal(t, in.ObsPoint, out.ObsPoint)
@@ -67,14 +67,14 @@ func TestDecodeTraceNotify(t *testing.T) {
 
 func TestDecodeTraceNotifyErrors(t *testing.T) {
 	tn := TraceNotify{}
-	err := DecodeTraceNotify([]byte{}, &tn)
+	err := tn.Decode([]byte{})
 	require.Error(t, err)
 	require.Equal(t, "unexpected TraceNotify data length, expected at least 32 but got 0", err.Error())
 
 	// invalid version
 	ev := make([]byte, traceNotifyV1Len)
 	ev[14] = 0xff
-	err = DecodeTraceNotify(ev, &tn)
+	err = tn.Decode(ev)
 	require.Error(t, err)
 	require.Equal(t, "Unrecognized trace event (version 255)", err.Error())
 }

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -323,7 +323,7 @@ func BenchmarkDecodeTraceNotifyVersion0(b *testing.B) {
 
 	for b.Loop() {
 		tn := &TraceNotify{}
-		if err := tn.decodeTraceNotify(buf.Bytes()); err != nil {
+		if err := tn.Decode(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -341,7 +341,7 @@ func BenchmarkDecodeTraceNotifyVersion1(b *testing.B) {
 
 	for b.Loop() {
 		tn := &TraceNotify{Version: TraceNotifyVersion1}
-		if err := tn.decodeTraceNotify(buf.Bytes()); err != nil {
+		if err := tn.Decode(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -16,13 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 )
 
-type DisplayFormat bool
-
-const (
-	DisplayLabel   DisplayFormat = false
-	DisplayNumeric DisplayFormat = true
-)
-
 type parserCache struct {
 	eth     layers.Ethernet
 	ip4     layers.IPv4

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -318,51 +318,51 @@ func GetConnectionSummary(data []byte, opts *decodeOpts) string {
 // Dissect parses and prints the provided data if dissect is set to true,
 // otherwise the data is printed as HEX output
 func Dissect(dissect bool, data []byte) {
-	if dissect {
-		dissectLock.Lock()
-		defer dissectLock.Unlock()
-
-		initParser()
-
-		var err error
-		// See comment in [GetConnectionSummary].
-		if len(data) > 0 {
-			err = parserL2Dev.DecodeLayers(data, &cache.decoded)
-		} else {
-			cache.decoded = cache.decoded[:0]
-		}
-
-		for _, typ := range cache.decoded {
-			switch typ {
-			case layers.LayerTypeEthernet:
-				fmt.Println(gopacket.LayerString(&cache.eth))
-			case layers.LayerTypeIPv4:
-				fmt.Println(gopacket.LayerString(&cache.ip4))
-			case layers.LayerTypeIPv6:
-				fmt.Println(gopacket.LayerString(&cache.ip6))
-			case layers.LayerTypeTCP:
-				fmt.Println(gopacket.LayerString(&cache.tcp))
-			case layers.LayerTypeUDP:
-				fmt.Println(gopacket.LayerString(&cache.udp))
-			case layers.LayerTypeSCTP:
-				fmt.Println(gopacket.LayerString(&cache.sctp))
-			case layers.LayerTypeICMPv4:
-				fmt.Println(gopacket.LayerString(&cache.icmp4))
-			case layers.LayerTypeICMPv6:
-				fmt.Println(gopacket.LayerString(&cache.icmp6))
-			default:
-				fmt.Println("Unknown layer")
-			}
-		}
-		if parserL2Dev.Truncated {
-			fmt.Println("  Packet has been truncated")
-		}
-		if err != nil {
-			fmt.Println("  Failed to decode layer:", err)
-		}
-
-	} else {
+	if !dissect {
 		fmt.Print(hex.Dump(data))
+		return
+	}
+
+	dissectLock.Lock()
+	defer dissectLock.Unlock()
+
+	initParser()
+
+	var err error
+	// See comment in [GetConnectionSummary].
+	if len(data) > 0 {
+		err = parserL2Dev.DecodeLayers(data, &cache.decoded)
+	} else {
+		cache.decoded = cache.decoded[:0]
+	}
+
+	for _, typ := range cache.decoded {
+		switch typ {
+		case layers.LayerTypeEthernet:
+			fmt.Println(gopacket.LayerString(&cache.eth))
+		case layers.LayerTypeIPv4:
+			fmt.Println(gopacket.LayerString(&cache.ip4))
+		case layers.LayerTypeIPv6:
+			fmt.Println(gopacket.LayerString(&cache.ip6))
+		case layers.LayerTypeTCP:
+			fmt.Println(gopacket.LayerString(&cache.tcp))
+		case layers.LayerTypeUDP:
+			fmt.Println(gopacket.LayerString(&cache.udp))
+		case layers.LayerTypeSCTP:
+			fmt.Println(gopacket.LayerString(&cache.sctp))
+		case layers.LayerTypeICMPv4:
+			fmt.Println(gopacket.LayerString(&cache.icmp4))
+		case layers.LayerTypeICMPv6:
+			fmt.Println(gopacket.LayerString(&cache.icmp6))
+		default:
+			fmt.Println("Unknown layer")
+		}
+	}
+	if parserL2Dev.Truncated {
+		fmt.Println("  Packet has been truncated")
+	}
+	if err != nil {
+		fmt.Println("  Failed to decode layer:", err)
 	}
 }
 

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -4,6 +4,7 @@
 package monitor
 
 import (
+	"bufio"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -317,9 +318,9 @@ func GetConnectionSummary(data []byte, opts *decodeOpts) string {
 
 // Dissect parses and prints the provided data if dissect is set to true,
 // otherwise the data is printed as HEX output
-func Dissect(dissect bool, data []byte) {
+func Dissect(buf *bufio.Writer, dissect bool, data []byte) {
 	if !dissect {
-		fmt.Print(hex.Dump(data))
+		fmt.Fprint(buf, hex.Dump(data))
 		return
 	}
 
@@ -339,30 +340,30 @@ func Dissect(dissect bool, data []byte) {
 	for _, typ := range cache.decoded {
 		switch typ {
 		case layers.LayerTypeEthernet:
-			fmt.Println(gopacket.LayerString(&cache.eth))
+			fmt.Fprintln(buf, gopacket.LayerString(&cache.eth))
 		case layers.LayerTypeIPv4:
-			fmt.Println(gopacket.LayerString(&cache.ip4))
+			fmt.Fprintln(buf, gopacket.LayerString(&cache.ip4))
 		case layers.LayerTypeIPv6:
-			fmt.Println(gopacket.LayerString(&cache.ip6))
+			fmt.Fprintln(buf, gopacket.LayerString(&cache.ip6))
 		case layers.LayerTypeTCP:
-			fmt.Println(gopacket.LayerString(&cache.tcp))
+			fmt.Fprintln(buf, gopacket.LayerString(&cache.tcp))
 		case layers.LayerTypeUDP:
-			fmt.Println(gopacket.LayerString(&cache.udp))
+			fmt.Fprintln(buf, gopacket.LayerString(&cache.udp))
 		case layers.LayerTypeSCTP:
-			fmt.Println(gopacket.LayerString(&cache.sctp))
+			fmt.Fprintln(buf, gopacket.LayerString(&cache.sctp))
 		case layers.LayerTypeICMPv4:
-			fmt.Println(gopacket.LayerString(&cache.icmp4))
+			fmt.Fprintln(buf, gopacket.LayerString(&cache.icmp4))
 		case layers.LayerTypeICMPv6:
-			fmt.Println(gopacket.LayerString(&cache.icmp6))
+			fmt.Fprintln(buf, gopacket.LayerString(&cache.icmp6))
 		default:
-			fmt.Println("Unknown layer")
+			fmt.Fprintln(buf, "Unknown layer")
 		}
 	}
 	if parserL2Dev.Truncated {
-		fmt.Println("  Packet has been truncated")
+		fmt.Fprintln(buf, "  Packet has been truncated")
 	}
 	if err != nil {
-		fmt.Println("  Failed to decode layer:", err)
+		fmt.Fprintln(buf, "  Failed to decode layer:", err)
 	}
 }
 

--- a/pkg/monitor/format/format.go
+++ b/pkg/monitor/format/format.go
@@ -114,21 +114,27 @@ func (m *MonitorFormatter) FormatSample(data []byte, cpu int) {
 	})
 }
 
-// LostEvent formats a lost event using the specified payload parameters.
-func LostEvent(lost uint64, cpu int) {
+// FormatLostEvent formats a lost event using the specified payload parameters.
+func (m *MonitorFormatter) FormatLostEvent(lost uint64, cpu int) {
 	fmt.Printf("CPU %02d: Lost %d events\n", cpu, lost)
+}
+
+// FormatUnknownEvent formats an unknown event using the specified payload parameters.
+func (m *MonitorFormatter) FormatUnknownEvent(lost uint64, cpu int, t int) {
+	fmt.Printf("Unknown payload type: %d, CPU %02d: Lost %d events\n", t, cpu, lost)
 }
 
 // FormatEvent formats an event from the specified payload to stdout.
 //
-// Returns true if the event was successfully printed, false otherwise.
+// Returns true if the event was successfully recognized, false otherwise.
 func (m *MonitorFormatter) FormatEvent(pl *payload.Payload) bool {
 	switch pl.Type {
 	case payload.EventSample:
 		m.FormatSample(pl.Data, pl.CPU)
 	case payload.RecordLost:
-		LostEvent(pl.Lost, pl.CPU)
+		m.FormatLostEvent(pl.Lost, pl.CPU)
 	default:
+		m.FormatUnknownEvent(pl.Lost, pl.CPU, pl.Type)
 		return false
 	}
 

--- a/pkg/monitor/format/fuzz_test.go
+++ b/pkg/monitor/format/fuzz_test.go
@@ -4,6 +4,7 @@
 package format
 
 import (
+	"os"
 	"runtime"
 	"testing"
 
@@ -38,7 +39,7 @@ func FuzzFormatEvent(f *testing.F) {
 			runtime.GC()
 		}()
 
-		mf := NewMonitorFormatter(0, nil)
+		mf := NewMonitorFormatter(0, nil, os.Stdout)
 
 		mf.FormatEvent(pl)
 	})

--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -10,12 +10,22 @@ import (
 
 	"github.com/cilium/dns"
 
+	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
 // LogRecordNotify is a proxy access log notification
 type LogRecordNotify struct {
 	accesslog.LogRecord
+}
+
+// Dump prints the message according to the verbosity level specified
+func (l *LogRecordNotify) Dump(args *api.DumpArgs) {
+	if args.Verbosity == api.JSON {
+		l.DumpJSON()
+	} else {
+		l.DumpInfo()
+	}
 }
 
 func (l *LogRecordNotify) direction() string {

--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -4,6 +4,8 @@
 package monitor
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -26,6 +28,23 @@ func (l *LogRecordNotify) Dump(args *api.DumpArgs) {
 	} else {
 		l.DumpInfo()
 	}
+}
+
+// GetSrc retrieves the source endpoint for the message
+func (l *LogRecordNotify) GetSrc() uint16 {
+	return uint16(l.SourceEndpoint.ID)
+}
+
+// GetDst retrieves the destination endpoint for the message.
+func (l *LogRecordNotify) GetDst() uint16 {
+	return uint16(l.DestinationEndpoint.ID)
+}
+
+// Decode decodes the message in 'data' into the struct.
+func (l *LogRecordNotify) Decode(data []byte) error {
+	buf := bytes.NewBuffer(data[1:])
+	dec := gob.NewDecoder(buf)
+	return dec.Decode(l)
 }
 
 func (l *LogRecordNotify) direction() string {

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -13,6 +13,10 @@ import (
 
 var _ pflag.Value = &monitorAPI.MessageTypeFilter{}
 
+const (
+	msgSeparator = "------------------------------------------------------------------------------"
+)
+
 // GetAllTypes returns a slice of all known message types, sorted
 func GetAllTypes() []string {
 	types := make([]string, 0, len(monitorAPI.MessageTypeNames))


### PR DESCRIPTION
Running bpf tests (see here https://github.com/cilium/cilium/pull/39919), I realized that today we print only `DebugMsg` (see the last commit in this PR). This could be misleading when we receive a different event like `TraceNotify` because it will be erroneously decoded as a Debug message.



So I searched if today we have a method to decode all types and obtain a unique message in a string, so that we can use the output in `t.Log()`.

The `MonitorFormatter` provides a method `FormatSample` that does all the decoding but prints the final message to stdout. We would avoid this in tests, we would print to the console only in case of failure or with `-v`. 
So the idea was to provide the `MonitorFormatter` with `*bufio.Writer` so that we can choose at init time where to dump messages. 

In doing that, I decided to create a common interface for monitor's messages, hoping this could help future extensibility and reduce ad-hoc methods for different types of messages.

Let me know what you think about this approach :) Reviewing it commit by commit should be easier!





