### PR TITLE
Makefile.kind: add make kind-dual

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -40,6 +40,10 @@ kind-clustermesh-ready: ## Check if both kind clustermesh clusters exist
 kind-ipv6: ## Create an ipv6 only kind cluster for Cilium development.
 	$(QUIET)SED=$(SED) ./contrib/scripts/kind.sh  "" "" "" "" "" "ipv6" "::1"
 
+.PHONY: kind-dual
+kind-dual: ## Create a dual stack kind cluster for Cilium development.
+	$(QUIET)SED=$(SED) IPFAMILY=dual PODSUBNET=10.1.0.0/16,fd00:10:1::/48 SERVICESUBNET=172.20.1.0/24,fd00:10:f1::/112 ./contrib/scripts/kind.sh
+
 .PHONY: kind-bgp-v4
 kind-bgp-v4:
 	$(QUIET) $(MAKE) -C contrib/containerlab/bgp-cplane-dev-v4 deploy


### PR DESCRIPTION
`make kind-dual` shortcut to create a dual-stack kind cluster without any extra features.

