### PR TITLE
ci: update scale-test-actions

### DIFF
--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -151,7 +151,7 @@ jobs:
           go-version: ${{ env.go_version }}
 
       - name: Install Kops
-        uses: cilium/scale-tests-action/install-kops@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/install-kops@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
 
       - name: Setup gcloud credentials
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
@@ -183,7 +183,7 @@ jobs:
 
       - name: Deploy cluster
         id: deploy-cluster
-        uses: cilium/scale-tests-action/create-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/create-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -215,7 +215,7 @@ jobs:
           gcloud version
 
       - name: Setup firewall rules
-        uses: cilium/scale-tests-action/setup-firewall@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/setup-firewall@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
 
@@ -224,7 +224,7 @@ jobs:
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
       - name: Wait for cluster to be ready
-        uses: cilium/scale-tests-action/validate-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/validate-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 20
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -284,14 +284,14 @@ jobs:
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
-        uses: cilium/scale-tests-action/cleanup-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/cleanup-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
       - name: Export results and sysdump to GS bucket
         if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
-        uses: cilium/scale-tests-action/export-results@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/export-results@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           test_name: ${{ env.test_name }}
           results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -322,7 +322,7 @@ jobs:
 
       - name: Export results and sysdump to GS bucket
         if: ${{ always() && steps.run-perf.outcome != 'skipped' && steps.run-perf.outcome != 'cancelled' }}
-        uses: cilium/scale-tests-action/export-results@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/export-results@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           test_name: ${{ env.test_name }}-${{ matrix.name }}
           results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}

--- a/.github/workflows/scale-cleanup-kops.yaml
+++ b/.github/workflows/scale-cleanup-kops.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/set-env-variables
 
       - name: Install Kops
-        uses: cilium/scale-tests-action/install-kops@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/install-kops@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
 
       - name: Setup gcloud credentials
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -171,7 +171,7 @@ jobs:
           go-version: ${{ env.go_version }}
 
       - name: Install Kops
-        uses: cilium/scale-tests-action/install-kops@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/install-kops@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
 
       - name: Setup gcloud credentials
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
@@ -223,7 +223,7 @@ jobs:
 
       - name: Deploy cluster
         id: deploy-cluster
-        uses: cilium/scale-tests-action/create-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/create-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -236,7 +236,7 @@ jobs:
           kube_proxy_enabled: false
 
       - name: Setup firewall rules
-        uses: cilium/scale-tests-action/setup-firewall@080c1407c40367026008aff9fec13aa48c128d22  # main
+        uses: cilium/scale-tests-action/setup-firewall@3e496a64133e35f5a9f241ebc5eccd56653a92a5  # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
 
@@ -272,7 +272,7 @@ jobs:
           fi
 
       - name: Wait for cluster to be ready
-        uses: cilium/scale-tests-action/validate-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/validate-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 20
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -302,7 +302,7 @@ jobs:
             2>&1 | tee cl2-setup.txt
 
       - name: Create Instance Group for workload deployments
-        uses: cilium/scale-tests-action/create-instance-group@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/create-instance-group@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -312,7 +312,7 @@ jobs:
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
       - name: Wait for cluster to be ready
-        uses: cilium/scale-tests-action/validate-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/validate-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 20
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -320,7 +320,7 @@ jobs:
           interval: 10s
 
       - name: Setup firewall rules
-        uses: cilium/scale-tests-action/setup-firewall@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/setup-firewall@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           create_native_routing_firewall: 'false'
@@ -371,14 +371,14 @@ jobs:
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
-        uses: cilium/scale-tests-action/cleanup-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/cleanup-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
       - name: Export results and sysdump to GS bucket
         if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
-        uses: cilium/scale-tests-action/export-results@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/export-results@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           test_name: ${{ env.test_name }}
           tested_version: ${{ steps.vars.outputs.version }}

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -157,7 +157,7 @@ jobs:
           go-version: ${{ env.go_version }}
 
       - name: Install Kops
-        uses: cilium/scale-tests-action/install-kops@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/install-kops@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
 
       - name: Setup gcloud credentials
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
@@ -209,7 +209,7 @@ jobs:
 
       - name: Deploy cluster
         id: deploy-cluster
-        uses: cilium/scale-tests-action/create-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/create-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -222,7 +222,7 @@ jobs:
           kube_proxy_enabled: false
 
       - name: Setup firewall rules
