### PR TITLE
datapath/linux/route: Fix Delete

### DIFF
--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -302,13 +302,23 @@ func Delete(route Route) error {
 	// Therefore do not use getNetlinkRoute().
 	routeSpec := netlink.Route{
 		Dst:       &route.Prefix,
+		Src:       route.Local,
 		LinkIndex: link.Attrs().Index,
+		Priority:  route.Priority,
 		Table:     route.Table,
+		Type:      route.Type,
+		Protocol:  netlink.RouteProtocol(route.Proto),
+		MTU:       route.MTU,
 	}
 
 	// Scope can only be specified for IPv4
 	if route.Prefix.IP.To4() != nil {
 		routeSpec.Scope = route.Scope
+		if route.Scope == netlink.SCOPE_UNIVERSE && route.Type == RTN_LOCAL {
+			routeSpec.Scope = netlink.SCOPE_HOST
+		} else {
+			routeSpec.Scope = route.Scope
+		}
 	}
 
 	if err := netlink.RouteDel(&routeSpec); err != nil {


### PR DESCRIPTION
Since the deletion of routes with the Nexthop or the Local field set fails (see the current comment in the code), the Delete function cannot call the getNetlinkRoute helper.  But since it is not using that helper, Delete lacks the copy of several important fields in the route to be deleted, like the source, the priority, the protocol and so on. This can lead to errors while deleting stale route inserted with the Upsert function. As an example, let's consider the deletion of the routes added in the IPSec specific routing table in multi-pool IPAM mode (to be added soon in a subsequent PR). In that case, with the previous version of the Delete function, the following error is returned:

`msg="Unable to delete the IPsec route IN from the host routing table" error="no such process"`

and the stale route is not deleted.

The commit fixes the Delete implementation to copy additional fields from the route.Route internal representation.

Related: https://github.com/cilium/cilium/pull/40460

```release-note
Fix a bug where Cilium leaks stale routes when IPsec is enabled.
```
