### PR TITLE
.github/workflows: remove reviewers if ciliumbot approved PR

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -51,3 +51,11 @@ jobs:
       run: |
         echo ${TOKEN} | gh auth login --with-token
         gh -R ${GITHUB_REPOSITORY} pr review ${PULL_REQUEST_NUMBER} --approve
+
+        echo "Remove other reviewers except ciliumbot to avoid noise"
+        reviewers=$(gh pr view ${PULL_REQUEST_NUMBER} --json reviewRequests --jq '.reviewRequests[] | select(."__typename"=="User") | .login')
+        for reviewer in $reviewers; do
+          if [ "$reviewer" != "ciliumbot" ]; then
+            gh pr edit ${PULL_REQUEST_NUMBER} --remove-reviewer "$reviewer"
+          fi
+        done


### PR DESCRIPTION
If the ciliumbot has approved a PR from renovate, we can safely remove the other reviewers from the list. This will decrease the noise towards those reviewers.