### PR TITLE
eni: use sane defaults when enabling ENI via helm

### DIFF
--- a/Documentation/installation/k8s-install-helm.rst
+++ b/Documentation/installation/k8s-install-helm.rst
@@ -121,13 +121,11 @@ Install Cilium
 
           helm install cilium |CHART_RELEASE| \\
             --namespace kube-system \\
-            --set eni.enabled=true \\
-            --set ipam.mode=eni \\
-            --set routingMode=native
+            --set eni.enabled=true
 
        .. note::
 
-          This helm command sets ``eni.enabled=true`` and ``routingMode=native``,
+          This helm command sets ``eni.enabled=true``,
           meaning that Cilium will allocate a fully-routable AWS ENI IP address
           for each pod, similar to the behavior of the `Amazon VPC CNI plugin
           <https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html>`_.
@@ -148,8 +146,7 @@ Install Cilium
 
           To set up Cilium overlay mode, follow the steps below:
 
-            1. Excluding the lines for ``eni.enabled=true``, ``ipam.mode=eni`` and 
-               ``routingMode=native`` from the helm command will configure Cilium to use
+            1. Excluding the line ``eni.enabled=true`` from the helm command will configure Cilium to use
                overlay routing mode (which is the helm default).
             2. Flush iptables rules added by VPC CNI
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -71,6 +71,10 @@
   {{- end }}
 {{- end -}}
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}
+{{- if .Values.eni.enabled }}
+  {{- $ipam = "eni" -}}
+{{- end }}
+
 {{- $bpfCtTcpMax := (coalesce .Values.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}
 {{- $bpfCtAnyMax := (coalesce .Values.bpf.ctAnyMax $defaultBpfCtAnyMax) -}}
 {{- $stringValueKPR := (toString .Values.kubeProxyReplacement) -}}
@@ -526,7 +530,7 @@ data:
   {{- end }}
 {{- end }}
 
-  routing-mode: {{ .Values.routingMode | default (ternary "native" "tunnel" .Values.gke.enabled) | quote }}
+  routing-mode: {{ .Values.routingMode | default (ternary "native" "tunnel" (or .Values.eni.enabled .Values.gke.enabled)) | quote }}
   tunnel-protocol: {{ .Values.tunnelProtocol | default "vxlan" | quote }}
 
 {{- if eq .Values.routingMode "native" }}


### PR DESCRIPTION
Currently, enabling ENI in the Helm chart by setting `eni.enabled=true` is not sufficient. Users are also required to manually set additional values to avoid conflicting configurations:

- `routingMode` must be explicitly set to `native`, otherwise the chart defaults to configuring a VXLAN interface — which is mutually exclusive with ENI in Cilium.

- `ipam.mode` must be explicitly set to eni, otherwise the default `cluster-pool` IPAM remains enabled — which is also incompatible with ENI.

These extra required settings are not obvious and can lead to misconfiguration and deployment issues.

This PR updates the chart logic to automatically handle these dependencies when the user sets `eni.enabled=true`.

```release-note
helm: use sane defaults in combination with `eni.enabled=true`
```
