### PR TITLE
bug_fix: updating the parseKernelVersion() function to support RHEL kernels

### DIFF
--- a/pkg/version/version_unix_test.go
+++ b/pkg/version/version_unix_test.go
@@ -37,6 +37,14 @@ func TestParseKernelVersion(t *testing.T) {
 		{"6.5-15-generic", mustHaveVersion(t, "6.5.0")},
 		{"6.5.2-rc8+", mustHaveVersion(t, "6.5.2")},
 		{"6-generic", mustHaveVersion(t, "6.0.0")},
+		// RHEL style kernel versions include release and arch bits.
+		{"4.18.0-240", mustHaveVersion(t, "4.18.0")},
+		{"4.18.0-240.el8", mustHaveVersion(t, "4.18.0")},
+		{"4.18.0-477.10.1", mustHaveVersion(t, "4.18.0")},
+		{"4.18.0-477.10.1.el8", mustHaveVersion(t, "4.18.0")},
+		{"4.18.0-477.10.1.el8.x86_64", mustHaveVersion(t, "4.18.0")},
+		{"5.14.0-284.11.1.el9", mustHaveVersion(t, "5.14.0")},
+		{"5.14.0-427.42.1.el9_4.x86_64", mustHaveVersion(t, "5.14.0")},
 	}
 	for _, tt := range flagtests {
 		s, err := parseKernelVersion(tt.in)


### PR DESCRIPTION
bug_fix: updating the parseKernelVersion() function to support RHEL kernels

Previously, Cilium expects a kernel version to include between 1 and 3 sections, delimited by a dot. However, on RHEL-style platforms, kernel versions encode release information in the kernel version, also delimited by dots. This means tests fail on RHEL-style kernel versions.

This change modifies:
- pkg/version/version_unix.go: to remove the explicit requirement for parseKernelVersion() to have no more than 3 sections, delimited by exactly 2 dots.
- pkg/version/version_unix_test.go: to add RHEL-style kernel version strings into testing.