### PR TITLE
ip-masq-agent: Ensure ip rules match the BPF ip-masq-agent configuration in AWS ENI mode

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -63,7 +63,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
-	"github.com/cilium/cilium/pkg/ipmasq"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
@@ -1399,7 +1398,6 @@ type daemonParams struct {
 	DNSProxy            bootstrap.FQDNProxyBootstrapper
 	DNSNameManager      namemanager.NameManager
 	KPRConfig           kpr.KPRConfig
-	IPMasqAgent         *ipmasq.IPMasqAgent
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], legacy.DaemonInitialization) {

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -60,7 +60,7 @@ var mtuMock = fakeMTU{}
 func TestAllocatedIPDump(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil)
+	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil, nil)
 	ipam.ConfigureAllocator()
 
 	allocv4, allocv6, status := ipam.Dump()
@@ -81,7 +81,7 @@ func TestExpirationTimer(t *testing.T) {
 
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil)
+	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil, nil)
 	ipam.ConfigureAllocator()
 
 	err := ipam.AllocateIP(ip, "foo", PoolDefault())
@@ -149,7 +149,7 @@ func TestAllocateNextWithExpiration(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	fakeMetadata := fakeMetadataFunc(func(owner string, family Family) (pool string, err error) { return "some-pool", nil })
-	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil)
+	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil, nil)
 	ipam.ConfigureAllocator()
 
 	// Allocate IPs and test expiration timer. 'pool' is empty in order to test

--- a/pkg/ipam/cell/cell.go
+++ b/pkg/ipam/cell/cell.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamapi "github.com/cilium/cilium/pkg/ipam/api"
 	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
+	"github.com/cilium/cilium/pkg/ipmasq"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/mtu"
@@ -53,10 +54,11 @@ type ipamParams struct {
 	NodeDiscovery       *nodediscovery.NodeDiscovery
 	Sysctl              sysctl.Sysctl
 	EndpointManager     endpointmanager.EndpointManager
+	IPMasqAgent         *ipmasq.IPMasqAgent
 }
 
 func newIPAddressManager(params ipamParams) *ipam.IPAM {
-	ipam := ipam.NewIPAM(params.Logger, params.NodeAddressing, params.AgentConfig, params.NodeDiscovery, params.LocalNodeStore, params.K8sEventReporter, params.NodeResource, params.MTU, params.Clientset, params.IPAMMetadataManager, params.Sysctl)
+	ipam := ipam.NewIPAM(params.Logger, params.NodeAddressing, params.AgentConfig, params.NodeDiscovery, params.LocalNodeStore, params.K8sEventReporter, params.NodeResource, params.MTU, params.Clientset, params.IPAMMetadataManager, params.Sysctl, params.IPMasqAgent)
 
 	params.EndpointManager.Subscribe(ipam)
 

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -122,7 +122,7 @@ func (f fakePoolAllocator) RestoreFinished() {}
 func TestLock(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil)
+	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil, nil)
 	ipam.ConfigureAllocator()
 
 	// Since the IPs we have allocated to the endpoints might or might not
@@ -146,7 +146,7 @@ func TestLock(t *testing.T) {
 func TestExcludeIP(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil)
+	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil, nil)
 	ipam.ConfigureAllocator()
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
@@ -194,7 +194,7 @@ func TestIPAMMetadata(t *testing.T) {
 		}
 	})
 
-	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil)
+	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil, nil)
 	ipam.ConfigureAllocator()
 	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
 		"default": "10.10.0.0/16",
@@ -253,7 +253,7 @@ func TestLegacyAllocatorIPAMMetadata(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	fakeMetadata := fakeMetadataFunc(func(owner string, family Family) (pool string, err error) { return "some-pool", nil })
-	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil)
+	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil, nil)
 	ipam.ConfigureAllocator()
 
 	// AllocateIP requires explicit pool

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -122,6 +123,7 @@ type IPAM struct {
 	clientset      client.Clientset
 	nodeDiscovery  Owner
 	sysctl         sysctl.Sysctl
+	ipMasqAgent    *ipmasq.IPMasqAgent
 }
 
 func (ipam *IPAM) EndpointCreated(ep *endpoint.Endpoint) {}

