### PR TITLE
Revert "fix: Adding ipv6 check on the node init function"

### DIFF
--- a/daemon/k8s/init.go
+++ b/daemon/k8s/init.go
@@ -136,17 +136,6 @@ func WaitForNodeInformation(ctx context.Context, log *slog.Logger, localNode Loc
 			logfields.K8sNodeIP, k8sNodeIP,
 		)
 
-		// If the host does not have an IPv6 address, return an error
-		if option.Config.EnableIPv6 && nodeIP6 == nil {
-			log.Error(
-				"No IPv6 support on node as ipv6 address is nil",
-				logfields.NodeName, n.Name,
-				logfields.IPv4, nodeIP4,
-				logfields.IPv6, nodeIP6,
-			)
-			return fmt.Errorf("node %s does not have an IPv6 address", n.Name)
-		}
-
 		useNodeCIDR(n)
 	} else {
 		// if node resource could not be received, fail if

--- a/daemon/k8s/init.go
+++ b/daemon/k8s/init.go
@@ -136,6 +136,11 @@ func WaitForNodeInformation(ctx context.Context, log *slog.Logger, localNode Loc
 			logfields.K8sNodeIP, k8sNodeIP,
 		)
 
+		if option.Config.EnableIPv6 && nodeIP6 == nil {
+			log.Warn("IPv6 is enabled, but Cilium cannot find the IPv6 address for this node. " +
+				"This may cause connectivity disruption for Endpoints that attempt to communicate using IPv6")
+		}
+
 		useNodeCIDR(n)
 	} else {
 		// if node resource could not be received, fail if


### PR DESCRIPTION
This reverts commit 2fc52eb444635c83843c45735766db0e338b581c.

The commit was added with the intent to have an uniform behavior when Cilium is started on a single stack cluster with ipv6 support enabled, despite the KPR setting being enabled or disabled. Specifically, the added check was stopping the agent startup in case of a missing IPv6 address on the node, even when KPR was disabled.

However, the IPv6 detection for NodePort, responsible for the startup error in case of missing IPv6 address with KPR enabled, has been removed in https://github.com/cilium/cilium/pull/29033. Therefore, there is no reason anymore to stop the agent at startup when the IPv6 support is enabled and the node is missing an IPv6 address.  Moreover, the commit above led to some unintended consequences in environments where KPR is disabled and the IPv6 address is set on the node after the Cilium agent is started (see https://github.com/cilium/cilium/issues/34861).

The same unintended consequence became more frequent after https://github.com/cilium/cilium/pull/32381, where we moved later in the daemon startup process the first call to SetDefaultPrefix. That function, among other things, was in charge of setting up a temporary IPv6 Unique Local Address in case the node does not have one yet. Since now the agent does this later (specifically, while configuring IPAM), the check introduced in 2fc52eb444 sees the IPv6 node address as nil and stops the agent.

Therefore, revert the check to avoid the unintended regressions.

Related: https://github.com/cilium/cilium/pull/28953
Related: https://github.com/cilium/cilium/issues/34861
Related: https://github.com/cilium/cilium/pull/29033
Related: https://github.com/cilium/cilium/pull/32381
Fixes: https://github.com/cilium/cilium/issues/37817

```release-note
Do not fail the agent startup in case IPv6 support is enabled and the node does not have an IPv6 address assigned yet
```
