### PR TITLE
CODEOWNERS: Have cilium/egress-gateway own relevant examples, manifest

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -302,6 +302,7 @@ Makefile* @cilium/build
 /cilium-cli/connectivity/ @cilium/ci-structure
 /cilium-cli/connectivity/check/frr.go @cilium/sig-bgp
 /cilium-cli/connectivity/check/ipcache.go @cilium/ipcache
+/cilium-cli/connectivity/check/manifests/egress-gateway-policy.yaml @cilium/egress-gateway
 /cilium-cli/connectivity/check/metrics*.go @cilium/metrics
 /cilium-cli/connectivity/check/policy.go @cilium/sig-policy
 /cilium-cli/connectivity/builder/** @cilium/ci-structure
@@ -449,6 +450,7 @@ Makefile* @cilium/build
 /Documentation/yaml.config @cilium/docs-structure
 /examples/ @cilium/docs-structure
 /examples/hubble/ @cilium/sig-hubble
+/examples/kubernetes-egress-gateway/ @cilium/egress-gateway
 /examples/kubernetes/ @cilium/sig-k8s
 /examples/kubernetes/clustermesh/ @cilium/sig-clustermesh
 /examples/minikube/ @cilium/sig-k8s


### PR DESCRIPTION
Pull the egress-gateway team for relevant code changes touching the relevant manifest in cilium-cli's connectivity tests, or the Egress Gateway examples.
