### PR TITLE
ip-masq-agent: refactor into a Hive Cell

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -63,6 +63,7 @@ cilium-agent hive [flags]
       --enable-hubble                                             Enable hubble server
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format.
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets
+      --enable-ip-masq-agent                                      Enable BPF ip-masq-agent
       --enable-ipv4-big-tcp                                       Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4
       --enable-ipv6-big-tcp                                       Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6
       --enable-k8s                                                Enable the k8s clientset (default true)
@@ -140,6 +141,7 @@ cilium-agent hive [flags]
       --identity-management-mode string                           Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ignore-flags-drift-checker strings                        Ignores specified flags during drift checking
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
+      --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server-urls strings                               Kubernetes API server URLs

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -69,6 +69,7 @@ cilium-agent hive dot-graph [flags]
       --enable-hubble                                             Enable hubble server
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format.
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets
+      --enable-ip-masq-agent                                      Enable BPF ip-masq-agent
       --enable-ipv4-big-tcp                                       Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4
       --enable-ipv6-big-tcp                                       Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6
       --enable-k8s                                                Enable the k8s clientset (default true)
@@ -145,6 +146,7 @@ cilium-agent hive dot-graph [flags]
       --identity-management-mode string                           Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ignore-flags-drift-checker strings                        Ignores specified flags during drift checking
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
+      --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server-urls strings                               Kubernetes API server URLs

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -45,6 +45,7 @@ import (
 	identity "github.com/cilium/cilium/pkg/identity/cell"
 	ipamcell "github.com/cilium/cilium/pkg/ipam/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/cell"
+	ipmasq "github.com/cilium/cilium/pkg/ipmasq/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
@@ -56,6 +57,7 @@ import (
 	loadbalancer_cell "github.com/cilium/cilium/pkg/loadbalancer/cell"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
+	ipmasqmaps "github.com/cilium/cilium/pkg/maps/ipmasq"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	natStats "github.com/cilium/cilium/pkg/maps/nat/stats"
 	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
@@ -252,6 +254,12 @@ var (
 
 		// Egress Gateway allows originating traffic from specific IPv4 addresses.
 		egressgateway.Cell,
+
+		// Provides the BPF ip-masq-agent maps
+		ipmasqmaps.Cell,
+
+		// Provides the BPF ip-masq-agent implementation, which is responsible for managing IP masquerading rules
+		ipmasq.Cell,
 
 		// Provides KPRConfig
 		kpr.Cell,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -577,9 +577,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableMasqueradeRouteSource, false, "Masquerade packets to the source IP provided from the routing layer rather than interface address")
 	option.BindEnv(vp, option.EnableMasqueradeRouteSource)
 
-	flags.Bool(option.EnableIPMasqAgent, false, "Enable BPF ip-masq-agent")
-	option.BindEnv(vp, option.EnableIPMasqAgent)
-
 	flags.Bool(option.EnableIPv4EgressGateway, false, "Enable egress gateway for IPv4")
 	flags.MarkDeprecated(option.EnableIPv4EgressGateway, "Use --enable-egress-gateway instead")
 	option.BindEnv(vp, option.EnableIPv4EgressGateway)
@@ -589,9 +586,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.Bool(option.EnableEnvoyConfig, false, "Enable Envoy Config CRDs")
 	option.BindEnv(vp, option.EnableEnvoyConfig)
-
-	flags.String(option.IPMasqAgentConfigPath, "/etc/config/ip-masq-agent", "ip-masq-agent configuration file path")
-	option.BindEnv(vp, option.IPMasqAgentConfigPath)
 
 	flags.Bool(option.InstallIptRules, true, "Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading)")
 	flags.MarkHidden(option.InstallIptRules)
@@ -1417,6 +1411,7 @@ type daemonParams struct {
 	DNSProxy            bootstrap.FQDNProxyBootstrapper
 	DNSNameManager      namemanager.NameManager
 	KPRConfig           kpr.KPRConfig
+	IPMasqAgent         *ipmasq.IPMasqAgent
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], legacy.DaemonInitialization) {
@@ -1583,14 +1578,6 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 				}
 			}
 		}
