### PR TITLE
auto-approve: add repository as part command

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -53,7 +53,7 @@ jobs:
         gh -R ${GITHUB_REPOSITORY} pr review ${PULL_REQUEST_NUMBER} --approve
 
         echo "Remove other reviewers except ciliumbot to avoid noise"
-        reviewers=$(gh pr view ${PULL_REQUEST_NUMBER} --json reviewRequests --jq '.reviewRequests[] | select(."__typename"=="User") | .login')
+        reviewers=$(gh -R ${GITHUB_REPOSITORY} pr view ${PULL_REQUEST_NUMBER} --json reviewRequests --jq '.reviewRequests[] | select(."__typename"=="User") | .login')
         for reviewer in $reviewers; do
           if [ "$reviewer" != "ciliumbot" ]; then
             gh -R ${GITHUB_REPOSITORY} pr edit ${PULL_REQUEST_NUMBER} --remove-reviewer "$reviewer"


### PR DESCRIPTION
If the command doesn't have the repository as part of the command, then gh will try to derive it from the .git directory. Since this directory doesn't exist, the command fails.

Fixes: 2b24f33648fa (".github/workflows: remove reviewers if ciliumbot approved PR")
