### PR TITLE
Don't create cilium-azure secret when azure.clientID is not set

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -170,6 +170,7 @@ spec:
         - name: AZURE_RESOURCE_GROUP
           value: {{ .Values.azure.resourceGroup }}
         {{- end }}
+        {{- if .Values.azure.clientID }}
         - name: AZURE_CLIENT_ID
           valueFrom:
             secretKeyRef:
@@ -180,6 +181,7 @@ spec:
             secretKeyRef:
               name: cilium-azure
               key: AZURE_CLIENT_SECRET
+        {{- end }}
         {{- end }}
         {{- with .Values.operator.extraEnv }}
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.operator.enabled }}
 {{- if .Values.azure.enabled }}
+{{- if .Values.azure.clientID }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,5 +18,6 @@ type: Opaque
 data:
   AZURE_CLIENT_ID: {{ default "" .Values.azure.clientID | b64enc | quote }}
   AZURE_CLIENT_SECRET: {{ default "" .Values.azure.clientSecret | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
When using Azure workload identity (the AKS-recommended authentication method), it is the AWI mutating admission webhook that injects client id, tenant id and so on into pods. If cilium-operator's pod spec already has the environment variable `AZURE_CLIENT_ID` mounted from the secret, the webhook does not overwrite it with the correct value, workload identity credential fails to acquire a token, and cilium-operator cannot sync IPAM information. And if neither client id nor client secret are specified, there is no need to create the cilium-azure secret.

This commit modifies the cilium helm chart to skip creating the cilium-azure secret and the environment variable bindings to it in cilium-operator's pod spec when `azure.clientID` helm value is not set.

```release-note
Fixes the Operator's configuration to be compatible with Azure workload identity.
```