### PR TITLE
workflows: Cover IPv6 underlay with encryption for dual-stack clusters

### DIFF
--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -338,6 +338,7 @@
   underlay: 'ipv6'
   lb-mode: 'snat'
   ingress-controller: 'true'
+  encryption: 'wireguard'
   skip-upgrade: 'true'
 - name: '30'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/.github/actions/e2e/ipsec_configs.yaml
+++ b/.github/actions/e2e/ipsec_configs.yaml
@@ -69,7 +69,6 @@
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'vxlan'
-  ipv4: 'false'
   underlay: 'ipv6'
   encryption: 'ipsec'
   key-one: 'rfc4106-gcm-aes'


### PR DESCRIPTION
Support for IPv6 underlays in dual-stack clusters was recently merged in https://github.com/cilium/cilium/pull/40324. This pull request now extends the IPsec and WireGuard coverage of IPv6 underlays to include dual-stack clusters.