### PR TITLE
pkg/egressgateway: ensure gateway IP is IPv4

### DIFF
--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -129,7 +129,7 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 				continue
 			}
 
-			addr, ok := netipx.FromStdIP(node.GetK8sNodeIP())
+			addr, ok := netipx.FromStdIP(node.GetNodeIP(false))
 			if !ok {
 				continue
 			}


### PR DESCRIPTION
If the agent assigns a IPv6 IP as the gateway IP packets will be dropped because the egress gateway feature doesn't support a IPv6 underlay. This commit ensures the IP chosen as the gateway IP is IPv4.

Fixes: #39985
