### PR TITLE
wireguard:fix: invalid dereference of nil peer config

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -353,7 +353,7 @@ func (a *Agent) RestoreFinished(cm *clustermesh.ClusterMesh) error {
 				return err
 			}
 		} else {
-			a.logger.Info("Removing obsolete peer", logfields.PubKey, pc.pubKey)
+			a.logger.Info("Removing obsolete peer", logfields.PubKey, p.PublicKey)
 			if err := a.deletePeerByPubKey(p.PublicKey); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fix back the line of code of interested, previously modifed in #37849, to use the non-nil value `p.PublicKey` rather than `pc.pubKey` in the else-branch where `pc` is nil.