### PR TITLE
bgp,script: Identify gobgp server with name

### DIFF
--- a/pkg/bgpv1/test/testdata/peering-auth.txtar
+++ b/pkg/bgpv1/test/testdata/peering-auth.txtar
@@ -6,7 +6,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server --router-id=1.2.3.4 65001 fd00::aa:bb:cc:101 1790
+gobgp/add-server test --router-id=1.2.3.4 65001 fd00::aa:bb:cc:101 1790
 gobgp/add-peer --password=Cilium123 fd00::aa:bb:cc:102 65001
 
 # Configure BGP on Cilium

--- a/pkg/bgpv1/test/testdata/peering-changes.txtar
+++ b/pkg/bgpv1/test/testdata/peering-changes.txtar
@@ -9,7 +9,7 @@ hive start
 k8s/add service-lb.yaml
 
 # Configure GoBGP server
-gobgp/add-server 65010 10.99.0.121 1790
+gobgp/add-server test 65010 10.99.0.121 1790
 gobgp/add-peer 10.99.0.130 65001
 
 # Configure BGP on Cilium
@@ -28,8 +28,8 @@ gobgp/routes -o routes.actual
 * cmp gobgp-routes.expected routes.actual
 
 # Re-configure GoBGP server with the new IP
-gobgp/delete-server 65010
-gobgp/add-server 65010 10.99.0.122 1790
+gobgp/delete-server test
+gobgp/add-server test 65010 10.99.0.122 1790
 gobgp/add-peer 10.99.0.130 65001
 
 # Update peer IP

--- a/pkg/bgpv1/test/testdata/peering-ipv6.txtar
+++ b/pkg/bgpv1/test/testdata/peering-ipv6.txtar
@@ -6,7 +6,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server --router-id=1.2.3.4 65001 fd00::aa:bb:cc:111 1790
+gobgp/add-server test --router-id=1.2.3.4 65001 fd00::aa:bb:cc:111 1790
 gobgp/add-peer fd00::aa:bb:cc:112 65001
 
 # Configure BGP on Cilium

--- a/pkg/bgpv1/test/testdata/peering-multi-instance.txtar
+++ b/pkg/bgpv1/test/testdata/peering-multi-instance.txtar
@@ -6,68 +6,68 @@
 hive start
 
 # Configure gobgp servers
-gobgp/add-server 65010 10.99.0.101 1790
-gobgp/add-server 65011 10.99.0.102 1790
-gobgp/add-server 65012 10.99.0.103 1790
+gobgp/add-server test0 65010 10.99.0.101 1790
+gobgp/add-server test1 65011 10.99.0.102 1790
+gobgp/add-server test2 65012 10.99.0.103 1790
 
 # Configure peers on GoBGP
-gobgp/add-peer --server-asn=65010 10.99.0.110 65001
-gobgp/add-peer --server-asn=65011 10.99.0.110 65001
-gobgp/add-peer --server-asn=65012 10.99.0.110 65002
+gobgp/add-peer -s test0 10.99.0.110 65001
+gobgp/add-peer -s test1 10.99.0.110 65001
+gobgp/add-peer -s test2 10.99.0.110 65002
 
 # Configure BGP on Cilium - only first peer
 k8s/add cilium-node.yaml bgp-peer-config.yaml bgp-advertisement.yaml
 k8s/add bgp-node-config-1.yaml
 
 # Wait for first peering to be established
-gobgp/wait-state --server-asn=65010 10.99.0.110 ESTABLISHED
+gobgp/wait-state -s test0 10.99.0.110 ESTABLISHED
 
 # Validate peering state (server 65010)
-gobgp/peers --server-asn=65010 -o peers.actual
+gobgp/peers -s test0 -o peers.actual
 * cmp gobgp-peers-65001.expected peers.actual
 
 # Validate PodCIDR routes (server 65010)
-gobgp/routes --server-asn=65010 -o routes.actual
+gobgp/routes -s test0 -o routes.actual
 * cmp gobgp-routes-podcidr-65001.expected routes.actual
 
 # Configure BGP on Cilium - add second and third peer
 k8s/update bgp-node-config-2.yaml
 
 # Wait for second peering to be established
