### PR TITLE
helm: Support extending cilium-agent volumes as a downstream packager

### DIFF
--- a/install/kubernetes/cilium/templates/_extensions.tpl
+++ b/install/kubernetes/cilium/templates/_extensions.tpl
@@ -4,6 +4,15 @@ to modify or extend the default chart behaviors.
 */}}
 
 {{/*
+Allow packagers to add extra volumes to cilium-agent.
+*/}}
+{{- define "cilium-agent.volumes.extra" }}
+{{- end }}
+
+{{- define "cilium-agent.volumeMounts.extra" }}
+{{- end }}
+
+{{/*
 Intentionally empty to allow downstream chart packagers to add extra
 containers to hubble-relay without having to modify the deployment manifest
 directly.

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -413,6 +413,7 @@ spec:
         {{- with .Values.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- include "cilium-agent.volumeMounts.extra" . | nindent 8 }}
       {{- if .Values.monitor.enabled }}
       - name: cilium-monitor
         image: {{ include "cilium.image" .Values.image | quote }}
@@ -1093,4 +1094,5 @@ spec:
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- include "cilium-agent.volumes.extra" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Similar to [hubble-relay](https://github.com/cilium/cilium/pull/30357), we want to repackage the cilium chart and mount volumes based on additional helm values and templates.

To support adding new volumes, new template blocks ("partial") have been added allowing downstream packagers to simplify modify `_extensions.tpl` in their fork with the required logic.

Can we mark this change for backport to 1.17/1.18 as well? Thanks!

```release-note
Support extending cilium-agent volumes as a downstream packager
```
