### PR TITLE
Refactor and generalize the clustermesh-apiserver, and improve testing

### DIFF
--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -15,8 +15,10 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/kvstore/heartbeat"
 	"github.com/cilium/cilium/pkg/pprof"
 )
@@ -95,6 +97,22 @@ var Synchronization = cell.Module(
 			newCiliumIdentityConverter,
 		),
 		cell.Invoke(RegisterSynchronizer[*cilium_api_v2.CiliumIdentity]),
+	),
+
+	cell.Group(
+		cell.Provide(
+			newCiliumEndpointOptions,
+			newCiliumEndpointConverter,
+		),
+		cell.Invoke(RegisterSynchronizer[*types.CiliumEndpoint]),
+	),
+
+	cell.Group(
+		cell.Provide(
+			newCiliumEndpointSliceOptions,
+			newCiliumEndpointSliceConverter,
+		),
+		cell.Invoke(RegisterSynchronizer[*cilium_api_v2a1.CiliumEndpointSlice]),
 	),
 )
 

--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -48,6 +48,16 @@ var Cell = cell.Module(
 
 	HealthAPIEndpointsCell,
 
+	Synchronization,
+
+	usersManagementCell,
+	cell.Invoke(registerHooks),
+)
+
+var Synchronization = cell.Module(
+	"clustermesh-synchronization",
+	"Synchronize information from Kubernetes to KVStore",
+
 	cell.Group(
 		cell.Provide(
 			func(syncState syncstate.SyncState) operatorWatchers.ServiceSyncConfig {
@@ -59,9 +69,6 @@ var Cell = cell.Module(
 		),
 		operatorWatchers.ServiceSyncCell,
 	),
-
-	usersManagementCell,
-	cell.Invoke(registerHooks),
 )
 
 var pprofConfig = pprof.Config{

--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/kvstore/heartbeat"
@@ -78,6 +79,14 @@ var Synchronization = cell.Module(
 			},
 		),
 		mcsapi.ServiceExportSyncCell,
+	),
+
+	cell.Group(
+		cell.Provide(
+			newCiliumNodeOptions,
+			newCiliumNodeConverter,
+		),
+		cell.Invoke(RegisterSynchronizer[*cilium_api_v2.CiliumNode]),
 	),
 )
 

--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -52,7 +52,7 @@ var Cell = cell.Module(
 	Synchronization,
 
 	usersManagementCell,
-	cell.Invoke(registerHooks),
+	cell.Invoke(RegisterHooks),
 )
 
 var Synchronization = cell.Module(

--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -88,6 +88,14 @@ var Synchronization = cell.Module(
 		),
 		cell.Invoke(RegisterSynchronizer[*cilium_api_v2.CiliumNode]),
 	),
+
+	cell.Group(
+		cell.Provide(
+			newCiliumIdentityOptions,
+			newCiliumIdentityConverter,
+		),
+		cell.Invoke(RegisterSynchronizer[*cilium_api_v2.CiliumIdentity]),
+	),
 )
 
 var pprofConfig = pprof.Config{

--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/clustermesh-apiserver/option"
 	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
+	"github.com/cilium/cilium/pkg/clustermesh/mcsapi"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
@@ -68,6 +69,15 @@ var Synchronization = cell.Module(
 			},
 		),
 		operatorWatchers.ServiceSyncCell,
+	),
+
+	cell.Group(
+		cell.Provide(
+			func(syncState syncstate.SyncState) mcsapi.ServiceExportSyncCallback {
+				return syncState.WaitForResource()
+			},
+		),
+		mcsapi.ServiceExportSyncCell,
 	),
 )
 

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh
+
+import (
+	"iter"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	nodeStore "github.com/cilium/cilium/pkg/node/store"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+// noneIter is a zero-length [Seq].
+func noneIter[T any](func(T) bool) {}
+
+// singleIter returns a [Seq] of length one that yields the given value.
+func singleIter[T any](value T) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		yield(value)
+	}
+}
+
+// ----- CiliumNodes ----- //
+
+func newCiliumNodeOptions() Options[*cilium_api_v2.CiliumNode] {
+	return Options[*cilium_api_v2.CiliumNode]{
+		Enabled:  true,
+		Resource: "CiliumNode",
+		Prefix:   nodeStore.NodeStorePrefix,
+	}
+}
+
+// CiliumNodeConverter implements Converter[*cilium_api_v2.CiliumNode]
+type CiliumNodeConverter struct{ cinfo cmtypes.ClusterInfo }
+
+func newCiliumNodeConverter(cinfo cmtypes.ClusterInfo) Converter[*cilium_api_v2.CiliumNode] {
+	return &CiliumNodeConverter{cinfo: cinfo}
+}
+
+func (nc *CiliumNodeConverter) Convert(event resource.Event[*cilium_api_v2.CiliumNode]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey]) {
+	if event.Kind == resource.Delete {
+		node := nodeTypes.Node{Cluster: nc.cinfo.Name, Name: event.Key.Name}
+		return noneIter[store.Key], singleIter[store.NamedKey](&node)
+	}
+
+	node := nodeTypes.ParseCiliumNode(event.Object)
+	node.Cluster = nc.cinfo.Name
+	node.ClusterID = nc.cinfo.ID
+	return singleIter[store.Key](&node), noneIter[store.NamedKey]
+}

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -4,12 +4,18 @@
 package clustermesh
 
 import (
+	"errors"
 	"iter"
+	"log/slog"
+	"path"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
@@ -51,4 +57,44 @@ func (nc *CiliumNodeConverter) Convert(event resource.Event[*cilium_api_v2.Ciliu
 	node.Cluster = nc.cinfo.Name
 	node.ClusterID = nc.cinfo.ID
 	return singleIter[store.Key](&node), noneIter[store.NamedKey]
+}
+
+// ----- CiliumIdentities ----- //
+
+func newCiliumIdentityOptions() Options[*cilium_api_v2.CiliumIdentity] {
+	return Options[*cilium_api_v2.CiliumIdentity]{
+		Enabled:   true,
+		Resource:  "CiliumIdentity",
+		Prefix:    path.Join(identityCache.IdentitiesPath, "id"),
+		StoreOpts: []store.WSSOpt{store.WSSWithSyncedKeyOverride(identityCache.IdentitiesPath)},
+	}
+}
+
+// CiliumIdentityConverter implements Converter[*cilium_api_v2.CiliumIdentity]
+type CiliumIdentityConverter struct{ logger *slog.Logger }
+
+func newCiliumIdentityConverter(logger *slog.Logger) Converter[*cilium_api_v2.CiliumIdentity] {
+	return &CiliumIdentityConverter{logger: logger}
+}
+
+func (ic *CiliumIdentityConverter) Convert(event resource.Event[*cilium_api_v2.CiliumIdentity]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey]) {
+	if event.Kind == resource.Delete {
+		key := store.NewKVPair(event.Key.Name, "")
+		return noneIter[store.Key], singleIter[store.NamedKey](key)
+	}
+
+	identity := event.Object
+	if len(identity.SecurityLabels) == 0 {
+		ic.logger.Warn(
+			"Ignoring invalid identity",
+			logfields.Error, errors.New("missing security labels"),
+			logfields.Identity, identity.Name,
+		)
+
+		return noneIter[store.Key], noneIter[store.NamedKey]
+	}
+
+	lbls := labels.Map2Labels(identity.SecurityLabels, "").SortedList()
+	kv := store.NewKVPair(identity.Name, string(lbls))
+	return singleIter[store.Key](kv), noneIter[store.NamedKey]
 }

--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
@@ -59,7 +58,6 @@ type parameters struct {
 	CfgMCSAPI   operator.MCSAPIConfig
 	ClusterInfo cmtypes.ClusterInfo
 	Backend     kvstore.Client
-	SyncState   syncstate.SyncState
 
 	Logger *slog.Logger
 }
@@ -67,7 +65,7 @@ type parameters struct {
 func RegisterHooks(lc cell.Lifecycle, params parameters) error {
 	lc.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
-			startServer(params.ClusterInfo, params.Backend, params.SyncState, params.CfgMCSAPI.ClusterMeshEnableMCSAPI, params.Logger)
+			startServer(params.ClusterInfo, params.Backend, params.CfgMCSAPI.ClusterMeshEnableMCSAPI, params.Logger)
 			return nil
 		},
 	})
