### PR TITLE
docs: Remove IPv6 limitation for IPsec

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -446,7 +446,6 @@ Limitations
       top of other CNI plugins. For more information, see :gh-issue:`15596`.
     * :ref:`HostPolicies` are not currently supported with IPsec encryption.
     * IPsec encryption currently does not work with BPF Host Routing.
-    * IPsec encryption is not currently supported in combination with IPv6-only clusters.
     * IPsec encryption is not supported on clusters or clustermeshes with more
       than 65535 nodes.
     * Decryption with Cilium IPsec is limited to a single CPU core per IPsec


### PR DESCRIPTION
IPsec is supported in IPv6-only clusters since commit 753a411ef1e ("daemon: Enable IPsec + IPv6 underlay").