### PR TITLE
gateway-api: Remove cluster default connection timeout

### DIFF
--- a/operator/pkg/gateway-api/testdata/gamma/mesh-basic/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-basic/cec-echo-output.yaml
@@ -85,7 +85,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:8080
     name: gateway-conformance-mesh:echo-v1:8080

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-frontend/cec-echo-v2-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-frontend/cec-echo-v2-output.yaml
@@ -95,7 +95,6 @@ spec:
             - name: gateway-conformance-mesh:echo-v2:80
               weight: 1
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v2:80
     name: gateway-conformance-mesh:echo-v2:80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-matching/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-matching/cec-echo-output.yaml
@@ -115,7 +115,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:8080
     name: gateway-conformance-mesh:echo-v1:8080
@@ -130,7 +129,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v2:8080
     name: gateway-conformance-mesh:echo-v2:8080

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-ports/cec-echo-v1-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-ports/cec-echo-v1-output.yaml
@@ -90,7 +90,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:80
     name: gateway-conformance-mesh:echo-v1:80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-ports/cec-echo-v2-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-ports/cec-echo-v2-output.yaml
@@ -95,7 +95,6 @@ spec:
             - name: gateway-conformance-mesh:echo-v2:80
               weight: 1
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v2:80
     name: gateway-conformance-mesh:echo-v2:80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-query-param-matching/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-query-param-matching/cec-echo-output.yaml
@@ -167,7 +167,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:8080
     name: gateway-conformance-mesh:echo-v1:8080
@@ -182,7 +181,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v2:8080
     name: gateway-conformance-mesh:echo-v2:8080

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-request-header-modifier/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-request-header-modifier/cec-echo-output.yaml
@@ -151,7 +151,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:8080
     name: gateway-conformance-mesh:echo-v1:8080

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-rewrite-path/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-rewrite-path/cec-echo-output.yaml
@@ -149,7 +149,6 @@ spec:
               regex: ^/.*$
             substitution: /one
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:80
     name: gateway-conformance-mesh:echo-v1:80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-split/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-split/cec-echo-output.yaml
@@ -105,7 +105,6 @@ spec:
             - name: gateway-conformance-mesh:echo-v2:80
               weight: 1
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:80
     name: gateway-conformance-mesh:echo-v1:80
@@ -120,7 +119,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v2:80
     name: gateway-conformance-mesh:echo-v2:80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-weighted-backends/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-weighted-backends/cec-echo-output.yaml
@@ -94,7 +94,6 @@ spec:
             - name: gateway-conformance-mesh:echo-v2:8080
               weight: 30
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:8080
     name: gateway-conformance-mesh:echo-v1:8080
@@ -109,7 +108,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v2:8080
     name: gateway-conformance-mesh:echo-v2:8080

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation-with-hostname-intersection.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation-with-hostname-intersection.yaml
@@ -126,7 +126,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation.yaml
@@ -118,7 +118,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-add-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-add-listener.yaml
@@ -125,7 +125,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-remove-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-remove-listener.yaml
@@ -136,7 +136,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backend-protocol-h2c/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backend-protocol-h2c/output/cec-same-namespace.yaml
@@ -85,7 +85,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8081
     name: gateway-conformance-infra:infra-backend-v1:8081

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backend-protocol-websocket/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backend-protocol-websocket/output/cec-same-namespace.yaml
@@ -85,7 +85,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8082
     name: gateway-conformance-infra:infra-backend-v1:8082

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-exact-path-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-exact-path-matching/output/cec-same-namespace.yaml
@@ -95,7 +95,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -110,7 +109,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-header-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-header-matching/output/cec-same-namespace.yaml
@@ -156,7 +156,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -171,7 +170,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-https-listener/output/cec-same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-https-listener/output/cec-same-namespace-with-https-listener.yaml
@@ -138,7 +138,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -153,7 +152,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-matching-across-routes/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-matching-across-routes/output/cec-same-namespace.yaml
@@ -137,7 +137,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -152,7 +151,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-matching/output/cec-same-namespace.yaml
@@ -115,7 +115,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -130,7 +129,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-method-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-method-matching/output/cec-same-namespace.yaml
@@ -192,7 +192,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -207,7 +206,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -222,7 +220,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-observed-generation-bump/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-observed-generation-bump/output/cec-same-namespace.yaml
@@ -85,7 +85,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-partially-invalid-via-invalid-reference-grant/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-partially-invalid-via-invalid-reference-grant/output/cec-same-namespace.yaml
@@ -91,7 +91,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-app-backend/app-backend-v1:8080
     name: gateway-conformance-app-backend:app-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-path-match-order/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-path-match-order/output/cec-same-namespace.yaml
