### PR TITLE
feat: add wildcard service support and virtual IP traffic dropping

### DIFF
--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -22,3 +22,5 @@ NODE_CONFIG(__u32, trace_payload_len, "Length of payload to capture when tracing
 #define TRACE_PAYLOAD_LEN CONFIG(trace_payload_len) /* Backwards compatibility */
 
 NODE_CONFIG(__u32, trace_payload_len_overlay, "Length of payload to capture when tracing overlay packets.")
+
+NODE_CONFIG(bool, drop_traffic_to_virtual_ips, "Drop traffic to non-existent ports on virtual IPs")

--- a/bpf/tests/lib/lb.h
+++ b/bpf/tests/lib/lb.h
@@ -89,6 +89,30 @@ lb_v4_add_service_with_flags(__be32 addr, __be16 port, __u8 proto, __u16 backend
 {
 	__lb_v4_add_service(addr, port, proto, proto, backend_count, rev_nat_index,
 			    flags, flags2, false, 0);
+
+	if (CONFIG(drop_traffic_to_virtual_ips) && (!(flags & SVC_FLAG_ROUTABLE) || (flags2 & SVC_FLAG_LOADBALANCER))) {
+		/* Automatically create wildcard entry for ClusterIP and LoadBalancer services
+		 * to enable dropping traffic to non-existent ports on virtual IPs or
+		 * to enable ICMP echo replies on virtual IPs
+		 */
+		/* This is a ClusterIP (not routable) or LoadBalancer service.
+		 * Create a wildcard entry (port=0, IPPROTO_ANY) with 0 backends
+		 * to trigger drops for non-existent ports or ICMP echo replies.
+		 */
+		struct lb4_key wildcard_key = {
+			.address = addr,
+			.dport = 0,
+			.proto = IPPROTO_ANY,
+			.scope = LB_LOOKUP_SCOPE_EXT,
+		};
+		struct lb4_service *existing = map_lookup_elem(&cilium_lb4_services_v2, &wildcard_key);
+
+		/* Only create wildcard if it doesn't exist yet */
+		if (!existing) {
+			__lb_v4_add_service(addr, 0, IPPROTO_ANY, IPPROTO_ANY, 0, rev_nat_index,
+					    flags, flags2, false, 0);
+		}
+	}
 }
 
 static __always_inline void
@@ -197,6 +221,30 @@ lb_v6_add_service_with_flags(const union v6addr *addr, __be16 port, __u8 proto,
 {
 	__lb_v6_add_service(addr, port, proto, backend_count, rev_nat_index, flags,
 			    flags2);
+
+	if (CONFIG(drop_traffic_to_virtual_ips) && (!(flags & SVC_FLAG_ROUTABLE) || (flags2 & SVC_FLAG_LOADBALANCER))) {
+		/* Automatically create wildcard entry for ClusterIP and LoadBalancer services
+		 * to enable dropping traffic to non-existent ports on virtual IPs or
+		 * to enable ICMPv6 echo replies on virtual IPs
+		 */
+		/* This is a ClusterIP (not routable) or LoadBalancer service.
+		 * Create a wildcard entry (port=0, IPPROTO_ANY) with 0 backends
+		 * to trigger drops for non-existent ports or ICMPv6 echo replies.
+		 */
+		struct lb6_key wildcard_key __align_stack_8 = {
+			.dport = 0,
+			.proto = IPPROTO_ANY,
+			.scope = LB_LOOKUP_SCOPE_EXT,
+		};
+		memcpy(&wildcard_key.address, addr, sizeof(*addr));
+		struct lb6_service *existing = map_lookup_elem(&cilium_lb6_services_v2, &wildcard_key);
+
+		/* Only create wildcard if it doesn't exist yet */
+		if (!existing) {
+			__lb_v6_add_service(addr, 0, IPPROTO_ANY, 0, rev_nat_index,
+					    flags, flags2);
+		}
+	}
 }
 
 static __always_inline void

--- a/bpf/tests/tc_lxc_drop_virtual_ip.c
+++ b/bpf/tests/tc_lxc_drop_virtual_ip.c
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#define ENABLE_NODEPORT 1
+
+
+
+#include <bpf_lxc.c>
+
+
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/policy.h"
+#include "lib/endpoint.h"
+
+ASSIGN_CONFIG(bool, drop_traffic_to_virtual_ips, true)
+
+#define CLUSTER_IP_V4 v4_svc_one
+#define CLUSTER_IP_V6 v6_svc_one
+#define NON_VIRTUAL_IP_V4 v4_pod_one
+#define NON_VIRTUAL_IP_V6 v6_pod_one
+
+#define SERVICE_PORT tcp_svc_one
+#define NON_SERVICE_PORT __bpf_htons(8080)
+
+#define CLIENT_IP_V4 v4_pod_two
+#define CLIENT_IP_V6 v6_pod_two
+#define CLIENT_PORT __bpf_htons(111)
+
+/* Configure endpoint IP addresses - CRITICAL for LXC tests */
+ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = CLIENT_IP_V4})
+ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_two_addr})
+
+#define FROM_CONTAINER 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+/* Test IPv4 packet to virtual IP without service - should be dropped */
+PKTGEN("tc", "test_lxc_drop_virtual_ip_no_service_v4")
+int test_lxc_drop_virtual_ip_no_service_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  CLIENT_IP_V4, CLUSTER_IP_V4,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_lxc_drop_virtual_ip_no_service_v4")
+int test_lxc_drop_virtual_ip_no_service_v4_setup(struct __ctx_buff *ctx)
+{
+	/* Add identity mappings */
+	ipcache_v4_add_entry(CLIENT_IP_V4, 0, SECLABEL_IPV4, 0, 0);
+	ipcache_v4_add_entry(CLUSTER_IP_V4, 0, SECLABEL_IPV4, 0, 0);
+
+	/* Create a ClusterIP service on a different port - no backend for the non-service port */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, SERVICE_PORT, IPPROTO_TCP, 1, 1, SVC_FLAG_ROUTABLE, 0);
+
+	/* Add wildcard entry to enable virtual IP drop logic */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+	/* Add a backend for the service on the existing port only */
+	lb_v4_add_backend(CLUSTER_IP_V4, SERVICE_PORT, 1, 1, v4_pod_one, __bpf_htons(8080), IPPROTO_TCP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_drop_virtual_ip_no_service_v4")
+int test_lxc_drop_virtual_ip_no_service_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	/* Should be dropped - no service for this port */
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(l3->daddr == CLUSTER_IP_V4);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}
+
+/* Test IPv6 packet to virtual IP without service - should be dropped */
+PKTGEN("tc", "test_lxc_drop_virtual_ip_no_service_v6")
+int test_lxc_drop_virtual_ip_no_service_v6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  (__u8 *)CLIENT_IP_V6, (__u8 *)CLUSTER_IP_V6,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_lxc_drop_virtual_ip_no_service_v6")
+int test_lxc_drop_virtual_ip_no_service_v6_setup(struct __ctx_buff *ctx)
+{
+	/* Add identity mappings */
+	ipcache_v6_add_entry((union v6addr *)&CLIENT_IP_V6, 0, SECLABEL_IPV6, 0, 0);
+	ipcache_v6_add_entry((union v6addr *)&CLUSTER_IP_V6, 0, SECLABEL_IPV6, 0, 0);
+
+	/* Create a ClusterIP service on a different port - no backend for the non-service port */
+	lb_v6_add_service_with_flags((union v6addr *)&CLUSTER_IP_V6, SERVICE_PORT, IPPROTO_TCP, 1, 1, SVC_FLAG_ROUTABLE, 0);
+
+	/* Add wildcard entry to enable virtual IP drop logic */
+	lb_v6_add_service_with_flags((union v6addr *)&CLUSTER_IP_V6, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+	/* Add a backend for the service on the existing port only */
+	lb_v6_add_backend((union v6addr *)&CLUSTER_IP_V6, SERVICE_PORT, 1, 1, (union v6addr *)&v6_pod_one, __bpf_htons(8080), IPPROTO_TCP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_drop_virtual_ip_no_service_v6")
+int test_lxc_drop_virtual_ip_no_service_v6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	/* Should be dropped - no service for this port */
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(memcmp(&l3->daddr, (void *)&CLUSTER_IP_V6, sizeof(l3->daddr)) == 0);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}
+
+/* Test UDP packet to virtual IP without UDP service - should be dropped */
+PKTGEN("tc", "test_lxc_drop_virtual_ip_udp_v4")
+int test_lxc_drop_virtual_ip_udp_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  CLIENT_IP_V4, CLUSTER_IP_V4,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_lxc_drop_virtual_ip_udp_v4")
+int test_lxc_drop_virtual_ip_udp_v4_setup(struct __ctx_buff *ctx)
+{
+	/* Add identity mappings */
+	ipcache_v4_add_entry(CLIENT_IP_V4, 0, SECLABEL_IPV4, 0, 0);
+	ipcache_v4_add_entry(CLUSTER_IP_V4, 0, SECLABEL_IPV4, 0, 0);
+
+	/* Create a TCP ClusterIP service (UDP packet should still be dropped) */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, SERVICE_PORT, IPPROTO_TCP, 1, 1, SVC_FLAG_ROUTABLE, 0);
+
+	/* Add wildcard entry to enable virtual IP drop logic */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+	/* Add a backend for the TCP service only - no UDP backend */
+	lb_v4_add_backend(CLUSTER_IP_V4, SERVICE_PORT, 1, 1, v4_pod_one, __bpf_htons(8080), IPPROTO_TCP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_drop_virtual_ip_udp_v4")
+int test_lxc_drop_virtual_ip_udp_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct udphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	/* Should be dropped - no UDP service */
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct udphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(l3->daddr == CLUSTER_IP_V4);
+	assert(l3->protocol == IPPROTO_UDP);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}

--- a/bpf/tests/tc_nodeport_drop_virtual_ip.c
+++ b/bpf/tests/tc_nodeport_drop_virtual_ip.c
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#define ENABLE_NODEPORT 1
+
+
+#define ENABLE_HOST_SERVICES_TCP 1
+#define ENABLE_HOST_SERVICES_UDP 1
+
+#include <bpf_host.c>
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+ASSIGN_CONFIG(bool, drop_traffic_to_virtual_ips, true)
+
+
+
+#define CLUSTER_IP_V4 v4_svc_one
+#define CLUSTER_IP_V6 v6_svc_one
+
+#define SERVICE_PORT tcp_svc_one
+#define NON_SERVICE_PORT __bpf_htons(8080)
+
+#define CLIENT_IP_V4 v4_ext_one
+#define CLIENT_IP_V6 v6_ext_node_one
+#define CLIENT_PORT __bpf_htons(111)
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[0] = &cil_from_netdev,
+	},
+};
+
+/* Test that packets to ClusterIP on non-service ports are dropped */
+PKTGEN("tc", "test_drop_clusterip_packet_v4")
+int test_drop_clusterip_packet_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  CLIENT_IP_V4, CLUSTER_IP_V4,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_drop_clusterip_packet_v4")
+int test_drop_clusterip_packet_v4_setup(struct __ctx_buff *ctx)
+{
+	/* Create a ClusterIP service with wildcard entry */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 0);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_drop_clusterip_packet_v4")
+int test_drop_clusterip_packet_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(l3->daddr == CLUSTER_IP_V4);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}
+
+/* Test that packets to ClusterIP on non-service ports are dropped (IPv6) */
+PKTGEN("tc", "test_drop_clusterip_packet_v6")
+int test_drop_clusterip_packet_v6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  (__u8 *)CLIENT_IP_V6, (__u8 *)CLUSTER_IP_V6,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_drop_clusterip_packet_v6")
+int test_drop_clusterip_packet_v6_setup(struct __ctx_buff *ctx)
+{
+	/* Create a ClusterIP service with wildcard entry */
+	lb_v6_add_service_with_flags((union v6addr *)&CLUSTER_IP_V6, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 0);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_drop_clusterip_packet_v6")
+int test_drop_clusterip_packet_v6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(memcmp(&l3->daddr, (void *)&CLUSTER_IP_V6, sizeof(l3->daddr)) == 0);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -9,6 +9,8 @@ package config
 // instantiate directly! Always use [NewNode] to ensure the default values
 // configured in the ELF are honored.
 type Node struct {
+	// Drop traffic to non-existent ports on virtual IPs.
+	DropTrafficToVirtualIps bool `config:"drop_traffic_to_virtual_ips"`
 	// Internal IPv6 router address assigned to the cilium_host interface.
 	RouterIPv6 [16]byte `config:"router_ipv6"`
 	// IPv4 source address used for SNAT when a Pod talks to itself over a Service.
@@ -20,6 +22,6 @@ type Node struct {
 }
 
 func NewNode() *Node {
-	return &Node{[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	return &Node{false, [16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0}, 0x0, 0x0}
 }

--- a/pkg/datapath/loader/config.go
+++ b/pkg/datapath/loader/config.go
@@ -22,6 +22,7 @@ func nodeConfig(lnc *datapath.LocalNodeConfiguration) config.Node {
 
 	node.TracePayloadLen = uint32(option.Config.TracePayloadlen)
 	node.TracePayloadLenOverlay = uint32(option.Config.TracePayloadlenOverlay)
+	node.DropTrafficToVirtualIps = lnc.LBConfig.DropTrafficToVirtualIPs
 
 	return node
 }


### PR DESCRIPTION
This PR splits the DROP functionality from the ICMP Echo Reply functionality implemented here: #37623

In this PR we implement support for wildcard service entries and traffic dropping on virtual IPs (ClusterIP and LoadBalancer services) when no service exists on the requested port for both UDP and TCP traffic.

This PR has:
- Wildcard service entries (port=0, proto=ANY) for ClusterIP and LoadBalancer services
- BPF configuration support for drop functionality
- test coverage for drop behavior (ish - the LXC path passed before test implementation because the path used nodeport lb service lookup)

The wildcard entries enable the datapath to identify when traffic is destined for a service IP but no actual service exists on that port, allowing for appropriate handling (currently dropping the traffic for security).

```release-note
datapath: introduce wildcard services and IP traffic drop to all load balancing paths
```
