### PR TITLE
loadbalancer: increase timeout for initial sync

### DIFF
--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -43,7 +43,7 @@ const (
 	// data sources. For example we might depend on Kubernetes data to connect to the ClusterMesh api-server and
 	// thus may need to first reconcile the Kubernetes services to connect to ClusterMesh (if endpoints have changed
 	// while agent was down).
-	initGracePeriod = 10 * time.Second
+	initGracePeriod = 1 * time.Minute
 )
 
 func newBPFReconciler(p reconciler.Params, g job.Group, cfg loadbalancer.Config, ops *BPFOps, fes statedb.Table[*loadbalancer.Frontend], w *writer.Writer) (reconciler.Reconciler[*loadbalancer.Frontend], error) {


### PR DESCRIPTION
Before, we were waiting for initial synchronization of endpoints and services only for 10s. However, this is definitely too low, as Kubernetes SLO for List call for 99th percentile is <= 30s. ref https://github.com/kubernetes/community/blob/master/sig-scalability/slos/slos.md#steady-state-slisslos
