### PR TITLE
docs: redirect Configuring IPAM Modes to comprehensive IPAM documentation 

### DIFF
--- a/Documentation/network/kubernetes/ipam.rst
+++ b/Documentation/network/kubernetes/ipam.rst
@@ -10,6 +10,11 @@
 Configuring IPAM Modes
 **********************
 
+Cilium supports multiple IP Address Management (IPAM) modes to meet the needs
+of different environments and cloud providers.
+
+The following sections provide documentation for each supported IPAM mode:
+
 .. toctree::
    :maxdepth: 1
    :glob:
@@ -17,3 +22,8 @@ Configuring IPAM Modes
    ipam-crd
    ipam-cluster-pool
    ipam-multi-pool
+
+   ../concepts/ipam/kubernetes
+   ../concepts/ipam/azure
+   ../concepts/ipam/azure-delegated-ipam
+   ../concepts/ipam/eni


### PR DESCRIPTION
This PR updates the Configuring IPAM Modes documentation to provide clear, direct links to all supported IPAM modes.
The page now offers a brief introduction and a structured navigation section , making it easier for users to find details for each mode.
Closes: #22236

```release-note
docs: Add missing IPAM modes to configuration page
```