### PR TITLE
Add initial script commands for kvstore testing

### DIFF
--- a/operator/watchers/testdata/servicesync.txtar
+++ b/operator/watchers/testdata/servicesync.txtar
@@ -6,14 +6,14 @@ hive/start
 k8s/add service.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * cmp services.actual services-1.expected
 
 # 2. Add the endpoint slice
 k8s/add endpointslice.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * cmp services.actual services-2.expected
 
 # 3. Test changing backend IPs
@@ -23,7 +23,7 @@ replace '10.244.1.1' '10.244.2.2' services-3.expected
 k8s/update endpointslice.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * cmp services.actual services-3.expected
 
 # 4. Test changing backend port
@@ -34,35 +34,35 @@ sed '"Port": 8080' '"Port": 9090' services-4.expected
 k8s/update service.yaml endpointslice.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * cmp services.actual services-4.expected
 
 # 5. Remove endpoint slice
 k8s/delete endpointslice.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * cmp services.actual services-1.expected
 
 # 6. Remove service
 k8s/delete service.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * empty services.actual
 
 # 7. Add endpoint slice before service
 k8s/add endpointslice.yaml
 
 # No service should exist
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 empty services.actual
 
 # 8. Add the service
 k8s/add service.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * cmp services.actual services-4.expected
 
 # 9. Toggle the global annotation. Service should be deleted.
@@ -70,7 +70,7 @@ sed 'service.cilium.io/global: "true"' 'service.cilium.io/global: "false"' servi
 k8s/update service.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * empty services.actual
 
 # 10. Toggle the global annotation back. The shared annotation is not neeeded.
@@ -80,7 +80,7 @@ sed 'service.cilium.io/global: "false"' 'service.cilium.io/global: "true"' servi
 k8s/update service.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * cmp services.actual services-4.expected
 
 # 11. Mark the service as not shared. Service should be deleted.
@@ -88,7 +88,7 @@ sed 'placeholder: "true"' 'service.cilium.io/shared: "false"' service.yaml
 k8s/update service.yaml
 
 # Wait for synchronization
-kvstore/list cilium/state/services services.actual
+kvstore/list -o json cilium/state/services services.actual
 * empty services.actual
 
 # ----

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -6,7 +6,6 @@ package clustermesh_test
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log/slog"
 	"maps"
 	"os"
