### PR TITLE
ci: Allow for running scale test for up to 1k nodes

### DIFF
--- a/.github/actions/cl2-modules/cilium-agent-pprofs.yaml
+++ b/.github/actions/cl2-modules/cilium-agent-pprofs.yaml
@@ -1,5 +1,7 @@
 {{$action := .action}}
 
+{{$PPROF_INTERVAL := DefaultParam .CL2_PPROF_INTERVAL_SECONDS 60}}
+
 steps:
   - name: {{$action}} Cilium Agent PProfs
     measurements:
@@ -8,7 +10,7 @@ steps:
       params:
         action: {{$action}}
         labelSelector: k8s-app=cilium
-        interval: 60s
+        interval: {{ $PPROF_INTERVAL }}s
         container: cilium-agent
         limit: 5
         failOnCommandError: true

--- a/.github/actions/cl2-modules/netpol/config.yaml
+++ b/.github/actions/cl2-modules/netpol/config.yaml
@@ -2,7 +2,7 @@
 {{$PODS_PER_DEPLOYMENT := 5}}
 {{$CNPS_PER_DEPLOYMENT := 5}}
 {{$namespaces := MaxInt (DivideInt .Nodes 100) 1}}
-{{$TimeToLoad := MultiplyInt $namespaces 6}}
+{{$TimeToLoad := MaxInt (MultiplyInt $namespaces 2) 6}}
 # number of deployments is 30 * #nodes / 5
 # for 1 node -> 6 deployments x 1 namespace
 # for 100 nodes -> 600 deployments x 1 namespace

--- a/.github/actions/cl2-modules/netpol/modules/metrics.yaml
+++ b/.github/actions/cl2-modules/netpol/modules/metrics.yaml
@@ -3,6 +3,7 @@
 {{$NETPOL_LATENCY_THRESHOLD := DefaultParam .CL2_NETPOL_LATENCY_THRESHOLD 0.1}}
 {{$MEDIAN_CPU_USAGE_THRESHOLD := DefaultParam .CL2_NETPOL_MEDIAN_CPU_USAGE_THRESHOLD 0.2}}
 {{$MEDIAN_MEM_USAGE_THRESHOLD := DefaultParam .CL2_NETPOL_MEDIAN_MEM_USAGE_THRESHOLD 450}}
+{{$ENABLE_VIOLATIONS := DefaultParam .CL2_ENABLE_VIOLATIONS true}}
 
 steps:
   - name: {{$action}} Cilium Agent Policy implementation delay
@@ -14,7 +15,7 @@ steps:
         metricName: NetPol Policy Implementation Delay
         metricVersion: v1
         unit: s