-	}
-
-	if option.Config.EnableIPMasqAgent {
-		ipmasqAgent, err := ipmasq.NewIPMasqAgent(d.logger, d.metricsRegistry, option.Config.IPMasqAgentConfigPath)
-		if err != nil {
-			return fmt.Errorf("failed to create ipmasq agent: %w", err)
-		}
-		ipmasqAgent.Start()
 	}
 
 	go func() {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/encrypt"
 	"github.com/cilium/cilium/pkg/maps/fragmap"
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
-	"github.com/cilium/cilium/pkg/maps/ipmasq"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
@@ -231,19 +230,6 @@ func (d *Daemon) initMaps() error {
 	if option.Config.EnableIPv6FragmentsTracking {
 		if err := fragmap.InitMap6(d.metricsRegistry, option.Config.FragmentsMapEntries); err != nil {
 			return fmt.Errorf("initializing fragments map: %w", err)
-		}
-	}
-
-	if option.Config.EnableIPMasqAgent {
-		if option.Config.EnableIPv4Masquerade {
-			if err := ipmasq.IPMasq4Map(d.metricsRegistry).OpenOrCreate(); err != nil {
-				return fmt.Errorf("initializing IPv4 masquerading map: %w", err)
-			}
-		}
-		if option.Config.EnableIPv6Masquerade {
-			if err := ipmasq.IPMasq6Map(d.metricsRegistry).OpenOrCreate(); err != nil {
-				return fmt.Errorf("initializing IPv6 masquerading map: %w", err)
-			}
 		}
 	}
 

--- a/pkg/ipmasq/cell/cell.go
+++ b/pkg/ipmasq/cell/cell.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/ipmasq"
+	ipmasqmaps "github.com/cilium/cilium/pkg/maps/ipmasq"
+
+	"github.com/cilium/hive/cell"
+)
+
+var Cell = cell.Module(
+	"ip-masq-agent",
+	"BPF ip-masq-agent implementation",
+
+	cell.Provide(newIPMasqAgentCell),
+	cell.Config(defaultConfig),
+)
+
+type ipMasqAgentParams struct {
+	cell.In
+
+	Logger    *slog.Logger
+	Lifecycle cell.Lifecycle
+	Config    Config
+	IPMasqMap *ipmasqmaps.IPMasqBPFMap
+}
+
+func newIPMasqAgentCell(params ipMasqAgentParams) (*ipmasq.IPMasqAgent, error) {
+	if !params.Config.EnableIPMasqAgent {
+		return nil, nil
+	}
+
+	agent := ipmasq.NewIPMasqAgent(params.Logger, params.Config.IPMasqAgentConfigPath, params.IPMasqMap)
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			params.Logger.Info("Starting ip-masq-agent")
+			if err := agent.Start(); err != nil {
+				return fmt.Errorf("failed to start ip-masq-agent: %w", err)
+			}
+			return nil
+		},
+		OnStop: func(cell.HookContext) error {
+			params.Logger.Info("Stopping ip-masq-agent")
+			agent.Stop()
+			return nil
+		},
+	})
+
+	return agent, nil
+}

