### PR TITLE
bgpv2: Refactor service route policy rendering logic

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -269,49 +269,21 @@ func (r *ServiceReconciler) getDesiredSvcRoutePolicies(desiredPeerAdverts PeerAd
 					continue
 				}
 
-				// LoadBalancerIP
-				lbPolicy, err := r.getLoadBalancerIPRoutePolicy(peer, agentFamily, svc, advert, ls)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get desired LoadBalancerIP route policy: %w", err)
-				}
-				if lbPolicy != nil {
-					currentLbPolicy := desiredSvcRoutePolicies[lbPolicy.Name]
-					if currentLbPolicy != nil {
-						if lbPolicy, err = MergeRoutePolicies(currentLbPolicy, lbPolicy); err != nil {
-							return nil, err
-						}
+				for _, advertType := range []v2.BGPServiceAddressType{v2.BGPLoadBalancerIPAddr, v2.BGPExternalIPAddr, v2.BGPClusterIPAddr} {
+					policy, err := r.getServiceRoutePolicy(peer, agentFamily, svc, advert, advertType, ls)
+					if err != nil {
+						return nil, fmt.Errorf("failed to get desired %s route policy: %w", advertType, err)
 					}
-					desiredSvcRoutePolicies[lbPolicy.Name] = lbPolicy
-				}
-
-				// ExternalIP
-				extPolicy, err := r.getExternalIPRoutePolicy(peer, agentFamily, svc, advert, ls)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get desired ExternalIP route policy: %w", err)
-				}
-				if extPolicy != nil {
-					currentExtPolicy := desiredSvcRoutePolicies[extPolicy.Name]
-					if currentExtPolicy != nil {
-						if extPolicy, err = MergeRoutePolicies(currentExtPolicy, extPolicy); err != nil {
-							return nil, err
+					if policy != nil {
+						existingPolicy := desiredSvcRoutePolicies[policy.Name]
+						if existingPolicy != nil {
+							policy, err = MergeRoutePolicies(existingPolicy, policy)
+							if err != nil {
+								return nil, fmt.Errorf("failed to merge %s route policies: %w", advertType, err)
+							}
 						}
+						desiredSvcRoutePolicies[policy.Name] = policy
 					}
-					desiredSvcRoutePolicies[extPolicy.Name] = extPolicy
-				}
-
-				// ClusterIP
-				clusterPolicy, err := r.getClusterIPRoutePolicy(peer, agentFamily, svc, advert, ls)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get desired ClusterIP route policy: %w", err)
-				}
-				if clusterPolicy != nil {
-					currentClusterPolicy := desiredSvcRoutePolicies[clusterPolicy.Name]
-					if currentClusterPolicy != nil {
-						if clusterPolicy, err = MergeRoutePolicies(currentClusterPolicy, clusterPolicy); err != nil {
-							return nil, err
-						}
-					}
-					desiredSvcRoutePolicies[clusterPolicy.Name] = clusterPolicy
 				}
 			}
 		}
