### PR TITLE
cilium: fix socket termination for v4-in-v6 clients

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -681,10 +681,6 @@ static __always_inline int sock6_delete_revnat(struct bpf_sock *ctx)
     ret = map_delete_elem(&cilium_lb6_reverse_sk, &key);
     return ret;
 }
-
-static __always_inline void ctx_get_v6_address(const struct bpf_sock_addr *ctx,
-					       union v6addr *addr);
-
 #endif /* ENABLE_IPV6 */
 
 static __always_inline void ctx_get_v6_address(const struct bpf_sock_addr *ctx,

--- a/pkg/loadbalancer/reconciler/termination.go
+++ b/pkg/loadbalancer/reconciler/termination.go
@@ -239,12 +239,14 @@ func terminateUDPConnectionsToBackend(p socketTerminationParams, l3n4Addr lb.L3n
 	// Iterate over all pod network namespaces, and terminate any stale connections.
 	if p.ExtConfig.EnableSocketLBPodConnectionTermination && !p.ExtConfig.BPFSocketLBHostnsOnly {
 		iter, errs := p.NetNSOps.all()
-		for name, ns := range iter {
-			destroy(name, ns)
-		}
 		for err := range errs {
 			p.Log.Debug("Error opening netns, skipping",
 				logfields.Error, err)
+		}
+		if iter != nil {
+			for name, ns := range iter {
+				destroy(name, ns)
+			}
 		}
 	}
 

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -256,9 +256,8 @@ func getFromThread(pid, tid int) (*os.File, error) {
 // The *NetNS handle is provided for to allow for cases where the ns must
 // be used explicitly*inside* the loop.
 func All() (iter.Seq2[string, *NetNS], <-chan error) {
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	files, err := os.ReadDir(defaults.NetNsPath)
-
 	if err != nil {
 		errCh <- err
 		close(errCh)
@@ -291,5 +290,4 @@ func All() (iter.Seq2[string, *NetNS], <-chan error) {
 			}
 		}
 	}, errCh
-
 }


### PR DESCRIPTION
(see commit desc)

Fixes: #39470

(For KPR=true we also need the fix in https://github.com/cilium/cilium/pull/40026 to trigger the reconciler.)