### PR TITLE
ci: fix north-south conn disrupt for 5.4 kernel

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -409,6 +409,8 @@ jobs:
 
       - name: Setup conn-disrupt-test before downgrading
         uses: ./.github/actions/conn-disrupt-test-setup
+        with:
+          kernel: ${{ matrix.kernel }}
 
       - name: Features tested before downgrade
         uses: ./.github/actions/feature-status

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -394,6 +394,8 @@ jobs:
       - name: Setup conn-disrupt-test before downgrading
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: ./.github/actions/conn-disrupt-test-setup
+        with:
+          kernel: ${{ matrix.kernel }}
 
       - name: Features tested before downgrade
         if: ${{ steps.vars.outputs.downgrade_version != '' }}


### PR DESCRIPTION
This commit updates the e2e-upgrade and ipsec-upgrade workflows to not run the north-south connection disruption test on 5.4 kernel when downgrading Cilium version. In #39443 we introduced the fix, using a `kernel` variable that will be sanitized and compared against version "5.4" to skip the test. This commit completes the fix by adding the check also when downgrading Cilium, otherwise the flake "FIB lookup failed" would still happen in the downgrade case.

Fixes: #40369