@@ -537,17 +509,11 @@ func (r *ServiceReconciler) getServiceAFPaths(p ReconcileParams, desiredPeerAdve
 				for _, prefix := range desiredPrefixes {
 					// we only add path corresponding to the family of the prefix.
 					if agentFamily.Afi == types.AfiIPv4 && prefix.Addr().Is4() {
-						if advert.Service.AggregationLengthIPv4 != nil && svc.Spec.ExternalTrafficPolicy != slim_corev1.ServiceExternalTrafficPolicyLocal {
-							prefix = netip.PrefixFrom(prefix.Addr(), int(*advert.Service.AggregationLengthIPv4))
-						}
 						path := types.NewPathForPrefix(prefix)
 						path.Family = agentFamily
 						addPathToAFPathsMap(desiredFamilyAdverts, agentFamily, path)
 					}
 					if agentFamily.Afi == types.AfiIPv6 && prefix.Addr().Is6() {
-						if advert.Service.AggregationLengthIPv6 != nil && svc.Spec.ExternalTrafficPolicy != slim_corev1.ServiceExternalTrafficPolicyLocal {
-							prefix = netip.PrefixFrom(prefix.Addr(), int(*advert.Service.AggregationLengthIPv6))
-						}
 						path := types.NewPathForPrefix(prefix)
 						path.Family = agentFamily
 						addPathToAFPathsMap(desiredFamilyAdverts, agentFamily, path)
@@ -585,18 +551,18 @@ func (r *ServiceReconciler) getServicePrefixes(svc *slim_corev1.Service, advert 
 	for _, svcAdv := range advert.Service.Addresses {
 		switch svcAdv {
 		case v2.BGPLoadBalancerIPAddr:
-			desiredRoutes = append(desiredRoutes, r.getLBSvcPaths(svc, ls)...)
+			desiredRoutes = append(desiredRoutes, r.getLBSvcPaths(svc, ls, advert)...)
 		case v2.BGPClusterIPAddr:
-			desiredRoutes = append(desiredRoutes, r.getClusterIPPaths(svc, ls)...)
+			desiredRoutes = append(desiredRoutes, r.getClusterIPPaths(svc, ls, advert)...)
 		case v2.BGPExternalIPAddr:
-			desiredRoutes = append(desiredRoutes, r.getExternalIPPaths(svc, ls)...)
+			desiredRoutes = append(desiredRoutes, r.getExternalIPPaths(svc, ls, advert)...)
 		}
 	}
 
 	return desiredRoutes, nil
 }
 
-func (r *ServiceReconciler) getExternalIPPaths(svc *slim_corev1.Service, ls sets.Set[resource.Key]) []netip.Prefix {
+func (r *ServiceReconciler) getExternalIPPaths(svc *slim_corev1.Service, ls sets.Set[resource.Key], advert v2.BGPAdvertisement) []netip.Prefix {
 	var desiredRoutes []netip.Prefix
 	// Ignore externalTrafficPolicy == Local && no local EPs.
 	if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal &&
@@ -611,12 +577,16 @@ func (r *ServiceReconciler) getExternalIPPaths(svc *slim_corev1.Service, ls sets
 		if err != nil {
 			continue
 		}
-		desiredRoutes = append(desiredRoutes, netip.PrefixFrom(addr, addr.BitLen()))
+		prefix, err := addr.Prefix(getServicePrefixLength(svc, addr, advert))
+		if err != nil {
+			continue
+		}
+		desiredRoutes = append(desiredRoutes, prefix)
 	}
 	return desiredRoutes
 }
 
-func (r *ServiceReconciler) getClusterIPPaths(svc *slim_corev1.Service, ls sets.Set[resource.Key]) []netip.Prefix {
+func (r *ServiceReconciler) getClusterIPPaths(svc *slim_corev1.Service, ls sets.Set[resource.Key], advert v2.BGPAdvertisement) []netip.Prefix {
 	var desiredRoutes []netip.Prefix
 	// Ignore internalTrafficPolicy == Local && no local EPs.
 	if svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == slim_corev1.ServiceInternalTrafficPolicyLocal &&
@@ -641,12 +611,16 @@ func (r *ServiceReconciler) getClusterIPPaths(svc *slim_corev1.Service, ls sets.
 		if err != nil {
 			continue
 		}
-		desiredRoutes = append(desiredRoutes, netip.PrefixFrom(addr, addr.BitLen()))
+		prefix, err := addr.Prefix(getServicePrefixLength(svc, addr, advert))
+		if err != nil {
+			continue
+		}
+		desiredRoutes = append(desiredRoutes, prefix)
 	}
 	return desiredRoutes
 }
 
-func (r *ServiceReconciler) getLBSvcPaths(svc *slim_corev1.Service, ls sets.Set[resource.Key]) []netip.Prefix {
+func (r *ServiceReconciler) getLBSvcPaths(svc *slim_corev1.Service, ls sets.Set[resource.Key], advert v2.BGPAdvertisement) []netip.Prefix {
 	var desiredRoutes []netip.Prefix
 	if svc.Spec.Type != slim_corev1.ServiceTypeLoadBalancer {
 		return desiredRoutes
@@ -669,27 +643,16 @@ func (r *ServiceReconciler) getLBSvcPaths(svc *slim_corev1.Service, ls sets.Set[
 		if err != nil {
 			continue
 		}
-		desiredRoutes = append(desiredRoutes, netip.PrefixFrom(addr, addr.BitLen()))
+		prefix, err := addr.Prefix(getServicePrefixLength(svc, addr, advert))
+		if err != nil {
+			continue
+		}
+		desiredRoutes = append(desiredRoutes, prefix)
 	}
 	return desiredRoutes
 }
 
-func (r *ServiceReconciler) getLoadBalancerIPRoutePolicy(peer PeerID, family types.Family, svc *slim_corev1.Service, advert v2.BGPAdvertisement, ls sets.Set[resource.Key]) (*types.RoutePolicy, error) {
-	if svc.Spec.Type != slim_corev1.ServiceTypeLoadBalancer {
-		return nil, nil
-	}
-	// Ignore externalTrafficPolicy == Local && no local EPs.
-	if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal &&
-		!hasLocalEndpoints(svc, ls) {
-		return nil, nil
-	}
-	// Ignore service managed by an unsupported LB class.
-	if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != v2.BGPLoadBalancerClass {
-		// The service is managed by a different LB class.
-		return nil, nil
-	}
-
-	// get the peer address
+func (r *ServiceReconciler) getServiceRoutePolicy(peer PeerID, family types.Family, svc *slim_corev1.Service, advert v2.BGPAdvertisement, advertType v2.BGPServiceAddressType, ls sets.Set[resource.Key]) (*types.RoutePolicy, error) {
 	if peer.Address == "" {
 		return nil, nil
 	}
@@ -698,140 +661,41 @@ func (r *ServiceReconciler) getLoadBalancerIPRoutePolicy(peer PeerID, family typ
 		return nil, fmt.Errorf("failed to parse peer address: %w", err)
 	}
 
-	valid, err := checkServiceAdvertisement(advert, v2.BGPLoadBalancerIPAddr)
+	valid, err := checkServiceAdvertisement(advert, advertType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check service advertisement: %w", err)
+		return nil, fmt.Errorf("failed to check %s advertisement: %w", advertType, err)
 	}
 	if !valid {
 		return nil, nil
 	}
 
-	var v4Prefixes, v6Prefixes types.PolicyPrefixMatchList
-	for _, ingress := range svc.Status.LoadBalancer.Ingress {
-		addr, err := netip.ParseAddr(ingress.IP)
-		if err != nil {
-			continue
-		}
-
-		v4Prefixes, v6Prefixes = getPrefixes(family, svc, advert, addr, v4Prefixes, v6Prefixes)
+	var svcPrefixes []netip.Prefix
+	switch advertType {
+	case v2.BGPLoadBalancerIPAddr:
+		svcPrefixes = r.getLBSvcPaths(svc, ls, advert)
+	case v2.BGPExternalIPAddr:
+		svcPrefixes = r.getExternalIPPaths(svc, ls, advert)
+	case v2.BGPClusterIPAddr:
+		svcPrefixes = r.getClusterIPPaths(svc, ls, advert)
 	}
 
+	var v4Prefixes, v6Prefixes types.PolicyPrefixMatchList
+	for _, prefix := range svcPrefixes {
+		if family.Afi == types.AfiIPv4 && prefix.Addr().Is4() {
+			v4Prefixes = append(v4Prefixes, &types.RoutePolicyPrefixMatch{CIDR: prefix, PrefixLenMin: prefix.Bits(), PrefixLenMax: prefix.Bits()})
+		}
+		if family.Afi == types.AfiIPv6 && prefix.Addr().Is6() {
+			v6Prefixes = append(v6Prefixes, &types.RoutePolicyPrefixMatch{CIDR: prefix, PrefixLenMin: prefix.Bits(), PrefixLenMax: prefix.Bits()})
+		}
+	}
 	if len(v4Prefixes) == 0 && len(v6Prefixes) == 0 {
 		return nil, nil
 	}
 
-	policyName := PolicyName(peer.Name, family.Afi.String(), advert.AdvertisementType, fmt.Sprintf("%s-%s-%s", svc.Name, svc.Namespace, v2.BGPLoadBalancerIPAddr))
+	policyName := PolicyName(peer.Name, family.Afi.String(), advert.AdvertisementType, fmt.Sprintf("%s-%s-%s", svc.Name, svc.Namespace, advertType))
 	policy, err := CreatePolicy(policyName, peerAddr, v4Prefixes, v6Prefixes, advert)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create LoadBalancer IP route policy: %w", err)
-	}
-
-	return policy, nil
-}
-
-func (r *ServiceReconciler) getExternalIPRoutePolicy(peer PeerID, family types.Family, svc *slim_corev1.Service, advert v2.BGPAdvertisement, ls sets.Set[resource.Key]) (*types.RoutePolicy, error) {
-	if peer.Address == "" {
-		return nil, nil
-	}
-	peerAddr, err := netip.ParseAddr(peer.Address)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse peer address: %w", err)
-	}
-
-	valid, err := checkServiceAdvertisement(advert, v2.BGPExternalIPAddr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check service advertisement: %w", err)
-	}
-
-	if !valid {
-		return nil, nil
-	}
-
-	// Ignore externalTrafficPolicy == Local && no local EPs.
-	if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal &&
-		!hasLocalEndpoints(svc, ls) {
-		return nil, nil
-	}
-
-	var v4Prefixes, v6Prefixes types.PolicyPrefixMatchList
-	for _, extIP := range svc.Spec.ExternalIPs {
-		if extIP == "" {
-			continue
-		}
-		addr, err := netip.ParseAddr(extIP)
-		if err != nil {
-			continue
-		}
-
-		v4Prefixes, v6Prefixes = getPrefixes(family, svc, advert, addr, v4Prefixes, v6Prefixes)
-	}
-
-	if len(v4Prefixes) == 0 && len(v6Prefixes) == 0 {
-		return nil, nil
-	}
-
-	policyName := PolicyName(peer.Name, family.Afi.String(), advert.AdvertisementType, fmt.Sprintf("%s-%s-%s", svc.Name, svc.Namespace, v2.BGPExternalIPAddr))
-	policy, err := CreatePolicy(policyName, peerAddr, v4Prefixes, v6Prefixes, advert)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create external IP route policy: %w", err)
-	}
-
-	return policy, nil
-}
-
-func (r *ServiceReconciler) getClusterIPRoutePolicy(peer PeerID, family types.Family, svc *slim_corev1.Service, advert v2.BGPAdvertisement, ls sets.Set[resource.Key]) (*types.RoutePolicy, error) {
-	if peer.Address == "" {
-		return nil, nil
-	}
-	peerAddr, err := netip.ParseAddr(peer.Address)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse peer address: %w", err)
-	}
-
-	valid, err := checkServiceAdvertisement(advert, v2.BGPClusterIPAddr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check service advertisement: %w", err)
-	}
-
-	if !valid {
-		return nil, nil
-	}
-
-	// Ignore internalTrafficPolicy == Local && no local EPs.
-	if svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == slim_corev1.ServiceInternalTrafficPolicyLocal &&
-		!hasLocalEndpoints(svc, ls) {
-		return nil, nil
-	}
-
-	var v4Prefixes, v6Prefixes types.PolicyPrefixMatchList
-
-	ips := sets.New[string]()
-	if svc.Spec.ClusterIP != "" {
-		ips.Insert(svc.Spec.ClusterIP)
-	}
-	for _, clusterIP := range svc.Spec.ClusterIPs {
-		if clusterIP == "" || clusterIP == corev1.ClusterIPNone {
-			continue
-		}
-		ips.Insert(clusterIP)
-	}
-	for _, ip := range sets.List(ips) {
-		addr, err := netip.ParseAddr(ip)
-		if err != nil {
-			continue
-		}
-
-		v4Prefixes, v6Prefixes = getPrefixes(family, svc, advert, addr, v4Prefixes, v6Prefixes)
-	}
-
-	if len(v4Prefixes) == 0 && len(v6Prefixes) == 0 {
-		return nil, nil
-	}
-
-	policyName := PolicyName(peer.Name, family.Afi.String(), advert.AdvertisementType, fmt.Sprintf("%s-%s-%s", svc.Name, svc.Namespace, v2.BGPClusterIPAddr))
-	policy, err := CreatePolicy(policyName, peerAddr, v4Prefixes, v6Prefixes, advert)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cluster IP route policy: %w", err)
+		return nil, fmt.Errorf("failed to create %s IP route policy: %w", advertType, err)
 	}
 
 	return policy, nil
@@ -871,21 +735,19 @@ func serviceLabelSet(svc *slim_corev1.Service) labels.Labels {
 	return labels.Set(svcLabels)
 }
 
-func getPrefixes(family types.Family, svc *slim_corev1.Service, advert v2.BGPAdvertisement, addr netip.Addr, v4Prefixes, v6Prefixes types.PolicyPrefixMatchList) (types.PolicyPrefixMatchList, types.PolicyPrefixMatchList) {
-	mask := addr.BitLen()
+func getServicePrefixLength(svc *slim_corev1.Service, addr netip.Addr, advert v2.BGPAdvertisement) int {
+	length := addr.BitLen()
 
-	if family.Afi == types.AfiIPv4 && addr.Is4() {
+	if addr.Is4() {
 		if advert.Service.AggregationLengthIPv4 != nil && svc.Spec.ExternalTrafficPolicy != slim_corev1.ServiceExternalTrafficPolicyLocal {
-			mask = int(*advert.Service.AggregationLengthIPv4)
+			length = int(*advert.Service.AggregationLengthIPv4)
 		}
-		v4Prefixes = append(v4Prefixes, &types.RoutePolicyPrefixMatch{CIDR: netip.PrefixFrom(addr, mask), PrefixLenMin: mask, PrefixLenMax: mask})
 	}
 
-	if family.Afi == types.AfiIPv6 && addr.Is6() {
+	if addr.Is6() {
 		if advert.Service.AggregationLengthIPv6 != nil && svc.Spec.ExternalTrafficPolicy != slim_corev1.ServiceExternalTrafficPolicyLocal {
-			mask = int(*advert.Service.AggregationLengthIPv6)
+			length = int(*advert.Service.AggregationLengthIPv6)
 		}
-		v6Prefixes = append(v6Prefixes, &types.RoutePolicyPrefixMatch{CIDR: netip.PrefixFrom(addr, mask), PrefixLenMin: mask, PrefixLenMax: mask})
 	}
-	return v4Prefixes, v6Prefixes
+	return length
 }

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -39,28 +39,22 @@ var (
 	mismatchSvcSelector  = &slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "blue"}}
 	ingressV4            = "192.168.0.1"
 	ingressV4Prefix      = "192.168.0.1/32"
-	ingressV4PrefixNet   = "192.168.0.0/24"
-	ingressV4PrefixAggr  = "192.168.0.1/24"
+	ingressV4PrefixAggr  = "192.168.0.0/24"
 	externalV4           = "192.168.0.2"
 	externalV4Prefix     = "192.168.0.2/32"
-	externalV4PrefixNet  = "192.168.0.0/24"
-	externalV4PrefixAggr = "192.168.0.2/24"
+	externalV4PrefixAggr = "192.168.0.0/24"
 	clusterV4            = "192.168.0.3"
 	clusterV4Prefix      = "192.168.0.3/32"
-	clusterV4PrefixNet   = "192.168.0.0/24"
-	clusterV4PrefixAggr  = "192.168.0.3/24"
+	clusterV4PrefixAggr  = "192.168.0.0/24"
 	ingressV6            = "2001:db8::1"
 	ingressV6Prefix      = "2001:db8::1/128"
-	ingressV6PrefixNet   = "2001:db8::/120"
-	ingressV6PrefixAggr  = "2001:db8::1/120"
+	ingressV6PrefixAggr  = "2001:db8::/120"
 	externalV6           = "2001:db8::2"
 	externalV6Prefix     = "2001:db8::2/128"
-	externalV6PrefixNet  = "2001:db8::/120"
-	externalV6PrefixAggr = "2001:db8::2/120"
+	externalV6PrefixAggr = "2001:db8::/120"
 	clusterV6            = "2001:db8::3"
 	clusterV6Prefix      = "2001:db8::3/128"
-	clusterV6PrefixNet   = "2001:db8::/120"
-	clusterV6PrefixAggr  = "2001:db8::3/120"
+	clusterV6PrefixAggr  = "2001:db8::/120"
 	aggregation          = Aggregation{aggregationLengthIPv4: 24, aggregationLengthIPv6: 120}
 
 	redLBSvc = &slim_corev1.Service{
@@ -812,10 +806,10 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4PrefixNet: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4PrefixAggr)),
+							ingressV4PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4PrefixAggr)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6PrefixNet: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6PrefixAggr)),
+							ingressV6PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6PrefixAggr)),
 						},
 					},
 				},
