### PR TITLE
Refactor the enforcement of the CiliumClusterConfig

### DIFF
--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/clustermesh-apiserver/option"
 	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
+	clustercfgcell "github.com/cilium/cilium/pkg/clustermesh/clustercfg/cell"
 	"github.com/cilium/cilium/pkg/clustermesh/mcsapi"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -55,10 +56,12 @@ var Cell = cell.Module(
 
 	HealthAPIEndpointsCell,
 
+	clustercfgcell.WithSyncedCanaries(true),
+	clustercfgcell.Cell,
+
 	Synchronization,
 
 	usersManagementCell,
-	cell.Invoke(RegisterHooks),
 )
 
 var Synchronization = cell.Module(

--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -10,9 +10,9 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/cobra"
 
+	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
@@ -93,7 +93,7 @@ func startServer(
 		},
 	}
 
-	_, err := cmutils.EnforceClusterConfig(context.Background(), cinfo.Name, config, backend, logger)
+	_, err := clustercfg.Enforce(context.Background(), cinfo.Name, config, backend, logger)
 	if err != nil {
 		logging.Fatal(logger, "Unable to set local cluster config on kvstore", logfields.Error, err)
 	}

--- a/clustermesh-apiserver/clustermesh/script_test.go
+++ b/clustermesh-apiserver/clustermesh/script_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/clustermesh-apiserver/clustermesh"
 	cmk8s "github.com/cilium/cilium/clustermesh-apiserver/clustermesh/k8s"
 	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
+	clustercfgcell "github.com/cilium/cilium/pkg/clustermesh/clustercfg/cell"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
@@ -74,8 +75,9 @@ func TestScript(t *testing.T) {
 				return syncstate.SyncState{StoppableWaitGroup: lock.NewStoppableWaitGroup()}
 			}),
 
+			clustercfgcell.WithSyncedCanaries(true),
+			clustercfgcell.Cell,
 			clustermesh.Synchronization,
-			cell.Invoke(clustermesh.RegisterHooks),
 		)
 
 		flags := pflag.NewFlagSet("", pflag.ContinueOnError)

--- a/clustermesh-apiserver/clustermesh/testdata/clusterconfig.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/clusterconfig.txtar
@@ -6,6 +6,22 @@ hive/start
 kvstore/list -o json cilium/cluster-config config.actual
 * cmp config.actual config.expected
 
+# Modify the ClusterConfig...
+kvstore/list -o plain --values-only cilium/cluster-config/cluster3 config.modified
+sed '"id":3' '"id":5' config.modified
+kvstore/update cilium/cluster-config/cluster3 config.modified
+
+# ... and assert that it gets reconciled
+kvstore/list -o json cilium/cluster-config config.actual
+* cmp config.actual config.expected
+
+# Delete the ClusterConfig...
+kvstore/delete cilium/cluster-config/cluster3
+
+# ... and assert that it gets recreated
+kvstore/list -o json cilium/cluster-config config.actual
+* cmp config.actual config.expected
+
 # ---
 
 -- config.expected --

--- a/operator/cmd/kvstore_watchdog.go
+++ b/operator/cmd/kvstore_watchdog.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/allocator"
+	clustercfg "github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	cmoperator "github.com/cilium/cilium/pkg/clustermesh/operator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -107,7 +107,7 @@ func startKvstoreWatchdog(logger *slog.Logger, client kvstore.Client, cfgMCSAPI 
 						MaxConnectedClusters:  option.Config.MaxConnectedClusters,
 						ServiceExportsEnabled: &cfgMCSAPI.ClusterMeshEnableMCSAPI,
 					}}
-				if err := cmutils.SetClusterConfig(ctx, option.Config.ClusterName, cfg, client); err != nil {
+				if err := clustercfg.Set(ctx, option.Config.ClusterName, cfg, client); err != nil {
 					logger.Warn("Unable to set local cluster config", logfields.Error, err)
 				}
 			}

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/nodeipam"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
+	clustercfgcell "github.com/cilium/cilium/pkg/clustermesh/clustercfg/cell"
 	"github.com/cilium/cilium/pkg/clustermesh/endpointslicesync"
 	"github.com/cilium/cilium/pkg/clustermesh/mcsapi"
 	cmoperator "github.com/cilium/cilium/pkg/clustermesh/operator"
