### PR TITLE
[v1.16] ci: don't run k8s conformance tests in conformance-k8s-kind

### DIFF
--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -178,8 +178,7 @@ jobs:
 
           # Kubernetes e2e tests use ginkgo and tags to select the tests that should run based on two regex, focus and skip:
           # Focus tests:
-          # \[Conformance\]|\[sig-network\]: Conformance tests are defined by the project to guarantee a consistent behaviour and some mandatory features on all clusters
-          #                                  sig-network tests are defined by sig-networkto guarantee a consistent behaviour on all the the k8s network implementations
+          # \[sig-network\]: sig-network tests are defined by sig-network to guarantee a consistent behaviour on all the the k8s network implementations
           # Skipped tests:
           # Disruptive|Serial : require to run in serial and perform disruptive operations on clusters (reboots, ...)
           # Federation|PerformanceDNS : unrelated sig-network tests
@@ -196,7 +195,7 @@ jobs:
           export KUBERNETES_CONFORMANCE_TEST='y'
           export E2E_REPORT_DIR=${PWD}/_artifacts
           /usr/local/bin/ginkgo --nodes=25                \
-            --focus="\[Conformance\]|\[sig-network\]"     \
+            --focus="\[sig-network\]"     \
             --skip="Feature|Federation|PerformanceDNS|DualStack|Disruptive|Serial|KubeProxy|kube-proxy|ExternalIP|LoadBalancer|GCE|Netpol|NetworkPolicy|rejected|externalTrafficPolicy|HostPort|same.port.number.but.different.protocols|should.serve.endpoints.on.same.port.and.different.protocols"   \
             /usr/local/bin/e2e.test                       \
             --                                            \


### PR DESCRIPTION
Partial backport of commit f7315dcf1e86 ("Update k8s kind (network) (conformance) tests") to v1.16.

Before, we ran both the `[sig-network]` and `[Conformance]` tests. But the `[Conformance]` tests include a lot of tests that are not relevant for Cilium, some of which are actually flaky, and take up a lot of CI time.

This commit changes the tests ran to only run the `[sig-network]` tests and no longer all `[Conformance]` tests.

Fixes #40004
