### PR TITLE
Decrease e2e-upgrade tests time from 34 minutes to 20 minutes

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -104,7 +104,10 @@ jobs:
         id: generate-matrix
         run: |
           cd /tmp/generated/e2e
-          jq '[.[] | del(."key-one", ."key-two") | . as $entry | [$entry + {mode: "minor"}]] | flatten' configs.json > matrix.json
+          # Add "mode" and "operation" fields to each entry.
+          # Remove all entries that have "skip-upgrade" set to "true" and "operation" set to "downgrade"
+          # since they are incompatible.
+          jq '[.[] | del(."key-one", ."key-two") | . as $entry | [ $entry + {mode: "minor", operation: "upgrade"}, $entry + {mode: "minor", operation: "downgrade"}] | map(select(.operation != "downgrade" or .["skip-upgrade"] != "true"))] | flatten' configs.json > matrix.json
           echo "Generated matrix:"
           cat /tmp/generated/e2e/matrix.json
           echo "matrix=$(jq -c . < /tmp/generated/e2e/matrix.json)" >> $GITHUB_OUTPUT
@@ -150,6 +153,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
+        # Consider removing this
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables
@@ -318,7 +322,7 @@ jobs:
           sparse-checkout: |
             install/kubernetes/cilium
 
-      - name: Install Cilium ${{ matrix.skip-upgrade == 'true' && 'from main' || steps.vars.outputs.downgrade_version }}
+      - name: Install Cilium ${{ (matrix.skip-upgrade == 'true' || matrix.operation == 'downgrade') && 'from main' || steps.vars.outputs.downgrade_version }}
         shell: bash
         run: |
           kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
@@ -327,7 +331,7 @@ jobs:
             cilium encrypt create-key --auth-algo rfc4106-gcm-aes
           fi
 
-          if ${{ matrix.skip-upgrade != 'true' }}; then
+          if ${{ matrix.skip-upgrade != 'true' && matrix.operation == 'upgrade' }}; then
             cilium install ${{ steps.cilium-stable-config.outputs.config }} ${{ steps.kvstore.outputs.config }} --set extraConfig.boot-id-file=/var/run/cilium/boot_id
           else
             cilium install ${{ steps.cilium-newest-config.outputs.config }} ${{ steps.kvstore.outputs.config }} --set extraConfig.boot-id-file=/var/run/cilium/boot_id
@@ -363,7 +367,7 @@ jobs:
           echo "params=$CILIUM_INTERNAL_IPS" >> $GITHUB_OUTPUT
 
       - name: Start unencrypted packets check for upgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.encryption != '' && matrix.operation == 'upgrade' }}
         uses: ./.github/actions/bpftrace/start
         with:
           # disable the check for proxy traffic.
@@ -371,10 +375,11 @@ jobs:
           args: ${{ steps.bpftrace-params.outputs.params }} "false" "${{ matrix.encryption }}"
 
       - name: Start conn-disrupt-test
+        if: ${{ matrix.operation == 'upgrade' }}
         uses: ./.github/actions/conn-disrupt-test-setup
 
       - name: Upgrade Cilium
-        if: ${{ matrix.skip-upgrade != 'true' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.operation == 'upgrade' }}
         shell: bash
         run: |
           cilium upgrade \
@@ -388,17 +393,18 @@ jobs:
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
       - name: Assert that no unencrypted packets are leaked during upgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.encryption != '' && matrix.operation == 'upgrade' }}
         uses: ./.github/actions/bpftrace/check
 
       - name: Test Cilium ${{ matrix.skip-upgrade != 'true' && 'after upgrade' }}
+        if: ${{ matrix.operation == 'upgrade' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Start unencrypted packets check for connectivity tests after upgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.encryption != '' && matrix.operation == 'upgrade' }}
         uses: ./.github/actions/bpftrace/start
         with:
           # Enable the check for proxy traffic only if IPv4 is enabled.
@@ -407,6 +413,7 @@ jobs:
           args: ${{ steps.bpftrace-params.outputs.params }} "${{ matrix.ipv4 != 'false' }}" "${{ matrix.encryption }}"
 
       - name: Run sequential Cilium tests
