### PR TITLE
gha: unbreak sysdump collection in scale test workflows

### DIFF
--- a/.github/actions/post-logic/action.yaml
+++ b/.github/actions/post-logic/action.yaml
@@ -17,6 +17,9 @@ inputs:
     description: "Capture sysdump in case of a test failure."
     type: boolean
     default: true
+  always_capture_sysdump:
+    description: "Always capture sysdump, regardless of test status; the result is uploaded as artifact only in case of test failure"
+    type: boolean
   junits-directory:
     description: "Directory where JUnit XML files are stored."
     type: string
@@ -33,7 +36,7 @@ runs:
         json-filename: "features-tested-${{ inputs.artifacts_suffix }}"
 
     - name: Post-test information gathering
-      if: ${{ always() && inputs.job_status == 'failure' && inputs.capture_sysdump }}
+      if: ${{ always() && ( ( inputs.job_status == 'failure' && inputs.capture_sysdump ) || inputs.always_capture_sysdump ) }}
       shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
       run: |
         echo "=== Retrieve cluster state ==="

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -296,7 +296,7 @@ jobs:
           sudo chmod -R +r ./output
 
       - name: Run common post steps
-        if: ${{ always() }}
+        if: ${{ always() && matrix.mode != 'baseline' }}
         uses: ./.github/actions/post-logic
         with:
           always_capture_sysdump: true
@@ -316,7 +316,7 @@ jobs:
       # be correctly uploaded, but we want the sysdump to have a fixed name when
       # uploading it to the GS bucket.
       - name: Rename sysdump before uploading it to the GS bucket
-        if : ${{ always() }}
+        if : ${{ always() && matrix.mode != 'baseline' }}
         run: |
           mv "cilium-sysdump-${{ env.job_name }} (${{ join(matrix.*, ', ') }}).zip" cilium-sysdump-final.zip
 

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -299,6 +299,7 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/post-logic
         with:
+          always_capture_sysdump: true
           artifacts_suffix: "${{ env.job_name }} (${{ join(matrix.*, ', ') }})"
           job_status: "${{ job.status }}"
 
@@ -310,6 +311,14 @@ jobs:
           done
           gcloud container clusters delete ${{ env.clusterName }}-${{ matrix.index }} --zone ${{ env.gcp_zone }} --quiet --async
         shell: bash {0} # Disable default fail-fast behavior so that all commands run independently
+
+      # We needed to configure a unique suffix to ensure that the artifacts can
+      # be correctly uploaded, but we want the sysdump to have a fixed name when
+      # uploading it to the GS bucket.
+      - name: Rename sysdump before uploading it to the GS bucket
+        if : ${{ always() }}
+        run: |
+          mv "cilium-sysdump-${{ env.job_name }} (${{ join(matrix.*, ', ') }}).zip" cilium-sysdump-final.zip
 
       - name: Export results and sysdump to GS bucket
         if: ${{ always() && steps.run-perf.outcome != 'skipped' && steps.run-perf.outcome != 'cancelled' }}

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -344,7 +344,8 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/post-logic
         with:
-          artifacts_suffix: "${{ env.job_name }}"
+          always_capture_sysdump: true
+          artifacts_suffix: "final"
           job_status: "${{ job.status }}"
 
       - name: Cleanup cluster

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -371,9 +371,9 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/post-logic
         with:
-          artifacts_suffix: "${{ env.job_name }}"
+          always_capture_sysdump: true
+          artifacts_suffix: "final"
           job_status: "${{ job.status }}"
-          capture_sysdump: false
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -212,7 +212,8 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/post-logic
         with:
-          artifacts_suffix: "${{ env.job_name }}"
+          always_capture_sysdump: true
+          artifacts_suffix: "final"
           job_status: "${{ job.status }}"
 
       - name: Cleanup cluster


### PR DESCRIPTION
The blamed commit replaced the bespoke sysdump collection logic with a reusable action. However, scale tests rely on sysdumps being always collected, regardless of the job status, as they are then uploaded alongside the other artifacts. Hence, let's update the action to support this use-case, as well as the suffix to match the expectation.

Fixes: 53fd5cf59b7e (".github: de-duplicate workflows logic")

