### PR TITLE
Speed up VM provisioning by storing and loading VM in GH cache

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -233,8 +233,163 @@ jobs:
           cat /tmp/merged.json
           echo "matrix=$(jq -c . < /tmp/merged.json)" >> $GITHUB_OUTPUT
 
-  setup-and-test:
-    needs: [setup-vars, build-ginkgo-binary, generate-matrix, wait-for-images]
+  setup:
+    needs: [setup-vars, generate-matrix]
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
+    timeout-minutes: 45
+    name: "E2E Setup (${{ matrix.k8s-version }}, ${{matrix.kernel}})"
+    env:
+      job_name: "E2E Setup (${{ matrix.k8s-version }}, ${{matrix.kernel}})"
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        include:
+          - k8s-version: "1.33"
+            ip-family: "dual"
+            # renovate: datasource=docker
+            kube-image: "quay.io/cilium/kindest-node:v1.33.0@sha256:03032c2e474eef9d706416a077f2eeb14600653eecbdfada9fc2d81a4e0461f9"
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: "6.12-20250630.013259"
+            kernel-type: "latest"
+
+          - k8s-version: "1.32"
+            ip-family: "dual"
+            # renovate: datasource=docker
+            kube-image: "quay.io/cilium/kindest-node:v1.32.0@sha256:22cf2864f90cfab0d442fda2decf2eae107edd03483053a902614dec637eff76"
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: "rhel8.6-20250630.013259"
+            kernel-type: "oldstable"
+
+          - k8s-version: "1.31"
+            ip-family: "dual"
+            # renovate: datasource=docker
+            kube-image: "quay.io/cilium/kindest-node:v1.31.0@sha256:d2b2a8cd6fa282b9a4126938341a4d2924dfa96f60b1f983d519498c9cde1a99"
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: "rhel8.6-20250630.013259"
+            kernel-type: "oldstable"
+
+          - k8s-version: "1.30"
+            ip-family: "dual"
+            # renovate: datasource=docker
+            kube-image: "quay.io/cilium/kindest-node:v1.30.0@sha256:edcb457c0b2ecc69a0fa9b0878bdcfd4a0f1205340cf08bf36a03d3a94a16dd9"
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: "5.10-20250630.013259"
+            kernel-type: "stable"
+
+    steps:
+
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
+        with:
+          comment_on_pr: false
+
+      - name: Check if cache key exists
+        id: check-if-cache-current
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          KEY=${{ runner.os }}-qemu-vm-e2e-${{ matrix.k8s-version }}-${{ matrix.kernel }}
+          CACHE_HIT=$(gh actions-cache list --key $KEY | grep -q $KEY && echo 'true' || echo 'false')
+          echo "cache-hit=$CACHE_HIT" >> $GITHUB_OUTPUT
+
+      # Load prepared VM from GH cache
+      - name: Load VM from GH cache
+        if: ${{ steps.check-if-cache-current.outputs.cache-hit != 'true' }}
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: cache-vm
+        with:
+          path: /tmp/cached-images
+          key: ${{ runner.os }}-qemu-vm-e2e-${{ matrix.k8s-version }}-${{ matrix.kernel }}
+
+      - name: Checkout context ref (trusted)
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
+        uses: ./.github/actions/set-env-variables
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.SHA || github.sha }}
+          persist-credentials: false
+
+      - name: Install cilium-cli
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
+        uses: cilium/cilium-cli@011bd4acc9dd898b40bca93faf2986ea4b55a95a # v0.18.5
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ needs.setup-vars.outputs.SHA }}
+          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
+          release-version: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Copy cilium-cli
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          cp -f /usr/local/bin/cilium ./cilium-cli-bin
+
+      - name: Install helm
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          # renovate: datasource=github-releases depName=helm/helm
+          HELM_VERSION=v3.13.1
+          wget "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          tar -xf "helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          mv ./linux-amd64/helm ./helm
+
+      - name: Provision LVH VMs
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
+        id: provision-vh-vms
+        timeout-minutes: 5
+        uses: aanm/little-vm-helper@e22ef818793c97fef61cd2c1a39dc43d119d404b # v0.0.25
+        with:
+          test-name: datapath-conformance
+          install-dependencies: true
+          image-version: ${{ matrix.kernel }}
+          images-folder-parent: "/tmp/cached-images"
+          host-mount: ./
+          cpu: 4
+          mem: 12G
+          # renovate: datasource=github-tags depName=cilium/little-vm-helper
+          lvh-version: "v0.0.25"
+          cmd: |
+            git config --global --add safe.directory /host
+            mv /host/helm /usr/bin
+            cp /host/cilium-cli-bin /usr/bin/cilium-cli
+            cd /host/
+            if [[ "${{ matrix.kernel-type }}" == latest ]]; then
+              ./contrib/scripts/kind.sh "" 2 "" "" "none" "dual"
+              kubectl label node kind-worker2 cilium.io/ci-node=kind-worker2
+              # Avoid re-labeling this node by setting "node-role.kubernetes.io/controlplane"
+              kubectl label node kind-worker2 node-role.kubernetes.io/controlplane=
+            else
+              ./contrib/scripts/kind.sh "" 1 "" "${{ matrix.kube-image }}" "iptables" "dual"
+            fi
+            shutdown -h now
+
+      - name: Wait for VM to go down
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
+        run: |
+          while pgrep -f "qemu.*.qcow2" > /dev/null; do
+            sleep 1
+          done
+          # Delete the zst file so that it's not part of the GH cache.
+          find /tmp/cached-images/images/amd64/images/ -type f -name "*.zst" -exec rm {} \;
+
+  test:
+    needs: [setup-vars, build-ginkgo-binary, generate-matrix, wait-for-images, setup]
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     timeout-minutes: 45
     name: "E2E Test (${{ matrix.k8s-version }}, ${{matrix.focus}})"
