### PR TITLE
bgp: Reset peers properly upon policy update with empty MatchNeighbors

### DIFF
--- a/pkg/bgpv1/gobgp/peer.go
+++ b/pkg/bgpv1/gobgp/peer.go
@@ -128,3 +128,36 @@ func (g *GoBGPServer) ResetNeighbor(ctx context.Context, r types.ResetNeighborRe
 	}
 	return nil
 }
+
+// ResetAllNeighbors resets BGP peering with all configured neighbors.
+func (g *GoBGPServer) ResetAllNeighbors(ctx context.Context, r types.ResetAllNeighborsRequest) error {
+	// Get all peers first
+	var peerAddresses []string
+	fn := func(peer *gobgp.Peer) {
+		if peer != nil && peer.Conf != nil {
+			peerAddresses = append(peerAddresses, peer.Conf.NeighborAddress)
+		}
+	}
+
+	err := g.server.ListPeer(ctx, &gobgp.ListPeerRequest{}, fn)
+	if err != nil {
+		return fmt.Errorf("failed to list peers: %w", err)
+	}
+
+	// Reset each peer
+	for _, peerAddr := range peerAddresses {
+		resetReq := &gobgp.ResetPeerRequest{
+			Address:       peerAddr,
+			Communication: r.AdminCommunication,
+		}
+		if r.Soft {
+			resetReq.Soft = true
+			resetReq.Direction = toGoBGPSoftResetDirection(r.SoftResetDirection)
+		}
+		if err := g.server.ResetPeer(ctx, resetReq); err != nil {
+			return fmt.Errorf("failed while resetting peer %s: %w", peerAddr, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -106,14 +106,37 @@ type NeighborRouteReflector struct {
 type SoftResetDirection int
 
 const (
-	SoftResetDirectionIn SoftResetDirection = iota
+	SoftResetDirectionNone SoftResetDirection = iota
+	SoftResetDirectionIn
 	SoftResetDirectionOut
 	SoftResetDirectionBoth
 )
 
+func (d SoftResetDirection) String() string {
+	switch d {
+	case SoftResetDirectionNone:
+		return "none"
+	case SoftResetDirectionIn:
+		return "in"
+	case SoftResetDirectionOut:
+		return "out"
+	case SoftResetDirectionBoth:
+		return "both"
+	default:
+		return "unknown"
+	}
+}
+
 // ResetNeighborRequest contains parameters used when resetting a BGP peer
 type ResetNeighborRequest struct {
 	PeerAddress        netip.Addr
+	Soft               bool
+	SoftResetDirection SoftResetDirection
+	AdminCommunication string
+}
+
+// ResetAllNeighborsRequest contains parameters used when resetting all BGP peers
+type ResetAllNeighborsRequest struct {
 	Soft               bool
 	SoftResetDirection SoftResetDirection
 	AdminCommunication string
@@ -391,6 +414,9 @@ type Router interface {
 
 	// ResetNeighbor resets BGP peering with the provided neighbor address
 	ResetNeighbor(ctx context.Context, r ResetNeighborRequest) error
+
+	// ResetAllNeighbors resets BGP peering with all configured neighbors
+	ResetAllNeighbors(ctx context.Context, r ResetAllNeighborsRequest) error
 
 	// AdvertisePath advertises BGP Path to all configured peers
 	AdvertisePath(ctx context.Context, p PathRequest) (PathResponse, error)

--- a/pkg/bgpv1/types/fake_router.go
+++ b/pkg/bgpv1/types/fake_router.go
@@ -35,6 +35,10 @@ func (f *FakeRouter) ResetNeighbor(ctx context.Context, r ResetNeighborRequest) 
 	return nil
 }
 
+func (f *FakeRouter) ResetAllNeighbors(ctx context.Context, r ResetAllNeighborsRequest) error {
+	return nil
+}
+
 func (f *FakeRouter) AdvertisePath(ctx context.Context, p PathRequest) (PathResponse, error) {
 	path := p.Path
 	f.paths[path.NLRI.String()] = path

--- a/pkg/bgpv1/types/log.go
+++ b/pkg/bgpv1/types/log.go
@@ -114,4 +114,7 @@ const (
 
 	// UpdatedInstancesLogField ...
 	UpdatedInstancesLogField = "updated_instances"
+
+	// DirectionLogField is a log field for direction of BGP reset
+	DirectionLogField = "direction"
 )


### PR DESCRIPTION
The policy with empty MatchNeighbors matches all neighbors. However, we don't reset any peers upon the update of such policies today. Handle those case properly.

```release-note
bgp: Reset peers properly upon policy update with empty MatchNeighbors
```
