### PR TITLE
auto-approve: add repository as part command

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -56,6 +56,6 @@ jobs:
         reviewers=$(gh pr view ${PULL_REQUEST_NUMBER} --json reviewRequests --jq '.reviewRequests[] | select(."__typename"=="User") | .login')
         for reviewer in $reviewers; do
           if [ "$reviewer" != "ciliumbot" ]; then
-            gh pr edit ${PULL_REQUEST_NUMBER} --remove-reviewer "$reviewer"
+            gh -R ${GITHUB_REPOSITORY} pr edit ${PULL_REQUEST_NUMBER} --remove-reviewer "$reviewer"
           fi
         done


### PR DESCRIPTION
If the command doesn't have the repository as part of the command, then gh will try to derive it from the .git directory. Since this directory doesn't exist, the command fails.

Fixes: 2b24f33648fa (".github/workflows: remove reviewers if ciliumbot approved PR")