### PR TITLE
ci/clustermesh: Restore sysdump capturing

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -669,7 +669,7 @@ jobs:
         uses: ./.github/actions/post-logic
         with:
           artifacts_suffix: "${{ matrix.name }}"
-          job_status: "success"
+          job_status: "${{ job.status }}"
           capture_features_tested: false
           capture_sysdump: false
 


### PR DESCRIPTION
While adding the `.github/actions/post-logic` action, the job status parameter in conformance-clustermesh was inadvertently hardcoded to "success". Therefore, the sysdump is not uploaded if the job fails. Fix the parameter passed to the action with the actual job result.

- [Example run](https://github.com/cilium/cilium/actions/runs/15675763312) of a failing workflow without the uploaded sysdump
- [Example run](https://github.com/cilium/cilium/actions/runs/15675289204) of a failing workflow with the uploaded sysdump (after applying this patch)

Fixes: 53fd5cf59b (".github: de-duplicate workflows logic")
