### PR TITLE
ci: Increase timeout for golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,7 +3,7 @@ run:
   modules-download-mode: readonly
   issues-exit-code: 1
   tests: true
-  timeout: 30m
+  timeout: 60m
 linters:
   default: none
   enable:


### PR DESCRIPTION
Set an explicit timeout for golangci-lint of 60 minutes to extend the 20 minutes default one.

Successful job run [here](https://github.com/cilium/cilium/actions/runs/16163844967/job/45620938586?pr=40432)