### PR TITLE
IPAM: AWS ENI: allow setting IPAM params via Helm

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -88,7 +88,7 @@ cilium-operator-alibabacloud [flags]
       --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
       --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
       --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
-      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -85,6 +85,10 @@ cilium-operator-alibabacloud [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "alibabacloud")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -63,6 +63,10 @@ cilium-operator-alibabacloud hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -68,6 +68,10 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -96,7 +96,7 @@ cilium-operator-aws [flags]
       --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
       --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
       --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
-      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -93,6 +93,10 @@ cilium-operator-aws [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "eni")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -63,6 +63,10 @@ cilium-operator-aws hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -68,6 +68,10 @@ cilium-operator-aws hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -91,7 +91,7 @@ cilium-operator-azure [flags]
       --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
       --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
       --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
-      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -88,6 +88,10 @@ cilium-operator-azure [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "azure")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -63,6 +63,10 @@ cilium-operator-azure hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -68,6 +68,10 @@ cilium-operator-azure hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -87,7 +87,7 @@ cilium-operator-generic [flags]
       --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
       --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
       --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
-      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -84,6 +84,10 @@ cilium-operator-generic [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -63,6 +63,10 @@ cilium-operator-generic hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -68,6 +68,10 @@ cilium-operator-generic hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -101,7 +101,7 @@ cilium-operator [flags]
       --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
       --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
       --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
-      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -98,6 +98,10 @@ cilium-operator [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -63,6 +63,10 @@ cilium-operator hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -68,6 +68,10 @@ cilium-operator hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ipam-max-above-watermark int                         Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes
+      --ipam-max-allocate int                                Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)
+      --ipam-min-allocate int                                Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes
+      --ipam-pre-allocate int                                Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type (default 8)
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2548,6 +2548,22 @@
      - The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity.
      - float
      - ``4.0``
+   * - :spelling:ignore:`ipam.operator.maxAboveWatermark`
+     - The maximum number of IPs to allocate beyond the PreAllocate buffer to reduce API allocation calls.
+     - int
+     - ``0``
+   * - :spelling:ignore:`ipam.operator.maxAllocate`
+     - The upper limit on the total number of IPs that can be allocated to a node.
+     - int
+     - ``0``
+   * - :spelling:ignore:`ipam.operator.minAllocate`
+     - The minimum number of IPs a node must have before PreAllocate and MaxAboveWatermark logic continues allocation.
+     - int
+     - ``0``
+   * - :spelling:ignore:`ipam.operator.preAllocate`
+     - The number of IPs that must always be immediately available for allocation without operator intervention.
+     - int
+     - ``8``
    * - :spelling:ignore:`iptablesRandomFully`
      - Configure iptables--random-fully. Disabled by default. View https://github.com/cilium/cilium/issues/13037 for more information.
      - bool

--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -87,6 +87,28 @@ Configuration
   You may override this behavior by setting a cluster-specific ``--eni-gc-tags``
   tag set.
 
+* The following IPAM parameters can be configured via Helm values
+  or operator flags to control IP address allocation behavior:
+
+  * ``ipam.operator.preAllocate`` (Helm) or ``--ipam-pre-allocate`` (operator flag):
+    Number of IP addresses to pre-allocate per ENI before a pod is scheduled.
+    Default: 8
+
+  * ``ipam.operator.minAllocate`` (Helm) or ``--ipam-min-allocate`` (operator flag):
+    Minimum number of IP addresses to allocate per ENI. Useful for ensuring
+    a minimum pool of addresses is always available.
+    Default: 0
+
+  * ``ipam.operator.maxAllocate`` (Helm) or ``--ipam-max-allocate`` (operator flag):
+    Maximum number of IP addresses to allocate per ENI. If not specified, this
+    is set to the maximum allowed for the ENI based on the instance type.
+    Default: 0 (use instance type maximum)
+
+  * ``ipam.operator.maxAboveWatermark`` (Helm) or ``--ipam-max-above-watermark`` (operator flag):
+    Maximum number of IP addresses to allocate above the watermark. Controls
+    how many additional IPs are allocated beyond the current need.
+    Default: 0
+
 Custom ENI Configuration
 ========================
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -687,6 +687,10 @@ contributors across the globe, there is almost always someone available to help.
 | ipam.operator.clusterPoolIPv6PodCIDRList | list | `["fd00::/104"]` | IPv6 CIDR list range to delegate to individual nodes for IPAM. |
 | ipam.operator.externalAPILimitBurstSize | int | `20` | The maximum burst size when rate limiting access to external APIs. Also known as the token bucket capacity. |
 | ipam.operator.externalAPILimitQPS | float | `4.0` | The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity. |
+| ipam.operator.maxAboveWatermark | int | `0` | The maximum number of IPs to allocate beyond the PreAllocate buffer to reduce API allocation calls. |
+| ipam.operator.maxAllocate | int | `0` | The upper limit on the total number of IPs that can be allocated to a node. |
+| ipam.operator.minAllocate | int | `0` | The minimum number of IPs a node must have before PreAllocate and MaxAboveWatermark logic continues allocation. |
+| ipam.operator.preAllocate | int | `8` | The number of IPs that must always be immediately available for allocation without operator intervention. |
 | iptablesRandomFully | bool | `false` | Configure iptables--random-fully. Disabled by default. View https://github.com/cilium/cilium/issues/13037 for more information. |
 | ipv4.enabled | bool | `true` | Enable IPv4 support. |
 | ipv4NativeRoutingCIDR | string | `""` | Allows to explicitly specify the IPv4 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -595,7 +595,6 @@ data:
 {{ if .Values.eni.gcTags }}
   eni-gc-tags: {{ .Values.eni.gcTags | toRawJson | quote }}
 {{- end }}
-
 {{- if .Values.azure.enabled }}
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"
@@ -1120,12 +1119,23 @@ data:
   {{- end }}
   auto-create-cilium-pod-ip-pools: {{ join "," $pools | quote }}
 {{- end }}
-
 {{- if .Values.ipam.operator.externalAPILimitBurstSize }}
   limit-ipam-api-burst: {{ .Values.ipam.operator.externalAPILimitBurstSize | quote }}
 {{- end }}
 {{- if .Values.ipam.operator.externalAPILimitQPS }}
   limit-ipam-api-qps: {{ .Values.ipam.operator.externalAPILimitQPS | quote }}
+{{- end }}
+{{- if .Values.ipam.operator.preAllocate }}
+  ipam-pre-allocate: {{ .Values.ipam.operator.preAllocate | quote }}
+{{- end }}
+{{- if .Values.ipam.operator.minAllocate }}
+  ipam-min-allocate: {{ .Values.ipam.operator.minAllocate | quote }}
+{{- end }}
+{{- if .Values.ipam.operator.maxAllocate }}
+  ipam-max-allocate: {{ .Values.ipam.operator.maxAllocate | quote }}
+{{- end }}
+{{- if .Values.ipam.operator.maxAboveWatermark }}
+  ipam-max-above-watermark: {{ .Values.ipam.operator.maxAboveWatermark | quote }}
 {{- end }}
 
 {{- if .Values.nodeIPAM.enabled }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3961,6 +3961,30 @@
                 "null",
                 "number"
               ]
+            },
+            "maxAboveWatermark": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "maxAllocate": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "minAllocate": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "preAllocate": {
+              "type": [
+                "null",
+                "integer"
+              ]
             }
           },
           "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2038,6 +2038,30 @@ ipam:
     # refill the bucket up to the burst size capacity.
     # @default -- `4.0`
     externalAPILimitQPS: ~
