### PR TITLE
Adds a new --device-prefixes-to-exclude flag to Cilium agent

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -87,6 +87,7 @@ cilium-agent [flags]
       --datapath-mode string                                      Datapath mode name (veth, netkit, netkit-l2) (default "veth")
   -D, --debug                                                     Enable debugging mode
       --debug-verbose strings                                     List of enabled verbose debug groups
+      --device-prefixes-to-exclude strings                        List of prefixes of devices to exclude from cilium management. Devices selected by --devices won't be excluded
       --devices strings                                           List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --direct-routing-skip-unreachable                           Enable skipping L2 routes between nodes on different subnets

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -41,6 +41,7 @@ cilium-agent hive [flags]
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                                 Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
+      --device-prefixes-to-exclude strings                        List of prefixes of devices to exclude from cilium management. Devices selected by --devices won't be excluded
       --devices strings                                           List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-envoy-version-check                               Do not perform Envoy version check

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -47,6 +47,7 @@ cilium-agent hive dot-graph [flags]
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                                 Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
+      --device-prefixes-to-exclude strings                        List of prefixes of devices to exclude from cilium management. Devices selected by --devices won't be excluded
       --devices strings                                           List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-envoy-version-check                               Do not perform Envoy version check

--- a/pkg/datapath/linux/testdata/device-detection-exclusion.txtar
+++ b/pkg/datapath/linux/testdata/device-detection-exclusion.txtar
@@ -1,0 +1,33 @@
+#! --device-prefixes-to-exclude=ex1-dummy,ex2-dummy
+
+# Tests the behavior of device detection when device-prefixes-to-exclude is provided
+
+# Start the hive
+hive start
+
+# Add dummy0 interface - doesn't match prefix, should be selected.
+exec ip link add dummy0 type dummy
+exec ip addr add 192.168.0.1/24 dev dummy0
+exec ip link set dummy0 up
+
+# Add ex1-dummy interface - matches prefix, should be excluded.
+exec ip link add ex1-dummy1 type dummy
+exec ip addr add 192.168.1.1/24 dev ex1-dummy1
+exec ip link set ex1-dummy1 up
+
+# Add ex2-dummy2 interface - matches prefix, should be excluded.
+exec ip link add ex2-dummy2 type dummy
+exec ip addr add 192.168.2.1/24 dev ex2-dummy2
+exec ip link set ex2-dummy2 up
+
+# Verify selected devices. Only dummy0 should be selected.
+db/cmp --grep='^(lo|dummy|ex)' devices devices.table
+
+# ---------------------------------------------
+
+-- devices.table --
+Name        Selected   Type
+lo          false      device
+dummy0      true       dummy
+ex1-dummy1  false      dummy
+ex2-dummy2  false      dummy

--- a/pkg/datapath/linux/testdata/device-detection-force.txtar
+++ b/pkg/datapath/linux/testdata/device-detection-force.txtar
@@ -1,11 +1,11 @@
-#! --devices=dummy+ --force-device-detection
+#! --devices=dummy+ --force-device-detection --device-prefixes-to-exclude=ex-dummy,dummy
 
 # Tests the behavior of device detection when forced detection is enabled.
 
 # Start the hive
 hive start
 
-# Add dummy0 interface - matches devices wildcard, should be selected.
+# Add dummy0 interface - matches devices wildcard, should be selected even it matches device-prefixes-to-exclude
 exec ip link add dummy0 type dummy
 exec ip addr add 192.168.0.1/24 dev dummy0
 exec ip link set dummy0 up
@@ -21,8 +21,13 @@ exec ip link add eth0 type dummy
 exec ip addr add 1.2.3.4/24 dev eth0
 exec ip link set eth0 up
 
+# Add ex-dummy3 interface - should be excluded due to device-prefixes-to-exclude
+exec ip link add ex-dummy3 type dummy
+exec ip addr add 192.168.1.1/24 dev ex-dummy3
+exec ip link set ex-dummy3 up
+
 # Verify selected devices. All 3 of them should be selected.
-db/cmp --grep='^(lo|dummy|eth)' devices devices.table
+db/cmp --grep='^(lo|dummy|eth|ex)' devices devices.table
 
 # ---------------------------------------------
 
@@ -32,3 +37,4 @@ lo          false      device
 dummy0      true       dummy
 dummy1      true       dummy
 eth0        true       dummy
+ex-dummy3   false      dummy


### PR DESCRIPTION
Devices with prefixes in --device-prefixes-to-exclude will be excluded from selection.

Cilium today allows to picks devices with --devices flag. But often times, we want a device exclusion instead and prefix is usually a good way to do that.


```release-note
Add device-prefixes-to-exclude flag to cilium agent to allow excluding devices with prefixes
```
