### PR TITLE
proxy: Bump envoy version to the latest v1.33.x

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1315,7 +1315,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:bea4f2294e795ab1642eba912673eabba3ed1fff5124ba2e307f396810b32780","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-1749716792-9cbedf28d3f4e8d7ff482744138ac3bdf65a868c","useDigest":true}``
+     - ``{"digest":"sha256:e885f8d3b22aefddb0ef6a699557b6304dc185c673608fde2ebbb776fe9d6d57","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-a241113e94bb38fedf9dd14a8bab9de12253ee49","useDigest":true}``
    * - :spelling:ignore:`envoy.initialFetchTimeoutSeconds`
      - Time in seconds after which the initial fetch on an xDS stream is considered timed out
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:a2c92145f56baa6f834364a35
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.33.3-1749716792-9cbedf28d3f4e8d7ff482744138ac3bdf65a868c@sha256:bea4f2294e795ab1642eba912673eabba3ed1fff5124ba2e307f396810b32780
+ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.33.3-a241113e94bb38fedf9dd14a8bab9de12253ee49@sha256:e885f8d3b22aefddb0ef6a699557b6304dc185c673608fde2ebbb776fe9d6d57
 
 FROM ${CILIUM_ENVOY_IMAGE} AS cilium-envoy
 

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -38,8 +38,8 @@ export CILIUM_NODEINIT_DIGEST:=sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6
 
 # renovate: datasource=docker
 export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy
-export CILIUM_ENVOY_VERSION:=v1.33.3-1749716792-9cbedf28d3f4e8d7ff482744138ac3bdf65a868c
-export CILIUM_ENVOY_DIGEST:=sha256:bea4f2294e795ab1642eba912673eabba3ed1fff5124ba2e307f396810b32780
+export CILIUM_ENVOY_VERSION:=v1.33.3-a241113e94bb38fedf9dd14a8bab9de12253ee49
+export CILIUM_ENVOY_DIGEST:=sha256:e885f8d3b22aefddb0ef6a699557b6304dc185c673608fde2ebbb776fe9d6d57
 
 # renovate: datasource=docker
 export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -378,7 +378,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.httpRetryCount | int | `3` | Maximum number of retries for each HTTP request |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:bea4f2294e795ab1642eba912673eabba3ed1fff5124ba2e307f396810b32780","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-1749716792-9cbedf28d3f4e8d7ff482744138ac3bdf65a868c","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:e885f8d3b22aefddb0ef6a699557b6304dc185c673608fde2ebbb776fe9d6d57","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.33.3-a241113e94bb38fedf9dd14a8bab9de12253ee49","useDigest":true}` | Envoy container image. |
 | envoy.initialFetchTimeoutSeconds | int | `30` | Time in seconds after which the initial fetch on an xDS stream is considered timed out |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2357,9 +2357,9 @@ envoy:
     # @schema
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.33.3-1749716792-9cbedf28d3f4e8d7ff482744138ac3bdf65a868c"
+    tag: "v1.33.3-a241113e94bb38fedf9dd14a8bab9de12253ee49"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:bea4f2294e795ab1642eba912673eabba3ed1fff5124ba2e307f396810b32780"
+    digest: "sha256:e885f8d3b22aefddb0ef6a699557b6304dc185c673608fde2ebbb776fe9d6d57"
     useDigest: true
   # -- Additional containers added to the cilium Envoy DaemonSet.
   extraContainers: []


### PR DESCRIPTION
This is mainly to assort all recent fixes.