### PR TITLE
ci: disable SCTPConnectivity k8s tests

### DIFF
--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -230,7 +230,7 @@ jobs:
           # DualStack : tests that are dual stack specific
           # IPv6 : tests that are IPv6 specific
 
-          SKIP_FLAG="Alpha|Beta|Experimental|Federation|PerformanceDNS|Disruptive|Serial|KubeProxy|kube-proxy|ExternalIP|LoadBalancer|GCE|Netpol|NetworkPolicy|rejected|externalTrafficPolicy"
+          SKIP_FLAG="Alpha|Beta|Experimental|Federation|PerformanceDNS|Disruptive|Serial|KubeProxy|kube-proxy|ExternalIP|LoadBalancer|GCE|Netpol|NetworkPolicy|rejected|externalTrafficPolicy|SCTPConnectivity"
           if [ "${IP_FAMILY}" != "dual" ]; then
             SKIP_FLAG="${SKIP_FLAG}|DualStack"
           fi


### PR DESCRIPTION
SCTPConnectivity related tests cause most of the flakiness of k8s Network E2E tests. Disable it, to allow for reenabling k8s Network tests as required.

Related: https://github.com/cilium/cilium/issues/40575