### PR TITLE
Fix LoadBalancerAlgorithm for LocalRedirect services

### DIFF
--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -758,16 +758,24 @@ func (rpm *Manager) upsertService(config *LRPConfig, frontendMapping *feMapping)
 			L3n4Addr: be.L3n4Addr,
 		})
 	}
+	loadBalancerAlgorithm := lb.ToSVCLoadBalancingAlgorithm(option.Config.NodePortAlg)
+	if loadBalancerAlgorithm == lb.SVCLoadBalancingAlgorithmUndef {
+		log.WithFields(logrus.Fields{
+			"service": config.id.Name,
+		}).Warn("LoadBalancer algorithm not configured, falling back to random")
+		loadBalancerAlgorithm = lb.SVCLoadBalancingAlgorithmRandom
+	}
 	p := &lb.SVC{
 		Name: lb.ServiceName{
 			Name:      config.id.Name + localRedirectSvcStr,
 			Namespace: config.id.Namespace,
 		},
-		Type:             lb.SVCTypeLocalRedirect,
-		Frontend:         frontendAddr,
-		Backends:         backendAddrs,
-		ExtTrafficPolicy: lb.SVCTrafficPolicyCluster,
-		IntTrafficPolicy: lb.SVCTrafficPolicyCluster,
+		Type:                  lb.SVCTypeLocalRedirect,
+		Frontend:              frontendAddr,
+		Backends:              backendAddrs,
+		ExtTrafficPolicy:      lb.SVCTrafficPolicyCluster,
+		IntTrafficPolicy:      lb.SVCTrafficPolicyCluster,
+		LoadBalancerAlgorithm: loadBalancerAlgorithm,
 	}
 
 	if _, _, err := rpm.svcManager.UpsertService(p); err != nil {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

## Initial conditions

- Cilium 1.17.4.
- Configuring Cilium for BPF LoadBalancer in `ConfigMap`:

```yaml
bpf-lb-algorithm: random
bpf-lb-external-clusterip: "true"
bpf-lb-map-max: "512000"
bpf-lb-mode: snat
bpf-lb-sock: "true"
bpf-lb-sock-hosts-only: "true"
bpf-lb-sock-terminate-pod-connections: "true"
```

- A `CiliumLocalRedirectPolicy` is configured that forwards DNS traffic to the local NodeLocal DNS:

```yaml
apiVersion: cilium.io/v2
kind: CiliumLocalRedirectPolicy
metadata:
  name: node-local-dns
  namespace: kube-system
spec:
  redirectBackend:
    localEndpointSelector:
      matchLabels:
        app: node-local-dns
    toPorts:
    - name: dns
      port: "53"
      protocol: UDP
    - name: dns-tcp
      port: "53"
      protocol: TCP
  redirectFrontend:
    serviceMatcher:
      namespace: kube-system
      serviceName: d8-kube-dns
```

No problems are observed with these settings.

## Problem description and how to reproduce it

When the Cilium setting `bpf-lb-algorithm-annotation: "true"` is enabled, `CiliumLocalRedirectPolicy` stops working and the DNS service becomes unavailable across the cluster:

```shell
# kubectl exec -it netshoot-client-5cf56f8774-6qp8s -- bash
netshoot-client-5cf56f8774-6qp8s:~# dig google.com +short
;; communications error to 10.222.0.10#53: connection refused
;; communications error to 10.222.0.10#53: connection refused
;; communications error to 10.222.0.10#53: connection refused

; <<>> DiG 9.20.10 <<>> google.com +short
;; global options: +cmd
;; no servers could be reached
```

In the agent logs, you can see that the `node-local-dns-local-redirect` service has no balancer algorithm defined (`LoadBalancerAlgorithm=0`):

```log
time="2025-06-27T07:11:41.054983112Z" level=debug msg="Upserting service" LoadBalancerAlgorithm=0 backends="[[10.111.0.219:53/TCP,State:active]]" l7LBProxyPort=0 loadBalancerSourceRanges="[]" loadBalancerSourceRangesPolicy= serviceIP="{10.222.0. 10 {TCP 53} 0}" serviceName=node-local-dns-local-redirect serviceNamespace=kube-system sessionAffinity=false sessionAffinityTimeout=0 subsys=service svcExtTrafficPolicy=Cluster svcForwardingMode= svcHealthCheckNodePort=0 svcIntTrafficPolicy=Cluster svcType=LocalRedirect
```

## Solution

This PR changes the logic in `pkg/redirectpolicy/manager.go` so that services like `LocalRedirect` inherit the `LoadBalancerAlgorithm` from the Cilium global settings, preventing `LoadBalancerAlgorithm=0` from being set. After the changes:

```log
time="2025-06-27T08:37:06.517037087Z" level=debug msg="Upserting service" LoadBalancerAlgorithm=1 backends="[[10.111.0.219:53/TCP,State:active]]" l7LBProxyPort=0 loadBalancerSourceRanges="[]" loadBalancerSourceRangesPolicy= serviceIP="{10.222.0. 10 {TCP 53} 0}" serviceName=node-local-dns-local-redirect serviceNamespace=kube-system sessionAffinity=false sessionAffinityTimeout=0 subsys=service svcExtTrafficPolicy=Cluster svcForwardingMode= svcHealthCheckNodePort=0 svcIntTrafficPolicy=Cluster svcType=LocalRedirect
```

DNS traffic is forwarded correctly through `CiliumLocalRedirectPolicy`:

```bash
# kubectl exec -it netshoot-client-5cf56f8774-6qp8s -- bash
netshoot-client-5cf56f8774-6qp8s:~# dig google.com +short
216.58.210.174
```

```release-note
Fix bug where LocalRedirectPolicy forwarding would break if you enable `bpf-lb-algorithm-annotation`
```