### PR TITLE
docs: remove l7 EnableDefaultDeny callout

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -820,10 +820,6 @@ latter rule will have no effect.
 .. note:: L7 policies for SNATed IPv6 traffic (e.g., pod-to-world) require a kernel with the `fix <https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/>`__ applied.
           The stable kernel versions with the fix are 6.14.1, 6.12.22, 6.6.86, 6.1.133, 5.15.180, 5.10.236. See :gh-issue:`37932` for the reference.
 
-.. note:: :ref:`EnableDefaultDeny <policy_mode_default>` does not apply to layer-7 rules.
-   If using a layer 7 rule in concert with ``EnableDefaultDeny``, the rule should
-   allow all layer-7 traffic. See :gh-issue:`38676`.
-
 HTTP
 ----
 


### PR DESCRIPTION
This has been fixed with #38841.

The fix was backported to v1.17.5 and v1.16.10; it's safe to remove the callout.