### PR TITLE
Fix Endpoint delete request processing during agent startup

### DIFF
--- a/api/v1/client/endpoint/delete_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/delete_endpoint_id_responses.go
@@ -63,6 +63,12 @@ func (o *DeleteEndpointIDReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewDeleteEndpointIDServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("[DELETE /endpoint/{id}] DeleteEndpointID", response, response.Code())
 	}
@@ -426,6 +432,62 @@ func (o *DeleteEndpointIDTooManyRequests) String() string {
 }
 
 func (o *DeleteEndpointIDTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewDeleteEndpointIDServiceUnavailable creates a DeleteEndpointIDServiceUnavailable with default headers values
+func NewDeleteEndpointIDServiceUnavailable() *DeleteEndpointIDServiceUnavailable {
+	return &DeleteEndpointIDServiceUnavailable{}
+}
+
+/*
+DeleteEndpointIDServiceUnavailable describes a response with status code 503, with default header values.
+
+Service Unavailable
+*/
+type DeleteEndpointIDServiceUnavailable struct {
+}
+
+// IsSuccess returns true when this delete endpoint Id service unavailable response has a 2xx status code
+func (o *DeleteEndpointIDServiceUnavailable) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this delete endpoint Id service unavailable response has a 3xx status code
+func (o *DeleteEndpointIDServiceUnavailable) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this delete endpoint Id service unavailable response has a 4xx status code
+func (o *DeleteEndpointIDServiceUnavailable) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this delete endpoint Id service unavailable response has a 5xx status code
+func (o *DeleteEndpointIDServiceUnavailable) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this delete endpoint Id service unavailable response a status code equal to that given
+func (o *DeleteEndpointIDServiceUnavailable) IsCode(code int) bool {
+	return code == 503
+}
+
+// Code gets the status code for the delete endpoint Id service unavailable response
+func (o *DeleteEndpointIDServiceUnavailable) Code() int {
+	return 503
+}
+
+func (o *DeleteEndpointIDServiceUnavailable) Error() string {
+	return fmt.Sprintf("[DELETE /endpoint/{id}][%d] deleteEndpointIdServiceUnavailable", 503)
+}
+
+func (o *DeleteEndpointIDServiceUnavailable) String() string {
+	return fmt.Sprintf("[DELETE /endpoint/{id}][%d] deleteEndpointIdServiceUnavailable", 503)
+}
+
+func (o *DeleteEndpointIDServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/delete_endpoint_responses.go
+++ b/api/v1/client/endpoint/delete_endpoint_responses.go
@@ -55,6 +55,12 @@ func (o *DeleteEndpointReader) ReadResponse(response runtime.ClientResponse, con
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewDeleteEndpointServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("[DELETE /endpoint] DeleteEndpoint", response, response.Code())
 	}
@@ -348,6 +354,62 @@ func (o *DeleteEndpointTooManyRequests) String() string {
 }
 
 func (o *DeleteEndpointTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewDeleteEndpointServiceUnavailable creates a DeleteEndpointServiceUnavailable with default headers values
+func NewDeleteEndpointServiceUnavailable() *DeleteEndpointServiceUnavailable {
+	return &DeleteEndpointServiceUnavailable{}
+}
+
+/*
+DeleteEndpointServiceUnavailable describes a response with status code 503, with default header values.
+
+Service Unavailable
+*/
+type DeleteEndpointServiceUnavailable struct {
+}
+
+// IsSuccess returns true when this delete endpoint service unavailable response has a 2xx status code
+func (o *DeleteEndpointServiceUnavailable) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this delete endpoint service unavailable response has a 3xx status code
+func (o *DeleteEndpointServiceUnavailable) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this delete endpoint service unavailable response has a 4xx status code
+func (o *DeleteEndpointServiceUnavailable) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this delete endpoint service unavailable response has a 5xx status code
+func (o *DeleteEndpointServiceUnavailable) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this delete endpoint service unavailable response a status code equal to that given
+func (o *DeleteEndpointServiceUnavailable) IsCode(code int) bool {
+	return code == 503
+}
+
+// Code gets the status code for the delete endpoint service unavailable response
+func (o *DeleteEndpointServiceUnavailable) Code() int {
+	return 503
+}
+
+func (o *DeleteEndpointServiceUnavailable) Error() string {
+	return fmt.Sprintf("[DELETE /endpoint][%d] deleteEndpointServiceUnavailable", 503)
+}
+
+func (o *DeleteEndpointServiceUnavailable) String() string {
+	return fmt.Sprintf("[DELETE /endpoint][%d] deleteEndpointServiceUnavailable", 503)
+}
+
+func (o *DeleteEndpointServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/patch_endpoint_id_config_responses.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_config_responses.go
@@ -63,6 +63,12 @@ func (o *PatchEndpointIDConfigReader) ReadResponse(response runtime.ClientRespon
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewPatchEndpointIDConfigServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("[PATCH /endpoint/{id}/config] PatchEndpointIDConfig", response, response.Code())
 	}
@@ -412,6 +418,62 @@ func (o *PatchEndpointIDConfigFailed) readResponse(response runtime.ClientRespon
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
+
+	return nil
+}
+
+// NewPatchEndpointIDConfigServiceUnavailable creates a PatchEndpointIDConfigServiceUnavailable with default headers values
+func NewPatchEndpointIDConfigServiceUnavailable() *PatchEndpointIDConfigServiceUnavailable {
+	return &PatchEndpointIDConfigServiceUnavailable{}
+}
+
+/*
+PatchEndpointIDConfigServiceUnavailable describes a response with status code 503, with default header values.
+
+Service Unavailable
+*/
+type PatchEndpointIDConfigServiceUnavailable struct {
+}
+
+// IsSuccess returns true when this patch endpoint Id config service unavailable response has a 2xx status code
+func (o *PatchEndpointIDConfigServiceUnavailable) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this patch endpoint Id config service unavailable response has a 3xx status code
+func (o *PatchEndpointIDConfigServiceUnavailable) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this patch endpoint Id config service unavailable response has a 4xx status code
+func (o *PatchEndpointIDConfigServiceUnavailable) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this patch endpoint Id config service unavailable response has a 5xx status code
+func (o *PatchEndpointIDConfigServiceUnavailable) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this patch endpoint Id config service unavailable response a status code equal to that given
+func (o *PatchEndpointIDConfigServiceUnavailable) IsCode(code int) bool {
+	return code == 503
+}
+
+// Code gets the status code for the patch endpoint Id config service unavailable response
+func (o *PatchEndpointIDConfigServiceUnavailable) Code() int {
+	return 503
+}
+
+func (o *PatchEndpointIDConfigServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PATCH /endpoint/{id}/config][%d] patchEndpointIdConfigServiceUnavailable", 503)
+}
+
+func (o *PatchEndpointIDConfigServiceUnavailable) String() string {
+	return fmt.Sprintf("[PATCH /endpoint/{id}/config][%d] patchEndpointIdConfigServiceUnavailable", 503)
+}
+
+func (o *PatchEndpointIDConfigServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/patch_endpoint_id_labels_responses.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_labels_responses.go
@@ -57,6 +57,12 @@ func (o *PatchEndpointIDLabelsReader) ReadResponse(response runtime.ClientRespon
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewPatchEndpointIDLabelsServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("[PATCH /endpoint/{id}/labels] PatchEndpointIDLabels", response, response.Code())
 	}
@@ -350,6 +356,62 @@ func (o *PatchEndpointIDLabelsUpdateFailed) readResponse(response runtime.Client
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
+
+	return nil
+}
+
+// NewPatchEndpointIDLabelsServiceUnavailable creates a PatchEndpointIDLabelsServiceUnavailable with default headers values
+func NewPatchEndpointIDLabelsServiceUnavailable() *PatchEndpointIDLabelsServiceUnavailable {
+	return &PatchEndpointIDLabelsServiceUnavailable{}
+}
+
+/*
+PatchEndpointIDLabelsServiceUnavailable describes a response with status code 503, with default header values.
+
+Service Unavailable
+*/
+type PatchEndpointIDLabelsServiceUnavailable struct {
+}
+
+// IsSuccess returns true when this patch endpoint Id labels service unavailable response has a 2xx status code
+func (o *PatchEndpointIDLabelsServiceUnavailable) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this patch endpoint Id labels service unavailable response has a 3xx status code
+func (o *PatchEndpointIDLabelsServiceUnavailable) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this patch endpoint Id labels service unavailable response has a 4xx status code
+func (o *PatchEndpointIDLabelsServiceUnavailable) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this patch endpoint Id labels service unavailable response has a 5xx status code
+func (o *PatchEndpointIDLabelsServiceUnavailable) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this patch endpoint Id labels service unavailable response a status code equal to that given
+func (o *PatchEndpointIDLabelsServiceUnavailable) IsCode(code int) bool {
+	return code == 503
+}
+
+// Code gets the status code for the patch endpoint Id labels service unavailable response
+func (o *PatchEndpointIDLabelsServiceUnavailable) Code() int {
+	return 503
+}
+
+func (o *PatchEndpointIDLabelsServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PATCH /endpoint/{id}/labels][%d] patchEndpointIdLabelsServiceUnavailable", 503)
+}
+
+func (o *PatchEndpointIDLabelsServiceUnavailable) String() string {
+	return fmt.Sprintf("[PATCH /endpoint/{id}/labels][%d] patchEndpointIdLabelsServiceUnavailable", 503)
+}
+
+func (o *PatchEndpointIDLabelsServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/patch_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/patch_endpoint_id_responses.go
@@ -63,6 +63,12 @@ func (o *PatchEndpointIDReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewPatchEndpointIDServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("[PATCH /endpoint/{id}] PatchEndpointID", response, response.Code())
 	}
@@ -424,6 +430,62 @@ func (o *PatchEndpointIDFailed) readResponse(response runtime.ClientResponse, co
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
+
+	return nil
+}
+
+// NewPatchEndpointIDServiceUnavailable creates a PatchEndpointIDServiceUnavailable with default headers values
+func NewPatchEndpointIDServiceUnavailable() *PatchEndpointIDServiceUnavailable {
+	return &PatchEndpointIDServiceUnavailable{}
+}
+
+/*
+PatchEndpointIDServiceUnavailable describes a response with status code 503, with default header values.
+
+Service Unavailable
+*/
+type PatchEndpointIDServiceUnavailable struct {
+}
+
+// IsSuccess returns true when this patch endpoint Id service unavailable response has a 2xx status code
+func (o *PatchEndpointIDServiceUnavailable) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this patch endpoint Id service unavailable response has a 3xx status code
+func (o *PatchEndpointIDServiceUnavailable) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this patch endpoint Id service unavailable response has a 4xx status code
+func (o *PatchEndpointIDServiceUnavailable) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this patch endpoint Id service unavailable response has a 5xx status code
+func (o *PatchEndpointIDServiceUnavailable) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this patch endpoint Id service unavailable response a status code equal to that given
+func (o *PatchEndpointIDServiceUnavailable) IsCode(code int) bool {
+	return code == 503
+}
+
+// Code gets the status code for the patch endpoint Id service unavailable response
+func (o *PatchEndpointIDServiceUnavailable) Code() int {
+	return 503
+}
+
+func (o *PatchEndpointIDServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PATCH /endpoint/{id}][%d] patchEndpointIdServiceUnavailable", 503)
+}
+
+func (o *PatchEndpointIDServiceUnavailable) String() string {
+	return fmt.Sprintf("[PATCH /endpoint/{id}][%d] patchEndpointIdServiceUnavailable", 503)
+}
+
+func (o *PatchEndpointIDServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/client/endpoint/put_endpoint_id_responses.go
+++ b/api/v1/client/endpoint/put_endpoint_id_responses.go
@@ -63,6 +63,12 @@ func (o *PutEndpointIDReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewPutEndpointIDServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("[PUT /endpoint/{id}] PutEndpointID", response, response.Code())
 	}
@@ -438,6 +444,62 @@ func (o *PutEndpointIDFailed) readResponse(response runtime.ClientResponse, cons
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
+
+	return nil
+}
+
+// NewPutEndpointIDServiceUnavailable creates a PutEndpointIDServiceUnavailable with default headers values
+func NewPutEndpointIDServiceUnavailable() *PutEndpointIDServiceUnavailable {
+	return &PutEndpointIDServiceUnavailable{}
+}
+
+/*
+PutEndpointIDServiceUnavailable describes a response with status code 503, with default header values.
+
+Service Unavailable
+*/
+type PutEndpointIDServiceUnavailable struct {
+}
+
+// IsSuccess returns true when this put endpoint Id service unavailable response has a 2xx status code
+func (o *PutEndpointIDServiceUnavailable) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this put endpoint Id service unavailable response has a 3xx status code
+func (o *PutEndpointIDServiceUnavailable) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this put endpoint Id service unavailable response has a 4xx status code
+func (o *PutEndpointIDServiceUnavailable) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this put endpoint Id service unavailable response has a 5xx status code
+func (o *PutEndpointIDServiceUnavailable) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this put endpoint Id service unavailable response a status code equal to that given
+func (o *PutEndpointIDServiceUnavailable) IsCode(code int) bool {
+	return code == 503
+}
+
+// Code gets the status code for the put endpoint Id service unavailable response
+func (o *PutEndpointIDServiceUnavailable) Code() int {
+	return 503
+}
+
+func (o *PutEndpointIDServiceUnavailable) Error() string {
+	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdServiceUnavailable", 503)
+}
+
+func (o *PutEndpointIDServiceUnavailable) String() string {
+	return fmt.Sprintf("[PUT /endpoint/{id}][%d] putEndpointIdServiceUnavailable", 503)
+}
+
+func (o *PutEndpointIDServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -153,6 +153,8 @@ paths:
             "$ref": "#/definitions/Error"
         '429':
           description: Rate-limiting too many requests in the given time frame
+        '503':
+          description: Service Unavailable
     patch:
       summary: Modify existing endpoint
       deprecated: true
@@ -182,6 +184,8 @@ paths:
             "$ref": "#/definitions/Error"
         '429':
           description: Rate-limiting too many requests in the given time frame
+        '503':
+          description: Service Unavailable
     delete:
       summary: Delete endpoint
       description: |
@@ -219,6 +223,8 @@ paths:
           description: Endpoint not found
         '429':
           description: Rate-limiting too many requests in the given time frame
+        '503':
+          description: Service Unavailable
   "/endpoint":
     get:
       summary: Retrieves a list of endpoints that have metadata matching the provided parameters.
@@ -262,6 +268,8 @@ paths:
           description: No endpoints with provided parameters found
         '429':
           description: Rate-limiting too many requests in the given time frame
+        '503':
+          description: Service Unavailable
   "/endpoint/{id}/config":
     get:
       summary: Retrieve endpoint configuration
@@ -311,6 +319,8 @@ paths:
             "$ref": "#/definitions/Error"
         '429':
           description: Rate-limiting too many requests in the given time frame
+        '503':
+          description: Service Unavailable
   "/endpoint/{id}/labels":
     get:
       summary: Retrieves the list of labels associated with an endpoint.
@@ -355,6 +365,8 @@ paths:
             "$ref": "#/definitions/Error"
         '429':
           description: Rate-limiting too many requests in the given time frame
+        '503':
+          description: Service Unavailable
   "/endpoint/{id}/log":
     get:
       summary: Retrieves the status logs associated with this endpoint.

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -342,6 +342,9 @@ func init() {
           },
           "429": {
             "description": "Rate-limiting too many requests in the given time frame"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       }
@@ -424,6 +427,9 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "Failed"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       },
@@ -464,6 +470,9 @@ func init() {
           },
           "429": {
             "description": "Rate-limiting too many requests in the given time frame"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       },
@@ -508,6 +517,9 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "Failed"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       }
@@ -581,6 +593,9 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "Failed"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       }
@@ -680,6 +695,9 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "UpdateFailed"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       }
@@ -5782,6 +5800,9 @@ func init() {
           },
           "429": {
             "description": "Rate-limiting too many requests in the given time frame"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       }
@@ -5877,6 +5898,9 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "Failed"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       },
@@ -5921,6 +5945,9 @@ func init() {
           },
           "429": {
             "description": "Rate-limiting too many requests in the given time frame"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       },
