### PR TITLE
.github/workflows: remove more directories from /mnt

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -101,6 +101,7 @@ jobs:
           fi
           echo "# Removing /mnt/tmp-pv.img"
           sudo rm -f '/mnt/tmp-pv.img'
+          sudo rm -rf '/mnt/docker-volumes'
 
       - name: Setup docker volumes into /mnt
         # This allows us to make use of all available disk.


### PR DESCRIPTION
It seems there are more directories under /mnt that is preventing docker images from being built. This commit cleans up even more that directory.