### PR TITLE
docs: fix syntax error for configuration/vlan bypass setting 

### DIFF
--- a/Documentation/configuration/vlan-802.1q.rst
+++ b/Documentation/configuration/vlan-802.1q.rst
@@ -14,7 +14,7 @@ Cilium enables firewalling on native devices in use and will filter all unknown 
 will always be passed through their main device with associated tag (e.g. VLAN device is ``eth0.4000`` and its main interface is ``eth0``).
 By default, Cilium will allow all tags from the native devices (i.e. if ``eth0.4000`` is controlled by Cilium and has
 an eBPF program attached, then VLAN tag ``4000`` will be allowed on device ``eth0``). Additional VLAN tags may be allowed
-with the cilium-agent flag ``--vlan-bpf-bypass=4001,4002`` (or Helm variable ``--set bpf.vlanBypass="{4001,4002}"``).
+with the cilium-agent flag ``--vlan-bpf-bypass=4001,4002`` (or Helm variable ``--set bpf.vlanBypass="[4001,4002]"``).
 
 The list of allowed VLAN tags cannot be too big in order to keep eBPF program of predictable size. Currently this list
 should contain no more than 5 entries. If you need more, then there is only one way for now: you need to allow


### PR DESCRIPTION
The [documentation](https://docs.cilium.io/en/stable/configuration/vlan-802.1q/) says

> ... Additional VLAN tags may be allowed with the cilium-agent flag --vlan-bpf-bypass=4001,4002 (or Helm variable --set bpf.vlanBypass="{4001,4002}").

The syntax used for the helm variable example is incorrect. The helm-chart expects an array.
