### PR TITLE
workflow: add ariane scheduled list

### DIFF
--- a/.github/ariane-scheduled.yaml
+++ b/.github/ariane-scheduled.yaml
@@ -1,0 +1,4 @@
+tests:
+- conformance-aks.yaml
+- conformance-gateway-api.yaml
+- conformance-gke.yaml

--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -51,7 +51,10 @@ jobs:
 
           REF="v${{ matrix.branch }}"
           SHA=$(git rev-parse ${REF})
-          readarray workflows < <(yq '.triggers["/test"].workflows[]' .github/ariane-config.yaml)
+          readarray workflows < <((
+            yq '.triggers["/test"].workflows[]' .github/ariane-config.yaml
+            yq '.tests[]' .github/ariane-scheduled.yaml
+          ) | sort -u)
 
           for workflow in "${workflows[@]}"; do
             echo triggering ${workflow}


### PR DESCRIPTION
Not-required tests were removed by #34726 from ariane `/tests`, inadvertently excluding them from scheduled runs on our stable branches. This PR introduces ariane-scheduled.yaml, a new test list for additional tests that run on a schedule across all stable branches.

This test [run](https://github.com/cilium/cilium/actions/runs/15828475561) shows both files are merged as a list; for testing purposes, running the workflows is disabled.

