### PR TITLE
cilium-cli: Print partial output upon `bgp peers` errors

### DIFF
--- a/cilium-cli/bgp/peers.go
+++ b/cilium-cli/bgp/peers.go
@@ -43,7 +43,12 @@ func (s *Status) GetPeeringState(ctx context.Context) error {
 
 	res, err := s.fetchPeeringStateConcurrently(ctx)
 	if err != nil {
-		return err
+		if len(res) == 0 {
+			// no results retrieved - just return the error
+			return err
+		}
+		// print the errors, but continue with printing results
+		fmt.Fprintf(os.Stderr, "Errors by retrieving routes: %v\n\n", err)
 	}
 
 	return s.writeStatus(res)


### PR DESCRIPTION
In clusters with multiple nodes, some of the cilium-agents may be in non-running state (e.g. init, crashloop, pending etc.). Instead of just erroring out completely, print the output for the nodes that are running, and error messages for the nodes where the bgp peer status retrieval failed.
Same behavior is already present for bgp routes output.