### PR TITLE
bpf: nat: Fix short packet MTU path discovery

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -781,6 +781,9 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off)
 	__u32 icmpoff;
 	__u8 type;
 	int ret;
+	__u32 icmp_xlen_off = (__u32)off + offsetof(struct icmphdr, un.frag.__unused) + 1;
+	__u8 icmp_xlen;
+	bool icmp_has_full_l4_header;
 
 	/* According to the RFC 5508, any networking equipment that is
 	 * responding with an ICMP Error packet should embed the original
@@ -837,12 +840,28 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off)
 	if (!state)
 		return NAT_PUNT_TO_STACK;
 
+	/*
+	 * The snat_v4_rewrite_headers() call only rewrites the checksum for
+	 * TCP and UDP.  UDP's checksum is covered by the RFC 792 inclusion
+	 * of the 1st 64 bits of the datagram following the IP header, but
+	 * TCP needs an additional 3 32-bit words to include the checksum.
+	 */
+	if (ctx_load_bytes(ctx, icmp_xlen_off, &icmp_xlen, sizeof(__u8)) < 0)
+		return DROP_INVALID;
+	icmp_has_full_l4_header = icmp_xlen >= ((tuple.nexthdr == IPPROTO_TCP) ? 3 : 0);
+
 	/* We found SNAT entry to NAT embedded packet. The destination addr
 	 * should be NATed according to the entry.
 	 */
 	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, icmpoff,
 				      tuple.saddr, state->to_saddr, IPV4_DADDR_OFF,
 				      tuple.sport, state->to_sport, port_off);
+	/* Failing to update the inner L4 checksum is not fatal if the header
+	 * is incomplete.
+	 */
+	if (!icmp_has_full_l4_header && ret == DROP_CSUM_L4)
+		ret = 0;
+
 	if (IS_ERR(ret))
 		return ret;
 
@@ -976,6 +995,11 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	__u16 port_off;
 	__u32 icmpoff;
 	__u8 type;
+	__u8 icmp_xlen;
+	bool icmp_has_full_l4_header;
+	int ret;
+	__u32 icmp_xlen_off = (__u32) inner_l3_off - sizeof(struct icmphdr) +
+	  offsetof(struct icmphdr, un.frag.__unused) + 1;
 
 	/* According to the RFC 5508, any networking equipment that is
 	 * responding with an ICMP Error packet should embed the original
@@ -1035,10 +1059,26 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	if (!*state)
 		return NAT_PUNT_TO_STACK;
 
+	/*
+	 * The snat_v4_rewrite_headers() call only rewrites the checksum for
+	 * TCP and UDP.  UDP's checksum is covered by the RFC 792 inclusion
+	 * of the 1st 64 bits of the datagram following the IP header, but
+	 * TCP needs an additional 3 32-bit words to include the checksum.
+	 */
+	if (ctx_load_bytes(ctx, icmp_xlen_off, &icmp_xlen, sizeof(__u8)) < 0)
+		return DROP_INVALID;
+	icmp_has_full_l4_header = icmp_xlen >= ((tuple.nexthdr == IPPROTO_TCP) ? 3 : 0);
+
 	/* The embedded packet was SNATed on egress. Reverse it again: */
-	return snat_v4_rewrite_headers(ctx, tuple.nexthdr, (int)inner_l3_off, true, icmpoff,
-				       tuple.daddr, (*state)->to_daddr, IPV4_SADDR_OFF,
-				       tuple.dport, (*state)->to_dport, port_off);
+	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, (int)inner_l3_off, true, icmpoff,
+				      tuple.daddr, (*state)->to_daddr, IPV4_SADDR_OFF,
+				      tuple.dport, (*state)->to_dport, port_off);
+	/* Failing to update the inner L4 checksum is not fatal if the header
+	 * is incomplete.
+	 */
+	if (!icmp_has_full_l4_header && ret == DROP_CSUM_L4)
+		ret = 0;
+	return ret;
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -27,9 +27,11 @@
 
 static char pkt[100];
 
