### PR TITLE
docs: clarify Prometheus annotation logic for metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -50,8 +50,10 @@ if you want to disable them, set Helm value ``operator.prometheus.enabled=false`
 The ports can be configured via ``prometheus.port``,
 ``envoy.prometheus.port``, or ``operator.prometheus.port`` respectively.
 
-When metrics are enabled, all Cilium components will have the following
-annotations. They can be used to signal Prometheus whether to scrape metrics:
+
+When metrics are enabled and ServiceMonitor is not enabled (``hubble.metrics.serviceMonitor.enabled: false``), all Cilium components will have the following annotations. These annotations can be used to signal Prometheus whether to scrape metrics.
+
+If ServiceMonitor is enabled (``hubble.metrics.serviceMonitor.enabled: true``), these annotations are omitted and Prometheus discovers metrics via the ServiceMonitor resource.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
This PR updates the Monitoring & Metrics documentation to clarify that Prometheus annotations (`prometheus.io/scrape`, `prometheus.io/port`) are only present when `hubble.metrics.serviceMonitor.enabled` is set to `false`. If ServiceMonitor is enabled, these annotations are omitted and Prometheus discovers metrics via the ServiceMonitor resource.

Closes: #21958

- Updated the explanation before the annotation code block.
- Built and checked the documentation locally.

## See the screenshot here how it looks 
<img width="1889" height="915" alt="Screenshot 2025-07-15 171748" src="https://github.com/user-attachments/assets/b129e432-51f7-47a3-b43b-7728db909afb" />