@@ -5974,6 +6001,9 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "Failed"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       }
@@ -6055,6 +6085,9 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "Failed"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       }
@@ -6166,6 +6199,9 @@ func init() {
               "$ref": "#/definitions/Error"
             },
             "x-go-name": "UpdateFailed"
+          },
+          "503": {
+            "description": "Service Unavailable"
           }
         }
       }

--- a/api/v1/server/restapi/endpoint/delete_endpoint_id_responses.go
+++ b/api/v1/server/restapi/endpoint/delete_endpoint_id_responses.go
@@ -202,3 +202,28 @@ func (o *DeleteEndpointIDTooManyRequests) WriteResponse(rw http.ResponseWriter, 
 
 	rw.WriteHeader(429)
 }
+
+// DeleteEndpointIDServiceUnavailableCode is the HTTP code returned for type DeleteEndpointIDServiceUnavailable
+const DeleteEndpointIDServiceUnavailableCode int = 503
+
+/*
+DeleteEndpointIDServiceUnavailable Service Unavailable
+
+swagger:response deleteEndpointIdServiceUnavailable
+*/
+type DeleteEndpointIDServiceUnavailable struct {
+}
+
+// NewDeleteEndpointIDServiceUnavailable creates DeleteEndpointIDServiceUnavailable with default headers values
+func NewDeleteEndpointIDServiceUnavailable() *DeleteEndpointIDServiceUnavailable {
+
+	return &DeleteEndpointIDServiceUnavailable{}
+}
+
+// WriteResponse to the client
+func (o *DeleteEndpointIDServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(503)
+}

