### PR TITLE
connectivity: rework sniffer to execute tcpdump in background

### DIFF
--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -4,16 +4,16 @@
 package sniff
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
+	"html/template"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
-	"github.com/cilium/cilium/cilium-cli/k8s"
-	"github.com/cilium/cilium/cilium-cli/utils/lock"
 )
 
 // Mode configures the Sniffer validation mode.
@@ -25,17 +25,111 @@ const (
 	// ModeSanity: expect to observe packets matching the filter, to be
 	// leveraged as a sanity check to verify that the filter is correct.
 	ModeSanity Mode = "sanity"
+
+	// Max wait time for tcpdump to start/stop in remote shell.
+	sniffScriptTimeout = 10 * time.Second
+	// Max timeout before aborting k8s connection in Start/Stop; must exceed sniffScriptTimeout.
+	sniffConnectionTimeout = sniffScriptTimeout + 5*time.Second
+	// Max remote sniffer runtime to prevent lingering processes in the pod.
+	// NOTE: too low may kill tcpdump while test is running.
+	sniffKillTimeout = sniffConnectionTimeout * 4
+
+	// Command executed to start the remote tcpdump in background inside a pod.
+	//
+	// We send tcpdump output to a file inside the pod rather than stdout,
+	// to avoid GH Issue #38643: tcpdump failing with error 14 due to one of
+	// its output streams not being available anymore.
+	// (tcpdump: Unable to write output: Broken pipe)
+	//
+	// Runs silently: succeeds if tcpdump is active ("listening on <iface>"),
+	// else fails with its error code. Includes `timeout 60` to prevent orphaned
+	// tcpdump if sniffer isn't properly stopped.
+	sniffScriptStartTmpl = `
+{
+	# Cleanup any leftover files from previous runs.
+	rm -f {{ .PidPath }} {{ .DumpPath }} {{ .LogPath }}
+
+	# Start tcpdump directly in background and capture its PID.
+	timeout {{ .KillSeconds }} tcpdump -i {{ .Iface }} {{ .Sanity }} --immediate-mode -U -w {{ .DumpPath }} "{{ .Filter }}" > {{ .LogPath }} 2>&1 &
+	pid=$!
+	echo $pid > {{ .PidPath }}
+
+	# Wait for startup confirmation and exit with success.
+	# Exit with error code if process is not running.
+	for i in $(seq 1 {{ .WaitSeconds }}); do
+		sleep 1
+		grep -q "listening on {{ .Iface }}" {{ .LogPath }} && exit 0
+		kill -0 $pid 2>/dev/null || {
+			wait $pid
+			exit $?
+		}
+	done
+
+	# Process is running but did not receive confirmation, kill and exit.
+	kill -9 $pid 2>/dev/null
+	wait $pid
+	exit $?
+}
+`
+
+	// Command executed to stop the remote tcpdump inside a pod.
+	sniffScriptStopTmpl = `
+{
+	# Ignore signals received when killing tcpdump.
+	trap '' TERM INT HUP
+
+	# Exit with error if tcpdump is not running.
+	if [ ! -f "{{ .PidPath }}" ]; then
+		exit 199
+	fi
+
+	pid=$(cat {{ .PidPath }} )
+
+	# Kill the process if it is still running.
+	# Return an error if tcpdump timed out before capturing any packets.
+	if kill -0 $pid 2>/dev/null; then
+		kill -2 $pid 2>/dev/null
+	elif [ "$(tcpdump -r {{ .DumpPath }} --count 2>/dev/null)" = "0 packets" ]; then
+		exit 198
+	else
+		exit 0
+	fi
+
+	# Confirm that process has been stopped and exit with success code.
+	for i in $(seq 1 {{ .WaitSeconds }}); do
+		if ! kill -0 $pid 2>/dev/null; then
+			exit 0
+		fi
+		sleep 1
+	done
+
+	# Process still exists, exit with error.
+	kill -9 $pid 2>/dev/null
+	exit 197
+}
+`
 )
 
 type Sniffer struct {
 	target   *check.Pod
 	dumpPath string
+	logPath  string
+	pidPath  string
 	mode     Mode
 	cmd      []string
+	stopCmd  []string
+	once     sync.Once
+}
 
