### PR TITLE
[v1.17] fix: kube-proxy healthz panic on port 10256

### DIFF
--- a/daemon/cmd/kube_proxy_healthz.go
+++ b/daemon/cmd/kube_proxy_healthz.go
@@ -54,7 +54,7 @@ func (d *Daemon) startKubeProxyHealthzHTTPService(addr string) {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/healthz", kubeproxyHealthzHandler{d: d, svc: d.svc})
+	mux.Handle("/healthz", kubeproxyHealthzHandler{d: d, svc: d.svc, localNode: d.nodeLocalStore})
 
 	srv := &http.Server{
 		Addr:    addr,


### PR DESCRIPTION
Initialized nodelocalstore and passed down to kube-proxy healthz handler

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!


Fixes: #40571 

