### PR TITLE
pkg/egw: Add missing waitForReconciliationRun

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -403,6 +403,7 @@ func TestEgressGatewayManager(t *testing.T) {
 	// Restore old DestCIDR
 	policy1.destinationCIDRs = []string{destCIDR, destCIDRv6}
 	addPolicy(t, k.policies, &policy1)
+	reconciliationEventsCount = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
 	// Create a new policy
 	addPolicy(t, k.policies, &policyParams{


### PR DESCRIPTION
This led to race conditions where the egress policy reconciliation had not completed before subsequent assertions, causing intermittent test failures. I was able to consistently reproduce a race condition by adding breakpoints.
Ran the test 100 times locally without any issues.

Fixes: https://github.com/cilium/cilium/issues/40351

