### PR TITLE
fix(bpf/tests): handle panic during program name mismatch

### DIFF
--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -175,6 +175,21 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 
 	testNameToPrograms := make(map[string]programSet)
 
+	checkProgExists := func(progName, testName, progType string) {
+		checkProgName := strings.Replace(progName, progType, "check", 1)
+		if spec, ok := spec.Programs[checkProgName]; ok {
+			match := checkProgRegex.FindStringSubmatch(spec.SectionName)
+			if match[1] != testName {
+				t.Fatalf(
+					"File '%s' contains a %s program for '%s' test, but no check program.",
+					elfPath,
+					progType,
+					testName,
+				)
+			}
+		}
+	}
+
 	for progName, spec := range spec.Programs {
 		match := checkProgRegex.FindStringSubmatch(spec.SectionName)
 		if len(match) == 0 {
@@ -183,25 +198,17 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 
 		progs := testNameToPrograms[match[1]]
 		if match[2] == "pktgen" {
+			checkProgExists(progName, match[1], match[2])
 			progs.pktgenProg = coll.Programs[progName]
 		}
 		if match[2] == "setup" {
+			checkProgExists(progName, match[1], match[2])
 			progs.setupProg = coll.Programs[progName]
 		}
 		if match[2] == "check" {
 			progs.checkProg = coll.Programs[progName]
 		}
 		testNameToPrograms[match[1]] = progs
-	}
-
-	for progName, set := range testNameToPrograms {
-		if set.checkProg == nil {
-			t.Fatalf(
-				"File '%s' contains a setup program in section '%s' but no check program.",
-				elfPath,
-				spec.Programs[progName].SectionName,
-			)
-		}
 	}
 
 	// Collect debug events and add them as logs of the main test


### PR DESCRIPTION
Whenever there is a mismatch between the program name of CHECK and SETUP/PKTGEN programs, the application panics and a nil-pointer de-reference error is thrown.

The panic is handled in this fix and an appropriate message is logged.

Fixes: #39840 
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Fixes: #39840 

```release-note
Fixes panic caused due to naming mismatch in bpf tests.
```
