### PR TITLE
cilium-cli: clean up log messages

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -168,14 +168,14 @@ func (a *Action) Run(f func(*Action)) {
 	for _, m := range a.expIngress.Metrics {
 		err := a.collectMetricsPerSource(m)
 		if err != nil {
-			a.Logf("❌ Failed to collect metrics for ingress from source %s: %w", m.Source, err)
+			a.Logf("❌ Failed to collect metrics for ingress from source %s: %s", m.Source, err)
 		}
 
 	}
 	for _, m := range a.expEgress.Metrics {
 		err := a.collectMetricsPerSource(m)
 		if err != nil {
-			a.Logf("❌ Failed to collect metrics for egress from source %s: %w", m.Source, err)
+			a.Logf("❌ Failed to collect metrics for egress from source %s: %s", m.Source, err)
 		}
 	}
 

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1917,15 +1917,15 @@ func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
 			    "` + perClientHighPriorityDeploymentName + `": ` + highPrioDeployAnnotations.String() + `
 			}`)
 		if err = ct.createServerPerfDeployment(ctx, perfServerDeploymentName, serverNode.Name, false); err != nil {
-			ct.Warnf("unable to create deployment: %w", err)
+			ct.Warnf("unable to create deployment: %s", err)
 		}
 		// Create low priority client on other node
 		if err = ct.createClientPerfDeployment(ctx, perClientLowPriorityDeploymentName, clientNode.Name, false); err != nil {
-			ct.Warnf("unable to create deployment: %w", err)
+			ct.Warnf("unable to create deployment: %s", err)
 		}
 		// Create high priority client on other node
 		if err = ct.createClientPerfDeployment(ctx, perClientHighPriorityDeploymentName, clientNode.Name, false); err != nil {
-			ct.Warnf("unable to create deployment: %w", err)
+			ct.Warnf("unable to create deployment: %s", err)
 		}
 
 		return nil
@@ -1944,69 +1944,69 @@ func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
 			    "` + perServerIngressDeploymentName + `": ` + ingressBandwidthAnnotations.String() + `
 			}`)
 		if err = ct.createServerPerfDeployment(ctx, perServerEgressDeploymentName, serverNode.Name, false); err != nil {
-			ct.Warnf("unable to create server deployment %s (egress): %w", perServerEgressDeploymentName, err)
+			ct.Warnf("unable to create server deployment %s (egress): %s", perServerEgressDeploymentName, err)
 		}
 		if err = ct.createServerPerfDeployment(ctx, perServerIngressDeploymentName, serverNode.Name, false); err != nil {
-			ct.Warnf("unable to create server deployment %s (ingress): %w", perServerIngressDeploymentName, err)
+			ct.Warnf("unable to create server deployment %s (ingress): %s", perServerIngressDeploymentName, err)
 		}
 		if err = ct.createClientPerfDeployment(ctx, perClientEgressDeploymentName, clientNode.Name, false); err != nil {
-			ct.Warnf("unable to create client deployment %s (egress): %w", perClientEgressDeploymentName, err)
+			ct.Warnf("unable to create client deployment %s (egress): %s", perClientEgressDeploymentName, err)
 		}
 		if err = ct.createClientPerfDeployment(ctx, perClientIngressDeploymentName, clientNode.Name, false); err != nil {
-			ct.Warnf("unable to create client deployment %s (ingress): %w", perClientIngressDeploymentName, err)
+			ct.Warnf("unable to create client deployment %s (ingress): %s", perClientIngressDeploymentName, err)
 		}
 	}
 
 	if ct.params.PerfParameters.PodNet || ct.params.PerfParameters.PodToHost {
 		if ct.params.PerfParameters.SameNode {
 			if err = ct.createClientPerfDeployment(ctx, perfClientDeploymentName, serverNode.Name, false); err != nil {
-				ct.Warnf("unable to create deployment: %w", err)
+				ct.Warnf("unable to create deployment: %s", err)
 			}
 		}
 
 		if ct.params.PerfParameters.OtherNode {
 			// Create second client on other node
 			if err = ct.createClientPerfDeployment(ctx, perfClientAcrossDeploymentName, clientNode.Name, false); err != nil {
-				ct.Warnf("unable to create deployment: %w", err)
+				ct.Warnf("unable to create deployment: %s", err)
 			}
 		}
 	}
 
 	if ct.params.PerfParameters.PodNet || ct.params.PerfParameters.HostToPod {
 		if err = ct.createServerPerfDeployment(ctx, perfServerDeploymentName, serverNode.Name, false); err != nil {
-			ct.Warnf("unable to create deployment: %w", err)
+			ct.Warnf("unable to create deployment: %s", err)
 		}
 	}
 
 	if ct.params.PerfParameters.HostNet || ct.params.PerfParameters.HostToPod {
 		if ct.params.PerfParameters.SameNode {
 			if err = ct.createClientPerfDeployment(ctx, perfClientHostNetDeploymentName, serverNode.Name, true); err != nil {
-				ct.Warnf("unable to create deployment: %w", err)
+				ct.Warnf("unable to create deployment: %s", err)
 			}
 		}
 
 		if ct.params.PerfParameters.OtherNode {
 			// Create second client on other node
 			if err = ct.createClientPerfDeployment(ctx, perfClientHostNetAcrossDeploymentName, clientNode.Name, true); err != nil {
-				ct.Warnf("unable to create deployment: %w", err)
+				ct.Warnf("unable to create deployment: %s", err)
 			}
 		}
 	}
 
 	if ct.params.PerfParameters.HostNet || ct.params.PerfParameters.PodToHost {
 		if err = ct.createServerPerfDeployment(ctx, perfServerHostNetDeploymentName, serverNode.Name, true); err != nil {
-			ct.Warnf("unable to create deployment: %w", err)
+			ct.Warnf("unable to create deployment: %s", err)
 		}
 	}
 
 	if ct.params.PerfParameters.KernelProfiles {
 		if err = ct.createProfilingPerfDeployment(ctx, PerfServerProfilingDeploymentName, serverNode.Name); err != nil {
-			ct.Warnf("unable to create deployment: %w", err)
+			ct.Warnf("unable to create deployment: %s", err)
 		}
 
 		if ct.params.PerfParameters.OtherNode {
 			if err = ct.createProfilingPerfDeployment(ctx, PerfClientProfilingAcrossDeploymentName, clientNode.Name); err != nil {
-				ct.Warnf("unable to create deployment: %w", err)
+				ct.Warnf("unable to create deployment: %s", err)
 			}
 		}
 	}

