### PR TITLE
Update kubeproxy-free.rst : Fix erroneous documentation and add warning

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -600,6 +600,15 @@ the extra hop, meaning, backends reply by using the service IP/port as a source.
 
 Another advantage in DSR mode is that the client's source IP is preserved, so policy
 can match on it at the backend node. In the SNAT mode this is not possible.
+
+.. warning::
+   Be aware that the client's source IP is **not** preserved by the ingress
+    (e.g. --set ingressController.enabled=true), so 
+    ``ciliumclusterwidenetworkpolicies.cilium.io``, ``ciliumnetworkpolicies.cilium.io`` 
+   and ``networkpolicies.networking.k8s.io`` can not match on it at the backend node 
+   if you enable the ingress controller, since the source IP address will be changed 
+   to that of the ingress-controler. (see also :gh-issue:`34786` for further details).
+
 Given a specific backend can be used by multiple services, the backends need to be
 made aware of the service IP/port which they need to reply with. Cilium encodes this
 information into the packet (using one of the dispatch mechanisms described below),

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -601,13 +601,7 @@ the extra hop, meaning, backends reply by using the service IP/port as a source.
 Another advantage in DSR mode is that the client's source IP is preserved, so policy
 can match on it at the backend node. In the SNAT mode this is not possible.
 
-.. warning::
-   Be aware that the client's source IP is **not** preserved by the ingress
-    (e.g. --set ingressController.enabled=true), so 
-    ``ciliumclusterwidenetworkpolicies.cilium.io``, ``ciliumnetworkpolicies.cilium.io`` 
-   and ``networkpolicies.networking.k8s.io`` can not match on it at the backend node 
-   if you enable the ingress controller, since the source IP address will be changed 
-   to that of the ingress-controler. (see also :gh-issue:`34786` for further details).
+When you deploy Cilium as a kube proxy replacement and Cilium Service Mesh at the same time, the client's source IP is not preserved when Service Mesh forwards the traffic to a backend service. See :ref:`ingress_reference` for more details.
 
 Given a specific backend can be used by multiple services, the backends need to be
 made aware of the service IP/port which they need to reply with. Cilium encodes this

--- a/Documentation/network/servicemesh/ingress-reference.rst
+++ b/Documentation/network/servicemesh/ingress-reference.rst
@@ -60,12 +60,9 @@ although the same principles also apply for Gateway API.
 Source IP Visibility
 ********************
 
-.. warning::
-   Be aware that that the client's source IP is **not** preserved by the ingress, so 
-   ``ciliumclusterwidenetworkpolicies.cilium.io``, ``ciliumnetworkpolicies.cilium.io`` 
-   and ``networkpolicies.networking.k8s.io`` can not match on it at the backend node 
-   (see also `GH#34786 <https://github.com/cilium/cilium/issues/34786>`__ for further 
-   details).
+When Cilium Ingress forwards traffic towards Pods within the cluster, the original source IP is not preserved, so 
+``ciliumclusterwidenetworkpolicies.cilium.io``, ``ciliumnetworkpolicies.cilium.io`` 
+and ``networkpolicies.networking.k8s.io`` can not match on the source IP at the backend node. See :gh-issue:`34786` for more information about this limitation.
 
 Having a backend be able to deduce what IP address the actual request came from
 is important for most applications. However, when traffic is sent through

--- a/Documentation/network/servicemesh/ingress-reference.rst
+++ b/Documentation/network/servicemesh/ingress-reference.rst
@@ -1,3 +1,5 @@
+.. _ingress_reference:
+
 Reference
 #########
 
@@ -53,6 +55,13 @@ This means that, when applying Network Policy to a cluster, it's important to
 ensure that both steps are allowed, and that traffic is allowed from ``world`` to
 ``ingress``, and from ``ingress`` to identities in the cluster (like the
 ``productpage`` identity in the image above).
+
+.. warning::
+   Be aware that that the client's source IP is **not** preserved by the ingress, so 
+   ``ciliumclusterwidenetworkpolicies.cilium.io``, ``ciliumnetworkpolicies.cilium.io`` 
+   and ``networkpolicies.networking.k8s.io`` can not match on it at the backend node 
+   (see also `GH#34786 <https://github.com/cilium/cilium/issues/34786>`__ for further 
+   details).
 
 Please see the :ref:`gs_ingress_and_network_policy` for more details for Ingress,
 although the same principles also apply for Gateway API.

--- a/Documentation/network/servicemesh/ingress-reference.rst
+++ b/Documentation/network/servicemesh/ingress-reference.rst
@@ -60,11 +60,12 @@ although the same principles also apply for Gateway API.
 Source IP Visibility
 ********************
 
-.. Note::
-
-    By default, source IP visibility for Cilium ingress config, both Ingress
-    and Gateway API, should *just work* on most installations. Read this section
-    for more information on requirements and relevant settings.
+.. warning::
+   Be aware that that the client's source IP is **not** preserved by the ingress, so 
+   ``ciliumclusterwidenetworkpolicies.cilium.io``, ``ciliumnetworkpolicies.cilium.io`` 
+   and ``networkpolicies.networking.k8s.io`` can not match on it at the backend node 
+   (see also `GH#34786 <https://github.com/cilium/cilium/issues/34786>`__ for further 
+   details).
 
 Having a backend be able to deduce what IP address the actual request came from
 is important for most applications.

--- a/Documentation/network/servicemesh/ingress-reference.rst
+++ b/Documentation/network/servicemesh/ingress-reference.rst
@@ -68,7 +68,10 @@ Source IP Visibility
    details).
 
 Having a backend be able to deduce what IP address the actual request came from
-is important for most applications.
+is important for most applications. However, when traffic is sent through
+an Ingress proxy, the original source IP address is not preserved in the IP
+headers when forwarding the traffic to a backend. Instead, the source IP
+address is preserved in an HTTP header.
 
 By default, Cilium's Envoy instances are configured to append the visible source
 address of incoming HTTP connections to the ``X-Forwarded-For`` header, using the


### PR DESCRIPTION
Add warning that policy filtering is currently not supported when ingress controller is enabled. See https://github.com/cilium/cilium/issues/34786 for a detailed report

NOTE TO MAINTAINER: 

I have no automated tests to validate this nor do I know where in your CI you test for this (and if you do). I just know that it currently does not work so I am updating the documentation to reflect that so that the next people dont waste hours figuring this out like I did. See the issue above for more details.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!
