### PR TITLE
ipsec: Extend BPF tests to cover IPv6 underlay

### DIFF
--- a/bpf/tests/ipsec_encryption_on_egress.c
+++ b/bpf/tests/ipsec_encryption_on_egress.c
@@ -47,8 +47,8 @@ struct {
 	},
 };
 
-PKTGEN("tc", "ipsec_encryption_on_egress")
-int ipsec_encryption_on_egress_pktgen(struct __ctx_buff *ctx)
+PKTGEN("tc", "ipsec_encryption_on_egress_ipv4")
+int ipsec_encryption_on_egress_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct iphdr *l3;
@@ -64,8 +64,8 @@ int ipsec_encryption_on_egress_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "ipsec_encryption_on_egress")
-int ipsec_encryption_on_egress_setup(struct __ctx_buff *ctx)
+SETUP("tc", "ipsec_encryption_on_egress_ipv4")
+int ipsec_encryption_on_egress_ipv4_setup(struct __ctx_buff *ctx)
 {
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	return TEST_ERROR;
@@ -78,8 +78,41 @@ int ipsec_encryption_on_egress_setup(struct __ctx_buff *ctx)
  * therefore, if this integration test fails, the datapath is no longer reliably
  * IPsec encrypting packets leaving the host.
  */
-CHECK("tc", "ipsec_encryption_on_egress")
-int ipsec_encryption_on_egress_check(__maybe_unused struct __ctx_buff *ctx)
+CHECK("tc", "ipsec_encryption_on_egress_ipv4")
+int ipsec_encryption_on_egress_ipv4_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	test_init();
+	assert(hook_reached);
+	test_finish();
+}
+
+PKTGEN("tc", "ipsec_encryption_on_egress_ipv6")
+int ipsec_encryption_on_egress_ipv6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ipv6hdr *l3;
+
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv6_packet(&builder, (__u8 *)mac_one, (__u8 *)mac_two,
+				      (__u8 *)v6_pod_one, (__u8 *)v6_pod_two);
+	if (!l3)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipsec_encryption_on_egress_ipv6")
+int ipsec_encryption_on_egress_ipv6_setup(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	return TEST_ERROR;
+}
+
+/* See IPv4 comment */
+CHECK("tc", "ipsec_encryption_on_egress_ipv6")
+int ipsec_encryption_on_egress_ipv6_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	test_init();
 	assert(hook_reached);

--- a/bpf/tests/ipsec_from_network_generic.h
+++ b/bpf/tests/ipsec_from_network_generic.h
@@ -97,7 +97,7 @@ int ipv4_not_decrypted_ipsec_from_network_setup(struct __ctx_buff *ctx)
 	/* We need to populate the node ID map because we'll lookup into it on
 	 * ingress to find the node ID to use to match against XFRM IN states.
 	 */
-	node_v4_add_entry(v4_pod_one, NODE_ID, 0);
+	node_v4_add_entry(v4_pod_one, NODE_ID, ENCRYPT_KEY);
 
 	tail_call_static(ctx, entry_call_map, FROM_NETWORK);
 	return TEST_ERROR;
@@ -216,7 +216,7 @@ int ipv6_not_decrypted_ipsec_from_network_setup(struct __ctx_buff *ctx)
 	/* We need to populate the node ID map because we'll lookup into it on
 	 * ingress to find the node ID to use to match against XFRM IN states.
 	 */
-	node_v6_add_entry((union v6addr *)v6_pod_one, NODE_ID, 0);
+	node_v6_add_entry((union v6addr *)v6_pod_one, NODE_ID, ENCRYPT_KEY);
 
 	tail_call_static(ctx, entry_call_map, FROM_NETWORK);
 	return TEST_ERROR;

--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -130,7 +130,7 @@ int ipv4_not_decrypted_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
 	/* We need to populate the node ID map because we'll lookup into it on
 	 * ingress to find the node ID to use to match against XFRM IN states.
 	 */
-	node_v4_add_entry(v4_pod_one, NODE_ID, 0);
+	node_v4_add_entry(v4_pod_one, NODE_ID, ENCRYPT_KEY);
 
 	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
 	return TEST_ERROR;
@@ -249,7 +249,7 @@ int ipv6_not_decrypted_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
 	/* We need to populate the node ID map because we'll lookup into it on
 	 * ingress to find the node ID to use to match against XFRM IN states.
 	 */
-	node_v6_add_entry((union v6addr *)v6_pod_one, NODE_ID, 0);
+	node_v6_add_entry((union v6addr *)v6_pod_one, NODE_ID, ENCRYPT_KEY);
 
 	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
 	return TEST_ERROR;

--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -3,7 +3,8 @@
 
 static __always_inline void
 __ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
