### PR TITLE
daemon: Postpone node ipv6 addr check after IPAM config

### DIFF
--- a/daemon/k8s/init.go
+++ b/daemon/k8s/init.go
@@ -136,17 +136,6 @@ func WaitForNodeInformation(ctx context.Context, log *slog.Logger, localNode Loc
 			logfields.K8sNodeIP, k8sNodeIP,
 		)
 
-		// If the host does not have an IPv6 address, return an error
-		if option.Config.EnableIPv6 && nodeIP6 == nil {
-			log.Error(
-				"No IPv6 support on node as ipv6 address is nil",
-				logfields.NodeName, n.Name,
-				logfields.IPv4, nodeIP4,
-				logfields.IPv6, nodeIP6,
-			)
-			return fmt.Errorf("node %s does not have an IPv6 address", n.Name)
-		}
-
 		useNodeCIDR(n)
 	} else {
 		// if node resource could not be received, fail if


### PR DESCRIPTION
As a consequence of moving the direct routing device resolution in a separate cell, the initial call to SetDefaultPrefix was removed in 72e5ca6c0b.  That initial call, beside checking the v4 and v6 alloc ranges, had the side effect of setting a temporary ipv6 Unique Local Address (namely "fc00::10CA:1") in case the node was missing one.

In certain environments, as reported in
https://github.com/cilium/cilium/issues/37817, the node IPv6 address might not be available immediately at startup time. Therefore, the above call to SetDefaultPrefix allowed the subsequent check in WaitForNodeInformation, where we stop the agent in case the v6 stack is enabled but the node is missing the v6 address, to complete successfully.

Since the first call to SetDefaultPrefix is done later in the IPAM initial configuration, alongside the setting of the ULA IPv6 node address, move the node IPv6 address check after this step.

Related: 72e5ca6c0b ("datapath: use direct routing device cell")
Related: 2fc52eb444 ("fix: Adding ipv6 check on the node init function")
Fixes: https://github.com/cilium/cilium/issues/37817

```release-note
Fix agent startup failure when ipv6 is enabled and the node ipv6 address is not immediately available.
```
