### PR TITLE
.github: check for hidden files in /mnt

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -96,6 +96,10 @@ jobs:
           sudo du --human-readable \
                 --threshold 50m \
                 -- /mnt
+          if compgen -G "/mnt/.*" > /dev/null; then
+            echo "# Hidden files in /mnt:"
+            sudo du --human-readable --threshold 50m -- /mnt/.* 2>/dev/null
+          fi
           echo "# Removing /mnt/tmp-pv.img"
           sudo rm -f '/mnt/tmp-pv.img'
 


### PR DESCRIPTION
The CI build workflow is currently failing due lack of space. Add this step to check for hidden files to see which other files that can be removed.