--- a/cilium-cli/connectivity/check/policy.go
+++ b/cilium-cli/connectivity/check/policy.go
@@ -51,7 +51,7 @@ func (ct *ConnectivityTest) getCiliumPolicyRevisions(ctx context.Context) (map[P
 			if err == nil {
 				break
 			}
-			ct.Debugf("Failed to get policy revision from pod %s (%d/%d): %w", cp, i, getPolicyRevisionRetries, err)
+			ct.Debugf("Failed to get policy revision from pod %s (%d/%d): %s", cp, i, getPolicyRevisionRetries, err)
 		}
 		if err != nil {
 			return revisions, err

--- a/cilium-cli/connectivity/tests/pod.go
+++ b/cilium-cli/connectivity/tests/pod.go
@@ -336,13 +336,13 @@ func (s *podToPodMissingIPCache) Run(ctx context.Context, t *check.Test) {
 		for _, ciliumPod := range ct.CiliumPods() {
 			addr, err := netip.ParseAddr(echoIP)
 			if err != nil {
-				ct.Warnf("invalid pod IP address: %w", err)
+				ct.Warnf("invalid pod IP address: %s", err)
 				continue
 			}
 
 			restore, err := ipcacheDeleteAndRestore(ctx, ct, ciliumPod, netip.PrefixFrom(addr, addr.BitLen()), s.useExactMatch)
 			if err != nil {
-				ct.Warnf("ipcache ip entries delete and restore failed: %w", err)
+				ct.Warnf("ipcache ip entries delete and restore failed: %s", err)
 				continue
 			}
 			defer restore()
@@ -354,14 +354,14 @@ func (s *podToPodMissingIPCache) Run(ctx context.Context, t *check.Test) {
 		for _, ciliumPod := range ct.CiliumPods() {
 			prefixes, err := remoteNodesPodCIDRs(ctx, ciliumPod)
 			if err != nil {
-				ct.Warnf("unable to get remote nodes pod CIDRs: %w", err)
+				ct.Warnf("unable to get remote nodes pod CIDRs: %s", err)
 				continue
 			}
 
 			for _, prefix := range prefixes {
 				restore, err := ipcacheDeleteAndRestore(ctx, ct, ciliumPod, prefix, s.useExactMatch)
 				if err != nil {
-					ct.Warnf("ipcache pod CIDR entries delete and restore failed: %w", err)
+					ct.Warnf("ipcache pod CIDR entries delete and restore failed: %s", err)
 					continue
 				}
 				defer restore()
@@ -495,7 +495,7 @@ func ipcacheDeleteAndRestore(
 		}
 		output, err := ciliumPod.K8sClient.ExecInPod(ctx, ciliumPod.Pod.Namespace, ciliumPod.Pod.Name, defaults.AgentContainerName, updateCmd)
 		if err != nil {
-			ct.Warnf("failed to restore ipcache entry: %q, %w, %q", updateCmd, err, output.String())
+			ct.Warnf("failed to restore ipcache entry: %q, %s, %q", updateCmd, err, output.String())
 		}
 	}, nil
 }

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -168,7 +168,7 @@ func (fs Set) MatchRequirements(reqs ...Requirement) (bool, string) {
 			return false, fmt.Sprintf("requires Feature %s mode %s, got %s", req.Feature, req.mode, status.Mode)
 		}
 		if req.requireModeIsNot && (req.mode == status.Mode) {
-			return false, fmt.Sprintf("requires Feature %s mode %s to not equal %s, req.Feature", req.Feature, status.Mode, req.mode)
+			return false, fmt.Sprintf("requires Feature %s not equal to %s", req.Feature, req.mode)
 		}
 	}
 


### PR DESCRIPTION
Use the correct format verb when logging error messages (`%s` instead of `%w`) and fix an error message related to requireModeIsNot requirements in feature detection.

See commits for details.