### PR TITLE
[v1.16] eks: Set egressMasqueradeInterfaces, concurrency

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -56,6 +56,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  test_concurrency: 2
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
@@ -343,6 +344,7 @@ jobs:
       - name: Run connectivity test (${{ join(matrix.*, ', ') }})
         run: |
           ./cilium-cli connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --test-concurrency=${{ env.test_concurrency }} \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
@@ -352,6 +354,10 @@ jobs:
           title: "Summary of all features tested"
           json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1"
           cilium-cli: './cilium-cli'
+
+      - name: Delete test namespaces to make space for conn-disrupt-test pods
+        run: |
+          for (( i=2; i<=${{ env.test_concurrency }}; i++ )); do kubectl delete ns cilium-test-$i; done
 
       - name: Setup conn-disrupt-test before rotating (${{ join(matrix.*, ', ') }})
         if: ${{ matrix.ipsec == true }}
@@ -369,7 +375,7 @@ jobs:
         if: ${{ matrix.ipsec == true }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
-          full-test: 'true'
+          full-test: 'false'
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Post-test information gathering

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -204,6 +204,7 @@ jobs:
             --helm-set=hubble.relay.enabled=true \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \
+            --helm-set=egressMasqueradeInterfaces='eth+ ens+' \
             --wait=false"
           if [[ "${{ matrix.ipsec }}" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true --helm-set encryption.type=ipsec"


### PR DESCRIPTION
This is a v1.16 backport of the `egressMasqueradeInterfaces` setting and the concurrency fix for ci-eks workflow to enable cluster-external traffic and to move back well under 1h of runtime.

Fixes: #40462
```release-note
Backported setting egressMasqueradeInterfaces and concurrent test runs to fix ci-eks workflow.
```
