### PR TITLE
kubespray: Don't quote branch names in push trigger

### DIFF
--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -19,7 +19,7 @@ on:
         default: '{}'
   push:
     branches:
-      - 'main'
+      - main
   pull_request:
     paths:
       - '.github/workflows/conformance-kubespray.yaml'


### PR DESCRIPTION
The stable branching instructions don't match this branch name to update
for stable branches if the branch name is quoted. Remove the quotes to
make this adhere to the same form as all of the other workflows.
