### PR TITLE
vendor: Bump to StateDB v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v0.0.0-20250611195437-5a5dacdfb354
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250526114940-b80199397e8a
-	github.com/cilium/statedb v0.4.0
+	github.com/cilium/statedb v0.4.1
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250526114940-b80199397e8a h1:5pJ6eaVk/y1C8cBMpfUWMuHa+qTefq2jqcNf0et0mGk=
 github.com/cilium/proxy v0.0.0-20250526114940-b80199397e8a/go.mod h1:Bs5kHQ+FYHLrAkEaTQpbwblJIv6NfU2Tsuo+wCkN+9s=
-github.com/cilium/statedb v0.4.0 h1:DfKqsWQIswFSbVZL/rY7vDiegQeEMyo4QzYn2h+Dpyo=
-github.com/cilium/statedb v0.4.0/go.mod h1:97Tuc0pVTQuiy0go9TTuNQWF8mF3LkTy1Lw/k4Ja5k4=
+github.com/cilium/statedb v0.4.1 h1:G08cH+j7Mn1EDQkjZRbborP05oy3Z1dqZE1zHhHu9o8=
+github.com/cilium/statedb v0.4.1/go.mod h1:TWktbTQ5u2OdsQpvhianS3xjOYGEtYdJBq0lBEfatR0=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/vendor/github.com/cilium/statedb/any_table.go
+++ b/vendor/github.com/cilium/statedb/any_table.go
@@ -16,7 +16,7 @@ type AnyTable struct {
 }
 
 func (t AnyTable) NumObjects(txn ReadTxn) int {
-	indexTxn := txn.getTxn().mustIndexReadTxn(t.Meta, PrimaryIndexPos)
+	indexTxn := txn.mustIndexReadTxn(t.Meta, PrimaryIndexPos)
 	return indexTxn.Len()
 }
 
@@ -26,7 +26,7 @@ func (t AnyTable) All(txn ReadTxn) iter.Seq2[any, Revision] {
 }
 
 func (t AnyTable) AllWatch(txn ReadTxn) (iter.Seq2[any, Revision], <-chan struct{}) {
-	indexTxn := txn.getTxn().mustIndexReadTxn(t.Meta, PrimaryIndexPos)
+	indexTxn := txn.mustIndexReadTxn(t.Meta, PrimaryIndexPos)
 	return partSeq[any](indexTxn.Iterator()), indexTxn.RootWatch()
 }
 
@@ -128,7 +128,7 @@ func (t AnyTable) queryIndex(txn ReadTxn, index string, key string) (indexReadTx
 	if err != nil {
 		return indexReadTxn{}, nil, err
 	}
-	itxn, err := txn.getTxn().indexReadTxn(t.Meta, indexer.pos)
+	itxn, err := txn.indexReadTxn(t.Meta, indexer.pos)
 	return itxn, rawKey, err
 }
 

--- a/vendor/github.com/cilium/statedb/db.go
+++ b/vendor/github.com/cilium/statedb/db.go
@@ -98,7 +98,7 @@ type dbState struct {
 	metrics             Metrics
 }
 
-type dbRoot []tableEntry
+type dbRoot = readTxn
 
 type Option func(*opts)
 
