### PR TITLE
cni/connector: Minor cleanups

### DIFF
--- a/pkg/datapath/connector/netkit.go
+++ b/pkg/datapath/connector/netkit.go
@@ -10,32 +10,17 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
-	"github.com/cilium/cilium/pkg/netns"
 )
-
-// SetupNetkitRemoteNs renames the netdevice in the target namespace to the
-// provided dstIfName.
-func SetupNetkitRemoteNs(ns *netns.NetNS, srcIfName, dstIfName string) error {
-	return ns.Do(func() error {
-		err := link.Rename(srcIfName, dstIfName)
-		if err != nil {
-			return fmt.Errorf("failed to rename netkit from %q to %q: %w", srcIfName, dstIfName, err)
-		}
-		return nil
-	})
-}
 
 // SetupNetkit sets up the net interface, the temporary interface and fills up some
 // endpoint fields such as mac, NodeMac, ifIndex and ifName. Returns a pointer for the
 // created netkit, a pointer for the temporary link, the name of the temporary link
 // and error if something fails.
-func SetupNetkit(defaultLogger *slog.Logger, id string, cfg LinkConfig, l2Mode bool, ep *models.EndpointChangeRequest, sysctl sysctl.Sysctl) (*netlink.Netkit, netlink.Link, string, error) {
+func SetupNetkit(defaultLogger *slog.Logger, id string, cfg LinkConfig, l2Mode bool, sysctl sysctl.Sysctl) (*netlink.Netkit, netlink.Link, string, error) {
 	if id == "" {
 		return nil, nil, "", fmt.Errorf("invalid: empty ID")
 	}
@@ -43,14 +28,14 @@ func SetupNetkit(defaultLogger *slog.Logger, id string, cfg LinkConfig, l2Mode b
 	lxcIfName := Endpoint2IfName(id)
 	tmpIfName := Endpoint2TempIfName(id)
 
-	netkit, link, err := SetupNetkitWithNames(defaultLogger, lxcIfName, tmpIfName, cfg, l2Mode, ep, sysctl)
+	netkit, link, err := SetupNetkitWithNames(defaultLogger, lxcIfName, tmpIfName, cfg, l2Mode, sysctl)
 	return netkit, link, tmpIfName, err
 }
 
 // SetupNetkitWithNames sets up the net interface, the peer interface and fills up some
 // endpoint fields such as mac, NodeMac, ifIndex and ifName. Returns a pointer for the
 // created netkit, a pointer for the peer link and error if something fails.
-func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName string, cfg LinkConfig, l2Mode bool, ep *models.EndpointChangeRequest, sysctl sysctl.Sysctl) (*netlink.Netkit, netlink.Link, error) {
+func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName string, cfg LinkConfig, l2Mode bool, sysctl sysctl.Sysctl) (*netlink.Netkit, netlink.Link, error) {
 	logger := defaultLogger.With(logfields.LogSubsys, "endpoint-connector")
 	var epHostMAC, epLXCMAC mac.MAC
 	var err error
@@ -145,11 +130,6 @@ func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName stri
 	if err != nil {
 		return nil, nil, err
 	}
-
-	ep.Mac = peer.Attrs().HardwareAddr.String()
-	ep.HostMac = netkit.Attrs().HardwareAddr.String()
-	ep.InterfaceIndex = int64(netkit.Attrs().Index)
-	ep.InterfaceName = lxcIfName
 
 	return netkit, peer, nil
 }

--- a/pkg/datapath/connector/netkit.go
+++ b/pkg/datapath/connector/netkit.go
@@ -35,7 +35,7 @@ func SetupNetkitRemoteNs(ns *netns.NetNS, srcIfName, dstIfName string) error {
 // endpoint fields such as mac, NodeMac, ifIndex and ifName. Returns a pointer for the
 // created netkit, a pointer for the temporary link, the name of the temporary link
 // and error if something fails.
-func SetupNetkit(defaultLogger *slog.Logger, id string, mtu, groIPv6MaxSize, gsoIPv6MaxSize, groIPv4MaxSize, gsoIPv4MaxSize int, l2Mode bool, ep *models.EndpointChangeRequest, sysctl sysctl.Sysctl) (*netlink.Netkit, netlink.Link, string, error) {
+func SetupNetkit(defaultLogger *slog.Logger, id string, cfg LinkConfig, l2Mode bool, ep *models.EndpointChangeRequest, sysctl sysctl.Sysctl) (*netlink.Netkit, netlink.Link, string, error) {
 	if id == "" {
 		return nil, nil, "", fmt.Errorf("invalid: empty ID")
 	}
@@ -43,15 +43,14 @@ func SetupNetkit(defaultLogger *slog.Logger, id string, mtu, groIPv6MaxSize, gso
 	lxcIfName := Endpoint2IfName(id)
 	tmpIfName := Endpoint2TempIfName(id)
 
-	netkit, link, err := SetupNetkitWithNames(defaultLogger, lxcIfName, tmpIfName, mtu,
-		groIPv6MaxSize, gsoIPv6MaxSize, groIPv4MaxSize, gsoIPv4MaxSize, l2Mode, ep, sysctl)
+	netkit, link, err := SetupNetkitWithNames(defaultLogger, lxcIfName, tmpIfName, cfg, l2Mode, ep, sysctl)
 	return netkit, link, tmpIfName, err
 }
 
 // SetupNetkitWithNames sets up the net interface, the peer interface and fills up some
 // endpoint fields such as mac, NodeMac, ifIndex and ifName. Returns a pointer for the
 // created netkit, a pointer for the peer link and error if something fails.
-func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName string, mtu, groIPv6MaxSize, gsoIPv6MaxSize, groIPv4MaxSize, gsoIPv4MaxSize int, l2Mode bool, ep *models.EndpointChangeRequest, sysctl sysctl.Sysctl) (*netlink.Netkit, netlink.Link, error) {
+func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName string, cfg LinkConfig, l2Mode bool, ep *models.EndpointChangeRequest, sysctl sysctl.Sysctl) (*netlink.Netkit, netlink.Link, error) {
 	logger := defaultLogger.With(logfields.LogSubsys, "endpoint-connector")
 	var epHostMAC, epLXCMAC mac.MAC
 	var err error
@@ -142,70 +141,14 @@ func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName stri
 		)
 	}
 
-	if err = netlink.LinkSetMTU(peer, mtu); err != nil {
-		return nil, nil, fmt.Errorf("unable to set MTU to %q: %w", peerIfName, err)
-	}
-
-	hostNetkit, err := safenetlink.LinkByName(lxcIfName)
+	err = configurePair(netkit, peer, cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to lookup netkit just created: %w", err)
-	}
-
-	if err = netlink.LinkSetMTU(hostNetkit, mtu); err != nil {
-		return nil, nil, fmt.Errorf("unable to set MTU to %q: %w", lxcIfName, err)
-	}
-
-	if err = netlink.LinkSetUp(netkit); err != nil {
-		return nil, nil, fmt.Errorf("unable to bring up netkit pair: %w", err)
-	}
-
-	if groIPv6MaxSize > 0 {
-		if err = netlink.LinkSetGROMaxSize(hostNetkit, groIPv6MaxSize); err != nil {
-			return nil, nil, fmt.Errorf("unable to set GRO max size to %q: %w",
-				lxcIfName, err)
-		}
-		if err = netlink.LinkSetGROMaxSize(peer, groIPv6MaxSize); err != nil {
-			return nil, nil, fmt.Errorf("unable to set GRO max size to %q: %w",
-				peerIfName, err)
-		}
-	}
-
-	if gsoIPv6MaxSize > 0 {
-		if err = netlink.LinkSetGSOMaxSize(hostNetkit, gsoIPv6MaxSize); err != nil {
-			return nil, nil, fmt.Errorf("unable to set GSO max size to %q: %w",
-				lxcIfName, err)
-		}
-		if err = netlink.LinkSetGSOMaxSize(peer, gsoIPv6MaxSize); err != nil {
-			return nil, nil, fmt.Errorf("unable to set GSO max size to %q: %w",
-				peerIfName, err)
-		}
-	}
-
-	if groIPv4MaxSize > 0 {
-		if err = netlink.LinkSetGROIPv4MaxSize(hostNetkit, groIPv4MaxSize); err != nil {
-			return nil, nil, fmt.Errorf("unable to set GRO max size to %q: %w",
-				lxcIfName, err)
-		}
-		if err = netlink.LinkSetGROIPv4MaxSize(peer, groIPv4MaxSize); err != nil {
-			return nil, nil, fmt.Errorf("unable to set GRO max size to %q: %w",
-				peerIfName, err)
-		}
-	}
-
-	if gsoIPv4MaxSize > 0 {
-		if err = netlink.LinkSetGSOIPv4MaxSize(hostNetkit, gsoIPv4MaxSize); err != nil {
-			return nil, nil, fmt.Errorf("unable to set GSO max size to %q: %w",
-				lxcIfName, err)
-		}
-		if err = netlink.LinkSetGSOIPv4MaxSize(peer, gsoIPv4MaxSize); err != nil {
-			return nil, nil, fmt.Errorf("unable to set GSO max size to %q: %w",
-				peerIfName, err)
-		}
+		return nil, nil, err
 	}
 
 	ep.Mac = peer.Attrs().HardwareAddr.String()
-	ep.HostMac = hostNetkit.Attrs().HardwareAddr.String()
-	ep.InterfaceIndex = int64(hostNetkit.Attrs().Index)
+	ep.HostMac = netkit.Attrs().HardwareAddr.String()
+	ep.InterfaceIndex = int64(netkit.Attrs().Index)
 	ep.InterfaceName = lxcIfName
 
 	return netkit, peer, nil

--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -255,11 +255,17 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		return nil, fmt.Errorf("create cilium-health netns: %w", err)
 	}
 
+	linkConfig := connector.LinkConfig{
+		GROIPv6MaxSize: bigTCPConfig.GetGROIPv6MaxSize(),
+		GSOIPv6MaxSize: bigTCPConfig.GetGSOIPv6MaxSize(),
+		GROIPv4MaxSize: bigTCPConfig.GetGROIPv4MaxSize(),
+		GSOIPv4MaxSize: bigTCPConfig.GetGSOIPv4MaxSize(),
+		DeviceMTU:      mtuConfig.GetDeviceMTU(),
+	}
+
 	switch option.Config.DatapathMode {
 	case datapathOption.DatapathModeVeth:
-		_, epLink, err := connector.SetupVethWithNames(h.logger, healthName, epIfaceName, mtuConfig.GetDeviceMTU(),
-			bigTCPConfig.GetGROIPv6MaxSize(), bigTCPConfig.GetGSOIPv6MaxSize(),
-			bigTCPConfig.GetGROIPv4MaxSize(), bigTCPConfig.GetGSOIPv4MaxSize(),
+		_, epLink, err := connector.SetupVethWithNames(h.logger, healthName, epIfaceName, linkConfig,
 			info, sysctl)
 		if err != nil {
 			return nil, fmt.Errorf("Error while creating veth: %w", err)
@@ -269,9 +275,7 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		}
 	case datapathOption.DatapathModeNetkit, datapathOption.DatapathModeNetkitL2:
 		l2Mode := option.Config.DatapathMode == datapathOption.DatapathModeNetkitL2
-		_, epLink, err := connector.SetupNetkitWithNames(h.logger, healthName, epIfaceName, mtuConfig.GetDeviceMTU(),
-			bigTCPConfig.GetGROIPv6MaxSize(), bigTCPConfig.GetGSOIPv6MaxSize(),
-			bigTCPConfig.GetGROIPv4MaxSize(), bigTCPConfig.GetGSOIPv4MaxSize(), l2Mode,
+		_, epLink, err := connector.SetupNetkitWithNames(h.logger, healthName, epIfaceName, linkConfig, l2Mode,
 			info, sysctl)
 		if err != nil {
 			return nil, fmt.Errorf("Error while creating netkit: %w", err)

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -635,12 +635,18 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 			return fmt.Errorf("unable to prepare endpoint configuration: %w", err)
 		}
 
+		linkConfig := connector.LinkConfig{
+			GROIPv6MaxSize: int(conf.GROMaxSize),
+			GSOIPv6MaxSize: int(conf.GSOMaxSize),
+			GROIPv4MaxSize: int(conf.GROIPV4MaxSize),
+			GSOIPv4MaxSize: int(conf.GSOIPV4MaxSize),
+			DeviceMTU:      int(conf.DeviceMTU),
+		}
+
 		switch conf.DatapathMode {
 		case datapathOption.DatapathModeVeth:
 			cniID := ep.ContainerID + ":" + ep.ContainerInterfaceName
-			veth, peer, tmpIfName, err := connector.SetupVeth(scopedLogger, cniID, int(conf.DeviceMTU),
-				int(conf.GROMaxSize), int(conf.GSOMaxSize),
-				int(conf.GROIPV4MaxSize), int(conf.GSOIPV4MaxSize), ep, sysctl)
+			veth, peer, tmpIfName, err := connector.SetupVeth(scopedLogger, cniID, linkConfig, ep, sysctl)
 			if err != nil {
 				return fmt.Errorf("unable to set up veth on host side: %w", err)
 			}
@@ -672,9 +678,7 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 		case datapathOption.DatapathModeNetkit, datapathOption.DatapathModeNetkitL2:
 			l2Mode := conf.DatapathMode == datapathOption.DatapathModeNetkitL2
 			cniID := ep.ContainerID + ":" + ep.ContainerInterfaceName
-			netkit, peer, tmpIfName, err := connector.SetupNetkit(scopedLogger, cniID, int(conf.DeviceMTU),
-				int(conf.GROMaxSize), int(conf.GSOMaxSize),
-				int(conf.GROIPV4MaxSize), int(conf.GSOIPV4MaxSize), l2Mode, ep, sysctl)
+			netkit, peer, tmpIfName, err := connector.SetupNetkit(scopedLogger, cniID, linkConfig, l2Mode, ep, sysctl)
 			if err != nil {
 				return fmt.Errorf("unable to set up netkit on host side: %w", err)
 			}

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -442,7 +442,12 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 			DeviceMTU:      int(driver.conf.DeviceMTU),
 		}
 		var veth *netlink.Veth
-		veth, _, _, err = connector.SetupVeth(driver.logger, create.EndpointID, linkConfig, endpoint, sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"))
+		var peer netlink.Link
+		veth, peer, _, err = connector.SetupVeth(driver.logger, create.EndpointID, linkConfig, sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"))
+		endpoint.Mac = peer.Attrs().HardwareAddr.String()
+		endpoint.HostMac = veth.Attrs().HardwareAddr.String()
+		endpoint.InterfaceIndex = int64(veth.Attrs().Index)
+		endpoint.InterfaceName = veth.Name
 		defer removeLinkOnErr(veth)
 	}
 	if err != nil {

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -434,10 +434,15 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 
 	switch driver.conf.DatapathMode {
 	case datapathOption.DatapathModeVeth:
+		linkConfig := connector.LinkConfig{
+			GROIPv6MaxSize: int(driver.conf.GROMaxSize),
+			GSOIPv6MaxSize: int(driver.conf.GSOMaxSize),
+			GROIPv4MaxSize: int(driver.conf.GROIPV4MaxSize),
+			GSOIPv4MaxSize: int(driver.conf.GSOIPV4MaxSize),
+			DeviceMTU:      int(driver.conf.DeviceMTU),
+		}
 		var veth *netlink.Veth
-		veth, _, _, err = connector.SetupVeth(driver.logger, create.EndpointID, int(driver.conf.DeviceMTU),
-			int(driver.conf.GROMaxSize), int(driver.conf.GSOMaxSize),
-			int(driver.conf.GROIPV4MaxSize), int(driver.conf.GSOIPV4MaxSize), endpoint, sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"))
+		veth, _, _, err = connector.SetupVeth(driver.logger, create.EndpointID, linkConfig, endpoint, sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"))
 		defer removeLinkOnErr(veth)
 	}
 	if err != nil {


### PR DESCRIPTION
This PR does some minor cleanups around the creation of veth/netkit pairs in the CNI plugin. In particular:

- It simplifies the function methods by moving parameters into a struct
- It removes the Cilium API dependency from the connector package 
- It deduplicates shared logic between veth and netkit

Review per commit.