### PR TITLE
docs: clarify CONFIG_FIB_RULES dependencies for custom kernels

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -194,6 +194,23 @@ The following kernel configuration options are required for proper operation:
         CONFIG_GENEVE=y
         CONFIG_FIB_RULES=y
 
+
+.. note::
+
+   On some embedded or custom Linux systems, especially when cross-compiling for
+   ARM, enabling ``CONFIG_FIB_RULES=y`` directly in the kernel ``.config`` is not sufficient,
+   as it depends on other routing-related kernel options to be enabled.
+
+   The recommended approach is to use:
+
+   ::
+
+       scripts/config --enable CONFIG_FIB_RULES
+       make olddefconfig
+
+   The kernel build system uses ``Kconfig`` logic to validate and manage dependencies, 
+   so direct edits to ``.config`` may be ignored or silently overridden.
+
 Requirements for L7 and FQDN Policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

---

### Description of change

This PR clarifies that `CONFIG_FIB_RULES` may not appear in the final kernel config on ARM embedded systems with custom Linux OS unless specific routing kernel modules are also enabled.

This documentation addition helps others avoid issues where Cilium fails due to missing policy routing functionality, even when `CONFIG_FIB_RULES=y` is set manually.

---

```release-note
docs: clarify kernel config dependencies for CONFIG_FIB_RULES on embedded/custom Linux
