### PR TITLE
loadbalancer: Fix socket termination of non-host namespaces

### DIFF
--- a/pkg/loadbalancer/reconciler/termination.go
+++ b/pkg/loadbalancer/reconciler/termination.go
@@ -239,14 +239,14 @@ func terminateUDPConnectionsToBackend(p socketTerminationParams, l3n4Addr lb.L3n
 	// Iterate over all pod network namespaces, and terminate any stale connections.
 	if p.ExtConfig.EnableSocketLBPodConnectionTermination && !p.ExtConfig.BPFSocketLBHostnsOnly {
 		iter, errs := p.NetNSOps.all()
-		for err := range errs {
-			p.Log.Debug("Error opening netns, skipping",
-				logfields.Error, err)
-		}
 		if iter != nil {
 			for name, ns := range iter {
 				destroy(name, ns)
 			}
+		}
+		for err := range errs {
+			p.Log.Debug("Error opening netns, skipping",
+				logfields.Error, err)
 		}
 	}
 


### PR DESCRIPTION
2296784f69fa iterated over the error channel before the namespaces which deadlocks. Switch the order back and change the test case to match how netns.All() iterator works.

Fixes: 2296784f69fa ("cilium, socklb: Fix socket termination error handling")