### PR TITLE
bgp: Use private fork of the GoBGP to fix BGP MD5 auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -323,6 +323,10 @@ require (
 // as to why we are using a private fork.
 replace sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16.5-1
 
+// Using private fork of gobgp. See commit msg for more context as to why we
+// are using a private fork.
+replace github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464
+
 tool (
 	github.com/cilium/deepequal-gen
 	github.com/cilium/linters

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c h1
 github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c/go.mod h1:izWO5C3waDVkh/nt++nNyozXyJAPL6tfFpJSMtzVnwQ=
 github.com/cilium/fake v0.7.0 h1:4EKBtTweQrJoD4q45qDGu8udulmYMo48Y0BhEbrB1jc=
 github.com/cilium/fake v0.7.0/go.mod h1:hA1YsEjgIs5Gdeq/DVrDWGuhLCoVok7THTvQaGDO5bc=
+github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464 h1:lQMPil6k4HhTG3PJXxKsNFzjqPHOnu55uQg+1rhl0VE=
+github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464/go.mod h1:kVHVFy1/fyZHJ8P32+ctvPeJogn9qKwa1YCeMRXXrP0=
 github.com/cilium/hive v0.0.0-20250611195437-5a5dacdfb354 h1:4G9PC8nQw4pGW5wCMA0g8J8rK1l4C3owlceAOQggXzs=
 github.com/cilium/hive v0.0.0-20250611195437-5a5dacdfb354/go.mod h1:pI2GJ1n3SLKIQVFrKF7W6A6gb6BQkZ+3Hp4PAEo5SuI=
 github.com/cilium/linters v0.2.0 h1:YxtPFl1XxOErU6I97qgmmMeGISDNHftoLRdF1G96J9U=
@@ -569,8 +571,6 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
-github.com/osrg/gobgp/v3 v3.37.0 h1:+ObuOdvj7G7nxrT0fKFta+EAupdWf/q1WzbXydr8IOY=
-github.com/osrg/gobgp/v3 v3.37.0/go.mod h1:kVHVFy1/fyZHJ8P32+ctvPeJogn9qKwa1YCeMRXXrP0=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/vendor/github.com/osrg/gobgp/v3/pkg/server/server.go
+++ b/vendor/github.com/osrg/gobgp/v3/pkg/server/server.go
@@ -117,6 +117,14 @@ func newTCPListener(logger log.Logger, address string, port uint32, bindToDev st
 		return nil
 	}
 
+	// Since 1.24, Go stdlib enables MPTCP for listeners by default. This
+	// makes setsockopt to call MPTCP-specific handler. This breaks the
+	// listener that enables TCP MD5 because it is not compatible with
+	// MPTCP. This is a workaround for that.
+	//
+	// See: https://github.com/golang/go/issues/74643 for more details.
+	lc.SetMultipathTCP(false)
+
 	l, err := lc.Listen(context.Background(), proto, addr)
 	if err != nil {
 		return nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1257,7 +1257,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
-# github.com/osrg/gobgp/v3 v3.37.0
+# github.com/osrg/gobgp/v3 v3.37.0 => github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464
 ## explicit; go 1.23.0
 github.com/osrg/gobgp/v3/api
 github.com/osrg/gobgp/v3/internal/pkg/table
@@ -2858,3 +2858,4 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
 # sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16.5-1
+# github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464


### PR DESCRIPTION
Temporally use the private fork of the GoBGP to fix the issue of BGP MD5 authentication reported in #40478. We could wait for the next GoBGP release, but the next release is going to be a major version update, so it may take time before release and may have some bugs. Therefore, we fork the GoBGP from the last release of the current major version (v3.37.0) and apply MD5 fix and use it until we migrate to the new major GoBGP version.

The forked repo and branch is here: https://github.com/cilium/gobgp/tree/v3.37.0-with-fix

We request backporting to the v1.18 - v1.16 since they are also affected (as they are using Go >= v1.24) and without this change, BGP MD5 auth doesn't work at all. We consider it as a "Major bugfixes relevant to the correct operation of Cilium" in the [backporting criteria](https://docs.cilium.io/en/stable/contributing/release/backports/).

Fixes: #40478

```release-note
bgp: Use private fork of the GoBGP to fix BGP MD5 auth
```
