### PR TITLE
build: Fix dynamic libraries in arm64 version of the cilium-builder image

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -19,6 +19,8 @@ FROM ${CILIUM_RUNTIME_IMAGE} AS rootfs
 # we want to re-run 'apt-get upgrade' for stale images.
 ENV FORCE_BUILD=1
 
+COPY --from=compilers-image /usr/lib/aarch64-linux-gnu /usr/lib/aarch64-linux-gnu
+
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETARCH
 RUN \
@@ -48,8 +50,6 @@ RUN \
     apt-get purge --auto-remove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-COPY --from=compilers-image /usr/lib/aarch64-linux-gnu /usr/lib/aarch64-linux-gnu
 
 COPY --from=golang-dist /usr/local/go /usr/local/go
 RUN mkdir -p /go


### PR DESCRIPTION
#### Context: 
* The `cilium-builder` image is build on top of the [`cilium-runtime`](https://github.com/cilium/cilium/blob/f57cf802244eb3eebf099e48fab0f9fedd68ce00/images/builder/Dockerfile#L16) one, which itself is based on [`docker.io/library/ubuntu:24.04`](https://github.com/cilium/cilium/blob/74259d7708a8b49876fc85bd53984cdbfc452925/images/runtime/Dockerfile#L6).
* The `compilers-image` image is build on top of [`docker.io/library/ubuntu:24.04`](https://github.com/cilium/image-tools/blob/1d8e3ec0ac91559edb5aea60f034a1e5a7e65b34/images/compilers/Dockerfile#L4)

#### Issue:
The `cilium-builder` image currently has these two instruction is the following order:
```
RUN apt-get update && apt-get upgrade -y
COPY --from=compilers-image /usr/lib/aarch64-linux-gnu /usr/lib/aarch64-linux-gnu
```
This means that when building the `linux/arm64` version of the `cilium-builder` image, the `/usr/lib/aarch64-linux-gnu` directory is first mutated by the `apt-get upgrade` operation, and then overriden by the version of it from the `compilers-image` image. This results in the arm version of the `cilium-builder` image having broken dynamic linking.

For example:
<details>
<summary>amd64 (works)</summary>

```sh
docker run --platform linux/amd64 quay.io/cilium/cilium-builder:b37296d28bbd6f18fd45e1e452ce77f1d3acf025@sha256:867699c0c3b034f96e3476e0782dbab45e28dafb6ea02a8922fc9b087be6f8b2 apt update

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Get:1 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Get:2 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
Get:3 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [1442 kB]
Get:4 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:5 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1097 kB]
Get:6 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [22.1 kB]
Get:7 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [1093 kB]
Get:8 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:9 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]
Get:10 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]
Get:11 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1808 kB]
Get:12 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]
Get:13 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1400 kB]
Get:14 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [1495 kB]
Get:15 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [26.7 kB]
Get:16 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1418 kB]
Get:17 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [31.8 kB]
Get:18 http://archive.ubuntu.com/ubuntu noble-backports/main amd64 Packages [48.0 kB]
Fetched 30.3 MB in 5s (5620 kB/s)
Reading package lists...
Building dependency tree...
Reading state information...
10 packages can be upgraded. Run 'apt list --upgradable' to see them.
```
</details>

<details>
<summary>arm64 (broken)</summary>

```sh
docker run --platform linux/arm64 quay.io/cilium/cilium-builder:b37296d28bbd6f18fd45e1e452ce77f1d3acf025@sha256:867699c0c3b034f96e3476e0782dbab45e28dafb6ea02a8922fc9b087be6f8b2 apt update

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Get:1 http://ports.ubuntu.com/ubuntu-ports noble InRelease [256 kB]
/usr/lib/apt/methods/gpgv: symbol lookup error: /usr/lib/apt/methods/gpgv: undefined symbol: _Z20IsAssertedPubKeyAlgoRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES6_, version APTPKG_6.0
Get:2 http://ports.ubuntu.com/ubuntu-ports noble-updates InRelease [126 kB]
/usr/lib/apt/methods/gpgv: symbol lookup error: /usr/lib/apt/methods/gpgv: undefined symbol: _Z20IsAssertedPubKeyAlgoRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES6_, version APTPKG_6.0
Get:3 http://ports.ubuntu.com/ubuntu-ports noble-backports InRelease [126 kB]
/usr/lib/apt/methods/gpgv: symbol lookup error: /usr/lib/apt/methods/gpgv: undefined symbol: _Z20IsAssertedPubKeyAlgoRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES6_, version APTPKG_6.0
Get:4 http://ports.ubuntu.com/ubuntu-ports noble-security InRelease [126 kB]
/usr/lib/apt/methods/gpgv: symbol lookup error: /usr/lib/apt/methods/gpgv: undefined symbol: _Z20IsAssertedPubKeyAlgoRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES6_, version APTPKG_6.0
Reading package lists...
E: Method gpgv has died unexpectedly!
E: Sub-process gpgv returned an error code (127)
E: Method /usr/lib/apt/methods/gpgv did not start correctly
E: Method gpgv has died unexpectedly!
E: Sub-process gpgv returned an error code (127)
E: Method /usr/lib/apt/methods/gpgv did not start correctly
E: Method gpgv has died unexpectedly!
E: Sub-process gpgv returned an error code (127)
E: Method /usr/lib/apt/methods/gpgv did not start correctly
E: Method gpgv has died unexpectedly!
E: Sub-process gpgv returned an error code (127)
E: Method /usr/lib/apt/methods/gpgv did not start correctly
```
</details>

<details>
<summary>Additional details: mutations of /usr/lib/aarch64-linux-gnu caused by the COPY from the compilers-image image</summary>

<img width="2104" alt="image" src="https://github.com/user-attachments/assets/65cc841e-14a7-41f1-bb56-28302f139060" />

</details>

#### Solution:

Swapping the order of those two dockerfile instructions solves the issue, producing a working arm64 version of the `cilium-builder` image. The amd64 version of the image is unaffected by the change as there was no conflicts between those two instructions on this arch so swapping their order is safe.

#### Final note:
While investigating this, I noticed that although the `compilers-image` has the same `ununtu:24.04` base as the `cilium-runtime` image, it is a much older version ([7 months old](https://github.com/cilium/image-tools/blob/1d8e3ec0ac91559edb5aea60f034a1e5a7e65b34/images/compilers/Dockerfile#L4)), there may be an issue with the renovate setup in the `image-tools` repository.

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
build: Fix dynamic libraries in arm64 version of the cilium-builder image
```