@@ -1099,10 +1093,10 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							externalV4PrefixNet: types.NewPathForPrefix(netip.MustParsePrefix(externalV4PrefixAggr)),
+							externalV4PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(externalV4PrefixAggr)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							externalV6PrefixNet: types.NewPathForPrefix(netip.MustParsePrefix(externalV6PrefixAggr)),
+							externalV6PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(externalV6PrefixAggr)),
 						},
 					},
 				},
@@ -1435,10 +1429,10 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4PrefixNet: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4PrefixAggr)),
+							clusterV4PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4PrefixAggr)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6PrefixNet: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6PrefixAggr)),
+							clusterV6PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6PrefixAggr)),
 						},
 					},
 				},

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -473,13 +473,13 @@ var (
 		},
 	}
 
-	redExternalAndClusterSvcWithITP = func(svc *slim_corev1.Service, iTP slim_corev1.ServiceInternalTrafficPolicy) *slim_corev1.Service {
+	svcWithITP = func(svc *slim_corev1.Service, iTP slim_corev1.ServiceInternalTrafficPolicy) *slim_corev1.Service {
 		cp := svc.DeepCopy()
 		cp.Spec.InternalTrafficPolicy = &iTP
 		return cp
 	}
 
-	redExternalAndClusterSvcWithETP = func(svc *slim_corev1.Service, eTP slim_corev1.ServiceExternalTrafficPolicy) *slim_corev1.Service {
+	svcWithETP = func(svc *slim_corev1.Service, eTP slim_corev1.ServiceExternalTrafficPolicy) *slim_corev1.Service {
 		cp := svc.DeepCopy()
 		cp.Spec.ExternalTrafficPolicy = eTP
 		return cp
@@ -796,9 +796,9 @@ func Test_ServiceLBReconciler(t *testing.T) {
 			},
 		},
 		{
-			name:       "Service (LB) with advertisement(LB) and routes aggregation - matching labels (eTP=cluster)",
+			name:       "Service (LB) with advertisement(LB) and routes aggregation - matching labels (eTP=cluster, iTP=local)",
 			peerConfig: []*v2.CiliumBGPPeerConfig{redPeerConfig},
-			services:   []*slim_corev1.Service{redLBSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyCluster)},
+			services:   []*slim_corev1.Service{svcWithITP(redLBSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyCluster), slim_corev1.ServiceInternalTrafficPolicyLocal)},
 			advertisements: []*v2.CiliumBGPAdvertisement{
 				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector, aggregation)),
 			},
