### PR TITLE
gateway-api: Avoid merging labels/annotations

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -211,7 +211,8 @@ func (r *gatewayReconciler) ensureService(ctx context.Context, desired *corev1.S
 		lbClass := svc.Spec.LoadBalancerClass
 		svc.Spec = desired.Spec
 		svc.OwnerReferences = desired.OwnerReferences
-		setMergedLabelsAndAnnotations(svc, desired)
+		svc.Labels = desired.Labels
+		svc.Annotations = desired.Annotations
 
 		// Ignore the loadBalancerClass if it was set by a mutating webhook
 		svc.Spec.LoadBalancerClass = lbClass
@@ -225,7 +226,8 @@ func (r *gatewayReconciler) ensureEndpoints(ctx context.Context, desired *corev1
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, ep, func() error {
 		ep.Subsets = desired.Subsets
 		ep.OwnerReferences = desired.OwnerReferences
-		setMergedLabelsAndAnnotations(ep, desired)
+		ep.Labels = desired.Labels
+		ep.Annotations = desired.Annotations
 		return nil
 	})
 	return err
@@ -235,7 +237,8 @@ func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *cili
 	cec := desired.DeepCopy()
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cec, func() error {
 		cec.Spec = desired.Spec
-		setMergedLabelsAndAnnotations(cec, desired)
+		cec.Labels = desired.Labels
+		cec.Annotations = desired.Annotations
 		return nil
 	})
 	return err

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -44,9 +44,6 @@ var gwFixture = []client.Object{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cilium-gateway-valid-gateway",
 			Namespace: "another-namespace",
-			Annotations: map[string]string{
-				"pre-existing-annotation": "true",
-			},
 		},
 		Status: corev1.ServiceStatus{
 			LoadBalancer: corev1.LoadBalancerStatus{
@@ -425,7 +422,6 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, corev1.ServiceTypeLoadBalancer, lb.Spec.Type)
 		require.Equal(t, "test-long-long-long-long-long-long-long-long-long-lo-4bftbgh5ht", lb.Labels["io.cilium.gateway/owning-gateway"])
-		require.Equal(t, "true", lb.Annotations["pre-existing-annotation"])
 
 		// Update LB status
 		lb.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{


### PR DESCRIPTION
The labels or annotations can be removed/updated/renamed in gateway spec.infrastructure.{labels, annotations} fields, so we should avoid merging to avoid dangling values.