+        if: ${{ matrix.operation == 'upgrade' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-sequential
@@ -414,6 +421,7 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Run concurrent Cilium tests
+        if: ${{ matrix.operation == 'upgrade' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-concurrent
@@ -422,6 +430,7 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Check for unexpected packet drops during connectivity tests
+        if: ${{ matrix.operation == 'upgrade' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-postcheck
@@ -429,10 +438,11 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after upgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.encryption != '' && matrix.operation == 'upgrade' }}
         uses: ./.github/actions/bpftrace/check
 
       - name: Features tested before downgrade
+        if: ${{ matrix.operation == 'upgrade' }}
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested before downgrade"
@@ -441,11 +451,11 @@ jobs:
       # Downgrade steps
 
       - name: Setup conn-disrupt-test before downgrading
-        if: ${{ matrix.skip-upgrade != 'true' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/conn-disrupt-test-setup
 
       - name: Start unencrypted packets check for downgrade
-        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/bpftrace/start
         with:
           # disable the check for proxy traffic.
@@ -453,7 +463,7 @@ jobs:
           args: ${{ steps.bpftrace-params.outputs.params }} "false" "${{ matrix.encryption }}"
 
       - name: Downgrade Cilium ${{ steps.vars.outputs.downgrade_version }}
-        if: ${{ matrix.skip-upgrade != 'true' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.operation == 'downgrade' }}
         shell: bash
         run: |
           cilium upgrade \
@@ -467,18 +477,18 @@ jobs:
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
       - name: Assert that no unencrypted packets are leaked during downgrade
-        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/bpftrace/check
 
       - name: Test Cilium after downgrade to ${{ steps.vars.outputs.downgrade_version }}
-        if: ${{ matrix.skip-upgrade != 'true' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Start unencrypted packets check for connectivity tests after downgrade
-        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/bpftrace/start
         with:
           # enable the check for proxy traffic.
@@ -486,7 +496,7 @@ jobs:
           args: ${{ steps.bpftrace-params.outputs.params }} "true" "${{ matrix.encryption }}"
 
       - name: Run sequential Cilium tests
-        if: ${{ matrix.skip-upgrade != 'true' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-sequential
@@ -494,7 +504,7 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Run concurrent Cilium tests
-        if: ${{ matrix.skip-upgrade != 'true' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-concurrent
@@ -503,7 +513,7 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Check for unexpected packet drops during connectivity tests
-        if: ${{ matrix.skip-upgrade != 'true' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-postcheck
@@ -511,11 +521,11 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after downgrade
-        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/bpftrace/check
 
       - name: Features tested after downgrade
-        if: ${{ matrix.skip-upgrade != 'true' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.operation == 'downgrade' }}
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested after downgrade"
@@ -535,7 +545,7 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/post-logic
         with:
-          artifacts_suffix: "${{ matrix.name }}"
+          artifacts_suffix: "${{ matrix.name }} - ${{ matrix.operation }}"
           job_status: "${{ job.status }}"
           capture_features_tested: false
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -432,23 +432,25 @@ jobs:
         if: ${{ matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/check
 
-      - name: Setup conn-disrupt-test before downgrading
-        uses: ./.github/actions/conn-disrupt-test-setup
-
       - name: Features tested before downgrade
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested before downgrade"
           json-filename: "${{ env.job_name }} (${{ matrix.name }}) - before downgrade"
 
+      # Downgrade steps
+
+      - name: Setup conn-disrupt-test before downgrading
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        uses: ./.github/actions/conn-disrupt-test-setup
+
       - name: Start unencrypted packets check for downgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/start
         with:
           # disable the check for proxy traffic.
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
           args: ${{ steps.bpftrace-params.outputs.params }} "false" "${{ matrix.encryption }}"
-
 
       - name: Downgrade Cilium ${{ steps.vars.outputs.downgrade_version }}
         if: ${{ matrix.skip-upgrade != 'true' }}
@@ -465,7 +467,7 @@ jobs:
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
       - name: Assert that no unencrypted packets are leaked during downgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/check
 
       - name: Test Cilium after downgrade to ${{ steps.vars.outputs.downgrade_version }}
@@ -476,7 +478,7 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Start unencrypted packets check for connectivity tests after downgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/start
         with:
           # enable the check for proxy traffic.
@@ -509,10 +511,11 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after downgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/check
 
       - name: Features tested after downgrade
+        if: ${{ matrix.skip-upgrade != 'true' }}
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested after downgrade"


### PR DESCRIPTION
At the moment, e2e-upgrade tests performs the following logical steps:

A Install "stable version"
B Upgrade to "main"
C Run connectivity tests
D Downgrade to "stable version"
E Run connectivity tests

With this PR we will be creating more matrix entry, named operation,
that allows us to split the tests into two.

Operation: "upgrade"
A Install "stable version"
B Upgrade to "main
C Run connectivity tests

Operation: "Downgrade"
B1 Install "main"
D Downgrade to "stable version"
E Run connectivity tests

As we are decreasing the number of steps each matrix combination
executes the tests times also decrease from an average of 34m to 20m.

The will gives us less 34.7% wait time at the expense of 23.7% more billing time.

A good way to visualize this is with the mermaid diagram where we can see that a chunk of 12-15 minutes is removed.
**Current w/ upgrade - downgrade**:
```mermaid
gantt
	title Setup & Test (26, 6.6-20250623.155211, none, true, {eth0,eth1}, true, vxlan, snat, true, true, mi...
	dateFormat x
	axisFormat %H:%M:%S
	Set up job : milestone, 1751634786000, 1751634791000
	Collect Workflow Telemetry : 1751634791000, 1751634792000
	Checkout context ref (trusted) : 1751634792000, 1751634796000
	Cleanup Disk space in runner : 1751634796000, 1751634852000
	Set Environment Variables : 1751634852000, 1751634852000
	Set up job variables : 1751634852000, 1751634852000
	Derive stable Cilium installation config : 1751634852000, 1751634852000
	Derive newest Cilium installation config : 1751634852000, 1751634853000
	Set Kind params : 1751634853000, 1751634853000
	Provision K8s on LVH VM : 1751634853000, 1751634964000
	Setup bootid file : 1751634964000, 1751634965000
	Start Cilium KVStore : done, 1751634965000, 1751634965000
	Install Cilium CLI : 1751634965000, 1751634968000
	Checkout pull request branch (NOT TRUSTED) : 1751634968000, 1751634969000
	Checkout v1.18 branch to get the Helm chart : 1751634969000, 1751634970000
	section A Install stable version / B1 Install main
	Install Cilium v1.18 : 1751634970000, 1751635078000
	Install node local DNS : done, 1751635078000, 1751635078000
	Prepare the bpftrace parameters : done, 1751635078000, 1751635078000
	section B Upgrade to main
	Start unencrypted packets check for upgrade : done, 1751635078000, 1751635078000
	Start conn-disrupt-test : 1751635078000, 1751635129000
	Upgrade Cilium : 1751635129000, 1751635261000
	Assert that no unencrypted packets are leaked during upgrade : done, 1751635261000, 1751635261000
	Test Cilium after upgrade : 1751635261000, 1751635272000
	section C Run connectivity tests
	Start unencrypted packets check for connectivity tests after upgrade : done, 1751635272000, 1751635272000
	Run sequential Cilium tests : 1751635272000, 1751635306000
	Run concurrent Cilium tests : 1751635306000, 1751635857000
	Check for unexpected packet drops during connectivity tests : 1751635857000, 1751635863000
	Assert that no unencrypted packets are leaked during connectivity tests after upgrade : done, 1751635863000, 1751635863000
	Features tested before downgrade : 1751635886000, 1751635889000
	section D Downgrade to stable version
	Setup conn-disrupt-test before downgrading : 1751635863000, 1751635886000
	Start unencrypted packets check for downgrade : done, 1751635889000, 1751635889000
	Downgrade Cilium v1.18 : 1751635889000, 1751636015000
	Assert that no unencrypted packets are leaked during downgrade : done, 1751636015000, 1751636015000
	Test Cilium after downgrade to v1.18 : 1751636015000, 1751636026000
	section E Run connectivity tests
	Start unencrypted packets check for connectivity tests after downgrade : done, 1751636026000, 1751636026000
	Run sequential Cilium tests : 1751636026000, 1751636061000
	Run concurrent Cilium tests : 1751636061000, 1751636599000
	Check for unexpected packet drops during connectivity tests : 1751636599000, 1751636606000
	Assert that no unencrypted packets are leaked during connectivity tests after downgrade : done, 1751636606000, 1751636606000
	Features tested after downgrade : 1751636608000, 1751636608000
    section  
	Fetch artifacts : done, 1751636608000, 1751636608000
	Run common post steps : 1751636608000, 1751636615000
	Post Run common post steps : 1751636615000, 1751636615000
	Post Checkout v1.18 branch to get the Helm chart : 1751636615000, 1751636615000
	Post Checkout pull request branch (NOT TRUSTED) : 1751636615000, 1751636615000
	Post Install Cilium CLI : 1751636615000, 1751636615000
	Post Setup bootid file : 1751636615000, 1751636615000
	Post Provision K8s on LVH VM : 1751636615000, 1751636616000
	Post Derive newest Cilium installation config : 1751636616000, 1751636616000
	Post Derive stable Cilium installation config : 1751636616000, 1751636616000
	Post Checkout context ref (trusted) : 1751636616000, 1751636616000
```
**After - Upgrade only**:
```mermaid
gantt
	title Setup & Test (26, 6.6-20250623.155211, none, true, {eth0,eth1}, true, vxlan, snat, true, true, mi...
	dateFormat x
	axisFormat %H:%M:%S
	Set up job : milestone, 1751634786000, 1751634791000
	Collect Workflow Telemetry : 1751634791000, 1751634792000
	Checkout context ref (trusted) : 1751634792000, 1751634796000
	Cleanup Disk space in runner : 1751634796000, 1751634852000
	Set Environment Variables : 1751634852000, 1751634852000
	Set up job variables : 1751634852000, 1751634852000
	Derive stable Cilium installation config : 1751634852000, 1751634852000
	Derive newest Cilium installation config : 1751634852000, 1751634853000
	Set Kind params : 1751634853000, 1751634853000
	Provision K8s on LVH VM : 1751634853000, 1751634964000
	Setup bootid file : 1751634964000, 1751634965000
	Start Cilium KVStore : done, 1751634965000, 1751634965000
	Install Cilium CLI : 1751634965000, 1751634968000
	Checkout pull request branch (NOT TRUSTED) : 1751634968000, 1751634969000
	Checkout v1.18 branch to get the Helm chart : 1751634969000, 1751634970000
	section A Install stable version
	Install Cilium v1.18 : 1751634970000, 1751635078000
	Install node local DNS : done, 1751635078000, 1751635078000
	Prepare the bpftrace parameters : done, 1751635078000, 1751635078000
	section B Upgrade to main
	Start unencrypted packets check for upgrade : done, 1751635078000, 1751635078000
	Start conn-disrupt-test : 1751635078000, 1751635129000
	Upgrade Cilium : 1751635129000, 1751635261000
	Assert that no unencrypted packets are leaked during upgrade : done, 1751635261000, 1751635261000
	Test Cilium after upgrade : 1751635261000, 1751635272000
	section C Run connectivity tests
	Start unencrypted packets check for connectivity tests after upgrade : done, 1751635272000, 1751635272000
	Run sequential Cilium tests : 1751635272000, 1751635306000
	Run concurrent Cilium tests : 1751635306000, 1751635857000
	Check for unexpected packet drops during connectivity tests : 1751635857000, 1751635863000
	Assert that no unencrypted packets are leaked during connectivity tests after upgrade : done, 1751635863000, 1751635863000
	Setup conn-disrupt-test before downgrading : 1751635863000, 1751635886000
	Features tested before downgrade : 1751635886000, 1751635889000
	section  
	Fetch artifacts : done, 1751636608000, 1751636608000
	Run common post steps : 1751636608000, 1751636615000
	Post Run common post steps : 1751636615000, 1751636615000
	Post Checkout v1.18 branch to get the Helm chart : 1751636615000, 1751636615000
	Post Checkout pull request branch (NOT TRUSTED) : 1751636615000, 1751636615000
	Post Install Cilium CLI : 1751636615000, 1751636615000
	Post Setup bootid file : 1751636615000, 1751636615000
	Post Provision K8s on LVH VM : 1751636615000, 1751636616000
	Post Derive newest Cilium installation config : 1751636616000, 1751636616000
	Post Derive stable Cilium installation config : 1751636616000, 1751636616000
	Post Checkout context ref (trusted) : 1751636616000, 1751636616000
```

**After - Downgrade only**:
```mermaid
gantt
	title Setup & Test (26, 6.6-20250623.155211, none, true, {eth0,eth1}, true, vxlan, snat, true, true, mi...
	dateFormat x
	axisFormat %H:%M:%S
	Set up job : milestone, 1751634786000, 1751634791000
	Collect Workflow Telemetry : 1751634791000, 1751634792000
	Checkout context ref (trusted) : 1751634792000, 1751634796000
	Cleanup Disk space in runner : 1751634796000, 1751634852000
	Set Environment Variables : 1751634852000, 1751634852000
	Set up job variables : 1751634852000, 1751634852000
	Derive stable Cilium installation config : 1751634852000, 1751634852000
	Derive newest Cilium installation config : 1751634852000, 1751634853000
	Set Kind params : 1751634853000, 1751634853000
	Provision K8s on LVH VM : 1751634853000, 1751634964000
	Setup bootid file : 1751634964000, 1751634965000
	Start Cilium KVStore : done, 1751634965000, 1751634965000
	Install Cilium CLI : 1751634965000, 1751634968000
	Checkout pull request branch (NOT TRUSTED) : 1751634968000, 1751634969000
	Checkout v1.18 branch to get the Helm chart : 1751634969000, 1751634970000
	section A Install main
	Install Cilium main : 1751634970000, 1751635078000
	Install node local DNS : done, 1751635078000, 1751635078000
	Prepare the bpftrace parameters : done, 1751635078000, 1751635078000
	section D Downgrade to stable version
	Setup conn-disrupt-test before downgrading : 1751635863000, 1751635886000
	Start unencrypted packets check for downgrade : done, 1751635889000, 1751635889000
	Downgrade Cilium v1.18 : 1751635889000, 1751636015000
	Assert that no unencrypted packets are leaked during downgrade : done, 1751636015000, 1751636015000
	Test Cilium after downgrade to v1.18 : 1751636015000, 1751636026000
	section E Run connectivity tests
	Start unencrypted packets check for connectivity tests after downgrade : done, 1751636026000, 1751636026000
	Run sequential Cilium tests : 1751636026000, 1751636061000
	Run concurrent Cilium tests : 1751636061000, 1751636599000
	Check for unexpected packet drops during connectivity tests : 1751636599000, 1751636606000
	Assert that no unencrypted packets are leaked during connectivity tests after downgrade : done, 1751636606000, 1751636606000
	Features tested after downgrade : 1751636608000, 1751636608000
    section  
	Fetch artifacts : done, 1751636608000, 1751636608000
	Run common post steps : 1751636608000, 1751636615000
	Post Run common post steps : 1751636615000, 1751636615000
	Post Checkout v1.18 branch to get the Helm chart : 1751636615000, 1751636615000
	Post Checkout pull request branch (NOT TRUSTED) : 1751636615000, 1751636615000
	Post Install Cilium CLI : 1751636615000, 1751636615000
	Post Setup bootid file : 1751636615000, 1751636615000
	Post Provision K8s on LVH VM : 1751636615000, 1751636616000
	Post Derive newest Cilium installation config : 1751636616000, 1751636616000
	Post Derive stable Cilium installation config : 1751636616000, 1751636616000
	Post Checkout context ref (trusted) : 1751636616000, 1751636616000
```

