### PR TITLE
Add vanilla cloud-provider configs for conformance tests

### DIFF
--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -9,10 +9,8 @@ include:
   - version: "1.32"
     region: ca-central-1
     default: true
-    ipsec: true
     kpr: true
     aws-eni-pd: true
   - version: "1.33"
     region: us-east-1
-    ipsec: true
     default: true

--- a/.github/actions/gke/test-config-helm.yaml
+++ b/.github/actions/gke/test-config-helm.yaml
@@ -6,13 +6,7 @@ config:
   - type: "tunnel"
     index: 2
     cilium-install-opts: "--datapath-mode=tunnel"
-  - type: "ipsec"
-    index: 3
-    cilium-install-opts: "--helm-set=encryption.enabled=true --helm-set=encryption.type=ipsec"
-  - type: "tunnel-ipsec"
-    index: 4
-    cilium-install-opts: "--helm-set=encryption.enabled=true --helm-set=encryption.type=ipsec --datapath-mode=tunnel"
   - type: "tunnel-ingress-controller"
-    index: 5
+    index: 3
     cilium-install-opts: "--helm-set=kubeProxyReplacement=true --helm-set=ingressController.enabled=true"
     nodes: 1

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -38,6 +38,9 @@ triggers:
   /ci-ipsec-upgrade:
     workflows:
     - tests-ipsec-upgrade.yaml
+  /ci-ipsec:
+    workflows:
+    - conformance-ipsec.yaml
   /ci-ipsec-e2e:
     workflows:
     - conformance-ipsec-e2e.yaml

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -2,6 +2,31 @@ name: Conformance AKS (ci-aks)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  workflow_call:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: false
+        type: string
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: false
+        type: string
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: false
+        type: string
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        type: string
+        default: '{}'
+      is-workflow-call:
+        description: "Distinguish if it's a workflow_call event."
+        required: false
+        type: boolean
+        default: true
+
   workflow_dispatch:
     inputs:
       PR-number:
@@ -20,9 +45,9 @@ on:
   push:
     branches:
       - 'renovate/main-**'
-  # Run every 8 hours
+  # Run every 12 hours
   schedule:
-    - cron:  '0 0/8 * * *'
+    - cron:  '0 0/12 * * *'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -44,7 +69,10 @@ concurrency:
   # - Event type
   # - A unique identifier depending on event type:
   #   - schedule: SHA
-  #   - workflow_dispatch: PR number
+  #   - workflow_dispatch: PR number. Because in workflow_call the parent context
+  #     is used, we need to add a prefix name ('aks') for the concurrency group
+  #     so that workflows that are executed in parallel don't conflict with each
+  #     other.
   #
   # This structure ensures a unique concurrency group name is generated for each
   # type of testing, such that re-runs will cancel the previous run.
@@ -54,7 +82,7 @@ concurrency:
     ${{
       (github.event_name == 'push' && github.sha) ||
       (github.event_name == 'schedule' && github.sha) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+      (github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.event.inputs.PR-number, 'aks'))
     }}
   cancel-in-progress: true
 
@@ -220,14 +248,20 @@ jobs:
             OWNER="${OWNER//[.\/]/-}"
           fi
 
+          # Check if ipsec is requested via extra-args
+          IPSEC=$(echo '${{ inputs.extra-args }}' | jq -r '.["ipsec"] // empty')
+          if [[ "$IPSEC" == "true" ]]; then
+            echo "::notice::IPsec enabled - setting ipsec=true for all matrix entries"
+          fi
+
           # We explicity set the cluster-pool Pod CIDR here to not clash with the AKS default Service CIDRs
           # which are 10.0.0.0/16 and fd12:3456:789a:1::/108
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --datapath-mode=aks-byocni \
-            --helm-set cluster.name=${{ env.name }} \
-            --helm-set loadBalancer.l7.backend=envoy \
+            --helm-set=cluster.name=${{ env.name }} \
+            --helm-set=loadBalancer.l7.backend=envoy \
             --helm-set=azure.resourceGroup=${{ env.name }} \
