### PR TITLE
build: Don't include `bpf` test files in cilium image

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -161,7 +161,7 @@ ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/images/cilium/Dockerfile),
 endif
 
 # Use git only if in a Git repo, otherwise find the files from the file system
-BPF_SRCFILES_IGNORE = bpf/.gitignore
+BPF_SRCFILES_IGNORE = bpf/.gitignore bpf/tests/% bpf/complexity-tests/% bpf/custom/% bpf/Makefile bpf/Makefile.bpf
 ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git/HEAD),)
     BPF_SRCFILES := $(shell git ls-files $(ROOT_DIR)/bpf/ | LC_ALL=C sort | tr "\n" ' ')
 else


### PR DESCRIPTION
Remove the following from the cilium image:
* Test files: `bpf/tests/` and `bpf/complexity-tests/`
* Examples: `bpf/custom/`
* Dev makefiles: `bpf/Makefile` and `bpf/Makefile.bpf`

Arguably, the filesize saved in the final image is probably negligible, but it's more about not embedding testing resources in the final image (similar idea as #34069)

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

```release-note
build: Don't include `bpf` test files in cilium image
```
