### PR TITLE
Add more comprehensive icmp6 snat testing

### DIFF
--- a/bpf/tests/tc_nodeport_icmp6_snat.c
+++ b/bpf/tests/tc_nodeport_icmp6_snat.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef TUNNEL_MODE
+
+#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_nodeport_icmp6_snat_hostfw.c
+++ b/bpf/tests/tc_nodeport_icmp6_snat_hostfw.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_HOST_FIREWALL
+
+#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_nodeport_icmp6_snat_tunnel.c
+++ b/bpf/tests/tc_nodeport_icmp6_snat_tunnel.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_DSR
+#define ENCAP_IFINDEX 1
+
+#include "bpf_nat_icmp6.h"


### PR DESCRIPTION
ICMPv6 PMTU response datapath logic is somewhat unique in that it depends in parsing encapsulated l4 headers
after the icmp header.   This is prone to regressions as the functionality may not be regularly exercised by normal e2e tests.

This refactors the bpf_nat6_netdev_tests bpf tests into a header `bpf_nat_icmp6.h` which instead provides a macro that expands into tcp/udp tests. As well, as adding a sctp scenario to provide coverage for all available l4 protocols.

Using this, we create three new test files to prevent regression on several env configuration tuples:

* tunnel=false hostfw=false
* tunnel=false hostfw=true
* tunnel=true hostfw=false

I'm also currently looking at possibly expanding E2E testing,  but this is a bit tricky due to needing some kind of external network upon which to test the "bounced" mtu messages.  Therefore, this should provide some protection against regressions in the meantime.

Also, we may expand this as needed to reach the desired coverage by adding further configuration tuples (**note:** we may also want to add some test cases covering non-"pkt-too-big" icmp6 cases).