### PR TITLE
lbipam: Fix deletion of multi-block IP pool

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1757,7 +1757,7 @@ func (ipam *LBIPAM) handlePoolDeleted(ctx context.Context, pool *cilium_api_v2.C
 
 	var svsModified []*ServiceView
 	poolRanges, _ := ipam.rangesStore.GetRangesForPool(pool.GetName())
-	for _, poolRange := range poolRanges {
+	for _, poolRange := range slices.Clone(poolRanges) {
 		// Remove allocations from services if the ranges no longer exist
 		ipam.rangesStore.Delete(poolRange)
 		svsModified = append(svsModified, ipam.deleteRangeAllocations(poolRange)...)

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1476,11 +1476,10 @@ func (ipam *LBIPAM) handlePoolModified(ctx context.Context, pool *cilium_api_v2.
 
 		// Remove allocations from services if the ranges no longer exist
 		ipam.rangesStore.Delete(extRange)
-		err := ipam.deleteRangeAllocations(ctx, extRange)
-		if err != nil {
-			return fmt.Errorf("deleteRangeAllocations: %w", err)
-		}
+		ipam.deleteRangeAllocations(extRange)
 	}
+	// no need to reconcile services now after ranges deletion, we are gonna reconcile
+	// them later in revalidateAllServices after inserting the new ranges.
 
 	// Add new ranges that were added
 	for _, newRange := range newRanges {
@@ -1677,9 +1676,9 @@ func (ipam *LBIPAM) setPoolCondition(
 	return true
 }
 
-// deleteRangeAllocations removes allocations from
-func (ipam *LBIPAM) deleteRangeAllocations(ctx context.Context, delRange *LBRange) error {
-	delAllocs := func(sv *ServiceView) error {
+// deleteRangeAllocations removes allocations from services
+func (ipam *LBIPAM) deleteRangeAllocations(delRange *LBRange) []*ServiceView {
+	delAllocs := func(sv *ServiceView) bool {
 		svModified := false
 		for i := len(sv.AllocatedIPs) - 1; i >= 0; i-- {
 			alloc := sv.AllocatedIPs[i]
@@ -1690,15 +1689,39 @@ func (ipam *LBIPAM) deleteRangeAllocations(ctx context.Context, delRange *LBRang
 			}
 		}
 
-		if !svModified {
-			return nil
-		}
+		return svModified
+	}
 
+	var svsModified []*ServiceView
+	for _, sv := range ipam.serviceStore.unsatisfied {
+		if modified := delAllocs(sv); modified {
+			svsModified = append(svsModified, sv)
+		}
+	}
+	for _, sv := range ipam.serviceStore.satisfied {
+		if modified := delAllocs(sv); modified {
+			svsModified = append(svsModified, sv)
+		}
+	}
+
+	return svsModified
+}
+
+// reconcileServicesAfterRangeDeletion upsert services that have been modified after a call
+// to deleteRangeAllocations, that is, all services from which an allocated IP has been removed
+// after the ranges deletion.
+// Before upserting the new status, reconcileServicesAfterRangeDeletion checks if the service
+// needs to be satisfied with a new allocation and in that case it tries to do so before the
+// upsertion. This is done in order to avoid multiple updates in a row.
+func (ipam *LBIPAM) reconcileServicesAfterRangeDeletion(ctx context.Context, svcViews ...*ServiceView) error {
+	var errs []error
+	for _, sv := range svcViews {
 		// Check for each ingress, if its IP has been allocated by us. If it isn't check if we can allocate that IP.
 		// If we can't, strip the ingress from the service.
 		svModifiedStatus, err := ipam.stripOrImportIngresses(sv)
 		if err != nil {
-			return fmt.Errorf("stripOrImportIngresses: %w", err)
+			errs = append(errs, fmt.Errorf("stripOrImportIngresses: %w", err))
+			continue
 		}
 
 		// Attempt to satisfy this service in particular now. We do this now instead of relying on
@@ -1706,7 +1729,8 @@ func (ipam *LBIPAM) deleteRangeAllocations(ctx context.Context, delRange *LBRang
 		if !sv.isSatisfied() {
 			statusModified, err := ipam.satisfyService(sv)
 			if err != nil {
-				return fmt.Errorf("satisfyService: %w", err)
+				errs = append(errs, fmt.Errorf("satisfyService: %w", err))
+				continue
 			}
 			if statusModified {
 				svModifiedStatus = true
@@ -1717,45 +1741,34 @@ func (ipam *LBIPAM) deleteRangeAllocations(ctx context.Context, delRange *LBRang
 		if svModifiedStatus {
 			err := ipam.patchSvcStatus(ctx, sv)
 			if err != nil {
-				return fmt.Errorf("patchSvcStatus: %w", err)
+				errs = append(errs, fmt.Errorf("patchSvcStatus: %w", err))
+				continue
 			}
 		}
 
 		ipam.serviceStore.Upsert(sv)
-
-		return nil
 	}
-	for _, sv := range ipam.serviceStore.unsatisfied {
-		if err := delAllocs(sv); err != nil {
-			return fmt.Errorf("delAllocs: %w", err)
-		}
-	}
-	for _, sv := range ipam.serviceStore.satisfied {
-		if err := delAllocs(sv); err != nil {
-			return fmt.Errorf("delAllocs: %w", err)
-		}
-	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 func (ipam *LBIPAM) handlePoolDeleted(ctx context.Context, pool *cilium_api_v2.CiliumLoadBalancerIPPool) error {
-	delete(ipam.pools, pool.GetName())
-
 	ipam.metrics.AvailableIPs.DeleteLabelValues(pool.Name)
 	ipam.metrics.UsedIPs.DeleteLabelValues(pool.Name)
 
+	var svsModified []*ServiceView
 	poolRanges, _ := ipam.rangesStore.GetRangesForPool(pool.GetName())
 	for _, poolRange := range poolRanges {
 		// Remove allocations from services if the ranges no longer exist
 		ipam.rangesStore.Delete(poolRange)
-		err := ipam.deleteRangeAllocations(ctx, poolRange)
-		if err != nil {
-			return fmt.Errorf("deleteRangeAllocations: %w", err)
-		}
+		svsModified = append(svsModified, ipam.deleteRangeAllocations(poolRange)...)
 	}
 
-	return nil
+	// delete the pool so that the subsequent reconciliation sees
+	// an updated view of the available pools
+	delete(ipam.pools, pool.GetName())
+
+	// reconcile modified services
+	return ipam.reconcileServicesAfterRangeDeletion(ctx, svsModified...)
 }
 
 func isPoolConflicting(pool *cilium_api_v2.CiliumLoadBalancerIPPool) bool {

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -1776,8 +1776,8 @@ func TestDisablePool(t *testing.T) {
 // TestPoolDelete tests that when a pool is deleted, all of the IPs from that pool are released and that any effected
 // services get a new IP from another pool.
 func TestPoolDelete(t *testing.T) {
-	poolA := mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"})
-	poolB := mkPool(poolBUID, "pool-b", []string{"10.0.20.0/24"})
+	poolA := mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24", "10.1.10.0/24"})
+	poolB := mkPool(poolBUID, "pool-b", []string{"10.0.20.0/24", "10.1.20.0/24"})
 
 	fixture := mkTestFixture(t, true, true)
 	fixture.UpsertPool(t, poolA)
@@ -1800,8 +1800,10 @@ func TestPoolDelete(t *testing.T) {
 		t.Error("Expected service to receive exactly one ingress IP")
 	}
 
+	svcAddr := svcA.Status.LoadBalancer.Ingress[0].IP
+
 	var allocPool string
-	if strings.HasPrefix(svcA.Status.LoadBalancer.Ingress[0].IP, "10.0.10") {
+	if strings.HasPrefix(svcAddr, "10.0.10") || strings.HasPrefix(svcAddr, "10.1.10") {
 		allocPool = "pool-a"
 	} else {
 		allocPool = "pool-b"


### PR DESCRIPTION
Currently, the operator panics when a multi blocks CiliumLoadBalancerIPPool is deleted. To reproduce it, just run Cilium in a local kind cluster and apply and delete the following pool:

```yaml
apiVersion: "cilium.io/v2alpha1"
kind: CiliumLoadBalancerIPPool
metadata:
  name: "ip-pool-blue"
spec:
  blocks:
  - cidr: 192.0.2.96/32
  - cidr: 2001:DB8:0:700::/124
  - cidr: 10.112.182.48/28
  - cidr: 2001:DB8:0:400::/128
  serviceSelector:
    matchExpressions:
      - {key: color, operator: In, values: [blue]}
```

The PR fixes the LBIPAM reconciliation following a deletion of a CiliumLoadBalancerIPPool with multiple IP blocks. To do so, rewrite the reconciliation to:

1) delete all the blocks first, then the pool in the LBIPAM internal status
2) reconcile all modified services
3) avoid removing items from the pool ranges slice when iterating on it

Please review commit by commit

```release-note
LBIPAM: Fix deletion of CiliumLoadBalancerIPPool with multiple IP blocks that led to an operator crash
```
