### PR TITLE
clustermesh/test: let kvstore service entries match expected format

### DIFF
--- a/pkg/clustermesh/testdata/clusterservice.txtar
+++ b/pkg/clustermesh/testdata/clusterservice.txtar
@@ -54,6 +54,7 @@ Address            Type       ServiceName   Status  Backends
 {
   "name": "echo",
   "namespace": "test",
+  "includeExternal": true,
   "shared": true,
   "cluster": "cluster2",
   "clusterID": 2,
@@ -71,6 +72,7 @@ Address            Type       ServiceName   Status  Backends
 {
   "name": "echo",
   "namespace": "test",
+  "includeExternal": true,
   "shared": true,
   "cluster": "cluster3",
   "clusterID": 3,
@@ -129,4 +131,3 @@ ports:
 - name: tcp
   port: 8080
   protocol: TCP
-

--- a/pkg/clustermesh/testdata/service-affinity.txtar
+++ b/pkg/clustermesh/testdata/service-affinity.txtar
@@ -63,6 +63,7 @@ Address            Type       ServiceName   Status  Backends
 {
   "name": "echo",
   "namespace": "test",
+  "includeExternal": true,
   "shared": true,
   "cluster": "cluster2",
   "clusterID": 2,


### PR DESCRIPTION
Slightly amend the clustermesh test data to fully match the expected format and, in particular, ensuring that the "includeExternal" field is set to true. While this better reflects the operations in real environments, it does not modify the test behavior, as the content of that flag is not explicitly checked by the current logic.