### PR TITLE
Support WireGuard with IPv6 Underlay

### DIFF
--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -382,4 +382,5 @@
   ipv4: 'false'
   tunnel: 'vxlan'
   underlay: 'ipv6'
+  encryption: 'wireguard'
   skip-upgrade: 'true'

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -231,12 +231,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		}
 	}
 
-	if option.Config.TunnelingEnabled() && params.TunnelConfig.UnderlayProtocol() == tunnel.IPv6 {
-		if option.Config.EnableWireguard {
-			return nil, nil, fmt.Errorf("WireGuard requires an IPv4 underlay")
-		}
-	}
-
 	// IPAMENI IPSec is configured from Reinitialize() to pull in devices
 	// that may be added or removed at runtime.
 	if option.Config.EnableIPSec &&


### PR DESCRIPTION
First two commits add support for WireGuard encryption with IPv6 underlay. Last two commits cover it in CI.