### PR TITLE
connectivity: reenable IPv6 in tests

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7.go
@@ -32,9 +32,7 @@ func clientEgressL7Test(ct *check.ConnectivityTest, templates map[string]string,
 		WithCiliumPolicy(templates[templateName]).                    // L7 allow policy with HTTP introspection
 		WithScenarios(
 			tests.PodToPod(),
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			tests.PodToWorld(false, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
+			tests.PodToWorld(true, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.

--- a/cilium-cli/connectivity/builder/client_egress_l7_named_port.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_named_port.go
@@ -19,9 +19,7 @@ func (t clientEgressL7NamedPort) build(ct *check.ConnectivityTest, templates map
 		WithCiliumPolicy(templates["clientEgressL7HTTPNamedPortPolicyYAML"]). // L7 allow policy with HTTP introspection (named port)
 		WithScenarios(
 			tests.PodToPod(),
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			tests.PodToWorld(false, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
+			tests.PodToWorld(true, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -28,9 +28,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld(false)).
+		WithScenarios(tests.PodToWorld(true)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -44,9 +42,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld(false)). // External Target is not allowed
+		WithScenarios(tests.PodToWorld(true)).                        // External Target is not allowed
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				// SSL error as another external target (e.g. cilium.io) SNI is not allowed
@@ -61,9 +57,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld(false)).
+		WithScenarios(tests.PodToWorld(true)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -77,9 +71,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld2(false)).
+		WithScenarios(tests.PodToWorld2(true)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				// SSL error as another external target (e.g. cilium.io) SNI is not allowed
@@ -97,9 +89,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 			WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 			WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 			WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			WithScenarios(tests.PodToWorld(false)).
+			WithScenarios(tests.PodToWorld(true)).
 			WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 				if a.Destination().Port() == 443 {
 					return check.ResultOK, check.ResultNone
@@ -113,9 +103,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 			WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 			WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 			WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			WithScenarios(tests.PodToWorld2(false)).
+			WithScenarios(tests.PodToWorld2(true)).
 			WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 				if a.Destination().Port() == 443 {
 					// SSL error as another external target (e.g. cilium.io) SNI is not allowed

--- a/cilium-cli/connectivity/builder/to_fqdns.go
+++ b/cilium-cli/connectivity/builder/to_fqdns.go
@@ -62,10 +62,8 @@ func (t toFqdnsWithProxy) build(ct *check.ConnectivityTest, templates map[string
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithScenarios(
-			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
-			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			tests.PodToWorld(false, tests.WithRetryDestPort(80)),
-			tests.PodToWorld2(false), // resolves to ExternalOtherTarget
+			tests.PodToWorld(true, tests.WithRetryDestPort(80)),
+			tests.PodToWorld2(true), // resolves to ExternalOtherTarget
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Address(features.IPFamilyAny) == ct.Params().ExternalOtherTarget {


### PR DESCRIPTION
This commit enables IPv6 in connectivity tests, which had been previously disabled due to a kernel bug. The upstream kernel fix has been merged: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v6.16-rc6&id=932b32ffd7604fb00b5c57e239a3cc4d901ccf6e