### PR TITLE
fix: Make gops use a directory with required permissions

### DIFF
--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -56,6 +56,10 @@ LABEL maintainer="maintainer@cilium.io"
 COPY --from=gops /out/${TARGETOS}/${TARGETARCH}/bin/gops /bin/gops
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/hubble-relay /usr/bin/hubble-relay
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
+# Configure gops to use a temporary directory, to prevent permission
+# issues depending on the UID configured to run the entrypoint.
+COPY --chmod=777 --from=scratch / /home/gops
+ENV GOPS_CONFIG_DIR=/home/gops
 # use uid:gid for the nonroot user for compatibility with runAsNonRoot
 USER 65532:65532
 ENTRYPOINT ["/usr/bin/hubble-relay"]

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -86,7 +86,10 @@ COPY --from=gops /out/${TARGETOS}/${TARGETARCH}/bin/gops /bin/gops
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-${OPERATOR_VARIANT} /usr/bin/cilium-${OPERATOR_VARIANT}
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 WORKDIR /
-ENV GOPS_CONFIG_DIR=/
+# Configure gops directory to prevent permission
+# issues depending on the UID configured to run the entrypoint.
+COPY --chmod=777 --from=scratch / /home/gops
+ENV GOPS_CONFIG_DIR=/home/gops
 CMD ["/usr/bin/cilium-${OPERATOR_VARIANT}"]
 
 FROM --platform=${BUILDPLATFORM} ${CILIUM_BUILDER_IMAGE} AS debug-tools


### PR DESCRIPTION
The cilium-operator and hubble-relay images use gops. It needs to be configured so that the directory it uses has the required permissions.
As DAC_OVERRIDE is dropped from the operator container this intends to prevent failures on OpenShift as:
"level=error msg="Start hook failed" subsys=cilium-operator-generic function="gops.registerGopsHooks.func1 (pkg/gops/cell.go:47) (operator.operator.operator-infra.gops)"
error="open /1: permission denied"".

Drop of capabilities was introduced by https://github.com/cilium/cilium/pull/39205

```release-note
Prevent Cilium operator failures on OpenShift due to permissions missing for gops.
```