-	stdout lock.Buffer
-	cancel context.CancelFunc
-	exited chan error
+type sniffScriptParams struct {
+	LogPath     string
+	DumpPath    string
+	PidPath     string
+	Iface       string
+	Sanity      string
+	Filter      string
+	WaitSeconds int
+	KillSeconds int
 }
 
 type debugLogger interface {
@@ -44,87 +138,75 @@ type debugLogger interface {
 
 // Start starts a tcpdump capture on the given pod, listening to the specified
 // interface. The mode configures whether Validate() will (not) expect any packet
-// to match the filter.
+// to match the filter. The returned finalization/close function must be run
+// to make sure the remote sniffer is properly closed, in case [*Sniffer.Validate] has
+// not been called (e.g., expired context or error in between).
 func Sniff(ctx context.Context, name string, target *check.Pod,
 	iface string, filter string, mode Mode, dbg debugLogger,
-) (*Sniffer, error) {
-	cmdctx, cancel := context.WithCancel(ctx)
+) (*Sniffer, func() error, error) {
 	sniffer := &Sniffer{
 		target:   target,
 		dumpPath: fmt.Sprintf("/tmp/%s.pcap", name),
+		logPath:  fmt.Sprintf("/tmp/%s.log", name),
+		pidPath:  fmt.Sprintf("/tmp/%s.pid", name),
 		mode:     mode,
-		cancel:   cancel,
-		exited:   make(chan error, 1),
 	}
 
-	go func() {
-		// Run tcpdump with -w instead of directly printing captured pkts. This
-		// is to avoid a race after sending ^C (triggered by cancel()) which
-		// might terminate the tcpdump process before it gets a chance to dump
-		// its captures.
-		//
-		// Add --print to have tcpdump print packet information to both stdout and our
-		// target filepath. This helps to ensure that the K8s exec connection does not
-		// close due to timeout.
-		args := []string{"-i", iface, "--immediate-mode", "--print", "-w", sniffer.dumpPath}
-		if sniffer.mode == ModeSanity {
-			// We limit the number of packets to be captured only when expecting
-			// them to be seen (i.e., in sanity mode). Otherwise, better to capture
-			// them all to provide more informative debug messages on failures.
-			args = append(args, "-c", "1")
-		}
-		sniffer.cmd = append([]string{"tcpdump"}, append(args, "\""+filter+"\"")...)
-		// We wait before starting tcpdump to avoid an observed race
-		// condition when using a websocket connection
-		sniffer.cmd = append([]string{"sh", "-c"}, "sleep 1 && "+strings.Join(sniffer.cmd, " "))
-
-		dbg.Debugf("Running sniffer in background on %s (%s), mode=%s: %s",
-			target.String(), target.NodeName(), mode, strings.Join(sniffer.cmd, " "))
-		err := target.K8sClient.ExecInPodWithWriters(ctx, cmdctx,
-			target.Pod.Namespace, target.Pod.Name, "", sniffer.cmd, &sniffer.stdout, k8s.StderrAsError)
-		if err != nil {
-			sniffer.exited <- err
-		}
-
-		close(sniffer.exited)
-	}()
-
-	// Wait until tcpdump is ready to capture pkts
-	wctx, wcancel := context.WithTimeout(ctx, 5*time.Second)
-	defer wcancel()
-	for {
-		select {
-		case <-wctx.Done():
-			return nil, fmt.Errorf("Failed to wait for tcpdump to be ready")
-		case err := <-sniffer.exited:
-			if err == nil {
-				// When running in sanity mode, tcpdump exits after capturing a
-				// single packet matching the filter. Hence, it is possible that
-				// it already terminated at this point. We'll then double check
-				// whether it was the case when performing validation.
-				return sniffer, nil
-			}
-
-			return nil, fmt.Errorf("Failed to execute `%s`: %w", strings.Join(sniffer.cmd, " "), err)
-		case <-time.After(100 * time.Millisecond):
-			line, err := sniffer.stdout.ReadString('\n')
-			if err != nil && !errors.Is(err, io.EOF) {
-				return nil, fmt.Errorf("Failed to read kubectl exec's stdout: %w", err)
-			}
-			if strings.Contains(line, fmt.Sprintf("listening on %s", iface)) {
-				return sniffer, nil
-			}
-		}
+	var sanity string
+	if sniffer.mode == ModeSanity {
+		// We limit the number of packets to be captured only when expecting
+		// them to be seen (i.e., in sanity mode). Otherwise, better to capture
+		// them all to provide more informative debug messages on failures.
+		sanity = "-c 1"
 	}
+
+	// Execute the template to have the final command.
+	var buf bytes.Buffer
+	tmpl := template.Must(template.New("sniffStart").Parse(sniffScriptStartTmpl))
+
+	err := tmpl.Execute(&buf, sniffScriptParams{
+		LogPath:     sniffer.logPath,
+		DumpPath:    sniffer.dumpPath,
+		PidPath:     sniffer.pidPath,
+		Iface:       iface,
+		Sanity:      sanity,
+		Filter:      filter,
+		WaitSeconds: int(sniffScriptTimeout.Seconds()),
+		KillSeconds: int(sniffKillTimeout.Seconds()),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("template execution failed: %w", err)
+	}
+
+	// Finally wrap the resulting command.
+	sniffer.cmd = append([]string{"nohup", "sh", "-c"}, buf.String())
+
+	// Context with a max timeout to start tcpdump.
+	ctx, cancel := context.WithTimeout(ctx, sniffConnectionTimeout)
+	defer cancel()
+
+	dbg.Debugf("Running sniffer in background on %s (%s), mode=%s: %s",
+		target.String(), target.NodeName(), mode, strings.Join(sniffer.cmd, " "))
+	if _, err := target.K8sClient.ExecInPod(ctx, target.Pod.Namespace, target.Pod.Name, "", sniffer.cmd); err != nil {
+		err = fmt.Errorf("Failed to execute tcpdump: %w", err)
+		if errors.Is(err, context.Canceled) {
+			// Child/Parent context has been canceled, we now stop the remote
+			// sniffer, despite tcpdump being wrapped within a `timeout`.
+			err = errors.Join(err, sniffer.stop())
+		}
+		return nil, nil, err
+	}
+
+	return sniffer, sniffer.stop, nil
 }
 
 // Validate stops the tcpdump capture previously started by Sniff and asserts that
 // no packets (or at least one packet when running in sanity mode) got captured. It
 // additionally dumps the captured packets in case of failure if debug logs are enabled.
 func (sniffer *Sniffer) Validate(ctx context.Context, a *check.Action) {
-	// Wait until tcpdump has exited
-	if err := sniffer.stopAndWait(ctx); err != nil {
-		a.Fatalf("Failed to execute tcpdump on %s (%s): %s", sniffer.target.String(), sniffer.target.NodeName(), err)
+	// Stop tcpdump if needed.
+	if err := sniffer.stop(); err != nil {
+		a.Fatal(err)
 	}
 
 	// Redirect stderr to /dev/null, as tcpdump logs to stderr, and ExecInPod
@@ -158,32 +240,40 @@ func (sniffer *Sniffer) Validate(ctx context.Context, a *check.Action) {
 	}
 }
 
-func (sniffer *Sniffer) stopAndWait(ctx context.Context) error {
-	select {
-	case err := <-sniffer.exited:
-		// When running in assert mode, it is an error if tcpdump already stopped
-		// at this point, as we may have missed packets. That's not the case in
-		// sanity mode, as configured to stop after receiving a single packet.
-		if err == nil && sniffer.mode == ModeAssert {
-			return errors.New("tcpdump terminated unexpectedly")
-		}
-		return err
+// stop runs the remote command to kill the sniffer process. It executes at most once.
+func (sniffer *Sniffer) stop() (err error) {
+	if sniffer == nil {
+		return
+	}
 
-	default:
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	sniffer.once.Do(func() {
+		// Execute the template with only the needed params.
+		var buf bytes.Buffer
+		tmpl := template.Must(template.New("sniffStop").Parse(sniffScriptStopTmpl))
+
+		err = tmpl.Execute(&buf, sniffScriptParams{
+			PidPath:     sniffer.pidPath,
+			WaitSeconds: int(sniffScriptTimeout.Seconds()),
+		})
+		if err != nil {
+			err = fmt.Errorf("template execution failed: %w", err)
+			return
+		}
+
+		// Finally wrap the resulting command.
+		sniffer.stopCmd = append([]string{"sh", "-c"}, buf.String())
+
+		// Context with timeout for stopping tcpdump.
+		// NOTE: Context is not passed anymore to this function to avoid premature cancellation.
+		ctx, cancel := context.WithTimeout(context.Background(), sniffConnectionTimeout)
 		defer cancel()
 
-		sniffer.cancel()
-		select {
-		case err := <-sniffer.exited:
-			// We canceled the context, so this is expected.
-			if errors.Is(err, context.Canceled) {
-				return nil
-			}
-			return err
-
-		case <-ctx.Done():
-			return errors.New("failed to wait for tcpdump to terminate within timeout")
+		// Stop tcpdump.
+		_, err = sniffer.target.K8sClient.ExecInPod(ctx, sniffer.target.Pod.Namespace, sniffer.target.Pod.Name, "", sniffer.stopCmd)
+		if err != nil {
+			err = fmt.Errorf("Failed to stop tcpdump on %s (%s): %w", sniffer.target.String(), sniffer.target.NodeName(), err)
 		}
-	}
+	})
+
+	return
 }

--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -79,8 +79,8 @@ const (
 	# Print captured packets and their count to stdout.
 	# Redirect stderr to /dev/null, as tcpdump logs to stderr.
 	report() {
-		tcpdump -r {{ .DumpPath }} --count 2>/dev/null || true
-		tcpdump -r {{ .DumpPath }}         2>/dev/null || true
+		tcpdump -n -r {{ .DumpPath }} --count 2>/dev/null || true
+		tcpdump -n -r {{ .DumpPath }}         2>/dev/null || true
 	}
 
 	# Ignore signals received when killing tcpdump.

--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -331,18 +331,18 @@ func testNoTrafficLeak(ctx context.Context, t *check.Test, s check.Scenario,
 		// Curl the server from the client to generate some traffic
 		t.NewAction(s, fmt.Sprintf("curl-%s", ipFam), client, server, ipFam).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, a.CurlCommand(server))
-			srcSniffer.Validate(ctx, a)
+			srcSniffer.Validate(a)
 			if dstSniffer != nil {
-				dstSniffer.Validate(ctx, a)
+				dstSniffer.Validate(a)
 			}
 		})
 	case requestICMPEcho:
 		// Ping the server from the client to generate some traffic
 		t.NewAction(s, fmt.Sprintf("ping-%s", ipFam), client, server, ipFam).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, t.Context().PingCommand(server, ipFam))
-			srcSniffer.Validate(ctx, a)
+			srcSniffer.Validate(a)
 			if dstSniffer != nil {
-				dstSniffer.Validate(ctx, a)
+				dstSniffer.Validate(a)
 			}
 		})
 	}

--- a/cilium-cli/connectivity/tests/encryption_v2.go
+++ b/cilium-cli/connectivity/tests/encryption_v2.go
@@ -541,8 +541,8 @@ func (s *podToPodEncryptionV2) clientToServerTest(ctx context.Context, t *check.
 		action := t.NewAction(s, fmt.Sprintf("curl-%s", features.IPFamilyV4), s.client, s.server, features.IPFamilyV4)
 		action.Run(func(a *check.Action) {
 			a.ExecInPod(ctx, a.CurlCommand(s.server))
-			s.clientSniffer4.Validate(ctx, a)
-			s.serverSniffer4.Validate(ctx, a)
+			s.clientSniffer4.Validate(a)
+			s.serverSniffer4.Validate(a)
 		})
 	}
 
@@ -551,8 +551,8 @@ func (s *podToPodEncryptionV2) clientToServerTest(ctx context.Context, t *check.
 		action := t.NewAction(s, fmt.Sprintf("curl-%s", features.IPFamilyV6), s.client, s.server, features.IPFamilyV6)
 		action.Run(func(a *check.Action) {
 			a.ExecInPod(ctx, a.CurlCommand(s.server))
-			s.clientSniffer6.Validate(ctx, a)
-			s.serverSniffer6.Validate(ctx, a)
+			s.clientSniffer6.Validate(a)
+			s.serverSniffer6.Validate(a)
 		})
 	}
 


### PR DESCRIPTION
Please do refer to commit messages for a detailed explanation.
I'd love as many feedback as possible, given this ended up being a not so easy change 😅 

1st and 2nd commit are the major updates. Sometimes while re-reading them they do feel quite hacky, but haven't found a better way to implement that.
3rd commit `connectivity: limit tcpdump capture also for Assert mode` is a **Why not?**, definitively can go in a different PR (or even cancel it if I missed the reason why we shouldn't do that).

Fixes: #38643
