### PR TITLE
renovate: Correct branch typo for cilium-envoy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -617,7 +617,7 @@
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
       "allowedVersions": "/^v1\\.34\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
-        "1.18",
+        "v1.18",
         "main",
       ]
     },


### PR DESCRIPTION
No wonder I didn't see any update recently in renovate dashboard :face_exhaling: 