### PR TITLE
.github/ipsec-key-rotation: shorten to 1m

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -89,6 +89,7 @@ runs:
             --nodes-without-cilium \
             --helm-set-string=kubeProxyReplacement=${{ inputs.kpr }} \
             --helm-set=l2NeighDiscovery.enabled=true \
+            --helm-set-string=encryption.ipsec.keyRotationDuration="1m" \
             --set='${{ inputs.misc }}'"
 
           if [ -f "${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml" ]; then

--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -40,8 +40,6 @@ runs:
         ((exp_nb_keys/=2))
 
         # Wait until key rotation completes
-        # By default the key rotation cleanup delay is 5min, let's sleep 4min before actively polling
-        sleep $((4*60))
         while true; do
           keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg encrypt status | awk '/Keys in use/ {print $NF}')
           if [[ $keys_in_use == $exp_nb_keys ]]; then


### PR DESCRIPTION
There's no point on having the IPSec Key rotation to take up to 5
minutes. We can shorten its time to 1 minute to speed up CI a little
bit.