### PR TITLE
v1.15: docs: Document encapsulation options

### DIFF
--- a/Documentation/network/concepts/routing.rst
+++ b/Documentation/network/concepts/routing.rst
@@ -77,6 +77,16 @@ MTU Overhead
   connection. This can be largely mitigated by enabling jumbo frames (50 bytes
   of overhead for each 1500 bytes vs 50 bytes of overhead for each 9000 bytes).
 
+Configuration
+-------------
+
+The following options can be used to configure encapsulation:
+
+* ``tunnel-protocol``: Set the encapsulation protocol to ``vxlan`` or
+  ``geneve``, defaults to ``vxlan``.
+* ``tunnel-port``: Set the port for the encapsulation protocol. Defaults
+  to ``8472`` for ``vxlan`` and ``6081`` for ``geneve``.
+
 .. _arch_direct_routing:
 .. _native_routing:
 


### PR DESCRIPTION
[ upstream commit 70b7ecdc50d143615444a40bf356ab6f1d0c9257 ]

[ backporter's notes: Remove mention of underlay-protocol option as that was introduced in v1.18. Keep the note on IPv4 being required on the underlying network. ]

Most of these options are only documented in the cmdref and mentioned in passing in various guides. The underlay-protocol option was also recently introduced. Let's document them all properly.