+    # @schema
+    # type: [null, integer]
+    # @schema
+    # -- The number of IPs that must always be immediately available for allocation without operator intervention.
+    # @default -- `8`
+    preAllocate: 8
+    # @schema
+    # type: [null, integer]
+    # @schema
+    # -- The minimum number of IPs a node must have before PreAllocate and MaxAboveWatermark logic continues allocation.
+    # @default -- `0`
+    minAllocate: 0
+    # @schema
+    # type: [null, integer]
+    # @schema
+    # -- The upper limit on the total number of IPs that can be allocated to a node.
+    # @default -- `0`
+    maxAllocate: 0
+    # @schema
+    # type: [null, integer]
+    # @schema
+    # -- The maximum number of IPs to allocate beyond the PreAllocate buffer to reduce API allocation calls.
+    # @default -- `0`
+    maxAboveWatermark: 0
 # -- defaultLBServiceIPAM indicates the default LoadBalancer Service IPAM when
 # no LoadBalancer class is set. Applicable values: lbipam, nodeipam, none
 # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2050,6 +2050,30 @@ ipam:
     # refill the bucket up to the burst size capacity.
     # @default -- `4.0`
     externalAPILimitQPS: ~
+    # @schema
+    # type: [null, integer]
+    # @schema
+    # -- The number of IPs that must always be immediately available for allocation without operator intervention.
+    # @default -- `8`
+    preAllocate: 8
+    # @schema
+    # type: [null, integer]
+    # @schema
+    # -- The minimum number of IPs a node must have before PreAllocate and MaxAboveWatermark logic continues allocation.
+    # @default -- `0`
+    minAllocate: 0
+    # @schema
+    # type: [null, integer]
+    # @schema
+    # -- The upper limit on the total number of IPs that can be allocated to a node.
+    # @default -- `0`
+    maxAllocate: 0
+    # @schema
+    # type: [null, integer]
+    # @schema
+    # -- The maximum number of IPs to allocate beyond the PreAllocate buffer to reduce API allocation calls.
+    # @default -- `0`
+    maxAboveWatermark: 0
 # -- defaultLBServiceIPAM indicates the default LoadBalancer Service IPAM when
 # no LoadBalancer class is set. Applicable values: lbipam, nodeipam, none
 # @schema

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -29,19 +29,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Float64(operatorOption.IPAMAPIQPSLimit, defaults.IPAMAPIQPSLimit, "Queries per second limit when accessing external IPAM APIs")
 	option.BindEnv(vp, operatorOption.IPAMAPIQPSLimit)
 
