### PR TITLE
fix(GH-37724): Sync policies on startup

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -801,7 +801,25 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 			if err != nil {
 				return fmt.Errorf("policymap synchronization failed: %w", err)
 			}
+			datapathRegenCtxt.policyMapSyncDone = true
 		} else {
+			// There is an edge case where on startup, the policy map for an endpoint
+			// is not empty (policyMapDump > 0) but no policy has been realized yet (realizedPolicy is empty).
+			// Default policy may exist in map to allow all ingress/egress traffic, something like this:
+			// --------------------------------------------------------------------------------------------------------------------------
+			// POLICY   DIRECTION   LABELS (source:key[=value])   PORT/PROTO   PROXY PORT   AUTH TYPE   BYTES   PACKETS   PREFIX
+			// Allow    Ingress     ANY                           ANY          NONE         disabled    2426    29        0
+			// Allow    Ingress     reserved:host                 ANY          NONE         disabled    0       0         0
+			// Allow    Egress      ANY                           ANY          NONE         disabled    30639   165       0
+			// ----------------------------------------------------------------------------------------------------------------------------
+			// If the code has reached here, it means:
+			// 1. The endpoint has a policy map that is not empty (default policy exists)
+			// 2. No policies has been realized (realized policy is empty)
+			// 3. New policies need to be applied for this endpoint (hence desiredPolicy != realizedPolicy)
+			// GH-37724: https://github.com/cilium/cilium/issues/37724
+			e.getLogger().Debug(
+				"Policy map is not empty, but no policy has been realized yet, setting policyMapSyncDone to false",
+			)
 			// Ensure that e.realizedPolicy actually represents the
 			// current policy map state in case rollback is
 			// necessary, so we don't try to "roll back" to an empty
@@ -809,8 +827,10 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 			// This may be the case if the agent just restarted,
 			// for example. See GH-38998.
 			e.realizedPolicy.CopyMapStateFrom(datapathRegenCtxt.policyMapDump)
+			// Not strictly required to set as false, but it is a good idea to absolutely
+			// ensure that the policy map is in sync with the desired policy.
+			datapathRegenCtxt.policyMapSyncDone = false
 		}
-		datapathRegenCtxt.policyMapSyncDone = true
 	}
 
 	// sync policy map for fake endpoints, bpf compilation will be skipped for them.


### PR DESCRIPTION
## Description

Currently, is a policy is applied before Cililum is installed (ex: through directory), agent fails to sync the policy for endpoint. This change fixes the issue.

Root cause of the above bug - https://github.com/cilium/cilium/issues/37724#issuecomment-3007065357 
Added a detailed comment explaining the fix in the commit.

## Testing done

1. Add following CNP to `kind-worker` node

```
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: static-coredns
spec:
  endpointSelector:
    matchLabels:
      k8s:io.kubernetes.pod.namespace: kube-system
      k8s:k8s-app: kube-dns
  ingress:
  - fromEntities:
    - cluster
    toPorts:
    - ports:
      - port: "53"
        protocol: ANY
      - port: "9153"
        protocol: TCP
  egress:
  - toEntities:
    - kube-apiserver
    - host
  - toCIDR:
    - 1.1.1.1/32
    - 8.8.8.8/32
```

2. Install Cilium. Added following to agent daemonset

```
diff --git a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
index 8588506c50..9aabf3982e 100644
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -126,6 +126,7 @@ spec:
         command:
         - cilium-agent
         args:
+        - --static-cnp-path=/policies
         - --config-dir=/tmp/cilium/config-map
         {{- with .Values.extraArgs }}
         {{- toYaml . | trim | nindent 8 }}
@@ -299,6 +300,9 @@ spec:
           {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - name: policies
+          mountPath: /policies
+          readOnly: false
         {{- if .Values.authentication.mutual.spire.enabled }}
         - name: spire-agent-socket
           mountPath: {{ dir .Values.authentication.mutual.spire.adminSocketPath }}
@@ -827,6 +831,10 @@ spec:
       {{- end }}
       {{- end }}
       volumes:
+      - name: policies
+        hostPath:
+          path: /tmp/policies
+          type: DirectoryOrCreate
``` 

3. Check policy map

```bash
$ k exec -it $(kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium-agent -o wide | awk '$7=="kind-worker"{print $1}') -- cilium-dbg endpoint list
ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                                  IPv6                  IPv4           STATUS
           ENFORCEMENT        ENFORCEMENT
159        Disabled           Disabled          1          reserved:host                                                                                                     ready
1711       Disabled           Disabled          4          reserved:health                                                              fd00:10:244:1::2486   10.244.1.216   ready
2580       Enabled            Enabled           59673      k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system   fd00:10:244:1::3a68   10.244.1.75    ready
                                                           k8s:io.cilium.k8s.policy.cluster=kind-kind
                                                           k8s:io.cilium.k8s.policy.serviceaccount=coredns
                                                           k8s:io.kubernetes.pod.namespace=kube-system
                                                           k8s:k8s-app=kube-dns
$
$
$  k exec -it $(kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium-agent -o wide | awk '$7=="kind-worker"{print $1}') -- cilium-dbg bpf policy get 2580
POLICY   DIRECTION   LABELS (source:key[=value])   PORT/PROTO   PROXY PORT   AUTH TYPE   BYTES    PACKETS   PREFIX
Allow    Ingress     ANY                           53/TCP       NONE         disabled    0        0         24
Allow    Ingress     ANY                           9153/TCP     NONE         disabled    0        0         24
Allow    Ingress     ANY                           53/UDP       NONE         disabled    0        0         24
Allow    Ingress     ANY                           53/SCTP      NONE         disabled    0        0         24
Allow    Ingress     reserved:host                 ANY          NONE         disabled    0        0         0
Allow    Egress      reserved:host                 ANY          NONE         disabled    0        0         0
Allow    Egress      reserved:kube-apiserver       ANY          NONE         disabled    461553   2015      0
                     reserved:remote-node
Allow    Egress      cidr:8.8.8.8/32               ANY          NONE         disabled    0        0         0
                     reserved:world-ipv4
Allow    Egress      cidr:1.1.1.1/32               ANY          NONE         disabled    39599    601       0
                     reserved:world-ipv4
```

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/37724
