### PR TITLE
metrics: Add AgentCell

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -104,7 +104,7 @@ var (
 		cni.Cell,
 
 		// Provide the modular metrics registry, metric HTTP server and legacy metrics cell.
-		metrics.Cell,
+		metrics.AgentCell,
 
 		// Provides cilium_datapath_drop/forward Prometheus metrics.
 		metricsmap.Cell,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1438,7 +1438,8 @@ func (reg *Registry) NewBPFMapPressureGauge(mapname string, threshold float64) *
 func Reinitialize() {
 	reg, err := registry.Await(context.Background())
 	if err == nil {
-		reg.Reinitialize()
+		reg.inner = prometheus.NewPedanticRegistry()
+		reg.registerMetrics()
 	}
 }
 


### PR DESCRIPTION
The [metrics.Cell] is difficult to use in tests as it pulls in the legacy metrics, register the BPF and status collectors and messes with the [metrics.registry] global variable.

To improve usability in tests and avoid failing go tests with `-race`, split off the cilium-agent specifics into [metrics.AgentCell].
