### PR TITLE
hubble: remove deprecated experimental fieldmask

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -304,7 +304,7 @@ communicating via the proxy must reconnect to re-establish connections.
   across different clusters. See :ref:`change_policy_default_local_cluster` for more details and migration recommendations
   to update your network policies.
 * Kafka Network Policy support is deprecated and will be removed in Cilium v1.20.
-* Hubble field mask support was stabilized. In the Observer gRPC API, ``GetFlowsRequest.Experimental.field_mask`` was removed in favor of ``GetFlowsRequest.field_mask``. In the Hubble CLI, the ``--experimental-field-mask`` has been renamed to ``--field-mask`` and ``--experimental-use-default-field-mask`` renamed to ``-use-default-field-mask``.
+* Hubble field mask support was stabilized. In the Observer gRPC API, ``GetFlowsRequest.Experimental.field_mask`` was removed in favor of ``GetFlowsRequest.field_mask``. In the Hubble CLI, the ``--experimental-field-mask`` has been renamed to ``--field-mask`` and ``--experimental-use-default-field-mask`` renamed to ``-use-default-field-mask`` (now ``true`` by default).
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -304,7 +304,7 @@ communicating via the proxy must reconnect to re-establish connections.
   across different clusters. See :ref:`change_policy_default_local_cluster` for more details and migration recommendations
   to update your network policies.
 * Kafka Network Policy support is deprecated and will be removed in Cilium v1.20.
-* Hubble field mask support was stabilized. In the Observer gRPC API, ``GetFlowsRequest.Experimental.field_mask`` was removed in favor of ``GetFlowsRequest.field_mask``.
+* Hubble field mask support was stabilized. In the Observer gRPC API, ``GetFlowsRequest.Experimental.field_mask`` was removed in favor of ``GetFlowsRequest.field_mask``. In the Hubble CLI, the ``--experimental-field-mask`` has been renamed to ``--field-mask`` and ``--experimental-use-default-field-mask`` renamed to ``-use-default-field-mask``.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -304,6 +304,7 @@ communicating via the proxy must reconnect to re-establish connections.
   across different clusters. See :ref:`change_policy_default_local_cluster` for more details and migration recommendations
   to update your network policies.
 * Kafka Network Policy support is deprecated and will be removed in Cilium v1.20.