-            --helm-set kubeProxyReplacement=true \
+            --helm-set=kubeProxyReplacement=true \
             --helm-set=bpf.masquerade=true \
             --helm-set=ipv4.enabled=true \
             --helm-set=ipv6.enabled=true \
@@ -240,6 +274,7 @@ jobs:
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
+          echo ipsec=${IPSEC} >> $GITHUB_OUTPUT
 
       - name: Login to Azure
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
@@ -327,28 +362,34 @@ jobs:
           json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1"
 
       - name: Clean up Cilium
+        if: ${{ steps.vars.outputs.ipsec == 'true' }}
         run: |
           cilium uninstall --wait
 
       - name: Create custom IPsec secret
+        if: ${{ steps.vars.outputs.ipsec == 'true' }}
         run: |
           cilium encrypt create-key --auth-algo rfc4106-gcm-aes
 
       - name: Install Cilium with encryption
+        if: ${{ steps.vars.outputs.ipsec == 'true' }}
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
             --helm-set encryption.enabled=true \
             --helm-set encryption.type=ipsec
 
       - name: Enable Relay
+        if: ${{ steps.vars.outputs.ipsec == 'true' }}
         run: |
           cilium hubble enable
 
       - name: Wait for Cilium status to be ready
+        if: ${{ steps.vars.outputs.ipsec == 'true' }}
         run: |
           cilium status --wait --interactive=false --wait-duration=10m
 
       - name: Run sequential connectivity test with IPSec (${{ join(matrix.*, ', ') }})
+        if: ${{ steps.vars.outputs.ipsec == 'true' }}
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
           --test "seq-.*" \
@@ -356,6 +397,7 @@ jobs:
           --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
 
       - name: Run concurrent connectivity test with IPSec (${{ join(matrix.*, ', ') }})
+        if: ${{ steps.vars.outputs.ipsec == 'true' }}
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
           --test-concurrency=${{ env.test_concurrency }} \
@@ -378,7 +420,7 @@ jobs:
 
   merge-upload-and-status:
     name: Merge Upload and Status
-    if: ${{ always() }}
+    if: ${{ always() && !inputs.is-workflow-call }}
     needs: installation-and-connectivity
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -2,6 +2,34 @@ name: Conformance EKS (ci-eks)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  workflow_call:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+        type: string
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+        type: string
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+        type: string
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+        type: string
+      is-workflow-call:
+        description: "Distinguish if it's a workflow_call event."
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      AWS_PR_ASSUME_ROLE:
+        required: true
+
   workflow_dispatch:
     inputs:
       PR-number:
@@ -20,9 +48,9 @@ on:
   push:
     branches:
       - 'renovate/main-**'
-  # Run every 8 hours
+  # Run every 12 hours
   schedule:
-    - cron:  '0 1/8 * * *'
+    - cron:  '0 1/12 * * *'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -44,7 +72,10 @@ concurrency:
   # - Event type
   # - A unique identifier depending on event type:
   #   - schedule: SHA
-  #   - workflow_dispatch: PR number
+  #   - workflow_dispatch: PR number. Because in workflow_call the parent context
+  #     is used, we need to add a prefix name ('eks') for the concurrency group
+  #     so that workflows that are executed in parallel don't conflict with each
+  #     other.
   #
   # This structure ensures a unique concurrency group name is generated for each
   # type of testing, such that re-runs will cancel the previous run.
@@ -54,7 +85,7 @@ concurrency:
     ${{
       (github.event_name == 'push' && github.sha) ||
       (github.event_name == 'schedule' && github.sha) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+      (github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.event.inputs.PR-number, 'eks'))
     }}
   cancel-in-progress: true
 
@@ -150,6 +181,15 @@ jobs:
         id: set-matrix
         run: |
           cp /tmp/matrix.json /tmp/result.json
