### PR TITLE
workflows/ipsec: Skip ext targets in IPv6-only case

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -188,6 +188,12 @@ jobs:
           echo downgrade_version=${CILIUM_DOWNGRADE_VERSION} >> $GITHUB_OUTPUT
           echo image_tag=${IMAGE_TAG} >> $GITHUB_OUTPUT
 
+          SEQUENTIAL_CONNECTIVITY_TESTS="seq-.*"
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            SEQUENTIAL_CONNECTIVITY_TESTS="seq-.*,!(pod-to-world.*|pod-to-cidr)"
+          fi
+          echo sequential_connectivity_tests=${SEQUENTIAL_CONNECTIVITY_TESTS} >> $GITHUB_OUTPUT
+
           CONCURRENT_CONNECTIVITY_TESTS="!seq-.*"
           if [ "${{ matrix.ipv4 }}" == "false" ]; then
             CONCURRENT_CONNECTIVITY_TESTS="!(seq-.*|pod-to-world.*|pod-to-cidr)"
@@ -393,7 +399,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-sequential
-          tests: 'seq-.*'
+          tests: ${{ steps.vars.outputs.sequential_connectivity_tests }}
 
       - name: Run concurrent tests after upgrading (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -450,7 +456,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-sequential
-          tests: 'seq-.*'
+          tests: ${{ steps.vars.outputs.sequential_connectivity_tests }}
 
       - name: Run concurrent tests after downgrading (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}


### PR DESCRIPTION
Similar to 67bd78653719a ("workflows/e2e: Skip tests to outside world in IPv6-only clusters"), we need to skip tests to the outside world when running with an IPv6-only cluster in the IPsec upgrade workflow.

This change is without impact on main, but will fix v1.18. I tested that assertion at https://github.com/cilium/cilium/actions/runs/16442404289.