### PR TITLE
bpf-map-event-buffers: Fix ipcache map name and usage 

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -151,11 +151,11 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	option.Config.BPFMapEventBuffersValidator = option.Validator(func(val string) (string, error) {
 		vals := strings.Split(val, "=")
 		if len(vals) != 2 {
-			return "", fmt.Errorf(`invalid bpf map event config: expecting "<map_name>=<enabled>,<max_size>,<ttl>" got %q`, val)
+			return "", fmt.Errorf(`invalid bpf map event config: expecting "<map_name>=<enabled>_<max_size>_<ttl>" got %q`, val)
 		}
 		_, err := option.ParseEventBufferTupleString(vals[1])
 		if err != nil {
-			return "", fmt.Errorf(`invalid bpf map event config: expecting "<map_name>=<enabled>,<max_size>,<ttl>" got %q`, val)
+			return "", err
 		}
 		return "", nil
 	})
@@ -855,7 +855,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.LocalRouterIPv6, "", "Link-local IPv6 used for Cilium's router devices")
 	option.BindEnv(vp, option.LocalRouterIPv6)
 
-	flags.Var(option.NewNamedMapOptions(option.BPFMapEventBuffers, &option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "Configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache=true,1024,1h)")
+	flags.Var(option.NewNamedMapOptions(option.BPFMapEventBuffers, &option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "Configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache_v2=enabled_1024_1h)")
 	flags.MarkHidden(option.BPFMapEventBuffers)
 
 	flags.Bool(option.EgressMultiHomeIPRuleCompat, false,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -577,27 +577,27 @@ var (
 	// Under the worst case GC may need to memcopy almost the entire buffer, which will
 	// cause memory spikes. Be mindful of this when increasing the default buffer configurations.
 	BPFEventBufferConfigs = map[string]string{
-		"cilium_lxc": "enabled,128,0",
-		// cilium_ipcache is the likely the most useful use of this feature, but also has
+		"cilium_lxc": "enabled_128_0",
+		// cilium_ipcache is likely the most useful use of this feature, but also has
 		// the highest churn.
-		"cilium_ipcache_v2":        "enabled,1024,0",
-		"cilium_lb_affinity_match": "enabled,128,0",
+		"cilium_ipcache_v2":        "enabled_1024_0",
+		"cilium_lb_affinity_match": "enabled_128_0",
 
 		// ip4
-		"cilium_lb4_services_v2":    "enabled,128,0",
-		"cilium_lb4_backends_v2":    "enabled,128,0",
-		"cilium_lb4_reverse_nat":    "enabled,128,0",
-		"cilium_lb4_backends_v3":    "enabled,128,0",
-		"cilium_lb4_source_range":   "enabled,128,0",
-		"cilium_lb4_affinity_match": "enabled,128,0",
+		"cilium_lb4_services_v2":    "enabled_128_0",
+		"cilium_lb4_backends_v2":    "enabled_128_0",
+		"cilium_lb4_reverse_nat":    "enabled_128_0",
+		"cilium_lb4_backends_v3":    "enabled_128_0",
+		"cilium_lb4_source_range":   "enabled_128_0",
+		"cilium_lb4_affinity_match": "enabled_128_0",
 
 		// ip6
-		"cilium_lb6_services_v2":    "enabled,128,0",
-		"cilium_lb6_backends_v2":    "enabled,128,0",
-		"cilium_lb6_reverse_nat":    "enabled,128,0",
-		"cilium_lb6_backends_v3":    "enabled,128,0",
-		"cilium_lb6_source_range":   "enabled,128,0",
-		"cilium_lb6_affinity_match": "enabled,128,0",
+		"cilium_lb6_services_v2":    "enabled_128_0",
+		"cilium_lb6_backends_v2":    "enabled_128_0",
+		"cilium_lb6_reverse_nat":    "enabled_128_0",
+		"cilium_lb6_backends_v3":    "enabled_128_0",
+		"cilium_lb6_source_range":   "enabled_128_0",
+		"cilium_lb6_affinity_match": "enabled_128_0",
 	}
 
 	PolicyCIDRMatchMode = []string{}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -580,7 +580,7 @@ var (
 		"cilium_lxc": "enabled,128,0",
 		// cilium_ipcache is the likely the most useful use of this feature, but also has
 		// the highest churn.
-		"cilium_ipcache":           "enabled,1024,0",
+		"cilium_ipcache_v2":        "enabled,1024,0",
 		"cilium_lb_affinity_match": "enabled,128,0",
 
 		// ip4

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3856,14 +3856,14 @@ func (cs BPFEventBufferConfigs) get(name string) BPFEventBufferConfig {
 }
 
 // ParseEventBufferTupleString parses a event buffer configuration tuple string.
-// For example: true,100,24h
+// For example: enabled_100_24h
 // Which refers to enabled=true, maxSize=100, ttl=24hours.
 func ParseEventBufferTupleString(optsStr string) (BPFEventBufferConfig, error) {
-	opts := strings.Split(optsStr, ",")
+	opts := strings.Split(optsStr, "_")
 	enabled := false
 	conf := BPFEventBufferConfig{}
 	if len(opts) != 3 {
-		return conf, fmt.Errorf("unexpected event buffer config value format, should be in format 'mapname=enabled,100,24h'")
+		return conf, fmt.Errorf("unexpected event buffer config value format, should be in format 'mapname=enabled_100_24h'")
 	}
 
 	if opts[0] != "enabled" && opts[0] != "disabled" {

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -992,25 +992,25 @@ func Test_backupFiles(t *testing.T) {
 
 func Test_parseEventBufferTupleString(t *testing.T) {
 	assert := assert.New(t)
-	c, err := ParseEventBufferTupleString("enabled,123,1h")
+	c, err := ParseEventBufferTupleString("enabled_123_1h")
 	assert.NoError(err)
 	assert.True(c.Enabled)
 	assert.Equal(123, c.MaxSize)
 	assert.Equal(time.Hour, c.TTL)
 
-	c, err = ParseEventBufferTupleString("disabled,123,1h")
+	c, err = ParseEventBufferTupleString("disabled_123_1h")
 	assert.NoError(err)
 	assert.False(c.Enabled)
 	assert.Equal(123, c.MaxSize)
 	assert.Equal(time.Hour, c.TTL)
 
-	c, err = ParseEventBufferTupleString("cat,123,1h")
+	c, err = ParseEventBufferTupleString("cat_123_1h")
 	assert.Error(err)
 
-	c, err = ParseEventBufferTupleString("enabled,xxx,1h")
+	c, err = ParseEventBufferTupleString("enabled_xxx_1h")
 	assert.Error(err)
 
-	c, err = ParseEventBufferTupleString("enabled,123,x")
+	c, err = ParseEventBufferTupleString("enabled_123_x")
 	assert.Error(err)
 }
 


### PR DESCRIPTION
Two changes done in this PR
- Update ipcache map name in default `BPFEventBufferConfigs`.
- Redid how values are formatted in bpf-map-event-buffers. Please see commit message for more details.
