### PR TITLE
golangci-lint: use gopacket/gopacket instead of google/gopacket

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -103,6 +103,10 @@ linters:
               recommendations:
                 - k8s.io/utils/ptr
               reason: k8s.io/utils/pointer is deprecated, see https://pkg.go.dev/k8s.io/utils/pointer
+          - github.com/google/gopacket:
+              recommendations:
+                - github.com/gopacket/gopacket
+              reason: This package is better supported and gets regular updates, see https://github.com/cilium/cilium/issues/34536
     gosec:
       includes:
         - G402


### PR DESCRIPTION
Commit 7a85cf19e9de changed the eintire code base to use the github.com/gopacket/gopacket package instead of
github.com/google/gopacket. Add a lint check to avoid accidentally re-adding the dependency.

For #34536