### PR TITLE
ci: fix renovate hourly and concurrent pr count

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,8 @@
   // self-hosted configuration
   "username": "cilium-renovate[bot]",
   "repositories": ["cilium/cilium"],
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   // renovate first reads this configuration, then reads the repository
   // configuration, since we don't split between the self-hosted and the
   // repository configuration, this can lead to duplicate of some areas of the
@@ -60,7 +62,6 @@
     "google/oss-fuzz"
   ],
   "pinDigests": true,
-  "ignorePresets": [":prHourlyLimit2"],
   // We don't want to separate major and minor upgrades in separate PRs since
   // we can upgrade them together in a single PR.
   "separateMajorMinor": false,


### PR DESCRIPTION
According to https://github.com/renovatebot/renovate/discussions/28069#discussioncomment-8864638 "ignorePresets": [":prHourlyLimit2"] is outdated 
This commit fix the prConcurrentLimit value to 0 and prHourlyLimit value to 0

More info on those parameters and their default values here : 
- https://docs.renovatebot.com/configuration-options/#prhourlylimit 
- https://docs.renovatebot.com/configuration-options/#prconcurrentlimit