@@ -817,6 +817,43 @@ func Test_ServiceLBReconciler(t *testing.T) {
 					redSvcKey: RoutePolicyMap{
 						redPeer65001v4LBRPName: redPeer65001v4LBRPAggr,
 						redPeer65001v6LBRPName: redPeer65001v6LBRPAggr,
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector, aggregation),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2.BGPAdvertisement{
+							lbSvcAdvertWithSelector(redSvcSelector, aggregation),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (LB) with advertisement(LB) and routes aggregation - matching labels (eTP=local, iTP=cluster - no aggregation)",
+			peerConfig: []*v2.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{svcWithITP(redLBSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyLocal), slim_corev1.ServiceInternalTrafficPolicyCluster)},
+			endpoints:  []*k8s.Endpoints{eps1Local},
+			advertisements: []*v2.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector, aggregation)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ResourceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+						},
+					},
+				},
+				ServiceRoutePolicies: ResourceRoutePolicyMap{
+					redSvcKey: RoutePolicyMap{
+						redPeer65001v4LBRPName: redPeer65001v4LBRP,
+						redPeer65001v6LBRPName: redPeer65001v6LBRP,
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -1083,9 +1120,9 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 			},
 		},
 		{
-			name:       "Service (External) with advertisement(External) and routes aggregation  - matching labels (eTP=cluster)",
+			name:       "Service (External) with advertisement(External) and routes aggregation - matching labels (eTP=cluster, iTP=local)",
 			peerConfig: []*v2.CiliumBGPPeerConfig{redPeerConfig},
-			services:   []*slim_corev1.Service{redExternalSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyCluster)},
+			services:   []*slim_corev1.Service{svcWithITP(redExternalSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyCluster), slim_corev1.ServiceInternalTrafficPolicyLocal)},
 			advertisements: []*v2.CiliumBGPAdvertisement{
 				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector, aggregation)),
 			},
