### PR TITLE
operator/secretsync: silence reconciliation logs

### DIFF
--- a/operator/pkg/secretsync/secretsync_reconcile.go
+++ b/operator/pkg/secretsync/secretsync_reconcile.go
@@ -28,7 +28,7 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		logfields.Controller, "secret-syncer",
 		logfields.Resource, req.NamespacedName,
 	)
-	scopedLog.Info("Reconciling secret")
+	scopedLog.Debug("Reconciling secret")
 
 	original := &corev1.Secret{}
 	if err := r.client.Get(ctx, req.NamespacedName, original); err != nil {
@@ -47,7 +47,7 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 				synced = synced || deleted
 			}
 
-			scopedLog.Info("Successfully reconciled Secret", logfields.Action, action(synced))
+			scopedLog.Debug("Successfully reconciled Secret", logfields.Action, action(synced))
 			return controllerruntime.Success()
 		}
 
@@ -85,7 +85,7 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		synced = synced || deleted
 	}
 
-	scopedLog.Info("Successfully reconciled Secret", logfields.Action, action(synced))
+	scopedLog.Debug("Successfully reconciled Secret", logfields.Action, action(synced))
 	return controllerruntime.Success()
 }
 


### PR DESCRIPTION
In production clusters with several secrets, these messages may flood the operator logs since they are also logged in case of no changes (`action=ignored`). Example from a recent sysdump:

    $ grep "Reconciling secret" logs-cilium-operator-<redacted>-cilium-operator-20250626-083319.log | wc -l
    36789
    $ grep "Successfully reconciled Secret.*action=ignored" logs-cilium-operator-<redacted>-cilium-operator-20250626-083319.log | wc -l
    36789

Decrease the log level to debug so the messages still appear in CI and during development, but their value in production clusters is limited.