### PR TITLE
ci: remove filter for runner update in lint wfs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -677,22 +677,6 @@
     {
       "enabled": false,
       "matchFileNames": [
-        ".github/workflows/lint-build-commits.yaml",
-        ".github/workflows/lint-bpf-checks.yaml"
-      ],
-      "matchDepTypes": [
-        "github-runner",
-      ],
-      "matchPackageNames": [
-        "ubuntu",
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-    },
-    {
-      "enabled": false,
-      "matchFileNames": [
         ".github/workflows/documentation.yaml"
       ],
       "matchDepTypes": [


### PR DESCRIPTION
Follow up of https://github.com/cilium/cilium/pull/40680, now workflows have no issue with 24.04, let renovate handle those updates again.