### PR TITLE
policy: improve performance of EndpointSelector Matches

### DIFF
--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -324,8 +324,9 @@ func (n *EndpointSelector) Matches(lblsToMatch k8sLbls.Labels) bool {
 			return false
 		}
 	}
-	for _, req := range *n.requirements {
-		if !req.Matches(lblsToMatch) {
+	reqs := *n.requirements
+	for i := range reqs {
+		if !reqs[i].Matches(lblsToMatch) {
 			return false
 		}
 	}


### PR DESCRIPTION
When performing network policy scale testing in #40227 I've noticed that ~20% of all object are allocated in (*EndpointSelector).Matches

This PR reduces allocations by half.

Before:
```
BenchmarkMatchesValid1000
BenchmarkMatchesValid1000-32              	100000000	       179.0 ns/op	      88 B/op	       2 allocs/op
BenchmarkMatchesInvalid1000
BenchmarkMatchesInvalid1000-32            	100000000	       214.2 ns/op	      88 B/op	       2 allocs/op
BenchmarkMatchesValid1000Parallel
BenchmarkMatchesValid1000Parallel-32      	100000000	        32.35 ns/op	      88 B/op	       2 allocs/op
BenchmarkMatchesInvalid1000Parallel
BenchmarkMatchesInvalid1000Parallel-32    	100000000	        33.35 ns/op	      88 B/op	       2 allocs/op
```

After:
```
BenchmarkMatchesValid1000
BenchmarkMatchesValid1000-32              	100000000	        85.30 ns/op	      24 B/op	       1 allocs/op
BenchmarkMatchesInvalid1000
BenchmarkMatchesInvalid1000-32            	100000000	        81.65 ns/op	      24 B/op	       1 allocs/op
BenchmarkMatchesValid1000Parallel
BenchmarkMatchesValid1000Parallel-32      	100000000	        27.45 ns/op	      24 B/op	       1 allocs/op
BenchmarkMatchesInvalid1000Parallel
BenchmarkMatchesInvalid1000Parallel-32    	100000000	        27.41 ns/op	      24 B/op	       1 allocs/op
```
