### PR TITLE
golangci-lint: bump timeout to 30m

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,7 +3,7 @@ run:
   modules-download-mode: readonly
   issues-exit-code: 1
   tests: true
-  timeout: 20m
+  timeout: 30m
 linters:
   default: none
   enable:


### PR DESCRIPTION
After recent changes to the golangci-lint configuration which lead to more tests being run, the timeout is occasionally hit in CI. Bump the timeout to account for that.