### PR TITLE
gateway-api: Add service type validation for CGCC

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumgatewayclassconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumgatewayclassconfigs.yaml
@@ -115,8 +115,12 @@ spec:
                     type: string
                   type:
                     default: LoadBalancer
-                    description: Sets the Service.Spec.Type in generated Service objects
-                      to the given value.
+                    description: |-
+                      Sets the Service.Spec.Type in generated Service objects to the given value.
+                      Only LoadBalancer and NodePort are supported.
+                    enum:
+                    - LoadBalancer
+                    - NodePort
                     type: string
                 type: object
             type: object

--- a/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
@@ -67,7 +67,9 @@ const (
 
 type ServiceConfig struct {
 	// Sets the Service.Spec.Type in generated Service objects to the given value.
+	// Only LoadBalancer and NodePort are supported.
 	//
+	// +kubebuilder:validation:Enum=LoadBalancer;NodePort
 	// +kubebuilder:default="LoadBalancer"
 	Type corev1.ServiceType `json:"type,omitempty"`
 


### PR DESCRIPTION
ClusterIP's behavior is not defined in the upstream, and arguably, it's probably not suited for Gateway resource, GAMMA can be used instead.

Relates: #38852


