### PR TITLE
Miscellaneous improvements to option.NewNamedMapOptions

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -42,19 +42,11 @@ func newCmdConnectivity(hooks api.Hooks) *cobra.Command {
 var params = check.Parameters{
 	ExternalDeploymentPort: 8080,
 	EchoServerHostPort:     4000,
-	JunitProperties:        make(map[string]string),
-	NamespaceLabels:        make(map[string]string),
-	NamespaceAnnotations:   make(map[string]string),
-	NodeSelector:           make(map[string]string),
 	Writer:                 os.Stdout,
 	SysdumpOptions: sysdump.Options{
 		LargeSysdumpAbortTimeout: sysdump.DefaultLargeSysdumpAbortTimeout,
 		LargeSysdumpThreshold:    sysdump.DefaultLargeSysdumpThreshold,
 		Writer:                   os.Stdout,
-	},
-	PerfParameters: check.PerfParameters{
-		NodeSelectorServer: make(map[string]string),
-		NodeSelectorClient: make(map[string]string),
 	},
 }
 

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -142,7 +142,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")
 	cmd.Flags().StringVar(&params.AgentPodSelector, "agent-pod-selector", defaults.AgentPodSelector, "Label on cilium-agent pods to select with")
 	cmd.Flags().StringVar(&params.CiliumPodSelector, "cilium-pod-selector", defaults.CiliumPodSelector, "Label selector matching all cilium-related pods")
-	cmd.Flags().Var(option.NewNamedMapOptions("node-selector", &params.NodeSelector, nil), "node-selector", "Restrict connectivity pods to nodes matching this label")
+	cmd.Flags().Var(option.NewMapOptions(&params.NodeSelector, nil), "node-selector", "Restrict connectivity pods to nodes matching this label")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
@@ -165,7 +165,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ServiceType, "service-type", "NodePort", "Type of Kubernetes Services created for connectivity tests")
 	cmd.Flags().StringSliceVar(&params.NodeCIDRs, "node-cidr", nil, "one or more CIDRs that cover all nodes in the cluster")
 	cmd.Flags().StringVar(&params.JunitFile, "junit-file", "", "Generate junit report and write to file")
-	cmd.Flags().Var(option.NewNamedMapOptions("junit-property", &params.JunitProperties, nil), "junit-property", "Add key=value properties to the generated junit file")
+	cmd.Flags().Var(option.NewMapOptions(&params.JunitProperties, nil), "junit-property", "Add key=value properties to the generated junit file")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().BoolVar(&params.IncludeUnsafeTests, "include-unsafe-tests", false, "Include tests which can modify cluster nodes state")
@@ -285,9 +285,9 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.PerfParameters.KernelProfiles, "unsafe-capture-kernel-profiles", false,
 		"Capture kernel profiles during test execution. Warning: run on disposable nodes only, as it installs additional software and modifies their configuration")
 
