### PR TITLE
docs: clarify kubeProxyReplacement and kube-proxy requirements for Istio integration

### DIFF
--- a/Documentation/network/servicemesh/istio.rst
+++ b/Documentation/network/servicemesh/istio.rst
@@ -17,6 +17,26 @@ This document covers the following common aspects of Cilium's integration with I
 * Istio configuration
 * Demo application
 
+.. note::
+
+   You can run Cilium with Istio in two ways:
+
+   1. **With kube-proxy present (recommended):**
+
+      - Set ``kubeProxyReplacement: false`` (the default).
+      - Cilium does not fully replace kube-proxy; kube-proxy continues to handle ClusterIP routing.
+      - This is the recommended setup for using Istio with minimal disruption, particularly in sidecar or ambient mode.
+
+   2. **With kube-proxy removed (full replacement):**
+
+      - Set ``kubeProxyReplacement: true``, ``socketLB.hostNamespaceOnly: true``, and ``cni.exclusive: false``.
+      - These settings prevent Cilium’s socket-based load balancing from interfering with Istio’s proxying.
+      - kube-proxy can be removed in this mode, but these configurations are required to ensure compatibility.
+
+   In summary, you can run Istio with Cilium and kube-proxy by setting ``kubeProxyReplacement: false`` (the default and recommended for most Istio installs);
+   or you can run without kube-proxy by setting ``kubeProxyReplacement: true``, but you must carefully configure Cilium to avoid conflicts with Istio.
+
+
 Cilium Configuration
 ====================
 


### PR DESCRIPTION

Clarifies the documentation on how to run Cilium with Istio, with or without kube-proxy, and the required configuration for kubeProxyReplacement and related settings.

Closes: #37974

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x]  Thanks for contributing!

<!-- Description of change -->

Fixes: #37974 

```release-note
Clarifies documentation for running Cilium with Istio, including kube-proxy and kubeProxyReplacement requirements, and improves configuration guidance for both deployment modes.
```
## screenshot for a preview how it looks 
<img width="1039" height="734" alt="Screenshot 2025-07-18 171357" src="https://github.com/user-attachments/assets/3ba3540a-8770-41c8-8321-678c830c2117" />
