### PR TITLE
helm: misc small cleanups with certgen job spec

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -96,7 +96,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccount: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
       automountServiceAccountToken: {{ .Values.serviceAccounts.clustermeshcertgen.automount }}
       {{- with .Values.imagePullSecrets }}
@@ -108,8 +107,8 @@ spec:
       volumes:
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      affinity:
       {{- with .Values.certgen.affinity }}
+      affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
   ttlSecondsAfterFinished: {{ .Values.certgen.ttlSecondsAfterFinished }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
@@ -137,7 +137,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccount: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
       automountServiceAccountToken: {{ .Values.serviceAccounts.hubblecertgen.automount }}
       {{- with .Values.imagePullSecrets }}
@@ -149,8 +148,8 @@ spec:
       volumes:
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      affinity:
       {{- with .Values.certgen.affinity }}
+      affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
   ttlSecondsAfterFinished: {{ .Values.certgen.ttlSecondsAfterFinished }}


### PR DESCRIPTION
This commit removes serviceAccount that was deprecated for 10+ versions (see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podspec-v1-core).

And we also fix affinity key that was always added even when no affinity was specified.

Spotted by @giorio94 in https://github.com/cilium/cilium/pull/40506 as this linked PR is also adding another kind of job which I took most of the code from those other jobs.
