### PR TITLE
endpoint: remove explicit debug log checks

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -582,17 +581,14 @@ func (e *Endpoint) policyMapSync(policyMapDump policy.MapStateMap, stats *regene
 func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (err error) {
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
-	debugEnabled := e.getLogger().Enabled(context.Background(), slog.LevelDebug)
 
-	if debugEnabled {
-		e.getLogger().Debug(
-			"Preparing to compile BPF",
-			fieldRegenLevel, datapathRegenCtxt.regenerationLevel,
-		)
-	}
+	e.getLogger().Debug(
+		"Preparing to compile BPF",
+		fieldRegenLevel, datapathRegenCtxt.regenerationLevel,
+	)
 
 	if datapathRegenCtxt.regenerationLevel > regeneration.RegenerateWithoutDatapath {
-		if debugEnabled {
+		if e.Options.IsEnabled(option.Debug) {
 			debugFunc := func(format string, args ...interface{}) {
 				e.getLogger().Debug(fmt.Sprintf(format, args))
 			}
@@ -619,7 +615,7 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (err error
 
 		e.getLogger().Info("Reloaded endpoint BPF program")
 		e.bpfHeaderfileHash = datapathRegenCtxt.bpfHeaderfilesHash
-	} else if debugEnabled {
+	} else {
 		e.getLogger().Debug(
 			"BPF header file unchanged, skipping BPF compilation and installation",
 			logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash,

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -135,15 +135,6 @@ func (e *Endpoint) UpdateLogger(fields map[string]any) {
 	// Create a base logger with the subsys attribute.
 	baseLoggerWithSubsys := baseLogger.With(logfields.LogSubsys, subsys)
 
-	// If this endpoint is set to debug ensure it will print debug by giving it
-	// an independent logger.
-	// If this endpoint is not set to debug, it will use the log level set by the user.
-	if e.Options != nil && e.Options.IsEnabled(option.Debug) {
-		// FIXME @aanm re-enable this functionality once we figure out a solution
-		//  to have a logger per subsystem.
-		// baseLogger.SetLevel(slog.LevelDebug)
-	}
-
 	e.logger.Store(baseLoggerWithSubsys)
 }
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -378,15 +378,12 @@ func (e *Endpoint) regenerate(ctx *regenerationContext) (retErr error) {
 	ctx.Stats = regenerationStatistics{}
 	stats := &ctx.Stats
 	stats.totalTime.Start()
-	debugLogsEnabled := e.getLogger().Enabled(context.Background(), slog.LevelDebug)
 
-	if debugLogsEnabled {
-		e.getLogger().Debug(
-			"Regenerating endpoint",
-			logfields.StartTime, time.Now(),
-			logfields.Reason, ctx.Reason,
-		)
-	}
+	e.getLogger().Debug(
+		"Regenerating endpoint",
+		logfields.StartTime, time.Now(),
+		logfields.Reason, ctx.Reason,
+	)
 
 	defer func() {
 		// This has to be within a func(), not deferred directly, so that the


### PR DESCRIPTION
Back when Cilium was using logrus for structure logging, commit 52c06e1b3b05 ("Add checks to avoid use of logrus WithFields function in hot paths") added explicit checks for the debug log level to avoid the overhead of logrus' WithFields. This in no longer an issue since switching Cilium's code base to slog entirely we are no longer using log fields in the affected debug logs. Remove these remnants of that change from the endpoint package.