### PR TITLE
feat(cli): Disable unexpected packet drops test by default

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -228,6 +228,7 @@ jobs:
             --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16 \
             --helm-set ipam.operator.clusterPoolIPv6PodCIDRList=fd00::/104"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled \
+            --include-no-unexpected-packet-drops-test \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --hubble=false --collect-sysdump-on-failure --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -231,6 +231,7 @@ jobs:
 
           # L7 policies are not supported in chaining mode.
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --test-concurrency=3 \
+            --include-no-unexpected-packet-drops-test \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --hubble=false --collect-sysdump-on-failure --test '!fqdn,!l7' \

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -374,6 +374,7 @@ jobs:
           fi
 
           CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
+            --include-no-unexpected-packet-drops-test \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --flow-validation=disabled \

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -156,6 +156,7 @@ jobs:
           fi
 
           CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
+            --include-no-unexpected-packet-drops-test \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --flow-validation=disabled --hubble=false --collect-sysdump-on-failure \

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -229,6 +229,7 @@ jobs:
           fi
 
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false \
+            --include-no-unexpected-packet-drops-test \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --collect-sysdump-on-failure --external-target amazon.com."

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -246,6 +246,7 @@ jobs:
             --wait=false"
 
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
+            --include-no-unexpected-packet-drops-test \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --external-target google.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4"

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -167,6 +167,7 @@ jobs:
           fi
 
           CONNECTIVITY_TEST_DEFAULTS="--include-unsafe-tests \
+                                      --include-no-unexpected-packet-drops-test \
                                       --collect-sysdump-on-failure \
                                       --sysdump-hubble-flows-count=1000000 \
                                       --sysdump-hubble-flows-timeout=5m \

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -89,6 +89,7 @@ jobs:
             --helm-set=ipv6.enabled=true \
             --wait=false"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --test-concurrency=5 \
+            --include-no-unexpected-packet-drops-test \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --hubble=false --collect-sysdump-on-failure \

--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -186,6 +186,7 @@ jobs:
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=cluster.name=${{ env.clusterName }}"
           CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
+            --include-no-unexpected-packet-drops-test \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --test='!/pod-to-world'"

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -243,6 +243,7 @@ jobs:
           esac
 
           CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
+            --include-no-unexpected-packet-drops-test \
             --sysdump-output-filename \"cilium-sysdump-${{ matrix.name }}-<ts>\" \
             --junit-file \"cilium-junits/${{ env.job_name }} ${{ matrix.name }}.xml\" \
             --junit-property github_job_step=\"Run tests ${{ matrix.name }}\" \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -167,7 +167,7 @@ jobs:
           CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh stable)
           echo downgrade_version=${CILIUM_DOWNGRADE_VERSION} >> $GITHUB_OUTPUT
 
-          EXTRA_CLI_FLAGS=()
+          EXTRA_CLI_FLAGS=("\"--include-no-unexpected-packet-drops-test=true\"")
           if [ "${{ matrix.secondary-network }}" = "true" ]; then
             EXTRA_CLI_FLAGS+=("\"--secondary-network-iface=eth1\"")
           fi

--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -50,6 +50,7 @@ cilium connectivity test [flags]
       --include-conn-disrupt-test                             Include conn disrupt test
       --include-conn-disrupt-test-egw                         Include conn disrupt test for Egress Gateway
       --include-conn-disrupt-test-ns-traffic                  Include conn disrupt test for NS traffic
+      --include-no-unexpected-packet-drops-test               Include no unexpected packet drops test
       --ip-families strings                                   Restrict test actions to specific IP families (default [ipv4,ipv6])
       --json-mock-image string                                Image path to use for json mock (default "quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603")
       --junit-file string                                     Generate junit report and write to file

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -205,6 +205,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().DurationVar(&params.ConnDisruptDispatchInterval, "conn-disrupt-dispatch-interval", 0, "TCP packet dispatch interval")
 
+	cmd.Flags().BoolVar(&params.IncludeNoUnexpectedPacketDropsTest, "include-no-unexpected-packet-drops-test", false, "Include no unexpected packet drops test")
 	cmd.Flags().StringSliceVar(&params.ExpectedDropReasons, "expected-drop-reasons", defaults.ExpectedDropReasons, "List of expected drop reasons")
 	cmd.Flags().MarkHidden("expected-drop-reasons")
 	cmd.Flags().StringSliceVar(&params.ExpectedXFRMErrors, "expected-xfrm-errors", defaults.ExpectedXFRMErrors, "List of expected XFRM errors")

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -327,10 +327,13 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 
 // finalTests injects the all connectivity tests that must be run as the last tests sequentially.
 func finalTests(ct *check.ConnectivityTest) error {
-	return injectTests([]testBuilder{
-		noUnexpectedPacketDrops{},
+	tests := []testBuilder{
 		checkLogErrors{},
-	}, ct)
+	}
+	if ct.Params().IncludeNoUnexpectedPacketDropsTest {
+		tests = append(tests, noUnexpectedPacketDrops{})
+	}
+	return injectTests(tests, ct)
 }
 
 func renderTemplates(clusterNameLocal, clusterNameRemote string, param check.Parameters) (map[string]string, error) {

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -122,8 +122,9 @@ type Parameters struct {
 	ConnDisruptTestXfrmErrorsPath       string
 	ConnDisruptDispatchInterval         time.Duration
 
-	ExpectedDropReasons []string
-	ExpectedXFRMErrors  []string
+	IncludeNoUnexpectedPacketDropsTest bool
+	ExpectedDropReasons                []string
+	ExpectedXFRMErrors                 []string
 
 	CodeOwners        []string
 	LogCodeOwners     bool


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

The "no unexpected packet drops" test is run by default as one of the final connectivity tests. [In environments with VLAN traffic present](https://github.com/cilium/cilium/issues/36830), the failure of this test is expected.

Therefore, we now simply disable this test by default, and expose the flag `--include-no-unexpected-packet-drops` for enabling it. This flag is now used in CI to retain previous behaviour there.

Fixes: #40564

```release-note
Disable noUnexpectedPacketDrops test by default. Can be enabled using the `--include-no-unexpected-packet-drops-test` flag.
```