-	flags.Int(operatorOption.IPAMPreAllocate, defaults.IPAMPreAllocation, "Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. "+
-		"If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type")
-	option.BindEnv(vp, operatorOption.IPAMPreAllocate)
-
-	flags.Int(operatorOption.IPAMMinAllocate, defaults.IPAMMinAllocation, "Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes")
-	option.BindEnv(vp, operatorOption.IPAMMinAllocate)
-
-	flags.Int(operatorOption.IPAMMaxAllocate, defaults.IPAMMaxAllocation, "Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)")
-	option.BindEnv(vp, operatorOption.IPAMMaxAllocate)
-
-	flags.Int(operatorOption.IPAMMaxAboveWatermark, defaults.IPAMMaxAboveWatermark, "Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes")
-	option.BindEnv(vp, operatorOption.IPAMMaxAboveWatermark)
-
 	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMSubnetsTags),
 		operatorOption.IPAMSubnetsTags, "Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag")
 	option.BindEnv(vp, operatorOption.IPAMSubnetsTags)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -29,6 +29,19 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Float64(operatorOption.IPAMAPIQPSLimit, defaults.IPAMAPIQPSLimit, "Queries per second limit when accessing external IPAM APIs")
 	option.BindEnv(vp, operatorOption.IPAMAPIQPSLimit)
 
