### PR TITLE
loadbalancer: Add rate limiting to reconcilation logging

### DIFF
--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -487,7 +487,7 @@ type TestConfig struct {
 }
 
 func (def TestConfig) Flags(flags *pflag.FlagSet) {
-	flags.Float32("lb-test-fault-probability", def.TestFaultProbability, "Probability for fault injection in LBMaps")
+	flags.Float32("lb-test-fault-probability", def.TestFaultProbability, "Probability for fault injection in LBMaps (0..1)")
 }
 
 // ExternalConfig are configuration options derived from external sources such as

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -118,7 +118,8 @@ func newBPFReconciler(p reconciler.Params, g job.Group, cfg loadbalancer.Config,
 
 type BPFOps struct {
 	LBMaps maps.LBMaps
-	log    *slog.Logger
+	log    rateLimitingLogger
+
 	cfg    loadbalancer.Config
 	extCfg loadbalancer.ExternalConfig
 	maglev *maglev.Maglev
@@ -185,7 +186,7 @@ func newBPFOps(p bpfOpsParams) *BPFOps {
 		cfg:       p.Config,
 		extCfg:    p.ExternalConfig,
 		maglev:    p.Maglev,
-		log:       p.Log,
+		log:       newRateLimitingLogger(p.Log),
 		LBMaps:    p.LBMaps,
 		db:        p.DB,
 		nodeAddrs: p.NodeAddresses,
@@ -295,20 +296,16 @@ func (ops *BPFOps) Delete(_ context.Context, _ statedb.ReadTxn, _ statedb.Revisi
 		fe.Type == loadbalancer.SVCTypeHostPort && fe.Address.AddrCluster.IsUnspecified() {
 
 		key := nodePortAddrKey{family: fe.Address.IsIPv6(), port: fe.Address.Port}
-		addrs, ok := ops.nodePortAddrByPort[key]
-		if ok {
-			for _, addr := range addrs {
-				fe = fe.Clone()
-				fe.Address.AddrCluster = cmtypes.AddrClusterFrom(addr, 0)
-				if err := ops.deleteFrontend(fe); err != nil {
-					ops.log.Warn("Deleting frontend failed, retrying", logfields.Error, err)
-					return err
-				}
+		addrs := ops.nodePortAddrByPort[key]
+		for _, addr := range addrs {
+			fe = fe.Clone()
+			fe.Address.AddrCluster = cmtypes.AddrClusterFrom(addr, 0)
+			if err := ops.deleteFrontend(fe); err != nil {
+				ops.log.Warn("Deleting frontend failed, retrying", logfields.Error, err)
+				return err
 			}
-			delete(ops.nodePortAddrByPort, key)
-		} else {
-			ops.log.Warn("no nodePortAddrs", logfields.Port, fe.Address.Port)
 		}
+		delete(ops.nodePortAddrByPort, key)
 	}
 
 	return nil
@@ -335,7 +332,6 @@ func (ops *BPFOps) deleteRestoredQuarantinedBackends(fe loadbalancer.L3n4Addr, b
 }
 
 func (ops *BPFOps) deleteFrontend(fe *loadbalancer.Frontend) error {
-
 	feID, err := ops.serviceIDAlloc.lookupLocalID(fe.Address)
 	if err != nil {
 		ops.log.Debug("Delete frontend: no ID found", logfields.Address, fe.Address)
@@ -454,7 +450,7 @@ func (ops *BPFOps) pruneServiceMaps() error {
 			expectedSlots = 1 + len(bes)
 		}
 		if svcKey.GetBackendSlot()+1 > expectedSlots {
-			ops.log.Info("pruneServiceMaps: deleting",
+			ops.log.Debug("pruneServiceMaps: deleting",
 				logfields.ID, svcValue.GetRevNat(),
 				logfields.Address, addr)
 			toDelete = append(toDelete, svcKey.ToNetwork())
@@ -468,7 +464,7 @@ func (ops *BPFOps) pruneServiceMaps() error {
 		}
 	}
 	if err := ops.LBMaps.DumpService(svcCB); err != nil {
-		ops.log.Warn("Failed to prune service maps", logfields.Error, err)
+		ops.log.Warn("Failed to dump service maps", logfields.Error, err)
 	}
 
 	for _, key := range toDelete {
@@ -485,7 +481,7 @@ func (ops *BPFOps) pruneBackendMaps() error {
 		beValue = beValue.ToHost()
 		addr := beValueToAddr(beValue)
 		if _, ok := ops.backendStates[addr]; !ok {
-			ops.log.Info("pruneBackendMaps: deleting",
+			ops.log.Debug("pruneBackendMaps: deleting",
 				logfields.ID, beKey.GetID(),
 				logfields.Address, addr,
 			)
@@ -493,7 +489,7 @@ func (ops *BPFOps) pruneBackendMaps() error {
 		}
 	}
 	if err := ops.LBMaps.DumpBackend(beCB); err != nil {
-		ops.log.Warn("Failed to prune backend maps", logfields.Error, err)
+		ops.log.Warn("Failed to dump backend maps", logfields.Error, err)
 	}
 
 	for _, key := range toDelete {
@@ -636,7 +632,7 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 	}
 
 	if err := ops.updateFrontend(fe); err != nil {
-		ops.log.Warn("Updating frontend failed, retrying", logfields.Error, err)
+		ops.log.Warn("Updating frontend failed", logfields.Error, err)
 		return err
 	}
 
@@ -665,7 +661,10 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 			fe = fe.Clone()
 			fe.Address.AddrCluster = cmtypes.AddrClusterFrom(addr, 0)
 			if err := ops.updateFrontend(fe); err != nil {
-				ops.log.Warn("Updating frontend failed, retrying", logfields.Error, err)
+				ops.log.Warn("Updating frontend failed",
+					logfields.Error, err,
+					logfields.Address, fe.Address,
+				)
 				return err
 			}
 			old.Delete(addr)
@@ -676,7 +675,10 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 			fe = fe.Clone()
 			fe.Address.AddrCluster = cmtypes.AddrClusterFrom(addr, 0)
 			if err := ops.deleteFrontend(fe); err != nil {
-				ops.log.Warn("Deleting orphan frontend failed, retrying", logfields.Error, err)
+				ops.log.Warn("Deleting orphan frontend failed",
+					logfields.Error, err,
+					logfields.Address, fe.Address,
+				)
 				return err
 			}
 		}

--- a/pkg/loadbalancer/reconciler/logger.go
+++ b/pkg/loadbalancer/reconciler/logger.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const (
+	// The amount of time to wait between log messages
+	logRateInterval = time.Second / 2
+
+	// The number of log messages to allow in burst when
+	// the [logRateInterval] has elapsed.
+	logRateBurst = 10
+)
+
+// rateLimitingLogger wraps [slog.Logger] and discards log messages
+// above a specific rate.
+type rateLimitingLogger struct {
+	limiter logging.Limiter
+	log     *slog.Logger
+}
+
+func newRateLimitingLogger(log *slog.Logger) rateLimitingLogger {
+	return rateLimitingLogger{
+		log:     log,
+		limiter: logging.NewLimiter(logRateInterval, logRateBurst),
+	}
+}
+
+func (log rateLimitingLogger) Debug(msg string, args ...any) {
+	// Debug messages are not rate limited.
+	log.log.Debug(msg, args...)
+}
+
+func (log rateLimitingLogger) Info(msg string, args ...any) {
+	if log.limiter.Allow() {
+		log.log.Info(msg, args...)
+	}
+}
+
+func (log rateLimitingLogger) Warn(msg string, args ...any) {
+	if log.limiter.Allow() {
+		log.log.Warn(msg, args...)
+	}
+}

--- a/pkg/loadbalancer/repl/main_test.go
+++ b/pkg/loadbalancer/repl/main_test.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+)
+
+func TestHive(t *testing.T) {
+	if err := Hive.Populate(hivetest.Logger(t)); err != nil {
+		t.Fatalf("Populate: %s", err)
+	}
+}


### PR DESCRIPTION
As the reconciler will retry failures we want to avoid spamming the logs if we have a lot frontends and the map becomes full. Add a logging.Limiter and use it for all non-debug logging in BPFOps.

Fix `pkg/loadbalancer/repl` (was missing `metrics.Cell`) to test out the limiter changes.