-        uses: cilium/scale-tests-action/setup-firewall@080c1407c40367026008aff9fec13aa48c128d22  # main
+        uses: cilium/scale-tests-action/setup-firewall@3e496a64133e35f5a9f241ebc5eccd56653a92a5  # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
 
@@ -253,7 +253,7 @@ jobs:
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
       - name: Wait for cluster to be ready
-        uses: cilium/scale-tests-action/validate-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/validate-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 20
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -283,7 +283,7 @@ jobs:
             2>&1 | tee cl2-setup.txt
 
       - name: Create Instance Group for workload deployments
-        uses: cilium/scale-tests-action/create-instance-group@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/create-instance-group@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -293,7 +293,7 @@ jobs:
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
       - name: Wait for cluster to be ready
-        uses: cilium/scale-tests-action/validate-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/validate-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 20
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -301,7 +301,7 @@ jobs:
           interval: 10s
 
       - name: Setup firewall rules
-        uses: cilium/scale-tests-action/setup-firewall@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/setup-firewall@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           create_native_routing_firewall: 'false'
@@ -372,14 +372,14 @@ jobs:
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
-        uses: cilium/scale-tests-action/cleanup-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/cleanup-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
       - name: Export results and sysdump to GS bucket
         if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
-        uses: cilium/scale-tests-action/export-results@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/export-results@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           test_name: ${{ env.test_name }}
           results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -121,7 +121,7 @@ jobs:
           go-version: ${{ env.go_version }}
 
       - name: Install Kops
-        uses: cilium/scale-tests-action/install-kops@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/install-kops@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
 
       - name: Setup gcloud credentials
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
@@ -162,7 +162,7 @@ jobs:
 
       - name: Deploy cluster
         id: deploy-cluster
-        uses: cilium/scale-tests-action/create-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/create-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.CLUSTER_NAME }}
@@ -196,7 +196,7 @@ jobs:
           gcloud version
 
       - name: Setup firewall rules
-        uses: cilium/scale-tests-action/setup-firewall@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/setup-firewall@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.CLUSTER_NAME }}
 
@@ -243,7 +243,7 @@ jobs:
       # This step must be run after installing Cilium, as it requires
       # system pods (e.g., coredns) to be running.
       - name: Wait for cluster to be ready
-        uses: cilium/scale-tests-action/validate-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/validate-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 20
         with:
           cluster_name: ${{ steps.vars.outputs.CLUSTER_NAME }}
@@ -377,14 +377,14 @@ jobs:
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
-        uses: cilium/scale-tests-action/cleanup-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/cleanup-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.CLUSTER_NAME }}
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
       - name: Export results and sysdump to GS bucket
         if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
-        uses: cilium/scale-tests-action/export-results@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/export-results@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           test_name: ${{ env.test_name }}
           results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -600,7 +600,7 @@ jobs:
 
       - name: Export results and sysdump to GS bucket
         if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
-        uses: cilium/scale-tests-action/export-results@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/export-results@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           test_name: ${{ steps.vars.outputs.test_name }}
           results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -100,7 +100,7 @@ jobs:
           go-version: ${{ env.go_version }}
 
       - name: Install Kops
-        uses: cilium/scale-tests-action/install-kops@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/install-kops@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
 
       - name: Setup gcloud credentials
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
@@ -132,7 +132,7 @@ jobs:
 
       - name: Deploy cluster
         id: deploy-cluster
-        uses: cilium/scale-tests-action/create-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/create-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -164,7 +164,7 @@ jobs:
           gcloud version
 
       - name: Setup firewall rules
-        uses: cilium/scale-tests-action/setup-firewall@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/setup-firewall@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
 
@@ -173,7 +173,7 @@ jobs:
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
       - name: Wait for cluster to be ready
-        uses: cilium/scale-tests-action/validate-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/validate-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         timeout-minutes: 20
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
@@ -218,14 +218,14 @@ jobs:
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
-        uses: cilium/scale-tests-action/cleanup-cluster@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/cleanup-cluster@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
       - name: Export results and sysdump to GS bucket
         if: ${{ always() && steps.run-cl2.outcome != 'skipped' }}
-        uses: cilium/scale-tests-action/export-results@080c1407c40367026008aff9fec13aa48c128d22 # main
+        uses: cilium/scale-tests-action/export-results@3e496a64133e35f5a9f241ebc5eccd56653a92a5 # main
         with:
           test_name: ${{ env.test_name }}
           results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}


### PR DESCRIPTION
Recent bump of kops to 1.32 did not seem to work, while our workflows work with 1.31. This commits bumps scale-test-actions to include revert.