### PR TITLE
Run only privileged tests on conformance-runtime

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -366,7 +366,7 @@ jobs:
           -cilium.SSHConfig="cat ./cilium-ssh-config.txt" \
           -cilium.extra-opts="${{ env.CILIUM_RUNTIME_EXTRA_ARGS }}"
 
-      - name: Runtime privileged tests
+      - name: Privileged unit tests
         id: run-tests
         if: ${{ matrix.focus == 'privileged' }}
         timeout-minutes: 40
@@ -383,7 +383,7 @@ jobs:
             go${{ env.go-version}} install github.com/mfridman/tparse@baf229e8494613f134bc0e1f4cb9dc9b12f66442
             # renovate: datasource=github-releases depName=cilium/go-junit-report/v2/cmd/go-junit-report
             go${{ env.go-version}} install github.com/cilium/go-junit-report/v2/cmd/go-junit-report@cc2d3acf69eeefab6f9a23ad61b175cd1d570623 # v2.3.0
-            make SKIP_COVERAGE=1 LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml" tests-privileged GO=go${{ env.go-version }}
+            make SKIP_COVERAGE=1 LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml" tests-privileged-only GO=go${{ env.go-version }}
 
       - name: Copy tested features
         if: ${{ matrix.focus == 'agent' || matrix.focus == 'datapath' }}

