### PR TITLE
Add allocator and datapath plumbing for cookie-based policy logging

### DIFF
--- a/Documentation/cmdref/cilium-dbg_bpf_policy_add.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_policy_add.md
@@ -11,8 +11,9 @@ cilium-dbg bpf policy add <endpoint id> <traffic-direction> <identity> [port/pro
 ### Options
 
 ```
-      --deny   Sets deny mode
-  -h, --help   help for add
+      --cookie uint32   Sets policy log cookie
+      --deny            Sets deny mode
+  -h, --help            help for add
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_bpf_policy_delete.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_policy_delete.md
@@ -11,7 +11,6 @@ cilium-dbg bpf policy delete <endpoint id> <identity> [port/proto] [flags]
 ### Options
 
 ```
-      --deny   Sets deny mode
   -h, --help   help for delete
 ```
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -509,6 +509,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	__u8 audited = 0;
 	__u8 auth_type = 0;
 	__u16 proxy_port = 0;
+	__u32 cookie = 0;
 	bool from_l7lb = false;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
@@ -584,7 +585,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		 */
 		verdict = policy_can_egress6(ctx, tuple, l4_off, SECLABEL_IPV6,
 					     *dst_sec_identity, &policy_match_type, &audited,
-					     ext_err, &proxy_port);
+					     ext_err, &proxy_port, &cookie);
 
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 			__u32 tunnel_endpoint = 0;
@@ -602,7 +603,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 						   tuple->nexthdr, POLICY_EGRESS, 1,
 						   verdict, proxy_port,
 						   policy_match_type, audited,
-						   auth_type);
+						   auth_type, cookie);
 		}
 
 		if (verdict != CTX_ACT_OK)
@@ -956,6 +957,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	__u8 auth_type = 0;
 	enum ct_status ct_status;
 	__u16 proxy_port = 0;
+	__u32 cookie = 0;
 	bool from_l7lb = false;
 	__u32 cluster_id = 0;
 	void *ct_map, *ct_related_map = NULL;
@@ -1028,7 +1030,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		 */
 		verdict = policy_can_egress4(ctx, tuple, l4_off, SECLABEL_IPV4,
 					     *dst_sec_identity, &policy_match_type, &audited,
-					     ext_err, &proxy_port);
+					     ext_err, &proxy_port, &cookie);
 
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 			__u32 tunnel_endpoint = 0;
@@ -1046,7 +1048,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 						   tuple->nexthdr, POLICY_EGRESS, 0,
 						   verdict, proxy_port,
 						   policy_match_type, audited,
-						   auth_type);
+						   auth_type, cookie);
 		}
 
 		if (verdict != CTX_ACT_OK) {
@@ -1616,6 +1618,7 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 	__u8 audited = 0;
 	__u8 auth_type = 0;
 	__maybe_unused union v6addr loopback_addr;
+	__u32 cookie = 0;
 
 	fraginfo = ipv6_get_fraginfo(ctx, ip6);
 	if (fraginfo < 0)
@@ -1698,7 +1701,8 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 
 		verdict = policy_can_ingress6(ctx, tuple, l4_off,
 					      is_untracked_fragment, src_label, SECLABEL_IPV6,
-					      &policy_match_type, &audited, ext_err, proxy_port);
+					      &policy_match_type, &audited, ext_err, proxy_port,
+					      &cookie);
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 			struct remote_endpoint_info *sep = lookup_ip6_remote_endpoint(&orig_sip, 0);
 
@@ -1714,7 +1718,7 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 			send_policy_verdict_notify(ctx, src_label, tuple->dport,
 						   tuple->nexthdr, POLICY_INGRESS, 1,
 						   verdict, *proxy_port, policy_match_type, audited,
-						   auth_type);
+						   auth_type, cookie);
 
 		if (verdict != CTX_ACT_OK)
 			return verdict;
@@ -1949,6 +1953,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 	__u8 audited = 0;
 	__u8 auth_type = 0;
+	__u32 cookie = 0;
 	__u32 zero = 0;
 
 	fraginfo = ipfrag_encode_ipv4(ip4);
@@ -2038,7 +2043,8 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 
 		verdict = policy_can_ingress4(ctx, tuple, l4_off,
 					      is_untracked_fragment, src_label, SECLABEL_IPV4,
-					      &policy_match_type, &audited, ext_err, proxy_port);
+					      &policy_match_type, &audited, ext_err, proxy_port,
+					      &cookie);
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 			struct remote_endpoint_info *sep = lookup_ip4_remote_endpoint(orig_sip, 0);
 
@@ -2053,7 +2059,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 			send_policy_verdict_notify(ctx, src_label, tuple->dport,
 						   tuple->nexthdr, POLICY_INGRESS, 0,
 						   verdict, *proxy_port, policy_match_type, audited,
-						   auth_type);
+						   auth_type, cookie);
 
 		if (verdict != CTX_ACT_OK)
 			return verdict;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -344,7 +344,8 @@ struct policy_entry {
 			has_explicit_auth_type:1;
 	__u8		proxy_port_priority;
 	__u8		pad1;
-	__u16	        pad2;
+	__u16		pad2;
+	__u32		cookie;
 };
 
 /*

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -63,6 +63,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	__u8 auth_type = 0;
 	__u32 dst_sec_identity = 0;
 	__u16 proxy_port = 0;
+	__u32 cookie = 0;
 
 	trace->monitor = ct_buffer->monitor;
 	trace->reason = (enum trace_reason)ret;
@@ -87,7 +88,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		/* Perform policy lookup. */
 		verdict = policy_can_egress6(ctx, tuple, ct_buffer->l4_off, HOST_ID,
 					     dst_sec_identity, &policy_match_type,
-					     &audited, ext_err, &proxy_port);
+					     &audited, ext_err, &proxy_port, &cookie);
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 			auth_type = (__u8)*ext_err;
 			verdict = auth_lookup(ctx, HOST_ID, dst_sec_identity,
@@ -120,7 +121,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 			send_policy_verdict_notify(ctx, dst_sec_identity, tuple->dport,
 						   tuple->nexthdr, POLICY_EGRESS, 1,
 						   verdict, proxy_port, policy_match_type, audited,
-						   auth_type);
+						   auth_type, cookie);
 
 		if (proxy_port > 0 && (ret == CT_NEW || ret == CT_ESTABLISHED)) {
 			/* Trace the packet before it is forwarded to proxy */
@@ -202,6 +203,7 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	fraginfo_t fraginfo __maybe_unused;
 	bool is_untracked_fragment = false;
 	__u16 proxy_port = 0;
+	__u32 cookie = 0;
 
 	trace->monitor = ct_buffer->monitor;
 	trace->reason = (enum trace_reason)ret;
@@ -232,7 +234,8 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	/* Perform policy lookup */
 	verdict = policy_can_ingress6(ctx, tuple, ct_buffer->l4_off,
 				      is_untracked_fragment, *src_sec_identity, HOST_ID,
-				      &policy_match_type, &audited, ext_err, &proxy_port);
+				      &policy_match_type, &audited, ext_err, &proxy_port,
+				      &cookie);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
 		verdict = auth_lookup(ctx, HOST_ID, *src_sec_identity, tunnel_endpoint, auth_type);
@@ -263,7 +266,7 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		send_policy_verdict_notify(ctx, *src_sec_identity, tuple->dport,
 					   tuple->nexthdr, POLICY_INGRESS, 1,
 					   verdict, proxy_port, policy_match_type, audited,
-					   auth_type);
+					   auth_type, cookie);
 out:
 	/* This change is necessary for packets redirected from the lxc device to
 	 * the host device.
@@ -332,6 +335,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	__u8 auth_type = 0;
 	__u32 dst_sec_identity = 0;
 	__u16 proxy_port = 0;
+	__u32 cookie = 0;
 
 	trace->monitor = ct_buffer->monitor;
 	trace->reason = (enum trace_reason)ret;
@@ -369,7 +373,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		/* Perform policy lookup. */
 		verdict = policy_can_egress4(ctx, tuple, ct_buffer->l4_off, HOST_ID,
 					     dst_sec_identity, &policy_match_type,
-					     &audited, ext_err, &proxy_port);
+					     &audited, ext_err, &proxy_port, &cookie);
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 			auth_type = (__u8)*ext_err;
 			verdict = auth_lookup(ctx, HOST_ID, dst_sec_identity,
@@ -402,7 +406,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 			send_policy_verdict_notify(ctx, dst_sec_identity, tuple->dport,
 						   tuple->nexthdr, POLICY_EGRESS, 0,
 						   verdict, proxy_port, policy_match_type, audited,
-						   auth_type);
+						   auth_type, cookie);
 
 		if (proxy_port > 0 && (ret == CT_NEW || ret == CT_ESTABLISHED)) {
 			/* Trace the packet before it is forwarded to proxy */
@@ -478,6 +482,7 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 	fraginfo_t fraginfo __maybe_unused;
 	bool is_untracked_fragment = false;
 	__u16 proxy_port = 0;
+	__u32 cookie = 0;
 
 	trace->monitor = ct_buffer->monitor;
 	trace->reason = (enum trace_reason)ret;
@@ -506,7 +511,8 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 	/* Perform policy lookup */
 	verdict = policy_can_ingress4(ctx, tuple, ct_buffer->l4_off,
 				      is_untracked_fragment, *src_sec_identity, HOST_ID,
-				      &policy_match_type, &audited, ext_err, &proxy_port);
+				      &policy_match_type, &audited, ext_err, &proxy_port,
+				      &cookie);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
 		verdict = auth_lookup(ctx, HOST_ID, *src_sec_identity, tunnel_endpoint, auth_type);
@@ -537,7 +543,7 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 		send_policy_verdict_notify(ctx, *src_sec_identity, tuple->dport,
 					   tuple->nexthdr, POLICY_INGRESS, 0,
 					   verdict, proxy_port, policy_match_type, audited,
-					   auth_type);
+					   auth_type, cookie);
 out:
 	/* This change is necessary for packets redirected from the lxc device to
 	 * the host device.

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -78,13 +78,15 @@ struct {
 
 static __always_inline int
 __policy_check(struct policy_entry *policy, const struct policy_entry *policy2, __s8 *ext_err,
-	       __u16 *proxy_port)
+	       __u16 *proxy_port, __u32 *cookie)
 {
 	/* auth_type is derived from the matched policy entry, except if both L3/L4 and L4-only
 	 * match, and the chosen policy has no explicit auth type: in this case the auth type is
 	 * derived from the less specific policy entry.
 	 */
 	__u8 auth_type;
+
+	*cookie = policy->cookie;
 
 	if (unlikely(policy->deny))
 		return DROP_POLICY_DENY;
@@ -125,7 +127,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		    __u32 remote_id, __u16 ethertype __maybe_unused, __be16 dport,
 		    __u8 proto, int off __maybe_unused, int dir,
 		    bool is_untracked_fragment, __u8 *match_type, __s8 *ext_err,
-		    __u16 *proxy_port)
+		    __u16 *proxy_port, __u32 *cookie)
 {
 	struct policy_entry *policy;
 	struct policy_entry *l4policy;
@@ -236,7 +238,7 @@ check_policy:
 		p_len > LPM_PROTO_PREFIX_BITS ? POLICY_MATCH_L3_L4 :	/* 1. id/proto/port */
 		p_len > 0 ? POLICY_MATCH_L3_PROTO :			/* 3. id/proto/ANY */
 		POLICY_MATCH_L3_ONLY;					/* 5. id/ANY/ANY */
-	return __policy_check(policy, l4policy, ext_err, proxy_port);
+	return __policy_check(policy, l4policy, ext_err, proxy_port, cookie);
 
 check_l4_policy:
 	p_len = l4policy->lpm_prefix_length;
@@ -247,7 +249,7 @@ check_l4_policy:
 		p_len == 0 ? POLICY_MATCH_ALL :					/* 6. ANY/ANY/ANY */
 		p_len <= LPM_PROTO_PREFIX_BITS ? POLICY_MATCH_PROTO_ONLY :	/* 4. ANY/proto/ANY */
 		POLICY_MATCH_L4_ONLY;						/* 2. ANY/proto/port */
-	return __policy_check(l4policy, policy, ext_err, proxy_port);
+	return __policy_check(l4policy, policy, ext_err, proxy_port, cookie);
 }
 
 static __always_inline int
@@ -255,12 +257,12 @@ policy_can_access(struct __ctx_buff *ctx, __u32 local_id,
 		  __u32 remote_id, __u16 ethertype __maybe_unused, __be16 dport,
 		  __u8 proto, int off __maybe_unused, int dir,
 		  bool is_untracked_fragment, __u8 *match_type, __s8 *ext_err,
-		  __u16 *proxy_port)
+		  __u16 *proxy_port, __u32 *cookie)
 {
 	return __policy_can_access(&cilium_policy_v2, ctx, local_id, remote_id,
 				   ethertype, dport, proto, off, dir,
 				   is_untracked_fragment, match_type, ext_err,
-				   proxy_port);
+				   proxy_port, cookie);
 }
 
 /**
@@ -276,6 +278,8 @@ policy_can_access(struct __ctx_buff *ctx, __u32 local_id,
  *				AND IPv4 fragment tracking is disabled
  * @arg match_type		Pointer to store layers used for policy match
  * @arg ext_err		Pointer to store extended error information if this packet isn't allowed
+ * @arg proxy_port	Pointer to store port for proxy redirect
+ * @arg cookie		Pointer to store policy log cookie, if any
  *
  * Returns:
  *   - Positive integer indicating the proxy_port to handle this traffic
@@ -286,13 +290,13 @@ static __always_inline int
 policy_can_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 		   __u16 ethertype, __be16 dport, __u8 proto, int l4_off,
 		   bool is_untracked_fragment, __u8 *match_type, __u8 *audited,
-		   __s8 *ext_err, __u16 *proxy_port)
+		   __s8 *ext_err, __u16 *proxy_port, __u32 *cookie)
 {
 	int ret;
 
 	ret = policy_can_access(ctx, dst_id, src_id, ethertype, dport,
 				proto, l4_off, CT_INGRESS, is_untracked_fragment,
-				match_type, ext_err, proxy_port);
+				match_type, ext_err, proxy_port, cookie);
 	if (ret >= CTX_ACT_OK)
 		return ret;
 
@@ -314,11 +318,12 @@ static __always_inline int policy_can_ingress6(struct __ctx_buff *ctx,
 					       int l4_off, bool is_untracked_fragment,
 					       __u32 src_id, __u32 dst_id,
 					       __u8 *match_type, __u8 *audited,
-					       __s8 *ext_err, __u16 *proxy_port)
+					       __s8 *ext_err, __u16 *proxy_port,
+					       __u32 *cookie)
 {
 	return policy_can_ingress(ctx, src_id, dst_id, ETH_P_IPV6, tuple->dport,
 				 tuple->nexthdr, l4_off, is_untracked_fragment,
-				 match_type, audited, ext_err, proxy_port);
+				 match_type, audited, ext_err, proxy_port, cookie);
 }
 
 static __always_inline int policy_can_ingress4(struct __ctx_buff *ctx,
@@ -326,11 +331,12 @@ static __always_inline int policy_can_ingress4(struct __ctx_buff *ctx,
 					       int l4_off, bool is_untracked_fragment,
 					       __u32 src_id, __u32 dst_id,
 					       __u8 *match_type, __u8 *audited,
-					       __s8 *ext_err, __u16 *proxy_port)
+					       __s8 *ext_err, __u16 *proxy_port,
+					       __u32 *cookie)
 {
 	return policy_can_ingress(ctx, src_id, dst_id, ETH_P_IP, tuple->dport,
 				 tuple->nexthdr, l4_off, is_untracked_fragment,
-				 match_type, audited, ext_err, proxy_port);
+				 match_type, audited, ext_err, proxy_port, cookie);
 }
 
 #ifdef HAVE_ENCAP
@@ -343,7 +349,7 @@ static __always_inline bool is_encap(__be16 dport, __u8 proto)
 static __always_inline int
 policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 		  __u16 ethertype, __be16 dport, __u8 proto, int l4_off, __u8 *match_type,
-		  __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
+		  __u8 *audited, __s8 *ext_err, __u16 *proxy_port, __u32 *cookie)
 {
 	int ret;
 
@@ -353,7 +359,7 @@ policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 #endif
 	ret = policy_can_access(ctx, src_id, dst_id, ethertype, dport,
 				proto, l4_off, CT_EGRESS, false, match_type,
-				ext_err, proxy_port);
+				ext_err, proxy_port, cookie);
 	if (ret >= 0)
 		return ret;
 	cilium_dbg(ctx, DBG_POLICY_DENIED, src_id, dst_id);
@@ -371,20 +377,20 @@ static __always_inline int policy_can_egress6(struct __ctx_buff *ctx,
 					      const struct ipv6_ct_tuple *tuple,
 					      int l4_off, __u32 src_id, __u32 dst_id,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,
-					      __u16 *proxy_port)
+					      __u16 *proxy_port, __u32 *cookie)
 {
 	return policy_can_egress(ctx, src_id, dst_id, ETH_P_IPV6, tuple->dport,
 				 tuple->nexthdr, l4_off, match_type, audited,
-				 ext_err, proxy_port);
+				 ext_err, proxy_port, cookie);
 }
 
 static __always_inline int policy_can_egress4(struct __ctx_buff *ctx,
 					      const struct ipv4_ct_tuple *tuple,
 					      int l4_off, __u32 src_id, __u32 dst_id,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,
-					      __u16 *proxy_port)
+					      __u16 *proxy_port, __u32 *cookie)
 {
 	return policy_can_egress(ctx, src_id, dst_id, ETH_P_IP, tuple->dport,
 				 tuple->nexthdr, l4_off, match_type, audited,
-				 ext_err, proxy_port);
+				 ext_err, proxy_port, cookie);
 }

--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -32,8 +32,9 @@ struct policy_verdict_notify {
 		audited:1,
 		pad0:1;
 	__u8	auth_type;
-	__u8	pad1; /* align with 64 bits */
-	__u16	pad2; /* align with 64 bits */
+	__u8	pad1[3]; /* align with 64 bits */
+	__u32	cookie;
+	__u32	pad2; /* align with 64 bits */
 };
 
 #ifdef POLICY_VERDICT_NOTIFY
@@ -50,7 +51,7 @@ static __always_inline bool policy_verdict_filter_allow(__u32 filter, __u8 dir)
 static __always_inline void
 send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst_port,
 			   __u8 proto, __u8 dir, __u8 is_ipv6, int verdict, __u16 proxy_port,
-			   __u8 match_type, __u8 is_audited, __u8 auth_type)
+			   __u8 match_type, __u8 is_audited, __u8 auth_type, __u32 cookie)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
@@ -105,6 +106,7 @@ send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst
 		.ipv6		= is_ipv6,
 		.audited	= is_audited,
 		.auth_type      = auth_type,
+		.cookie		= cookie,
 	};
 
 	ctx_event_output(ctx, &cilium_events,
@@ -119,7 +121,7 @@ send_policy_verdict_notify(struct __ctx_buff *ctx __maybe_unused,
 			   __u8 is_ipv6 __maybe_unused, int verdict __maybe_unused,
 			   __u16 proxy_port __maybe_unused,
 			   __u8 match_type __maybe_unused, __u8 is_audited __maybe_unused,
-			   __u8 auth_type __maybe_unused)
+			   __u8 auth_type __maybe_unused, __u32 cookie __maybe_unused)
 {
 }
 #endif /* POLICY_VERDICT_NOTIFY */

--- a/bpf/tests/network_policy.c
+++ b/bpf/tests/network_policy.c
@@ -19,11 +19,13 @@ check_egress_policy(struct __ctx_buff *ctx, __u32 dst_id, __u8 proto, __be16 dpo
 	__u8 audited;
 	__s8 ext_err;
 	__u16 proxy_port;
+	__u32 cookie;
 
 	return policy_can_egress(ctx, 0 /* ignored */, dst_id,
 				 0 /* ICMP only */,
 				 dport, proto, 0 /* ICMP only */,
-				 &match_type, &audited, &ext_err, &proxy_port);
+				 &match_type, &audited, &ext_err, &proxy_port,
+				 &cookie);
 }
 
 CHECK("tc", "network_policy_egress_allow")

--- a/cilium-dbg/cmd/bpf_policy_add.go
+++ b/cilium-dbg/cmd/bpf_policy_add.go
@@ -9,7 +9,10 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 )
 
-var isDeny bool
+var (
+	isDeny bool
+	cookie uint32
+)
 
 // bpfPolicyAddCmd represents the bpf_policy_add command
 var bpfPolicyAddCmd = &cobra.Command{
@@ -18,11 +21,12 @@ var bpfPolicyAddCmd = &cobra.Command{
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf policy add")
-		updatePolicyKey(parsePolicyUpdateArgs(log, cmd, args, isDeny), true)
+		updatePolicyKey(parsePolicyUpdateArgs(log, cmd, args, isDeny, cookie), true)
 	},
 }
 
 func init() {
 	bpfPolicyAddCmd.Flags().BoolVar(&isDeny, "deny", false, "Sets deny mode")
+	bpfPolicyAddCmd.Flags().Uint32Var(&cookie, "cookie", 0, "Sets policy log cookie")
 	BPFPolicyCmd.AddCommand(bpfPolicyAddCmd)
 }

--- a/cilium-dbg/cmd/bpf_policy_delete.go
+++ b/cilium-dbg/cmd/bpf_policy_delete.go
@@ -16,11 +16,10 @@ var bpfPolicyDeleteCmd = &cobra.Command{
 	PreRun: requireEndpointID,
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf policy delete")
-		updatePolicyKey(parsePolicyUpdateArgs(log, cmd, args, isDeny), false)
+		updatePolicyKey(parsePolicyUpdateArgs(log, cmd, args, isDeny, cookie), false)
 	},
 }
 
 func init() {
-	bpfPolicyDeleteCmd.Flags().BoolVar(&isDeny, "deny", false, "Sets deny mode")
 	BPFPolicyCmd.AddCommand(bpfPolicyDeleteCmd)
 }

--- a/cilium-dbg/cmd/bpf_policy_get.go
+++ b/cilium-dbg/cmd/bpf_policy_get.go
@@ -155,6 +155,7 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 		bytesTitle            = "BYTES"
 		packetsTitle          = "PACKETS"
 		prefixTitle           = "PREFIX"
+		cookieTitle           = "COOKIE"
 	)
 
 	labelsID := map[identity.NumericIdentity]*identity.Identity{}
@@ -172,11 +173,11 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 	}
 
 	if printIDs {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
-			policyTitle, trafficDirectionTitle, labelsIDTitle, portTitle, proxyPortTitle, authTypeTitle, bytesTitle, packetsTitle, prefixTitle)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			policyTitle, trafficDirectionTitle, labelsIDTitle, portTitle, proxyPortTitle, authTypeTitle, bytesTitle, packetsTitle, prefixTitle, cookieTitle)
 	} else {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
-			policyTitle, trafficDirectionTitle, labelsDesTitle, portTitle, proxyPortTitle, authTypeTitle, bytesTitle, packetsTitle, prefixTitle)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			policyTitle, trafficDirectionTitle, labelsDesTitle, portTitle, proxyPortTitle, authTypeTitle, bytesTitle, packetsTitle, prefixTitle, cookieTitle)
 	}
 	for _, stat := range statsMap {
 		prefixLen := stat.Key.GetPrefixLen()
@@ -203,9 +204,10 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 		if stat.Bytes != policymap.StatNotAvailable {
 			bytes = strconv.FormatUint(stat.Bytes, 10)
 		}
+		cookie := stat.Cookie
 		if printIDs {
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%d\t\n",
-				policyStr, trafficDirectionString, id, port, proxyPort, stat.AuthRequirement.AuthType(), bytes, packets, prefixLen)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%d\t%d\n",
+				policyStr, trafficDirectionString, id, port, proxyPort, stat.AuthRequirement.AuthType(), bytes, packets, prefixLen, cookie)
 		} else if lbls := labelsID[id]; lbls != nil && len(lbls.Labels) > 0 {
 			first := true
 			for _, lbl := range lbls.Labels.GetPrintableModel() {
@@ -213,16 +215,16 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 					lbl = "ANY"
 				}
 				if first {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t\n",
-						policyStr, trafficDirectionString, lbl, port, proxyPort, stat.AuthRequirement.AuthType(), bytes, packets, prefixLen)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\n",
+						policyStr, trafficDirectionString, lbl, port, proxyPort, stat.AuthRequirement.AuthType(), bytes, packets, prefixLen, cookie)
 					first = false
 				} else {
 					fmt.Fprintf(w, "\t\t%s\t\t\t\t\t\t\t\n", lbl)
 				}
 			}
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%d\t\n",
-				policyStr, trafficDirectionString, id, port, proxyPort, stat.AuthRequirement.AuthType(), bytes, packets, prefixLen)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%d\t%d\n",
+				policyStr, trafficDirectionString, id, port, proxyPort, stat.AuthRequirement.AuthType(), bytes, packets, prefixLen, cookie)
 		}
 	}
 }

--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -188,7 +188,11 @@ type PolicyUpdateArgs struct {
 	// command, if specified.
 	protocols []u8proto.U8proto
 
+	// isDeny is true when the policy should be denied.
 	isDeny bool
+
+	// cookie is the policy log cookie.
+	cookie uint32
 }
 
 // parseTrafficString converts the provided string to its corresponding
@@ -211,12 +215,18 @@ func parseTrafficString(td string) (trafficdirection.TrafficDirection, error) {
 // command, provided as a list containing the endpoint ID, traffic direction,
 // identity and optionally, a list of ports.
 // Returns a parsed representation of the command arguments.
-func parsePolicyUpdateArgs(logger *slog.Logger, cmd *cobra.Command, args []string, isDeny bool) *PolicyUpdateArgs {
+func parsePolicyUpdateArgs(
+	logger *slog.Logger,
+	cmd *cobra.Command,
+	args []string,
+	isDeny bool,
+	cookie uint32,
+) *PolicyUpdateArgs {
 	if len(args) < 3 {
 		Usagef(cmd, "<endpoint id>, <traffic-direction>, and <identity> required")
 	}
 
-	pa, err := parsePolicyUpdateArgsHelper(logger, args, isDeny)
+	pa, err := parsePolicyUpdateArgsHelper(logger, args, isDeny, cookie)
 	if err != nil {
 		Fatalf("%s", err)
 	}
@@ -243,7 +253,7 @@ func endpointToPolicyMapPath(logger *slog.Logger, endpointID string) (string, er
 	return bpf.MapPath(logger, mapName), nil
 }
 
-func parsePolicyUpdateArgsHelper(logger *slog.Logger, args []string, isDeny bool) (*PolicyUpdateArgs, error) {
+func parsePolicyUpdateArgsHelper(logger *slog.Logger, args []string, isDeny bool, cookie uint32) (*PolicyUpdateArgs, error) {
 	trafficDirection := args[1]
 	parsedTd, err := parseTrafficString(trafficDirection)
 	if err != nil {
@@ -291,6 +301,7 @@ func parsePolicyUpdateArgsHelper(logger *slog.Logger, args []string, isDeny bool
 		port:             port,
 		protocols:        protos,
 		isDeny:           isDeny,
+		cookie:           cookie,
 	}
 
 	return pa, nil
@@ -314,7 +325,7 @@ func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 		entry := fmt.Sprintf("%d %d/%s", pa.label, pa.port, u8p.String())
 		mapKey := policymap.NewKeyFromPolicyKey(policyTypes.KeyForDirection(pa.trafficDirection).WithIdentity(pa.label).WithPortProto(proto, pa.port))
 		if add {
-			mapEntry := policymap.NewEntryFromPolicyEntry(mapKey, policyTypes.MapStateEntry{}.WithDeny(pa.isDeny))
+			mapEntry := policymap.NewEntryFromPolicyEntry(mapKey, policyTypes.MapStateEntry{Cookie: pa.cookie}.WithDeny(pa.isDeny))
 			if err := policyMap.Update(&mapKey, &mapEntry); err != nil {
 				Fatalf("Cannot add policy key '%s': %s\n", entry, err)
 			}

--- a/cilium-dbg/cmd/helpers_test.go
+++ b/cilium-dbg/cmd/helpers_test.go
@@ -569,6 +569,7 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 		port             uint16
 		protos           []u8proto.U8proto
 		isDeny           bool
+		cookie           uint32
 	}{
 		{
 			args:             []string{labels.IDNameHost, "ingress", "12345"},
@@ -611,6 +612,7 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 			args:             []string{labels.IDNameHost, "ingress", "12345"},
 			invalid:          false,
 			isDeny:           true,
+			cookie:           0x010203,
 			mapBaseName:      "cilium_policy_v2_reserved_1",
 			trafficDirection: trafficdirection.Ingress,
 			peerLbl:          12345,
@@ -621,6 +623,7 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 			args:             []string{"123", "egress", "12345", "1/tcp"},
 			invalid:          false,
 			isDeny:           true,
+			cookie:           0x010203,
 			mapBaseName:      "cilium_policy_v2_00123",
 			trafficDirection: trafficdirection.Egress,
 			peerLbl:          12345,
@@ -631,6 +634,7 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 			args:             []string{"123", "ingress", "12345", "1"},
 			invalid:          false,
 			isDeny:           true,
+			cookie:           0x010203,
 			mapBaseName:      "cilium_policy_v2_00123",
 			trafficDirection: trafficdirection.Ingress,
 			peerLbl:          12345,
@@ -641,13 +645,14 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 	for _, tt := range tests {
-		args, err := parsePolicyUpdateArgsHelper(logger, tt.args, tt.isDeny)
+		args, err := parsePolicyUpdateArgsHelper(logger, tt.args, tt.isDeny, tt.cookie)
 
 		if tt.invalid {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
 			require.Equal(t, args.isDeny, tt.isDeny)
+			require.Equal(t, args.cookie, tt.cookie)
 			require.Equal(t, path.Base(args.path), tt.mapBaseName)
 			require.Equal(t, args.trafficDirection, tt.trafficDirection)
 			require.Equal(t, args.label, tt.peerLbl)

--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba
 	golang.org/x/crypto v0.42.0
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
 	golang.org/x/mod v0.28.0
 	golang.org/x/net v0.44.0
 	golang.org/x/oauth2 v0.31.0
@@ -301,7 +302,6 @@ require (
 	go.uber.org/dig v1.17.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/telemetry v0.0.0-20250908211612-aef8a434d053 // indirect
 	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -127,6 +127,12 @@ const (
 	// PolicyEntriesOld is a set of old policy map keys and values
 	PolicyEntriesOld = "policyEntriesOld"
 
+	// PolicyLogCookie is a policy log cookie.
+	PolicyLogCookie = "policyLogCookie"
+
+	// PolicyLogString is a policy log string.
+	PolicyLogString = "policyLogString"
+
 	// DatapathPolicyRevision is the policy revision currently running in
 	// the datapath
 	DatapathPolicyRevision = "datapathPolicyRevision"

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -156,6 +156,7 @@ type PolicyEntry struct {
 	ProxyPortPriority policyTypes.ProxyPortPriority `align:"proxy_port_priority"`
 	Pad1              uint8                         `align:"pad1"`
 	Pad2              uint16                        `align:"pad2"`
+	Cookie            uint32                        `align:"cookie"`
 }
 
 // GetProxyPort returns the ProxyPortNetwork in host byte order
@@ -307,7 +308,8 @@ func NewEntryFromPolicyEntry(key PolicyKey, pe policyTypes.MapStateEntry) Policy
 
 	if pe.IsDeny() {
 		return PolicyEntry{
-			Flags: pef,
+			Flags:  pef,
+			Cookie: pe.Cookie,
 		}
 	} else {
 		return PolicyEntry{
@@ -315,6 +317,7 @@ func NewEntryFromPolicyEntry(key PolicyKey, pe policyTypes.MapStateEntry) Policy
 			Flags:             pef,
 			AuthRequirement:   pe.AuthRequirement,
 			ProxyPortPriority: pe.ProxyPortPriority,
+			Cookie:            pe.Cookie,
 		}
 	}
 }
@@ -399,6 +402,7 @@ func (pm *PolicyMap) DumpToMapStateMap() (policyTypes.MapStateMap, error) {
 			ProxyPortPriority: val.ProxyPortPriority,
 			ProxyPort:         val.GetProxyPort(),
 			AuthRequirement:   val.AuthRequirement,
+			Cookie:            val.Cookie,
 		}.WithDeny(val.IsDeny())
 		// if policymapEntry has invalid prefix length, force update by storing as an
 		// invalid MapStateEntry

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	// PolicyVerdictNotifyLen is the amount of packet data provided in a Policy notification
-	PolicyVerdictNotifyLen = 32
+	// PolicyVerdictNotifyLen is the length (in bytes) of the PolicyVerdictNotify message
+	// header, i.e. the offset of the packet data provided in a policy verdict notification.
+	PolicyVerdictNotifyLen = 40
 
 	// The values below are for parsing PolicyVerdictNotify. They need to be consistent
 	// with what are defined in data plane.
@@ -56,8 +57,9 @@ type PolicyVerdictNotify struct {
 	Proto       uint8
 	Flags       uint8
 	AuthType    uint8
-	Pad1        uint8
-	Pad2        uint16
+	_           [3]uint8
+	Cookie      uint32
+	_           uint32
 	// data
 }
 
@@ -97,8 +99,7 @@ func (n *PolicyVerdictNotify) Decode(data []byte) error {
 	n.Proto = data[26]
 	n.Flags = data[27]
 	n.AuthType = data[28]
-	n.Pad1 = data[29]
-	n.Pad2 = byteorder.Native.Uint16(data[30:32])
+	n.Cookie = byteorder.Native.Uint32(data[32:36])
 
 	return nil
 }

--- a/pkg/monitor/datapath_policy_test.go
+++ b/pkg/monitor/datapath_policy_test.go
@@ -16,7 +16,7 @@ import (
 func TestDecodePolicyVerdicyNotify(t *testing.T) {
 	// This check on the struct length constant is there to ensure that this
 	// test is updated when the struct changes.
-	require.Equal(t, 32, PolicyVerdictNotifyLen)
+	require.Equal(t, 40, PolicyVerdictNotifyLen)
 
 	input := PolicyVerdictNotify{
 		Type:        0x00,
@@ -32,8 +32,7 @@ func TestDecodePolicyVerdicyNotify(t *testing.T) {
 		Proto:       0x1b,
 		Flags:       0x1c,
 		AuthType:    0x1d,
-		Pad1:        0x1e,
-		Pad2:        0x20_21,
+		Cookie:      0x1e_1f_20_21,
 	}
 	buf := bytes.NewBuffer(nil)
 	err := binary.Write(buf, byteorder.Native, input)
@@ -56,8 +55,7 @@ func TestDecodePolicyVerdicyNotify(t *testing.T) {
 	require.Equal(t, input.Proto, output.Proto)
 	require.Equal(t, input.Flags, output.Flags)
 	require.Equal(t, input.AuthType, output.AuthType)
-	require.Equal(t, input.Pad1, output.Pad1)
-	require.Equal(t, input.Pad2, output.Pad2)
+	require.Equal(t, input.Cookie, output.Cookie)
 }
 
 func BenchmarkNewDecodePolicyVerdictNotify(b *testing.B) {

--- a/pkg/policy/cookie/bakery.go
+++ b/pkg/policy/cookie/bakery.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cookie
+
+import (
+	"log/slog"
+
+	"golang.org/x/exp/constraints"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// Bakery allocates unique unsigned integer cookies of type C for a comparable value of type. It
+// allows looking up the value for a given cookie and mark-and-sweep garbage collection.
+type Bakery[C constraints.Unsigned, V comparable] interface {
+	// Allocate returns a unique, cookie for the given value and whether a cookie could be
+	// allocated or reused. A successfully allocated cookie is always non-zero. If no cookie
+	// could be allocated, a zero cookie is returned. If the same value is provided again,
+	// Allocate returns the previously allocated cookie for that value.
+	Allocate(value V) (cookie C, ok bool)
+	// Get returns the value for a given cookie and whether it exists in the bakery. If the
+	// cookie doesn't exist, a zero value will be returned.
+	Get(cookie C) (value V, exists bool)
+	// MarkInUse marks a cookie as in-use for the next sweep.
+	MarkInUse(cookie C)
+	// Sweep removes all cookies not marked as in-use since the last time sweep cycle.
+	Sweep()
+	// Count returns the number of allocated cookies.
+	Count() int
+}
+
+type bakery[C constraints.Unsigned, V comparable] struct {
+	logger *slog.Logger
+
+	mu                 lock.RWMutex
+	cookieSet          *bitset
+	cookieToValue      map[C]holder[V]
+	valueToCookie      map[V]C
+	lastSeenGeneration uint64
+}
+
+var _ Bakery[uint32, string] = (*bakery[uint32, string])(nil)
+
+type holder[T comparable] struct {
+	value T
+	since uint64
+}
+
+// maxOf returns the maximum value for unsigned type T.
+func maxOf[T constraints.Unsigned]() T {
+	var zero T
+	return ^zero
+}
+
+// NewBakery creates a new Bakery. It manages cookies of type C for values of type V.
+func NewBakery[C constraints.Unsigned, V comparable](logger *slog.Logger) *bakery[C, V] {
+	return &bakery[C, V]{
+		logger:             logger,
+		cookieSet:          newBitset(int(maxOf[C]())),
+		cookieToValue:      make(map[C]holder[V]),
+		valueToCookie:      make(map[V]C),
+		lastSeenGeneration: 0,
+	}
+}
+
+// Allocate returns a unique, cookie for the given value and whether a cookie could be allocated or
+// reused. A successfully allocated cookie is always non-zero. If no cookie could be allocated, a
+// zero cookie is returned. If the same value is provided again, Allocate returns the previously
+// allocated cookie for that value.
+func (b *bakery[C, V]) Allocate(value V) (cookie C, ok bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	cookie, ok = b.valueToCookie[value]
+	if ok {
+		return cookie, ok
+	}
+	next, ok := b.cookieSet.Allocate()
+	if !ok {
+		return 0, false
+	}
+	// Offset of 1 because a non-zero cookie is needed. Cookie value 0 means no cookie.
+	cookie = C(next + 1)
+	b.cookieToValue[cookie] = holder[V]{value: value, since: b.lastSeenGeneration}
+	b.valueToCookie[value] = cookie
+	b.logger.Debug("Allocated policy log cookie",
+		logfields.PolicyLogCookie, cookie,
+		logfields.PolicyLogString, value,
+	)
+	return cookie, true
+}
+
+// Get returns the value for a given cookie and whether it exists in the bakery. If the cookie
+// doesn't exist, a zero value will be returned.
+func (b *bakery[C, V]) Get(cookie C) (value V, exists bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	v, exists := b.cookieToValue[cookie]
+	return v.value, exists
+}
+
+// MarkInUse marks a cookie as in-use for the next sweep.
+func (b *bakery[C, V]) MarkInUse(cookie C) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if value, ok := b.cookieToValue[cookie]; ok {
+		b.cookieToValue[cookie] = holder[V]{
+			value: value.value,
+			since: b.lastSeenGeneration,
+		}
+	}
+}
+
+// Sweep removes all cookies not marked as in-use since the last time sweep cycle.
+func (b *bakery[C, V]) Sweep() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for cookie, val := range b.cookieToValue {
+		if val.since < b.lastSeenGeneration {
+			delete(b.cookieToValue, cookie)
+			delete(b.valueToCookie, val.value)
+			// Correct for offset added during allocation. See comment in Allocate.
+			b.cookieSet.Release(int(cookie - 1))
+			b.logger.Debug("Released policy log cookie",
+				logfields.PolicyLogCookie, cookie,
+				logfields.PolicyLogCookie, val.value,
+			)
+		}
+	}
+	b.lastSeenGeneration++
+}
+
+// Count returns the number of allocated cookies.
+func (b *bakery[C, V]) Count() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return b.cookieSet.Count()
+}

--- a/pkg/policy/cookie/bakery_test.go
+++ b/pkg/policy/cookie/bakery_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cookie
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBakery(t *testing.T) {
+	b := NewBakery[uint32, string](hivetest.Logger(t))
+	assert.Equal(t, 0, b.Count())
+
+	value, ok := b.Get(rand.Uint32())
+	assert.False(t, ok)
+	assert.Empty(t, value)
+
+	key1 := "foo"
+	cookie1, ok := b.Allocate(key1)
+	assert.NotZero(t, cookie1)
+	assert.True(t, ok)
+	assert.Equal(t, 1, b.Count())
+
+	value, ok = b.Get(cookie1)
+	assert.True(t, ok)
+	assert.Equal(t, value, key1)
+
+	sameCookie, ok := b.Allocate(key1)
+	assert.NotZero(t, cookie1)
+	assert.True(t, ok)
+	assert.Equal(t, sameCookie, cookie1)
+	assert.Equal(t, 1, b.Count())
+
+	key2 := "bar"
+	cookie2, ok := b.Allocate(key2)
+	assert.NotZero(t, cookie2)
+	assert.True(t, ok)
+	assert.NotEqual(t, cookie2, cookie1)
+	assert.Equal(t, 2, b.Count())
+
+	// 1. Generation
+	b.Sweep()
+	value, ok = b.Get(cookie1)
+	assert.True(t, ok)
+	assert.Equal(t, value, key1)
+	value, ok = b.Get(cookie2)
+	assert.True(t, ok)
+	assert.Equal(t, value, key2)
+
+	b.MarkInUse(cookie2)
+
+	// 2. Generation
+	b.Sweep()
+	value, ok = b.Get(cookie1)
+	assert.False(t, ok)
+	assert.Empty(t, value)
+	value, ok = b.Get(cookie2)
+	assert.True(t, ok)
+	assert.Equal(t, value, key2)
+	assert.Equal(t, 1, b.Count())
+
+	// 3. Generation
+	b.Sweep()
+	value, ok = b.Get(cookie1)
+	assert.False(t, ok)
+	assert.Empty(t, value)
+	value, ok = b.Get(cookie2)
+	assert.False(t, ok)
+	assert.Empty(t, value)
+	assert.Equal(t, 0, b.Count())
+}
+
+func TestBakeryAllocationBounds(t *testing.T) {
+	b := NewBakery[uint8, string](hivetest.Logger(t))
+
+	for i := range math.MaxUint8 {
+		cookie, ok := b.Allocate(fmt.Sprintf("key%d", i))
+		assert.NotZero(t, cookie, "could not allocate %dth cookie", i)
+		assert.True(t, ok)
+	}
+
+	cookie, ok := b.Allocate(fmt.Sprintf("key%d", math.MaxUint8))
+	assert.Zero(t, cookie)
+	assert.False(t, ok)
+}

--- a/pkg/policy/cookie/bitset.go
+++ b/pkg/policy/cookie/bitset.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cookie
+
+import (
+	"math/big"
+	"math/rand/v2"
+)
+
+// bitset is an uncompressed bitset/bitmap.
+type bitset struct {
+	// length is the maximum length.
+	length int
+	// count is the number of allocated bits.
+	count int
+	// set stores allocated bits.
+	set *big.Int
+}
+
+// newBitset allocates a new bitset holding a maximum of length bits.
+func newBitset(length int) *bitset {
+	return &bitset{
+		length: length,
+		count:  0,
+		set:    big.NewInt(0),
+	}
+}
+
+// Allocates a bit at the next free offset, starting at 0 and filling any gaps. It also returns
+// whether a bit could be allocated.
+//
+// By allocating sequentially and filling gaps we save memory compared to a random strategy which in
+// the worst case would allocate the bit at 2^32-1 in a big.Int on first allocation.
+//
+// We expect a sparse set of allocated bits, thus a random allocation strategy is not suitable.
+//
+// TODO: if this assumption changes, consider using a compressed bitset such as Roaring bitmaps.
+func (b *bitset) Allocate() (int, bool) {
+	if b.count >= b.length {
+		return 0, false
+	}
+	for next := range b.length {
+		if b.set.Bit(next) == 0 {
+			b.set = b.set.SetBit(b.set, next, 1)
+			b.count++
+			return next, true
+		}
+	}
+	return 0, false
+}
+
+// Allocates a bit at a random free offset. It also returns whether a bit could be allocated.
+func (b *bitset) AllocateRand() (int, bool) {
+	if b.count >= b.length {
+		return 0, false
+	}
+	off := rand.IntN(b.length)
+	for i := range b.length {
+		next := (off + i) % b.length
+		if b.set.Bit(next) == 0 {
+			b.set = b.set.SetBit(b.set, next, 1)
+			b.count++
+			return next, true
+		}
+	}
+	return 0, false
+}
+
+// Release releases the bit at offset.
+func (b *bitset) Release(offset int) {
+	if b.set.Bit(offset) == 0 {
+		return
+	}
+	b.set = b.set.SetBit(b.set, offset, 0)
+	b.count--
+}
+
+// Count returns the number of set bits.
+func (b *bitset) Count() int {
+	return b.count
+}
+
+// Cap returns the number of unset bits, the remaining capacity of the bit set.
+func (b *bitset) Cap() int {
+	return b.length - b.count
+}

--- a/pkg/policy/cookie/bitset_test.go
+++ b/pkg/policy/cookie/bitset_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cookie
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBitset(t *testing.T) {
+	length := 128
+
+	b := newBitset(length)
+
+	assert.Equal(t, 0, b.Count())
+	assert.Equal(t, length, b.Cap())
+
+	b.Release(0)
+	assert.Equal(t, 0, b.Count())
+	assert.Equal(t, length, b.Cap())
+
+	seenBits := make(map[int]struct{})
+
+	lastBit, ok := b.Allocate()
+	assert.True(t, ok)
+	assert.Equal(t, 1, b.Count())
+	assert.Equal(t, length-1, b.Cap())
+	seenBits[lastBit] = struct{}{}
+
+	for i := range length - 2 {
+		bit, ok := b.Allocate()
+		assert.True(t, ok)
+		// Allocate allocates sequentially
+		assert.Equal(t, bit, lastBit+1)
+		assert.Equal(t, b.Count(), i+1+1)
+		assert.Equal(t, b.Cap(), length-1-i-1)
+
+		_, seen := seenBits[bit]
+		assert.False(t, seen, "seen bit %d more than once", bit)
+		seenBits[bit] = struct{}{}
+
+		lastBit = bit
+	}
+
+	bit, ok := b.AllocateRand()
+	assert.True(t, ok)
+	assert.Equal(t, length, b.Count())
+	assert.Equal(t, 0, b.Cap())
+
+	_, seen := seenBits[bit]
+	assert.False(t, seen, "seen bit %d more than once", bit)
+	seenBits[bit] = struct{}{}
+
+	// Bit set full
+	bit, ok = b.Allocate()
+	assert.False(t, ok)
+	assert.Zero(t, bit)
+	assert.Equal(t, length, b.Count())
+	assert.Equal(t, 0, b.Cap())
+
+	bit, ok = b.AllocateRand()
+	assert.False(t, ok)
+	assert.Zero(t, bit)
+	assert.Equal(t, length, b.Count())
+	assert.Equal(t, 0, b.Cap())
+
+	// Free bit at random offset
+	off := rand.IntN(length)
+	b.Release(off)
+	assert.Equal(t, length-1, b.Count())
+	assert.Equal(t, 1, b.Cap())
+
+	// Allocate should allocate the only free bit
+	bit, ok = b.Allocate()
+	assert.True(t, ok)
+	assert.Equal(t, bit, off)
+	assert.Equal(t, length, b.Count())
+	assert.Equal(t, 0, b.Cap())
+
+	// Free bit at random offset
+	off = rand.IntN(length)
+	b.Release(off)
+	assert.Equal(t, length-1, b.Count())
+	assert.Equal(t, 1, b.Cap())
+	// Releasing twice shouldn't change anything
+	b.Release(off)
+	assert.Equal(t, length-1, b.Count())
+	assert.Equal(t, 1, b.Cap())
+
+	// AllocateRand should allocate the only free bit
+	bit, ok = b.AllocateRand()
+	assert.True(t, ok)
+	assert.Equal(t, off, bit)
+	assert.Equal(t, length, b.Count())
+	assert.Equal(t, 0, b.Cap())
+
+	for i := range length {
+		b.Release(i)
+		assert.Equal(t, b.Count(), length-i-1)
+		assert.Equal(t, b.Cap(), i+1)
+	}
+}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -400,7 +400,13 @@ type mapStateEntry struct {
 }
 
 // newMapStateEntry creates a map state entry.
-func newMapStateEntry(derivedFrom ruleOrigin, proxyPort uint16, priority ListenerPriority, deny bool, authReq AuthRequirement) mapStateEntry {
+func newMapStateEntry(
+	derivedFrom ruleOrigin,
+	proxyPort uint16,
+	priority ListenerPriority,
+	deny bool,
+	authReq AuthRequirement,
+) mapStateEntry {
 	return mapStateEntry{
 		MapStateEntry:    types.NewMapStateEntry(deny, proxyPort, priority, authReq),
 		derivedFromRules: derivedFrom,

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -81,11 +81,11 @@ type Repository struct {
 	// Always positive (>0).
 	revision atomic.Uint64
 
-	// SelectorCache tracks the selectors used in the policies
+	// selectorCache tracks the selectors used in the policies
 	// resolved from the repository.
 	selectorCache *SelectorCache
 
-	// PolicyCache tracks the selector policies created from this repo
+	// policyCache tracks the selector policies created from this repo
 	policyCache *policyCache
 
 	certManager certificatemanager.CertificateManager

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -394,7 +394,6 @@ var errMissingKey = errors.New("Key not found")
 
 // GetRuleMeta returns the list of labels of the rules that contributed
 // to the entry at this key.
-// The returned string is the string representation of a LabelArrayList.
 func (p *EndpointPolicy) GetRuleMeta(k Key) (RuleMeta, error) {
 	entry, ok := p.policyMapState.get(k)
 	if !ok {

--- a/pkg/policy/types/entry.go
+++ b/pkg/policy/types/entry.go
@@ -33,6 +33,10 @@ type MapStateEntry struct {
 	// AuthRequirement is non-zero when authentication is required for the traffic to be
 	// allowed, except for when it explicitly defines authentication is not required.
 	AuthRequirement AuthRequirement
+
+	// Cookie is the policy log cookie. It is non-zero, datapath will pass up the cookie on any
+	// policy verdict.
+	Cookie uint32
 }
 
 type MapStateMap map[Key]MapStateEntry
@@ -51,12 +55,18 @@ func (e MapStateEntry) String() string {
 	return "IsDeny=" + strconv.FormatBool(e.IsDeny()) +
 		",ProxyPort=" + strconv.FormatUint(uint64(e.ProxyPort), 10) +
 		",Priority=" + strconv.FormatUint(uint64(e.ProxyPortPriority), 10) +
-		authText
+		authText +
+		",Cookie=" + strconv.FormatUint(uint64(e.Cookie), 10)
 }
 
 // NewMapStateEntry creates a new MapStateEntry
 // Listener 'priority' is encoded in ProxyPortPriority, inverted
-func NewMapStateEntry(deny bool, proxyPort uint16, priority ListenerPriority, authReq AuthRequirement) MapStateEntry {
+func NewMapStateEntry(
+	deny bool,
+	proxyPort uint16,
+	priority ListenerPriority,
+	authReq AuthRequirement,
+) MapStateEntry {
 	// Normalize inputs
 	if deny {
 		proxyPort = 0


### PR DESCRIPTION
This adds the necessary plumbing in the policy engine and the datapath to make the  arbitrary plain-text Log policy rule field introduced in https://github.com/cilium/cilium/pull/39902 useful. This works as follows:

1. A unique 32-bit value (called a cookie) is allocated for each unique policy log string when distilling policy rules. A cookie value of 0 means no cookie (default case). Cookies are managed by a data structure called the cookie bakery (kudos for the name to @squeed).
2. That cookie is written to the endpoint's policy map as part of the policy rule and passed up by the datapath as part of the policy verdict notification message whenever an allow or deny based on the respective rule entry occurs.
3. The cookie (if non-zero) is used to look up the corresponding policy log string from the cookie bakery and (if found) used to populate the respective Hubble flow with the log string.
4. The cookie bakery is garbage collected at a regular interval using a mark-and-sweep approach.

Note that this PR only adds the cookie allocator for step 1 and the necessary datapath plumbing for step 2 (also see https://github.com/cilium/cilium/pull/40023#issuecomment-3389586917). Follow-up changes will wire this up in the policy engine and Hubble policy correlation.

See individual commits for details.