### PR TITLE
[v1.16] doc:monitor: clarify direction traced with default aggregation level

### DIFF
--- a/Documentation/network/kubernetes/configuration.rst
+++ b/Documentation/network/kubernetes/configuration.rst
@@ -49,9 +49,9 @@ to your preferences:
 
   - ``none`` - Generate a tracing event on every receive and send packet.
   - ``low`` - Generate a tracing event on every send packet.
-  - ``medium`` - Generate a tracing event on every new connection, any time a
-    packet contains TCP flags that have not been previously seen for the packet
-    direction, and on average once per ``monitor-aggregation-interval``
+  - ``medium`` - Generate a tracing event for send packets only on every new
+    connection, any time a packet contains TCP flags that have not been previously
+    seen for the packet direction, and on average once per ``monitor-aggregation-interval``
     (assuming that a packet is seen during the interval). Each direction tracks
     TCP flags and report interval separately. If Cilium drops a packet, it will
     emit one event per packet dropped.

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -428,9 +428,10 @@ should consider increasing the aggregation interval or rate limiting events.
 Increase Aggregation Interval
 -----------------------------
 
-By default Cilium generates a tracing event on every new connection, any time a packet
-contains TCP flags that have not been previously seen for the packet direction, and on
-average once per ``monitor-aggregation-interval``, which defaults to 5 seconds.
+By default Cilium generates a tracing event for send packets only on every new
+connection, any time a packet contains TCP flags that have not been previously
+seen for the packet direction, and on average once per ``monitor-aggregation-interval``,
+which defaults to 5 seconds.
 
 Depending on your network traffic patterns, the re-emitting of trace events per
 aggregation interval can make up a large part of the total events. Increasing the

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -353,7 +353,137 @@ Running with Hubble observability enabled can come at the expense of
 performance. The overhead of Hubble is somewhere between 1-15% depending
 on your network traffic patterns and Hubble aggregation settings.
 
