### PR TITLE
bpf: gitignore CLANG tmp files (*.o.tmp)

### DIFF
--- a/bpf/.gitignore
+++ b/bpf/.gitignore
@@ -3,3 +3,6 @@ compile_commands.json
 *.i
 *.s
 .rebuild_all
+
+# ignore CLANG intermediate compilation tmp files
+*.o.tmp


### PR DESCRIPTION
Add to gitignore CLANG intermediate compilation files (.o.tmp), e.g.:

```
On branch bpf_tests_ignore_tmp_files
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	bpf_host-b1c95b47.o.tmp
```