### PR TITLE
endpointmanager: clean up unused EndpointManager interface methods

### DIFF
--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -22,8 +22,6 @@ import (
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/time"
 )
 
 // Cell provides the EndpointManager which maintains the collection of locally
@@ -91,9 +89,6 @@ type EndpointsLookup interface {
 
 	// IngressEndpointExists returns true if the ingress endpoint exists.
 	IngressEndpointExists() bool
-
-	// GetEndpointNetnsCookieByIP returns the netns cookie for the passed endpoint with ip address if found.
-	GetEndpointNetnsCookieByIP(ip netip.Addr) (uint64, error)
 }
 
 type EndpointsModify interface {
@@ -151,19 +146,6 @@ type EndpointManager interface {
 	// InitHostEndpointLabels initializes the host endpoint's labels with the
 	// node's known labels.
 	InitHostEndpointLabels(ctx context.Context)
-
-	// GetPolicyEndpoints returns a map of all endpoints present in endpoint
-	// manager as policy.Endpoint interface set for the map key.
-	GetPolicyEndpoints() map[policy.Endpoint]struct{}
-
-	// CallbackForEndpointsAtPolicyRev registers a callback on all endpoints that
-	// exist when invoked. It is similar to WaitForEndpointsAtPolicyRevision but
-	// each endpoint that reaches the desired revision calls 'done' independently.
-	// The provided callback should not block and generally be lightweight.
-	CallbackForEndpointsAtPolicyRev(ctx context.Context, rev uint64, done func(time.Time)) error
-
-	// GetEndpointNetnsCookieByIP returns the netns cookie for the passed endpoint with ip address if found.
-	GetEndpointNetnsCookieByIP(ip netip.Addr) (uint64, error)
 
 	// UpdatePolicy triggers policy updates for all live endpoints.
 	// Endpoints with security IDs in provided set will be regenerated. Otherwise, the endpoint's

--- a/pkg/endpointmanager/errors_test.go
+++ b/pkg/endpointmanager/errors_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestErrInvalidPrefix_Error(t *testing.T) {
-	setupEndpointManagerSuite(t)
-
 	type args struct {
 		err ErrInvalidPrefix
 	}
@@ -48,8 +46,6 @@ func TestErrInvalidPrefix_Error(t *testing.T) {
 }
 
 func TestIsErrUnsupportedID(t *testing.T) {
-	setupEndpointManagerSuite(t)
-
 	type args struct {
 		err error
 	}
@@ -99,8 +95,6 @@ func TestIsErrUnsupportedID(t *testing.T) {
 }
 
 func TestIsErrInvalidPrefix(t *testing.T) {
-	setupEndpointManagerSuite(t)
-
 	type args struct {
 		err error
 	}


### PR DESCRIPTION
These are unused since commit 52c00bc405e9 ("daemon: remove daemon policy import code") and commit 6fa7f8129d1a ("loadbalancer/legacy: Remove the old control-plane"), respectively.

Also remove some unnecessary test suite setup calls (see 2nd commit).