### PR TITLE
helm: add validation for removed CiliumEndpointSlice-related values

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -1,5 +1,13 @@
 {{/* validate deprecated options are not being used */}}
 
+{{/* Options removed in v1.18 */}}
+{{- if (dig "enableCiliumEndpointSlice" "" .Values.AsMap) }}
+  {{ fail "enableCiliumEndpointSlice was deprecated in v1.16 and has been removed in v1.18. For details please refer to https://docs.cilium.io/en/v1.18/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if (dig "ciliumEndpointSlice" "sliceMode" "" .Values.AsMap) }}
+  {{ fail "ciliumEndpointSlice.sliceMode has been removed in v1.18. For details please refer to https://docs.cilium.io/en/v1.18/operations/upgrade/#helm-options" }}
+{{- end }}
+
 {{/* Options deprecated in v1.15 and removed in v1.16 */}}
 {{- if or
   (dig "encryption" "keyFile" "" .Values.AsMap)


### PR DESCRIPTION
Add validation to yell at users if they configure the deprecated and now removed `enableCiliumEndpointSlice` and `ciliumEndpointSlice.sliceMode` helm values.

Related: c5ca80d9b887 ("helm: remove deprecated enableCiliumEndpointSlice option")
Related: c847f21e7579 ("helm: remove ciliumEndpointSlice.sliceMode option")

Suggested-by: Sebastian Wicki <sebastian@isovalent.com>