+
+          # Check if ipsec is requested via extra-args
+          IPSEC=$(echo '${{ inputs.extra-args }}' | jq -r '.["ipsec"] // false')
+          if [[ "$IPSEC" == "true" ]]; then
+            echo "::notice::IPsec enabled - setting ipsec=true for all matrix entries"
+            jq '.include |= map(. + {"ipsec": true})' /tmp/result.json > /tmp/result.json.tmp
+            mv /tmp/result.json.tmp /tmp/result.json
+          fi
+
           jq -c '.include[]' /tmp/matrix.json | while read i; do
             VERSION=$(echo $i | jq -r '.version')
             aws eks describe-cluster-versions | jq -r '.clusterVersions[].clusterVersion' > /tmp/output
@@ -223,7 +263,7 @@ jobs:
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=cluster.name=${{ env.clusterName }} \
             --helm-set=hubble.relay.enabled=true \
-            --helm-set loadBalancer.l7.backend=envoy \
+            --helm-set=loadBalancer.l7.backend=envoy \
             --wait=false"
           if [[ "${{ matrix.ipsec }}" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true --helm-set encryption.type=ipsec"
@@ -381,7 +421,7 @@ jobs:
 
   merge-upload-and-status:
     name: Merge Upload and Status
-    if: ${{ always() }}
+    if: ${{ always() && !inputs.is-workflow-call }}
     needs: installation-and-connectivity
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -2,6 +2,31 @@ name: Conformance GKE (ci-gke)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  workflow_call:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: false
+        type: string
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: false
+        type: string
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: false
+        type: string
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        type: string
+        default: '{}'
+      is-workflow-call:
+        description: "Distinguish if it's a workflow_call event."
+        required: false
+        type: boolean
+        default: true
+
   workflow_dispatch:
     inputs:
       PR-number:
@@ -20,9 +45,9 @@ on:
   push:
     branches:
       - 'renovate/main-**'
-  # Run every 8 hours
+  # Run every 12 hours
   schedule:
-    - cron:  '0 2/8 * * *'
+    - cron:  '0 3/12 * * *'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -44,7 +69,10 @@ concurrency:
   # - Event type
   # - A unique identifier depending on event type:
   #   - schedule: SHA
-  #   - workflow_dispatch: PR number
+  #   - workflow_dispatch: PR number. Because in workflow_call the parent context
+  #     is used, we need to add a prefix name ('gke') for the concurrency group
+  #     so that workflows that are executed in parallel don't conflict with each
+  #     other.
   #
   # This structure ensures a unique concurrency group name is generated for each
   # type of testing, such that re-runs will cancel the previous run.
@@ -54,7 +82,7 @@ concurrency:
     ${{
       (github.event_name == 'push' && github.sha) ||
       (github.event_name == 'schedule' && github.sha) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+      (github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.event.inputs.PR-number, 'gke'))
     }}
   cancel-in-progress: true
 
@@ -120,11 +148,30 @@ jobs:
           # main -> event_name = schedule
           # other stable branches -> PR-number starting with v (e.g. v1.14)
           VERSIONS=$(echo ${{ inputs.extra-args }} | awk -F'=' '{print $2}')
+          IPSEC=$(echo '${{ inputs.extra-args }}' | jq -r '.["ipsec"] // empty')
+
           # shellcheck disable=SC2193
           if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* || "$VERSIONS" == "all" ]];then
             cp gke.json /tmp/matrix.json
           else
             jq '{ "k8s": [ .k8s[] | select(.default) ], "config": .config}' gke.json > /tmp/matrix.json
