### PR TITLE
Revert "gha: prevent circular dependency in clustermesh-upgrade workflow"

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -650,16 +650,11 @@ jobs:
 
       # Perform an additional "stress" test, scaling the clustermesh-apiservers in both clusters
       # to zero replicas, and restarting all agents. Existing connections should not be disrupted.
-      # One exception to this is represented by Cilium being in charge of handling NodePort
-      # traffic, as the simultaneous restart of the clustermesh-apiserver pods in both clusters
-      # after rolling out all agents can lead to a circular dependency (#30156).
       - name: Scale the clustermesh-apiserver replicas to 0
         if: ${{ !matrix.external-kvstore }}
         run: |
           kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
-          if [ "${{ matrix.kube-proxy }}" != "none" ]; then
-            kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
-          fi
+          kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
 
       - name: Rollout Cilium agents in both clusters
         run: |


### PR DESCRIPTION
This reverts commit 00ed827d9c6f7962df34f3a500468a1b42c7f2f4.

This workaround is no longer necessary since \[1], given that we now insert the PodCIDR associated with any node into the ipcache as a fallback. Hence, even if the exact ipcache entry is not found since the host endpoint has not been regenerated yet, routing can still happen thanks to the fallback entry. Previously, the tunnel map did not help in this case, as it was not considered by this code path.

\[1]: 463fd2da462d ("node/manager: Store node allocation CIDRs into ipcache")
