### PR TITLE
CODEOWNERS: move pkg/logging to sig-agent

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -582,7 +582,7 @@ Makefile* @cilium/build
 /pkg/loadbalancer @cilium/sig-lb
 /pkg/loadinfo/ @cilium/sig-agent
 /pkg/lock @cilium/sig-agent
-/pkg/logging/ @cilium/cli
+/pkg/logging/ @cilium/sig-agent
 /pkg/mac @cilium/sig-datapath
 /pkg/maglev @cilium/sig-lb
 /pkg/maps/ @cilium/sig-datapath


### PR DESCRIPTION
It contains `logfields.go`, which is a very active file. So, spread the review burden to a larger group.