--- a/pkg/ipmasq/cell/cell_test.go
+++ b/pkg/ipmasq/cell/cell_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipmasq"
+	ipmasqmaps "github.com/cilium/cilium/pkg/maps/ipmasq"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func TestPrivileged_TestIPMasqAgentCell(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	var agent *ipmasq.IPMasqAgent
+
+	testHive := hive.New(
+		// Needed for the metrics.Cell
+		cell.Provide(func() *option.DaemonConfig { return &option.DaemonConfig{} }),
+		// Needed for the IPMasqBPFMap
+		metrics.Cell,
+		ipmasqmaps.Cell,
+		Cell,
+		cell.Invoke(func(a *ipmasq.IPMasqAgent) {
+			agent = a
+		}),
+	)
+
+	hive.AddConfigOverride(testHive, func(cfg *Config) {
+		cfg.EnableIPMasqAgent = true
+		cfg.IPMasqAgentConfigPath = path.Join(t.TempDir(), "placeholder.yaml")
+	})
+
+	// Start the hive
+	ctx := context.Background()
+	tlog := hivetest.Logger(t)
+	err := testHive.Start(tlog, ctx)
+	require.NoError(t, err)
+
+	// Verify that the agent was successfully created
+	assert.NotNil(t, agent)
+
+	// Stop the hive
+	err = testHive.Stop(tlog, ctx)
+	require.NoError(t, err)
+}
+
+func TestPrivileged_TestIPMasqAgentCellDisabled(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	var agent *ipmasq.IPMasqAgent
+
+	testHive := hive.New(
+		// Needed for the metrics.Cell
+		cell.Provide(func() *option.DaemonConfig { return &option.DaemonConfig{} }),
+		// Needed for the IPMasqBPFMap
+		metrics.Cell,
+		ipmasqmaps.Cell,
+		Cell,
+		cell.Invoke(func(a *ipmasq.IPMasqAgent) {
+			agent = a
+		}),
+	)
+
+	// Disable via config
+	hive.AddConfigOverride(testHive, func(cfg *Config) {
+		cfg.EnableIPMasqAgent = false
+	})
+
+	// Start the hive
+	ctx := context.Background()
+	tlog := hivetest.Logger(t)
+	err := testHive.Start(tlog, ctx)
+	require.NoError(t, err)
+
+	// Verify that the agent was not created
+	assert.Nil(t, agent)
+
+	// Stop the hive
+	err = testHive.Stop(tlog, ctx)
+	require.NoError(t, err)
+}

--- a/pkg/ipmasq/cell/config.go
+++ b/pkg/ipmasq/cell/config.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type Config struct {
+	EnableIPMasqAgent     bool   `mapstructure:"enable-ip-masq-agent"`
+	IPMasqAgentConfigPath string `mapstructure:"ip-masq-agent-config-path"`
+}
+
+var defaultConfig = Config{
+	EnableIPMasqAgent:     false,
+	IPMasqAgentConfigPath: "/etc/config/ip-masq-agent",
+}
+
+func (c Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool(option.EnableIPMasqAgent, c.EnableIPMasqAgent, "Enable BPF ip-masq-agent")
+	flags.String(option.IPMasqAgentConfigPath, c.IPMasqAgentConfigPath, "ip-masq-agent configuration file path")
+}

