### PR TITLE
gha: enable ipv6-only tunneling matrix entry in conformance-clustermesh

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -227,16 +227,19 @@ jobs:
             policy-default-local-cluster: false
             multipool-ipam: 'disabled'
 
-        # Tunneling is currently not supported in case of ipv6-only clusters (#17240)
-        #  - name: '9'
-        #    tunnel: 'vxlan'
-        #    ipFamily: 'ipv6'
-        #    encryption: 'disabled'
-        #    kube-proxy: 'none'
-        #    mode: 'kvstoremesh'
-        #    tls-auto-method: certmanager
-        #    cm-auth-mode-1: 'cluster'
-        #    cm-auth-mode-2: 'cluster'
+          - name: '9'
+            tunnel: 'vxlan'
+            ipFamily: 'ipv6'
+            encryption: 'disabled'
+            kube-proxy: 'none'
+            mode: 'kvstoremesh'
+            tls-auto-method: certmanager
+            cm-auth-mode-1: 'cluster'
+            cm-auth-mode-2: 'cluster'
+            maxConnectedClusters: '255'
+            ciliumEndpointSlice: 'enabled'
+            policy-default-local-cluster: true
+            multipool-ipam: 'disabled'
 
           - name: '10'
             tunnel: 'vxlan'
@@ -297,7 +300,10 @@ jobs:
             --helm-set=extraConfig.clustermesh-sync-timeout=5m \
             "
 
-          CILIUM_INSTALL_TUNNEL="--helm-set=tunnelProtocol=${{ matrix.tunnel }}"
+          CILIUM_INSTALL_TUNNEL=" \
+            --helm-set=tunnelProtocol=${{ matrix.tunnel }} \
+            --helm-set=underlayProtocol=${{ matrix.ipFamily == 'ipv6' && 'ipv6' || 'ipv4' }} \
+          "
           if [ "${{ matrix.tunnel }}" == "disabled" ]; then
             CILIUM_INSTALL_TUNNEL="--helm-set-string=routingMode=native \
               --helm-set=autoDirectNodeRoutes=true \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -182,7 +182,7 @@ jobs:
 
           CONCURRENT_CONNECTIVITY_TESTS="!seq-.*"
           if [ "${{ matrix.ipv4 }}" == "false" ]; then
-            CONCURRENT_CONNECTIVITY_TESTS="!(seq-.*|pod-to-world.*|pod-to-cidr|pod-to-pod-encryption-v2)"
+            CONCURRENT_CONNECTIVITY_TESTS="!(seq-.*|pod-to-world.*|pod-to-cidr)"
           fi
           echo concurrent_connectivity_tests=${CONCURRENT_CONNECTIVITY_TESTS} >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Now that the long standing tunneling + IPv6-only limitation has been lifted \[1,2,3], let's enable this previously commented-out matrix entry of the conformance-clustermesh workflow. As a pre-requisite, let's also make sure that the `pod-to-pod-encryption-v2` check works with IPv6 underlay.

\[1]: cilium/cilium#38523
\[2]: cilium/cilium#38296
\[3]: cilium/cilium#39074
