### PR TITLE
wireguard: Modularization of Agent

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -76,6 +76,7 @@ cilium-agent hive [flags]
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
+      --enable-wireguard                                          Enable WireGuard
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
@@ -176,6 +177,7 @@ cilium-agent hive [flags]
       --multicast-enabled                                         Enables multicast in Cilium
       --nat-map-stats-entries int                                 Number k top stats entries to store locally in statedb (default 32)
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)
+      --node-encryption-opt-out-labels string                     Label selector for nodes which will opt-out of node-to-node encryption (default "node-role.kubernetes.io/control-plane")
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --policy-default-local-cluster                              Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
@@ -216,6 +218,7 @@ cilium-agent hive [flags]
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")
       --underlay-protocol string                                  IP family for the underlay ("ipv4" or "ipv6") (default "ipv4")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
+      --wireguard-persistent-keepalive duration                   The Wireguard keepalive interval as a Go duration string
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
 ```
 

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -82,6 +82,7 @@ cilium-agent hive dot-graph [flags]
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
+      --enable-wireguard                                          Enable WireGuard
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
@@ -181,6 +182,7 @@ cilium-agent hive dot-graph [flags]
       --multicast-enabled                                         Enables multicast in Cilium
       --nat-map-stats-entries int                                 Number k top stats entries to store locally in statedb (default 32)
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)
+      --node-encryption-opt-out-labels string                     Label selector for nodes which will opt-out of node-to-node encryption (default "node-role.kubernetes.io/control-plane")
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --policy-default-local-cluster                              Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
@@ -221,6 +223,7 @@ cilium-agent hive dot-graph [flags]
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")
       --underlay-protocol string                                  IP family for the underlay ("ipv4" or "ipv6") (default "ipv4")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
+      --wireguard-persistent-keepalive duration                   The Wireguard keepalive interval as a Go duration string
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
 ```
 

--- a/api/v1/models/wireguard_status.go
+++ b/api/v1/models/wireguard_status.go
@@ -27,6 +27,9 @@ type WireguardStatus struct {
 	// WireGuard interfaces managed by this Cilium instance
 	Interfaces []*WireguardInterface `json:"interfaces"`
 
+	// Label selector for nodes which will opt-out of node-to-node encryption
+	NodeEncryptOptOutLabels string `json:"node-encrypt-opt-out-labels,omitempty"`
+
 	// Node Encryption status
 	NodeEncryption string `json:"node-encryption,omitempty"`
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3760,6 +3760,9 @@ definitions:
       node-encryption:
         description: Node Encryption status
         type: string
+      node-encrypt-opt-out-labels:
+        description: Label selector for nodes which will opt-out of node-to-node encryption
+        type: string
       interfaces:
         description: WireGuard interfaces managed by this Cilium instance
         type: array

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -5181,6 +5181,10 @@ func init() {
             "$ref": "#/definitions/WireguardInterface"
           }
         },
