### PR TITLE
loadbalancer: Optimize ServiceName and L3n4Addr key construction

### DIFF
--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -147,7 +147,7 @@ func EndpointsResource(logger *slog.Logger, lc cell.Lifecycle, cfg k8s.Config, c
 				if !ok {
 					return nil, fmt.Errorf("unexpected object type: %T", obj)
 				}
-				return []string{eps.ServiceID.String()}, nil
+				return []string{eps.ServiceName.String()}, nil
 			},
 		},
 	)

--- a/operator/watchers/service_sync.go
+++ b/operator/watchers/service_sync.go
@@ -176,7 +176,7 @@ func (s *serviceSync) loop(ctx context.Context, health cell.Health) error {
 
 			ep := ev.Object
 
-			svc, exists, _ := services.GetByKey(resource.Key{Namespace: ep.ServiceID.Namespace, Name: ep.ServiceID.Name})
+			svc, exists, _ := services.GetByKey(resource.Key{Namespace: ep.ServiceName.Namespace(), Name: ep.ServiceName.Name()})
 			if !exists {
 				// Service does not exist yet.
 				continue

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
 func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
@@ -116,10 +117,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -135,10 +133,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -155,10 +150,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -174,10 +166,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -196,10 +185,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv6",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -215,10 +201,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv6",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -234,10 +217,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -840,10 +820,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -859,10 +836,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -878,10 +852,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -900,10 +871,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv6",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -919,10 +887,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv6",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -938,10 +903,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -1501,10 +1463,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -1520,10 +1479,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -1539,10 +1495,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -1561,10 +1514,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv6",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -1580,10 +1530,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv6",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -1599,10 +1546,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -2114,10 +2058,7 @@ func TestEPUpdateOnly(t *testing.T) {
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      "svc-1",
-				Namespace: "default",
-			},
+			ServiceName:       loadbalancer.NewServiceName("default", "svc-1"),
 			EndpointSliceName: "svc-1-ipv4",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -384,8 +384,8 @@ endpointsLoop:
 		}
 
 		svcKey := resource.Key{
-			Name:      eps.ServiceID.Name,
-			Namespace: eps.ServiceID.Namespace,
+			Name:      eps.ServiceName.Name(),
+			Namespace: eps.ServiceName.Namespace(),
 		}
 
 		for _, be := range eps.Backends {
@@ -407,8 +407,8 @@ func hasLocalEndpoints(svc *slim_corev1.Service, ls sets.Set[resource.Key]) bool
 
 func (r *ServiceReconciler) resolveSvcFromEndpoints(eps *k8s.Endpoints) (*slim_corev1.Service, bool, error) {
 	k := resource.Key{
-		Name:      eps.ServiceID.Name,
-		Namespace: eps.ServiceID.Namespace,
+		Name:      eps.ServiceName.Name(),
+		Namespace: eps.ServiceName.Namespace(),
 	}
 	return r.svcDiffStore.GetByKey(k)
 }

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
 type Aggregation struct {
@@ -626,10 +627,9 @@ var (
 			Namespace: "non-default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      redSvcKey.Name,
-				Namespace: redSvcKey.Namespace,
-			},
+			ServiceName: loadbalancer.NewServiceName(
+				redSvcKey.Namespace, redSvcKey.Name,
+			),
 			EndpointSliceName: "svc-1",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -648,10 +648,10 @@ var (
 			Namespace: "non-default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      redSvcKey.Name,
-				Namespace: redSvcKey.Namespace,
-			},
+			ServiceName: loadbalancer.NewServiceName(
+				redSvcKey.Namespace,
+				redSvcKey.Name,
+			),
 			EndpointSliceName: "svc-1",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -672,10 +672,10 @@ var (
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      redSvcKey.Name,
-				Namespace: redSvcKey.Namespace,
-			},
+			ServiceName: loadbalancer.NewServiceName(
+				redSvcKey.Namespace,
+				redSvcKey.Name,
+			),
 			EndpointSliceName: "svc-1",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
@@ -694,10 +694,10 @@ var (
 			Namespace: "default",
 		},
 		EndpointSliceID: k8s.EndpointSliceID{
-			ServiceID: k8s.ServiceID{
-				Name:      redSvcKey.Name,
-				Namespace: redSvcKey.Namespace,
-			},
+			ServiceName: loadbalancer.NewServiceName(
+				redSvcKey.Namespace,
+				redSvcKey.Name,
+			),
 			EndpointSliceName: "svc-1",
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{

--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -248,9 +248,9 @@ func (c *cecProcessor) processCEC(wtxn statedb.WriteTxn, cecName CECName) *state
 	for svcName, ports := range cec.ServicePorts {
 		resName := EnvoyResourceName{
 			Origin:    EnvoyResourceOriginBackendSync,
-			Cluster:   svcName.Cluster,
-			Namespace: svcName.Namespace,
-			Name:      svcName.Name,
+			Cluster:   svcName.Cluster(),
+			Namespace: svcName.Namespace(),
+			Name:      svcName.Name(),
 		}
 
 		res, _, found := c.envoyResources.Get(wtxn, EnvoyResourceByName(resName))
@@ -299,9 +299,9 @@ func (c *cecProcessor) processCEC(wtxn statedb.WriteTxn, cecName CECName) *state
 func (c *cecProcessor) removeClusterReference(wtxn statedb.WriteTxn, cecName CECName, svcName loadbalancer.ServiceName) {
 	res, _, found := c.envoyResources.Get(wtxn, EnvoyResourceByName(EnvoyResourceName{
 		Origin:    EnvoyResourceOriginBackendSync,
-		Cluster:   svcName.Cluster,
-		Namespace: svcName.Namespace,
-		Name:      svcName.Name,
+		Cluster:   svcName.Cluster(),
+		Namespace: svcName.Namespace(),
+		Name:      svcName.Name(),
 	}))
 	if found {
 		newRefs := res.ClusterReferences.Remove(cecName)

--- a/pkg/ciliumenvoyconfig/tables.go
+++ b/pkg/ciliumenvoyconfig/tables.go
@@ -108,12 +108,7 @@ var (
 		FromObject: func(obj *CEC) index.KeySet {
 			keys := make([]index.Key, len(obj.Spec.Services))
 			for i, svcl := range obj.Spec.Services {
-				keys[i] = index.String(
-					loadbalancer.ServiceName{
-						Namespace: svcl.Namespace,
-						Name:      svcl.Name,
-					}.String(),
-				)
+				keys[i] = loadbalancer.NewServiceName(svcl.Namespace, svcl.Name).Key()
 			}
 			return index.NewKeySet(keys...)
 		},
@@ -203,11 +198,7 @@ type EnvoyResource struct {
 }
 
 func (r *EnvoyResource) ClusterServiceName() loadbalancer.ServiceName {
-	return loadbalancer.ServiceName{
-		Namespace: r.Name.Namespace,
-		Name:      r.Name.Name,
-		Cluster:   r.Name.Cluster,
-	}
+	return loadbalancer.NewServiceNameInCluster(r.Name.Cluster, r.Name.Namespace, r.Name.Name)
 }
 
 type clusterReference struct {

--- a/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
@@ -366,11 +366,7 @@ spec:
   },
   "Redirects": [
     {
-      "k": {
-        "Namespace": "test",
-        "Name": "echo",
-        "Cluster": ""
-      },
+      "k": "test/echo",
       "v": {
         "ProxyPort": 1000,
         "Ports": [
@@ -381,11 +377,7 @@ spec:
   ],
   "ReconciledRedirects": [
     {
-      "k": {
-        "Namespace": "test",
-        "Name": "echo",
-        "Cluster": ""
-      },
+      "k": "test/echo",
       "v": {
         "ProxyPort": 1000,
         "Ports": [
@@ -395,10 +387,6 @@ spec:
     }
   ],
   "ReferencedServices": [
-    {
-      "Namespace": "test",
-      "Name": "echo",
-      "Cluster": ""
-    }
+    "test/echo"
   ]
 }

--- a/pkg/clustermesh/service_merger.go
+++ b/pkg/clustermesh/service_merger.go
@@ -63,10 +63,7 @@ type serviceMerger struct {
 }
 
 func (sm *serviceMerger) MergeExternalServiceDelete(service *serviceStore.ClusterService) {
-	name := loadbalancer.ServiceName{
-		Namespace: service.Namespace,
-		Name:      service.Name,
-	}
+	name := loadbalancer.NewServiceName(service.Namespace, service.Name)
 	txn := sm.writer.WriteTxn()
 	defer txn.Commit()
 	sm.writer.DeleteBackendsOfServiceFromCluster(
@@ -78,10 +75,7 @@ func (sm *serviceMerger) MergeExternalServiceDelete(service *serviceStore.Cluste
 }
 
 func (sm *serviceMerger) MergeExternalServiceUpdate(service *serviceStore.ClusterService) {
-	name := loadbalancer.ServiceName{
-		Namespace: service.Namespace,
-		Name:      service.Name,
-	}
+	name := loadbalancer.NewServiceName(service.Namespace, service.Name)
 
 	txn := sm.writer.WriteTxn()
 	defer txn.Commit()

--- a/pkg/container/cache/cache.go
+++ b/pkg/container/cache/cache.go
@@ -59,3 +59,17 @@ func (c *Cache[T]) get(x T) (T, uint64) {
 	c.pool.Put(arr)
 	return v, hash
 }
+
+// GetOrPutWith tries to find the object from the cache with the given hash and equality
+// function. . If not found, [get] is called to construct the object.
+func GetOrPutWith[T any](c *Cache[T], hash uint64, eq func(T) bool, get func() T) T {
+	arr := c.pool.Get().(*[cacheSize]T)
+	idx := hash & cacheMask
+	v := (*arr)[idx]
+	if !eq(v) {
+		v = get()
+		(*arr)[idx] = v
+	}
+	c.pool.Put(arr)
+	return v
+}

--- a/pkg/container/cache/cache.go
+++ b/pkg/container/cache/cache.go
@@ -4,11 +4,13 @@
 package cache
 
 import (
-	"sync"
+	"weak"
+
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 const (
-	cacheSize = 512
+	cacheSize = 1024
 	cacheMask = cacheSize - 1
 )
 
@@ -17,19 +19,15 @@ func New[T any](hashfn func(T) uint64, skipfn func(x T) bool, eqfn func(a, b T) 
 		hashfn: hashfn,
 		eqfn:   eqfn,
 		skipfn: skipfn,
-		pool: sync.Pool{New: func() any {
-			var arr [cacheSize]T
-			return &arr
-		}},
 	}
 }
 
 // Cache is a simple fixed size cache for efficient deduplication of objects.
+// The underlying array is held onto with a weak pointer to allow GC to collect
+// it when under memory pressure.
 type Cache[T any] struct {
-	// pool of cache arrays. Pool is used here as it provides a very efficient
-	// shared access to a set of "cache arrays", and under low memory scenarios
-	// allows the Go runtime to drop the caches.
-	pool sync.Pool
+	mu  lock.Mutex
+	arr weak.Pointer[[cacheSize]T]
 
 	skipfn func(T) bool
 	hashfn func(T) uint64
@@ -43,33 +41,48 @@ func (c *Cache[T]) Get(x T) T {
 	if c.skipfn != nil && c.skipfn(x) {
 		return x
 	}
-	x, _ = c.get(x)
+	x, _ = c.getWithHash(x)
 	return x
 }
 
-func (c *Cache[T]) get(x T) (T, uint64) {
+func (c *Cache[T]) getArray() *[cacheSize]T {
+	if v := c.arr.Value(); v != nil {
+		return v
+	}
+	arr := [cacheSize]T{}
+	c.arr = weak.Make(&arr)
+	return &arr
+}
+
+func (c *Cache[T]) getWithHash(x T) (T, uint64) {
 	hash := c.hashfn(x)
-	arr := c.pool.Get().(*[cacheSize]T)
 	idx := hash & cacheMask
-	v := (*arr)[idx]
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	arr := c.getArray()
+	v := arr[idx]
 	if !c.eqfn(x, v) {
-		(*arr)[idx] = x
+		arr[idx] = x
 		v = x
 	}
-	c.pool.Put(arr)
 	return v, hash
 }
 
 // GetOrPutWith tries to find the object from the cache with the given hash and equality
 // function. . If not found, [get] is called to construct the object.
 func GetOrPutWith[T any](c *Cache[T], hash uint64, eq func(T) bool, get func() T) T {
-	arr := c.pool.Get().(*[cacheSize]T)
 	idx := hash & cacheMask
-	v := (*arr)[idx]
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	arr := c.getArray()
+	v := arr[idx]
 	if !eq(v) {
 		v = get()
-		(*arr)[idx] = v
+		arr[idx] = v
 	}
-	c.pool.Put(arr)
 	return v
 }

--- a/pkg/container/cache/caches.go
+++ b/pkg/container/cache/caches.go
@@ -22,8 +22,9 @@ var (
 	StringMaps = New(
 		func(m map[string]string) (hash uint64) {
 			for k, v := range m {
-				_, hashk := Strings.get(k)
-				_, hashv := Strings.get(v)
+				// Dedup the strings
+				_, hashk := Strings.getWithHash(k)
+				_, hashv := Strings.getWithHash(v)
 				hash = hash ^ hashk ^ hashv
 			}
 			return

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -174,7 +174,7 @@ func (h *payloadGetters) GetServiceByAddr(ip netip.Addr, port uint16) *flowpb.Se
 		return nil
 	}
 	return &flowpb.Service{
-		Namespace: fe.ServiceName.Namespace,
-		Name:      fe.ServiceName.Name,
+		Namespace: fe.ServiceName.Namespace(),
+		Name:      fe.ServiceName.Name(),
 	}
 }

--- a/pkg/k8s/apis/cilium.io/v2/cec_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types.go
@@ -108,10 +108,7 @@ type Service struct {
 }
 
 func (l *Service) ServiceName() loadbalancer.ServiceName {
-	return loadbalancer.ServiceName{
-		Namespace: l.Namespace,
-		Name:      l.Name,
-	}
+	return loadbalancer.NewServiceName(l.Namespace, l.Name)
 }
 
 type ServiceListener struct {
@@ -146,10 +143,7 @@ type ServiceListener struct {
 }
 
 func (l *ServiceListener) ServiceName() loadbalancer.ServiceName {
-	return loadbalancer.ServiceName{
-		Namespace: l.Namespace,
-		Name:      l.Name,
-	}
+	return loadbalancer.NewServiceName(l.Namespace, l.Name)
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields

--- a/pkg/k8s/client/restConfig_provider.go
+++ b/pkg/k8s/client/restConfig_provider.go
@@ -452,10 +452,8 @@ func registerMappingsUpdater(p mappingUpdaterParams) {
 				for {
 					fe, _, watch, found := p.Frontends.GetWatch(
 						p.DB.ReadTxn(),
-						loadbalancer.FrontendByServiceName(loadbalancer.ServiceName{
-							Name:      "kubernetes",
-							Namespace: "default",
-						}))
+						loadbalancer.FrontendByServiceName(loadbalancer.NewServiceName(
+							"default", "kubernetes")))
 					if found {
 						mapping := frontendToMapping(fe)
 						if !mapping.Equal(previous) {

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -263,7 +263,7 @@ func Test_parseK8sEPv1(t *testing.T) {
 		Namespace: "bar",
 	}
 	sliceID := EndpointSliceID{
-		ServiceID:         ServiceID{Name: "foo", Namespace: "bar"},
+		ServiceName:       loadbalancer.NewServiceName("bar", "foo"),
 		EndpointSliceName: "foo",
 	}
 	newEmptyEndpoints := func() *Endpoints {
@@ -578,7 +578,7 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 		Labels:    map[string]string{slim_discovery_v1beta1.LabelServiceName: "quux"},
 	}
 	sliceID := EndpointSliceID{
-		ServiceID:         ServiceID{Name: "quux", Namespace: "bar"},
+		ServiceName:       loadbalancer.NewServiceName("bar", "quux"),
 		EndpointSliceName: "foo",
 	}
 
@@ -1141,7 +1141,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 		Labels:    map[string]string{slim_discovery_v1.LabelServiceName: "quux"},
 	}
 	sliceID := EndpointSliceID{
-		ServiceID:         ServiceID{Name: "quux", Namespace: "bar"},
+		ServiceName:       loadbalancer.NewServiceName("bar", "quux"),
 		EndpointSliceName: "foo",
 	}
 

--- a/pkg/k8s/watchers/endpoints.go
+++ b/pkg/k8s/watchers/endpoints.go
@@ -111,8 +111,8 @@ func (k *K8sEndpointsWatcher) updateEndpoint(eps *k8s.Endpoints, swgEps *lock.St
 
 func (k *K8sEndpointsWatcher) addKubeAPIServerServiceEndpoints(eps *k8s.Endpoints) {
 	if eps == nil ||
-		eps.EndpointSliceID.ServiceID.Name != "kubernetes" ||
-		eps.EndpointSliceID.ServiceID.Namespace != "default" {
+		eps.EndpointSliceID.ServiceName.Name() != "kubernetes" ||
+		eps.EndpointSliceID.ServiceName.Namespace() != "default" {
 		return
 	}
 	resource := ipcacheTypes.NewResourceID(

--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -84,12 +84,13 @@ type BackendInstanceKey struct {
 }
 
 func (k BackendInstanceKey) Key() []byte {
+	if k.SourcePriority == 0 {
+		return k.ServiceName.Key()
+	}
 	var buf bytes.Buffer
 	buf.WriteString(k.ServiceName.String())
-	if k.SourcePriority != 0 {
-		buf.WriteByte(' ')
-		buf.WriteByte(k.SourcePriority)
-	}
+	buf.WriteByte(' ')
+	buf.WriteByte(k.SourcePriority)
 	return buf.Bytes()
 }
 
@@ -236,12 +237,12 @@ func (be *Backend) serviceNameKeys() index.KeySet {
 	if be.Instances.Len() == 1 {
 		// Avoid allocating the slice.
 		for k := range be.PreferredInstances() {
-			return index.NewKeySet(index.String(k.ServiceName.String()))
+			return index.NewKeySet(k.ServiceName.Key())
 		}
 	}
 	keys := make([]index.Key, 0, be.Instances.Len()) // This may be more than enough if non-preferred instances exist.
 	for k := range be.PreferredInstances() {
-		keys = append(keys, index.String(k.ServiceName.String()))
+		keys = append(keys, k.ServiceName.Key())
 	}
 	return index.NewKeySet(keys...)
 }
@@ -283,7 +284,7 @@ var (
 	backendServiceIndex = statedb.Index[*Backend, ServiceName]{
 		Name:       "service",
 		FromObject: (*Backend).serviceNameKeys,
-		FromKey:    index.Stringer[ServiceName],
+		FromKey:    ServiceName.Key,
 		FromString: index.FromString,
 		Unique:     false,
 	}

--- a/pkg/loadbalancer/benchmark/benchmark.go
+++ b/pkg/loadbalancer/benchmark/benchmark.go
@@ -407,11 +407,11 @@ func checkTables(db *statedb.DB, writer *writer.Writer, svcs []*slim_corev1.Serv
 			i := 0
 			for svc := range writer.Services().All(txn) {
 				want := svcs[i]
-				if svc.Name.Namespace != want.Namespace {
-					err = errors.Join(err, fmt.Errorf("Incorrect namespace for service #%06d, got %q, want %q", i, svc.Name.Namespace, want.Namespace))
+				if svc.Name.Namespace() != want.Namespace {
+					err = errors.Join(err, fmt.Errorf("Incorrect namespace for service #%06d, got %q, want %q", i, svc.Name.Namespace(), want.Namespace))
 				}
-				if svc.Name.Name != want.Name {
-					err = errors.Join(err, fmt.Errorf("Incorrect name for service #%06d, got %q, want %q", i, svc.Name.Name, want.Name))
+				if svc.Name.Name() != want.Name {
+					err = errors.Join(err, fmt.Errorf("Incorrect name for service #%06d, got %q, want %q", i, svc.Name.Name(), want.Name))
 				}
 				if svc.Source != "k8s" {
 					err = errors.Join(err, fmt.Errorf("Incorrect source for service #%06d, got %q, want %q", i, svc.Source, "k8s"))
@@ -435,11 +435,11 @@ func checkTables(db *statedb.DB, writer *writer.Writer, svcs []*slim_corev1.Serv
 			i := 0
 			for fe := range writer.Frontends().All(txn) {
 				want := svcs[i]
-				if fe.ServiceName.Namespace != want.Namespace {
-					err = errors.Join(err, fmt.Errorf("Incorrect namespace for frontend #%06d, got %q, want %q", i, fe.ServiceName.Namespace, want.Namespace))
+				if fe.ServiceName.Namespace() != want.Namespace {
+					err = errors.Join(err, fmt.Errorf("Incorrect namespace for frontend #%06d, got %q, want %q", i, fe.ServiceName.Namespace(), want.Namespace))
 				}
-				if fe.ServiceName.Name != want.Name {
-					err = errors.Join(err, fmt.Errorf("Incorrect name for frontend #%06d, got %q, want %q", i, fe.ServiceName.Name, want.Name))
+				if fe.ServiceName.Name() != want.Name {
+					err = errors.Join(err, fmt.Errorf("Incorrect name for frontend #%06d, got %q, want %q", i, fe.ServiceName.Name(), want.Name))
 				}
 				wantIP, _ := netip.ParseAddr(want.Spec.ClusterIP)
 				if fe.Address.AddrCluster.Addr() != wantIP {
@@ -490,8 +490,8 @@ func checkTables(db *statedb.DB, writer *writer.Writer, svcs []*slim_corev1.Serv
 					err = errors.Join(err, fmt.Errorf("Incorrect instances count for backend #%06d, got %v, want %v", i, be.Instances.Len(), 1))
 				} else {
 					for k, instance := range be.Instances.All() { // There should
-						if k.ServiceName.Name != svcs[i].Name {
-							err = errors.Join(err, fmt.Errorf("Incorrect service name for backend #%06d, got %v, want %v", i, k.ServiceName.Name, svcs[i].Name))
+						if k.ServiceName.Name() != svcs[i].Name {
+							err = errors.Join(err, fmt.Errorf("Incorrect service name for backend #%06d, got %v, want %v", i, k.ServiceName.Name(), svcs[i].Name))
 						}
 						if state, tmpErr := instance.State.String(); tmpErr != nil || state != "active" {
 							err = errors.Join(err, fmt.Errorf("Incorrect state for backend #%06d, got %q, want %q", i, state, "active"))

--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -143,8 +143,8 @@ func (fe *Frontend) ToModel() *models.Service {
 			IntTrafficPolicy:    string(svc.IntTrafficPolicy),
 			NatPolicy:           natPolicy,
 			HealthCheckNodePort: svc.HealthCheckNodePort,
-			Name:                svc.Name.Name,
-			Namespace:           svc.Name.Namespace,
+			Name:                svc.Name.Name(),
+			Namespace:           svc.Name.Namespace(),
 		},
 	}
 
@@ -152,8 +152,8 @@ func (fe *Frontend) ToModel() *models.Service {
 		spec.Flags.Type = string(SVCTypeLocalRedirect)
 	}
 
-	if svc.Name.Cluster != option.Config.ClusterName {
-		spec.Flags.Cluster = svc.Name.Cluster
+	if svc.Name.Cluster() != option.Config.ClusterName {
+		spec.Flags.Cluster = svc.Name.Cluster()
 	}
 
 	backendModel := func(be BackendParams) *models.BackendAddress {
@@ -223,9 +223,9 @@ var (
 	frontendServiceIndex = statedb.Index[*Frontend, ServiceName]{
 		Name: "service",
 		FromObject: func(fe *Frontend) index.KeySet {
-			return index.NewKeySet(index.Stringer(fe.ServiceName))
+			return index.NewKeySet(fe.ServiceName.Key())
 		},
-		FromKey:    index.Stringer[ServiceName],
+		FromKey:    ServiceName.Key,
 		FromString: index.FromString,
 		Unique:     false,
 	}

--- a/pkg/loadbalancer/healthserver/healthserver.go
+++ b/pkg/loadbalancer/healthserver/healthserver.go
@@ -352,7 +352,7 @@ func (h *httpHealthServer) shutdown(ctx context.Context) {
 func (h *httpHealthServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Use headers and JSON output compatible with kube-proxy
 	response := healthResponse{
-		Service:        healthResponseServiceName{Namespace: h.name.Namespace, Name: h.name.Name},
+		Service:        healthResponseServiceName{Namespace: h.name.Namespace(), Name: h.name.Name()},
 		LocalEndpoints: h.getLocalEndpointCount(),
 	}
 

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.yaml.in/yaml/v3"
 
+	"github.com/cilium/statedb/index"
+
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 )
 
@@ -719,6 +721,16 @@ func TestServiceNameYAML(t *testing.T) {
 			if assert.NoError(t, err, "Unmarshal") {
 				assert.True(t, test.name.Equal(name), "Equal")
 			}
+		}
+	}
+}
+
+func BenchmarkServiceNameKey(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if len(index.Stringer(ServiceName{"foo", "bar", "baz"})) == 0 {
+			// Do something so this won't be optimized out.
+			b.Fatalf("empty length")
 		}
 	}
 }

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -781,34 +781,6 @@ func BenchmarkServiceNameKey(b *testing.B) {
 	}
 }
 
-func benchmarkHash(b *testing.B, addr *L3n4Addr) {
-	b.ReportAllocs()
-
-	for b.Loop() {
-		addr.Hash()
-	}
-}
-
-func BenchmarkL3n4Addr_Hash_IPv4(b *testing.B) {
-	addr := NewL3n4Addr(TCP, cmtypes.MustParseAddrCluster("1.2.3.4"), 8080, ScopeInternal)
-	benchmarkHash(b, addr)
-}
-
-func BenchmarkL3n4Addr_Hash_IPv6_Short(b *testing.B) {
-	addr := NewL3n4Addr(TCP, cmtypes.MustParseAddrCluster("fd00::1:36c6"), 8080, ScopeInternal)
-	benchmarkHash(b, addr)
-}
-
-func BenchmarkL3n4Addr_Hash_IPv6_Long(b *testing.B) {
-	addr := NewL3n4Addr(TCP, cmtypes.MustParseAddrCluster("2001:0db8:85a3::8a2e:0370:7334"), 8080, ScopeInternal)
-	benchmarkHash(b, addr)
-}
-
-func BenchmarkL3n4Addr_Hash_IPv6_Max(b *testing.B) {
-	addr := NewL3n4Addr(TCP, cmtypes.MustParseAddrCluster("1020:3040:5060:7080:90a0:b0c0:d0e0:f000"), 30303, 100)
-	benchmarkHash(b, addr)
-}
-
 func benchmarkString(b *testing.B, addr *L3n4Addr) {
 	b.ReportAllocs()
 

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -153,7 +153,7 @@ type testCase struct {
 	maps, maglev []maps.MapDump
 }
 
-var testServiceName = loadbalancer.ServiceName{Name: "test", Namespace: "test"}
+var testServiceName = loadbalancer.NewServiceName("test", "test")
 
 var baseService = loadbalancer.Service{
 	Name:                   testServiceName,
@@ -729,7 +729,8 @@ var localRedirectTestCases = []testCase{
 		"LocalRedirect",
 		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
 			fe.Type = ClusterIP
-			fe.RedirectTo = &loadbalancer.ServiceName{Name: "foo", Namespace: "bar"}
+			svcName := loadbalancer.NewServiceName("bar", "foo")
+			fe.RedirectTo = &svcName
 			fe.Address = autoAddr
 			return false, []loadbalancer.Backend{}
 		},

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -132,7 +132,7 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 	wtxn := db.WriteTxn(backends)
 	be := &loadbalancer.Backend{Address: beAddr}
 	be.Instances = be.Instances.Set(loadbalancer.BackendInstanceKey{
-		ServiceName:    loadbalancer.ServiceName{Name: "foo", Namespace: "bar"},
+		ServiceName:    loadbalancer.NewServiceName("bar", "foo"),
 		SourcePriority: 0,
 	}, loadbalancer.BackendParams{
 		Address:   beAddr,
@@ -431,7 +431,7 @@ func benchmarkChangeIteration(b *testing.B, proto loadbalancer.L4Type) {
 		be.Address.L4Addr.Protocol = proto
 		be.Instances = be.Instances.Set(
 			loadbalancer.BackendInstanceKey{
-				ServiceName:    loadbalancer.ServiceName{Namespace: "foo", Name: "bar"},
+				ServiceName:    loadbalancer.NewServiceName("foo", "bar"),
 				SourcePriority: 0,
 			}, loadbalancer.BackendParams{
 				Address:   be.Address,

--- a/pkg/loadbalancer/redirectpolicy/api.go
+++ b/pkg/loadbalancer/redirectpolicy/api.go
@@ -65,8 +65,8 @@ func (lrp *LocalRedirectPolicy) getModel() *models.LRPSpec {
 
 	return &models.LRPSpec{
 		UID:              string(lrp.UID),
-		Name:             lrp.ID.Name,
-		Namespace:        lrp.ID.Namespace,
+		Name:             lrp.ID.Name(),
+		Namespace:        lrp.ID.Namespace(),
 		FrontendType:     feType,
 		LrpType:          lrpType,
 		ServiceID:        lrp.ServiceID.String(),

--- a/pkg/loadbalancer/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/redirectpolicy/cell.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/api/v1/server/restapi/service"
-	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
@@ -94,17 +93,17 @@ func newControllerMetrics() controllerMetrics {
 }
 
 type LRPMetrics interface {
-	AddLRPConfig(k8s.ServiceID)
-	DelLRPConfig(k8s.ServiceID)
+	AddLRPConfig(loadbalancer.ServiceName)
+	DelLRPConfig(loadbalancer.ServiceName)
 }
 
 type lrpMetricsNoop struct {
 }
 
-func (p *lrpMetricsNoop) AddLRPConfig(k8s.ServiceID) {
+func (p *lrpMetricsNoop) AddLRPConfig(loadbalancer.ServiceName) {
 }
 
-func (p *lrpMetricsNoop) DelLRPConfig(k8s.ServiceID) {
+func (p *lrpMetricsNoop) DelLRPConfig(loadbalancer.ServiceName) {
 }
 
 func NewLRPMetricsNoop() LRPMetrics {

--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -213,7 +213,7 @@ func (c *lrpController) processRedirectPolicy(wtxn writer.WriteTxn, lrpID k8s.Se
 	cleanup := func(wtxn writer.WriteTxn) {
 		// Unset the redirect on all frontends.
 		if lrp.LRPType == lrpConfigTypeSvc {
-			targetName := lb.ServiceName{Name: lrp.ServiceID.Name, Namespace: lrp.ServiceID.Namespace}
+			targetName := lb.NewServiceName(lrp.ServiceID.Namespace, lrp.ServiceID.Name)
 			for fe := range c.p.Writer.Frontends().List(wtxn, lb.FrontendByServiceName(targetName)) {
 				c.p.Writer.SetRedirectTo(wtxn, fe, nil)
 			}
@@ -261,7 +261,7 @@ func (c *lrpController) processRedirectPolicy(wtxn writer.WriteTxn, lrpID k8s.Se
 	case lrpConfigTypeSvc:
 		// Find frontends associated with the target service that match the redirection criteria and
 		// redirect them to the LRP "pseudo-service".
-		targetName := lb.ServiceName{Name: lrp.ServiceID.Name, Namespace: lrp.ServiceID.Namespace}
+		targetName := lb.NewServiceName(lrp.ServiceID.Namespace, lrp.ServiceID.Name)
 		fes, watch := c.p.Writer.Frontends().ListWatch(wtxn, lb.FrontendByServiceName(targetName))
 		ws.Add(watch)
 		for fe := range fes {
@@ -401,7 +401,7 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, ws *statedb
 	// If the LRP is an address matcher, then lrpServiceName == targetName and we already
 	// refreshed the frontend via SetBackends() above.
 	if lrp.LRPType == lrpConfigTypeSvc {
-		targetName := lb.ServiceName{Name: lrp.ServiceID.Name, Namespace: lrp.ServiceID.Namespace}
+		targetName := lb.NewServiceName(lrp.ServiceID.Namespace, lrp.ServiceID.Name)
 		c.p.Writer.RefreshFrontends(wtxn, targetName)
 	}
 }
@@ -534,7 +534,7 @@ func (c *lrpController) frontendsToSkip(txn statedb.ReadTxn, ws *statedb.WatchSe
 		// For address-based matching we created the frontends, so we look up from the pseudo-service
 		targetName = lrp.ServiceName()
 	} else {
-		targetName = lb.ServiceName{Name: lrp.ServiceID.Name, Namespace: lrp.ServiceID.Namespace}
+		targetName = lb.NewServiceName(lrp.ServiceID.Namespace, lrp.ServiceID.Name)
 	}
 
 	feAddrs := []lb.L3n4Addr{}

--- a/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
+++ b/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
@@ -24,10 +24,10 @@ import (
 const localRedirectServiceSuffix = ":local-redirect"
 
 func lrpServiceName(lrpID k8s.ServiceID) lb.ServiceName {
-	return lb.ServiceName{
-		Name:      lrpID.Name + localRedirectServiceSuffix,
-		Namespace: lrpID.Namespace,
-	}
+	return lb.NewServiceName(
+		lrpID.Namespace,
+		lrpID.Name+localRedirectServiceSuffix,
+	)
 }
 
 type lrpConfigType = int

--- a/pkg/loadbalancer/redirectpolicy/table.go
+++ b/pkg/loadbalancer/redirectpolicy/table.go
@@ -25,21 +25,21 @@ const (
 )
 
 var (
-	lrpIDIndex = statedb.Index[*LocalRedirectPolicy, k8s.ServiceID]{
+	lrpIDIndex = statedb.Index[*LocalRedirectPolicy, lb.ServiceName]{
 		Name: "id",
 		FromObject: func(obj *LocalRedirectPolicy) index.KeySet {
 			return index.NewKeySet(index.String(obj.ID.String()))
 		},
-		FromKey: index.Stringer[k8s.ServiceID],
+		FromKey: index.Stringer[lb.ServiceName],
 		Unique:  true,
 	}
 
-	lrpServiceIndex = statedb.Index[*LocalRedirectPolicy, k8s.ServiceID]{
+	lrpServiceIndex = statedb.Index[*LocalRedirectPolicy, lb.ServiceName]{
 		Name: "service",
 		FromObject: func(lrp *LocalRedirectPolicy) index.KeySet {
 			return index.NewKeySet(index.String(lrp.ServiceID.String()))
 		},
-		FromKey: index.Stringer[k8s.ServiceID],
+		FromKey: index.Stringer[lb.ServiceName],
 		Unique:  false,
 	}
 
@@ -104,11 +104,7 @@ func registerLRPReflector(enabled lrpIsEnabled, cfg Config, db *statedb.DB, log 
 						logfields.Error, err)
 					toDelete = func(yield func(*LocalRedirectPolicy) bool) {
 						yield(&LocalRedirectPolicy{
-							ID: k8s.ServiceID{
-								Cluster:   "",
-								Name:      clrp.Name,
-								Namespace: clrp.Namespace,
-							},
+							ID:  lb.NewServiceName(clrp.Namespace, clrp.Name),
 							UID: clrp.UID,
 						})
 					}

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -75,7 +75,7 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 		)
 	})
 
-	name := loadbalancer.ServiceName{Namespace: svc.Namespace, Name: svc.Name}
+	name := loadbalancer.NewServiceName(svc.Namespace, svc.Name)
 	s = &loadbalancer.Service{
 		Name:                name,
 		Source:              source,

--- a/pkg/loadbalancer/reflectors/file.go
+++ b/pkg/loadbalancer/reflectors/file.go
@@ -227,12 +227,8 @@ func (s *fileReflector) synchronize(txn writer.WriteTxn, state *StateFile) (numS
 	}
 	for i := range state.Endpoints {
 		eps := k8s.ParseEndpointSliceV1(s.log, &state.Endpoints[i])
-		svcName := loadbalancer.NewServiceName(
-			eps.ServiceID.Namespace,
-			eps.ServiceID.Name,
-		)
-		bes := convertEndpoints(s.log, s.extConfig, svcName, maps.All(eps.Backends))
-		if err := s.w.UpsertBackends(txn, svcName, source.LocalAPI, bes...); err != nil {
+		bes := convertEndpoints(s.log, s.extConfig, eps.ServiceName, maps.All(eps.Backends))
+		if err := s.w.UpsertBackends(txn, eps.ServiceName, source.LocalAPI, bes...); err != nil {
 			return 0, 0, 0, fmt.Errorf("failed to upsert backends: %w", err)
 		}
 		numBackends++

--- a/pkg/loadbalancer/reflectors/file.go
+++ b/pkg/loadbalancer/reflectors/file.go
@@ -227,10 +227,10 @@ func (s *fileReflector) synchronize(txn writer.WriteTxn, state *StateFile) (numS
 	}
 	for i := range state.Endpoints {
 		eps := k8s.ParseEndpointSliceV1(s.log, &state.Endpoints[i])
-		svcName := loadbalancer.ServiceName{
-			Name:      eps.ServiceID.Name,
-			Namespace: eps.ServiceID.Namespace,
-		}
+		svcName := loadbalancer.NewServiceName(
+			eps.ServiceID.Namespace,
+			eps.ServiceID.Name,
+		)
 		bes := convertEndpoints(s.log, s.extConfig, svcName, maps.All(eps.Backends))
 		if err := s.w.UpsertBackends(txn, svcName, source.LocalAPI, bes...); err != nil {
 			return 0, 0, 0, fmt.Errorf("failed to upsert backends: %w", err)

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -470,7 +470,7 @@ func bufferInsert(buf buffer, ev resource.Event[runtime.Object]) buffer {
 			return buf
 		}
 		key := bufferKey{
-			resource.Key{Name: obj.ServiceID.Name, Namespace: obj.ServiceID.Namespace},
+			resource.Key{Name: obj.ServiceName.Name(), Namespace: obj.ServiceName.Namespace()},
 			false,
 		}
 		var allEps allEndpoints

--- a/pkg/loadbalancer/reflectors/k8s_test.go
+++ b/pkg/loadbalancer/reflectors/k8s_test.go
@@ -61,14 +61,10 @@ func BenchmarkConvertEndpoints(b *testing.B) {
 	epSlice := obj.(*slim_discovery_v1.EndpointSlice)
 	logger := hivetest.Logger(b)
 	eps := k8s.ParseEndpointSliceV1(logger, epSlice)
-	name := loadbalancer.NewServiceName(
-		eps.ServiceID.Namespace,
-		eps.ServiceID.Name,
-	)
 	backends := maps.All(eps.Backends)
 
 	for b.Loop() {
-		convertEndpoints(logger, benchmarkExternalConfig, name, backends)
+		convertEndpoints(logger, benchmarkExternalConfig, eps.ServiceName, backends)
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpoints/sec")
 }

--- a/pkg/loadbalancer/reflectors/k8s_test.go
+++ b/pkg/loadbalancer/reflectors/k8s_test.go
@@ -61,10 +61,10 @@ func BenchmarkConvertEndpoints(b *testing.B) {
 	epSlice := obj.(*slim_discovery_v1.EndpointSlice)
 	logger := hivetest.Logger(b)
 	eps := k8s.ParseEndpointSliceV1(logger, epSlice)
-	name := loadbalancer.ServiceName{
-		Name:      eps.ServiceID.Name,
-		Namespace: eps.ServiceID.Namespace,
-	}
+	name := loadbalancer.NewServiceName(
+		eps.ServiceID.Namespace,
+		eps.ServiceID.Name,
+	)
 	backends := maps.All(eps.Backends)
 
 	for b.Loop() {

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -272,9 +272,9 @@ var (
 	serviceNameIndex = statedb.Index[*Service, ServiceName]{
 		Name: "name",
 		FromObject: func(obj *Service) index.KeySet {
-			return index.NewKeySet(index.Stringer(obj.Name))
+			return index.NewKeySet(obj.Name.Key())
 		},
-		FromKey:    index.Stringer[ServiceName],
+		FromKey:    ServiceName.Key,
 		FromString: index.FromString,
 		Unique:     true,
 	}

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -187,7 +187,7 @@ func (tc testCommands) updateHealth() script.Cmd {
 				return nil, fmt.Errorf("%w: expected service name, backend address and health", script.ErrUsage)
 			}
 			ns, name, _ := strings.Cut(args[0], "/")
-			svc := loadbalancer.ServiceName{Namespace: ns, Name: name}
+			svc := loadbalancer.NewServiceName(ns, name)
 
 			var beAddr loadbalancer.L3n4Addr
 			if err := beAddr.ParseFromString(args[1]); err != nil {

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -51,11 +51,7 @@ Address              Instances
 
 -- services-expected.json --
 {
-  "Name": {
-    "Namespace": "test",
-    "Name": "echo",
-    "Cluster": ""
-  },
+  "Name": "test/echo",
   "Source": "k8s",
   "Labels": {},
   "Annotations": null,
@@ -87,11 +83,7 @@ Address              Instances
     "Scope": 0
   },
   "Type": "ClusterIP",
-  "ServiceName": {
-    "Namespace": "test",
-    "Name": "echo",
-    "Cluster": ""
-  },
+  "ServiceName": "test/echo",
   "PortName": "http",
   "ServicePort": 80,
   "Status": {
@@ -132,11 +124,7 @@ Address              Instances
     "Scope": 0
   },
   "Type": "ClusterIP",
-  "ServiceName": {
-    "Namespace": "test",
-    "Name": "echo",
-    "Cluster": ""
-  },
+  "ServiceName": "test/echo",
   "PortName": "http",
   "ServicePort": 80,
   "Status": {
@@ -180,11 +168,7 @@ Address              Instances
   "Instances": [
     {
       "k": {
-        "ServiceName": {
-          "Namespace": "test",
-          "Name": "echo",
-          "Cluster": ""
-        },
+        "ServiceName": "test/echo",
         "SourcePriority": 4
       },
       "v": {
@@ -220,11 +204,7 @@ Address              Instances
   "Instances": [
     {
       "k": {
-        "ServiceName": {
-          "Namespace": "test",
-          "Name": "echo",
-          "Cluster": ""
-        },
+        "ServiceName": "test/echo",
         "SourcePriority": 4
       },
       "v": {

--- a/pkg/loadbalancer/writer/benchmark_test.go
+++ b/pkg/loadbalancer/writer/benchmark_test.go
@@ -36,7 +36,7 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int) {
 	// inserts slightly more costly.
 	wtxn := p.Writer.WriteTxn()
 	for i := range 1000 {
-		name := loadbalancer.ServiceName{Namespace: "test-existing", Name: fmt.Sprintf("svc-%d", i)}
+		name := loadbalancer.NewServiceName("test-existing", fmt.Sprintf("svc-%d", i))
 		var addr1 [4]byte
 		binary.BigEndian.PutUint32(addr1[:], 0x02000000+uint32(i))
 		addrCluster, _ := types.AddrClusterFromIP(addr1[:])
@@ -61,7 +61,7 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int) {
 	for b.Loop() {
 		wtxn := p.Writer.WriteTxn()
 		for i := range numObjects {
-			name := loadbalancer.ServiceName{Namespace: "test-new", Name: fmt.Sprintf("svc-%d", i)}
+			name := loadbalancer.NewServiceName("test-new", fmt.Sprintf("svc-%d", i))
 			var addr1 [4]byte
 			binary.BigEndian.PutUint32(addr1[:], 0x01000000+uint32(i))
 			addrCluster, _ := types.AddrClusterFromIP(addr1[:])
@@ -91,7 +91,7 @@ func BenchmarkInsertBackend(b *testing.B) {
 	addrCluster1 := types.MustParseAddrCluster("1.0.0.1")
 	addrCluster2 := types.MustParseAddrCluster("2.0.0.2")
 
-	name := loadbalancer.ServiceName{Namespace: "test", Name: "svc"}
+	name := loadbalancer.NewServiceName("test", "svc")
 	wtxn := p.Writer.WriteTxn()
 
 	p.Writer.UpsertServiceAndFrontends(
@@ -140,7 +140,7 @@ func BenchmarkReplaceBackend(b *testing.B) {
 	addrCluster1 := types.MustParseAddrCluster("1.0.0.1")
 	addrCluster2 := types.MustParseAddrCluster("2.0.0.2")
 
-	name := loadbalancer.ServiceName{Namespace: "test", Name: "svc"}
+	name := loadbalancer.NewServiceName("test", "svc")
 	wtxn := p.Writer.WriteTxn()
 
 	p.Writer.UpsertServiceAndFrontends(
@@ -192,7 +192,7 @@ func BenchmarkReplaceService(b *testing.B) {
 	addrCluster := types.MustParseAddrCluster("1.0.0.1")
 	l3n4Addr := *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster, 12345, loadbalancer.ScopeExternal)
 
-	name := loadbalancer.ServiceName{Namespace: "test", Name: "svc"}
+	name := loadbalancer.NewServiceName("test", "svc")
 	wtxn := p.Writer.WriteTxn()
 
 	p.Writer.UpsertServiceAndFrontends(

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -91,7 +91,7 @@ func TestWriter_Service_UpsertDelete(t *testing.T) {
 		svc.HealthCheckNodePort = hookSentinel
 		serviceUpserts = append(serviceUpserts, svc)
 	})
-	name := loadbalancer.ServiceName{Namespace: "test", Name: "test1"}
+	name := loadbalancer.NewServiceName("test", "test1")
 	addrCluster := intToAddr(1)
 	frontend := *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster, 12345, loadbalancer.ScopeExternal)
 
@@ -212,8 +212,8 @@ func TestWriter_Backend_UpsertDelete(t *testing.T) {
 		}
 	})
 
-	name1 := loadbalancer.ServiceName{Namespace: "test", Name: "test1"}
-	name2 := loadbalancer.ServiceName{Namespace: "test", Name: "test2"}
+	name1 := loadbalancer.NewServiceName("test", "test1")
+	name2 := loadbalancer.NewServiceName("test", "test2")
 
 	nextAddr := 0
 	mkAddr := func(port uint16) loadbalancer.L3n4Addr {
@@ -326,7 +326,7 @@ func TestWriter_Initializers(t *testing.T) {
 
 	wtxn := p.Writer.WriteTxn()
 	addr := *loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(123), 12345, loadbalancer.ScopeExternal)
-	name := loadbalancer.ServiceName{Name: "test", Namespace: "test"}
+	name := loadbalancer.NewServiceName("test-ns", "test-name")
 	err := p.Writer.UpsertServiceAndFrontends(
 		wtxn,
 		&loadbalancer.Service{
@@ -379,8 +379,8 @@ func TestWriter_Initializers(t *testing.T) {
 func TestWriter_SetBackends(t *testing.T) {
 	p := fixture(t)
 
-	name1 := loadbalancer.ServiceName{Namespace: "test", Name: "test1"}
-	name2 := loadbalancer.ServiceName{Namespace: "test", Name: "test2"}
+	name1 := loadbalancer.NewServiceName("test", "test1")
+	name2 := loadbalancer.NewServiceName("test", "test2")
 
 	feAddr1 := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(1231), 1231, loadbalancer.ScopeExternal)
 	feAddr2 := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(1232), 1232, loadbalancer.ScopeExternal)
@@ -553,8 +553,8 @@ func TestWriter_SetBackends(t *testing.T) {
 func TestWriter_WithConflictingSources(t *testing.T) {
 	p := fixture(t)
 
-	name1 := loadbalancer.ServiceName{Namespace: "test", Name: "test1"}
-	name2 := loadbalancer.ServiceName{Namespace: "test", Name: "test2"}
+	name1 := loadbalancer.NewServiceName("test", "test1")
+	name2 := loadbalancer.NewServiceName("test", "test2")
 
 	feAddr1 := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(1234), 1234, loadbalancer.ScopeExternal)
 	feAddr2 := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(1235), 1235, loadbalancer.ScopeExternal)
@@ -686,7 +686,7 @@ func TestWriter_SetSelectBackends(t *testing.T) {
 
 	var feAddr loadbalancer.L3n4Addr
 	feAddr.ParseFromString("1.0.0.1:80/TCP")
-	svcName := loadbalancer.ServiceName{Namespace: "test", Name: "svc"}
+	svcName := loadbalancer.NewServiceName("test", "svc")
 
 	var beAddr loadbalancer.L3n4Addr
 	beAddr.ParseFromString("2.0.0.1:80/TCP")
@@ -707,7 +707,7 @@ func TestWriter_SetSelectBackends(t *testing.T) {
 	wtxn := w.WriteTxn()
 	err := w.UpsertServiceAndFrontends(wtxn,
 		&loadbalancer.Service{Name: svcName},
-		loadbalancer.FrontendParams{Address: feAddr, ServiceName: loadbalancer.ServiceName{Namespace: "test", Name: "test"}})
+		loadbalancer.FrontendParams{Address: feAddr, ServiceName: loadbalancer.NewServiceName("test", "test")})
 	require.NoError(t, err, "UpsertServiceAndFrontends")
 	txn := wtxn.Commit()
 

--- a/pkg/metrics/features/misc.go
+++ b/pkg/metrics/features/misc.go
@@ -4,16 +4,15 @@
 package features
 
 import (
-	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
-func (m Metrics) AddLRPConfig(_ k8s.ServiceID) {
+func (m Metrics) AddLRPConfig(_ loadbalancer.ServiceName) {
 	m.NPLRPIngested.WithLabelValues(actionAdd).Inc()
 }
 
-func (m Metrics) DelLRPConfig(_ k8s.ServiceID) {
+func (m Metrics) DelLRPConfig(_ loadbalancer.ServiceName) {
 	m.NPLRPIngested.WithLabelValues(actionDel).Inc()
 }
 

--- a/pkg/metrics/features/misc_test.go
+++ b/pkg/metrics/features/misc_test.go
@@ -10,14 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
 func TestLRPConfig(t *testing.T) {
 	type args struct {
-		lrpID k8s.ServiceID
+		lrpID loadbalancer.ServiceName
 	}
 	type metrics struct {
 		npLRPConfigIngested float64
@@ -33,7 +32,7 @@ func TestLRPConfig(t *testing.T) {
 		{
 			name: "LRP Config",
 			args: args{
-				lrpID: k8s.ServiceID{},
+				lrpID: loadbalancer.ServiceName{},
 			},
 			want: wanted{
 				wantMetrics: metrics{

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -58,8 +58,8 @@ func (s serviceEvent) Equal(other serviceEvent) bool {
 }
 
 func (s serviceEvent) getLabels() labels.Labels { return s.labels }
-func (s serviceEvent) getName() string          { return s.name.Name }
-func (s serviceEvent) getNamespace() string     { return s.name.Namespace }
+func (s serviceEvent) getName() string          { return s.name.Name() }
+func (s serviceEvent) getNamespace() string     { return s.name.Namespace() }
 
 var _ serviceDetailer = serviceEvent{}
 
@@ -381,8 +381,8 @@ var _ k8sLabels.Labels = labelsMatcher{}
 // serviceRefMatches returns true if the ToServices k8sService reference
 // matches the name/namespace of the provided service svc
 func serviceRefMatches(ref *api.K8sServiceNamespace, svcID loadbalancer.ServiceName) bool {
-	return (ref.Namespace == svcID.Namespace || ref.Namespace == "") &&
-		ref.ServiceName == svcID.Name
+	return (ref.Namespace == svcID.Namespace() || ref.Namespace == "") &&
+		ref.ServiceName == svcID.Name()
 }
 
 // serviceEndpoints stores the endpoints associated with a service
@@ -394,8 +394,8 @@ type serviceEndpoints struct {
 }
 
 func (s serviceEndpoints) getLabels() labels.Labels { return s.svc.Labels }
-func (s serviceEndpoints) getName() string          { return s.svc.Name.Name }
-func (s serviceEndpoints) getNamespace() string     { return s.svc.Name.Namespace }
+func (s serviceEndpoints) getName() string          { return s.svc.Name.Name() }
+func (s serviceEndpoints) getNamespace() string     { return s.svc.Name.Namespace() }
 
 var _ serviceDetailer = serviceEndpoints{}
 
@@ -447,7 +447,7 @@ func (s *serviceEndpoints) processRule(rule *api.Rule) (numMatches int) {
 					if len(s.svc.Selector) == 0 || s.enableHighScaleIPcache {
 						appendEndpoints(&rule.Egress[i].ToCIDRSet, s.backendPrefixes())
 					} else {
-						appendSelector(&rule.Egress[i].ToEndpoints, s.svc.Selector, s.svc.Name.Namespace)
+						appendSelector(&rule.Egress[i].ToEndpoints, s.svc.Selector, s.svc.Name.Namespace())
 					}
 					numMatches++
 				}
@@ -456,7 +456,7 @@ func (s *serviceEndpoints) processRule(rule *api.Rule) (numMatches int) {
 					if len(s.svc.Selector) == 0 || s.enableHighScaleIPcache {
 						appendEndpoints(&rule.Egress[i].ToCIDRSet, s.backendPrefixes())
 					} else {
-						appendSelector(&rule.Egress[i].ToEndpoints, s.svc.Selector, s.svc.Name.Namespace)
+						appendSelector(&rule.Egress[i].ToEndpoints, s.svc.Selector, s.svc.Name.Namespace())
 					}
 					numMatches++
 				}


### PR DESCRIPTION
* Use weak.Pointer for container/cache to avoid ending up with many cache arrays when there are lots of cores. Since we're doing a lot of string dedup'ing already this should increase cache hit rates and reduce memory usage overall in the agent. Since we'll only hold onto one array, bump the cache size to 1024 entries to improve hit rate (8*1024=~8k per cache, and we have Strings, StringMap, ServiceCache and L3n4AddrBytes caches, so static allocation of ~32k for them all).
* Use a single string for ServiceName allowing direct casting into the StateDB key
* Use a cache for L3n4Addr Bytes() to greatly reduce constructing the StateDB from scratch
* Remove some old unused methods from `loadbalancer.go`
* Remove `k8s.ServiceID` and use `loadbalancer.ServiceName` instead in `redirectpolicy` and `k8s.Endpoints`

Before:
```
pkg: github.com/cilium/cilium/pkg/loadbalancer/writer
cpu: 13th Gen Intel(R) Core(TM) i9-13950HX
Benchmark_UpsertServiceAndFrontends_100-32          2673            424350 ns/op            235655 objects/sec    456719 B/op       6286 allocs/op
Avg: Allocated 685859kB in total, 2441351 objects / 166553kB still reachable (per service:  48 objs, 14046B alloc,  3411B in-use)
Avg: Reconciled 50000 objects in 846.8988ms  (16.937µs  per service /  59042 services per second)
```

After:
```
Benchmark_UpsertServiceAndFrontends_100-32          2842            408752 ns/op            244647 objects/sec    428990 B/op       5202 allocs/op
Avg: Allocated 646749kB in total, 2381278 objects / 162073kB still reachable (per service:  47 objs, 13245B alloc,  3319B in-use)
Avg: Reconciled 50000 objects in 831.240522ms (16.624µs  per service /  60154 services per second)

```

`Benchmark_UpsertServiceAndFrontends` allocates ~15% less, ~4% faster.
~6% less allocations and ~4% less resident memory use in `pkg/loadbalancer/benchmark`.
