### PR TITLE
Disable host firewall bypass by default

### DIFF
--- a/pkg/k8s/hostfirewallbypass/cell.go
+++ b/pkg/k8s/hostfirewallbypass/cell.go
@@ -15,7 +15,7 @@ var Cell = cell.Module(
 	"Kubernetes host firewall bypass",
 
 	cell.Config(Params{
-		EnableK8sHostFirewallBypass: true,
+		EnableK8sHostFirewallBypass: false,
 	}),
 	cell.Provide(NewK8sHostFirewallBypass),
 )


### PR DESCRIPTION
As we have seen suspicious connectivity problems with k8s apiserver since merging #40346 let's disable it for time being to see if it resolves problems in CI.

Related: #40682
Some additional context: https://github.com/cilium/cilium/pull/40346#issuecomment-3113079473
