### PR TITLE
docs: Update python dependencies

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:e332e05b42048187962d81c83afd32d4c790aeed@sha256:7b1a2f8a4fada4c77cc5e99f5210784c9856ded068a22d971f31a15b86c8533e
+        uses: docker://quay.io/cilium/docs-builder:4015b45ded282d474b3c72d7f2c61c70ef82d96a@sha256:455cde42f0abcdd7a3ee480197dd7fc52dfc66af8a54113ae517dc3c7054c27c
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -49,7 +49,7 @@ pyenchant==3.2.2
 Pygments==2.16.1
 PyYAML==6.0.1
 referencing==0.30.2
-requests==2.32.0
+requests==2.32.4
 rich==13.5.2
 rpds-py==0.10.3
 rstcheck-core==1.1.1
@@ -68,4 +68,4 @@ sphinxcontrib-serializinghtml==1.1.5
 tornado==6.5
 typer==0.9.0
 typing_extensions==4.7.1
-urllib3==2.2.2
+urllib3==2.5.0


### PR DESCRIPTION
Update some of the python dependencies.

Unfortunately a fully `make -C Documentation/ update-requirements` seems to break the build, so more investigation will be necessary to bump the remaining dependencies.

