### PR TITLE
fix: fallback to ipv6 node address usage for endpoint kvstore sync

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/cilium/ebpf"
-	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/controller"
@@ -1026,10 +1025,10 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				logger := e.getLogger()
 
 				ID := e.SecurityIdentity.ID
-				hostIP, ok := netipx.FromStdIP(node.GetIPv4(logger))
-				if !ok {
+				hostIP, err := netip.ParseAddr(node.GetCiliumEndpointNodeIP(logger))
+				if err != nil {
 					e.runlock()
-					return controller.NewExitReason("Failed to convert node IPv4 address")
+					return controller.NewExitReason("Failed to get node IP")
 				}
 				key := node.GetEndpointEncryptKeyIndex(logger)
 				metadata := e.FormatGlobalEndpointID()
@@ -1086,8 +1085,12 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 
 	// Whenever the identity is updated, propagate change to key-value store
 	// of IP to identity mapping.
-	e.runIPIdentitySync(e.IPv4)
-	e.runIPIdentitySync(e.IPv6)
+	if option.Config.EnableIPv4 {
+		e.runIPIdentitySync(e.IPv4)
+	}
+	if option.Config.EnableIPv6 {
+		e.runIPIdentitySync(e.IPv6)
+	}
 
 	if oldIdentity != identity.StringID() {
 		e.getLogger().Info(


### PR DESCRIPTION
This PR addresses root cause of #37791
Cilium-agent endpoint synchronization with kvstore fails in IPv6-only environments when nodes don't have IPv4 addresses. The `runIPIdentitySync()` function was hardcoded to use `node.GetIPv4()` for the host IP regardless of the endpoint's address family or node configuration. Now we call `runIPIdentitySync()` per enabled address family and checking node IP before creating sync controller.

<!-- Description of change -->

Fixes: #37791

```release-note
Ensure that kvstore synchronisation can work in IPv6-only environments.
```
