### PR TITLE
make: fix cilium-cni binary installation in fast targets

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -295,9 +295,9 @@ kind-image-fast-agent: kind-ready build-cli build-cni build-agent build-hubble-c
 			docker cp "$(CILIUM_BUILD_DIR)/cilium-dbg/cilium-dbg" $${node_name}:"${dst}"; \
 			docker exec $${node_name} chmod +x "${dst}/cilium-dbg"; \
 			\
-			docker exec $${node_name} rm -f "${dst}/cilium-cni"; \
-			docker cp "$(CILIUM_BUILD_DIR)/plugins/cilium-cni/cilium-cni" $${node_name}:"${dst}"; \
-			docker exec $${node_name} chmod +x "${dst}/cilium-cni"; \
+			docker exec $${node_name} rm -f "/opt/cni/bin/cilium-cni"; \
+			docker cp "$(CILIUM_BUILD_DIR)/plugins/cilium-cni/cilium-cni" $${node_name}:"/opt/cni/bin/"; \
+			docker exec $${node_name} chmod +x "/opt/cni/bin/cilium-cni"; \
 			\
 			docker exec $${node_name} rm -f "${dst}/cilium-agent"; \
 			docker cp "$(CILIUM_BUILD_DIR)/daemon/cilium-agent" $${node_name}:"${dst}"; \

--- a/contrib/testing/kind-fast.yaml
+++ b/contrib/testing/kind-fast.yaml
@@ -66,3 +66,9 @@ clustermesh:
       pullPolicy: IfNotPresent
 image:
   pullPolicy: IfNotPresent
+
+cni:
+  # Set a dummy path, as we don't want the init-container to override the
+  # binary we directly copied to the node. But we still want the configuration
+  # to be created, which is also controlled by `cni.install`.
+  binPath: /opt/dummy/


### PR DESCRIPTION
The blamed commit introduced the support for building and installing the cilium-cni binary in the kind-image-fast-agent target. However, while the binary is copied into the kind nodes, it is not installed in the expected path, and does not get actually invoked.

Let's get this fixed by directly copying the binary into the expected directory, and configuring a dummy cni.binPath setting so that it does not get overwritten by the Cilium's init container with the previous one. We don't completely disable that init container because the same setting (`cni.install`) also controls the creation of the CNI configuration, which we still want to be automatically performed.

Fixes: a951c39c8ea4 ("make: build and install cilium-cni binary in fast targets")