### PR TITLE
cilium-cli: Ignore errors and warnings with "Link not found"

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -52,7 +52,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 	errorLogExceptions := []logMatcher{
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock,
-		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision, nilDetailsForService}
+		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision, nilDetailsForService, linkNotFound}
 	if ciliumVersion.LT(semver.MustParse("1.14.0")) {
 		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR, klogLeaderElectionFail)
 	}
@@ -70,7 +70,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI,
 		envoyExternalTargetTLSWarning, envoyExternalOtherTargetTLSWarning, ciliumNodeConfigDeprecation,
 		hubbleUIEnvVarFallback, k8sClientNetworkStatusError, bgpAlphaResourceDeprecation, ccgAlphaResourceDeprecation,
-		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn}
+		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn, linkNotFound}
 	// The list is adopted from cilium/cilium/test/helper/utils.go
 	var errorMsgsWithExceptions = map[string][]logMatcher{
 		panicMessage:         nil,
@@ -479,4 +479,6 @@ var (
 	bgpAlphaResourceDeprecation = regexMatcher{regexp.MustCompile(`cilium.io/v2alpha1 CiliumBGP\w+ is deprecated`)}
 	// ccgAlphaResourceDeprecation is the same as bgpAlphaResourceDeprecation but for the CiliumCIDRGroup.
 	ccgAlphaResourceDeprecation = regexMatcher{regexp.MustCompile(`cilium.io/v2alpha1 CiliumCIDRGroup is deprecated`)}
+	// https://github.com/cilium/cilium/issues/39370 needs investigation.
+	linkNotFound = regexMatcher{regexp.MustCompile(`retrieving device .+\: Link not found`)}
 )


### PR DESCRIPTION
Errors like those described in https://github.com/cilium/cilium/issues/39370 are causing a lot of noise in CI. To cut down on test flakes, ignore these warnings/errors until these issues can be investigated further.

`Link not found` (https://github.com/cilium/cilium/issues/39370)
```
2025-05-06T15:36:41.438279873Z level=error source=/go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:610 msg="Error while reloading endpoint BPF program" ipv4=10.244.2.44 containerInterface=eth0 k8sPodName=kube-system/clustermesh-apiserver-generate-certs-4kgkm containerID=5072ef6b95 desiredPolicyRevision=1 endpointID=1362 datapathPolicyRevision=0 ipv6=fd00:10:244:2::917d ciliumEndpointName=kube-system/clustermesh-apiserver-generate-certs-4kgkm identity=16756690 subsys=endpoint error="retrieving device lxc863c5237af4c: Link not found"
2025-05-06T15:36:41.438747716Z level=warn source=/go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:607 msg="Regeneration of endpoint failed" ipv4=10.244.2.44 containerInterface=eth0 k8sPodName=kube-system/clustermesh-apiserver-generate-certs-4kgkm containerID=5072ef6b95 desiredPolicyRevision=1 endpointID=1362 datapathPolicyRevision=0 ipv6=fd00:10:244:2::917d ciliumEndpointName=kube-system/clustermesh-apiserver-generate-certs-4kgkm identity=16756690 subsys=endpoint reason="syncing state to host" waitingForPolicyRepository=361ns prepareBuild=28.113µs total=12.088630966s waitingForLock=4.809098796s proxyConfiguration=0s proxyPolicyCalculation=980.03µs mapSync=0s bpfCompilation=6.854898416s bpfWaitForELF=6.870777505s waitingForCTClean=391ns selectorPolicyCalculation=0s endpointPolicyCalculation=0s proxyWaitForAck=0s policyCalculation=413.032µs bpfLoadProg=405.58053ms bpfCompilation=6.854898416s bpfWaitForELF=6.870777505s bpfLoadProg=405.58053ms error="retrieving device lxc863c5237af4c: Link not found"
2025-05-06T15:36:41.439164485Z level=error source=/go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:803 msg="endpoint regeneration failed" ipv4=10.244.2.44 containerInterface=eth0 k8sPodName=kube-system/clustermesh-apiserver-generate-certs-4kgkm containerID=5072ef6b95 desiredPolicyRevision=1 endpointID=1362 datapathPolicyRevision=0 ipv6=fd00:10:244:2::917d ciliumEndpointName=kube-system/clustermesh-apiserver-generate-certs-4kgkm identity=16756690 subsys=endpoint error="retrieving device lxc863c5237af4c: Link not found"
2025-05-06T15:37:10.223490385Z level=warning msg="Unable to assert if endpoint BPF programs need to be reloaded" source="/go/src/github.com/cilium/cilium/daemon/cmd/watchdogs.go:115" ciliumEndpointName=kube-system/clustermesh-apiserver-generate-certs-4kgkm endpoint=lxc863c5237af4c endpointID=1362 error="retrieving device lxc863c5237af4c: Link not found" subsys=daemon
```

```release-note
cilium-cli: connectivity tests: Ignore some logs in error log check
```