### PR TITLE
bpf/tests: remove unused method `mock_ctx_redirect_peer`

### DIFF
--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -15,14 +15,6 @@
 /* Skip ingress policy checks */
 #define USE_BPF_PROG_FOR_INGRESS_POLICY
 
-#define ctx_redirect_peer mock_ctx_redirect_peer
-static __always_inline __maybe_unused int
-mock_ctx_redirect_peer(const struct __sk_buff *ctx __maybe_unused, int ifindex __maybe_unused,
-		       __u32 flags __maybe_unused)
-{
-	return TC_ACT_REDIRECT;
-}
-
 #include <bpf_lxc.c>
 
 /* Set the LXC source address to be the address of pod one */


### PR DESCRIPTION
In these hairpin tests, we call [`ctx_redirect`](https://github.com/cilium/cilium/blob/2c6035c958f6d45e08a957311bbdc8f0abcc7287/bpf/lib/local_delivery.h#L77) and not `ctx_redirect_peer` because `ENABLE_HOST_ROUTING` is not defined, so it shouldn't be necessary to mock it. I tried to put a log there, and I can see that it is never called running `-test=tc_nodeport_test`

