### PR TITLE
images ci: use shared action for disk cleanup

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -87,20 +87,8 @@ jobs:
           mkdir -p ../cilium-base-branch
           cp -r .github/actions/set-runtime-image ../cilium-base-branch
 
-      - name: Check for disk usage and cleanup /mnt
-        shell: bash
-        run: |
-          echo "# Disk usage"
-          df -h
-          echo "# Usage for /mnt"
-          sudo du --human-readable \
-                -- /mnt
-          if compgen -G "/mnt/.*" > /dev/null; then
-            echo "# Hidden files in /mnt:"
-            sudo du --human-readable -- /mnt/.* 2>/dev/null
-          fi
-          echo "# Removing /mnt/tmp-pv.img"
-          sudo rm -f '/mnt/tmp-pv.img'
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
 
       - name: Setup docker volumes into /mnt
         # This allows us to make use of all available disk.


### PR DESCRIPTION
We noticed with [this build](https://github.com/cilium/cilium/actions/runs/16126231632/job/45503677488?pr=40379#step:5:43), that the images-ci workflow could not complete because space was not being freed on the disk at the start of the run.

That workflow previously used its own implementation of a [disk cleanup step](https://github.com/cilium/cilium/blob/main/.github/workflows/build-images-ci.yaml#L90-L103). This step only removed a [specific file](https://github.com/cilium/cilium/blob/main/.github/workflows/build-images-ci.yaml#L103).

This changes that workflow to use our [shared action](https://github.com/cilium/cilium/blob/main/.github/actions/disk-cleanup/action.yaml) for disk cleanup. This action removes all of the [following files](https://github.com/cilium/cilium/blob/main/.github/actions/disk-cleanup/action.yaml#L56).

We should determine which directories we need to add to this list before merging this PR.

```release-note
images ci: use shared action for disk cleanup
```
