### PR TITLE
connectivity: reenable IPv6 in client egress L7 test

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7.go
@@ -32,9 +32,7 @@ func clientEgressL7Test(ct *check.ConnectivityTest, templates map[string]string,
 		WithCiliumPolicy(templates[templateName]).                    // L7 allow policy with HTTP introspection
 		WithScenarios(
 			tests.PodToPod(),
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			tests.PodToWorld(false, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
+			tests.PodToWorld(true, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.


### PR DESCRIPTION
This commit reenables the IPv6 PodToWorld path in the client egress L7 test, which had been disaled due to a kernel bug. The upstream kernel fix has been merged: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v6.16-rc6&id=932b32ffd7604fb00b5c57e239a3cc4d901ccf6e