@@ -271,7 +426,16 @@ jobs:
           ref: ${{ inputs.SHA || github.sha }}
           persist-credentials: false
 
+      # Load prepared VM from GH cache
+      - name: Load VM from GH cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: cache-vm
+        with:
+          path: /tmp/cached-images
+          key: ${{ runner.os }}-qemu-vm-e2e-${{ matrix.k8s-version }}-${{ matrix.kernel }}
+
       - name: Install cilium-cli
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
         uses: cilium/cilium-cli@011bd4acc9dd898b40bca93faf2986ea4b55a95a # v0.18.5
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
@@ -281,11 +445,13 @@ jobs:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
       - name: Copy cilium-cli
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
           cp -f /usr/local/bin/cilium ./cilium-cli-bin
 
       - name: Install helm
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
           # renovate: datasource=github-releases depName=helm/helm
@@ -295,29 +461,31 @@ jobs:
           mv ./linux-amd64/helm ./helm
 
       - name: Provision LVH VMs
+        if: ${{ steps.cache-vm.outputs.cache-hit == 'true' }}
         id: provision-vh-vms
-        uses: cilium/little-vm-helper@3b6f374a9b62e6987efee7e3ab226f968d857c7c # v0.0.25
+        uses: aanm/little-vm-helper@e22ef818793c97fef61cd2c1a39dc43d119d404b # v0.0.25
         with:
           test-name: datapath-conformance
           install-dependencies: true
+          reprovision: "true"
           image-version: ${{ matrix.kernel }}
-          images-folder-parent: "/tmp"
+          images-folder-parent: "/tmp/cached-images"
           host-mount: ./
           cpu: 4
           mem: 12G
           # renovate: datasource=github-tags depName=cilium/little-vm-helper
           lvh-version: "v0.0.25"
+
+      - name: Provision kind
+        if: ${{ steps.cache-vm.outputs.cache-hit != 'true' }}
+        timeout-minutes: 5
+        uses: aanm/little-vm-helper@e22ef818793c97fef61cd2c1a39dc43d119d404b # v0.0.25
+        with:
+          provision: 'false'
           cmd: |
             git config --global --add safe.directory /host
             mv /host/helm /usr/bin
             cp /host/cilium-cli-bin /usr/bin/cilium-cli
