### PR TITLE
ci/clustermesh: Add multipool IPAM matrix config

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -119,7 +119,7 @@ jobs:
             tunnel: 'disabled'
             ipFamily: 'ipv4'
             encryption: 'disabled'
-            kube-proxy: 'iptables'
+            kube-proxy: 'none'
             mode: 'kvstoremesh'
             tls-auto-method: helm
             cm-auth-mode-1: 'legacy'
@@ -127,6 +127,7 @@ jobs:
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'enabled'
             policy-default-local-cluster: true
+            multipool-ipam: 'enabled'
 
           - name: '2'
             tunnel: 'disabled'
@@ -140,6 +141,7 @@ jobs:
             maxConnectedClusters: '511'
             ciliumEndpointSlice: 'disabled'
             policy-default-local-cluster: false
+            multipool-ipam: 'disabled'
 
           - name: '3'
             tunnel: 'disabled'
@@ -153,6 +155,7 @@ jobs:
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'disabled'
             policy-default-local-cluster: true
+            multipool-ipam: 'disabled'
 
           # IPsec encryption is currently not supported in case of ipv6-only clusters (#23553)
           # Wireguard encryption is currently affected by a bug in case of ipv6-only clusters (#23917)
@@ -168,6 +171,7 @@ jobs:
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'disabled'
             policy-default-local-cluster: false
+            multipool-ipam: 'disabled'
 
           - name: '5'
             tunnel: 'disabled'
@@ -179,19 +183,21 @@ jobs:
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'disabled'
             policy-default-local-cluster: true
+            multipool-ipam: 'disabled'
 
           - name: '6'
             tunnel: 'vxlan'
             ipFamily: 'ipv4'
             encryption: 'disabled'
             kube-proxy: 'none'
-            mode: 'clustermesh'
+            mode: 'kvstoremesh'
             tls-auto-method: helm
             cm-auth-mode-1: 'cluster'
             cm-auth-mode-2: 'cluster'
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'enabled'
             policy-default-local-cluster: false
+            multipool-ipam: 'enabled'
 
           - name: '7'
             tunnel: 'geneve'
@@ -205,6 +211,7 @@ jobs:
             maxConnectedClusters: '511'
             ciliumEndpointSlice: 'disabled'
             policy-default-local-cluster: true
+            multipool-ipam: 'disabled'
 
           - name: '8'
             tunnel: 'vxlan'
@@ -218,6 +225,7 @@ jobs:
             maxConnectedClusters: '255'
             ciliumEndpointSlice: 'disabled'
             policy-default-local-cluster: false
+            multipool-ipam: 'disabled'
 
         # Tunneling is currently not supported in case of ipv6-only clusters (#17240)
         #  - name: '9'
@@ -240,6 +248,7 @@ jobs:
             maxConnectedClusters: '511'
             ciliumEndpointSlice: 'disabled'
             policy-default-local-cluster: true
+            multipool-ipam: 'disabled'
 
     steps:
       - name: Collect Workflow Telemetry
@@ -334,6 +343,30 @@ jobs:
             CILIUM_INSTALL_INGRESS="--helm-set=ingressController.enabled=true"
           fi
 
+          CILIUM_INSTALL_MULTIPOOL_IPAM=""
+          CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER1=""
+          CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER2=""
+          if [ "${{ matrix.multipool-ipam }}" != "disabled" ]; then
+            CILIUM_INSTALL_MULTIPOOL_IPAM="--helm-set=endpointRoutes.enabled=true \
+              --helm-set=bpf.hostLegacyRouting=true \
+              --helm-set=ipam.mode=multi-pool \
+              --helm-set=ipMasqAgent.config.nonMasqueradeCIDRs='{10.0.0.0/8,11.0.0.0/8,192.168.0.0/20,192.168.16.0/20}'"
+
+            CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER1="--helm-set=ipMasqAgent.enabled=true \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.cidrs='{10.10.0.0/16}' \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.maskSize=24 \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.cilium-test-pool.ipv4.cidrs='{10.20.0.0/16}' \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.cilium-test-pool.ipv4.maskSize=24 \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.client-pool.ipv4.cidrs='{192.168.0.0/24}' \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.client-pool.ipv4.maskSize=27"
+
+            CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER2="--helm-set=ipMasqAgent.enabled=true \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.cidrs='{11.10.0.0/16}' \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.maskSize=24 \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.cidrs='{192.168.16.0/24}' \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.maskSize=27"
+          fi
+
           CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
