### PR TITLE
helm: set agent terminationGracePeriod to 10 seconds

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3435,7 +3435,7 @@
    * - :spelling:ignore:`terminationGracePeriodSeconds`
      - Configure termination grace period for cilium-agent DaemonSet.
      - int
-     - ``1``
+     - ``10``
    * - :spelling:ignore:`tls`
      - Configure TLS configuration in the agent.
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -908,7 +908,7 @@ contributors across the globe, there is almost always someone available to help.
 | synchronizeK8sNodes | bool | `true` | Synchronize Kubernetes nodes to kvstore and perform CNP GC. |
 | sysctlfix | object | `{"enabled":true}` | Configure sysctl override described in #20072. |
 | sysctlfix.enabled | bool | `true` | Enable the sysctl override. When enabled, the init container will mount the /proc of the host so that the `sysctlfix` utility can execute. |
-| terminationGracePeriodSeconds | int | `1` | Configure termination grace period for cilium-agent DaemonSet. |
+| terminationGracePeriodSeconds | int | `10` | Configure termination grace period for cilium-agent DaemonSet. |
 | tls | object | `{"ca":{"cert":"","certValidityDuration":1095,"key":""},"caBundle":{"enabled":false,"key":"ca.crt","name":"cilium-root-ca.crt","useSecret":false},"readSecretsOnlyFromSecretsNamespace":null,"secretSync":{"enabled":null},"secretsBackend":null,"secretsNamespace":{"create":true,"name":"cilium-secrets"}}` | Configure TLS configuration in the agent. |
 | tls.ca | object | `{"cert":"","certValidityDuration":1095,"key":""}` | Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components. It is neither required nor used when cert-manager is used to generate the certificates. |
 | tls.ca.cert | string | `""` | Optional CA cert. If it is provided, it will be used by cilium to generate all other certificates. Otherwise, an ephemeral CA is generated. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -205,7 +205,7 @@ serviceAccounts:
     automount: true
     annotations: {}
 # -- Configure termination grace period for cilium-agent DaemonSet.
-terminationGracePeriodSeconds: 1
+terminationGracePeriodSeconds: 10
 # -- Install the cilium agent resources.
 agent: true
 # -- Agent daemonset name.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -208,7 +208,7 @@ serviceAccounts:
     automount: true
     annotations: {}
 # -- Configure termination grace period for cilium-agent DaemonSet.
-terminationGracePeriodSeconds: 1
+terminationGracePeriodSeconds: 10
 # -- Install the cilium agent resources.
 agent: true
 # -- Agent daemonset name.


### PR DESCRIPTION
There are a number of items that need to run while the agent is shutting down. Ideally, these all complete very quickly, but 1 second is very short. Let's give ourselves 10 seconds to shut down.

```release-note
The cilium agent now waits for up to 10 seconds for shutdown tasks to finish.
```
