### PR TITLE
[v1.18] monitor: fix cache references + overlay and L3 packets decoding support in Dissect

### DIFF
--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -499,7 +499,7 @@ func (n *DebugCapture) DumpVerbose(dissect bool, data []byte, prefix string) {
 	fmt.Println(n.subTypeString())
 
 	if n.Len > 0 && len(data) > DebugCaptureLen {
-		Dissect(dissect, data[DebugCaptureLen:])
+		Dissect(dissect, data[DebugCaptureLen:], nil)
 	}
 }
 

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -186,7 +186,7 @@ func (n *DropNotify) getJSON(data []byte, cpuPrefix string) (string, error) {
 	v := DropNotifyToVerbose(n)
 	v.CPUPrefix = cpuPrefix
 	if offset := int(n.DataOffset()); n.CapLen > 0 && len(data) > offset {
-		v.Summary = GetDissectSummary(data[offset:])
+		v.Summary = GetDissectSummary(data[offset:], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()})
 	}
 
 	ret, err := json.Marshal(v)

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -176,7 +176,7 @@ func (n *DropNotify) DumpVerbose(dissect bool, data []byte, prefix string, numer
 	}
 
 	if offset := int(n.DataOffset()); n.CapLen > 0 && len(data) > offset {
-		Dissect(dissect, data[offset:])
+		Dissect(dissect, data[offset:], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()})
 	}
 	buf.Flush()
 }

--- a/pkg/monitor/datapath_recorder.go
+++ b/pkg/monitor/datapath_recorder.go
@@ -36,7 +36,7 @@ func (n *RecorderCapture) DumpInfo(data []byte) {
 	fmt.Fprintf(buf, "Recorder capture: dir:%s rule:%d ts:%d caplen:%d len:%d\n",
 		dir, int(n.RuleID), int(n.TimeBoot), int(n.CapLen), int(n.Len))
 	buf.Flush()
-	Dissect(true, data[RecorderCaptureLen:])
+	Dissect(true, data[RecorderCaptureLen:], nil)
 	fmt.Fprintf(buf, "----\n")
 	buf.Flush()
 }

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -345,7 +345,7 @@ func (n *TraceNotify) getJSON(data []byte, cpuPrefix string, linkMonitor getters
 	v.CPUPrefix = cpuPrefix
 	hdrLen := n.DataOffset()
 	if n.CapLen > 0 && len(data) > int(hdrLen) {
-		v.Summary = GetDissectSummary(data[hdrLen:])
+		v.Summary = GetDissectSummary(data[hdrLen:], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()})
 	}
 
 	ret, err := json.Marshal(v)

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -335,7 +335,7 @@ func (n *TraceNotify) DumpVerbose(dissect bool, data []byte, prefix string, nume
 
 	hdrLen := n.DataOffset()
 	if n.CapLen > 0 && len(data) > int(hdrLen) {
-		Dissect(dissect, data[hdrLen:])
+		Dissect(dissect, data[hdrLen:], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()})
 	}
 	buf.Flush()
 }

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -141,6 +141,15 @@ func getTCPInfo(isOverlay bool) string {
 	return info
 }
 
