### PR TITLE
endpoint, policy: Don't accidentally clear out endpoint policy maps

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -801,6 +801,14 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 			if err != nil {
 				return fmt.Errorf("policymap synchronization failed: %w", err)
 			}
+		} else {
+			// Ensure that e.realizedPolicy actually represents the
+			// current policy map state in case rollback is
+			// necessary, so we don't try to "roll back" to an empty
+			// map and delete all the entries, even momentarily.
+			// This may be the case if the agent just restarted,
+			// for example. See GH-38998.
+			e.realizedPolicy.CopyMapStateFrom(datapathRegenCtxt.policyMapDump)
 		}
 		datapathRegenCtxt.policyMapSyncDone = true
 	}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -249,6 +249,15 @@ func (p *EndpointPolicy) Lookup(key Key) (MapStateEntry, RuleMeta, bool) {
 	return entry.MapStateEntry, entry.derivedFromRules.Value(), found
 }
 
+// CopyMapStateFrom copies the policy map entries from m.
+func (p *EndpointPolicy) CopyMapStateFrom(m MapStateMap) {
+	for key, entry := range m {
+		p.policyMapState.entries[key] = mapStateEntry{
+			MapStateEntry: entry,
+		}
+	}
+}
+
 // PolicyOwner is anything which consumes a EndpointPolicy.
 type PolicyOwner interface {
 	GetID() uint64


### PR DESCRIPTION
*Note*: https://github.com/cilium/cilium/pull/40255 was reverted, since it was merged after I pushed a stale version of the branch. Open this PR with the correct contents.

Transient errors inside `regenerateBPF` can lead to an endpoint's policy map either not being initialized or being accidentally cleared out, resulting in broken connectivity.

### Scenario
In this scenario, a transient error causes the first call to `regenerateBPF` to fail for an endpoint. The second regeneration attempt succeeds, but the final policy map state is empty.

```
initial state:
    e.desiredPolicy == e.realizedPolicy == <empty EndpointPolicy>

0:  e.ComputeInitialPolicy(...)
1:      e.regeneratePolicy(...)
2:          result := &policyGenerateResult{
                endpointPolicy:   e.desiredPolicy,
                identityRevision: e.identityRevision,
            }
3:          selectorPolicy, ... = e.policyRepo.GetSelectorPolicy(...)
            ...
4:          result.endpointPolicy = selectorPolicy.DistillPolicy(...)
            ...
5:      e.setDesiredPolicy(...)
6:          e.setNextPolicyRevision(res.policyRevision)
7:              e.nextPolicyRevision = revision
8:          if ... && res.endpointPolicy != e.desiredPolicy {
                ...
9:              e.desiredPolicy = res.endpointPolicy
10:             datapathRegenCtx.revertStack.Push(func() error {
                    ...
                    e.desiredPolicy = e.realizedPolicy
                    ...
                    _, _, err = e.syncPolicyMapWith(currentMap, false);
                    ...
                })
            }
12:         res.endpointPolicy = nil

current state:
    e.desiredPolicy = <computed policy>
    e.realizedPolicy = <empty policy>

13: e.regenerate(...)
14:     revision, err := e.regenerateBPF(...)
            e.runPreCompilationSteps(regenContext)
	        e.regeneratePolicy(...)
		    ...
		    selectorPolicy, ... = e.policyRepo.GetSelectorPolicy(...)
		    <no-op, since selectorPolicy == nil>
                e.setDesiredPolicy(...) <no-op - e.desiredPolicy matches
                                         the computed policy from above>
15:         defer func() {
                if !e.isProperty(PropertyFakeEndpoint) {
                    e.finalizeProxyState(regenContext, reterr)
                }
            }()
	    ...
16:         err = e.realizeBPFState(regenContext)
17:         if err != nil {
                <e.realizeBPFState returns an error>
                ...
            }
18:         e.finalizeProxyState(regenContext, reterr) <run deferred
	                                                function>
19:             datapathRegenCtx.revertStack.Revert() <run pushed
                                                       revertStack
                                                       function from 10>
20:                 e.desiredPolicy = e.realizedPolicy <from 10>

current state:
    e.desiredPolicy == e.realizedPolicy == <empty policy>

<reattempt regeneration>
22: e.regenerate(...)
23:     revision, err := e.regenerateBPF(...)
            e.runPreCompilationSteps(regenContext)
	        e.regeneratePolicy(...)
		    ...
		    selectorPolicy, ... = e.policyRepo.GetSelectorPolicy(...)
		    <no-op, since selectorPolicy == nil>
                e.setDesiredPolicy(...) <no-op - e.desiredPolicy still
                                         points to e.realizedPolicy,
					 which is empty>
	    ...

current state:
    e.desiredPolicy == e.realizedPolicy == <empty policy>

25:         err = e.realizeBPFState(regenContext) <e.realizeBPFState
                                                   succeeds>
	    ...
	...
26:     return e.updateRealizedState(stats, origDir, revision) <
            ...
            e.realizedPolicy = e.desiredPolicy <"locks in" the empty
                                                map>
            ...

current state:
    e.desiredPolicy == e.realizedPolicy == <empty policy>

<regeneration is done>
```

### Explanation
The second regeneration attempt does not recompute the endpoint policy, since we update `e.nextPolicyRevision` in the first attempt, and hence, `e.desiredPolicy` is not changed. The call succeeds, then the empty map state is "locked in" until a recomputation happens in the future.

### The Fix
To remedy this, revert `nextPolicyRevision` in the revert stack to ensure that `e.desiredPolicy` is recomputed on the next regeneration attempt.

### Make Sure e.realizedPolicy Reflects Reality
Note that the `revertStack` function above relies on the assumption that `e.realizedPolicy` reflects the current endpoint policy map state. However, if the agent has just started, `e.realizedPolicy` may be empty even for existing endpoints. Copy the state from the `policyMapDump` to `e.realizedPolicy` inside `e.runPreCompilationSteps` to make sure the restore logic actually works in these situations instead of clearing out the existing map.

### Testing
I tested this manually using the repro described in [#38998](https://github.com/cilium/cilium/issues/38998#issuecomment-2994303949). Before applying this patch, the repro resulted in broken connectivity to the `coredns` pods every time I started up my kind cluster. After applying this patch, they start up reliably and all liveness/readiness probes succeed.

Fixes: #38998

```release-note
policy: Fix a bug where transient errors in endpoint regeneration lead to broken connectivity.
```