--- a/api/v1/server/restapi/endpoint/delete_endpoint_responses.go
+++ b/api/v1/server/restapi/endpoint/delete_endpoint_responses.go
@@ -156,3 +156,28 @@ func (o *DeleteEndpointTooManyRequests) WriteResponse(rw http.ResponseWriter, pr
 
 	rw.WriteHeader(429)
 }
+
+// DeleteEndpointServiceUnavailableCode is the HTTP code returned for type DeleteEndpointServiceUnavailable
+const DeleteEndpointServiceUnavailableCode int = 503
+
+/*
+DeleteEndpointServiceUnavailable Service Unavailable
+
+swagger:response deleteEndpointServiceUnavailable
+*/
+type DeleteEndpointServiceUnavailable struct {
+}
+
+// NewDeleteEndpointServiceUnavailable creates DeleteEndpointServiceUnavailable with default headers values
+func NewDeleteEndpointServiceUnavailable() *DeleteEndpointServiceUnavailable {
+
+	return &DeleteEndpointServiceUnavailable{}
+}
+
+// WriteResponse to the client
+func (o *DeleteEndpointServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(503)
+}

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_config_responses.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_config_responses.go
@@ -183,3 +183,28 @@ func (o *PatchEndpointIDConfigFailed) WriteResponse(rw http.ResponseWriter, prod
 		panic(err) // let the recovery middleware deal with this
 	}
 }
+
+// PatchEndpointIDConfigServiceUnavailableCode is the HTTP code returned for type PatchEndpointIDConfigServiceUnavailable
+const PatchEndpointIDConfigServiceUnavailableCode int = 503
+
+/*
+PatchEndpointIDConfigServiceUnavailable Service Unavailable
+
+swagger:response patchEndpointIdConfigServiceUnavailable
+*/
+type PatchEndpointIDConfigServiceUnavailable struct {
+}
+
+// NewPatchEndpointIDConfigServiceUnavailable creates PatchEndpointIDConfigServiceUnavailable with default headers values
+func NewPatchEndpointIDConfigServiceUnavailable() *PatchEndpointIDConfigServiceUnavailable {
+
+	return &PatchEndpointIDConfigServiceUnavailable{}
+}
+
+// WriteResponse to the client
+func (o *PatchEndpointIDConfigServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(503)
+}

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_labels_responses.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_labels_responses.go
@@ -158,3 +158,28 @@ func (o *PatchEndpointIDLabelsUpdateFailed) WriteResponse(rw http.ResponseWriter
 		panic(err) // let the recovery middleware deal with this
 	}
 }
+
+// PatchEndpointIDLabelsServiceUnavailableCode is the HTTP code returned for type PatchEndpointIDLabelsServiceUnavailable
+const PatchEndpointIDLabelsServiceUnavailableCode int = 503
+
+/*
+PatchEndpointIDLabelsServiceUnavailable Service Unavailable
+
+swagger:response patchEndpointIdLabelsServiceUnavailable
+*/
+type PatchEndpointIDLabelsServiceUnavailable struct {
+}
+
+// NewPatchEndpointIDLabelsServiceUnavailable creates PatchEndpointIDLabelsServiceUnavailable with default headers values
+func NewPatchEndpointIDLabelsServiceUnavailable() *PatchEndpointIDLabelsServiceUnavailable {
+
+	return &PatchEndpointIDLabelsServiceUnavailable{}
+}
+
+// WriteResponse to the client
+func (o *PatchEndpointIDLabelsServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(503)
+}