+func getEthInfo(isOverlay bool) string {
+	target := cache.eth
+	if isOverlay {
+		target = cache.overlay.eth
+	}
+
+	return fmt.Sprintf("%s -> %s %s", target.SrcMAC, target.DstMAC, target.EthernetType.String())
+}
+
 // ConnectionInfo contains tuple information and icmp code for a connection
 type ConnectionInfo struct {
 	SrcIP    net.IP
@@ -315,7 +324,7 @@ func GetConnectionSummary(data []byte, opts *decodeOpts) string {
 	case hasIP:
 		str += fmt.Sprintf("%s -> %s", c.SrcIP, c.DstIP)
 	case hasEth:
-		str += fmt.Sprintf("%s -> %s %s", cache.eth.SrcMAC, cache.eth.DstMAC, cache.eth.EthernetType.String())
+		str += getEthInfo(c.isOverlay())
 	default:
 		str += "[unknown]"
 	}

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -454,6 +454,19 @@ type Flow struct {
 	Dst string `json:"dst"`
 }
 
+// Tunnel holds VXLAN or GENEVE tunnel info for DissectSummary.
+type Tunnel struct {
+	Ethernet string `json:"ethernet,omitempty"`
+	IPv4     string `json:"ipv4,omitempty"`
+	IPv6     string `json:"ipv6,omitempty"`
+	UDP      string `json:"udp,omitempty"`
+	VXLAN    string `json:"vxlan,omitempty"`
+	GENEVE   string `json:"geneve,omitempty"`
+	L2       *Flow  `json:"l2,omitempty"`
+	L3       *Flow  `json:"l3,omitempty"`
+	L4       *Flow  `json:"l4,omitempty"`
+}
+
 // DissectSummary bundles decoded layers into json-marshallable message
 type DissectSummary struct {
 	Ethernet string `json:"ethernet,omitempty"`
@@ -467,23 +480,37 @@ type DissectSummary struct {
 	L2       *Flow  `json:"l2,omitempty"`
 	L3       *Flow  `json:"l3,omitempty"`
 	L4       *Flow  `json:"l4,omitempty"`
+
+	Tunnel *Tunnel `json:"tunnel,omitempty"`
 }
 
 // GetDissectSummary returns DissectSummary created from data
-func GetDissectSummary(data []byte) *DissectSummary {
+func GetDissectSummary(data []byte, opts *decodeOpts) *DissectSummary {
 	dissectLock.Lock()
 	defer dissectLock.Unlock()
 
 	initParser()
 
 	// See comment in [GetConnectionSummary].
-	if len(data) > 0 {
-		err := parserL2Dev.DecodeLayers(data, &cache.decoded)
-		if err != nil {
-			return nil
-		}
-	} else {
+	if len(data) == 0 {
 		cache.decoded = cache.decoded[:0]
+		cache.overlay.decoded = cache.overlay.decoded[:0]
+		return nil
+	}
+
+	var err error
+	// See comment in [GetConnectionSummary].
+	switch {
+	case opts == nil || !opts.IsL3Device:
+		err = parserL2Dev.DecodeLayers(data, &cache.decoded)
+	case opts.IsIPv6:
+		err = parserL3Dev.IPv6.DecodeLayers(data, &cache.decoded)
+	default:
+		err = parserL3Dev.IPv4.DecodeLayers(data, &cache.decoded)
+	}
+
+	if err != nil {
+		return nil
 	}
 
 	ret := &DissectSummary{}
@@ -520,5 +547,82 @@ func GetDissectSummary(data []byte) *DissectSummary {
 			ret.ICMPv6 = gopacket.LayerString(&cache.icmp6)
 		}
 	}
+
+	// See comment in [GetConnectionSummary].
+	switch {
+	case opts != nil && opts.IsVXLAN:
+		err = parserOverlay.VXLAN.DecodeLayers(cache.udp.Payload, &cache.overlay.decoded)
+	case opts != nil && opts.IsGeneve:
+		err = parserOverlay.Geneve.DecodeLayers(cache.udp.Payload, &cache.overlay.decoded)
+	default:
+		// Truncate layers to avoid accidental re-use.
+		cache.overlay.decoded = cache.overlay.decoded[:0]
+		return ret
+	}
+
+	if err != nil {
+		return ret
+	}
+
+	if len(cache.overlay.decoded) == 0 {
+		return ret
+	}
+
+	// See comment in [GetConnectionSummary].
+	// In case of VXLAN/GENEVE, let's move decoded layers inside the Tunnel
+	// field, and keep decoding after overlay headers.
+	switch cache.overlay.decoded[0] {
+	case layers.LayerTypeVXLAN, layers.LayerTypeGeneve:
+		ret = &DissectSummary{Tunnel: &Tunnel{
+			Ethernet: ret.Ethernet,
+			IPv4:     ret.IPv4,
+			IPv6:     ret.IPv6,
+			UDP:      ret.UDP,
+			L2:       ret.L2,
+			L3:       ret.L3,
+			L4:       ret.L4,
+		}}
+		if cache.overlay.decoded[0] == layers.LayerTypeVXLAN {
+			ret.Tunnel.VXLAN = gopacket.LayerString(&cache.overlay.vxlan)
+		} else {
+			ret.Tunnel.GENEVE = gopacket.LayerString(&cache.overlay.geneve)
+		}
+	default:
+		return ret
+	}
+
+	for _, typ := range cache.overlay.decoded[1:] {
+		switch typ {
+		case layers.LayerTypeEthernet:
+			ret.Ethernet = gopacket.LayerString(&cache.overlay.eth)
+			src, dst := cache.overlay.eth.LinkFlow().Endpoints()
+			ret.L2 = &Flow{Src: src.String(), Dst: dst.String()}
+		case layers.LayerTypeIPv4:
+			ret.IPv4 = gopacket.LayerString(&cache.overlay.ip4)
+			src, dst := cache.overlay.ip4.NetworkFlow().Endpoints()
+			ret.L3 = &Flow{Src: src.String(), Dst: dst.String()}
+		case layers.LayerTypeIPv6:
+			ret.IPv6 = gopacket.LayerString(&cache.overlay.ip6)
+			src, dst := cache.overlay.ip6.NetworkFlow().Endpoints()
+			ret.L3 = &Flow{Src: src.String(), Dst: dst.String()}
+		case layers.LayerTypeTCP:
+			ret.TCP = gopacket.LayerString(&cache.overlay.tcp)
+			src, dst := cache.overlay.tcp.TransportFlow().Endpoints()
+			ret.L4 = &Flow{Src: src.String(), Dst: dst.String()}
+		case layers.LayerTypeUDP:
+			ret.UDP = gopacket.LayerString(&cache.overlay.udp)
+			src, dst := cache.overlay.udp.TransportFlow().Endpoints()
+			ret.L4 = &Flow{Src: src.String(), Dst: dst.String()}
+		case layers.LayerTypeSCTP:
+			ret.SCTP = gopacket.LayerString(&cache.overlay.sctp)
+			src, dst := cache.overlay.sctp.TransportFlow().Endpoints()
+			ret.L4 = &Flow{Src: src.String(), Dst: dst.String()}
+		case layers.LayerTypeICMPv4:
+			ret.ICMPv4 = gopacket.LayerString(&cache.overlay.icmp4)
+		case layers.LayerTypeICMPv6:
+			ret.ICMPv6 = gopacket.LayerString(&cache.overlay.icmp6)
+		}
+	}
+
 	return ret
 }

--- a/pkg/monitor/dissect_test.go
+++ b/pkg/monitor/dissect_test.go
@@ -23,24 +23,100 @@ func TestDissectSummary(t *testing.T) {
 	sport := "80"
 	dport := "443"
 
-	// Generated in scapy:
-	// Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/TCP(sport=80,dport=443)
-	packetData := []byte{2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 2, 32, 0, 125, 196, 0, 0}
+	for _, c := range []struct {
+		Name       string
+		IsL3Device bool
+	}{{"L3Device", true}, {"L2Device", false}} {
+		t.Run(c.Name, func(t *testing.T) {
+			// Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/TCP(sport=80,dport=443,flags="A")
+			data := []byte{2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 16, 32, 0, 125, 182, 0, 0}
+			if c.IsL3Device {
+				// Remove ethernet layer.
+				data = data[14:]
+			}
+			summary := GetDissectSummary(data, &decodeOpts{IsL3Device: c.IsL3Device})
 
-	summary := GetDissectSummary(packetData)
+			if c.IsL3Device {
+				require.Empty(t, summary.Ethernet)
+			} else {
+				require.NotEmpty(t, summary.Ethernet)
+			}
 
-	require.NotEmpty(t, summary.Ethernet)
-	require.NotEmpty(t, summary.IPv4)
-	require.NotEmpty(t, summary.TCP)
+			require.NotEmpty(t, summary.IPv4)
+			require.NotEmpty(t, summary.TCP)
 
-	require.Equal(t, srcMAC, summary.L2.Src)
-	require.Equal(t, dstMAC, summary.L2.Dst)
+			if c.IsL3Device {
+				require.Nil(t, summary.L2)
+			} else {
+				require.Equal(t, srcMAC, summary.L2.Src)
+				require.Equal(t, dstMAC, summary.L2.Dst)
+			}
 
-	require.Equal(t, srcIP, summary.L3.Src)
-	require.Equal(t, dstIP, summary.L3.Dst)
+			require.Equal(t, srcIP, summary.L3.Src)
+			require.Equal(t, dstIP, summary.L3.Dst)
 
-	require.Equal(t, sport, summary.L4.Src)
-	require.Equal(t, dport, summary.L4.Dst)
+			require.Equal(t, sport, summary.L4.Src)
+			require.Equal(t, dport, summary.L4.Dst)
+
+		})
+	}
+
+	srcMacOuter := "01:02:03:04:05:06"
+	dstMacOuter := "11:12:13:14:15:16"
+
+	srcIPOuter := "1.1.1.1"
+	dstIPOuter := "2.2.2.2"
+
+	sportOuter := "8472"
+	dportOuter := "9999"
+
+	for _, c := range []struct {
+		Name string
+		Flag string
+		Data []byte
+	}{
+		// Ether(src="01:02:03:04:05:06", dst="11:12:13:14:15:16")/IP(src="1.1.1.1",dst="2.2.2.2")/UDP(sport=8472,dport=9999)/VXLAN(vni=2)/Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/TCP(sport=80,dport=443,flags="S")
+		{"VXLAN", "SYN", []byte{17, 18, 19, 20, 21, 22, 1, 2, 3, 4, 5, 6, 8, 0, 69, 0, 0, 90, 0, 1, 0, 0, 64, 17, 116, 141, 1, 1, 1, 1, 2, 2, 2, 2, 33, 24, 39, 15, 0, 70, 9, 229, 12, 0, 0, 3, 0, 0, 2, 0, 2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 2, 32, 0, 125, 196, 0, 0}},
+		// Ether(src="01:02:03:04:05:06", dst="11:12:13:14:15:16")/IP(src="1.1.1.1",dst="2.2.2.2")/UDP(sport=8472,dport=9999)/GENEVE(vni=2,proto=0x6558)/Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/TCP(sport=80,dport=443,flags="A")
+		{"Geneve", "ACK", []byte{17, 18, 19, 20, 21, 22, 1, 2, 3, 4, 5, 6, 8, 0, 69, 0, 0, 90, 0, 1, 0, 0, 64, 17, 116, 141, 1, 1, 1, 1, 2, 2, 2, 2, 33, 24, 39, 15, 0, 70, 176, 143, 0, 0, 101, 88, 0, 0, 2, 0, 2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 16, 32, 0, 125, 182, 0, 0}},
+	} {
+		t.Run(c.Name, func(t *testing.T) {
+			summary := GetDissectSummary(c.Data, &decodeOpts{IsVXLAN: c.Name == "VXLAN", IsGeneve: c.Name == "Geneve"})
+
+			require.NotEmpty(t, summary.Ethernet)
+			require.NotEmpty(t, summary.IPv4)
+			require.NotEmpty(t, summary.TCP)
+
+			require.Equal(t, srcMAC, summary.L2.Src)
+			require.Equal(t, dstMAC, summary.L2.Dst)
+
+			require.Equal(t, srcIP, summary.L3.Src)
+			require.Equal(t, dstIP, summary.L3.Dst)
+
+			require.Equal(t, sport, summary.L4.Src)
+			require.Equal(t, dport, summary.L4.Dst)
+
+			require.NotNil(t, summary.Tunnel)
+			require.NotEmpty(t, summary.Tunnel.Ethernet)
+			require.NotEmpty(t, summary.Tunnel.IPv4)
+			require.NotEmpty(t, summary.Tunnel.UDP)
+			switch c.Name {
+			case "VXLAN":
+				require.NotEmpty(t, summary.Tunnel.VXLAN)
+			case "GENEVE":
+				require.NotEmpty(t, summary.Tunnel.GENEVE)
+			}
+
+			require.Equal(t, srcMacOuter, summary.Tunnel.L2.Src)
+			require.Equal(t, dstMacOuter, summary.Tunnel.L2.Dst)
+
+			require.Equal(t, srcIPOuter, summary.Tunnel.L3.Src)
+			require.Equal(t, dstIPOuter, summary.Tunnel.L3.Dst)
+
+			require.Equal(t, sportOuter, summary.Tunnel.L4.Src)
+			require.Equal(t, dportOuter, summary.Tunnel.L4.Dst)
+		})
+	}
 }
 
 func TestConnectionSummaryTcp(t *testing.T) {


### PR DESCRIPTION
Manual backport of:

* https://github.com/cilium/cilium/pull/40308
* https://github.com/cilium/cilium/pull/40307

Doing to soften the pain for future fixes/changes to the script.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 40308 40307
```