@@ -222,6 +223,10 @@ var (
 			// Updates the heartbeat key in the kvstore.
 			heartbeat.Enabled,
 			heartbeat.Cell,
+
+			// Configures the cluster config key in the kvstore.
+			clustercfgcell.WithSyncedCanaries(false),
+			clustercfgcell.Cell,
 
 			bgpv2.Cell,
 			lbipam.Cell,
@@ -533,7 +538,7 @@ var legacyCell = cell.Module(
 	metrics.Metric(NewUnmanagedPodsMetric),
 )
 
-func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, kvstoreClient kvstore.Client, resources operatorK8s.Resources, cfgMCSAPI cmoperator.MCSAPIConfig, cfgClusterMeshPolicy cmtypes.PolicyConfig, metrics *UnmanagedPodsMetric, logger *slog.Logger) {
+func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, kvstoreClient kvstore.Client, resources operatorK8s.Resources, cfgClusterMeshPolicy cmtypes.PolicyConfig, metrics *UnmanagedPodsMetric, logger *slog.Logger) {
 	ctx, cancel := context.WithCancel(context.Background())
 	legacy := &legacyOnLeader{
 		ctx:                  ctx,
@@ -541,7 +546,6 @@ func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, kv
 		clientset:            clientset,
 		kvstoreClient:        kvstoreClient,
 		resources:            resources,
-		cfgMCSAPI:            cfgMCSAPI,
 		cfgClusterMeshPolicy: cfgClusterMeshPolicy,
 		metrics:              metrics,
 		logger:               logger,
@@ -559,7 +563,6 @@ type legacyOnLeader struct {
 	kvstoreClient        kvstore.Client
 	wg                   sync.WaitGroup
 	resources            operatorK8s.Resources
-	cfgMCSAPI            cmoperator.MCSAPIConfig
 	cfgClusterMeshPolicy cmtypes.PolicyConfig
 	metrics              *UnmanagedPodsMetric
 
@@ -644,7 +647,7 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 			withKVStore = true
 		}
 
-		startKvstoreWatchdog(legacy.logger, legacy.kvstoreClient, legacy.cfgMCSAPI)
+		startKvstoreWatchdog(legacy.logger, legacy.kvstoreClient)
 	}
 
 	if legacy.clientset.IsEnabled() &&

--- a/pkg/clustermesh/clustercfg/cell/cell.go
+++ b/pkg/clustermesh/clustercfg/cell/cell.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustercfgcell
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
+	"github.com/cilium/cilium/pkg/clustermesh/operator"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+)
+
+// Cell takes care of writing the cluster configuration to the kvstore, and
+// automatically reverting possible external modifications.
+var Cell = cell.Module(
+	"cluster-config-enforcement",
+	"Enforce the CiliumClusterConfig in the KVStore",
+
+	cell.Provide(
+		func(cinfo cmtypes.ClusterInfo, mcsAPICfg operator.MCSAPIConfig, sc syncedCanaries) cmtypes.CiliumClusterConfig {
+			return cmtypes.CiliumClusterConfig{
+				ID: cinfo.ID,
+				Capabilities: cmtypes.CiliumClusterConfigCapabilities{
+					SyncedCanaries:        bool(sc),
+					MaxConnectedClusters:  cinfo.MaxConnectedClusters,
+					ServiceExportsEnabled: &mcsAPICfg.ClusterMeshEnableMCSAPI,
+				},
+			}
+		},
+	),
+
+	cell.Invoke(clustercfg.RegisterEnforcer),
+)
+
+// WithSyncedCanaries configures the SyncedCanaries field of the ClusterConfig.
+func WithSyncedCanaries(enabled bool) cell.Cell {
+	return cell.Provide(func() syncedCanaries {
+		return syncedCanaries(enabled)
+	})
+}
+
+type syncedCanaries bool

