### PR TITLE
lint: Update staticcheck config in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -105,8 +105,34 @@ linters:
         - source
       args-on-sep-lines: true
     staticcheck:
+      dot-import-whitelist:
+        - github.com/cilium/cilium/api/v1/health/server/restapi
+        - github.com/cilium/cilium/api/v1/health/server/restapi/connectivity
+        - github.com/cilium/cilium/api/v1/server/restapi/policy
+        - github.com/cilium/cilium/api/v1/server/restapi/endpoint
+        - github.com/cilium/cilium/test/ginkgo-ext
+        - github.com/onsi/gomega
       checks:
-        - ST1019
+        # Default checks https://golangci-lint.run/usage/linters/#staticcheck
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1006
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        # Disable additional checks that are not applicable to Cilium. Enable them if needed in the future.
+        - -ST1005
+        - -ST1008
+        - -ST1019
+        - -QF1001
+        - -QF1002
+        - -QF1003
+        - -QF1006
+        - -QF1007
+        - -QF1008
+        - -QF1012
     testifylint:
       enable-all: true
       disable: # TODO: remove each disabled rule and fix it

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -405,8 +405,8 @@ func execCommand(prompt string) ([]byte, error) {
 // writeCmdToFile will execute command and write markdown output to a file
 func writeCmdToFile(cmdDir, prompt string, enableMarkdown bool, postProcess func(output []byte) []byte) {
 	// Clean up the filename
-	name := strings.Replace(prompt, "/", " ", -1)
-	name = strings.Replace(name, " ", "-", -1)
+	name := strings.ReplaceAll(prompt, "/", " ")
+	name = strings.ReplaceAll(name, " ", "-")
 	suffix := ".md"
 	if strings.HasSuffix(name, "html") {
 		// If the command we run ends in 'html' (such as 'metrics/html'), write out the

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -668,8 +668,7 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 		t.Fatal("Cannot get egress gateway node internal IPv4")
 	}
 
-	var egressGatewayNodeInternalIPv6 net.IP
-	egressGatewayNodeInternalIPv6 = ct.GetGatewayNodeInternalIP(egressGatewayNode, true)
+	var egressGatewayNodeInternalIPv6 = ct.GetGatewayNodeInternalIP(egressGatewayNode, true)
 	if ipv6Enabled && egressGatewayNodeInternalIPv6 == nil {
 		t.Fatal("Cannot get egress gateway node internal IPv6")
 	}

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -40,7 +40,7 @@ type regexMatcher struct {
 }
 
 func (r regexMatcher) IsMatch(log string) bool {
-	return r.Regexp.MatchString(log)
+	return r.MatchString(log)
 }
 
 // NoErrorsInLogs checks whether there are no error messages in cilium-agent

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -448,7 +448,7 @@ func (k *K8sStatusCollector) logComponentTask(status *Status, namespace, deploym
 						if containerStatus.RestartCount > 0 {
 							getPrevious = true
 						}
-						logs, errLogCollection := k.client.ContainerLogs(ctx, namespace, podName, containerName, terminated.FinishedAt.Time.Add(-2*time.Minute), getPrevious)
+						logs, errLogCollection := k.client.ContainerLogs(ctx, namespace, podName, containerName, terminated.FinishedAt.Add(-2*time.Minute), getPrevious)
 						if errLogCollection != nil {
 							status.CollectionError(fmt.Errorf("failed to gather logs from %s:%s:%s: %w", namespace, podName, containerName, err))
 						} else if logs != "" {

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -403,7 +403,7 @@ func (c *Collector) teardownLogging() {
 
 // replaceTimestamp can be used to replace the special timestamp placeholder in file and directory names.
 func (c *Collector) replaceTimestamp(f string) string {
-	return strings.Replace(f, timestampPlaceholderFileName, c.startTime.Format(timeFormat), -1)
+	return strings.ReplaceAll(f, timestampPlaceholderFileName, c.startTime.Format(timeFormat))
 }
 
 // AbsoluteTempPath returns the absolute path where to store the specified filename temporarily.
@@ -2236,7 +2236,7 @@ func (c *Collector) SubmitTetragonBugtoolTasks(pods []*corev1.Pod, tetragonAgent
 			if err != nil {
 				return fmt.Errorf("failed to collect 'tetragon-bugtool' output for %q: %w", p.Name, err)
 			}
-			if err := untar(f, strings.Replace(f, ".tar.gz", "", -1)); err != nil {
+			if err := untar(f, strings.ReplaceAll(f, ".tar.gz", "")); err != nil {
 				c.logWarn("Failed to unarchive 'tetragon-bugtool' output for %q: %v", p.Name, err)
 				return nil
 			}
@@ -2412,7 +2412,7 @@ func (c *Collector) submitCiliumBugtoolTasks(pods []*corev1.Pod) error {
 				return fmt.Errorf("failed to collect 'cilium-bugtool' output for %q: %w", p.Name, err)
 			}
 			// Untar the resulting file.
-			if err := untar(f, strings.Replace(f, ".tar.gz", "", -1)); err != nil {
+			if err := untar(f, strings.ReplaceAll(f, ".tar.gz", "")); err != nil {
 				c.logWarn("Failed to unarchive 'cilium-bugtool' output for %q: %v", p.Name, err)
 				return nil
 			}

--- a/cilium-dbg/cmd/fqdn.go
+++ b/cilium-dbg/cmd/fqdn.go
@@ -100,7 +100,7 @@ func cleanFQDNCache() {
 }
 
 func listFQDNCache() {
-	var lookups []*models.DNSLookup = []*models.DNSLookup{}
+	var lookups = []*models.DNSLookup{}
 
 	if fqdnEndpointID != "" {
 		params := policy.NewGetFqdnCacheIDParams()

--- a/operator/api/server.go
+++ b/operator/api/server.go
@@ -107,7 +107,7 @@ func (s *server) Start(ctx cell.HookContext) error {
 	mux := http.NewServeMux()
 
 	// Index handler is the handler for Open-API router.
-	mux.Handle("/", s.Server.GetHandler())
+	mux.Handle("/", s.GetHandler())
 	// Create a custom handler for /healthz as an alias to /v1/healthz. A http mux
 	// is required for this because open-api spec does not allow multiple base paths
 	// to be specified.

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -147,7 +147,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.priorityNamespaces["FastNamespace"] = struct{}{}
 	cesController.initializeQueue()
-	var ns string = "NotSoImportant"
+	var ns = "NotSoImportant"
 	var standardQueueLen int
 	var fastQueueLen int
 
@@ -248,7 +248,7 @@ func TestCESManagement(t *testing.T) {
 	cesController.cond = *sync.NewCond(&lock.Mutex{})
 	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.initializeQueue()
-	var ns string = "ns"
+	var ns = "ns"
 
 	cep1 := tu.CreateStoreEndpoint(fmt.Sprintf("cep-%d", 0), ns, 0)
 	cesController.onEndpointUpdate(cep1)

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -156,7 +156,7 @@ func (r *ciliumEnvoyConfigReconciler) getListenerResource(svc *corev1.Service) (
 		return ciliumv2.XDSResource{}, nil
 	}
 
-	var filterChains []*envoy_config_listener.FilterChain = []*envoy_config_listener.FilterChain{
+	var filterChains = []*envoy_config_listener.FilterChain{
 		{
 			FilterChainMatch: &envoy_config_listener.FilterChainMatch{
 				TransportProtocol: "raw_buffer",

--- a/operator/pkg/gateway-api/gamma.go
+++ b/operator/pkg/gateway-api/gamma.go
@@ -197,9 +197,5 @@ func getGammaReconcileRequestsForRoute(ctx context.Context, c client.Client, obj
 }
 
 func isValidGammaService(svc *corev1.Service) bool {
-	if svc.Spec.Type == corev1.ServiceTypeClusterIP {
-		return true
-	}
-
-	return false
+	return svc.Spec.Type == corev1.ServiceTypeClusterIP
 }

--- a/operator/pkg/model/ingestion/ingress.go
+++ b/operator/pkg/model/ingestion/ingress.go
@@ -162,12 +162,8 @@ func Ingress(log *slog.Logger, ing networkingv1.Ingress, defaultSecretNamespace,
 	// Before we check for TLS config, we need to see if the force-https annotation
 	// is set.
 	forceHTTPsannotation := annotations.GetAnnotationForceHTTPSEnabled(&ing)
-	forceHTTPs := false
-
 	// We only care about enforcedHTTPS if the annotation is unset
-	if (forceHTTPsannotation == nil && enforcedHTTPS) || (forceHTTPsannotation != nil && *forceHTTPsannotation) {
-		forceHTTPs = true
-	}
+	forceHTTPs := (forceHTTPsannotation == nil && enforcedHTTPS) || (forceHTTPsannotation != nil && *forceHTTPsannotation)
 
 	// First, we check for TLS config, and set them up with Listeners to return.
 	for _, tlsConfig := range ing.Spec.TLS {

--- a/pkg/act/act.go
+++ b/pkg/act/act.go
@@ -400,7 +400,7 @@ func (a *ACT) countFailed(svc uint16, key lbmaps.BackendKey) {
 		)
 		return
 	}
-	zone := val.(lbmaps.BackendValue).GetZone()
+	zone := val.GetZone()
 	if zone == 0 {
 		scopedLog.Debug("Ignoring backend without zone")
 		return

--- a/pkg/auth/mutual_authhandler.go
+++ b/pkg/auth/mutual_authhandler.go
@@ -111,7 +111,7 @@ func (m *mutualAuthHandler) authenticate(ar *authRequest) (*authResponse, error)
 	}
 	defer conn.Close()
 
-	var expirationTime *time.Time = &clientCert.Leaf.NotAfter
+	var expirationTime = &clientCert.Leaf.NotAfter
 
 	// set up TLS socket
 

--- a/pkg/cgroups/manager/provider.go
+++ b/pkg/cgroups/manager/provider.go
@@ -217,7 +217,7 @@ func toSystemd(cgroupName []string) (string, error) {
 }
 
 func escapeSystemdCgroupName(part string) string {
-	return strings.Replace(part, "-", "_", -1)
+	return strings.ReplaceAll(part, "-", "_")
 }
 
 // systemd represents slice hierarchy using `-`, so we need to follow suit when

--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -222,8 +222,6 @@ func (c *cecProcessor) process(wtxn statedb.WriteTxn, closedWatches []<-chan str
 	}
 
 	c.orphans = existing
-
-	return
 }
 
 func (c *cecProcessor) processCEC(wtxn statedb.WriteTxn, cecName CECName) *statedb.WatchSet {

--- a/pkg/clustermesh/clustercfg/clustercfg_test.go
+++ b/pkg/clustermesh/clustercfg/clustercfg_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 )
 
-var mockerr = errors.New("error")
+var errMock = errors.New("error")
 
 // Configure a generous timeout to prevent flakes when running in a noisy CI environment.
 var (
@@ -35,7 +35,7 @@ type mockBackend struct {
 }
 
 func (mb *mockBackend) withError(clusterName string) {
-	mb.errors.Store(path.Join(kvstore.ClusterConfigPrefix, clusterName), mockerr)
+	mb.errors.Store(path.Join(kvstore.ClusterConfigPrefix, clusterName), errMock)
 }
 
 func (mb *mockBackend) Get(_ context.Context, key string) ([]byte, error) {
@@ -70,7 +70,7 @@ func TestGetSetClusterConfig(t *testing.T) {
 	require.NoError(t, Set(ctx, "bar", cfg3, &mb), "failed to update cluster configuration (same value)")
 
 	mb.withError("error")
-	require.ErrorIs(t, Set(ctx, "error", cfg1, &mb), mockerr, "kvstore error not propagated correctly")
+	require.ErrorIs(t, Set(ctx, "error", cfg1, &mb), errMock, "kvstore error not propagated correctly")
 
 	got, err := Get(ctx, "foo", &mb)
 	require.NoError(t, err, "failed to read cluster configuration")
@@ -85,7 +85,7 @@ func TestGetSetClusterConfig(t *testing.T) {
 
 	mb.withError("error")
 	_, err = Get(ctx, "error", &mb)
-	require.ErrorIs(t, err, mockerr, "kvstore error not propagated correctly")
+	require.ErrorIs(t, err, errMock, "kvstore error not propagated correctly")
 
 	// Simulate invalid data stored in the kvstore
 	mb.UpdateIfDifferent(ctx, path.Join(kvstore.ClusterConfigPrefix, "invalid"), []byte("invalid"), true)
@@ -118,7 +118,7 @@ func TestEnforceClusterConfig(t *testing.T) {
 	mb.withError("error")
 	stopAndWait3, err := Enforce(ctx, "error", cfg2, &mb, log)
 	defer stopAndWait3()
-	require.ErrorIs(t, err, mockerr, "kvstore error not propagated correctly")
+	require.ErrorIs(t, err, errMock, "kvstore error not propagated correctly")
 
 	got, err := Get(ctx, "foo", &mb)
 	require.NoError(t, err, "failed to read cluster configuration")

--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
@@ -411,11 +411,7 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) needUpdate(
 	equalsEndpointPort := func(a, b discoveryv1.EndpointPort) bool {
 		return reflect.DeepEqual(a, b)
 	}
-	if !slices.EqualFunc(derivedEpSlice.Ports, desiredDerivedEndpointSlice.Ports, equalsEndpointPort) {
-		return true
-	}
-
-	return false
+	return !slices.EqualFunc(derivedEpSlice.Ports, desiredDerivedEndpointSlice.Ports, equalsEndpointPort)
 }
 
 func (r *mcsAPIEndpointSliceMirrorReconciler) getDerivedEndpointSliceByLabel(ctx context.Context, key types.NamespacedName) (*discoveryv1.EndpointSlice, error) {

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -67,8 +67,8 @@ var Cell = cell.Module(
 		func() (promise.Promise[nat.NatMap4], promise.Promise[nat.NatMap6]) {
 			r4, p4 := promise.New[nat.NatMap4]()
 			r6, p6 := promise.New[nat.NatMap6]()
-			r4.Reject(nat.MapDisabled)
-			r6.Reject(nat.MapDisabled)
+			r4.Reject(nat.ErrMapDisabled)
+			r6.Reject(nat.ErrMapDisabled)
 			return p4, p6
 		},
 

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -88,7 +88,7 @@ func (n *linuxNodeHandler) allocateIDForNode(oldNode *nodeTypes.Node, node *node
 	// Perform an SPI refresh opportunistically.
 	// This avoids the scenario where the agent may have been down and didn't
 	// catch a NodeDelete event, leaving a stale IP address in the map.
-	var SPIChanged bool = true
+	var SPIChanged = true
 	if oldNode != nil {
 		SPIChanged = (oldNode.EncryptionKey != node.EncryptionKey)
 	}

--- a/pkg/datapath/tables/l2_announce.go
+++ b/pkg/datapath/tables/l2_announce.go
@@ -35,7 +35,7 @@ type L2AnnounceEntry struct {
 
 func (pne *L2AnnounceEntry) DeepCopy() *L2AnnounceEntry {
 	// Shallow copy
-	var n L2AnnounceEntry = *pne
+	var n = *pne
 	// Explicit clone for slices
 	n.Origins = slices.Clone(pne.Origins)
 	return &n

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -199,7 +199,7 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 
 	if ep.K8sNamespaceAndPodNameIsSet() && m.clientset.IsEnabled() {
 		pod, k8sMetadata, err := m.handleOutdatedPodInformer(ctx, ep)
-		if errors.Is(err, endpointmetadata.PodStoreOutdatedErr) {
+		if errors.Is(err, endpointmetadata.ErrPodStoreOutdated) {
 			m.logger.Warn("Timeout occurred waiting for Pod store, fetching latest Pod via the apiserver.",
 				logfields.K8sPodName, ep.K8sNamespace+"/"+ep.K8sPodName,
 				logfields.K8sUID, ep.K8sUID,
@@ -362,7 +362,7 @@ func (m *endpointAPIManager) handleOutdatedPodInformer(ctx context.Context, ep *
 			return true, err2
 		}
 
-		if errors.Is(err2, endpointmetadata.PodStoreOutdatedErr) {
+		if errors.Is(err2, endpointmetadata.ErrPodStoreOutdated) {
 			once.Do(func() {
 				m.logger.Warn("Detected outdated Pod UID during Endpoint creation. Endpoint creation cannot proceed with an outdated Pod store. Attempting to fetch latest Pod.",
 					logfields.K8sPodName, ep.K8sNamespace+"/"+ep.K8sPodName,
@@ -376,7 +376,7 @@ func (m *endpointAPIManager) handleOutdatedPodInformer(ctx context.Context, ep *
 	})
 
 	if wait.Interrupted(err) {
-		return nil, nil, endpointmetadata.PodStoreOutdatedErr
+		return nil, nil, endpointmetadata.ErrPodStoreOutdated
 	}
 
 	return pod, k8sMetadata, err

--- a/pkg/endpoint/api/endpoint_api_manager_test.go
+++ b/pkg/endpoint/api/endpoint_api_manager_test.go
@@ -55,7 +55,7 @@ func TestHandleOutdatedPodInformer(t *testing.T) {
 				if uid == "" {
 					return nil
 				}
-				return endpointmetadata.PodStoreOutdatedErr
+				return endpointmetadata.ErrPodStoreOutdated
 			},
 			retries: 20,
 		},
@@ -122,7 +122,7 @@ func (f *fetcher) FetchK8sMetadataForEndpoint(nsName string, podName string, uid
 
 	pod, m, err := f.fn(f.runs, nsName, podName)
 	if uid != "" && err == nil && pod != nil && string(pod.GetUID()) != uid {
-		return nil, nil, endpointmetadata.PodStoreOutdatedErr
+		return nil, nil, endpointmetadata.ErrPodStoreOutdated
 	}
 	return pod, m, err
 }

--- a/pkg/endpoint/metadata/k8s_metadatafetcher.go
+++ b/pkg/endpoint/metadata/k8s_metadatafetcher.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-var PodStoreOutdatedErr = errors.New("pod store outdated")
+var ErrPodStoreOutdated = errors.New("pod store outdated")
 
 type EndpointMetadataFetcher interface {
 	FetchK8sMetadataForEndpoint(nsName, podName, uid string) (*slim_corev1.Pod, *endpoint.K8sMetadata, error)
@@ -53,7 +53,7 @@ func (cemf *cachedEndpointMetadataFetcher) FetchK8sMetadataForEndpoint(nsName, p
 	}
 
 	if uid != "" && uid != string(p.GetUID()) {
-		return nil, nil, PodStoreOutdatedErr
+		return nil, nil, ErrPodStoreOutdated
 	}
 
 	metadata, err := cemf.FetchK8sMetadataForEndpointFromPod(p)

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -1265,7 +1265,7 @@ func TestNotAckedAfterRestart(t *testing.T) {
 	// Since we don't update resources, we expect that we will not receive
 	// any response. However, we want to make sure that previously
 	// pending completions are still not ACKed, but they are NACKed.
-	resp, err = stream.RecvResponse()
+	_, err = stream.RecvResponse()
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	// IsCompleted is true only for completions without error
 	require.Condition(t, isNotCompletedComparison(comp1))

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -98,10 +98,10 @@ func ToUnAnchoredRegexp(pattern string) string {
 
 func escapeRegexpCharacters(pattern string) string {
 	// base case. "." becomes a literal .
-	pattern = strings.Replace(pattern, ".", "[.]", -1)
+	pattern = strings.ReplaceAll(pattern, ".", "[.]")
 
 	// base case. * becomes .*, but only for DNS valid characters
 	// NOTE: this only works because the case above does not leave the *
-	pattern = strings.Replace(pattern, "*", allowedDNSCharsREGroup+"*", -1)
+	pattern = strings.ReplaceAll(pattern, "*", allowedDNSCharsREGroup+"*")
 	return pattern
 }

--- a/pkg/hive/fence_test.go
+++ b/pkg/hive/fence_test.go
@@ -91,7 +91,7 @@ func TestFence_Errors(t *testing.T) {
 	require.NoError(t, lc.Start(log, t.Context()))
 	t.Cleanup(func() { require.NoError(t, lc.Stop(log, context.TODO())) })
 
-	require.ErrorIs(t, iwg.Wait(t.Context()), testWaitErr)
+	require.ErrorIs(t, iwg.Wait(t.Context()), errTestWait)
 
 	require.Len(t, iwg.(*fence).waitFuncs, 1)
 
@@ -118,12 +118,12 @@ func testWaitFn() (stop chan struct{}, fn WaitFunc) {
 	return
 }
 
-var testWaitErr = errors.New("fail")
+var errTestWait = errors.New("fail")
 
 func testWaitFailFn(success *bool) WaitFunc {
 	return func(ctx context.Context) error {
 		if !*success {
-			return testWaitErr
+			return errTestWait
 		}
 		return nil
 	}

--- a/pkg/hubble/parser/common/labels.go
+++ b/pkg/hubble/parser/common/labels.go
@@ -31,7 +31,7 @@ func FilterCIDRLabels(log *slog.Logger, labels []string) []string {
 		// labels for IPv6 addresses are represented with - instead of : as
 		// : cannot be used in labels; make sure to convert it to a valid
 		// IPv6 representation
-		currLabel = strings.Replace(currLabel, "-", ":", -1)
+		currLabel = strings.ReplaceAll(currLabel, "-", ":")
 		_, curr, err := net.ParseCIDR(currLabel)
 		if err != nil {
 			log.Warn(

--- a/pkg/ipam/service/allocator/utils.go
+++ b/pkg/ipam/service/allocator/utils.go
@@ -11,7 +11,7 @@ import (
 
 // countBits returns the number of set bits in n
 func countBits(n *big.Int) int {
-	var count int = 0
+	var count = 0
 	for _, w := range n.Bits() {
 		count += bits.OnesCount64(uint64(w))
 	}

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -390,7 +390,6 @@ func (in *Subnet) DeepCopyInto(out *Subnet) {
 			(*out)[key] = val
 		}
 	}
-	return
 }
 
 // DeepCopy is a deepcopy function, copying the receiver, creating a new Subnet.

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -645,7 +645,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	assert.Empty(t, remaining)
 
 	// Assert that there should only be the entry with the tunnelPeer set.
-	ip, key = IPIdentityCache.getHostIPCacheRLocked(inClusterPrefix.String())
+	_, key = IPIdentityCache.getHostIPCacheRLocked(inClusterPrefix.String())
 	assert.Equal(t, uint8(0), key)
 
 	// The following tests whether an entry with a high priority source

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -123,5 +123,5 @@ func RemoveNodeAnnotations(c kubernetes.Interface, nodeName string, annotation n
 }
 
 func encodeJsonElement(element string) string {
-	return strings.Replace(element, "/", "~1", -1)
+	return strings.ReplaceAll(element, "/", "~1")
 }

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	unknownObj    = 100
-	unknownObjErr = fmt.Errorf("unknown object type %T", unknownObj)
+	errUnknownObj = fmt.Errorf("unknown object type %T", unknownObj)
 )
 
 func Test_EqualV2CNP(t *testing.T) {
@@ -1093,7 +1093,7 @@ func Test_TransformToCNP(t *testing.T) {
 					Obj: unknownObj,
 				},
 			},
-			want:     unknownObjErr,
+			want:     errUnknownObj,
 			expected: false,
 		},
 		{
@@ -1101,7 +1101,7 @@ func Test_TransformToCNP(t *testing.T) {
 			args: args{
 				obj: unknownObj,
 			},
-			want:     unknownObjErr,
+			want:     errUnknownObj,
 			expected: false,
 		},
 	}
@@ -1192,7 +1192,7 @@ func Test_TransformToCCNP(t *testing.T) {
 					Obj: unknownObj,
 				},
 			},
-			want:     unknownObjErr,
+			want:     errUnknownObj,
 			expected: false,
 		},
 		{
@@ -1200,7 +1200,7 @@ func Test_TransformToCCNP(t *testing.T) {
 			args: args{
 				obj: unknownObj,
 			},
-			want:     unknownObjErr,
+			want:     errUnknownObj,
 			expected: false,
 		},
 	}
@@ -1387,7 +1387,7 @@ func Test_TransformToCiliumEndpoint(t *testing.T) {
 					Obj: unknownObj,
 				},
 			},
-			want:     unknownObjErr,
+			want:     errUnknownObj,
 			expected: false,
 		},
 		{
@@ -1409,7 +1409,7 @@ func Test_TransformToCiliumEndpoint(t *testing.T) {
 			args: args{
 				obj: unknownObj,
 			},
-			want:     unknownObjErr,
+			want:     errUnknownObj,
 			expected: false,
 		},
 	}

--- a/pkg/k8s/slim/k8s/apis/apiextensions/v1/types_jsonschema.go
+++ b/pkg/k8s/slim/k8s/apis/apiextensions/v1/types_jsonschema.go
@@ -323,14 +323,14 @@ type JSON struct {
 // the OpenAPI spec of this type.
 //
 // See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
-func (_ JSON) OpenAPISchemaType() []string {
+func (JSON) OpenAPISchemaType() []string {
 	// TODO: return actual types when anyOf is supported
 	return nil
 }
 
 // OpenAPISchemaFormat is used by the kube-openapi generator when constructing
 // the OpenAPI spec of this type.
-func (_ JSON) OpenAPISchemaFormat() string { return "" }
+func (JSON) OpenAPISchemaFormat() string { return "" }
 
 // JSONSchemaURL represents a schema url.
 type JSONSchemaURL string
@@ -390,14 +390,14 @@ type JSONSchemaPropsOrStringArray struct {
 // the OpenAPI spec of this type.
 //
 // See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
-func (_ JSONSchemaPropsOrStringArray) OpenAPISchemaType() []string {
+func (JSONSchemaPropsOrStringArray) OpenAPISchemaType() []string {
 	// TODO: return actual types when anyOf is supported
 	return nil
 }
 
 // OpenAPISchemaFormat is used by the kube-openapi generator when constructing
 // the OpenAPI spec of this type.
-func (_ JSONSchemaPropsOrStringArray) OpenAPISchemaFormat() string { return "" }
+func (JSONSchemaPropsOrStringArray) OpenAPISchemaFormat() string { return "" }
 
 // JSONSchemaDefinitions contains the models explicitly defined in this spec.
 type JSONSchemaDefinitions map[string]JSONSchemaProps

--- a/pkg/k8s/slim/k8s/apis/labels/selector.go
+++ b/pkg/k8s/slim/k8s/apis/labels/selector.go
@@ -924,7 +924,7 @@ func SelectorFromSet(ls Set) Selector {
 // nil and empty Sets are considered equivalent to Everything().
 // The Set is validated client-side, which allows to catch errors early.
 func ValidatedSelectorFromSet(ls Set) (Selector, error) {
-	if ls == nil || len(ls) == 0 {
+	if len(ls) == 0 {
 		return internalSelector{}, nil
 	}
 	requirements := make([]Requirement, 0, len(ls))
@@ -946,7 +946,7 @@ func ValidatedSelectorFromSet(ls Set) (Selector, error) {
 // Note: this method copies the Set; if the Set is immutable, consider wrapping it with ValidatedSetSelector
 // instead, which does not copy.
 func SelectorFromValidatedSet(ls Set) Selector {
-	if ls == nil || len(ls) == 0 {
+	if len(ls) == 0 {
 		return internalSelector{}
 	}
 	requirements := make([]Requirement, 0, len(ls))

--- a/pkg/k8s/slim/k8s/apis/util/intstr/intstr.go
+++ b/pkg/k8s/slim/k8s/apis/util/intstr/intstr.go
@@ -214,7 +214,7 @@ func getIntOrPercentValue(intOrStr *IntOrString) (int, bool, error) {
 	case Int:
 		return intOrStr.IntValue(), false, nil
 	case String:
-		s := strings.Replace(intOrStr.StrVal, "%", "", -1)
+		s := strings.ReplaceAll(intOrStr.StrVal, "%", "")
 		v, err := strconv.Atoi(s)
 		if err != nil {
 			return 0, false, fmt.Errorf("invalid value %q: %w", intOrStr.StrVal, err)

--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -110,7 +110,7 @@ func (lbls Labels) AddWorldLabel(addr netip.Addr) {
 }
 
 func LabelToPrefix(key string) (netip.Prefix, error) {
-	prefixStr := strings.Replace(key, "-", ":", -1)
+	prefixStr := strings.ReplaceAll(key, "-", ":")
 	pfx, err := netip.ParsePrefix(prefixStr)
 	if err != nil {
 		return netip.Prefix{}, fmt.Errorf("failed to parse label prefix %s: %w", key, err)

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -601,7 +601,7 @@ func TestNewLabelCIDR(t *testing.T) {
 		assert.Equal(t, LabelSourceCIDR, lbl.Source)
 		assert.NotNil(t, lbl.cidr)
 		ll := strings.SplitN(labelSpec, ":", 2)
-		prefixString := strings.Replace(ll[1], "-", ":", -1)
+		prefixString := strings.ReplaceAll(ll[1], "-", ":")
 		assert.Equal(t, netip.MustParsePrefix(prefixString).String(), lbl.cidr.String())
 	}
 

--- a/pkg/logging/multihandler.go
+++ b/pkg/logging/multihandler.go
@@ -76,9 +76,7 @@ func (i *multiSlogHandler) WithGroup(name string) slog.Handler {
 func (i *multiSlogHandler) AddHandlers(handlers ...slog.Handler) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	for _, h := range handlers {
-		i.handlers = append(i.handlers, h)
-	}
+	i.handlers = append(i.handlers, handlers...)
 }
 
 func (i *multiSlogHandler) SetHandler(handler slog.Handler) {

--- a/pkg/mac/mac.go
+++ b/pkg/mac/mac.go
@@ -101,7 +101,7 @@ func (m *MAC) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("invalid MAC address length %s", string(data))
 	}
 	data = data[1 : len(data)-1]
-	macStr := bytes.Replace(data, []byte(`:`), []byte(``), -1)
+	macStr := bytes.ReplaceAll(data, []byte(`:`), []byte(``))
 	if len(macStr) != 12 {
 		return fmt.Errorf("invalid MAC address format")
 	}

--- a/pkg/maps/nat/cell.go
+++ b/pkg/maps/nat/cell.go
@@ -17,9 +17,9 @@ import (
 	"github.com/cilium/hive/cell"
 )
 
-// MapDisabled is the expected error will be if map was not created
+// ErrMapDisabled is the expected error will be if map was not created
 // due to configuration.
-var MapDisabled = fmt.Errorf("nat map is disabled")
+var ErrMapDisabled = fmt.Errorf("nat map is disabled")
 
 // Cell exposes global nat maps via Hive. These maps depend on
 // the final state of EnableNodePort, thus the maps are currently
@@ -43,8 +43,8 @@ var Cell = cell.Module(
 					return fmt.Errorf("failed to wait for config promise: %w", err)
 				}
 				if !kprCfg.EnableNodePort {
-					res4.Reject(fmt.Errorf("nat IPv4: %w", MapDisabled))
-					res6.Reject(fmt.Errorf("nat IPv6: %w", MapDisabled))
+					res4.Reject(fmt.Errorf("nat IPv4: %w", ErrMapDisabled))
+					res6.Reject(fmt.Errorf("nat IPv6: %w", ErrMapDisabled))
 					return nil
 				}
 
@@ -66,7 +66,7 @@ var Cell = cell.Module(
 					}
 					res4.Resolve(ipv4Nat)
 				} else {
-					res4.Reject(MapDisabled)
+					res4.Reject(ErrMapDisabled)
 				}
 				if cfg.EnableIPv6 {
 					if err := ipv6Nat.Open(); err != nil {
@@ -74,7 +74,7 @@ var Cell = cell.Module(
 					}
 					res6.Resolve(ipv6Nat)
 				} else {
-					res6.Reject(MapDisabled)
+					res6.Reject(ErrMapDisabled)
 				}
 				return nil
 			},

--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -169,13 +169,13 @@ func newStats(params params) (*Stats, error) {
 			defer cancel()
 			nmap4, err := params.NatMap4.Await(ctx)
 			if err != nil {
-				if !errors.Is(err, nat.MapDisabled) {
+				if !errors.Is(err, nat.ErrMapDisabled) {
 					return err
 				}
 			}
 			nmap6, err := params.NatMap6.Await(ctx)
 			if err != nil {
-				if !errors.Is(err, nat.MapDisabled) {
+				if !errors.Is(err, nat.ErrMapDisabled) {
 					return err
 				}
 			}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1164,7 +1164,7 @@ const (
 
 // getEnvName returns the environment variable to be used for the given option name.
 func getEnvName(option string) string {
-	under := strings.Replace(option, "-", "_", -1)
+	under := strings.ReplaceAll(option, "-", "_")
 	upper := strings.ToUpper(under)
 	return ciliumEnvPrefix + upper
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -357,8 +357,6 @@ func (l7 L7ParserType) defaultPriority() ListenerPriority {
 		return ListenerPriorityHTTP
 	case ParserTypeKafka:
 		return ListenerPriorityKafka
-	default: // proxylib parsers
-		return ListenerPriorityProxylib
 	case ParserTypeTLS:
 		return ListenerPriorityTLS
 	case ParserTypeDNS:
@@ -366,6 +364,8 @@ func (l7 L7ParserType) defaultPriority() ListenerPriority {
 	case ParserTypeCRD:
 		// CRD type can have an explicit higher priority in range 1-100
 		return ListenerPriorityCRD
+	default: // proxylib parsers
+		return ListenerPriorityProxylib
 	}
 }
 

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -432,7 +432,7 @@ func (r *Recorder) createRecInfoLocked(ri *RecInfo, withID bool) bool {
 }
 
 func (r *Recorder) updateRecInfoLocked(riNew, riOld *RecInfo) error {
-	triggerRegen := false
+	var triggerRegen bool
 	if r.createRecInfoLocked(riNew, true) {
 		triggerRegen = true
 	}

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -139,7 +139,7 @@ func (f *MockIdentityAllocator) AllocateLocalIdentity(lbls labels.Labels, notify
 	if scope == identity.IdentityScopeGlobal {
 		return nil, false, cache.ErrNonLocalIdentity
 	}
-	return f.AllocateIdentity(nil, lbls, notifyOwner, oldNID)
+	return f.AllocateIdentity(context.TODO(), lbls, notifyOwner, oldNID)
 }
 
 func (f *MockIdentityAllocator) ReleaseLocalIdentities(nids ...identity.NumericIdentity) ([]identity.NumericIdentity, error) {
@@ -148,12 +148,12 @@ func (f *MockIdentityAllocator) ReleaseLocalIdentities(nids ...identity.NumericI
 		if nid.Scope() == identity.IdentityScopeGlobal {
 			continue
 		}
-		id := f.LookupIdentityByID(nil, nid)
+		id := f.LookupIdentityByID(context.TODO(), nid)
 		if id == nil {
 			continue
 		}
 
-		if r, _ := f.Release(nil, id, true); r {
+		if r, _ := f.Release(context.TODO(), id, true); r {
 			dealloc = append(dealloc, nid)
 		}
 	}

--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -176,9 +176,9 @@ func GinkgoPrint(message string, optionalValues ...any) {
 // GetTestName returns the test Name in a single string without spaces or /
 func GetTestName() string {
 	testDesc := ginkgo.CurrentGinkgoTestDescription()
-	name := strings.Replace(testDesc.FullTestText, " ", "_", -1)
+	name := strings.ReplaceAll(testDesc.FullTestText, " ", "_")
 	name = strings.Trim(name, "*")
-	return strings.Replace(name, "/", "-", -1)
+	return strings.ReplaceAll(name, "/", "-")
 }
 
 // BeforeAll runs the function once before any test in context

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -401,8 +401,8 @@ func (res *CmdRes) Reset() {
 // SingleOut returns res's stdout as a string without any newline characters
 func (res *CmdRes) SingleOut() string {
 	strstdout := res.stdout.String()
-	strstdoutSingle := strings.Replace(strstdout, "\n", "", -1)
-	return strings.Replace(strstdoutSingle, "\r", "", -1)
+	strstdoutSingle := strings.ReplaceAll(strstdout, "\n", "")
+	return strings.ReplaceAll(strstdoutSingle, "\r", "")
 }
 
 // Unmarshal unmarshalls res's stdout into data. It assumes that the stdout of

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4054,9 +4054,9 @@ func addrsEqual(addr1, addr2 *models.BackendAddress) bool {
 func GenerateNamespaceForTest(seed string) string {
 	lowered := strings.ToLower(ginkgoext.CurrentGinkgoTestDescription().FullTestText)
 	// K8s namespaces cannot have spaces, underscores or slashes.
-	replaced := strings.Replace(lowered, " ", "", -1)
-	replaced = strings.Replace(replaced, "_", "", -1)
-	replaced = strings.Replace(replaced, "/", "", -1)
+	replaced := strings.ReplaceAll(lowered, " ", "")
+	replaced = strings.ReplaceAll(replaced, "_", "")
+	replaced = strings.ReplaceAll(replaced, "/", "")
 
 	timestamped := time.Now().Format("200601021504") + seed + replaced
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -213,7 +213,7 @@ func ReportDirectoryPath() string {
 	prefix := ""
 	testName := ginkgoext.GetTestName()
 	if strings.HasPrefix(strings.ToLower(testName), K8s) {
-		prefix = fmt.Sprintf("%s-", strings.Replace(GetCurrentK8SEnv(), ".", "", -1))
+		prefix = fmt.Sprintf("%s-", strings.ReplaceAll(GetCurrentK8SEnv(), ".", ""))
 	}
 	return filepath.Join(TestResultsPath, prefix, testName)
 }

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -232,7 +232,7 @@ var _ = Describe("RuntimeAgentFQDNPolicies", func() {
 	})
 
 	expectFQDNSareApplied := func(domain string, minNumIDs int) {
-		escapedDomain := strings.Replace(domain, `.`, `\\.`, -1)
+		escapedDomain := strings.ReplaceAll(domain, `.`, `\\.`)
 		jqfilter := fmt.Sprintf(`jq -c '.[] | select(.identities|length >= %d) | select(.users|length > 0) | .selector | match("^MatchName: (\\w+\\.%s|), MatchPattern: ([\\w*]+\\.%s|)$") | length > 0'`, minNumIDs, escapedDomain, escapedDomain)
 		body := func() bool {
 			res := vm.Exec(fmt.Sprintf(`cilium-dbg policy selectors -o json | %s`, jqfilter))

--- a/tools/dev-doctor/envvarcheck.go
+++ b/tools/dev-doctor/envvarcheck.go
@@ -18,7 +18,7 @@ type envVarCheck struct {
 func (c *envVarCheck) Name() string {
 	name := c.name
 	name = strings.ToLower(name)
-	name = strings.Replace(name, "_", "-", -1)
+	name = strings.ReplaceAll(name, "_", "-")
 	return name
 }
 

--- a/tools/feature-helm-generator/main.go
+++ b/tools/feature-helm-generator/main.go
@@ -91,7 +91,7 @@ func printMetrics(o io.Writer, metrics []Metric, prefix string, separators []str
 		printed = map[string]struct{}{}
 	)
 	for _, separator := range separators {
-		groupName := strings.Replace(prefix+"_"+separator, "_", "-", -1)
+		groupName := strings.ReplaceAll(prefix+"_"+separator, "_", "-")
 		fmt.Fprintf(o, ".. _%s:\n\n"+
 			"``%s``\n"+
 			"%s\n",

--- a/tools/slogloggercheck/main.go
+++ b/tools/slogloggercheck/main.go
@@ -36,9 +36,7 @@ func main() {
 	// Check each path provided as argument
 	for _, arg := range args {
 		// Handle paths with trailing /...
-		if strings.HasSuffix(arg, "/...") {
-			arg = strings.TrimSuffix(arg, "/...")
-		}
+		arg = strings.TrimSuffix(arg, "/...")
 
 		if err := filepath.Walk(arg, func(path string, info os.FileInfo, err error) error {
 			if err != nil {


### PR DESCRIPTION
Keep the sensible default values from upstream, and a few extra disabled checks applicable to Cilium.

Fixes: https://github.com/cilium/cilium/issues/40197