+          fi
+
+          # Add IPsec options to all configurations if ipsec is true
+          if [[ "$IPSEC" == "true" ]]; then
+            echo "::notice::IPsec enabled - setting ipsec=true for all matrix entries"
+            echo "Adding IPsec encryption options to all configurations"
+            jq '.config |= map(
+              # Add -ipsec suffix to type unless it already contains ipsec
+              .type = (if (.type | test("ipsec")) then .type else .type + "-ipsec" end) |
+              # Add IPsec helm options to cilium-install-opts
+              if .["cilium-install-opts"] then
+                .["cilium-install-opts"] += " --helm-set=encryption.enabled=true --helm-set=encryption.type=ipsec"
+              else
+                .["cilium-install-opts"] = "--helm-set=encryption.enabled=true --helm-set=encryption.type=ipsec"
+              end
+            )' /tmp/matrix.json > /tmp/matrix.json.tmp
+            mv /tmp/matrix.json.tmp /tmp/matrix.json
           fi
 
           echo "Generated matrix:"
@@ -254,7 +301,7 @@ jobs:
             --helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.config.index }} \
             --helm-set=hubble.relay.enabled=true \
             --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
-            --helm-set loadBalancer.l7.backend=envoy \
+            --helm-set=loadBalancer.l7.backend=envoy \
             --wait=false"
 
           CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
@@ -338,7 +385,7 @@ jobs:
             install/kubernetes/cilium
 
       - name: Create custom IPsec secret
-        if: ${{ matrix.config.type == 'ipsec' || matrix.config.type == 'tunnel-ipsec' }}
+        if: ${{ contains(fromJSON('["no-tunnel-ipsec", "tunnel-ipsec", "tunnel-ingress-controller-ipsec"]'), matrix.config.type) }}
         run: |
           cilium encrypt create-key --auth-algo rfc4106-gcm-aes
 
@@ -367,7 +414,7 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/post-logic
         with:
-          artifacts_suffix: "${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }})"
+          artifacts_suffix: "${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ matrix.config.type }})"
           job_status: "${{ job.status }}"
 
       - name: Clean up ESP allow firewall rule
@@ -388,7 +435,7 @@ jobs:
 
   merge-upload-and-status:
     name: Merge Upload and Status
-    if: ${{ always() }}
+    if: ${{ always() && !inputs.is-workflow-call }}
     needs: installation-and-connectivity
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit

--- a/.github/workflows/conformance-ipsec.yaml
+++ b/.github/workflows/conformance-ipsec.yaml
@@ -1,0 +1,138 @@
+name: Conformance IPsec (ci-ipsec)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+  # Run every 12 hours
+  schedule:
+    - cron:  '0 4/12 * * *'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+
+concurrency:
+  # Structure:
+  # - Parent concurrency group name to avoid deadlock with child workflows
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    parent
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  wait-for-images:
+    name: Wait for images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ inputs.SHA || github.sha }}
+          images: cilium-ci operator-generic-ci hubble-relay-ci
+
+  conformance-aks-ipsec:
+    name: Conformance AKS with IPsec
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-aks.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"ipsec": true}'
+
+  conformance-eks-ipsec:
+    name: Conformance EKS with IPsec
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-eks.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"ipsec": true}'
+
+  conformance-gke-ipsec:
+    name: Conformance GKE with IPsec
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-gke.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"ipsec": true}'
+
+  merge-upload-and-status:
+    name: Merge Upload and Status
+    if: ${{ always() }}
+    needs: [conformance-aks-ipsec, conformance-eks-ipsec, conformance-gke-ipsec]
+    uses: ./.github/workflows/common-post-jobs.yaml
+    secrets: inherit
+    with:
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      sha: ${{ inputs.SHA || github.sha }}
+      result: ${{ (needs.conformance-aks-ipsec.result == 'failure' || needs.conformance-eks-ipsec.result == 'failure' || needs.conformance-gke-ipsec.result == 'failure') && 'failure' || 'success' }}


### PR DESCRIPTION
Introduce vanilla configurations for cloud providers to enable testing
Cilium with minimal, default settings. This provides a baseline for
conformance, ensuring core functionality without extra features.

First we add vanilla configs for each supported cloud provider,
then we enable extensible testing by layering additional configs (e.g., IPsec).

You can look at a run here https://github.com/cilium/cilium/actions/runs/17467364735