+	flags.Int(operatorOption.IPAMPreAllocate, defaults.IPAMPreAllocation, "Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. "+
+		"If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type")
+	option.BindEnv(vp, operatorOption.IPAMPreAllocate)
+
+	flags.Int(operatorOption.IPAMMinAllocate, defaults.IPAMMinAllocation, "Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes")
+	option.BindEnv(vp, operatorOption.IPAMMinAllocate)
+
+	flags.Int(operatorOption.IPAMMaxAllocate, defaults.IPAMMaxAllocation, "Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)")
+	option.BindEnv(vp, operatorOption.IPAMMaxAllocate)
+
+	flags.Int(operatorOption.IPAMMaxAboveWatermark, defaults.IPAMMaxAboveWatermark, "Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes")
+	option.BindEnv(vp, operatorOption.IPAMMaxAboveWatermark)
+
 	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMSubnetsTags),
 		operatorOption.IPAMSubnetsTags, "Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag")
 	option.BindEnv(vp, operatorOption.IPAMSubnetsTags)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -469,10 +469,6 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.IPAMAPIQPSLimit = vp.GetFloat64(IPAMAPIQPSLimit)
 	c.IPAMAPIBurst = vp.GetInt(IPAMAPIBurst)
 	c.ParallelAllocWorkers = vp.GetInt64(ParallelAllocWorkers)
