### PR TITLE
loadbalancer: Fix flakyness in script tests

### DIFF
--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -61,25 +61,24 @@ func TestScript(t *testing.T) {
 	// Set the node name
 	nodeTypes.SetName("testnode")
 
-	var opts []hivetest.LogOption
-	if *debug {
-		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
-	}
-	log := hivetest.Logger(t, opts...)
-
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 
 	scripttest.Test(t,
 		ctx,
 		func(t testing.TB, args []string) *script.Engine {
+
+			var opts []hivetest.LogOption
+			if *debug {
+				opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+				logging.SetLogLevelToDebug()
+			}
+			log := hivetest.Logger(t, opts...)
+
 			h := hive.New(
 				k8sClient.FakeClientCell(),
 				daemonk8s.ResourcesCell,
 				daemonk8s.TablesCell,
-
-				lbcell.Cell,
 
 				cell.Config(loadbalancer.TestConfig{
 					// By default 10% of the time the LBMap operations fail
@@ -113,8 +112,9 @@ func TestScript(t *testing.T) {
 						return uhive.NewScriptCmds(testCommands{w, lns, ops, waitFn}.cmds())
 					},
 				),
-
 				cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
+
+				lbcell.Cell,
 			)
 
 			flags := pflag.NewFlagSet("", pflag.ContinueOnError)

--- a/pkg/loadbalancer/tests/testdata/hostport.txtar
+++ b/pkg/loadbalancer/tests/testdata/hostport.txtar
@@ -29,8 +29,10 @@ lb/maps-dump lbmaps.actual
 replace 'phase: Running' 'phase: Succeeded' pod.yaml
 k8s/update pod.yaml
 
-# Services should be empty
+# Services and maps should be empty
 * db/empty services
+lb/maps-dump lbmaps.actual
+* empty lbmaps.actual
 
 # Add a new pod to take over the HostPort
 k8s/add other-pod.yaml

--- a/pkg/loadbalancer/tests/testdata/quarantined.txtar
+++ b/pkg/loadbalancer/tests/testdata/quarantined.txtar
@@ -1,9 +1,13 @@
-#! --lb-test-fault-probability=0.0
+#! --lb-test-fault-probability=0.0 --metrics-sampling-interval=100ms
 #
 # Test the infra for implementing active backend health checking and the restoration
 # of quarantined backends.
 
 hive/start
+
+# Wait until the initial pruning is done to avoid it messing with the test
+metrics -s reconciler_prune_count -o metrics.actual
+* grep 'prune_count.*1' metrics.actual
 
 # Add our test service and backends.
 k8s/add service.yaml endpointslice.yaml
@@ -31,41 +35,18 @@ k8s/delete service.yaml endpointslice.yaml
 lb/maps-restore
 test/bpfops-reset
 
-# We should see a quarantined restored backend.
-test/bpfops-summary
-stdout 'restoredQuarantines: 1'
-
-# Restore service and backends. Add an additional backend to ensure we've
-# actually updated the maps.
-k8s/add service.yaml endpointslice2.yaml
+# Restore service and backends. Add an additional backend to check we're actually updating
+# maps.
+k8s/add endpointslice2.yaml
+db/cmp backends backends_healthy2.table
+k8s/add service.yaml
 
 # Wait for reconciliation.
 db/show frontends --columns=Address,Status -o frontends.actual
 * grep '10.96.*Done' frontends.actual
 
-# Check BPF maps. We should get the same contents as before but
-# with an extra backend.
-lb/maps-dump maps.actual
-* grep 'SLOT=0.*COUNT=1 QCOUNT=1' maps2.expected
-* cmp maps.actual maps2.expected
-
-# Mark the quarantined backend as healthy again
-test/update-backend-health test/echo 10.244.1.2:80/TCP true
-db/cmp backends backends_healthy2.table
-
-# Check BPF maps
-lb/maps-dump maps.actual
-* grep 'SLOT=0.*COUNT=2 QCOUNT=0' maps3.expected
-* cmp maps.actual maps3.expected
-
-# The quarantined restored state is clean now.
-test/bpfops-summary
-stdout 'restoredQuarantines: 0'
-stdout 'restoredServiceIDs: 1'
-stdout 'restoredBackendIDs: 2'
-
-# Since we now have some restored data, check that forced
-# pruning will now clean up the state.
+# Since we now have some restored data, force the prune to make sure 10.244.1.1
+# has been removed.
 lb/prune
 
 # Wait until prune is done by checking that internal state
@@ -74,9 +55,26 @@ test/bpfops-summary
 * stdout 'restoredServiceIDs: 0'
 stdout 'restoredBackendIDs: 0'
 
-# Pruning should have removed the leftover 10.244.1.1:80.
+# Check BPF maps. We should get the same contents as before but
+# with 10.244.1.1 gone and 10.244.1.3 added.
 lb/maps-dump maps.actual
-* cmp maps.actual maps4.expected
+* grep 'SLOT=0.*COUNT=2 QCOUNT=1' maps2.expected
+* cmp maps.actual maps2.expected
+
+# Mark the quarantined backend as healthy again
+test/update-backend-health test/echo 10.244.1.2:80/TCP true
+db/cmp backends backends_healthy2.table
+
+# Check BPF maps
+lb/maps-dump maps.actual
+* grep 'SLOT=0.*COUNT=3 QCOUNT=0' maps3.expected
+* cmp maps.actual maps3.expected
+
+# The quarantined restored state is clean now.
+test/bpfops-summary
+stdout 'restoredQuarantines: 0'
+stdout 'restoredServiceIDs: 0'
+stdout 'restoredBackendIDs: 0'
 
 -- maps1.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
@@ -90,26 +88,19 @@ BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
 BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
 BE: ID=3 ADDR=10.244.1.3:80/TCP STATE=active
 REV: ID=1 ADDR=10.96.50.104:80
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP+non-routable
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=1 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=3 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 -- maps3.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
 BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
 BE: ID=3 ADDR=10.244.1.3:80/TCP STATE=active
 REV: ID=1 ADDR=10.96.50.104:80
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- maps4.expected --
-BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
-BE: ID=3 ADDR=10.244.1.3:80/TCP STATE=active
-REV: ID=1 ADDR=10.96.50.104:80
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- maps.empty --
-
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=3 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 -- services.table --
 Name
 test/echo
@@ -127,6 +118,7 @@ Address             Instances
 
 -- backends_healthy2.table --
 Address             Instances
+10.244.1.1:80/TCP   test/echo (http)
 10.244.1.2:80/TCP   test/echo (http)
 10.244.1.3:80/TCP   test/echo (http)
 
@@ -155,7 +147,7 @@ kind: EndpointSlice
 metadata:
   labels:
     kubernetes.io/service-name: echo
-  name: echo-kvlm2
+  name: echo-eps1
   namespace: test
 addressType: IPv4
 endpoints:
@@ -172,18 +164,18 @@ ports:
   port: 80
   protocol: TCP
 
-
 -- endpointslice2.yaml --
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
   labels:
     kubernetes.io/service-name: echo
-  name: echo-kvlm2
+  name: echo-eps2
   namespace: test
 addressType: IPv4
 endpoints:
 - addresses:
+  - 10.244.1.1
   - 10.244.1.2
   - 10.244.1.3
   conditions:

--- a/pkg/loadbalancer/writer/node_addr_reconciler.go
+++ b/pkg/loadbalancer/writer/node_addr_reconciler.go
@@ -6,6 +6,8 @@ package writer
 import (
 	"context"
 	"log/slog"
+	"net/netip"
+	"slices"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -22,9 +24,10 @@ import (
 type nodePortAddressReconcilerParams struct {
 	cell.In
 
-	Config   loadbalancer.Config
-	JobGroup job.Group
-	Log      *slog.Logger
+	Lifecycle cell.Lifecycle
+	Config    loadbalancer.Config
+	JobGroup  job.Group
+	Log       *slog.Logger
 
 	DB            *statedb.DB
 	NodeAddresses statedb.Table[tables.NodeAddress]
@@ -39,6 +42,17 @@ func registerNodePortAddressReconciler(p nodePortAddressReconcilerParams) {
 		frontends: p.Frontends.(statedb.RWTable[*loadbalancer.Frontend]),
 	}
 
+	// Grab the initial read transaction synchronously from a start hook. This will read
+	// the node addresses after they have been initially populated and this makes it
+	// possible for the tests to populate it before hive/start and not cause unexpected
+	// refreshing.
+	p.Lifecycle.Append(cell.Hook{
+		OnStart: func(hc cell.HookContext) error {
+			r.initTxn = p.DB.ReadTxn()
+			return nil
+		},
+	})
+
 	p.JobGroup.Add(job.OneShot("node-addr-reconciler", r.nodePortAddressReconcilerLoop))
 }
 
@@ -47,6 +61,14 @@ type nodePortAddrReconciler struct {
 	db        *statedb.DB
 	nodeAddrs statedb.Table[tables.NodeAddress]
 	frontends statedb.RWTable[*loadbalancer.Frontend]
+	initTxn   statedb.ReadTxn
+}
+
+func (r *nodePortAddrReconciler) getAddrs(txn statedb.ReadTxn) ([]netip.Addr, <-chan struct{}) {
+	iter, watch := r.nodeAddrs.ListWatch(txn, tables.NodeAddressNodePortIndex.Query(true))
+	return statedb.Collect(
+		statedb.Map(iter, func(addr tables.NodeAddress) netip.Addr { return addr.Addr }),
+	), watch
 }
 
 func (r *nodePortAddrReconciler) nodePortAddressReconcilerLoop(ctx context.Context, health cell.Health) error {
@@ -54,37 +76,45 @@ func (r *nodePortAddrReconciler) nodePortAddressReconcilerLoop(ctx context.Conte
 	limiter := rate.NewLimiter(time.Second, 1)
 	defer limiter.Stop()
 
+	prevAddrs, watch := r.getAddrs(r.initTxn)
+	r.initTxn = nil
+
 	for {
-		wtxn := r.db.WriteTxn(r.frontends)
-		_, watch := r.nodeAddrs.ListWatch(wtxn, tables.NodeAddressNodePortIndex.Query(true))
-
-		// The node port addresses have changed, set all NodePort/HostPort frontends as pending to reconcile
-		// the new addresses.
-		for fe := range r.frontends.All(wtxn) {
-			if fe.Type != loadbalancer.SVCTypeNodePort &&
-				!(fe.Type == loadbalancer.SVCTypeHostPort && fe.Address.AddrCluster.IsUnspecified()) {
-				continue
-			}
-
-			fe = fe.Clone()
-			// Set status to Pending, so that BPFOps reconciler gets invoked to update Frontend(s)' addrs accordingly
-			fe.Status = reconciler.StatusPending()
-			_, _, err := r.frontends.Insert(wtxn, fe)
-			if err != nil {
-				// Should not happen, but let's log it anyway
-				r.log.Warn("Could not set frontend status to pending",
-					logfields.Frontend, fe,
-					logfields.Error, err,
-				)
-			}
-		}
-
-		wtxn.Commit()
-
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-watch:
+		}
+
+		wtxn := r.db.WriteTxn(r.frontends)
+		var newAddrs []netip.Addr
+		newAddrs, watch = r.getAddrs(wtxn)
+
+		if !slices.Equal(prevAddrs, newAddrs) {
+			// The node port addresses have changed, set all NodePort/HostPort frontends as pending to reconcile
+			// the new addresses.
+			for fe := range r.frontends.All(wtxn) {
+				if fe.Type != loadbalancer.SVCTypeNodePort &&
+					!(fe.Type == loadbalancer.SVCTypeHostPort && fe.Address.AddrCluster.IsUnspecified()) {
+					continue
+				}
+
+				fe = fe.Clone()
+				// Set status to Pending, so that BPFOps reconciler gets invoked to update Frontend(s)' addrs accordingly
+				fe.Status = reconciler.StatusPending()
+				_, _, err := r.frontends.Insert(wtxn, fe)
+				if err != nil {
+					// Should not happen, but let's log it anyway
+					r.log.Warn("Could not set frontend status to pending",
+						logfields.Frontend, fe,
+						logfields.Error, err,
+					)
+				}
+			}
+			prevAddrs = newAddrs
+			wtxn.Commit()
+		} else {
+			wtxn.Abort()
 		}
 
 		if err := limiter.Wait(ctx); err != nil {


### PR DESCRIPTION
* Fix the logger used by LB script tests so that logs are associated with the proper test case.
* Wait for actual changes in nodePortAddrReconciler before refreshing. This way the refreshing won't mess up tests due to e.g. frontend processing order getting mixed up by it
* Fix few minor issues in the script tests themselves

```
$ stress -count 10000 ./tests.test
...
8m50s: 10000 runs total, 0 failures
```