### PR TITLE
spire: Fix unreliable test

### DIFF
--- a/pkg/auth/spire/certificate_provider_test.go
+++ b/pkg/auth/spire/certificate_provider_test.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509/pkix"
 	"math/big"
 	"net/url"
-	"reflect"
 	"testing"
 	"time"
 
@@ -50,9 +49,8 @@ func TestSpireDelegateClient_NumericIdentityToSNI(t *testing.T) {
 				},
 				log: hivetest.Logger(t).With(logfields.LogSubsys, "spire"),
 			}
-			if got := s.NumericIdentityToSNI(tt.args.id); got != tt.want {
-				t.Errorf("SpireDelegateClient.NumericIdentityToSNI() = %v, want %v", got, tt.want)
-			}
+			got := s.NumericIdentityToSNI(tt.args.id)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -101,13 +99,8 @@ func TestSpireDelegateClient_SNIToNumericIdentity(t *testing.T) {
 				log: hivetest.Logger(t).With(logfields.LogSubsys, "spire"),
 			}
 			got, err := s.SNIToNumericIdentity(tt.args.sni)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("SpireDelegateClient.SNIToNumericIdentity() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SpireDelegateClient.SNIToNumericIdentity() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -137,9 +130,8 @@ func TestSpireDelegateClient_sniToSPIFFEID(t *testing.T) {
 				},
 				log: hivetest.Logger(t).With(logfields.LogSubsys, "spire"),
 			}
-			if got := s.sniToSPIFFEID(tt.args.id); got != tt.want {
-				t.Errorf("SpireDelegateClient.sniToSPIFFEID() = %v, want %v", got, tt.want)
-			}
+			got := s.sniToSPIFFEID(tt.args.id)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -210,13 +202,8 @@ func TestSpireDelegateClient_ValidateIdentity(t *testing.T) {
 				log: hivetest.Logger(t).With(logfields.LogSubsys, "spire"),
 			}
 			got, err := s.ValidateIdentity(tt.args.id, tt.args.cert)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("SpireDelegateClient.ValidateIdentity() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("SpireDelegateClient.ValidateIdentity() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -259,13 +246,8 @@ func TestSpireDelegateClient_GetTrustBundle(t *testing.T) {
 				trustBundle: tt.trustBundle,
 			}
 			got, err := s.GetTrustBundle()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("SpireDelegateClient.GetTrustBundle() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SpireDelegateClient.GetTrustBundle() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -493,9 +475,7 @@ func TestSpireDelegateClient_SubscribeToRotatedIdentities(t *testing.T) {
 				break
 			}
 
-			if !reflect.DeepEqual(got, tt.events) {
-				t.Errorf("SpireDelegateClient.SubscribeToRotatedIdentities() = %v, want %v", got, tt.events)
-			}
+			assert.Equal(t, tt.events, got)
 		})
 	}
 }

--- a/pkg/auth/spire/certificate_provider_test.go
+++ b/pkg/auth/spire/certificate_provider_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/auth/certs"
 	"github.com/cilium/cilium/pkg/identity"
@@ -385,13 +386,25 @@ func TestSpireDelegateClient_GetCertificateForIdentity(t *testing.T) {
 				svidStore: svidStore,
 			}
 			got, err := s.GetCertificateForIdentity(tt.args.id)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("SpireDelegateClient.GetCertificateForIdentity() error = %v, wantErr %v", err, tt.wantErr)
+			assert.Equal(t, tt.wantErr, err != nil)
+			if tt.want == nil {
+				assert.Nil(t, got)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SpireDelegateClient.GetCertificateForIdentity() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want.Certificate, got.Certificate)
+			// Standard library hides private fields in the
+			// PrivateKey for FIPS compliance, which causes
+			// "assert.Equal()" to report inconsistent results,
+			// leading to unreliable failures of the test. Since
+			// we know the types here we can cast and use the type
+			// specific Equals.
+			wantKey := tt.want.PrivateKey.(*rsa.PrivateKey)
+			gotKey := got.PrivateKey.(*rsa.PrivateKey)
+			assert.True(t, wantKey.Equal(gotKey),
+				"SpireDelegateClient.GetCertificateForIdentity().PrivateKey: %v\nwant: %v",
+				got.PrivateKey, tt.want.PrivateKey,
+			)
+			assert.Equal(t, tt.want.Leaf, got.Leaf)
 		})
 	}
 }


### PR DESCRIPTION
Since the introduction of private FIPS fields in core library RSA
key fields, the Certificate.PrivateKey fields can differ when generated
from the same key, as observed by `reflect.DeepEqual`. If you use the native
type's `.Equal()` function, it reports the fields are the same.

This difference only appears when running this test frequently or many
times in a row, such as by using `go test -count=1000 -failfast ...`

Expand out the checks for the Certificate's child fields to validate
the Certificate, PrivateKey and Leaf independently. While we're at it,
switch to `assert.Equal` so that there's a higher chance that the output
can be interpreted by developers when the test fails.

Fixes: https://github.com/cilium/cilium/issues/40130