-	c.IPAMPreAllocate = vp.GetInt(IPAMPreAllocate)
-	c.IPAMMinAllocate = vp.GetInt(IPAMMinAllocate)
-	c.IPAMMaxAllocate = vp.GetInt(IPAMMaxAllocate)
-	c.IPAMMaxAboveWatermark = vp.GetInt(IPAMMaxAboveWatermark)
 
 	// Gateways and Ingress
 	c.KubeProxyReplacement = vp.GetString(KubeProxyReplacement)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -63,6 +63,18 @@ const (
 	// IPAMAPIQPSLimit is the queries per second limit when accessing external IPAM APIs
 	IPAMAPIQPSLimit = "limit-ipam-api-qps"
 
+	// IPAMPreAllocate defines the number of IPs that must always be immediately available for allocation without operator intervention.
+	IPAMPreAllocate = "ipam-pre-allocate"
+
+	// IPAMMinAllocate defines the minimum number of IPs a node must have before PreAllocate and MaxAboveWatermark logic continues allocation.
+	IPAMMinAllocate = "ipam-min-allocate"
+
+	// IPAMMaxAllocate defines the upper limit on the total number of IPs that can be allocated to a node.
+	IPAMMaxAllocate = "ipam-max-allocate"
+
+	// IPAMMaxAboveWatermark defines the maximum number of IPs to allocate beyond the PreAllocate buffer to reduce API allocation calls.
+	IPAMMaxAboveWatermark = "ipam-max-above-watermark"
+
 	// IPAMSubnetsIDs are optional subnets IDs used to filter subnets and interfaces listing
 	IPAMSubnetsIDs = "subnet-ids-filter"
 
@@ -261,6 +273,18 @@ type OperatorConfig struct {
 	// IPAMAPIQPSLimit is the queries per second limit when accessing external IPAM APIs
 	IPAMAPIQPSLimit float64
 
+	// IPAMPreAllocate is the default value for CiliumNode.Spec.IPAM.PreAllocate for all IPAM modes
+	IPAMPreAllocate int
+
+	// IPAMMinAllocate is the default value for CiliumNode.Spec.IPAM.MinAllocate for all IPAM modes
+	IPAMMinAllocate int
+
+	// IPAMMaxAllocate is the default value for CiliumNode.Spec.IPAM.MaxAllocate for all IPAM modes
+	IPAMMaxAllocate int
+
+	// IPAMMaxAboveWatermark is the default value for CiliumNode.Spec.IPAM.MaxAboveWatermark for all IPAM modes
+	IPAMMaxAboveWatermark int
+
 	// IPAMSubnetsIDs are optional subnets IDs used to filter subnets and interfaces listing
 	IPAMSubnetsIDs []string
 
@@ -323,17 +347,16 @@ type OperatorConfig struct {
 	// IP addresses. Allows for increased pod density on nodes.
 	AWSEnablePrefixDelegation bool
 
-	// AWSUsePrimaryAddress specifies whether an interface's primary address should be available for allocations on
-	// node
+	// AWSUsePrimaryAddress specifies whether an interface's primary address should be available for allocations on node
 	AWSUsePrimaryAddress bool
-
-	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
-	// Defaults to 180 secs
-	ExcessIPReleaseDelay int
 
 	// EC2APIEndpoint is the custom API endpoint to use for the EC2 AWS service,
 	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
 	EC2APIEndpoint string
+
+	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
+	// Defaults to 180 secs
+	ExcessIPReleaseDelay int
 
 	// Azure options
 
@@ -446,6 +469,10 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.IPAMAPIQPSLimit = vp.GetFloat64(IPAMAPIQPSLimit)
 	c.IPAMAPIBurst = vp.GetInt(IPAMAPIBurst)
 	c.ParallelAllocWorkers = vp.GetInt64(ParallelAllocWorkers)
+	c.IPAMPreAllocate = vp.GetInt(IPAMPreAllocate)
+	c.IPAMMinAllocate = vp.GetInt(IPAMMinAllocate)
+	c.IPAMMaxAllocate = vp.GetInt(IPAMMaxAllocate)
+	c.IPAMMaxAboveWatermark = vp.GetInt(IPAMMaxAboveWatermark)
 
 	// Gateways and Ingress
 	c.KubeProxyReplacement = vp.GetString(KubeProxyReplacement)

--- a/operator/pkg/config/ipam/cell.go
+++ b/operator/pkg/config/ipam/cell.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/defaults"
+)
+
+// Config contains the IPAM allocation parameters configuration.
+type Config struct {
+	IPAMPreAllocate       int `mapstructure:"ipam-pre-allocate"`
+	IPAMMinAllocate       int `mapstructure:"ipam-min-allocate"`
+	IPAMMaxAllocate       int `mapstructure:"ipam-max-allocate"`
+	IPAMMaxAboveWatermark int `mapstructure:"ipam-max-above-watermark"`
+}
+
+// Flags implements the cell.Flagger interface, registering the IPAM allocation flags.
+func (cfg Config) Flags(flags *pflag.FlagSet) {
+	flags.Int(operatorOption.IPAMPreAllocate, cfg.IPAMPreAllocate,
+		"Number of IP addresses that must be pre-allocated when using cloud provider IPAM modes. "+
+			"If this value exceeds the instance type limits, it will be automatically clamped to the maximum safe value for the instance type")
+
+	flags.Int(operatorOption.IPAMMinAllocate, cfg.IPAMMinAllocate,
+		"Minimum number of IP addresses that must be allocated when using cloud provider IPAM modes")
+
+	flags.Int(operatorOption.IPAMMaxAllocate, cfg.IPAMMaxAllocate,
+		"Maximum number of IP addresses that can be allocated to a node when using cloud provider IPAM modes (0 = unlimited)")
+
+	flags.Int(operatorOption.IPAMMaxAboveWatermark, cfg.IPAMMaxAboveWatermark,
+		"Maximum number of IP addresses that can be allocated beyond the current need when using cloud provider IPAM modes")
+}
+
+var defaultConfig = Config{
+	IPAMPreAllocate:       defaults.IPAMPreAllocation,
+	IPAMMinAllocate:       defaults.IPAMMinAllocation,
+	IPAMMaxAllocate:       defaults.IPAMMaxAllocation,
+	IPAMMaxAboveWatermark: defaults.IPAMMaxAboveWatermark,
+}
+
+// Cell provides the IPAM allocation parameters configuration cell.
+var Cell = cell.Module(
+	"operator-ipam-config",
+	"Operator IPAM Configuration",
+
+	cell.Config(defaultConfig),
+)

--- a/operator/pkg/config/ipam/cell_test.go
+++ b/operator/pkg/config/ipam/cell_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/defaults"
+)
+
+func TestConfigDefaults(t *testing.T) {
+	cfg := defaultConfig
+
+	assert.Equal(t, defaults.IPAMPreAllocation, cfg.IPAMPreAllocate)
+	assert.Equal(t, defaults.IPAMMinAllocation, cfg.IPAMMinAllocate)
+	assert.Equal(t, defaults.IPAMMaxAllocation, cfg.IPAMMaxAllocate)
+	assert.Equal(t, defaults.IPAMMaxAboveWatermark, cfg.IPAMMaxAboveWatermark)
+}
+
+func TestConfigFlags(t *testing.T) {
+	cfg := defaultConfig
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	cfg.Flags(flags)
+
+	// Verify that flags are registered
+	assert.NotNil(t, flags.Lookup("ipam-pre-allocate"))
+	assert.NotNil(t, flags.Lookup("ipam-min-allocate"))
+	assert.NotNil(t, flags.Lookup("ipam-max-allocate"))
+	assert.NotNil(t, flags.Lookup("ipam-max-above-watermark"))
+
+	// Verify default values
+	preAllocateFlag := flags.Lookup("ipam-pre-allocate")
+	assert.Equal(t, "8", preAllocateFlag.DefValue)
+
+	minAllocateFlag := flags.Lookup("ipam-min-allocate")
+	assert.Equal(t, "0", minAllocateFlag.DefValue)
+}

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -207,6 +207,7 @@ func TestIpamPreAllocate8(t *testing.T) {
 func TestIpamMinAllocate10(t *testing.T) {
 	preAllocate := 8
 	minAllocate := 10
+	clampedMinAllocate := 8
 	toUse := 7
 
 	api := apimock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVnet})
@@ -251,7 +252,8 @@ func TestIpamMinAllocate10(t *testing.T) {
 
 	node := mngr.Get("node1")
 	require.NotNil(t, node)
-	require.Equal(t, minAllocate, node.Stats().IPv4.AvailableIPs)
+	// MinAllocate=10 is clamped to instance limit of 8 by the getMinAllocate() method in pkg/ipam/node.go
+	require.Equal(t, clampedMinAllocate, node.Stats().IPv4.AvailableIPs)
 	require.Equal(t, 0, node.Stats().IPv4.UsedIPs)
 
 	// Use 7 out of 10 IPs

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -358,6 +358,18 @@ const (
 	// CiliumNode.Spec.IPAM.PreAllocate if no value is set
 	IPAMPreAllocation = 8
 
+	// IPAMMinAllocation is the default value for
+	// CiliumNode.Spec.IPAM.MinAllocate if no value is set
+	IPAMMinAllocation = 0
+
+	// IPAMMaxAllocation is the default value for
+	// CiliumNode.Spec.IPAM.MaxAllocate if no value is set
+	IPAMMaxAllocation = 0
+
+	// IPAMMaxAboveWatermark is the default value for
+	// CiliumNode.Spec.IPAM.MaxAboveWatermark if no value is set
+	IPAMMaxAboveWatermark = 0
+
 	// IPAMDefaultIPPool is the default value for the multi-pool default pool name.
 	IPAMDefaultIPPool = "default"
 

--- a/pkg/ipam/allocator/alibabacloud/alibabacloud.go
+++ b/pkg/ipam/allocator/alibabacloud/alibabacloud.go
@@ -106,7 +106,11 @@ func (a *AllocatorAlibabaCloud) Start(ctx context.Context, getterUpdater ipam.Ci
 	}
 	instances := eni.NewInstancesManager(a.rootLogger, a.client)
 	nodeManager, err := ipam.NewNodeManager(a.logger, instances, getterUpdater, iMetrics,
-		operatorOption.Config.ParallelAllocWorkers, operatorOption.Config.AlibabaCloudReleaseExcessIPs, false)
+		operatorOption.Config.ParallelAllocWorkers, operatorOption.Config.AlibabaCloudReleaseExcessIPs, false,
+		ipam.WithIPAMPreAllocate(operatorOption.Config.IPAMPreAllocate),
+		ipam.WithIPAMMinAllocate(operatorOption.Config.IPAMMinAllocate),
+		ipam.WithIPAMMaxAllocate(operatorOption.Config.IPAMMaxAllocate),
+		ipam.WithIPAMMaxAboveWatermark(operatorOption.Config.IPAMMaxAboveWatermark))
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize AlibabaCloud node manager: %w", err)
 	}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -84,7 +84,11 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNod
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}
 	instances := azureIPAM.NewInstancesManager(a.rootLogger, azureClient)
