### PR TITLE
[v1.17] crypto/certloader: Add reusable cell provider for WatchedServerConfig + client variants

### DIFF
--- a/pkg/crypto/certloader/cell.go
+++ b/pkg/crypto/certloader/cell.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package certloader
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// Config is the configuration for NewWatchedServerConfigPromise.
+type Config struct {
+	// Enable TLS watched server configuration.
+	TLS bool
+	// Path to a TLS public certificate file. The file must contain PEM encoded data.
+	TLSCertFile string
+	// Path to a TLS private key file. The file must contain PEM encoded data.
+	TLSKeyFile string
+	// Paths to one or more TLS public client CA certificates files to use for TLS with mutual
+	// authentication (mTLS). The files must contain PEM encoded data. When provided, this option
+	// effectively enables mTLS.
+	TLSClientCAFiles []string
+}
+
+// NewWatchedServerConfigPromise provides a promise that resolves to a WatchedServerConfig.
+// The resolved config can be used to obtain a tls.Config which can transparently reload
+// certificates between two connections. The promise resolves when the certificates become
+// ready and have been loaded.
+//
+// This is meant to be used as a Hive constructor and is recommended to be placed in a module
+// and the promise provided wrapped in another type to avoid possible conflicts/replacements
+// when used multiple times in the same hive.
+func NewWatchedServerConfigPromise(lc cell.Lifecycle, jobGroup job.Group, log logrus.FieldLogger, cfg Config) (promise.Promise[*WatchedServerConfig], error) {
+	log = log.WithField(logfields.Config, "certloader-tls")
+	if !cfg.TLS {
+		log.Info("Certloader TLS watcher disabled")
+		return nil, nil
+	}
+
+	resolver, promise := promise.New[*WatchedServerConfig]()
+
+	jobGroup.Add(job.OneShot("certloader-tls", func(ctx context.Context, _ cell.Health) error {
+		metricsTLSConfigChan, err := FutureWatchedServerConfig(
+			log, cfg.TLSClientCAFiles, cfg.TLSCertFile, cfg.TLSKeyFile,
+		)
+		if err != nil {
+			err := fmt.Errorf("failed to initialize certloader TLS configuration: %w", err)
+			resolver.Reject(err)
+			return err
+		}
+
+		waitingMsgTimeout := time.After(30 * time.Second)
+		var metricsTLSConfig *WatchedServerConfig
+		for metricsTLSConfig == nil {
+			select {
+			case metricsTLSConfig = <-metricsTLSConfigChan:
+			case <-waitingMsgTimeout:
+				log.Info("Waiting for certloader TLS certificate and key files to be created")
+			case <-ctx.Done():
+				return nil
+			}
+		}
+		resolver.Resolve(metricsTLSConfig)
+		return nil
+	}))
+
+	lc.Append(cell.Hook{
+		OnStop: func(ctx cell.HookContext) error {
+			// stop the resolved config watcher (best effort)
+			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			cfg, _ := promise.Await(ctx)
+			if cfg != nil {
+				cfg.Stop()
+			}
+			return nil
+		},
+	})
+
+	return promise, nil
+}

--- a/pkg/crypto/certloader/cell.go
+++ b/pkg/crypto/certloader/cell.go
@@ -16,17 +16,16 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-// Config is the configuration for NewWatchedServerConfigPromise.
+// Config is the configuration for NewWatchedServerConfigPromise and NewWatchedClientConfigPromise.
 type Config struct {
-	// Enable TLS watched server configuration.
+	// Enable TLS watched configuration.
 	TLS bool
 	// Path to a TLS public certificate file. The file must contain PEM encoded data.
 	TLSCertFile string
 	// Path to a TLS private key file. The file must contain PEM encoded data.
 	TLSKeyFile string
 	// Paths to one or more TLS public client CA certificates files to use for TLS with mutual
-	// authentication (mTLS). The files must contain PEM encoded data. When provided, this option
-	// effectively enables mTLS.
+	// authentication (mTLS). The files must contain PEM encoded data.
 	TLSClientCAFiles []string
 }
 
