### PR TITLE
ci: fix oss-fuzz after cleanups

### DIFF
--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -15,7 +15,6 @@ printf "package policy\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testin
 go mod tidy && go mod vendor
 mv $SRC/cilium/pkg/policy/distillery_test.go $SRC/cilium/pkg/policy/distillery_test_fuzz.go
 mv $SRC/cilium/pkg/policy/l4_filter_test.go $SRC/cilium/pkg/policy/l4_filter_test_fuzz.go
-mv $SRC/cilium/pkg/policy/policy_test.go $SRC/cilium/pkg/policy/policy_test_fuzz.go
 mv $SRC/cilium/pkg/policy/mapstate_test.go $SRC/cilium/pkg/policy/mapstate_test_fuzz.go
 mv $SRC/cilium/pkg/policy/repository_test.go $SRC/cilium/pkg/policy/repository_test_fuzz.go
 mv $SRC/cilium/pkg/policy/resolve_test.go $SRC/cilium/pkg/policy/resolve_test_fuzz.go


### PR DESCRIPTION
The fuzzers are failing with

  mv: cannot stat '/src/cilium/pkg/policy/policy_test.go'

as that file was removed in 9d3c5e5b98. Remove it from the fuzz setup script.
