### PR TITLE
docs: add egressDeny example to CiliumNetworkPolicy language guide

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -124,6 +124,17 @@ Note that while the above examples allow all egress traffic from an endpoint, th
 of the egress traffic may have ingress rules that deny the traffic. In other words,
 policy must be configured on both sides (sender and receiver).
 
+Simple Egress Deny
+~~~~~~~~~~~~~~~~~~
+
+The following example illustrates how to deny communication to endpoints with
+the label ``role=backend`` from endpoints with the label ``role=frontend``.
+If an ``egressDeny`` rule matches, egress traffic is denied even if the policy
+contains ``egress`` rules that would otherwise allow it.
+
+.. literalinclude:: ../../../examples/policies/l3/egress-deny/egress-deny.yaml
+   :language: yaml
+
 Ingress/Egress Default Deny
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -666,7 +677,7 @@ which is defined as follows:
             // +kubebuilder:validation:Optional
             // +kubebuilder:validation:Enum=IPv4;IPv6
             Family string `json:"family,omitempty"`
-        
+
 	        // Type is a ICMP-type.
 	        // It should be an 8bit code (0-255), or it's CamelCase name (for example, "EchoReply").
 	        // Allowed ICMP types are:
@@ -811,7 +822,7 @@ latter rule will have no effect.
 
 .. note:: :ref:`EnableDefaultDeny <policy_mode_default>` does not apply to layer-7 rules.
    If using a layer 7 rule in concert with ``EnableDefaultDeny``, the rule should
-   allow all layer-7 traffic. See :gh-issue:`38676`. 
+   allow all layer-7 traffic. See :gh-issue:`38676`.
 
 HTTP
 ----
@@ -847,7 +858,7 @@ Allow GET /public
 ~~~~~~~~~~~~~~~~~
 
 The following example allows ``GET`` requests to the URL ``/public`` from the
-endpoints with the labels ``env=prod`` to endpoints with the labels 
+endpoints with the labels ``env=prod`` to endpoints with the labels
 ``app=service``, but requests to any other URL, or using another method, will
 be rejected. Requests on ports other than port 80 will be dropped.
 
@@ -1018,7 +1029,7 @@ respecting TTL.
 
 .. _DNS Proxy:
 
-DNS Proxy 
+DNS Proxy
 """""""""
   A DNS Proxy intercepts egress DNS traffic and records IPs seen in the
   responses. This interception is, itself, a separate policy rule governing the
@@ -1133,33 +1144,33 @@ domain name.
 Disk based Cilium Network Policies
 ==================================
 This functionality enables users to place network policy YAML files directly into
-the node's filesystem, bypassing the need for definition via k8s CRD. 
-By setting the config field ``static-cnp-path``, users specify the directory from 
-which policies will be loaded. The Cilium agent then processes all policy YAML files 
-present in this directory, transforming them into rules that are incorporated into 
-the policy engine. Additionally, the Cilium agent monitors this directory for any 
-new policy YAML files as well as any updates or deletions, making corresponding 
-updates to the policy engine's rules. It is important to note that this feature 
+the node's filesystem, bypassing the need for definition via k8s CRD.
+By setting the config field ``static-cnp-path``, users specify the directory from
+which policies will be loaded. The Cilium agent then processes all policy YAML files
+present in this directory, transforming them into rules that are incorporated into
+the policy engine. Additionally, the Cilium agent monitors this directory for any
+new policy YAML files as well as any updates or deletions, making corresponding
+updates to the policy engine's rules. It is important to note that this feature
 only supports CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy.
 
-The directory that the Cilium agent needs to monitor should be mounted from the host 
+The directory that the Cilium agent needs to monitor should be mounted from the host
 using volume mounts. For users deploying via Helm, this can be enabled via ``extraArgs``
 and ``extraHostPathMounts`` as follows:
 
 .. code-block:: yaml
 
-   extraArgs:                                                                                                                                        
-   - --static-cnp-path=/policies                                                                                                                   
-   extraHostPathMounts:                                                                                                                              
-   - name: static-policies                                                                                                                         
-      mountPath: /policies                                                                                                                          
-      hostPath: /policies                                                                                                                           
-      hostPathType: Directory  
+   extraArgs:
+   - --static-cnp-path=/policies
+   extraHostPathMounts:
+   - name: static-policies
+      mountPath: /policies
+      hostPath: /policies
+      hostPathType: Directory
 
-To determine whether a policy was established via Kubernetes CRD or directly from a directory, 
-execute the command ``cilium policy get`` and examine the source attribute within the policy. 
-In output, you could notice policies that have been sourced from a directory will have the 
-``source`` field set as ``directory``. Additionally, ``cilium endpoint get <endpoint_id>`` also have 
+To determine whether a policy was established via Kubernetes CRD or directly from a directory,
+execute the command ``cilium policy get`` and examine the source attribute within the policy.
+In output, you could notice policies that have been sourced from a directory will have the
+``source`` field set as ``directory``. Additionally, ``cilium endpoint get <endpoint_id>`` also have
 fields to show the source of policy associated with that endpoint.
 
 Previous limitations and known issues

--- a/examples/policies/l3/egress-deny/egress-deny.yaml
+++ b/examples/policies/l3/egress-deny/egress-deny.yaml
@@ -1,0 +1,15 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "deny-egress-example"
+spec:
+  endpointSelector:
+    matchLabels:
+      role: frontend
+  egress:
+  - toEntities:
+    - all
+  egressDeny:
+  - toEndpoints:
+    - matchLabels:
+        role: backend


### PR DESCRIPTION
### Summary

This PR adds a new section to the network policy language documentation introducing the `egressDeny` field in `CiliumNetworkPolicy`. It includes a real-world use case, explanation, and YAML/JSON examples.

### What This PR Adds

- A new section: **Simple Egress Deny**, following the structure of existing examples like *Simple Egress Allow*
- A single YAML usage example: `egress-deny.yaml`
- Documentation updated to use the latest `literalinclude` format (introduced in #40212)
- Clarification on precedence behavior: `egressDeny` rules override matching `egress` rules
- All content has been tested against a local kind + Cilium v1.17.4 cluster and confirmed to function as expected


### Testing

Manually verified using:
- `kubectl apply -f egress-deny.yaml`
- Busybox pods with appropriate labels (`role=frontend`, `role=backend`)
- Confirmed enforcement using `ping`, `nslookup`, and Hubble (`DROP EGRESS PolicyDeny`)

### Related

This PR provides the missing documentation for `egressDeny` discussed in [#39697](https://github.com/cilium/cilium/issues/39697).


---

### Release Note

```release-note
Add documentation and examples for using the egressDeny field in CiliumNetworkPolicy
