### PR TITLE
[v1.17] Fix missing return error in GetSelectorPolicy()

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -112,6 +112,11 @@ func (t *TLSContext) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&redacted)
 }
 
+func (t *TLSContext) String() string {
+	data, _ := t.MarshalJSON()
+	return string(data)
+}
+
 type StringSet map[string]struct{}
 
 func (a StringSet) Equal(b StringSet) bool {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -878,7 +878,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 		stats.PolicyCalculation().Reset()
 	}
 
-	return sp, rev, nil
+	return sp, rev, err
 }
 
 // ReplaceByResource replaces all rules by resource, returning the complete set of affected endpoints.

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -220,16 +220,16 @@ func mergePortProto(ctx *SearchContext, existingFilter, filterToMerge *L4Filter,
 					l7Rules.TerminatingTLS = newL7Rules.TerminatingTLS
 				}
 			} else if !newL7Rules.TerminatingTLS.Equal(l7Rules.TerminatingTLS) {
-				ctx.PolicyTrace("   Merge conflict: mismatching terminating TLS contexts %v/%v\n", newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
-				return fmt.Errorf("cannot merge conflicting terminating TLS contexts for cached selector %s: (%v/%v)", cs.String(), newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
+				ctx.PolicyTrace("   Merge conflict: mismatching terminating TLS contexts %s/%s\n", newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
+				return fmt.Errorf("cannot merge conflicting terminating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
 			}
 			if l7Rules.OriginatingTLS == nil || newL7Rules.OriginatingTLS == nil {
 				if newL7Rules.OriginatingTLS != nil {
 					l7Rules.OriginatingTLS = newL7Rules.OriginatingTLS
 				}
 			} else if !newL7Rules.OriginatingTLS.Equal(l7Rules.OriginatingTLS) {
-				ctx.PolicyTrace("   Merge conflict: mismatching originating TLS contexts %v/%v\n", newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
-				return fmt.Errorf("cannot merge conflicting originating TLS contexts for cached selector %s: (%v/%v)", cs.String(), newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
+				ctx.PolicyTrace("   Merge conflict: mismatching originating TLS contexts %s/%s\n", newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
+				return fmt.Errorf("cannot merge conflicting originating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
 			}
 
 			// For now we simply merge the set of allowed SNIs from different rules


### PR DESCRIPTION
* Fix missing error return in policy repo `GetSelectorPolicy()` method
* Redact sensitive TLS key information for logging.

Backport for - https://github.com/cilium/cilium/commit/c22cc3c5201b808695897231316147df21c4063f

Fixes: #39535
Fixes: 52d61cb11424636fc89af027e48c8c07f63cc22e ("policy: gather policy calculation in the repository")

```release-note
policy: fix error handling for selector policy resolution
```