--- a/pkg/clustermesh/clustercfg/enforce.go
+++ b/pkg/clustermesh/clustercfg/enforce.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustercfg
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+)
+
+// RegisterEnforcer sets up the logic to write the cluster configuration to the
+// kvstore, and automatically revert possible external modifications.
+func RegisterEnforcer(in struct {
+	cell.In
+
+	JobGroup job.Group
+
+	ClusterInfo   cmtypes.ClusterInfo
+	ClusterConfig cmtypes.CiliumClusterConfig
+
+	Client       kvstore.Client
+	StoreFactory store.Factory
+}) error {
+	if !in.Client.IsEnabled() || in.ClusterInfo.ID == 0 {
+		return nil
+	}
+
+	key := path.Join(kvstore.ClusterConfigPrefix, in.ClusterInfo.Name)
+	value, err := json.Marshal(in.ClusterConfig)
+	if err != nil {
+		return fmt.Errorf("cannot marshal CiliumClusterConfig: %w", err)
+	}
+
+	watching := make(chan struct{})
+	enforce := func(ctx context.Context) error {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		select {
+		// Make sure that the watcher actually started. This is mostly for testing
+		// purposes, to prevent possible race conditions, but it is also helpful
+		// as a sanity check in production environments.
+		case <-watching:
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for cluster configuration watcher to be started")
+		}
+
+		_, err := in.Client.UpdateIfDifferent(ctx, key, value, true)
+		if err != nil {
+			return fmt.Errorf("failed to write cluster configuration: %w", err)
+		}
+
+		return nil
+	}
+
+	trigger := job.NewTrigger()
+	store := in.StoreFactory.NewWatchStore(
+		in.ClusterInfo.Name, store.KVPairCreator,
+		&observer{
+			key:      in.ClusterInfo.Name,
+			expected: value,
+			trigger:  trigger,
+		},
+		store.RWSWithOnSyncCallback(func(context.Context) { close(watching) }),
+	)
+
+	in.JobGroup.Add(
+		job.OneShot(
+			"cluster-config-writer",
+			func(ctx context.Context, _ cell.Health) error {
+				return enforce(ctx)
+			},
+			job.WithRetry(3, &job.ExponentialBackoff{
+				Min: 2 * time.Second,
+				Max: 30 * time.Second,
+			}), job.WithShutdown()),
+
+		job.Timer(
+			"cluster-config-refresh",
+			enforce,
+			runInterval,
+			job.WithTrigger(trigger),
+		),
+
+		job.OneShot(
+			"cluster-config-watcher",
+			func(ctx context.Context, _ cell.Health) error {
+				store.Watch(ctx, in.Client, kvstore.ClusterConfigPrefix)
+				return nil
+			},
+		),
+	)
+
+	return nil
+}
+
+type observer struct {
+	key      string
+	expected []byte
+	trigger  job.Trigger
+}
+
+func (o *observer) OnUpdate(key store.Key) {
+	if key.GetKeyName() == o.key &&
+		!bytes.Equal(key.(*store.KVPair).Value, o.expected) {
+		o.trigger.Trigger()
+	}
+}
+
+func (o *observer) OnDelete(key store.NamedKey) {
+	if key.GetKeyName() == o.key {
+		o.trigger.Trigger()
+	}
+}

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
-	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -92,7 +92,7 @@ func TestClusterMesh(t *testing.T) {
 			config.Capabilities.SyncedCanaries = true
 		}
 
-		err := cmutils.SetClusterConfig(ctx, name, config, client)
+		err := clustercfg.Set(ctx, name, config, client)
 		require.NoErrorf(t, err, "Failed to set cluster config for %s", name)
 	}
 
@@ -161,7 +161,7 @@ func TestClusterMesh(t *testing.T) {
 			MaxConnectedClusters: 255,
 		},
 	}
-	err := cmutils.SetClusterConfig(ctx, "cluster1", config, client)
+	err := clustercfg.Set(ctx, "cluster1", config, client)
 	require.NoErrorf(t, err, "Failed to set cluster config for cluster1")
 	// Ugly hack to trigger config update
 	etcdConfigNew := append(etcdConfig, []byte("\n")...)

