### PR TITLE
node: Add proper prefix to TestAll privileged test

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -247,7 +247,7 @@ func removeDevice(name string) {
 	}
 }
 
-func TestAll(t *testing.T) {
+func TestPrivilegedAll(t *testing.T) {
 	for _, tt := range []string{"IPv4", "IPv6", "dual"} {
 		t.Run(tt, func(t *testing.T) {
 			t.Run("TestUpdateNodeRoute", func(t *testing.T) {


### PR DESCRIPTION
After 4951b2c7b2, all the privileged tests are required to have the "TestPrivileged" prefix to be run. Change the "TestAll" name into "TestPrivilegedAll" in order to run it as expected.

Fixes: 4951b2c7b2 ("run only privileged tests on conformance-runtime")