-gobgp/wait-state --server-asn=65011 10.99.0.110 ESTABLISHED
+gobgp/wait-state -s test1 10.99.0.110 ESTABLISHED
 
 # Wait for third peering to be established
-gobgp/wait-state --server-asn=65012 10.99.0.110 ESTABLISHED
+gobgp/wait-state -s test2 10.99.0.110 ESTABLISHED
 
 # Validate peering state (server 65011)
-gobgp/peers --server-asn=65011 -o peers.actual
+gobgp/peers -s test1 -o peers.actual
 * cmp gobgp-peers-65001.expected peers.actual
 
 # Validate PodCIDR routes (server 65011)
-gobgp/routes --server-asn=65011 -o routes.actual
+gobgp/routes -s test1 -o routes.actual
 * cmp gobgp-routes-podcidr-65001.expected routes.actual
 
 # Validate peering state (server 65012)
-gobgp/peers --server-asn=65012 -o peers.actual
+gobgp/peers -s test2 -o peers.actual
 * cmp gobgp-peers-65002.expected peers.actual
 
 # Validate PodCIDR routes (server 65012)
-gobgp/routes --server-asn=65012 -o routes.actual
+gobgp/routes -s test2 -o routes.actual
 * cmp gobgp-routes-podcidr-65002.expected routes.actual
 
 # Add a k8s service
 k8s/add service.yaml
 
 # Validate PodCIDR + Service routes (server 65010)
-gobgp/routes --server-asn=65010 -o routes.actual
+gobgp/routes -s test0 -o routes.actual
 * cmp gobgp-routes-all-65001.expected routes.actual
 
 # Validate PodCIDR + Service routes (server 65011)
-gobgp/routes --server-asn=65011 -o routes.actual
+gobgp/routes -s test1 -o routes.actual
 * cmp gobgp-routes-all-65001.expected routes.actual
 
 # Validate PodCIDR + Service routes (server 65012)
-gobgp/routes --server-asn=65012 -o routes.actual
+gobgp/routes -s test2 -o routes.actual
 * cmp gobgp-routes-all-65002.expected routes.actual
 
 # Validate peers on Cilium
@@ -86,11 +86,11 @@ bgp/route-policies -o policies.actual
 k8s/update bgp-node-config-1.yaml
 
 # Validate peering state (server 65010)
-gobgp/peers --server-asn=65010 -o peers.actual
+gobgp/peers -s test0 -o peers.actual
 * cmp gobgp-peers-65001.expected peers.actual
 
 # Validate PodCIDR + Service routes (server 65010)
-gobgp/routes --server-asn=65010 -o routes.actual
+gobgp/routes -s test0 -o routes.actual
 * cmp gobgp-routes-all-65001.expected routes.actual
 
 #####

--- a/pkg/bgpv1/test/testdata/pod-cidr.txtar
+++ b/pkg/bgpv1/test/testdata/pod-cidr.txtar
@@ -6,7 +6,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server --router-id=1.2.3.4 65001 fd00::aa:bb:dd:101 1790
+gobgp/add-server test --router-id=1.2.3.4 65001 fd00::aa:bb:dd:101 1790
 gobgp/add-peer fd00::aa:bb:dd:102 65001
 
 # Configure BGP on Cilium

--- a/pkg/bgpv1/test/testdata/pod-ip-pool.txtar
+++ b/pkg/bgpv1/test/testdata/pod-ip-pool.txtar
@@ -6,7 +6,7 @@
 hive start
 
 # Configure GoBGP server
-gobgp/add-server 65010 10.99.2.1 1790
+gobgp/add-server test 65010 10.99.2.1 1790
 gobgp/add-peer 10.99.2.2 65001
 
 # Configure BGP on Cilium

--- a/pkg/bgpv1/test/testdata/svc-adverts.txtar
+++ b/pkg/bgpv1/test/testdata/svc-adverts.txtar
@@ -7,12 +7,12 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server --router-id=1.2.3.4 65010 fd00::bb:cc:dd:1 1790
-gobgp/add-server --router-id=5.6.7.8 65011 fd00::bb:cc:dd:2 1790
+gobgp/add-server test0 --router-id=1.2.3.4 65010 fd00::bb:cc:dd:1 1790
+gobgp/add-server test1 --router-id=5.6.7.8 65011 fd00::bb:cc:dd:2 1790
 
 # Configure peers on GoBGP
