### PR TITLE
loadbalancer: Remove BackendParams.ClusterID

### DIFF
--- a/pkg/clustermesh/testdata/clusterservice-without-local-eps.txtar
+++ b/pkg/clustermesh/testdata/clusterservice-without-local-eps.txtar
@@ -27,12 +27,12 @@ db/cmp backends backends_v2.table
 
 -- backends.table --
 Address              Instances         NodeName
-20.0.0.2:9090/TCP    test/echo (tcp)
+20.0.0.2@2:9090/TCP  test/echo (tcp)
 
 -- backends_v2.table --
 Address              Instances         NodeName
-20.0.0.2:9090/TCP    test/echo (tcp)
-20.0.0.3:9090/TCP    test/echo (tcp)
+20.0.0.2@2:9090/TCP  test/echo (tcp)
+20.0.0.3@2:9090/TCP  test/echo (tcp)
 
 -- frontends.table --
 Address            Type       ServiceName   Status  Backends
@@ -40,11 +40,11 @@ Address            Type       ServiceName   Status  Backends
 
 -- frontends-with-clusterservice.table --
 Address            Type       ServiceName   Status  Backends
-10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2:9090/TCP
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2@2:9090/TCP
 
 -- frontends-with-clusterservice_v2.table --
 Address            Type       ServiceName   Status  Backends
-10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2:9090/TCP, 20.0.0.3:9090/TCP
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2@2:9090/TCP, 20.0.0.3@2:9090/TCP
 
 
 -- clusterservice2.json --

--- a/pkg/clustermesh/testdata/clusterservice.txtar
+++ b/pkg/clustermesh/testdata/clusterservice.txtar
@@ -42,20 +42,20 @@ db/cmp frontends frontends.table
 -- backends-2+3.table --
 Address              Instances         NodeName
 10.1.0.1:8080/TCP    test/echo (tcp)   nodeport-worker
-20.0.0.2:9090/TCP    test/echo (tcp)
-30.0.0.3:9090/TCP    test/echo (tcp)
+20.0.0.2@2:9090/TCP  test/echo (tcp)
+30.0.0.3@3:9090/TCP  test/echo (tcp)
 
 -- backends-2+3_v2.table --
 Address              Instances         NodeName
 10.1.0.1:8080/TCP    test/echo (tcp)   nodeport-worker
-20.0.0.2:9090/TCP    test/echo (tcp)
-20.0.0.3:9090/TCP    test/echo (tcp)
-30.0.0.3:9090/TCP    test/echo (tcp)
+20.0.0.2@2:9090/TCP  test/echo (tcp)
+20.0.0.3@2:9090/TCP  test/echo (tcp)
+30.0.0.3@3:9090/TCP  test/echo (tcp)
 
 -- backends-3.table --
 Address              Instances         NodeName
 10.1.0.1:8080/TCP    test/echo (tcp)   nodeport-worker
-30.0.0.3:9090/TCP    test/echo (tcp)
+30.0.0.3@3:9090/TCP  test/echo (tcp)
 
 -- frontends.table --
 Address            Type       ServiceName   Status  Backends
@@ -63,11 +63,11 @@ Address            Type       ServiceName   Status  Backends
 
 -- frontends-with-clusterservice-3.table --
 Address            Type       ServiceName   Status  Backends
-10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP, 30.0.0.3:9090/TCP
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP, 30.0.0.3@3:9090/TCP
 
 -- frontends-with-clusterservice-2+3.table --
 Address            Type       ServiceName   Status  Backends
-10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP, 20.0.0.2:9090/TCP, 30.0.0.3:9090/TCP
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP, 20.0.0.2@2:9090/TCP, 30.0.0.3@3:9090/TCP
 
 
 

--- a/pkg/clustermesh/testdata/service-affinity.txtar
+++ b/pkg/clustermesh/testdata/service-affinity.txtar
@@ -45,7 +45,7 @@ db/cmp frontends frontends-all.table
 -- backends.table --
 Address              Instances         NodeName
 10.1.0.1:8080/TCP    test/echo (tcp)   nodeport-worker
-20.0.0.2:9090/TCP    test/echo (tcp)
+20.0.0.2@2:9090/TCP  test/echo (tcp)
 
 -- frontends-local.table --
 Address            Type       ServiceName   Status  Backends