--- a/pkg/clustermesh/common/clustermesh_test.go
+++ b/pkg/clustermesh/common/clustermesh_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -56,7 +56,7 @@ func TestClusterMesh(t *testing.T) {
 	capabilities := types.CiliumClusterConfigCapabilities{Cached: true, MaxConnectedClusters: 511}
 	for i, cluster := range []string{"cluster1", "cluster2", "cluster3"} {
 		cfg := types.CiliumClusterConfig{ID: uint32(i + 1), Capabilities: capabilities}
-		require.NoError(t, utils.SetClusterConfig(context.Background(), cluster, cfg, client))
+		require.NoError(t, clustercfg.Set(context.Background(), cluster, cfg, client))
 	}
 
 	var ready, stopped, removed lock.Map[string, bool]
@@ -200,7 +200,7 @@ func TestClusterMeshMultipleAddRemove(t *testing.T) {
 	for i, cluster := range []string{"cluster1", "cluster2", "cluster3", "cluster4"} {
 		writeFile(t, path(cluster), fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
 		cfg := types.CiliumClusterConfig{ID: uint32(i + 1)}
-		require.NoError(t, utils.SetClusterConfig(context.Background(), cluster, cfg, client))
+		require.NoError(t, clustercfg.Set(context.Background(), cluster, cfg, client))
 	}
 
 	var ready lock.Map[string, bool]

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -16,8 +16,8 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
-	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/dial"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -193,7 +193,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 					default:
 					}
 
-					if errors.Is(err, cmutils.ErrClusterConfigNotFound) {
+					if errors.Is(err, clustercfg.ErrNotFound) {
 						rc.logger.Warn("Unable to get remote cluster configuration",
 							logfields.Error, err,
 							logfields.Hint, "If KVStoreMesh is enabled, check whether it is connected to the target cluster."+
@@ -302,7 +302,7 @@ func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.B
 		Group: clusterConfigControllerGroup,
 		DoFunc: func(ctx context.Context) error {
 			rc.logger.Debug("Retrieving cluster configuration from remote kvstore")
-			config, err := cmutils.GetClusterConfig(ctx, rc.name, backend)
+			config, err := clustercfg.Get(ctx, rc.name, backend)
 			if err != nil {
 				lastErrorLock.Lock()
 				lastError = err

--- a/pkg/clustermesh/common/remote_cluster_test.go
+++ b/pkg/clustermesh/common/remote_cluster_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/testutils"
 )
@@ -37,7 +37,7 @@ func TestRemoteClusterWatchdog(t *testing.T) {
 	const name = "remote"
 	path := filepath.Join(t.TempDir(), name)
 	writeFile(t, path, fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
-	require.NoError(t, utils.SetClusterConfig(context.Background(), name, types.CiliumClusterConfig{ID: 2}, client))
+	require.NoError(t, clustercfg.Set(context.Background(), name, types.CiliumClusterConfig{ID: 2}, client))
 
 	wait := func(t *testing.T, ch <-chan struct{}, msg string) {
 		t.Helper()

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
+	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -258,7 +258,7 @@ func TestRemoteClusterRun(t *testing.T) {
 
 			// Assert that the cluster config got properly propagated
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				cfg, err := utils.GetClusterConfig(ctx, "foo", client)
+				cfg, err := clustercfg.Get(ctx, "foo", client)
 				assert.NoError(c, err)
 				assert.Equal(c, tt.dstcfg, cfg)
 			}, timeout, tick, "Failed to retrieve the cluster config")
@@ -539,7 +539,7 @@ func TestRemoteClusterRemoveShutdown(t *testing.T) {
 	// Let's manually create a fake cluster configuration for the remote cluster,
 	// because we are using the same kvstore. This will be used as a synchronization
 	// point to stop the hive while blocked waiting for the grace period.
-	require.NoError(t, utils.SetClusterConfig(ctx, "remote", types.CiliumClusterConfig{ID: 20}, client))
+	require.NoError(t, clustercfg.Set(ctx, "remote", types.CiliumClusterConfig{ID: 20}, client))
 
 	var km *KVStoreMesh
 	h := hive.New(

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -16,11 +16,11 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
-	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -85,7 +85,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		},
 	}
 
-	stopAndWait, err := cmutils.EnforceClusterConfig(ctx, rc.name, dstcfg, rc.localBackend, rc.logger)
+	stopAndWait, err := clustercfg.Enforce(ctx, rc.name, dstcfg, rc.localBackend, rc.logger)
 	defer stopAndWait()
 	if err != nil {
 		ready <- fmt.Errorf("failed to propagate cluster configuration: %w", err)

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -27,9 +27,9 @@ import (
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/clustermesh"
+	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -167,7 +167,7 @@ func TestScript(t *testing.T) {
 							MaxConnectedClusters: 255,
 						},
 					}
-					err := cmutils.SetClusterConfig(context.TODO(), name, config, client)
+					err := clustercfg.Set(context.TODO(), name, config, client)
 					require.NoErrorf(t, err, "Failed to set cluster config for %s", name)
 				}
 			}),


### PR DESCRIPTION
Introduce a new job-based logic to write the CiliumClusterConfig into the kvstore, and periodically refresh it in case it gets modified. Adapt the clustermesh-apiserver and Cilium operator to use the new cell, rather than the previous bespoke logic.

Please review commit by commit, and refer to the individual messages for additional details. 

Follow-up of https://github.com/cilium/cilium/pull/40034