-		       __u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel, __u32 mask_size)
+		       const union v6addr *tunnel_ep, __u8 spi, bool flag_skip_tunnel,
+		       bool ipv6_underlay, __u32 mask_size)
 {
 	struct ipcache_key key = {
 		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(mask_size),
@@ -14,10 +15,16 @@ __ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 	struct remote_endpoint_info value = {};
 
 	value.sec_identity = sec_identity;
-	value.tunnel_endpoint.ip4 = tunnel_ep;
+	if (ipv6_underlay) {
+		/* The tunnel endpoint is misaligned on the stack so we need to use the builtin. */
+		__bpf_memcpy_builtin(&value.tunnel_endpoint.ip6, tunnel_ep, sizeof(*tunnel_ep));
+		value.flag_ipv6_tunnel_ep = true;
+	} else {
+		value.tunnel_endpoint.ip4 = tunnel_ep->p1;
+	}
 	value.key = spi;
 	value.flag_skip_tunnel = flag_skip_tunnel;
-	if (tunnel_ep)
+	if (tunnel_ep->p1)
 		value.flag_has_tunnel_ep = true;
 
 	map_update_elem(&cilium_ipcache_v2, &key, &value, BPF_ANY);
@@ -26,14 +33,24 @@ __ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 static __always_inline void
 ipcache_v4_add_world_entry()
 {
-	__ipcache_v4_add_entry(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0, 0);
+	union v6addr tunnel_ep = {0};
+
+	__ipcache_v4_add_entry(v4_all, 0, WORLD_IPV4_ID, &tunnel_ep, 0, false, false, 0);
 }
 
 static __always_inline void
 ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 		     __u32 tunnel_ep, __u8 spi)
 {
-	__ipcache_v4_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false,
+	__ipcache_v4_add_entry(addr, cluster_id, sec_identity, (union v6addr *)&tunnel_ep, spi,
+			       false, false, V4_CACHE_KEY_LEN);
+}
+
+static __always_inline void
+ipcache_v4_add_entry_ipv6_underlay(__be32 addr, __u8 cluster_id, __u32 sec_identity,
+				   const union v6addr *tunnel_ep, __u8 spi)
+{
+	__ipcache_v4_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false, true,
 			       V4_CACHE_KEY_LEN);
 }
 
@@ -41,20 +58,22 @@ static __always_inline void
 ipcache_v4_add_entry_with_flags(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 				__u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel)
 {
-	__ipcache_v4_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, flag_skip_tunnel,
-			       V4_CACHE_KEY_LEN);
+	__ipcache_v4_add_entry(addr, cluster_id, sec_identity, (union v6addr *)&tunnel_ep, spi,
+			       flag_skip_tunnel, false, V4_CACHE_KEY_LEN);
 }
 
 static __always_inline void
 ipcache_v4_add_entry_with_mask_size(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 				    __u32 tunnel_ep, __u8 spi, __u32 mask_size)
 {
-	__ipcache_v4_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false, mask_size);
+	__ipcache_v4_add_entry(addr, cluster_id, sec_identity, (union v6addr *)&tunnel_ep, spi,
+			       false, false, mask_size);
 }
 
 static __always_inline void
 __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
-		       __u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel)
+		       const union v6addr *tunnel_ep, __u8 spi, bool flag_skip_tunnel,
+		       bool ipv6_underlay)
 {
 	struct ipcache_key key = {
 		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(V6_CACHE_KEY_LEN),
@@ -64,10 +83,16 @@ __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_iden
 	struct remote_endpoint_info value = {};
 
 	value.sec_identity = sec_identity;
-	value.tunnel_endpoint.ip4 = tunnel_ep;
+	if (ipv6_underlay) {
+		/* The tunnel endpoint is misaligned on the stack so we need to use the builtin. */
+		__bpf_memcpy_builtin(&value.tunnel_endpoint.ip6, tunnel_ep, sizeof(*tunnel_ep));
+		value.flag_ipv6_tunnel_ep = true;
+	} else {
+		value.tunnel_endpoint.ip4 = tunnel_ep->p1;
+	}
 	value.key = spi;
 	value.flag_skip_tunnel = flag_skip_tunnel;
-	if (tunnel_ep)
+	if (tunnel_ep->p1)
 		value.flag_has_tunnel_ep = true;
 
 	memcpy(&key.ip6, addr, sizeof(*addr));
@@ -79,12 +104,21 @@ static __always_inline void
 ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
 		     __u32 tunnel_ep, __u8 spi)
 {
-	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false);
+	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, (union v6addr *)&tunnel_ep, spi,
+			       false, false);
+}
+
+static __always_inline void
+ipcache_v6_add_entry_ipv6_underlay(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
+				   const union v6addr *tunnel_ep, __u8 spi)
+{
+	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false, true);
 }
 
 static __always_inline void
 ipcache_v6_add_entry_with_flags(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
 				__u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel)
 {
-	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, flag_skip_tunnel);
+	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, (union v6addr *)&tunnel_ep, spi,
+			       flag_skip_tunnel, false);
 }


### PR DESCRIPTION
The first commit is a small "fix" without consequences. Second commit covers IPv6 in the `encryption_on_egress` test. The third and fourth commits cover IPv6 underlay in the `ipsec_redirect` tests. See commits for details.