-__always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress)
+__always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress, bool rfc4884)
 {
 	void *orig = dst;
+	void *inner_l4_start;
+	void *icmp_ptr;
 
 	struct ethhdr l2 = {
 		.h_source = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
@@ -65,6 +67,7 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress)
 		},
 	};
 	memcpy(dst, &icmphdr, sizeof(struct icmphdr));
+	icmp_ptr = dst;
 	dst += sizeof(struct icmphdr);
 
 	/* Embedded packet is referring the original packet that triggers the
@@ -85,10 +88,11 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress)
 	memcpy(dst, &inner_l3, sizeof(struct iphdr));
 	dst += sizeof(struct iphdr);
 
-	__u16 sport = 32768, dport = 80;
+	inner_l4_start = dst;
+	__u16 sport = 32768, dport = rfc4884 ? 80 : 78;
 
 	if (egress) {
-		sport = 79;
+		sport = rfc4884 ? 79 : 77;
 		dport = error_hdr == IPPROTO_SCTP ? 32767 : 3030;
 	}
 
@@ -98,8 +102,12 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress)
 			.source = bpf_htons(sport),
 			.dest = bpf_htons(dport),
 		};
-		memcpy(dst, &inner_l4, sizeof(struct tcphdr));
-		dst += sizeof(struct tcphdr);
+		{
+			__u64 l4_size =  rfc4884 ? sizeof(struct tcphdr) : 8;
+
+			memcpy(dst, &inner_l4, l4_size);
+			dst += l4_size;
+		}
 	}
 		break;
 	case IPPROTO_UDP: {
@@ -138,13 +146,23 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress)
 	}
 		break;
 	}
+	/* account for any content longer than 64 bits of the original data datagram
+	 * in accordance with RFC 4884
+	 */
+	if (rfc4884 && (dst - inner_l4_start > 8)) {
+		__u8 extra_words = (__u8)(dst - inner_l4_start - 8 + 3) / 4;
+
+		memcpy(icmp_ptr + offsetof(struct icmphdr, un.frag.__unused) + 1,
+		       &extra_words, 1);
+	}
+
 	return (int)(dst - orig);
 }
 
 CHECK("tc", "nat4_icmp_error_tcp")
 int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, false);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, false, true);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -255,10 +273,128 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
