### PR TITLE
[v1.18] LB-IPAM: Fix `bpf-lb-proto-diff` being disabled by default

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -13,6 +13,7 @@ cilium-operator-alibabacloud [flags]
 ```
       --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
+      --bpf-lb-proto-diff                                    Enable support for service protocol differentiation (TCP, UDP, SCTP) (default true)
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -15,6 +15,7 @@ cilium-operator-aws [flags]
       --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
       --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
+      --bpf-lb-proto-diff                                    Enable support for service protocol differentiation (TCP, UDP, SCTP) (default true)
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -16,6 +16,7 @@ cilium-operator-azure [flags]
       --azure-subscription-id string                         Subscription ID to access Azure API
       --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
+      --bpf-lb-proto-diff                                    Enable support for service protocol differentiation (TCP, UDP, SCTP) (default true)
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -12,6 +12,7 @@ cilium-operator-generic [flags]
 
 ```
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
+      --bpf-lb-proto-diff                                    Enable support for service protocol differentiation (TCP, UDP, SCTP) (default true)
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -20,6 +20,7 @@ cilium-operator [flags]
       --azure-subscription-id string                         Subscription ID to access Azure API
       --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
+      --bpf-lb-proto-diff                                    Enable support for service protocol differentiation (TCP, UDP, SCTP) (default true)
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -286,6 +286,9 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableCiliumClusterwideNetworkPolicy)
 	option.BindEnv(vp, option.EnableCiliumClusterwideNetworkPolicy)
 
+	flags.Bool(option.LoadBalancerProtocolDifferentiation, true, "Enable support for service protocol differentiation (TCP, UDP, SCTP)")
+	option.BindEnv(vp, option.LoadBalancerProtocolDifferentiation)
+
 	// Options used for policy validation
 
 	flags.Bool(option.EnableL7Proxy, defaults.EnableL7Proxy, "Enable L7 proxy for L7 policy enforcement")


### PR DESCRIPTION
Protocol differentiation for load balancers is enabled by default, at least on the agent side because the flag defaults to true. However, the operator never got the same flag added, and since we do not have a config value in the configmap unless explicitly set, we get this odd behavior where the operator thinks protocol differentiation is disabled, while the agent thinks it is enabled.

This mostly impacts LB-IPAM which is the only user of the flag/config value.

This commit adds the missing flag to the operator, matching it to the agent's default value of true.

This only affects v1.17 and v1.18, on main the whole flag has already been removed: https://github.com/cilium/cilium/pull/40505

Fixes: https://github.com/cilium/cilium/issues/39172

```release-note
Enable protocol differentiation by default on the operator, matching the agent
```
