### PR TITLE
cli: Enable `tolerations` flag for all connectivity tests

### DIFF
--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -116,6 +116,7 @@ cilium connectivity test [flags]
       --test-namespace string                                 Namespace to perform the connectivity in (always suffixed with a sequence number to be compliant with test-concurrency param, e.g.: cilium-test-1) (default "cilium-test")
       --timeout duration                                      Maximum time to allow the connectivity test suite to take
   -t, --timestamp                                             Show timestamp in messages
+      --tolerations strings                                   Extra NoSchedule tolerations added to test pods
   -v, --verbose                                               Show informational messages and don't buffer any lines
 ```
 

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -297,7 +297,6 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 		"node-selector-server", "Node selector for the server pod (and client same-node)")
 	cmd.Flags().Var(option.NewNamedMapOptions("node-selector-client", &params.PerfParameters.NodeSelectorClient, nil),
 		"node-selector-client", "Node selector for the other-node client pod")
-	cmd.Flags().StringSliceVar(&params.PerfParameters.Tolerations, "tolerations", nil, "Extra NoSchedule tolerations added to test pods")
 
 	cmd.Flags().StringVar(&params.PerfParameters.Image, "performance-image", defaults.ConnectivityCheckImagesPerf["ConnectivityPerformanceImage"], "Image path to use for performance")
 	cmd.Flags().StringVar(&params.PerfParameters.ReportDir, "report-dir", "", "Directory to save perf results in json format")
@@ -308,6 +307,7 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 
 func registerCommonFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
+	flags.StringSliceVar(&params.Tolerations, "tolerations", nil, "Extra NoSchedule tolerations added to test pods")
 	flags.StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity in (always suffixed with a sequence number to be compliant with test-concurrency param, e.g.: cilium-test-1)")
 	flags.Var(option.NewNamedMapOptions("namespace-labels", &params.NamespaceLabels, nil), "namespace-labels", "Add labels to the connectivity test namespace")
 	flags.Var(option.NewNamedMapOptions("namespace-annotations", &params.NamespaceAnnotations, nil), "namespace-annotations", "Add annotations to the connectivity test namespace")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -46,15 +46,6 @@ type PerfParameters struct {
 
 	NodeSelectorServer map[string]string
 	NodeSelectorClient map[string]string
-	Tolerations        []string
-}
-
-func (p *PerfParameters) GetTolerations() []corev1.Toleration {
-	tolerations := make([]corev1.Toleration, 0, len(p.Tolerations))
-	for _, t := range p.Tolerations {
-		tolerations = append(tolerations, corev1.Toleration{Key: t, Operator: corev1.TolerationOpExists})
-	}
-	return tolerations
 }
 
 type Parameters struct {
@@ -96,6 +87,7 @@ type Parameters struct {
 	AgentPodSelector          string
 	CiliumPodSelector         string
 	NodeSelector              map[string]string
+	Tolerations               []string
 	DeploymentAnnotations     annotationsMap
 	NamespaceLabels           map[string]string
 	NamespaceAnnotations      map[string]string
@@ -160,6 +152,14 @@ type Parameters struct {
 	ExternalTargetCAName      string
 
 	Timeout time.Duration
+}
+
+func (p *Parameters) GetTolerations() []corev1.Toleration {
+	tolerations := make([]corev1.Toleration, 0, len(p.Tolerations))
+	for _, t := range p.Tolerations {
+		tolerations = append(tolerations, corev1.Toleration{Key: t, Operator: corev1.TolerationOpExists})
+	}
+	return tolerations
 }
 
 type podCIDRs struct {


### PR DESCRIPTION
Currently the cilium CLI's performance connectivity check (`cilium connectivity perf`) has a `--tolerations` flag allowing to set tolerations on the test pods. This feature would also be useful for the connectivity tests (`cilium connectivity test`). This PR moves this flag from being a `perf` only flag to being a global `connectivity` flag so that it can be used with both commands.

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
cli: Enable tolerations flag for all connectivity tests
```