@@ -123,7 +123,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -138,7 +137,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -153,7 +151,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-query-param-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-query-param-matching/output/cec-same-namespace.yaml
@@ -218,7 +218,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -233,7 +232,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -248,7 +246,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-reference-grant/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-reference-grant/output/cec-same-namespace.yaml
@@ -85,7 +85,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-web-backend/web-backend:8080
     name: gateway-conformance-web-backend:web-backend:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-header-modifier-backend-weights/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-header-modifier-backend-weights/output/cec-same-namespace.yaml
@@ -104,7 +104,6 @@ spec:
                   value: infra-backend-v2
               weight: 10
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -119,7 +118,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-header-modifier/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-header-modifier/output/cec-same-namespace.yaml
@@ -151,7 +151,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-mirror/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-mirror/output/cec-same-namespace.yaml
@@ -118,7 +118,6 @@ spec:
               defaultValue:
                 numerator: 100
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -133,7 +132,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-multiple-mirrors/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-multiple-mirrors/output/cec-same-namespace.yaml
@@ -130,7 +130,6 @@ spec:
               defaultValue:
                 numerator: 100
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -145,7 +144,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -160,7 +158,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-percentage-mirror/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-percentage-mirror/output/cec-same-namespace.yaml
@@ -129,7 +129,6 @@ spec:
               defaultValue:
                 numerator: 20
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -144,7 +143,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-response-header-modifier/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-response-header-modifier/output/cec-same-namespace.yaml
@@ -200,7 +200,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-timeout-backend-request/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-timeout-backend-request/output/cec-same-namespace.yaml
@@ -89,7 +89,6 @@ spec:
           cluster: gateway-conformance-infra:infra-backend-v1:8080
           timeout: 0.500s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-timeout-request/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-timeout-request/output/cec-same-namespace.yaml
@@ -89,7 +89,6 @@ spec:
           cluster: gateway-conformance-infra:infra-backend-v1:8080
           timeout: 0.500s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-weight/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-weight/output/cec-same-namespace.yaml
