### PR TITLE
multicast: use Go 1.20 slice-to-array conversion for SolicitedNodeMaddr()

### DIFF
--- a/pkg/multicast/multicast.go
+++ b/pkg/multicast/multicast.go
@@ -156,9 +156,7 @@ func (a Address) SolicitedNodeMaddr() netip.Addr {
 	copy(maddr[:13], SolicitedNodeMaddrPrefix[:13])
 	copy(maddr[13:], ipv6.AsSlice()[13:])
 
-	// Use slice-to-array-pointer conversion, available since Go 1.17.
-	// TODO: use slice-to-array conversion when switching to Go 1.20
-	return netip.AddrFrom16(*(*[16]byte)(maddr))
+	return netip.AddrFrom16([16]byte(maddr))
 }
 
 // interfaceByName get *net.Interface by name using netlink.

--- a/pkg/multicast/multicast_test.go
+++ b/pkg/multicast/multicast_test.go
@@ -67,7 +67,7 @@ func TestSolicitedNodeMaddr(t *testing.T) {
 func randMaddr() netip.Addr {
 	maddr := make([]byte, 16)
 	rand.Read(maddr[13:])
-	return Address(netip.AddrFrom16(*(*[16]byte)(maddr))).SolicitedNodeMaddr()
+	return Address(netip.AddrFrom16(([16]byte)(maddr))).SolicitedNodeMaddr()
 }
 
 func TestMcastKey(t *testing.T) {


### PR DESCRIPTION
Go 1.20 introduced slice-to-array conversions, which allow directly casting a slice to an array. This commit updates the Address.SolicitedNodeMaddr() method to use the cleaner [16]byte(slice) syntax instead of \*(\*[16]byte)(slice) as mentioned in the TODO.