-	nodeManager, err := ipam.NewNodeManager(a.logger, instances, getterUpdater, iMetrics, operatorOption.Config.ParallelAllocWorkers, false, false)
+	nodeManager, err := ipam.NewNodeManager(a.logger, instances, getterUpdater, iMetrics, operatorOption.Config.ParallelAllocWorkers, false, false,
+		ipam.WithIPAMPreAllocate(operatorOption.Config.IPAMPreAllocate),
+		ipam.WithIPAMMinAllocate(operatorOption.Config.IPAMMinAllocate),
+		ipam.WithIPAMMaxAllocate(operatorOption.Config.IPAMMaxAllocate),
+		ipam.WithIPAMMaxAboveWatermark(operatorOption.Config.IPAMMaxAboveWatermark))
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize Azure node manager: %w", err)
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Allows setting `min-allocate`, `max-allocate`, `pre-allocate` & `max-above-watermark` values via Helm / cilium-operator config.
Previously, the only way to override this setting was either by editing the node's CNI file directly or via a custom config-map containing the params that needed to be distributed separately to the Kubernetes cluster (outside of the Cilium Helm chart). 

With this change, the Helm values / cilium-operator flags may set the values during initial node setup in `syncToAPIServer` (only if they're not already set), while preserving the existing recalculation logic in the cloud-specific implementations. 
When the CiliumNode object is initialized, `(NodeDiscovery).mutateNodeResource()` may read these parameters from the custom config-map and set them on the CiliumNode spec.

If `mutateNodeResource` sets values from CNI config, `syncToAPIServer` will respect those.
If `mutateNodeResource` doesn't set values (no CNI config), `syncToAPIServer` will apply operator defaults.
If `syncToAPIServer` runs before `mutateNodeResource`, the values would be set by `syncToAPIServer` and then potentially overwritten by `mutateNodeResource`.
If `mutateNodeResource` runs first, `syncToAPIServer` would see that values are already set (not 0) and wouldn't modify them.

**Limitation:**
The current architecture cannot distinguish between "not configured" and "explicitly set to 0" values for `PreAllocate` and other values because the CNI config uses `int` and not `*int`.

**NodeDiscovery** (`mutateNodeResource`): 
Always sets `PreAllocate` from CNI config (including 0 if not specified).
Always sets `MinAllocate` from CNI config (including 0 if not specified).

**Operator** (`syncToAPIServer`): 
Sets defaults for `PreAllocate` if it's 0.
Sets defaults for `MinAllocate` if it's 0 (but only from manager config, not hardcoded defaults).

**IPAM Node** (getter methods):
`getPreAllocate()`: Returns configured value if non-zero, otherwise returns default (clamped by instance limits).
`getMinAllocate()`: Always returns configured value (clamped by instance limits).


Fixes: #39940

```release-note
Allow setting AWS ENI IPAM params min-allocate, max-allocate, pre-allocate & max-above-watermark via Helm
```
