### PR TITLE
Rename --enable-ipv4-egress-gateway flag to --enable-egress-gateway

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -121,6 +121,7 @@ cilium-agent [flags]
       --enable-drift-checker                                      Enables support for config drift checker (default true)
       --enable-dynamic-config                                     Enables support for dynamic agent config (default true)
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
+      --enable-egress-gateway                                     Enable egress gateway
       --enable-encryption-strict-mode                             Enable encryption strict mode
       --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-lockdown-on-policy-overflow               When an endpoint's policy map overflows, shutdown all (ingress and egress) network traffic for that endpoint.
@@ -144,7 +145,6 @@ cilium-agent [flags]
       --enable-ipsec-key-watcher                                  Enable watcher for IPsec key. If disabled, a restart of the agent will be necessary on key rotations. (default true)
       --enable-ipv4                                               Enable IPv4 support (default true)
       --enable-ipv4-big-tcp                                       Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4
-      --enable-ipv4-egress-gateway                                Enable egress gateway for IPv4
       --enable-ipv4-fragment-tracking                             Enable IPv4 fragments tracking for L4-based lookups (default true)
       --enable-ipv4-masquerade                                    Masquerade IPv4 traffic from endpoints leaving the host (default true)
       --enable-ipv6                                               Enable IPv6 support (default true)

--- a/Documentation/network/egress-gateway/egress-gateway.rst
+++ b/Documentation/network/egress-gateway/egress-gateway.rst
@@ -101,7 +101,7 @@ The egress gateway feature and all the requirements can be enabled as follow:
         .. code-block:: yaml
 
             enable-bpf-masquerade: true
-            enable-ipv4-egress-gateway: true
+            enable-egress-gateway: true
             kube-proxy-replacement: true
 
 Rollout both the agent pods and the operator pods to make the changes effective:

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -373,6 +373,8 @@ Deprecated Options
 * The flag ``--egress-multi-home-ip-rule-compat`` and the old IP rule scheme has been deprecated and will be removed
   in Cilium 1.19. Running Cilium 1.18 with the flag set to ``false`` (default value) will migrate any existing IP rules
   to the new scheme.
+* The flag ``--enable-ipv4-egress-gateway`` has been deprecated in favor of ``--enable-egress-gateway`` and will
+  be removed in Cilium 1.19.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -101,7 +101,7 @@ const (
 
 	IngressController Feature = "ingress-controller"
 
-	EgressGateway Feature = "enable-ipv4-egress-gateway"
+	EgressGateway Feature = "enable-egress-gateway"
 	GatewayAPI    Feature = "enable-gateway-api"
 
 	EnableEnvoyConfig Feature = "enable-envoy-config"
@@ -348,7 +348,7 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 	}
 
 	fs[EgressGateway] = Status{
-		Enabled: cm.Data["enable-ipv4-egress-gateway"] == "true",
+		Enabled: cm.Data[string(EgressGateway)] == "true" || cm.Data["enable-ipv4-egress-gateway"] == "true",
 	}
 
 	fs[CIDRMatchNodes] = Status{

--- a/cilium-cli/utils/features/features_test.go
+++ b/cilium-cli/utils/features/features_test.go
@@ -127,7 +127,7 @@ func TestFeatureSet_extractFromConfigMap(t *testing.T) {
 		"enable-ipv4":                  "true",
 		"enable-ipv6":                  "true",
 		"mesh-auth-mutual-enabled":     "true",
-		"enable-ipv4-egress-gateway":   "true",
+		"enable-egress-gateway":        "true",
 		"ipam":                         "eni",
 		"enable-ipsec":                 "true",
 		"enable-local-redirect-policy": "true",

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -638,7 +638,11 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.EnableIPMasqAgent)
 
 	flags.Bool(option.EnableIPv4EgressGateway, false, "Enable egress gateway for IPv4")
+	flags.MarkDeprecated(option.EnableIPv4EgressGateway, "Use --enable-egress-gateway instead")
 	option.BindEnv(vp, option.EnableIPv4EgressGateway)
+
+	flags.Bool(option.EnableEgressGateway, false, "Enable egress gateway")
+	option.BindEnv(vp, option.EnableEgressGateway)
 
 	flags.Bool(option.EnableEnvoyConfig, false, "Enable Envoy Config CRDs")
 	option.BindEnv(vp, option.EnableEnvoyConfig)

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1143,7 +1143,7 @@ data:
 {{- end }}
 
 {{- if .Values.egressGateway.enabled }}
-  enable-ipv4-egress-gateway: "true"
+  enable-egress-gateway: "true"
 {{- end }}
 {{- if hasKey .Values.egressGateway "reconciliationTriggerInterval" }}
   egress-gateway-reconciliation-trigger-interval: {{ .Values.egressGateway.reconciliationTriggerInterval | quote }}

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -71,6 +71,10 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableIPv4EgressGateway)
 	option.BindEnv(vp, option.EnableIPv4EgressGateway)
 