-
-      - name: Provision kind
-        timeout-minutes: 5
-        uses: cilium/little-vm-helper@3b6f374a9b62e6987efee7e3ab226f968d857c7c # v0.0.25
-        with:
-          provision: 'false'
-          cmd: |
             cd /host/
             if [[ "${{ matrix.kernel-type }}" == latest ]]; then
               ./contrib/scripts/kind.sh "" 2 "" "${{ matrix.kube-image }}" "none" "${{ matrix.ip-family }}"
@@ -327,7 +495,16 @@ jobs:
             else
               ./contrib/scripts/kind.sh "" 1 "" "${{ matrix.kube-image }}" "iptables" "${{ matrix.ip-family }}"
             fi
-            git config --add safe.directory /cilium
+
+      - name: Waiting on K8s to be Ready
+        timeout-minutes: 5
+        uses: aanm/little-vm-helper@e22ef818793c97fef61cd2c1a39dc43d119d404b # v0.0.25
+        with:
+          provision: 'false'
+          cmd: |
+            while ! kubectl version > /dev/null; do
+              sleep 1
+            done
 
       # Load Ginkgo build from GitHub
       - name: Load ${{ matrix.name }} Ginkgo build from GitHub
@@ -380,7 +557,7 @@ jobs:
       - name: Run tests
         id: run-tests
         timeout-minutes: 40
-        uses: cilium/little-vm-helper@3b6f374a9b62e6987efee7e3ab226f968d857c7c # v0.0.25
+        uses: aanm/little-vm-helper@e22ef818793c97fef61cd2c1a39dc43d119d404b # v0.0.25
         with:
           provision: 'false'
           cmd: |
@@ -434,7 +611,7 @@ jobs:
 
       - name: Fetch artifacts
         if: ${{ !success() && steps.provision-vh-vms.outcome == 'success' }}
-        uses: cilium/little-vm-helper@3b6f374a9b62e6987efee7e3ab226f968d857c7c # v0.0.25
+        uses: aanm/little-vm-helper@e22ef818793c97fef61cd2c1a39dc43d119d404b # v0.0.25
         with:
           provision: 'false'
           cmd: |
@@ -461,7 +638,7 @@ jobs:
       - name: Fetch features tested
         if: ${{ always() && steps.provision-vh-vms.outcome == 'success' }}
         continue-on-error: true
-        uses: cilium/little-vm-helper@3b6f374a9b62e6987efee7e3ab226f968d857c7c # v0.0.25
+        uses: aanm/little-vm-helper@e22ef818793c97fef61cd2c1a39dc43d119d404b # v0.0.25
         with:
           provision: 'false'
           cmd: |
@@ -511,7 +688,7 @@ jobs:
     if: ${{ always() }}
     name: Merge and Upload Artifacts
     runs-on: ubuntu-24.04
-    needs: setup-and-test
+    needs: test
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -540,18 +717,18 @@ jobs:
   commit-status-final:
     if: ${{ always() }}
     name: Commit Status Final
-    needs: setup-and-test
+    needs: test
     runs-on: ubuntu-24.04
     steps:
       - name: Determine final commit status
         id: commit-status
         shell: bash
         run: |
-          # When one of the prerequisites of setup-and-test fails, then that
+          # When one of the prerequisites of test fails, then that
           # job gets skipped. Let's convert the status so that we correctly
           # report that as a proper failure.
-          if [ "${{ needs.setup-and-test.result }}" != "skipped" ]; then
-            echo "status=${{ needs.setup-and-test.result }}" >> $GITHUB_OUTPUT
+          if [ "${{ needs.test.result }}" != "skipped" ]; then
+            echo "status=${{ needs.test.result }}" >> $GITHUB_OUTPUT
           else
             echo "status=failure" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
This PR was an attempt to speed up ginkgo workflows by provisioning the VM with k8s once and load it up on all the jobs. Unfortunately, not much is gained due to the fact the loading the cache takes as much time as provisioning k8s from scratch.