### PR TITLE
bpf: Add ICMP echo reply support for virtual IPs with unified lookup

### DIFF
--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -24,3 +24,9 @@ NODE_CONFIG(__u32, trace_payload_len, "Length of payload to capture when tracing
 NODE_CONFIG(__u32, trace_payload_len_overlay, "Length of payload to capture when tracing overlay packets.")
 
 NODE_CONFIG(bool, drop_traffic_to_virtual_ips, "Drop traffic to non-existent ports on virtual IPs")
+
+/* This CONFIG is used to control ICMP echo reply functionality for virtual IPs.
+ * When enabled, virtual service IPs will respond to ICMP echo requests (ping)
+ * making them appear reachable for network diagnostics.
+ */
+NODE_CONFIG(bool, reply_to_icmp_echo_on_virtual_ips, "Reply to ICMP echo requests on virtual IPs")

--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -22,3 +22,5 @@ NODE_CONFIG(__u32, trace_payload_len, "Length of payload to capture when tracing
 #define TRACE_PAYLOAD_LEN CONFIG(trace_payload_len) /* Backwards compatibility */
 
 NODE_CONFIG(__u32, trace_payload_len_overlay, "Length of payload to capture when tracing overlay packets.")
+
+NODE_CONFIG(bool, drop_traffic_to_virtual_ips, "Drop traffic to non-existent ports on virtual IPs")

--- a/bpf/lib/icmp.h
+++ b/bpf/lib/icmp.h
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+/*
+ * ICMP Echo Reply Support for Virtual IPs
+ *
+ * This module provides functionality to respond to ICMP echo requests (ping)
+ * sent to virtual service IPs (ClusterIP and LoadBalancer IPs) with ICMP echo
+ * replies, making services appear "pingable" even when they don't have actual
+ * ICMP services running.
+ *
+ * This feature is controlled by the reply_to_icmp_echo_on_virtual_ips configuration option.
+ */
+
+#if !defined(__LIB_ICMP__) && defined(ENABLE_IPV4)
+#define __LIB_ICMP__
+
+#include <linux/icmp.h>
+#include "common.h"
+#include "eth.h"
+#include "drop.h"
+#include "ipv4.h"
+#include "csum.h"
+
+/**
+ * icmp_send_echo_reply - Send ICMP echo reply
+ * @ctx:	Packet context
+ *
+ * Converts an ICMP echo request packet to an echo reply by:
+ * - Swapping source and destination MAC addresses
+ * - Swapping source and destination IP addresses
+ * - Converting ICMP type from ECHO to ECHOREPLY
+ * - Updating checksums
+ *
+ * Returns:
+ *   - 0 on success
+ *   - Negative error code on failure
+ */
+static __always_inline
+int icmp_send_echo_reply(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct ethhdr *ethhdr;
+	struct iphdr *ip4;
+	struct icmphdr *icmphdr;
+	union macaddr smac = {};
+	union macaddr dmac = {};
+	__be32 saddr;
+	__be32 daddr;
+	int ret;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	/* Copy the incoming src and dest IPs and mac addresses to the stack.
+	 * The pointers will not be valid after modifying the packet.
+	 */
+	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
+		return DROP_INVALID;
+
+	if (eth_load_daddr(ctx, dmac.addr, 0) < 0)
+		return DROP_INVALID;
+
+	saddr = ip4->saddr;
+	daddr = ip4->daddr;
+
+	/* Load ICMP header and check bounds */
+	icmphdr = (struct icmphdr *)(data + sizeof(struct ethhdr) + sizeof(struct iphdr));
+	if ((void *)(icmphdr + 1) > data_end)
+		return DROP_INVALID;
+
+	/* Only respond to ICMP echo requests */
+	if (icmphdr->type != ICMP_ECHO)
+		return DROP_INVALID;
+
+	/* Rewrite ethernet header */
+	ethhdr = (struct ethhdr *)data;
+	if ((void *)(ethhdr + 1) > data_end)
+		return DROP_INVALID;
+
+	/* Swap src/dst MAC addresses */
+	memcpy(ethhdr->h_dest, smac.addr, ETH_ALEN);
+	memcpy(ethhdr->h_source, dmac.addr, ETH_ALEN);
+
+	/* Rewrite IP header - swap addresses and update TTL */
+	__u8 old_ttl = ip4->ttl;
+	
+	ip4->saddr = daddr; /* Swap src/dst IP */
+	ip4->daddr = saddr;
+	ip4->ttl = IPDEFTTL;
+	
+	/* Update IPv4 checksum for TTL change using standard helper */
+	ret = ipv4_csum_update_by_value(ctx, ETH_HLEN, old_ttl, ip4->ttl, 2);
+	if (ret < 0)
+		return ret;
+
+	/* Revalidate data pointers after packet modifications */
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	/* Recompute ICMP header pointer after packet modifications */
+	icmphdr = (struct icmphdr *)(data + sizeof(struct ethhdr) + sizeof(struct iphdr));
+	if ((void *)(icmphdr + 1) > data_end)
+		return DROP_INVALID;
+
+	/* Change ICMP type from ECHO to ECHOREPLY and update checksum.
+	 * We save the old type+code before modification for checksum update.
+	 * ICMP doesn't use pseudo-headers, so we don't need BPF_F_PSEUDO_HDR.
+	 */
+	__be16 old_type_code = *(__be16 *)icmphdr;  /* Save old type+code */
+	icmphdr->type = ICMP_ECHOREPLY;             /* Change type */
+	__be16 new_type_code = *(__be16 *)icmphdr;  /* Get new type+code */
+	
+	/* Update ICMP checksum using standard helper.
+	 * The checksum offset for ICMP is at byte 2.
+	 * We specify size 2 since we're replacing a 16-bit value.
+	 */
+	ret = l4_csum_replace(ctx, ETH_HLEN + sizeof(struct iphdr) + offsetof(struct icmphdr, checksum),
+			      old_type_code, new_type_code, 2);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+#endif /* __LIB_ICMP__ */

--- a/bpf/lib/virtual_ip.h
+++ b/bpf/lib/virtual_ip.h
@@ -1,0 +1,158 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include "lib/lb.h"
+
+#ifdef ENABLE_IPV4
+/**
+ * lookup_virtual_service_v4 - Look up a virtual service using wildcard entry
+ * @dest_ip:	Destination IP address to look up
+ *
+ * Performs a wildcard lookup (port=0, proto=ANY) for a virtual service IP.
+ * Tries both external and internal scopes to handle all service types.
+ *
+ * Returns pointer to lb4_service if found, NULL otherwise.
+ */
+static __always_inline struct lb4_service *
+lookup_virtual_service_v4(__be32 dest_ip)
+{
+	struct lb4_key key = {
+		.address = dest_ip,
+		.dport = 0,
+		.backend_slot = 0,
+		.proto = IPPROTO_ANY,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	struct lb4_service *svc;
+
+	/* First try external scope (where ClusterIP/LoadBalancer/NodePort services live) */
+	svc = lb4_lookup_service(&key, false);
+	if (!svc) {
+		/* Then try internal scope (for dual-scope LoadBalancer/NodePort services) */
+		key.scope = LB_LOOKUP_SCOPE_INT;
+		svc = lb4_lookup_service(&key, false);
+	}
+
+	return svc;
+}
+
+/**
+ * is_virtual_service_v4 - Check if an IP is a virtual service IP
+ * @dest_ip:	Destination IP address to check
+ *
+ * Checks if the destination IP is a virtual service IP (ClusterIP or LoadBalancer)
+ * by performing a wildcard lookup and checking if the service is non-routable.
+ *
+ * Returns true if the IP is a virtual service IP, false otherwise.
+ */
+static __always_inline bool
+is_virtual_service_v4(__be32 dest_ip)
+{
+	struct lb4_service *svc = lookup_virtual_service_v4(dest_ip);
+	return svc && !lb4_svc_is_routable(svc);
+}
+
+/**
+ * lookup_virtual_service_v4_ext_only - Look up virtual service in external scope only
+ * @dest_ip:	Destination IP address to look up
+ *
+ * Performs a wildcard lookup (port=0, proto=ANY) for a virtual service IP
+ * in external scope only. This is used for compatibility with existing
+ * drop traffic functionality that only checked external scope.
+ *
+ * Returns pointer to lb4_service if found, NULL otherwise.
+ */
+static __always_inline struct lb4_service *
+lookup_virtual_service_v4_ext_only(__be32 dest_ip)
+{
+	struct lb4_key key = {
+		.address = dest_ip,
+		.dport = 0,
+		.backend_slot = 0,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+
+	lb4_key_set_protocol(&key, IPPROTO_ANY);
+	return __lb4_lookup_service(&key);
+}
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+/**
+ * lookup_virtual_service_v6 - Look up a virtual service using wildcard entry
+ * @dest_ip:	Destination IP address to look up
+ *
+ * Performs a wildcard lookup (port=0, proto=ANY) for a virtual service IP.
+ * Tries both external and internal scopes to handle all service types.
+ *
+ * Returns pointer to lb6_service if found, NULL otherwise.
+ */
+static __always_inline struct lb6_service *
+lookup_virtual_service_v6(const union v6addr *dest_ip)
+{
+	struct lb6_key key __align_stack_8 = {
+		.dport = 0,
+		.backend_slot = 0,
+		.proto = IPPROTO_ANY,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	struct lb6_service *svc;
+
+	ipv6_addr_copy(&key.address, dest_ip);
+
+	/* First try external scope (where ClusterIP/LoadBalancer/NodePort services live) */
+	svc = lb6_lookup_service(&key, false);
+	if (!svc) {
+		/* Then try internal scope (for dual-scope LoadBalancer/NodePort services) */
+		key.scope = LB_LOOKUP_SCOPE_INT;
+		svc = lb6_lookup_service(&key, false);
+	}
+
+	return svc;
+}
+
+/**
+ * is_virtual_service_v6 - Check if an IP is a virtual service IP
+ * @dest_ip:	Destination IP address to check
+ *
+ * Checks if the destination IP is a virtual service IP (ClusterIP or LoadBalancer)
+ * by performing a wildcard lookup and checking if the service is non-routable.
+ *
+ * Returns true if the IP is a virtual service IP, false otherwise.
+ */
+static __always_inline bool
+is_virtual_service_v6(const union v6addr *dest_ip)
+{
+	struct lb6_service *svc = lookup_virtual_service_v6(dest_ip);
+	return svc && !lb6_svc_is_routable(svc);
+}
+
+/**
+ * lookup_virtual_service_v6_ext_only - Look up virtual service in external scope only
+ * @dest_ip:	Destination IP address to look up
+ *
+ * Performs a wildcard lookup (port=0, proto=ANY) for a virtual service IP
+ * in external scope only. This is used for compatibility with existing
+ * drop traffic functionality that only checked external scope.
+ *
+ * Returns pointer to lb6_service if found, NULL otherwise.
+ */
+static __always_inline struct lb6_service *
+lookup_virtual_service_v6_ext_only(const union v6addr *dest_ip)
+{
+	struct lb6_key key = {};
+
+	memcpy(&key.address, dest_ip, sizeof(key.address));
+	key.dport = 0;
+	key.scope = LB_LOOKUP_SCOPE_EXT;
+	key.backend_slot = 0;
+	lb6_key_set_protocol(&key, IPPROTO_ANY);
+
+	return __lb6_lookup_service(&key);
+}
+#endif /* ENABLE_IPV6 */
+
+
+

--- a/bpf/tests/lib/lb.h
+++ b/bpf/tests/lib/lb.h
@@ -89,6 +89,30 @@ lb_v4_add_service_with_flags(__be32 addr, __be16 port, __u8 proto, __u16 backend
 {
 	__lb_v4_add_service(addr, port, proto, proto, backend_count, rev_nat_index,
 			    flags, flags2, false, 0);
+
+	if (CONFIG(drop_traffic_to_virtual_ips) && (!(flags & SVC_FLAG_ROUTABLE) || (flags2 & SVC_FLAG_LOADBALANCER))) {
+		/* Automatically create wildcard entry for ClusterIP and LoadBalancer services
+		 * to enable dropping traffic to non-existent ports on virtual IPs or
+		 * to enable ICMP echo replies on virtual IPs
+		 */
+		/* This is a ClusterIP (not routable) or LoadBalancer service.
+		 * Create a wildcard entry (port=0, IPPROTO_ANY) with 0 backends
+		 * to trigger drops for non-existent ports or ICMP echo replies.
+		 */
+		struct lb4_key wildcard_key = {
+			.address = addr,
+			.dport = 0,
+			.proto = IPPROTO_ANY,
+			.scope = LB_LOOKUP_SCOPE_EXT,
+		};
+		struct lb4_service *existing = map_lookup_elem(&cilium_lb4_services_v2, &wildcard_key);
+
+		/* Only create wildcard if it doesn't exist yet */
+		if (!existing) {
+			__lb_v4_add_service(addr, 0, IPPROTO_ANY, IPPROTO_ANY, 0, rev_nat_index,
+					    flags, flags2, false, 0);
+		}
+	}
 }
 
 static __always_inline void
@@ -197,6 +221,30 @@ lb_v6_add_service_with_flags(const union v6addr *addr, __be16 port, __u8 proto,
 {
 	__lb_v6_add_service(addr, port, proto, backend_count, rev_nat_index, flags,
 			    flags2);
+
+	if (CONFIG(drop_traffic_to_virtual_ips) && (!(flags & SVC_FLAG_ROUTABLE) || (flags2 & SVC_FLAG_LOADBALANCER))) {
+		/* Automatically create wildcard entry for ClusterIP and LoadBalancer services
+		 * to enable dropping traffic to non-existent ports on virtual IPs or
+		 * to enable ICMPv6 echo replies on virtual IPs
+		 */
+		/* This is a ClusterIP (not routable) or LoadBalancer service.
+		 * Create a wildcard entry (port=0, IPPROTO_ANY) with 0 backends
+		 * to trigger drops for non-existent ports or ICMPv6 echo replies.
+		 */
+		struct lb6_key wildcard_key __align_stack_8 = {
+			.dport = 0,
+			.proto = IPPROTO_ANY,
+			.scope = LB_LOOKUP_SCOPE_EXT,
+		};
+		memcpy(&wildcard_key.address, addr, sizeof(*addr));
+		struct lb6_service *existing = map_lookup_elem(&cilium_lb6_services_v2, &wildcard_key);
+
+		/* Only create wildcard if it doesn't exist yet */
+		if (!existing) {
+			__lb_v6_add_service(addr, 0, IPPROTO_ANY, 0, rev_nat_index,
+					    flags, flags2);
+		}
+	}
 }
 
 static __always_inline void

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -1253,6 +1253,86 @@ static __always_inline void pktgen__finish_udp(const struct pktgen *builder, int
 	pktgen__udp_csum(builder, i, udp_layer);
 }
 
+static __always_inline void pktgen__finish_icmp(const struct pktgen *builder, int i)
+{
+	struct icmphdr *icmp_layer;
+	__u64 layer_off;
+	__u32 icmp_len;
+	__wsum csum = 0;
+
+	layer_off = builder->layer_offsets[i];
+	/* Check that any value within the struct will not exceed a u16 which
+	 * is the max allowed offset within a packet from ctx->data.
+	 */
+	if (layer_off >= MAX_PACKET_OFF - sizeof(struct icmphdr))
+		return;
+
+	icmp_layer = ctx_data(builder->ctx) + layer_off;
+	if ((void *)icmp_layer + sizeof(struct icmphdr) > ctx_data_end(builder->ctx))
+		return;
+
+	/* Calculate ICMP message length (header + data) */
+	icmp_len = (__u32)(builder->cur_off - layer_off);
+
+	/* Verify the entire ICMP message is within bounds */
+	if ((void *)icmp_layer + icmp_len > ctx_data_end(builder->ctx))
+		return;
+	/* Zero out checksum field before calculation */
+	icmp_layer->checksum = 0;
+
+	/* Calculate checksum over entire ICMP message (header + data) */
+	csum = csum_diff(NULL, 0, icmp_layer, icmp_len, 0);
+	icmp_layer->checksum = csum_fold(csum);
+}
+
+static __always_inline void pktgen__finish_icmp6(const struct pktgen *builder, int i)
+{
+	struct icmp6hdr *icmp6_layer;
+	__u64 layer_off;
+	__u32 icmp6_len;
+	__u32 csum = 0;
+
+	if (i == 0)
+		return;
+
+	layer_off = builder->layer_offsets[i];
+	/* Check that any value within the struct will not exceed a u16 which
+	 * is the max allowed offset within a packet from ctx->data.
+	 */
+	if (layer_off >= MAX_PACKET_OFF - sizeof(struct icmp6hdr))
+		return;
+
+	icmp6_layer = ctx_data(builder->ctx) + layer_off;
+	if ((void *)icmp6_layer + sizeof(struct icmp6hdr) > ctx_data_end(builder->ctx))
+		return;
+
+	/* Calculate ICMPv6 message length (header + data) */
+	icmp6_len = (__u32)(builder->cur_off - layer_off);
+
+	/* Verify the entire ICMPv6 message is within bounds */
+	if ((void *)icmp6_layer + icmp6_len > ctx_data_end(builder->ctx))
+		return;
+	/* Zero out checksum field before calculation */
+	icmp6_layer->icmp6_cksum = 0;
+
+	if (builder->layers[i - 1] == PKT_LAYER_IPV6) {
+		__be32 icmp6_len_be32;
+
+		/* Get pseudo-header checksum (addresses + next header) */
+		csum = pktgen__ip_csum(builder, i);
+
+		/* Add length field to pseudo-header */
+		icmp6_len_be32 = __bpf_htonl(icmp6_len);
+		csum = csum_diff(NULL, 0, &icmp6_len_be32, sizeof(__be32), csum);
+
+		/* Add ICMPv6 message (header + data) to checksum */
+		csum = csum_diff(NULL, 0, icmp6_layer, icmp6_len, csum);
+
+		/* Store final checksum */
+		icmp6_layer->icmp6_cksum = csum_fold(csum);
+	}
+}
+
 static __always_inline void pktgen__finish_geneve(const struct pktgen *builder, int i)
 {
 	struct genevehdr *geneve_layer;
@@ -1336,11 +1416,11 @@ void pktgen__finish(const struct pktgen *builder)
 			break;
 
 		case PKT_LAYER_ICMP:
-			/* TODO implement checksum calc? */
+			pktgen__finish_icmp(builder, i);
 			break;
 
 		case PKT_LAYER_ICMPV6:
-			/* TODO implement checksum calc? */
+			pktgen__finish_icmp6(builder, i);
 			break;
 
 		case PKT_LAYER_SCTP:

--- a/bpf/tests/skip_lb_xlate_icmp_socket_lb.c
+++ b/bpf/tests/skip_lb_xlate_icmp_socket_lb.c
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/unspec.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define TEST_BPF_SOCK 1
+
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#undef ENABLE_HEALTH_CHECK
+#define ENABLE_SOCKET_LB_FULL 1
+
+#define POD_IP v4_pod_one
+#define POD_IPV6 v6_pod_one
+#define CLUSTERIP_IP v4_svc_one
+#define CLUSTERIP_IPV6 v6_node_one
+#define SERVICE_PORT tcp_svc_one
+#define BACKEND_IP v4_pod_two
+#define BACKEND_IPV6 v6_pod_two
+#define BACKEND_PORT __bpf_htons(8080)
+#define NETNS_COOKIE 5000ULL
+
+#define get_netns_cookie(ctx) test_get_netns_cookie(ctx)
+/* Set netns_cookie based on the source ip in the addr */
+static __always_inline __u64
+test_get_netns_cookie(__maybe_unused const struct bpf_sock_addr *addr)
+{
+	return NETNS_COOKIE;
+}
+
+#include "bpf_sock.c"
+#include "lib/common.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+/* Enable ICMP echo reply on virtual IPs for testing */
+ASSIGN_CONFIG(bool, reply_to_icmp_echo_on_virtual_ips, true);
+
+/* Test that ICMP to ClusterIP should skip socket layer load balancing */
+CHECK("xdp", "sock4_xlate_fwd_icmp_skip")
+int test_sock4_xlate_fwd_icmp_skip(__maybe_unused struct xdp_md *ctx)
+{
+	int ret;
+	__u16 revnat_id = 1;
+	struct bpf_sock sk = {
+		.src_ip4 = POD_IP
+	};
+	struct bpf_sock_addr addr = {
+		.user_ip4 = CLUSTERIP_IP,
+		.user_port = SERVICE_PORT,
+		.protocol = IPPROTO_ICMP,
+		.sk = &sk,
+	};
+
+	/* Set up service and backend */
+	lb_v4_add_service(CLUSTERIP_IP, SERVICE_PORT, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(CLUSTERIP_IP, SERVICE_PORT, 1, 124,
+			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	/* Add IPCache entries */
+	ipcache_v4_add_entry(POD_IP, 0, 112233, 0, 0);
+	ipcache_v4_add_entry(CLUSTERIP_IP, 0, WORLD_IPV4_ID, 0, 0);
+	ipcache_v4_add_entry(BACKEND_IP, 0, 112244, 0, 0);
+
+	test_init();
+
+	/* ICMP to ClusterIP should skip load balancing (return -ENXIO) */
+	ret = __sock4_xlate_fwd(&addr, &addr, false);
+	test_log("ICMP xlate ret: %d", ret);
+	test_log("ICMP dest IP: %x (should remain %x)", addr.user_ip4, CLUSTERIP_IP);
+	test_log("ICMP dest port: %d (should remain %d)", addr.user_port, SERVICE_PORT);
+	
+	/* We expect -ENXIO to indicate that socket layer should skip this */
+	assert(ret == -ENXIO);
+	/* IP and port should remain unchanged */
+	assert(addr.user_ip4 == CLUSTERIP_IP);
+	assert(addr.user_port == SERVICE_PORT);
+
+	/* For comparison: TCP to the same ClusterIP should do load balancing */
+	addr.protocol = IPPROTO_TCP;
+	addr.user_ip4 = CLUSTERIP_IP;
+	addr.user_port = SERVICE_PORT;
+	ret = __sock4_xlate_fwd(&addr, &addr, false);
+	test_log("TCP xlate ret: %d", ret);
+	test_log("TCP dest IP: %x (should be %x)", addr.user_ip4, BACKEND_IP);
+	test_log("TCP dest port: %d (should be %d)", addr.user_port, BACKEND_PORT);
+	
+	/* TCP should succeed and translate to backend */
+	assert(ret == 0);
+	assert(addr.user_ip4 == BACKEND_IP);
+	assert(addr.user_port == BACKEND_PORT);
+
+	test_finish();
+}
+
+/* Test that ICMPv6 to ClusterIP should skip socket layer load balancing */
+CHECK("xdp", "sock6_xlate_fwd_icmp_skip")
+int test_sock6_xlate_fwd_icmp_skip(__maybe_unused struct xdp_md *ctx)
+{
+	int ret;
+	__u16 revnat_id = 1;
+	union v6addr frontend_ip = {};
+	union v6addr backend_ip = {};
+	struct bpf_sock sk = {};
+	struct bpf_sock_addr addr = {
+		.user_port = SERVICE_PORT,
+		.protocol = IPPROTO_ICMPV6,
+		.sk = &sk,
+	};
+
+	/* Set up IPv6 addresses */
+	memcpy(frontend_ip.addr, (void *)&CLUSTERIP_IPV6, 16);
+	memcpy(backend_ip.addr, (void *)&BACKEND_IPV6, 16);
+	memcpy(addr.user_ip6, (void *)&CLUSTERIP_IPV6, 16);
+	memcpy(sk.src_ip6, (void *)&POD_IPV6, 16);
+
+	/* Set up service and backend */
+	lb_v6_add_service(&frontend_ip, SERVICE_PORT, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_backend(&frontend_ip, SERVICE_PORT, 1, 124,
+			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	/* Add IPCache entries */
+	ipcache_v6_add_entry((union v6addr *)&POD_IPV6, 0, 112233, 0, 0);
+	ipcache_v6_add_entry(&frontend_ip, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_entry(&backend_ip, 0, 112244, 0, 0);
+
+	test_init();
+
+	/* ICMPv6 to ClusterIP should skip load balancing (return -ENXIO) */
+	ret = __sock6_xlate_fwd(&addr, false);
+	test_log("ICMPv6 xlate ret: %d", ret);
+	test_log("ICMPv6 dest IP: %x (should remain %x)", addr.user_ip6[0], ((union v6addr *)&CLUSTERIP_IPV6)->addr[0]);
+	test_log("ICMPv6 dest port: %d (should remain %d)", addr.user_port, SERVICE_PORT);
+	
+	/* We expect -ENXIO to indicate that socket layer should skip this */
+	assert(ret == -ENXIO);
+	/* IP and port should remain unchanged */
+	assert(memcmp(addr.user_ip6, (void *)&CLUSTERIP_IPV6, 16) == 0);
+	assert(addr.user_port == SERVICE_PORT);
+
+	/* For comparison: TCP to the same ClusterIP should do load balancing */
+	addr.protocol = IPPROTO_TCP;
+	memcpy(addr.user_ip6, (void *)&CLUSTERIP_IPV6, 16);
+	addr.user_port = SERVICE_PORT;
+	ret = __sock6_xlate_fwd(&addr, false);
+	test_log("TCP xlate ret: %d", ret);
+	test_log("TCP dest IP: %x (should be %x)", addr.user_ip6[0], ((union v6addr *)&BACKEND_IPV6)->addr[0]);
+	test_log("TCP dest port: %d (should be %d)", addr.user_port, BACKEND_PORT);
+	
+	/* TCP should succeed and translate to backend */
+	assert(ret == 0);
+	assert(memcmp(addr.user_ip6, (void *)&BACKEND_IPV6, 16) == 0);
+	assert(addr.user_port == BACKEND_PORT);
+
+	test_finish();
+}

--- a/bpf/tests/tc_lxc_drop_virtual_ip.c
+++ b/bpf/tests/tc_lxc_drop_virtual_ip.c
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#define ENABLE_NODEPORT 1
+
+
+
+#include <bpf_lxc.c>
+
+
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/policy.h"
+#include "lib/endpoint.h"
+
+ASSIGN_CONFIG(bool, drop_traffic_to_virtual_ips, true)
+
+#define CLUSTER_IP_V4 v4_svc_one
+#define CLUSTER_IP_V6 v6_svc_one
+#define NON_VIRTUAL_IP_V4 v4_pod_one
+#define NON_VIRTUAL_IP_V6 v6_pod_one
+
+#define SERVICE_PORT tcp_svc_one
+#define NON_SERVICE_PORT __bpf_htons(8080)
+
+#define CLIENT_IP_V4 v4_pod_two
+#define CLIENT_IP_V6 v6_pod_two
+#define CLIENT_PORT __bpf_htons(111)
+
+/* Configure endpoint IP addresses - CRITICAL for LXC tests */
+ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = CLIENT_IP_V4})
+ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_two_addr})
+
+#define FROM_CONTAINER 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+/* Test IPv4 packet to virtual IP without service - should be dropped */
+PKTGEN("tc", "test_lxc_drop_virtual_ip_no_service_v4")
+int test_lxc_drop_virtual_ip_no_service_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  CLIENT_IP_V4, CLUSTER_IP_V4,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_lxc_drop_virtual_ip_no_service_v4")
+int test_lxc_drop_virtual_ip_no_service_v4_setup(struct __ctx_buff *ctx)
+{
+	/* Add identity mappings */
+	ipcache_v4_add_entry(CLIENT_IP_V4, 0, SECLABEL_IPV4, 0, 0);
+	ipcache_v4_add_entry(CLUSTER_IP_V4, 0, SECLABEL_IPV4, 0, 0);
+
+	/* Create a ClusterIP service on a different port - no backend for the non-service port */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, SERVICE_PORT, IPPROTO_TCP, 1, 1, SVC_FLAG_ROUTABLE, 0);
+
+	/* Add wildcard entry to enable virtual IP drop logic */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+	/* Add a backend for the service on the existing port only */
+	lb_v4_add_backend(CLUSTER_IP_V4, SERVICE_PORT, 1, 1, v4_pod_one, __bpf_htons(8080), IPPROTO_TCP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_drop_virtual_ip_no_service_v4")
+int test_lxc_drop_virtual_ip_no_service_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	/* Should be dropped - no service for this port */
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(l3->daddr == CLUSTER_IP_V4);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}
+
+/* Test IPv6 packet to virtual IP without service - should be dropped */
+PKTGEN("tc", "test_lxc_drop_virtual_ip_no_service_v6")
+int test_lxc_drop_virtual_ip_no_service_v6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  (__u8 *)CLIENT_IP_V6, (__u8 *)CLUSTER_IP_V6,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_lxc_drop_virtual_ip_no_service_v6")
+int test_lxc_drop_virtual_ip_no_service_v6_setup(struct __ctx_buff *ctx)
+{
+	/* Add identity mappings */
+	ipcache_v6_add_entry((union v6addr *)&CLIENT_IP_V6, 0, SECLABEL_IPV6, 0, 0);
+	ipcache_v6_add_entry((union v6addr *)&CLUSTER_IP_V6, 0, SECLABEL_IPV6, 0, 0);
+
+	/* Create a ClusterIP service on a different port - no backend for the non-service port */
+	lb_v6_add_service_with_flags((union v6addr *)&CLUSTER_IP_V6, SERVICE_PORT, IPPROTO_TCP, 1, 1, SVC_FLAG_ROUTABLE, 0);
+
+	/* Add wildcard entry to enable virtual IP drop logic */
+	lb_v6_add_service_with_flags((union v6addr *)&CLUSTER_IP_V6, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+	/* Add a backend for the service on the existing port only */
+	lb_v6_add_backend((union v6addr *)&CLUSTER_IP_V6, SERVICE_PORT, 1, 1, (union v6addr *)&v6_pod_one, __bpf_htons(8080), IPPROTO_TCP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_drop_virtual_ip_no_service_v6")
+int test_lxc_drop_virtual_ip_no_service_v6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	/* Should be dropped - no service for this port */
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(memcmp(&l3->daddr, (void *)&CLUSTER_IP_V6, sizeof(l3->daddr)) == 0);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}
+
+/* Test UDP packet to virtual IP without UDP service - should be dropped */
+PKTGEN("tc", "test_lxc_drop_virtual_ip_udp_v4")
+int test_lxc_drop_virtual_ip_udp_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  CLIENT_IP_V4, CLUSTER_IP_V4,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_lxc_drop_virtual_ip_udp_v4")
+int test_lxc_drop_virtual_ip_udp_v4_setup(struct __ctx_buff *ctx)
+{
+	/* Add identity mappings */
+	ipcache_v4_add_entry(CLIENT_IP_V4, 0, SECLABEL_IPV4, 0, 0);
+	ipcache_v4_add_entry(CLUSTER_IP_V4, 0, SECLABEL_IPV4, 0, 0);
+
+	/* Create a TCP ClusterIP service (UDP packet should still be dropped) */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, SERVICE_PORT, IPPROTO_TCP, 1, 1, SVC_FLAG_ROUTABLE, 0);
+
+	/* Add wildcard entry to enable virtual IP drop logic */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+	/* Add a backend for the TCP service only - no UDP backend */
+	lb_v4_add_backend(CLUSTER_IP_V4, SERVICE_PORT, 1, 1, v4_pod_one, __bpf_htons(8080), IPPROTO_TCP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_drop_virtual_ip_udp_v4")
+int test_lxc_drop_virtual_ip_udp_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct udphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	/* Should be dropped - no UDP service */
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct udphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(l3->daddr == CLUSTER_IP_V4);
+	assert(l3->protocol == IPPROTO_UDP);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}

--- a/bpf/tests/tc_lxc_lb4_icmp_reply.c
+++ b/bpf/tests/tc_lxc_lb4_icmp_reply.c
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Test that verifies ICMP echo replies work for pod-to-ClusterIP traffic */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define SERVICE_NO_BACKEND_RESPONSE
+
+
+/* Test network and addresses */
+#define POD_IP              v4_pod_one    /* Source pod IP */
+#define CLUSTERIP_IP        v4_svc_two    /* ClusterIP service IP */
+#define LOADBALANCER_IP     v4_svc_three  /* LoadBalancer service IP */
+#define SERVICE_PORT        tcp_svc_one   /* Port with actual service */
+#define BACKEND_IP          v4_pod_two    /* Backend pod IP */
+#define BACKEND_PORT        __bpf_htons(8080)
+#define ICMP_ID             __bpf_htons(0x1234)
+
+/* MAC addresses for tests */
+static volatile const __u8 *pod_mac = mac_one;
+static volatile const __u8 *node_mac = mac_two;
+
+#include <bpf_lxc.c>
+
+/* Override LXC_ID after including bpf_lxc.c to avoid conflicts */
+#undef LXC_ID
+#define LXC_ID 107
+
+/* Include test helpers */
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+/* Enable ICMP echo reply on virtual IPs for testing */
+ASSIGN_CONFIG(bool, reply_to_icmp_echo_on_virtual_ips, true);
+
+/* Program array for tail calls */
+#define FROM_CONTAINER 0
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(key_size, sizeof(__u32));
+    __uint(max_entries, 1);
+    __array(values, int());
+} entry_call_map __section(".maps") = {
+    .values = {
+        [FROM_CONTAINER] = &cil_from_container,
+    },
+};
+
+/* Test 1: ClusterIP should reply to ICMP echo requests from pods */
+PKTGEN("tc", "test_lxc_clusterip_icmp_echo_request")
+int lxc_clusterip_icmp_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+    struct pktgen builder;
+    struct icmphdr *icmphdr;
+    struct ethhdr *l2;
+    struct iphdr *l3;
+    void *data;
+
+    /* Init packet builder */
+    pktgen__init(&builder, ctx);
+
+    /* Push ethernet header */
+    l2 = pktgen__push_ethhdr(&builder);
+    if (!l2)
+        return TEST_ERROR;
+
+    ethhdr__set_macs(l2, (__u8 *)pod_mac, (__u8 *)node_mac);
+
+    /* Push IPv4 header */
+    l3 = pktgen__push_default_iphdr(&builder);
+    if (!l3)
+        return TEST_ERROR;
+
+    l3->saddr = POD_IP;
+    l3->daddr = CLUSTERIP_IP;
+
+    /* Push ICMP header */
+    icmphdr = pktgen__push_icmphdr(&builder);
+    if (!icmphdr)
+        return TEST_ERROR;
+
+    icmphdr->type = ICMP_ECHO;
+    icmphdr->code = 0;
+    icmphdr->un.echo.id = ICMP_ID;
+    icmphdr->un.echo.sequence = __bpf_htons(1);
+
+    data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+    if (!data)
+        return TEST_ERROR;
+
+    /* Calc lengths, set protocol fields and calc checksums */
+    pktgen__finish(&builder);
+
+    return 0;
+}
+
+SETUP("tc", "test_lxc_clusterip_icmp_echo_request")
+int lxc_clusterip_icmp_echo_request_setup(struct __ctx_buff *ctx)
+{
+    /* Create a ClusterIP service */
+    lb_v4_add_service_with_flags(CLUSTERIP_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+    /* Add a backend for the service */
+    lb_v4_add_backend(CLUSTERIP_IP, SERVICE_PORT, 1, 1, BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+    /* Create wildcard service entry for ICMP echo reply handling */
+    lb_v4_add_service_with_flags(CLUSTERIP_IP, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+    /* Configure IPCache entries for source pod and service */
+    ipcache_v4_add_entry(POD_IP, 0, 112233, 0, 0);        /* Source pod */
+    ipcache_v4_add_entry(CLUSTERIP_IP, 0, WORLD_IPV4_ID, 0, 0);  /* Service IP */
+    ipcache_v4_add_entry(BACKEND_IP, 0, 112244, 0, 0);    /* Backend pod */
+
+    /* Jump into the LXC entrypoint (pod egress) */
+    tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+    /* Fail if we didn't jump */
+    return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_clusterip_icmp_echo_request")
+int lxc_clusterip_icmp_echo_request_check(const struct __ctx_buff *ctx)
+{
+    void *data, *data_end;
+    __u32 *status_code;
+    struct ethhdr *l2;
+    struct iphdr *l3;
+    struct icmphdr *icmphdr;
+
+    test_init();
+
+    data = (void *)(long)ctx_data(ctx);
+    data_end = (void *)(long)ctx->data_end;
+
+    if (data + sizeof(__u32) > data_end)
+        test_fatal("status code out of bounds");
+
+    status_code = data;
+    test_log("Status code: %d, expected: %d (CTX_ACT_REDIRECT)", *status_code, CTX_ACT_REDIRECT);
+    assert(*status_code == CTX_ACT_REDIRECT);
+
+    l2 = data + sizeof(__u32);
+    if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+        test_fatal("l2 out of bounds");
+
+    assert(l2->h_proto == bpf_htons(ETH_P_IP));
+
+    l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+    if ((void *)l3 + sizeof(struct iphdr) > data_end)
+        test_fatal("l3 out of bounds");
+
+    assert(l3->protocol == IPPROTO_ICMP);
+
+    icmphdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
+    if ((void *)icmphdr + sizeof(struct icmphdr) > data_end)
+        test_fatal("icmphdr out of bounds");
+
+    /* Verify this is an ICMP echo reply */
+    test_log("ICMP type: %d, expected: %d (ICMP_ECHOREPLY)", icmphdr->type, ICMP_ECHOREPLY);
+    assert(icmphdr->type == ICMP_ECHOREPLY);
+
+    /* Verify the ICMP ID is preserved */
+    assert(icmphdr->un.echo.id == ICMP_ID);
+
+    /* Verify IP addresses are swapped */
+    test_log("Reply src IP: 0x%x, expected: 0x%x (CLUSTERIP_IP)", bpf_ntohl(l3->saddr), bpf_ntohl(CLUSTERIP_IP));
+    test_log("Reply dst IP: 0x%x, expected: 0x%x (POD_IP)", bpf_ntohl(l3->daddr), bpf_ntohl(POD_IP));
+    assert(l3->saddr == CLUSTERIP_IP);
+    assert(l3->daddr == POD_IP);
+
+    /* Verify MAC addresses are swapped */
+    test_log("Checking MAC address swapping: src should be node_mac, dst should be pod_mac");
+    assert(memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) == 0);
+    assert(memcmp(l2->h_dest, (__u8 *)pod_mac, ETH_ALEN) == 0);
+    test_log("MAC address swapping verified successfully");
+
+    test_finish();
+}
+
+/* Test 2: LoadBalancer should reply to ICMP echo requests from pods */
+PKTGEN("tc", "test_lxc_loadbalancer_icmp_echo_request")
+int lxc_loadbalancer_icmp_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+    struct pktgen builder;
+    struct icmphdr *icmphdr;
+    struct ethhdr *l2;
+    struct iphdr *l3;
+    void *data;
+
+    /* Init packet builder */
+    pktgen__init(&builder, ctx);
+
+    /* Push ethernet header */
+    l2 = pktgen__push_ethhdr(&builder);
+    if (!l2)
+        return TEST_ERROR;
+
+    ethhdr__set_macs(l2, (__u8 *)pod_mac, (__u8 *)node_mac);
+
+    /* Push IPv4 header */
+    l3 = pktgen__push_default_iphdr(&builder);
+    if (!l3)
+        return TEST_ERROR;
+
+    l3->saddr = POD_IP;
+    l3->daddr = LOADBALANCER_IP;
+
+    /* Push ICMP header */
+    icmphdr = pktgen__push_icmphdr(&builder);
+    if (!icmphdr)
+        return TEST_ERROR;
+
+    icmphdr->type = ICMP_ECHO;
+    icmphdr->code = 0;
+    icmphdr->un.echo.id = ICMP_ID;
+    icmphdr->un.echo.sequence = __bpf_htons(2);
+
+    data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+    if (!data)
+        return TEST_ERROR;
+
+    /* Calc lengths, set protocol fields and calc checksums */
+    pktgen__finish(&builder);
+
+    return 0;
+}
+
+SETUP("tc", "test_lxc_loadbalancer_icmp_echo_request")
+int lxc_loadbalancer_icmp_echo_request_setup(struct __ctx_buff *ctx)
+{
+    /* Create a LoadBalancer service */
+    lb_v4_add_service_with_flags(LOADBALANCER_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, SVC_FLAG_LOADBALANCER);
+
+    /* Add a backend for the service */
+    lb_v4_add_backend(LOADBALANCER_IP, SERVICE_PORT, 1, 1, BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+    /* Create wildcard service entry for ICMP echo reply handling */
+    lb_v4_add_service_with_flags(LOADBALANCER_IP, 0, IPPROTO_ANY, 1, 1, 0, SVC_FLAG_LOADBALANCER);
+
+    /* Configure IPCache entries for source pod and service */
+    ipcache_v4_add_entry(POD_IP, 0, 112233, 0, 0);        /* Source pod */
+    ipcache_v4_add_entry(LOADBALANCER_IP, 0, WORLD_IPV4_ID, 0, 0);  /* Service IP */
+    ipcache_v4_add_entry(BACKEND_IP, 0, 112244, 0, 0);    /* Backend pod */
+
+    /* Jump into the LXC entrypoint (pod egress) */
+    tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+    /* Fail if we didn't jump */
+    return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_loadbalancer_icmp_echo_request")
+int lxc_loadbalancer_icmp_echo_request_check(const struct __ctx_buff *ctx)
+{
+    void *data, *data_end;
+    __u32 *status_code;
+    struct ethhdr *l2;
+    struct iphdr *l3;
+    struct icmphdr *icmphdr;
+
+    test_init();
+
+    data = (void *)(long)ctx_data(ctx);
+    data_end = (void *)(long)ctx->data_end;
+
+    if (data + sizeof(__u32) > data_end)
+        test_fatal("status code out of bounds");
+
+    status_code = data;
+    test_log("Status code: %d, expected: %d (CTX_ACT_REDIRECT)", *status_code, CTX_ACT_REDIRECT);
+    assert(*status_code == CTX_ACT_REDIRECT);
+
+    l2 = data + sizeof(__u32);
+    if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+        test_fatal("l2 out of bounds");
+
+    assert(l2->h_proto == bpf_htons(ETH_P_IP));
+
+    l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+    if ((void *)l3 + sizeof(struct iphdr) > data_end)
+        test_fatal("l3 out of bounds");
+
+    assert(l3->protocol == IPPROTO_ICMP);
+
+    icmphdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
+    if ((void *)icmphdr + sizeof(struct icmphdr) > data_end)
+        test_fatal("icmphdr out of bounds");
+
+    /* Verify this is an ICMP echo reply */
+    test_log("ICMP type: %d, expected: %d (ICMP_ECHOREPLY)", icmphdr->type, ICMP_ECHOREPLY);
+    assert(icmphdr->type == ICMP_ECHOREPLY);
+
+    /* Verify the ICMP ID is preserved */
+    assert(icmphdr->un.echo.id == ICMP_ID);
+
+    /* Verify IP addresses are swapped */
+    test_log("Reply src IP: 0x%x, expected: 0x%x (LOADBALANCER_IP)", bpf_ntohl(l3->saddr), bpf_ntohl(LOADBALANCER_IP));
+    test_log("Reply dst IP: 0x%x, expected: 0x%x (POD_IP)", bpf_ntohl(l3->daddr), bpf_ntohl(POD_IP));
+    assert(l3->saddr == LOADBALANCER_IP);
+    assert(l3->daddr == POD_IP);
+
+    /* Verify MAC addresses are swapped */
+    test_log("Checking MAC address swapping: src should be node_mac, dst should be pod_mac");
+    assert(memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) == 0);
+    assert(memcmp(l2->h_dest, (__u8 *)pod_mac, ETH_ALEN) == 0);
+    test_log("MAC address swapping verified successfully");
+
+    test_finish();
+}
+
+/* Test 3: Non-echo ICMP packets should NOT be handled by echo reply logic */
+PKTGEN("tc", "test_lxc_icmp_other")
+int lxc_icmp_other_pktgen(struct __ctx_buff *ctx)
+{
+    struct pktgen builder;
+    struct icmphdr *icmphdr;
+    struct ethhdr *l2;
+    struct iphdr *l3;
+    void *data;
+
+    /* Init packet builder */
+    pktgen__init(&builder, ctx);
+
+    /* Push ethernet header */
+    l2 = pktgen__push_ethhdr(&builder);
+    if (!l2)
+        return TEST_ERROR;
+
+    ethhdr__set_macs(l2, (__u8 *)pod_mac, (__u8 *)node_mac);
+
+    /* Push IPv4 header */
+    l3 = pktgen__push_default_iphdr(&builder);
+    if (!l3)
+        return TEST_ERROR;
+
+    l3->saddr = POD_IP;
+    l3->daddr = CLUSTERIP_IP;
+
+    /* Push ICMP header with destination unreachable type */
+    icmphdr = pktgen__push_icmphdr(&builder);
+    if (!icmphdr)
+        return TEST_ERROR;
+
+    icmphdr->type = ICMP_DEST_UNREACH;
+    icmphdr->code = ICMP_PORT_UNREACH;
+    icmphdr->un.gateway = 0;
+
+    data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+    if (!data)
+        return TEST_ERROR;
+
+    /* Calc lengths, set protocol fields and calc checksums */
+    pktgen__finish(&builder);
+
+    return 0;
+}
+
+SETUP("tc", "test_lxc_icmp_other")
+int lxc_icmp_other_setup(struct __ctx_buff *ctx)
+{
+    /* Create a ClusterIP service for the non-echo ICMP test */
+    lb_v4_add_service_with_flags(CLUSTERIP_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+    /* Add a backend for the service */
+    lb_v4_add_backend(CLUSTERIP_IP, SERVICE_PORT, 1, 1, BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+    /* Configure IPCache entries */
+    ipcache_v4_add_entry(POD_IP, 0, 112233, 0, 0);        /* Source pod */
+    ipcache_v4_add_entry(CLUSTERIP_IP, 0, WORLD_IPV4_ID, 0, 0);  /* Service IP */
+    ipcache_v4_add_entry(BACKEND_IP, 0, 112244, 0, 0);    /* Backend pod */
+
+    /* Jump into the LXC entrypoint (pod egress) */
+    tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+    /* Fail if we didn't jump */
+    return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_icmp_other")
+int lxc_icmp_other_check(const struct __ctx_buff *ctx)
+{
+    void *data, *data_end;
+    __u32 *status_code;
+    struct ethhdr *l2;
+    struct iphdr *l3;
+    struct icmphdr *icmphdr;
+
+    test_init();
+
+    data = (void *)(long)ctx_data(ctx);
+    data_end = (void *)(long)ctx->data_end;
+
+    if (data + sizeof(__u32) > data_end)
+        test_fatal("status code out of bounds");
+
+    status_code = data;
+    /* Non-echo ICMP should be dropped as they are error packets not suitable for load balancing */
+    test_log("Status code: %d, expected: %d (CTX_ACT_DROP)", *status_code, CTX_ACT_DROP);
+    assert(*status_code == CTX_ACT_DROP);
+
+    l2 = data + sizeof(__u32);
+    if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+        test_fatal("l2 out of bounds");
+
+    assert(l2->h_proto == bpf_htons(ETH_P_IP));
+
+    l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+    if ((void *)l3 + sizeof(struct iphdr) > data_end)
+        test_fatal("l3 out of bounds");
+
+    assert(l3->protocol == IPPROTO_ICMP);
+
+    icmphdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
+    if ((void *)icmphdr + sizeof(struct icmphdr) > data_end)
+        test_fatal("icmphdr out of bounds");
+
+    /* Verify this is NOT an ICMP echo reply - other ICMP types should not be handled */
+    test_log("ICMP type: %d, should NOT be: %d (ICMP_ECHOREPLY)", icmphdr->type, ICMP_ECHOREPLY);
+    assert(icmphdr->type != ICMP_ECHOREPLY);
+
+    /* Verify this is the expected ICMP type that was dropped */
+    assert(icmphdr->type == ICMP_DEST_UNREACH);
+
+    test_finish();
+}
+

--- a/bpf/tests/tc_lxc_lb4_icmp_reply_no_per_packet_lb.c
+++ b/bpf/tests/tc_lxc_lb4_icmp_reply_no_per_packet_lb.c
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define SERVICE_NO_BACKEND_RESPONSE
+/* Enable ICMP echo reply on virtual IPs for testing */
+
+
+/* Prevent automatic ENABLE_PER_PACKET_LB definition in bpf_lxc.c */
+#define ENABLE_SOCKET_LB_FULL
+#undef ENABLE_SOCKET_LB_HOST_ONLY  
+#undef ENABLE_L7_LB
+#undef ENABLE_SCTP
+#undef ENABLE_CLUSTER_AWARE_ADDRESSING
+#undef ENABLE_PER_PACKET_LB
+
+#define POD_IP		v4_pod_one
+#define CLUSTERIP_IP	v4_svc_two
+#define SERVICE_PORT	tcp_svc_one
+#define BACKEND_IP	v4_pod_two
+#define BACKEND_PORT	__bpf_htons(8080)
+#define ICMP_ID		__bpf_htons(0x1234)
+
+static volatile const __u8 *pod_mac = mac_one;
+static volatile const __u8 *node_mac = mac_two;
+
+#include <bpf_lxc.c>
+
+/* Force disable per-packet LB after bpf_lxc.c includes */
+#ifdef ENABLE_PER_PACKET_LB
+#undef ENABLE_PER_PACKET_LB
+#endif
+
+/* Verify that per-packet LB is now disabled */
+#ifdef ENABLE_PER_PACKET_LB
+#error "Test compilation failed: ENABLE_PER_PACKET_LB should be undefined"
+#endif
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+/* Enable ICMP echo reply on virtual IPs for testing */
+ASSIGN_CONFIG(bool, reply_to_icmp_echo_on_virtual_ips, true);
+
+#define FROM_CONTAINER	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+/* Test that ClusterIP replies to ICMP echo when per-packet LB is disabled */
+PKTGEN("tc", "tc_lxc_icmp_echo_reply_no_per_packet_lb")
+int lxc_icmp_echo_reply_no_per_packet_lb_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmphdr *icmphdr;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)pod_mac, (__u8 *)node_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = POD_IP;
+	l3->daddr = CLUSTERIP_IP;
+
+	/* Push ICMP header */
+	icmphdr = pktgen__push_icmphdr(&builder);
+	if (!icmphdr)
+		return TEST_ERROR;
+
+	icmphdr->type = ICMP_ECHO;
+	icmphdr->code = 0;
+	icmphdr->un.echo.id = ICMP_ID;
+	icmphdr->un.echo.sequence = __bpf_htons(1);
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_icmp_echo_reply_no_per_packet_lb")
+int lxc_icmp_echo_reply_no_per_packet_lb_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	/* Create a ClusterIP service and manually add wildcard entry
+	 * to test our non-per-packet LB datapath ICMP handling code
+	 */
+	lb_v4_add_service(CLUSTERIP_IP, SERVICE_PORT, IPPROTO_TCP, 1, revnat_id);
+	
+	/* Manually create the wildcard entry that our datapath code should find */
+	lb_v4_add_service(CLUSTERIP_IP, 0, IPPROTO_ANY, 0, revnat_id);
+
+	/* Add a backend for the service */
+	lb_v4_add_backend(CLUSTERIP_IP, SERVICE_PORT, 1, 1, BACKEND_IP, 
+			  BACKEND_PORT, IPPROTO_TCP, 0);
+
+	/* Configure IPCache entries */
+	ipcache_v4_add_entry(POD_IP, 0, 112233, 0, 0);
+	ipcache_v4_add_entry(CLUSTERIP_IP, 0, WORLD_IPV4_ID, 0, 0);
+	ipcache_v4_add_entry(BACKEND_IP, 0, 112244, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_lxc_icmp_echo_reply_no_per_packet_lb")
+int lxc_icmp_echo_reply_no_per_packet_lb_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct icmphdr *icmphdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	test_log("Status code: %d", *status_code);
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IP));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->protocol == IPPROTO_ICMP);
+
+	icmphdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
+	if ((void *)icmphdr + sizeof(struct icmphdr) > data_end)
+		test_fatal("icmphdr out of bounds");
+
+	/* Verify this is an ICMP echo reply */
+	test_log("ICMP type: %d", icmphdr->type);
+	assert(icmphdr->type == ICMP_ECHOREPLY);
+
+	/* Verify the ICMP ID is preserved */
+	assert(icmphdr->un.echo.id == ICMP_ID);
+
+	/* Verify IP addresses are swapped */
+	assert(l3->saddr == CLUSTERIP_IP);
+	assert(l3->daddr == POD_IP);
+
+	/* Verify MAC addresses are swapped */
+	assert(memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) == 0);
+	assert(memcmp(l2->h_dest, (__u8 *)pod_mac, ETH_ALEN) == 0);
+
+	test_finish();
+}
+

--- a/bpf/tests/tc_lxc_lb6_icmp_reply.c
+++ b/bpf/tests/tc_lxc_lb6_icmp_reply.c
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Test that verifies ICMPv6 echo replies work for pod-to-ClusterIP traffic */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define SERVICE_NO_BACKEND_RESPONSE
+
+
+/* Test network and addresses */
+#define POD_IP              v6_pod_one    /* Source pod IP */
+#define CLUSTERIP_IP        v6_node_one   /* ClusterIP service IP */
+#define LOADBALANCER_IP     v6_node_two   /* LoadBalancer service IP */
+#define SERVICE_PORT        tcp_svc_one   /* Port with actual service */
+#define BACKEND_IP          v6_pod_two    /* Backend pod IP */
+#define BACKEND_PORT        __bpf_htons(8080)
+#define ICMP_ID             __bpf_htons(0x5678)
+
+/* MAC addresses for tests */
+static volatile const __u8 *pod_mac = mac_one;
+static volatile const __u8 *node_mac = mac_two;
+
+#include <bpf_lxc.c>
+
+/* Override LXC_ID after including bpf_lxc.c to avoid conflicts */
+#undef LXC_ID
+#define LXC_ID 107
+
+/* Include test helpers */
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+/* Enable ICMP echo reply on virtual IPs for testing */
+ASSIGN_CONFIG(bool, reply_to_icmp_echo_on_virtual_ips, true);
+
+/* Program array for tail calls */
+#define FROM_CONTAINER 0
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(key_size, sizeof(__u32));
+    __uint(max_entries, 1);
+    __array(values, int());
+} entry_call_map __section(".maps") = {
+    .values = {
+        [FROM_CONTAINER] = &cil_from_container,
+    },
+};
+
+/* Test 1: ClusterIP should reply to ICMPv6 echo requests from pods */
+PKTGEN("tc", "test_lxc_clusterip_icmpv6_echo_request")
+int lxc_clusterip_icmpv6_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+    struct pktgen builder;
+    struct icmp6hdr *icmp6hdr;
+    struct ethhdr *l2;
+    struct ipv6hdr *l3;
+    void *data;
+
+    /* Init packet builder */
+    pktgen__init(&builder, ctx);
+
+    /* Push ethernet header */
+    l2 = pktgen__push_ethhdr(&builder);
+    if (!l2)
+        return TEST_ERROR;
+
+    ethhdr__set_macs(l2, (__u8 *)pod_mac, (__u8 *)node_mac);
+
+    /* Push IPv6 header */
+    l3 = pktgen__push_default_ipv6hdr(&builder);
+    if (!l3)
+        return TEST_ERROR;
+
+    memcpy(&l3->saddr, (__u8 *)&POD_IP, 16);
+    memcpy(&l3->daddr, (__u8 *)&CLUSTERIP_IP, 16);
+
+    /* Push ICMPv6 header */
+    icmp6hdr = pktgen__push_icmp6hdr(&builder);
+    if (!icmp6hdr)
+        return TEST_ERROR;
+
+    icmp6hdr->icmp6_type = ICMPV6_ECHO_REQUEST;
+    icmp6hdr->icmp6_code = 0;
+    icmp6hdr->icmp6_identifier = ICMP_ID;
+    icmp6hdr->icmp6_sequence = __bpf_htons(1);
+
+    data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+    if (!data)
+        return TEST_ERROR;
+
+    /* Calc lengths, set protocol fields and calc checksums */
+    pktgen__finish(&builder);
+
+    return 0;
+}
+
+SETUP("tc", "test_lxc_clusterip_icmpv6_echo_request")
+int lxc_clusterip_icmpv6_echo_request_setup(struct __ctx_buff *ctx)
+{
+    /* Create a ClusterIP service */
+    lb_v6_add_service_with_flags((union v6addr *)&CLUSTERIP_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+    /* Add a backend for the service */
+    lb_v6_add_backend((union v6addr *)&CLUSTERIP_IP, SERVICE_PORT, 1, 1, (union v6addr *)&BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+    /* Create wildcard service entry for ICMP echo reply handling */
+    lb_v6_add_service_with_flags((union v6addr *)&CLUSTERIP_IP, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+    /* Configure IPCache entries for source pod and service */
+    ipcache_v6_add_entry((union v6addr *)&POD_IP, 0, 112233, 0, 0);        /* Source pod */
+    ipcache_v6_add_entry((union v6addr *)&CLUSTERIP_IP, 0, WORLD_IPV6_ID, 0, 0);  /* Service IP */
+    ipcache_v6_add_entry((union v6addr *)&BACKEND_IP, 0, 112244, 0, 0);    /* Backend pod */
+
+    /* Jump into the LXC entrypoint (pod egress) */
+    tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+    /* Fail if we didn't jump */
+    return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_clusterip_icmpv6_echo_request")
+int lxc_clusterip_icmpv6_echo_request_check(const struct __ctx_buff *ctx)
+{
+    void *data, *data_end;
+    __u32 *status_code;
+    struct ethhdr *l2;
+    struct ipv6hdr *l3;
+    struct icmp6hdr *icmp6hdr;
+
+    test_init();
+
+    data = (void *)(long)ctx_data(ctx);
+    data_end = (void *)(long)ctx->data_end;
+
+    if (data + sizeof(__u32) > data_end)
+        test_fatal("status code out of bounds");
+
+    status_code = data;
+    test_log("Status code: %d, expected: %d (CTX_ACT_REDIRECT)", *status_code, CTX_ACT_REDIRECT);
+    assert(*status_code == CTX_ACT_REDIRECT);
+
+    l2 = data + sizeof(__u32);
+    if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+        test_fatal("l2 out of bounds");
+
+    assert(l2->h_proto == bpf_htons(ETH_P_IPV6));
+
+    l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+    if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+        test_fatal("l3 out of bounds");
+
+    assert(l3->nexthdr == IPPROTO_ICMPV6);
+
+    icmp6hdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr);
+    if ((void *)icmp6hdr + sizeof(struct icmp6hdr) > data_end)
+        test_fatal("icmp6hdr out of bounds");
+
+    /* Verify this is an ICMPv6 echo reply */
+    test_log("ICMPv6 type: %d, expected: %d (ICMPV6_ECHO_REPLY)", icmp6hdr->icmp6_type, ICMPV6_ECHO_REPLY);
+    assert(icmp6hdr->icmp6_type == ICMPV6_ECHO_REPLY);
+
+    /* Verify the ICMP ID is preserved */
+    assert(icmp6hdr->icmp6_identifier == ICMP_ID);
+
+    /* Verify IPv6 addresses are swapped */
+    test_log("Checking IPv6 address swapping: src should be CLUSTERIP_IP, dst should be POD_IP");
+    assert(memcmp(&l3->saddr, (__u8 *)&CLUSTERIP_IP, 16) == 0);
+    assert(memcmp(&l3->daddr, (__u8 *)&POD_IP, 16) == 0);
+    test_log("IPv6 address swapping verified successfully");
+
+    /* Verify MAC addresses are swapped */
+    test_log("Checking MAC address swapping: src should be node_mac, dst should be pod_mac");
+    assert(memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) == 0);
+    assert(memcmp(l2->h_dest, (__u8 *)pod_mac, ETH_ALEN) == 0);
+    test_log("MAC address swapping verified successfully");
+
+    test_finish();
+}
+
+/* Test 2: LoadBalancer should reply to ICMPv6 echo requests from pods */
+PKTGEN("tc", "test_lxc_loadbalancer_icmpv6_echo_request")
+int lxc_loadbalancer_icmpv6_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+    struct pktgen builder;
+    struct icmp6hdr *icmp6hdr;
+    struct ethhdr *l2;
+    struct ipv6hdr *l3;
+    void *data;
+
+    /* Init packet builder */
+    pktgen__init(&builder, ctx);
+
+    /* Push ethernet header */
+    l2 = pktgen__push_ethhdr(&builder);
+    if (!l2)
+        return TEST_ERROR;
+
+    ethhdr__set_macs(l2, (__u8 *)pod_mac, (__u8 *)node_mac);
+
+    /* Push IPv6 header */
+    l3 = pktgen__push_default_ipv6hdr(&builder);
+    if (!l3)
+        return TEST_ERROR;
+
+    memcpy(&l3->saddr, (__u8 *)&POD_IP, 16);
+    memcpy(&l3->daddr, (__u8 *)&LOADBALANCER_IP, 16);
+
+    /* Push ICMPv6 header */
+    icmp6hdr = pktgen__push_icmp6hdr(&builder);
+    if (!icmp6hdr)
+        return TEST_ERROR;
+
+    icmp6hdr->icmp6_type = ICMPV6_ECHO_REQUEST;
+    icmp6hdr->icmp6_code = 0;
+    icmp6hdr->icmp6_identifier = ICMP_ID;
+    icmp6hdr->icmp6_sequence = __bpf_htons(2);
+
+    data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+    if (!data)
+        return TEST_ERROR;
+
+    /* Calc lengths, set protocol fields and calc checksums */
+    pktgen__finish(&builder);
+
+    return 0;
+}
+
+SETUP("tc", "test_lxc_loadbalancer_icmpv6_echo_request")
+int lxc_loadbalancer_icmpv6_echo_request_setup(struct __ctx_buff *ctx)
+{
+    /* Create a LoadBalancer service */
+    lb_v6_add_service_with_flags((union v6addr *)&LOADBALANCER_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, SVC_FLAG_LOADBALANCER);
+
+    /* Add a backend for the service */
+    lb_v6_add_backend((union v6addr *)&LOADBALANCER_IP, SERVICE_PORT, 1, 1, (union v6addr *)&BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+    /* Create wildcard service entry for ICMP echo reply handling */
+    lb_v6_add_service_with_flags((union v6addr *)&LOADBALANCER_IP, 0, IPPROTO_ANY, 1, 1, 0, SVC_FLAG_LOADBALANCER);
+
+    /* Configure IPCache entries for source pod and service */
+    ipcache_v6_add_entry((union v6addr *)&POD_IP, 0, 112233, 0, 0);        /* Source pod */
+    ipcache_v6_add_entry((union v6addr *)&LOADBALANCER_IP, 0, WORLD_IPV6_ID, 0, 0);  /* Service IP */
+    ipcache_v6_add_entry((union v6addr *)&BACKEND_IP, 0, 112244, 0, 0);    /* Backend pod */
+
+    /* Jump into the LXC entrypoint (pod egress) */
+    tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+    /* Fail if we didn't jump */
+    return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_loadbalancer_icmpv6_echo_request")
+int lxc_loadbalancer_icmpv6_echo_request_check(const struct __ctx_buff *ctx)
+{
+    void *data, *data_end;
+    __u32 *status_code;
+    struct ethhdr *l2;
+    struct ipv6hdr *l3;
+    struct icmp6hdr *icmp6hdr;
+
+    test_init();
+
+    data = (void *)(long)ctx_data(ctx);
+    data_end = (void *)(long)ctx->data_end;
+
+    if (data + sizeof(__u32) > data_end)
+        test_fatal("status code out of bounds");
+
+    status_code = data;
+    test_log("Status code: %d, expected: %d (CTX_ACT_REDIRECT)", *status_code, CTX_ACT_REDIRECT);
+    assert(*status_code == CTX_ACT_REDIRECT);
+
+    l2 = data + sizeof(__u32);
+    if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+        test_fatal("l2 out of bounds");
+
+    assert(l2->h_proto == bpf_htons(ETH_P_IPV6));
+
+    l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+    if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+        test_fatal("l3 out of bounds");
+
+    assert(l3->nexthdr == IPPROTO_ICMPV6);
+
+    icmp6hdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr);
+    if ((void *)icmp6hdr + sizeof(struct icmp6hdr) > data_end)
+        test_fatal("icmp6hdr out of bounds");
+
+    /* Verify this is an ICMPv6 echo reply */
+    test_log("ICMPv6 type: %d, expected: %d (ICMPV6_ECHO_REPLY)", icmp6hdr->icmp6_type, ICMPV6_ECHO_REPLY);
+    assert(icmp6hdr->icmp6_type == ICMPV6_ECHO_REPLY);
+
+    /* Verify the ICMP ID is preserved */
+    assert(icmp6hdr->icmp6_identifier == ICMP_ID);
+
+    /* Verify IPv6 addresses are swapped */
+    test_log("Checking IPv6 address swapping: src should be LOADBALANCER_IP, dst should be POD_IP");
+    assert(memcmp(&l3->saddr, (__u8 *)&LOADBALANCER_IP, 16) == 0);
+    assert(memcmp(&l3->daddr, (__u8 *)&POD_IP, 16) == 0);
+    test_log("IPv6 address swapping verified successfully");
+
+    /* Verify MAC addresses are swapped */
+    test_log("Checking MAC address swapping: src should be node_mac, dst should be pod_mac");
+    assert(memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) == 0);
+    assert(memcmp(l2->h_dest, (__u8 *)pod_mac, ETH_ALEN) == 0);
+    test_log("MAC address swapping verified successfully");
+
+    test_finish();
+}
+
+/* Test 3: Non-echo ICMPv6 packets should NOT be handled by echo reply logic */
+PKTGEN("tc", "test_lxc_icmpv6_other")
+int lxc_icmpv6_other_pktgen(struct __ctx_buff *ctx)
+{
+    struct pktgen builder;
+    struct icmp6hdr *icmp6hdr;
+    struct ethhdr *l2;
+    struct ipv6hdr *l3;
+    void *data;
+
+    /* Init packet builder */
+    pktgen__init(&builder, ctx);
+
+    /* Push ethernet header */
+    l2 = pktgen__push_ethhdr(&builder);
+    if (!l2)
+        return TEST_ERROR;
+
+    ethhdr__set_macs(l2, (__u8 *)pod_mac, (__u8 *)node_mac);
+
+    /* Push IPv6 header */
+    l3 = pktgen__push_default_ipv6hdr(&builder);
+    if (!l3)
+        return TEST_ERROR;
+
+    memcpy(&l3->saddr, (__u8 *)&POD_IP, 16);
+    memcpy(&l3->daddr, (__u8 *)&CLUSTERIP_IP, 16);
+
+    /* Push ICMPv6 header with destination unreachable type */
+    icmp6hdr = pktgen__push_icmp6hdr(&builder);
+    if (!icmp6hdr)
+        return TEST_ERROR;
+
+    icmp6hdr->icmp6_type = ICMPV6_DEST_UNREACH;
+    icmp6hdr->icmp6_code = ICMPV6_PORT_UNREACH;
+    icmp6hdr->icmp6_dataun.un_data32[0] = 0;
+
+    data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+    if (!data)
+        return TEST_ERROR;
+
+    /* Calc lengths, set protocol fields and calc checksums */
+    pktgen__finish(&builder);
+
+    return 0;
+}
+
+SETUP("tc", "test_lxc_icmpv6_other")
+int lxc_icmpv6_other_setup(struct __ctx_buff *ctx)
+{
+    /* Create a ClusterIP service for the non-echo ICMPv6 test */
+    lb_v6_add_service_with_flags((union v6addr *)&CLUSTERIP_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+    /* Add a backend for the service */
+    lb_v6_add_backend((union v6addr *)&CLUSTERIP_IP, SERVICE_PORT, 1, 1, (union v6addr *)&BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+    /* Configure IPCache entries */
+    ipcache_v6_add_entry((union v6addr *)&POD_IP, 0, 112233, 0, 0);        /* Source pod */
+    ipcache_v6_add_entry((union v6addr *)&CLUSTERIP_IP, 0, WORLD_IPV6_ID, 0, 0);  /* Service IP */
+    ipcache_v6_add_entry((union v6addr *)&BACKEND_IP, 0, 112244, 0, 0);    /* Backend pod */
+
+    /* Jump into the LXC entrypoint (pod egress) */
+    tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+    /* Fail if we didn't jump */
+    return TEST_ERROR;
+}
+
+CHECK("tc", "test_lxc_icmpv6_other")
+int lxc_icmpv6_other_check(const struct __ctx_buff *ctx)
+{
+    void *data, *data_end;
+    __u32 *status_code;
+    struct ethhdr *l2;
+    struct ipv6hdr *l3;
+    struct icmp6hdr *icmp6hdr;
+
+    test_init();
+
+    data = (void *)(long)ctx_data(ctx);
+    data_end = (void *)(long)ctx->data_end;
+
+    if (data + sizeof(__u32) > data_end)
+        test_fatal("status code out of bounds");
+
+    status_code = data;
+    /* Non-echo ICMPv6 should be dropped as they are error packets not suitable for load balancing */
+    test_log("Status code: %d, expected: %d (CTX_ACT_DROP)", *status_code, CTX_ACT_DROP);
+    assert(*status_code == CTX_ACT_DROP);
+
+    l2 = data + sizeof(__u32);
+    if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+        test_fatal("l2 out of bounds");
+
+    assert(l2->h_proto == bpf_htons(ETH_P_IPV6));
+
+    l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+    if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+        test_fatal("l3 out of bounds");
+
+    assert(l3->nexthdr == IPPROTO_ICMPV6);
+
+    icmp6hdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr);
+    if ((void *)icmp6hdr + sizeof(struct icmp6hdr) > data_end)
+        test_fatal("icmp6hdr out of bounds");
+
+    /* Verify this is NOT an ICMPv6 echo reply - other ICMP types should not be handled */
+    test_log("ICMPv6 type: %d, should NOT be: %d (ICMPV6_ECHO_REPLY)", icmp6hdr->icmp6_type, ICMPV6_ECHO_REPLY);
+    assert(icmp6hdr->icmp6_type != ICMPV6_ECHO_REPLY);
+
+    /* Verify this is the expected ICMPv6 type that was dropped */
+    assert(icmp6hdr->icmp6_type == ICMPV6_DEST_UNREACH);
+
+    test_finish();
+}
+

--- a/bpf/tests/tc_lxc_lb6_icmp_reply_no_per_packet_lb.c
+++ b/bpf/tests/tc_lxc_lb6_icmp_reply_no_per_packet_lb.c
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6
+#define SERVICE_NO_BACKEND_RESPONSE
+
+
+/* Prevent automatic ENABLE_PER_PACKET_LB definition in bpf_lxc.c */
+#define ENABLE_SOCKET_LB_FULL
+#undef ENABLE_SOCKET_LB_HOST_ONLY  
+#undef ENABLE_L7_LB
+#undef ENABLE_SCTP
+#undef ENABLE_CLUSTER_AWARE_ADDRESSING
+#undef ENABLE_PER_PACKET_LB
+
+#define POD_IP		v6_pod_one
+#define CLUSTERIP_IP	v6_node_one
+#define SERVICE_PORT	tcp_svc_one
+#define BACKEND_IP	v6_pod_two
+#define BACKEND_PORT	__bpf_htons(8080)
+#define ICMP_ID		__bpf_htons(0x5678)
+
+static volatile const __u8 *pod_mac = mac_one;
+static volatile const __u8 *node_mac = mac_two;
+
+#include <bpf_lxc.c>
+
+/* Force disable per-packet LB after bpf_lxc.c includes */
+#ifdef ENABLE_PER_PACKET_LB
+#undef ENABLE_PER_PACKET_LB
+#endif
+
+/* Verify that per-packet LB is now disabled */
+#ifdef ENABLE_PER_PACKET_LB
+#error "Test compilation failed: ENABLE_PER_PACKET_LB should be undefined"
+#endif
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+/* Enable ICMP echo reply on virtual IPs for testing */
+ASSIGN_CONFIG(bool, reply_to_icmp_echo_on_virtual_ips, true);
+
+#define FROM_CONTAINER	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+/* Test that ClusterIP replies to ICMPv6 echo when per-packet LB is disabled */
+PKTGEN("tc", "tc_lxc_icmpv6_echo_reply_no_per_packet_lb")
+int lxc_icmpv6_echo_reply_no_per_packet_lb_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *icmp6hdr;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)pod_mac, (__u8 *)node_mac);
+
+	/* Push IPv6 header */
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	memcpy(&l3->saddr, (__u8 *)&POD_IP, 16);
+	memcpy(&l3->daddr, (__u8 *)&CLUSTERIP_IP, 16);
+
+	/* Push ICMPv6 header */
+	icmp6hdr = pktgen__push_icmp6hdr(&builder);
+	if (!icmp6hdr)
+		return TEST_ERROR;
+
+	icmp6hdr->icmp6_type = ICMPV6_ECHO_REQUEST;
+	icmp6hdr->icmp6_code = 0;
+	icmp6hdr->icmp6_identifier = ICMP_ID;
+	icmp6hdr->icmp6_sequence = __bpf_htons(1);
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_icmpv6_echo_reply_no_per_packet_lb")
+int lxc_icmpv6_echo_reply_no_per_packet_lb_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	/* Create a ClusterIP service and manually add wildcard entry
+	 * to test our non-per-packet LB datapath ICMPv6 handling code
+	 */
+	lb_v6_add_service((union v6addr *)&CLUSTERIP_IP, SERVICE_PORT, IPPROTO_TCP, 1, revnat_id);
+	
+	/* Manually create the wildcard entry that our datapath code should find */
+	lb_v6_add_service((union v6addr *)&CLUSTERIP_IP, 0, IPPROTO_ANY, 0, revnat_id);
+
+	/* Add a backend for the service */
+	lb_v6_add_backend((union v6addr *)&CLUSTERIP_IP, SERVICE_PORT, 1, 1, 
+			  (union v6addr *)&BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	/* Configure IPCache entries */
+	ipcache_v6_add_entry((union v6addr *)&POD_IP, 0, 112233, 0, 0);
+	ipcache_v6_add_entry((union v6addr *)&CLUSTERIP_IP, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_entry((union v6addr *)&BACKEND_IP, 0, 112244, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_lxc_icmpv6_echo_reply_no_per_packet_lb")
+int lxc_icmpv6_echo_reply_no_per_packet_lb_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *icmp6hdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	test_log("Status code: %d", *status_code);
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IPV6));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->nexthdr == IPPROTO_ICMPV6);
+
+	icmp6hdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr);
+	if ((void *)icmp6hdr + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("icmp6hdr out of bounds");
+
+	/* Verify this is an ICMPv6 echo reply */
+	test_log("ICMPv6 type: %d", icmp6hdr->icmp6_type);
+	assert(icmp6hdr->icmp6_type == ICMPV6_ECHO_REPLY);
+
+	/* Verify the ICMP ID is preserved */
+	assert(icmp6hdr->icmp6_identifier == ICMP_ID);
+
+	/* Verify IPv6 addresses are swapped */
+	assert(memcmp(&l3->saddr, (__u8 *)&CLUSTERIP_IP, 16) == 0);
+	assert(memcmp(&l3->daddr, (__u8 *)&POD_IP, 16) == 0);
+
+	/* Verify MAC addresses are swapped */
+	assert(memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) == 0);
+	assert(memcmp(l2->h_dest, (__u8 *)pod_mac, ETH_ALEN) == 0);
+
+	test_finish();
+}
+

--- a/bpf/tests/tc_nodeport_drop_virtual_ip.c
+++ b/bpf/tests/tc_nodeport_drop_virtual_ip.c
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4 1
+#define ENABLE_IPV6 1
+#define ENABLE_NODEPORT 1
+
+
+#define ENABLE_HOST_SERVICES_TCP 1
+#define ENABLE_HOST_SERVICES_UDP 1
+
+#include <bpf_host.c>
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+ASSIGN_CONFIG(bool, drop_traffic_to_virtual_ips, true)
+
+
+
+#define CLUSTER_IP_V4 v4_svc_one
+#define CLUSTER_IP_V6 v6_svc_one
+
+#define SERVICE_PORT tcp_svc_one
+#define NON_SERVICE_PORT __bpf_htons(8080)
+
+#define CLIENT_IP_V4 v4_ext_one
+#define CLIENT_IP_V6 v6_ext_node_one
+#define CLIENT_PORT __bpf_htons(111)
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[0] = &cil_from_netdev,
+	},
+};
+
+/* Test that packets to ClusterIP on non-service ports are dropped */
+PKTGEN("tc", "test_drop_clusterip_packet_v4")
+int test_drop_clusterip_packet_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  CLIENT_IP_V4, CLUSTER_IP_V4,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_drop_clusterip_packet_v4")
+int test_drop_clusterip_packet_v4_setup(struct __ctx_buff *ctx)
+{
+	/* Create a ClusterIP service with wildcard entry */
+	lb_v4_add_service_with_flags(CLUSTER_IP_V4, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 0);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_drop_clusterip_packet_v4")
+int test_drop_clusterip_packet_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(l3->daddr == CLUSTER_IP_V4);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}
+
+/* Test that packets to ClusterIP on non-service ports are dropped (IPv6) */
+PKTGEN("tc", "test_drop_clusterip_packet_v6")
+int test_drop_clusterip_packet_v6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  (__u8 *)CLIENT_IP_V6, (__u8 *)CLUSTER_IP_V6,
+					  CLIENT_PORT, NON_SERVICE_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "test_drop_clusterip_packet_v6")
+int test_drop_clusterip_packet_v6_setup(struct __ctx_buff *ctx)
+{
+	/* Create a ClusterIP service with wildcard entry */
+	lb_v6_add_service_with_flags((union v6addr *)&CLUSTER_IP_V6, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 0);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "test_drop_clusterip_packet_v6")
+int test_drop_clusterip_packet_v6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_DROP);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Verify packet was for the right destination */
+	assert(memcmp(&l3->daddr, (void *)&CLUSTER_IP_V6, sizeof(l3->daddr)) == 0);
+	assert(l4->dest == NON_SERVICE_PORT);
+
+	test_finish();
+}

--- a/bpf/tests/tc_nodeport_lb4_icmp_reply.c
+++ b/bpf/tests/tc_nodeport_lb4_icmp_reply.c
@@ -1,0 +1,519 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define SERVICE_NO_BACKEND_RESPONSE
+#define ENABLE_MASQUERADE_IPV4		1
+
+#define CLIENT_IP		v4_ext_one
+#define ICMP_ID			__bpf_htons(0x1234)
+
+#define CLUSTERIP_IP		v4_svc_two
+#define LOADBALANCER_IP		v4_svc_three
+#define NODEPORT_IP		v4_node_one
+#define SERVICE_PORT		tcp_svc_one
+
+#define BACKEND_IP		v4_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+static volatile const __u8 *client_mac = mac_one;
+/* this matches the default node_config.h: */
+static volatile const __u8 lb_mac[ETH_ALEN] = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
+
+#include <bpf_host.c>
+
+ASSIGN_CONFIG(union v4addr, nat_ipv4_masquerade, (union v4addr) { .be32 = CLUSTERIP_IP })
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+/* Enable ICMP echo reply on virtual IPs for testing */
+ASSIGN_CONFIG(bool, reply_to_icmp_echo_on_virtual_ips, true);
+
+#define FROM_NETDEV	0
+#define TO_NETDEV	1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Test that ICMP echo requests to ClusterIP services generate ICMP echo replies */
+PKTGEN("tc", "tc_nodeport_lb4_icmp_clusterip_echo_request")
+int nodeport_lb4_icmp_clusterip_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmphdr *icmphdr;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = CLUSTERIP_IP;
+
+	/* Push ICMP header */
+	icmphdr = pktgen__push_icmphdr(&builder);
+	if (!icmphdr)
+		return TEST_ERROR;
+
+	icmphdr->type = ICMP_ECHO;
+	icmphdr->code = 0;
+	icmphdr->un.echo.id = ICMP_ID;
+	icmphdr->un.echo.sequence = __bpf_htons(1);
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_icmp_clusterip_echo_request")
+int nodeport_lb4_icmp_clusterip_echo_request_setup(struct __ctx_buff *ctx)
+{
+	    /* Create a ClusterIP service */
+	    lb_v4_add_service_with_flags(CLUSTERIP_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+	    /* Add a backend for the service */
+	    lb_v4_add_backend(CLUSTERIP_IP, SERVICE_PORT, 1, 1, BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	    /* Create wildcard service entry for ICMP echo reply handling */
+	    lb_v4_add_service_with_flags(CLUSTERIP_IP, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_lb4_icmp_clusterip_echo_request")
+int nodeport_lb4_icmp_clusterip_echo_request_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct icmphdr *icmphdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	test_log("Status code: %d, expected: %d (CTX_ACT_REDIRECT)", *status_code, CTX_ACT_REDIRECT);
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IP));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->protocol == IPPROTO_ICMP);
+
+	icmphdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
+	if ((void *)icmphdr + sizeof(struct icmphdr) > data_end)
+		test_fatal("icmphdr out of bounds");
+
+	/* Verify this is an ICMP echo reply */
+	test_log("ICMP type: %d, expected: %d (ICMP_ECHOREPLY)", icmphdr->type, ICMP_ECHOREPLY);
+	assert(icmphdr->type == ICMP_ECHOREPLY);
+
+	/* Verify the ICMP ID is preserved */
+	assert(icmphdr->un.echo.id == ICMP_ID);
+
+	/* Verify IP addresses are swapped */
+	test_log("Reply src IP: 0x%x, expected: 0x%x (CLUSTERIP_IP)", bpf_ntohl(l3->saddr), bpf_ntohl(CLUSTERIP_IP));
+	test_log("Reply dst IP: 0x%x, expected: 0x%x (CLIENT_IP)", bpf_ntohl(l3->daddr), bpf_ntohl(CLIENT_IP));
+	assert(l3->saddr == CLUSTERIP_IP);
+	assert(l3->daddr == CLIENT_IP);
+
+	/* Verify MAC addresses are swapped */
+	test_log("Checking MAC address swapping: src should be lb_mac, dst should be client_mac");
+	assert(memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) == 0);
+	assert(memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) == 0);
+	test_log("MAC address swapping verified successfully");
+
+	test_finish();
+}
+
+/* Test that ICMP echo requests to LoadBalancer services generate ICMP echo replies */
+PKTGEN("tc", "tc_nodeport_lb4_icmp_loadbalancer_echo_request")
+int nodeport_lb4_icmp_loadbalancer_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmphdr *icmphdr;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = LOADBALANCER_IP;
+
+	/* Push ICMP header */
+	icmphdr = pktgen__push_icmphdr(&builder);
+	if (!icmphdr)
+		return TEST_ERROR;
+
+	icmphdr->type = ICMP_ECHO;
+	icmphdr->code = 0;
+	icmphdr->un.echo.id = ICMP_ID;
+	icmphdr->un.echo.sequence = __bpf_htons(2);
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_icmp_loadbalancer_echo_request")
+int nodeport_lb4_icmp_loadbalancer_echo_request_setup(struct __ctx_buff *ctx)
+{
+	    /* Create a LoadBalancer service */
+	    lb_v4_add_service_with_flags(LOADBALANCER_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, SVC_FLAG_LOADBALANCER);
+
+	    /* Add a backend for the service */
+	    lb_v4_add_backend(LOADBALANCER_IP, SERVICE_PORT, 1, 1, BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	    /* Create wildcard service entry for ICMP echo reply handling */
+	    lb_v4_add_service_with_flags(LOADBALANCER_IP, 0, IPPROTO_ANY, 1, 1, 0, SVC_FLAG_LOADBALANCER);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_lb4_icmp_loadbalancer_echo_request")
+int nodeport_lb4_icmp_loadbalancer_echo_request_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct icmphdr *icmphdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	test_log("Status code: %d, expected: %d (CTX_ACT_REDIRECT)", *status_code, CTX_ACT_REDIRECT);
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IP));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->protocol == IPPROTO_ICMP);
+
+	icmphdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
+	if ((void *)icmphdr + sizeof(struct icmphdr) > data_end)
+		test_fatal("icmphdr out of bounds");
+
+	/* Verify this is an ICMP echo reply */
+	test_log("ICMP type: %d, expected: %d (ICMP_ECHOREPLY)", icmphdr->type, ICMP_ECHOREPLY);
+	assert(icmphdr->type == ICMP_ECHOREPLY);
+
+	/* Verify the ICMP ID is preserved */
+	assert(icmphdr->un.echo.id == ICMP_ID);
+
+	/* Verify IP addresses are swapped */
+	test_log("Reply src IP: 0x%x, expected: 0x%x (LOADBALANCER_IP)", bpf_ntohl(l3->saddr), bpf_ntohl(LOADBALANCER_IP));
+	test_log("Reply dst IP: 0x%x, expected: 0x%x (CLIENT_IP)", bpf_ntohl(l3->daddr), bpf_ntohl(CLIENT_IP));
+	assert(l3->saddr == LOADBALANCER_IP);
+	assert(l3->daddr == CLIENT_IP);
+
+	/* Verify MAC addresses are swapped */
+	test_log("Checking MAC address swapping: src should be lb_mac, dst should be client_mac");
+	assert(memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) == 0);
+	assert(memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) == 0);
+	test_log("MAC address swapping verified successfully");
+
+	test_finish();
+}
+
+/* Test that ICMP echo requests to NodePort services are forwarded (not replied to) */
+PKTGEN("tc", "tc_nodeport_lb4_icmp_nodeport_forward")
+int nodeport_lb4_icmp_nodeport_forward_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmphdr *icmphdr;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = NODEPORT_IP;
+
+	/* Push ICMP header */
+	icmphdr = pktgen__push_icmphdr(&builder);
+	if (!icmphdr)
+		return TEST_ERROR;
+
+	icmphdr->type = ICMP_ECHO;
+	icmphdr->code = 0;
+	icmphdr->un.echo.id = ICMP_ID;
+	icmphdr->un.echo.sequence = __bpf_htons(3);
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_icmp_nodeport_forward")
+int nodeport_lb4_icmp_nodeport_forward_setup(struct __ctx_buff *ctx)
+{
+	/* Create a NodePort service - this should NOT get a wildcard entry
+	 * because NodePort uses real node IPs and should forward ICMP to the node
+	 */
+	lb_v4_add_service_with_flags(NODEPORT_IP, SERVICE_PORT, IPPROTO_TCP, 1, 3, SVC_FLAG_NODEPORT | SVC_FLAG_ROUTABLE, 0);
+
+	/* Add a backend for the service */
+	lb_v4_add_backend(NODEPORT_IP, SERVICE_PORT, 1, 3, BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_lb4_icmp_nodeport_forward")
+int nodeport_lb4_icmp_nodeport_forward_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct icmphdr *icmphdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	/* NodePort should forward the packet, not generate an echo reply */
+	test_log("Status code: %d, expected: %d (CTX_ACT_OK)", *status_code, CTX_ACT_OK);
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IP));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->protocol == IPPROTO_ICMP);
+
+	icmphdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
+	if ((void *)icmphdr + sizeof(struct icmphdr) > data_end)
+		test_fatal("icmphdr out of bounds");
+
+	/* Verify this is still an ICMP echo request (not converted to reply) */
+	test_log("ICMP type: %d, expected: %d (ICMP_ECHO)", icmphdr->type, ICMP_ECHO);
+	assert(icmphdr->type == ICMP_ECHO);
+
+	/* Verify the packet is unchanged - addresses should not be swapped */
+	test_log("Packet src IP: 0x%x, expected: 0x%x (CLIENT_IP)", bpf_ntohl(l3->saddr), bpf_ntohl(CLIENT_IP));
+	test_log("Packet dst IP: 0x%x, expected: 0x%x (NODEPORT_IP)", bpf_ntohl(l3->daddr), bpf_ntohl(NODEPORT_IP));
+	assert(l3->saddr == CLIENT_IP);
+	assert(l3->daddr == NODEPORT_IP);
+
+	test_finish();
+}
+
+/* Test that non-ICMP echo requests to services are load balanced normally */
+PKTGEN("tc", "tc_nodeport_lb4_icmp_other")
+int nodeport_lb4_icmp_other_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmphdr *icmphdr;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = CLUSTERIP_IP;
+
+	/* Push ICMP header with destination unreachable type */
+	icmphdr = pktgen__push_icmphdr(&builder);
+	if (!icmphdr)
+		return TEST_ERROR;
+
+	icmphdr->type = ICMP_DEST_UNREACH;
+	icmphdr->code = ICMP_PORT_UNREACH;
+	icmphdr->un.gateway = 0;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_icmp_other")
+int nodeport_lb4_icmp_other_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_lb4_icmp_other")
+int nodeport_lb4_icmp_other_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct icmphdr *icmphdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IP));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->protocol == IPPROTO_ICMP);
+
+	icmphdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
+	if ((void *)icmphdr + sizeof(struct icmphdr) > data_end)
+		test_fatal("icmphdr out of bounds");
+
+	/* Verify this is NOT an ICMP echo reply - other ICMP types should not be handled */
+	assert(icmphdr->type != ICMP_ECHOREPLY);
+
+	/* Non-echo ICMP should be dropped or pass through unchanged */
+	assert(icmphdr->type == ICMP_DEST_UNREACH);
+
+	test_finish();
+}

