### PR TITLE
workflow: add k8s v1.33 in CI

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -1,15 +1,15 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.29"
-    region: us-west-1
   - version: "1.30"
-    region: us-east-2
+    region: us-west-1
   - version: "1.31"
+    region: us-east-2
+  - version: "1.32"
     region: ca-central-1
     default: true
     kpr: true
-  - version: "1.32"
+  - version: "1.33"
     region: us-east-1
     default: true
     wireguard: true

--- a/.github/actions/azure/k8s-versions-schema.yaml
+++ b/.github/actions/azure/k8s-versions-schema.yaml
@@ -3,4 +3,7 @@ include: list(include('includeItem'))
 includeItem:
   version: str()
   location: str()
+  index: int()
+  disabled: bool(required=False)
+  preview: bool(required=False)
   default: bool(required=False)

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,13 +1,17 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.29"
-    location: westus2
-    index: 1
   - version: "1.30"
-    location: eastus2
-    index: 2
+    location: westus3
+    index: 1
   - version: "1.31"
-    location: eastus
+    location: westus2
+    index: 2
+  - version: "1.32"
+    location: eastus2
     index: 3
+  - version: "1.33"
+    location: eastus
     default: true
+    preview: true
+    index: 4

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -1,18 +1,18 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.29"
-    region: us-west-1
   - version: "1.30"
+    region: us-west-1
+  - version: "1.31"
     region: us-east-2
     ipsec: true
-  - version: "1.31"
+  - version: "1.32"
     region: ca-central-1
     default: true
     ipsec: true
     kpr: true
     aws-eni-pd: true
-  - version: "1.32"
+  - version: "1.33"
     region: us-east-1
     ipsec: true
     default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,16 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.29"
+  - version: "1.30"
     zone: us-west2-c
     vmIndex: 1
-  - version: "1.30"
+  - version: "1.31"
     zone: us-west3-a
     vmIndex: 2
-  - version: "1.31"
+  - version: "1.32"
     zone: us-east4-b
     vmIndex: 3
-  - version: "1.32"
+  - version: "1.33"
     zone: us-east1-c
     vmIndex: 4
     default: true


### PR DESCRIPTION
- Remove older versions not available on platforms anymore.
- Fixed schema validation for AKS k8s versions

Tests:
- [aks](https://github.com/cilium/cilium/actions/runs/15763062142)
- [aws-cni](https://github.com/cilium/cilium/actions/runs/15758401067)
- [eks](https://github.com/cilium/cilium/actions/runs/15758393137)
- [gke](https://github.com/cilium/cilium/actions/runs/15758391201)