### PR TITLE
Add option for daemon kube-apiserver access to bypass host firewall

### DIFF
--- a/cilium-dbg/cmd/build-config.go
+++ b/cilium-dbg/cmd/build-config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sConsts "github.com/cilium/cilium/pkg/k8s/constants"
+	"github.com/cilium/cilium/pkg/k8s/hostfirewallbypass"
 	"github.com/cilium/cilium/pkg/option/resolver"
 )
 
@@ -28,6 +29,7 @@ var buildConfigCell = cell.Module(
 
 var buildConfigHive = hive.New(
 	k8sClient.Cell,
+	hostfirewallbypass.Cell,
 	buildConfigCell,
 	cell.Invoke(func(*buildConfig) {}),
 )

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -47,6 +47,7 @@ import (
 	ipcache "github.com/cilium/cilium/pkg/ipcache/cell"
 	ipmasq "github.com/cilium/cilium/pkg/ipmasq/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/hostfirewallbypass"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
@@ -105,6 +106,10 @@ var (
 
 		// Provides Clientset, API for accessing Kubernetes objects.
 		k8sClient.Cell,
+
+		// Provides optional configuration callback to bypass
+		// host firewall when accessing Kubernetes objects.
+		hostfirewallbypass.Cell,
 
 		// Provide the logic to map DNS names matching Kubernetes services to the
 		// corresponding ClusterIP, without depending on CoreDNS. Leveraged by etcd

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -510,6 +510,16 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          {{- if .Values.securityContext.privileged }}
+          privileged: true
+          {{- else }}
+          capabilities:
+            add:
+              - NET_ADMIN
+            drop:
+              - ALL
+          {{- end}}
       {{- if .Values.cgroup.autoMount.enabled }}
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.

--- a/pkg/datapath/linux/linux_defaults/mark.go
+++ b/pkg/datapath/linux/linux_defaults/mark.go
@@ -3,6 +3,10 @@
 
 package linux_defaults
 
+import (
+	"github.com/cilium/cilium/pkg/identity"
+)
+
 // The skb mark is used to transmit both identity and special markers to
 // identify traffic from and to proxies. The mark field is being used in the
 // following way:
@@ -125,3 +129,10 @@ const (
 	// needs to encrypt a packet.
 	MagicMarkEncrypt = 0x0E00
 )
+
+// Constructs a full packet mark from one of the magic values above
+// and a security identity.
+func MakeMagicMark(mark uint32, securityIdentity identity.NumericIdentity) uint32 {
+	mark |= uint32(securityIdentity&0xFFFF)<<16 | uint32((securityIdentity&0xFF0000)>>16)
+	return mark
+}

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -857,8 +857,7 @@ func (p *DNSProxy) CheckAllowed(endpointID uint64, destPortProto restore.PortPro
 //     until a DNS response has been received.
 func setSoMarks(fd int, ipFamily ipfamily.IPFamily, secId identity.NumericIdentity) error {
 	// Set SO_MARK to allow datapath to know these upstream packets from an egress proxy
-	mark := linux_defaults.MagicMarkEgress
-	mark |= uint32(secId&0xFFFF)<<16 | uint32((secId&0xFF0000)>>16)
+	mark := linux_defaults.MakeMagicMark(linux_defaults.MagicMarkEgress, secId)
 	err := unix.SetsockoptUint64(fd, unix.SOL_SOCKET, unix.SO_MARK, uint64(mark))
 	if err != nil {
 		return fmt.Errorf("error setting SO_MARK: %w", err)

--- a/pkg/k8s/hostfirewallbypass/bypass.go
+++ b/pkg/k8s/hostfirewallbypass/bypass.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hostfirewallbypass
+
+import (
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/k8s/client"
+)
+
+type k8sHostFirewallBypass struct{}
+
+func NewK8sHostFirewallBypass(config Params) client.ConfigureK8sClientsetDialer {
+	if config.EnableK8sHostFirewallBypass {
+		return &k8sHostFirewallBypass{}
+	} else {
+		return nil
+	}
+}
+
+// Sets SO_MARK so that connections to kube-apiserver bypass host firewall and DNS proxy
+func (*k8sHostFirewallBypass) ConfigureK8sClientsetDialer(dialer *net.Dialer) {
+	dialer.Control = setProxyEgressMark
+	dialer.Resolver = &net.Resolver{
+		PreferGo: true,
+		Dial: (&net.Dialer{
+			Control: setProxyEgressMark,
+		}).DialContext,
+	}
+}
+
+func setProxyEgressMark(network, address string, c syscall.RawConn) error {
+	var soerr error
+	if err := c.Control(func(su uintptr) {
+		mark := linux_defaults.MakeMagicMark(linux_defaults.MagicMarkEgress, identity.ReservedIdentityHost)
+		soerr = unix.SetsockoptUint64(int(su), unix.SOL_SOCKET, unix.SO_MARK, uint64(mark))
+	}); err != nil {
+		return err
+	}
+	return soerr
+}

--- a/pkg/k8s/hostfirewallbypass/cell.go
+++ b/pkg/k8s/hostfirewallbypass/cell.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hostfirewallbypass
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+)
+
+// Provides a host firewall bypass for k8s Clientset
+// when accessing Kubernetes objects.
+var Cell = cell.Module(
+	"k8s-host-firewall-bypaass",
+	"Kubernetes host firewall bypass",
+
+	cell.Config(Params{
+		EnableK8sHostFirewallBypass: true,
+	}),
+	cell.Provide(NewK8sHostFirewallBypass),
+)
+
+type Params struct {
+	EnableK8sHostFirewallBypass bool
+}
+
+func (p Params) Flags(flags *pflag.FlagSet) {
+	enable := "enable-k8s-host-firewall-bypass"
+	flags.Bool(enable, p.EnableK8sHostFirewallBypass, "Enable bypassing host firewall for Kubernetes API server access.")
+	flags.MarkHidden(enable)
+}


### PR DESCRIPTION
When L7 DNS proxy for nodes is enabled and kube-apiserver is a FQDN, Cilium agent deadlocks on restart, because k8sClientset's start hook which checks connection to kube-apiserver and verifies the version runs before the daemon bootstraps the DNS proxy with restored endpoints. This commit adds a daemon command-line option which configures the dialer of k8sClientset to bypass DNS proxy and host firewall in the same manner as DNS proxy's requests to remote DNS servers do. Since Cilium trusts both DNS and kube-apiserver responses, exempting the daemon's connections to kube-apiserver from host firewall does not degrade security.

Note: both DNS resolution of and actual connection to kube-apiserver are exempted. If only DNS resolution of kube-apiserver's address is exempted, DNS proxy would not create correct IP-based rules for its address, and if kube-apiserver's IP address changes while the Cilium daemon is restarting, kube-apiserver will not be accessible and the daemon will fail on startup.


```release-note
Introduce the option `enable-k8s-host-firewall-bypass` to allow cilium to bypass the host firewall both for resolving (when configured as a FQDN) and connecting to kube-apiserver.  
```

Fixes: #35433