-	cmd.Flags().Var(option.NewNamedMapOptions("node-selector-server", &params.PerfParameters.NodeSelectorServer, nil),
+	cmd.Flags().Var(option.NewMapOptions(&params.PerfParameters.NodeSelectorServer, nil),
 		"node-selector-server", "Node selector for the server pod (and client same-node)")
-	cmd.Flags().Var(option.NewNamedMapOptions("node-selector-client", &params.PerfParameters.NodeSelectorClient, nil),
+	cmd.Flags().Var(option.NewMapOptions(&params.PerfParameters.NodeSelectorClient, nil),
 		"node-selector-client", "Node selector for the other-node client pod")
 
 	cmd.Flags().StringVar(&params.PerfParameters.Image, "performance-image", defaults.ConnectivityCheckImagesPerf["ConnectivityPerformanceImage"], "Image path to use for performance")
@@ -301,8 +301,8 @@ func registerCommonFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	flags.StringSliceVar(&params.Tolerations, "tolerations", nil, "Extra NoSchedule tolerations added to test pods")
 	flags.StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity in (always suffixed with a sequence number to be compliant with test-concurrency param, e.g.: cilium-test-1)")
-	flags.Var(option.NewNamedMapOptions("namespace-labels", &params.NamespaceLabels, nil), "namespace-labels", "Add labels to the connectivity test namespace")
-	flags.Var(option.NewNamedMapOptions("namespace-annotations", &params.NamespaceAnnotations, nil), "namespace-annotations", "Add annotations to the connectivity test namespace")
+	flags.Var(option.NewMapOptions(&params.NamespaceLabels, nil), "namespace-labels", "Add labels to the connectivity test namespace")
+	flags.Var(option.NewMapOptions(&params.NamespaceAnnotations, nil), "namespace-annotations", "Add annotations to the connectivity test namespace")
 	flags.MarkHidden("namespace-annotations")
 	flags.Var(&params.DeploymentAnnotations, "deployment-pod-annotations", "Add annotations to the connectivity pods, e.g. '{\"client\":{\"foo\":\"bar\"}}'")
 	flags.MarkHidden("deployment-pod-annotations")

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -142,7 +142,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")
 	cmd.Flags().StringVar(&params.AgentPodSelector, "agent-pod-selector", defaults.AgentPodSelector, "Label on cilium-agent pods to select with")
 	cmd.Flags().StringVar(&params.CiliumPodSelector, "cilium-pod-selector", defaults.CiliumPodSelector, "Label selector matching all cilium-related pods")
-	cmd.Flags().Var(option.NewMapOptions(&params.NodeSelector, nil), "node-selector", "Restrict connectivity pods to nodes matching this label")
+	cmd.Flags().Var(option.NewMapOptions(&params.NodeSelector), "node-selector", "Restrict connectivity pods to nodes matching this label")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
@@ -165,7 +165,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ServiceType, "service-type", "NodePort", "Type of Kubernetes Services created for connectivity tests")
 	cmd.Flags().StringSliceVar(&params.NodeCIDRs, "node-cidr", nil, "one or more CIDRs that cover all nodes in the cluster")
 	cmd.Flags().StringVar(&params.JunitFile, "junit-file", "", "Generate junit report and write to file")
-	cmd.Flags().Var(option.NewMapOptions(&params.JunitProperties, nil), "junit-property", "Add key=value properties to the generated junit file")
+	cmd.Flags().Var(option.NewMapOptions(&params.JunitProperties), "junit-property", "Add key=value properties to the generated junit file")
 	cmd.Flags().BoolVar(&params.SkipIPCacheCheck, "skip-ip-cache-check", true, "Skip IPCache check")
 	cmd.Flags().MarkHidden("skip-ip-cache-check")
 	cmd.Flags().BoolVar(&params.IncludeUnsafeTests, "include-unsafe-tests", false, "Include tests which can modify cluster nodes state")
@@ -285,9 +285,9 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.PerfParameters.KernelProfiles, "unsafe-capture-kernel-profiles", false,
 		"Capture kernel profiles during test execution. Warning: run on disposable nodes only, as it installs additional software and modifies their configuration")
 