--- a/api/v1/server/restapi/endpoint/patch_endpoint_id_responses.go
+++ b/api/v1/server/restapi/endpoint/patch_endpoint_id_responses.go
@@ -201,3 +201,28 @@ func (o *PatchEndpointIDFailed) WriteResponse(rw http.ResponseWriter, producer r
 		panic(err) // let the recovery middleware deal with this
 	}
 }
+
+// PatchEndpointIDServiceUnavailableCode is the HTTP code returned for type PatchEndpointIDServiceUnavailable
+const PatchEndpointIDServiceUnavailableCode int = 503
+
+/*
+PatchEndpointIDServiceUnavailable Service Unavailable
+
+swagger:response patchEndpointIdServiceUnavailable
+*/
+type PatchEndpointIDServiceUnavailable struct {
+}
+
+// NewPatchEndpointIDServiceUnavailable creates PatchEndpointIDServiceUnavailable with default headers values
+func NewPatchEndpointIDServiceUnavailable() *PatchEndpointIDServiceUnavailable {
+
+	return &PatchEndpointIDServiceUnavailable{}
+}
+
+// WriteResponse to the client
+func (o *PatchEndpointIDServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(503)
+}

--- a/api/v1/server/restapi/endpoint/put_endpoint_id_responses.go
+++ b/api/v1/server/restapi/endpoint/put_endpoint_id_responses.go
@@ -221,3 +221,28 @@ func (o *PutEndpointIDFailed) WriteResponse(rw http.ResponseWriter, producer run
 		panic(err) // let the recovery middleware deal with this
 	}
 }
+
+// PutEndpointIDServiceUnavailableCode is the HTTP code returned for type PutEndpointIDServiceUnavailable
+const PutEndpointIDServiceUnavailableCode int = 503
+
+/*
+PutEndpointIDServiceUnavailable Service Unavailable
+
+swagger:response putEndpointIdServiceUnavailable
+*/
+type PutEndpointIDServiceUnavailable struct {
+}
+
+// NewPutEndpointIDServiceUnavailable creates PutEndpointIDServiceUnavailable with default headers values
+func NewPutEndpointIDServiceUnavailable() *PutEndpointIDServiceUnavailable {
+
+	return &PutEndpointIDServiceUnavailable{}
+}
+
+// WriteResponse to the client
+func (o *PutEndpointIDServiceUnavailable) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(503)
+}

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -52,7 +52,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 	errorLogExceptions := []logMatcher{
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock,
-		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision, nilDetailsForService, linkNotFound}
+		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision, nilDetailsForService}
 	if ciliumVersion.LT(semver.MustParse("1.14.0")) {
 		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR, klogLeaderElectionFail)
 	}
@@ -70,7 +70,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI,
 		envoyExternalTargetTLSWarning, envoyExternalOtherTargetTLSWarning, ciliumNodeConfigDeprecation,
 		hubbleUIEnvVarFallback, k8sClientNetworkStatusError, bgpAlphaResourceDeprecation, ccgAlphaResourceDeprecation,
-		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn, linkNotFound}
+		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn}
 	// The list is adopted from cilium/cilium/test/helper/utils.go
 	var errorMsgsWithExceptions = map[string][]logMatcher{
 		panicMessage:         nil,
@@ -479,6 +479,4 @@ var (
 	bgpAlphaResourceDeprecation = regexMatcher{regexp.MustCompile(`cilium.io/v2alpha1 CiliumBGP\w+ is deprecated`)}
 	// ccgAlphaResourceDeprecation is the same as bgpAlphaResourceDeprecation but for the CiliumCIDRGroup.
 	ccgAlphaResourceDeprecation = regexMatcher{regexp.MustCompile(`cilium.io/v2alpha1 CiliumCIDRGroup is deprecated`)}
-	// https://github.com/cilium/cilium/issues/39370 needs investigation.
-	linkNotFound = regexMatcher{regexp.MustCompile(`retrieving device .+\: Link not found`)}
 )

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
 	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
 	endpointmetadata "github.com/cilium/cilium/pkg/endpoint/metadata"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -100,6 +101,8 @@ type Daemon struct {
 
 	endpointCreator endpointcreator.EndpointCreator
 	endpointManager endpointmanager.EndpointManager
+
+	endpointAPIFence endpointapi.Fence
 
 	endpointRestoreComplete       chan struct{}
 	endpointInitialPolicyComplete chan struct{}
@@ -310,6 +313,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		lbConfig:          params.LBConfig,
 		kprCfg:            params.KPRConfig,
 		ciliumHealth:      params.CiliumHealth,
+		endpointAPIFence:  params.EndpointAPIFence,
 	}
 
 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -46,6 +46,7 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
 	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
 	endpointmetadata "github.com/cilium/cilium/pkg/endpoint/metadata"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -1370,6 +1371,7 @@ type daemonParams struct {
 	DNSProxy            bootstrap.FQDNProxyBootstrapper
 	DNSNameManager      namemanager.NameManager
 	KPRConfig           kpr.KPRConfig
+	EndpointAPIFence    endpointapi.Fence
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], legacy.DaemonInitialization) {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -352,7 +352,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 
 	go func() {
 		for _, ep := range state.restored {
-			<-ep.InitialEnvoyPolicyComputed
+			ep.WaitForInitialPolicy()
 		}
 		close(d.endpointInitialPolicyComplete)
 	}()

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func (d *Daemon) WaitForEndpointRestore(ctx context.Context) error {
@@ -357,15 +358,39 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 	}()
 }
 
