### PR TITLE
.github/release: Filter out CLI-only release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,4 +89,5 @@ jobs:
             --repo-dir "$(pwd)/../cilium" \
             --repo ${{ github.repository }} \
             --target-version ${{ github.event.inputs.version }} \
-            --steps ${{ github.event.inputs.step }}
+            --steps ${{ github.event.inputs.step }} \
+            --exclude-labels "cilium-cli-exclusive"


### PR DESCRIPTION
When preparing release notes for Cilium itself, the CLI-only changes
aren't relevant. Exclude those release notes when generating the
changelogs for the Cilium network suite (cilium-agent, cilium-operator).

Requires: https://github.com/cilium/release/pull/342
Related: https://github.com/cilium/release/issues/272
