### PR TITLE
version: parse Cilium version string only once

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 )
 
 // CiliumVersion provides a minimal structure to the version string
@@ -57,9 +58,9 @@ func FromString(versionString string) CiliumVersion {
 }
 
 // GetCiliumVersion returns a initialized CiliumVersion structure
-func GetCiliumVersion() CiliumVersion {
+var GetCiliumVersion = sync.OnceValue(func() CiliumVersion {
 	return FromString(Version)
-}
+})
 
 // Base64 returns the version in a base64 format.
 func Base64() (string, error) {


### PR DESCRIPTION
`Version` is populated in `init()` and not expected to change at runtime. Parse it only once into a `CiliumVersion` and store its value to avoid re-parsing it on every call to `GetCiliumVersion`.
