### PR TITLE
workflows: Run k8s e2e network workflow periodically

### DIFF
--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -13,6 +13,9 @@ on:
     paths-ignore:
       - 'Documentation/**'
       - 'test/**'
+  # Run every 8 hours
+  schedule:
+    - cron: '0 4/8 * * *'
 
 permissions: read-all
 


### PR DESCRIPTION
There have been a few instances of the workflow
failing with the error -

```
Run for p in $(pidof cilium-agent); do
cilium-agent(11062) has 522 file descriptors open
cilium-agent(11062) has more than 500 file descriptors (potential leak)
Error: Process completed with exit code 1.
```

Let's track in it the CI dashboard.
