### PR TITLE
fqdn: clean up regex cache

### DIFF
--- a/cilium-dbg/cmd/policy.go
+++ b/cilium-dbg/cmd/policy.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/safeio"
@@ -37,14 +36,6 @@ var (
 
 func init() {
 	RootCmd.AddCommand(PolicyCmd)
-
-	// Initialize LRU here because the policy subcommands (validate, import)
-	// will call down to sanitizing the FQDN rules which contains regexes.
-	// Regexes need to be compiled as part of the FQDN rule validation.
-	//
-	// It's not necessary to pass a useful size here because it's not
-	// necessary to cache regexes in a short-lived binary (CLI).
-	re.InitRegexCompileLRU(log, 1)
 }
 
 func getContext(content []byte, offset int64) (int, string, int) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -734,7 +734,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(option.FQDNProxyResponseMaxDelay, defaults.FQDNProxyResponseMaxDelay, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
 	option.BindEnv(vp, option.FQDNProxyResponseMaxDelay)
 
-	flags.Int(option.FQDNRegexCompileLRUSize, defaults.FQDNRegexCompileLRUSize, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated DNS L7 rules with MatchName or MatchPattern")
+	flags.Uint(option.FQDNRegexCompileLRUSize, defaults.FQDNRegexCompileLRUSize, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated DNS L7 rules with MatchName or MatchPattern")
 	flags.MarkHidden(option.FQDNRegexCompileLRUSize)
 	option.BindEnv(vp, option.FQDNRegexCompileLRUSize)
 

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/go-openapi/swag v0.23.1
 	github.com/go-openapi/validate v0.24.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/google/cel-go v0.25.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v73 v73.0.0
@@ -203,6 +202,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/certificate-transparency-go v1.1.7 // indirect

--- a/operator/pkg/networkpolicy/cell.go
+++ b/operator/pkg/networkpolicy/cell.go
@@ -20,7 +20,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/cilium/cilium/pkg/fqdn/re"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8s_client "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -77,13 +76,6 @@ func registerPolicyValidator(params PolicyParams) {
 
 	if !option.Config.EnableCiliumNetworkPolicy && !option.Config.EnableCiliumClusterwideNetworkPolicy {
 		params.Logger.Info(fmt.Sprintf("CNP / CCNP validator doesn't run when CNP and CCNP are disabled (%s=false AND %s=false)", option.EnableCiliumNetworkPolicy, option.EnableCiliumClusterwideNetworkPolicy))
-		return
-	}
-
-	// LRU size of 1 since we are only doing one-off validation of policies and
-	// the FQDN regexes are not referenced again.
-	if err := re.InitRegexCompileLRU(params.Logger, 1); err != nil {
-		params.Logger.Error("CNP / CCNP validator can't run due to failure in initializing regex LRU cache.", logfields.Error, err)
 		return
 	}
 

--- a/pkg/fqdn/bootstrap/dns_proxy.go
+++ b/pkg/fqdn/bootstrap/dns_proxy.go
@@ -45,10 +45,7 @@ type dnsProxyParams struct {
 
 // newDNSProxy initializes the DNS l7 proxy.
 func newDNSProxy(params dnsProxyParams) (proxy.DNSProxier, error) {
-	if err := re.InitRegexCompileLRU(params.Logger, option.Config.FQDNRegexCompileLRUSize); err != nil {
-		// can only happen if LRUSize is negative
-		return nil, err
-	}
+	re.Resize(params.Logger, option.Config.FQDNRegexCompileLRUSize)
 
 	// Do not start the proxy in dry mode or if L7 proxy is disabled.
 	// The proxy would not get any traffic in the dry mode anyway, and some of the socket

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/ip"
 )
 
@@ -26,9 +25,6 @@ import (
 // iterate through time, ensuring that data is expired as appropriate. We also
 // insert redundant DNS entries that should not change the output.
 func TestUpdateLookup(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	name := "test.com"
 	now := time.Now()
 	cache := NewDNSCache(0)
@@ -79,9 +75,6 @@ func TestUpdateLookup(t *testing.T) {
 
 // TestDelete tests that we can forcibly clear parts of the cache.
 func TestDelete(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	names := map[string]netip.Addr{
 		"test1.com": netip.MustParseAddr("2.2.2.1"),
 		"test2.com": netip.MustParseAddr("2.2.2.2"),
@@ -152,9 +145,6 @@ func TestDelete(t *testing.T) {
 }
 
 func Test_forceExpiredByNames(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	names := []string{"test1.com", "test2.com"}
 	cache := NewDNSCache(0)
 	for i := 1; i < 4; i++ {
@@ -171,9 +161,6 @@ func Test_forceExpiredByNames(t *testing.T) {
 }
 
 func TestReverseUpdateLookup(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	names := map[string]netip.Addr{
 		"test1.com": netip.MustParseAddr("2.2.2.1"),
 		"test2.com": netip.MustParseAddr("2.2.2.2"),
@@ -241,9 +228,6 @@ func TestReverseUpdateLookup(t *testing.T) {
 }
 
 func TestJSONMarshal(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	names := map[string]netip.Addr{
 		"test1.com": netip.MustParseAddr("2.2.2.1"),
 		"test2.com": netip.MustParseAddr("2.2.2.2"),
@@ -296,9 +280,6 @@ func TestJSONMarshal(t *testing.T) {
 }
 
 func TestCountIPs(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	names := map[string]netip.Addr{
 		"test1.com": netip.MustParseAddr("1.1.1.1"),
 		"test2.com": netip.MustParseAddr("2.2.2.2"),
@@ -386,9 +367,6 @@ func makeEntries(now time.Time, live, redundant, expired uint32) (entries []*cac
 
 // Note: each "op" works on size things
 func BenchmarkGetIPs(b *testing.B) {
-	logger := hivetest.Logger(b)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	now := time.Now()
 	cache := NewDNSCache(0)
 	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 60)
@@ -404,9 +382,6 @@ func BenchmarkGetIPs(b *testing.B) {
 
 // Note: each "op" works on size things
 func BenchmarkUpdateIPs(b *testing.B) {
-	logger := hivetest.Logger(b)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	for b.Loop() {
 		b.StopTimer()
 		now := time.Now()
@@ -456,9 +431,6 @@ func BenchmarkMarshalJSON1000Repeat2(b *testing.B) {
 // Note: It assumes the JSON only uses data in DNSCache.forward when generating
 // the data. Changes to the implementation need to also change this benchmark.
 func benchmarkMarshalJSON(b *testing.B, numDNSEntries int) {
-	logger := hivetest.Logger(b)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	ips := makeIPs(uint32(numIPsPerEntry))
 
 	cache := NewDNSCache(0)
@@ -478,9 +450,6 @@ func benchmarkMarshalJSON(b *testing.B, numDNSEntries int) {
 // Note: It assumes the JSON only uses data in DNSCache.forward when generating
 // the data. Changes to the implementation need to also change this benchmark.
 func benchmarkUnmarshalJSON(b *testing.B, numDNSEntries int) {
-	logger := hivetest.Logger(b)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	ips := makeIPs(uint32(numIPsPerEntry))
 
 	cache := NewDNSCache(0)
@@ -505,9 +474,6 @@ func benchmarkUnmarshalJSON(b *testing.B, numDNSEntries int) {
 }
 
 func TestTTLInsertWithMinValue(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	now := time.Now()
 	cache := NewDNSCache(60)
 	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 3)
@@ -529,9 +495,6 @@ func TestTTLInsertWithMinValue(t *testing.T) {
 }
 
 func TestTTLInsertWithZeroValue(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	now := time.Now()
 	cache := NewDNSCache(0)
 	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 10)
@@ -553,9 +516,6 @@ func TestTTLInsertWithZeroValue(t *testing.T) {
 }
 
 func TestTTLCleanupEntries(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	cache := NewDNSCache(0)
 	cache.Update(now, "test.com", []netip.Addr{netip.MustParseAddr("1.2.3.4")}, 3)
 	require.Len(t, cache.cleanup, 1)
@@ -566,9 +526,6 @@ func TestTTLCleanupEntries(t *testing.T) {
 }
 
 func TestTTLCleanupWithoutForward(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	cache := NewDNSCache(0)
 	now := time.Now()
 	cache.cleanup[now.Unix()] = []string{"test.com"}
@@ -580,9 +537,6 @@ func TestTTLCleanupWithoutForward(t *testing.T) {
 }
 
 func TestOverlimitEntriesWithValidLimit(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	limit := 5
 	cache := NewDNSCacheWithLimit(0, limit)
 
@@ -603,9 +557,6 @@ func TestOverlimitEntriesWithValidLimit(t *testing.T) {
 }
 
 func TestOverlimitEntriesWithoutLimit(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	limit := 0
 	cache := NewDNSCacheWithLimit(0, limit)
 	for i := range 5 {
@@ -617,9 +568,6 @@ func TestOverlimitEntriesWithoutLimit(t *testing.T) {
 }
 
 func TestGCOverlimitAfterTTLCleanup(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	limit := 5
 	cache := NewDNSCacheWithLimit(0, limit)
 
@@ -641,9 +589,6 @@ func TestGCOverlimitAfterTTLCleanup(t *testing.T) {
 }
 
 func TestOverlimitAfterDeleteForwardEntry(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	// Validate if something delete the forward entry no invalid key access on
 	// CG operation
 	dnsCache := NewDNSCache(0)
@@ -653,9 +598,6 @@ func TestOverlimitAfterDeleteForwardEntry(t *testing.T) {
 }
 
 func assertZombiesContain(t *testing.T, zombies []*DNSZombieMapping, expected map[string][]string) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	t.Helper()
 	require.Lenf(t, zombies, len(expected), "Different number of zombies than expected: %+v", zombies)
 
@@ -675,7 +617,6 @@ func assertZombiesContain(t *testing.T, zombies []*DNSZombieMapping, expected ma
 
 func TestZombiesSiblingsGC(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	now := time.Now()
 	zombies := NewDNSZombieMappings(logger, defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
@@ -706,7 +647,6 @@ func TestZombiesSiblingsGC(t *testing.T) {
 
 func TestZombiesGC(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	now := time.Now()
 	zombies := NewDNSZombieMappings(logger, defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
@@ -808,7 +748,6 @@ func TestZombiesGC(t *testing.T) {
 
 func TestZombiesGCOverLimit(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	now := time.Now()
 	zombies := NewDNSZombieMappings(logger, defaults.ToFQDNsMaxDeferredConnectionDeletes, 1)
@@ -835,7 +774,6 @@ func TestZombiesGCOverLimit(t *testing.T) {
 
 func TestZombiesGCOverLimitWithCTGC(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	now := time.Now()
 	afterNow := now.Add(1 * time.Nanosecond)
@@ -873,7 +811,6 @@ func TestZombiesGCOverLimitWithCTGC(t *testing.T) {
 
 func TestZombiesGCDeferredDeletes(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	now := time.Now()
 	zombies := NewDNSZombieMappings(logger, defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
@@ -935,7 +872,6 @@ func TestZombiesGCDeferredDeletes(t *testing.T) {
 
 func TestZombiesForceExpire(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	now := time.Now()
 	zombies := NewDNSZombieMappings(logger, defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
@@ -1008,7 +944,6 @@ func TestZombiesForceExpire(t *testing.T) {
 
 func TestCacheToZombiesGCCascade(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	now := time.Now()
 	cache := NewDNSCache(0)
@@ -1056,7 +991,6 @@ func TestCacheToZombiesGCCascade(t *testing.T) {
 
 func TestZombiesDumpAlive(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	now := time.Now()
 	zombies := NewDNSZombieMappings(logger, defaults.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxIPsPerHost)
@@ -1134,7 +1068,6 @@ func TestZombiesDumpAlive(t *testing.T) {
 
 func TestOverlimitPreferNewerEntries(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	toFQDNsMinTTL := 100
 	toFQDNsMaxIPsPerHost := 5
@@ -1223,7 +1156,6 @@ func TestOverlimitPreferNewerEntries(t *testing.T) {
 // the front).
 func TestPerHostLimitBehaviourForS3(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	someDomain := "s3.example.com"
 	maxIPs := 5
@@ -1376,9 +1308,6 @@ func validateZombieSort(t *testing.T, zombies []*DNSZombieMapping) {
 }
 
 func Test_sortZombieMappingSlice(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	// Create three moments in time, so we can have before, equal and after.
 	moments := []time.Time{
 		time.Date(2001, time.January, 1, 1, 1, 1, 0, time.Local),

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -7,11 +7,9 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/container/versioned"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -23,8 +21,6 @@ import (
 )
 
 func TestSetPortRulesForID(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, 1)
 	rules := policy.L7DataMap{}
 	epID := uint64(1)
 	pea := perEPAllow{}
@@ -85,8 +81,6 @@ func TestSetPortRulesForID(t *testing.T) {
 }
 
 func TestSetPortRulesForIDFromUnifiedFormat(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, 1)
 	rules := make(CachedSelectorREEntry)
 	epID := uint64(1)
 	pea := perEPAllow{}
@@ -119,7 +113,6 @@ func TestSetPortRulesForIDFromUnifiedFormat(t *testing.T) {
 }
 
 func TestGeneratePattern(t *testing.T) {
-	logger := hivetest.Logger(t)
 	l7 := &policy.PerSelectorPolicy{
 		L7Rules: api.L7Rules{DNS: []api.PortRuleDNS{
 			{MatchName: "example.name."},
@@ -133,7 +126,6 @@ func TestGeneratePattern(t *testing.T) {
 	matching := []string{"example.name.", "example.com.", "demo.io.", "demoo.tld.", "testpattern.com.", "pattern.com.", "a.b.cmiddle.io."}
 	notMatching := []string{"eexample.name.", "eexample.com.", "vdemo.io.", "demo.ioo.", "emoo.tld.", "test.ppattern.com.", "b.cmiddle.io."}
 
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 	pattern := GeneratePattern(l7)
 
 	regex, err := re.CompileRegex(pattern)

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
-	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
@@ -79,8 +78,6 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 
 		wg sync.WaitGroup
 	)
-
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	policyRepo := policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	ipc := &mockipc.MockIPCache{}

--- a/pkg/fqdn/namemanager/bench_test.go
+++ b/pkg/fqdn/namemanager/bench_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
-	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/policy/api"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 	"github.com/cilium/cilium/pkg/time"
@@ -40,8 +39,6 @@ func BenchmarkUpdateGenerateDNS(b *testing.B) {
 	// with a random new IP
 
 	numSelectors := 1000
-
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	nameManager := New(ManagerParams{
 		Logger: logger,

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
-	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -42,7 +41,6 @@ var (
 
 func TestMapIPsToSelectors(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	var (
 		ciliumIP1   = netip.MustParseAddr("1.2.3.4")
@@ -100,7 +98,6 @@ func TestMapIPsToSelectors(t *testing.T) {
 
 func TestNameManagerIPCacheUpdates(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	ipc := newMockIPCache()
 	nameManager := New(ManagerParams{
@@ -151,9 +148,6 @@ func TestNameManagerIPCacheUpdates(t *testing.T) {
 }
 
 func Test_deriveLabelsForNames(t *testing.T) {
-	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
-
 	ciliumIORe, err := ciliumIOSel.ToRegex()
 	require.NoError(t, err)
 	githubRe, err := githubSel.ToRegex()

--- a/pkg/fqdn/re/re.go
+++ b/pkg/fqdn/re/re.go
@@ -6,15 +6,13 @@
 package re
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
-	"sync/atomic"
 
-	"github.com/golang/groupcache/lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 
-	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -25,53 +23,47 @@ import (
 // LRU. This function will return an error if the LRU has not already been
 // initialized.
 func CompileRegex(p string) (*regexp.Regexp, error) {
-	lru := regexCompileLRU.Load()
-	if lru == nil {
-		return nil, errors.New("FQDN regex compilation LRU not yet initialized")
-	}
-	lru.Lock()
-	r, ok := lru.Get(p)
-	lru.Unlock()
+	r, ok := regexCompileLRU.cache.Get(p)
 	if ok {
-		return r.(*regexp.Regexp), nil
+		return r, nil
 	}
 	n, err := regexp.Compile(p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile regex: %w", err)
 	}
-	lru.Lock()
-	lru.Add(p, n)
-	lru.Unlock()
+	regexCompileLRU.cache.Add(p, n)
 	return n, nil
 }
 
-// InitRegexCompileLRU creates a new instance of the regex compilation LRU.
-func InitRegexCompileLRU(logger *slog.Logger, size int) error {
-	if size < 0 {
-		return fmt.Errorf("failed to initialize FQDN regex compilation LRU due to invalid size %d", size)
-	} else if size == 0 {
+func Resize(logger *slog.Logger, size uint) {
+	if size == 0 {
+		// effectively unlimited
+		size = 16_000_000
 		logger.Warn(fmt.Sprintf(
 			"FQDN regex compilation LRU size is unlimited, which can grow unbounded potentially consuming too much memory. Consider passing a maximum size via --%s.",
 			option.FQDNRegexCompileLRUSize,
 		))
 	}
-	regexCompileLRU.Store(&RegexCompileLRU{
-		Mutex: &lock.Mutex{},
-		Cache: lru.New(size),
-	})
-	return nil
+	regexCompileLRU.cache.Resize(int(size))
+}
+
+func newRegexCache(size uint) *RegexCompileLRU {
+	c, err := lru.New[string, *regexp.Regexp](int(size))
+	if err != nil {
+		panic(err) // unreachable, only for zero size
+	}
+	return &RegexCompileLRU{
+		cache: c,
+	}
 }
 
 // regexCompileLRU is the singleton instance of the LRU that's shared
 // throughout Cilium.
-var regexCompileLRU atomic.Pointer[RegexCompileLRU]
+var regexCompileLRU = newRegexCache(defaults.FQDNRegexCompileLRUSize)
 
 // RegexCompileLRU is an LRU cache for storing compiled regex objects of FQDN
 // names or patterns, used in CiliumNetworkPolicy or
 // ClusterwideCiliumNetworkPolicy.
 type RegexCompileLRU struct {
-	// The lru package doesn't provide any concurrency guarantees so we must
-	// provide our own locking.
-	*lock.Mutex
-	*lru.Cache
+	cache *lru.Cache[string, *regexp.Regexp]
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1583,7 +1583,7 @@ type DaemonConfig struct {
 
 	// FQDNRegexCompileLRUSize is the size of the FQDN regex compilation LRU.
 	// Useful for heavy but repeated FQDN MatchName or MatchPattern use.
-	FQDNRegexCompileLRUSize int
+	FQDNRegexCompileLRUSize uint
 
 	// Path to a file with DNS cache data to preload on startup
 	ToFQDNsPreCache string
@@ -2847,7 +2847,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	// toFQDNs options
 	c.DNSMaxIPsPerRestoredRule = vp.GetInt(DNSMaxIPsPerRestoredRule)
 	c.DNSPolicyUnloadOnShutdown = vp.GetBool(DNSPolicyUnloadOnShutdown)
-	c.FQDNRegexCompileLRUSize = vp.GetInt(FQDNRegexCompileLRUSize)
+	c.FQDNRegexCompileLRUSize = vp.GetUint(FQDNRegexCompileLRUSize)
 	c.ToFQDNsMaxIPsPerHost = vp.GetInt(ToFQDNsMaxIPsPerHost)
 	if maxZombies := vp.GetInt(ToFQDNsMaxDeferredConnectionDeletes); maxZombies >= 0 {
 		c.ToFQDNsMaxDeferredConnectionDeletes = vp.GetInt(ToFQDNsMaxDeferredConnectionDeletes)

--- a/pkg/policy/api/egress_test.go
+++ b/pkg/policy/api/egress_test.go
@@ -107,8 +107,6 @@ func TestCreateDerivativeWithoutErrorAndNoIPs(t *testing.T) {
 }
 
 func TestIsLabelBasedEgress(t *testing.T) {
-	setUpSuite(t)
-
 	type args struct {
 		eg *EgressRule
 	}

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -12,8 +12,6 @@ import (
 // TestFQDNSelectorSanitize tests that the sanitizer correctly catches bad
 // cases, and allows good ones.
 func TestFQDNSelectorSanitize(t *testing.T) {
-	setUpSuite(t)
-
 	for _, accept := range []FQDNSelector{
 		{MatchName: "cilium.io."},
 		{MatchName: "get-cilium.io."},
@@ -42,8 +40,6 @@ func TestFQDNSelectorSanitize(t *testing.T) {
 // TestPortRuleDNSSanitize tests that the sanitizer correctly catches bad
 // cases, and allows good ones.
 func TestPortRuleDNSSanitize(t *testing.T) {
-	setUpSuite(t)
-
 	for _, accept := range []PortRuleDNS{
 		{MatchName: "cilium.io."},
 		{MatchName: "get-cilium.io."},

--- a/pkg/policy/api/groups_test.go
+++ b/pkg/policy/api/groups_test.go
@@ -80,8 +80,6 @@ func TestGetCIDRSetWithUniqueCIDRRule(t *testing.T) {
 }
 
 func TestGetCIDRSetWithError(t *testing.T) {
-	setUpSuite(t)
-
 	cb := func(ctx context.Context, group *Groups) ([]netip.Addr, error) {
 		return []netip.Addr{}, fmt.Errorf("Invalid credentials")
 	}
@@ -93,8 +91,6 @@ func TestGetCIDRSetWithError(t *testing.T) {
 }
 
 func TestWithoutProviderRegister(t *testing.T) {
-	setUpSuite(t)
-
 	providers.Delete(AWSProvider)
 	group := GetGroupsRule()
 	cidr, err := group.GetCidrSet(context.TODO())

--- a/pkg/policy/api/icmp_test.go
+++ b/pkg/policy/api/icmp_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestICMPFieldUnmarshal(t *testing.T) {
-	setUpSuite(t)
-
 	var i ICMPField
 
 	value1 := []byte("{\"family\": \"IPv4\", \"type\": 8}")

--- a/pkg/policy/api/ingress_test.go
+++ b/pkg/policy/api/ingress_test.go
@@ -66,8 +66,6 @@ func TestCreateDerivativeRuleWithFromGroups(t *testing.T) {
 }
 
 func TestIsLabelBasedIngress(t *testing.T) {
-	setUpSuite(t)
-
 	type args struct {
 		eg *IngressRule
 	}

--- a/pkg/policy/api/rule_test.go
+++ b/pkg/policy/api/rule_test.go
@@ -26,8 +26,6 @@ func checkMarshalUnmarshal(t *testing.T, r *Rule) {
 // This test ensures that the NodeSelector and EndpointSelector fields are kept
 // empty when the rule is marshalled/unmarshalled.
 func TestJSONMarshalling(t *testing.T) {
-	setUpSuite(t)
-
 	validEndpointRule := Rule{
 		EndpointSelector: WildcardEndpointSelector,
 	}
@@ -96,8 +94,6 @@ func getIngressDenyRuleWithFromGroups() *Rule {
 }
 
 func TestRequiresDerivative(t *testing.T) {
-	setUpSuite(t)
-
 	egressWithoutToGroups := Rule{}
 	require.False(t, egressWithoutToGroups.RequiresDerivative())
 
@@ -115,8 +111,6 @@ func TestRequiresDerivative(t *testing.T) {
 }
 
 func TestCreateDerivative(t *testing.T) {
-	setUpSuite(t)
-
 	egressWithoutToGroups := Rule{}
 	newRule, err := egressWithoutToGroups.CreateDerivative(context.TODO())
 	require.NoError(t, err)

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -21,8 +21,6 @@ import (
 // are invalid if any protocol except TCP is used as a protocol for any port
 // in the list of PortProtocol supplied to the rule.
 func TestL7RulesWithNonTCPProtocols(t *testing.T) {
-	setUpSuite(t)
-
 	// Rule is valid because only ProtoTCP is allowed for L7 rules (except with ToFQDNs, below).
 	validPortRule := Rule{
 		EndpointSelector: WildcardEndpointSelector,
@@ -498,8 +496,6 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 
 // This test ensures that L7 rules reject unspecified ports.
 func TestL7RuleRejectsEmptyPort(t *testing.T) {
-	setUpSuite(t)
-
 	invalidL7PortRule := Rule{
 		EndpointSelector: WildcardEndpointSelector,
 		Ingress: []IngressRule{
@@ -528,8 +524,6 @@ func TestL7RuleRejectsEmptyPort(t *testing.T) {
 // This test ensures that PortRules using the HTTP protocol have valid regular
 // expressions for the method and path fields.
 func TestHTTPRuleRegexes(t *testing.T) {
-	setUpSuite(t)
-
 	invalidHTTPRegexPathRule := Rule{
 		EndpointSelector: WildcardEndpointSelector,
 		Ingress: []IngressRule{
@@ -583,7 +577,6 @@ func TestHTTPRuleRegexes(t *testing.T) {
 
 // Test the validation of CIDR rule prefix definitions
 func TestCIDRsanitize(t *testing.T) {
-	setUpSuite(t)
 	sel := &slim_metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
 
 	cidr := CIDRRule{}
@@ -635,8 +628,6 @@ func TestCIDRsanitize(t *testing.T) {
 }
 
 func TestToServicesSanitize(t *testing.T) {
-	setUpSuite(t)
-
 	svcLabels := map[string]string{
 		"app": "tested-service",
 	}
@@ -697,8 +688,6 @@ func TestToServicesSanitize(t *testing.T) {
 
 // This test ensures that PortRules using key-value pairs do not have empty keys
 func TestL7Rules(t *testing.T) {
-	setUpSuite(t)
-
 	validL7Rule := Rule{
 		EndpointSelector: WildcardEndpointSelector,
 		Ingress: []IngressRule{
@@ -809,8 +798,6 @@ func TestPortRangesNotAllowedWithDNSRules(t *testing.T) {
 
 // This test ensures that host policies with L7 rules (except for DNS egress) are rejected.
 func TestL7RulesWithNodeSelector(t *testing.T) {
-	setUpSuite(t)
-
 	toPortsHTTP := []PortRule{{
 		Ports: []PortProtocol{
 			{Port: "80", Protocol: ProtoTCP},
@@ -902,8 +889,6 @@ func TestL7RulesWithNodeSelector(t *testing.T) {
 }
 
 func TestInvalidEndpointSelectors(t *testing.T) {
-	setUpSuite(t)
-
 	// Operator in MatchExpressions is invalid, so sanitization should fail.
 	labelSel := &slim_metav1.LabelSelector{
 		MatchLabels: map[string]string{
@@ -1042,8 +1027,6 @@ func TestInvalidEndpointSelectors(t *testing.T) {
 }
 
 func TestNodeSelector(t *testing.T) {
-	setUpSuite(t)
-
 	// Operator in MatchExpressions is invalid, so sanitization should fail.
 	labelSel := &slim_metav1.LabelSelector{
 		MatchLabels: map[string]string{
@@ -1082,8 +1065,6 @@ func TestNodeSelector(t *testing.T) {
 }
 
 func TestTooManyPortsRule(t *testing.T) {
-	setUpSuite(t)
-
 	var portProtocols []PortProtocol
 
 	for i := 80; i <= 80+maxPorts; i++ {
@@ -1127,8 +1108,6 @@ func TestTooManyPortsRule(t *testing.T) {
 }
 
 func TestInvalidIPProtocolRules(t *testing.T) {
-	setUpSuite(t)
-
 	nonZeroPortRule1 := Rule{
 		EndpointSelector: WildcardEndpointSelector,
 		Ingress: []IngressRule{
@@ -1173,8 +1152,6 @@ func TestInvalidIPProtocolRules(t *testing.T) {
 }
 
 func TestTooManyICMPFields(t *testing.T) {
-	setUpSuite(t)
-
 	var fields []ICMPField
 
 	for i := 1; i <= 1+maxICMPFields; i++ {
@@ -1218,8 +1195,6 @@ func TestTooManyICMPFields(t *testing.T) {
 }
 
 func TestWrongICMPFieldFamily(t *testing.T) {
-	setUpSuite(t)
-
 	icmpType := intstr.FromInt(0)
 	wrongFamilyICMPRule := Rule{
 		EndpointSelector: WildcardEndpointSelector,
@@ -1261,8 +1236,6 @@ func TestWrongICMPFieldFamily(t *testing.T) {
 }
 
 func TestICMPRuleWithOtherRuleFailed(t *testing.T) {
-	setUpSuite(t)
-
 	icmpType := intstr.FromInt(8)
 
 	ingressICMPWithPort := Rule{
@@ -1364,8 +1337,6 @@ func TestICMPRuleWithOtherRuleFailed(t *testing.T) {
 // which ends up being a no-op with only vague error messages rather than a
 // clear indication that something is wrong in the policy.
 func TestL7RuleDirectionalitySupport(t *testing.T) {
-	setUpSuite(t)
-
 	// Kafka egress is now supported.
 	egressKafkaRule := Rule{
 		EndpointSelector: WildcardEndpointSelector,

--- a/pkg/policy/api/rules_test.go
+++ b/pkg/policy/api/rules_test.go
@@ -19,8 +19,6 @@ import (
 // a collection of rules (via Rules.DeepEqual()) correctly validates the
 // equality of the rule or rules.
 func TestRulesDeepEqual(t *testing.T) {
-	setUpSuite(t)
-
 	var invalidRules *Rules
 
 	require.True(t, invalidRules.DeepEqual(nil))

--- a/pkg/policy/api/selector_test.go
+++ b/pkg/policy/api/selector_test.go
@@ -23,8 +23,6 @@ func selectorRequirementsConverter(t *testing.T, key string, sel selection.Opera
 }
 
 func TestSelectsAllEndpoints(t *testing.T) {
-	setUpSuite(t)
-
 	// Empty endpoint selector slice does NOT equate to a wildcard.
 	selectorSlice := EndpointSelectorSlice{}
 	require.False(t, selectorSlice.SelectsAllEndpoints())
@@ -45,8 +43,6 @@ func TestSelectsAllEndpoints(t *testing.T) {
 }
 
 func TestLabelSelectorToRequirements(t *testing.T) {
-	setUpSuite(t)
-
 	labelSelector := &slim_metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"any.foo": "bar",

--- a/pkg/policy/api/utils_test.go
+++ b/pkg/policy/api/utils_test.go
@@ -6,21 +6,11 @@ package api
 import (
 	"testing"
 
-	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/fqdn/re"
 )
 
-func setUpSuite(b testing.TB) {
-	re.InitRegexCompileLRU(hivetest.Logger(b), defaults.FQDNRegexCompileLRUSize)
-}
-
 func TestHTTPEqual(t *testing.T) {
-	setUpSuite(t)
-
 	rule1 := PortRuleHTTP{Path: "/foo$", Method: "GET", Headers: []string{"X-Test: Foo"}}
 	rule2 := PortRuleHTTP{Path: "/bar$", Method: "GET", Headers: []string{"X-Test: Foo"}}
 	rule3 := PortRuleHTTP{Path: "/foo$", Method: "GET", Headers: []string{"X-Test: Bar"}}
@@ -39,8 +29,6 @@ func TestHTTPEqual(t *testing.T) {
 }
 
 func TestKafkaEqual(t *testing.T) {
-	setUpSuite(t)
-
 	rule1 := kafka.PortRule{APIVersion: "1", APIKey: "foo", Topic: "topic1"}
 	rule2 := kafka.PortRule{APIVersion: "1", APIKey: "bar", Topic: "topic1"}
 	rule3 := kafka.PortRule{APIVersion: "1", APIKey: "foo", Topic: "topic2"}
@@ -55,8 +43,6 @@ func TestKafkaEqual(t *testing.T) {
 }
 
 func TestL7Equal(t *testing.T) {
-	setUpSuite(t)
-
 	rule1 := PortRuleL7{"Path": "/foo$", "Method": "GET"}
 	rule2 := PortRuleL7{"Path": "/bar$", "Method": "GET"}
 	rule3 := PortRuleL7{"Path": "/foo$", "Method": "GET", "extra": ""}
@@ -82,8 +68,6 @@ func TestL7Equal(t *testing.T) {
 }
 
 func TestValidateL4Proto(t *testing.T) {
-	setUpSuite(t)
-
 	require.NoError(t, L4Proto("TCP").Validate())
 	require.NoError(t, L4Proto("UDP").Validate())
 	require.NoError(t, L4Proto("ANY").Validate())
@@ -92,8 +76,6 @@ func TestValidateL4Proto(t *testing.T) {
 }
 
 func TestParseL4Proto(t *testing.T) {
-	setUpSuite(t)
-
 	p, err := ParseL4Proto("tcp")
 	require.Equal(t, ProtoTCP, p)
 	require.NoError(t, err)
@@ -111,8 +93,6 @@ func TestParseL4Proto(t *testing.T) {
 }
 
 func TestResourceQualifiedName(t *testing.T) {
-	setUpSuite(t)
-
 	// Empty resource name is passed through
 	name, updated := ResourceQualifiedName("", "", "")
 	require.Empty(t, name)
@@ -214,8 +194,6 @@ func TestResourceQualifiedName(t *testing.T) {
 }
 
 func TestParseQualifiedName(t *testing.T) {
-	setUpSuite(t)
-
 	// Empty name is passed through
 	namespace, name, resourceName := ParseQualifiedName("")
 	require.Empty(t, namespace)

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -20,9 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
-	"github.com/cilium/cilium/pkg/defaults"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
-	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -1945,7 +1943,6 @@ func addFQDNIdentity(fqdnSel api.FQDNSelector, c identity.IdentityMap) (id ident
 // Validate that incrementally deleted identities are handled properly when present in both CIDR and FQDN rules.
 func Test_IncrementalFQDNDeletion(t *testing.T) {
 	logger := hivetest.Logger(t)
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 	// Cache policy enforcement value from when test was ran to avoid pollution
 	// across tests.
 	oldPolicyEnable := GetPolicyEnabled()

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -18,9 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
-	"github.com/cilium/cilium/pkg/defaults"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
-	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -65,7 +63,6 @@ type testData struct {
 }
 
 func newTestData(logger *slog.Logger) *testData {
-	re.InitRegexCompileLRU(logger, defaults.FQDNRegexCompileLRUSize)
 
 	td := &testData{
 		sc:                testNewSelectorCache(logger, nil),


### PR DESCRIPTION
This code path has always annoyed me. It has led to bugs before such as #37355. We have a global singleton that needs explicit initialization, always a recipe for errors.

Switch the regex cache to the maintained (and already imported) hashicorp/go-lru package. Initialize the cache in `init()`, rather than requiring every single test and binary to initialize it.

One nice property of go-lru is that it doesn't initially allocate a buffer of the given size, so we don't need to restrict the size to 1 for one-off CLI programs. The default size is fine.

This allows us to remove the initialization code from lots and lots and lots of unit tests. Hooray.