--- a/bpf/tests/tc_nodeport_lb6_icmp_reply.c
+++ b/bpf/tests/tc_nodeport_lb6_icmp_reply.c
@@ -1,0 +1,518 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define SERVICE_NO_BACKEND_RESPONSE
+#define ENABLE_MASQUERADE_IPV6		1
+
+
+#define CLIENT_IP		v6_pod_one
+#define ICMP_ID			__bpf_htons(0x5678)
+
+#define CLUSTERIP_IP		v6_node_one
+#define LOADBALANCER_IP		v6_node_two
+#define NODEPORT_IP		v6_node_three
+#define SERVICE_PORT		tcp_svc_one
+
+#define BACKEND_IP		v6_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+static volatile const __u8 *client_mac = mac_one;
+/* this matches the default node_config.h: */
+static volatile const __u8 lb_mac[ETH_ALEN] = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
+
+#include <bpf_host.c>
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+/* Enable ICMP echo reply on virtual IPs for testing */
+ASSIGN_CONFIG(bool, reply_to_icmp_echo_on_virtual_ips, true);
+
+#define FROM_NETDEV	0
+#define TO_NETDEV	1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Test that ICMPv6 echo requests to ClusterIP services generate ICMPv6 echo replies */
+PKTGEN("tc", "tc_nodeport_lb6_icmp_clusterip_echo_request")
+int nodeport_lb6_icmp_clusterip_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *icmp6hdr;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv6 header */
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	memcpy(&l3->saddr, (__u8 *)&CLIENT_IP, 16);
+	memcpy(&l3->daddr, (__u8 *)&CLUSTERIP_IP, 16);
+
+	/* Push ICMPv6 header */
+	icmp6hdr = pktgen__push_icmp6hdr(&builder);
+	if (!icmp6hdr)
+		return TEST_ERROR;
+
+	icmp6hdr->icmp6_type = ICMPV6_ECHO_REQUEST;
+	icmp6hdr->icmp6_code = 0;
+	icmp6hdr->icmp6_identifier = ICMP_ID;
+	icmp6hdr->icmp6_sequence = __bpf_htons(1);
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb6_icmp_clusterip_echo_request")
+int nodeport_lb6_icmp_clusterip_echo_request_setup(struct __ctx_buff *ctx)
+{
+	/* Create a ClusterIP service */
+	lb_v6_add_service_with_flags((union v6addr *)&CLUSTERIP_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, 0);
+
+	/* Add a backend for the service */
+	lb_v6_add_backend((union v6addr *)&CLUSTERIP_IP, SERVICE_PORT, 1, 1, (union v6addr *)&BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	/* Create wildcard service entry for ICMP echo reply handling */
+	lb_v6_add_service_with_flags((union v6addr *)&CLUSTERIP_IP, 0, IPPROTO_ANY, 1, 1, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_lb6_icmp_clusterip_echo_request")
+int nodeport_lb6_icmp_clusterip_echo_request_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *icmp6hdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	test_log("Status code: %d, expected: %d (CTX_ACT_REDIRECT)", *status_code, CTX_ACT_REDIRECT);
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IPV6));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->nexthdr == IPPROTO_ICMPV6);
+
+	icmp6hdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr);
+	if ((void *)icmp6hdr + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("icmp6hdr out of bounds");
+
+	/* Verify this is an ICMPv6 echo reply */
+	test_log("ICMPv6 type: %d, expected: %d (ICMPV6_ECHO_REPLY)", icmp6hdr->icmp6_type, ICMPV6_ECHO_REPLY);
+	assert(icmp6hdr->icmp6_type == ICMPV6_ECHO_REPLY);
+
+	/* Verify the ICMP ID is preserved */
+	assert(icmp6hdr->icmp6_identifier == ICMP_ID);
+
+	/* Verify IPv6 addresses are swapped */
+	test_log("Checking IPv6 address swapping: src should be CLUSTERIP_IP, dst should be CLIENT_IP");
+	assert(memcmp(&l3->saddr, (__u8 *)&CLUSTERIP_IP, 16) == 0);
+	assert(memcmp(&l3->daddr, (__u8 *)&CLIENT_IP, 16) == 0);
+	test_log("IPv6 address swapping verified successfully");
+
+	/* Verify MAC addresses are swapped */
+	test_log("Checking MAC address swapping: src should be lb_mac, dst should be client_mac");
+	assert(memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) == 0);
+	assert(memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) == 0);
+	test_log("MAC address swapping verified successfully");
+
+	test_finish();
+}
+
+/* Test that ICMPv6 echo requests to LoadBalancer services generate ICMPv6 echo replies */
+PKTGEN("tc", "tc_nodeport_lb6_icmp_loadbalancer_echo_request")
+int nodeport_lb6_icmp_loadbalancer_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *icmp6hdr;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv6 header */
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	memcpy(&l3->saddr, (__u8 *)&CLIENT_IP, 16);
+	memcpy(&l3->daddr, (__u8 *)&LOADBALANCER_IP, 16);
+
+	/* Push ICMPv6 header */
+	icmp6hdr = pktgen__push_icmp6hdr(&builder);
+	if (!icmp6hdr)
+		return TEST_ERROR;
+
+	icmp6hdr->icmp6_type = ICMPV6_ECHO_REQUEST;
+	icmp6hdr->icmp6_code = 0;
+	icmp6hdr->icmp6_identifier = ICMP_ID;
+	icmp6hdr->icmp6_sequence = __bpf_htons(2);
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb6_icmp_loadbalancer_echo_request")
+int nodeport_lb6_icmp_loadbalancer_echo_request_setup(struct __ctx_buff *ctx)
+{
+	/* Create a LoadBalancer service */
+	lb_v6_add_service_with_flags((union v6addr *)&LOADBALANCER_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1, 0, SVC_FLAG_LOADBALANCER);
+
+	/* Add a backend for the service */
+	lb_v6_add_backend((union v6addr *)&LOADBALANCER_IP, SERVICE_PORT, 1, 1, (union v6addr *)&BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	/* Create wildcard service entry for ICMP echo reply handling */
+	lb_v6_add_service_with_flags((union v6addr *)&LOADBALANCER_IP, 0, IPPROTO_ANY, 1, 1, 0, SVC_FLAG_LOADBALANCER);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_lb6_icmp_loadbalancer_echo_request")
+int nodeport_lb6_icmp_loadbalancer_echo_request_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *icmp6hdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	test_log("Status code: %d, expected: %d (CTX_ACT_REDIRECT)", *status_code, CTX_ACT_REDIRECT);
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IPV6));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->nexthdr == IPPROTO_ICMPV6);
+
+	icmp6hdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr);
+	if ((void *)icmp6hdr + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("icmp6hdr out of bounds");
+
+	/* Verify this is an ICMPv6 echo reply */
+	test_log("ICMPv6 type: %d, expected: %d (ICMPV6_ECHO_REPLY)", icmp6hdr->icmp6_type, ICMPV6_ECHO_REPLY);
+	assert(icmp6hdr->icmp6_type == ICMPV6_ECHO_REPLY);
+
+	/* Verify the ICMP ID is preserved */
+	assert(icmp6hdr->icmp6_identifier == ICMP_ID);
+
+	/* Verify IPv6 addresses are swapped */
+	test_log("Checking IPv6 address swapping: src should be LOADBALANCER_IP, dst should be CLIENT_IP");
+	assert(memcmp(&l3->saddr, (__u8 *)&LOADBALANCER_IP, 16) == 0);
+	assert(memcmp(&l3->daddr, (__u8 *)&CLIENT_IP, 16) == 0);
+	test_log("IPv6 address swapping verified successfully");
+
+	/* Verify MAC addresses are swapped */
+	test_log("Checking MAC address swapping: src should be lb_mac, dst should be client_mac");
+	assert(memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) == 0);
+	assert(memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) == 0);
+	test_log("MAC address swapping verified successfully");
+
+	test_finish();
+}
+
+/* Test that ICMPv6 echo requests to NodePort services are forwarded (not replied to) */
+PKTGEN("tc", "tc_nodeport_lb6_icmp_nodeport_forward")
+int nodeport_lb6_icmp_nodeport_forward_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *icmp6hdr;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv6 header */
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	memcpy(&l3->saddr, (__u8 *)&CLIENT_IP, 16);
+	memcpy(&l3->daddr, (__u8 *)&NODEPORT_IP, 16);
+
+	/* Push ICMPv6 header */
+	icmp6hdr = pktgen__push_icmp6hdr(&builder);
+	if (!icmp6hdr)
+		return TEST_ERROR;
+
+	icmp6hdr->icmp6_type = ICMPV6_ECHO_REQUEST;
+	icmp6hdr->icmp6_code = 0;
+	icmp6hdr->icmp6_identifier = ICMP_ID;
+	icmp6hdr->icmp6_sequence = __bpf_htons(3);
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb6_icmp_nodeport_forward")
+int nodeport_lb6_icmp_nodeport_forward_setup(struct __ctx_buff *ctx)
+{
+	/* Create a NodePort service - this should NOT get a wildcard entry
+	 * because NodePort uses real node IPs and should forward ICMPv6 to the node
+	 */
+	lb_v6_add_service_with_flags((union v6addr *)&NODEPORT_IP, SERVICE_PORT, IPPROTO_TCP, 1, 3, SVC_FLAG_NODEPORT | SVC_FLAG_ROUTABLE, 0);
+
+	/* Add a backend for the service */
+	lb_v6_add_backend((union v6addr *)&NODEPORT_IP, SERVICE_PORT, 1, 3, (union v6addr *)&BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_lb6_icmp_nodeport_forward")
+int nodeport_lb6_icmp_nodeport_forward_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *icmp6hdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	/* NodePort should forward the packet, not generate an echo reply */
+	test_log("Status code: %d, expected: %d (CTX_ACT_OK)", *status_code, CTX_ACT_OK);
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IPV6));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->nexthdr == IPPROTO_ICMPV6);
+
+	icmp6hdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr);
+	if ((void *)icmp6hdr + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("icmp6hdr out of bounds");
+
+	/* Verify this is still an ICMPv6 echo request (not converted to reply) */
+	test_log("ICMPv6 type: %d, expected: %d (ICMPV6_ECHO_REQUEST)", icmp6hdr->icmp6_type, ICMPV6_ECHO_REQUEST);
+	assert(icmp6hdr->icmp6_type == ICMPV6_ECHO_REQUEST);
+
+	/* Verify the packet is unchanged - addresses should not be swapped */
+	test_log("Checking packet unchanged: src should be CLIENT_IP, dst should be NODEPORT_IP");
+	assert(memcmp(&l3->saddr, (__u8 *)&CLIENT_IP, 16) == 0);
+	assert(memcmp(&l3->daddr, (__u8 *)&NODEPORT_IP, 16) == 0);
+	test_log("Packet unchanged verification successful");
+
+	test_finish();
+}
+
+/* Test that non-ICMPv6 echo requests to services are load balanced normally */
+PKTGEN("tc", "tc_nodeport_lb6_icmp_other")
+int nodeport_lb6_icmp_other_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *icmp6hdr;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv6 header */
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	memcpy(&l3->saddr, (__u8 *)&CLIENT_IP, 16);
+	memcpy(&l3->daddr, (__u8 *)&CLUSTERIP_IP, 16);
+
+	/* Push ICMPv6 header with destination unreachable type */
+	icmp6hdr = pktgen__push_icmp6hdr(&builder);
+	if (!icmp6hdr)
+		return TEST_ERROR;
+
+	icmp6hdr->icmp6_type = ICMPV6_DEST_UNREACH;
+	icmp6hdr->icmp6_code = ICMPV6_PORT_UNREACH;
+	icmp6hdr->icmp6_dataun.un_data32[0] = 0;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb6_icmp_other")
+int nodeport_lb6_icmp_other_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_lb6_icmp_other")
+int nodeport_lb6_icmp_other_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct icmp6hdr *icmp6hdr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == bpf_htons(ETH_P_IPV6));
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->nexthdr == IPPROTO_ICMPV6);
+
+	icmp6hdr = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct ipv6hdr);
+	if ((void *)icmp6hdr + sizeof(struct icmp6hdr) > data_end)
+		test_fatal("icmp6hdr out of bounds");
+
+	/* Verify this is NOT an ICMPv6 echo reply - other ICMP types should not be handled */
+	assert(icmp6hdr->icmp6_type != ICMPV6_ECHO_REPLY);
+
+	/* Non-echo ICMP should be dropped or pass through unchanged */
+	assert(icmp6hdr->icmp6_type == ICMPV6_DEST_UNREACH);
+
+	test_finish();
+}

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -9,6 +9,8 @@ package config
 // instantiate directly! Always use [NewNode] to ensure the default values
 // configured in the ELF are honored.
 type Node struct {
+	// Drop traffic to non-existent ports on virtual IPs.
+	DropTrafficToVirtualIps bool `config:"drop_traffic_to_virtual_ips"`
 	// Internal IPv6 router address assigned to the cilium_host interface.
 	RouterIPv6 [16]byte `config:"router_ipv6"`
 	// IPv4 source address used for SNAT when a Pod talks to itself over a Service.
@@ -20,6 +22,6 @@ type Node struct {
 }
 
 func NewNode() *Node {
-	return &Node{[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	return &Node{false, [16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0}, 0x0, 0x0}
 }

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -11,6 +11,8 @@ package config
 type Node struct {
 	// Drop traffic to non-existent ports on virtual IPs.
 	DropTrafficToVirtualIps bool `config:"drop_traffic_to_virtual_ips"`
+	// Reply to ICMP echo requests on virtual IPs.
+	ReplyToICMPEchoOnVirtualIps bool `config:"reply_to_icmp_echo_on_virtual_ips"`
 	// Internal IPv6 router address assigned to the cilium_host interface.
 	RouterIPv6 [16]byte `config:"router_ipv6"`
 	// IPv4 source address used for SNAT when a Pod talks to itself over a Service.
@@ -22,6 +24,6 @@ type Node struct {
 }
 
 func NewNode() *Node {
-	return &Node{false, [16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	return &Node{false, false, [16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0}, 0x0, 0x0}
 }

--- a/pkg/datapath/config/overlay_config.go
+++ b/pkg/datapath/config/overlay_config.go
@@ -12,6 +12,7 @@ type BPFOverlay struct {
 	// MTU of the device the bpf program is attached to (default: MTU set in
 	// node_config.h by agent).
 	DeviceMTU uint16 `config:"device_mtu"`
+
 	// Pass traffic with extended IP protocols.
 	EnableExtendedIPProtocols bool `config:"enable_extended_ip_protocols"`
 	// Ifindex of the interface the bpf program is attached to.

--- a/pkg/datapath/loader/config.go
+++ b/pkg/datapath/loader/config.go
@@ -22,6 +22,7 @@ func nodeConfig(lnc *datapath.LocalNodeConfiguration) config.Node {
 
 	node.TracePayloadLen = uint32(option.Config.TracePayloadlen)
 	node.TracePayloadLenOverlay = uint32(option.Config.TracePayloadlenOverlay)
+	node.DropTrafficToVirtualIps = lnc.LBConfig.DropTrafficToVirtualIPs
 
 	return node
 }

--- a/pkg/datapath/loader/config.go
+++ b/pkg/datapath/loader/config.go
@@ -23,6 +23,7 @@ func nodeConfig(lnc *datapath.LocalNodeConfiguration) config.Node {
 	node.TracePayloadLen = uint32(option.Config.TracePayloadlen)
 	node.TracePayloadLenOverlay = uint32(option.Config.TracePayloadlenOverlay)
 	node.DropTrafficToVirtualIps = lnc.LBConfig.DropTrafficToVirtualIPs
+	node.ReplyToICMPEchoOnVirtualIps = lnc.LBConfig.ReplyToICMPEchoOnVirtualIPs
 
 	return node
 }

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -90,6 +90,10 @@ const (
 	// (ClusterIP and LoadBalancer) on ports without services instead of forwarding them.
 	// This enhances security by preventing unintended access to virtual service addresses.
 	DropTrafficToVirtualIPsName = "bpf-lb-drop-traffic-to-virtual-ips"
+
+	// ReplyToICMPEchoOnVirtualIPsName is the name of the option to reply to ICMP echo requests
+	// on virtual IPs (ClusterIP and LoadBalancer) to make them appear reachable for diagnostics.
+	ReplyToICMPEchoOnVirtualIPsName = "bpf-lb-reply-icmp-echo-virtual-ips"
 )
 
 // Configuration option defaults
@@ -200,6 +204,11 @@ type UserConfig struct {
 	// and LoadBalancer) on ports without services instead of forwarding them.
 	// This provides better security by preventing access to non-existent services.
 	DropTrafficToVirtualIPs bool `mapstructure:"bpf-lb-drop-traffic-to-virtual-ips"`
+
+	// ReplyToICMPEchoOnVirtualIPs enables responding to ICMP echo requests (ping)
+	// on virtual IPs (ClusterIP and LoadBalancer) to make them appear reachable
+	// for network diagnostics.
+	ReplyToICMPEchoOnVirtualIPs bool `mapstructure:"bpf-lb-reply-icmp-echo-virtual-ips"`
 
 	// LBPressureMetricsInterval sets the interval for updating the load-balancer BPF map
 	// pressure metrics. A batch lookup is performed for all maps periodically to count
@@ -317,6 +326,9 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 
 	flags.Bool(DropTrafficToVirtualIPsName, def.DropTrafficToVirtualIPs, "Drop traffic to virtual IPs (ClusterIP/LoadBalancer) on ports without services instead of forwarding (experimental)")
 	flags.MarkHidden(DropTrafficToVirtualIPsName)
+
+	flags.Bool(ReplyToICMPEchoOnVirtualIPsName, def.ReplyToICMPEchoOnVirtualIPs, "Reply to ICMP echo requests on virtual IPs (ClusterIP/LoadBalancer) to make them appear reachable (experimental)")
+	flags.MarkHidden(ReplyToICMPEchoOnVirtualIPsName)
 
 	flags.Duration("lb-pressure-metrics-interval", def.LBPressureMetricsInterval, "Interval for reporting pressure metrics for load-balancing BPF maps. 0 disables reporting.")
 	flags.MarkHidden("lb-pressure-metrics-interval")
@@ -501,6 +513,8 @@ var DefaultUserConfig = UserConfig{
 	EnableServiceTopology: false,
 
 	DropTrafficToVirtualIPs: false, // Experimental feature, disabled by default
+
+	ReplyToICMPEchoOnVirtualIPs: false, // Experimental feature, disabled by default
 }
 
 var DefaultConfig = Config{


### PR DESCRIPTION
Introduce support for responding to ICMP/ICMPv6 echo requests sent to virtual service IPs (ClusterIP and LoadBalancer IPs) with echo replies, making services appear "pingable" for network diagnostics. This is distinct, builds on the wildcard service implementation from the packet DROP feature. 

This feature is controlled by the `reply_to_icmp_echo_on_virtual_ips` configuration option and works alongside the `drop_traffic_to_virtual_ips` feature. Both features require wildcard service lookups `(port=0, proto=ANY)` to determine if a destination IP is a virtual service IP (this is determined in the control plane and a wildcard service is introduced into the service map if it is indeed a virtual IP).

To avoid code duplication and improve performance, this patch consolidates the previously scattered wildcard lookup logic into a new shared helper library (`lib/virtual_ip.h`) that provides:

- Unified lookup functions with dual-scope logic (external and internal scopes) for all service types
- Combined handlers that perform a single lookup when both features are enabled, eliminating duplicate map lookups

Replaces: #37623 

Fixes: #14118
Fixes: #37608

```
bpf: Add ICMP echo request handling for service IPs
```