### PR TITLE
ciliumenvoyconfig: Add 'Labels' to CEC

### DIFF
--- a/pkg/ciliumenvoyconfig/k8s_reflector.go
+++ b/pkg/ciliumenvoyconfig/k8s_reflector.go
@@ -169,6 +169,7 @@ func registerCECK8sReflector(
 				Name:      objMeta.GetName(),
 				Namespace: objMeta.GetNamespace(),
 			},
+			Labels:           objMeta.Labels,
 			Selector:         selector,
 			SelectsLocalNode: selectsLocalNode,
 			ServicePorts:     servicePorts,

--- a/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
@@ -77,6 +77,8 @@ kind: CiliumEnvoyConfig
 metadata:
   name: envoy-lb-listener
   namespace: test
+  labels:
+    foo: bar
 spec:
   services:
     - name: echo
@@ -112,6 +114,9 @@ spec:
         "name": "envoy-lb-listener"
       }
     ]
+  },
+  "Labels": {
+    "foo": "bar"
   },
   "SelectsLocalNode": true,
   "Listeners": [

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -97,8 +97,8 @@ Address               Type        ServiceName   PortName   Status  Backends
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:8080/TCP
 
 -- cec.table --
-Name                    Services
-test/envoy-lb-listener  test/echo
+Name                    Labels   Services
+test/envoy-lb-listener  foo=bar  test/echo
 
 -- envoy-resources.table --
 Name                            Listeners                                  Endpoints                    References             Status   Error
@@ -111,6 +111,8 @@ kind: CiliumEnvoyConfig
 metadata:
   name: envoy-lb-listener
   namespace: test
+  labels:
+    foo: bar
 spec:
   services:
     - name: echo


### PR DESCRIPTION
Add the 'Labels' field to ciliumenvoyconfig.CEC and show it in the table output. This will be used by future features.