### PR TITLE
workflows/tests-datapath-verifier: Test mcpu v3 with RHEL 8.6 kernel

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -88,7 +88,7 @@ jobs:
         include:
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: 'rhel8.6-20250630.013259'
-            ci-kernel: '54'
+            ci-kernel: '510'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '5.10-20250630.013259'
             ci-kernel: '510'

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1942,6 +1942,12 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *)&iphdr.saddr);
 	tuple.flags = NAT_DIR_INGRESS;
 
+	/* Force tuple to be on the stack, a fix for a odd compiler bug
+	 * where the above assignment would be optimized to be reads
+	 * from the ctx->data pointer instead.
+	 */
+	asm volatile ("" ::"r"(&tuple));
+
 	hdrlen = ipv6_hdrlen_offset(ctx, inner_l3_off, &tuple.nexthdr, &fraginfo);
 	if (hdrlen < 0)
 		return hdrlen;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2541,7 +2541,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	ctx_snat_done_set(ctx);
 
 #ifdef TUNNEL_MODE
-	if (tunnel_endpoint) {
+	if (info && tunnel_endpoint) {
 		__be16 src_port;
 
 		src_port = tunnel_gen_src_port_v4(&tuple);


### PR DESCRIPTION
Currently when compiling verifier tests we use a mcpu value that is based on a kernel version number passed in by the test matrix. For RHEL 8.6 we had it set at `54`. For `54` specifically we were compiling with `mcpu=v2` instead of `mcpu=v3` which we use for all other kernels. However, while working on https://github.com/cilium/cilium/pull/40367 I discovered that the probe we use during runtime to detect mcpu version tells us that RHEL 8.6 should use `v3` as well.

So, that means that our CI is not aligned with what we actually run. Furthermore, when you change the value (the first commit in this PR) it actually breaks the complexity tests. The other two commits in this PR tweak the code so the compiler emits bytecode that passes RHEL 8.6 when under `mcpu=v3`. See the commit messages for details.

```release-note
make verifier complexity tests on RHEL 8.6 run with mcpu=v3
```
