### PR TITLE
Fix ingress reconciliation errors when host network is enabled

### DIFF
--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -74,7 +74,7 @@ func GetAnnotationServiceType(ingress *networkingv1.Ingress) string {
 func GetAnnotationServiceExternalTrafficPolicy(ingress *networkingv1.Ingress) (string, error) {
 	val, exists := annotation.Get(ingress, ServiceExternalTrafficPolicyAnnotation)
 	if !exists {
-		return string(corev1.ServiceExternalTrafficPolicyCluster), nil
+		return "", nil
 	}
 
 	switch val {

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -80,7 +80,7 @@ func TestGetAnnotationServiceExternalTrafficPolicy(t *testing.T) {
 			args: args{
 				ingress: &networkingv1.Ingress{},
 			},
-			want: "Cluster",
+			want: "",
 		},
 		{
 			name: "externalTrafficPolicy as Cluster",

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -272,7 +272,9 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 	if err != nil {
 		scopedLog.WarnContext(ctx, "Failed to get externalTrafficPolicy annotation from Ingress object", logfields.Error, err)
 	}
-	svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicy(eTP)
+	if eTP != "" {
+		svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicy(eTP)
+	}
 
 	// Explicitly set the controlling OwnerReference on the CiliumEnvoyConfig
 	if err := controllerutil.SetControllerReference(ingress, cec, r.client.Scheme()); err != nil {
@@ -338,7 +340,10 @@ func (r *ingressReconciler) createOrUpdateService(ctx context.Context, desiredSe
 		lbClass := svc.Spec.LoadBalancerClass
 		svc.Spec = desiredService.Spec
 		svc.Spec.LoadBalancerClass = lbClass
-		svc.Spec.ExternalTrafficPolicy = desiredService.Spec.ExternalTrafficPolicy
+
+		if desiredService.Spec.ExternalTrafficPolicy != "" {
+			svc.Spec.ExternalTrafficPolicy = desiredService.Spec.ExternalTrafficPolicy
+		}
 
 		svc.OwnerReferences = desiredService.OwnerReferences
 		svc.Annotations = mergeMap(svc.Annotations, desiredService.Annotations)


### PR DESCRIPTION
Previously the ingress annotation code for the external traffic policy was returning `Cluster` as a default. This would cause a reconciliation error when using the host network and prevent the service from being created:

```
failed to create or update Service: Service "cilium-ingress-basic-ingress" is invalid: spec.externalTrafficPolicy: Invalid value: "Cluster": may only be set for externally-accessible services
```

For the service to work in this mode, there should be no external traffic policy.

To support this, the ingress service template also had to be adjusted to check the host network flag before setting the policy.

```release-note
Fixes an error where the Ingress controller, when run in host network, created an invalid Service.
```

Fixes: #34028
