### PR TITLE
Fix persisted endpoint state synchronization for FQDN operations

### DIFF
--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -363,6 +363,13 @@ func (e *Endpoint) Stop() {
 	// will be processed on its EventQueue, specifically regenerations.
 	e.eventQueue.WaitToBeDrained()
 
+	// Shutdown the DNS History trigger after event queue has been drained.
+	// This makes sure that any pending changes to endpoint DNS state are flushed
+	// to disk.
+	if trigger := e.dnsHistoryTrigger.Swap(nil); trigger != nil {
+		trigger.Shutdown()
+	}
+
 	// Given that we are deleting the endpoint and that no more builds are
 	// going to occur for this endpoint, close the channel which signals whether
 	// the endpoint has its BPF program compiled or not to avoid it persisting

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -617,7 +617,7 @@ func (c *DNSCache) GetIPs() map[netip.Addr][]string {
 //
 //	ForceExpire(time.Time{}, 'cilium.io') expires all entries for cilium.io.
 //	ForceExpire(time.Now(), 'cilium.io') expires all entries for cilium.io
-//	that expired before the current time.
+//	that expired or had a lookup time before the current time.
 //
 // expireLookupsBefore requires a lookup to have a LookupTime before it in
 // order to remove it.
@@ -1088,10 +1088,11 @@ func (zombies *DNSZombieMappings) MarkAlive(now time.Time, ip netip.Addr) {
 // returned by GC.
 func (zombies *DNSZombieMappings) SetCTGCTime(ctGCStart, estNext time.Time) {
 	zombies.Lock()
+	defer zombies.Unlock()
+
 	zombies.lastCTGCUpdate = ctGCStart
 	zombies.nextCTGCUpdate = estNext
 	zombies.ctGCRevision++
-	zombies.Unlock()
 }
 
 // NextCTGCUpdate returns the estimated next CT GC time.

--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -125,7 +125,7 @@ func (n *manager) doGC(ctx context.Context) error {
 			namesToClean.Insert(zombie.Names...)
 		}
 
-		// Sync endpoint persisted state if DNS state changed during GC run.
+		// Sync endpoint's persisted state if the DNS state changed during this GC run.
 		if len(affectedNames) > 0 || len(dead) > 0 {
 			ep.SyncEndpointHeaderFile()
 		}

--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -124,6 +124,11 @@ func (n *manager) doGC(ctx context.Context) error {
 		for _, zombie := range dead {
 			namesToClean.Insert(zombie.Names...)
 		}
+
+		// Sync endpoint persisted state if DNS state changed during GC run.
+		if len(affectedNames) > 0 || len(dead) > 0 {
+			ep.SyncEndpointHeaderFile()
+		}
 	}
 
 	if namesToClean.Len() == 0 {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1351,6 +1351,8 @@ const (
 
 	NextTryIn = "nextTryIn"
 
+	NextRunIn = "nextRunIn"
+
 	Operation = "operation"
 
 	KeyPairSN = "keyPairSN"

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -177,7 +177,7 @@ func (gc *GC) Enable() {
 			}
 
 			if len(eps) > 0 || initialScan {
-				gc.logger.Info("Starting initial GC of connection tracking")
+				gc.logger.Info("Starting GC of connection tracking", logfields.First, initialScan)
 				maxDeleteRatio, success = gc.runGC(ipv4, ipv6, triggeredBySignal, gcFilter)
 			}
 
@@ -195,6 +195,11 @@ func (gc *GC) Enable() {
 				gc.logger.Info("initial gc of ct and nat maps completed",
 					logfields.Duration, time.Since(gcStart),
 				)
+			} else {
+				gc.logger.Debug("CT GC Run completed",
+					logfields.Success, success,
+					logfields.Duration, time.Since(gcStart),
+					logfields.NextRunIn, interval)
 			}
 
 			triggeredBySignal = false


### PR DESCRIPTION
See commit messages for details.

Fixes: #40074

```release-note
fqdn: fix persisted endpoint state synchronization for FQDN operations
```