@@ -100,7 +100,6 @@ spec:
             - name: gateway-conformance-infra:infra-backend-v3:8080
               weight: 0
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -115,7 +114,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -130,7 +128,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/model/translation/envoy_cluster.go
+++ b/operator/pkg/model/translation/envoy_cluster.go
@@ -33,7 +33,6 @@ const (
 
 func (i *cecTranslator) clusterMutators(grpcService bool, appProtocol string) []ClusterMutator {
 	res := []ClusterMutator{
-		withConnectionTimeout(5),
 		withIdleTimeout(i.Config.ClusterConfig.IdleTimeoutSeconds),
 		withClusterLbPolicy(int32(envoy_config_cluster_v3.Cluster_ROUND_ROBIN)),
 		withOutlierDetection(true),
@@ -54,7 +53,6 @@ func (i *cecTranslator) clusterMutators(grpcService bool, appProtocol string) []
 
 func (i *cecTranslator) tcpClusterMutators(mutationFunc ...ClusterMutator) []ClusterMutator {
 	return append(mutationFunc,
-		withConnectionTimeout(5),
 		withClusterLbPolicy(int32(envoy_config_cluster_v3.Cluster_ROUND_ROBIN)),
 		withOutlierDetection(true),
 	)

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener/cec-output.yaml
@@ -95,7 +95,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/cec-output.yaml
@@ -94,7 +94,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/cec-output.yaml
@@ -94,7 +94,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/cec-output.yaml
@@ -94,7 +94,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/cec-output.yaml
@@ -105,7 +105,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_tls_sni_listener/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_tls_sni_listener/cec-output.yaml
@@ -53,7 +53,6 @@ spec:
       level: "6"
       name: "6"
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_frontend/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_frontend/cec-output.yaml
@@ -100,7 +100,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v2:80
     name: gateway-conformance-mesh:echo-v2:80

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_ports/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_ports/cec-output.yaml
@@ -100,7 +100,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:80
     name: gateway-conformance-mesh:echo-v1:80

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_splits/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_splits/cec-output.yaml
@@ -115,7 +115,6 @@ spec:
             - name: gateway-conformance-mesh:echo-v2:80
               weight: 1
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v1:80
     name: gateway-conformance-mesh:echo-v1:80
@@ -130,7 +129,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-mesh/echo-v2:80
     name: gateway-conformance-mesh:echo-v2:80

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httpexact_path_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httpexact_path_matching/cec-output.yaml
@@ -105,7 +105,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -120,7 +119,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c/cec-output.yaml
@@ -95,7 +95,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/backend-protocol-h2c:8080
     name: gateway-conformance-infra:backend-protocol-h2c:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c_app_protocol/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c_app_protocol/cec-output.yaml
@@ -95,7 +95,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/backend-protocol-h2c:8080
     name: gateway-conformance-infra:backend-protocol-h2c:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_request_header_modifier/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_request_header_modifier/cec-output.yaml
@@ -246,7 +246,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -261,7 +260,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -276,7 +274,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_response_header_modifier/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_response_header_modifier/cec-output.yaml
@@ -246,7 +246,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -261,7 +260,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -276,7 +274,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_cross_namespace/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_cross_namespace/cec-output.yaml
@@ -95,7 +95,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-web-backend/web-backend:8080
     name: gateway-conformance-web-backend:web-backend:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_header_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_header_matching/cec-output.yaml
@@ -166,7 +166,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -181,7 +180,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_hostname_intersection/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_hostname_intersection/cec-output.yaml
@@ -154,7 +154,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -169,7 +168,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -184,7 +182,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_listener_hostname_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_listener_hostname_matching/cec-output.yaml
@@ -137,7 +137,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -152,7 +151,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -167,7 +165,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching/cec-output.yaml
@@ -113,7 +113,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -128,7 +127,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching_across_routes/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching_across_routes/cec-output.yaml
@@ -129,7 +129,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -144,7 +143,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_method_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_method_matching/cec-output.yaml
@@ -113,7 +113,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -128,7 +127,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_query_param_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_query_param_matching/cec-output.yaml
@@ -140,7 +140,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -155,7 +154,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080
@@ -170,7 +168,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v3:8080
     name: gateway-conformance-infra:infra-backend-v3:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_header_modifier/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_header_modifier/cec-output.yaml
@@ -161,7 +161,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_mirror/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_mirror/cec-output.yaml
@@ -104,7 +104,6 @@ spec:
               defaultValue:
                 numerator: 100
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -119,7 +118,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/cec-output.yaml
@@ -103,7 +103,6 @@ spec:
           hostRedirect: example.com
           portRedirect: 80
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/cec-output.yaml
@@ -172,7 +172,6 @@ spec:
           prefixRewrite: /request-redirect
           responseCode: FOUND
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_response_header_modifier/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_response_header_modifier/cec-output.yaml
@@ -173,7 +173,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_host/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_host/cec-output.yaml
@@ -108,7 +108,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080
@@ -123,7 +122,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v2:8080
     name: gateway-conformance-infra:infra-backend-v2:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_path/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_path/cec-output.yaml
@@ -149,7 +149,6 @@ spec:
               regex: ^/.*$
             substitution: /one
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_simple_same_namespace/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_simple_same_namespace/cec-output.yaml
@@ -95,7 +95,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
     name: gateway-conformance-infra:infra-backend-v1:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/cec-output.yaml
@@ -97,7 +97,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/cec-output.yaml
@@ -97,7 +97,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/cec-output.yaml
@@ -97,7 +97,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/cec-output.yaml
@@ -97,7 +97,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/cec-output.yaml
@@ -91,7 +91,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/cec-output.yaml
@@ -91,7 +91,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/cec-output.yaml
@@ -100,7 +100,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/cec-output.yaml
@@ -100,7 +100,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: default/my-service:8080
     name: default:my-service:8080

--- a/operator/pkg/model/translation/ingress/testdata/complex_node_port_ingress/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/complex_node_port_ingress/output-cec.yaml
@@ -297,7 +297,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: dummy-namespace/another-dummy-backend:8081
     name: dummy-namespace:another-dummy-backend:8081
@@ -312,7 +311,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: dummy-namespace/default-backend:8080
     name: dummy-namespace:default-backend:8080
@@ -327,7 +325,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: dummy-namespace/dummy-backend:8080
     name: dummy-namespace:dummy-backend:8080

--- a/operator/pkg/model/translation/ingress/testdata/conformance/default_backend/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/default_backend/output-cec.yaml
@@ -88,7 +88,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/default-backend:8080
     name: random-namespace:default-backend:8080

--- a/operator/pkg/model/translation/ingress/testdata/conformance/host_network/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/host_network/output-cec.yaml
@@ -100,7 +100,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/default-backend:8080
     name: random-namespace:default-backend:8080

--- a/operator/pkg/model/translation/ingress/testdata/conformance/host_rules/no_force_https/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/host_rules/no_force_https/output-cec.yaml
@@ -171,7 +171,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/foo-bar-com:http
     name: random-namespace:foo-bar-com:http
@@ -186,7 +185,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/wildcard-foo-com:8080
     name: random-namespace:wildcard-foo-com:8080

--- a/operator/pkg/model/translation/ingress/testdata/conformance/host_rules/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/host_rules/output-cec.yaml
@@ -169,7 +169,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/foo-bar-com:http
     name: random-namespace:foo-bar-com:http
@@ -184,7 +183,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/wildcard-foo-com:8080
     name: random-namespace:wildcard-foo-com:8080

--- a/operator/pkg/model/translation/ingress/testdata/conformance/path_rules/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/path_rules/output-cec.yaml
@@ -166,7 +166,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/aaa-prefix:8080
     name: random-namespace:aaa-prefix:8080
@@ -181,7 +180,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/aaa-slash-bbb-prefix:8080
     name: random-namespace:aaa-slash-bbb-prefix:8080
@@ -196,7 +194,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/aaa-slash-bbb-slash-prefix:8080
     name: random-namespace:aaa-slash-bbb-slash-prefix:8080
@@ -211,7 +208,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/foo-exact:8080
     name: random-namespace:foo-exact:8080
@@ -226,7 +222,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/foo-prefix:8080
     name: random-namespace:foo-prefix:8080
@@ -241,7 +236,6 @@ spec:
         useDownstreamProtocolConfig:
           http2ProtocolOptions: {}
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/foo-slash-exact:8080
     name: random-namespace:foo-slash-exact:8080

--- a/operator/pkg/model/translation/ingress/testdata/conformance/proxy_protocol/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/proxy_protocol/output-cec.yaml
@@ -91,7 +91,6 @@ spec:
           maxStreamDuration:
             maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 5s
     edsClusterConfig:
       serviceName: random-namespace/default-backend:8080
     name: random-namespace:default-backend:8080


### PR DESCRIPTION
This was added unintentionally in the below commit.

Fixes: 7af797c16b949b7c1c578d68bed7f70969967216
Fixes: #40428
Reported-by: Bryon Roché <kain@kain.org>

