### PR TITLE
loadbalancer: Only delay reconciliation if previous BPF state existed

### DIFF
--- a/pkg/loadbalancer/healthserver/healthserver.go
+++ b/pkg/loadbalancer/healthserver/healthserver.go
@@ -224,7 +224,7 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 									Protocol: lb.TCP,
 									Port:     port,
 								},
-								Scope: lb.ScopeInternal,
+								Scope: lb.ScopeExternal,
 							},
 							NodeName: s.nodeName,
 							State:    lb.BackendStateActive,

--- a/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
@@ -121,7 +121,7 @@ Address                 Type         ServiceName            PortName   Status  B
 [::]:30781/TCP          NodePort     test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
 [fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
 [fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
-[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP/i
+[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP
 
 -- frontends_tpcluster.table --
 Address                 Type         ServiceName            PortName   Status  Backends
@@ -134,7 +134,7 @@ Address                 Type         ServiceName            PortName   Status  B
 [::]:30781/TCP          NodePort     test/echo              http       Done    
 [fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    
 [fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    
-[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP/i
+[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP
 
 -- frontends_nohealthcheck.table --
 Address                 Type         ServiceName            PortName   Status  Backends
@@ -155,7 +155,7 @@ test/echo (http)       [fd02::1]:80/TCP
 test/echo (http)       [fd02::2]:80/TCP
 test/echo (http)       [fd02::3]:80/TCP
 test/echo (http)       [fd02::4]:80/TCP
-test/echo:healthserver [fd03::1111]:$HEALTHPORT/TCP/i
+test/echo:healthserver [fd03::1111]:$HEALTHPORT/TCP
 
 -- backends_othernode.table --
 Address           Instances              NodeName

--- a/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
@@ -121,7 +121,7 @@ Address               Type         ServiceName            PortName   Status  Bac
 0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
 10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
 172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
-172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP/i
+172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP
 
 -- frontends_tpcluster.table --
 Address               Type         ServiceName            PortName   Status  Backends
@@ -134,7 +134,7 @@ Address               Type         ServiceName            PortName   Status  Bac
 0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    
 10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    
 172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    
-172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP/i
+172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP
 
 -- frontends_nohealthcheck.table --
 Address               Type         ServiceName            PortName   Status  Backends
@@ -151,7 +151,7 @@ test/echo (http)       10.244.1.4:80/TCP
 
 -- backends.table --
 Instances              Address
-test/echo:healthserver 1.1.1.1:$HEALTHPORT/TCP/i
+test/echo:healthserver 1.1.1.1:$HEALTHPORT/TCP
 test/echo (http)       10.244.1.1:80/TCP
 test/echo (http)       10.244.1.2:80/TCP
 test/echo (http)       10.244.1.3:80/TCP

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -39,6 +39,8 @@ const (
 	// we start reconciling towards the BPF maps. This reduces the probability that load-balancing is scaled
 	// down temporarily due to not yet seeing all backends.
 	//
+	// The delay happens only when existing BPF state existed.
+	//
 	// We must not wait forever for initialization though due to potential interdependencies between load-balancing
 	// data sources. For example we might depend on Kubernetes data to connect to the ClusterMesh api-server and
 	// thus may need to first reconcile the Kubernetes services to connect to ClusterMesh (if endpoints have changed
@@ -94,17 +96,26 @@ func newBPFReconciler(p reconciler.Params, g job.Group, cfg loadbalancer.Config,
 	g.Add(
 		job.OneShot("start-reconciler", func(ctx context.Context, health cell.Health) error {
 			defer close(started)
-			// We give a short grace period for initializers to finish populating the initial contents
-			// of the tables to avoid scaling down load-balancing due to e.g. seeing services before
-			// the endpoint slices.
-			health.OK("Waiting for load-balancing tables to initialize")
-			_, initWatch := w.Frontends().Initialized(p.DB.ReadTxn())
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-initWatch:
-			case <-time.After(initGracePeriod):
+
+			if len(ops.restoredServiceIDs) > 0 {
+				// We give a short grace period for initializers to finish populating the initial contents
+				// of the tables to avoid scaling down load-balancing due to e.g. seeing backends from k8s
+				// much earlier than from ClusterMesh for the same service.
+				//
+				// We only do this if we restored data from BPF maps as only in that scenario we could
+				// be scaling down. This way we also don't introduce an unnecessary delay to connecting
+				// to the ClusterMesh api-server if it connects via a k8s service.
+				health.OK("Waiting for load-balancing tables to initialize")
+				_, initWatch := w.Frontends().Initialized(p.DB.ReadTxn())
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-initWatch:
+				case <-time.After(initGracePeriod):
+					p.Log.Warn("Timed out waiting for load-balancing state to initialize, proceeding with reconciliation")
+				}
 			}
+
 			health.OK("Starting")
 			if err := rlc.Start(p.Log, ctx); err != nil {
 				return err

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -45,7 +45,7 @@ const (
 	// data sources. For example we might depend on Kubernetes data to connect to the ClusterMesh api-server and
 	// thus may need to first reconcile the Kubernetes services to connect to ClusterMesh (if endpoints have changed
 	// while agent was down).
-	initGracePeriod = 10 * time.Second
+	initGracePeriod = 1 * time.Minute
 )
 
 func newBPFReconciler(p reconciler.Params, g job.Group, cfg loadbalancer.Config, ops *BPFOps, fes statedb.Table[*loadbalancer.Frontend], w *writer.Writer) (reconciler.Reconciler[*loadbalancer.Frontend], error) {


### PR DESCRIPTION
There is no need to delay the reconciliation of the LB BPF maps if there was no previous state as in that scenario we wouldn't be scaling down the number of backends (since there are none yet).

Further this would be causing an unnecessary delay for a LB data source like ClusterMesh if it connects via a k8s service.

The second commit bumps the init wait timeout back to 1 minute.

These changes also uncovered an issue in the healthserver implementation which incorrectly created a backend with the scope set to internal which caused it to be pruned. This is fixed by the last commit.

Marked this as blocker for v1.18 as we should really avoid the init delay when connecting to clustermesh api-server when it's behind a k8s service, and we need the healthserver fix. The second commit is AFAIK not backported to v1.18 and can be skipped.