+* Hubble field mask support was stabilized. In the Observer gRPC API, ``GetFlowsRequest.Experimental.field_mask`` was removed in favor of ``GetFlowsRequest.field_mask``.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/api/v1/observer/README.md
+++ b/api/v1/observer/README.md
@@ -160,11 +160,6 @@ Experimental contains fields that are not stable yet. Support for
 experimental features is always optional and subject to change.
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| field_mask | [google.protobuf.FieldMask](#google-protobuf-FieldMask) |  | **Deprecated.** FieldMask allows clients to limit flow&#39;s fields that will be returned. For example, {paths: [&#34;source.id&#34;, &#34;destination.id&#34;]} will return flows with only these two fields set. Deprecated in favor of top-level field_mask. This field will be removed in v1.17. |
-
-
 
 
 

--- a/api/v1/observer/observer.pb.go
+++ b/api/v1/observer/observer.pb.go
@@ -1686,15 +1686,7 @@ func (*ExportEvent_DebugEvent) isExportEvent_ResponseTypes() {}
 // Experimental contains fields that are not stable yet. Support for
 // experimental features is always optional and subject to change.
 type GetFlowsRequest_Experimental struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// FieldMask allows clients to limit flow's fields that will be returned.
-	// For example, {paths: ["source.id", "destination.id"]} will return flows
-	// with only these two fields set.
-	// Deprecated in favor of top-level field_mask. This field will be
-	// removed in v1.17.
-	//
-	// Deprecated: Marked as deprecated in observer/observer.proto.
-	FieldMask     *fieldmaskpb.FieldMask `protobuf:"bytes,1,opt,name=field_mask,json=fieldMask,proto3" json:"field_mask,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1729,14 +1721,6 @@ func (*GetFlowsRequest_Experimental) Descriptor() ([]byte, []int) {
 	return file_observer_observer_proto_rawDescGZIP(), []int{2, 0}
 }
 
-// Deprecated: Marked as deprecated in observer/observer.proto.
-func (x *GetFlowsRequest_Experimental) GetFieldMask() *fieldmaskpb.FieldMask {
-	if x != nil {
-		return x.FieldMask
-	}
-	return nil
-}
-
 var File_observer_observer_proto protoreflect.FileDescriptor
 
 const file_observer_observer_proto_rawDesc = "" +
@@ -1754,7 +1738,7 @@ const file_observer_observer_proto_rawDesc = "" +
 	"\x11unavailable_nodes\x18\a \x03(\tR\x10unavailableNodes\x12\x18\n" +
 	"\aversion\x18\b \x01(\tR\aversion\x12\x1d\n" +
 	"\n" +
-	"flows_rate\x18\t \x01(\x01R\tflowsRate\"\xb0\x04\n" +
+	"flows_rate\x18\t \x01(\x01R\tflowsRate\"\xf7\x03\n" +
 	"\x0fGetFlowsRequest\x12\x16\n" +
 	"\x06number\x18\x01 \x01(\x04R\x06number\x12\x14\n" +
 	"\x05first\x18\t \x01(\bR\x05first\x12\x16\n" +
@@ -1769,10 +1753,8 @@ const file_observer_observer_proto_rawDesc = "" +
 	"\fexperimental\x18\xe7\a \x01(\v2&.observer.GetFlowsRequest.ExperimentalR\fexperimental\x126\n" +
 	"\n" +
 	"extensions\x18\xf0\x93\t \x01(\v2\x14.google.protobuf.AnyR\n" +
-	"extensions\x1aM\n" +
-	"\fExperimental\x12=\n" +
-	"\n" +
-	"field_mask\x18\x01 \x01(\v2\x1a.google.protobuf.FieldMaskB\x02\x18\x01R\tfieldMaskJ\x04\b\x02\x10\x03\"\x84\x02\n" +
+	"extensions\x1a\x14\n" +
+	"\fExperimentalJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03\"\x84\x02\n" +
 	"\x10GetFlowsResponse\x12 \n" +
 	"\x04flow\x18\x01 \x01(\v2\n" +
 	".flow.FlowH\x00R\x04flow\x129\n" +
@@ -1928,24 +1910,23 @@ var file_observer_observer_proto_depIdxs = []int32{
 	25, // 28: observer.ExportEvent.agent_event:type_name -> flow.AgentEvent
 	26, // 29: observer.ExportEvent.debug_event:type_name -> flow.DebugEvent
 	19, // 30: observer.ExportEvent.time:type_name -> google.protobuf.Timestamp
-	20, // 31: observer.GetFlowsRequest.Experimental.field_mask:type_name -> google.protobuf.FieldMask
-	2,  // 32: observer.Observer.GetFlows:input_type -> observer.GetFlowsRequest
-	4,  // 33: observer.Observer.GetAgentEvents:input_type -> observer.GetAgentEventsRequest
-	6,  // 34: observer.Observer.GetDebugEvents:input_type -> observer.GetDebugEventsRequest
-	8,  // 35: observer.Observer.GetNodes:input_type -> observer.GetNodesRequest
-	12, // 36: observer.Observer.GetNamespaces:input_type -> observer.GetNamespacesRequest
-	0,  // 37: observer.Observer.ServerStatus:input_type -> observer.ServerStatusRequest
-	3,  // 38: observer.Observer.GetFlows:output_type -> observer.GetFlowsResponse
-	5,  // 39: observer.Observer.GetAgentEvents:output_type -> observer.GetAgentEventsResponse
-	7,  // 40: observer.Observer.GetDebugEvents:output_type -> observer.GetDebugEventsResponse
-	9,  // 41: observer.Observer.GetNodes:output_type -> observer.GetNodesResponse
-	13, // 42: observer.Observer.GetNamespaces:output_type -> observer.GetNamespacesResponse
-	1,  // 43: observer.Observer.ServerStatus:output_type -> observer.ServerStatusResponse
-	38, // [38:44] is the sub-list for method output_type
-	32, // [32:38] is the sub-list for method input_type
-	32, // [32:32] is the sub-list for extension type_name
-	32, // [32:32] is the sub-list for extension extendee
-	0,  // [0:32] is the sub-list for field type_name
+	2,  // 31: observer.Observer.GetFlows:input_type -> observer.GetFlowsRequest
+	4,  // 32: observer.Observer.GetAgentEvents:input_type -> observer.GetAgentEventsRequest
+	6,  // 33: observer.Observer.GetDebugEvents:input_type -> observer.GetDebugEventsRequest
+	8,  // 34: observer.Observer.GetNodes:input_type -> observer.GetNodesRequest
+	12, // 35: observer.Observer.GetNamespaces:input_type -> observer.GetNamespacesRequest
+	0,  // 36: observer.Observer.ServerStatus:input_type -> observer.ServerStatusRequest
+	3,  // 37: observer.Observer.GetFlows:output_type -> observer.GetFlowsResponse
+	5,  // 38: observer.Observer.GetAgentEvents:output_type -> observer.GetAgentEventsResponse
+	7,  // 39: observer.Observer.GetDebugEvents:output_type -> observer.GetDebugEventsResponse
+	9,  // 40: observer.Observer.GetNodes:output_type -> observer.GetNodesResponse
+	13, // 41: observer.Observer.GetNamespaces:output_type -> observer.GetNamespacesResponse
+	1,  // 42: observer.Observer.ServerStatus:output_type -> observer.ServerStatusResponse
+	37, // [37:43] is the sub-list for method output_type
+	31, // [31:37] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_observer_observer_proto_init() }

--- a/api/v1/observer/observer.proto
+++ b/api/v1/observer/observer.proto
@@ -126,12 +126,7 @@ message GetFlowsRequest {
     // Experimental contains fields that are not stable yet. Support for
     // experimental features is always optional and subject to change.
     message Experimental {
-        // FieldMask allows clients to limit flow's fields that will be returned.
-        // For example, {paths: ["source.id", "destination.id"]} will return flows
-        // with only these two fields set.
-        // Deprecated in favor of top-level field_mask. This field will be
-        // removed in v1.17.
-        google.protobuf.FieldMask field_mask = 1 [deprecated=true];
+        reserved 1; // field_mask was moved outside of Experimental.
     }
     Experimental experimental = 999;
 

--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -692,11 +692,11 @@ func handleFlowArgs(writer io.Writer, ofilter *flowFilter, debug bool) (err erro
 		return fmt.Errorf("invalid output format: %s", formattingOpts.output)
 	}
 	if !jsonOut {
-		if len(experimentalOpts.fieldMask) > 0 {
+		if len(maskOpts.fieldMask) > 0 {
 			return fmt.Errorf("%s output format is not compatible with custom field mask", formattingOpts.output)
 		}
-		if experimentalOpts.useDefaultMasks {
-			experimentalOpts.fieldMask = defaults.FieldMask
+		if maskOpts.useDefaultMasks {
+			maskOpts.fieldMask = defaults.FieldMask
 		}
 	}
 
@@ -834,8 +834,8 @@ func getFlowsRequest(ofilter *flowFilter, allowlist []string, denylist []string)
 		First:     first,
 	}
 
-	if len(experimentalOpts.fieldMask) > 0 {
-		fm, err := fieldmaskpb.New(&flowpb.Flow{}, experimentalOpts.fieldMask...)
+	if len(maskOpts.fieldMask) > 0 {
+		fm, err := fieldmaskpb.New(&flowpb.Flow{}, maskOpts.fieldMask...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct field mask: %w", err)
 		}

--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -839,9 +839,7 @@ func getFlowsRequest(ofilter *flowFilter, allowlist []string, denylist []string)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct field mask: %w", err)
 		}
-		req.Experimental = &observerpb.GetFlowsRequest_Experimental{
-			FieldMask: fm,
-		}
+		req.FieldMask = fm
 	}
 
 	return req, nil

--- a/hubble/cmd/observe/flows_test.go
+++ b/hubble/cmd/observe/flows_test.go
@@ -136,10 +136,8 @@ func Test_getFlowsRequest_ExperimentalFieldMask_valid(t *testing.T) {
 	req, err := getFlowsRequest(filter, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, &observerpb.GetFlowsRequest{
-		Number: 20,
-		Experimental: &observerpb.GetFlowsRequest_Experimental{
-			FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"time", "verdict"}},
-		},
+		Number:    20,
+		FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"time", "verdict"}},
 	}, req)
 }
 
@@ -160,10 +158,8 @@ func Test_getFlowsRequest_ExperimentalUseDefaultFieldMask(t *testing.T) {
 	req, err := getFlowsRequest(filter, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, &observerpb.GetFlowsRequest{
-		Number: 20,
-		Experimental: &observerpb.GetFlowsRequest_Experimental{
-			FieldMask: &fieldmaskpb.FieldMask{Paths: defaults.FieldMask},
-		},
+		Number:    20,
+		FieldMask: &fieldmaskpb.FieldMask{Paths: defaults.FieldMask},
 	}, req)
 }
 

--- a/hubble/cmd/observe/flows_test.go
+++ b/hubble/cmd/observe/flows_test.go
@@ -129,9 +129,9 @@ denylist:
 	assert.Equal(t, expected, out)
 }
 
-func Test_getFlowsRequest_ExperimentalFieldMask_valid(t *testing.T) {
+func Test_getFlowsRequest_FieldMask_valid(t *testing.T) {
 	selectorOpts.until = ""
-	experimentalOpts.fieldMask = []string{"time", "verdict"}
+	maskOpts.fieldMask = []string{"time", "verdict"}
 	filter := newFlowFilter()
 	req, err := getFlowsRequest(filter, nil, nil)
 	require.NoError(t, err)
@@ -141,18 +141,18 @@ func Test_getFlowsRequest_ExperimentalFieldMask_valid(t *testing.T) {
 	}, req)
 }
 
-func Test_getFlowsRequest_ExperimentalFieldMask_invalid(t *testing.T) {
-	experimentalOpts.fieldMask = []string{"time", "verdict", "invalid-field"}
+func Test_getFlowsRequest_FieldMask_invalid(t *testing.T) {
+	maskOpts.fieldMask = []string{"time", "verdict", "invalid-field"}
 	filter := newFlowFilter()
 	_, err := getFlowsRequest(filter, nil, nil)
 	require.ErrorContains(t, err, "invalid-field")
 }
 
-func Test_getFlowsRequest_ExperimentalUseDefaultFieldMask(t *testing.T) {
+func Test_getFlowsRequest_UseDefaultFieldMask(t *testing.T) {
 	selectorOpts.until = ""
 	formattingOpts.output = "dict"
-	experimentalOpts.fieldMask = nil
-	experimentalOpts.useDefaultMasks = true
+	maskOpts.fieldMask = nil
+	maskOpts.useDefaultMasks = true
 	filter := newFlowFilter()
 	require.NoError(t, handleFlowArgs(os.Stdout, filter, false))
 	req, err := getFlowsRequest(filter, nil, nil)
@@ -163,10 +163,10 @@ func Test_getFlowsRequest_ExperimentalUseDefaultFieldMask(t *testing.T) {
 	}, req)
 }
 
-func Test_getFlowsRequest_ExperimentalFieldMask_non_json_output(t *testing.T) {
+func Test_getFlowsRequest_FieldMask_non_json_output(t *testing.T) {
 	selectorOpts.until = ""
 	formattingOpts.output = "compact"
-	experimentalOpts.fieldMask = []string{"time", "verdict"}
+	maskOpts.fieldMask = []string{"time", "verdict"}
 	filter := newFlowFilter()
 	err := handleFlowArgs(os.Stdout, filter, false)
 	require.ErrorContains(t, err, "not compatible")

--- a/hubble/cmd/observe/observe.go
+++ b/hubble/cmd/observe/observe.go
@@ -162,7 +162,7 @@ func init() {
 	otherFlags.StringSliceVar(&maskOpts.fieldMask, "field-mask", nil,
 		"Comma-separated list of fields for mask. Fields not in the mask will be removed from server response.")
 
-	otherFlags.BoolVar(&maskOpts.useDefaultMasks, "use-default-field-masks", false,
+	otherFlags.BoolVar(&maskOpts.useDefaultMasks, "use-default-field-masks", true,
 		"Request only visible fields when the output format is compact, tab, or dict.")
 }
 

--- a/hubble/cmd/observe/observe.go
+++ b/hubble/cmd/observe/observe.go
@@ -38,15 +38,15 @@ var (
 		color               string
 	}
 
+	maskOpts struct {
+		fieldMask       []string
+		useDefaultMasks bool
+	}
+
 	otherOpts struct {
 		ignoreStderr    bool
 		printRawFilters bool
 		inputFile       string
-	}
-
-	experimentalOpts struct {
-		fieldMask       []string
-		useDefaultMasks bool
 	}
 
 	printer *hubprinter.Printer
@@ -159,11 +159,11 @@ func init() {
 	otherFlags.StringVar(&otherOpts.inputFile, "input-file", "",
 		"Query flows from this file instead of the server. Use '-' to read from stdin.")
 
-	otherFlags.StringSliceVar(&experimentalOpts.fieldMask, "experimental-field-mask", nil,
-		"Experimental: Comma-separated list of fields for mask. Fields not in the mask will be removed from server response.")
+	otherFlags.StringSliceVar(&maskOpts.fieldMask, "field-mask", nil,
+		"Comma-separated list of fields for mask. Fields not in the mask will be removed from server response.")
 
-	otherFlags.BoolVar(&experimentalOpts.useDefaultMasks, "experimental-use-default-field-masks", false,
-		"Experimental: request only visible fields when the output format is compact, tab, or dict.")
+	otherFlags.BoolVar(&maskOpts.useDefaultMasks, "use-default-field-masks", false,
+		"Request only visible fields when the output format is compact, tab, or dict.")
 }
 
 // New observer command.

--- a/hubble/cmd/observe_help.txt
+++ b/hubble/cmd/observe_help.txt
@@ -169,11 +169,11 @@ Server Flags:
       --tls-server-name string        Specify a server name to verify the hostname on the returned certificate (eg: 'instance.hubble-relay.cilium.io').
 
 Other Flags:
-      --experimental-field-mask strings        Experimental: Comma-separated list of fields for mask. Fields not in the mask will be removed from server response.
-      --experimental-use-default-field-masks   Experimental: request only visible fields when the output format is compact, tab, or dict.
-      --input-file string                      Query flows from this file instead of the server. Use '-' to read from stdin.
-      --print-raw-filters                      Print allowlist/denylist filters and exit without sending the request to Hubble server
-  -s, --silent-errors                          Silently ignores errors and warnings
+      --field-mask strings        Comma-separated list of fields for mask. Fields not in the mask will be removed from server response.
+      --input-file string         Query flows from this file instead of the server. Use '-' to read from stdin.
+      --print-raw-filters         Print allowlist/denylist filters and exit without sending the request to Hubble server
+  -s, --silent-errors             Silently ignores errors and warnings
+      --use-default-field-masks   Request only visible fields when the output format is compact, tab, or dict.
 
 Global Flags:
       --config string   Optional config file (default "%s")

--- a/hubble/cmd/observe_help.txt
+++ b/hubble/cmd/observe_help.txt
@@ -173,7 +173,7 @@ Other Flags:
       --input-file string         Query flows from this file instead of the server. Use '-' to read from stdin.
       --print-raw-filters         Print allowlist/denylist filters and exit without sending the request to Hubble server
   -s, --silent-errors             Silently ignores errors and warnings
-      --use-default-field-masks   Request only visible fields when the output format is compact, tab, or dict.
+      --use-default-field-masks   Request only visible fields when the output format is compact, tab, or dict. (default true)
 
 Global Flags:
       --config string   Optional config file (default "%s")

--- a/hubble/pkg/defaults/defaults.go
+++ b/hubble/pkg/defaults/defaults.go
@@ -43,9 +43,29 @@ var (
 	// It may be unset.
 	ConfigFile string
 
-	// FieldMask is a list of requested fields when using "dict", "tab", or "compact"
-	// output format and no custom mask is specified.
-	FieldMask = []string{"time", "source.identity", "source.namespace", "source.pod_name", "destination.identity", "destination.namespace", "destination.pod_name", "source_service", "destination_service", "l4", "IP", "ethernet", "l7", "Type", "node_name", "is_reply", "event_type", "verdict", "Summary"}
+	// FieldMask is a list of requested fields when using "dict", "tab", or
+	// "compact" output format and no custom mask is specified.
+	FieldMask = []string{
+		"time",
+		"verdict",
+		"ethernet",
+		"IP",
+		"l4",
+		"source.identity",
+		"source.namespace",
+		"source.pod_name",
+		"destination.identity",
+		"destination.namespace",
+		"destination.pod_name",
+		"Type",
+		"node_name",
+		"l7",
+		"event_type",
+		"source_service",
+		"destination_service",
+		"is_reply",
+		"Summary",
+	}
 )
 
 func init() {

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -317,10 +317,6 @@ func (s *LocalObserverServer) GetFlows(
 	}
 
 	fm := req.GetFieldMask()
-	if len(fm.GetPaths()) == 0 {
-		// TODO: Remove req.Experimental.GetFieldMask after v1.17
-		fm = req.Experimental.GetFieldMask()
-	}
 	mask, err := fieldmask.New(fm)
 	if err != nil {
 		return err

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -291,9 +291,6 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 	req = &observerpb.GetFlowsRequest{
 		Number:    uint64(10),
 		FieldMask: &fieldmaskpb.FieldMask{Paths: fmPaths},
-		Experimental: &observerpb.GetFlowsRequest_Experimental{
-			FieldMask: &fieldmaskpb.FieldMask{Paths: fmPaths},
-		},
 	}
 	err = s.GetFlows(req, fakeServer)
 	assert.NoError(t, err)
@@ -316,9 +313,6 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 	req = &observerpb.GetFlowsRequest{
 		Number:    uint64(10),
 		FieldMask: &fieldmaskpb.FieldMask{Paths: []string{""}},
-		Experimental: &observerpb.GetFlowsRequest_Experimental{
-			FieldMask: &fieldmaskpb.FieldMask{Paths: []string{""}},
-		},
 	}
 	err = s.GetFlows(req, fakeServer)
 	assert.EqualError(t, err, "invalid fieldmask")

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -255,9 +255,6 @@ func benchmarkRelayGetFlows(b *testing.B, withFieldMask bool) {
 		)
 		require.NoError(b, err)
 		getFlowsReq.FieldMask = fieldmask
-		getFlowsReq.Experimental = &observerpb.GetFlowsRequest_Experimental{
-			FieldMask: fieldmask,
-		}
 	}
 	found := make([]*observerpb.Flow, 0, numFlows)
 	b.StartTimer()


### PR DESCRIPTION
Promote the CLI fieldmask related flags to stable on the way, and make `--use-default-field-masks` the default. To be merged after v1.18 so we have some time to test the `--use-default-field-masks` change.

<del>_Still TODO: update upgrade.rst to document the CLI and API changes._</del>

Closes #40235