--- a/pkg/ipmasq/ipmasq.go
+++ b/pkg/ipmasq/ipmasq.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
@@ -256,6 +257,10 @@ func (a *IPMasqAgent) readConfig() (bool, error) {
 	a.masqLinkLocalIPv6 = cfg.MasqLinkLocalIPv6
 
 	return false, nil
+}
+
+func (a *IPMasqAgent) NonMasqCIDRsFromConfig() []netip.Prefix {
+	return slices.Collect(maps.Values(a.nonMasqCIDRsFromConfig))
 }
 
 // restore dumps the ipmasq BPF map and populates IPMasqAgent.nonMasqCIDRsInMap


### PR DESCRIPTION
# Description
See detailed description of the issue in https://github.com/cilium/cilium/issues/35501

This PR ensures that when BPF Masquerading is enabled together with the BPF `ip-masq-agent`, the Cilium Agent managed datapath `ip rule`s are actually consistent with the `ip-masq-agent` configuration. The idea is that all `nonMasqueradeCIDRs` from `ip-masq-agent` configuration actually need to be propagated down to the datapath to ensure that these CIDRs are not masqueraded. 

As mentioned in the issue, the actual datapath `ip rule` setup is here: https://github.com/cilium/cilium/blob/e3a93b184040afe69f394e08bbbc8e69a5feb671/pkg/datapath/linux/routing/routing.go#L88-L103
The `To` CIDRs are coming from the response to the CNI IP Allocation request. The response is populated here:
https://github.com/cilium/cilium/blob/cad67ba4299a9c8f70e5edef7658747685cd7e41/pkg/ipam/crd.go#L686-L691

The newly added logic in my PR simply reads the `ip-masq-agent` config file and returns the non-masqueradable CIDRs in the CNI IP allocation response. 

It's somewhat of a hotpath so I made sure that it fails gracefully if something goes wrong. ~It also makes the best effort to read the CIDRs from memory and not from disk. I also moved the `fsnotify` Watcher instantiation to the `Start()` function to avoid its overhead in the codepath. Finally, in order to avoid race conditions with the `ip-masq-agent` startup and the IP allocation requests (the IPAM Allocator is started before the `ip-masq-agent`), this code doesn't rely on the `ip-masq-agent` being in running state.~ -> This part of the description is obsolete since I ended up doing a refactoring of the `ip-masq-agent` in https://github.com/cilium/cilium/pull/40347 to extract it into a separate Cell.

One small limitation is that the `ip rule`s will not be updated dynamically if the `ip-masq-agent` configuration changes. The new CIDRs will apply to all newly started pods however existing pods will need to be restarted in order for the new CIDRs to be applied. IMO it's not a big deal since the situation is already much better than what we had previously.

# Testing
## Before the PR
Taking the same AWS setup as described in my original issue, when we enable masquerading for a given pod, its `ip rule`s look something like this:
```
$ ip rule | grep 10.130.100.133
111:	from 10.130.100.133 to 10.128.0.0/13 lookup 11
111:	from 10.130.100.133 to 100.112.0.0/13 lookup 11
``` 
The `to` CIDRs are only coming from the VPC CIDRs auto-detected by the Operator. If we enable the `ip-masq-agent`, the rules stay the same.

## After the PR
Once we deploy the PR and then enable `ip-masq-agent` with the following config:
```yaml
  config.yaml: |
    nonMasqueradeCIDRs:
    - 10.0.0.0/8
    - 172.16.0.0/12
    - 100.64.0.0/10
    - 192.168.0.0/16
    masqLinkLocal: false
```
The CIDRs are now properly propagated down to the `ip rule` level:
```
$ ip rule | grep 10.112.49.248
111:	from 10.112.49.248 to 10.0.0.0/8 lookup 11
111:	from 10.112.49.248 to 100.64.0.0/10 lookup 11
111:	from 10.112.49.248 to 169.254.0.0/16 lookup 11
111:	from 10.112.49.248 to 172.16.0.0/12 lookup 11
111:	from 10.112.49.248 to 192.168.0.0/16 lookup 11
```

We can also confirm that cross-VPC traffic is no longer dropped.

Fixes: https://github.com/cilium/cilium/issues/35501

```release-note
ip-masq-agent: Ensure ip rules on the host match the BPF ip-masq-agent configuration in AWS ENI mode. Note that rules are set up once at pod creation and will not be regenerated if the ip-masq-agent configuration changes.
```