-        enableViolations: true
+        enableViolations: {{$ENABLE_VIOLATIONS}}
         queries:
         - name: Perc99
           query: histogram_quantile(0.99, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
@@ -31,7 +32,7 @@ steps:
         metricName: NetPol Average CPU Usage
         metricVersion: v1
         unit: cpu
-        enableViolations: true
+        enableViolations: {{$ENABLE_VIOLATIONS}}
         queries:
         - name: Perc99
           query: quantile(0.99, avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
@@ -48,7 +49,7 @@ steps:
         metricName: NetPol Max Memory Usage
         metricVersion: v1
         unit: MB
-        enableViolations: true
+        enableViolations: {{$ENABLE_VIOLATIONS}}
         queries:
         - name: Perc99
           query: quantile(0.99, max_over_time(cilium_process_resident_memory_bytes[%v]) / 1024 / 1024)

--- a/.github/actions/cl2-modules/servicechurn/modules/metrics.yaml
+++ b/.github/actions/cl2-modules/servicechurn/modules/metrics.yaml
@@ -2,6 +2,7 @@
 
 {{$MEDIAN_CPU_USAGE_THRESHOLD := DefaultParam .CL2_SERVICECHURN_MEDIAN_CPU_USAGE_THRESHOLD 0.25}}
 {{$MEDIAN_MEM_USAGE_THRESHOLD := DefaultParam .CL2_SERVICECHURN_MEDIAN_MEM_USAGE_THRESHOLD 300}}
+{{$ENABLE_VIOLATIONS := DefaultParam .CL2_ENABLE_VIOLATIONS true}}
 
 steps:
   - name: {{$action}} Cilium Agent metrics
@@ -13,7 +14,7 @@ steps:
         metricName: ServiceChurn Average CPU Usage
         metricVersion: v1
         unit: cpu
-        enableViolations: true
+        enableViolations: {{$ENABLE_VIOLATIONS}}
         queries:
         - name: Perc99
           query: quantile(0.99, avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
@@ -30,7 +31,7 @@ steps:
         metricName: ServiceChurn Max Memory Usage
         metricVersion: v1
         unit: MB
-        enableViolations: true
+        enableViolations: {{$ENABLE_VIOLATIONS}}
         queries:
         - name: Perc99
           query: quantile(0.99, max_over_time(cilium_process_resident_memory_bytes[%v]) / 1024 / 1024)

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -74,7 +74,7 @@ triggers:
   /fqdn-perf:
     workflows:
     - fqdn-perf.yaml
-  /scale-100(\s+(?:\s*version=[-+.0-9a-z]+)?)?:
+  /scale-100(\s+(?:nodes=[0-9]+)?(?:\s*version=[-+.0-9a-z]+)?(?:\s*sha=[a-f0-9]+)?)?:
     workflows:
     - scale-test-100-gce.yaml
   /scale-5:

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -429,7 +429,7 @@ jobs:
           tested_sha: ${{ steps.vars.outputs.sha }}
           results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}
           artifacts: ./perf-tests/clusterloader2/report/
-          other_files: cilium-sysdump-final.zip ./perf-tests/clusterloader2/cl2-output.txt
+          other_files: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 'cilium-sysdump-final.zip' || '' }} ./perf-tests/clusterloader2/cl2-output.txt
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -184,6 +184,7 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ steps.vars.outputs.SHA }}
+          images: cilium-ci operator-generic-ci hubble-relay-ci
 
       - name: Install Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -368,6 +368,7 @@ jobs:
           CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR: "true"
           CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT: "true"
           CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 12.0 || 24.0 }}
+          CL2_PPROF_INTERVAL_SECONDS: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 60 || 300 }}
         run: |
           ./clusterloader \
             -v=2 \

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -336,13 +336,25 @@ jobs:
           ig_name: workloads
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
-      - name: Wait for cluster to be ready
-        uses: cilium/scale-tests-action/validate-cluster@969e82091d02975fbc5a798f5b7ba065fb8c67c3 # main
+      - name: Wait for workloads nodes to be ready
         timeout-minutes: 20
-        with:
-          cluster_name: ${{ steps.vars.outputs.cluster_name }}
-          kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
-          interval: 10s
+        run: |
+          cnt=0
+
+          # Allow for a 2 per thousand toleration in the expected nodes count, to
+          # continue with the test even if a tiny fraction of the workers failed
+          # bootstrapping and joining the cluster.
+          desired=$(( ${{ steps.vars.outputs.WORKLOAD_NODES}} - ${{ steps.vars.outputs.WORKLOAD_NODES}} * 2 / 1000 ))
+
+          # A more idiomatic way would be using the kops.k8s.io/instancegroup=workloads
+          # label selector, but kops appears to be significantly slow at reconciling
+          # the labels to the node objects. Hence, let's just grep for the node names.
+          while [[ "$cnt" -lt "$desired" ]]; do
+            # shellcheck disable=SC2196
+            cnt=$(kubectl get nodes --no-headers | egrep -c 'workloads-[-a-z0-9]+\s+Ready\s' || true)
+            echo "workloads nodes count: $cnt"
+            sleep 10
+          done
 
       - name: Setup firewall rules
         uses: cilium/scale-tests-action/setup-firewall@969e82091d02975fbc5a798f5b7ba065fb8c67c3 # main
@@ -352,7 +364,8 @@ jobs:
 
       - name: Wait for Cilium status to be ready
         run: |
-          cilium status --wait --interactive=false
+          kubectl rollout status -n kube-system ds/cilium
+          kubectl rollout status -n kube-system ds/cilium-envoy
 
       - name: Run CL2
         id: run-cl2

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -83,7 +83,7 @@ jobs:
   install-and-scaletest:
     runs-on: ubuntu-24.04
     name: Install and Scale Test