--- a/daemon/cmd/daemon_privileged_test.go
+++ b/daemon/cmd/daemon_privileged_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
-func Test_removeOldRouterState(t *testing.T) {
+func TestPrivilegedRemoveOldRouterState(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	t.Run("test-1", func(t *testing.T) {
@@ -93,7 +93,7 @@ func createDevices(t *testing.T) {
 	assert.NoError(t, netlink.AddrAdd(ciliumHost, addr))
 }
 
-func Test_removeStaleEPIfaces(t *testing.T) {
+func TestPrivilegedRemoveStaleEPIfaces(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	ns := netns.NewNetNS(t)

--- a/daemon/cmd/nodeport_linux_test.go
+++ b/daemon/cmd/nodeport_linux_test.go
@@ -46,7 +46,7 @@ func setupNodePortSuite(tb testing.TB) *NodePortSuite {
 	return s
 }
 
-func TestCheckNodePortAndEphemeralPortRanges(t *testing.T) {
+func TestPrivilegedCheckNodePortAndEphemeralPortRanges(t *testing.T) {
 	s := setupNodePortSuite(t)
 
 	cases := []struct {

--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -30,7 +30,7 @@ var (
 )
 
 // Test_PodCIDRAdvert validates pod IPv4/v6 subnet is advertised, withdrawn and modified on node addresses change.
-func Test_PodCIDRAdvert(t *testing.T) {
+func TestPrivilegedPodCIDRAdvert(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	// steps define order in which test is run. Note, this is different from table tests, in which each unit is
@@ -181,7 +181,7 @@ func Test_PodCIDRAdvert(t *testing.T) {
 }
 
 // Test_PodIPPoolAdvert validates pod ip pools are advertised to BGP peers.
-func Test_PodIPPoolAdvert(t *testing.T) {
+func TestPrivilegedPodIPPoolAdvert(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	// Steps define the order that tests are run. Note, this is different from table tests,
@@ -506,7 +506,7 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 }
 
 // Test_LBEgressAdvertisementWithLoadBalancerIP validates Service v4 and v6 IPs is advertised, withdrawn and modified on changing policy.
-func Test_LBEgressAdvertisementWithLoadBalancerIP(t *testing.T) {
+func TestPrivilegedLBEgressAdvertisementWithLoadBalancerIP(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	var steps = []struct {
@@ -733,8 +733,8 @@ func Test_LBEgressAdvertisementWithLoadBalancerIP(t *testing.T) {
 	}
 }
 
-// Test_LBEgressAdvertisementWithClusterIP validates Service v4 and v6 IPs is advertised, withdrawn and modified on changing policy.
-func Test_LBEgressAdvertisementWithClusterIP(t *testing.T) {
+// TestPrivilegedLBEgressAdvertisementWithClusterIP validates Service v4 and v6 IPs is advertised, withdrawn and modified on changing policy.
+func TestPrivilegedLBEgressAdvertisementWithClusterIP(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	var steps = []struct {
@@ -934,7 +934,7 @@ func Test_LBEgressAdvertisementWithClusterIP(t *testing.T) {
 }
 
 // Test_LBEgressAdvertisementWithExternalIP validates Service v4 and v6 IPs is advertised, withdrawn and modified on changing policy.
-func Test_LBEgressAdvertisementWithExternalIP(t *testing.T) {
+func TestPrivilegedLBEgressAdvertisementWithExternalIP(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	var steps = []struct {
@@ -1133,8 +1133,8 @@ func Test_LBEgressAdvertisementWithExternalIP(t *testing.T) {
 	}
 }
 
-// Test_AdvertisedPathAttributes validates optional path attributes in advertised paths.
-func Test_AdvertisedPathAttributes(t *testing.T) {
+// TestPrivilegedAdvertisedPathAttributes validates optional path attributes in advertised paths.
+func TestPrivilegedAdvertisedPathAttributes(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	var steps = []struct {

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -39,7 +39,7 @@ type peeringState struct {
 // Test_NeighborAddDel validates neighbor add and delete are working as expected. Test validates this using
 // peering status which is reported from BGP control plane.
 // Topology - (BGP CP) === (2 x gobgp instances)
-func Test_NeighborAddDel(t *testing.T) {
+func TestPrivilegedNeighborAddDel(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	var steps = []struct {
@@ -187,7 +187,7 @@ func Test_NeighborAddDel(t *testing.T) {
 }
 
 // Test_NeighborGracefulRestart tests graceful restart configuration knobs with single peer.
-func Test_NeighborGracefulRestart(t *testing.T) {
+func TestPrivilegedNeighborGracefulRestart(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	var steps = []struct {

--- a/pkg/bgpv1/test/script_test.go
+++ b/pkg/bgpv1/test/script_test.go
@@ -53,7 +53,7 @@ const (
 	probeTCPMD5Flag    = "probe-tcp-md5"
 )
 
-func TestScript(t *testing.T) {
+func TestPrivilegedScript(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	slog.SetLogLoggerLevel(slog.LevelDebug) // used by test GoBGP instances
 

--- a/pkg/bpf/collection_test.go
+++ b/pkg/bpf/collection_test.go
@@ -38,7 +38,7 @@ func TestRemoveUnreachableTailcalls(t *testing.T) {
 	assert.NotContains(t, spec.Programs, "e")
 }
 
-func TestUpgradeMap(t *testing.T) {
+func TestPrivilegedUpgradeMap(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -115,7 +115,7 @@ func mapsEqual(a, b *Map) bool {
 		reflect.DeepEqual(a.spec, b.spec)
 }
 
-func TestOpen(t *testing.T) {
+func TestPrivilegedOpen(t *testing.T) {
 	setup(t)
 
 	// Ensure that os.IsNotExist() can be used with Map.Open()
@@ -142,7 +142,7 @@ func TestOpen(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestOpenMap(t *testing.T) {
+func TestPrivilegedOpenMap(t *testing.T) {
 	testMap := setup(t)
 	logger := hivetest.Logger(t)
 
@@ -155,7 +155,7 @@ func TestOpenMap(t *testing.T) {
 	require.True(t, mapsEqual(openedMap, testMap))
 }
 
-func TestOpenOrCreate(t *testing.T) {
+func TestPrivilegedOpenOrCreate(t *testing.T) {
 	setup(t)
 
 	// existingMap is the same as testMap. OpenOrCreate should skip recreation.
@@ -186,7 +186,7 @@ func TestOpenOrCreate(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRecreateMap(t *testing.T) {
+func TestPrivilegedRecreateMap(t *testing.T) {
 	testMap := setup(t)
 
 	parallelMap := NewMap("cilium_test",
@@ -230,7 +230,7 @@ func TestRecreateMap(t *testing.T) {
 	require.EqualValues(t, value, value2)
 }
 
-func TestBasicManipulation(t *testing.T) {
+func TestPrivilegedBasicManipulation(t *testing.T) {
 	setup(t)
 	// existingMap is the same as testMap. Opening should succeed.
 	existingMap := NewMap("cilium_test",
@@ -422,7 +422,7 @@ func TestBasicManipulation(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSubscribe(t *testing.T) {
+func TestPrivilegedSubscribe(t *testing.T) {
 	setup(t)
 
 	existingMap := NewMap("cilium_test",
@@ -466,7 +466,7 @@ func TestSubscribe(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDump(t *testing.T) {
+func TestPrivilegedDump(t *testing.T) {
 	testMap := setup(t)
 
 	key1 := &TestKey{Key: 105}
@@ -539,7 +539,7 @@ func TestDump(t *testing.T) {
 	}, dump5)
 }
 
-func TestDumpPerCPU(t *testing.T) {
+func TestPrivilegedDumpPerCPU(t *testing.T) {
 	testMap := setupPerCPU(t)
 
 	key1 := &TestKey{Key: 0}
@@ -588,13 +588,13 @@ func TestDumpPerCPU(t *testing.T) {
 	}, dump)
 }
 
-// TestDumpReliablyWithCallbackOverlapping attempts to test that DumpReliablyWithCallback
+// TestPrivilegedDumpReliablyWithCallbackOverlapping attempts to test that DumpReliablyWithCallback
 // will reliably iterate all keys that are known to be in a map, even if keys that are ahead
 // of the current iteration can be deleted or updated concurrently.
 // This test is not deterministic, it establishes a condition where we have keys that are known
 // to be in the map and other keys which are volatile.  The test passes if the dump can reliably
 // iterate all keys that are not volatile.
-func TestDumpReliablyWithCallbackOverlapping(t *testing.T) {
+func TestPrivilegedDumpReliablyWithCallbackOverlapping(t *testing.T) {
 	setup(t)
 
 	iterations := 10000
@@ -679,11 +679,11 @@ func TestDumpReliablyWithCallbackOverlapping(t *testing.T) {
 	wg.Wait()
 }
 
-// TestDumpReliablyWithCallback tests that DumpReliablyWithCallback by concurrently
+// TestPrivilegedDumpReliablyWithCallback tests that DumpReliablyWithCallback by concurrently
 // upserting/removing keys in range [0, 4) in the map and then continuously dumping
 // the map.
 // The test validates that all keys that are not being removed/added are contained in the dump.
-func TestDumpReliablyWithCallback(t *testing.T) {
+func TestPrivilegedDumpReliablyWithCallback(t *testing.T) {
 	setup(t)
 
 	maxEntries := uint32(256)
@@ -769,7 +769,7 @@ func TestDumpReliablyWithCallback(t *testing.T) {
 	wg.Wait()
 }
 
-func TestDeleteAll(t *testing.T) {
+func TestPrivilegedDeleteAll(t *testing.T) {
 	testMap := setup(t)
 
 	key1 := &TestKey{Key: 105}
@@ -806,14 +806,14 @@ func TestDeleteAll(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestGetModel(t *testing.T) {
+func TestPrivilegedGetModel(t *testing.T) {
 	testMap := setup(t)
 
 	model := testMap.GetModel()
 	require.NotNil(t, model)
 }
 
-func TestCheckAndUpgrade(t *testing.T) {
+func TestPrivilegedCheckAndUpgrade(t *testing.T) {
 	setup(t)
 
 	// CheckAndUpgrade removes map file if upgrade is needed
@@ -848,7 +848,7 @@ func TestCheckAndUpgrade(t *testing.T) {
 	DisableMapPreAllocation()
 }
 
-func TestUnpin(t *testing.T) {
+func TestPrivilegedUnpin(t *testing.T) {
 	setup(t)
 
 	var exist bool
@@ -887,7 +887,7 @@ func TestUnpin(t *testing.T) {
 	require.False(t, exist)
 }
 
-func TestCreateUnpinned(t *testing.T) {
+func TestPrivilegedCreateUnpinned(t *testing.T) {
 	setup(t)
 
 	m := NewMap("cilium_test_create_unpinned",
@@ -938,7 +938,7 @@ func BenchmarkMapLookup(b *testing.B) {
 	}
 }
 
-func TestErrorResolver(t *testing.T) {
+func TestPrivilegedErrorResolver(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 	CheckOrMountFS(logger, "")
@@ -1030,7 +1030,7 @@ func TestBatchIteratorTypes(t *testing.T) {
 	assert.NotNil(t, iter)
 }
 
-func TestBatchIterator(t *testing.T) {
+func TestPrivilegedBatchIterator(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	runTest := func(mapType ebpf.MapType, size, mapSize int, t *testing.T, opts ...BatchIteratorOpt[TestLPMKey, TestValue, *TestLPMKey, *TestValue]) {

--- a/pkg/bpf/ops_linux_test.go
+++ b/pkg/bpf/ops_linux_test.go
@@ -41,7 +41,7 @@ func (o *TestObject) BinaryValue() encoding.BinaryMarshaler {
 
 var emptySeq iter.Seq2[*TestObject, statedb.Revision] = func(yield func(*TestObject, uint64) bool) {}
 
-func Test_MapOps(t *testing.T) {
+func TestPrivilegedMapOps(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	testMap := NewMap("cilium_ops_test",
@@ -96,7 +96,7 @@ func Test_MapOps(t *testing.T) {
 	assert.Empty(t, data)
 }
 
-func Test_MapOpsPrune(t *testing.T) {
+func TestPrivilegedMapOpsPrune(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	// This tests pruning with an LPM trie. This ensures we do not regress, as
@@ -138,7 +138,7 @@ func Test_MapOpsPrune(t *testing.T) {
 
 // Test_MapOps_ReconcilerExample serves as a testable example for the map ops.
 // This is not an "Example*" function as it can only run privileged.
-func Test_MapOps_ReconcilerExample(t *testing.T) {
+func TestPrivilegedMapOps_ReconcilerExample(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	exampleMap := NewMap("example",

--- a/pkg/crypto/certloader/reloader_test.go
+++ b/pkg/crypto/certloader/reloader_test.go
@@ -387,7 +387,7 @@ func TestKeypairAndCACertPool(t *testing.T) {
 	}
 }
 
-func TestReload(t *testing.T) {
+func TestPrivilegedReload(t *testing.T) {
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)

--- a/pkg/datapath/link/link_test.go
+++ b/pkg/datapath/link/link_test.go
@@ -16,7 +16,7 @@ func setup(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 }
 
-func TestDeleteByName(t *testing.T) {
+func TestPrivilegedDeleteByName(t *testing.T) {
 	setup(t)
 
 	testCases := []struct {
@@ -42,7 +42,7 @@ func TestDeleteByName(t *testing.T) {
 	}
 }
 
-func TestRename(t *testing.T) {
+func TestPrivilegedRename(t *testing.T) {
 	setup(t)
 
 	testCases := []struct {

--- a/pkg/datapath/linux/bandwidth/ops_test.go
+++ b/pkg/datapath/linux/bandwidth/ops_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
-func TestOps(t *testing.T) {
+func TestPrivilegedOps(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	log := hivetest.Logger(t)
 

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -117,14 +117,14 @@ func writeConfig(t *testing.T, header string, write writeFn) {
 	}
 }
 
-func TestWriteNodeConfig(t *testing.T) {
+func TestPrivilegedWriteNodeConfig(t *testing.T) {
 	setupConfigSuite(t)
 	writeConfig(t, "node", func(w io.Writer, dp datapath.ConfigWriter) error {
 		return dp.WriteNodeConfig(w, &dummyNodeCfg)
 	})
 }
 
-func TestWriteNetdevConfig(t *testing.T) {
+func TestPrivilegedWriteNetdevConfig(t *testing.T) {
 	setupConfigSuite(t)
 	writeConfig(t, "netdev", func(w io.Writer, dp datapath.ConfigWriter) error {
 		return dp.WriteNetdevConfig(w, dummyDevCfg.GetOptions())
@@ -158,7 +158,7 @@ func createVlanLink(vlanId int, mainLink *netlink.Dummy, t *testing.T) *netlink.
 	return link
 }
 
-func TestVLANBypassConfig(t *testing.T) {
+func TestPrivilegedVLANBypassConfig(t *testing.T) {
 	setupConfigSuite(t)
 
 	var devs []*tables.Device
@@ -233,7 +233,7 @@ return false;`, main1.Index, main2.Index), m)
 	require.Equal(t, "return true", m)
 }
 
-func TestWriteNodeConfigExtraDefines(t *testing.T) {
+func TestPrivilegedWriteNodeConfigExtraDefines(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	setupConfigSuite(t)
 
@@ -381,7 +381,7 @@ func TestPreferredIPv6Address(t *testing.T) {
 	}
 }
 
-func TestNewHeaderfileWriter(t *testing.T) {
+func TestPrivilegedNewHeaderfileWriter(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	setupConfigSuite(t)
 

--- a/pkg/datapath/linux/devices_controller_test.go
+++ b/pkg/datapath/linux/devices_controller_test.go
@@ -51,7 +51,7 @@ func devicesControllerTestSetup(t *testing.T) {
 	})
 }
 
-func TestDevicesControllerScript(t *testing.T) {
+func TestPrivilegedDevicesControllerScript(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	devicesControllerTestSetup(t)
 

--- a/pkg/datapath/linux/ethtool/ethtool_linux_test.go
+++ b/pkg/datapath/linux/ethtool/ethtool_linux_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
-func TestIsVirtualDriver(t *testing.T) {
+func TestPrivilegedIsVirtualDriver(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	ns := netns.NewNetNS(t)

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -84,7 +84,7 @@ func TestCreateNodeRouteSpecMtu(t *testing.T) {
 	require.Equal(t, 0, generatedRoute.MTU)
 }
 
-func TestLocalRule(t *testing.T) {
+func TestPrivilegedLocalRule(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	ns := netns.NewNetNS(t)

--- a/pkg/datapath/linux/probes/attach_cgroup_test.go
+++ b/pkg/datapath/linux/probes/attach_cgroup_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func TestAttachCgroup(t *testing.T) {
+func TestPrivilegedAttachCgroup(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	// Cgroup attachment expected to succeed in all testing environments.

--- a/pkg/datapath/linux/probes/attach_type_test.go
+++ b/pkg/datapath/linux/probes/attach_type_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func TestHaveAttachType(t *testing.T) {
+func TestPrivilegedHaveAttachType(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	testCases := []struct {
@@ -40,7 +40,7 @@ func TestHaveAttachType(t *testing.T) {
 	}
 }
 
-func TestHaveAttachTypeUnsupported(t *testing.T) {
+func TestPrivilegedHaveAttachTypeUnsupported(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	if err := HaveAttachType(ebpf.CGroupSockAddr, ^ebpf.AttachType(0)); !errors.Is(err, ebpf.ErrNotSupported) {

--- a/pkg/datapath/linux/probes/managed_neighbors_test.go
+++ b/pkg/datapath/linux/probes/managed_neighbors_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func TestManagedNeighbors(t *testing.T) {
+func TestPrivilegedManagedNeighbors(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	testutils.SkipOnOldKernel(t, "5.16", "NTF_EXT_MANAGED")
 

--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -56,7 +56,7 @@ func TestWriteFeatureHeader(t *testing.T) {
 	}
 }
 
-func TestExecuteHeaderProbes(t *testing.T) {
+func TestPrivilegedExecuteHeaderProbes(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	if ExecuteHeaderProbes(hivetest.Logger(t)) == nil {
@@ -64,7 +64,7 @@ func TestExecuteHeaderProbes(t *testing.T) {
 	}
 }
 
-func TestSKBAdjustRoomL2RoomMACSupportProbe(t *testing.T) {
+func TestPrivilegedSKBAdjustRoomL2RoomMACSupportProbe(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	testutils.SkipOnOldKernel(t, "5.2", "BPF_ADJ_ROOM_MAC mode support in bpf_skb_adjust_room")
 	assert.NoError(t, HaveSKBAdjustRoomL2RoomMACSupport(hivetest.Logger(t)))
@@ -74,33 +74,33 @@ func TestIPv6Support(t *testing.T) {
 	assert.NoError(t, HaveIPv6Support())
 }
 
-func TestHaveBPF(t *testing.T) {
+func TestPrivilegedHaveBPF(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	assert.NoError(t, HaveBPF())
 }
 
-func TestHaveBPFJIT(t *testing.T) {
+func TestPrivilegedHaveBPFJIT(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	assert.NoError(t, HaveBPFJIT())
 }
 
-func TestHaveDeadCodeElimSupport(t *testing.T) {
+func TestPrivilegedHaveDeadCodeElimSupport(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	assert.NoError(t, HaveDeadCodeElim())
 }
 
-func TestHaveTCBPF(t *testing.T) {
+func TestPrivilegedHaveTCBPF(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	assert.NoError(t, HaveTCBPF())
 }
 
-func TestHaveTCX(t *testing.T) {
+func TestPrivilegedHaveTCX(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	testutils.SkipOnOldKernel(t, "6.6", "tcx bpf_link")
 	assert.NoError(t, HaveTCX())
 }
 
-func TestHaveNetkit(t *testing.T) {
+func TestPrivilegedHaveNetkit(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	testutils.SkipOnOldKernel(t, "6.7", "netkit bpf_link")
 	assert.NoError(t, HaveNetkit())

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -46,7 +46,7 @@ func testReplaceNexthopRoute(t *testing.T, link netlink.Link, routerNet *net.IPN
 	require.NoError(t, err)
 }
 
-func TestReplaceNexthopRoute(t *testing.T) {
+func TestPrivilegedReplaceNexthopRoute(t *testing.T) {
 	setup(t)
 
 	link, err := safenetlink.LinkByName("lo")
@@ -103,7 +103,7 @@ func testReplaceRoute(t *testing.T, prefixStr, nexthopStr string, lookupTest boo
 	require.NoError(t, err)
 }
 
-func TestReplaceRoute(t *testing.T) {
+func TestPrivilegedReplaceRoute(t *testing.T) {
 	setup(t)
 
 	testReplaceRoute(t, "2.2.0.0/16", "1.2.3.4", true)
@@ -161,7 +161,7 @@ func testReplaceRuleIPv6(t *testing.T, mark uint32, from, to *net.IPNet, table i
 	require.False(t, exists)
 }
 
-func TestReplaceRule(t *testing.T) {
+func TestPrivilegedReplaceRule(t *testing.T) {
 	setup(t)
 
 	_, cidr1, err := net.ParseCIDR("10.10.0.0/16")
@@ -172,7 +172,7 @@ func TestReplaceRule(t *testing.T) {
 	testReplaceRule(t, 0, cidr1, cidr1, 126)
 }
 
-func TestReplaceRule6(t *testing.T) {
+func TestPrivilegedReplaceRule6(t *testing.T) {
 	setup(t)
 
 	_, cidr1, err := net.ParseCIDR("beef::/48")
@@ -183,7 +183,7 @@ func TestReplaceRule6(t *testing.T) {
 	testReplaceRuleIPv6(t, 0, cidr1, cidr1, 126)
 }
 
-func TestRule_String(t *testing.T) {
+func TestPrivilegedRule_String(t *testing.T) {
 	setup(t)
 
 	_, fakeIP, _ := net.ParseCIDR("10.10.10.10/32")
@@ -239,7 +239,7 @@ func TestRule_String(t *testing.T) {
 	}
 }
 
-func TestListRules(t *testing.T) {
+func TestPrivilegedListRules(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	testListRules4(t)

--- a/pkg/datapath/linux/routing/info_test.go
+++ b/pkg/datapath/linux/routing/info_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/mac"
 )
 
-func TestParse(t *testing.T) {
+func TestPrivilegedParse(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	_, fakeCIDR, err := net.ParseCIDR("192.168.0.0/16")

--- a/pkg/datapath/linux/routing/migrate_test.go
+++ b/pkg/datapath/linux/routing/migrate_test.go
@@ -48,7 +48,7 @@ func setupMigrateSuite(tb testing.TB) *MigrateSuite {
 // setUpRoutingTable() as fixtures for this test suite.
 const n = 5
 
-func TestMigrateENIDatapathUpgradeSuccess(t *testing.T) {
+func TestPrivilegedMigrateENIDatapathUpgradeSuccess(t *testing.T) {
 	m := setupMigrateSuite(t)
 	logger := hivetest.Logger(t)
 	// First, we need to setupMigrateSuite the Linux routing policy database to mimic a
@@ -123,7 +123,7 @@ func TestMigrateENIDatapathUpgradeSuccess(t *testing.T) {
 	})
 }
 
-func TestMigrateENIDatapathUpgradeFailure(t *testing.T) {
+func TestPrivilegedMigrateENIDatapathUpgradeFailure(t *testing.T) {
 	logger := hivetest.Logger(t)
 	// This test case will cover one failure path where we successfully migrate
 	// all the old rules and routes, but fail to cleanup the old rule. This
@@ -194,7 +194,7 @@ func TestMigrateENIDatapathUpgradeFailure(t *testing.T) {
 	})
 }
 
-func TestMigrateENIDatapathDowngradeSuccess(t *testing.T) {
+func TestPrivilegedMigrateENIDatapathDowngradeSuccess(t *testing.T) {
 	// This test case will cover the successful downgrade path. We will create:
 	//   - One rule with the new priority referencing the new table ID.
 	//   - One route with the new table ID.
@@ -264,7 +264,7 @@ func TestMigrateENIDatapathDowngradeSuccess(t *testing.T) {
 	})
 }
 
-func TestMigrateENIDatapathDowngradeFailure(t *testing.T) {
+func TestPrivilegedMigrateENIDatapathDowngradeFailure(t *testing.T) {
 	// This test case will cover one downgrade failure path where we failed to
 	// migrate the rule to the old scheme. This test case will be set up
 	// identically to the successful case. "New" meaning the rules and routes
@@ -333,7 +333,7 @@ func TestMigrateENIDatapathDowngradeFailure(t *testing.T) {
 	})
 }
 
-func TestMigrateENIDatapathPartial(t *testing.T) {
+func TestPrivilegedMigrateENIDatapathPartial(t *testing.T) {
 	// This test case will cover one case where we find a partial rule. It will
 	// be set up with a rule with the newer priority and the user has indicated
 	// compatbility=false, meaning they intend to upgrade. The fact that

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -27,7 +27,7 @@ func setupLinuxRoutingSuite(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 }
 
-func TestConfigure(t *testing.T) {
+func TestPrivilegedConfigure(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	ns1 := netns.NewNetNS(t)
@@ -53,7 +53,7 @@ func TestConfigure(t *testing.T) {
 	})
 }
 
-func TestConfigureZeros(t *testing.T) {
+func TestPrivilegedConfigureZeros(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	ns1 := netns.NewNetNS(t)
@@ -68,7 +68,7 @@ func TestConfigureZeros(t *testing.T) {
 	})
 }
 
-func TestConfigureRouteWithIncompatibleIP(t *testing.T) {
+func TestPrivilegedConfigureRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	_, ri := getFakes(t, true, false)
@@ -77,7 +77,7 @@ func TestConfigureRouteWithIncompatibleIP(t *testing.T) {
 	require.ErrorContains(t, err, "IP not compatible")
 }
 
-func TestDeleteRouteWithIncompatibleIP(t *testing.T) {
+func TestPrivilegedDeleteRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	ip := netip.Addr{}
@@ -86,7 +86,7 @@ func TestDeleteRouteWithIncompatibleIP(t *testing.T) {
 	require.ErrorContains(t, err, "IP not compatible")
 }
 
-func TestDelete(t *testing.T) {
+func TestPrivilegedDelete(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	fakeIP, fakeRoutingInfo := getFakes(t, true, false)

--- a/pkg/datapath/loader/compile_test.go
+++ b/pkg/datapath/loader/compile_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func TestCompile(t *testing.T) {
+func TestPrivilegedCompile(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	debugOutput := func(p *progInfo) *progInfo {

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -103,25 +103,25 @@ func testReloadDatapath(t *testing.T, ep *testutils.TestEndpoint) {
 	require.NoError(t, err)
 }
 
-// TestCompileOrLoadDefaultEndpoint checks that the datapath can be compiled
+// TestPrivilegedCompileOrLoadDefaultEndpoint checks that the datapath can be compiled
 // and loaded.
-func TestCompileOrLoadDefaultEndpoint(t *testing.T) {
+func TestPrivilegedCompileOrLoadDefaultEndpoint(t *testing.T) {
 	ep := testutils.NewTestEndpoint(t)
 	initEndpoint(t, &ep)
 	testReloadDatapath(t, &ep)
 }
 
-// TestCompileOrLoadHostEndpoint is the same as
+// TestPrivilegedCompileOrLoadHostEndpoint is the same as
 // TestCompileAndLoadDefaultEndpoint, but for the host endpoint.
-func TestCompileOrLoadHostEndpoint(t *testing.T) {
+func TestPrivilegedCompileOrLoadHostEndpoint(t *testing.T) {
 	hostEp := testutils.NewTestHostEndpoint(t)
 	initEndpoint(t, &hostEp)
 
 	testReloadDatapath(t, &hostEp)
 }
 
-// TestReload compiles and attaches the datapath.
-func TestReload(t *testing.T) {
+// TestPrivilegedReload compiles and attaches the datapath.
+func TestPrivilegedReload(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 
@@ -184,17 +184,17 @@ func testCompileFailure(t *testing.T, ep *testutils.TestEndpoint) {
 	require.Error(t, err)
 }
 
-// TestCompileFailureDefaultEndpoint attempts to compile then cancels the
+// TestPrivilegedCompileFailureDefaultEndpoint attempts to compile then cancels the
 // context and ensures that the failure paths may be hit.
-func TestCompileFailureDefaultEndpoint(t *testing.T) {
+func TestPrivilegedCompileFailureDefaultEndpoint(t *testing.T) {
 	ep := testutils.NewTestEndpoint(t)
 	initEndpoint(t, &ep)
 	testCompileFailure(t, &ep)
 }
 
-// TestCompileFailureHostEndpoint is the same as
-// TestCompileFailureDefaultEndpoint, but for the host endpoint.
-func TestCompileFailureHostEndpoint(t *testing.T) {
+// TestPrivilegedCompileFailureHostEndpoint is the same as
+// TestPrivilegedCompileFailureDefaultEndpoint, but for the host endpoint.
+func TestPrivilegedCompileFailureHostEndpoint(t *testing.T) {
 	hostEp := testutils.NewTestHostEndpoint(t)
 	initEndpoint(t, &hostEp)
 	testCompileFailure(t, &hostEp)

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -50,7 +50,7 @@ func mustXDPProgram(t *testing.T, name string) *ebpf.Program {
 	return p
 }
 
-func TestSetupDev(t *testing.T) {
+func TestPrivilegedSetupDev(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -107,7 +107,7 @@ func TestSetupDev(t *testing.T) {
 	})
 }
 
-func TestSetupTunnelDevice(t *testing.T) {
+func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -408,7 +408,7 @@ func TestSetupTunnelDevice(t *testing.T) {
 	})
 }
 
-func TestAddHostDeviceAddr(t *testing.T) {
+func TestPrivilegedAddHostDeviceAddr(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	// test IP addresses

--- a/pkg/datapath/loader/netlink_unparallel_test.go
+++ b/pkg/datapath/loader/netlink_unparallel_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
-func TestSetupIPIPDevices(t *testing.T) {
+func TestPrivilegedSetupIPIPDevices(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 

--- a/pkg/datapath/loader/tc_test.go
+++ b/pkg/datapath/loader/tc_test.go
@@ -58,7 +58,7 @@ func mustTCProgramWithName(t *testing.T, name string) *ebpf.Program {
 	return p
 }
 
-func TestAttachDetachSKBProgramLegacy(t *testing.T) {
+func TestPrivilegedAttachDetachSKBProgramLegacy(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -81,7 +81,7 @@ func TestAttachDetachSKBProgramLegacy(t *testing.T) {
 	})
 }
 
-func TestAttachDetachTCProgram(t *testing.T) {
+func TestPrivilegedAttachDetachTCProgram(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -103,7 +103,7 @@ func TestAttachDetachTCProgram(t *testing.T) {
 	})
 }
 
-func TestHasCiliumTCFilters(t *testing.T) {
+func TestPrivilegedHasCiliumTCFilters(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -137,7 +137,7 @@ func TestHasCiliumTCFilters(t *testing.T) {
 }
 
 // Upgrade a legacy tc program to tcx.
-func TestAttachSKBUpgrade(t *testing.T) {
+func TestPrivilegedAttachSKBUpgrade(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -169,7 +169,7 @@ func TestAttachSKBUpgrade(t *testing.T) {
 }
 
 // Downgrade a tcx program to legacy tc.
-func TestAttachSKBDowngrade(t *testing.T) {
+func TestPrivilegedAttachSKBDowngrade(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -198,7 +198,7 @@ func TestAttachSKBDowngrade(t *testing.T) {
 	})
 }
 
-func TestCleanupStaleTCFilters(t *testing.T) {
+func TestPrivilegedCleanupStaleTCFilters(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 

--- a/pkg/datapath/loader/tcx_test.go
+++ b/pkg/datapath/loader/tcx_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
-func TestAttachDetachTCX(t *testing.T) {
+func TestPrivilegedAttachDetachTCX(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -55,7 +55,7 @@ func TestAttachDetachTCX(t *testing.T) {
 	})
 }
 
-func TestHasCiliumTCXLinks(t *testing.T) {
+func TestPrivilegedHasCiliumTCXLinks(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	skipTCXUnsupported(t)

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
-func TestMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
+func TestPrivilegedMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -93,7 +93,7 @@ func TestMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 }
 
 // Attach a program to a clean dummy device, no replacing necessary.
-func TestAttachXDP(t *testing.T) {
+func TestPrivilegedAttachXDP(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -121,7 +121,7 @@ func TestAttachXDP(t *testing.T) {
 }
 
 // Replace an existing program attached using netlink attach.
-func TestAttachXDPWithPreviousAttach(t *testing.T) {
+func TestPrivilegedAttachXDPWithPreviousAttach(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -152,7 +152,7 @@ func TestAttachXDPWithPreviousAttach(t *testing.T) {
 }
 
 // On kernels that support it, make sure an existing bpf_link can be updated.
-func TestAttachXDPWithExistingLink(t *testing.T) {
+func TestPrivilegedAttachXDPWithExistingLink(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -206,7 +206,7 @@ func TestAttachXDPWithExistingLink(t *testing.T) {
 }
 
 // Detach an XDP program that was attached using netlink.
-func TestDetachXDPWithPreviousAttach(t *testing.T) {
+func TestPrivilegedDetachXDPWithPreviousAttach(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	ns := netns.NewNetNS(t)

--- a/pkg/datapath/neighbor/test/script_test.go
+++ b/pkg/datapath/neighbor/test/script_test.go
@@ -43,7 +43,7 @@ import (
 
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
-func TestScript(t *testing.T) {
+func TestPrivilegedScript(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	defer goleak.VerifyNone(t)

--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -236,7 +236,7 @@ func setupAndRunTest(t *testing.T, n int, proto netlink.Proto, testFn func(t *te
 	testFn(t, conns)
 }
 
-func TestDestroy(t *testing.T) {
+func TestPrivilegedDestroy(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	n := 3
 	log := hivetest.Logger(t)
@@ -273,7 +273,7 @@ func TestDestroy(t *testing.T) {
 	})
 }
 
-func TestIterateAndDestroy(t *testing.T) {
+func TestPrivilegedIterateAndDestroy(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	log := hivetest.Logger(t)
 	setupAndRunTest(t, 1, unix.IPPROTO_TCP, func(t *testing.T, clientConns []net.Conn) {

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -181,7 +181,7 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	return k
 }
 
-func TestEgressGatewayCEGPParser(t *testing.T) {
+func TestPrivilegedEgressGatewayCEGPParser(t *testing.T) {
 	setupEgressGatewayTestSuite(t)
 	// must specify name
 	policy := policyParams{
@@ -301,7 +301,7 @@ func TestEgressGatewayCEGPParser(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestEgressGatewayManager(t *testing.T) {
+func TestPrivilegedEgressGatewayManager(t *testing.T) {
 	k := setupEgressGatewayTestSuite(t)
 	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1, egressCIDR1v6})
 	createTestInterface(t, k.sysctl, testInterface2, []string{egressCIDR2, egressCIDR2v6})
@@ -604,7 +604,7 @@ func TestEgressGatewayManager(t *testing.T) {
 	})
 }
 
-func TestNodeSelector(t *testing.T) {
+func TestPrivilegedNodeSelector(t *testing.T) {
 	k := setupEgressGatewayTestSuite(t)
 
 	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1, egressCIDR1v6})
@@ -690,7 +690,7 @@ func TestNodeSelector(t *testing.T) {
 	assertEgressRules6(t, policyMap6, []egressRule{})
 }
 
-func TestEndpointDataStore(t *testing.T) {
+func TestPrivilegedEndpointDataStore(t *testing.T) {
 	k := setupEgressGatewayTestSuite(t)
 
 	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1, egressCIDR1v6})
@@ -779,7 +779,7 @@ func TestEndpointDataStore(t *testing.T) {
 	})
 }
 
-func TestMultigatewayPolicy(t *testing.T) {
+func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 	k := setupEgressGatewayTestSuite(t)
 	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1, egressCIDR1v6})
 

--- a/pkg/endpoint/id/id_test.go
+++ b/pkg/endpoint/id/id_test.go
@@ -104,7 +104,7 @@ func BenchmarkSplitID(b *testing.B) {
 	b.ReportAllocs()
 }
 
-func TestParse(t *testing.T) {
+func TestPrivilegedParse(t *testing.T) {
 	type test struct {
 		input      PrefixType
 		wantPrefix PrefixType

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -73,8 +73,8 @@ func TestUpdateLookup(t *testing.T) {
 	}
 }
 
-// TestDelete tests that we can forcibly clear parts of the cache.
-func TestDelete(t *testing.T) {
+// TestPrivilegedDelete tests that we can forcibly clear parts of the cache.
+func TestPrivilegedDelete(t *testing.T) {
 	names := map[string]netip.Addr{
 		"test1.com": netip.MustParseAddr("2.2.2.1"),
 		"test2.com": netip.MustParseAddr("2.2.2.2"),

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -232,7 +232,7 @@ var (
 	tcpProtoPort53   = restore.MakeV2PortProto(53, u8proto.TCP)
 )
 
-func TestRejectFromDifferentEndpoint(t *testing.T) {
+func TestPrivilegedRejectFromDifferentEndpoint(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 
 	name := "cilium.io."
@@ -253,7 +253,7 @@ func TestRejectFromDifferentEndpoint(t *testing.T) {
 	require.False(t, allowed, "request was not rejected when it should be blocked")
 }
 
-func TestAcceptFromMatchingEndpoint(t *testing.T) {
+func TestPrivilegedAcceptFromMatchingEndpoint(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 
 	name := "cilium.io."
@@ -274,7 +274,7 @@ func TestAcceptFromMatchingEndpoint(t *testing.T) {
 	require.True(t, allowed, "request was rejected when it should be allowed")
 }
 
-func TestAcceptNonRegex(t *testing.T) {
+func TestPrivilegedAcceptNonRegex(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 
 	name := "simple.io."
@@ -295,7 +295,7 @@ func TestAcceptNonRegex(t *testing.T) {
 	require.True(t, allowed, "request was rejected when it should be allowed")
 }
 
-func TestRejectNonRegex(t *testing.T) {
+func TestPrivilegedRejectNonRegex(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 
 	name := "cilium.io."
@@ -338,7 +338,7 @@ func (s *DNSProxyTestSuite) requestRejectNonMatchingRefusedResponse(t *testing.T
 	return request
 }
 
-func TestRejectNonMatchingRefusedResponseWithNameError(t *testing.T) {
+func TestPrivilegedRejectNonMatchingRefusedResponseWithNameError(t *testing.T) {
 	// reject a query with NXDomain
 	option.Config.FQDNRejectResponse = option.FQDNProxyDenyWithNameError
 	t.Cleanup(func() {
@@ -353,7 +353,7 @@ func TestRejectNonMatchingRefusedResponseWithNameError(t *testing.T) {
 	require.Equal(t, dns.RcodeNameError, response.Rcode, "DNS request from test client was not rejected when it should be blocked")
 }
 
-func TestRejectNonMatchingRefusedResponseWithRefused(t *testing.T) {
+func TestPrivilegedRejectNonMatchingRefusedResponseWithRefused(t *testing.T) {
 	// reject a query with Refused
 	option.Config.FQDNRejectResponse = option.FQDNProxyDenyWithRefused
 	t.Cleanup(func() {
@@ -368,7 +368,7 @@ func TestRejectNonMatchingRefusedResponseWithRefused(t *testing.T) {
 	require.Equal(t, dns.RcodeRefused, response.Rcode, "DNS request from test client was not rejected when it should be blocked")
 }
 
-func TestErrorResponseServfail(t *testing.T) {
+func TestPrivilegedErrorResponseServfail(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 	// Trigger an error in the lookupTargetDNSServer function to force a SERVFAIL response
 	s.proxy.lookupTargetDNSServer = func(w dns.ResponseWriter) (network u8proto.U8proto, server netip.AddrPort, err error) {
@@ -383,7 +383,7 @@ func TestErrorResponseServfail(t *testing.T) {
 	require.Equal(t, dns.RcodeServerFailure, response.Rcode, "DNS request from test client did not trigger a SERVFAIL response")
 }
 
-func TestRespondViaCorrectProtocol(t *testing.T) {
+func TestPrivilegedRespondViaCorrectProtocol(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 
 	// Respond with an actual answer for the query. This also tests that the
@@ -414,7 +414,7 @@ func TestRespondViaCorrectProtocol(t *testing.T) {
 	require.Equal(t, "cilium.io.\t60\tIN\tA\t1.1.1.1", response.Answer[0].String(), "Proxy returned incorrect RRs")
 }
 
-func TestRespondMixedCaseInRequestResponse(t *testing.T) {
+func TestPrivilegedRespondMixedCaseInRequestResponse(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 
 	// Test that mixed case query is allowed out and then back in to support
@@ -450,7 +450,7 @@ func TestRespondMixedCaseInRequestResponse(t *testing.T) {
 	require.Equal(t, "ciliuM.io.\t60\tIN\tA\t1.1.1.1", response.Answer[0].String(), "Proxy returned incorrect RRs")
 }
 
-func TestCheckNoRules(t *testing.T) {
+func TestPrivilegedCheckNoRules(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 
 	name := "cilium.io."
@@ -484,7 +484,7 @@ func TestCheckNoRules(t *testing.T) {
 	require.True(t, allowed, "request was rejected when it should be allowed")
 }
 
-func TestCheckAllowedTwiceRemovedOnce(t *testing.T) {
+func TestPrivilegedCheckAllowedTwiceRemovedOnce(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 
 	name := "cilium.io."
@@ -531,7 +531,7 @@ func makeMapOfRuleIPOrCIDR(addrs ...string) map[restore.RuleIPOrCIDR]struct{} {
 	return m
 }
 
-func TestFullPathDependence(t *testing.T) {
+func TestPrivilegedFullPathDependence(t *testing.T) {
 	logger := hivetest.Logger(t)
 	s := setupDNSProxyTestSuite(t)
 
@@ -1053,7 +1053,7 @@ func TestFullPathDependence(t *testing.T) {
 	require.False(t, exists)
 }
 
-func TestRestoredEndpoint(t *testing.T) {
+func TestPrivilegedRestoredEndpoint(t *testing.T) {
 	logger := hivetest.Logger(t)
 	s := setupDNSProxyTestSuite(t)
 

--- a/pkg/ipam/pool_privileged_test.go
+++ b/pkg/ipam/pool_privileged_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
-func Test_cleanupUnreachableRoutes(t *testing.T) {
+func TestPrivilegedCleanupUnreachableRoutes(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	RegisterTestingT(t)

--- a/pkg/labels/array_test.go
+++ b/pkg/labels/array_test.go
@@ -32,7 +32,7 @@ func TestMatches(t *testing.T) {
 	require.False(t, empty.Contains(a)) // a is NOT in empty
 }
 
-func TestParse(t *testing.T) {
+func TestPrivilegedParse(t *testing.T) {
 	require.Equal(t, LabelArray{}, ParseLabelArray())
 	require.Equal(t, LabelArray{ParseLabel("magic")}, ParseLabelArray("magic"))
 	// LabelArray is sorted

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-func TestSocketTermination_ControlPlane(t *testing.T) {
+func TestPrivilegedSocketTermination_ControlPlane(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	for _, hostOnly := range []bool{true, false} {
@@ -205,7 +205,7 @@ func initializeNetns(t *testing.T, ns *netns.NetNS, addr string) net.Conn {
 	return conn
 }
 
-func TestSocketTermination_Datapath(t *testing.T) {
+func TestPrivilegedSocketTermination_Datapath(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	ns1, err := netns.New()

--- a/pkg/maps/authmap/auth_map_privileged_test.go
+++ b/pkg/maps/authmap/auth_map_privileged_test.go
@@ -24,7 +24,7 @@ func setup(tb testing.TB) {
 	require.NoError(tb, err)
 }
 
-func TestAuthMap(t *testing.T) {
+func TestPrivilegedAuthMap(t *testing.T) {
 	setup(t)
 	authMap := newMap(hivetest.Logger(t), 10)
 	err := authMap.init()

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -541,7 +541,7 @@ func GC(m *Map, filter GCFilter, next4, next6 func(GCEvent)) (int, error) {
 //
 // In all 4 cases we create a CT_EGRESS CT entry. This allows the
 // CT GC to remove corresponding SNAT entries.
-// See the unit test TestOrphanNatGC for more examples.
+// See the unit test TestPrivilegedOrphanNatGC for more examples.
 func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 	// Both CT maps should point to the same natMap, so use the first one
 	// to determine natMap

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -120,9 +120,9 @@ func Benchmark_MapUpdate(b *testing.B) {
 	require.Equal(b, b.N, t)
 }
 
-// TestCtGcIcmp tests whether ICMP NAT entries are removed upon a removal of
+// TestPrivilegedCtGcIcmp tests whether ICMP NAT entries are removed upon a removal of
 // their CT entry (GH#12625).
-func TestCtGcIcmp(t *testing.T) {
+func TestPrivilegedCtGcIcmp(t *testing.T) {
 	setupCTMap(t)
 
 	// Init maps
@@ -235,9 +235,9 @@ func TestCtGcIcmp(t *testing.T) {
 	require.Empty(t, buf)
 }
 
-// TestCtGcTcp tests whether TCP SNAT entries are removed upon a removal of
+// TestPrivilegedCtGcTcp tests whether TCP SNAT entries are removed upon a removal of
 // their CT entry.
-func TestCtGcTcp(t *testing.T) {
+func TestPrivilegedCtGcTcp(t *testing.T) {
 	setupCTMap(t)
 	// Init maps
 	natMap := nat.NewMap(nil, "cilium_nat_any4_test", nat.IPv4, 1000)
@@ -349,9 +349,9 @@ func TestCtGcTcp(t *testing.T) {
 	require.Empty(t, buf)
 }
 
-// TestCtGcDsr tests whether DSR NAT entries are removed upon a removal of
+// TestPrivilegedCtGcDsr tests whether DSR NAT entries are removed upon a removal of
 // their CT entry (== CT_EGRESS).
-func TestCtGcDsr(t *testing.T) {
+func TestPrivilegedCtGcDsr(t *testing.T) {
 	setupCTMap(t)
 
 	// Init maps
@@ -444,7 +444,7 @@ func TestCtGcDsr(t *testing.T) {
 }
 
 // TestOrphanNat checks whether dangling NAT entries are GC'd (GH#12686)
-func TestOrphanNatGC(t *testing.T) {
+func TestPrivilegedOrphanNatGC(t *testing.T) {
 	setupCTMap(t)
 
 	// Init maps
@@ -744,7 +744,7 @@ func TestOrphanNatGC(t *testing.T) {
 
 // TestCount checks whether the CT map batch lookup dumps the count of the
 // entire map.
-func TestCount(t *testing.T) {
+func TestPrivilegedCount(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	// Set the max size of the map explicitly so we can provide enough buffer

--- a/pkg/maps/ctmap/per_cluster_ctmap_test.go
+++ b/pkg/maps/ctmap/per_cluster_ctmap_test.go
@@ -70,7 +70,7 @@ func BenchmarkPerClusterCTMapLookup(b *testing.B) {
 	b.StopTimer()
 }
 
-func TestPerClusterCTMaps(t *testing.T) {
+func TestPrivilegedPerClusterCTMaps(t *testing.T) {
 	setup(t)
 	logger := hivetest.Logger(t)
 
@@ -162,7 +162,7 @@ func TestPerClusterCTMaps(t *testing.T) {
 	require.NoError(t, maps.DeleteClusterCTMaps(cmtypes.ClusterIDMax), "Failed to delete maps")
 }
 
-func TestPerClusterCTMapsCleanup(t *testing.T) {
+func TestPrivilegedPerClusterCTMapsCleanup(t *testing.T) {
 	setup(t)
 	logger := hivetest.Logger(t)
 

--- a/pkg/maps/egressmap/policy_test.go
+++ b/pkg/maps/egressmap/policy_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func TestPolicyMap(t *testing.T) {
+func TestPrivilegedPolicyMap(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	logger := hivetest.Logger(t)

--- a/pkg/maps/multicast/subscribermap_test.go
+++ b/pkg/maps/multicast/subscribermap_test.go
@@ -19,7 +19,7 @@ const (
 	TestGroupV4OuterMapName = "test_cilium_mcast_group_v4_outer"
 )
 
-func TestSubscriberMap(t *testing.T) {
+func TestPrivilegedSubscriberMap(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 

--- a/pkg/maps/nat/nap_flush_test.go
+++ b/pkg/maps/nat/nap_flush_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/types"
 )
 
-func TestFlushNat(t *testing.T) {
+func TestPrivilegedFlushNat(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	numEntries := 5

--- a/pkg/maps/nat/nat_batch_test.go
+++ b/pkg/maps/nat/nat_batch_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDumpBatch4(t *testing.T) {
+func TestPrivilegedDumpBatch4(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	m := NewMap(nil, "test_snat_map", IPv4, 1<<18) // approximate default map size.
 	m.family = IPv4

--- a/pkg/maps/nat/per_cluster_nat_test.go
+++ b/pkg/maps/nat/per_cluster_nat_test.go
@@ -33,7 +33,7 @@ func path(tb testing.TB, m *bpf.Map) string {
 	return path
 }
 
-func TestPerClusterMaps(t *testing.T) {
+func TestPrivilegedPerClusterMaps(t *testing.T) {
 	setup(t)
 
 	maps := newPerClusterNATMaps(true, true, option.NATMapEntriesGlobalDefault)
@@ -112,7 +112,7 @@ func TestPerClusterMaps(t *testing.T) {
 	require.NoError(t, maps.DeleteClusterNATMaps(cmtypes.ClusterIDMax), "Failed to delete maps")
 }
 
-func TestPerClusterMapsCleanup(t *testing.T) {
+func TestPrivilegedPerClusterMapsCleanup(t *testing.T) {
 	setup(t)
 
 	tests := []struct {

--- a/pkg/maps/nat/stats/stats_test.go
+++ b/pkg/maps/nat/stats/stats_test.go
@@ -37,7 +37,7 @@ func Test_topk(t *testing.T) {
 	assert.Equal(t, []int{5, 6, 7, 8, 9}, out)
 }
 
-func Test_countNat(t *testing.T) {
+func TestPrivilegedCountNat(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	ip4Map := nat.NewMap(nil, "test_nat_map_ip4", nat.IPv4, 262144)

--- a/pkg/maps/nodemap/node_map_v2_privileged_test.go
+++ b/pkg/maps/nodemap/node_map_v2_privileged_test.go
@@ -23,7 +23,7 @@ func setupNodeMapV2TestSuite(tb testing.TB) {
 	require.NoError(tb, err)
 }
 
-func TestNodeMapV2(t *testing.T) {
+func TestPrivilegedNodeMapV2(t *testing.T) {
 	setupNodeMapV2TestSuite(t)
 	logger := hivetest.Logger(t)
 	nodeMap := newMapV2(logger, "test_cilium_node_map_v2", Config{

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -59,7 +59,7 @@ func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
 	return testMap
 }
 
-func TestPolicyMapDumpToSlice(t *testing.T) {
+func TestPrivilegedPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
 	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)
@@ -89,7 +89,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 	require.Len(t, dump, 2)
 }
 
-func TestDeleteNonexistentKey(t *testing.T) {
+func TestPrivilegedDeleteNonexistentKey(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 	key := newKey(trafficdirection.Ingress, 27, u8proto.TCP, 80, SinglePortPrefixLen)
 	err := testMap.Map.Delete(&key)
@@ -99,7 +99,7 @@ func TestDeleteNonexistentKey(t *testing.T) {
 	require.Equal(t, unix.ENOENT, errno)
 }
 
-func TestDenyPolicyMapDumpToSlice(t *testing.T) {
+func TestPrivilegedDenyPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
 	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)

--- a/pkg/maps/policymap/statsmap_privileged_test.go
+++ b/pkg/maps/policymap/statsmap_privileged_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatMap(t *testing.T) {
+func TestPrivilegedStatMap(t *testing.T) {
 	policyMap := setupPolicyMapPrivilegedTestSuite(t)
 	require.NotNil(t, policyMap)
 

--- a/pkg/maps/srv6map/policy_test.go
+++ b/pkg/maps/srv6map/policy_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func TestPolicyMapsHive(t *testing.T) {
+func TestPrivilegedPolicyMapsHive(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	type in struct {

--- a/pkg/maps/srv6map/sid_test.go
+++ b/pkg/maps/srv6map/sid_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func TestSIDMapsHive(t *testing.T) {
+func TestPrivilegedSIDMapsHive(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	type in struct {

--- a/pkg/maps/srv6map/state_test.go
+++ b/pkg/maps/srv6map/state_test.go
@@ -41,7 +41,7 @@ func (v *dummyStateValue) String() string {
 	return ""
 }
 
-func TestStateMapsHive(t *testing.T) {
+func TestPrivilegedStateMapsHive(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 

--- a/pkg/maps/srv6map/vrf_test.go
+++ b/pkg/maps/srv6map/vrf_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func TestVRFMapsHive(t *testing.T) {
+func TestPrivilegedVRFMapsHive(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	type in struct {

--- a/pkg/metrics/bpf_test.go
+++ b/pkg/metrics/bpf_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func TestGetBPFUsage(t *testing.T) {
+func TestPrivilegedGetBPFUsage(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	prefix := "_ciltest_"

--- a/pkg/mountinfo/mountinfo_privileged_test.go
+++ b/pkg/mountinfo/mountinfo_privileged_test.go
@@ -17,7 +17,7 @@ import (
 
 // TestIsMountFSbyMount tests the public function IsMountFS by performing
 // an actual mount.
-func TestIsMountFSbyMount(t *testing.T) {
+func TestPrivilegedIsMountFSbyMount(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	tmpDir, err := os.MkdirTemp("", "IsMountFS_")

--- a/pkg/netns/netns_test.go
+++ b/pkg/netns/netns_test.go
@@ -31,7 +31,7 @@ func get(t *testing.T) *NetNS {
 	return newNetNS(orig)
 }
 
-func TestNetNSUnchangedAfterCreate(t *testing.T) {
+func TestPrivilegedNetNSUnchangedAfterCreate(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	lock(t)
 
@@ -49,7 +49,7 @@ func TestNetNSUnchangedAfterCreate(t *testing.T) {
 	assert.True(t, equal(orig, after))
 }
 
-func TestNetNSSet(t *testing.T) {
+func TestPrivilegedNetNSSet(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	lock(t)
 
@@ -70,7 +70,7 @@ func TestNetNSSet(t *testing.T) {
 	assert.True(t, equal(ns, after))
 }
 
-func TestNetNSClose(t *testing.T) {
+func TestPrivilegedNetNSClose(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	lock(t)
 
@@ -83,7 +83,7 @@ func TestNetNSClose(t *testing.T) {
 	assert.Equal(t, ns.FD(), -1)
 }
 
-func TestNetNSDo(t *testing.T) {
+func TestPrivilegedNetNSDo(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	lock(t)
 

--- a/pkg/node/address_linux_test.go
+++ b/pkg/node/address_linux_test.go
@@ -21,7 +21,7 @@ func setUpSuite(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 }
 
-func Test_firstGlobalV4Addr(t *testing.T) {
+func TestPrivilegedFirstGlobalV4Addr(t *testing.T) {
 	setUpSuite(t)
 
 	testCases := []struct {

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -79,7 +79,7 @@ func TestSetBool(t *testing.T) {
 	require.Equal(t, OptionEnabled, o.GetValue(k3))
 }
 
-func TestDelete(t *testing.T) {
+func TestPrivilegedDelete(t *testing.T) {
 	k1, k2 := "foo", "bar"
 
 	o := IntOptions{

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -1026,7 +1026,7 @@ func TestInvalidEndpointSelectors(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestNodeSelector(t *testing.T) {
+func TestPrivilegedNodeSelector(t *testing.T) {
 	// Operator in MatchExpressions is invalid, so sanitization should fail.
 	labelSel := &slim_metav1.LabelSelector{
 		MatchLabels: map[string]string{

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -40,7 +40,7 @@ func filterDefaultRouteIPv6(t *testing.T, rt []netlink.Route) netlink.Route {
 	return rt[i]
 }
 
-func TestRoutes(t *testing.T) {
+func TestPrivilegedRoutes(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	t.Run("IPv4", func(t *testing.T) {

--- a/pkg/socketlb/cgroup_test.go
+++ b/pkg/socketlb/cgroup_test.go
@@ -33,7 +33,7 @@ func mustCgroupProgram(t *testing.T) *ebpf.Program {
 }
 
 // Attach a program to a clean cgroup hook, no replacing necessary.
-func TestAttachCgroup(t *testing.T) {
+func TestPrivilegedAttachCgroup(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -54,7 +54,7 @@ func TestAttachCgroup(t *testing.T) {
 
 // Replace an existing program attached using PROG_ATTACH. On newer kernels,
 // this will attempt to replace a PROG_ATTACH with a bpf_link.
-func TestAttachCgroupWithPreviousAttach(t *testing.T) {
+func TestPrivilegedAttachCgroupWithPreviousAttach(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -89,7 +89,7 @@ func TestAttachCgroupWithPreviousAttach(t *testing.T) {
 }
 
 // On kernels that support it, update a bpf_link attachment by opening a pin.
-func TestAttachCgroupWithExistingLink(t *testing.T) {
+func TestPrivilegedAttachCgroupWithExistingLink(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -132,7 +132,7 @@ func TestAttachCgroupWithExistingLink(t *testing.T) {
 }
 
 // Detach an existing PROG_ATTACH.
-func TestDetachCGroupWithPreviousAttach(t *testing.T) {
+func TestPrivilegedDetachCGroupWithPreviousAttach(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
@@ -159,7 +159,7 @@ func TestDetachCGroupWithPreviousAttach(t *testing.T) {
 }
 
 // Detach an existing bpf_link.
-func TestDetachCGroupWithExistingLink(t *testing.T) {
+func TestPrivilegedDetachCGroupWithExistingLink(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 

--- a/pkg/testutils/privileged.go
+++ b/pkg/testutils/privileged.go
@@ -5,6 +5,7 @@ package testutils
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -12,14 +13,40 @@ const (
 	privilegedEnv            = "PRIVILEGED_TESTS"
 	integrationEnv           = "INTEGRATION_TESTS"
 	gatewayAPIConformanceEnv = "GATEWAY_API_CONFORMANCE_TESTS"
+
+	requiredPrefix = "TestPrivileged"
 )
 
 func PrivilegedTest(tb testing.TB) {
 	tb.Helper()
+	testName := tb.Name()
+
+	// Check if test name has the required prefix
+	if !hasTestPrivilegedPrefix(testName) {
+		tb.Fatalf("Privileged tests must have prefix '%s' in their name, got: %s", requiredPrefix, testName)
+	}
 
 	if os.Getenv(privilegedEnv) == "" {
 		tb.Skipf("Set %s to run this test", privilegedEnv)
 	}
+}
+
+// hasTestPrivilegedPrefix checks if the test name has the TestPrivileged prefix.
+// It handles both normal test functions "TestPrivileged*" and subtests that have
+// a parent test name included like "TestPrivileged*/SubTest".
+func hasTestPrivilegedPrefix(testName string) bool {
+	// Handle regular test function
+	if strings.HasPrefix(testName, requiredPrefix) {
+		return true
+	}
+
+	// Handle subtests (format: ParentTest/SubTest)
+	parts := strings.Split(testName, "/")
+	if len(parts) > 0 && strings.HasPrefix(parts[0], requiredPrefix) {
+		return true
+	}
+
+	return false
 }
 
 func IsPrivileged() bool {


### PR DESCRIPTION
At the moment, we are running the unit non-privileged unit tests on
Runtime Test, where it was only meant for privileged tests.
```
A - unit test
B - privileged unit tests
C - integration tests

Runtime Test (privileged) runs A+B -> it will only run B
Integration Test (ubuntu-latest) runs A+C
Integration Test (ubuntu-24.04-arm64) runs A+C
```

Instead, we should make sure only privileged tests are ran in the
Runtime Test by only running the tests with the prefix "TestPrivileged".
If developers forget to add this prefix, the test will also fail as it
detects that all privileged tests should have the "TestPrivileged"
prefix.