@@ -1104,6 +1141,43 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 					redSvcKey: RoutePolicyMap{
 						redPeer65001v4ExtRPName: redPeer65001v4ExtRPAggr,
 						redPeer65001v6ExtRPName: redPeer65001v6ExtRPAggr,
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector, aggregation),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2.BGPAdvertisement{
+							externalSvcAdvertWithSelector(redSvcSelector, aggregation),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (External) with advertisement(External) and routes aggregation - matching labels (eTP=local, iTP=cluster - no aggregation)",
+			peerConfig: []*v2.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{svcWithITP(redExternalSvcWithETP(slim_corev1.ServiceExternalTrafficPolicyLocal), slim_corev1.ServiceInternalTrafficPolicyCluster)},
+			endpoints:  []*k8s.Endpoints{eps1Local},
+			advertisements: []*v2.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(externalSvcAdvertWithSelector(redSvcSelector, aggregation)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ResourceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+						},
+					},
+				},
+				ServiceRoutePolicies: ResourceRoutePolicyMap{
+					redSvcKey: RoutePolicyMap{
+						redPeer65001v4ExtRPName: redPeer65001v4ExtRP,
+						redPeer65001v6ExtRPName: redPeer65001v6ExtRP,
 					},
 				},
 				ServiceAdvertisements: PeerAdvertisements{
@@ -1455,7 +1529,44 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 			},
 		},
 		{
-			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (eTP=local, ep on node)",
+			name:       "Service (Cluster) with advertisement(Cluster) and routes aggregation - matching labels (iTP=local - no aggregation)",
+			peerConfig: []*v2.CiliumBGPPeerConfig{redPeerConfig},
+			services:   []*slim_corev1.Service{redClusterSvcWithITP(slim_corev1.ServiceInternalTrafficPolicyLocal)},
+			endpoints:  []*k8s.Endpoints{eps1Local},
+			advertisements: []*v2.CiliumBGPAdvertisement{
+				redSvcAdvertWithAdvertisements(clusterIPSvcAdvertWithSelector(redSvcSelector, aggregation)),
+			},
+			expectedMetadata: ServiceReconcilerMetadata{
+				ServicePaths: ResourceAFPathsMap{
+					redSvcKey: AFPathsMap{
+						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+						},
+						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
+							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+						},
+					},
+				},
+				ServiceRoutePolicies: ResourceRoutePolicyMap{
+					redSvcKey: RoutePolicyMap{
+						redPeer65001v4ClusterRPName: redPeer65001v4ClusterRP,
+						redPeer65001v6ClusterRPName: redPeer65001v6ClusterRP,
+					},
+				},
+				ServiceAdvertisements: PeerAdvertisements{
+					testPeerID: PeerFamilyAdvertisements{
+						{Afi: "ipv4", Safi: "unicast"}: []v2.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector, aggregation),
+						},
+						{Afi: "ipv6", Safi: "unicast"}: []v2.BGPAdvertisement{
+							clusterIPSvcAdvertWithSelector(redSvcSelector, aggregation),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (iTP=local, ep on node)",
 			peerConfig: []*v2.CiliumBGPPeerConfig{redPeerConfig},
 			services:   []*slim_corev1.Service{redClusterSvcWithITP(slim_corev1.ServiceInternalTrafficPolicyLocal)},
 			endpoints:  []*k8s.Endpoints{eps1Local},
@@ -1492,7 +1603,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 			},
 		},
 		{
-			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (eTP=local, mixed ep)",
+			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (iTP=local, mixed ep)",
 			peerConfig: []*v2.CiliumBGPPeerConfig{redPeerConfig},
 			services:   []*slim_corev1.Service{redClusterSvcWithITP(slim_corev1.ServiceInternalTrafficPolicyLocal)},
 			endpoints:  []*k8s.Endpoints{eps1Mixed},
@@ -1529,7 +1640,7 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 			},
 		},
 		{
-			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (eTP=local, ep on remote)",
+			name:       "Service (Cluster) with advertisement(Cluster) - matching labels (iTP=local, ep on remote)",
 			peerConfig: []*v2.CiliumBGPPeerConfig{redPeerConfig},
 			services:   []*slim_corev1.Service{redClusterSvcWithITP(slim_corev1.ServiceInternalTrafficPolicyLocal)},
 			endpoints:  []*k8s.Endpoints{eps1Remote},
@@ -1857,8 +1968,8 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 		{
 			name: "Update service (Cluster, External) traffic policy local",
 			upsertServices: []*slim_corev1.Service{
-				redExternalAndClusterSvcWithITP(
-					redExternalAndClusterSvcWithETP(redExternalAndClusterSvc, slim_corev1.ServiceExternalTrafficPolicyLocal),
+				svcWithITP(
+					svcWithETP(redExternalAndClusterSvc, slim_corev1.ServiceExternalTrafficPolicyLocal),
 					slim_corev1.ServiceInternalTrafficPolicyLocal),
 			},
 			expectedMetadata: ServiceReconcilerMetadata{


### PR DESCRIPTION
Use common method for rendering service route policies for all types of svc advertisements instead of 3 different methods, to avoid code repetition. Rely on exiting path rendering methods (`get<svcType>IPPaths`) instead of copying the same logic in the policy rendering methods.

Also move prefix length rendering to `get<svcType>IPPaths` and properly zero masked-out bits (e.g. to produce `192.168.1.0/24` instead of `192.168.1.1/24`) to produce proper keys for the `PathMap`.
