### PR TITLE
refactor: replace reflect.DeepEqual with assert.Equal

### DIFF
--- a/cilium-cli/clustermesh/clustermesh_test.go
+++ b/cilium-cli/clustermesh/clustermesh_test.go
@@ -18,23 +18,23 @@ import (
 )
 
 // Helper function to compare two slices of maps ignoring the order
-func equalClusterSlices(a, b []map[string]any) bool {
-	if len(a) != len(b) {
-		return false
-	}
+func equalClusterSlices(t assert.TestingT, a, b []map[string]any) {
+	assert.Equal(t, len(a), len(b))
 
 	bCopy := make([]map[string]any, len(b))
 	copy(bCopy, b)
 
-	return slices.EqualFunc(a, bCopy, func(m1, m2 map[string]any) bool {
+	found := false
+	for _, am := range a {
 		for i, bm := range bCopy {
-			if reflect.DeepEqual(m1, bm) {
+			if reflect.DeepEqual(am, bm) {
 				bCopy = slices.Delete(bCopy, i, i+1)
-				return true
+				found = true
+				break
 			}
 		}
-		return false
-	})
+	}
+	assert.Equal(t, found, true, "%v not found in the actual clusters", b)
 }
 
 func TestMergeClusters(t *testing.T) {
@@ -444,7 +444,7 @@ func TestMergeClusters(t *testing.T) {
 			expectedClusters := u.e["clustermesh"].(map[string]any)["config"].(map[string]any)["clusters"].([]map[string]any)
 			actualClusters := ee["clustermesh"].(map[string]any)["config"].(map[string]any)["clusters"].([]map[string]any)
 
-			assert.True(t, equalClusterSlices(expectedClusters, actualClusters))
+			equalClusterSlices(t, expectedClusters, actualClusters)
 		})
 	}
 }

--- a/cilium-cli/clustermesh/clustermesh_test.go
+++ b/cilium-cli/clustermesh/clustermesh_test.go
@@ -19,7 +19,7 @@ import (
 
 // Helper function to compare two slices of maps ignoring the order
 func equalClusterSlices(t assert.TestingT, a, b []map[string]any) {
-	assert.Equal(t, len(a), len(b))
+	assert.Len(t, a, len(b))
 
 	bCopy := make([]map[string]any, len(b))
 	copy(bCopy, b)
@@ -34,7 +34,7 @@ func equalClusterSlices(t assert.TestingT, a, b []map[string]any) {
 			}
 		}
 	}
-	assert.Equal(t, found, true, "%v not found in the actual clusters", b)
+	assert.True(t, found, "%v not found in the actual clusters", b)
 }
 
 func TestMergeClusters(t *testing.T) {

--- a/cilium-cli/connectivity/check/test_test.go
+++ b/cilium-cli/connectivity/check/test_test.go
@@ -4,7 +4,6 @@
 package check
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,9 +47,8 @@ func TestWithFeatureRequirements(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			test := Test{requirements: tc.requirements}
-			if got := test.WithFeatureRequirements(tc.in...); !reflect.DeepEqual(got.requirements, tc.want) {
-				t.Errorf("WithFeatureRequirements() = %v, want %v", got.requirements, tc.want)
-			}
+			got := test.WithFeatureRequirements(tc.in...)
+			assert.Equal(t, tc.want, got.requirements)
 		})
 	}
 }

--- a/cilium-cli/internal/helm/helm_test.go
+++ b/cilium-cli/internal/helm/helm_test.go
@@ -4,7 +4,6 @@
 package helm
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -59,9 +58,7 @@ func TestResolveHelmChartVersion(t *testing.T) {
 				t.Errorf("ResolveHelmChartVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ResolveHelmChartVersion() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -130,9 +127,7 @@ func TestParseVals(t *testing.T) {
 				t.Errorf("ParseVals() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseVals() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/cilium-cli/utils/features/utils_test.go
+++ b/cilium-cli/utils/features/utils_test.go
@@ -5,9 +5,10 @@ package features
 
 import (
 	"fmt"
-	"reflect"
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestComputeFailureExceptions(t *testing.T) {
@@ -50,9 +51,7 @@ func TestComputeFailureExceptions(t *testing.T) {
 			// computeFailureExceptions doesn't guarantee the order of the
 			// returned slice so we have to sort both slices.
 			slices.Sort(result)
-			if !reflect.DeepEqual(result, test.expectedExceptions) {
-				t.Errorf("Expected exceptions to be %v, but got: %v", test.expectedExceptions, result)
-			}
+			assert.Equal(t, test.expectedExceptions, result)
 		})
 	}
 }

--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/go-openapi/runtime"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/api/v1/operator/models"
@@ -159,6 +159,7 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 	}
 
 	if err := testMetric(
+		t,
 		metrics,
 		"operator_api_metrics_test_metric_a",
 		float64(1),
@@ -174,16 +175,14 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 	}
 }
 
