### PR TITLE
v1.18: .github: Re-add the labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,30 @@
+# Add 'cilium-cli' label to any file changes in 'cilium-cli/'
+cilium-cli:
+- changed-files:
+  - any-glob-to-any-file:
+    - cilium-cli/**
+# Add 'cilium-cli-exclusive' label if the changed files are only in 'cilium-cli'
+cilium-cli-exclusive:
+- changed-files:
+  - all-globs-to-all-files:
+    - cilium-cli/**
+# Add 'hubble-cli' label to any file changes in 'hubble/'
+hubble-cli:
+- changed-files:
+  - any-glob-to-any-file:
+    - hubble/**
+# Add 'hubble-cli-exclusive' label if the changed files are only in 'hubble'
+hubble-cli-exclusive:
+- changed-files:
+  - all-globs-to-all-files:
+    - hubble/**
+sig/policy:
+- changed-files:
+  - any-glob-to-any-file:
+    - daemon/cmd/policy*
+    - daemon/cmd/fqdn*
+    - pkg/fqdn/**
+    - pkg/policy/**
+    - pkg/identity/**
+    - pkg/proxy/dns.go
+    - test/**/net_policies.go


### PR DESCRIPTION
The branching instructions were to remove this configuration file, but
the corresponding workflow was still present in the tree. Removing the
configuration caused the workflow to begin to fail for all new PRs
against this stable branch. Restore the configuration to resolve the
failure.

Fixes: b42d82b6fd2b ("Prepare v1.18 stable branch")
Reported-by: @aanm