-gobgp/add-peer --server-asn=65010 fd00::bb:cc:dd:10 65001
-gobgp/add-peer --server-asn=65011 fd00::bb:cc:dd:10 65001
+gobgp/add-peer -s test0 fd00::bb:cc:dd:10 65001
+gobgp/add-peer -s test1 fd00::bb:cc:dd:10 65001
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml
@@ -20,27 +20,27 @@ k8s/add bgp-peer-config-1.yaml bgp-advertisement-1.yaml
 k8s/add bgp-peer-config-2.yaml bgp-advertisement-2.yaml
 
 # Wait for peerings to be established
-gobgp/wait-state --server-asn=65010 fd00::bb:cc:dd:10 ESTABLISHED
-gobgp/wait-state --server-asn=65011 fd00::bb:cc:dd:10 ESTABLISHED
+gobgp/wait-state -s test0 fd00::bb:cc:dd:10 ESTABLISHED
+gobgp/wait-state -s test1 fd00::bb:cc:dd:10 ESTABLISHED
 
 
 # Add a LoadBalancer service
 k8s/add service-lb.yaml
 
 # Validate the IPv4 LoadBalancer service route (65010)
-gobgp/routes --server-asn=65010 -o routes.actual ipv4 unicast
+gobgp/routes -s test0 -o routes.actual ipv4 unicast
 * cmp gobgp-routes-svc1-lb-ipv4.expected routes.actual
 
 # Validate the IPv6 LoadBalancer service route (65010)
-gobgp/routes --server-asn=65010 -o routes.actual ipv6 unicast
+gobgp/routes -s test0 -o routes.actual ipv6 unicast
 * cmp gobgp-routes-svc1-lb-ipv6.expected routes.actual
 
 # Validate the IPv4 ClusterIP + LoadBalancer service route (65011)
-gobgp/routes --server-asn=65011 -o routes.actual ipv4 unicast
+gobgp/routes -s test1 -o routes.actual ipv4 unicast
 * cmp gobgp-routes-svc1-cluster-lb-ipv4.expected routes.actual
 
 # Validate the IPv6 ClusterIP + LoadBalancer service route (65011)
-gobgp/routes --server-asn=65011 -o routes.actual ipv6 unicast
+gobgp/routes -s test1 -o routes.actual ipv6 unicast
 * cmp gobgp-routes-svc1-cluster-lb-ipv6.expected routes.actual
 
 
@@ -48,19 +48,19 @@ gobgp/routes --server-asn=65011 -o routes.actual ipv6 unicast
 k8s/add service-cluster-external.yaml
 
 # Validate the IPv4 LoadBalancer service route (65010)
-gobgp/routes --server-asn=65010 -o routes.actual ipv4 unicast
+gobgp/routes -s test0 -o routes.actual ipv4 unicast
 * cmp gobgp-routes-svc1-lb-ipv4.expected routes.actual
 
 # Validate the IPv6 LoadBalancer service route (65010)
-gobgp/routes --server-asn=65010 -o routes.actual ipv6 unicast
+gobgp/routes -s test0 -o routes.actual ipv6 unicast
 * cmp gobgp-routes-svc1-lb-ipv6.expected routes.actual
 
 # Validate all IPv4 ClusterIP + ExternalIP service routes (65011)
-gobgp/routes --server-asn=65011 -o routes.actual ipv4 unicast
+gobgp/routes -s test1 -o routes.actual ipv4 unicast
 * cmp gobgp-routes-all-ipv4.expected routes.actual
 
 # Validate all IPv6 ClusterIP + ExternalIP service routes (65011)
-gobgp/routes --server-asn=65011 -o routes.actual ipv6 unicast
+gobgp/routes -s test1 -o routes.actual ipv6 unicast
 * cmp gobgp-routes-all-ipv6.expected routes.actual
 
 
@@ -68,19 +68,19 @@ gobgp/routes --server-asn=65011 -o routes.actual ipv6 unicast
 k8s/delete service-lb.yaml
 
 # Validate empty LoadBalancerIP service routes (65010)
