### PR TITLE
Support IPv6 underlay on dual-stack clusters

### DIFF
--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -335,9 +335,11 @@
   devices: '{eth0,eth1}'
   secondary-network: 'true'
   tunnel: 'vxlan'
+  underlay: 'ipv6'
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  skip-upgrade: 'true'
 - name: '30'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '6.12-20250616.013250'

--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -337,7 +337,6 @@
   tunnel: 'vxlan'
   underlay: 'ipv6'
   lb-mode: 'snat'
-  egress-gateway: 'true'
   ingress-controller: 'true'
   skip-upgrade: 'true'
 - name: '30'

--- a/daemon/cmd/local_node_sync.go
+++ b/daemon/cmd/local_node_sync.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -32,6 +33,7 @@ type localNodeSynchronizerParams struct {
 
 	Logger             *slog.Logger
 	Config             *option.DaemonConfig
+	TunnelConfig       tunnel.Config
 	K8sLocalNode       agentK8s.LocalNodeResource
 	K8sCiliumLocalNode agentK8s.LocalCiliumNodeResource
 
@@ -54,6 +56,8 @@ func (ini *localNodeSynchronizer) InitLocalNode(ctx context.Context, n *node.Loc
 	if err := ini.initFromConfig(ctx, n); err != nil {
 		return err
 	}
+
+	n.UnderlayProtocol = ini.TunnelConfig.UnderlayProtocol()
 
 	if err := ini.initFromK8s(ctx, n); err != nil {
 		return err

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -167,6 +167,7 @@ type Params struct {
 
 	Config            Config
 	DaemonConfig      *option.DaemonConfig
+	TunnelConfig      tunnel.Config
 	IdentityAllocator identityCache.IdentityAllocator
 	PolicyMap4        *egressmap.PolicyMap4
 	PolicyMap6        *egressmap.PolicyMap6
@@ -202,6 +203,10 @@ func NewEgressGatewayManager(p Params) (out struct {
 	// We need to make sure that ipv4/v6 only environments only create the necessary resources and don't fail if unneeded features are missing.
 	if !dcfg.EnableIPv4Masquerade || !dcfg.EnableBPFMasquerade {
 		return out, fmt.Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
+	}
+
+	if p.TunnelConfig.UnderlayProtocol() != tunnel.IPv4 {
+		return out, errors.New("egress gateway requires an IPv4 underlay")
 	}
 
 	if !dcfg.EnableIPv6Masquerade {

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -62,6 +62,12 @@ var Cell = cell.Module(
 	cell.Config(defaultConfig),
 	cell.Provide(NewEgressGatewayManager),
 	cell.Provide(newPolicyResource),
+	cell.Provide(func(dcfg *option.DaemonConfig) tunnel.EnablerOut {
+		if !dcfg.EnableEgressGateway {
+			return tunnel.EnablerOut{}
+		}
+		return tunnel.NewEnabler(true)
+	}),
 )
 
 type eventType int
@@ -177,7 +183,6 @@ func NewEgressGatewayManager(p Params) (out struct {
 
 	*Manager
 	defines.NodeOut
-	tunnel.EnablerOut
 }, err error) {
 	dcfg := p.DaemonConfig
 
@@ -211,8 +216,6 @@ func NewEgressGatewayManager(p Params) (out struct {
 	out.NodeDefines = map[string]string{
 		"ENABLE_EGRESS_GATEWAY": "1",
 	}
-
-	out.EnablerOut = tunnel.NewEnabler(true)
 
 	return out, nil
 }

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -90,7 +90,8 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 	group := p.JobRegistry.NewGroup(p.Health, lc)
 	lc.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
-			tunnelOverIPv6 := !option.Config.EnableIPv4 && option.Config.RoutingMode == option.RoutingModeTunnel
+			tunnelOverIPv6 := option.Config.RoutingMode == option.RoutingModeTunnel &&
+				p.TunnelConfig.UnderlayProtocol() == tunnel.IPv6
 			*c = NewConfiguration(
 				p.IPsec.AuthKeySize(),
 				option.Config.EnableIPSec,

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/common"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -247,7 +248,8 @@ func GetInternalIPv6(logger *slog.Logger) net.IP {
 // GetCiliumEndpointNodeIP is the node IP that will be referenced by CiliumEndpoints with endpoints
 // running on this node.
 func GetCiliumEndpointNodeIP(logger *slog.Logger) string {
-	if option.Config.EnableIPv4 {
+	n := getLocalNode(logger)
+	if option.Config.EnableIPv4 && n.UnderlayProtocol == tunnel.IPv4 {
 		return GetIPv4(logger).String()
 	}
 	return GetIPv6(logger).String()

--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -15,6 +15,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
@@ -43,6 +44,8 @@ type LocalNode struct {
 	ServiceLoopbackIPv4 net.IP
 	// IsBeingDeleted indicates that the local node is being deleted.
 	IsBeingDeleted bool
+	// UnderlayProtocol is the IP family of our underlay.
+	UnderlayProtocol tunnel.UnderlayProtocol
 }
 
 // LocalNodeSynchronizer specifies how to build, and keep synchronized the local

--- a/pkg/node/zz_generated.deepequal.go
+++ b/pkg/node/zz_generated.deepequal.go
@@ -64,6 +64,9 @@ func (in *LocalNode) DeepEqual(other *LocalNode) bool {
 	if in.IsBeingDeleted != other.IsBeingDeleted {
 		return false
 	}
+	if in.UnderlayProtocol != other.UnderlayProtocol {
+		return false
+	}
 
 	return true
 }


### PR DESCRIPTION
This pull request is a follow up to https://github.com/cilium/cilium/pull/38296, to extend the IPv6 underlay support to dual-stack clusters. The first commit ensures IPv6 node addresses are passed through CEPs when IPv6 underlay is enabled. The second commit works around a Hive dependency cycle introduced by the first commit. The third commit fixes the MTU calculation. The last two commit cover IPv6 underlay with a dual-stack cluster in CI.

Fixes: https://github.com/cilium/cilium/issues/17240.