@@ -39,7 +38,7 @@ type Config struct {
 // and the promise provided wrapped in another type to avoid possible conflicts/replacements
 // when used multiple times in the same hive.
 func NewWatchedServerConfigPromise(lc cell.Lifecycle, jobGroup job.Group, log logrus.FieldLogger, cfg Config) (promise.Promise[*WatchedServerConfig], error) {
-	log = log.WithField(logfields.Config, "certloader-tls")
+	log = log.WithField(logfields.Config, "certloader-server-tls")
 	if !cfg.TLS {
 		log.Info("Certloader TLS watcher disabled")
 		return nil, nil
@@ -47,29 +46,87 @@ func NewWatchedServerConfigPromise(lc cell.Lifecycle, jobGroup job.Group, log lo
 
 	resolver, promise := promise.New[*WatchedServerConfig]()
 
-	jobGroup.Add(job.OneShot("certloader-tls", func(ctx context.Context, _ cell.Health) error {
-		metricsTLSConfigChan, err := FutureWatchedServerConfig(
+	jobGroup.Add(job.OneShot("certloader-server-tls", func(ctx context.Context, _ cell.Health) error {
+		watchedConfigChan, err := FutureWatchedServerConfig(
 			ctx, log,
 			cfg.TLSClientCAFiles, cfg.TLSCertFile, cfg.TLSKeyFile,
 		)
 		if err != nil {
-			err := fmt.Errorf("failed to initialize certloader TLS configuration: %w", err)
+			err := fmt.Errorf("failed to initialize certloader TLS watched server configuration: %w", err)
 			resolver.Reject(err)
 			return err
 		}
 
 		waitingMsgTimeout := time.After(30 * time.Second)
-		var metricsTLSConfig *WatchedServerConfig
-		for metricsTLSConfig == nil {
+		var watchedConfig *WatchedServerConfig
+		for watchedConfig == nil {
 			select {
-			case metricsTLSConfig = <-metricsTLSConfigChan:
+			case watchedConfig = <-watchedConfigChan:
 			case <-waitingMsgTimeout:
 				log.Info("Waiting for certloader TLS certificate and key files to be created")
 			case <-ctx.Done():
 				return nil
 			}
 		}
-		resolver.Resolve(metricsTLSConfig)
+		resolver.Resolve(watchedConfig)
+		return nil
+	}))
+
+	lc.Append(cell.Hook{
+		OnStop: func(ctx cell.HookContext) error {
+			// stop the resolved config watcher (best effort)
+			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			cfg, _ := promise.Await(ctx)
+			if cfg != nil {
+				cfg.Stop()
+			}
+			return nil
+		},
+	})
+
+	return promise, nil
+}
+
+// NewWatchedClientConfigPromise provides a promise that resolves to a WatchedClientConfig.
+// The resolved config can be used to obtain a tls.Config. The promise resolves when the
+// certificates become ready and have been loaded.
+//
+// This is meant to be used as a Hive constructor and is recommended to be placed in a module
+// and the promise provided wrapped in another type to avoid possible conflicts/replacements
+// when used multiple times in the same hive.
+func NewWatchedClientConfigPromise(lc cell.Lifecycle, jobGroup job.Group, log logrus.FieldLogger, cfg Config) (promise.Promise[*WatchedClientConfig], error) {
+	log = log.WithField(logfields.Config, "certloader-client-tls")
+	if !cfg.TLS {
+		log.Info("Certloader TLS watcher disabled")
+		return nil, nil
+	}
+
+	resolver, promise := promise.New[*WatchedClientConfig]()
+
+	jobGroup.Add(job.OneShot("certloader-client-tls", func(ctx context.Context, _ cell.Health) error {
+		watchedConfigChan, err := FutureWatchedClientConfig(
+			ctx, log,
+			cfg.TLSClientCAFiles, cfg.TLSCertFile, cfg.TLSKeyFile,
+		)
+		if err != nil {
+			err := fmt.Errorf("failed to initialize certloader TLS watched client configuration: %w", err)
+			resolver.Reject(err)
+			return err
+		}
+
+		waitingMsgTimeout := time.After(30 * time.Second)
+		var watchedConfig *WatchedClientConfig
+		for watchedConfig == nil {
+			select {
+			case watchedConfig = <-watchedConfigChan:
+			case <-waitingMsgTimeout:
+				log.Info("Waiting for certloader TLS certificate and key files to be created")
+			case <-ctx.Done():
+				return nil
+			}
+		}
+		resolver.Resolve(watchedConfig)
 		return nil
 	}))
 

--- a/pkg/crypto/certloader/cell.go
+++ b/pkg/crypto/certloader/cell.go
@@ -49,7 +49,8 @@ func NewWatchedServerConfigPromise(lc cell.Lifecycle, jobGroup job.Group, log lo
 
 	jobGroup.Add(job.OneShot("certloader-tls", func(ctx context.Context, _ cell.Health) error {
 		metricsTLSConfigChan, err := FutureWatchedServerConfig(
-			log, cfg.TLSClientCAFiles, cfg.TLSCertFile, cfg.TLSKeyFile,
+			ctx, log,
+			cfg.TLSClientCAFiles, cfg.TLSCertFile, cfg.TLSKeyFile,
 		)
 		if err != nil {
 			err := fmt.Errorf("failed to initialize certloader TLS configuration: %w", err)

--- a/pkg/crypto/certloader/cell_test.go
+++ b/pkg/crypto/certloader/cell_test.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package certloader
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/job"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/health/types"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+func TestCell(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	// create directory structure and config inputs
+	dir, hubble, relay := directories(t)
+
+	// init hive
+	ctx := t.Context()
+	var err error
+	var serverConfig *WatchedServerConfig
+
+	config := testConfig{
+		TLS:              true,
+		TLSCertFile:      hubble.certFile,
+		TLSKeyFile:       hubble.privkeyFile,
+		TLSClientCAFiles: hubble.caFiles,
+	}
+
+	hive := hive.New(
+		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
+			h := p.ForModule(cell.FullModuleID{"test"})
+			return jr.NewGroup(h, lc)
+		}),
+		cell.ProvidePrivate(func(cfg testConfig) Config {
+			return Config(cfg)
+		}),
+		cell.Provide(NewWatchedServerConfigPromise),
+		cell.Config(config),
+		cell.Invoke(func(p promise.Promise[*WatchedServerConfig]) {
+			if p != nil {
+				go func() {
+					serverConfig, err = p.Await(ctx)
+				}()
+			}
+		}),
+	)
+
+	// start hive
+	tlog := hivetest.Logger(t)
+	if err := hive.Start(tlog, ctx); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	// create tmp certs after a delay
+	go func() {
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return
+		}
+		setup(t, hubble, relay)
+		t.Cleanup(func() {
+			cleanup(dir)
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		return err == nil && serverConfig != nil && serverConfig.certFile == config.TLSCertFile
+	}, 5*time.Second, 100*time.Millisecond, "TLS server config promise should resolve after a delay")
+
+	if err := hive.Stop(tlog, ctx); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func TestCellConfigError(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	// init hive
+	ctx := t.Context()
+	var err error
+	var serverConfig *WatchedServerConfig
+
+	hive := hive.New(
+		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
+			h := p.ForModule(cell.FullModuleID{"test"})
+			return jr.NewGroup(h, lc)
+		}),
+		cell.ProvidePrivate(func(cfg testConfig) Config {
+			return Config(cfg)
+		}),
+		cell.Provide(NewWatchedServerConfigPromise),
+		//exhaustruct:ignore
+		cell.Config(testConfig{
+			TLS: true,
+		}),
+		cell.Invoke(func(p promise.Promise[*WatchedServerConfig]) {
+			if p != nil {
+				go func() {
+					serverConfig, err = p.Await(ctx)
+				}()
+			}
+		}),
+	)
+
+	// start hive
+	tlog := hivetest.Logger(t)
+	if err := hive.Start(tlog, ctx); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	// add a small delay
+	time.Sleep(time.Second)
+
+	require.Eventually(t, func() bool {
+		return err != nil && serverConfig == nil
+	}, 5*time.Second, 100*time.Millisecond, "TLS server config promise should resolve with an error after a delay")
+
+	if err := hive.Stop(tlog, ctx); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func TestCellDisabled(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	ctx := t.Context()
+	var cfgPromise promise.Promise[*WatchedServerConfig]
+
+	hive := hive.New(
+		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
+			h := p.ForModule(cell.FullModuleID{"test"})
+			return jr.NewGroup(h, lc)
+		}),
+		cell.ProvidePrivate(func(cfg testConfig) Config {
+			return Config(cfg)
+		}),
+		cell.Provide(NewWatchedServerConfigPromise),
+		//exhaustruct:ignore
+		cell.Config(testConfig{
+			TLS: false,
+		}),
+		cell.Invoke(func(p promise.Promise[*WatchedServerConfig]) {
+			cfgPromise = p
+		}),
+	)
+
+	tlog := hivetest.Logger(t)
+	if err := hive.Start(tlog, ctx); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if cfgPromise != nil {
+		t.Fatalf("certloader unexpectedly enabled")
+	}
+
+	if err := hive.Stop(tlog, ctx); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+type testConfig struct {
+	TLS              bool     `mapstructure:"tls"`
+	TLSCertFile      string   `mapstructure:"tls-cert-file"`
+	TLSKeyFile       string   `mapstructure:"tls-key-file"`
+	TLSClientCAFiles []string `mapstructure:"tls-client-ca-files"`
+}
+
+func (def testConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("tls", def.TLS, "")
+	flags.String("tls-cert-file", def.TLSCertFile, "")
+	flags.String("tls-key-file", def.TLSKeyFile, "")
+	flags.StringSlice("tls-client-ca-files", def.TLSClientCAFiles, "")
+}

--- a/pkg/crypto/certloader/client_test.go
+++ b/pkg/crypto/certloader/client_test.go
@@ -11,9 +11,14 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
 
 func TestWatchedClientConfigIsMutualTLS(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)
@@ -72,6 +77,10 @@ func TestWatchedClientConfigIsMutualTLS(t *testing.T) {
 }
 
 func TestNewWatchedClientConfig(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)
@@ -105,6 +114,10 @@ func TestNewWatchedClientConfig(t *testing.T) {
 }
 
 func TestNewWatchedClientConfigWithoutClientCert(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)
@@ -129,6 +142,10 @@ func TestNewWatchedClientConfigWithoutClientCert(t *testing.T) {
 }
 
 func TestWatchedClientConfigRotation(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)

--- a/pkg/crypto/certloader/client_test.go
+++ b/pkg/crypto/certloader/client_test.go
@@ -76,6 +76,36 @@ func TestWatchedClientConfigIsMutualTLS(t *testing.T) {
 	}
 }
 
+func TestFutureWatchedClientConfig(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	dir, hubble, relay := directories(t)
+	// don't call setup() yet, we only want the directories created without the
+	// TLS files.
+	defer cleanup(dir)
+	logger, _ := test.NewNullLogger()
+
+	ch, err := FutureWatchedClientConfig(t.Context(), logger, relay.caFiles, hubble.certFile, hubble.privkeyFile)
+	assert.NoError(t, err)
+
+	// the files don't exists, expect the config to not be ready yet.
+	select {
+	case <-ch:
+		t.Fatal("FutureWatchedClientConfig should not be ready without the TLS files")
+	case <-time.After(testReloadDelay):
+	}
+
+	setup(t, hubble, relay)
+
+	// the files exists now, expect the watcher to become ready.
+	s := <-ch
+	if assert.NotNil(t, s) {
+		s.Stop()
+	}
+}
+
 func TestNewWatchedClientConfig(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)

--- a/pkg/crypto/certloader/server.go
+++ b/pkg/crypto/certloader/server.go
@@ -4,6 +4,7 @@
 package certloader
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -63,14 +64,14 @@ func NewWatchedServerConfig(log logrus.FieldLogger, caFiles []string, certFile, 
 // themselves don't exist yet. both certFile and privkeyFile must be provided.
 // To configure a mTLS capable ServerConfigBuilder, caFiles must contains at
 // least one file path.
-func FutureWatchedServerConfig(log logrus.FieldLogger, caFiles []string, certFile, privkeyFile string) (<-chan *WatchedServerConfig, error) {
+func FutureWatchedServerConfig(ctx context.Context, log logrus.FieldLogger, caFiles []string, certFile, privkeyFile string) (<-chan *WatchedServerConfig, error) {
 	if certFile == "" {
 		return nil, ErrMissingCertFile
 	}
 	if privkeyFile == "" {
 		return nil, ErrMissingPrivkeyFile
 	}
-	ew, err := FutureWatcher(log, caFiles, certFile, privkeyFile)
+	ew, err := FutureWatcher(ctx, log, caFiles, certFile, privkeyFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crypto/certloader/server_test.go
+++ b/pkg/crypto/certloader/server_test.go
@@ -100,7 +100,9 @@ func TestFutureWatchedServerConfig(t *testing.T) {
 
 	// the files exists now, expect the watcher to become ready.
 	s := <-ch
-	s.Stop()
+	if assert.NotNil(t, s) {
+		s.Stop()
+	}
 }
 
 func TestNewWatchedServerConfig(t *testing.T) {

--- a/pkg/crypto/certloader/server_test.go
+++ b/pkg/crypto/certloader/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
 
 func TestNewWatchedServerConfigErrors(t *testing.T) {
@@ -27,6 +28,10 @@ func TestNewWatchedServerConfigErrors(t *testing.T) {
 }
 
 func TestWatchedServerConfigIsMutualTLS(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)
@@ -71,13 +76,17 @@ func TestWatchedServerConfigIsMutualTLS(t *testing.T) {
 }
 
 func TestFutureWatchedServerConfig(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	// don't call setup() yet, we only want the directories created without the
 	// TLS files.
 	defer cleanup(dir)
 	logger, _ := test.NewNullLogger()
 
-	ch, err := FutureWatchedServerConfig(logger, relay.caFiles, hubble.certFile, hubble.privkeyFile)
+	ch, err := FutureWatchedServerConfig(t.Context(), logger, relay.caFiles, hubble.certFile, hubble.privkeyFile)
 	assert.NoError(t, err)
 
 	// the files don't exists, expect the config to not be ready yet.
@@ -95,6 +104,10 @@ func TestFutureWatchedServerConfig(t *testing.T) {
 }
 
 func TestNewWatchedServerConfig(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)
@@ -131,6 +144,10 @@ func TestNewWatchedServerConfig(t *testing.T) {
 }
 
 func TestWatchedServerConfigRotation(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)

--- a/pkg/crypto/certloader/watcher_test.go
+++ b/pkg/crypto/certloader/watcher_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
 
 func TestNewWatcherError(t *testing.T) {
@@ -23,6 +24,10 @@ func TestNewWatcherError(t *testing.T) {
 }
 
 func TestNewWatcher(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)
@@ -47,6 +52,10 @@ func TestNewWatcher(t *testing.T) {
 }
 
 func TestRotation(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)
@@ -86,6 +95,10 @@ func TestRotation(t *testing.T) {
 }
 
 func TestFutureWatcherImmediately(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	setup(t, hubble, relay)
 	defer cleanup(dir)
@@ -100,7 +113,7 @@ func TestFutureWatcherImmediately(t *testing.T) {
 		t.Fatal("tls.X509KeyPair", err)
 	}
 
-	ch, err := FutureWatcher(logger, relay.caFiles, hubble.certFile, hubble.privkeyFile)
+	ch, err := FutureWatcher(t.Context(), logger, relay.caFiles, hubble.certFile, hubble.privkeyFile)
 	assert.NoError(t, err)
 
 	// the files already exists, expect the watcher to be readily available.
@@ -113,6 +126,10 @@ func TestFutureWatcherImmediately(t *testing.T) {
 }
 
 func TestFutureWatcher(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble, relay := directories(t)
 	// don't call setup() yet, we only want the directories created without the
 	// TLS files.
@@ -128,7 +145,7 @@ func TestFutureWatcher(t *testing.T) {
 		t.Fatal("tls.X509KeyPair", err)
 	}
 
-	ch, err := FutureWatcher(logger, relay.caFiles, hubble.certFile, hubble.privkeyFile)
+	ch, err := FutureWatcher(t.Context(), logger, relay.caFiles, hubble.certFile, hubble.privkeyFile)
 	assert.NoError(t, err)
 
 	// the files don't exists, expect the watcher to not be ready yet.
@@ -150,12 +167,40 @@ func TestFutureWatcher(t *testing.T) {
 	assert.Equal(t, expectedCaCertPool.Subjects(), caCertPool.Subjects())
 }
 
+func TestFutureWatcherShutdownBeforeReady(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	dir, hubble, relay := directories(t)
+	defer cleanup(dir)
+	logger, _ := test.NewNullLogger()
+
+	// FutureWatcher starts a goroutine and waits for files to be ready
+	// before returning a watcher. We use goleak to validate that the
+	// goroutine does not leak files never become ready before the context
+	// is cancelled.
+	ch, err := FutureWatcher(t.Context(), logger, relay.caFiles, hubble.certFile, hubble.privkeyFile)
+	assert.NoError(t, err)
+
+	// the files don't exists, expect the watcher to not be ready after a delay
+	select {
+	case <-ch:
+		t.Fatal("FutureWatcher should not be ready without the TLS files")
+	case <-time.After(testReloadDelay):
+	}
+}
+
 func TestKubernetesMount(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	dir, hubble := k8sDirectories(t)
 	defer cleanup(dir)
 	logger, _ := test.NewNullLogger()
 
-	ch, err := FutureWatcher(logger, hubble.caFiles, hubble.certFile, hubble.privkeyFile)
+	ch, err := FutureWatcher(t.Context(), logger, hubble.caFiles, hubble.certFile, hubble.privkeyFile)
 	assert.NoError(t, err)
 
 	// the files don't exists, expect the watcher to not be ready yet.

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -343,6 +343,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 	var metricsTLSConfig *certloader.WatchedServerConfig
 	if h.config.EnableMetricsServerTLS {
 		metricsTLSConfigChan, err := certloader.FutureWatchedServerConfig(
+			ctx,
 			h.log.WithField("config", "hubble-metrics-server-tls"),
 			h.config.MetricsServerTLSClientCAFiles,
 			h.config.MetricsServerTLSCertFile,
@@ -569,6 +570,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 			options = append(options, serveroption.WithInsecure())
 		} else {
 			tlsServerConfigChan, err := certloader.FutureWatchedServerConfig(
+				ctx,
 				h.log.WithField("config", "tls-server"),
 				h.config.ServerTLSClientCAFiles,
 				h.config.ServerTLSCertFile,

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -780,6 +780,9 @@ const (
 	// Expected is an expected value
 	Expected = "expected"
 
+	// Config is a configuration object.
+	Config = "config"
+
 	// ConfigSource is a configuration source (for process options, e.g. agent)
 	ConfigSource = "configSource"
 


### PR DESCRIPTION
Manual Backport of #40399 for 1.17.

Required cherry-picking commits from [PR](https://github.com/cilium/cilium/pull/39549):
- https://github.com/cilium/cilium/commit/0a6b63c961c67d14b86a3948fa3a0409a9243773
- https://github.com/cilium/cilium/commit/6b264c8741205a27145eea2a0831bef966872e82

And adapting slog logger to logrus since we did not backport the slog transition in v1.17.

```upstream-prs
40399
```