### PR TITLE
renovate: Allow cilium-proxy 1.33.x for 1.17 branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -594,7 +594,6 @@
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
       "allowedVersions": "/^v1\\.32\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
-        "v1.17",
         "v1.16",
         "v1.15"
       ]
@@ -606,6 +605,7 @@
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
       "allowedVersions": "/^v1\\.33\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
+        "v1.17",
         "main",
       ]
     },


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/40088