-    timeout-minutes: 150
+    timeout-minutes: 300
     env:
       job_name: "Install and Scale Test"
     steps:
@@ -142,6 +142,8 @@ jobs:
             --set=kubeProxyReplacement=true \
             --set=operator.replicas=1 \
             --set=updateStrategy.rollingUpdate.maxUnavailable=100% \
+            --set=ipam.mode=\"cluster-pool\" \
+            --set=ipam.operator.clusterPoolIPv4PodCIDRList[0]=\"10.0.0.0/9\" \
             --wait=false"
 
           # only add SHA to the image tags if VERSION is not set
@@ -245,13 +247,17 @@ jobs:
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
-          control_plane_size: n1-standard-8
-          control_plane_count: 1
-          node_size: e2-standard-8
+          control_plane_size: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 'n2-standard-8' || 'n2-standard-16' }}
+          control_plane_count: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 1 || 3 }}
+          node_size: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 'n2-standard-8' || 'n2-standard-16' }}
           node_count: 1
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
+          node_cidr: 10.255.0.0/16
           kube_proxy_enabled: false
+          sync_cloud_routes: false
+          etcd_volume_size: 250
+          max_in_flight: 200
 
       - name: Setup firewall rules
         uses: cilium/scale-tests-action/setup-firewall@969e82091d02975fbc5a798f5b7ba065fb8c67c3  # main
@@ -304,7 +310,7 @@ jobs:
           CL2_PROMETHEUS_PVC_ENABLED: "false"
           CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR: "true"
           CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT: "true"
-          CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 2.0
+          CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 12.0 || 24.0 }}
         timeout-minutes: 10
         run: |
           # Don't run any tasks at this point, just setup the monitoring stack
@@ -352,7 +358,7 @@ jobs:
         id: run-cl2
         working-directory: ./perf-tests/clusterloader2
         shell: bash
-        timeout-minutes: 60
+        timeout-minutes: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 60 || 180 }}
         env:
           CL2_ENABLE_PVS: "false"
           CL2_ENABLE_NETWORKPOLICIES: "true"
@@ -361,7 +367,7 @@ jobs:
           CL2_PROMETHEUS_PVC_ENABLED: "false"
           CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR: "true"
           CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT: "true"
-          CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 2.0
+          CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 12.0 || 24.0 }}
         run: |
           ./clusterloader \
             -v=2 \

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -371,8 +371,8 @@ jobs:
         run: |
           ./clusterloader \
             -v=2 \
-            --testconfig=./testing/load/config.yaml \
-            --testconfig=./testing/custom/common/restart.yaml \
+            ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && '--testconfig=./testing/load/config.yaml' || '' }}  \
+            ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && '--testconfig=./testing/custom/common/restart.yaml' || '' }}  \
             --testconfig=./testing/custom/netpol/config.yaml \
             --testconfig=./testing/custom/common/restart.yaml \
             --testconfig=./testing/custom/servicechurn/config.yaml \
@@ -393,7 +393,8 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/post-logic
         with:
-          always_capture_sysdump: true
+          capture_sysdump: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && true || false }}
+          always_capture_sysdump: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && true || false }}
           artifacts_suffix: "final"
           job_status: "${{ job.status }}"
 

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -382,6 +382,7 @@ jobs:
           CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT: "true"
           CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 12.0 || 24.0 }}
           CL2_PPROF_INTERVAL_SECONDS: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 60 || 300 }}
+          CL2_ENABLE_VIOLATIONS: ${{ steps.vars.outputs.WORKLOAD_NODES <= 100 && 'true' || 'false' }}
         run: |
           ./clusterloader \
             -v=2 \

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -105,11 +105,28 @@ jobs:
             SHA="${{ github.sha }}"
           fi
 
+          # Run test against specific commit SHA if provided
+          if [[ '${{ inputs.extra-args }}' =~ sha=([a-f0-9]+) ]]; then
+            SHA=${BASH_REMATCH[1]}
+          fi
+
           # Retrieve the desired version from the arguments.
-          if [[ "${{ inputs.extra-args }}" =~ version=([-+.0-9a-z]+) ]]; then
+          if [[ '${{ inputs.extra-args }}' =~ version=([-+.0-9a-z]+) ]]; then
             VERSION=${BASH_REMATCH[1]}
           else
             VERSION=""
