### PR TITLE
vendor: Prevent renovate from updating gobgp dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -230,8 +230,15 @@
       "matchPackageNames": [
         "github.com/miekg/dns",
         "github.com/cilium/dns",
+
+        // See https://github.com/cilium/cilium/pull/11607
         "sigs.k8s.io/controller-tools",
         "github.com/cilium/controller-tools",
+
+        // See https://github.com/cilium/cilium/pull/40566
+        "github.com/osrg/gobgp/v3",
+        "github.com/cilium/gobgp/v3",
+
         "github.com/cilium/client-go",
         // We update this dependency manually together with envoy proxy updates
         "github.com/cilium/proxy",


### PR DESCRIPTION
We use a fork of `github.com/osrg/gobgp/v3` (see #40566), this PR disables renovate from updating this dependency as it's currently breaking renovate automated updates, see #40593.

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

```release-note
vendor: Prevent renovate from updating gobgp dependency
```
