### PR TITLE
Redact tls context private key for logging

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -76,6 +76,11 @@ func (t *TLSContext) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&redacted)
 }
 
+func (t *TLSContext) String() string {
+	data, _ := t.MarshalJSON()
+	return string(data)
+}
+
 type StringSet map[string]struct{}
 
 func (a StringSet) Equal(b StringSet) bool {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -226,16 +226,16 @@ func mergePortProto(policyCtx PolicyContext, existingFilter, filterToMerge *L4Fi
 					l7Rules.TerminatingTLS = newL7Rules.TerminatingTLS
 				}
 			} else if !newL7Rules.TerminatingTLS.Equal(l7Rules.TerminatingTLS) {
-				policyCtx.PolicyTrace("   Merge conflict: mismatching terminating TLS contexts %v/%v\n", newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
-				return fmt.Errorf("cannot merge conflicting terminating TLS contexts for cached selector %s: (%v/%v)", cs.String(), newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
+				policyCtx.PolicyTrace("   Merge conflict: mismatching terminating TLS contexts %s/%s\n", newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
+				return fmt.Errorf("cannot merge conflicting terminating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
 			}
 			if l7Rules.OriginatingTLS == nil || newL7Rules.OriginatingTLS == nil {
 				if newL7Rules.OriginatingTLS != nil {
 					l7Rules.OriginatingTLS = newL7Rules.OriginatingTLS
 				}
 			} else if !newL7Rules.OriginatingTLS.Equal(l7Rules.OriginatingTLS) {
-				policyCtx.PolicyTrace("   Merge conflict: mismatching originating TLS contexts %v/%v\n", newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
-				return fmt.Errorf("cannot merge conflicting originating TLS contexts for cached selector %s: (%v/%v)", cs.String(), newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
+				policyCtx.PolicyTrace("   Merge conflict: mismatching originating TLS contexts %s/%s\n", newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
+				return fmt.Errorf("cannot merge conflicting originating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
 			}
 
 			// For now we simply merge the set of allowed SNIs from different rules


### PR DESCRIPTION
Cleanup for: #39535

```release-note
policy: redact sensitive tls context properties for logging
```
