### PR TITLE
update deps

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -406,3 +406,16 @@ jobs:
       checkout_ref: ${{ needs.build-and-push-prs.outputs.sha }}
       image_tag: ${{ needs.build-and-push-prs.outputs.sha }}
     secrets: inherit
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: build-and-push-prs
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/ci-re-run.yaml
+++ b/.github/workflows/ci-re-run.yaml
@@ -1,0 +1,21 @@
+name: Rerun workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "The ID of the workflow run to rerun"
+        required: true
+
+jobs:
+  re-run-workflow:
+    name: Re-run Workflow
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-running ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -735,3 +735,16 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       result: ${{ needs.installation-and-connectivity.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: installation-and-connectivity
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -412,3 +412,16 @@ jobs:
         run: |
           eksctl delete cluster --name ${{ env.clusterName }} --region ${{ matrix.region }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: installation-and-connectivity
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -368,3 +368,16 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       result: ${{ needs.gateway-api-conformance-test.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: gateway-api-conformance-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -561,3 +561,16 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ steps.commit-status.outputs.status }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: setup-and-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -448,3 +448,16 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       result: ${{ needs.ingress-conformance-test.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: ingress-conformance-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -443,3 +443,16 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       result: ${{ needs.setup-and-test.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: setup-and-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -407,3 +407,16 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       result: ${{ needs.multi-pool-ipam-conformance-test.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: multi-pool-ipam-conformance-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -570,3 +570,16 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ needs.setup-and-test.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: setup-and-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -269,3 +269,16 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ needs.integration-test.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: integration-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -823,3 +823,16 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       result: ${{ needs.upgrade-and-downgrade.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: upgrade-and-downgrade
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -189,3 +189,16 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ needs.setup-and-test.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: setup-and-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -546,3 +546,16 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       result: ${{ needs.setup-and-test.result }}
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: setup-and-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -160,3 +160,16 @@ jobs:
         with:
           artifacts_suffix: "${{ env.job_name }}"
           job_status: "${{ job.status }}"
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: conformance-test-ipv6
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -216,3 +216,16 @@ jobs:
         with:
           artifacts_suffix: "${{ env.job_name }}"
           job_status: "${{ job.status }}"
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: conformance-test
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml -F run_id=${{ github.run_id }}


### PR DESCRIPTION
Orig title: ci: Add automatic retry mechanism for flaky test failures

Add rerun-on-failure jobs to critical CI workflows to automatically retry failed runs up to 2 additional times (3 total attempts). This helps mitigate the impact of flaky tests and transient infrastructure issues that can cause spurious CI failures.

The retry mechanism is implemented with the following safeguards:
- Only retries on failure() conditions
- Limited to maximum 3 attempts (fromJSON(github.run_attempt) < 3)
- Skips retries for draft PRs to avoid unnecessary compute on WIP code
- Uses existing ci-re-run.yaml workflow for consistent retry behavior

This addresses the ongoing issue of flaky tests in the Cilium CI pipeline that require manual intervention, reducing developer friction and improving CI reliability. The retry logic is conservative to prevent abuse while providing value for legitimate transient failures.

The workflows updated are the only the ones marked as required.

The retry mechanism will help maintain green CI status for legitimate code changes while still catching real test failures that require developer attention.