-func testMetric(metrics []models.Metric, name string, value float64, labels map[string]string,
+func testMetric(t assert.TestingT, metrics []models.Metric, name string, value float64, labels map[string]string,
 ) error {
 	for _, metric := range metrics {
 		if metric.Name == name {
 			if metric.Value != value {
 				return fmt.Errorf("expected value %f for %q, got %f", value, name, metric.Value)
 			}
-			if !reflect.DeepEqual(metric.Labels, labels) {
-				return fmt.Errorf("expected labels map %v for %q, got %v", labels, name, metric.Labels)
-			}
+			assert.Equal(t, metric.Labels, labels)
 			return nil
 		}
 	}

--- a/operator/auth/spire/client_test.go
+++ b/operator/auth/spire/client_test.go
@@ -6,12 +6,12 @@ package spire
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 	entryv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
@@ -476,13 +476,11 @@ func Test_resolvedK8sService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := resolvedK8sService(t.Context(), tt.args.client, tt.args.address)
-			if tt.wantedErr != nil && (err == nil || !reflect.DeepEqual(err.Error(), tt.wantedErr.Error())) {
-				t.Errorf("resolvedK8sService() error = %v, wantErr %v", err, tt.wantedErr)
+			if tt.wantedErr != nil && err != nil {
+				assert.Equal(t, tt.wantedErr.Error(), err.Error())
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("resolvedK8sService() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -4,10 +4,8 @@
 package ciliumidentity
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
-	"reflect"
 	"sync"
 	"testing"
 
@@ -55,7 +53,7 @@ func TestCIDState(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 1 added")
+		validateCIDState(t, state, expectedState, "cid 1 added")
 
 		state.Upsert("2", k2)
 		expectedState = &CIDState{
@@ -72,7 +70,7 @@ func TestCIDState(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 2 added")
+		validateCIDState(t, state, expectedState, "cid 2 added")
 
 		state.Upsert("3", k3)
 		expectedState = &CIDState{
@@ -89,7 +87,7 @@ func TestCIDState(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 3 added - duplicate")
+		validateCIDState(t, state, expectedState, "cid 3 added - duplicate")
 	})
 
 	t.Run("Lookup CID state", func(t *testing.T) {
@@ -124,7 +122,7 @@ func TestCIDState(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 2 removed")
+		validateCIDState(t, state, expectedState, "cid 2 removed")
 
 		_, exists := state.LookupByID("2")
 		assert.False(t, exists, "cid 2 LookupByID - not found")
@@ -139,7 +137,7 @@ func TestCIDState(t *testing.T) {
 				},
 			},
 		}
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 3 removed")
+		validateCIDState(t, state, expectedState, "cid 3 removed")
 	})
 }
 
@@ -175,14 +173,9 @@ func TestCIDStateThreadSafety(t *testing.T) {
 	wg.Wait()
 }
 
-func validateCIDState(state, expectedState *CIDState) error {
-	if !reflect.DeepEqual(state.idToLabels, expectedState.idToLabels) {
-		return fmt.Errorf("failed to validate the state, expected idToLabels %v, got %v", expectedState.idToLabels, state.idToLabels)
-	}
-
-	if !reflect.DeepEqual(state.labelsToID, expectedState.labelsToID) {
-		return fmt.Errorf("failed to validate the state, expected labelsToID %v, got %v", expectedState.labelsToID, state.labelsToID)
-	}
+func validateCIDState(t assert.TestingT, state, expectedState *CIDState, cidStatus string) error {
+	assert.Equal(t, expectedState.idToLabels, state.idToLabels, "%s, idToLabels does not match expected result", cidStatus)
+	assert.Equal(t, expectedState.labelsToID, state.labelsToID, "%s, labelsToID does not match expected result", cidStatus)
 
 	return nil
 }

--- a/operator/pkg/ciliumidentity/namespace_test.go
+++ b/operator/pkg/ciliumidentity/namespace_test.go
@@ -4,8 +4,9 @@
 package ciliumidentity
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -64,9 +65,7 @@ func TestGetNamespaceLabels(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			result := getNamespaceLabels(tc.namespace)
 
-			if !reflect.DeepEqual(result, tc.expected) {
-				t.Errorf("Expected %v, but got %v", tc.expected, result)
-			}
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sTesting "k8s.io/client-go/testing"
@@ -289,12 +289,8 @@ func TestReconcileCID(t *testing.T) {
 				t.Errorf("Unexpected error during reconciliation: %v", err)
 			}
 
-			if !reflect.DeepEqual(createCID, tc.expectedCreate) {
-				t.Errorf("Unexpected createCID result: got %v, want %v", createCID, tc.expectedCreate)
-			}
-			if !reflect.DeepEqual(updateCID, tc.expectedUpdate) {
-				t.Errorf("Unexpected updateCID result: got %v, want %v", updateCID, tc.expectedUpdate)
-			}
+			assert.Equal(t, tc.expectedCreate, createCID)
+			assert.Equal(t, tc.expectedUpdate, updateCID)
 			if deleteCIDName != tc.expectedDelete {
 				t.Errorf("Unexpected deleteCIDName result: got %v, want %v", deleteCIDName, tc.expectedDelete)
 			}

--- a/operator/pkg/gateway-api/gamma_test.go
+++ b/operator/pkg/gateway-api/gamma_test.go
@@ -4,10 +4,10 @@
 package gateway_api
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -165,9 +165,8 @@ func Test_getGammaHTTPRouteParentIndexFunc(t *testing.T) {
 			logger := hivetest.Logger(t)
 			parentIndexFunc := getGammaHTTPRouteParentIndexFunc(logger)
 
-			if got := parentIndexFunc(tt.args.obj); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getGammaHTTPRouteParentIndexFunc() = %#v, want %#v", got, tt.want)
-			}
+			got := parentIndexFunc(tt.args.obj)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -4,10 +4,10 @@
 package annotations
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -130,9 +130,7 @@ func TestGetAnnotationServiceExternalTrafficPolicy(t *testing.T) {
 				t.Errorf("GetAnnotationServiceExternalTrafficPolicy() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationServiceExternalTrafficPolicy() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -192,9 +190,7 @@ func TestGetAnnotationRequestTimeout(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationRequestTimeout() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -252,9 +248,7 @@ func TestGetAnnotationSecureNodePort(t *testing.T) {
 				t.Errorf("GetAnnotationSecureNodePort() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -311,9 +305,7 @@ func TestGetAnnotationInsecureNodePort(t *testing.T) {
 				t.Errorf("GetAnnotationSecureNodePort() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -371,9 +363,7 @@ func TestGetAnnotationHostListenerPort(t *testing.T) {
 				t.Errorf("GetAnnotationHostListenerPort() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationHostListenerPort() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -464,9 +454,7 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetAnnotationTLSPassthroughEnabled(tt.args.ingress)
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -557,9 +545,7 @@ func TestGetAnnotationEnforceHTTPSEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetAnnotationForceHTTPSEnabled(tt.args.ingress)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationForceHTTPSEnabled() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/kvstore/locksweeper/locksweeper_test.go
+++ b/operator/pkg/kvstore/locksweeper/locksweeper_test.go
@@ -6,8 +6,9 @@ package locksweeper
 import (
 	"testing"
 
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/kvstore"
 )
 
 func Test_getOldestLeases(t *testing.T) {

--- a/operator/pkg/kvstore/locksweeper/locksweeper_test.go
+++ b/operator/pkg/kvstore/locksweeper/locksweeper_test.go
@@ -4,10 +4,10 @@
 package locksweeper
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_getOldestLeases(t *testing.T) {
@@ -88,9 +88,8 @@ func Test_getOldestLeases(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getOldestLeases(tt.args.m); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getOldestLeases() = %v, want %v", got, tt.want)
-			}
+			got := getOldestLeases(tt.args.m)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -4,8 +4,9 @@
 package model
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var testTLSListener = TLSPassthroughListener{
@@ -72,9 +73,8 @@ func TestModel_GetListeners(t *testing.T) {
 				HTTP:           tt.fields.HTTP,
 				TLSPassthrough: tt.fields.TLS,
 			}
-			if got := m.GetListeners(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Model.GetListeners() = %v, want %v", got, tt.want)
-			}
+			got := m.GetListeners()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/alibabacloud/utils/utils_test.go
+++ b/pkg/alibabacloud/utils/utils_test.go
@@ -4,10 +4,10 @@
 package utils
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetENIIndexFromTags(t *testing.T) {
@@ -61,9 +61,8 @@ func TestFillTagWithENIIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FillTagWithENIIndex(tt.args.tags, tt.args.index); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FillTagWithENIIndex() = %v, want %v", got, tt.want)
-			}
+			got := FillTagWithENIIndex(tt.args.tags, tt.args.index)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/auth/always_fail_authhandler_test.go
+++ b/pkg/auth/always_fail_authhandler_test.go
@@ -4,8 +4,9 @@
 package auth
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_alwaysFailAuthHandler_authenticate(t *testing.T) {
@@ -32,9 +33,7 @@ func Test_alwaysFailAuthHandler_authenticate(t *testing.T) {
 				t.Errorf("alwaysFailAuthHandler.authenticate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("alwaysFailAuthHandler.authenticate() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/auth/mutual_authhandler_test.go
+++ b/pkg/auth/mutual_authhandler_test.go
@@ -15,12 +15,12 @@ import (
 	"math/big"
 	"net"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/auth/certs"
@@ -265,9 +265,7 @@ func Test_mutualAuthHandler_verifyPeerCertificate(t *testing.T) {
 				t.Errorf("mutualAuthHandler.verifyPeerCertificate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("mutualAuthHandler.verifyPeerCertificate() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -342,9 +340,7 @@ func Test_mutualAuthHandler_GetCertificateForIncomingConnection(t *testing.T) {
 					t.Errorf("mutualAuthHandler.GetCertificateForIncomingConnection() leaf certificate has no URIs")
 				}
 				gotURI := got.Leaf.URIs[0].String()
-				if !reflect.DeepEqual(gotURI, tt.wantURI) {
-					t.Errorf("mutualAuthHandler.GetCertificateForIncomingConnection() = %v, want %v", got, tt.wantURI)
-				}
+				assert.Equal(t, tt.wantURI, gotURI)
 			}
 
 		})
@@ -432,9 +428,7 @@ func Test_mutualAuthHandler_authenticate(t *testing.T) {
 				t.Errorf("mutualAuthHandler.authenticate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("mutualAuthHandler.authenticate() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/aws/ec2/ec2_test.go
+++ b/pkg/aws/ec2/ec2_test.go
@@ -4,13 +4,13 @@
 package ec2
 
 import (
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
 )
 
 type Filters []ec2_types.Filter
@@ -94,9 +94,7 @@ func TestNewSubnetsFilters(t *testing.T) {
 			got := NewSubnetsFilters(tt.args.tags, tt.args.ids)
 			sort.Sort(Filters(got))
 			sort.Sort(Filters(tt.want))
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewSubnetsFilters() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -141,9 +139,7 @@ func TestNewTagsFilters(t *testing.T) {
 			got := NewTagsFilter(tt.args.tags)
 			sort.Sort(Filters(got))
 			sort.Sort(Filters(tt.want))
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewTagsFilter() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -110,9 +109,9 @@ var (
 	maxEntries = 16
 )
 
-func mapsEqual(a, b *Map) bool {
+func mapsEqual(t assert.TestingT, a, b *Map) bool {
 	return a.name == b.name &&
-		reflect.DeepEqual(a.spec, b.spec)
+		assert.Equal(t, b.spec, a.spec)
 }
 
 func TestPrivilegedOpen(t *testing.T) {
@@ -152,7 +151,7 @@ func TestPrivilegedOpenMap(t *testing.T) {
 
 	openedMap, err = OpenMap(MapPath(logger, "cilium_test"), &TestKey{}, &TestValue{})
 	require.NoError(t, err)
-	require.True(t, mapsEqual(openedMap, testMap))
+	mapsEqual(t, openedMap, testMap)
 }
 
 func TestPrivilegedOpenOrCreate(t *testing.T) {
@@ -203,7 +202,7 @@ func TestPrivilegedRecreateMap(t *testing.T) {
 	require.Error(t, err)
 
 	// Check OpenMap warning section
-	require.True(t, mapsEqual(parallelMap, testMap))
+	mapsEqual(t, parallelMap, testMap)
 
 	key1 := &TestKey{Key: 101}
 	value1 := &TestValue{Value: 201}

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"net/netip"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -200,9 +199,7 @@ func TestDescendants(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("Descendants prefix %s, expected to get %v, but got: %v", pref.String(), expectedRes, gotRes)
-			}
+			assert.Equal(t, expectedRes, gotRes)
 		}
 	}
 }
@@ -322,9 +319,7 @@ func TestDescendantsShortestPrefixFirst(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("LPM Descendants prefix %s, expected to get %v, but got: %v", pref.String(), expectedRes, gotRes)
-			}
+			assert.Equal(t, expectedRes, gotRes)
 		}
 	}
 }

--- a/pkg/container/bitlpm/unsigned_test.go
+++ b/pkg/container/bitlpm/unsigned_test.go
@@ -6,11 +6,12 @@ package bitlpm
 import (
 	"fmt"
 	"math/bits"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type uint16Range struct {
@@ -177,9 +178,7 @@ func TestUnsignedUpsert(t *testing.T) {
 				sort.Slice(got, func(i, j int) bool {
 					return got[i].start < got[j].start
 				})
-				if !reflect.DeepEqual(got, tt.ranges[:i+1]) {
-					t.Fatalf("When updating an unsigned trie with the key-prefix %d/%d: got %+v, but expected %+v", pr.start, pr.prefix(), got, tt.ranges[:i+1])
-				}
+				assert.Equal(t, tt.ranges[:i+1], got)
 			}
 		})
 	}
@@ -504,9 +503,7 @@ func TestUnsignedAncestors(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("Ancestors range %s, expected to get %v, but got: %v", entry, expectedRes, gotRes)
-			}
+			assert.Equal(t, expectedRes, gotRes)
 		})
 	}
 }
@@ -538,9 +535,7 @@ func TestUnsignedDescendants(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("Descendants range %s, expected to get %v, but got: %v", entry, expectedRes, gotRes)
-			}
+			assert.Equal(t, expectedRes, gotRes)
 			// It should still work even if the entry is not present
 			tu.Delete(i, rng)
 			expectedRes = expectedRes[1:]
@@ -549,9 +544,7 @@ func TestUnsignedDescendants(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("Descendants range %s, expected to get %v, but got: %v", entry, expectedRes, gotRes)
-			}
+			assert.Equal(t, expectedRes, gotRes)
 		})
 	}
 }
@@ -622,9 +615,7 @@ func TestUnsignedDelete(t *testing.T) {
 				sort.Slice(got, func(i, j int) bool {
 					return got[i].start < got[j].start
 				})
-				if !reflect.DeepEqual(got, tt.ranges[i+1:]) {
-					t.Fatalf("When deleting an entry from an unsigned trie with the key-prefix %d/%d: got %+v, but expected %+v", pr.start, pr.prefix(), got, tt.ranges[i+1:])
-				}
+				assert.Equal(t, tt.ranges[i+1:], got)
 			}
 		})
 		// Delete in reverse order.
@@ -649,9 +640,7 @@ func TestUnsignedDelete(t *testing.T) {
 				sort.Slice(got, func(i, j int) bool {
 					return got[i].start < got[j].start
 				})
-				if !reflect.DeepEqual(got, tt.ranges[:i]) {
-					t.Fatalf("When deleting an entry from an unsigned trie with the key-prefix %d/%d: got %+v, but expected %+v", pr.start, pr.prefix(), got, tt.ranges[:i])
-				}
+				assert.Equal(t, tt.ranges[:i], got)
 			}
 		})
 	}

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"net"
 	"net/netip"
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/cell"
@@ -353,7 +352,7 @@ func TestReconciliationLoop(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		if err := assertIptablesState(state, testCases[0].expected); err != nil {
+		if err := assertIptablesState(t, state, testCases[0].expected); err != nil {
 			t.Logf("assertIptablesState: %s", err)
 			return false
 		}
@@ -375,7 +374,7 @@ func TestReconciliationLoop(t *testing.T) {
 
 				mu.Lock()
 				defer mu.Unlock()
-				if err := assertIptablesState(state, tc.expected); err != nil {
+				if err := assertIptablesState(t, state, tc.expected); err != nil {
 					t.Logf("assertIptablesState: %s", err)
 					return false
 				}
@@ -397,7 +396,7 @@ func TestReconciliationLoop(t *testing.T) {
 
 		mu.Lock()
 		defer mu.Unlock()
-		if err := assertIptablesState(state, expected); err != nil {
+		if err := assertIptablesState(t, state, expected); err != nil {
 			t.Logf("assertIptablesState: %s", err)
 			return false
 		}
@@ -413,7 +412,7 @@ func TestReconciliationLoop(t *testing.T) {
 	assert.NoError(t, <-errs)
 }
 
-func assertIptablesState(current, expected desiredState) error {
+func assertIptablesState(t assert.TestingT, current, expected desiredState) error {
 	if current.installRules != expected.installRules {
 		return fmt.Errorf("expected installRules to be %t, found %t",
 			expected.installRules, current.installRules)
@@ -426,10 +425,8 @@ func assertIptablesState(current, expected desiredState) error {
 		return fmt.Errorf("expected local node info to be %v, found %v",
 			expected.localNodeInfo, current.localNodeInfo)
 	}
-	if len(current.proxies) != 0 && len(expected.proxies) != 0 &&
-		!reflect.DeepEqual(current.proxies, expected.proxies) {
-		return fmt.Errorf("expected proxies info to be %v, found %v",
-			expected.proxies, current.proxies)
+	if len(current.proxies) != 0 && len(expected.proxies) != 0 {
+		assert.Equal(t, expected.proxies, current.proxies)
 	}
 	if !current.noTrackPods.Equal(expected.noTrackPods) {
 		return fmt.Errorf("expected no tracking pods info to be %v, found %v",

--- a/pkg/driftchecker/checker_test.go
+++ b/pkg/driftchecker/checker_test.go
@@ -6,7 +6,6 @@ package driftchecker
 import (
 	"context"
 	"log/slog"
-	"reflect"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
 	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/dynamicconfig"
@@ -143,9 +143,7 @@ func TestComputeDelta(t *testing.T) {
 				ignoredFlags: sets.New[string](tt.ignored...),
 			}
 			result := c.computeDelta(tt.desired, tt.actual)
-			if !reflect.DeepEqual(tt.expected, result) {
-				t.Errorf("Expected %v, but got %v", tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/dynamicconfig/table_test.go
+++ b/pkg/dynamicconfig/table_test.go
@@ -6,7 +6,6 @@ package dynamicconfig
 import (
 	"context"
 	"encoding/json"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -71,9 +71,7 @@ func TestWatchAllKeys(t *testing.T) {
 	}
 
 	keys, _ := WatchAllKeys(db.ReadTxn(), dct)
-	if !reflect.DeepEqual(keys, expected) {
-		t.Errorf("WatchAllKeys returned unexpected result. Got: %v, Expected: %v", keys, expected)
-	}
+	assert.Equal(t, expected, keys)
 }
 
 func TestWatchKey(t *testing.T) {
@@ -203,9 +201,7 @@ func TestDynamicConfigMap(t *testing.T) {
 				t.Fatalf("waiting for config table timed out: %v", err)
 			}
 
-			if !reflect.DeepEqual(gotMap, tc.expectedConfig) {
-				t.Fatalf("expectedConfig:\n%+v\ngot:\n%+v", tc.expectedConfig, gotMap)
-			}
+			assert.Equal(t, tc.expectedConfig, gotMap)
 
 			for _, cm := range tc.cms {
 				for k, v := range cm.Data {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -588,9 +587,8 @@ func TestEndpoint_GetK8sPodLabels(t *testing.T) {
 				mutex:  lock.RWMutex{},
 				labels: tt.labels,
 			}
-			if got := e.getK8sPodLabels(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Endpoint.getK8sPodLabels() = %v, want %v", got, tt.want)
-			}
+			got := e.getK8sPodLabels()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -54,7 +54,7 @@ func responseCheck(t assert.TestingT, response *envoy_service_discovery.Discover
 		resourcesAny := make([]*anypb.Any, 0, len(resources))
 		for _, res := range resources {
 			a, err := anypb.New(res)
-			assert.Equal(t, err, nil)
+			assert.NoError(t, err)
 			resourcesAny = append(resourcesAny, a)
 		}
 		// Sort both lists.

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -4,7 +4,6 @@
 package envoy
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -14,6 +13,7 @@ import (
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -1670,9 +1670,8 @@ func Test_getPublicListenerAddress(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getPublicListenerAddress(tt.args.port, tt.args.ipv4, tt.args.ipv6); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getPublicListenerAddress() = %v, want %v", got, tt.want)
-			}
+			got := getPublicListenerAddress(tt.args.port, tt.args.ipv4, tt.args.ipv6)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1742,12 +1741,8 @@ func Test_getLocalListenerAddresses(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotAdditional := GetLocalListenerAddresses(tt.args.port, tt.args.ipv4, tt.args.ipv6)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getLocalListenerAddresses() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(gotAdditional, tt.wantAdditional) {
-				t.Errorf("getLocalListenerAddresses() got1 = %v, want %v", gotAdditional, tt.wantAdditional)
-			}
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantAdditional, gotAdditional)
 		})
 	}
 }

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
 	"sync"
 	"testing"
 
@@ -397,9 +396,7 @@ func TestRing_Read(t *testing.T) {
 					t.Errorf("LostEvent mismatch (-want +got):\n%s", diff)
 				}
 			} else {
-				if !reflect.DeepEqual(got, tt.want) {
-					t.Errorf("Ring.read() got = %v, want %v", got, tt.want)
-				}
+				assert.Equal(t, tt.want, got)
 			}
 			if !errors.Is(got1, tt.wantErr) {
 				t.Errorf("Ring.read() got1 = %v, want %v", got1, tt.wantErr)
@@ -489,7 +486,7 @@ func TestRing_Write(t *testing.T) {
 				data: tt.want.data,
 			}
 			want.write.Store(tt.want.write)
-			reflect.DeepEqual(want, r)
+			assert.Equal(t, want, r)
 		})
 	}
 }

--- a/pkg/hubble/filters/labelparser_test.go
+++ b/pkg/hubble/filters/labelparser_test.go
@@ -4,8 +4,9 @@
 package filters
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_translateSelector(t *testing.T) {
@@ -93,8 +94,8 @@ func Test_translateSelector(t *testing.T) {
 				t.Errorf("parseSelector() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseSelector() = %q, want %q", got, tt.want)
+			if !tt.wantErr {
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}

--- a/pkg/hubble/filters/labels_test.go
+++ b/pkg/hubble/filters/labels_test.go
@@ -6,9 +6,10 @@ package filters
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLabelSelectorFilter(t *testing.T) {

--- a/pkg/hubble/filters/labels_test.go
+++ b/pkg/hubble/filters/labels_test.go
@@ -4,11 +4,11 @@
 package filters
 
 import (
-	"reflect"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLabelSelectorFilter(t *testing.T) {
@@ -647,8 +647,8 @@ func Test_parseSelector(t *testing.T) {
 				t.Errorf("parseSelector() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !tt.wantErr && !reflect.DeepEqual(got.String(), tt.want) {
-				t.Errorf("parseSelector() = %q, want %q", got, tt.want)
+			if !tt.wantErr {
+				assert.Equal(t, tt.want, got.String())
 			}
 		})
 	}

--- a/pkg/hubble/metrics/metrics_test.go
+++ b/pkg/hubble/metrics/metrics_test.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -237,7 +236,7 @@ func assertHandlersInDfp(t *testing.T, dfp *DynamicFlowProcessor, cfg *api.Confi
 	for _, m := range dfp.Metrics {
 		_, ok := names[m.Name]
 		assert.True(t, ok)
-		assert.True(t, reflect.DeepEqual(*m.MetricConfig, *(names[m.Name])))
+		assert.Equal(t, *m.MetricConfig, *(names[m.Name]))
 	}
 }
 

--- a/pkg/hubble/parser/seven/kafka_test.go
+++ b/pkg/hubble/parser/seven/kafka_test.go
@@ -6,11 +6,12 @@ package seven
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/defaults"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_decodeKafka(t *testing.T) {

--- a/pkg/hubble/parser/seven/kafka_test.go
+++ b/pkg/hubble/parser/seven/kafka_test.go
@@ -4,13 +4,13 @@
 package seven
 
 import (
-	"reflect"
 	"testing"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/defaults"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_decodeKafka(t *testing.T) {
@@ -143,9 +143,7 @@ func Test_decodeKafka(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := decodeKafka(tt.args.flowType, tt.args.kafka, tt.args.opts)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("decodeKafka() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/ipam/cidrset/cidr_set_test.go
+++ b/pkg/ipam/cidrset/cidr_set_test.go
@@ -7,8 +7,9 @@ package cidrset
 import (
 	"math/big"
 	"net"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCIDRSetFullyAllocated(t *testing.T) {
@@ -250,9 +251,7 @@ func TestCIDRSet_RandomishAllocation(t *testing.T) {
 			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
 		}
 
-		if !reflect.DeepEqual(cidrs, rcidrs) {
-			t.Fatalf("expected re-allocated cidrs are the same collection for %v", tc.description)
-		}
+		assert.Equal(t, cidrs, rcidrs)
 	}
 }
 
@@ -320,9 +319,7 @@ func TestCIDRSet_AllocationOccupied(t *testing.T) {
 		for i := numCIDRs / 2; i < numCIDRs; i++ {
 			rcidrs = append(rcidrs, cidrs[i])
 		}
-		if !reflect.DeepEqual(cidrs, rcidrs) {
-			t.Fatalf("expected re-allocated cidrs are the same collection for %v", tc.description)
-		}
+		assert.Equal(t, cidrs, rcidrs)
 	}
 }
 

--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -5,7 +5,6 @@ package utils
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +15,7 @@ import (
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestServiceProxyName(t *testing.T) {
@@ -204,9 +204,8 @@ func TestValidIPs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ValidIPs(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ValidIPs() = %v, want %v", got, tt.want)
-			}
+			got := ValidIPs(tt.args)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -237,9 +236,8 @@ func TestIsPodRunning(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsPodRunning(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("TestIsPodRunning() = %v, want %v", got, tt.want)
-			}
+			got := IsPodRunning(tt.args)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -326,9 +324,8 @@ func TestGetLatestPodReadiness(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetLatestPodReadiness(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetLatestPodReadiness() = %v, want %v", got, tt.want)
-			}
+			got := GetLatestPodReadiness(tt.args)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -449,9 +446,8 @@ func TestStripPodLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := StripPodSpecialLabels(tt.labels); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("StripPodSpecialLabels() = %v, want %v", got, tt.want)
-			}
+			got := StripPodSpecialLabels(tt.labels)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -504,9 +500,8 @@ func Test_filterPodLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := RemoveCiliumLabels(tt.labels); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("filterPodLabels() = %v, want %v", got, tt.want)
-			}
+			got := RemoveCiliumLabels(tt.labels)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -12,10 +12,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/stretchr/testify/assert"
+
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestServiceProxyName(t *testing.T) {

--- a/pkg/k8s/utils/workload_test.go
+++ b/pkg/k8s/utils/workload_test.go
@@ -11,11 +11,11 @@
 package utils
 
 import (
-	"reflect"
 	"testing"
 
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDeploymentMetadata(t *testing.T) {
@@ -97,12 +97,8 @@ func TestDeploymentMetadata(t *testing.T) {
 				t.Fatalf("expected ok=%t, got ok=%t", tt.expectOK, ok)
 			}
 			if ok {
-				if !reflect.DeepEqual(gotObjectMeta, tt.wantObjectMetadata) {
-					t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantObjectMetadata)
-				}
-				if !reflect.DeepEqual(gotTypeMeta, tt.wantTypeMetadata) {
-					t.Errorf("Type metadata got %+v want %+v", gotTypeMeta, tt.wantTypeMetadata)
-				}
+				assert.Equal(t, tt.wantObjectMetadata, gotObjectMeta)
+				assert.Equal(t, tt.wantTypeMetadata, gotTypeMeta)
 			}
 		})
 	}
@@ -189,12 +185,8 @@ func TestCronJobMetadata(t *testing.T) {
 				t.Fatalf("expected ok=true, got ok=%t", ok)
 			}
 			if ok {
-				if !reflect.DeepEqual(gotObjectMeta, tt.wantObjectMetadata) {
-					t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantObjectMetadata)
-				}
-				if !reflect.DeepEqual(gotTypeMeta, tt.wantTypeMetadata) {
-					t.Errorf("Type metadata got %+v want %+v", gotTypeMeta, tt.wantTypeMetadata)
-				}
+				assert.Equal(t, tt.wantObjectMetadata, gotObjectMeta)
+				assert.Equal(t, tt.wantTypeMetadata, gotTypeMeta)
 			}
 		})
 	}
@@ -251,12 +243,8 @@ func TestDeploymentConfigMetadata(t *testing.T) {
 			if !ok {
 				t.Fatalf("expected ok=true, got ok=%t", ok)
 			}
-			if !reflect.DeepEqual(gotObjectMeta, tt.wantObjectMetadata) {
-				t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantObjectMetadata)
-			}
-			if !reflect.DeepEqual(gotTypeMeta, tt.wantTypeMetadata) {
-				t.Errorf("Type metadata got %+v want %+v", gotTypeMeta, tt.wantTypeMetadata)
-			}
+			assert.Equal(t, tt.wantObjectMetadata, gotObjectMeta)
+			assert.Equal(t, tt.wantTypeMetadata, gotTypeMeta)
 		})
 	}
 }
@@ -319,12 +307,8 @@ func TestStatefulSetMetadata(t *testing.T) {
 				t.Fatalf("expected ok=true, got ok=%t", ok)
 			}
 			if ok {
-				if !reflect.DeepEqual(gotObjectMeta, tt.wantObjectMetadata) {
-					t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantObjectMetadata)
-				}
-				if !reflect.DeepEqual(gotTypeMeta, tt.wantTypeMetadata) {
-					t.Errorf("Type metadata got %+v want %+v", gotTypeMeta, tt.wantTypeMetadata)
-				}
+				assert.Equal(t, tt.wantObjectMetadata, gotObjectMeta)
+				assert.Equal(t, tt.wantTypeMetadata, gotTypeMeta)
 			}
 		})
 	}

--- a/pkg/k8s/utils/workload_test.go
+++ b/pkg/k8s/utils/workload_test.go
@@ -13,9 +13,10 @@ package utils
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDeploymentMetadata(t *testing.T) {

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -451,9 +451,8 @@ func TestLabels_GetFromSource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.l.GetFromSource(tt.args.source); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Labels.GetFromSource() = %v, want %v", got, tt.want)
-			}
+			got := tt.l.GetFromSource(tt.args.source)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -4,11 +4,11 @@
 package labelsfilter
 
 import (
-	"reflect"
 	"regexp"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -244,9 +244,8 @@ func TestFilterLabelsByRegex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FilterLabelsByRegex(tt.args.excludePatterns, tt.args.labels); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FilterLabelsByRegex() = %v, want %v", got, tt.want)
-			}
+			got := FilterLabelsByRegex(tt.args.excludePatterns, tt.args.labels)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
This pr aims to replace reflect.DeepEqual with assert.Equal (`github.com/stretchr/testify/assert`) in testing code in the tree.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Fixes: #40562 
