### PR TITLE
disk-cleanup: parallelize cleanup process to speed up step

### DIFF
--- a/.github/actions/disk-cleanup/action.yaml
+++ b/.github/actions/disk-cleanup/action.yaml
@@ -21,23 +21,44 @@ runs:
       shell: bash
       run: |
         echo "Removing unnecessary files to free up disk space..."
-        # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832
-        sudo rm -rf \
-          /opt/hostedtoolcache \
-          /opt/google/chrome \
-          /opt/microsoft/msedge \
-          /opt/microsoft/powershell \
-          /opt/pipx \
-          /opt/ghc \
-          /usr/local/.ghcup \
-          /usr/lib/mono \
-          /usr/local/julia* \
-          /usr/local/lib/android \
-          /usr/local/lib/node_modules \
-          /usr/local/share/chromium \
-          /usr/local/share/powershell \
-          /usr/share/dotnet \
-          /usr/share/swift
+        # Optimize deletion speed by using maximum parallelism:
+        # 1. Use find with -delete which is more efficient for large directories
+        # 2. Run ALL deletions in parallel since CPU load is not a limiting factor
+        # 3. Use ionice to reduce I/O contention with highest priority
+        # 4. Use nice with highest priority for CPU scheduling
+
+        # Function to efficiently delete a directory
+        fast_delete() {
+          local dir="$1"
+          if [ -d "$dir" ]; then
+            echo "Deleting $dir..."
+            # Use find with maximum priority for both CPU and I/O
+            sudo nice -n -20 ionice -c 1 -n 0 find "$dir" -delete &>/dev/null || sudo nice -n -20 ionice -c 1 -n 0 rm -rf "$dir" &>/dev/null
+            echo "Completed deletion of $dir"
+          fi
+        }
+
+        # Run ALL deletions in parallel - maximum parallelization
+        fast_delete "/opt/hostedtoolcache" &
+        fast_delete "/usr/local/lib/android" &
+        fast_delete "/usr/share/dotnet" &
+        fast_delete "/opt/google/chrome" &
+        fast_delete "/opt/microsoft/msedge" &
+        fast_delete "/opt/microsoft/powershell" &
+        fast_delete "/opt/pipx" &
+        fast_delete "/opt/ghc" &
+        fast_delete "/usr/local/.ghcup" &
+        fast_delete "/usr/lib/mono" &
+        fast_delete "/usr/local/julia*" &
+        fast_delete "/usr/local/lib/node_modules" &
+        fast_delete "/usr/local/share/chromium" &
+        fast_delete "/usr/local/share/powershell" &
+        fast_delete "/usr/share/swift" &
+
+        # Wait for all deletions to complete
+        wait
+
+        echo "Disk cleanup completed with maximum parallelism"
     - name: Assess disk usage after cleanup
       shell: bash
       run: |


### PR DESCRIPTION
This step can be parallelized so that this step runs faster to remove these directories.