+CHECK("tc", "nat4_icmp_error_tcp_rfc1191")
+int test_nat4_icmp_error_tcp_rfc1191(__maybe_unused struct __ctx_buff *ctx)
+{
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, false, false);
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+
+		if (data + pkt_size > data_end)
+			return TEST_ERROR;
+
+		memcpy(data, pkt, pkt_size);
+	}
+
+	test_init();
+	/* The test is validating that the function snat_v4_rev_nat()
+	 * will rev-nat the ICMP Unreach error need to fragment to the
+	 * correct endpoint.  Also, to be valid, the embedded packet
+	 * should be NATed as-well, meaning that the source addr of
+	 * the original packet will be switched from IP_HOST to
+	 * IP_ENDPOINT, Also for TCP/UDP the dest port and ICMP the
+	 * identifier.
+	 *
+	 * This test is validating the TCP case.
+	 */
+
+	int ret;
+
+	/* As a pre-requist we intruct the NAT table
+	 * to simulate an ingress packet sent by
+	 * endpoint to the world.
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_TCP,
+		.saddr = bpf_htonl(IP_ENDPOINT),
+		.daddr = bpf_htonl(IP_WORLD),
+		.sport = bpf_htons(3030),
+		.dport = bpf_htons(78),
+		.flags = 0,
+	};
+	struct ipv4_nat_target target = {
+		.addr = bpf_htonl(IP_HOST),
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MIN_NAT,
+	};
+	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
+	void *map;
+
+	map = get_cluster_snat_map_v4(target.cluster_id);
+	assert(map);
+
+	ret = snat_v4_new_mapping(ctx, map, &tuple, &state, &target,
+				  false, NULL);
+	assert(ret == 0);
+
+	/* This is the entry-point of the test, calling
+	 * snat_v4_rev_nat().
+	 */
+	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
+	assert(ret == 0);
+
+	__u16 proto;
+	void *data;
+	void *data_end;
+
+	int l3_off;
+	int l4_off;
+	struct iphdr *ip4;
+	struct icmphdr icmphdr __align_stack_8;
+
+	assert(validate_ethertype(ctx, &proto));
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	if (data + pkt_size > data_end)
+		test_fatal("packet shrank");
+
+	/* Validating outer headers */
+	assert(ip4->protocol == IPPROTO_ICMP);
+	assert(ip4->saddr == bpf_htonl(IP_ROUTER));
+	assert(ip4->daddr == bpf_htonl(IP_ENDPOINT));
+
+	l3_off = ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		test_fatal("can't load icmp headers");
+	assert(icmphdr.type == ICMP_DEST_UNREACH);
+	assert(icmphdr.code == ICMP_FRAG_NEEDED);
+
+	/* Validating inner headers */
+	int in_l3_off;
+	int in_l4_off;
+	struct iphdr in_ip4;
+	struct {
+		__be16 sport;
+		__be16 dport;
+	} in_l4hdr;
+
+	in_l3_off = l4_off + sizeof(icmphdr);
+	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,
+			   sizeof(in_ip4)) < 0)
+		test_fatal("can't load embedded ip headers");
+	assert(in_ip4.protocol == IPPROTO_TCP);
+	assert(in_ip4.saddr == bpf_htonl(IP_ENDPOINT));
+	assert(in_ip4.daddr == bpf_htonl(IP_WORLD));
+
+	in_l4_off = in_l3_off + ipv4_hdrlen(&in_ip4);
+	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
+		test_fatal("can't load embedded l4 headers");
+	/* A minimal RFC 1191 packet without RFC 4884 length extension
+	 * won't get an updated checksum for the inner L4 but will get
+	 * the ports changed.
+	 */
+	assert(in_l4hdr.sport == bpf_htons(3030));
+	assert(in_l4hdr.dport == bpf_htons(78));
+
+	test_finish();
+}
+
 CHECK("tc", "nat4_icmp_error_udp")
 int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP, false);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP, false, true);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -372,7 +508,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 CHECK("tc", "nat4_icmp_error_icmp")
 int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP, false);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP, false, true);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -481,7 +617,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 CHECK("tc", "nat4_icmp_error_sctp")
 int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_SCTP, false);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_SCTP, false, true);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -539,7 +675,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 CHECK("tc", "nat4_icmp_error_tcp_egress")
 int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, true);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, true, true);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -655,10 +791,133 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
