### PR TITLE
maps/policymap: clean up test code

### DIFF
--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -284,25 +284,6 @@ func (key *PolicyKey) String() string {
 
 func (key *PolicyKey) New() bpf.MapKey { return &PolicyKey{} }
 
-// NewKey returns a PolicyKey representing the specified parameters in network
-// byte-order.
-func NewKey(trafficDirection trafficdirection.TrafficDirection, id identity.NumericIdentity, proto u8proto.U8proto, dport uint16, portPrefixLen uint8) PolicyKey {
-	prefixLen := StaticPrefixBits
-	if proto != 0 || dport != 0 {
-		prefixLen += uint32(NexthdrBits)
-		if dport != 0 {
-			prefixLen += uint32(portPrefixLen)
-		}
-	}
-	return PolicyKey{
-		Prefixlen:        prefixLen,
-		Identity:         uint32(id),
-		TrafficDirection: uint8(trafficDirection),
-		Nexthdr:          uint8(proto),
-		DestPortNetwork:  byteorder.HostToNetwork16(dport),
-	}
-}
-
 // NewKeyFromPolicyKey converts a policy MapState key to a bpf PolicyMap key.
 func NewKeyFromPolicyKey(pk policyTypes.Key) PolicyKey {
 	prefixLen := StaticPrefixBits

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -342,15 +342,6 @@ func NewEntryFromPolicyEntry(key PolicyKey, pe policyTypes.MapStateEntry) Policy
 	}
 }
 
-// Exists determines whether PolicyMap currently contains an entry that
-// allows traffic in `trafficDirection` for identity `id` with destination port
-// `dport`over protocol `proto`. It is assumed that `dport` is in host byte-order.
-func (pm *PolicyMap) Exists(trafficDirection trafficdirection.TrafficDirection, id identity.NumericIdentity, proto u8proto.U8proto, dport uint16, portPrefixLen uint8) bool {
-	key := NewKey(trafficDirection, id, proto, dport, portPrefixLen)
-	_, err := pm.Lookup(&key)
-	return err == nil
-}
-
 // Update pushes an 'entry' into the PolicyMap for the given PolicyKey 'key'.
 // Clears the associated policy stat entry, if in debug mode.
 // Returns an error if the update of the PolicyMap fails.
@@ -365,15 +356,6 @@ func (pm *PolicyMap) Update(key *PolicyKey, entry *PolicyEntry) error {
 // k. Returns an error if deletion from the PolicyMap fails.
 func (pm *PolicyMap) DeleteKey(key PolicyKey) error {
 	return pm.Map.Delete(&key)
-}
-
-// Delete removes an entry from the PolicyMap for identity `id`
-// sending traffic in direction `trafficDirection` with destination port `dport`
-// over protocol `proto`. It is assumed that `dport` is in host byte-order.
-// Returns an error if the deletion did not succeed.
-func (pm *PolicyMap) Delete(trafficDirection trafficdirection.TrafficDirection, id identity.NumericIdentity, proto u8proto.U8proto, dport uint16, portPrefixLen uint8) error {
-	k := NewKey(trafficDirection, id, proto, dport, portPrefixLen)
-	return pm.Map.Delete(&k)
 }
 
 // DeleteEntry removes an entry from the PolicyMap. It can be used in

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -321,17 +321,6 @@ func NewKeyFromPolicyKey(pk policyTypes.Key) PolicyKey {
 	}
 }
 
-// newEntry returns a PolicyEntry representing the specified parameters in
-// network byte-order.
-func newEntry(proxyPortPriority policyTypes.ProxyPortPriority, authReq policyTypes.AuthRequirement, proxyPort uint16, flags policyEntryFlags) PolicyEntry {
-	return PolicyEntry{
-		ProxyPortNetwork:  byteorder.HostToNetwork16(proxyPort),
-		Flags:             flags,
-		AuthRequirement:   authReq,
-		ProxyPortPriority: proxyPortPriority,
-	}
-}
-
 // NewEntryFromPolicyEntry converts a policy MapState entry to a PolicyMap entry.
 func NewEntryFromPolicyEntry(key PolicyKey, pe policyTypes.MapStateEntry) PolicyEntry {
 	pef := getPolicyEntryFlags(policyEntryFlagParams{

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -62,7 +62,7 @@ func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
 func TestPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooKey := NewKey(1, 1, 1, 1, SinglePortPrefixLen)
+	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)
 	entry := newAllowEntry(fooKey, 42, policyTypes.AuthTypeSpire.AsDerivedRequirement(), 0)
 	// err := testMap.AllowKey(fooKey, 42, policyTypes.AuthTypeSpire.AsDerivedRequirement(), 0)
 	err := testMap.Update(&fooKey, &entry)
@@ -79,7 +79,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 	require.Equal(t, policyTypes.ProxyPortPriority(42), dump[0].PolicyEntry.ProxyPortPriority)
 
 	// Special case: allow-all entry
-	barKey := NewKey(0, 0, 0, 0, 0)
+	barKey := newKey(0, 0, 0, 0, 0)
 	barEntry := newAllowEntry(barKey, 0, policyTypes.AuthRequirement(0), 0)
 	err = testMap.Update(&barKey, &barEntry)
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 
 func TestDeleteNonexistentKey(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
-	key := NewKey(trafficdirection.Ingress, 27, u8proto.TCP, 80, SinglePortPrefixLen)
+	key := newKey(trafficdirection.Ingress, 27, u8proto.TCP, 80, SinglePortPrefixLen)
 	err := testMap.Map.Delete(&key)
 	require.Error(t, err)
 	var errno unix.Errno
@@ -102,7 +102,7 @@ func TestDeleteNonexistentKey(t *testing.T) {
 func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooKey := NewKey(1, 1, 1, 1, SinglePortPrefixLen)
+	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)
 	fooEntry := newDenyEntry(fooKey)
 	err := testMap.Update(&fooKey, &fooEntry)
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	require.Equal(t, fooEntry, dump[0].PolicyEntry)
 
 	// Special case: deny-all entry
-	barKey := NewKey(0, 0, 0, 0, 0)
+	barKey := newKey(0, 0, 0, 0, 0)
 	barEntry := newDenyEntry(barKey)
 	err = testMap.Update(&barKey, &barEntry)
 	require.NoError(t, err)

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -16,6 +16,22 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
+// newEntry returns a PolicyEntry representing the specified parameters in
+// network byte-order.
+func newEntry(
+	proxyPortPriority policyTypes.ProxyPortPriority,
+	authReq policyTypes.AuthRequirement,
+	proxyPort uint16,
+	flags policyEntryFlags,
+) PolicyEntry {
+	return PolicyEntry{
+		ProxyPortNetwork:  byteorder.HostToNetwork16(proxyPort),
+		Flags:             flags,
+		AuthRequirement:   authReq,
+		ProxyPortPriority: proxyPortPriority,
+	}
+}
+
 // newAllowEntry returns an allow PolicyEntry for the specified parameters in
 // network byte-order.
 // This is separated out to be used in unit testing.

--- a/pkg/maps/policymap/statsmap_privileged_test.go
+++ b/pkg/maps/policymap/statsmap_privileged_test.go
@@ -16,7 +16,7 @@ func TestStatMap(t *testing.T) {
 	testMap := policyMap.stats
 	require.NotNil(t, testMap)
 
-	fooKey := NewKey(1, 1, 1, 1, SinglePortPrefixLen)
+	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)
 
 	err := testMap.ClearStat(0, fooKey)
 	require.NoError(t, err)


### PR DESCRIPTION
Move and remove some test related code.

See commits for details.

Split out of #40023.