### PR TITLE
fix: kube-proxy-healthz to return 503 if node terminating

### DIFF
--- a/daemon/healthz/kube_proxy_healthz_test.go
+++ b/daemon/healthz/kube_proxy_healthz_test.go
@@ -4,98 +4,160 @@
 package healthz
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/node"
 )
 
-type KubeProxyHealthzTestSuite struct{}
-
-// Injected fake service.
-type fakeLastUpdatedAter struct {
-	injectedLastUpdatedTs time.Time
+// Mock implementations of dependencies
+type mockStatusCollector struct {
+	statusResponse models.StatusResponse
 }
 
-func (s *fakeLastUpdatedAter) GetLastUpdatedAt() time.Time {
-	return s.injectedLastUpdatedTs
+func (m *mockStatusCollector) GetStatus(bool, bool) models.StatusResponse {
+	return m.statusResponse
 }
 
-// Injected fake status collector
-type FakeStatusCollector struct {
-	injectedStatusResponse models.StatusResponse
+type mockServiceInterface struct {
+	lastUpdatedTs time.Time
 }
 
-func (d *FakeStatusCollector) GetStatus(brief bool, requireK8sConnectivity bool) models.StatusResponse {
-	return d.injectedStatusResponse
+func (m *mockServiceInterface) GetLastUpdatedAt() time.Time {
+	return m.lastUpdatedTs
 }
 
-type healthzPayload struct {
-	LastUpdated string
-	CurrentTime string
+type mockLocalNodeStore struct {
+	node        *node.LocalNode
+	returnError bool
 }
 
-func TestKubeProxyHealth(t *testing.T) {
-	s := KubeProxyHealthzTestSuite{}
-	s.healthTestHelper(t, models.StatusStateOk, http.StatusOK, true)
-	s.healthTestHelper(t, models.StatusStateWarning,
-		http.StatusServiceUnavailable, false)
-	s.healthTestHelper(t, models.StatusStateFailure,
-		http.StatusServiceUnavailable, false)
-}
-
-func (s *KubeProxyHealthzTestSuite) healthTestHelper(t *testing.T, ciliumStatus string,
-	expectedHttpStatus int, testcasepositive bool,
-) {
-	var lastUpdateTs, currentTs, expectedTs time.Time
-	lastUpdateTs = time.Unix(100, 0) // Fake 100 seconds after Unix.
-	currentTs = time.Unix(200, 0)    // Fake 200 seconds after Unix.
-	prevTime := time.Now
-	time.Now = func() time.Time {
-		return currentTs
+func (m *mockLocalNodeStore) Get(ctx context.Context) (node.LocalNode, error) {
+	if m.returnError {
+		return node.LocalNode{}, assert.AnError
 	}
-	t.Cleanup(func() {
-		time.Now = prevTime
-	})
+	return *m.node, nil
+}
 
-	expectedTs = lastUpdateTs
-	if testcasepositive {
-		expectedTs = currentTs
-	}
-	// Create handler with injected behavior.
-	h := kubeproxyHealthzHandler{
-		statusCollector: &FakeStatusCollector{injectedStatusResponse: models.StatusResponse{
-			Cilium: &models.Status{State: ciliumStatus},
-		}},
-		lastUpdateAter: &fakeLastUpdatedAter{
-			injectedLastUpdatedTs: lastUpdateTs,
+func TestKubeproxyHealthzHandler(t *testing.T) {
+	currentTs := time.Now()
+	lastUpdatedTs := currentTs.Add(-2 * time.Minute)
+
+	testCases := []struct {
+		name                string
+		status              string
+		nodeIsBeingDeleted  bool
+		nodeStoreReturnErr  bool
+		expectedStatusCode  int
+		expectedLastUpdated time.Time
+	}{
+		{
+			name:                "healthy node",
+			status:              models.StatusStateOk,
+			nodeIsBeingDeleted:  false,
+			nodeStoreReturnErr:  false,
+			expectedStatusCode:  http.StatusOK,
+			expectedLastUpdated: currentTs,
+		},
+		{
+			name:                "node being deleted",
+			status:              models.StatusStateOk,
+			nodeIsBeingDeleted:  true,
+			nodeStoreReturnErr:  false,
+			expectedStatusCode:  http.StatusServiceUnavailable,
+			expectedLastUpdated: lastUpdatedTs,
+		},
+		{
+			name:                "unhealthy warning status",
+			status:              models.StatusStateWarning,
+			nodeIsBeingDeleted:  false,
+			nodeStoreReturnErr:  false,
+			expectedStatusCode:  http.StatusServiceUnavailable,
+			expectedLastUpdated: lastUpdatedTs,
+		},
+		{
+			name:                "unhealthy failure status",
+			status:              models.StatusStateFailure,
+			nodeIsBeingDeleted:  false,
+			nodeStoreReturnErr:  false,
+			expectedStatusCode:  http.StatusServiceUnavailable,
+			expectedLastUpdated: lastUpdatedTs,
+		},
+		{
+			name:                "unhealthy status and node being deleted",
+			status:              models.StatusStateWarning,
+			nodeIsBeingDeleted:  true,
+			nodeStoreReturnErr:  false,
+			expectedStatusCode:  http.StatusServiceUnavailable,
+			expectedLastUpdated: lastUpdatedTs,
 		},
 	}
 
-	// Create a new request.
-	req, err := http.NewRequest(http.MethodGet, "/healthz", nil)
-	require.NoError(t, err)
-	w := httptest.NewRecorder()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set up mocks
+			mockStatus := &mockStatusCollector{}
+			mockStatus.statusResponse = models.StatusResponse{
+				Cilium: &models.Status{
+					State: tc.status,
+				},
+			}
 
-	// Serve.
-	h.ServeHTTP(w, req)
+			mockSvc := &mockServiceInterface{
+				lastUpdatedTs: lastUpdatedTs,
+			}
 
-	// Main return code meets expectations.
-	require.Equalf(t, expectedHttpStatus, w.Code, "expected status code %v, got %v", expectedHttpStatus, w.Code)
+			mockNode := &mockLocalNodeStore{
+				node: &node.LocalNode{
+					IsBeingDeleted: tc.nodeIsBeingDeleted,
+				},
+				returnError: tc.nodeStoreReturnErr,
+			}
 
-	// Timestamps meet expectations.
-	var payload healthzPayload
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &payload))
-	layout := "2006-01-02 15:04:05 -0700 MST"
-	lastUpdateTs, err = time.Parse(layout, payload.LastUpdated)
-	require.NoError(t, err)
+			handler := kubeproxyHealthzHandler{
+				statusCollector: mockStatus,
+				localNode:       mockNode,
+				lastUpdateAter:  mockSvc,
+			}
 
-	_, err = time.Parse(layout, payload.CurrentTime)
-	require.NoError(t, err)
-	require.True(t, lastUpdateTs.Equal(expectedTs))
+			// Create request and recorder
+			req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+			recorder := httptest.NewRecorder()
+
+			// Call handler
+			handler.ServeHTTP(recorder, req)
+
+			// Check response
+			resp := recorder.Result()
+			defer resp.Body.Close()
+
+			assert.Equal(t, tc.expectedStatusCode, resp.StatusCode, tc.name+" testcase failed with unexpected status code")
+
+			// Parse response body
+			var respBody struct {
+				LastUpdated string `json:"lastUpdated"`
+				CurrentTime string `json:"currentTime"`
+			}
+			err := json.NewDecoder(resp.Body).Decode(&respBody)
+			require.NoError(t, err)
+
+			// For the time comparison, we just need to check if the timestamps match
+			// in terms of which reference time they match (current vs lastUpdated)
+			if tc.expectedStatusCode == http.StatusOK {
+				// In OK state, lastUpdated should NOT contain lastUpdatedTs
+				assert.NotContains(t, respBody.LastUpdated, lastUpdatedTs.Format("15:04:05"), tc.name+" testcase failed with unexpected lastUpdated value")
+			} else {
+				// In error states, lastUpdated should contain lastUpdatedTs
+				assert.Contains(t, respBody.LastUpdated, lastUpdatedTs.Format("15:04:05"), tc.name+" testcase failed with unexpected lastUpdated value")
+			}
+		})
+	}
 }

--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -41,6 +41,8 @@ type LocalNode struct {
 	// ServiceLoopbackIPv4 is the source address used for SNAT when a Pod talks to
 	// itself through a Service.
 	ServiceLoopbackIPv4 net.IP
+	// IsBeingDeleted indicates that the local node is being deleted.
+	IsBeingDeleted bool
 }
 
 // LocalNodeSynchronizer specifies how to build, and keep synchronized the local

--- a/pkg/node/zz_generated.deepequal.go
+++ b/pkg/node/zz_generated.deepequal.go
@@ -61,5 +61,9 @@ func (in *LocalNode) DeepEqual(other *LocalNode) bool {
 		}
 	}
 
+	if in.IsBeingDeleted != other.IsBeingDeleted {
+		return false
+	}
+
 	return true
 }


### PR DESCRIPTION
This PR addresses this [KEP]( https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3836-kube-proxy-improved-ingress-connectivity-reliability#implementation-history). kube-proxy healthz handler will return 503 if node is being deleted. Leveraged existing local node watcher to watch for deletion events and added `IsBeingDeleted` field in LocalNode structure. `IsBeingDeleted` field will be set to true on node deletion. Kube-proxy health handler will get local node details via get call and if `IsBeingDeleted` set, it returns 503 (ServiceUnavailable) error.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #39911

```release-note
Fix kube-proxy healthz to return 503 if node in terminating state  
```