+// Trigger asynchronous regeneration of restored endpoints.
+//
+// This method assumes that all the endpoints for which regeneration is requested are
+// already exposed to EndpointManager. It waits until the Endpoint API fence is unblocked
+// before regenerating all remaining live endpoints.
+//
+// Once complete, this method closes the daemon 'endpointRestoreComplete' channel.
 func (d *Daemon) handleRestoredEndpointsRegeneration(endpoints []*endpoint.Endpoint, endpointsRegenerator *endpoint.Regenerator) {
+	startTime := time.Now()
+	// Wait for Endpoint DeletionQueue to be processed first so we can avoid
+	// expensive regeneration for already deleted endpoints.
+	_ = d.endpointAPIFence.Wait(context.Background())
+
+	d.logger.Debug(
+		"Endpoint API fence unblocked, attempting regeneration for alive endpoints",
+		logfields.Duration, time.Since(startTime),
+	)
+
 	regenWg := &sync.WaitGroup{}
 	epRegenerated := make(chan bool, len(endpoints))
 
 	for _, ep := range endpoints {
-		d.logger.Info(
-			"Successfully restored endpoint. Scheduling regeneration",
-			logfields.EndpointID, ep.ID,
-		)
+		// Check if the endpoint still exists in EndpointManager.
+		epFromLookup := d.endpointManager.LookupCiliumID(ep.ID)
+		if epFromLookup == nil {
+			d.logger.Debug(
+				"Endpoint missing in EndpointManager, assuming already deleted",
+				logfields.EndpointID, ep.ID,
+			)
+			continue
+		}
+
+		d.logger.Info("Scheduling restored endpoint regeneration", logfields.EndpointID, ep.ID)
 
 		regenWg.Add(1)
 		go func(ep *endpoint.Endpoint, wg *sync.WaitGroup, endpointsRegenerated chan<- bool) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -197,7 +197,7 @@ func Hint(err error) error {
 	if strings.Contains(err.Error(), defaults.SockPath) {
 		return fmt.Errorf("%s\nIs the agent running?", e)
 	}
-	return fmt.Errorf("%s", e)
+	return err
 }
 
 func timeSince(since time.Time) string {

--- a/pkg/endpoint/api/fence.go
+++ b/pkg/endpoint/api/fence.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/hive"
+)
+
+// A new type around [hive.Fence] to give it a unique type that can be provided
+// to Hive.
+type Fence hive.Fence
+
+// Create a new fence to wait on readiness of Endpoint API subsystem.
+// The fence is unblocked once the endpoint DeletionQueue processing is complete.
+func newFence(lc cell.Lifecycle, log *slog.Logger, dq *DeletionQueue) Fence {
+	fence := hive.NewFence(lc, log)
+	fence.Add("cni-deletion-queue", dq.Wait)
+
+	return fence
+}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -639,7 +639,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	// computations fail.
 	defer func() {
 		e.unconditionalLock()
-		e.InitialPolicyComputedLocked()
+		e.initialPolicyComputedLocked()
 		e.unlock()
 	}()
 
@@ -750,7 +750,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		}
 
 		// Signal computation of the initial Envoy policy if not done yet
-		e.InitialPolicyComputedLocked()
+		e.initialPolicyComputedLocked()
 	}
 
 	currentDir := datapathRegenCtxt.currentDir

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -176,7 +176,7 @@ type Endpoint struct {
 	// recalculated on endpoint restore.
 	createdAt time.Time
 
-	InitialEnvoyPolicyComputed chan struct{}
+	initialEnvoyPolicyComputed chan struct{}
 
 	// mutex protects write operations to this endpoint structure
 	mutex lock.RWMutex
@@ -641,7 +641,7 @@ func createEndpoint(logger *slog.Logger, dnsRulesAPI DNSRulesAPI, epBuildQueue E
 		forcePolicyCompute: true,
 	}
 
-	ep.InitialEnvoyPolicyComputed = make(chan struct{})
+	ep.initialEnvoyPolicyComputed = make(chan struct{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ep.aliveCancel = cancel

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -30,7 +30,7 @@ func (ev *EndpointRegenerationEvent) Handle(res chan any) {
 	// Compute policy on the first regeneration before acquiring the build permit in
 	// QueueEndpointBuild below
 	select {
-	case <-e.InitialEnvoyPolicyComputed:
+	case <-e.initialEnvoyPolicyComputed:
 		// Already done
 	default:
 		err, release := e.ComputeInitialPolicy(regenContext)

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -578,7 +578,7 @@ func (ep *Endpoint) MarshalJSON() ([]byte, error) {
 func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ID = r.ID
 	ep.createdAt = time.Now()
-	ep.InitialEnvoyPolicyComputed = make(chan struct{})
+	ep.initialEnvoyPolicyComputed = make(chan struct{})
 	ep.containerName.Store(&r.ContainerName)
 	ep.containerID.Store(&r.ContainerID)
 	ep.dockerNetworkID = r.DockerNetworkID

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -268,6 +268,11 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 func (f *GenericVethChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext, delClient *lib.DeletionFallbackClient) (err error) {
 	req := &models.EndpointBatchDeleteRequest{ContainerID: pluginCtx.Args.ContainerID}
 	if err := delClient.EndpointDeleteMany(req); err != nil {
+		if errors.Is(err, lib.ErrClientFailure) {
+			pluginCtx.Logger.Error("Failed to delete endpoint", logfields.Error, err)
+			return err
+		}
+
 		pluginCtx.Logger.Warn(
 			"Errors encountered while deleting endpoint",
 			logfields.Error, err,

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -951,6 +951,7 @@ func (cmd *Cmd) Del(args *skel.CmdArgs) error {
 		// We are not returning an error as this is very unlikely to be recoverable
 	}
 
+	scopedLogger.Debug("CNI DEL processing complete")
 	return nil
 }
 

--- a/plugins/cilium-cni/lib/deletion_queue.go
+++ b/plugins/cilium-cni/lib/deletion_queue.go
@@ -94,9 +94,10 @@ func (dc *DeletionFallbackClient) tryConnect() error {
 
 func (dc *DeletionFallbackClient) tryQueueLock() error {
 	dc.logger.Debug(
-		"attempting to acquire deletion queue lock",
+		"Attempting to acquire deletion queue lock",
 		logfields.Path, defaults.DeleteQueueLockfile,
 	)
+	startTime := time.Now()
 
 	// Ensure deletion queue directory exists, obtain shared lock
 	err := os.MkdirAll(defaults.DeleteQueueDir, 0755)
@@ -117,28 +118,12 @@ func (dc *DeletionFallbackClient) tryQueueLock() error {
 		lf.Close()
 		return fmt.Errorf("failed to acquire lock: %w", err)
 	}
+
+	dc.logger.Debug("Deletion Queue lock acquired",
+		logfields.Path, defaults.DeleteQueueLockfile,
+		logfields.Duration, time.Since(startTime))
 	dc.lockfile = lf
 	return nil
-}
-
-// EndpointDelete deletes an endpoint given by an endpoint id, either
-// by directly accessing the API or dropping in a queued-deletion file.
-// endpoint-id is a qualified endpoint reference, e.g. "container-id:XXXXXXX"
-func (dc *DeletionFallbackClient) EndpointDelete(id string) error {
-	if dc.cli != nil {
-		return dc.cli.EndpointDelete(id)
-	}
-
-	// fall-back mode
-	if dc.lockfile != nil {
-		dc.logger.Info(
-			"Queueing deletion request for endpoint",
-			logfields.EndpointID, id,
-		)
-		return dc.enqueueDeletionRequestLocked(id)
-	}
-
-	return errors.New("attempt to delete with no valid connection")
 }
 
 func (dc *DeletionFallbackClient) unlockQueue() {
@@ -223,7 +208,7 @@ func (dc *DeletionFallbackClient) enqueueDeletionRequestLocked(req *models.Endpo
 	files, err := os.ReadDir(defaults.DeleteQueueDir)
 	if err != nil {
 		dc.logger.Error(
-			"failed to list deletion queue directory",
+			"Failed to list deletion queue directory",
 			logfields.Error, err,
 			logfields.Path, defaults.DeleteQueueDir,
 		)
@@ -242,12 +227,12 @@ func (dc *DeletionFallbackClient) enqueueDeletionRequestLocked(req *models.Endpo
 	err = os.WriteFile(path, contents, 0644)
 	if err != nil {
 		dc.logger.Error(
-			"failed to write deletion file",
+			"Failed to write deletion file",
 			logfields.Error, err,
 			logfields.Path, path,
 		)
 		return fmt.Errorf("failed to write deletion file %s: %w", path, err)
 	}
-	dc.logger.Info("wrote queued deletion file")
+	dc.logger.Info("Wrote queued deletion file", logfields.Path, path)
 	return nil
 }

--- a/plugins/cilium-cni/lib/deletion_queue.go
+++ b/plugins/cilium-cni/lib/deletion_queue.go
@@ -38,52 +38,22 @@ const timeoutSeconds = 10
 const maxDeletionFiles = 256
 
 var (
-	errServiceUnavailable = errors.New("cilium api not available")
+	// Indicates a non-recoverable error for DeletionFallbackClient.
+	ErrClientFailure = errors.New("client failed")
 )
 
-// NewDeletionFallbackClient creates a client that will either issue an EndpointDelete
-// request via the api, *or* queue one in a temporary directory.
-// To prevent race conditions, the logic is:
-// 1. Try and connect to the socket. if that succeeds, done
-// 2. Otherwise, take a shared lock on the delete queue directory
-// 3. Once we get the lock, check to see if the socket now exists
-// 4. If it exists, drop the lock and use the api
-func NewDeletionFallbackClient(logger *slog.Logger) (*DeletionFallbackClient, error) {
-	dc := &DeletionFallbackClient{
+// NewDeletionFallbackClient creates a new deletion client.
+func NewDeletionFallbackClient(logger *slog.Logger) *DeletionFallbackClient {
+	return &DeletionFallbackClient{
 		logger: logger,
 	}
-
-	// Try and connect (the usual case)
-	err := dc.tryConnect()
-	if err == nil {
-		return dc, nil
-	}
-	dc.logger.Warn(
-		"Failed to connect to agent socket",
-		logfields.Error, err,
-		logfields.Socket, client.DefaultSockPath(),
-	)
-
-	// We failed to connect: get the queue lock
-	if err := dc.tryQueueLock(); err != nil {
-		return nil, fmt.Errorf("failed to acquire deletion queue: %w", err)
-	}
-
-	// We have the queue lock; try and connect again
-	// just in case the agent finished starting up while we were waiting
-	if err := dc.tryConnect(); err == nil {
-		dc.logger.Info("Successfully connected to API on second try.")
-		// hey, it's back up!
-		dc.unlockQueue()
-		return dc, nil
-	}
-
-	// We have the lockfile, but no valid client
-	dc.logger.Info("Agent is down, falling back to deletion queue directory")
-	return dc, nil
 }
 
 func (dc *DeletionFallbackClient) tryConnect() error {
+	if dc.cli != nil {
+		return nil
+	}
+
 	c, err := client.NewDefaultClientWithTimeout(timeoutSeconds * time.Second)
 	if err != nil {
 		return err
@@ -126,64 +96,75 @@ func (dc *DeletionFallbackClient) tryQueueLock() error {
 	return nil
 }
 
-func (dc *DeletionFallbackClient) unlockQueue() {
-	if dc.lockfile != nil {
-		dc.lockfile.Unlock()
-		dc.lockfile = nil
-	}
-}
-
 // EndpointDeleteMany deletes multiple endpoints based on the endpoint deletion request,
 // either by directly accessing the API or dropping in a queued-deletion file.
+//
+// To prevent race conditions, the logic is:
+// 1. Try and connect to the socket and request deletion. if that succeeds, done.
+// 2. Otherwise, take a shared lock on the delete queue directory.
+// 3. Once we have the lock, check again to see if the deletion request succeeds.
+// 4. Persist the request to offline queue in case of failure.
+//
+// Endpoint Deletion handled by this method returns two types of errors:
+// 1. Delete request processing errors propagated from cilium-agent(eg. NotFound, Invalid)
+// 2. Client failure indicating a non-recoverable error(eg. when deletion queue locking during fallback fails)
 func (dc *DeletionFallbackClient) EndpointDeleteMany(req *models.EndpointBatchDeleteRequest) error {
-	if dc.lockfile != nil {
-		return dc.enqueueDeletionRequestLocked(req)
-	}
-
-	// If lock was not acquired, we have a valid client.
-	err := dc.deleteEndpointsBatch(req)
-	if err == nil || !errors.Is(err, errServiceUnavailable) {
-		// Propagate the error if its not related to service unavailability.
+	fallback, err := dc.deleteEndpointsBatch(req)
+	if err == nil || !fallback {
 		return err
 	}
 
 	// If the Endpoint Deletion request to cilium-agent failed, fallback to
 	// queuing the deletion.
-	dc.logger.Debug("Failed to delete Endpoints batch, ServiceUnvailable",
+	dc.logger.Debug("Failed to delete Endpoints batch",
 		logfields.Request, req,
 		logfields.Error, err,
 	)
 
-	if err := dc.tryQueueLock(); err != nil {
-		return fmt.Errorf("failed to acquire deletion queue lock: %w", err)
+	err = dc.tryQueueLock()
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrClientFailure, err)
 	}
-	defer dc.unlockQueue()
+	defer dc.lockfile.Unlock()
 
-	// We have the lock, we can retry deleting the endpoints.
-	err = dc.deleteEndpointsBatch(req)
+	// We have the lock now, we can retry deleting the endpoints.
+	fallback, err = dc.deleteEndpointsBatch(req)
 
 	// Only enqueue the Deletion request if the failure is API server related, so cilium-agent
-	// can retry when DeletionQueue is replayed.
-	if errors.Is(err, errServiceUnavailable) {
-		return dc.enqueueDeletionRequestLocked(req)
+	// can process the request when DeletionQueue is replayed.
+	if fallback {
+		err = dc.enqueueDeletionRequestLocked(req)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrClientFailure, err)
+		}
 	}
 
 	return err
 }
 
-func (dc *DeletionFallbackClient) deleteEndpointsBatch(req *models.EndpointBatchDeleteRequest) error {
+// deleteEndpointsBatch attempts to connect to cilium api and request endpoint deletion for the provided
+// request. If either the connection fails or Endpoint API is not available, this method returns true
+// indicating the caller to attempt fallback logic.
+func (dc *DeletionFallbackClient) deleteEndpointsBatch(req *models.EndpointBatchDeleteRequest) (bool, error) {
+	if err := dc.tryConnect(); err != nil {
+		// Failed to setup cilium client.
+		return true, err
+	}
+
 	err := dc.cli.EndpointDeleteMany(req)
 	if err != nil {
 		status, ok := err.(runtime.ClientResponseStatus)
 		if !ok || !status.IsCode(http.StatusServiceUnavailable) {
 			// Propagate unhandled server side Endpoint delete errors.
-			return err
+			return false, err
 		}
 
-		return errServiceUnavailable
+		// Endpoint API is unavailable.
+		return true, err
 	}
 
-	return nil
+	// Endpoint deleted successfully.
+	return false, nil
 }
 
 // enqueueDeletionRequestLocked enqueues the encoded endpoint deletion request into the

--- a/plugins/cilium-cni/lib/deletion_queue.go
+++ b/plugins/cilium-cni/lib/deletion_queue.go
@@ -9,9 +9,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/go-openapi/runtime"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/client"
@@ -33,6 +36,10 @@ const timeoutSeconds = 10
 
 // the maximum number of queued deletions allowed, to protect against kubelet insanity
 const maxDeletionFiles = 256
+
+var (
+	errServiceUnavailable = errors.New("cilium api not available")
+)
 
 // NewDeletionFallbackClient creates a client that will either issue an EndpointDelete
 // request via the api, *or* queue one in a temporary directory.
@@ -67,8 +74,7 @@ func NewDeletionFallbackClient(logger *slog.Logger) (*DeletionFallbackClient, er
 	if err := dc.tryConnect(); err == nil {
 		dc.logger.Info("Successfully connected to API on second try.")
 		// hey, it's back up!
-		dc.lockfile.Unlock()
-		dc.lockfile = nil
+		dc.unlockQueue()
 		return dc, nil
 	}
 
@@ -135,32 +141,79 @@ func (dc *DeletionFallbackClient) EndpointDelete(id string) error {
 	return errors.New("attempt to delete with no valid connection")
 }
 
+func (dc *DeletionFallbackClient) unlockQueue() {
+	if dc.lockfile != nil {
+		dc.lockfile.Unlock()
+		dc.lockfile = nil
+	}
+}
+
 // EndpointDeleteMany deletes multiple endpoints based on the endpoint deletion request,
 // either by directly accessing the API or dropping in a queued-deletion file.
 func (dc *DeletionFallbackClient) EndpointDeleteMany(req *models.EndpointBatchDeleteRequest) error {
-	if dc.cli != nil {
-		return dc.cli.EndpointDeleteMany(req)
-	}
-
-	// fall-back mode
 	if dc.lockfile != nil {
-		dc.logger.Info(
-			"Queueing endpoint batch deletion request",
-			logfields.Request, req,
-		)
-		b, err := req.MarshalBinary()
-		if err != nil {
-			return fmt.Errorf("failed to marshal endpoint delete request: %w", err)
-		}
-		return dc.enqueueDeletionRequestLocked(string(b))
+		return dc.enqueueDeletionRequestLocked(req)
 	}
 
-	return errors.New("attempt to delete with no valid connection")
+	// If lock was not acquired, we have a valid client.
+	err := dc.deleteEndpointsBatch(req)
+	if err == nil || !errors.Is(err, errServiceUnavailable) {
+		// Propagate the error if its not related to service unavailability.
+		return err
+	}
+
+	// If the Endpoint Deletion request to cilium-agent failed, fallback to
+	// queuing the deletion.
+	dc.logger.Debug("Failed to delete Endpoints batch, ServiceUnvailable",
+		logfields.Request, req,
+		logfields.Error, err,
+	)
+
+	if err := dc.tryQueueLock(); err != nil {
+		return fmt.Errorf("failed to acquire deletion queue lock: %w", err)
+	}
+	defer dc.unlockQueue()
+
+	// We have the lock, we can retry deleting the endpoints.
+	err = dc.deleteEndpointsBatch(req)
+
+	// Only enqueue the Deletion request if the failure is API server related, so cilium-agent
+	// can retry when DeletionQueue is replayed.
+	if errors.Is(err, errServiceUnavailable) {
+		return dc.enqueueDeletionRequestLocked(req)
+	}
+
+	return err
+}
+
+func (dc *DeletionFallbackClient) deleteEndpointsBatch(req *models.EndpointBatchDeleteRequest) error {
+	err := dc.cli.EndpointDeleteMany(req)
+	if err != nil {
+		status, ok := err.(runtime.ClientResponseStatus)
+		if !ok || !status.IsCode(http.StatusServiceUnavailable) {
+			// Propagate unhandled server side Endpoint delete errors.
+			return err
+		}
+
+		return errServiceUnavailable
+	}
+
+	return nil
 }
 
 // enqueueDeletionRequestLocked enqueues the encoded endpoint deletion request into the
 // endpoint deletion queue. Requires the caller to hold the deletion queue lock.
-func (dc *DeletionFallbackClient) enqueueDeletionRequestLocked(contents string) error {
+func (dc *DeletionFallbackClient) enqueueDeletionRequestLocked(req *models.EndpointBatchDeleteRequest) error {
+	dc.logger.Info(
+		"Queueing endpoint batch deletion request",
+		logfields.Request, req,
+	)
+
+	contents, err := req.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("failed to marshal endpoint delete request: %w", err)
+	}
+
 	// sanity check: if there are too many queued deletes, just return error
 	// back up to the kubelet. If we get here, it's either because something
 	// has gone wrong with the kubelet, or the agent has been down for a very
@@ -182,11 +235,11 @@ func (dc *DeletionFallbackClient) enqueueDeletionRequestLocked(contents string) 
 
 	// hash endpoint id for a random filename
 	h := sha256.New()
-	h.Write([]byte(contents))
+	h.Write(contents)
 	filename := fmt.Sprintf("%x.delete", h.Sum(nil))
 	path := filepath.Join(defaults.DeleteQueueDir, filename)
 
-	err = os.WriteFile(path, []byte(contents), 0644)
+	err = os.WriteFile(path, contents, 0644)
 	if err != nil {
 		dc.logger.Error(
 			"failed to write deletion file",

--- a/plugins/cilium-cni/lib/deletion_queue_test.go
+++ b/plugins/cilium-cni/lib/deletion_queue_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lib
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/client/endpoint"
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/lock/lockfile"
+)
+
+type errorCase int
+
+const (
+	errorCaseNever errorCase = iota
+	errorCaseOnce
+	errorCaseAlways
+)
+
+type errorMock struct {
+	errorCase errorCase
+	err       error
+
+	callCount int
+}
+
+func (e *errorMock) call() error {
+	e.callCount++
+
+	switch e.errorCase {
+	case errorCaseNever:
+		return nil
+	case errorCaseOnce:
+		if e.callCount == 1 {
+			return e.err
+		}
+		return nil
+	case errorCaseAlways:
+		return e.err
+	default:
+		return nil
+	}
+}
+
+type fakeCiliumClient struct {
+	errorMock
+}
+
+func (f *fakeCiliumClient) EndpointDeleteMany(_ *models.EndpointBatchDeleteRequest) error {
+	return f.call()
+}
+
+type fakeCiliumClientCreator struct {
+	errorMock
+
+	clientErrorMock errorMock
+}
+
+func (f *fakeCiliumClientCreator) ToString() string {
+	errMockStrs := []string{"Never", "Once", "Always"}
+
+	return fmt.Sprintf("NewClient: %s, EndpointDelete: %s",
+		errMockStrs[f.errorMock.errorCase],
+		errMockStrs[f.clientErrorMock.errorCase])
+}
+
+func (f *fakeCiliumClientCreator) newClient(_ time.Duration) (ciliumClient, error) {
+	err := f.call()
+	if err != nil {
+		return nil, err
+	}
+
+	return &fakeCiliumClient{f.clientErrorMock}, nil
+}
+
+func TestDeletionFallbackClient(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	newDeletionClient := func(newClientFn newCiliumClientFn, testDir string) DeletionFallbackClient {
+		deleteQueueLockfile := path.Join(testDir, "lockfile")
+		return DeletionFallbackClient{
+			logger: logger,
+
+			deleteQueueDir:      testDir,
+			deleteQueueLockfile: deleteQueueLockfile,
+
+			newCiliumClientFn: newClientFn,
+		}
+	}
+
+	newClientErr := errors.New("error creating cilium client")
+	newClientErrorNever := errorMock{
+		errorCase: errorCaseNever,
+	}
+	newClientErrorOnce := errorMock{
+		errorCase: errorCaseOnce,
+		err:       newClientErr,
+	}
+	newClientErrorAlways := errorMock{
+		errorCase: errorCaseAlways,
+		err:       newClientErr,
+	}
+
+	deletionClientErr := &endpoint.DeleteEndpointServiceUnavailable{}
+	deletionClientErrorNever := errorMock{
+		errorCase: errorCaseNever,
+	}
+	deletionClientErrorOnce := errorMock{
+		errorCase: errorCaseOnce,
+		err:       deletionClientErr,
+	}
+	deletionClientErrorAlways := errorMock{
+		errorCase: errorCaseAlways,
+		err:       deletionClientErr,
+	}
+
+	tt := []struct {
+		newClientCreator    fakeCiliumClientCreator
+		shouldQueueDeletion bool
+	}{
+		{
+			newClientCreator: fakeCiliumClientCreator{
+				errorMock:       newClientErrorNever,
+				clientErrorMock: deletionClientErrorNever,
+			},
+			shouldQueueDeletion: false,
+		},
+		{
+			newClientCreator: fakeCiliumClientCreator{
+				errorMock:       newClientErrorNever,
+				clientErrorMock: deletionClientErrorOnce,
+			},
+			shouldQueueDeletion: false,
+		},
+		{
+			newClientCreator: fakeCiliumClientCreator{
+				errorMock:       newClientErrorNever,
+				clientErrorMock: deletionClientErrorAlways,
+			},
+			shouldQueueDeletion: true,
+		},
+		{
+			newClientCreator: fakeCiliumClientCreator{
+				errorMock:       newClientErrorOnce,
+				clientErrorMock: deletionClientErrorNever,
+			},
+			shouldQueueDeletion: false,
+		},
+		{
+			newClientCreator: fakeCiliumClientCreator{
+				errorMock:       newClientErrorOnce,
+				clientErrorMock: deletionClientErrorOnce,
+			},
+			shouldQueueDeletion: true,
+		},
+		{
+			newClientCreator: fakeCiliumClientCreator{
+				errorMock:       newClientErrorOnce,
+				clientErrorMock: deletionClientErrorAlways,
+			},
+			shouldQueueDeletion: true,
+		},
+		{
+			newClientCreator: fakeCiliumClientCreator{
+				errorMock:       newClientErrorAlways,
+				clientErrorMock: deletionClientErrorNever,
+			},
+			shouldQueueDeletion: true,
+		},
+	}
+
+	deleteReq := &models.EndpointBatchDeleteRequest{
+		ContainerID: "test-container-id",
+	}
+
+	contents, err := deleteReq.MarshalBinary()
+	require.NoError(t, err)
+
+	h := sha256.New()
+	h.Write(contents)
+	deleteQueueFilename := fmt.Sprintf("%x.delete", h.Sum(nil))
+
+	for _, tc := range tt {
+		testName := tc.newClientCreator.ToString()
+
+		t.Run(testName, func(t *testing.T) {
+			testDir := t.TempDir()
+
+			dc := newDeletionClient(tc.newClientCreator.newClient, testDir)
+
+			err = dc.EndpointDeleteMany(deleteReq)
+			require.NoError(t, err)
+
+			deleteQueueFile := path.Join(testDir, deleteQueueFilename)
+			if tc.shouldQueueDeletion {
+				require.FileExists(t, deleteQueueFile)
+			} else {
+				require.NoFileExists(t, deleteQueueFile)
+			}
+		})
+	}
+}
+
+func acquireExclusiveLock(t *testing.T, lockFile string) (*lockfile.Lockfile, error) {
+	t.Helper()
+
+	lf, err := lockfile.NewLockfile(lockFile)
+	require.NoError(t, err)
+	require.NotNil(t, lf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = lf.Lock(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return lf, nil
+}
+
+func TestQueueLock(t *testing.T) {
+	testDir := t.TempDir()
+
+	lockDir := path.Join(testDir, "deletion_queue")
+	lockFile := path.Join(lockDir, "lockfile")
+
+	dc := &DeletionFallbackClient{
+		logger:              hivetest.Logger(t),
+		deleteQueueDir:      lockDir,
+		deleteQueueLockfile: lockFile,
+	}
+
+	lf, err := dc.tryQueueLock()
+	require.NoError(t, err)
+	require.NotNil(t, lf)
+
+	// CNI acquires shared lock.
+	lf2, err := dc.tryQueueLock()
+	require.NoError(t, err)
+	require.NotNil(t, lf2)
+
+	lf3, err := acquireExclusiveLock(t, lockFile)
+	require.Error(t, err)
+	require.Nil(t, lf3)
+
+	lf.Unlock()
+	lf2.Unlock()
+
+	lf3, err = acquireExclusiveLock(t, lockFile)
+	require.NoError(t, err)
+	require.NotNil(t, lf3)
+	lf3.Unlock()
+}


### PR DESCRIPTION
This PR fixes an issue in the Endpoint API's delete request
processing during cilium-agent startup.
Currently, when cilium-agent boots up, the API server is started first
which allows CNI to interact with the endpoint subsystem. This exposes
endpoint APIs like `Put`, `Delete` to CNI plugin without waiting for
initial state restore to complete.
This leads to a stituation where CNI plugin can request Delete for an
endpoint that is not yet restored and exposed to EndpointManager. In
such cases cilium-agent will respond with `NotFound` error to CNI.
Currently, the CNI plugin ignores all errors in the delete path and
continues to clean up corresponding resources for the endpoint(eg.Link),
reporting success back to kubelet. When eventually endpoint restore
finishes regeneration fails for these endpoints, because the underlying
resources(eg. Link) no longer exist.

This patch fixes the issue by coordinating endpoint restore handling
with API requests processing for endpoint subsystem. With this patch,
the API server responds with a special 503(Service Unavailble) http
error for requests when the state restore is in progress. CNI
appropriately handles this error code by persisting the delete request
on the disk before cleaning up the associated resources. Once the state
restore is complete, this persisted deletion requests are replayed and
all pending deletes are processed.

With this patch the end-to-end flow for interaction between CNI plugin
and agent during startup behaves as follows:

* Agent is down:
  * Connection to API server fails. CNI plugin persists DELs on disk.
* Agent is up; API server is started:
  * Server responds with 503 for endpoint API requests.
  * CNI processes and persists DELs on disk; ADDs are rejected.
* Agent is up; API Server is up; Bootstrap in progress
  * Endpoint state is restored from the disk and exposed to EndpointManager.
* Agent is up; API Server is up; Bootstrap completed:
  * API accepts DELs but still rejects ADDs
  * Deletion Queue handler processes persisted DELs from disk.
* Agent is up; API Server is up; Bootstrap completed; DeletionQueue drained:
  * API is fully functional
* Regeneration is triggered for all alive restored endpoints.

Fixes: #39370

```release-note
Fix a bug where cilium-agent would report "Link not found" for an endpoint deleted during state restore after cilium-agent restart.
```
