### PR TITLE
cli: Add the check for l7 proxy for `to-fqdns` test

### DIFF
--- a/cilium-cli/connectivity/builder/to_fqdns.go
+++ b/cilium-cli/connectivity/builder/to_fqdns.go
@@ -23,6 +23,7 @@ func (t toFqdns) build(ct *check.ConnectivityTest, templates map[string]string) 
 			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryDestPort(80)),
 			tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable), // resolves to ExternalOtherTarget
 		).
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Address(features.IPFamilyAny) == ct.Params().ExternalOtherTarget {
 				if a.Destination().Path() == "/" || a.Destination().Path() == "" {


### PR DESCRIPTION
### Issue
PR #38750 introduced an IPv6 check for FQDN and other scenarios, gated by the `external-target-ipv6-capable` flag. However, deploying a DNS-only CNP on a cluster where the L7 proxy is disabled causes the test to fail with a timeout.

On clusters without L7 proxy enabled, the Cilium CLI still applies the policy and marks it as "changed" since it's accepted by Kubernetes. However, the policy isn't actually enforced by Cilium due to unsupported L7 features — which is only visible in the Cilium agent logs:

```
level=warning msg="Unable to add CiliumNetworkPolicy" ciliumNetworkPolicyName=client-egress-only-dns error="Invalid CiliumNetworkPolicy spec: L7 policy is not supported since L7 proxy is not enabled"
```
Since the CLI detects two policies as applied but only one is enforced, it waits for the policy revision to increment by 2. But only one policy is truly applied, so the revision increases by 1, resulting in a timeout:

```
📜 Applying CiliumNetworkPolicy 'client-egress-to-fqdns-one.one.one.one' to namespace 'cilium-test-1' on cluster kind-kind..
  ℹ️  📜 Successfully applied CiliumNetworkPolicy 'client-egress-to-fqdns-one.one.one.one' to namespace 'cilium-test-1' on cluster kind-kind
  ℹ️  Changed: true
  ℹ️  📜 Applying CiliumNetworkPolicy 'client-egress-only-dns' to namespace 'cilium-test-1' on cluster kind-kind..
  ℹ️  📜 Successfully applied CiliumNetworkPolicy 'client-egress-only-dns' to namespace 'cilium-test-1' on cluster kind-kind
  ℹ️  Changed: true
  🐛 Waiting for Cilium agents to increment policy revisions by map[kind-kind:2]
  🐛 Current policy revisions: map[kube-system/cilium-74ngv:13 kube-system/cilium-nthvw:13]
  🐛 Policy difference detected, waiting for Cilium agents to increment policy revisions..
  ```

CLI applies both policies and assumes they are valid.
It does not validate if policies are supported by Cilium (e.g., L7 rules without L7 proxy).
It then waits for policy revisions based on the number of applied resources, not actual enforcement.

### Fix
Since `to-fqdns` is not valid feature without l7 proxy, add that to the test.

```release-note
Add l7 proxy check for `to-fqdns` connectivity test
```