### PR TITLE
 ipcache/metadata: flatten metadata once on read 

### DIFF
--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -4,11 +4,9 @@
 package ipcache
 
 import (
-	"bytes"
 	"log/slog"
 	"maps"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/identity"
@@ -29,6 +27,10 @@ import (
 // means it needs to be deep-copied via (*resourceInfo).DeepCopy().
 type prefixInfo struct {
 	byResource map[ipcachetypes.ResourceID]*resourceInfo
+
+	// flattened is the fully resolved information, with all information
+	// by resource merged.
+	flattened *resourceInfo
 }
 
 func newPrefixInfo() *prefixInfo {
@@ -138,6 +140,55 @@ func (m *resourceInfo) unmerge(logger *slog.Logger, info IPMetadata) {
 	}
 }
 
+// has returns true if the resourceInfo already has the particular metadata.
+// in the case of labels, the existing labels may be a superset.
+// In other words, returns true if merging info would result in m
+// being unchanged. It is used to prevent needless cache busting
+// when updating metadata.
+func (m *resourceInfo) has(src source.Source, infos []IPMetadata) bool {
+	if m == nil {
+		return false
+	}
+	if m.source != src {
+		return false
+	}
+
+	for _, info := range infos {
+		switch i := info.(type) {
+		case labels.Labels:
+			for key, newLabel := range i {
+				existingLabel, ok := m.labels[key]
+				if !ok || newLabel != existingLabel {
+					return false
+				}
+			}
+		case overrideIdentity:
+			if m.identityOverride != i {
+				return false
+			}
+		case ipcachetypes.TunnelPeer:
+			if m.tunnelPeer != i {
+				return false
+			}
+		case ipcachetypes.EncryptKey:
+			if m.encryptKey != i {
+				return false
+			}
+		case ipcachetypes.RequestedIdentity:
+			if m.requestedIdentity != i {
+				return false
+			}
+		case ipcachetypes.EndpointFlags:
+			if m.endpointFlags != i {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func (m *resourceInfo) isValid() bool {
 	if m.labels != nil {
 		return true
@@ -194,211 +245,207 @@ func (s *prefixInfo) sortedBySourceThenResourceID() []ipcachetypes.ResourceID {
 	})
 }
 
-func (s *prefixInfo) ToLabels() labels.Labels {
-	l := labels.NewLabelsFromModel(nil)
-	if s == nil {
-		return l
+func (r *resourceInfo) ToLabels() labels.Labels {
+	if r.labels == nil {
+		return labels.Labels{} // code expects non-nil Labels.
 	}
-	for _, v := range s.byResource {
-		l.MergeLabels(v.labels)
-	}
-	return l
+	return r.labels
 }
 
-func (s *prefixInfo) Source() source.Source {
-	src := source.Unspec
-	for _, v := range s.byResource {
-		if source.AllowOverwrite(src, v.source) {
-			src = v.source
-		}
+func (r *resourceInfo) Source() source.Source {
+	if r == nil {
+		return source.Unspec
 	}
-	return src
+	return r.source
 }
 
-func (s *prefixInfo) EncryptKey() ipcachetypes.EncryptKey {
-	for rid := range s.byResource {
-		if k := s.byResource[rid].encryptKey; k.IsValid() {
-			return k
-		}
+func (r *resourceInfo) EncryptKey() ipcachetypes.EncryptKey {
+	if r == nil {
+		return ipcachetypes.EncryptKeyEmpty
 	}
-	return ipcachetypes.EncryptKeyEmpty
+	return r.encryptKey
 }
 
-func (s *prefixInfo) TunnelPeer() ipcachetypes.TunnelPeer {
-	for rid := range s.byResource {
-		if t := s.byResource[rid].tunnelPeer; t.IsValid() {
-			return t
-		}
+func (r *resourceInfo) TunnelPeer() ipcachetypes.TunnelPeer {
+	if r == nil {
+		return ipcachetypes.TunnelPeer{}
 	}
-	return ipcachetypes.TunnelPeer{}
+	return r.tunnelPeer
 }
 
-func (s *prefixInfo) RequestedIdentity() ipcachetypes.RequestedIdentity {
-	for _, rid := range s.sortedBySourceThenResourceID() {
-		if id := s.byResource[rid].requestedIdentity; id.IsValid() {
-			return id
-		}
+func (r *resourceInfo) RequestedIdentity() ipcachetypes.RequestedIdentity {
+	if r == nil {
+		return ipcachetypes.RequestedIdentity(identity.InvalidIdentity)
 	}
-	return ipcachetypes.RequestedIdentity(identity.InvalidIdentity)
+	return r.requestedIdentity
 }
 
-func (s *prefixInfo) EndpointFlags() ipcachetypes.EndpointFlags {
-	for _, rid := range s.sortedBySourceThenResourceID() {
-		if flags := s.byResource[rid].endpointFlags; flags.IsValid() {
-			return flags
-		}
+func (r *resourceInfo) EndpointFlags() ipcachetypes.EndpointFlags {
+	if r == nil {
+		return ipcachetypes.EndpointFlags{}
 	}
-	return ipcachetypes.EndpointFlags{}
+	return r.endpointFlags
 }
 
-// identityOverride extracts the labels of the pre-determined identity from
-// the prefix info. If no override identity is present, this returns nil.
-// This pre-determined identity will overwrite any other identity which may
-// be derived from the prefix labels.
-func (s *prefixInfo) identityOverride() (lbls labels.Labels, hasOverride bool) {
-	identities := make([]labels.Labels, 0, 1)
-	for _, info := range s.byResource {
-		// We emit a warning in logConflicts if an identity override
-		// was requested without labels
-		if info.identityOverride && len(info.labels) > 0 {
-			identities = append(identities, info.labels)
+// identityOverride returns true if the exact set of labels has been specified
+// and should not be manipulated further.
+func (r *resourceInfo) IdentityOverride() bool {
+	if r == nil {
+		return false
+	}
+	return bool(r.identityOverride)
+
+}
+
+// flatten resolves the set of all possible metadata in to a single
+// flattened resource.
+// In the event of a conflict, entries with a higher precedence source
+// will win.
+func (s *prefixInfo) flatten(scopedLog *slog.Logger) *resourceInfo {
+	// shortcut: with exactly one resource, we just return it
+	if len(s.byResource) == 1 {
+		for _, r := range s.byResource {
+			return r
 		}
 	}
 
-	// No override identity present
-	if len(identities) == 0 {
-		return nil, false
-	}
+	out := &resourceInfo{}
 
-	// Conflict-resolution: We pick the labels with the alphabetically
-	// lowest value when formatted in the KV store format. The conflict
-	// is logged below in logConflicts.
-	if len(identities) > 1 {
-		sort.Slice(identities, func(i, j int) bool {
-			a := identities[i].SortedList()
-			b := identities[j].SortedList()
-			return bytes.Compare(a, b) == -1
-		})
-	}
-
-	return identities[0], true
-}
-
-func (ri resourceInfo) shouldLogConflicts() bool {
-	return bool(ri.identityOverride) || ri.tunnelPeer.IsValid() || ri.encryptKey.IsValid() || ri.requestedIdentity.IsValid() || ri.endpointFlags.IsValid()
-}
-
-func (s *prefixInfo) logConflicts(scopedLog *slog.Logger) {
 	var (
-		override           labels.Labels
-		overrideResourceID ipcachetypes.ResourceID
-
-		tunnelPeer           ipcachetypes.TunnelPeer
-		tunnelPeerResourceID ipcachetypes.ResourceID
-
-		encryptKey           ipcachetypes.EncryptKey
-		encryptKeyResourceID ipcachetypes.ResourceID
-
-		requestedID           ipcachetypes.RequestedIdentity
-		requestedIDResourceID ipcachetypes.ResourceID
-
-		endpointFlags           ipcachetypes.EndpointFlags
+		overrideResourceID      ipcachetypes.ResourceID
+		tunnelPeerResourceID    ipcachetypes.ResourceID
+		encryptKeyResourceID    ipcachetypes.ResourceID
+		requestedIDResourceID   ipcachetypes.ResourceID
 		endpointFlagsResourceID ipcachetypes.ResourceID
 	)
+
+	labelResourceIDs := map[string]ipcachetypes.ResourceID{}
 
 	for _, resourceID := range s.sortedBySourceThenResourceID() {
 		info := s.byResource[resourceID]
 
-		if info.identityOverride {
-			if len(override) > 0 {
-				scopedLog.Warn(
-					"Detected conflicting identity override for prefix. "+
-						"This may cause connectivity issues for this address.",
-					logfields.Identity, override,
-					logfields.Resource, overrideResourceID,
-					logfields.ConflictingIdentity, info.labels,
-					logfields.ConflictingResource, resourceID,
-				)
-			}
+		// Sorted by source priority, so the first source wins.
+		if out.source == "" {
+			out.source = info.source
+		}
 
+		if len(info.labels) > 0 && !out.identityOverride /* identityOverride already fixed the labels */ {
+			if len(out.labels) > 0 {
+				// merge labels, complaining if the value exists
+				for key, newLabel := range info.labels {
+					otherLabel, exists := out.labels[key]
+					if exists && !otherLabel.DeepEqual(&newLabel) {
+						scopedLog.Warn(
+							"Detected conflicting label for prefix. "+
+								"This may cause connectivity issues for this address.",
+							logfields.Labels, out.labels,
+							logfields.Resource, labelResourceIDs[key],
+							logfields.ConflictingLabels, otherLabel,
+						)
+					} else if !exists {
+						out.labels[key] = newLabel
+						labelResourceIDs[key] = resourceID
+					}
+				}
+			} else {
+				out.labels = labels.NewFrom(info.labels) // copy map, as we will be mutating it
+			}
+		}
+
+		if info.identityOverride {
 			if len(info.labels) == 0 {
 				scopedLog.Warn(
 					"Detected identity override, but no labels where specified. "+
 						"Falling back on the old non-override labels. "+
 						"This may cause connectivity issues for this address.",
 					logfields.Resource, resourceID,
-					logfields.IdentityOld, s.ToLabels(),
 				)
 			} else {
-				override = info.labels
-				overrideResourceID = resourceID
+				if out.identityOverride {
+					scopedLog.Warn(
+						"Detected conflicting identity override for prefix. "+
+							"This may cause connectivity issues for this address.",
+						logfields.Labels, out.labels,
+						logfields.Resource, overrideResourceID,
+						logfields.ConflictingLabels, info.labels,
+						logfields.ConflictingResource, resourceID,
+					)
+				} else {
+					out.identityOverride = true
+					out.labels = info.labels
+					overrideResourceID = resourceID
+				}
 			}
 		}
 
-		if info.tunnelPeer.IsValid() {
-			if tunnelPeer.IsValid() {
+		if info.tunnelPeer.IsValid() && info.tunnelPeer != out.tunnelPeer {
+			if out.tunnelPeer.IsValid() {
 				if option.Config.TunnelingEnabled() {
 					scopedLog.Warn(
 						"Detected conflicting tunnel peer for prefix. "+
 							"This may cause connectivity issues for this address.",
-						logfields.TunnelPeer, tunnelPeerResourceID,
-						logfields.Resource, resourceID,
+						logfields.TunnelPeer, out.tunnelPeer,
+						logfields.Resource, tunnelPeerResourceID,
 						logfields.ConflictingTunnelPeer, info.tunnelPeer,
 						logfields.ConflictingResource, resourceID,
 					)
 				}
 			} else {
-				tunnelPeer = info.tunnelPeer
+				out.tunnelPeer = info.tunnelPeer
 				tunnelPeerResourceID = resourceID
 			}
 		}
 
-		if info.encryptKey.IsValid() {
-			if encryptKey.IsValid() {
+		if info.encryptKey.IsValid() && info.encryptKey != out.encryptKey {
+			if out.encryptKey.IsValid() {
 				scopedLog.Warn(
 					"Detected conflicting encryption key index for prefix. "+
 						"This may cause connectivity issues for this address.",
-					logfields.Key, encryptKey,
+					logfields.Key, out.encryptKey,
 					logfields.Resource, encryptKeyResourceID,
 					logfields.ConflictingKey, info.encryptKey,
 					logfields.ConflictingResource, resourceID,
 				)
 			} else {
-				encryptKey = info.encryptKey
+				out.encryptKey = info.encryptKey
 				encryptKeyResourceID = resourceID
 			}
 		}
 
-		if info.requestedIdentity.IsValid() {
-			if requestedID.IsValid() {
+		if info.requestedIdentity.IsValid() && info.requestedIdentity != out.requestedIdentity {
+			if out.requestedIdentity.IsValid() {
 				scopedLog.Warn(
 					"Detected conflicting requested numeric identity for prefix. "+
 						"This may cause momentary connectivity issues for this address.",
-					logfields.Identity, requestedID,
+					logfields.Identity, out.requestedIdentity,
 					logfields.Resource, requestedIDResourceID,
-					logfields.ConflictingKey, info.requestedIdentity,
+					logfields.ConflictingIdentity, info.requestedIdentity,
 					logfields.ConflictingResource, resourceID,
 				)
 			} else {
-				requestedID = info.requestedIdentity
+				out.requestedIdentity = info.requestedIdentity
 				requestedIDResourceID = resourceID
 			}
 		}
 
-		if info.endpointFlags.IsValid() {
-			if endpointFlags.IsValid() {
+		// Note: if more flags are added in pkg/ipcache/types/types.go,
+		// they must be merged here.
+		if info.endpointFlags.IsValid() && info.endpointFlags != out.endpointFlags {
+			if out.endpointFlags.IsValid() {
 				scopedLog.Warn(
 					"Detected conflicting endpoint flags for prefix. "+
 						"This may cause connectivity issues for this address.",
-					logfields.EndpointFlags, endpointFlags,
+					logfields.EndpointFlags, out.endpointFlags,
 					logfields.Resource, endpointFlagsResourceID,
 					logfields.ConflictingEndpointFlags, info.endpointFlags,
 					logfields.ConflictingResource, resourceID,
 				)
 			} else {
-				endpointFlags = info.endpointFlags
+				out.endpointFlags = info.endpointFlags
 				endpointFlagsResourceID = resourceID
 			}
 		}
 	}
+
+	return out
 }

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -116,6 +116,9 @@ type EndpointFlags struct {
 	// packets destined for said endpoint shall not be forwarded through
 	// an overlay tunnel, regardless of Cilium's configuration.
 	flagSkipTunnel bool
+
+	// Note: if you add any more flags here, be sure to update (*prefixInfo).flatten()
+	// to merge them across different resources.
 }
 
 func (e *EndpointFlags) SetSkipTunnel(skip bool) {

--- a/pkg/ipcache/types_test.go
+++ b/pkg/ipcache/types_test.go
@@ -4,11 +4,17 @@
 package ipcache
 
 import (
+	"net/netip"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cilium/hive/hivetest"
+
 	"github.com/cilium/cilium/pkg/ipcache/types"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -59,4 +65,261 @@ func Test_sortedByResourceIDsAndSource(t *testing.T) {
 		"b-restored-uid",
 	}
 	assert.Equal(t, expected, pi.sortedBySourceThenResourceID())
+}
+
+func TestFlatten(t *testing.T) {
+	ipA := netip.MustParseAddr("1.2.3.4")
+	ipB := netip.MustParseAddr("1.2.3.5")
+
+	flagsT := ipcacheTypes.EndpointFlags{}
+	flagsT.SetSkipTunnel(true)
+
+	flagsF := ipcacheTypes.EndpointFlags{}
+	flagsF.SetSkipTunnel(false)
+
+	tests := []struct {
+		resourceA *resourceInfo
+		resourceB *resourceInfo
+		expected  *resourceInfo
+	}{
+		{
+			resourceA: &resourceInfo{
+				source: source.Local,
+				labels: labels.NewLabelsFromSortedList("source:a=b;source:k=v;"),
+			},
+			resourceB: &resourceInfo{
+				source: source.Generated,
+				labels: labels.NewLabelsFromSortedList("source:c=d;source:k=x"),
+			},
+			expected: &resourceInfo{
+				source: source.Local,
+				labels: labels.NewLabelsFromSortedList("source:a=b;source:c=d;source:k=v"),
+			},
+		},
+		{
+			resourceA: &resourceInfo{
+				source: source.Local,
+				labels: labels.NewLabelsFromSortedList("source:a=b;source:k=v;"),
+			},
+			resourceB: &resourceInfo{
+				source:           source.Generated,
+				labels:           labels.NewLabelsFromSortedList("source:c=d;source:k=x"),
+				identityOverride: true,
+			},
+			expected: &resourceInfo{
+				source:           source.Local,
+				labels:           labels.NewLabelsFromSortedList("source:c=d;source:k=x"),
+				identityOverride: true,
+			},
+		},
+		// all conflicts
+		{
+			resourceA: &resourceInfo{
+				source:            source.Local,
+				tunnelPeer:        types.TunnelPeer{Addr: ipA},
+				encryptKey:        types.EncryptKey(1),
+				requestedIdentity: types.RequestedIdentity(10),
+				endpointFlags:     flagsF,
+			},
+			resourceB: &resourceInfo{
+				source:            source.Generated,
+				tunnelPeer:        types.TunnelPeer{Addr: ipB},
+				encryptKey:        types.EncryptKey(2),
+				requestedIdentity: types.RequestedIdentity(11),
+				endpointFlags:     flagsT,
+			},
+			expected: &resourceInfo{
+				source:            source.Local,
+				tunnelPeer:        types.TunnelPeer{Addr: ipA},
+				encryptKey:        types.EncryptKey(1),
+				requestedIdentity: types.RequestedIdentity(10),
+				endpointFlags:     flagsF,
+			},
+		},
+		// half and half, no conflicts
+		{
+			resourceA: &resourceInfo{
+				source:     source.Local,
+				tunnelPeer: types.TunnelPeer{Addr: ipA},
+				encryptKey: types.EncryptKey(1),
+			},
+			resourceB: &resourceInfo{
+				requestedIdentity: types.RequestedIdentity(11),
+				endpointFlags:     flagsT,
+				labels:            labels.NewLabelsFromSortedList("source:a=b;source:k=v;"),
+			},
+			expected: &resourceInfo{
+				labels:            labels.NewLabelsFromSortedList("source:a=b;source:k=v;"),
+				source:            source.Local,
+				tunnelPeer:        types.TunnelPeer{Addr: ipA},
+				encryptKey:        types.EncryptKey(1),
+				requestedIdentity: types.RequestedIdentity(11),
+				endpointFlags:     flagsT,
+			},
+		},
+		// identity override from higher precedence
+		{
+			resourceA: &resourceInfo{
+				source:           source.Local,
+				labels:           labels.NewLabelsFromSortedList("source:a=b;"),
+				identityOverride: true,
+			},
+			resourceB: &resourceInfo{
+				source: source.Generated,
+				labels: labels.NewLabelsFromSortedList("source:a=x;source:c=d;"),
+			},
+			expected: &resourceInfo{
+				source:           source.Local,
+				labels:           labels.NewLabelsFromSortedList("source:a=b"),
+				identityOverride: true,
+			},
+		},
+		// identity override from lower precedence
+		{
+			resourceA: &resourceInfo{
+				source: source.Local, // Local has higher precedence, but we will override it
+				labels: labels.NewLabelsFromSortedList("source:a=b;"),
+			},
+			resourceB: &resourceInfo{
+				source:           source.Generated,
+				labels:           labels.NewLabelsFromSortedList("source:a=x;source:c=d;"),
+				identityOverride: true,
+			},
+			expected: &resourceInfo{
+				source:           source.Local,
+				labels:           labels.NewLabelsFromSortedList("source:a=x;source:c=d;"),
+				identityOverride: true,
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			logger := hivetest.Logger(t)
+			logger.Info("warnings are expected here")
+			pi := newPrefixInfo()
+
+			// resources are prioritized by source and lexicographical resource ordering.
+			pi.byResource["resourceA"] = test.resourceA
+			pi.byResource["resourceB"] = test.resourceB
+			pi.flattened = pi.flatten(logger)
+			assert.Equal(t, test.expected, pi.flattened)
+
+			// Test that one resource is exactly copied
+			pi = newPrefixInfo()
+			pi.byResource["resourceA"] = test.resourceA
+			pi.flattened = pi.flatten(logger)
+			assert.Equal(t, test.resourceA, pi.flattened)
+
+			pi = newPrefixInfo()
+			pi.byResource["resourceA"] = test.resourceB
+			pi.flattened = pi.flatten(logger)
+			assert.Equal(t, test.resourceB, pi.flattened)
+
+			// also test that merging two identical resources is sane.
+			pi = newPrefixInfo()
+			pi.byResource["resourceA"] = test.resourceA
+			pi.byResource["resourceB"] = test.resourceA
+			pi.flattened = pi.flatten(logger)
+			assert.Equal(t, test.resourceA, pi.flattened)
+
+			pi = newPrefixInfo()
+			pi.byResource["resourceA"] = test.resourceB
+			pi.byResource["resourceB"] = test.resourceB
+			pi.flattened = pi.flatten(logger)
+			assert.Equal(t, test.resourceB, pi.flattened)
+
+		})
+	}
+}
+
+func TestResourceHas(t *testing.T) {
+	flagsT := ipcacheTypes.EndpointFlags{}
+	flagsT.SetSkipTunnel(true)
+
+	flagsF := ipcacheTypes.EndpointFlags{}
+	flagsF.SetSkipTunnel(false)
+
+	tests := []struct {
+		existing []IPMetadata
+		new      []IPMetadata
+		expected bool
+	}{
+
+		// Note: we test every metadata set with itself, so there's
+		// no need to supply any cases where existing == new
+
+		{
+			[]IPMetadata{labels.NewLabelsFromSortedList("a=b;c=d"), ipcacheTypes.TunnelPeer{Addr: netip.MustParseAddr("1.1.1.1")}},
+			[]IPMetadata{labels.NewLabelsFromSortedList("a=b")},
+			true,
+		},
+
+		{
+			[]IPMetadata{labels.NewLabelsFromSortedList("a=b")},
+			[]IPMetadata{labels.NewLabelsFromSortedList("a=b;c=d")},
+			false,
+		},
+		{
+			[]IPMetadata{overrideIdentity(true), labels.NewLabelsFromSortedList("a=b")},
+			[]IPMetadata{overrideIdentity(false), labels.NewLabelsFromSortedList("a=b")},
+			false,
+		},
+		{
+			[]IPMetadata{overrideIdentity(true), ipcacheTypes.EncryptKey(1)},
+			[]IPMetadata{overrideIdentity(true)},
+			true,
+		},
+		{
+			[]IPMetadata{ipcacheTypes.EncryptKey(1)},
+			[]IPMetadata{ipcacheTypes.EncryptKey(2)},
+			false,
+		},
+		{
+			[]IPMetadata{ipcacheTypes.RequestedIdentity(1)},
+			[]IPMetadata{ipcacheTypes.RequestedIdentity(2)},
+			false,
+		},
+		{
+			[]IPMetadata{flagsF},
+			[]IPMetadata{flagsT},
+			false,
+		},
+		{
+			[]IPMetadata{labels.NewLabelsFromSortedList("a=b;c=d")},
+			[]IPMetadata{labels.NewLabelsFromSortedList("a=b")},
+			true,
+		},
+		{
+			[]IPMetadata{labels.NewLabelsFromSortedList("a=b;c=d")},
+			[]IPMetadata{labels.NewLabelsFromSortedList("a=b"), ipcacheTypes.EncryptKey(42)},
+			false,
+		},
+	}
+
+	logger := hivetest.Logger(t)
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			ri := &resourceInfo{}
+			for _, meta := range tc.existing {
+				ri.merge(logger, meta, source.KVStore)
+			}
+
+			assert.Equal(t, tc.expected, ri.has(source.KVStore, tc.new))
+
+			// Ensure that merging from existing is always true
+			assert.True(t, ri.has(source.KVStore, tc.existing))
+
+			// ensure that merging from empty is always false
+			ri = &resourceInfo{source: source.KVStore}
+			assert.False(t, ri.has(source.KVStore, tc.new))
+			assert.False(t, ri.has(source.KVStore, tc.existing))
+
+			for _, meta := range tc.new {
+				ri.merge(logger, meta, source.KVStore)
+			}
+			assert.True(t, ri.has(source.KVStore, tc.new))
+		})
+	}
 }

--- a/pkg/ipcache/types_test.go
+++ b/pkg/ipcache/types_test.go
@@ -13,35 +13,36 @@ import (
 )
 
 func Test_sortedByResourceIDsAndSource(t *testing.T) {
-	pi := make(prefixInfo, 1)
-	pi["a-restored-uid"] = &resourceInfo{
+	pi := newPrefixInfo()
+	pim := pi.byResource
+	pim["a-restored-uid"] = &resourceInfo{
 		source: source.Restored,
 	}
-	pi["b-restored-uid"] = &resourceInfo{
+	pim["b-restored-uid"] = &resourceInfo{
 		source: source.Restored,
 	}
-	pi["node-uid"] = &resourceInfo{
+	pim["node-uid"] = &resourceInfo{
 		source: source.CustomResource,
 	}
-	pi["node2-uid"] = &resourceInfo{
+	pim["node2-uid"] = &resourceInfo{
 		source: source.Local,
 	}
-	pi["daemon-uid"] = &resourceInfo{
+	pim["daemon-uid"] = &resourceInfo{
 		source: source.Local,
 	}
-	pi["endpoints-uid"] = &resourceInfo{
+	pim["endpoints-uid"] = &resourceInfo{
 		source: source.KubeAPIServer,
 	}
-	pi["2-identity-uid"] = &resourceInfo{
+	pim["2-identity-uid"] = &resourceInfo{
 		source: source.Kubernetes,
 	}
-	pi["1-identity-uid"] = &resourceInfo{
+	pim["1-identity-uid"] = &resourceInfo{
 		source: source.Kubernetes,
 	}
-	pi["generated-uid"] = &resourceInfo{
+	pim["generated-uid"] = &resourceInfo{
 		source: source.Generated,
 	}
-	pi["kvstore-uid"] = &resourceInfo{
+	pim["kvstore-uid"] = &resourceInfo{
 		source: source.KVStore,
 	}
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -80,6 +80,10 @@ const (
 	// Label is a singular label, where relevant
 	Label = "label"
 
+	// ConflictingLabels is the set of labels that conflict
+	// with an existing label set.
+	ConflictingLabels = "conflictingLabels"
+
 	// SourceFilter is the label or node information source
 	SourceFilter = "sourceFilter"
 


### PR DESCRIPTION
The ipcache aggregates metadata for a given prefix by resource. When
determining the ultimate metadata, it loops through all the
resource-level metadata to determine the value for each property.

This changes the code to flatten all the metadata once. It serves two
purposes:

1. It fixes a race condition, where we performed metadata reads
       without holding the ipcache metadata lock. Since the values were
       updated in-place, this caused races. Specifically, if a resource was
       deleted for a prefix while injection was happening, this caused
       nil panics.
2. It prevents needless prefix updates when multiple resources all
   provide the same information. This is particularly prevalent for CIDR
   labels.

As a further optimization, if a given metadata update would not change
the flattened metadata, then we short-cut the prefix update and save an
ipcache iteration.

This includes another commit which fixes an awkward usage of the metadata data that interacted poorly with this change.

Fixes: https://github.com/cilium/cilium/issues/40134
Fixes: https://github.com/cilium/cilium/commit/495164abb76c49cb1cb2c855a31555cac8102a6c
