### PR TITLE
doc:monitor: clarify direction traced with default aggregation level

### DIFF
--- a/Documentation/network/kubernetes/configuration.rst
+++ b/Documentation/network/kubernetes/configuration.rst
@@ -49,9 +49,9 @@ to your preferences:
 
   - ``none`` - Generate a tracing event on every receive and send packet.
   - ``low`` - Generate a tracing event on every send packet.
-  - ``medium`` - Generate a tracing event on every new connection, any time a
-    packet contains TCP flags that have not been previously seen for the packet
-    direction, and on average once per ``monitor-aggregation-interval``
+  - ``medium`` - Generate a tracing event for send packets only on every new
+    connection, any time a packet contains TCP flags that have not been previously
+    seen for the packet direction, and on average once per ``monitor-aggregation-interval``
     (assuming that a packet is seen during the interval). Each direction tracks
     TCP flags and report interval separately. If Cilium drops a packet, it will
     emit one event per packet dropped.

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -447,9 +447,10 @@ should consider increasing the aggregation interval or rate limiting events.
 Increase Aggregation Interval
 -----------------------------
 
-By default Cilium generates a tracing event on every new connection, any time a packet
-contains TCP flags that have not been previously seen for the packet direction, and on
-average once per ``monitor-aggregation-interval``, which defaults to 5 seconds.
+By default Cilium generates a tracing event for send packets only on every new
+connection, any time a packet contains TCP flags that have not been previously
+seen for the packet direction, and on average once per ``monitor-aggregation-interval``,
+which defaults to 5 seconds.
 
 Depending on your network traffic patterns, the re-emitting of trace events per
 aggregation interval can make up a large part of the total events. Increasing the


### PR DESCRIPTION
We do rely on monitorAggregation value to know which/when tracing network packets in our datapath. The current default `medium` level allows tracing ONLY send packets matching the conditions correctly described in the documentation. However, prior to this commit, we did not specify the `send direction only` in its definition, causing potential misinterpretation.