### PR TITLE
cec: introduce annotation to override IsL7LB detection during CEC parsing

### DIFF
--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -209,6 +209,7 @@ const (
 	LBIPAMSharingAcrossNamespaceAlias = Prefix + "/lb-ipam-sharing-cross-namespace"
 
 	CECInjectCiliumFilters = CECPrefix + "/inject-cilium-filters"
+	CECIsL7LB              = CECPrefix + "/is-l7lb"
 )
 
 // CiliumPrefixRegex is a regex matching Cilium specific annotations.

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -1005,3 +1005,17 @@ func InjectCiliumEnvoyFilters(meta *metav1.ObjectMeta, spec *cilium_v2.CiliumEnv
 
 	return len(spec.Services) > 0
 }
+
+// isL7LB returns true if the given object indicates that CiliumEnvoyConfig handles L7 loadbalancing.
+// This can be an explicit annotation or the implicit presence of a L7LB service via the Services property.
+func isL7LB(meta *metav1.ObjectMeta, spec *cilium_v2.CiliumEnvoyConfigSpec) bool {
+	if meta.GetAnnotations() != nil {
+		if v, ok := meta.GetAnnotations()[annotation.CECIsL7LB]; ok {
+			if boolValue, err := strconv.ParseBool(v); err == nil {
+				return boolValue
+			}
+		}
+	}
+
+	return len(spec.Services) > 0
+}

--- a/pkg/ciliumenvoyconfig/k8s_reflector.go
+++ b/pkg/ciliumenvoyconfig/k8s_reflector.go
@@ -118,7 +118,7 @@ func registerCECK8sReflector(
 			objMeta.GetNamespace(),
 			objMeta.GetName(),
 			spec.Resources,
-			len(spec.Services) > 0,
+			isL7LB(objMeta, spec),
 			InjectCiliumEnvoyFilters(objMeta, spec),
 			UseOriginalSourceAddress(objMeta),
 			true,


### PR DESCRIPTION
Currently, CEC parsing treats a `CiliumEnvoyConfig` as `isL7LB` only if
services are defined in `.spec.services`.

There might be cases where this behaviour wants to be manually overruled -
the same way as it's already possible for "filter injection" & "original
source address preservation".

Therefore, this commit adds a new annotation `cec.cilium.io/is-l7lb`. If
it is defined on a `CiliumEnvoyConfig` it's value takes presedence over the
automatic value evaluation via `.spec.services`.

Signed-off-by: Marco Hofstetter <marco.hofstetter@isovalent.com>
