### PR TITLE
ipcache: slightly reduce API surface 

### DIFF
--- a/pkg/ipcache/api/ipcache_api_handler.go
+++ b/pkg/ipcache/api/ipcache_api_handler.go
@@ -71,7 +71,7 @@ func (ipc *ipCacheDumpListener) getIdentity(securityIdentity uint32) (*identity.
 	return ident, nil
 }
 
-// OnIPIdentityCacheChange is called by DumpToListenerLocked
+// OnIPIdentityCacheChange is called by ipcache.(*IPCache).DumpToListener
 func (ipc *ipCacheDumpListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 	cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity,
 	newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcache.K8sMetadata, endpointFlags uint8,

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -182,16 +182,6 @@ func (ipc *IPCache) Shutdown() error {
 	return ipc.controllers.RemoveControllerAndWait(LabelInjectorName)
 }
 
-// Lock locks the IPCache's mutex.
-func (ipc *IPCache) Lock() {
-	ipc.mutex.Lock()
-}
-
-// Unlock unlocks the IPCache's mutex.
-func (ipc *IPCache) Unlock() {
-	ipc.mutex.Unlock()
-}
-
 // RLock RLocks the IPCache's mutex.
 func (ipc *IPCache) RLock() {
 	ipc.mutex.RLock()

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -215,7 +215,7 @@ func (ipc *IPCache) AddListener(listener IPIdentityMappingListener) {
 	ipc.mutex.UnlockToRLock()
 	defer ipc.mutex.RUnlock()
 	// Initialize new listener with the current mappings
-	ipc.DumpToListenerLocked(listener)
+	ipc.dumpToListenerLocked(listener)
 }
 
 // Update a controller for this IPCache
@@ -500,9 +500,9 @@ func (ipc *IPCache) upsertLocked(
 // DumpToListener dumps the entire contents of the IPCache by triggering
 // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
 func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
-	ipc.RLock()
-	ipc.DumpToListenerLocked(listener)
-	ipc.RUnlock()
+	ipc.mutex.RLock()
+	ipc.dumpToListenerLocked(listener)
+	ipc.mutex.RUnlock()
 }
 
 // MU is a batched metadata update, the short name is to cut down on visual clutter.
@@ -622,11 +622,11 @@ func (ipc *IPCache) WaitForRevision(ctx context.Context, desired uint64) error {
 	return ipc.metadata.waitForRevision(ctx, desired)
 }
 
-// DumpToListenerLocked dumps the entire contents of the IPCache by triggering
+// dumpToListenerLocked dumps the entire contents of the IPCache by triggering
 // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
 // The caller *MUST* grab the IPCache.Lock for reading before calling this
 // function.
-func (ipc *IPCache) DumpToListenerLocked(listener IPIdentityMappingListener) {
+func (ipc *IPCache) dumpToListenerLocked(listener IPIdentityMappingListener) {
 	for ip, identity := range ipc.ipToIdentityCache {
 		if identity.shadowed {
 			continue

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -604,7 +604,7 @@ func (dl *dummyListener) ExpectMapping(t *testing.T, targetIP string, targetIden
 
 	// Dump reliably supplies the IP once and only the pod identity.
 	dl.entries = make(map[string]identityPkg.NumericIdentity)
-	dl.ipc.DumpToListenerLocked(dl)
+	dl.ipc.dumpToListenerLocked(dl)
 	require.Equal(t, map[string]identityPkg.NumericIdentity{
 		targetIP: targetIdentity,
 	}, dl.entries)


### PR DESCRIPTION
Unexport `(*IPCache).DumpToListenerLocked` (which requires locking the IPCache mutex) and remove the now unused public Lock and Unlock methods.

See commit messages for details.