@@ -77,7 +75,6 @@ func RegisterHooks(lc cell.Lifecycle, params parameters) error {
 func startServer(
 	cinfo cmtypes.ClusterInfo,
 	backend kvstore.BackendOperations,
-	syncState syncstate.SyncState,
 	clusterMeshEnableMCSAPI bool,
 	logger *slog.Logger,
 ) {
@@ -100,8 +97,6 @@ func startServer(
 	if err != nil {
 		logging.Fatal(logger, "Unable to set local cluster config on kvstore", logfields.Error, err)
 	}
-
-	syncState.Stop()
 
 	logger.Info("Initialization complete")
 }

--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -5,7 +5,6 @@ package clustermesh
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
@@ -16,7 +15,6 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/hive"
-	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -60,7 +58,6 @@ type parameters struct {
 
 	CfgMCSAPI   operator.MCSAPIConfig
 	ClusterInfo cmtypes.ClusterInfo
-	Clientset   k8sClient.Clientset
 	Backend     kvstore.Client
 	SyncState   syncstate.SyncState
 
@@ -70,10 +67,6 @@ type parameters struct {
 func RegisterHooks(lc cell.Lifecycle, params parameters) error {
 	lc.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
-			if !params.Clientset.IsEnabled() {
-				return errors.New("Kubernetes client not configured, cannot continue.")
-			}
-
 			startServer(params.ClusterInfo, params.Backend, params.SyncState, params.CfgMCSAPI.ClusterMeshEnableMCSAPI, params.Logger)
 			return nil
 		},

--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -86,7 +86,7 @@ type parameters struct {
 	Logger *slog.Logger
 }
 
-func registerHooks(lc cell.Lifecycle, params parameters) error {
+func RegisterHooks(lc cell.Lifecycle, params parameters) error {
 	lc.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
 			if !params.Clientset.IsEnabled() {

--- a/clustermesh-apiserver/clustermesh/script_test.go
+++ b/clustermesh-apiserver/clustermesh/script_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh_test
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"maps"
+	"testing"
+
+	uhive "github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/clustermesh-apiserver/clustermesh"
+	cmk8s "github.com/cilium/cilium/clustermesh-apiserver/clustermesh/k8s"
+	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
+	"github.com/cilium/cilium/pkg/clustermesh/operator"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hive"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
+func TestScript(t *testing.T) {
+	version.Force(testutils.DefaultVersion)
+
+	var opts []hivetest.LogOption
+	if *debug {
+		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+		logging.SetLogLevelToDebug()
+	}
+	log := hivetest.Logger(t, opts...)
+
+	setup := func(t testing.TB, args []string) *script.Engine {
+		storeFactory := store.NewFactory(hivetest.Logger(t), store.MetricsProvider())
+
+		h := hive.New(
+			cell.Config(cmtypes.DefaultClusterInfo),
+			cell.Config(operator.MCSAPIConfig{}),
+			cell.Invoke(cmtypes.ClusterInfo.Validate),
+
+			k8sClient.FakeClientCell(),
+			cmk8s.ResourcesCell,
+
+			cell.Provide(func(db *statedb.DB) (kvstore.Client, uhive.ScriptCmdsOut) {
+				client := kvstore.NewInMemoryClient(db, "__local__")
+				return client, uhive.NewScriptCmds(kvstore.Commands(client))
+			}),
+
+			cell.Provide(
+				func() store.Factory {
+					return storeFactory
+				},
+			),
+
+			cell.Provide(func() syncstate.SyncState {
+				return syncstate.SyncState{StoppableWaitGroup: lock.NewStoppableWaitGroup()}
+			}),
+
+			clustermesh.Synchronization,
+			cell.Invoke(clustermesh.RegisterHooks),
+		)
+
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		h.RegisterFlags(flags)
+
+		// Parse the shebang arguments in the script.
+		require.NoError(t, flags.Parse(args), "flags.Parse")
+
+		t.Cleanup(func() {
+			assert.NoError(t, h.Stop(log, context.TODO()))
+		})
+		cmds, err := h.ScriptCommands(log)
+		require.NoError(t, err, "ScriptCommands")
+		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+
+		return &script.Engine{
+			Cmds:             cmds,
+			RetryInterval:    20 * time.Millisecond,
+			MaxRetryInterval: time.Second,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	scripttest.Test(t,
+		ctx,
+		setup,
+		[]string{},
+		"testdata/*.txtar")
+}

--- a/clustermesh-apiserver/clustermesh/synchronizer.go
+++ b/clustermesh-apiserver/clustermesh/synchronizer.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// Options represents the options to synchronize a given resource type.
+type Options[T runtime.Object] struct {
+	Enabled   bool
+	Resource  string
+	Prefix    string
+	StoreOpts []store.WSSOpt
+}
+
+// Converter knows how to convert a given Kubernetes event into the corresponding
+// set of kvstore upsert and delete operations.
+type Converter[T runtime.Object] interface {
+	Convert(event resource.Event[T]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey])
+}
+
+type syncParams[T runtime.Object] struct {
+	cell.In
+
+	Logger      *slog.Logger
+	JobGroup    job.Group
+	ClusterInfo cmtypes.ClusterInfo
+
+	Client  kvstore.Client
+	Factory store.Factory
+
+	Resource  resource.Resource[T]
+	Options   Options[T]
+	Converter Converter[T]
+	SyncState syncstate.SyncState
+}
+
+// RegisterSynchronizer registers a new synchronizer for the given resource,
+// which watches for Kubernetes events and propagates the corresponding
+// representation to the kvstore.
+func RegisterSynchronizer[T runtime.Object](in syncParams[T]) {
+	logger := in.Logger.With(logfields.Resource, in.Options.Resource)
+	if !in.Options.Enabled {
+		logger.Info("Synchronization is disabled")
+		return
+	}
+	logger.Info("Synchronization is enabled")
+
+	store := in.Factory.NewSyncStore(
+		in.ClusterInfo.Name, in.Client,
+		in.Options.Prefix, in.Options.StoreOpts...)
+	synced := in.SyncState.WaitForResource()
+
+	in.JobGroup.Add(
+		job.OneShot(
+			fmt.Sprintf("%s-sync", strings.ToLower(in.Options.Resource)),
+			func(ctx context.Context, _ cell.Health) error {
+				for event := range in.Resource.Events(ctx) {
+					event.Done(nil)
+
+					if event.Kind == resource.Sync {
+						logger.Info("Initial entries successfully received from Kubernetes")
+						store.Synced(ctx, synced)
+						continue
+					}
+
+					process := func(op, key string, do func() error) {
+						logger.Info("Updating resource in etcd",
+							logfields.Operation, op,
+							logfields.Key, key,
+						)
+
+						if err := do(); err != nil {
+							logger.Warn("Failed updating resource in etcd",
+								logfields.Error, err,
+								logfields.Operation, op,
+								logfields.Key, key,
+							)
+						}
+					}
+
+					upserts, deletes := in.Converter.Convert(event)
+					for upsert := range upserts {
+						process("upsert", upsert.GetKeyName(), func() error { return store.UpsertKey(ctx, upsert) })
+					}
+					for delete := range deletes {
+						process("delete", delete.GetKeyName(), func() error { return store.DeleteKey(ctx, delete) })
+					}
+				}
+				return nil
+			},
+		),
+		job.OneShot(
+			fmt.Sprintf("run-%s-store", strings.ToLower(in.Options.Resource)),
+			func(ctx context.Context, _ cell.Health) error {
+				store.Run(ctx)
+				return nil
+			},
+		),
+	)
+}

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -1,0 +1,270 @@
+#! --cluster-id=3 --cluster-name=cluster3
+
+hive/start
+
+# Add two CiliumEndpoints
+k8s/add endpoint-1.yaml endpoint-2.yaml
+
+# Assert that the synced key gets created. We compare on the key only as the
+# value is the timestamp at which synchronization completed
+kvstore/list -o plain cilium/synced synced.actual
+* grep -q '^# cilium/synced/cluster3/cilium/state/ip/v1$' synced.actual
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+2.actual
+* cmp ips-1+2.actual ips-1+2.expected
+
+# Update one of the CiliumEndpoints
+cp endpoint-1.yaml endpoint-1-v2.yaml
+replace '10.244.1.79' '10.244.1.80' endpoint-1-v2.yaml
+replace 'ipv6:' '# ipv6:' endpoint-1-v2.yaml
+k8s/update endpoint-1-v2.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+2-v2.actual
+* cmp ips-1+2-v2.actual ips-1+2-v2.expected
+
+# Add one more CiliumEndpoint
+k8s/add endpoint-3.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+2+3.actual
+* cmp ips-1+2+3.actual ips-1+2+3.expected
+
+# Delete one of the CiliumEndpoints
+k8s/delete endpoint-2.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+3.actual
+* cmp ips-1+3.actual ips-1+3.expected
+
+# ---
+
+-- endpoint-1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEndpoint
+metadata:
+  name: cep-001
+  namespace: foo
+status:
+  id: 1481
+  identity:
+    id: 199472
+    labels:
+    - k8s:app=bar
+  networking:
+    addressing:
+    - ipv4: 10.244.1.79
+      ipv6: fd00:10:244:1::d643
+    node: 172.18.0.3
+  state: ready
+
+-- endpoint-2.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEndpoint
+metadata:
+  name: cep-002
+  namespace: bar
+status:
+  encryption:
+    key: 5
+  id: 1482
+  identity:
+    id: 199475
+    labels:
+    - k8s:app=qux
+  networking:
+    addressing:
+    - ipv4: 10.244.2.74
+      ipv6: fd00:10:244:2::e024
+    node: 172.18.0.2
+  state: ready
+
+-- endpoint-3.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEndpoint
+metadata:
+  name: cep-002
+  namespace: foo
+status:
+  id: 1483
+  identity:
+    id: 199472
+    labels:
+    - k8s:app=bar
+  networking:
+    addressing:
+    - ipv4: 10.244.2.91
+      ipv6: fd00:10:244:2::e4b4
+    node: 172.18.0.2
+  state: ready
+
+-- ips-1+2.expected --
+# cilium/state/ip/v1/default/10.244.1.79
+{
+  "IP": "10.244.1.79",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001"
+}
+# cilium/state/ip/v1/default/10.244.2.74
+{
+  "IP": "10.244.2.74",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "bar",
+  "K8sPodName": "cep-002"
+}
+# cilium/state/ip/v1/default/fd00:10:244:1::d643
+{
+  "IP": "fd00:10:244:1::d643",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e024
+{
+  "IP": "fd00:10:244:2::e024",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "bar",
+  "K8sPodName": "cep-002"
+}
+-- ips-1+2-v2.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001"
+}
+# cilium/state/ip/v1/default/10.244.2.74
+{
+  "IP": "10.244.2.74",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "bar",
+  "K8sPodName": "cep-002"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e024
+{
+  "IP": "fd00:10:244:2::e024",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "bar",
+  "K8sPodName": "cep-002"
+}
+-- ips-1+2+3.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001"
+}
+# cilium/state/ip/v1/default/10.244.2.74
+{
+  "IP": "10.244.2.74",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "bar",
+  "K8sPodName": "cep-002"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e024
+{
+  "IP": "fd00:10:244:2::e024",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "bar",
+  "K8sPodName": "cep-002"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b4
+{
+  "IP": "fd00:10:244:2::e4b4",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002"
+}
+-- ips-1+3.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b4
+{
+  "IP": "fd00:10:244:2::e4b4",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002"
+}

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpointslices.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpointslices.txtar
@@ -1,0 +1,440 @@
+#! --cluster-id=3 --cluster-name=cluster3 --enable-cilium-endpoint-slice=true
+
+hive/start
+
+# Add two CiliumEndpointSlices
+k8s/add endpointslice-1.yaml endpointslice-2.yaml
+
+# Assert that the synced key gets created. We compare on the key only as the
+# value is the timestamp at which synchronization completed
+kvstore/list -o plain cilium/synced synced.actual
+* grep -q '^# cilium/synced/cluster3/cilium/state/ip/v1$' synced.actual
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+2.actual
+* cmp ips-1+2.actual ips-1+2.expected
+
+# Update one of the CiliumEndpointSlices
+k8s/update endpointslice-1-v2.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+2-v2.actual
+* cmp ips-1+2-v2.actual ips-1+2-v2.expected
+
+# Add one more CiliumEndpointSlices
+k8s/add endpointslice-3.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+2+3.actual
+* cmp ips-1+2+3.actual ips-1+2+3.expected
+
+# Delete one of the CiliumEndpointSlices
+k8s/delete endpointslice-2.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+3.actual
+* cmp ips-1+3.actual ips-1+3.expected
+
+# ---
+
+-- endpointslice-1.yaml --
+apiVersion: cilium.io/v2alpha1
+endpoints:
+- encryption: {}
+  id: 199472
+  name: foo-001
+  networking:
+    addressing:
+    - ipv4: 10.244.1.79
+      ipv6: fd00:10:244:1::d643
+    node: 172.18.0.3
+- encryption:
+    key: 5
+  id: 199475
+  name: foo-002
+  networking:
+    addressing:
+    - ipv4: 10.244.2.74
+      ipv6: fd00:10:244:2::e024
+    node: 172.18.0.2
+- encryption: {}
+  id: 199475
+  name: foo-003
+  networking:
+    addressing:
+    - ipv4: 10.244.2.91
+      ipv6: fd00:10:244:2::e4b4
+    node: 172.18.0.2
+kind: CiliumEndpointSlice
+metadata:
+  name: ces-c7hlcxqpt-rwqlm
+namespace: qux
+
+-- endpointslice-1-v2.yaml --
+apiVersion: cilium.io/v2alpha1
+endpoints:
+- encryption: {}
+  id: 199477
+  name: foo-001
+  networking:
+    addressing:
+    - ipv4: 10.244.2.15
+      ipv6: fd00:10:244:2::d615
+    node: 172.18.0.2
+- encryption: {}
+  id: 199481
+  name: foo-009
+  networking:
+    addressing:
+    - ipv4: 10.244.2.91
+      ipv6: fd00:10:244:2::e4b3
+    node: 172.18.0.2
+kind: CiliumEndpointSlice
+metadata:
+  name: ces-c7hlcxqpt-rwqlm
+namespace: qux
+
+-- endpointslice-2.yaml --
+apiVersion: cilium.io/v2alpha1
+endpoints:
+- encryption: {}
+  id: 199494
+  name: foo-004
+  networking:
+    addressing:
+    - ipv4: 10.244.2.78
+      ipv6: fd00:10:244:2::9182
+    node: 172.18.0.2
+kind: CiliumEndpointSlice
+metadata:
+  name: ces-l4wvwxg7q-wgmhr
+namespace: fred
+
+-- endpointslice-3.yaml --
+apiVersion: cilium.io/v2alpha1
+endpoints:
+- encryption: {}
+  id: 199494
+  name: foo-005
+  networking:
+    addressing:
+    - ipv4: 10.244.2.120
+      ipv6: fd00:10:244:2::5e16
+    node: 172.18.0.2
+kind: CiliumEndpointSlice
+metadata:
+  name: ces-67mn6kyjn-4tmqc
+namespace: fred
+
+-- ips-1+2.expected --
+# cilium/state/ip/v1/default/10.244.1.79
+{
+  "IP": "10.244.1.79",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001"
+}
+# cilium/state/ip/v1/default/10.244.2.74
+{
+  "IP": "10.244.2.74",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-002"
+}
+# cilium/state/ip/v1/default/10.244.2.78
+{
+  "IP": "10.244.2.78",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-004"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-003"
+}
+# cilium/state/ip/v1/default/fd00:10:244:1::d643
+{
+  "IP": "fd00:10:244:1::d643",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::9182
+{
+  "IP": "fd00:10:244:2::9182",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-004"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e024
+{
+  "IP": "fd00:10:244:2::e024",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-002"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b4
+{
+  "IP": "fd00:10:244:2::e4b4",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-003"
+}
+-- ips-1+2-v2.expected --
+# cilium/state/ip/v1/default/10.244.2.15
+{
+  "IP": "10.244.2.15",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199477,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001"
+}
+# cilium/state/ip/v1/default/10.244.2.78
+{
+  "IP": "10.244.2.78",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-004"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199481,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-009"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::9182
+{
+  "IP": "fd00:10:244:2::9182",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-004"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::d615
+{
+  "IP": "fd00:10:244:2::d615",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199477,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b3
+{
+  "IP": "fd00:10:244:2::e4b3",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199481,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-009"
+}
+-- ips-1+2+3.expected --
+# cilium/state/ip/v1/default/10.244.2.120
+{
+  "IP": "10.244.2.120",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-005"
+}
+# cilium/state/ip/v1/default/10.244.2.15
+{
+  "IP": "10.244.2.15",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199477,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001"
+}
+# cilium/state/ip/v1/default/10.244.2.78
+{
+  "IP": "10.244.2.78",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-004"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199481,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-009"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::5e16
+{
+  "IP": "fd00:10:244:2::5e16",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-005"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::9182
+{
+  "IP": "fd00:10:244:2::9182",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-004"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::d615
+{
+  "IP": "fd00:10:244:2::d615",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199477,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b3
+{
+  "IP": "fd00:10:244:2::e4b3",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199481,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-009"
+}
+-- ips-1+3.expected --
+# cilium/state/ip/v1/default/10.244.2.120
+{
+  "IP": "10.244.2.120",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-005"
+}
+# cilium/state/ip/v1/default/10.244.2.15
+{
+  "IP": "10.244.2.15",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199477,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199481,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-009"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::5e16
+{
+  "IP": "fd00:10:244:2::5e16",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-005"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::d615
+{
+  "IP": "fd00:10:244:2::d615",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199477,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b3
+{
+  "IP": "fd00:10:244:2::e4b3",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199481,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-009"
+}

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumidentitites.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumidentitites.txtar
@@ -1,0 +1,89 @@
+#! --cluster-id=3 --cluster-name=cluster3
+
+hive/start
+
+# Add two CiliumIdentities
+k8s/add identity-1.yaml identity-2.yaml
+
+# Assert that the synced key gets created. We compare on the key only as the
+# value is the timestamp at which synchronization completed
+kvstore/list -o plain cilium/synced synced.actual
+* grep -q '^# cilium/synced/cluster3/cilium/state/identities/v1$' synced.actual
+
+# Wait for synchronization
+kvstore/list -o plain cilium/state/identities identities-1+2.actual
+* cmp identities-1+2.actual identities-1+2.expected
+
+# Update one of the CiliumIdentities
+cp identity-1.yaml identity-1-v2.yaml
+replace 'foo' 'fred' identity-1-v2.yaml
+k8s/update identity-1-v2.yaml
+
+# Wait for synchronization
+kvstore/list -o plain cilium/state/identities identities-1+2-v2.actual
+* cmp identities-1+2-v2.actual identities-1+2-v2.expected
+
+# Add one more CiliumIdentity
+cp identity-1.yaml identity-3.yaml
+replace '196915' '214794' identity-3.yaml
+k8s/add identity-3.yaml
+
+# Wait for synchronization
+kvstore/list -o plain cilium/state/identities identities-1+2+3.actual
+* cmp identities-1+2+3.actual identities-1+2+3.expected
+
+# Delete one of the CiliumIdentities
+k8s/delete identity-2.yaml
+
+# Wait for synchronization
+kvstore/list -o plain cilium/state/identities identities-1+3.actual
+* cmp identities-1+3.actual identities-1+3.expected
+
+# ---
+
+-- identity-1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumIdentity
+metadata:
+  name: "196915"
+  labels:
+    io.kubernetes.pod.namespace: bar
+security-labels:
+  k8s:app: baz
+  k8s:io.cilium.k8s.policy.cluster: cluster3
+  k8s:io.kubernetes.pod.namespace: bar
+
+-- identity-2.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumIdentity
+metadata:
+  name: "199472"
+  labels:
+    io.kubernetes.pod.namespace: foo
+security-labels:
+  k8s:app: baz
+  k8s:io.cilium.k8s.policy.cluster: cluster3
+  k8s:io.kubernetes.pod.namespace: bar
+
+-- identities-1+2.expected --
+# cilium/state/identities/v1/id/196915
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+# cilium/state/identities/v1/id/199472
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+-- identities-1+2-v2.expected --
+# cilium/state/identities/v1/id/196915
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+# cilium/state/identities/v1/id/199472
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+-- identities-1+2+3.expected --
+# cilium/state/identities/v1/id/196915
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+# cilium/state/identities/v1/id/199472
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+# cilium/state/identities/v1/id/214794
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+-- identities-1+3.expected --
+# cilium/state/identities/v1/id/196915
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+# cilium/state/identities/v1/id/214794
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumnodes.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumnodes.txtar
@@ -1,0 +1,190 @@
+#! --cluster-id=3 --cluster-name=cluster3
+
+hive/start
+
+# Add two CiliumNodes
+k8s/add node-1.yaml node-2.yaml
+
+# Assert that the synced key gets created. We compare on the key only as the
+# value is the timestamp at which synchronization completed
+kvstore/list -o plain cilium/synced synced.actual
+* grep -q '^# cilium/synced/cluster3/cilium/state/nodes/v1$' synced.actual
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/nodes/v1/cluster3/test-node-1 node-1.actual
+* cmp node-1.actual node-1.expected
+kvstore/list -o json cilium/state/nodes/v1/cluster3/test-node-2 node-2.actual
+* cmp node-2.actual node-2.expected
+
+# Update one of the CiliumNodes
+replace '10.244.0.134' '10.244.0.135' node-1.yaml
+k8s/update node-1.yaml
+
+# Wait for synchronization
+replace '10.244.0.134' '10.244.0.135' node-1.expected
+kvstore/list -o json cilium/state/nodes/v1/cluster3/test-node-1 node-1.actual
+* cmp node-1.actual node-1.expected
+
+# Delete one of the CiliumNodes
+k8s/delete node-2.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/nodes/v1/cluster3/test-node-2 node-2.actual
+* empty node-2.actual
+
+# ---
+
+-- node-1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node-1
+  labels:
+    kubernetes.io/hostname: test-node-1
+  annotations:
+    network.cilium.io/wg-pub-key: VRksOB6ZNds4oXWIGfSVpvc0gBhcOWFmzvTDcyvULlI=
+spec:
+  addresses:
+  - ip: 172.18.0.2
+    type: InternalIP
+  - ip: fc00:c111::2
+    type: InternalIP
+  - ip: 10.244.0.10
+    type: CiliumInternalIP
+  - ip: fd00:10:244::e2d6
+    type: CiliumInternalIP
+  bootid: 570d3fd1-93db-4862-ba99-6a3c2c10c38f
+  health:
+    ipv4: 10.244.0.134
+    ipv6: fd00:10:244::d812
+  ipam:
+    podCIDRs:
+    - 10.244.0.0/24
+    - fd00:10:244::/64
+
+-- node-2.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node-2
+  labels:
+    kubernetes.io/hostname: test-node-2
+spec:
+  addresses:
+  - ip: 172.18.0.3
+    type: InternalIP
+  - ip: fc00:c111::3
+    type: InternalIP
+  - ip: 10.244.1.130
+    type: CiliumInternalIP
+  - ip: fd00:10:244:1::9089
+    type: CiliumInternalIP
+  bootid: c1d2cda2-aca0-4033-abca-3843298860b9
+  encryption:
+    key: 7
+  health:
+    ipv4: 10.244.1.153
+    ipv6: fd00:10:244:1::835d
+  ipam:
+    podCIDRs:
+    - 10.244.1.0/24
+    - fd00:10:244:1::/64
+
+-- node-1.expected --
+# cilium/state/nodes/v1/cluster3/test-node-1
+{
+  "Name": "test-node-1",
+  "Cluster": "cluster3",
+  "IPAddresses": [
+    {
+      "Type": "InternalIP",
+      "IP": "172.18.0.2"
+    },
+    {
+      "Type": "InternalIP",
+      "IP": "fc00:c111::2"
+    },
+    {
+      "Type": "CiliumInternalIP",
+      "IP": "10.244.0.10"
+    },
+    {
+      "Type": "CiliumInternalIP",
+      "IP": "fd00:10:244::e2d6"
+    }
+  ],
+  "IPv4AllocCIDR": {
+    "IP": "10.244.0.0",
+    "Mask": "////AA=="
+  },
+  "IPv4SecondaryAllocCIDRs": null,
+  "IPv6AllocCIDR": {
+    "IP": "fd00:10:244::",
+    "Mask": "//////////8AAAAAAAAAAA=="
+  },
+  "IPv6SecondaryAllocCIDRs": null,
+  "IPv4HealthIP": "10.244.0.134",
+  "IPv6HealthIP": "fd00:10:244::d812",
+  "IPv4IngressIP": "",
+  "IPv6IngressIP": "",
+  "ClusterID": 3,
+  "Source": "custom-resource",
+  "EncryptionKey": 0,
+  "Labels": {
+    "kubernetes.io/hostname": "test-node-1"
+  },
+  "Annotations": {
+    "network.cilium.io/wg-pub-key": "VRksOB6ZNds4oXWIGfSVpvc0gBhcOWFmzvTDcyvULlI="
+  },
+  "NodeIdentity": 0,
+  "WireguardPubKey": "VRksOB6ZNds4oXWIGfSVpvc0gBhcOWFmzvTDcyvULlI=",
+  "BootID": "570d3fd1-93db-4862-ba99-6a3c2c10c38f"
+}
+-- node-2.expected --
+# cilium/state/nodes/v1/cluster3/test-node-2
+{
+  "Name": "test-node-2",
+  "Cluster": "cluster3",
+  "IPAddresses": [
+    {
+      "Type": "InternalIP",
+      "IP": "172.18.0.3"
+    },
+    {
+      "Type": "InternalIP",
+      "IP": "fc00:c111::3"
+    },
+    {
+      "Type": "CiliumInternalIP",
+      "IP": "10.244.1.130"
+    },
+    {
+      "Type": "CiliumInternalIP",
+      "IP": "fd00:10:244:1::9089"
+    }
+  ],
+  "IPv4AllocCIDR": {
+    "IP": "10.244.1.0",
+    "Mask": "////AA=="
+  },
+  "IPv4SecondaryAllocCIDRs": null,
+  "IPv6AllocCIDR": {
+    "IP": "fd00:10:244:1::",
+    "Mask": "//////////8AAAAAAAAAAA=="
+  },
+  "IPv6SecondaryAllocCIDRs": null,
+  "IPv4HealthIP": "10.244.1.153",
+  "IPv6HealthIP": "fd00:10:244:1::835d",
+  "IPv4IngressIP": "",
+  "IPv6IngressIP": "",
+  "ClusterID": 3,
+  "Source": "custom-resource",
+  "EncryptionKey": 7,
+  "Labels": {
+    "kubernetes.io/hostname": "test-node-2"
+  },
+  "Annotations": null,
+  "NodeIdentity": 0,
+  "WireguardPubKey": "",
+  "BootID": "c1d2cda2-aca0-4033-abca-3843298860b9"
+}

--- a/clustermesh-apiserver/clustermesh/testdata/clusterconfig-serviceexport.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/clusterconfig-serviceexport.txtar
@@ -1,0 +1,20 @@
+#! --cluster-id=5 --cluster-name=cluster5 --clustermesh-enable-mcs-api
+
+hive/start
+
+# Assert that the ClusterConfig has been correctly created
+kvstore/list -o json cilium/cluster-config config.actual
+* cmp config.actual config.expected
+
+# ---
+
+-- config.expected --
+# cilium/cluster-config/cluster5
+{
+  "id": 5,
+  "capabilities": {
+    "syncedCanaries": true,
+    "maxConnectedClusters": 255,
+    "serviceExportsEnabled": true
+  }
+}

--- a/clustermesh-apiserver/clustermesh/testdata/clusterconfig.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/clusterconfig.txtar
@@ -1,0 +1,20 @@
+#! --cluster-id=3 --cluster-name=cluster3
+
+hive/start
+
+# Assert that the ClusterConfig has been correctly created
+kvstore/list -o json cilium/cluster-config config.actual
+* cmp config.actual config.expected
+
+# ---
+
+-- config.expected --
+# cilium/cluster-config/cluster3
+{
+  "id": 3,
+  "capabilities": {
+    "syncedCanaries": true,
+    "maxConnectedClusters": 255,
+    "serviceExportsEnabled": false
+  }
+}

--- a/clustermesh-apiserver/clustermesh/users_mgmt_test.go
+++ b/clustermesh-apiserver/clustermesh/users_mgmt_test.go
@@ -47,19 +47,11 @@ func (f *fakeUserMgmtClient) UserEnforceAbsence(_ context.Context, name string) 
 	return nil
 }
 
-func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(
-		m,
-		// To ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go
-		// init function
-		goleak.IgnoreTopFunction("time.Sleep"),
-		// Delaying workqueues used by resource.Resource[T].Events leaks this waitingLoop goroutine.
-		// It does stop when shutting down but is not guaranteed to before we actually exit.
-		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop"),
-	)
-}
-
 func TestUsersManagement(t *testing.T) {
+	// Catch any leaked goroutines. Ignoring goroutines possibly left by other tests.
+	leakOpts := goleak.IgnoreCurrent()
+	t.Cleanup(func() { goleak.VerifyNone(t, leakOpts) })
+
 	var client fakeUserMgmtClient
 	client.init()
 

--- a/clustermesh-apiserver/syncstate/syncstate_test.go
+++ b/clustermesh-apiserver/syncstate/syncstate_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 func TestSyncState(t *testing.T) {
 	var doneFuncs []func(context.Context)
-	ss := new(MetricsProvider(), types.ClusterInfo{Name: "test"})
+	ss := SyncState{StoppableWaitGroup: lock.NewStoppableWaitGroup()}
 
 	// add several resource to the SyncState
 	for range 3 {

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh.go
@@ -124,7 +124,6 @@ type SyncWaiterParams struct {
 
 func RegisterSyncWaiter(p SyncWaiterParams) {
 	syncedCallback := p.SyncState.WaitForResource()
-	p.SyncState.Stop()
 
 	p.JobGroup.Add(
 		job.OneShot("kvstoremesh-sync-waiter", func(ctx context.Context, health cell.Health) error {

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -30,6 +30,13 @@ var Cell = cell.Module(
 	cell.Invoke(registerMCSAPIController),
 )
 
+var ServiceExportSyncCell = cell.Module(
+	"service-export-sync",
+	"Synchronizes Kubernetes ServiceExports to KVStore",
+
+	cell.Invoke(registerServiceExportSync),
+)
+
 type mcsAPIParams struct {
 	cell.In
 

--- a/pkg/clustermesh/mcsapi/serviceexportsync.go
+++ b/pkg/clustermesh/mcsapi/serviceexportsync.go
@@ -6,17 +6,20 @@ package mcsapi
 import (
 	"context"
 	"log/slog"
-	"sync"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	"github.com/cilium/cilium/pkg/clustermesh/operator"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -34,66 +37,116 @@ func ServiceExportResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(
 	return resource.New[*mcsapiv1alpha1.ServiceExport](lc, lw, resource.WithMetric("ServiceExport"))
 }
 
-type ServiceExportSyncParameters struct {
-	Logger                  *slog.Logger
-	ClusterName             string
-	ClusterMeshEnableMCSAPI bool
-	Clientset               client.Clientset
-	ServiceExports          resource.Resource[*mcsapiv1alpha1.ServiceExport]
-	Services                resource.Resource[*slim_corev1.Service]
-	Backend                 store.SyncStoreBackend
-	StoreFactory            store.Factory
-	SyncCallback            func(context.Context)
+// ServiceExportSyncCallback represents a callback that, if provided, is executed
+// when the first synchronization is completed.
+type ServiceExportSyncCallback func(context.Context)
 
-	// Used for testing purposes
-	store        store.SyncStore
-	skipCrdCheck bool
+type ServiceExportSyncParameters struct {
+	cell.In
+
+	Logger      *slog.Logger
+	Config      operator.MCSAPIConfig
+	ClusterInfo cmtypes.ClusterInfo
+
+	Clientset     client.Clientset
+	KVStoreClient kvstore.Client
+	StoreFactory  store.Factory
+
+	ServiceExports resource.Resource[*mcsapiv1alpha1.ServiceExport]
+	Services       resource.Resource[*slim_corev1.Service]
+
+	SyncCallback ServiceExportSyncCallback `optional:"true"`
 }
 
-func StartSynchronizingServiceExports(ctx context.Context, cfg ServiceExportSyncParameters) {
-	logger := cfg.Logger.With(logfields.LogSubsys, "mcsapi")
-	if cfg.store == nil {
-		cfg.store = cfg.StoreFactory.NewSyncStore(cfg.ClusterName,
-			cfg.Backend, types.ServiceExportStorePrefix)
+func registerServiceExportSync(jg job.Group, cfg ServiceExportSyncParameters) {
+	if !cfg.Clientset.IsEnabled() || !cfg.KVStoreClient.IsEnabled() {
+		return
 	}
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		cfg.store.Run(ctx)
-		wg.Done()
-	}()
+	store := cfg.StoreFactory.NewSyncStore(
+		cfg.ClusterInfo.Name,
+		cfg.KVStoreClient,
+		types.ServiceExportStorePrefix,
+	)
 
-	if !cfg.ClusterMeshEnableMCSAPI || cfg.ServiceExports == nil {
+	jg.Add(
+		job.OneShot(
+			"serviceexport-sync",
+			func(ctx context.Context, _ cell.Health) error {
+				(&serviceExportSync{
+					logger:      cfg.Logger,
+					enabled:     cfg.Config.ClusterMeshEnableMCSAPI,
+					clusterName: cfg.ClusterInfo.Name,
+
+					clientset:      cfg.Clientset,
+					serviceExports: cfg.ServiceExports,
+					services:       cfg.Services,
+
+					store:        store,
+					syncCallback: cfg.SyncCallback,
+				}).loop(ctx)
+				return nil
+			},
+		),
+		job.OneShot(
+			"run-serviceexport-store",
+			func(ctx context.Context, _ cell.Health) error {
+				store.Run(ctx)
+				return nil
+			},
+		),
+	)
+}
+
+type serviceExportSync struct {
+	logger      *slog.Logger
+	enabled     bool
+	clusterName string
+
+	clientset      client.Clientset
+	serviceExports resource.Resource[*mcsapiv1alpha1.ServiceExport]
+	services       resource.Resource[*slim_corev1.Service]
+
+	store        store.SyncStore
+	syncCallback ServiceExportSyncCallback
+}
+
+func (s *serviceExportSync) loop(ctx context.Context) {
+	if s.syncCallback == nil {
+		s.syncCallback = func(ctx context.Context) {}
+	}
+
+	if !s.enabled {
 		// We pretend that service exports are synced even if the feature is
 		// disabled to simplify consumers logic so that they don't have to do any
 		// special handling/checks if a remote cluster has this feature disabled
 		// as it's the only cluster mesh type that can be disabled separately.
 		// This is especially useful in the case of the kvstoremesh.
-		cfg.store.Synced(ctx, cfg.SyncCallback)
+		s.store.Synced(ctx, s.syncCallback)
 		return
 	}
-	if !cfg.skipCrdCheck {
-		err := checkCRD(ctx, cfg.Clientset, mcsapiv1alpha1.SchemeGroupVersion.WithKind("serviceexports"))
+
+	if s.clientset != nil /* clientset is nil in tests */ {
+		err := checkCRD(ctx, s.clientset, mcsapiv1alpha1.SchemeGroupVersion.WithKind("serviceexports"))
 		if err != nil {
-			logger.Warn("starting synchronizing service exports without the required CRD installed", logfields.Error, err)
+			s.logger.Warn("starting synchronizing service exports without the required CRD installed", logfields.Error, err)
 			// Also pretend that the service exports are synced for the same reason
 			// as above.
-			cfg.store.Synced(ctx, cfg.SyncCallback)
+			s.store.Synced(ctx, s.syncCallback)
 			return
 		}
 	}
 
-	serviceEvents := cfg.Services.Events(ctx)
-	serviceStore, err := cfg.Services.Store(ctx)
+	serviceEvents := s.services.Events(ctx)
+	serviceStore, err := s.services.Store(ctx)
 	if err != nil {
-		logger.Error("can't init service store", logfields.Error, err)
+		s.logger.Error("can't init service store", logfields.Error, err)
 		return
 	}
-	serviceExportsEvents := cfg.ServiceExports.Events(ctx)
-	serviceExportStore, err := cfg.ServiceExports.Store(ctx)
+	serviceExportsEvents := s.serviceExports.Events(ctx)
+	serviceExportStore, err := s.serviceExports.Store(ctx)
 	if err != nil {
-		logger.Error("can't init service export store", logfields.Error, err)
+		s.logger.Error("can't init service export store", logfields.Error, err)
 		return
 	}
 
@@ -109,13 +162,13 @@ func StartSynchronizingServiceExports(ctx context.Context, cfg ServiceExportSync
 			if ev.Kind == resource.Sync {
 				servicesSynced = true
 				if servicesSynced && serviceExportsSynced {
-					cfg.store.Synced(ctx, cfg.SyncCallback)
+					s.store.Synced(ctx, s.syncCallback)
 				}
 				ev.Done(nil)
 				continue
 			}
 
-			ev.Done(syncMCSAPIServiceSpec(ctx, cfg.ClusterName, cfg.store,
+			ev.Done(s.syncMCSAPIServiceSpec(ctx,
 				serviceStore, serviceExportStore, ev.Key))
 
 		case ev, ok := <-serviceExportsEvents:
@@ -127,21 +180,20 @@ func StartSynchronizingServiceExports(ctx context.Context, cfg ServiceExportSync
 			if ev.Kind == resource.Sync {
 				serviceExportsSynced = true
 				if servicesSynced && serviceExportsSynced {
-					cfg.store.Synced(ctx, cfg.SyncCallback)
+					s.store.Synced(ctx, s.syncCallback)
 				}
 				ev.Done(nil)
 				continue
 			}
 
-			ev.Done(syncMCSAPIServiceSpec(ctx, cfg.ClusterName, cfg.store,
+			ev.Done(s.syncMCSAPIServiceSpec(ctx,
 				serviceStore, serviceExportStore, ev.Key))
 		}
 	}
-	wg.Wait()
 }
 
-func syncMCSAPIServiceSpec(
-	ctx context.Context, clusterName string, kvs store.SyncStore,
+func (s *serviceExportSync) syncMCSAPIServiceSpec(
+	ctx context.Context,
 	serviceStore resource.Store[*slim_corev1.Service],
 	serviceExportStore resource.Store[*mcsapiv1alpha1.ServiceExport],
 	key resource.Key,
@@ -151,16 +203,16 @@ func syncMCSAPIServiceSpec(
 		return err
 	}
 	if !exist {
-		return kvs.DeleteKey(ctx, types.NewEmptyMCSAPIServiceSpec(clusterName, key.Namespace, key.Name))
+		return s.store.DeleteKey(ctx, types.NewEmptyMCSAPIServiceSpec(s.clusterName, key.Namespace, key.Name))
 	}
 	svcExport, exist, err := serviceExportStore.GetByKey(key)
 	if err != nil {
 		return err
 	}
 	if !exist {
-		return kvs.DeleteKey(ctx, types.NewEmptyMCSAPIServiceSpec(clusterName, key.Namespace, key.Name))
+		return s.store.DeleteKey(ctx, types.NewEmptyMCSAPIServiceSpec(s.clusterName, key.Namespace, key.Name))
 	}
 
-	mcsAPISvcSpec := types.FromCiliumServiceToMCSAPIServiceSpec(clusterName, svc, svcExport)
-	return kvs.UpsertKey(ctx, mcsAPISvcSpec)
+	mcsAPISvcSpec := types.FromCiliumServiceToMCSAPIServiceSpec(s.clusterName, svc, svcExport)
+	return s.store.UpsertKey(ctx, mcsAPISvcSpec)
 }


### PR DESCRIPTION
Let's introduce a new generic logic responsible for watching Kubernetes events and propagating the corresponding representation to the kvstore. The idea being to uniform how the clustermesh-apiserver performs the synchronization of the different resources, as well as favor easier extensibility and testing. Migrate CiliumNodes, CiliumIdentities and CiliumEndpoint(Slice)s to use it. Additionally, add an initial battery of tests to cover the synchronization of the above mentioned resources. The cluster config enforcement logic is intended to be refactored in a separate PR.

Please review commit by commit, and refer to the individual messages for additional details.

Depends on https://github.com/cilium/cilium/pull/39965 and https://github.com/cilium/cilium/pull/39966.