### PR TITLE
contrib/git: add merge drivers to automate post-merge commands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,22 @@ pkg/k8s/client/clientset/** linguist-generated
 pkg/k8s/client/informers/** linguist-generated
 pkg/k8s/client/listers/** linguist-generated
 *.bt linguist-language=D
+
+# Merge driver configuration for specific paths
+# To set up these merge drivers locally, run:
+#   contrib/git/setup-merge-drivers.sh
+#
+# This will configure Git to use the appropriate merge drivers for each file pattern.
+#
+go.mod merge=go-mod-tidy
+go.sum merge=go-mod-tidy
+vendor/** merge=go-mod-tidy
+install/kubernetes/** merge=kubernetes-update
+Documentation/helm-values.rst merge=helm-values-update
+images/cilium/Dockerfile merge=images-update
+images/operator/Dockerfile merge=images-update
+images/hubble-relay/Dockerfile merge=images-update
+.devcontainer/devcontainer.json merge=images-update
+Documentation/cmdref/** merge=cmdref-update
+install/kubernetes/cilium/values.schema.json merge=schema-permissions
+api/** merge=generate-apis

--- a/contrib/git/setup-merge-drivers.sh
+++ b/contrib/git/setup-merge-drivers.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Script to configure Git merge drivers
+
+# Configure Go modules driver
+git config merge.go-mod-tidy.name "Go Modules Merge Driver"
+git config merge.go-mod-tidy.driver "go mod tidy && go mod vendor"
+
+# Configure Kubernetes update driver
+git config merge.kubernetes-update.name "Kubernetes Update Merge Driver"
+git config merge.kubernetes-update.driver "make -C install/kubernetes && make -C Documentation update-helm-values"
+
+# Configure Helm values update driver
+git config merge.helm-values-update.name "Helm Values Update Merge Driver"
+git config merge.helm-values-update.driver "make -C install/kubernetes && make -C Documentation update-helm-values"
+
+# Configure Images update driver
+git config merge.images-update.name "Images Update Merge Driver"
+git config merge.images-update.driver "make -C images update-builder-image update-runtime-image"
+
+# Configure cmdref update driver
+git config merge.cmdref-update.name "cmdref Update Merge Driver"
+git config merge.cmdref-update.driver "make -C Documentation update-cmdref"
+
+# Configure Schema permissions driver
+git config merge.schema-permissions.name "Schema Permissions Merge Driver"
+git config merge.schema-permissions.driver "chmod 644 install/kubernetes/cilium/values.schema.json"
+
+# Configure API generation driver
+git config merge.generate-apis.name "API Generation Merge Driver"
+git config merge.generate-apis.driver "make generate-apis"
+
+echo "Git merge drivers configured successfully!"


### PR DESCRIPTION
Add merge driver configuration that automatically runs specific commands when certain files are merged. This automation helps maintain consistency by running essential tasks like `go mod tidy`, updating Kubernetes manifests, regenerating documentation, and fixing permissions after merge operations.