### PR TITLE
gha: fix operator tolerations in GKE-based workflows

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -242,6 +242,8 @@ jobs:
             --helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.config.index }} \
             --helm-set=hubble.relay.enabled=true \
             --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
+            --helm-set=operator.tolerations[0].key=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
+            --helm-set=operator.tolerations[0].operator=Exists \
             --helm-set loadBalancer.l7.backend=envoy \
             --wait=false"
 

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -184,6 +184,8 @@ jobs:
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.index }} \
             --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
+            --helm-set=operator.tolerations[0].key=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
+            --helm-set=operator.tolerations[0].operator=Exists \
             --wait=false \
             --datapath-mode=${{ matrix.mode }}"
 


### PR DESCRIPTION
The blamed commit replaced the default wildcard toleration associated with the Cilium Operator with a precise set of keys. However, the GKE workflows configure a different toleration, hence we need to explicitly include it as part of the tolerations list.

Fixes: 589164b4b582 ("Adding taint to block deployment to drained nodes")