-gobgp/routes --server-asn=65010 -o routes.actual ipv4 unicast
+gobgp/routes -s test0 -o routes.actual ipv4 unicast
 * cmp gobgp-routes-empty.expected routes.actual
 
 # Validate empty LoadBalancerIP service routes (65010)
-gobgp/routes --server-asn=65010 -o routes.actual ipv6 unicast
+gobgp/routes -s test0 -o routes.actual ipv6 unicast
 * cmp gobgp-routes-empty.expected routes.actual
 
 # Validate IPv4 svc2 ClusterIP + ExternalIP service routes (65011)
-gobgp/routes --server-asn=65011 -o routes.actual ipv4 unicast
+gobgp/routes -s test1 -o routes.actual ipv4 unicast
 * cmp gobgp-routes-svc2-cluster-external-ipv4.expected routes.actual
 
 # Validate IPv6 svc2 ClusterIP + ExternalIP service routes (65011)
-gobgp/routes --server-asn=65011 -o routes.actual ipv6 unicast
+gobgp/routes -s test1 -o routes.actual ipv6 unicast
 * cmp gobgp-routes-svc2-cluster-external-ipv6.expected routes.actual
 
 
@@ -88,11 +88,11 @@ gobgp/routes --server-asn=65011 -o routes.actual ipv6 unicast
 k8s/update service-cluster-external-updated.yaml
 
 # Validate updated IPv4 svc2 ClusterIP + ExternalIP service routes (65011)
-gobgp/routes --server-asn=65011 -o routes.actual ipv4 unicast
+gobgp/routes -s test1 -o routes.actual ipv4 unicast
 * cmp gobgp-routes-svc2-cluster-external-updated-ipv4.expected routes.actual
 
 # Validate updated IPv6 svc2 ClusterIP + ExternalIP service routes (65011)
-gobgp/routes --server-asn=65011 -o routes.actual ipv6 unicast
+gobgp/routes -s test1 -o routes.actual ipv6 unicast
 * cmp gobgp-routes-svc2-cluster-external-updated-ipv6.expected routes.actual
 
 

--- a/pkg/bgpv1/test/testdata/svc-aggregation.txtar
+++ b/pkg/bgpv1/test/testdata/svc-aggregation.txtar
@@ -7,7 +7,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server 65010 10.99.4.211 1790
+gobgp/add-server test 65010 10.99.4.211 1790
 
 # Configure peers on GoBGP
 gobgp/add-peer 10.99.4.212 65001

--- a/pkg/bgpv1/test/testdata/svc-path-attributes.txtar
+++ b/pkg/bgpv1/test/testdata/svc-path-attributes.txtar
@@ -8,7 +8,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server --router-id=1.2.3.4 65001 fd00::bb:cc:dd:101 1790
+gobgp/add-server test --router-id=1.2.3.4 65001 fd00::bb:cc:dd:101 1790
 gobgp/add-peer fd00::bb:cc:dd:102 65001
 
 # Configure BGP on Cilium

--- a/pkg/bgpv1/test/testdata/svc-sharing.txtar
+++ b/pkg/bgpv1/test/testdata/svc-sharing.txtar
@@ -7,7 +7,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server 65010 10.99.4.201 1790
+gobgp/add-server test 65010 10.99.4.201 1790
 
 # Configure peers on GoBGP
 gobgp/add-peer 10.99.4.202 65001

--- a/pkg/bgpv1/test/testdata/svc-traffic-policy.txtar
+++ b/pkg/bgpv1/test/testdata/svc-traffic-policy.txtar
@@ -7,7 +7,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server 65010 10.99.4.101 1790
+gobgp/add-server test 65010 10.99.4.101 1790
 
 # Configure peers on GoBGP
 gobgp/add-peer 10.99.4.102 65001


### PR DESCRIPTION
Currently, gobgp/* commands identify gobgp server with ASN. This makes impossible to spin-up multiple servers with same ASN in the script test. We can instead identify them by name. Modify -s option semantics and fixed the existing test cases.

```release-note
bgp,script: Identify gobgp server with name
```