@@ -184,10 +184,7 @@ func (db *DB) registerTable(table TableMeta, root *dbRoot) error {
 //
 // The returned ReadTxn is not thread-safe.
 func (db *DB) ReadTxn() ReadTxn {
-	return &txn{
-		db:   db,
-		root: *db.root.Load(),
-	}
+	return (*readTxn)(db.root.Load())
 }
 
 // WriteTxn constructs a new write transaction against the given set of tables.
@@ -211,15 +208,13 @@ func (db *DB) WriteTxn(table TableMeta, tables ...TableMeta) WriteTxn {
 	root := *db.root.Load()
 	tableEntries := make([]*tableEntry, len(root))
 
-	txn := &txn{
-		db:         db,
-		root:       root,
-		handle:     db.handleName,
-		acquiredAt: time.Now(),
-		writeTxn: writeTxn{
-			modifiedTables: tableEntries,
-			smus:           smus,
-		},
+	txn := &writeTxn{
+		db:             db,
+		dbRoot:         root,
+		handle:         db.handleName,
+		acquiredAt:     time.Now(),
+		modifiedTables: tableEntries,
+		smus:           smus,
 	}
 
 	var tableNames []string
@@ -252,7 +247,7 @@ func (db *DB) WriteTxn(table TableMeta, tables ...TableMeta) WriteTxn {
 }
 
 func (db *DB) GetTables(txn ReadTxn) (tbls []TableMeta) {
-	root := txn.getTxn().root
+	root := txn.root()
 	tbls = make([]TableMeta, 0, len(root))
 	for _, table := range root {
 		tbls = append(tbls, table.meta)
@@ -261,7 +256,7 @@ func (db *DB) GetTables(txn ReadTxn) (tbls []TableMeta) {
 }
 
 func (db *DB) GetTable(txn ReadTxn, name string) TableMeta {
-	root := txn.getTxn().root
+	root := txn.root()
 	for _, table := range root {
 		if table.meta.Name() == name {
 			return table.meta

--- a/vendor/github.com/cilium/statedb/deletetracker.go
+++ b/vendor/github.com/cilium/statedb/deletetracker.go
@@ -35,8 +35,8 @@ func (dt *deleteTracker[Obj]) getRevision() uint64 {
 // Deleted returns an iterator for deleted objects in this table starting from
 // 'minRevision'. The deleted objects are not garbage-collected unless 'Mark' is
 // called!
-func (dt *deleteTracker[Obj]) deleted(txn *txn, minRevision Revision) Iterator[Obj] {
-	indexEntry := txn.root[dt.table.tablePos()].indexes[GraveyardRevisionIndexPos]
+func (dt *deleteTracker[Obj]) deleted(txn ReadTxn, minRevision Revision) Iterator[Obj] {
+	indexEntry := txn.root()[dt.table.tablePos()].indexes[GraveyardRevisionIndexPos]
 	indexTxn := indexReadTxn{indexEntry.tree, indexEntry.unique}
 	iter := indexTxn.LowerBound(index.Uint64(minRevision))
 	return &iterator[Obj]{iter}

--- a/vendor/github.com/cilium/statedb/http.go
+++ b/vendor/github.com/cilium/statedb/http.go
@@ -74,11 +74,11 @@ func (h dbHandler) query(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	txn := h.db.ReadTxn().getTxn()
+	txn := h.db.ReadTxn()
 
 	// Look up the table
 	var table TableMeta
-	for _, e := range txn.root {
+	for _, e := range txn.root() {
 		if e.meta.Name() == req.Table {
 			table = e.meta
 			break
@@ -161,7 +161,7 @@ func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {
 
 	// Look up the table
 	var tableMeta TableMeta
-	for _, e := range h.db.ReadTxn().getTxn().root {
+	for _, e := range h.db.ReadTxn().root() {
 		if e.meta.Name() == tableName {
 			tableMeta = e.meta
 			break

--- a/vendor/github.com/cilium/statedb/iterator.go
+++ b/vendor/github.com/cilium/statedb/iterator.go
@@ -271,11 +271,10 @@ func (it *changeIterator[Obj]) refresh(txn ReadTxn) {
 	// refresh from mutated indexes in case [txn] is a WriteTxn. This
 	// is important as the WriteTxn may be aborted and thus revisions will
 	// reset back and watermarks bumped from here would be invalid.
-	itxn := txn.getTxn()
-	indexEntry := itxn.root[it.table.tablePos()].indexes[RevisionIndexPos]
+	indexEntry := txn.root()[it.table.tablePos()].indexes[RevisionIndexPos]
 	indexTxn := indexReadTxn{indexEntry.tree, indexEntry.unique}
 	updateIter := &iterator[Obj]{indexTxn.LowerBound(index.Uint64(it.revision + 1))}
-	deleteIter := it.dt.deleted(itxn, it.deleteRevision+1)
+	deleteIter := it.dt.deleted(txn, it.deleteRevision+1)
 	it.iter = NewDualIterator(deleteIter, updateIter)
 
 	// It is enough to watch the revision index and not the graveyard since

--- a/vendor/github.com/cilium/statedb/part/iterator.go
+++ b/vendor/github.com/cilium/statedb/part/iterator.go
@@ -75,11 +75,11 @@ func prefixSearch[T any](root *header[T], key []byte) (*Iterator[T], <-chan stru
 		}
 
 		switch {
-		case bytes.Equal(key, this.prefix[:min(len(key), len(this.prefix))]):
+		case bytes.Equal(key, this.prefix()[:min(len(key), int(this.prefixLen))]):
 			return newIterator(this), watch
 
-		case bytes.HasPrefix(key, this.prefix):
-			key = key[len(this.prefix):]
+		case bytes.HasPrefix(key, this.prefix()):
+			key = key[this.prefixLen:]
 			if len(key) == 0 {
 				return newIterator(this), this.watch
 			}
@@ -124,14 +124,14 @@ func lowerbound[T any](start *header[T], key []byte) *Iterator[T] {
 	this := start
 loop:
 	for {
-		switch bytes.Compare(this.prefix, key[:min(len(key), len(this.prefix))]) {
+		switch bytes.Compare(this.prefix(), key[:min(len(key), int(this.prefixLen))]) {
 		case -1:
 			// Prefix is smaller, stop here and return an iterator for
 			// the larger nodes in the parent's.
 			break loop
 
 		case 0:
-			if len(this.prefix) == len(key) {
+			if int(this.prefixLen) == len(key) {
 				// Exact match.
 				edges = append(edges, []*header[T]{this})
 				break loop
@@ -140,7 +140,7 @@ loop:
 			// Prefix matches the beginning of the key, but more
 			// remains of the key. Drop the matching part and keep
 			// going further.
-			key = key[len(this.prefix):]
+			key = key[this.prefixLen:]
 
 			if this.kind() == nodeKind256 {
 				children := this.node256().children[:]
@@ -162,7 +162,7 @@ loop:
 
 				// Find the smallest child that is equal or larger than the lower bound
 				idx := sort.Search(len(children), func(i int) bool {
-					return children[i].prefix[0] >= key[0]
+					return children[i].key() >= key[0]
 				})
 				if idx >= this.size() {
 					break loop

--- a/vendor/github.com/cilium/statedb/part/node.go
+++ b/vendor/github.com/cilium/statedb/part/node.go
@@ -24,9 +24,25 @@ const (
 
 // header is the common header shared by all node kinds.
 type header[T any] struct {
-	flags  uint16        // kind(4b) | unused(3b) | size(9b)
-	prefix []byte        // the compressed prefix, [0] is the key
-	watch  chan struct{} // watch channel that is closed when this node mutates
+	flags     uint16 // kind(4b) | unused(3b) | size(9b)
+	prefixLen uint16
+	prefixP   *byte         // the compressed prefix, [0] is the key
+	watch     chan struct{} // watch channel that is closed when this node mutates
+}
+
+func (n *header[T]) key() byte {
+	return *n.prefixP
+}
+
+func (n *header[T]) prefix() []byte {
+	return unsafe.Slice(n.prefixP, n.prefixLen)
+}
+
+func (n *header[T]) setPrefix(p []byte) {
+	if len(p) > 0 {
+		n.prefixP = &p[0]
+	}
+	n.prefixLen = uint16(len(p))
 }
 
 const kindMask = uint16(0b1111_000_00000000_0)
@@ -160,7 +176,8 @@ func (n *header[T]) promote(watch bool) *header[T] {
 	switch n.kind() {
 	case nodeKindLeaf:
 		node4 := &node4[T]{}
-		node4.prefix = n.prefix
+		node4.prefixLen = n.prefixLen
+		node4.prefixP = n.prefixP
 		node4.leaf = n.getLeaf()
 		node4.setKind(nodeKind4)
 		if watch {
@@ -201,7 +218,7 @@ func (n *header[T]) promote(watch bool) *header[T] {
 		// Since Node256 has children indexed directly, iterate over the children
 		// to assign them to the right index.
 		for _, child := range node48.children[:node48.size()] {
-			node256.children[child.prefix[0]] = child
+			node256.children[child.prefix()[0]] = child
 		}
 		if watch {
 			node256.watch = make(chan struct{})
@@ -220,18 +237,18 @@ func (n *header[T]) printTree(level int) {
 	var children []*header[T]
 	switch n.kind() {
 	case nodeKindLeaf:
-		fmt.Printf("leaf[%x]:", n.prefix)
+		fmt.Printf("leaf[%x]:", n.prefix())
 	case nodeKind4:
-		fmt.Printf("node4[%x]:", n.prefix)
+		fmt.Printf("node4[%x]:", n.prefix())
 		children = n.node4().children[:n.size()]
 	case nodeKind16:
-		fmt.Printf("node16[%x]:", n.prefix)
+		fmt.Printf("node16[%x]:", n.prefix())
 		children = n.node16().children[:n.size()]
 	case nodeKind48:
-		fmt.Printf("node48[%x]:", n.prefix)
+		fmt.Printf("node48[%x]:", n.prefix())
 		children = n.node48().children[:n.size()]
 	case nodeKind256:
-		fmt.Printf("node256[%x]:", n.prefix)
+		fmt.Printf("node256[%x]:", n.prefix())
 		children = n.node256().children[:]
 	default:
 		panic("unknown node kind")
@@ -294,9 +311,9 @@ func (n *header[T]) findIndex(key byte) (*header[T], int) {
 	case nodeKind48:
 		children := n.children()
 		idx := sort.Search(len(children), func(i int) bool {
-			return children[i].prefix[0] >= key
+			return children[i].prefix()[0] >= key
 		})
-		if idx >= n.size() || children[idx].prefix[0] != key {
+		if idx >= n.size() || children[idx].prefix()[0] != key {
 			// No node found, return nil and the index into
 			// which it should go.
 			return nil, idx
@@ -359,26 +376,26 @@ func (n *header[T]) insert(idx int, child *header[T]) {
 		copy(n4.children[idx+1:newSize], n4.children[idx:newSize])
 		copy(n4.keys[idx+1:newSize], n4.keys[idx:newSize])
 		n4.children[idx] = child
-		n4.keys[idx] = child.prefix[0]
+		n4.keys[idx] = child.key()
 	case nodeKind16:
 		n16 := n.node16()
 		// Shift to make room
 		copy(n16.children[idx+1:newSize], n16.children[idx:newSize])
 		copy(n16.keys[idx+1:newSize], n16.keys[idx:newSize])
 		n16.children[idx] = child
-		n16.keys[idx] = child.prefix[0]
+		n16.keys[idx] = child.key()
 	case nodeKind48:
 		// Shift to make room
 		n48 := n.node48()
 		for i := size - 1; i >= idx; i-- {
 			c := n48.children[i]
-			n48.index[c.prefix[0]] = int8(i + 1)
+			n48.index[c.key()] = int8(i + 1)
 			n48.children[i+1] = c
 		}
 		n48.children[idx] = child
-		n48.index[child.prefix[0]] = int8(idx)
+		n48.index[child.key()] = int8(idx)
 	case nodeKind256:
-		n.node256().children[child.prefix[0]] = child
+		n.node256().children[child.key()] = child
 	default:
 		panic(fmt.Sprintf("unknown node kind: %x", n.kind()))
 	}
@@ -404,12 +421,12 @@ func (n *header[T]) remove(idx int) {
 		n16.keys[newSize] = 255
 	case nodeKind48:
 		children := n.children()
-		key := children[idx].prefix[0]
+		key := children[idx].key()
 		n48 := n.node48()
 		for i := idx; i < newSize; i++ {
 			child := children[i+1]
 			children[i] = child
-			n48.index[child.prefix[0]] = int8(i)
+			n48.index[child.key()] = int8(i)
 		}
 		n48.index[key] = -1
 		children[newSize] = nil
@@ -423,16 +440,16 @@ func (n *header[T]) remove(idx int) {
 
 type leaf[T any] struct {
 	header[T]
-	key   []byte
 	value T
+	key   []byte
 }
 
-func newLeaf[T any](o *options, prefix, key []byte, value T) *leaf[T] {
+func newLeaf[T any](o options, prefix, key []byte, value T) *leaf[T] {
 	leaf := &leaf[T]{key: key, value: value}
-	leaf.prefix = prefix
+	leaf.setPrefix(prefix)
 	leaf.setKind(nodeKindLeaf)
 
-	if !o.rootOnlyWatch {
+	if !o.rootOnlyWatch() {
 		leaf.watch = make(chan struct{})
 	}
 
@@ -441,29 +458,29 @@ func newLeaf[T any](o *options, prefix, key []byte, value T) *leaf[T] {
 
 type node4[T any] struct {
 	header[T]
-	keys     [4]byte
-	children [4]*header[T]
 	leaf     *leaf[T] // non-nil if this node contains a value
+	children [4]*header[T]
+	keys     [4]byte
 }
 
 type node16[T any] struct {
 	header[T]
-	keys     [16]byte
-	children [16]*header[T]
 	leaf     *leaf[T] // non-nil if this node contains a value
+	children [16]*header[T]
+	keys     [16]byte
 }
 
 type node48[T any] struct {
 	header[T]
-	index    [256]int8
 	children [48]*header[T]
 	leaf     *leaf[T] // non-nil if this node contains a value
+	index    [256]int8
 }
 
 type node256[T any] struct {
 	header[T]
-	children [256]*header[T]
 	leaf     *leaf[T] // non-nil if this node contains a value
+	children [256]*header[T]
 }
 
 func newNode4[T any]() *header[T] {
@@ -478,10 +495,10 @@ func search[T any](root *header[T], key []byte) (value T, watch <-chan struct{},
 		watch = this.watch
 
 		// Consume the prefix
-		if !bytes.HasPrefix(key, this.prefix) {
+		if !bytes.HasPrefix(key, this.prefix()) {
 			return
 		}
-		key = key[len(this.prefix):]
+		key = key[this.prefixLen:]
 
 		if len(key) == 0 {
 			if leaf := this.getLeaf(); leaf != nil {
@@ -501,7 +518,7 @@ func search[T any](root *header[T], key []byte) (value T, watch <-chan struct{},
 
 func commonPrefix(a, b []byte) []byte {
 	n := min(len(a), len(b))
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if a[i] != b[i] {
 			return a[:i]
 		}

--- a/vendor/github.com/cilium/statedb/part/options.go
+++ b/vendor/github.com/cilium/statedb/part/options.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+type options uint8
+
+const (
+	rootOnlyWatchOpt = options(1 << 1)
+	noCacheOpt       = options(1 << 2)
+)
+
+func (o *options) setRootOnlyWatch() {
+	*o |= rootOnlyWatchOpt
+}
+
+func (o *options) setNoCache() {
+	*o |= noCacheOpt
+
+}
+func (o options) rootOnlyWatch() bool {
+	return o&rootOnlyWatchOpt != 0
+}
+
+func (o options) noCache() bool {
+	return o&noCacheOpt != 0
+}

--- a/vendor/github.com/cilium/statedb/part/set.go
+++ b/vendor/github.com/cilium/statedb/part/set.go
@@ -27,23 +27,29 @@ type Set[T any] struct {
 // NewSet creates a new set of T.
 // The value type T must be registered with RegisterKeyType.
 func NewSet[T any](values ...T) Set[T] {
-	s := Set[T]{tree: New[T](RootOnlyWatch)}
-	s.toBytes = lookupKeyType[T]()
-	if len(values) > 0 {
-		txn := s.tree.Txn()
-		for _, v := range values {
-			txn.Insert(s.toBytes(v), v)
-		}
-		s.tree = txn.CommitOnly()
+	if len(values) == 0 {
+		return Set[T]{}
 	}
+	s := Set[T]{}
+	s.ensureTree()
+	txn := s.tree.Txn()
+	for _, v := range values {
+		txn.Insert(s.toBytes(v), v)
+	}
+	s.tree = txn.CommitOnly()
 	return s
+}
+
+func (s *Set[T]) ensureTree() {
+	if s.tree == nil {
+		s.tree = New[T](RootOnlyWatch, NoCache)
+	}
+	s.toBytes = lookupKeyType[T]()
 }
 
 // Set a value. Returns a new set. Original is unchanged.
 func (s Set[T]) Set(v T) Set[T] {
-	if s.tree == nil {
-		return NewSet(v)
-	}
+	s.ensureTree()
 	txn := s.tree.Txn()
 	txn.Insert(s.toBytes(v), v)
 	s.tree = txn.CommitOnly() // As Set is passed by value we can just modify it.
@@ -59,6 +65,9 @@ func (s Set[T]) Delete(v T) Set[T] {
 	txn := s.tree.Txn()
 	txn.Delete(s.toBytes(v))
 	s.tree = txn.CommitOnly()
+	if s.tree.Len() == 0 {
+		s.tree = nil
+	}
 	return s
 }
 
@@ -186,9 +195,8 @@ func (s *Set[T]) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("%T.UnmarshalJSON: expected '[' got %v", s, t)
 	}
 
-	if s.tree == nil {
-		*s = NewSet[T]()
-	}
+	*s = Set[T]{}
+	s.ensureTree()
 	txn := s.tree.Txn()
 
 	for dec.More() {
@@ -200,6 +208,9 @@ func (s *Set[T]) UnmarshalJSON(data []byte) error {
 		txn.Insert(s.toBytes(x), x)
 	}
 	s.tree = txn.CommitOnly()
+	if s.tree.Len() == 0 {
+		s.tree = nil
+	}
 
 	t, err = dec.Token()
 	if err != nil {
@@ -221,9 +232,8 @@ func (s *Set[T]) UnmarshalYAML(value *yaml.Node) error {
 		return fmt.Errorf("%T.UnmarshalYAML: expected sequence", s)
 	}
 
-	if s.tree == nil {
-		*s = NewSet[T]()
-	}
+	*s = Set[T]{}
+	s.ensureTree()
 	txn := s.tree.Txn()
 
 	for _, e := range value.Content {

--- a/vendor/github.com/cilium/statedb/part/tree.go
+++ b/vendor/github.com/cilium/statedb/part/tree.go
@@ -9,9 +9,10 @@ package part
 // has an associated channel that is closed when that node is mutated.
 // This allows watching any part of the tree (any prefix) for changes.
 type Tree[T any] struct {
-	opts *options
 	root *header[T]
+	txn  *Txn[T]
 	size int // the number of objects in the tree
+	opts options
 }
 
 // New constructs a new tree.
@@ -20,11 +21,15 @@ func New[T any](opts ...Option) *Tree[T] {
 	for _, opt := range opts {
 		opt(&o)
 	}
-	return &Tree[T]{
+	t := &Tree[T]{
 		root: newNode4[T](),
 		size: 0,
-		opts: &o,
+		opts: o,
 	}
+	if !o.noCache() {
+		t.txn = newTxn[T](o)
+	}
+	return t
 }
 
 type Option func(*options)
@@ -32,16 +37,38 @@ type Option func(*options)
 // RootOnlyWatch sets the tree to only have a watch channel on the root
 // node. This improves the speed at the cost of having a much more coarse
 // grained notifications.
-func RootOnlyWatch(o *options) { o.rootOnlyWatch = true }
+var RootOnlyWatch = (*options).setRootOnlyWatch
+
+// NoCache disables the mutated node cache
+var NoCache = (*options).setNoCache
+
+func newTxn[T any](o options) *Txn[T] {
+	txn := &Txn[T]{
+		watches: make(map[chan struct{}]struct{}),
+	}
+	if !o.noCache() {
+		txn.mutated = &nodeMutated{}
+		txn.deleteParentsCache = make([]deleteParent[T], 0, 32)
+	}
+	txn.opts = o
+	return txn
+}
 
 // Txn constructs a new transaction against the tree. Transactions
 // enable efficient large mutations of the tree by caching cloned
-// nodes.
+// nodes. Only a single transaction can be in flight at a time.
 func (t *Tree[T]) Txn() *Txn[T] {
-	txn := &Txn[T]{
-		Tree:    *t,
-		watches: make(map[chan struct{}]struct{}),
+	var txn *Txn[T]
+	if t.txn != nil {
+		txn = t.txn
+		txn.mutated.clear()
+		clear(txn.watches)
+	} else {
+		txn = newTxn[T](t.opts)
 	}
+	txn.opts = t.opts
+	txn.root = t.root
+	txn.size = t.size
 	return txn
 }
 
@@ -56,7 +83,7 @@ func (t *Tree[T]) Len() int {
 // value was found.
 func (t *Tree[T]) Get(key []byte) (T, <-chan struct{}, bool) {
 	value, watch, ok := search(t.root, key)
-	if t.opts.rootOnlyWatch {
+	if t.opts.rootOnlyWatch() {
 		watch = t.root.watch
 	}
 	return value, watch, ok
@@ -67,7 +94,7 @@ func (t *Tree[T]) Get(key []byte) (T, <-chan struct{}, bool) {
 // the given prefix are upserted or deleted.
 func (t *Tree[T]) Prefix(prefix []byte) (*Iterator[T], <-chan struct{}) {
 	iter, watch := prefixSearch(t.root, prefix)
-	if t.opts.rootOnlyWatch {
+	if t.opts.rootOnlyWatch() {
 		watch = t.root.watch
 	}
 	return iter, watch
@@ -123,8 +150,4 @@ func (t *Tree[T]) Iterator() *Iterator[T] {
 // PrintTree to the standard output. For debugging.
 func (t *Tree[T]) PrintTree() {
 	t.root.printTree(0)
-}
-
-type options struct {
-	rootOnlyWatch bool
 }

--- a/vendor/github.com/cilium/statedb/part/txn.go
+++ b/vendor/github.com/cilium/statedb/part/txn.go
@@ -10,14 +10,15 @@ import (
 // Txn is a transaction against a tree. It allows doing efficient
 // modifications to a tree by caching and reusing cloned nodes.
 type Txn[T any] struct {
-	// tree is the tree being modified
-	Tree[T]
+	root *header[T]
+	opts options
+	size int // the number of objects in the tree
 
 	// mutated is the set of nodes mutated in this transaction
 	// that we can keep mutating without cloning them again.
 	// It is cleared if the transaction is cloned or iterated
 	// upon.
-	mutated nodeMutated[T]
+	mutated *nodeMutated
 
 	// watches contains the channels of cloned nodes that should be closed
 	// when transaction is committed.
@@ -39,8 +40,12 @@ func (txn *Txn[T]) Clone() Ops[T] {
 	// Clear the mutated nodes so that the returned clone won't be changed by
 	// further modifications in this transaction.
 	txn.mutated.clear()
-	treeCopy := txn.Tree
-	return &treeCopy
+	return &Tree[T]{
+		opts: txn.opts,
+		root: txn.root,
+		size: txn.size,
+		txn:  nil,
+	}
 }
 
 // Insert or update the tree with the given key and value.
@@ -57,6 +62,9 @@ func (txn *Txn[T]) InsertWatch(key []byte, value T) (old T, hadOld bool, watch <
 	old, hadOld, watch, txn.root = txn.insert(txn.root, key, value)
 	if !hadOld {
 		txn.size++
+	}
+	if txn.opts.rootOnlyWatch() {
+		watch = txn.root.watch
 	}
 	return
 }
@@ -79,6 +87,9 @@ func (txn *Txn[T]) ModifyWatch(key []byte, mod func(T) T) (old T, hadOld bool, w
 	old, hadOld, watch, txn.root = txn.modify(txn.root, key, mod)
 	if !hadOld {
 		txn.size++
+	}
+	if txn.opts.rootOnlyWatch() {
+		watch = txn.root.watch
 	}
 	return
 }
@@ -106,7 +117,7 @@ func (txn *Txn[T]) RootWatch() <-chan struct{} {
 // value was found.
 func (txn *Txn[T]) Get(key []byte) (T, <-chan struct{}, bool) {
 	value, watch, ok := search(txn.root, key)
-	if txn.opts.rootOnlyWatch {
+	if txn.opts.rootOnlyWatch() {
 		watch = txn.root.watch
 	}
 	return value, watch, ok
@@ -118,7 +129,7 @@ func (txn *Txn[T]) Get(key []byte) (T, <-chan struct{}, bool) {
 func (txn *Txn[T]) Prefix(key []byte) (*Iterator[T], <-chan struct{}) {
 	txn.mutated.clear()
 	iter, watch := prefixSearch(txn.root, key)
-	if txn.opts.rootOnlyWatch {
+	if txn.opts.rootOnlyWatch() {
 		watch = txn.root.watch
 	}
 	return iter, watch
@@ -134,34 +145,35 @@ func (txn *Txn[T]) LowerBound(key []byte) *Iterator[T] {
 // Iterator returns an iterator for all objects.
 func (txn *Txn[T]) Iterator() *Iterator[T] {
 	txn.mutated.clear()
-	return newIterator[T](txn.root)
+	return newIterator(txn.root)
 }
 
 // Commit the transaction and produce the new tree.
 func (txn *Txn[T]) Commit() *Tree[T] {
-	txn.mutated.clear()
-	for ch := range txn.watches {
-		close(ch)
-	}
-	txn.watches = nil
-	return &Tree[T]{txn.opts, txn.root, txn.size}
+	txn.Notify()
+	return txn.CommitOnly()
 }
 
 // CommitOnly the transaction, but do not close the
 // watch channels. Returns the new tree.
-// To close the watch channels call Notify().
+// To close the watch channels call Notify(). You must call Notify() before
+// Tree.Txn().
 func (txn *Txn[T]) CommitOnly() *Tree[T] {
-	txn.mutated.clear()
-	return &Tree[T]{txn.opts, txn.root, txn.size}
+	t := &Tree[T]{opts: txn.opts, root: txn.root, size: txn.size}
+	if !txn.opts.noCache() {
+		t.txn = txn
+	}
+	return t
 }
 
 // Notify closes the watch channels of nodes that were
-// mutated as part of this transaction.
+// mutated as part of this transaction. Must be called before
+// Tree.Txn() is used again.
 func (txn *Txn[T]) Notify() {
 	for ch := range txn.watches {
 		close(ch)
 	}
-	txn.watches = nil
+	clear(txn.watches)
 }
 
 // PrintTree to the standard output. For debugging.
@@ -170,14 +182,14 @@ func (txn *Txn[T]) PrintTree() {
 }
 
 func (txn *Txn[T]) cloneNode(n *header[T]) *header[T] {
-	if txn.mutated.exists(n) {
+	if nodeMutatedExists(txn.mutated, n) {
 		return n
 	}
 	if n.watch != nil {
 		txn.watches[n.watch] = struct{}{}
 	}
-	n = n.clone(!txn.opts.rootOnlyWatch || n == txn.root)
-	txn.mutated.put(n)
+	n = n.clone(!txn.opts.rootOnlyWatch() || n == txn.root)
+	nodeMutatedSet(txn.mutated, n)
 	return n
 }
 
@@ -188,6 +200,8 @@ func (txn *Txn[T]) insert(root *header[T], key []byte, value T) (oldValue T, had
 func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue T, hadOld bool, watch <-chan struct{}, newRoot *header[T]) {
 	fullKey := key
 
+	// Start recursing from the root to find the insertion point.
+	// Point [thisp] to the root we're returning. It'll be replaced by a clone of the root when we recurse into it.
 	this := root
 	thisp := &newRoot
 
@@ -195,20 +209,11 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 	// it, we do it and return. If an existing node exists where the key should go, then
 	// we stop. 'this' points to that node, and 'thisp' to its memory location. It has
 	// not been cloned.
-	for {
-		if this.isLeaf() {
-			// We've reached a leaf node, cannot go further.
-			break
-		}
-
-		if !bytes.HasPrefix(key, this.prefix) {
-			break
-		}
-
+	for !this.isLeaf() && bytes.HasPrefix(key, this.prefix()) {
 		// Prefix matched. Consume it and go further.
-		key = key[len(this.prefix):]
+		key = key[this.prefixLen:]
 		if len(key) == 0 {
-			// Our key matches this node.
+			// Our key matches this node or we reached a leaf node.
 			break
 		}
 
@@ -220,8 +225,8 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 				if this.watch != nil {
 					txn.watches[this.watch] = struct{}{}
 				}
-				this = this.promote(!txn.opts.rootOnlyWatch || this == newRoot)
-				txn.mutated.put(this)
+				this = this.promote(!txn.opts.rootOnlyWatch() || this == root)
+				nodeMutatedSet(txn.mutated, this)
 			} else {
 				// Node is big enough, clone it so we can mutate it
 				this = txn.cloneNode(this)
@@ -242,132 +247,93 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 		this = *thisp
 	}
 
-	// A node exists where we wanted to insert the key.
+	common := commonPrefix(key, this.prefix())
+
+	// A node already exists where we wanted to insert the key.
 	// 'this' points to it, and 'thisp' is its memory location. The parents
 	// have been cloned.
-	switch {
-	case this.isLeaf():
-		common := commonPrefix(key, this.prefix)
-		if len(common) == len(this.prefix) && len(common) == len(key) {
-			// Exact match, clone and update the value.
-			oldValue = this.getLeaf().value
-			hadOld = true
-			this = txn.cloneNode(this)
-			*thisp = this
-			leaf := this.getLeaf()
-			leaf.value = mod(oldValue)
-			watch = leaf.watch
-		} else {
-			// Partially matching prefix.
-			newNode := &node4[T]{
-				header: header[T]{prefix: common},
-			}
-			newNode.setKind(nodeKind4)
-
-			// Make a shallow copy of the leaf. But keep its watch channel
-			// intact since we're only manipulating its prefix.
-			oldLeafCopy := *this.getLeaf()
-			oldLeaf := &oldLeafCopy
-			oldLeaf.prefix = oldLeaf.prefix[len(common):]
-			key = key[len(common):]
-			var zero T
-			newLeaf := newLeaf(txn.opts, key, fullKey, mod(zero))
-			watch = newLeaf.watch
-
-			// Insert the two leaves into the node we created. If one has
-			// a key that is a subset of the other, then we can insert them
-			// as a leaf of the node4, otherwise they become children.
-			switch {
-			case len(oldLeaf.prefix) == 0:
-				oldLeaf.prefix = common
-				newNode.setLeaf(oldLeaf)
-				newNode.children[0] = newLeaf.self()
-				newNode.keys[0] = newLeaf.prefix[0]
-				newNode.setSize(1)
-
-			case len(key) == 0:
-				newLeaf.prefix = common
-				newNode.setLeaf(newLeaf)
-				newNode.children[0] = oldLeaf.self()
-				newNode.keys[0] = oldLeaf.prefix[0]
-				newNode.setSize(1)
-
-			case oldLeaf.prefix[0] < key[0]:
-				newNode.children[0] = oldLeaf.self()
-				newNode.keys[0] = oldLeaf.prefix[0]
-				newNode.children[1] = newLeaf.self()
-				newNode.keys[1] = key[0]
-				newNode.setSize(2)
-
-			default:
-				newNode.children[0] = newLeaf.self()
-				newNode.keys[0] = key[0]
-				newNode.children[1] = oldLeaf.self()
-				newNode.keys[1] = oldLeaf.prefix[0]
-				newNode.setSize(2)
-			}
-			*thisp = newNode.self()
-		}
-	case len(key) == 0:
-		// Exact match, but not a leaf node
+	//
+	// Check first if it's an exact match.
+	if len(key) == 0 || len(key) == len(common) && len(key) == int(this.prefixLen) {
 		this = txn.cloneNode(this)
 		*thisp = this
 		if leaf := this.getLeaf(); leaf != nil {
-			// Replace the existing leaf
 			oldValue = leaf.value
 			hadOld = true
-			leaf = txn.cloneNode(leaf.self()).getLeaf()
+			if !this.isLeaf() {
+				// [this] is a non-leaf node, clone its leaf so we can update it.
+				leaf = txn.cloneNode(leaf.self()).getLeaf()
+				this.setLeaf(leaf)
+			}
 			leaf.value = mod(oldValue)
 			watch = leaf.watch
-			this.setLeaf(leaf)
 		} else {
 			// Set the leaf
 			var zero T
-			leaf := newLeaf(txn.opts, this.prefix, fullKey, mod(zero))
+			leaf := newLeaf(txn.opts, this.prefix(), fullKey, mod(zero))
 			watch = leaf.watch
 			this.setLeaf(leaf)
 		}
-
-	default:
-		// Partially matching prefix, non-leaf node.
-		common := commonPrefix(key, this.prefix)
-
-		this = txn.cloneNode(this)
-		*thisp = this
-		this.prefix = this.prefix[len(common):]
-		key = key[len(common):]
-
-		var zero T
-		newLeaf := newLeaf(txn.opts, key, fullKey, mod(zero))
-		watch = newLeaf.watch
-		newNode := &node4[T]{
-			header: header[T]{prefix: common},
-		}
-		newNode.setKind(nodeKind4)
-
-		switch {
-		case len(key) == 0:
-			newLeaf.prefix = common
-			newNode.setLeaf(newLeaf)
-			newNode.children[0] = this
-			newNode.keys[0] = this.prefix[0]
-			newNode.setSize(1)
-
-		case this.prefix[0] < key[0]:
-			newNode.children[0] = this
-			newNode.keys[0] = this.prefix[0]
-			newNode.children[1] = newLeaf.self()
-			newNode.keys[1] = key[0]
-			newNode.setSize(2)
-		default:
-			newNode.children[0] = newLeaf.self()
-			newNode.keys[0] = key[0]
-			newNode.children[1] = this
-			newNode.keys[1] = this.prefix[0]
-			newNode.setSize(2)
-		}
-		*thisp = newNode.self()
+		return
 	}
+
+	// The target node into which we want to insert has only a partially matching prefix.
+	// We'll replace target with a new [node4] and insert the target and new node into it
+	// (either as children or as leaf, depending on the prefixes).
+	if this.isLeaf() {
+		// We're replacing a leaf node, make a shallow copy to retain
+		// its watch channel since we're just manipulating prefix.
+		leafCopy := *this.getLeaf()
+		this = &leafCopy.header
+	} else {
+		this = txn.cloneNode(this)
+	}
+	*thisp = this
+	this.setPrefix(this.prefix()[len(common):])
+	key = key[len(common):]
+
+	var zero T
+	newLeaf := newLeaf(txn.opts, key, fullKey, mod(zero))
+	watch = newLeaf.watch
+	newNode := &node4[T]{}
+	newNode.setPrefix(common)
+	newNode.setKind(nodeKind4)
+	if !txn.opts.rootOnlyWatch() {
+		newNode.watch = make(chan struct{})
+	}
+
+	switch {
+	case this.prefixLen == 0:
+		// target has shorter key than new leaf
+		newNode.setLeaf(this.getLeaf())
+		newNode.children[0] = newLeaf.self()
+		newNode.keys[0] = key[0]
+		newNode.setSize(1)
+
+	case len(key) == 0:
+		// new leaf has shorter key than target
+		newNode.setLeaf(newLeaf)
+		newNode.children[0] = this
+		newNode.keys[0] = this.key()
+		newNode.setSize(1)
+
+	case this.key() < key[0]:
+		// target node has smaller key then new leaf
+		newNode.children[0] = this
+		newNode.keys[0] = this.key()
+		newNode.children[1] = newLeaf.self()
+		newNode.keys[1] = key[0]
+		newNode.setSize(2)
+	default:
+		// new leaf has smaller key then target node
+		newNode.children[0] = newLeaf.self()
+		newNode.keys[0] = key[0]
+		newNode.children[1] = this
+		newNode.keys[1] = this.key()
+		newNode.setSize(2)
+	}
+	*thisp = newNode.self()
+
 	return
 }
 
@@ -393,8 +359,8 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	// Find the target node and record the path to it.
 	var leaf *leaf[T]
 	for {
-		if bytes.HasPrefix(key, this.prefix) {
-			key = key[len(this.prefix):]
+		if bytes.HasPrefix(key, this.prefix()) {
+			key = key[this.prefixLen:]
 			if len(key) == 0 {
 				leaf = this.getLeaf()
 				if leaf == nil {
@@ -486,8 +452,8 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 				n16 := newNode.node16()
 				n16.leaf = parent.node.getLeaf()
 				size := n16.size()
-				for i := 0; i < size; i++ {
-					n16.keys[i] = n16.children[i].prefix[0]
+				for i := range size {
+					n16.keys[i] = n16.children[i].key()
 				}
 			case parent.node.kind() == nodeKind16 && parent.node.size() <= 3:
 				newNode = (&node4[T]{header: *parent.node}).self()

--- a/vendor/github.com/cilium/statedb/read_txn.go
+++ b/vendor/github.com/cilium/statedb/read_txn.go
@@ -1,0 +1,110 @@
+package statedb
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+)
+
+type readTxn []tableEntry
+
+func (r readTxn) getTableEntry(meta TableMeta) *tableEntry {
+	return &r[meta.tablePos()]
+}
+
+// indexReadTxn implements ReadTxn.
+func (r readTxn) indexReadTxn(meta TableMeta, indexPos int) (indexReadTxn, error) {
+	if meta.tablePos() < 0 {
+		return indexReadTxn{}, tableError(meta.Name(), ErrTableNotRegistered)
+	}
+	indexEntry := r[meta.tablePos()].indexes[indexPos]
+	return indexReadTxn{indexEntry.tree, indexEntry.unique}, nil
+}
+
+// mustIndexReadTxn implements ReadTxn.
+func (r readTxn) mustIndexReadTxn(meta TableMeta, indexPos int) indexReadTxn {
+	indexTxn, err := r.indexReadTxn(meta, indexPos)
+	if err != nil {
+		panic(err)
+	}
+	return indexTxn
+}
+
+// root implements ReadTxn.
+func (r readTxn) root() dbRoot {
+	return dbRoot(r)
+}
+
+// WriteJSON marshals out the database as JSON into the given writer.
+// If tables are given then only these tables are written.
+func (txn readTxn) WriteJSON(w io.Writer, tables ...string) error {
+	buf := bufio.NewWriter(w)
+	buf.WriteString("{\n")
+	first := true
+
+	for _, table := range txn {
+		if len(tables) > 0 && !slices.Contains(tables, table.meta.Name()) {
+			continue
+		}
+
+		if !first {
+			buf.WriteString(",\n")
+		} else {
+			first = false
+		}
+
+		if err := writeTableAsJSON(buf, txn, &table); err != nil {
+			return err
+		}
+	}
+	buf.WriteString("\n}\n")
+	return buf.Flush()
+}
+
+var _ ReadTxn = readTxn{}
+
+func marshalJSON(data any) (out []byte) {
+	// Catch panics from JSON marshalling to ensure we have some output for debugging
+	// purposes even if the object has panicing JSON marshalling.
+	defer func() {
+		if r := recover(); r != nil {
+			out = fmt.Appendf(nil, "\"panic marshalling JSON: %.32s\"", r)
+		}
+	}()
+	bs, err := json.Marshal(data)
+	if err != nil {
+		return []byte("\"marshalling error: " + err.Error() + "\"")
+	}
+	return bs
+}
+
+func writeTableAsJSON(buf *bufio.Writer, txn ReadTxn, table *tableEntry) (err error) {
+	indexTxn := txn.mustIndexReadTxn(table.meta, PrimaryIndexPos)
+	iter := indexTxn.Iterator()
+
+	writeString := func(s string) {
+		if err != nil {
+			return
+		}
+		_, err = buf.WriteString(s)
+	}
+	writeString("  \"" + table.meta.Name() + "\": [\n")
+
+	_, obj, ok := iter.Next()
+	for ok {
+		writeString("    ")
+		if _, err := buf.Write(marshalJSON(obj.data)); err != nil {
+			return err
+		}
+		_, obj, ok = iter.Next()
+		if ok {
+			writeString(",\n")
+		} else {
+			writeString("\n")
+		}
+	}
+	writeString("  ]")
+	return
+}

--- a/vendor/github.com/cilium/statedb/table.go
+++ b/vendor/github.com/cilium/statedb/table.go
@@ -132,10 +132,10 @@ type genTable[Obj any] struct {
 	primaryAnyIndexer    anyIndexer
 	secondaryAnyIndexers map[string]anyIndexer
 	indexPositions       map[string]int
-	lastWriteTxn         atomic.Pointer[txn]
+	lastWriteTxn         atomic.Pointer[writeTxn]
 }
 
-func (t *genTable[Obj]) acquired(txn *txn) {
+func (t *genTable[Obj]) acquired(txn *writeTxn) {
 	t.lastWriteTxn.Store(txn)
 }
 
@@ -222,7 +222,7 @@ func (t *genTable[Obj]) ToTable() Table[Obj] {
 }
 
 func (t *genTable[Obj]) Initialized(txn ReadTxn) (bool, <-chan struct{}) {
-	table := txn.getTxn().getTableEntry(t)
+	table := txn.getTableEntry(t)
 	if len(table.pendingInitializers) == 0 {
 		return true, closedWatchChannel
 	}
@@ -230,7 +230,7 @@ func (t *genTable[Obj]) Initialized(txn ReadTxn) (bool, <-chan struct{}) {
 }
 
 func (t *genTable[Obj]) PendingInitializers(txn ReadTxn) []string {
-	return txn.getTxn().getTableEntry(t).pendingInitializers
+	return txn.getTableEntry(t).pendingInitializers
 }
 
 func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(WriteTxn) {
@@ -258,16 +258,16 @@ func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(Writ
 }
 
 func (t *genTable[Obj]) Revision(txn ReadTxn) Revision {
-	return txn.getTxn().getTableEntry(t).revision
+	return txn.getTableEntry(t).revision
 }
 
 func (t *genTable[Obj]) NumObjects(txn ReadTxn) int {
-	table := txn.getTxn().getTableEntry(t)
+	table := txn.getTableEntry(t)
 	return table.numObjects()
 }
 
 func (t *genTable[Obj]) numDeletedObjects(txn ReadTxn) int {
-	table := txn.getTxn().getTableEntry(t)
+	table := txn.getTableEntry(t)
 	return table.numDeletedObjects()
 }
 
@@ -278,27 +278,29 @@ func (t *genTable[Obj]) Get(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64
 
 func (t *genTable[Obj]) GetWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
 	indexPos := t.indexPos(q.index)
-	itxn := txn.getTxn()
 	var (
 		ops    part.Ops[object]
 		unique bool
 	)
-	if itxn.modifiedTables != nil {
-		if table := itxn.modifiedTables[t.tablePos()]; table != nil {
-			// Since we're not returning an iterator here we can optimize and not use
-			// indexReadTxn which clones if this is a WriteTxn (to avoid invalidating iterators).
-			indexEntry := &table.indexes[indexPos]
-			if indexEntry.txn != nil {
-				ops = indexEntry.txn
-			} else {
-				ops = indexEntry.tree
+	if wtxn, ok := txn.(WriteTxn); ok {
+		itxn := wtxn.getTxn()
+		if itxn.modifiedTables != nil {
+			if table := itxn.modifiedTables[t.tablePos()]; table != nil {
+				// Since we're not returning an iterator here we can optimize and not use
+				// indexReadTxn which clones if this is a WriteTxn (to avoid invalidating iterators).
+				indexEntry := &table.indexes[indexPos]
+				if indexEntry.txn != nil {
+					ops = indexEntry.txn
+				} else {
+					ops = indexEntry.tree
+				}
+				unique = indexEntry.unique
 			}
-			unique = indexEntry.unique
 		}
 	}
 
 	if ops == nil {
-		entry := itxn.root[t.tablePos()].indexes[indexPos]
+		entry := txn.root()[t.tablePos()].indexes[indexPos]
 		ops = entry.tree
 		unique = entry.unique
 	}
@@ -343,7 +345,7 @@ func (t *genTable[Obj]) LowerBound(txn ReadTxn, q Query[Obj]) iter.Seq2[Obj, Rev
 }
 
 func (t *genTable[Obj]) LowerBoundWatch(txn ReadTxn, q Query[Obj]) (iter.Seq2[Obj, Revision], <-chan struct{}) {
-	indexTxn := txn.getTxn().mustIndexReadTxn(t, t.indexPos(q.index))
+	indexTxn := txn.mustIndexReadTxn(t, t.indexPos(q.index))
 	// Since LowerBound query may be invalidated by changes in another branch
 	// of the tree, we cannot just simply watch the node we seeked to. Instead
 	// we watch the whole table for changes.
@@ -361,7 +363,7 @@ func (t *genTable[Obj]) Prefix(txn ReadTxn, q Query[Obj]) iter.Seq2[Obj, Revisio
 }
 
 func (t *genTable[Obj]) PrefixWatch(txn ReadTxn, q Query[Obj]) (iter.Seq2[Obj, Revision], <-chan struct{}) {
-	indexTxn := txn.getTxn().mustIndexReadTxn(t, t.indexPos(q.index))
+	indexTxn := txn.mustIndexReadTxn(t, t.indexPos(q.index))
 	iter, watch := indexTxn.Prefix(q.key)
 	if indexTxn.unique {
 		return partSeq[Obj](iter), watch
@@ -375,7 +377,7 @@ func (t *genTable[Obj]) All(txn ReadTxn) iter.Seq2[Obj, Revision] {
 }
 
 func (t *genTable[Obj]) AllWatch(txn ReadTxn) (iter.Seq2[Obj, Revision], <-chan struct{}) {
-	indexTxn := txn.getTxn().mustIndexReadTxn(t, PrimaryIndexPos)
+	indexTxn := txn.mustIndexReadTxn(t, PrimaryIndexPos)
 	return partSeq[Obj](indexTxn.Iterator()), indexTxn.RootWatch()
 }
 
@@ -385,7 +387,7 @@ func (t *genTable[Obj]) List(txn ReadTxn, q Query[Obj]) iter.Seq2[Obj, Revision]
 }
 
 func (t *genTable[Obj]) ListWatch(txn ReadTxn, q Query[Obj]) (iter.Seq2[Obj, Revision], <-chan struct{}) {
-	indexTxn := txn.getTxn().mustIndexReadTxn(t, t.indexPos(q.index))
+	indexTxn := txn.mustIndexReadTxn(t, t.indexPos(q.index))
 	if indexTxn.unique {
 		// Unique index means that there can be only a single matching object.
 		// Doing a Get() is more efficient than constructing an iterator.

--- a/vendor/github.com/cilium/statedb/types.go
+++ b/vendor/github.com/cilium/statedb/types.go
@@ -252,18 +252,23 @@ type tableInternal interface {
 	proto() any                             // Returns the zero value of 'Obj', e.g. the prototype
 	unmarshalYAML(data []byte) (any, error) // Unmarshal the data into 'Obj'
 	numDeletedObjects(txn ReadTxn) int      // Number of objects in graveyard
-	acquired(*txn)
+	acquired(*writeTxn)
 	getAcquiredInfo() string
 }
 
 type ReadTxn interface {
-	getTxn() *txn
+	indexReadTxn(meta TableMeta, indexPos int) (indexReadTxn, error)
+	mustIndexReadTxn(meta TableMeta, indexPos int) indexReadTxn
+	getTableEntry(meta TableMeta) *tableEntry
+	root() dbRoot
 
 	// WriteJSON writes the contents of the database as JSON.
 	WriteJSON(w io.Writer, tables ...string) error
 }
 
 type WriteTxn interface {
+	getTxn() *writeTxn
+
 	// WriteTxn is always also a ReadTxn
 	ReadTxn
 

--- a/vendor/github.com/cilium/statedb/write_txn.go
+++ b/vendor/github.com/cilium/statedb/write_txn.go
@@ -4,9 +4,7 @@
 package statedb
 
 import (
-	"bufio"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -20,17 +18,14 @@ import (
 	"github.com/cilium/statedb/part"
 )
 
-type txn struct {
-	db   *DB
-	root dbRoot
+type writeTxn struct {
+	db     *DB
+	dbRoot dbRoot
 
 	handle     string
 	acquiredAt time.Time     // the time at which the transaction acquired the locks
 	duration   atomic.Uint64 // the transaction duration after it finished
-	writeTxn
-}
 
-type writeTxn struct {
 	modifiedTables []*tableEntry            // table entries being modified
 	smus           internal.SortableMutexes // the (sorted) table locks
 	tableNames     []string
@@ -46,16 +41,19 @@ type indexTxn struct {
 	unique bool
 }
 
-// txn fulfills the ReadTxn/WriteTxn interface.
-func (txn *txn) getTxn() *txn {
+func (txn *writeTxn) getTxn() *writeTxn {
 	return txn
+}
+
+func (txn *writeTxn) root() dbRoot {
+	return txn.dbRoot
 }
 
 // acquiredInfo returns the information for the "Last WriteTxn" column
 // in "db tables" command. The correctness of this relies on the following assumptions:
 // - txn.handle and txn.acquiredAt are not modified
 // - txn.duration is atomically updated on Commit or Abort
-func (txn *txn) acquiredInfo() string {
+func (txn *writeTxn) acquiredInfo() string {
 	if txn == nil {
 		return ""
 	}
@@ -71,25 +69,25 @@ func (txn *txn) acquiredInfo() string {
 // txnFinalizer is called when the GC frees *txn. It checks that a WriteTxn
 // has been Aborted or Committed. This is a safeguard against forgetting to
 // Abort/Commit which would cause the table to be locked forever.
-func txnFinalizer(txn *txn) {
+func txnFinalizer(txn *writeTxn) {
 	if txn.modifiedTables != nil {
 		panic(fmt.Sprintf("WriteTxn from handle %s against tables %v was never Abort()'d or Commit()'d", txn.handle, txn.tableNames))
 	}
 }
 
-func (txn *txn) getTableEntry(meta TableMeta) *tableEntry {
+func (txn *writeTxn) getTableEntry(meta TableMeta) *tableEntry {
 	if txn.modifiedTables != nil {
 		entry := txn.modifiedTables[meta.tablePos()]
 		if entry != nil {
 			return entry
 		}
 	}
-	return &txn.root[meta.tablePos()]
+	return &txn.dbRoot[meta.tablePos()]
 }
 
 // indexReadTxn returns a transaction to read from the specific index.
 // If the table or index is not found this returns nil & error.
-func (txn *txn) indexReadTxn(meta TableMeta, indexPos int) (indexReadTxn, error) {
+func (txn *writeTxn) indexReadTxn(meta TableMeta, indexPos int) (indexReadTxn, error) {
 	if meta.tablePos() < 0 {
 		return indexReadTxn{}, tableError(meta.Name(), ErrTableNotRegistered)
 	}
@@ -102,13 +100,13 @@ func (txn *txn) indexReadTxn(meta TableMeta, indexPos int) (indexReadTxn, error)
 			return indexReadTxn{indexEntry.getClone(), indexEntry.unique}, nil
 		}
 	}
-	indexEntry := txn.root[meta.tablePos()].indexes[indexPos]
+	indexEntry := txn.dbRoot[meta.tablePos()].indexes[indexPos]
 	return indexReadTxn{indexEntry.tree, indexEntry.unique}, nil
 }
 
 // indexWriteTxn returns a transaction to read/write to a specific index.
 // The created transaction is memoized and used for subsequent reads and/or writes.
-func (txn *txn) indexWriteTxn(meta TableMeta, indexPos int) (indexTxn, error) {
+func (txn *writeTxn) indexWriteTxn(meta TableMeta, indexPos int) (indexTxn, error) {
 	table := txn.modifiedTables[meta.tablePos()]
 	if table == nil {
 		return indexTxn{}, tableError(meta.Name(), ErrTableNotLockedForWriting)
@@ -123,7 +121,7 @@ func (txn *txn) indexWriteTxn(meta TableMeta, indexPos int) (indexTxn, error) {
 
 // mustIndexReadTxn returns a transaction to read from the specific index.
 // Panics if table or index are not found.
-func (txn *txn) mustIndexReadTxn(meta TableMeta, indexPos int) indexReadTxn {
+func (txn *writeTxn) mustIndexReadTxn(meta TableMeta, indexPos int) indexReadTxn {
 	indexTxn, err := txn.indexReadTxn(meta, indexPos)
 	if err != nil {
 		panic(err)
@@ -133,7 +131,7 @@ func (txn *txn) mustIndexReadTxn(meta TableMeta, indexPos int) indexReadTxn {
 
 // mustIndexReadTxn returns a transaction to read or write from the specific index.
 // Panics if table or index not found.
-func (txn *txn) mustIndexWriteTxn(meta TableMeta, indexPos int) indexTxn {
+func (txn *writeTxn) mustIndexWriteTxn(meta TableMeta, indexPos int) indexTxn {
 	indexTxn, err := txn.indexWriteTxn(meta, indexPos)
 	if err != nil {
 		panic(err)
@@ -141,11 +139,11 @@ func (txn *txn) mustIndexWriteTxn(meta TableMeta, indexPos int) indexTxn {
 	return indexTxn
 }
 
-func (txn *txn) insert(meta TableMeta, guardRevision Revision, data any) (object, bool, <-chan struct{}, error) {
+func (txn *writeTxn) insert(meta TableMeta, guardRevision Revision, data any) (object, bool, <-chan struct{}, error) {
 	return txn.modify(meta, guardRevision, data, func(_ any) any { return data })
 }
 
-func (txn *txn) modify(meta TableMeta, guardRevision Revision, newData any, merge func(any) any) (object, bool, <-chan struct{}, error) {
+func (txn *writeTxn) modify(meta TableMeta, guardRevision Revision, newData any, merge func(any) any) (object, bool, <-chan struct{}, error) {
 	if txn.modifiedTables == nil {
 		return object{}, false, nil, ErrTransactionClosed
 	}
@@ -265,15 +263,15 @@ func (txn *txn) modify(meta TableMeta, guardRevision Revision, newData any, merg
 	return oldObj, oldExists, watch, nil
 }
 
-func (txn *txn) hasDeleteTrackers(meta TableMeta) bool {
+func (txn *writeTxn) hasDeleteTrackers(meta TableMeta) bool {
 	table := txn.modifiedTables[meta.tablePos()]
 	if table != nil {
 		return table.deleteTrackers.Len() > 0
 	}
-	return txn.root[meta.tablePos()].deleteTrackers.Len() > 0
+	return txn.dbRoot[meta.tablePos()].deleteTrackers.Len() > 0
 }
 
-func (txn *txn) addDeleteTracker(meta TableMeta, trackerName string, dt anyDeleteTracker) error {
+func (txn *writeTxn) addDeleteTracker(meta TableMeta, trackerName string, dt anyDeleteTracker) error {
 	if txn.modifiedTables == nil {
 		return ErrTransactionClosed
 	}
@@ -288,7 +286,7 @@ func (txn *txn) addDeleteTracker(meta TableMeta, trackerName string, dt anyDelet
 	return nil
 }
 
-func (txn *txn) delete(meta TableMeta, guardRevision Revision, data any) (object, bool, error) {
+func (txn *writeTxn) delete(meta TableMeta, guardRevision Revision, data any) (object, bool, error) {
 	if txn.modifiedTables == nil {
 		return object{}, false, ErrTransactionClosed
 	}
@@ -449,7 +447,7 @@ func (k nonUniqueKey) encodedSecondary() []byte {
 	return k[:k.secondaryLen()]
 }
 
-func (txn *txn) Abort() {
+func (txn *writeTxn) Abort() {
 	runtime.SetFinalizer(txn, nil)
 
 	// If modifiedTables is nil, this transaction has already been committed or aborted, and
@@ -479,12 +477,12 @@ func (txn *txn) Abort() {
 		txn.tableNames,
 		time.Since(txn.acquiredAt))
 
-	txn.writeTxn = writeTxn{}
+	*txn = writeTxn{}
 }
 
 // Commit the transaction. Returns a ReadTxn that is the snapshot of the database at the
 // point of commit.
-func (txn *txn) Commit() ReadTxn {
+func (txn *writeTxn) Commit() ReadTxn {
 	runtime.SetFinalizer(txn, nil)
 
 	// We operate here under the following properties:
@@ -568,18 +566,18 @@ func (txn *txn) Commit() ReadTxn {
 
 	// Commit the transaction to build the new root tree and then
 	// atomically store it.
-	txn.root = root
+	txn.dbRoot = root
 	db.root.Store(&root)
 	db.mu.Unlock()
-
-	// With the root pointer updated, we can now release the tables for the next write transaction.
-	txn.smus.Unlock()
 
 	// Now that new root is committed, we can notify readers by closing the watch channels of
 	// mutated radix tree nodes in all changed indexes and on the root itself.
 	for _, txn := range txnToNotify {
 		txn.Notify()
 	}
+
+	// With the root pointer updated, we can now release the tables for the next write transaction.
+	txn.smus.Unlock()
 
 	// Notify table initializations
 	for _, ch := range initChansToClose {
@@ -591,77 +589,12 @@ func (txn *txn) Commit() ReadTxn {
 		txn.tableNames,
 		time.Since(txn.acquiredAt))
 
-	// Convert into a ReadTxn
-	txn.writeTxn = writeTxn{}
-	return txn
-}
-
-func marshalJSON(data any) (out []byte) {
-	// Catch panics from JSON marshalling to ensure we have some output for debugging
-	// purposes even if the object has panicing JSON marshalling.
-	defer func() {
-		if r := recover(); r != nil {
-			out = []byte(fmt.Sprintf("\"panic marshalling JSON: %.32s\"", r))
-		}
-	}()
-	bs, err := json.Marshal(data)
-	if err != nil {
-		return []byte("\"marshalling error: " + err.Error() + "\"")
-	}
-	return bs
-}
-
-func writeTableAsJSON(buf *bufio.Writer, txn *txn, table *tableEntry) (err error) {
-	indexTxn := txn.mustIndexReadTxn(table.meta, PrimaryIndexPos)
-	iter := indexTxn.Iterator()
-
-	writeString := func(s string) {
-		if err != nil {
-			return
-		}
-		_, err = buf.WriteString(s)
-	}
-	writeString("  \"" + table.meta.Name() + "\": [\n")
-
-	_, obj, ok := iter.Next()
-	for ok {
-		writeString("    ")
-		if _, err := buf.Write(marshalJSON(obj.data)); err != nil {
-			return err
-		}
-		_, obj, ok = iter.Next()
-		if ok {
-			writeString(",\n")
-		} else {
-			writeString("\n")
-		}
-	}
-	writeString("  ]")
-	return
+	*txn = writeTxn{}
+	return readTxn(root)
 }
 
 // WriteJSON marshals out the database as JSON into the given writer.
 // If tables are given then only these tables are written.
-func (txn *txn) WriteJSON(w io.Writer, tables ...string) error {
-	buf := bufio.NewWriter(w)
-	buf.WriteString("{\n")
-	first := true
-
-	for _, table := range txn.root {
-		if len(tables) > 0 && !slices.Contains(tables, table.meta.Name()) {
-			continue
-		}
-
-		if !first {
-			buf.WriteString(",\n")
-		} else {
-			first = false
-		}
-
-		if err := writeTableAsJSON(buf, txn, &table); err != nil {
-			return err
-		}
-	}
-	buf.WriteString("\n}\n")
-	return buf.Flush()
+func (txn *writeTxn) WriteJSON(w io.Writer, tables ...string) error {
+	return readTxn(txn.dbRoot).WriteJSON(w, tables...)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -319,8 +319,8 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.4.0
-## explicit; go 1.23
+# github.com/cilium/statedb v0.4.1
+## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index
 github.com/cilium/statedb/internal


### PR DESCRIPTION
This includes minor bug fix to "RootOnlyWatch" trees, e.g. StateDB revision index (https://github.com/cilium/statedb/pull/81).

Also some significant optimizations to reduce memory usage and allocations (https://github.com/cilium/statedb/pull/83).

Load-balancer benchmark before (go run ./pkg/loadbalancer/benchmark/cmd): 
```
Min: Allocated 782955kB in total, 2010590 objects / 130741kB still reachable (per service:  40 objs, 16034B alloc,  2677B in-use) 
Avg: Allocated 799586kB in total, 2311243 objects / 163071kB still reachable (per service:  46 objs, 16375B alloc,  3339B in-use) 
Max: Allocated 846467kB in total, 3908765 objects / 345972kB still reachable (per service:  78 objs, 17335B alloc,  7085B in-use)
```

After:
```
Min: Allocated 710088kB in total, 2056143 objects / 121313kB still reachable (per service:  41 objs, 14542B alloc,  2484B in-use) 
Avg: Allocated 727354kB in total, 2394286 objects / 160861kB still reachable (per service:  47 objs, 14896B alloc,  3294B in-use) 
Max: Allocated 775640kB in total, 3649041 objects / 317865kB still reachable (per service:  72 objs, 15885B alloc,  6509B in-use)
```

So roughly ~10% less allocations and ~6% less memory usage.