-In order to optimize for maximum performance, Hubble can be disabled:
+In clusters with a huge amount of network traffic, cilium-agent might spend
+a significant portion of CPU time on processing monitored events and Hubble may
+even lose some events.
+There are multiple ways to tune Hubble to avoid this.
+
+Increase Hubble Event Queue Size
+--------------------------------
+
+The Hubble Event Queue buffers events after they have been emitted from datapath and
+before they are processed by the Hubble subsystem. If this queue is full, because Hubble
+can't keep up with the amount of emitted events, Cilium will start dropping events.
+This does not impact traffic, but the events won't be processed by Hubble and won't show
+up in Hubble flows or metrics.
+
+When this happens you will see log lines similar to the following.
+
+::
+
+   level=info msg="hubble events queue is processing messages again: NN messages were lost" subsys=hubble
+   level=warning msg="hubble events queue is full: dropping messages; consider increasing the queue size (hubble-event-queue-size) or provisioning more CPU" subsys=hubble
+
+By default the Hubble event queue size is ``#CPU * 1024``, or ``16384`` if your nodes have
+more than 16 CPU cores. If you encounter event bursts that result in dropped events,
+increasing this queue size might help. We recommend gradually doubling the queue length
+until the drops disappear. If you don't see any improvements after increasing the queue
+length to 128k, further increasing the event queue size is unlikely to help.
+
+Be aware that increasing the Hubble event queue size will result in increased memory
+usage. Depending on your traffic pattern, increasing the queue size by ``10,000`` may
+increase the memory usage by up to five Megabytes.
+
+.. tabs::
+
+    .. group-tab:: Cilium CLI
+
+       .. parsed-literal::
+
+           cilium install |CHART_VERSION| \\
+             --set hubble.eventQueueSize=32768
+
+    .. group-tab:: Helm
+
+       .. parsed-literal::
+
+           helm install cilium |CHART_RELEASE| \\
+             --namespace kube-system \\
+             --set hubble.eventQueueSize=32768
+
+    .. group-tab:: Per-Node
+
+      If only certain nodes are effected you may also set the queue length on a per-node
+      basis using a :ref:`CiliumNodeConfig object <per-node-configuration>`.
+
+      ::
+
+          apiVersion: cilium.io/v2
+          kind: CiliumNodeConfig
+          metadata:
+            namespace: kube-system
+            name: set-hubble-event-queue
+          spec:
+            nodeSelector:
+              matchLabels:
+                # Update selector to match your nodes
+                io.cilium.update-hubble-event-queue: "true"
+            defaults:
+              hubble-event-queue-size: "32768"
+
+Increasing the Hubble event queue size can't mitigate a consistently high rate of events
+being emitted by Cilium datapath and it does not reduce CPU utilization. For this you
+should consider increasing the aggregation interval or rate limiting events.
+
+Increase Aggregation Interval
+-----------------------------
+
+By default Cilium generates a tracing event on every new connection, any time a packet
+contains TCP flags that have not been previously seen for the packet direction, and on
+average once per ``monitor-aggregation-interval``, which defaults to 5 seconds.
+
+Depending on your network traffic patterns, the re-emitting of trace events per
+aggregation interval can make up a large part of the total events. Increasing the
+aggregation interval may decrease CPU utilization and can prevent lost events.
+
+The following will set the aggregation interval to 10 seconds.
+
+.. tabs::
+    .. group-tab:: Cilium CLI
+
+       .. parsed-literal::
+
+           cilium install |CHART_VERSION| \\
+             --set bpf.events.monitorInterval="10s"
+
+    .. group-tab:: Helm
+
+       .. parsed-literal::
+
+           helm install cilium |CHART_RELEASE| \\
+             --namespace kube-system \\
+             --set bpf.events.monitorInterval="10s"
+
+You can also choose to stop exposing event types in which you
+are not interested. For instance if you are mainly interested in
+dropped traffic, you can disable "trace" events which will likely reduce
+the overall CPU consumption of the agent.
+
+.. tabs::
+
+    .. group-tab:: Cilium CLI
+
+       .. code-block:: shell-session
+
+           cilium config set bpf-events-trace-enabled false
+
+    .. group-tab:: Helm
+
+       .. parsed-literal::
+
+           helm install cilium |CHART_RELEASE| \\
+             --namespace kube-system \\
+             --set bpf.events.trace.enabled=false
+
+.. warning::
+
+    Suppressing one or more event types will impact ``cilium monitor`` as well as Hubble observability capabilities, metrics and exports.
+
+Disable Hubble
+--------------
+
+If all this is not sufficient, in order to optimize for maximum performance,
+you can disable Hubble:
 
 .. tabs::
 
@@ -370,31 +500,6 @@ In order to optimize for maximum performance, Hubble can be disabled:
            helm install cilium |CHART_RELEASE| \\
              --namespace kube-system \\
              --set hubble.enabled=false
-
-You can also choose to stop exposing event types in which you
-are not interested. For instance if you are mainly interested in
-dropped traffic, you can disable "trace" events which will likely reduce
-the overall CPU consumption of the agent.
-
-.. tabs::
-
-    .. group-tab:: Cilium CLI
-
-       .. code-block:: shell-session
-
-           cilium config TraceNotification=disable
-
-    .. group-tab:: Helm
-
-       .. parsed-literal::
-
-           helm install cilium |CHART_RELEASE| \\
-             --namespace kube-system \\
-             --set bpf.events.trace.enabled=false
-
-.. warning::
-
-    Suppressing one or more event types will impact ``cilium monitor`` as well as Hubble observability capabilities, metrics and exports.
 
 MTU
 ===


### PR DESCRIPTION
Manual backport of:

* [ ] https://github.com/cilium/cilium/pull/34665: needed by the next. Dropping section `Rate Limit Events` as not present in v1.16.
* [ ] https://github.com/cilium/cilium/pull/40398

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 34665 40398
```