### PR TITLE
Revert commit 59b97eee28b7 ("maps/policymap, daemon: Create policy maps from daemon")

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -170,10 +170,6 @@ func (d *Daemon) initMaps() error {
 		}
 	}
 
-	for _, ep := range d.endpointManager.GetEndpoints() {
-		ep.InitMap()
-	}
-
 	for _, m := range ctmap.GlobalMaps(option.Config.EnableIPv4,
 		option.Config.EnableIPv6) {
 		if err := m.Create(); err != nil {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -858,14 +858,6 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 	}
 }
 
-// InitMap creates the policy map in the kernel.
-func (e *Endpoint) InitMap() error {
-	if e.policyMapFactory == nil {
-		return fmt.Errorf("endpoint has nil policyMapFactory")
-	}
-	return e.policyMapFactory.CreateEndpoint(e.ID)
-}
-
 // deleteMaps deletes the endpoint's entry from the global
 // cilium_(egress)call_policy maps and removes endpoint-specific cilium_calls_,
 // cilium_policy_v2_ and cilium_ct{4,6}_ map pins.

--- a/pkg/maps/policymap/cell.go
+++ b/pkg/maps/policymap/cell.go
@@ -50,7 +50,6 @@ func (def PolicyConfig) Flags(flags *pflag.FlagSet) {
 
 type Factory interface {
 	OpenEndpoint(id uint16) (*PolicyMap, error)
-	CreateEndpoint(id uint16) error
 	RemoveEndpoint(id uint16) error
 
 	PolicyMaxEntries() int
@@ -90,16 +89,7 @@ func (f *factory) OpenEndpoint(id uint16) (*PolicyMap, error) {
 	return m, nil
 }
 
-// CreateEndpoint creates a policy map for the specified endpoint.
-func (f *factory) CreateEndpoint(id uint16) error {
-	m, err := newPolicyMap(f.logger, id, f.policyMapEntries, f.stats)
-	if err != nil {
-		return err
-	}
-	return m.Create()
-}
-
-// CreateEndpoint removes the policy map if the specified endpoint.
+// RemoveEndpoint removes the policy map of the specified endpoint.
 func (f *factory) RemoveEndpoint(id uint16) error {
 	return os.RemoveAll(bpf.LocalMapPath(f.logger, MapName, id))
 }


### PR DESCRIPTION
This PR reverts commit 59b97eee28b7 ("maps/policymap, daemon: Create policy maps from daemon"). Endpoint manager is newly created and empty at the point where `d.initMaps()` is called, so the loop over endpoints does nothing (and never did anything).