### PR TITLE
.github/workflows: remove threshold 50m to show all files

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -94,11 +94,10 @@ jobs:
           df -h
           echo "# Usage for /mnt"
           sudo du --human-readable \
-                --threshold 50m \
                 -- /mnt
           if compgen -G "/mnt/.*" > /dev/null; then
             echo "# Hidden files in /mnt:"
-            sudo du --human-readable --threshold 50m -- /mnt/.* 2>/dev/null
+            sudo du --human-readable -- /mnt/.* 2>/dev/null
           fi
           echo "# Removing /mnt/tmp-pv.img"
           sudo rm -f '/mnt/tmp-pv.img'


### PR DESCRIPTION
There are still some files under /mnt. We would like to know which ones are they so that we can delete them.