--- a/pkg/ipmasq/ipmasq_test.go
+++ b/pkg/ipmasq/ipmasq_test.go
@@ -145,9 +145,7 @@ func setUpTest(tb testing.TB) *IPMasqTestSuite {
 	require.NoError(tb, err)
 	i.configFilePath = configFile.Name()
 
-	agent, err := newIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
-	require.NoError(tb, err)
-	i.ipMasqAgent = agent
+	i.ipMasqAgent = NewIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
 
 	tb.Cleanup(func() {
 		i.ipMasqAgent.Stop()
@@ -167,7 +165,8 @@ func TestUpdateIPv4(t *testing.T) {
 
 	i.ipMasqMap.ipv4Enabled = true
 	i.ipMasqMap.ipv6Enabled = false
-	i.ipMasqAgent.Start()
+	err := i.ipMasqAgent.Start()
+	require.NoError(t, err)
 	i.writeConfig(t, "nonMasqueradeCIDRs:\n- 1.1.1.1/32\n- 2.2.2.2/16")
 	time.Sleep(300 * time.Millisecond)
 
@@ -216,7 +215,7 @@ func TestUpdateIPv4(t *testing.T) {
 	require.True(t, ok)
 
 	// Delete file, should remove the CIDRs and add default nonMasq CIDRs
-	err := os.Remove(i.configFilePath)
+	err = os.Remove(i.configFilePath)
 	require.NoError(t, err)
 	time.Sleep(300 * time.Millisecond)
 	ipnets = i.ipMasqMap.dumpToSet()
@@ -234,7 +233,8 @@ func TestUpdateIPv6(t *testing.T) {
 
 	i.ipMasqMap.ipv4Enabled = false
 	i.ipMasqMap.ipv6Enabled = true
-	i.ipMasqAgent.Start()
+	err := i.ipMasqAgent.Start()
+	require.NoError(t, err)
 	i.writeConfig(t, "nonMasqueradeCIDRs:\n- 1:1:1:1::/64\n- 2:2::/32")
 	time.Sleep(300 * time.Millisecond)
 
@@ -281,7 +281,7 @@ func TestUpdateIPv6(t *testing.T) {
 	require.True(t, ok)
 
 	// Delete file, should remove the CIDRs and add default nonMasq CIDRs
-	err := os.Remove(i.configFilePath)
+	err = os.Remove(i.configFilePath)
 	require.NoError(t, err)
 	time.Sleep(300 * time.Millisecond)
 	ipnets = i.ipMasqMap.dumpToSet()
@@ -294,7 +294,8 @@ func TestUpdate(t *testing.T) {
 	i := setUpTest(t)
 	i.ipMasqMap.ipv4Enabled = true
 	i.ipMasqMap.ipv6Enabled = true
-	i.ipMasqAgent.Start()
+	err := i.ipMasqAgent.Start()
+	require.NoError(t, err)
 	i.writeConfig(t, "nonMasqueradeCIDRs:\n- 1.1.1.1/32\n- 2:2::/32")
 	time.Sleep(300 * time.Millisecond)
 
@@ -349,7 +350,7 @@ func TestUpdate(t *testing.T) {
 	require.True(t, ok)
 
 	// Delete file, should remove the CIDRs and add default nonMasq CIDRs
-	err := os.Remove(i.configFilePath)
+	err = os.Remove(i.configFilePath)
 	require.NoError(t, err)
 	time.Sleep(300 * time.Millisecond)
 	ipnets = i.ipMasqMap.dumpToSet()
@@ -367,7 +368,8 @@ func TestRestoreIPv4(t *testing.T) {
 	i := setUpTest(t)
 	i.ipMasqMap.ipv4Enabled = true
 	i.ipMasqMap.ipv6Enabled = false
-	i.ipMasqAgent.Start()
+	err = i.ipMasqAgent.Start()
+	require.NoError(t, err)
 	// Check that stale entry is removed from the map after restore
 	i.ipMasqAgent.Stop()
 
@@ -377,9 +379,9 @@ func TestRestoreIPv4(t *testing.T) {
 	i.ipMasqMap.cidrsIPv4[cidr.String()] = cidr
 	i.writeConfig(t, "nonMasqueradeCIDRs:\n- 4.4.0.0/16")
 
-	i.ipMasqAgent, err = newIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	i.ipMasqAgent = NewIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	err = i.ipMasqAgent.Start()
 	require.NoError(t, err)
-	i.ipMasqAgent.Start()
 	time.Sleep(300 * time.Millisecond)
 
 	ipnets := i.ipMasqMap.dumpToSet()
@@ -399,9 +401,9 @@ func TestRestoreIPv4(t *testing.T) {
 	}
 	i.ipMasqAgent.ipMasqMap = i.ipMasqMap
 	i.writeConfig(t, "nonMasqueradeCIDRs:\n- 3.3.0.0/16\nmasqLinkLocal: true")
-	i.ipMasqAgent, err = newIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	i.ipMasqAgent = NewIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	err = i.ipMasqAgent.Start()
 	require.NoError(t, err)
-	i.ipMasqAgent.Start()
 
 	ipnets = i.ipMasqMap.dumpToSet()
 	require.Len(t, ipnets, 1)
@@ -416,7 +418,8 @@ func TestRestoreIPv6(t *testing.T) {
 	i := setUpTest(t)
 	i.ipMasqMap.ipv4Enabled = false
 	i.ipMasqMap.ipv6Enabled = true
-	i.ipMasqAgent.Start()
+	err = i.ipMasqAgent.Start()
+	require.NoError(t, err)
 	// Check that stale entry is removed from the map after restore
 	i.ipMasqAgent.Stop()
 
@@ -426,9 +429,9 @@ func TestRestoreIPv6(t *testing.T) {
 	i.ipMasqMap.cidrsIPv6[cidr.String()] = cidr
 	i.writeConfig(t, "nonMasqueradeCIDRs:\n- 4:4::/32")
 
-	i.ipMasqAgent, err = newIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	i.ipMasqAgent = NewIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	err = i.ipMasqAgent.Start()
 	require.NoError(t, err)
-	i.ipMasqAgent.Start()
 	time.Sleep(300 * time.Millisecond)
 
 	ipnets := i.ipMasqMap.dumpToSet()
@@ -448,9 +451,9 @@ func TestRestoreIPv6(t *testing.T) {
 	}
 	i.ipMasqAgent.ipMasqMap = i.ipMasqMap
 	i.writeConfig(t, "nonMasqueradeCIDRs:\n- 3:3::/96\nmasqLinkLocalIPv6: true")
-	i.ipMasqAgent, err = newIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	i.ipMasqAgent = NewIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	err = i.ipMasqAgent.Start()
 	require.NoError(t, err)
-	i.ipMasqAgent.Start()
 
 	ipnets = i.ipMasqMap.dumpToSet()
 	require.Len(t, ipnets, 1)
@@ -465,7 +468,8 @@ func TestRestore(t *testing.T) {
 	i := setUpTest(t)
 	i.ipMasqMap.ipv4Enabled = true
 	i.ipMasqMap.ipv6Enabled = true
-	i.ipMasqAgent.Start()
+	err = i.ipMasqAgent.Start()
+	require.NoError(t, err)
 	// Check that stale entry is removed from the map after restore
 	i.ipMasqAgent.Stop()
 
@@ -479,9 +483,9 @@ func TestRestore(t *testing.T) {
 	i.ipMasqMap.cidrsIPv4[cidr.String()] = cidr
 	i.writeConfig(t, "nonMasqueradeCIDRs:\n- 4.4.0.0/16\n- 4:4::/32")
 
-	i.ipMasqAgent, err = newIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	i.ipMasqAgent = NewIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	err = i.ipMasqAgent.Start()
 	require.NoError(t, err)
-	i.ipMasqAgent.Start()
 	time.Sleep(300 * time.Millisecond)
 
 	ipnets := i.ipMasqMap.dumpToSet()
@@ -506,9 +510,9 @@ func TestRestore(t *testing.T) {
 	}
 	i.ipMasqAgent.ipMasqMap = i.ipMasqMap
 	i.writeConfig(t, "nonMasqueradeCIDRs:\n- 3.3.0.0/16\n- 3:3:3:3::/96\nmasqLinkLocal: true\nmasqLinkLocalIPv6: true")
-	i.ipMasqAgent, err = newIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	i.ipMasqAgent = NewIPMasqAgent(logger, i.configFilePath, i.ipMasqMap)
+	err = i.ipMasqAgent.Start()
 	require.NoError(t, err)
-	i.ipMasqAgent.Start()
 
 	ipnets = i.ipMasqMap.dumpToSet()
 	require.Len(t, ipnets, 2)

--- a/pkg/maps/ipmasq/cell.go
+++ b/pkg/maps/ipmasq/cell.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipmasq
+
+import (
+	"fmt"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var Cell = cell.Module(
+	"ip-masq-maps",
+	"BPF ip-masq-agent maps",
+
+	cell.Provide(newIPMasqMaps),
+)
+
+type ipMasqMapsParams struct {
+	cell.In
+
+	Lifecycle       cell.Lifecycle
+	MetricsRegistry *metrics.Registry
+}
+
+func newIPMasqMaps(p ipMasqMapsParams) bpf.MapOut[*IPMasqBPFMap] {
+	m := &IPMasqBPFMap{MetricsRegistry: p.MetricsRegistry}
+
+	p.Lifecycle.Append(cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			if option.Config.EnableIPMasqAgent {
+				if option.Config.EnableIPv4Masquerade {
+					if err := IPMasq4Map(p.MetricsRegistry).OpenOrCreate(); err != nil {
+						return fmt.Errorf("initializing IPv4 masquerading map: %w", err)
+					}
+				}
+				if option.Config.EnableIPv6Masquerade {
+					if err := IPMasq6Map(p.MetricsRegistry).OpenOrCreate(); err != nil {
+						return fmt.Errorf("initializing IPv6 masquerading map: %w", err)
+					}
+				}
+			}
+			return nil
+		},
+		OnStop: func(cell.HookContext) error {
+			// No clean-up required for the ip-masq-agent maps at shutdown.
+			return nil
+		},
+	})
+
+	return bpf.NewMapOut(m)
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1529,7 +1529,6 @@ type DaemonConfig struct {
 	EnableBPFMasquerade         bool
 	EnableMasqueradeRouteSource bool
 	EnableIPMasqAgent           bool
-	IPMasqAgentConfigPath       string
 
 	EnableBPFClockProbe    bool
 	EnableEgressGateway    bool
@@ -2682,7 +2681,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
 	c.EnableEgressGateway = vp.GetBool(EnableEgressGateway) || vp.GetBool(EnableIPv4EgressGateway)
 	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)
-	c.IPMasqAgentConfigPath = vp.GetString(IPMasqAgentConfigPath)
 	c.AgentHealthRequireK8sConnectivity = vp.GetBool(AgentHealthRequireK8sConnectivity)
 	c.InstallIptRules = vp.GetBool(InstallIptRules)
 	c.IPSecKeyFile = vp.GetString(IPSecKeyFileName)


### PR DESCRIPTION
# Description
This PR wraps the existing `ip-masq-agent` code into a Hive Cell. This goes in-line with the current efforts to modularize the codebase and is a pre-requisite for https://github.com/cilium/cilium/pull/40141. 

The `ip-masq-agent` and its Maps used to be created inside the [Legacy Daemon Cell](https://github.com/cilium/cilium/blob/09121c28545e908559f2a8a9f27f81675a299e92/daemon/cmd/daemon_main.go#L1336-L1341). Both the Agent and its Maps are now modularized and are created before the Daemon Cell starts.

# Testing
On top of unit tests, I also tried the PR in a real cluster. Unfortunately I don't have an easy way to setup a 1.18 environment so I backported my change to 1.17.5. I then verified that:
- When `--enable-ip-masq-agent=false`:
  - [x] The Agents start properly, there are no errors
- When `--enable-ip-masq-agent=true`:
  - [x] The Agents start properly, there are no errors. There is the "Starting ip-masq-agent" log from `module=agent.controlplane.ip-masq-agent`
  - [x] `cilium status` shows correctly:
    ```
    # cilium status
    [...]
    Masquerading:            BPF (ip-masq-agent)   [ens5, ens6]   10.128.0.0/16 [IPv4: Enabled, IPv6: Disabled]
    ```
  - [x] The `--ip-masq-agent-config-path` option is taken into account and the BPF Map is populated with the expected values from the config path:
     ```
      # cilium bpf ipmasq list
      IP PREFIX/ADDRESS
      169.254.0.0/16
      172.16.0.0/12
      192.168.0.0/16
      10.0.0.0/8
      100.64.0.0/10
      ```

```release-note
ip-masq-agent: refactor into a Hive Cell
```