+	flags.Bool(option.EnableEgressGateway, false, "")
+	flags.MarkHidden(option.EnableEgressGateway)
+	option.BindEnv(vp, option.EnableEgressGateway)
+
 	flags.Bool(option.EnableLocalRedirectPolicy, false, "")
 	flags.MarkHidden(option.EnableLocalRedirectPolicy)
 	option.BindEnv(vp, option.EnableLocalRedirectPolicy)

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -181,8 +181,7 @@ func NewEgressGatewayManager(p Params) (out struct {
 }, err error) {
 	dcfg := p.DaemonConfig
 
-	// TODO: deprecate --enable-ipv4-egress-gateway, create new --enable-egress-gateway
-	if !dcfg.EnableIPv4EgressGateway {
+	if !dcfg.EnableEgressGateway {
 		return out, nil
 	}
 
@@ -198,6 +197,10 @@ func NewEgressGatewayManager(p Params) (out struct {
 	// We need to make sure that ipv4/v6 only environments only create the necessary resources and don't fail if unneeded features are missing.
 	if !dcfg.EnableIPv4Masquerade || !dcfg.EnableBPFMasquerade {
 		return out, fmt.Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
+	}
+
+	if !dcfg.EnableIPv6Masquerade {
+		p.Logger.Info(fmt.Sprintf("egress gateway ipv6 policies require --%s=\"true\"", option.EnableIPv6Masquerade))
 	}
 
 	out.Manager, err = newEgressGatewayManager(p)

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -66,7 +66,7 @@ func agentCRDResourceNames() []string {
 		result = append(result, CRDResourceName(v2.CCGName))
 	}
 
-	if option.Config.EnableIPv4EgressGateway {
+	if option.Config.EnableEgressGateway {
 		result = append(result, CRDResourceName(v2.CEGPName))
 	}
 	if option.Config.EnableLocalRedirectPolicy {

--- a/pkg/maps/egressmap/policy.go
+++ b/pkg/maps/egressmap/policy.go
@@ -106,7 +106,7 @@ func createPolicyMapFromDaemonConfig(in struct {
 		"EGRESS_POLICY_MAP_SIZE": fmt.Sprint(in.EgressGatewayPolicyMapMax),
 	}
 
-	if !in.EnableIPv4EgressGateway {
+	if !in.EnableEgressGateway {
 		return
 	}
 

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -1030,7 +1030,7 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 		m.ACLBBGPEnabled.Add(1)
 	}
 
-	if config.EnableIPv4EgressGateway {
+	if config.EnableEgressGateway {
 		m.ACLBEgressGatewayEnabled.Add(1)
 	}
 

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -952,12 +952,12 @@ func TestUpdateIPv4EgressGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
-				IPAM:                    defaultIPAMModes[0],
-				EnableIPv4:              true,
-				IdentityAllocationMode:  defaultIdentityAllocationModes[0],
-				DatapathMode:            defaultDeviceModes[0],
-				NodePortAcceleration:    defaultNodePortModeAccelerations[0],
-				EnableIPv4EgressGateway: tt.enableEGW,
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+				EnableEgressGateway:    tt.enableEGW,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -337,6 +337,9 @@ const (
 	// EnableIPv4EgressGateway enables the IPv4 egress gateway
 	EnableIPv4EgressGateway = "enable-ipv4-egress-gateway"
 
+	// EnableEgressGateway enables the egress gateway
+	EnableEgressGateway = "enable-egress-gateway"
+
 	// EnableEnvoyConfig enables processing of CiliumClusterwideEnvoyConfig and CiliumEnvoyConfig CRDs
 	EnableEnvoyConfig = "enable-envoy-config"
 
@@ -1572,19 +1575,19 @@ type DaemonConfig struct {
 	EnableIPMasqAgent           bool
 	IPMasqAgentConfigPath       string
 
-	EnableBPFClockProbe     bool
-	EnableIPv4EgressGateway bool
-	EnableEnvoyConfig       bool
-	InstallIptRules         bool
-	MonitorAggregation      string
-	PreAllocateMaps         bool
-	IPv6NodeAddr            string
-	IPv4NodeAddr            string
-	SocketPath              string
-	TracePayloadlen         int
-	Version                 string
-	PrometheusServeAddr     string
-	ToFQDNsMinTTL           int
+	EnableBPFClockProbe bool
+	EnableEgressGateway bool
+	EnableEnvoyConfig   bool
+	InstallIptRules     bool
+	MonitorAggregation  string
+	PreAllocateMaps     bool
+	IPv6NodeAddr        string
+	IPv4NodeAddr        string
+	SocketPath          string
+	TracePayloadlen     int
+	Version             string
+	PrometheusServeAddr string
+	ToFQDNsMinTTL       int
 
 	// DNSMaxIPsPerRestoredRule defines the maximum number of IPs to maintain
 	// for each FQDN selector in endpoint's restored DNS rules
@@ -2781,7 +2784,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.LocalRouterIPv6 = vp.GetString(LocalRouterIPv6)
 	c.EnableBPFClockProbe = vp.GetBool(EnableBPFClockProbe)
 	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
-	c.EnableIPv4EgressGateway = vp.GetBool(EnableIPv4EgressGateway)
+	c.EnableEgressGateway = vp.GetBool(EnableEgressGateway) || vp.GetBool(EnableIPv4EgressGateway)
 	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)
 	c.IPMasqAgentConfigPath = vp.GetString(IPMasqAgentConfigPath)
 	c.AgentHealthRequireK8sConnectivity = vp.GetBool(AgentHealthRequireK8sConnectivity)


### PR DESCRIPTION
This commit renames the feature flag from `enable-ipv4-egress-gateway` to `enable-egress-gateway` and updates the necessary documentation and upgade guide.

Fixes: #38957
