### PR TITLE
certloader: Add client variants of watched TLS configs

### DIFF
--- a/pkg/crypto/certloader/cell.go
+++ b/pkg/crypto/certloader/cell.go
@@ -16,17 +16,16 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-// Config is the configuration for NewWatchedServerConfigPromise.
+// Config is the configuration for NewWatchedServerConfigPromise and NewWatchedClientConfigPromise.
 type Config struct {
-	// Enable TLS watched server configuration.
+	// Enable TLS watched configuration.
 	TLS bool
 	// Path to a TLS public certificate file. The file must contain PEM encoded data.
 	TLSCertFile string
 	// Path to a TLS private key file. The file must contain PEM encoded data.
 	TLSKeyFile string
 	// Paths to one or more TLS public client CA certificates files to use for TLS with mutual
-	// authentication (mTLS). The files must contain PEM encoded data. When provided, this option
-	// effectively enables mTLS.
+	// authentication (mTLS). The files must contain PEM encoded data.
 	TLSClientCAFiles []string
 }
 
@@ -39,7 +38,7 @@ type Config struct {
 // and the promise provided wrapped in another type to avoid possible conflicts/replacements
 // when used multiple times in the same hive.
 func NewWatchedServerConfigPromise(lc cell.Lifecycle, jobGroup job.Group, log *slog.Logger, cfg Config) (promise.Promise[*WatchedServerConfig], error) {
-	log = log.With(logfields.Config, "certloader-tls")
+	log = log.With(logfields.Config, "certloader-server-tls")
 	if !cfg.TLS {
 		log.Info("Certloader TLS watcher disabled")
 		return nil, nil
@@ -47,29 +46,87 @@ func NewWatchedServerConfigPromise(lc cell.Lifecycle, jobGroup job.Group, log *s
 
 	resolver, promise := promise.New[*WatchedServerConfig]()
 
-	jobGroup.Add(job.OneShot("certloader-tls", func(ctx context.Context, _ cell.Health) error {
-		metricsTLSConfigChan, err := FutureWatchedServerConfig(
+	jobGroup.Add(job.OneShot("certloader-server-tls", func(ctx context.Context, _ cell.Health) error {
+		watchedConfigChan, err := FutureWatchedServerConfig(
 			ctx, log,
 			cfg.TLSClientCAFiles, cfg.TLSCertFile, cfg.TLSKeyFile,
 		)
 		if err != nil {
-			err := fmt.Errorf("failed to initialize certloader TLS configuration: %w", err)
+			err := fmt.Errorf("failed to initialize certloader TLS watched server configuration: %w", err)
 			resolver.Reject(err)
 			return err
 		}
 
 		waitingMsgTimeout := time.After(30 * time.Second)
-		var metricsTLSConfig *WatchedServerConfig
-		for metricsTLSConfig == nil {
+		var watchedConfig *WatchedServerConfig
+		for watchedConfig == nil {
 			select {
-			case metricsTLSConfig = <-metricsTLSConfigChan:
+			case watchedConfig = <-watchedConfigChan:
 			case <-waitingMsgTimeout:
 				log.Info("Waiting for certloader TLS certificate and key files to be created")
 			case <-ctx.Done():
 				return nil
 			}
 		}
-		resolver.Resolve(metricsTLSConfig)
+		resolver.Resolve(watchedConfig)
+		return nil
+	}))
+
+	lc.Append(cell.Hook{
+		OnStop: func(ctx cell.HookContext) error {
+			// stop the resolved config watcher (best effort)
+			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			cfg, _ := promise.Await(ctx)
+			if cfg != nil {
+				cfg.Stop()
+			}
+			return nil
+		},
+	})
+
+	return promise, nil
+}
+
+// NewWatchedClientConfigPromise provides a promise that resolves to a WatchedClientConfig.
+// The resolved config can be used to obtain a tls.Config. The promise resolves when the
+// certificates become ready and have been loaded.
+//
+// This is meant to be used as a Hive constructor and is recommended to be placed in a module
+// and the promise provided wrapped in another type to avoid possible conflicts/replacements
+// when used multiple times in the same hive.
+func NewWatchedClientConfigPromise(lc cell.Lifecycle, jobGroup job.Group, log *slog.Logger, cfg Config) (promise.Promise[*WatchedClientConfig], error) {
+	log = log.With(logfields.Config, "certloader-client-tls")
+	if !cfg.TLS {
+		log.Info("Certloader TLS watcher disabled")
+		return nil, nil
+	}
+
+	resolver, promise := promise.New[*WatchedClientConfig]()
+
+	jobGroup.Add(job.OneShot("certloader-client-tls", func(ctx context.Context, _ cell.Health) error {
+		watchedConfigChan, err := FutureWatchedClientConfig(
+			ctx, log,
+			cfg.TLSClientCAFiles, cfg.TLSCertFile, cfg.TLSKeyFile,
+		)
+		if err != nil {
+			err := fmt.Errorf("failed to initialize certloader TLS watched client configuration: %w", err)
+			resolver.Reject(err)
+			return err
+		}
+
+		waitingMsgTimeout := time.After(30 * time.Second)
+		var watchedConfig *WatchedClientConfig
+		for watchedConfig == nil {
+			select {
+			case watchedConfig = <-watchedConfigChan:
+			case <-waitingMsgTimeout:
+				log.Info("Waiting for certloader TLS certificate and key files to be created")
+			case <-ctx.Done():
+				return nil
+			}
+		}
+		resolver.Resolve(watchedConfig)
 		return nil
 	}))
 

--- a/pkg/crypto/certloader/client.go
+++ b/pkg/crypto/certloader/client.go
@@ -40,6 +40,32 @@ func NewWatchedClientConfig(log *slog.Logger, caFiles []string, certFile, privke
 	return c, nil
 }
 
+// FutureWatchedClientConfig returns a channel where exactly one
+// WatchedClientConfig will be sent once the given files are ready and loaded.
+// This can be useful when the file paths are well-known, but the files
+// themselves don't exist yet. When caFiles is nil or empty, the system CA
+// CertPool is used. To configure a mTLS capable ClientConfigBuilder, both
+// certFile and privkeyFile must be provided.
+func FutureWatchedClientConfig(ctx context.Context, log *slog.Logger, caFiles []string, certFile, privkeyFile string) (<-chan *WatchedClientConfig, error) {
+	ew, err := FutureWatcher(ctx, log, caFiles, certFile, privkeyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(chan *WatchedClientConfig)
+	go func(res chan<- *WatchedClientConfig) {
+		defer close(res)
+		if watcher, ok := <-ew; ok {
+			res <- &WatchedClientConfig{
+				Watcher: watcher,
+				log:     log,
+			}
+		}
+	}(res)
+
+	return res, nil
+}
+
 // IsMutualTLS implement ClientConfigBuilder.
 func (c *WatchedClientConfig) IsMutualTLS() bool {
 	return c.HasKeypair()

--- a/pkg/crypto/certloader/server_test.go
+++ b/pkg/crypto/certloader/server_test.go
@@ -100,7 +100,9 @@ func TestFutureWatchedServerConfig(t *testing.T) {
 
 	// the files exists now, expect the watcher to become ready.
 	s := <-ch
-	s.Stop()
+	if assert.NotNil(t, s) {
+		s.Stop()
+	}
 }
 
 func TestNewWatchedServerConfig(t *testing.T) {


### PR DESCRIPTION
Add:
- `FutureWatchedClientConfig ` to mirror `FutureWatchedServerConfig`
- `NewWatchedClientConfigPromise` to mirror `NewWatchedServerConfigPromise`

Can we mark this change for backport to 1.17 as well? Thanks!