+CHECK("tc", "nat4_icmp_error_tcp_egress_rfc1191")
+int test_nat4_icmp_error_tcp_egress_rfc1191(__maybe_unused struct __ctx_buff *ctx)
+{
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, true, false);
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+
+		if (data + pkt_size > data_end)
+			return TEST_ERROR;
+
+		memcpy(data, pkt, pkt_size);
+	}
+
+	test_init();
+	/* The test is validating that the function snat_v4_nat()
+	 * will nat the ICMP Unreach error need to fragment to the
+	 * correct source.  Also, to be valid, the embedded packet
+	 * should be NATed as-well, meaning that the dest addr of
+	 * the original packet will be switched from IP_ENDPOINT to
+	 * IP_HOST, Also for TCP/UDP the dest port and ICMP the
+	 * identifier.
+	 *
+	 * This test is validating the TCP case.
+	 */
+
+	int ret;
+
+	/* As a pre-requist we intruct the NAT table
+	 * to simulate an egress packet sent by
+	 * endpoint to the world.
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_TCP,
+		.saddr = bpf_htonl(IP_ENDPOINT),
+		.daddr = bpf_htonl(IP_WORLD),
+		.sport = bpf_htons(3030),
+		.dport = bpf_htons(77),
+		.flags = 0,
+	};
+	struct ipv4_nat_target target = {
+		.addr = bpf_htonl(IP_HOST),
+		.min_port = NODEPORT_PORT_MIN_NAT - 1,
+		.max_port = NODEPORT_PORT_MIN_NAT - 1,
+	};
+	struct ipv4_nat_entry state;
+	void *map;
+
+	map = get_cluster_snat_map_v4(target.cluster_id);
+	assert(map);
+
+	ret = snat_v4_new_mapping(ctx, map, &tuple, &state, &target,
+				  false, NULL);
+	assert(ret == 0);
+
+	struct ipv4_ct_tuple icmp_tuple = {};
+	struct trace_ctx trace;
+	void *data, *data_end;
+	struct iphdr *ip4;
+	int l4_off;
+
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &icmp_tuple);
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+
+	/* This is the entry-point of the test, calling
+	 * snat_v4_nat().
+	 */
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, ipfrag_encode_ipv4(ip4),
+			  l4_off, &target, &trace, NULL);
+	assert(ret == 0);
+
+	__u16 proto;
+	int l3_off;
+	struct icmphdr icmphdr __align_stack_8;
+
+	assert(validate_ethertype(ctx, &proto));
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	if (data + pkt_size > data_end)
+		test_fatal("packet shrank");
+
+	/* Validating outer headers */
+	assert(ip4->protocol == IPPROTO_ICMP);
+	assert(ip4->saddr == bpf_htonl(IP_HOST));
+	assert(ip4->daddr == bpf_htonl(IP_WORLD));
+
+	l3_off = ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		test_fatal("can't load icmp headers");
+	assert(icmphdr.type == ICMP_DEST_UNREACH);
+	assert(icmphdr.code == ICMP_FRAG_NEEDED);
+
+	/* Validating inner headers */
+	int in_l3_off;
+	int in_l4_off;
+	struct iphdr in_ip4;
+	struct {
+		__be16 sport;
+		__be16 dport;
+	} in_l4hdr;
+
+	in_l3_off = l4_off + sizeof(icmphdr);
+	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,
+			   sizeof(in_ip4)) < 0)
+		test_fatal("can't load embedded ip headers");
+	assert(in_ip4.protocol == IPPROTO_TCP);
+	assert(in_ip4.saddr == bpf_htonl(IP_WORLD));
+	assert(in_ip4.daddr == bpf_htonl(IP_HOST));
+
+	in_l4_off = in_l3_off + ipv4_hdrlen(&in_ip4);
+	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
+		test_fatal("can't load embedded l4 headers");
+	/* A minimal RFC 1191 packet without RFC 4884 length extension
+	 * won't get an updated checksum for the inner L4 but will get
+	 * the ports changed.
+	 */
+	assert(in_l4hdr.sport == bpf_htons(77));
+	assert(in_l4hdr.dport == bpf_htons(32767));
+
+	test_finish();
+}
+
 CHECK("tc", "nat4_icmp_error_udp_egress")
 int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP, true);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP, true, true);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -777,7 +1036,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 CHECK("tc", "nat4_icmp_error_icmp_egress")
 int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP, true);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP, true, true);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -891,7 +1150,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 CHECK("tc", "nat4_icmp_error_sctp_egress")
 int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_SCTP, true);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_SCTP, true, true);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;


### PR DESCRIPTION
Routers that send minimal RFC 1191 ICMP Error packets for MTU path discovery only include the first two 32-bit words of the original L4 header.  This is enough to include the L4 checksum for UDP, but not TCP; TCP needs an additional 3 32-bit words of the original datagram.  RFC 4884 provides a length field in octet 5 of the ICMP Error packet header to indicate there are additional words of the original datagram included.

This pays attention to the RFC 4884 length field and limits the L4 checksum update attempt to cases where there are enough bits of the original datagram included.

Signed-off-by:  Bill Reese <reesew@computer.org>

Fixes: #33844

```release-note
Fix "Error while correcting L4 checksum" dropped packets for ICMP destination unreachable error packets.
```
