### PR TITLE
v1.17: helm: Restore hostPort.enabled flag

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1644,6 +1644,10 @@
      - Enables the enforcement of host policies in the eBPF datapath.
      - bool
      - ``false``
+   * - :spelling:ignore:`hostPort.enabled`
+     - Enable hostPort service support.
+     - bool
+     - ``false``
    * - :spelling:ignore:`hubble.annotations`
      - Annotations to be added to all top-level hubble objects (resources under templates/hubble)
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -461,6 +461,7 @@ contributors across the globe, there is almost always someone available to help.
 | highScaleIPcache.enabled | bool | `false` | Enable the high scale mode for the ipcache. |
 | hostFirewall | object | `{"enabled":false}` | Configure the host firewall. |
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
+| hostPort.enabled | bool | `false` | Enable hostPort service support. |
 | hubble.annotations | object | `{}` | Annotations to be added to all top-level hubble objects (resources under templates/hubble) |
 | hubble.dropEventEmitter | object | `{"enabled":false,"interval":"2m","reasons":["auth_required","policy_denied"]}` | Emit v1.Events related to pods on detection of packet drops.    This feature is alpha, please provide feedback at https://github.com/cilium/cilium/issues/33975. |
 | hubble.dropEventEmitter.interval | string | `"2m"` | - Minimum time between emitting same events. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -754,6 +754,12 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if hasKey .Values "hostPort" }}
+{{- if eq $kubeProxyReplacement "false" }}
+  enable-host-port: {{ .Values.hostPort.enabled | quote }}
+{{- end }}
+{{- end }}
+
 {{- if hasKey .Values "nodePort" }}
 {{- if eq $kubeProxyReplacement "false" }}
   enable-node-port: {{ .Values.nodePort.enabled | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2490,6 +2490,14 @@
       },
       "type": "object"
     },
+    "hostPort": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "hubble": {
       "properties": {
         "annotations": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1090,6 +1090,9 @@ healthCheckICMPFailureThreshold: 3
 hostFirewall:
   # -- Enables the enforcement of host policies in the eBPF datapath.
   enabled: false
+hostPort:
+  # -- Enable hostPort service support.
+  enabled: false
 # -- Configure socket LB
 socketLB:
   # -- Enable socket LB

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1099,6 +1099,9 @@ healthCheckICMPFailureThreshold: 3
 hostFirewall:
   # -- Enables the enforcement of host policies in the eBPF datapath.
   enabled: false
+hostPort:
+  # -- Enable hostPort service support.
+  enabled: false
 # -- Configure socket LB
 socketLB:
   # -- Enable socket LB


### PR DESCRIPTION
The \[1\] commit removed the hostPort.enabled too early. It will be no longer possible to enable each individual KPR flag only in v1.19. So, before that we need to support enabling HostPort when KPR=false.

\[1\] got backported to v1.17 by https://github.com/cilium/cilium/pull/40222 to fix \[2\].

NB: we did not restore externalIPs.enabled, because it is no-op when KPR=false, and it is implicitly enabled when nodePort.enabled is true.

\[1\]: https://github.com/cilium/cilium/pull/39721/commits/88d1e705c84a8b151ae34bcab54249ee7806a87c
\[2\]: https://github.com/cilium/cilium/issues/40073