### PR TITLE
Add "MetricScope" to the K8s-to-StateDB reflector

### DIFF
--- a/daemon/k8s/namespaces.go
+++ b/daemon/k8s/namespaces.go
@@ -109,6 +109,7 @@ func namespaceReflectorConfig(cs client.Clientset, namespaces statedb.RWTable[Na
 		Name:          reflectorName,
 		Table:         namespaces,
 		ListerWatcher: lw,
+		MetricScope:   "Namespace",
 		Transform: func(_ statedb.ReadTxn, obj any) (Namespace, bool) {
 			ns, ok := obj.(*slim_corev1.Namespace)
 			if !ok {

--- a/daemon/k8s/pods.go
+++ b/daemon/k8s/pods.go
@@ -129,6 +129,7 @@ func podReflectorConfig(cs client.Clientset, pods statedb.RWTable[LocalPod]) k8s
 		Name:          reflectorName,
 		Table:         pods,
 		ListerWatcher: lw,
+		MetricScope:   "Pod",
 		Transform: func(_ statedb.ReadTxn, obj any) (LocalPod, bool) {
 			pod, ok := obj.(*slim_corev1.Pod)
 			if !ok {

--- a/pkg/ciliumenvoyconfig/k8s_reflector.go
+++ b/pkg/ciliumenvoyconfig/k8s_reflector.go
@@ -188,6 +188,7 @@ func registerCECK8sReflector(
 			Table:         tbl,
 			ListerWatcher: lws.cec,
 			Transform:     transform,
+			MetricScope:   "CiliumEnvoyConfig",
 			QueryAll: func(txn statedb.ReadTxn, tbl statedb.Table[*CEC]) iter.Seq2[*CEC, statedb.Revision] {
 				return statedb.Filter(
 					tbl.All(txn),
@@ -210,6 +211,7 @@ func registerCECK8sReflector(
 			Table:         tbl,
 			ListerWatcher: lws.ccec,
 			Transform:     transform,
+			MetricScope:   "CiliumClusterwideEnvoyConfig",
 			QueryAll: func(txn statedb.ReadTxn, tbl statedb.Table[*CEC]) iter.Seq2[*CEC, statedb.Revision] {
 				return statedb.Filter(
 					tbl.All(txn),

--- a/pkg/dynamicconfig/reflectors.go
+++ b/pkg/dynamicconfig/reflectors.go
@@ -99,8 +99,9 @@ func getPriorityForKey(key string, overrides resolver.ConfigOverride, index int,
 
 func configMapReflector(name string, namespace string, cs k8sClient.Clientset, t statedb.RWTable[DynamicConfig], index int, sourceLen int, overrides resolver.ConfigOverride) k8s.ReflectorConfig[DynamicConfig] {
 	return k8s.ReflectorConfig[DynamicConfig]{
-		Name:  "cm-" + name + "-" + namespace,
-		Table: t,
+		Name:        "cm-" + name + "-" + namespace,
+		Table:       t,
+		MetricScope: "ConfigMap",
 		TransformMany: func(txn statedb.ReadTxn, deleted bool, o any) (toInsert, toDelete iter.Seq[DynamicConfig]) {
 			cm := o.(*v1.ConfigMap)
 			var entries map[Key]DynamicConfig
@@ -143,8 +144,9 @@ func configMapReflector(name string, namespace string, cs k8sClient.Clientset, t
 }
 func ciliumNodeConfigReflector(name string, namespace string, cs k8sClient.Clientset, t statedb.RWTable[DynamicConfig], index int, sourceLen int, overrides resolver.ConfigOverride) k8s.ReflectorConfig[DynamicConfig] {
 	return k8s.ReflectorConfig[DynamicConfig]{
-		Name:  "cnc-" + name + "-" + namespace,
-		Table: t,
+		Name:        "cnc-" + name + "-" + namespace,
+		Table:       t,
+		MetricScope: "CiliumNodeConfig",
 		TransformMany: func(txn statedb.ReadTxn, deleted bool, o any) (toInsert, toDelete iter.Seq[DynamicConfig]) {
 			cnc := o.(*ciliumv2.CiliumNodeConfig)
 			var entries map[Key]DynamicConfig
@@ -189,8 +191,9 @@ func ciliumNodeConfigReflector(name string, namespace string, cs k8sClient.Clien
 
 func ciliumNodeReflector(name string, cs k8sClient.Clientset, t statedb.RWTable[DynamicConfig], l *slog.Logger, index int, sourceLen int, overrides resolver.ConfigOverride) k8s.ReflectorConfig[DynamicConfig] {
 	return k8s.ReflectorConfig[DynamicConfig]{
-		Name:  "node-" + name,
-		Table: t,
+		Name:        "node-" + name,
+		Table:       t,
+		MetricScope: "Node",
 		TransformMany: func(txn statedb.ReadTxn, deleted bool, o any) (toInsert, toDelete iter.Seq[DynamicConfig]) {
 			var entries map[Key]DynamicConfig
 			node := o.(*corev1.Node)

--- a/pkg/loadbalancer/redirectpolicy/table.go
+++ b/pkg/loadbalancer/redirectpolicy/table.go
@@ -89,6 +89,7 @@ func registerLRPReflector(enabled lrpIsEnabled, db *statedb.DB, jg job.Group, lw
 			Name:          "lrps",
 			Table:         lrps,
 			ListerWatcher: lw,
+			MetricScope:   "CiliumLocalRedirectPolicy",
 			Transform: func(_ statedb.ReadTxn, obj any) (*LocalRedirectPolicy, bool) {
 				clrp, ok := obj.(*ciliumv2.CiliumLocalRedirectPolicy)
 				if !ok {


### PR DESCRIPTION
This ports the "MetricScope" feature from `Resource[T]` to the Kubernetes-to-StateDB reflector
and adds it to where `RegisterReflector` is being used.