### PR TITLE
Add "Fence" for delaying initial endpoint regeneration

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -463,11 +463,6 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState, endpointsRegenerator *endpoint.Regenerator) {
 	bootstrapStats.restore.Start()
 	if option.Config.RestoreState {
-		// When we regenerate restored endpoints, it is guaranteed that we have
-		// received the full list of policies present at the time the daemon
-		// is bootstrapped.
-		d.regenerateRestoredEndpoints(restoredEndpoints, endpointsRegenerator)
-
 		go func() {
 			if d.clientset.IsEnabled() {
 				// Configure the controller which removes any leftover Kubernetes
@@ -530,6 +525,11 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState, endpointsR
 				syncServices(false /* all services */)
 			}
 		}()
+
+		// When we regenerate restored endpoints, it is guaranteed that we have
+		// received the full list of policies present at the time the daemon
+		// is bootstrapped.
+		d.regenerateRestoredEndpoints(restoredEndpoints, endpointsRegenerator)
 	} else {
 		d.logger.Info("State restore is disabled. Existing endpoints on node are ignored")
 	}

--- a/pkg/ciliumenvoyconfig/cell.go
+++ b/pkg/ciliumenvoyconfig/cell.go
@@ -41,7 +41,7 @@ var (
 	controllerCells = cell.Group(
 		cell.Invoke(
 			registerCECController,
-			registerCachesSyncedJob,
+			registerRegenerationWait,
 		),
 		metrics.Metric(newMetrics),
 	)

--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -10,7 +10,6 @@ import (
 	"maps"
 	"slices"
 	"strconv"
-	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -23,8 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/hive"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/option"
@@ -528,71 +528,56 @@ func computeLoadAssignments(
 }
 
 // maxSyncWaitTime is the amount of time to wait for CECs to be synced to Envoy before
-// marking the (C)CEC resources as synced. This is the maximum delay introduced by the
+// allowing endpoint regeneration to proceed. This is the maximum delay introduced by the
 // CEC processing to the initial endpoint generation.
 const maxSyncWaitTime = time.Minute
 
-// registerCachesSyncedJob registers a job to wait for Table[EnvoyResource] to
-// be initialized and all entries to have been reconciled to Envoy. This will block
-// the initial endpoint generation to reduce churn.
-func registerCachesSyncedJob(p cecControllerParams, res *synced.Resources) {
+// registerRegenerationWait registers initializer to block the endpoint regeneration
+// before we've reconciled to Envoy.
+func registerRegenerationWait(p cecControllerParams, fence regeneration.Fence) {
 	if !p.DaemonConfig.EnableL7Proxy || !p.DaemonConfig.EnableEnvoyConfig {
 		return
 	}
+	fence.Add("ciliumenvoyconfig", initWaitFunc(p))
+}
 
-	var synced atomic.Bool
+func initWaitFunc(p cecControllerParams) hive.WaitFunc {
+	return func(ctx context.Context) error {
+		ctx, cancel := context.WithTimeout(ctx, maxSyncWaitTime)
+		defer cancel()
 
-	res.BlockWaitGroupToSyncResources(
-		nil, /* Use nil stop channel as we'll eventually mark synced as true */
-		nil, /* SWG */
-		synced.Load,
-		k8sAPIGroupCiliumEnvoyConfigV2,
-	)
+		// Wait until the table has been populated.
+		_, initWatch := p.EnvoyResources.Initialized(p.DB.ReadTxn())
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-initWatch:
+		}
 
-	res.BlockWaitGroupToSyncResources(
-		nil, /* Use nil stop channel as we'll eventually mark synced as true */
-		nil, /* SWG */
-		synced.Load,
-		k8sAPIGroupCiliumClusterwideEnvoyConfigV2,
-	)
-
-	p.JobGroup.Add(
-		job.OneShot(
-			"mark-caches-synced",
-			func(ctx context.Context, health cell.Health) error {
-				defer synced.Store(true)
-
-				ctx, cancel := context.WithTimeout(ctx, maxSyncWaitTime)
-				defer cancel()
-
-				// Wait until the table has been populated.
-				_, initWatch := p.EnvoyResources.Initialized(p.DB.ReadTxn())
-				select {
-				case <-ctx.Done():
-					return nil
-				case <-initWatch:
+		// Wait for all initial resources to have been synced to Envoy.
+		seen := sets.New[EnvoyResourceName]()
+		for {
+			ers, watch := p.EnvoyResources.AllWatch(p.DB.ReadTxn())
+			done := true
+			for er := range ers {
+				if seen.Has(er.Name) {
+					continue
 				}
-
-				// Wait for all initial resources to have been synced to Envoy.
-				for {
-					ers, watch := p.EnvoyResources.AllWatch(p.DB.ReadTxn())
-					done := true
-					for er := range ers {
-						if er.Status.Kind != reconciler.StatusKindDone {
-							done = false
-							break
-						}
-					}
-					if done {
-						break
-					}
-
-					select {
-					case <-ctx.Done():
-						return nil
-					case <-watch:
-					}
+				if er.Status.Kind == reconciler.StatusKindPending {
+					done = false
+					break
 				}
+				seen.Insert(er.Name)
+			}
+			if done {
+				break
+			}
+			select {
+			case <-ctx.Done():
 				return nil
-			}))
+			case <-watch:
+			}
+		}
+		return nil
+	}
 }

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -37,6 +37,7 @@ import (
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -85,6 +86,7 @@ func TestScript(t *testing.T) {
 				tables.NewNodeAddressTable,
 				statedb.RWTable[tables.NodeAddress].ToTable,
 				source.NewSources,
+				regeneration.NewFence,
 				func() *option.DaemonConfig {
 					return &option.DaemonConfig{
 						EnableIPv4:           true,

--- a/pkg/endpoint/regeneration/fence.go
+++ b/pkg/endpoint/regeneration/fence.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package regeneration
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/hive"
+)
+
+// Fence delays the endpoint regeneration until all registered wait functions
+// have returned.
+//
+// A new type around [hive.Fence] to give it a unique type that can be provided
+// to Hive.
+type Fence hive.Fence
+
+func NewFence(lc cell.Lifecycle, log *slog.Logger) Fence {
+	return hive.NewFence(lc, log)
+}

--- a/pkg/endpoint/regenerator.go
+++ b/pkg/endpoint/regenerator.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -21,7 +23,13 @@ var (
 		"endpoint-regeneration",
 		"Endpoints regeneration",
 
-		cell.Provide(newRegenerator),
+		cell.Provide(
+			newRegenerator,
+
+			// Provide [regeneration.Fence] to allow sub-systems to delay the initial
+			// endpoint regeneration.
+			regeneration.NewFence,
+		),
 	)
 )
 
@@ -35,6 +43,7 @@ type Regenerator struct {
 	ipcacheWaitFn wait.Fn
 	cmWaitFn      wait.Fn
 	cmWaitTimeout time.Duration
+	fence         regeneration.Fence
 
 	logger        *slog.Logger
 	cmSyncLogOnce sync.Once
@@ -49,22 +58,50 @@ func newRegenerator(in struct {
 	NodesWaitFn KVStoreNodesWaitFn
 	IPCacheSync *ipcache.IPIdentityWatcher
 	ClusterMesh *clustermesh.ClusterMesh
+	Fence       regeneration.Fence
 }) *Regenerator {
 	waitFn := func(context.Context) error { return nil }
 	if in.ClusterMesh != nil {
 		waitFn = in.ClusterMesh.IPIdentitiesSynced
 	}
-
-	return &Regenerator{
+	r := &Regenerator{
 		logger:        in.Logger,
 		nodesWaitFn:   in.NodesWaitFn,
 		ipcacheWaitFn: in.IPCacheSync.WaitForSync,
 		cmWaitFn:      waitFn,
 		cmWaitTimeout: in.Config.ClusterMeshSyncTimeout,
+		fence:         in.Fence,
 	}
+
+	// !!! Do not add more waits here. These will eventually move out from here
+	// to their proper places !!!
+
+	// Wait for ipcache sync before regeneration for endpoints including
+	// the ones with fixed identity (e.g. host endpoint), this ensures that
+	// the regenerated datapath always lookups from a ready ipcache map.
+	// Additionally wait for node synchronization, as nodes also contribute
+	// entries to the ipcache map, most notably about the remote node IPs.
+	if option.Config.KVStore != "" {
+		in.Fence.Add(
+			"kvstore",
+			r.waitForKVStoreSync,
+		)
+	}
+
+	// Wait for ipcache and identities synchronization from all remote clusters,
+	// to prevent disrupting cross-cluster connections on endpoint regeneration.
+	in.Fence.Add(
+		"clustermesh",
+		r.waitForClusterMeshIPIdentitiesSync,
+	)
+	return r
 }
 
-func (r *Regenerator) WaitForKVStoreSync(ctx context.Context) error {
+func (r *Regenerator) WaitForFence(ctx context.Context) error {
+	return r.fence.Wait(ctx)
+}
+
+func (r *Regenerator) waitForKVStoreSync(ctx context.Context) error {
 	if err := r.nodesWaitFn(ctx); err != nil {
 		return err
 	}
@@ -72,7 +109,7 @@ func (r *Regenerator) WaitForKVStoreSync(ctx context.Context) error {
 	return r.ipcacheWaitFn(ctx)
 }
 
-func (r *Regenerator) WaitForClusterMeshIPIdentitiesSync(ctx context.Context) error {
+func (r *Regenerator) waitForClusterMeshIPIdentitiesSync(ctx context.Context) error {
 	wctx, cancel := context.WithTimeout(ctx, r.cmWaitTimeout)
 	defer cancel()
 	err := r.cmWaitFn(wctx)

--- a/pkg/endpoint/regenerator_test.go
+++ b/pkg/endpoint/regenerator_test.go
@@ -49,7 +49,7 @@ func TestRegeneratorWaitForIPCacheSync(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.assert(t, regenerator.WaitForClusterMeshIPIdentitiesSync(tt.ctx))
+			tt.assert(t, regenerator.waitForClusterMeshIPIdentitiesSync(tt.ctx))
 		})
 	}
 }

--- a/pkg/hive/fence.go
+++ b/pkg/hive/fence.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hive
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// Fence is an utility for blocking until registered wait functions have completed.
+//
+// The wait functions can only be Add()'d' before Hive is started, e.g. from constructors
+// or invoke functions. Conversely Wait() method can only be called during/after Hive start.
+type Fence interface {
+	// Add a named wait function to the fence.
+	// The provided function should block until ready or until context has been
+	// cancelled. It should return [context.Err] if context is cancelled.
+	//
+	// This method will panic if called after Hive has started to ensure that when
+	// Wait() is called all initializers have already been registered.
+	Add(name string, waitFn WaitFunc)
+
+	// Wait blocks until all registered initializers have completed or until
+	// context has cancelled.
+	//
+	// This method will panic if called before Hive is started.
+	// Can be called any number of times.
+	Wait(ctx context.Context) error
+}
+
+// NewFence constructs a new [Fence].
+func NewFence(lc cell.Lifecycle, log *slog.Logger) Fence {
+	iwg := &fence{
+		mu:        newContextMutex(),
+		log:       log,
+		waitFuncs: map[string]WaitFunc{},
+	}
+	lc.Append(iwg)
+	return iwg
+}
+
+// WaitFunc is a function for waiting until some initialization has completed.
+// If the context given to it is cancelled the function should stop and return ctx.Err().
+type WaitFunc = func(context.Context) error
+
+const nameLogField = "name"
+
+type fence struct {
+	mu        contextMutex
+	log       *slog.Logger
+	started   bool
+	waitFuncs map[string]WaitFunc
+}
+
+func (w *fence) Add(name string, waitFn WaitFunc) {
+	// Add calls must happen sequentially during Hive population so no context here.
+	w.mu.Lock(context.Background())
+	defer w.mu.Unlock()
+
+	if w.started {
+		panic("Add() called after Hive had already started! Add() must be used from provide/invoke functions.")
+	}
+	if _, found := w.waitFuncs[name]; found {
+		panic(fmt.Sprintf("%s already registered", name))
+	}
+	w.waitFuncs[name] = waitFn
+}
+
+func (w *fence) Wait(ctx context.Context) error {
+	if err := w.mu.Lock(ctx); err != nil {
+		return err
+	}
+	defer w.mu.Unlock()
+
+	if !w.started {
+		panic("Wait() called before Hive had already started! Wait() must be called during start to ensure all Add() calls have happened.")
+	}
+
+	if len(w.waitFuncs) == 0 {
+		return nil
+	}
+
+	remaining := len(w.waitFuncs)
+	for name, fn := range w.waitFuncs {
+		t0 := time.Now()
+		log := w.log.With(
+			nameLogField, name,
+			logfields.Remaining, remaining,
+		)
+		log.Info("Fence waiting")
+		if err := fn(ctx); err != nil {
+			log.Error("Fence error",
+				logfields.Error, err)
+			return fmt.Errorf("%s: %w", name, err)
+		}
+		log.Info("Fence done", logfields.Duration, time.Since(t0))
+		remaining--
+		delete(w.waitFuncs, name)
+	}
+
+	return nil
+}
+
+// Start implements cell.HookInterface.
+func (w *fence) Start(ctx cell.HookContext) error {
+	if err := w.mu.Lock(ctx); err != nil {
+		return err
+	}
+	defer w.mu.Unlock()
+	w.started = true
+	return nil
+}
+
+// Stop implements cell.HookInterface.
+func (w *fence) Stop(cell.HookContext) error {
+	return nil
+}
+
+var _ cell.HookInterface = &fence{}
+
+type contextMutex struct {
+	sem *semaphore.Weighted
+}
+
+func newContextMutex() contextMutex {
+	return contextMutex{sem: semaphore.NewWeighted(1)}
+}
+
+func (c *contextMutex) Lock(ctx context.Context) error {
+	return c.sem.Acquire(ctx, 1)
+}
+
+func (c *contextMutex) Unlock() {
+	c.sem.Release(1)
+}

--- a/pkg/hive/fence_test.go
+++ b/pkg/hive/fence_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hive
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFence(t *testing.T) {
+	lc := &cell.DefaultLifecycle{}
+	log := hivetest.Logger(t)
+
+	iwg := NewFence(lc, log)
+
+	fooStop, fooFn := testWaitFn()
+	barStop, barFn := testWaitFn()
+
+	iwg.Add("foo", fooFn)
+	iwg.Add("bar", barFn)
+
+	require.Len(t, iwg.(*fence).waitFuncs, 2)
+
+	require.NoError(t, lc.Start(log, t.Context()))
+	t.Cleanup(func() { require.NoError(t, lc.Stop(log, context.TODO())) })
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, iwg.Wait(ctx), context.DeadlineExceeded)
+
+	close(fooStop)
+
+	ctx, cancel = context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, iwg.Wait(ctx), context.DeadlineExceeded)
+
+	close(barStop)
+
+	require.NoError(t, iwg.Wait(t.Context()))
+	require.NoError(t, iwg.Wait(t.Context()))
+
+	// After we've successfully waited on everything we should forget the
+	// wait functions.
+	require.Empty(t, iwg.(*fence).waitFuncs)
+
+	require.Panics(t, func() {
+		iwg.Add("foo", fooFn)
+	})
+}
+
+func TestFence_WaitContext(t *testing.T) {
+	lc := &cell.DefaultLifecycle{}
+	log := hivetest.Logger(t)
+
+	iwg := NewFence(lc, log)
+	iwg.Add("stuck", testStuckFn)
+	require.NoError(t, lc.Start(log, t.Context()))
+	t.Cleanup(func() { require.NoError(t, lc.Stop(log, context.TODO())) })
+
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	defer cancel1()
+
+	// Blocks until cancel1() called
+	go iwg.Wait(ctx1)
+
+	// Wait() stuck acquiring lock until context is cancelled.
+	ctx2, cancel2 := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel2()
+	require.ErrorIs(t, iwg.Wait(ctx2), context.DeadlineExceeded)
+
+}
+
+func TestFence_Errors(t *testing.T) {
+	lc := &cell.DefaultLifecycle{}
+	log := hivetest.Logger(t)
+
+	iwg := NewFence(lc, log)
+
+	var success bool
+	iwg.Add("fail", testWaitFailFn(&success))
+
+	require.Len(t, iwg.(*fence).waitFuncs, 1)
+
+	require.NoError(t, lc.Start(log, t.Context()))
+	t.Cleanup(func() { require.NoError(t, lc.Stop(log, context.TODO())) })
+
+	require.ErrorIs(t, iwg.Wait(t.Context()), testWaitErr)
+
+	require.Len(t, iwg.(*fence).waitFuncs, 1)
+
+	success = true
+
+	require.NoError(t, iwg.Wait(t.Context()))
+	require.NoError(t, iwg.Wait(t.Context()))
+
+	// After we've successfully waited on everything we should forget the
+	// wait functions.
+	require.Empty(t, iwg.(*fence).waitFuncs)
+}
+
+func testWaitFn() (stop chan struct{}, fn WaitFunc) {
+	stop = make(chan struct{})
+	fn = func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-stop:
+			return nil
+		}
+	}
+	return
+}
+
+var testWaitErr = errors.New("fail")
+
+func testWaitFailFn(success *bool) WaitFunc {
+	return func(ctx context.Context) error {
+		if !*success {
+			return testWaitErr
+		}
+		return nil
+	}
+}
+
+func testStuckFn(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -41,8 +41,6 @@ const (
 	k8sAPIGroupCiliumEndpointV2                 = "cilium/v2::CiliumEndpoint"
 	k8sAPIGroupCiliumLocalRedirectPolicyV2      = "cilium/v2::CiliumLocalRedirectPolicy"
 	k8sAPIGroupCiliumEndpointSliceV2Alpha1      = "cilium/v2alpha1::CiliumEndpointSlice"
-	k8sAPIGroupCiliumEnvoyConfigV2              = "cilium/v2::CiliumEnvoyConfig"
-	k8sAPIGroupCiliumClusterwideEnvoyConfigV2   = "cilium/v2::CiliumClusterwideEnvoyConfig"
 
 	metricCLRP = "CiliumLocalRedirectPolicy"
 	metricPod  = "Pod"
@@ -212,16 +210,16 @@ var ciliumResourceToGroupMapping = map[string]watcherInfo{
 	synced.CRDResourceName(cilium_v2.CLRPName):          {start, k8sAPIGroupCiliumLocalRedirectPolicyV2},
 	synced.CRDResourceName(cilium_v2.CEGPName):          {skip, ""}, // Handled via Resource[T].
 	synced.CRDResourceName(v2alpha1.CESName):            {start, k8sAPIGroupCiliumEndpointSliceV2Alpha1},
-	synced.CRDResourceName(cilium_v2.CCECName):          {waitOnly, k8sAPIGroupCiliumClusterwideEnvoyConfigV2}, // Handled in pkg/ciliumenvoyconfig/
-	synced.CRDResourceName(cilium_v2.CECName):           {waitOnly, k8sAPIGroupCiliumEnvoyConfigV2},            // Handled in pkg/ciliumenvoyconfig/
-	synced.CRDResourceName(v2alpha1.BGPPName):           {skip, ""},                                            // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPCCName):          {skip, ""},                                            // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPAName):           {skip, ""},                                            // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPPCName):          {skip, ""},                                            // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPNCName):          {skip, ""},                                            // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.BGPNCOName):         {skip, ""},                                            // Handled in BGP control plane
-	synced.CRDResourceName(v2alpha1.LBIPPoolName):       {skip, ""},                                            // Handled in LB IPAM
-	synced.CRDResourceName(v2alpha1.CNCName):            {skip, ""},                                            // Handled by init directly
+	synced.CRDResourceName(cilium_v2.CCECName):          {skip, ""}, // Handled in pkg/ciliumenvoyconfig/
+	synced.CRDResourceName(cilium_v2.CECName):           {skip, ""}, // Handled in pkg/ciliumenvoyconfig/
+	synced.CRDResourceName(v2alpha1.BGPPName):           {skip, ""}, // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPCCName):          {skip, ""}, // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPAName):           {skip, ""}, // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPPCName):          {skip, ""}, // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPNCName):          {skip, ""}, // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.BGPNCOName):         {skip, ""}, // Handled in BGP control plane
+	synced.CRDResourceName(v2alpha1.LBIPPoolName):       {skip, ""}, // Handled in LB IPAM
+	synced.CRDResourceName(v2alpha1.CNCName):            {skip, ""}, // Handled by init directly
 	synced.CRDResourceName(cilium_v2.CCGName):           {waitOnly, k8sAPIGroupCiliumCIDRGroupV2},
 	synced.CRDResourceName(v2alpha1.L2AnnouncementName): {skip, ""}, // Handled by L2 announcement directly
 	synced.CRDResourceName(v2alpha1.CPIPName):           {skip, ""}, // Handled by multi-pool IPAM allocator

--- a/pkg/loadbalancer/cell/adapters.go
+++ b/pkg/loadbalancer/cell/adapters.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/store"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/client"
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/legacy/service"
@@ -39,6 +40,7 @@ import (
 type adapterParams struct {
 	cell.In
 
+	Clientset    client.Clientset
 	JobGroup     job.Group
 	Log          *slog.Logger
 	DaemonConfig *option.DaemonConfig
@@ -91,7 +93,7 @@ func newAdapters(p adapterParams) (sca *serviceCacheAdapter, sma *serviceManager
 	// (*Daemon).initRestore in daemon/cmd/state.go. Once ClusterMesh has switched
 	// to using the Writer directly this can be removed.
 	var initDone func(writer.WriteTxn)
-	if p.TestConfig == nil {
+	if p.TestConfig == nil && p.Clientset.IsEnabled() {
 		initDone = p.Writer.RegisterInitializer("adapters")
 	} else {
 		initDone = func(writer.WriteTxn) {}

--- a/pkg/loadbalancer/cell/cell.go
+++ b/pkg/loadbalancer/cell/cell.go
@@ -47,4 +47,8 @@ var Cell = cell.Group(
 		cell.Provide(newAdapters),
 		cell.DecorateAll(decorateAdapters),
 	),
+
+	// Provide a function to wait until load-balancing control-plane has received
+	// and reconciled the initial state.
+	cell.Provide(newInitWaitFunc),
 )

--- a/pkg/loadbalancer/cell/wait.go
+++ b/pkg/loadbalancer/cell/wait.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/statedb/reconciler"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const logfieldInitializers = "initializers"
+
+func newInitWaitFunc(log *slog.Logger, w *writer.Writer) loadbalancer.InitWaitFunc {
+	return func(ctx context.Context) error {
+		// Wait until the frontends table has been initialized.
+		initialized, initDone := w.Frontends().Initialized(w.ReadTxn())
+		for !initialized {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-initDone:
+				initialized = true
+			case <-time.After(time.Second):
+				pending := w.Frontends().PendingInitializers(w.ReadTxn())
+				log.Info("Still waiting for initializers", logfieldInitializers, pending)
+			}
+		}
+
+		// Wait until no pending frontends remain, e.g. reconciliation has been
+		// tried at least once.
+		seen := sets.New[loadbalancer.L3n4Addr]()
+		for {
+			fes, watch := w.Frontends().AllWatch(w.ReadTxn())
+			ready := true
+			for fe := range fes {
+				if seen.Has(fe.Address) {
+					continue
+				}
+				if fe.Status.Kind == reconciler.StatusKindPending {
+					ready = false
+					break
+				}
+				seen.Insert(fe.Address)
+			}
+			if ready {
+				return nil
+			}
+
+			// Wait until frontends table updates. We don't need to rate limit here
+			// as reflector and reconciler processes in large batches.
+			select {
+			case <-watch:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -19,8 +19,14 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
+
+// InitWaitFunc is provided by the load-balancing cell to wait until the
+// load-balancing control-plane has finished reconciliation of the initial
+// data set.
+type InitWaitFunc hive.WaitFunc
 
 type IPFamily = bool
 

--- a/pkg/loadbalancer/tests/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/tests/testdata/clusterip.txtar
@@ -10,6 +10,9 @@ k8s/add endpointslice.yaml
 db/cmp backends backends.table 
 db/cmp frontends frontends.table
 
+# Verify that the [loadbalancer.InitWaitFunc] returns.
+test/init-wait
+
 # Check the BPF maps
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual


### PR DESCRIPTION
Traditionally we've used the "CachesSynced" as the mechanism to delay the initial endpoint regeneration. This is now starting to be a difficult mechanism to conform to as we may have a) multiple components consuming the same K8s resource and there can be only one "BlockWaitGroupToSyncResources" per resource, b) we have other data sources besides k8s like kvstore, c) the mechanism is not easy to extend modularly.

This PR proposes adding an "Fence", a wait group style object to which "wait functions" can be added and which can be waited on. This is similar to `StoppableWaitGroup`, but enforces that `Add` is used before Hive starts and `Wait` is used after starting to make sure we don't `Add` to late or `Wait` too early. It also allows bubbling up the error from the initializer through `Wait`.

We provide a "regeneration.Fence" which is just a type wrapper around `hive.Fence` and switch the endpoint "regenerator" to using it. 

The load-balancing and ciliumenvoyconfig waiting is added to this to allow removing of the `BlockWaitGroupToSyncResources` in https://github.com/cilium/cilium/pull/39915.

More context for this is in https://github.com/cilium/cilium/pull/39915#discussion_r2139879852.