### PR TITLE
hive: Log fence errors at Info level

### DIFF
--- a/pkg/hive/fence.go
+++ b/pkg/hive/fence.go
@@ -97,7 +97,7 @@ func (w *fence) Wait(ctx context.Context) error {
 		)
 		log.Info("Fence waiting")
 		if err := fn(ctx); err != nil {
-			log.Error("Fence error",
+			log.Info("Fence error",
 				logfields.Error, err)
 			return fmt.Errorf("%s: %w", name, err)
 		}


### PR DESCRIPTION
We don't know how the [hive.Fence] is used and some errors are expected, e.g. [regeneration.Fence] errors when endpoint is being removed which is normal and we shouldn't log.Error as CI will be unhappy.

It is still useful to see what's happening to the regeneration fence so keep the logging, but change log.Error to log.Info.

This fixes CI issues like this:
```
check-log-errors/no-errors-in-logs:pkg/hive:kind-cluster2/kube-system/cilium-k65jb (cilium-agent): Found 1 logs in kind-cluster2/kube-system/cilium-k65jb (cilium-agent) matching list of errors that must be investigated:
time=2025-06-16T12:03:57.433497119Z level=error source=/go/src/github.com/cilium/cilium/pkg/hive/fence.go:100 msg="Fence error" module=agent.controlplane.endpoint-regeneration name=clustermesh remaining=3 error="lock failed: endpoint is in the process of being removed" (1 occurrences)
```