+          fi
+
+          # Retrive number of workload nodes from the arguments.
+          if [[ '${{ inputs.extra-args }}' =~ nodes=([0-9+]+) ]]; then
+            WORKLOAD_NODES=${BASH_REMATCH[1]}
+          else
+            WORKLOAD_NODES=100
+          fi
+
+          if [ "${WORKLOAD_NODES}" -gt 1000 ]; then
+            echo "WORKLOAD_NODES cannot be larger than 1000, got ${WORKLOAD_NODES}"
+            exit 1
           fi
 
           # Adding k8s.local to the end makes kops happy
@@ -129,7 +146,6 @@ jobs:
 
           # only add SHA to the image tags if VERSION is not set
           if [ -z "${VERSION}" ]; then
-            echo sha=${SHA} >> $GITHUB_OUTPUT
             CILIUM_INSTALL_DEFAULTS+=" --set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
             --set=image.useDigest=false \
             --set=image.tag=${SHA} \
@@ -149,6 +165,7 @@ jobs:
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo CLUSTER_NAME=${CLUSTER_NAME} >> $GITHUB_OUTPUT
           echo VERSION=${VERSION} >> $GITHUB_OUTPUT
+          echo WORKLOAD_NODES=${WORKLOAD_NODES} >> $GITHUB_OUTPUT
 
       - name: Checkout pull request branch (NOT TRUSTED)
         if: ${{ steps.vars.outputs.version == '' }} # We don't need to checkout the PR if it's released version
@@ -295,6 +312,7 @@ jobs:
             -v=2 \
             --testconfig=./testing/custom/common/setup.yaml \
             --testoverrides=./testing/prometheus/not-scrape-kube-proxy.yaml \
+            --nodes=${{ steps.vars.outputs.workload_nodes }} \
             --provider=gce \
             --enable-exec-service=false \
             --enable-prometheus-server \
@@ -308,7 +326,7 @@ jobs:
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           node_size: e2-medium
-          node_count: 100
+          node_count: ${{ steps.vars.outputs.workload_nodes }}
           ig_name: workloads
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
 
@@ -355,7 +373,7 @@ jobs:
             --provider=gce \
             --enable-prometheus-server \
             --tear-down-prometheus-server=false \
-            --nodes=100 \
+            --nodes=${{ steps.vars.outputs.workload_nodes }} \
             --report-dir=./report \
             --experimental-prometheus-snapshot-to-report-dir=true \
             --kubeconfig=$HOME/.kube/config \


### PR DESCRIPTION
Extend scale test to allow for triggering 1k node runs. 

# Example runs:
1.17.5 run: https://github.com/cilium/cilium/actions/runs/16051518877/
Additional run: https://github.com/cilium/cilium/actions/runs/16073350779/
1.18.0-rc.0 run: https://github.com/cilium/cilium/actions/runs/16069999915/
# Test results:
Test performed with default Cilium settings + KPR enabled.
Format: Percentile v1.17.5 1.18.0-rc.0 Change
# Network policy scale test:
1k nodes / 6k identities / 30k pods / 30k network policies
CPU usage:
                                v1.17       v1.18	
50th percentile	0.39	0.30	-23% 
90th percentile	0.45	0.33	-26.6%
99th percentile	0.52	0.39	-25%
Memory usage:
                                v1.17       v1.18
50th percentile	1566 MB	1507 MB	-3.8%
90th percentile	1652 MB	1585 MB	-4%
99th percentile	1743 MB	1684 MB	-3.4%
Policy implementation latency:
                                v1.17       v1.18
50th percentile	0.009 s	0.009 s	~
90th percentile	0.023 s	0.023 s	~
99th percentile	0.53 s	0.317 s	-40%

# Service churn scale test:
1k nodes / 2.5k identities / 2.5k services / 40k backends
Services of sizes (5, 30, 250, 1000) backends
CPU usage:
                                v1.17  v1.18
50th percentile	0.24	   0.13	-45%
90th percentile	0.27	   0.15	-44%
99th percentile	0.30	   0.17	-43%
Memory usage:
50th percentile	721 MB	762 MB	+5.7%
90th percentile	758 MB	769 MB	+1.5%
99th percentile	791 MB	774 MB	+2.1%