-	cmd.Flags().Var(option.NewMapOptions(&params.PerfParameters.NodeSelectorServer, nil),
+	cmd.Flags().Var(option.NewMapOptions(&params.PerfParameters.NodeSelectorServer),
 		"node-selector-server", "Node selector for the server pod (and client same-node)")
-	cmd.Flags().Var(option.NewMapOptions(&params.PerfParameters.NodeSelectorClient, nil),
+	cmd.Flags().Var(option.NewMapOptions(&params.PerfParameters.NodeSelectorClient),
 		"node-selector-client", "Node selector for the other-node client pod")
 
 	cmd.Flags().StringVar(&params.PerfParameters.Image, "performance-image", defaults.ConnectivityCheckImagesPerf["ConnectivityPerformanceImage"], "Image path to use for performance")
@@ -301,8 +301,8 @@ func registerCommonFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	flags.StringSliceVar(&params.Tolerations, "tolerations", nil, "Extra NoSchedule tolerations added to test pods")
 	flags.StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity in (always suffixed with a sequence number to be compliant with test-concurrency param, e.g.: cilium-test-1)")
-	flags.Var(option.NewMapOptions(&params.NamespaceLabels, nil), "namespace-labels", "Add labels to the connectivity test namespace")
-	flags.Var(option.NewMapOptions(&params.NamespaceAnnotations, nil), "namespace-annotations", "Add annotations to the connectivity test namespace")
+	flags.Var(option.NewMapOptions(&params.NamespaceLabels), "namespace-labels", "Add labels to the connectivity test namespace")
+	flags.Var(option.NewMapOptions(&params.NamespaceAnnotations), "namespace-annotations", "Add annotations to the connectivity test namespace")
 	flags.MarkHidden("namespace-annotations")
 	flags.Var(&params.DeploymentAnnotations, "deployment-pod-annotations", "Add annotations to the connectivity pods, e.g. '{\"client\":{\"foo\":\"bar\"}}'")
 	flags.MarkHidden("deployment-pod-annotations")

--- a/cilium-dbg/cmd/kvstore.go
+++ b/cilium-dbg/cmd/kvstore.go
@@ -64,5 +64,5 @@ func init() {
 	RootCmd.AddCommand(kvstoreCmd)
 	flags := kvstoreCmd.PersistentFlags()
 	flags.StringVar(&kvStore, "kvstore", "", "Key-Value Store type")
-	flags.Var(option.NewMapOptions(&kvStoreOpts, nil), "kvstore-opt", "Key-Value Store options")
+	flags.Var(option.NewMapOptions(&kvStoreOpts), "kvstore-opt", "Key-Value Store options")
 }

--- a/cilium-dbg/cmd/kvstore.go
+++ b/cilium-dbg/cmd/kvstore.go
@@ -64,5 +64,5 @@ func init() {
 	RootCmd.AddCommand(kvstoreCmd)
 	flags := kvstoreCmd.PersistentFlags()
 	flags.StringVar(&kvStore, "kvstore", "", "Key-Value Store type")
-	flags.Var(option.NewNamedMapOptions("kvstore-opts", &kvStoreOpts, nil), "kvstore-opt", "Key-Value Store options")
+	flags.Var(option.NewMapOptions(&kvStoreOpts, nil), "kvstore-opt", "Key-Value Store options")
 }

--- a/cilium-dbg/cmd/preflight.go
+++ b/cilium-dbg/cmd/preflight.go
@@ -59,7 +59,7 @@ func init() {
 	// From preflight_migrate_crd_identity.go
 	miCmd := migrateIdentityCmd()
 	miCmd.Flags().StringVar(&kvStore, "kvstore", "", "Key-value store type")
-	miCmd.Flags().Var(option.NewNamedMapOptions("kvstore-opts", &kvStoreOpts, nil), "kvstore-opt", "Key-value store options e.g. etcd.address=127.0.0.1:4001")
+	miCmd.Flags().Var(option.NewMapOptions(&kvStoreOpts, nil), "kvstore-opt", "Key-value store options e.g. etcd.address=127.0.0.1:4001")
 	PreflightCmd.AddCommand(miCmd)
 
 	PreflightCmd.AddCommand(validateCNPCmd())

--- a/cilium-dbg/cmd/preflight.go
+++ b/cilium-dbg/cmd/preflight.go
@@ -59,7 +59,7 @@ func init() {
 	// From preflight_migrate_crd_identity.go
 	miCmd := migrateIdentityCmd()
 	miCmd.Flags().StringVar(&kvStore, "kvstore", "", "Key-value store type")
-	miCmd.Flags().Var(option.NewMapOptions(&kvStoreOpts, nil), "kvstore-opt", "Key-value store options e.g. etcd.address=127.0.0.1:4001")
+	miCmd.Flags().Var(option.NewMapOptions(&kvStoreOpts), "kvstore-opt", "Key-value store options e.g. etcd.address=127.0.0.1:4001")
 	PreflightCmd.AddCommand(miCmd)
 
 	PreflightCmd.AddCommand(validateCNPCmd())

--- a/cilium-dbg/cmd/root.go
+++ b/cilium-dbg/cmd/root.go
@@ -58,7 +58,7 @@ func init() {
 	flags.StringVar(&cfgFile, "config", "", "Config file (default is $HOME/.cilium.yaml)")
 	flags.BoolP("debug", "D", false, "Enable debug messages")
 	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use (example: syslog)")
-	flags.Var(option.NewMapOptions(&option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
+	flags.Var(option.NewMapOptions(&option.Config.LogOpt), option.LogOpt, "Log driver options (example: format=json)")
 	flags.StringP("host", "H", "", "URI to server-side API")
 	vp.BindPFlags(flags)
 	RootCmd.AddCommand(cmdref.NewCmd(RootCmd))

--- a/cilium-dbg/cmd/root.go
+++ b/cilium-dbg/cmd/root.go
@@ -58,7 +58,7 @@ func init() {
 	flags.StringVar(&cfgFile, "config", "", "Config file (default is $HOME/.cilium.yaml)")
 	flags.BoolP("debug", "D", false, "Enable debug messages")
 	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use (example: syslog)")
-	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
+	flags.Var(option.NewMapOptions(&option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
 	flags.StringP("host", "H", "", "URI to server-side API")
 	vp.BindPFlags(flags)
 	RootCmd.AddCommand(cmdref.NewCmd(RootCmd))

--- a/clustermesh-apiserver/option/config.go
+++ b/clustermesh-apiserver/option/config.go
@@ -37,5 +37,5 @@ var DefaultLegacyClusterMeshConfig = LegacyClusterMeshConfig{
 func (def LegacyClusterMeshConfig) Flags(flags *pflag.FlagSet) {
 	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
 	flags.StringSlice(option.LogDriver, def.LogDriver, "Logging endpoints to use (example: syslog)")
-	flags.Var(option.NewMapOptions(&option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
+	flags.Var(option.NewMapOptions(&option.Config.LogOpt), option.LogOpt, "Log driver options (example: format=json)")
 }

--- a/clustermesh-apiserver/option/config.go
+++ b/clustermesh-apiserver/option/config.go
@@ -37,5 +37,5 @@ var DefaultLegacyClusterMeshConfig = LegacyClusterMeshConfig{
 func (def LegacyClusterMeshConfig) Flags(flags *pflag.FlagSet) {
 	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
 	flags.StringSlice(option.LogDriver, def.LogDriver, "Logging endpoints to use (example: syslog)")
-	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
+	flags.Var(option.NewMapOptions(&option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
 }

--- a/contrib/scripts/check-viper.sh
+++ b/contrib/scripts/check-viper.sh
@@ -19,7 +19,7 @@ if grep -r -E --exclude-dir={.git,_build,vendor,contrib} -i --include \*.go "(vi
 fi
 
 if grep -r --exclude-dir={.git,_build,vendor,contrib} -i --include \*.go "StringToStringVar" .; then
-  echo "Found flags.StringToStringVar usage. Please use option.NewNamedMapOptions instead";
+  echo "Found flags.StringToStringVar usage. Please use option.NewMapOptions instead";
   exit 1
 fi
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -290,7 +290,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.IPv6PodSubnets, []string{}, "List of IPv6 pod subnets to preconfigure for encryption")
 	option.BindEnv(vp, option.IPv6PodSubnets)
 
-	flags.Var(option.NewNamedMapOptions(option.IPAMMultiPoolPreAllocation, &option.Config.IPAMMultiPoolPreAllocation, nil),
+	flags.Var(option.NewMapOptions(&option.Config.IPAMMultiPoolPreAllocation, nil),
 		option.IPAMMultiPoolPreAllocation,
 		fmt.Sprintf("Defines the minimum number of IPs a node should pre-allocate from each pool (default %s=8)", defaults.IPAMDefaultIPPool))
 	vp.SetDefault(option.IPAMMultiPoolPreAllocation, "")
@@ -407,7 +407,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EncryptionStrictModeAllowRemoteNodeIdentities, false, "Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.")
 	option.BindEnv(vp, option.EncryptionStrictModeAllowRemoteNodeIdentities)
 
-	flags.Var(option.NewNamedMapOptions(option.FixedIdentityMapping, &option.Config.FixedIdentityMapping, option.Config.FixedIdentityMappingValidator),
+	flags.Var(option.NewMapOptions(&option.Config.FixedIdentityMapping, option.Config.FixedIdentityMappingValidator),
 		option.FixedIdentityMapping, "Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns")
 	option.BindEnv(vp, option.FixedIdentityMapping)
 
@@ -549,7 +549,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use for example syslog")
 	option.BindEnv(vp, option.LogDriver)
 
-	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil),
+	flags.Var(option.NewMapOptions(&option.Config.LogOpt, nil),
 		option.LogOpt, `Log driver options for cilium-agent, `+
 			`configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}`)
 	option.BindEnv(vp, option.LogOpt)
@@ -795,7 +795,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.LocalRouterIPv6, "", "Link-local IPv6 used for Cilium's router devices")
 	option.BindEnv(vp, option.LocalRouterIPv6)
 
-	flags.Var(option.NewNamedMapOptions(option.BPFMapEventBuffers, &option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "Configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache_v2=enabled_1024_1h)")
+	flags.Var(option.NewMapOptions(&option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "Configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache_v2=enabled_1024_1h)")
 	flags.MarkHidden(option.BPFMapEventBuffers)
 
 	flags.Bool(option.EgressMultiHomeIPRuleCompat, false,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -122,56 +122,56 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags := cmd.Flags()
 
 	// Validators
-	option.Config.FixedIdentityMappingValidator = option.Validator(func(val string) (string, error) {
+	option.Config.FixedIdentityMappingValidator = option.Validator(func(val string) error {
 		vals := strings.Split(val, "=")
 		if len(vals) != 2 {
-			return "", fmt.Errorf(`invalid fixed identity: expecting "<numeric-identity>=<identity-name>" got %q`, val)
+			return fmt.Errorf(`invalid fixed identity: expecting "<numeric-identity>=<identity-name>" got %q`, val)
 		}
 		ni, err := identity.ParseNumericIdentity(vals[0])
 		if err != nil {
-			return "", fmt.Errorf(`invalid numeric identity %q: %w`, val, err)
+			return fmt.Errorf(`invalid numeric identity %q: %w`, val, err)
 		}
 		if !identity.IsUserReservedIdentity(ni) {
-			return "", fmt.Errorf(`invalid numeric identity %q: valid numeric identity is between %d and %d`,
+			return fmt.Errorf(`invalid numeric identity %q: valid numeric identity is between %d and %d`,
 				val, identity.UserReservedNumericIdentity.Uint32(), identity.MinimalNumericIdentity.Uint32())
 		}
 		lblStr := vals[1]
 		lbl := labels.ParseLabel(lblStr)
 		if lbl.IsReservedSource() {
-			return "", fmt.Errorf(`invalid source %q for label: %s`, labels.LabelSourceReserved, lblStr)
+			return fmt.Errorf(`invalid source %q for label: %s`, labels.LabelSourceReserved, lblStr)
 		}
-		return val, nil
+		return nil
 	})
 
-	option.Config.BPFMapEventBuffersValidator = option.Validator(func(val string) (string, error) {
+	option.Config.BPFMapEventBuffersValidator = option.Validator(func(val string) error {
 		vals := strings.Split(val, "=")
 		if len(vals) != 2 {
-			return "", fmt.Errorf(`invalid bpf map event config: expecting "<map_name>=<enabled>_<max_size>_<ttl>" got %q`, val)
+			return fmt.Errorf(`invalid bpf map event config: expecting "<map_name>=<enabled>_<max_size>_<ttl>" got %q`, val)
 		}
 		_, err := option.ParseEventBufferTupleString(vals[1])
 		if err != nil {
-			return "", err
+			return err
 		}
-		return "", nil
+		return nil
 	})
 
-	option.Config.FixedZoneMappingValidator = option.Validator(func(val string) (string, error) {
+	option.Config.FixedZoneMappingValidator = option.Validator(func(val string) error {
 		vals := strings.Split(val, "=")
 		if len(vals) != 2 {
-			return "", fmt.Errorf(`invalid fixed zone: expecting "<zone-name>=<numeric-id>" got %q`, val)
+			return fmt.Errorf(`invalid fixed zone: expecting "<zone-name>=<numeric-id>" got %q`, val)
 		}
 		lblStr := vals[0]
 		if len(lblStr) == 0 {
-			return "", fmt.Errorf(`invalid label: %q`, lblStr)
+			return fmt.Errorf(`invalid label: %q`, lblStr)
 		}
 		ni, err := strconv.Atoi(vals[1])
 		if err != nil {
-			return "", fmt.Errorf(`invalid numeric ID %q: %w`, vals[1], err)
+			return fmt.Errorf(`invalid numeric ID %q: %w`, vals[1], err)
 		}
 		if min, max := 1, math.MaxUint8; ni < min || ni >= max {
-			return "", fmt.Errorf(`invalid numeric ID %q: valid numeric ID is between %d and %d`, vals[1], min, max)
+			return fmt.Errorf(`invalid numeric ID %q: valid numeric ID is between %d and %d`, vals[1], min, max)
 		}
-		return val, nil
+		return nil
 	})
 
 	// Env bindings
@@ -290,7 +290,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.IPv6PodSubnets, []string{}, "List of IPv6 pod subnets to preconfigure for encryption")
 	option.BindEnv(vp, option.IPv6PodSubnets)
 
-	flags.Var(option.NewMapOptions(&option.Config.IPAMMultiPoolPreAllocation, nil),
+	flags.Var(option.NewMapOptions(&option.Config.IPAMMultiPoolPreAllocation),
 		option.IPAMMultiPoolPreAllocation,
 		fmt.Sprintf("Defines the minimum number of IPs a node should pre-allocate from each pool (default %s=8)", defaults.IPAMDefaultIPPool))
 	vp.SetDefault(option.IPAMMultiPoolPreAllocation, "")
@@ -549,7 +549,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use for example syslog")
 	option.BindEnv(vp, option.LogDriver)
 
-	flags.Var(option.NewMapOptions(&option.Config.LogOpt, nil),
+	flags.Var(option.NewMapOptions(&option.Config.LogOpt),
 		option.LogOpt, `Log driver options for cilium-agent, `+
 			`configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}`)
 	option.BindEnv(vp, option.LogOpt)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -29,7 +29,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Float64(operatorOption.IPAMAPIQPSLimit, defaults.IPAMAPIQPSLimit, "Queries per second limit when accessing external IPAM APIs")
 	option.BindEnv(vp, operatorOption.IPAMAPIQPSLimit)
 
-	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMSubnetsTags, nil),
+	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMSubnetsTags),
 		operatorOption.IPAMSubnetsTags, "Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag")
 	option.BindEnv(vp, operatorOption.IPAMSubnetsTags)
 
@@ -37,11 +37,11 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 		"Subnets IDs (separated by commas)")
 	option.BindEnv(vp, operatorOption.IPAMSubnetsIDs)
 
-	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMInstanceTags, nil), operatorOption.IPAMInstanceTags,
+	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMInstanceTags), operatorOption.IPAMInstanceTags,
 		"EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag")
 	option.BindEnv(vp, operatorOption.IPAMInstanceTags)
 
-	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMAutoCreateCiliumPodIPPools, nil),
+	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMAutoCreateCiliumPodIPPools),
 		operatorOption.IPAMAutoCreateCiliumPodIPPools,
 		"Automatically create CiliumPodIPPool resources on startup. "+
 			"Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)")
@@ -93,7 +93,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use for example syslog")
 	option.BindEnv(vp, option.LogDriver)
 
-	flags.Var(option.NewMapOptions(&option.Config.LogOpt, nil),
+	flags.Var(option.NewMapOptions(&option.Config.LogOpt),
 		option.LogOpt, `Log driver options for cilium-operator, `+
 			`configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}`)
 	option.BindEnv(vp, option.LogOpt)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -29,7 +29,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Float64(operatorOption.IPAMAPIQPSLimit, defaults.IPAMAPIQPSLimit, "Queries per second limit when accessing external IPAM APIs")
 	option.BindEnv(vp, operatorOption.IPAMAPIQPSLimit)
 
-	flags.Var(option.NewNamedMapOptions(operatorOption.IPAMSubnetsTags, &operatorOption.Config.IPAMSubnetsTags, nil),
+	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMSubnetsTags, nil),
 		operatorOption.IPAMSubnetsTags, "Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag")
 	option.BindEnv(vp, operatorOption.IPAMSubnetsTags)
 
@@ -37,11 +37,11 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 		"Subnets IDs (separated by commas)")
 	option.BindEnv(vp, operatorOption.IPAMSubnetsIDs)
 
-	flags.Var(option.NewNamedMapOptions(operatorOption.IPAMInstanceTags, &operatorOption.Config.IPAMInstanceTags, nil), operatorOption.IPAMInstanceTags,
+	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMInstanceTags, nil), operatorOption.IPAMInstanceTags,
 		"EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag")
 	option.BindEnv(vp, operatorOption.IPAMInstanceTags)
 
-	flags.Var(option.NewNamedMapOptions(operatorOption.IPAMAutoCreateCiliumPodIPPools, &operatorOption.Config.IPAMAutoCreateCiliumPodIPPools, nil),
+	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMAutoCreateCiliumPodIPPools, nil),
 		operatorOption.IPAMAutoCreateCiliumPodIPPools,
 		"Automatically create CiliumPodIPPool resources on startup. "+
 			"Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)")
@@ -93,7 +93,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use for example syslog")
 	option.BindEnv(vp, option.LogDriver)
 
-	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil),
+	flags.Var(option.NewMapOptions(&option.Config.LogOpt, nil),
 		option.LogOpt, `Log driver options for cilium-operator, `+
 			`configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}`)
 	option.BindEnv(vp, option.LogOpt)

--- a/operator/cmd/provider_aws_flags.go
+++ b/operator/cmd/provider_aws_flags.go
@@ -32,11 +32,11 @@ func (hook *awsFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.Vi
 	flags.Bool(operatorOption.AWSEnablePrefixDelegation, false, "Allows operator to allocate prefixes to ENIs instead of individual IP addresses")
 	option.BindEnv(vp, operatorOption.AWSEnablePrefixDelegation)
 
-	flags.Var(option.NewMapOptions(&operatorOption.Config.ENITags, nil),
+	flags.Var(option.NewMapOptions(&operatorOption.Config.ENITags),
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(vp, operatorOption.ENITags)
 
-	flags.Var(option.NewMapOptions(&operatorOption.Config.ENIGarbageCollectionTags, nil),
+	flags.Var(option.NewMapOptions(&operatorOption.Config.ENIGarbageCollectionTags),
 		operatorOption.ENIGarbageCollectionTags, "Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected")
 	option.BindEnv(vp, operatorOption.ENIGarbageCollectionTags)
 

--- a/operator/cmd/provider_aws_flags.go
+++ b/operator/cmd/provider_aws_flags.go
@@ -32,11 +32,11 @@ func (hook *awsFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.Vi
 	flags.Bool(operatorOption.AWSEnablePrefixDelegation, false, "Allows operator to allocate prefixes to ENIs instead of individual IP addresses")
 	option.BindEnv(vp, operatorOption.AWSEnablePrefixDelegation)
 
-	flags.Var(option.NewNamedMapOptions(operatorOption.ENITags, &operatorOption.Config.ENITags, nil),
+	flags.Var(option.NewMapOptions(&operatorOption.Config.ENITags, nil),
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(vp, operatorOption.ENITags)
 
-	flags.Var(option.NewNamedMapOptions(operatorOption.ENIGarbageCollectionTags, &operatorOption.Config.ENIGarbageCollectionTags, nil),
+	flags.Var(option.NewMapOptions(&operatorOption.Config.ENIGarbageCollectionTags, nil),
 		operatorOption.ENIGarbageCollectionTags, "Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected")
 	option.BindEnv(vp, operatorOption.ENIGarbageCollectionTags)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1502,10 +1502,10 @@ type DaemonConfig struct {
 	EnableIPIPTermination         bool
 	EnableUnreachableRoutes       bool
 	FixedIdentityMapping          map[string]string
-	FixedIdentityMappingValidator func(val string) (string, error) `json:"-"`
+	FixedIdentityMappingValidator Validator `json:"-"`
 	FixedZoneMapping              map[string]uint8
 	ReverseFixedZoneMapping       map[uint8]string
-	FixedZoneMappingValidator     func(val string) (string, error) `json:"-"`
+	FixedZoneMappingValidator     Validator `json:"-"`
 	IPv4Range                     string
 	IPv6Range                     string
 	IPv4ServiceRange              string
@@ -1941,7 +1941,7 @@ type DaemonConfig struct {
 	// BPFMapEventBuffers has configuration on what BPF map event buffers to enabled
 	// and configuration options for those.
 	BPFMapEventBuffers          map[string]string
-	BPFMapEventBuffersValidator func(val string) (string, error) `json:"-"`
+	BPFMapEventBuffersValidator Validator `json:"-"`
 	bpfMapEventConfigs          BPFEventBufferConfigs
 
 	// BPFDistributedLRU enables per-CPU distributed backend memory

--- a/pkg/option/map_options.go
+++ b/pkg/option/map_options.go
@@ -31,18 +31,6 @@ func NewMapOptions(values *map[string]string, validator Validator) *MapOptions {
 	}
 }
 
-// NewMapOpts creates a new MapOpts with the specified map of values and an
-// optional validator.
-func NewMapOpts(values map[string]string, validator Validator) *MapOptions {
-	if values == nil {
-		values = make(map[string]string)
-	}
-	return &MapOptions{
-		vals:      values,
-		validator: validator,
-	}
-}
-
 func (opts *MapOptions) String() string {
 	var kvs []string
 	for k, v := range opts.vals {

--- a/pkg/option/map_options.go
+++ b/pkg/option/map_options.go
@@ -29,6 +29,10 @@ type NamedMapOptions struct {
 
 // NewNamedMapOptions creates a reference to a new NamedMapOpts struct.
 func NewNamedMapOptions(name string, values *map[string]string, validator Validator) *NamedMapOptions {
+	if *values == nil {
+		*values = make(map[string]string)
+	}
+
 	return &NamedMapOptions{
 		name:       name,
 		MapOptions: *NewMapOpts(*values, validator),

--- a/pkg/option/map_options.go
+++ b/pkg/option/map_options.go
@@ -19,23 +19,15 @@ type MapOptions struct {
 	validator Validator
 }
 
-// NamedMapOptions is a MapOptions struct with a configuration name.
-// This struct is useful to keep reference to the assigned
-// field name in the internal configuration struct.
-type NamedMapOptions struct {
-	name string
-	MapOptions
-}
-
-// NewNamedMapOptions creates a reference to a new NamedMapOpts struct.
-func NewNamedMapOptions(name string, values *map[string]string, validator Validator) *NamedMapOptions {
+// NewMapOptions creates a reference to a new MapOptions struct.
+func NewMapOptions(values *map[string]string, validator Validator) *MapOptions {
 	if *values == nil {
 		*values = make(map[string]string)
 	}
 
-	return &NamedMapOptions{
-		name:       name,
-		MapOptions: *NewMapOpts(*values, validator),
+	return &MapOptions{
+		vals:      *values,
+		validator: validator,
 	}
 }
 

--- a/pkg/option/map_options_test.go
+++ b/pkg/option/map_options_test.go
@@ -61,18 +61,18 @@ func TestMapOptions(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			opts := NewNamedMapOptions("flag-1", &tc.target, tc.validator)
+			opts := NewMapOptions(&tc.target, tc.validator)
 			err := opts.Set(tc.input)
 			if err != nil {
 				if len(tc.wantErr) == 0 {
-					t.Fatalf("NewNamedMapOptions()=%v, want nil", err)
+					t.Fatalf("NewMapOptions()=%v, want nil", err)
 				}
 				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("NewNamedMapOptions()=%v, want error with substring %q", err, tc.wantErr)
+					t.Fatalf("NewMapOptions()=%v, want error with substring %q", err, tc.wantErr)
 				}
 				return
 			} else if len(tc.wantErr) != 0 {
-				t.Fatalf("NewNamedMapOptions()=nil, want error with substring %q", tc.wantErr)
+				t.Fatalf("NewMapOptions()=nil, want error with substring %q", tc.wantErr)
 			}
 			if diff := cmp.Diff(tc.want, tc.target); diff != "" {
 				t.Errorf("Unexpected result map (-want +got):\n%s", diff)

--- a/pkg/option/map_options_test.go
+++ b/pkg/option/map_options_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestMapOptions(t *testing.T) {
 	for _, tc := range []struct {
-		desc      string
-		input     string
-		validator Validator
-		target    map[string]string
-		wantErr   string
-		want      map[string]string
+		desc       string
+		input      string
+		validators []Validator
+		target     map[string]string
+		wantErr    string
+		want       map[string]string
 	}{
 		{
 			desc:   "no validator",
@@ -33,25 +33,19 @@ func TestMapOptions(t *testing.T) {
 			desc:   "validator that returns error",
 			input:  "k1=v1,k2=v2",
 			target: make(map[string]string),
-			validator: func(val string) (string, error) {
-				return "", fmt.Errorf("invalid value %s", val)
+			validators: []Validator{
+				func(val string) error { return fmt.Errorf("invalid value %s", val) },
 			},
 			wantErr: "invalid value k1=v1",
 		},
 		{
-			desc:   "validator that modifies entries",
-			input:  "k8s:k1 =v1,k8s:k2= v2",
-			target: make(map[string]string),
-			validator: func(val string) (string, error) {
-				val = strings.TrimPrefix(val, "k8s:")
-				vals := strings.SplitN(val, "=", 2)
-				kv := []string{strings.TrimSpace(vals[0]), strings.TrimSpace(vals[1])}
-				return strings.Join(kv, "="), nil
+			desc:  "multiple validators that return success",
+			input: "k1=v1,k2=v2",
+			validators: []Validator{
+				func(val string) error { return nil },
+				func(val string) error { return nil },
 			},
-			want: map[string]string{
-				"k1": "v1",
-				"k2": "v2",
-			},
+			want: map[string]string{"k1": "v1", "k2": "v2"},
 		},
 		{
 			desc:   "nil target map",
@@ -61,7 +55,7 @@ func TestMapOptions(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			opts := NewMapOptions(&tc.target, tc.validator)
+			opts := NewMapOptions(&tc.target, tc.validators...)
 			err := opts.Set(tc.input)
 			if err != nil {
 				if len(tc.wantErr) == 0 {


### PR DESCRIPTION
Remove a few pitfalls associated with `option.NewNamedMapOptions`, and simplify its API surface. Please refer to the individual commits for additional details. 