@@ -136,7 +135,7 @@ func TestScript(t *testing.T) {
 			cell.Provide(func(db *statedb.DB) (kvstore.Client, uhive.ScriptCmdsOut) {
 				kvstore.SetupInMemory(db)
 				client := kvstore.SetupDummy(t, "in-memory")
-				return client, uhive.NewScriptCmds(kvstoreCommands{client}.cmds())
+				return client, uhive.NewScriptCmds(kvstore.Commands(client))
 			}),
 
 			cell.DecorateAll(func(client kvstore.Client) common.RemoteClientFactoryFn {
@@ -285,73 +284,3 @@ func (d dummyRemoteIdentityWatcher) WatchRemoteIdentities(remoteName string, rem
 }
 
 var _ clustermesh.RemoteIdentityWatcher = dummyRemoteIdentityWatcher{}
-
-type kvstoreCommands struct {
-	client kvstore.BackendOperations
-}
-
-func (e kvstoreCommands) cmds() map[string]script.Cmd {
-	return map[string]script.Cmd{
-		"kvstore/update": e.update(),
-		"kvstore/delete": e.delete(),
-		"kvstore/list":   e.list(),
-	}
-}
-
-func (e kvstoreCommands) update() script.Cmd {
-	return script.Command(
-		script.CmdUsage{
-			Summary: "update kvstore key-value",
-			Args:    "key value-file",
-		},
-		func(s *script.State, args ...string) (script.WaitFunc, error) {
-			if len(args) != 2 {
-				return nil, fmt.Errorf("%w: expected key and value file", script.ErrUsage)
-			}
-			b, err := os.ReadFile(s.Path(args[1]))
-			if err != nil {
-				return nil, err
-			}
-
-			return nil, e.client.Update(s.Context(), args[0], b, false)
-		},
-	)
-}
-
-func (e kvstoreCommands) delete() script.Cmd {
-	return script.Command(
-		script.CmdUsage{
-			Summary: "delete kvstore key-value",
-			Args:    "key",
-		},
-		func(s *script.State, args ...string) (script.WaitFunc, error) {
-			if len(args) != 1 {
-				return nil, fmt.Errorf("%w: expected key", script.ErrUsage)
-			}
-			return nil, e.client.Delete(s.Context(), args[0])
-		},
-	)
-}
-
-func (e kvstoreCommands) list() script.Cmd {
-	return script.Command(
-		script.CmdUsage{
-			Summary: "list kvstore key-value pairs",
-			Args:    "(prefix)",
-		},
-		func(s *script.State, args ...string) (script.WaitFunc, error) {
-			prefix := ""
-			if len(args) > 0 {
-				prefix = args[0]
-			}
-			kvs, err := e.client.ListPrefix(s.Context(), prefix)
-			if err != nil {
-				return nil, err
-			}
-			for k, v := range kvs {
-				s.Logf("%s: %s\n", k, v.Data)
-			}
-			return nil, nil
-		},
-	)
-}

--- a/pkg/kvstore/commands.go
+++ b/pkg/kvstore/commands.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstore
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+)
+
+// Commands returns the script commands associated with the given client.
+func Commands(client Client) map[string]script.Cmd {
+	if !client.IsEnabled() {
+		return nil
+	}
+
+	cmds := cmds{client: client}
+	return map[string]script.Cmd{
+		"kvstore/update": cmds.update(),
+		"kvstore/delete": cmds.delete(),
+		"kvstore/list":   cmds.list(),
+	}
+}
+
+type cmds struct{ client Client }
+
+func (c cmds) update() script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "update kvstore key-value",
+			Args:    "key value-file",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 2 {
+				return nil, fmt.Errorf("%w: expected key and value file", script.ErrUsage)
+			}
+			b, err := os.ReadFile(s.Path(args[1]))
+			if err != nil {
+				return nil, fmt.Errorf("could not read %q: %w", s.Path(args[1]), err)
+			}
+
+			return nil, c.client.Update(s.Context(), args[0], b, false)
+		},
+	)
+}
+
+func (c cmds) delete() script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "delete kvstore key-value",
+			Args:    "key",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("%w: expected key", script.ErrUsage)
+			}
+			return nil, c.client.Delete(s.Context(), args[0])
+		},
+	)
+}
+
+func (c cmds) list() script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "list kvstore key-value pairs",
+			Args:    "prefix (output file)",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP("output", "o", "plain", "Output format. One of: (plain, json)")
+				fs.Bool("keys-only", false, "Only output the listed keys")
+				fs.Bool("values-only", false, "Only output the listed values")
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			var prefix string
+			if len(args) > 0 {
+				prefix = args[0]
+			}
+
+			keysOnly, _ := s.Flags.GetBool("keys-only")
+			valuesOnly, _ := s.Flags.GetBool("values-only")
+			if keysOnly && valuesOnly {
+				return nil, errors.New("--keys-only and --values-only are mutually exclusive")
+			}
+
+			kvs, err := c.client.ListPrefix(s.Context(), prefix)
+			if err != nil {
+				return nil, fmt.Errorf("error listing %q: %w", prefix, err)
+			}
+
+			return func(s *script.State) (stdout string, stderr string, err error) {
+				var b bytes.Buffer
+				for _, k := range slices.Sorted(maps.Keys(kvs)) {
+					if !valuesOnly {
+						fmt.Fprintf(&b, "# %s\n", k)
+					}
+
+					if !keysOnly {
+						outfmt, _ := s.Flags.GetString("output")
+						switch outfmt {
+						case "plain":
+							fmt.Fprintln(&b, string(kvs[k].Data))
+						case "json":
+							if err := json.Indent(&b, kvs[k].Data, "", "  "); err != nil {
+								fmt.Fprintf(&b, "ERROR: %s", err)
+							}
+							fmt.Fprintln(&b)
+						default:
+							return "", "", fmt.Errorf("unexpected output format %q", outfmt)
+						}
+					}
+
+					fmt.Fprint(&b)
+				}
+				if len(args) == 2 {
+					err = os.WriteFile(s.Path(args[1]), b.Bytes(), 0644)
+					if err != nil {
+						err = fmt.Errorf("could not write %q: %w", s.Path(args[1]), err)
+					}
+				} else {
+					stdout = b.String()
+				}
+				return
+			}, nil
+		},
+	)
+}


### PR DESCRIPTION
Follow-up of https://github.com/cilium/cilium/pull/39927.

The kvstore script commands are potentially useful for multiple tests. Let's move them into the kvstore package to favor reuse. While being there, let's also extend the kvstore/list one to allow selecting the output format, given that certain values are json encoded, while others are not. Finally, let's ensure that the listed entries are sorted, to   guarantee consistent ordering in tests.