@@ -345,6 +378,15 @@ jobs:
             --collect-sysdump-on-failure \
             --sysdump-output-filename 'cilium-sysdump-${{ matrix.name }}-<ts>'" \
 
+          if [ "${{ matrix.multipool-ipam }}" != "disabled" ]; then
+            CONNECTIVITY_TEST_DEFAULTS="$CONNECTIVITY_TEST_DEFAULTS \
+              --namespace-annotations=ipam.cilium.io/ip-pool=cilium-test-pool \
+              --deployment-pod-annotations='{ \
+                  \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \
+                  \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
+              }'"
+          fi
+
           # Skip external traffic (e.g. 1.1.1.1 and www.google.com) tests as IPv6 is not supported
           # in GitHub runners: https://github.com/actions/runner-images/issues/668
           if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
@@ -354,7 +396,9 @@ jobs:
           fi
 
           echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} \
-            ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_ENCRYPTION} ${CILIUM_INSTALL_INGRESS}" >> $GITHUB_OUTPUT
+            ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_ENCRYPTION} ${CILIUM_INSTALL_INGRESS} ${CILIUM_INSTALL_MULTIPOOL_IPAM}" >> $GITHUB_OUTPUT
+          echo cilium_install_multipool_ipam_cluster1="${CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER1}" >> $GITHUB_OUTPUT
+          echo cilium_install_multipool_ipam_cluster2="${CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER2}" >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
@@ -522,6 +566,7 @@ jobs:
             --helm-set cluster.id=1 \
             --helm-set clustermesh.apiserver.service.nodePort=32379 \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-1 }} \
+            ${{ steps.vars.outputs.cilium_install_multipool_ipam_cluster1 }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_clustermesh }} \
             --nodes-without-cilium
@@ -544,6 +589,7 @@ jobs:
             --helm-set cluster.id=${{ matrix.maxConnectedClusters }} \
             --helm-set clustermesh.apiserver.service.nodePort=32380 \
             --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-2 }} \
+            ${{ steps.vars.outputs.cilium_install_multipool_ipam_cluster2 }} \
             ${{ steps.kvstore.outputs.cilium_install_kvstore }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_clustermesh }}
 

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -337,9 +337,6 @@ func (ct *ConnectivityTest) setupAndValidate(ctx context.Context, extra SetupHoo
 	if err := ct.getNodes(ctx); err != nil {
 		return err
 	}
-	if err := ct.getCiliumNodes(ctx); err != nil {
-		return err
-	}
 	// Detect Cilium version after Cilium pods have been initialized and before feature
 	// detection.
 	if err := ct.detectCiliumVersion(ctx); err != nil {
@@ -370,6 +367,9 @@ func (ct *ConnectivityTest) setupAndValidate(ctx context.Context, extra SetupHoo
 		return err
 	}
 	if err := ct.patchDeployment(ctx); err != nil {
+		return err
+	}
+	if err := ct.getCiliumNodes(ctx); err != nil {
 		return err
 	}
 	if ct.params.Hubble {


### PR DESCRIPTION
Extend the conformance-clustermesh to test multipool IPAM mode.

In order for the tests to run successfully, additional routes must be installed on unmanaged nodes. Specifically, the connectivity tests are updated to consider all the mutli-pool IPAM related pod CIDRs when installing those rules (see individual commit description for further details).