### PR TITLE
Fix nodeSelector validation in CiliumNetworkPolicy Specs array

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -203,6 +203,9 @@ func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger, clusterName string) (ap
 			if err := rule.Sanitize(); err != nil {
 				return nil, NewErrParse(fmt.Sprintf("Invalid CiliumNetworkPolicy specs: %s", err))
 			}
+			if rule.NodeSelector.LabelSelector != nil {
+				return nil, NewErrParse("Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector")
+			}
 			cr := k8sCiliumUtils.ParseToCiliumRule(logger, clusterName, namespace, name, uid, rule)
 			retRules = append(retRules, cr)
 		}

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -558,6 +558,21 @@ func TestParseWithNodeSelector(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ccnplAsCNP.Parse(logger, cmtypes.PolicyAnyCluster)
 	require.NoError(t, err)
+
+	// Now test the case where nodeSelector is in Specs (plural) instead of Spec (singular).
+	// This should also be rejected for namespaced CNPs.
+	rule.EndpointSelector = emptySelector
+	rule.NodeSelector = prevEPSelector
+	cnplWithSpecs := CiliumNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "rule",
+			UID:       uuidRule,
+		},
+		Specs: api.Rules{&rule}, // Using Specs instead of Spec
+	}
+	_, err = cnplWithSpecs.Parse(logger, cmtypes.PolicyAnyCluster)
+	require.ErrorContains(t, err, "Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector")
 }
 
 func TestCiliumNodeInstanceID(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Fix nodeSelector validation in CiliumNetworkPolicy Specs array

This PR fixes a bug where namespaced `CiliumNetworkPolicy` objects with `nodeSelector` specified in the `specs` array were being silently accepted but ignored, instead of being properly rejected with a validation error.

### Problem

The issue was that nodeSelector validation was only applied to the singular `spec` field but not to individual rules within the `specs` array. This led to inconsistent behavior:

- ✅ `spec: { nodeSelector: {} }` → Correctly rejected  
- ❌ `specs: [{ nodeSelector: {} }]` → Silently accepted but ignored

### Solution

Added the missing nodeSelector validation check inside the `r.Specs` loop in the `Parse` method of `CiliumNetworkPolicy`. Now both cases consistently reject the policy with the error message: `"Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector"`

### Testing

- Added comprehensive test case in `TestParseWithNodeSelector` to cover the `specs` array scenario
- All existing tests pass, ensuring no regressions
- Verified the exact policy from the issue is now properly rejected

Fixes: #40268

```release-note
Fix validation bug where namespaced CiliumNetworkPolicies with nodeSelector in specs array were silently accepted but ignored. Now properly rejected with validation error.
```
