### PR TITLE
Revert "Update .readthedocs.yaml"

### DIFF
--- a/Documentation/.readthedocs.yaml
+++ b/Documentation/.readthedocs.yaml
@@ -21,8 +21,3 @@ sphinx:
 python:
   install:
   - requirements: Documentation/requirements.txt
-
-# to allow generating offline documentation
-formats:
-  - pdf
-  - epub


### PR DESCRIPTION
This reverts commit 01c4393f61eb60535e1572b3fd0e99b3ce8f3e3b.
Sphinx on ReadTheDocs reports an error with converting SVGs to PNGs
during the PDF build.

Reverts: https://github.com/cilium/cilium/pull/40330
