### PR TITLE
bpf:tests:egressgw: fix metrics count

### DIFF
--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -155,7 +155,10 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 	entry = map_lookup_elem(&cilium_metrics, &key);
 	if (!entry)
 		test_fatal("metrics entry not found");
-	assert(entry->count == 1);
+
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 	map_delete_elem(&cilium_metrics, &key);
@@ -209,7 +212,10 @@ int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 	entry = map_lookup_elem(&cilium_metrics, &key);
 	if (!entry)
 		test_fatal("metrics entry not found");
-	assert(entry->count == 1);
+
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 	endpoint_v4_del_entry(GATEWAY_NODE_IP);
@@ -359,7 +365,10 @@ int egressgw_skip_no_gateway_redirect_check_v6(const struct __ctx_buff *ctx)
 	entry = map_lookup_elem(&cilium_metrics, &key);
 	if (!entry)
 		test_fatal("metrics entry not found");
-	assert(entry->count == 1);
+
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 
 	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
 	map_delete_elem(&cilium_metrics, &key);
@@ -418,7 +427,10 @@ int egressgw_drop_no_egress_ip_check_v6(const struct __ctx_buff *ctx)
 	entry = map_lookup_elem(&cilium_metrics, &key);
 	if (!entry)
 		test_fatal("metrics entry not found");
-	assert(entry->count == 1);
+
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 
 	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
 	endpoint_v4_del_entry(GATEWAY_NODE_IP);

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -125,6 +125,12 @@ int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_skip_no_gateway_redirect")
 int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 {
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_NO_EGRESS_GATEWAY,
+		.dir = METRIC_EGRESS,
+	};
+
+	map_delete_elem(&cilium_metrics, &key);
 	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
 	create_ct_entry(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY,
@@ -161,7 +167,6 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 	assert_metrics_count(key, count);
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
-	map_delete_elem(&cilium_metrics, &key);
 
 	test_finish();
 }
@@ -180,6 +185,12 @@ int egressgw_drop_no_egress_ip_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_drop_no_egress_ip")
 int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 {
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_NO_EGRESS_IP,
+		.dir = METRIC_EGRESS,
+	};
+
+	map_delete_elem(&cilium_metrics, &key);
 	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
 	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, 0, NULL, NULL);
 
@@ -219,7 +230,6 @@ int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 	endpoint_v4_del_entry(GATEWAY_NODE_IP);
-	map_delete_elem(&cilium_metrics, &key);
 
 	test_finish();
 }
@@ -329,6 +339,12 @@ int egressgw_skip_no_gateway_redirect_pktgen_v6(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_skip_no_gateway_redirect_v6")
 int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 {
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_NO_EGRESS_GATEWAY,
+		.dir = METRIC_EGRESS,
+	};
+
+	map_delete_elem(&cilium_metrics, &key);
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
 	union v6addr client_ip = CLIENT_IP_V6;
 	union v6addr egress_ip = EGRESS_IP_V6;
@@ -371,7 +387,6 @@ int egressgw_skip_no_gateway_redirect_check_v6(const struct __ctx_buff *ctx)
 	assert_metrics_count(key, count);
 
 	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
-	map_delete_elem(&cilium_metrics, &key);
 
 	test_finish();
 }
@@ -390,6 +405,12 @@ int egressgw_drop_no_egress_ip_pktgen_v6(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_drop_no_egress_ip_v6")
 int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 {
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_NO_EGRESS_IP,
+		.dir = METRIC_EGRESS,
+	};
+
+	map_delete_elem(&cilium_metrics, &key);
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
 	union v6addr client_ip = CLIENT_IP_V6;
 
@@ -434,7 +455,6 @@ int egressgw_drop_no_egress_ip_check_v6(const struct __ctx_buff *ctx)
 
 	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
 	endpoint_v4_del_entry(GATEWAY_NODE_IP);
-	map_delete_elem(&cilium_metrics, &key);
 
 	test_finish();
 }


### PR DESCRIPTION
This PR fixes a flake in our tc_egressgw_redirect_from_host.c tests. The metrics map is PERCPU, so in order to make sure that a specific test has updated our metrics as required, we should call `assert_metrics_count(key, count);`, a utility that loops through all the percpu values, sums them up, and asserts the sum is equal to count. This is due to cpu scheduling execution that might differ between SETUP and CHECK. In addition, let's clear the metric in the SETUP rather than in CHECK, so we make sure that no other tests playing with the same metrics (and they forgot to clear it) affects us.

Fixes: #39841.