### PR TITLE
Revert "endpoint, policy: Don't accidentally clear out endpoint policy maps"

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -801,14 +801,6 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 			if err != nil {
 				return fmt.Errorf("policymap synchronization failed: %w", err)
 			}
-		} else {
-			// Ensure that e.realizedPolicy actually represents the
-			// current policy map state in case rollback is
-			// necessary, so we don't try to "roll back" to an empty
-			// map and delete all the entries, even momentarily.
-			// This may be the case if the agent just restarted,
-			// for example. See GH-38998.
-			e.realizedPolicy.CopyMapStateFrom(datapathRegenCtxt.policyMapDump)
 		}
 		datapathRegenCtxt.policyMapSyncDone = true
 	}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -333,18 +333,6 @@ func (e *Endpoint) setDesiredPolicy(datapathRegenCtxt *datapathRegenerationConte
 			// Do nothing if e.policyMap was not initialized already
 			if e.policyMap != nil && e.desiredPolicy != e.realizedPolicy {
 				e.desiredPolicy.Detach(e.getLogger())
-				// Make sure e.desiredPolicy still reflects the
-				// desired state of the world after reverting
-				// back to the last known good state. On the
-				// next regeneration attempt, res.endpointPolicy
-				// will not be recalculated, since we already
-				// updated e.nextPolicyRevision; we want to
-				// preserve the desired policy calculated in
-				// this round so that we don't just end up with
-				// an empty map. See GH-38998.
-				defer func(p *policy.EndpointPolicy) {
-					e.desiredPolicy = p
-				}(e.desiredPolicy)
 				e.desiredPolicy = e.realizedPolicy
 
 				currentMap, err := e.policyMap.DumpToMapStateMap()

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -249,15 +249,6 @@ func (p *EndpointPolicy) Lookup(key Key) (MapStateEntry, RuleMeta, bool) {
 	return entry.MapStateEntry, entry.derivedFromRules.Value(), found
 }
 
-// CopyMapStateFrom copies the policy map entries from m.
-func (p *EndpointPolicy) CopyMapStateFrom(m MapStateMap) {
-	for key, entry := range m {
-		p.policyMapState.entries[key] = mapStateEntry{
-			MapStateEntry: entry,
-		}
-	}
-}
-
 // PolicyOwner is anything which consumes a EndpointPolicy.
 type PolicyOwner interface {
 	GetID() uint64


### PR DESCRIPTION
This reverts commit f052828b3a7378f116c7785090d6132f3c6c4e7b. This was not the version of https://github.com/cilium/cilium/pull/40255 that was approved by reviewers.