+        "node-encrypt-opt-out-labels": {
+          "description": "Label selector for nodes which will opt-out of node-to-node encryption",
+          "type": "string"
+        },
         "node-encryption": {
           "description": "Node Encryption status",
           "type": "string"
@@ -11302,6 +11306,10 @@ func init() {
           "items": {
             "$ref": "#/definitions/WireguardInterface"
           }
+        },
+        "node-encrypt-opt-out-labels": {
+          "description": "Label selector for nodes which will opt-out of node-to-node encryption",
+          "type": "string"
         },
         "node-encryption": {
           "description": "Node Encryption status",

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -59,6 +59,7 @@ import (
 	policyAPI "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/time"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 const (
@@ -233,7 +234,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	// WireGuard and IPSec are mutually exclusive.
 	if option.Config.EnableIPSec && params.WGAgent.Enabled() {
-		return nil, nil, fmt.Errorf("WireGuard (--%s) cannot be used with IPsec (--%s)", option.EnableWireguard, option.EnableIPSecName)
+		return nil, nil, fmt.Errorf("WireGuard (--%s) cannot be used with IPsec (--%s)", wgTypes.EnableWireguard, option.EnableIPSecName)
 	}
 
 	// IPAMENI IPSec is configured from Reinitialize() to pull in devices

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -231,6 +231,11 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		}
 	}
 
+	// WireGuard and IPSec are mutually exclusive.
+	if option.Config.EnableIPSec && option.Config.EnableWireguard {
+		return nil, nil, fmt.Errorf("WireGuard (--%s) cannot be used with IPsec (--%s)", option.EnableWireguard, option.EnableIPSecName)
+	}
+
 	// IPAMENI IPSec is configured from Reinitialize() to pull in devices
 	// that may be added or removed at runtime.
 	if option.Config.EnableIPSec &&

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -495,7 +495,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		bootstrapStats.k8sInit.End(true)
 	}
 
-	if params.WGAgent != nil && option.Config.EnableWireguard {
+	if option.Config.EnableWireguard {
 		if err := params.WGAgent.Init(d.ipcache); err != nil {
 			d.logger.Error("failed to initialize WireGuard agent", logfields.Error, err)
 			return nil, nil, fmt.Errorf("failed to initialize WireGuard agent: %w", err)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -496,7 +496,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	if option.Config.EnableWireguard {
-		if err := params.WGAgent.Init(d.ipcache); err != nil {
+		if err := params.WGAgent.Init(d.ipcache, ctx); err != nil {
 			d.logger.Error("failed to initialize WireGuard agent", logfields.Error, err)
 			return nil, nil, fmt.Errorf("failed to initialize WireGuard agent: %w", err)
 		}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -495,13 +495,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		bootstrapStats.k8sInit.End(true)
 	}
 
-	if option.Config.EnableWireguard {
-		if err := params.WGAgent.Init(d.ipcache, ctx); err != nil {
-			d.logger.Error("failed to initialize WireGuard agent", logfields.Error, err)
-			return nil, nil, fmt.Errorf("failed to initialize WireGuard agent: %w", err)
-		}
-	}
-
 	// The kube-proxy replacement and host-fw devices detection should happen after
 	// establishing a connection to kube-apiserver, but before starting a k8s watcher.
 	// This is because the device detection requires self (Cilium)Node object.

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -500,8 +500,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			d.logger.Error("failed to initialize WireGuard agent", logfields.Error, err)
 			return nil, nil, fmt.Errorf("failed to initialize WireGuard agent: %w", err)
 		}
-
-		params.NodeManager.Subscribe(params.WGAgent)
 	}
 
 	// The kube-proxy replacement and host-fw devices detection should happen after

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -84,7 +84,6 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
-	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
@@ -1349,7 +1348,6 @@ type daemonParams struct {
 	CacheStatus         k8sSynced.CacheStatus
 	K8sResourceSynced   *k8sSynced.Resources
 	K8sAPIGroups        *k8sSynced.APIGroups
-	NodeManager         nodeManager.NodeManager
 	NodeHandler         datapath.NodeHandler
 	NodeAddressing      datapath.NodeAddressing
 	EndpointCreator     endpointcreator.EndpointCreator

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -92,7 +92,7 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
-	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 const (
@@ -1340,7 +1340,7 @@ type daemonParams struct {
 	MetricsRegistry     *metrics.Registry
 	Clientset           k8sClient.Clientset
 	KVStoreClient       kvstore.Client
-	WGAgent             *wireguard.Agent
+	WGAgent             wgTypes.WireguardAgent
 	LocalNodeStore      *node.LocalNodeStore
 	Shutdowner          hive.Shutdowner
 	Resources           agentK8s.Resources

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1512,7 +1512,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	params.CTNATMapGC.Observe6().Observe(d.ctx, ctmap.NatMapNext6, func(err error) {})
 	bootstrapStats.enableConntrack.End(true)
 
-	if params.WGAgent != nil {
+	if option.Config.EnableWireguard {
 		go func() {
 			// Wait until the kvstore synchronization completed, to avoid
 			// causing connectivity blips due incorrectly removing

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -375,9 +375,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableIPSecEncryptedOverlay, defaults.EnableIPSecEncryptedOverlay, "Enable IPsec encrypted overlay. If enabled tunnel traffic will be encrypted before leaving the host. Requires ipsec and tunnel mode vxlan to be enabled.")
 	option.BindEnv(vp, option.EnableIPSecEncryptedOverlay)
 
-	flags.Bool(option.EnableWireguard, false, "Enable WireGuard")
-	option.BindEnv(vp, option.EnableWireguard)
-
 	flags.Bool(option.EnableL2Announcements, false, "Enable L2 announcements")
 	option.BindEnv(vp, option.EnableL2Announcements)
 
@@ -389,12 +386,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.Duration(option.L2AnnouncerRetryPeriod, 2*time.Second, "Timeout after a renew failure, before the next retry")
 	option.BindEnv(vp, option.L2AnnouncerRetryPeriod)
-
-	flags.Duration(option.WireguardPersistentKeepalive, 0, "The Wireguard keepalive interval as a Go duration string")
-	option.BindEnv(vp, option.WireguardPersistentKeepalive)
-
-	flags.String(option.NodeEncryptionOptOutLabels, defaults.NodeEncryptionOptOutLabels, "Label selector for nodes which will opt-out of node-to-node encryption")
-	option.BindEnv(vp, option.NodeEncryptionOptOutLabels)
 
 	flags.Bool(option.EnableEncryptionStrictMode, false, "Enable encryption strict mode")
 	option.BindEnv(vp, option.EnableEncryptionStrictMode)
@@ -905,10 +896,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableNonDefaultDenyPolicies, defaults.EnableNonDefaultDenyPolicies, "Enable use of non-default-deny policies")
 	flags.MarkHidden(option.EnableNonDefaultDenyPolicies)
 	option.BindEnv(vp, option.EnableNonDefaultDenyPolicies)
-
-	flags.Bool(option.WireguardTrackAllIPsFallback, defaults.WireguardTrackAllIPsFallback, "Force WireGuard to track all IPs")
-	flags.MarkHidden(option.WireguardTrackAllIPsFallback)
-	option.BindEnv(vp, option.WireguardTrackAllIPsFallback)
 
 	flags.Bool(option.EnableEndpointLockdownOnPolicyOverflow, false, "When an endpoint's policy map overflows, shutdown all (ingress and egress) network traffic for that endpoint.")
 	option.BindEnv(vp, option.EnableEndpointLockdownOnPolicyOverflow)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -98,7 +98,7 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 				fmt.Sprintf(
 					"With %s: %s and %s, %s enabled, N/S Loadbalancer traffic won't be encrypted "+
 						"when an intermediate node redirects a request to another node where a selected backend is running.",
-					option.NodePortAcceleration, option.Config.NodePortAcceleration, option.EnableWireguard, option.EncryptNode),
+					option.NodePortAcceleration, option.Config.NodePortAcceleration, wgTypes.EnableWireguard, option.EncryptNode),
 				logfields.Hint,
 				"Disable XDP acceleration to encrypt N/S Loadbalancer traffic.")
 		}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/mountinfo"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/safeio"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // initKubeProxyReplacementOptions will grok the global config and determine
@@ -41,7 +42,7 @@ import (
 //
 // if this function cannot determine the strictness an error is returned and the boolean
 // is false. If an error is returned the boolean is of no meaning.
-func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, tunnelConfig tunnel.Config, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig) error {
+func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, tunnelConfig tunnel.Config, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.WireguardConfig) error {
 	if !kprCfg.EnableNodePort {
 		option.Config.EnableHostLegacyRouting = true
 	}
@@ -92,7 +93,7 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 		}
 
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled &&
-			option.Config.EnableWireguard && option.Config.EncryptNode {
+			wgCfg.Enabled() && option.Config.EncryptNode {
 			logger.Warn(
 				fmt.Sprintf(
 					"With %s: %s and %s, %s enabled, N/S Loadbalancer traffic won't be encrypted "+

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -14,12 +14,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 type KPRSuite struct{}
@@ -98,9 +100,9 @@ func errorMatch(err error, regex string) assert.Comparison {
 	}
 }
 
-func (cfg *kprConfig) verify(t *testing.T, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, tc tunnel.Config) {
+func (cfg *kprConfig) verify(t *testing.T, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, tc tunnel.Config, wgCfg wgTypes.WireguardConfig) {
 	logger := hivetest.Logger(t)
-	err := initKubeProxyReplacementOptions(logger, sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"), tc, lbConfig, kprCfg)
+	err := initKubeProxyReplacementOptions(logger, sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"), tc, lbConfig, kprCfg, wgCfg)
 	if err != nil || cfg.expectedErrorRegex != "" {
 		t.Logf("err=%s, expected=%s, cfg=%+v", err, cfg.expectedErrorRegex, cfg)
 		require.Condition(t, errorMatch(err, cfg.expectedErrorRegex))
@@ -417,7 +419,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		cfg := def
 		testCase.mod(&cfg)
 		require.NoError(t, cfg.set())
-		testCase.out.verify(t, cfg.lbConfig, cfg.kprConfig, tunnel.NewTestConfig(cfg.tunnelProtocol))
+		testCase.out.verify(t, cfg.lbConfig, cfg.kprConfig, tunnel.NewTestConfig(cfg.tunnelProtocol), fakeTypes.WireguardConfig{})
 		def.set()
 	}
 }

--- a/daemon/cmd/local_node_sync.go
+++ b/daemon/cmd/local_node_sync.go
@@ -25,7 +25,6 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
-	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 )
 
 type localNodeSynchronizerParams struct {
@@ -36,8 +35,6 @@ type localNodeSynchronizerParams struct {
 	TunnelConfig       tunnel.Config
 	K8sLocalNode       agentK8s.LocalNodeResource
 	K8sCiliumLocalNode agentK8s.LocalCiliumNodeResource
-
-	WireGuard *wg.Agent // nil if WireGuard is disabled
 }
 
 // localNodeSynchronizer performs the bootstrapping of the LocalNodeStore,
@@ -61,10 +58,6 @@ func (ini *localNodeSynchronizer) InitLocalNode(ctx context.Context, n *node.Loc
 
 	if err := ini.initFromK8s(ctx, n); err != nil {
 		return err
-	}
-
-	if option.Config.EnableWireguard {
-		ini.WireGuard.InitLocalNodeFromWireGuard(n)
 	}
 
 	n.BootID = node.GetBootID(ini.Logger)

--- a/daemon/cmd/local_node_sync.go
+++ b/daemon/cmd/local_node_sync.go
@@ -63,7 +63,7 @@ func (ini *localNodeSynchronizer) InitLocalNode(ctx context.Context, n *node.Loc
 		return err
 	}
 
-	if ini.WireGuard != nil {
+	if option.Config.EnableWireguard {
 		ini.WireGuard.InitLocalNodeFromWireGuard(n)
 	}
 

--- a/daemon/cmd/local_node_sync_test.go
+++ b/daemon/cmd/local_node_sync_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sLabels "k8s.io/apimachinery/pkg/labels"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
@@ -113,9 +112,8 @@ func TestLocalNodeSync(t *testing.T) {
 		sync = newLocalNodeSynchronizer(localNodeSynchronizerParams{
 			Logger: hivetest.Logger(t),
 			Config: &option.DaemonConfig{
-				IPv4NodeAddr:               "1.2.3.4",
-				IPv6NodeAddr:               "fd00::1",
-				NodeEncryptionOptOutLabels: k8sLabels.Nothing(),
+				IPv4NodeAddr: "1.2.3.4",
+				IPv6NodeAddr: "fd00::1",
 			},
 			K8sLocalNode: fln,
 			K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{
@@ -171,7 +169,6 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 				EnableIPv6:                   true,
 				EnableHealthChecking:         true,
 				EnableEndpointHealthChecking: true,
-				NodeEncryptionOptOutLabels:   k8sLabels.NewSelector(),
 			},
 			K8sLocalNode: &mockResource[*slim_corev1.Node]{
 				items: []resource.Event[*slim_corev1.Node]{
@@ -312,9 +309,8 @@ func testNodeDeletion(t *testing.T, nodeEvent resource.Event[*slim_corev1.Node])
 	sync := newLocalNodeSynchronizer(localNodeSynchronizerParams{
 		Logger: hivetest.Logger(t),
 		Config: &option.DaemonConfig{
-			IPv4NodeAddr:               "1.2.3.4",
-			IPv6NodeAddr:               "fd00::1",
-			NodeEncryptionOptOutLabels: k8sLabels.Nothing(),
+			IPv4NodeAddr: "1.2.3.4",
+			IPv6NodeAddr: "fd00::1",
 		},
 		K8sLocalNode: fakeNode,
 		K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -75,6 +75,7 @@ type configModifyApiHandlerParams struct {
 	BigTCPConfig    *bigtcp.Configuration
 	TunnelConfig    tunnel.Config
 	BandwidthConfig datapath.BandwidthConfig
+	WgConfig        wgTypes.WireguardConfig
 
 	EventHandler *ConfigModifyEventHandler
 }
@@ -99,6 +100,7 @@ func newConfigModifyApiHandler(params configModifyApiHandlerParams) configModify
 			bigTCPConfig:    params.BigTCPConfig,
 			tunnelConfig:    params.TunnelConfig,
 			bandwidthConfig: params.BandwidthConfig,
+			wgConfig:        params.WgConfig,
 		},
 		PatchConfigHandler: &patchConfigHandler{
 			logger:       params.Logger,
@@ -343,6 +345,7 @@ type getConfigHandler struct {
 	bigTCPConfig    *bigtcp.Configuration
 	tunnelConfig    tunnel.Config
 	bandwidthConfig datapath.BandwidthConfig
+	wgConfig        wgTypes.WireguardConfig
 }
 
 func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.Responder {
@@ -431,7 +434,7 @@ func (h *getConfigHandler) getIPLocalReservedPorts() string {
 	// range and thus may conflict with the ephemeral source port of DNS clients
 	// in the container network namespace.
 	var ports []string
-	if option.Config.EnableWireguard {
+	if h.wgConfig.Enabled() {
 		ports = append(ports, strconv.Itoa(wgTypes.ListenPort))
 	}
 

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -154,11 +154,6 @@ var Cell = cell.Module(
 func newWireguardAgent(rootLogger *slog.Logger, lc cell.Lifecycle, sysctl sysctl.Sysctl, health cell.Health, registry job.Registry, db *statedb.DB, mtuTable statedb.Table[mtu.RouteMTU]) *wg.Agent {
 	var wgAgent *wg.Agent
 	if option.Config.EnableWireguard {
-		if option.Config.EnableIPSec {
-			logging.Fatal(rootLogger, fmt.Sprintf("WireGuard (--%s) cannot be used with IPsec (--%s)",
-				option.EnableWireguard, option.EnableIPSecName))
-		}
-
 		jobGroup := registry.NewGroup(health, lc)
 
 		var err error

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -33,7 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/time"
-	wg "github.com/cilium/cilium/pkg/wireguard/agent"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // Cell provides a fake version of the datapath cell.
@@ -59,7 +59,7 @@ var Cell = cell.Module(
 		func() types.BandwidthManager { return &fakeTypes.BandwidthManager{} },
 		func() types.IPsecKeyCustodian { return &ipsecKeyCustodian{} },
 		func() mtu.MTU { return &fakeTypes.MTU{} },
-		func() *wg.Agent { return nil },
+		func() wgTypes.WireguardAgent { return &fakeTypes.WireguardAgent{} },
 		func() types.Loader { return &fakeTypes.FakeLoader{} },
 		func() types.Orchestrator { return &fakeTypes.FakeOrchestrator{} },
 		loader.NewCompilationLock,

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -60,6 +60,7 @@ var Cell = cell.Module(
 		func() types.IPsecKeyCustodian { return &ipsecKeyCustodian{} },
 		func() mtu.MTU { return &fakeTypes.MTU{} },
 		func() wgTypes.WireguardAgent { return &fakeTypes.WireguardAgent{} },
+		func() wgTypes.WireguardConfig { return &fakeTypes.WireguardConfig{} },
 		func() types.Loader { return &fakeTypes.FakeLoader{} },
 		func() types.Orchestrator { return &fakeTypes.FakeOrchestrator{} },
 		loader.NewCompilationLock,

--- a/pkg/datapath/fake/types/wireguard.go
+++ b/pkg/datapath/fake/types/wireguard.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"github.com/cilium/cilium/api/v1/models"
+
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
+)
+
+var (
+	_ wgTypes.WireguardAgent = (*WireguardAgent)(nil)
+)
+
+type WireguardAgent struct {
+	EnableWireguard bool
+}
+
+func (fwa *WireguardAgent) Enabled() bool {
+	return fwa.EnableWireguard
+}
+
+func (fwa *WireguardAgent) Status(withPeers bool) (*models.WireguardStatus, error) {
+	return nil, nil
+}

--- a/pkg/datapath/fake/types/wireguard.go
+++ b/pkg/datapath/fake/types/wireguard.go
@@ -10,17 +10,26 @@ import (
 )
 
 var (
-	_ wgTypes.WireguardAgent = (*WireguardAgent)(nil)
+	_ wgTypes.WireguardAgent  = (*WireguardAgent)(nil)
+	_ wgTypes.WireguardConfig = (*WireguardConfig)(nil)
 )
 
 type WireguardAgent struct {
-	EnableWireguard bool
+	config WireguardConfig
 }
 
 func (fwa *WireguardAgent) Enabled() bool {
-	return fwa.EnableWireguard
+	return fwa.config.Enabled()
 }
 
 func (fwa *WireguardAgent) Status(withPeers bool) (*models.WireguardStatus, error) {
 	return nil, nil
+}
+
+type WireguardConfig struct {
+	EnableWireguard bool
+}
+
+func (fwc WireguardConfig) Enabled() bool {
+	return fwc.EnableWireguard
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -250,7 +250,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 	}
 
-	if option.Config.EnableWireguard {
+	if cfg.EnableWireguard {
 		cDefinesMap["ENABLE_WIREGUARD"] = "1"
 		ifindex, err := link.GetIfIndex(wgtypes.IfaceName)
 		if err != nil {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -184,7 +184,7 @@ func (l *loader) reinitializeIPSec(lnc *datapath.LocalNodeConfiguration) error {
 	// the code below, specific to EncryptInterface. Specifically, we will load
 	// bpf_host code in reloadHostDatapath onto the physical devices as selected
 	// by configuration.
-	if !option.Config.EnableIPSec || option.Config.AreDevicesRequired(lnc.KPRConfig) {
+	if !option.Config.EnableIPSec || option.Config.AreDevicesRequired(lnc.KPRConfig, lnc.EnableWireguard) {
 		return nil
 	}
 
@@ -289,7 +289,7 @@ func reinitializeOverlay(ctx context.Context, logger *slog.Logger, lnc *datapath
 }
 
 func reinitializeWireguard(ctx context.Context, logger *slog.Logger, lnc *datapath.LocalNodeConfiguration) (err error) {
-	if !option.Config.EnableWireguard {
+	if !lnc.EnableWireguard {
 		cleanCallsMaps("cilium_calls_wireguard*")
 		return
 	}

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -529,7 +529,7 @@ func attachNetworkDevices(logger *slog.Logger, ep datapath.Endpoint, lnc *datapa
 			return fmt.Errorf("interface %s ingress: %w", device, err)
 		}
 
-		if option.Config.AreDevicesRequired(lnc.KPRConfig) {
+		if option.Config.AreDevicesRequired(lnc.KPRConfig, lnc.EnableWireguard) {
 			// Attach cil_to_netdev to egress.
 			if err := attachSKBProgram(logger, iface, netdevObj.ToNetdev, symbolToHostNetdevEp,
 				linkDir, netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
@@ -776,7 +776,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, lnc *dat
 
 	linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), device)
 	// Attach/detach cil_to_wireguard to/from egress.
-	if option.Config.NeedEgressOnWireGuardDevice(lnc.KPRConfig) {
+	if option.Config.NeedEgressOnWireGuardDevice(lnc.KPRConfig, lnc.EnableWireguard) {
 		if err := attachSKBProgram(logger, device, obj.ToWireguard, symbolToWireguard,
 			linkDir, netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
 			return fmt.Errorf("interface %s egress: %w", device, err)
@@ -791,7 +791,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, lnc *dat
 		}
 	}
 	// Attach/detach cil_from_wireguard to/from ingress.
-	if option.Config.NeedIngressOnWireGuardDevice(lnc.KPRConfig) {
+	if option.Config.NeedIngressOnWireGuardDevice(lnc.KPRConfig, lnc.EnableWireguard) {
 		if err := attachSKBProgram(logger, device, obj.FromWireguard, symbolFromWireguard,
 			linkDir, netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 			return fmt.Errorf("interface %s ingress: %w", device, err)

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 const (
@@ -109,6 +110,7 @@ type orchestratorParams struct {
 	LBConfig            loadbalancer.Config
 	KPRConfig           kpr.KPRConfig
 	MaglevConfig        maglev.Config
+	WgConfig            wgTypes.WireguardConfig
 }
 
 func newOrchestrator(params orchestratorParams) *orchestrator {
@@ -208,6 +210,7 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 			o.params.KPRConfig,
 			o.params.MaglevConfig,
 			o.params.MTU,
+			o.params.WgConfig,
 		)
 		if err != nil {
 			health.Degraded("failed to get local node configuration", err)

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -162,6 +162,10 @@ type LocalNodeConfiguration struct {
 	// allocation CIDR IPs into Cilium endpoints.
 	EnableLocalNodeRoute bool
 
+	// EnableWireguard is used to check if we need to attach to the native
+	// device and to cilium_wg0.
+	EnableWireguard bool
+
 	// EnableIPSec enables IPSec routes
 	EnableIPSec bool
 

--- a/pkg/datapath/types/zz_generated.deepequal.go
+++ b/pkg/datapath/types/zz_generated.deepequal.go
@@ -224,6 +224,9 @@ func (in *LocalNodeConfiguration) DeepEqual(other *LocalNodeConfiguration) bool 
 	if in.EnableLocalNodeRoute != other.EnableLocalNodeRoute {
 		return false
 	}
+	if in.EnableWireguard != other.EnableWireguard {
+		return false
+	}
 	if in.EnableIPSec != other.EnableIPSec {
 		return false
 	}

--- a/pkg/debug/api/cell.go
+++ b/pkg/debug/api/cell.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/status"
-	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // Cell provides the Debug-Info API handler
@@ -35,7 +35,7 @@ type debugAPIHandlerParams struct {
 	Frontends       statedb.Table[*loadbalancer.Frontend]
 	EndpointManager endpointmanager.EndpointManager
 	PolicyRepo      policy.PolicyRepository
-	WireguardAgent  *wireguard.Agent
+	WireguardAgent  wgTypes.WireguardAgent
 
 	StatusCollector status.StatusCollector
 	CellSettings    cellSettings

--- a/pkg/debug/api/debug_api_handler.go
+++ b/pkg/debug/api/debug_api_handler.go
@@ -17,11 +17,10 @@ import (
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/status"
 	"github.com/cilium/cilium/pkg/version"
-	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 type GetDebuginfoHandler struct {
@@ -29,7 +28,7 @@ type GetDebuginfoHandler struct {
 	policyRepo      policy.PolicyRepository
 	db              *statedb.DB
 	frontends       statedb.Table[*loadbalancer.Frontend]
-	wireguardAgent  *wireguard.Agent
+	wireguardAgent  wgTypes.WireguardAgent
 
 	statusCollector status.StatusCollector
 
@@ -69,7 +68,7 @@ func (h *GetDebuginfoHandler) Handle(params restapi.GetDebuginfoParams) middlewa
 		)
 
 	dr.Encryption = &models.DebugInfoEncryption{}
-	if option.Config.EnableWireguard {
+	if h.wireguardAgent.Enabled() {
 		if wgStatus, err := h.wireguardAgent.Status(true); err == nil {
 			dr.Encryption.Wireguard = wgStatus
 		}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -239,10 +239,6 @@ const (
 	// which are not part of Cilium manged pods.
 	EncryptNode = false
 
-	// NodeEncryptionOptOutLabels contains the label selectors for nodes opting out of
-	// node-to-node encryption
-	NodeEncryptionOptOutLabels = "node-role.kubernetes.io/control-plane"
-
 	// MonitorQueueSizePerCPU is the default value for the monitor queue
 	// size per CPU
 	MonitorQueueSizePerCPU = 1024
@@ -566,9 +562,6 @@ const (
 
 	// EnableSourceIPVerification is the default value for source ip validation
 	EnableSourceIPVerification = true
-
-	// WireguardTrackAllIPsFallback forces the WireGuard agent to track all IPs.
-	WireguardTrackAllIPsFallback = false
 
 	// ConnectivityProbeFrequencyRatio is the default connectivity probe frequency
 	ConnectivityProbeFrequencyRatio = 0.5

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // GetLabelsModel returns the labels of the endpoint in their representation
@@ -63,12 +64,12 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 }
 
 // NewEndpointFromChangeModel creates a new endpoint from a request
-func NewEndpointFromChangeModel(ctx context.Context, logger *slog.Logger, dnsRulesAPI DNSRulesAPI, epBuildQueue EndpointBuildQueue, loader datapath.Loader, orchestrator datapath.Orchestrator, compilationLock datapath.CompilationLock, bandwidthManager datapath.BandwidthManager, ipTablesManager datapath.IptablesManager, identityManager identitymanager.IDManager, monitorAgent monitoragent.Agent, policyMapFactory policymap.Factory, policyRepo policy.PolicyRepository, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ctMapGC ctmap.GCRunner, kvstoreSyncher *ipcache.IPIdentitySynchronizer, model *models.EndpointChangeRequest) (*Endpoint, error) {
+func NewEndpointFromChangeModel(ctx context.Context, logger *slog.Logger, dnsRulesAPI DNSRulesAPI, epBuildQueue EndpointBuildQueue, loader datapath.Loader, orchestrator datapath.Orchestrator, compilationLock datapath.CompilationLock, bandwidthManager datapath.BandwidthManager, ipTablesManager datapath.IptablesManager, identityManager identitymanager.IDManager, monitorAgent monitoragent.Agent, policyMapFactory policymap.Factory, policyRepo policy.PolicyRepository, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ctMapGC ctmap.GCRunner, kvstoreSyncher *ipcache.IPIdentitySynchronizer, model *models.EndpointChangeRequest, wgCfg wgTypes.WireguardConfig) (*Endpoint, error) {
 	if model == nil {
 		return nil, nil
 	}
 
-	ep := createEndpoint(logger, dnsRulesAPI, epBuildQueue, loader, orchestrator, compilationLock, bandwidthManager, ipTablesManager, identityManager, monitorAgent, policyMapFactory, policyRepo, namedPortsGetter, proxy, allocator, ctMapGC, kvstoreSyncher, uint16(model.ID), model.InterfaceName)
+	ep := createEndpoint(logger, dnsRulesAPI, epBuildQueue, loader, orchestrator, compilationLock, bandwidthManager, ipTablesManager, identityManager, monitorAgent, policyMapFactory, policyRepo, namedPortsGetter, proxy, allocator, ctMapGC, kvstoreSyncher, uint16(model.ID), model.InterfaceName, wgCfg)
 	ep.ifIndex = int(model.InterfaceIndex)
 	ep.containerIfName = model.ContainerInterfaceName
 	ep.parentIfIndex = int(model.ParentInterfaceIndex)

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -26,7 +27,7 @@ func TestWriteInformationalComments(t *testing.T) {
 	s := setupEndpointSuite(t)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -46,7 +47,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 	s := setupEndpointSuite(b)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(b.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(b.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))

--- a/pkg/endpoint/creator/creator.go
+++ b/pkg/endpoint/creator/creator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/time"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 var launchTime = 30 * time.Second
@@ -63,6 +64,7 @@ type endpointCreator struct {
 	// kvstoreSyncher updates the kvstore (e.g., etcd) with up-to-date
 	// information about endpoints.
 	kvstoreSyncher *ipcache.IPIdentitySynchronizer
+	wgConfig       wgTypes.WireguardConfig
 }
 
 var _ EndpointCreator = &endpointCreator{}
@@ -88,6 +90,7 @@ type endpointManagerParams struct {
 	Allocator           cache.IdentityAllocator
 	CTMapGC             ctmap.GCRunner
 	KVStoreSynchronizer *ipcache.IPIdentitySynchronizer
+	WgConfig            wgTypes.WireguardConfig
 }
 
 func newEndpointCreator(p endpointManagerParams) EndpointCreator {
@@ -110,6 +113,7 @@ func newEndpointCreator(p endpointManagerParams) EndpointCreator {
 		allocator:        p.Allocator,
 		ctMapGC:          p.CTMapGC,
 		kvstoreSyncher:   p.KVStoreSynchronizer,
+		wgConfig:         p.WgConfig,
 	}
 }
 
@@ -134,6 +138,7 @@ func (c *endpointCreator) NewEndpointFromChangeModel(ctx context.Context, base *
 		c.ctMapGC,
 		c.kvstoreSyncher,
 		base,
+		c.wgConfig,
 	)
 }
 
@@ -157,6 +162,7 @@ func (c *endpointCreator) ParseEndpoint(epJSON []byte) (*endpoint.Endpoint, erro
 		c.ctMapGC,
 		c.kvstoreSyncher,
 		epJSON,
+		c.wgConfig,
 	)
 }
 
@@ -179,6 +185,7 @@ func (c *endpointCreator) AddIngressEndpoint(ctx context.Context) error {
 		c.allocator,
 		c.ctMapGC,
 		c.kvstoreSyncher,
+		c.wgConfig,
 	)
 	if err != nil {
 		return err
@@ -212,6 +219,7 @@ func (c *endpointCreator) AddHostEndpoint(ctx context.Context) error {
 		c.allocator,
 		c.ctMapGC,
 		c.kvstoreSyncher,
+		c.wgConfig,
 	)
 	if err != nil {
 		return err

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -73,7 +73,7 @@ func (e *Endpoint) GetCiliumEndpointStatus() *cilium_v2.EndpointStatus {
 		Identity:            getEndpointIdentity(identitymodel.CreateModel(e.SecurityIdentity)),
 		Networking:          getEndpointNetworking(logger, e.getModelNetworkingRLocked()),
 		State:               compressEndpointState(e.getModelCurrentStateRLocked()),
-		Encryption:          cilium_v2.EncryptionSpec{Key: int(node.GetEndpointEncryptKeyIndex(logger))},
+		Encryption:          cilium_v2.EncryptionSpec{Key: int(node.GetEndpointEncryptKeyIndex(logger, e.wgConfig))},
 		NamedPorts:          e.getNamedPortsModel(),
 	}
 

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
@@ -36,7 +37,7 @@ func TestGetCiliumEndpointStatus(t *testing.T) {
 			"k8s:name=probe",
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
-	})
+	}, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	status := e.GetCiliumEndpointStatus()

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -195,7 +195,7 @@ func TestEndpointDatapathOptions(t *testing.T) {
 		DatapathConfiguration: &models.EndpointDatapathConfiguration{
 			DisableSipVerification: true,
 		},
-	})
+	}, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	require.Equal(t, option.OptionDisabled, e.Options.GetValue(option.SourceIPVerification))
 }
@@ -205,7 +205,7 @@ func TestEndpointUpdateLabels(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -252,7 +252,7 @@ func TestEndpointState(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	e.Start(uint16(model.ID))
 	t.Cleanup(e.Stop)
@@ -640,7 +640,7 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 	}()
 
 	model := newTestEndpointModel(12345, StateReady)
-	ep, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -722,7 +722,7 @@ func BenchmarkEndpointGetModel(b *testing.B) {
 	logger := hivetest.Logger(b)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(b.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	e, err := NewEndpointFromChangeModel(b.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))
@@ -801,7 +801,7 @@ func TestMetadataResolver(t *testing.T) {
 			t.Run(fmt.Sprintf("%s (restored=%t)", tt.name, restored), func(t *testing.T) {
 				model := newTestEndpointModel(100, StateWaitingForIdentity)
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-				ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, &fakeTypes.BandwidthManager{}, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+				ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, &fakeTypes.BandwidthManager{}, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{})
 				require.NoError(t, err)
 
 				ep.K8sNamespace, ep.K8sPodName, ep.K8sUID = "bar", "foo", "uid"

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/option"
@@ -29,7 +30,7 @@ func TestPolicyLog(t *testing.T) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 
 	model := newTestEndpointModel(12345, StateReady)
-	ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, do.repo, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, do.repo, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1037,7 +1037,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 					e.runlock()
 					return controller.NewExitReason("Failed to get node IP")
 				}
-				key := node.GetEndpointEncryptKeyIndex(logger)
+				key := node.GetEndpointEncryptKeyIndex(logger, e.wgConfig)
 				metadata := e.FormatGlobalEndpointID()
 				k8sNamespace := e.K8sNamespace
 				k8sPodName := e.K8sPodName

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -168,7 +169,7 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 	logger := hivetest.Logger(t)
 	model := newTestEndpointModel(12345, StateRegenerating)
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-	ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.do.repo, testipcache.NewMockIPCache(), s.rsp, s.mgr, ctmap.NewFakeGCRunner(), kvstoreSync, model)
+	ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.do.repo, testipcache.NewMockIPCache(), s.rsp, s.mgr, ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -65,7 +66,7 @@ func (s *EndpointSuite) endpointCreator(t testing.TB, id uint16, secID identity.
 	identity.Sanitize()
 
 	model := newTestEndpointModel(int(id), StateReady)
-	ep, err := NewEndpointFromChangeModel(context.TODO(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := NewEndpointFromChangeModel(context.TODO(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -288,7 +289,7 @@ type fakeParser struct {
 }
 
 func (f *fakeParser) ParseEndpoint(epJSON []byte) (*Endpoint, error) {
-	return ParseEndpoint(f.logger, nil, nil, nil, f.orchestrator, nil, nil, nil, nil, nil, nil, f.policyRepo, nil, nil, nil, nil, nil, epJSON)
+	return ParseEndpoint(f.logger, nil, nil, nil, f.orchestrator, nil, nil, nil, nil, nil, nil, f.policyRepo, nil, nil, nil, nil, nil, epJSON, fakeTypes.WireguardConfig{})
 }
 
 var _ EndpointParser = &fakeParser{}

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/api/v1/models"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -46,7 +47,7 @@ func TestMarkAndSweep(t *testing.T) {
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
 		model := newTestEndpointModel(int(id), endpoint.StateReady)
-		ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+		ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 		require.NoError(t, err)
 
 		ep.Start(uint16(model.ID))

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	apiv1 "github.com/cilium/cilium/api/v1/models"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -390,7 +391,7 @@ func TestLookup(t *testing.T) {
 			logger := hivetest.Logger(t)
 			mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 			if tt.cm != nil {
-				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, tt.cm)
+				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, tt.cm, fakeTypes.WireguardConfig{})
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
 				err = mgr.expose(ep)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
@@ -415,7 +416,7 @@ func TestLookupCiliumID(t *testing.T) {
 
 	model := newTestEndpointModel(2, endpoint.StateReady)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -493,7 +494,7 @@ func TestLookupCNIAttachmentID(t *testing.T) {
 	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &apiv1.EndpointChangeRequest{
 		ContainerID:            "foo",
 		ContainerInterfaceName: "bar",
-	})
+	}, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	require.NoError(t, mgr.expose(ep))
 
@@ -513,7 +514,7 @@ func TestLookupIPv4(t *testing.T) {
 
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	model := newTestEndpointModel(4, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -666,7 +667,7 @@ func TestLookupCEPName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm)
+		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm, fakeTypes.WireguardConfig{})
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		tt.preTestRun(ep)
 		args := tt.setupArgs()
@@ -709,7 +710,7 @@ func TestUpdateReferences(t *testing.T) {
 	}
 	for _, tt := range tests {
 		var err error
-		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm)
+		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm, fakeTypes.WireguardConfig{})
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		logger := hivetest.Logger(t)
 		mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
@@ -745,7 +746,7 @@ func TestRemove(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	model := newTestEndpointModel(7, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -791,7 +792,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	model := newTestEndpointModel(1, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -834,7 +835,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -865,7 +866,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -896,7 +897,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+				ep, err = endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -936,7 +937,7 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	// Create host endpoint and expose it in the endpoint manager.
 	model := newTestEndpointModel(1, endpoint.StateReady)
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -981,7 +982,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			name: "Add labels",
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{})
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -1013,7 +1014,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
-				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{})
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -1047,7 +1048,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model)
+				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{})
 				ep.SetIsHost(true)
 				require.NoError(t, err)
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/container/versioned"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	fqdndns "github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -97,7 +98,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 				return nil, false, fmt.Errorf("No EPs available when restoring")
 			}
 			model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-			ep, err := endpoint.NewEndpointFromChangeModel(tb.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+			ep, err := endpoint.NewEndpointFromChangeModel(tb.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 			ep.Start(uint16(model.ID))
 			tb.Cleanup(ep.Stop)
 			return ep, false, err
@@ -873,7 +874,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))
@@ -925,7 +926,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules for epID3
 	modelEP3 := newTestEndpointModel(int(epID3), endpoint.StateReady)
-	ep3, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, modelEP3)
+	ep3, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, modelEP3, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep3.Start(uint16(modelEP3.ID))
@@ -1136,7 +1137,7 @@ func TestPrivilegedRestoredEndpoint(t *testing.T) {
 	// restore rules, set the mock to restoring state
 	s.restoring = true
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
+	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/source"
 	ciliumTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 type k8sCiliumEndpointsWatcherParams struct {
@@ -40,6 +41,7 @@ type k8sCiliumEndpointsWatcherParams struct {
 	EndpointManager endpointmanager.EndpointManager
 	PolicyUpdater   *policy.Updater
 	IPCache         *ipcache.IPCache
+	WgConfig        wgTypes.WireguardConfig
 }
 
 func newK8sCiliumEndpointsWatcher(params k8sCiliumEndpointsWatcherParams) *K8sCiliumEndpointsWatcher {
@@ -51,6 +53,7 @@ func newK8sCiliumEndpointsWatcher(params k8sCiliumEndpointsWatcherParams) *K8sCi
 		endpointManager:   params.EndpointManager,
 		policyManager:     params.PolicyUpdater,
 		ipcache:           params.IPCache,
+		wgConfig:          params.WgConfig,
 	}
 }
 
@@ -68,6 +71,7 @@ type K8sCiliumEndpointsWatcher struct {
 	endpointManager endpointManager
 	policyManager   policyManager
 	ipcache         ipcacheManager
+	wgConfig        wgTypes.WireguardConfig
 
 	resources agentK8s.Resources
 }
@@ -155,7 +159,7 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 	}
 
 	// default to the standard key
-	encryptionKey := node.GetEndpointEncryptKeyIndex(k.logger)
+	encryptionKey := node.GetEndpointEncryptKeyIndex(k.logger, k.wgConfig)
 
 	id := identity.ReservedIdentityUnmanaged
 	if endpoint.Identity != nil {

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -27,6 +27,7 @@ import (
 	k8s2 "github.com/cilium/cilium/pkg/policy/k8s"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/promise"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 var (
@@ -92,6 +93,7 @@ type featuresParams struct {
 	BigTCP              types.BigTCPConfig
 	L2PodAnnouncement   gneigh.L2PodAnnouncementConfig
 	DynamicConfigSource dynamicconfig.ConfigSource
+	WgConfig            wgTypes.WireguardConfig
 }
 
 func (fp *featuresParams) TunnelProtocol() tunnel.EncapProtocol {

--- a/pkg/metrics/features/features.go
+++ b/pkg/metrics/features/features.go
@@ -21,7 +21,7 @@ func updateAgentConfigMetricOnStart(jg job.Group, params featuresParams, m featu
 		if err != nil {
 			return fmt.Errorf("failed to get agent config: %w", err)
 		}
-		m.update(&params, agentConfig, params.LBConfig, params.KPRConfig)
+		m.update(&params, agentConfig, params.LBConfig, params.KPRConfig, params.WgConfig)
 		return nil
 	}))
 

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // Metrics represents a collection of metrics related to a specific feature.
@@ -944,10 +945,10 @@ func NewMetrics(withDefaults bool) Metrics {
 }
 
 type featureMetrics interface {
-	update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig)
+	update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.WireguardConfig)
 }
 
-func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig) {
+func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.WireguardConfig) {
 	networkMode := networkModeDirectRouting
 	if config.TunnelingEnabled() {
 		switch params.TunnelProtocol() {
@@ -1013,7 +1014,7 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 			m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncIPSec, "false").Add(1)
 		}
 	}
-	if config.EnableWireguard {
+	if wgCfg.Enabled() {
 		if config.EncryptNode {
 			m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncWireGuard, "true").Add(1)
 		} else {

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/kpr"
@@ -114,7 +115,7 @@ func TestUpdateNetworkMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultNetworkModes {
@@ -166,7 +167,7 @@ func TestUpdateIPAMMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultIPAMModes {
@@ -218,7 +219,7 @@ func TestUpdateCNIChainingMode(t *testing.T) {
 				CNIChainingMode: tt.chainingMode,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultChainingModes {
@@ -280,7 +281,7 @@ func TestUpdateInternetProtocol(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultChainingModes {
@@ -331,7 +332,7 @@ func TestUpdateIdentityAllocationMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultIdentityAllocationModes {
@@ -387,7 +388,7 @@ func TestUpdateCiliumEndpointSlices(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.CPCiliumEndpointSlicesEnabled.Get()
 
@@ -429,7 +430,7 @@ func TestUpdateDeviceMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultDeviceModes {
@@ -484,7 +485,7 @@ func TestUpdateHostFirewall(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.NPHostFirewallEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableHostFirewall, counterValue)
@@ -529,7 +530,7 @@ func TestUpdateLocalRedirectPolicies(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.NPLocalRedirectPolicyEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableLRP, counterValue)
@@ -575,7 +576,7 @@ func TestUpdateMutualAuth(t *testing.T) {
 				MutualAuth:      tt.enableMutualAuth,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.NPMutualAuthEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableMutualAuth, counterValue)
@@ -621,7 +622,7 @@ func TestUpdateNonDefaultDeny(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.NPNonDefaultDenyEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableNonDefaultDeny, counterValue)
@@ -664,7 +665,7 @@ func TestUpdateCIDRPolicyModeToNode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultCIDRPolicies {
@@ -736,7 +737,6 @@ func TestUpdateEncryptionMode(t *testing.T) {
 				DatapathMode:           defaultDeviceModes[0],
 				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				EnableIPSec:            tt.enableIPSec,
-				EnableWireguard:        tt.enableWireguard,
 				EncryptNode:            tt.enableNode2NodeEncryption,
 			}
 
@@ -748,7 +748,7 @@ func TestUpdateEncryptionMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{EnableWireguard: tt.enableWireguard})
 
 			// Check that only the expected mode's counter is incremented
 			for _, encMode := range defaultEncryptionModes {
@@ -805,7 +805,7 @@ func TestUpdateKubeProxyReplacement(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{KubeProxyReplacement: tt.enableKubeProxyReplacement})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{KubeProxyReplacement: tt.enableKubeProxyReplacement}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBKubeProxyReplacementEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableKubeProxyReplacement, counterValue)
@@ -861,7 +861,7 @@ func TestUpdateNodePortConfig(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, portMode := range defaultNodePortModes {
@@ -922,7 +922,7 @@ func TestUpdateBGP(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBBGPEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for bgpControlPlane: %t, got %.f", tt.expected, tt.bgpControlPlane, counterValue)
@@ -968,7 +968,7 @@ func TestUpdateIPv4EgressGateway(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBEgressGatewayEnabled.Get()
 
@@ -1015,7 +1015,7 @@ func TestUpdateBandwidthManager(t *testing.T) {
 				BandwidthManager: tt.enableBandwidthManager,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBBandwidthManagerEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableBandwidthManager, counterValue)
@@ -1061,7 +1061,7 @@ func TestUpdateSCTP(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBSCTPEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableSCTP, counterValue)
@@ -1107,7 +1107,7 @@ func TestUpdateInternalTrafficPolicy(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBInternalTrafficPolicyEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableInternalTrafficPolicy, counterValue)
@@ -1153,7 +1153,7 @@ func TestUpdateVTEP(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBVTEPEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableVTEP, counterValue)
@@ -1199,7 +1199,7 @@ func TestUpdateEnvoyConfig(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBCiliumEnvoyConfigEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableEnvoyConfig, counterValue)
@@ -1255,7 +1255,7 @@ func TestUpdateBigTCPProtocol(t *testing.T) {
 				},
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultBigTCPAddressFamilies {
@@ -1311,7 +1311,7 @@ func TestUpdateL2Announcements(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBL2LBEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableL2Announcements, counterValue)
@@ -1357,7 +1357,7 @@ func TestUpdateL2PodAnnouncements(t *testing.T) {
 				L2PodAnnouncement: tt.enableL2PodAnnouncements,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBL2PodAnnouncementEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableL2PodAnnouncements, counterValue)
@@ -1403,7 +1403,7 @@ func TestUpdateExtEnvoyProxyMode(t *testing.T) {
 				CNIChainingMode: defaultChainingModes[0],
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultExternalEnvoyProxyModes {
@@ -1459,7 +1459,7 @@ func TestUpdateDynamicNodeConfig(t *testing.T) {
 				isDynamicConfigSourceKindNodeConfig: tt.enableDynamicNodeConfig,
 			}
 
-			metrics.update(params, config, lbConfig, kpr.KPRConfig{})
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{})
 
 			counterValue := metrics.ACLBCiliumNodeConfigEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableDynamicNodeConfig, counterValue)

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 var Cell = cell.Module(
@@ -68,6 +69,7 @@ type mtuParams struct {
 	Log             *slog.Logger
 	DaemonConfig    *option.DaemonConfig
 	LocalCiliumNode k8s.LocalCiliumNodeResource
+	WgConfig        wgTypes.WireguardConfig
 
 	Config Config
 }
@@ -96,7 +98,7 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 				p.IPsec.AuthKeySize(),
 				option.Config.EnableIPSec,
 				p.TunnelConfig.ShouldAdaptMTU(),
-				option.Config.EnableWireguard,
+				p.WgConfig.Enabled(),
 				tunnelOverIPv6,
 			)
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -528,11 +528,11 @@ func GetIngressIPv6(logger *slog.Logger) net.IP {
 // Note that the key index returned by this function is only valid for _endpoints_
 // of the local node. If you want to obtain the key index of the local node itself,
 // access the `EncryptionKey` field via the LocalNodeStore.
-func GetEndpointEncryptKeyIndex(logger *slog.Logger) uint8 {
+func GetEndpointEncryptKeyIndex(logger *slog.Logger, wgCfg wgTypes.WireguardConfig) uint8 {
 	switch {
 	case option.Config.EnableIPSec:
 		return getLocalNode(logger).EncryptionKey
-	case option.Config.EnableWireguard:
+	case wgCfg.Enabled():
 		return wgTypes.StaticEncryptKey
 
 	}

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // Cell provides the NodeManager, which manages information about Cilium nodes
@@ -94,9 +95,10 @@ func newAllNodeManager(in struct {
 	JobGroup    job.Group
 	DB          *statedb.DB
 	Devices     statedb.Table[*tables.Device]
+	WGConfig    wgTypes.WireguardConfig
 },
 ) (NodeManager, error) {
-	mngr, err := New(in.Logger, option.Config, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices)
+	mngr, err := New(in.Logger, option.Config, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices, in.WGConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 type nodeEvent struct {
@@ -263,7 +264,7 @@ func TestNodeLifecycle(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 
@@ -343,7 +344,7 @@ func TestMultipleSources(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -427,7 +428,7 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(b)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(b, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -451,7 +452,7 @@ func TestClusterSizeDependantInterval(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -477,7 +478,7 @@ func TestBackgroundSync(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	mngr.Subscribe(signalNodeHandler)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -547,7 +548,7 @@ func TestIpcache(t *testing.T) {
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -692,7 +693,7 @@ func TestIpcacheHealthIP(t *testing.T) {
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -741,7 +742,7 @@ func TestNodeEncryption(t *testing.T) {
 	mngr, err := New(logger, &option.DaemonConfig{
 		EncryptNode: true,
 		EnableIPSec: true,
-	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -865,7 +866,7 @@ func TestNode(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -994,6 +995,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 			return testParams{
 				Config:        config,
 				TunnelConf:    tunnel.Config{},
+				WgConf:        fakeTypes.WireguardConfig{},
 				IPCache:       ipcacheMock,
 				IPSet:         newIPSetMock(),
 				NodeMetrics:   NewNodeMetrics(),
@@ -1092,6 +1094,7 @@ type testParams struct {
 	cell.Out
 	Config        *option.DaemonConfig
 	TunnelConf    tunnel.Config
+	WgConf        wgTypes.WireguardConfig
 	IPCache       IPCache
 	IPSet         ipset.Manager
 	NodeMetrics   *nodeMetrics
@@ -1124,7 +1127,7 @@ func TestNodeWithSameInternalIP(t *testing.T) {
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(logger, &option.DaemonConfig{
 		LocalRouterIPv4: "169.254.4.6",
-	}, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	}, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1225,7 +1228,7 @@ func TestNodeIpset(t *testing.T) {
 	mngr, err := New(logger, &option.DaemonConfig{
 		RoutingMode:          option.RoutingModeNative,
 		EnableIPv4Masquerade: true,
-	}, tunnel.Config{}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil)
+	}, tunnel.Config{}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -1407,7 +1410,7 @@ func TestNodesStartupPruning(t *testing.T) {
 	mngr, err := New(logger, &option.DaemonConfig{
 		StateDir:    tmp,
 		ClusterName: "c1",
-	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
+	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		mngr.Stop(context.TODO())

--- a/pkg/node/manager/rest_api_test.go
+++ b/pkg/node/manager/rest_api_test.go
@@ -36,7 +36,7 @@ func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {
 	option.Config.IPv6ServiceRange = "auto"
 
 	h, _ := cell.NewSimpleHealth()
-	nm, err := New(logger, fakeConfig, tunnel.Config{}, nil, &fakeTypes.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil)
+	nm, err := New(logger, fakeConfig, tunnel.Config{}, nil, &fakeTypes.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
 	require.NoError(tb, err)
 
 	g := &GetNodesSuite{

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -98,6 +98,11 @@ func NewNodeDiscovery(
 // start configures the local node and starts node discovery. This is called on
 // agent startup to configure the local node based on the configuration options
 // passed to the agent. nodeName is the name to be used in the local agent.
+//
+// NOTE: StartDiscovery is manually called from newDaemon after the Wireguard and
+// IPSec cells have been initialized, as they modify the local node. This requires
+// the daemon to always hold references to both cells to ensure they're started first.
+// Keep this behavior in mind when modifying this function, its cell, or the daemon.
 func (n *NodeDiscovery) StartDiscovery(ctx context.Context) {
 	// Start observing local node changes, so that we keep the corresponding CiliumNode
 	// and kvstore representations in sync. The first update is performed synchronously

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2132,15 +2132,15 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
 
 // AreDevicesRequired returns true if the agent needs to attach to the native
 // devices to implement some features.
-func (c *DaemonConfig) AreDevicesRequired(kprCfg kpr.KPRConfig) bool {
-	return kprCfg.EnableNodePort || c.EnableHostFirewall || c.EnableWireguard ||
+func (c *DaemonConfig) AreDevicesRequired(kprCfg kpr.KPRConfig, wireguardEnabled bool) bool {
+	return kprCfg.EnableNodePort || c.EnableHostFirewall || wireguardEnabled ||
 		c.EnableL2Announcements || c.ForceDeviceRequired || c.EnableIPSec
 }
 
 // NeedIngressOnWireGuardDevice returns true if the agent needs to attach
 // cil_from_wireguard on the Ingress of Cilium's WireGuard device
-func (c *DaemonConfig) NeedIngressOnWireGuardDevice(kprCfg kpr.KPRConfig) bool {
-	if !c.EnableWireguard {
+func (c *DaemonConfig) NeedIngressOnWireGuardDevice(kprCfg kpr.KPRConfig, wireguardEnabled bool) bool {
+	if !wireguardEnabled {
 		return false
 	}
 
@@ -2168,8 +2168,8 @@ func (c *DaemonConfig) NeedIngressOnWireGuardDevice(kprCfg kpr.KPRConfig) bool {
 
 // NeedEgressOnWireGuardDevice returns true if the agent needs to attach
 // cil_to_wireguard on the Egress of Cilium's WireGuard device
-func (c *DaemonConfig) NeedEgressOnWireGuardDevice(kprCfg kpr.KPRConfig) bool {
-	if !c.EnableWireguard {
+func (c *DaemonConfig) NeedEgressOnWireGuardDevice(kprCfg kpr.KPRConfig, wireguardEnabled bool) bool {
+	if !wireguardEnabled {
 		return false
 	}
 
@@ -2313,7 +2313,7 @@ func (c *DaemonConfig) validatePolicyCIDRMatchMode() error {
 
 // DirectRoutingDeviceRequired return whether the Direct Routing Device is needed under
 // the current configuration.
-func (c *DaemonConfig) DirectRoutingDeviceRequired(kprCfg kpr.KPRConfig) bool {
+func (c *DaemonConfig) DirectRoutingDeviceRequired(kprCfg kpr.KPRConfig, wireguardEnabled bool) bool {
 	// BPF NodePort and BPF Host Routing are using the direct routing device now.
 	// When tunneling is enabled, node-to-node redirection will be done by tunneling.
 	BPFHostRoutingEnabled := !c.EnableHostLegacyRouting
@@ -2323,7 +2323,7 @@ func (c *DaemonConfig) DirectRoutingDeviceRequired(kprCfg kpr.KPRConfig) bool {
 		return true
 	}
 
-	return kprCfg.EnableNodePort || BPFHostRoutingEnabled || Config.EnableWireguard
+	return kprCfg.EnableNodePort || BPFHostRoutingEnabled || wireguardEnabled
 }
 
 func (c *DaemonConfig) validateIPv6ClusterAllocCIDR() error {

--- a/pkg/status/cell.go
+++ b/pkg/status/cell.go
@@ -42,7 +42,7 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/time"
-	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 // Cell provides the Cilium status collector that is responsible for
@@ -100,7 +100,7 @@ type statusParams struct {
 	NodeDiscovery    *nodediscovery.NodeDiscovery
 	PolicyMapFactory policymap.Factory
 	TunnelConfig     tunnel.Config
-	WireguardAgent   *wireguard.Agent
+	WireguardAgent   wgTypes.WireguardAgent
 }
 
 // Config is the collector configuration

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -906,7 +906,7 @@ func (d *statusCollector) getProbes() []Probe {
 					return &models.EncryptionStatus{
 						Mode: models.EncryptionStatusModeIPsec,
 					}, nil
-				case d.statusParams.DaemonConfig.EnableWireguard:
+				case d.statusParams.WireguardAgent.Enabled():
 					var msg string
 					status, err := d.statusParams.WireguardAgent.Status(false)
 					if err != nil {

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -147,7 +147,7 @@ func newAgent(p params) *Agent {
 
 // Start implements cell.HookInterface.
 func (a *Agent) Start(cell.HookContext) error {
-	if !a.config.EnableWireguard {
+	if !a.Enabled() {
 		// Delete WireGuard device from previous run (if such exists)
 		link.DeleteByName(types.IfaceName)
 		return nil
@@ -187,7 +187,7 @@ func (a *Agent) Start(cell.HookContext) error {
 
 // Stop implements cell.HookInterface.
 func (a *Agent) Stop(cell.HookContext) error {
-	if !a.config.EnableWireguard {
+	if !a.Enabled() {
 		return nil
 	}
 
@@ -200,6 +200,11 @@ func (a *Agent) Stop(cell.HookContext) error {
 // Name implements datapath.NodeHandler.
 func (a *Agent) Name() string {
 	return "wireguard-agent"
+}
+
+// Returns true when enabled. Implements [types.WireguardAgent].
+func (a *Agent) Enabled() bool {
+	return a.config.EnableWireguard
 }
 
 // needsIPCache returns true if the agent should subscribe to IPCache events.
@@ -813,7 +818,7 @@ func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrC
 // If withPeers is true, then the details about each connected peer are
 // are populated as well.
 func (a *Agent) Status(withPeers bool) (*models.WireguardStatus, error) {
-	if !a.config.EnableWireguard {
+	if !a.Enabled() {
 		return nil, nil
 	}
 

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -188,7 +188,7 @@ func containsIP(allowedIPs iter.Seq[net.IPNet], ipnet *net.IPNet) bool {
 	return false
 }
 
-func newTestAgent(ctx context.Context, logger *slog.Logger, wgClient wireguardClient, config *option.DaemonConfig) (*Agent, *ipcache.IPCache) {
+func newTestAgent(ctx context.Context, logger *slog.Logger, wgClient wireguardClient, config Config) (*Agent, *ipcache.IPCache) {
 	ipCache := ipcache.NewIPCache(&ipcache.Configuration{
 		Context: ctx,
 		Logger:  logger,
@@ -225,18 +225,20 @@ type config struct {
 }
 
 // toAgentConfig returns the needed config for the WireGuard agent.
-func (c *config) toAgentConfig() *option.DaemonConfig {
-	return &option.DaemonConfig{
-		EnableIPv4: true,
-		EnableIPv6: true,
+func (c *config) toAgentConfig() Config {
+	return Config{
+		UserConfig: UserConfig{
+			EnableWireguard:              true,
+			WireguardTrackAllIPsFallback: c.Fallback,
+			WireguardPersistentKeepalive: 0,
+			NodeEncryptionOptOutLabels:   "",
+		},
 
-		RoutingMode: c.RoutingMode,
-
-		EncryptNode:                false,
-		NodeEncryptionOptOutLabels: nil,
-
-		WireguardTrackAllIPsFallback: c.Fallback,
-		WireguardPersistentKeepalive: 0,
+		StateDir:         "",
+		EnableIPv4:       true,
+		EnableIPv6:       true,
+		TunnelingEnabled: c.RoutingMode != option.RoutingModeNative,
+		EncryptNode:      false,
 	}
 }
 

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -536,7 +536,7 @@ func TestAgent_AllowedIPsRestoration(t *testing.T) {
 			c.CheckExpectations(assertAllowedIPs) // checks entry 3
 
 			// Run the GC process, and assert the AllowedIPs correctness again
-			require.NoError(t, wgAgent.RestoreFinished(nil))
+			require.NoError(t, wgAgent.restoreFinished())
 			c.CheckExpectations(assertAllowedIPs) // checks entry 4
 
 			// Ensure that a public key change results in deletion of the old peer entry.

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -194,7 +194,7 @@ func newTestAgent(ctx context.Context, logger *slog.Logger, wgClient wireguardCl
 		Logger:  logger,
 	})
 	wgAgent := &Agent{
-		logger:           logger.With(subsysLogAttr...),
+		logger:           logger,
 		wgClient:         wgClient,
 		ipCache:          ipCache,
 		listenPort:       types.ListenPort,

--- a/pkg/wireguard/agent/cell.go
+++ b/pkg/wireguard/agent/cell.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package agent
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+var Cell = cell.Module(
+	"wireguard-agent",
+	"Manages WireGuard device and peers",
+
+	cell.Provide(newAgent),
+)

--- a/pkg/wireguard/agent/cell.go
+++ b/pkg/wireguard/agent/cell.go
@@ -5,11 +5,18 @@ package agent
 
 import (
 	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 var Cell = cell.Module(
 	"wireguard-agent",
 	"Manages WireGuard device and peers",
 
-	cell.Provide(newAgent),
+	cell.Provide(newWireguardAgent),
 )
+
+// newWireguardAgent returns the [*Agent] as an interface [types.WireguardAgent].
+func newWireguardAgent(p params) types.WireguardAgent {
+	return newAgent(p)
+}

--- a/pkg/wireguard/agent/cell.go
+++ b/pkg/wireguard/agent/cell.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/wireguard/types"
 )
 
@@ -13,10 +14,33 @@ var Cell = cell.Module(
 	"wireguard-agent",
 	"Manages WireGuard device and peers",
 
-	cell.Provide(newWireguardAgent),
+	cell.Provide(newWireguardAgent, newWireguardConfig),
+	cell.ProvidePrivate(buildConfigFrom),
 )
 
 // newWireguardAgent returns the [*Agent] as an interface [types.WireguardAgent].
 func newWireguardAgent(p params) types.WireguardAgent {
 	return newAgent(p)
+}
+
+// newWireguardConfig returns the [Config] as an interface [types.WireguardConfig].
+func newWireguardConfig(c Config) types.WireguardConfig {
+	return c
+}
+
+// buildConfigFrom creates the [Config] from [option.DaemonConfig].
+func buildConfigFrom(dc *option.DaemonConfig) Config {
+	return Config{
+		EnableWireguard: dc.EnableWireguard,
+	}
+}
+
+// Final config of the WireGuard agent.
+type Config struct {
+	EnableWireguard bool
+}
+
+// Returns true when enabled. Implements [types.WireguardConfig].
+func (c Config) Enabled() bool {
+	return c.EnableWireguard
 }

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package agent
+
+import (
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+
+	cnicell "github.com/cilium/cilium/daemon/cmd/cni"
+	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
+	"github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/clustermesh"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/dial"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipcache"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeManager "github.com/cilium/cilium/pkg/node/manager"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/nodediscovery"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/testutils/netns"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/wireguard/types"
+)
+
+var TestTimeout = 5 * time.Second
+
+// paramsOut holds the output parameters needed for running cells in the test.
+type paramsOut struct {
+	cell.Out
+
+	WireguardConfig       Config
+	TunnelConfig          tunnel.Config
+	DaemonConfig          *option.DaemonConfig
+	LBConfig              loadbalancer.Config
+	LBExternalConfig      loadbalancer.ExternalConfig
+	LocalNode             node.LocalNode
+	IPCache               *ipcache.IPCache
+	CNIConfigManager      cnicell.CNIConfigManager
+	K8SAPIGroups          *k8sSynced.APIGroups
+	K8SResources          *k8sSynced.Resources
+	Sysctl                sysctl.Sysctl
+	StoreFactory          store.Factory
+	ClusterMeshMetrics    clustermesh.ClusterMeshMetrics
+	RemoteIdentityWatcher clustermesh.RemoteIdentityWatcher
+	CacheStatus           k8sSynced.CacheStatus
+	ClusterInfo           cmtypes.ClusterInfo
+}
+
+func TestPrivileged_TestWireGuardCell(t *testing.T) {
+	// Needed to create the test namespace where the agent creates the cilium_wg0 link.
+	testutils.PrivilegedTest(t)
+
+	// Create a temporary directory, used also by the agent for the private key.
+	testRunDir := t.TempDir()
+
+	// Use the temporary directory in daemon config.
+	oldRunDir, oldStateDir := option.Config.RunDir, option.Config.StateDir
+	defer func() {
+		option.Config.RunDir = oldRunDir
+		option.Config.StateDir = oldStateDir
+	}()
+	option.Config.RunDir = testRunDir
+	option.Config.StateDir = testRunDir
+
+	var (
+		// Local references are updated when starting the Hive.
+		wgAgent       *Agent
+		ipCache       *ipcache.IPCache
+		nodeStore     *node.LocalNodeStore
+		nodeDiscovery *nodediscovery.NodeDiscovery
+		manager       nodeManager.NodeManager
+		cacheStatus   k8sSynced.CacheStatus
+
+		ctx = t.Context()
+		ns  = netns.NewNetNS(t)
+		log = hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+	)
+
+	// getHive returns a new hive with Wireguard enabled/disabled.
+	getHive := func(wireguardEnabled bool) *hive.Hive {
+		return hive.New(
+			mtu.Cell,
+			nodeManager.Cell,
+			nodediscovery.Cell,
+			source.Cell,
+			watchers.Cell,
+			dial.ServiceResolverCell,
+			clustermesh.Cell,
+			writer.Cell,
+			ipset.Cell,
+			k8s.ResourcesCell,
+			k8sClient.FakeClientCell(),
+			kvstore.Cell(kvstore.DisabledBackendName),
+
+			cell.Provide(
+				newWireguardAgent,
+				newWireguardConfig,
+
+				node.NewTestLocalNodeStore,
+				regeneration.NewFence,
+				tables.NewDeviceTable,
+				tables.NewNodeAddressTable,
+				ipcache.NewLocalIPIdentityWatcher,
+				ipcache.NewIPIdentitySynchronizer,
+				statedb.RWTable[*tables.Device].ToTable,
+				statedb.RWTable[tables.NodeAddress].ToTable,
+
+				func() paramsOut {
+					return paramsOut{
+						WireguardConfig: Config{
+							UserConfig: UserConfig{
+								EnableWireguard:              wireguardEnabled,
+								WireguardTrackAllIPsFallback: false,
+								WireguardPersistentKeepalive: 0,
+								NodeEncryptionOptOutLabels:   "",
+							},
+							EnableIPv4:       true,
+							EnableIPv6:       true,
+							StateDir:         testRunDir,
+							TunnelingEnabled: false,
+							EncryptNode:      false,
+						},
+						TunnelConfig:     tunnel.Config{},
+						DaemonConfig:     option.Config,
+						LBConfig:         loadbalancer.Config{},
+						LBExternalConfig: loadbalancer.ExternalConfig{},
+						LocalNode: node.LocalNode{
+							Node: nodeTypes.Node{
+								Name: k8s1NodeName,
+								IPAddresses: []nodeTypes.Address{
+									{
+										Type: addressing.NodeInternalIP,
+										IP:   k8s1NodeIPv4,
+									},
+								},
+								Annotations: map[string]string{},
+							},
+						},
+						IPCache: ipcache.NewIPCache(&ipcache.Configuration{
+							Context: ctx,
+							Logger:  hivetest.Logger(t),
+						}),
+						K8SAPIGroups:          &k8sSynced.APIGroups{},
+						K8SResources:          &k8sSynced.Resources{},
+						CNIConfigManager:      &fakecni.FakeCNIConfigManager{},
+						Sysctl:                sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
+						StoreFactory:          store.NewFactory(hivetest.Logger(t), store.MetricsProvider()),
+						ClusterMeshMetrics:    nil,
+						RemoteIdentityWatcher: nil,
+						CacheStatus:           make(k8sSynced.CacheStatus),
+						ClusterInfo:           cmtypes.DefaultClusterInfo,
+					}
+				},
+			),
+
+			cell.Invoke(
+				statedb.RegisterTable[tables.NodeAddress],
+				statedb.RegisterTable[*tables.Device],
+				func(a types.WireguardAgent, n *nodediscovery.NodeDiscovery, s *node.LocalNodeStore, u nodeManager.NodeManager, i *ipcache.IPCache, c k8sSynced.CacheStatus) {
+					wgAgent = a.(*Agent)
+					nodeDiscovery = n
+					manager = u
+					nodeStore = s
+					ipCache = i
+					cacheStatus = c
+				}),
+		)
+	}
+
+	t.Run("WireguardEnabled", func(t *testing.T) {
+		ns.Do(func() error {
+			// 0. Create a hive with WireGuard enabled.
+			hive := getHive(true)
+
+			// 1. Start the hive.
+			require.NoError(t, hive.Start(log, ctx))
+
+			// 2. Ensure the wireguard Agent is enabled.
+			require.True(t, wgAgent.Enabled())
+
+			// 3. Ensure the link cilium_wg0 has been created.
+			link, err := safenetlink.LinkByName(types.IfaceName)
+			require.NoError(t, err)
+
+			// 4. Ensure the MTU is set accordingly (mtu-reconciler job).
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, mtu.EthernetMTU-mtu.WireguardOverhead, link.Attrs().MTU)
+			}, TestTimeout, 50*time.Millisecond)
+
+			// 5. Ensure local node has been updated (localnode-updater job).
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				localNode, err := nodeStore.Get(ctx)
+				require.NoError(c, err)
+				assert.NotEmpty(c, localNode.WireguardPubKey)
+			}, TestTimeout, 50*time.Millisecond)
+
+			// 6.a Ensure obsolete peer are removed (peer-reconciler job).
+			//     Let's add an obsolete peer to the wireguard Device (but not to the agent),
+			//     then trigger the node discovery and ensure the peer is removed from the device.
+			dev, err := wgAgent.wgClient.Device(types.IfaceName)
+			require.NoError(t, err)
+			require.Empty(t, dev.Peers)
+
+			// 6.b Inject the obsolete peer.
+			cfg := wgtypes.Config{
+				PrivateKey:   nil,
+				ListenPort:   nil,
+				FirewallMark: nil,
+				ReplacePeers: false,
+				Peers: []wgtypes.PeerConfig{
+					{
+						AllowedIPs: []net.IPNet{{IP: k8s2NodeIPv4, Mask: net.IPv4Mask(255, 255, 255, 255)}},
+					},
+				},
+			}
+			require.NoError(t, wgAgent.wgClient.ConfigureDevice(types.IfaceName, cfg))
+
+			// 6.c Ensure the injection was successful.
+			dev, err = wgAgent.wgClient.Device(types.IfaceName)
+			require.NoError(t, err)
+			require.Len(t, dev.Peers, 1)
+
+			// 6.d Close CacheStatus to unlock wait from the [*Agent.peerGarbageCollector].
+			close(cacheStatus)
+
+			// 6.e TriggerLabelInjection to unlock WaitForRevision from the [*Agent.peerGarbageCollector].
+			ipCache.TriggerLabelInjection()
+
+			// 6.f Start node discovery.
+			nodeDiscovery.StartDiscovery(ctx)
+
+			// 6.g Ensure the obsolete peer has been removed.
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				dev, err = wgAgent.wgClient.Device(types.IfaceName)
+				require.NoError(c, err)
+				assert.Empty(c, dev.Peers)
+			}, TestTimeout, 50*time.Millisecond)
+
+			// 7.a Ensure the agent subscribed to node events (nodemanager-subscribe job).
+			//     Let's upsert a new node, and ensure the agent maps contain the new peer.
+			manager.NodeUpdated(nodeTypes.Node{
+				Name: k8s2NodeName,
+				IPAddresses: []nodeTypes.Address{
+					{
+						Type: addressing.NodeInternalIP,
+						IP:   k8s2NodeIPv4,
+					},
+				},
+				Source:          source.Unspec,
+				WireguardPubKey: wgAgent.privKey.String(),
+			})
+
+			// 7.b Ensure the agent has stored a peer configuration for the new node.
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Contains(c, wgAgent.nodeNameByNodeIP, k8s2NodeIPv4.String())
+				assert.Contains(c, wgAgent.peerByNodeName, k8s2NodeName)
+			}, TestTimeout, 50*time.Millisecond)
+
+			// 8.a Ensure the agent subscribed to IPCache events (ipcache-listener job).
+			//     Let's upsert a new identity, and ensure the agent contains it as allowedIP.
+			ipCache.Upsert(pod2IPv4Str, k8s2NodeIPv4, 0, nil, ipcache.Identity{ID: 1, Source: source.Kubernetes})
+
+			// 8.b Ensure the agent has the identity in the peer allowedIPs.
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Contains(c, wgAgent.peerByNodeName, k8s2NodeName)
+				assert.Truef(c, func() bool {
+					for _, n := range wgAgent.peerByNodeName[k8s2NodeName].allowedIPs {
+						if n.Contains(pod2IPv4.IP) {
+							return true
+						}
+					}
+					return false
+				}(), "Expected allowed IP %v", pod2IPv4.String())
+			}, TestTimeout, 50*time.Millisecond)
+
+			// 9. Stop the hive.
+			require.NoError(t, hive.Stop(log, ctx))
+
+			// 10. Ensure the link cilium_wg0 is not deleted.
+			_, err = safenetlink.LinkByName(types.IfaceName)
+			require.NoError(t, err)
+
+			return nil
+		})
+	})
+
+	t.Run("WireguardDisabled", func(t *testing.T) {
+		ns.Do(func() error {
+			// 0. Create link cilium_wg0 in case no leftover from previous test.
+			netlink.LinkAdd(&netlink.Wireguard{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: types.IfaceName,
+				},
+			})
+
+			// 1. Ensure the link cilium_wg0 exists.
+			_, err := safenetlink.LinkByName(types.IfaceName)
+			require.NoError(t, err)
+
+			// 2. Create a hive with WireGuard disabled.
+			hive := getHive(false)
+
+			// 3. Start the hive.
+			require.NoError(t, hive.Start(log, ctx))
+
+			// 4. Ensure the wireguard Agent is disabled.
+			require.False(t, wgAgent.Enabled())
+
+			// 5. Ensure the link is deleted.
+			_, err = safenetlink.LinkByName(types.IfaceName)
+			require.Error(t, err)
+			require.ErrorAs(t, err, &netlink.LinkNotFoundError{})
+
+			// 6. Stop the hive.
+			require.NoError(t, hive.Stop(log, ctx))
+
+			return nil
+		})
+	})
+}

--- a/pkg/wireguard/agent/node_handler.go
+++ b/pkg/wireguard/agent/node_handler.go
@@ -26,7 +26,7 @@ func (a *Agent) NodeDelete(node nodeTypes.Node) error {
 		return nil
 	}
 
-	return a.DeletePeer(node.Fullname())
+	return a.deletePeer(node.Fullname())
 }
 
 // AllNodeValidateImplementation is called to validate the implementation of
@@ -49,7 +49,7 @@ func (a *Agent) nodeUpsert(node nodeTypes.Node) error {
 	newIP4 := node.GetNodeIP(false)
 	newIP6 := node.GetNodeIP(true)
 
-	if err := a.UpdatePeer(node.Fullname(), node.WireguardPubKey, newIP4, newIP6); err != nil {
+	if err := a.updatePeer(node.Fullname(), node.WireguardPubKey, newIP4, newIP6); err != nil {
 		a.logger.Warn(
 			"Failed to update WireGuard configuration for peer",
 			logfields.Error, err,

--- a/pkg/wireguard/types/option.go
+++ b/pkg/wireguard/types/option.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+// Command-line flags for WireGuard.
+const (
+	EnableWireguard              = "enable-wireguard"
+	WireguardPersistentKeepalive = "wireguard-persistent-keepalive"
+	WireguardTrackAllIPsFallback = "wireguard-track-all-ips-fallback"
+	NodeEncryptionOptOutLabels   = "node-encryption-opt-out-labels"
+)

--- a/pkg/wireguard/types/types.go
+++ b/pkg/wireguard/types/types.go
@@ -4,6 +4,8 @@
 // Common WireGuard types and constants
 package types
 
+import "github.com/cilium/cilium/api/v1/models"
+
 const (
 	// ListenPort is the port on which the WireGuard tunnel device listens on
 	ListenPort = 51871
@@ -15,3 +17,9 @@ const (
 	// want to enable WireGuard encryption
 	StaticEncryptKey = uint8(0xFF)
 )
+
+// WireguardAgent exports the Enabled and Status commands from the agent.
+type WireguardAgent interface {
+	Enabled() bool
+	Status(withPeers bool) (*models.WireguardStatus, error)
+}

--- a/pkg/wireguard/types/types.go
+++ b/pkg/wireguard/types/types.go
@@ -23,3 +23,9 @@ type WireguardAgent interface {
 	Enabled() bool
 	Status(withPeers bool) (*models.WireguardStatus, error)
 }
+
+// WireguardConfig exports the Enabled method rather than the whole config.
+// This is useful when the whole agent is not needed. See [WireguardAgent] otherwise.
+type WireguardConfig interface {
+	Enabled() bool
+}


### PR DESCRIPTION
Each change has been carefully split in a separate logical commit to ease the review process.
Please refer to each commit and its description for further details.
I'd strongly suggest to review files owned by each group.

Major concerns:
* `wireguard: move local node to config param for updating EncryptionKey`: discussed and solved, see [below](https://github.com/cilium/cilium/pull/40360#discussion_r2185344257).
* `wireguard: rely on mtu reconciler job only for MTU settings`: please refer to commit description. This one is not strictly needed anymore (no more circular deps), but it feels right to keep. The link is created with default MTU, then the reconciler job will adjust it accordingly. No problems are expected for pods/host connections, given they'd rely on the already established routeMTU from the mtu subsystem.

Edit: there was a security threat discussion here https://github.com/cilium/cilium/pull/40360#discussion_r2222930079. The concerns arise from a previous implementation, but we noticed that there's an unrelated possibility to for an attacker to mess with the encryption by changing the key from k8s objects (CiliumEndpoint and CiliumNode). So to sum up, here we're not touching this anymore, but the threat is still available in Cilium.

Fixes: #25262

```release-note
Modularization of WireGuard Agent.
```