@@ -53,11 +53,11 @@ Address            Type       ServiceName   Status  Backends
 
 -- frontends-remote.table --
 Address            Type       ServiceName   Status  Backends
-10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2:9090/TCP
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2@2:9090/TCP
 
 -- frontends-all.table --
 Address            Type       ServiceName   Status  Backends
-10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP, 20.0.0.2:9090/TCP
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP, 20.0.0.2@2:9090/TCP
 
 -- clusterservice2.json --
 {

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -106,7 +106,6 @@ Address              Instances
       "NodeName": "nodeport-worker",
       "Zone": "",
       "ForZones": null,
-      "ClusterID": 0,
       "Source": "k8s",
       "State": 0,
       "Unhealthy": false,
@@ -147,7 +146,6 @@ Address              Instances
       "NodeName": "nodeport-worker",
       "Zone": "",
       "ForZones": null,
-      "ClusterID": 0,
       "Source": "k8s",
       "State": 0,
       "Unhealthy": false,
@@ -185,7 +183,6 @@ Address              Instances
         "NodeName": "nodeport-worker",
         "Zone": "",
         "ForZones": null,
-        "ClusterID": 0,
         "Source": "k8s",
         "State": 0,
         "Unhealthy": false,
@@ -221,7 +218,6 @@ Address              Instances
         "NodeName": "nodeport-worker",
         "Zone": "",
         "ForZones": null,
-        "ClusterID": 0,
         "Source": "k8s",
         "State": 0,
         "Unhealthy": false,
@@ -270,7 +266,6 @@ backends:
       nodename: nodeport-worker
       zone: ""
       forzones: []
-      clusterid: 0
       source: k8s
       state: 0
       unhealthy: false
@@ -296,7 +291,6 @@ backends:
       nodename: nodeport-worker
       zone: ""
       forzones: []
-      clusterid: 0
       source: k8s
       state: 0
       unhealthy: false
@@ -317,7 +311,6 @@ instances:
         nodename: nodeport-worker
         zone: ""
         forzones: []
-        clusterid: 0
         source: k8s
         state: 0
         unhealthy: false
@@ -336,7 +329,6 @@ instances:
         nodename: nodeport-worker
         zone: ""
         forzones: []
-        clusterid: 0
         source: k8s
         state: 0
         unhealthy: false

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -560,7 +560,7 @@ func (w *Writer) SetBackendsOfCluster(txn WriteTxn, name loadbalancer.ServiceNam
 			continue
 		}
 		inst := be.GetInstanceFromSource(name, source)
-		if inst == nil || inst.ClusterID != clusterID {
+		if inst == nil || inst.ClusterID() != clusterID {
 			continue
 		}
 		if err := w.removeBackendRefPerSource(txn, name, be, source, clusterID); err != nil {
@@ -598,7 +598,6 @@ func (w *Writer) updateBackends(txn WriteTxn, serviceName loadbalancer.ServiceNa
 		}
 
 		bep.Source = source
-		bep.ClusterID = clusterID
 		be.Instances = be.Instances.Set(
 			loadbalancer.BackendInstanceKey{ServiceName: serviceName, SourcePriority: w.sourcePriority(bep.Source)},
 			bep,
@@ -776,7 +775,7 @@ func backendRelease(be *loadbalancer.Backend, name loadbalancer.ServiceName) (*l
 
 func backendReleasePerSource(be *loadbalancer.Backend, name loadbalancer.ServiceName, source source.Source, clusterID uint32) (*loadbalancer.Backend, bool) {
 	for k, inst := range be.GetInstancesOfService(name) {
-		if inst.Source == source && inst.ClusterID == clusterID {
+		if inst.Source == source && inst.ClusterID() == clusterID {
 			if be.Instances.Len() == 1 {
 				// This was the last instance.
 				return nil, true


### PR DESCRIPTION
The ClusterID is already part of AddrCluster (in L3n4Addr) and thus we shouldn't duplicate it.

Remove BackendParams.ClusterID and use Address.AddrCluster.ClusterID() instead.

Fixes: 49a8edf7da2 ("experimental: Include ClusterID when manipulating backends")