### PR TITLE
cec: introduce annotation to control use-original-source-address

### DIFF
--- a/Documentation/network/servicemesh/l7-traffic-management.rst
+++ b/Documentation/network/servicemesh/l7-traffic-management.rst
@@ -41,14 +41,14 @@ Caveats
   as possible.
 * If you create a ``CiliumEnvoyConfig`` resource directly (ie, not via the
   Cilium Ingress or Gateway API controllers), if the CEC is intended to manage
-  E/W traffic, set the label ``cilium.io/use-original-source-address: "false"``.
+  E/W traffic, set the annotation ``cec.cilium.io/use-original-source-address: "false"``.
   Otherwise, Envoy will bind the sockets for the upstream connection pools to
   the original source address/port. This may cause 5-tuple collisions when pods
   send multiple requests over the same pipelined HTTP/1.1 or HTTP/2 connection.
   (The Cilium agent assumes all CECs with parentRefs pointing to the Cilium
-  Ingress or Gateway API controllers have
-  ``cilium.io/use-original-source-address`` set to ``"false"``, but all other CECs
-  are assumed to have this label set to ``"true"``.)
+  Ingress or Gateway API controllers have annotation
+  ``cec.cilium.io/use-original-source-address`` set to ``"false"``, but all other CECs
+  are assumed to have this annotation set to ``"true"``.)
 
 .. include:: installation.rst
 

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-basic/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-basic/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: gateway-conformance-mesh-test
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-frontend/cec-echo-v2-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-frontend/cec-echo-v2-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-split-v1
   name: echo-v2
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-matching/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-matching/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-matching
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-ports/cec-echo-v1-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-ports/cec-echo-v1-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-split-v1
   name: echo-v1
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-ports/cec-echo-v2-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-ports/cec-echo-v2-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-split-v2
   name: echo-v2
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-query-param-matching/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-query-param-matching/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-query-param-matching
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-host-and-status/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-host-and-status/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-redirect-host-and-status
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-path/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-path/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-redirect-path
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-port/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-port/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-redirect-port
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-scheme/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-scheme/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-redirect-scheme
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-request-header-modifier/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-request-header-modifier/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-request-header-modifier
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-rewrite-path/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-rewrite-path/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-rewrite-path
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-split/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-split/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-split
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-weighted-backends/cec-echo-output.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-weighted-backends/cec-echo-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-weighted-backends
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation-with-hostname-intersection.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation-with-hostname-intersection.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: http-listener-isolation-with-hostname-intersection
   name: cilium-gateway-http-listener-isolation-with-hostname-intersection
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: http-listener-isolation
   name: cilium-gateway-http-listener-isolation
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-infrastructure/output/cec-gateway-with-infrastructure-metadata.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-infrastructure/output/cec-gateway-with-infrastructure-metadata.yaml
@@ -1,9 +1,9 @@
 metadata:
-  annotations:
-    key1: value1
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+    key1: value1
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-with-infrastructure-metadata
     key2: value2
   name: cilium-gateway-gateway-with-infrastructure-metadata

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/cec-gateway-only-invalid-route-kind.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/cec-gateway-only-invalid-route-kind.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-only-invalid-route-kind
   name: cilium-gateway-gateway-only-invalid-route-kind
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/cec-gateway-supported-and-invalid-route-kind.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/cec-gateway-supported-and-invalid-route-kind.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-supported-and-invalid-route-kind
   name: cilium-gateway-gateway-supported-and-invalid-route-kind
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-malformed-secret.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-malformed-secret.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-certificate-malformed-secret
   name: cilium-gateway-gateway-certificate-malformed-secret
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-nonexistent-secret.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-nonexistent-secret.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-certificate-nonexistent-secret
   name: cilium-gateway-gateway-certificate-nonexistent-secret
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-unsupported-group.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-unsupported-group.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-certificate-unsupported-group
   name: cilium-gateway-gateway-certificate-unsupported-group
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-unsupported-kind.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-unsupported-kind.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-certificate-unsupported-kind
   name: cilium-gateway-gateway-certificate-unsupported-kind
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-add-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-add-listener.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-add-listener
   name: cilium-gateway-gateway-add-listener
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-remove-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-remove-listener.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-remove-listener
   name: cilium-gateway-gateway-remove-listener
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-observed-generation-bump/output/cec-gateway-observed-generation-bump.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-observed-generation-bump/output/cec-gateway-observed-generation-bump.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-observed-generation-bump
   name: cilium-gateway-gateway-observed-generation-bump
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-secret-invalid-reference-grant/output/cec-gateway-secret-invalid-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-secret-invalid-reference-grant/output/cec-gateway-secret-invalid-reference-grant.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-secret-invalid-reference-grant
   name: cilium-gateway-gateway-secret-invalid-reference-grant
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-secret-missing-reference-grant/output/cec-gateway-secret-missing-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-secret-missing-reference-grant/output/cec-gateway-secret-missing-reference-grant.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-secret-missing-reference-grant
   name: cilium-gateway-gateway-secret-missing-reference-grant
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-all-in-namespace/output/cec-gateway-secret-reference-grant-all-in-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-all-in-namespace/output/cec-gateway-secret-reference-grant-all-in-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-secret-reference-grant-all-in-namespace
   name: cilium-gateway-gateway-secret-reference-grant-all-in-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-specific/output/cec-gateway-secret-reference-grant-specific.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-specific/output/cec-gateway-secret-reference-grant-specific.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-secret-reference-grant-specific
   name: cilium-gateway-gateway-secret-reference-grant-specific
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-static-addresses/output/cec-gateway-static-addresses.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-static-addresses/output/cec-gateway-static-addresses.yaml
@@ -1,9 +1,9 @@
 metadata:
-  annotations:
-    io.cilium/lb-ipam-ips: 10.10.10.10,20.20.20.20
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+    io.cilium/lb-ipam-ips: 10.10.10.10,20.20.20.20
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-static-addresses
   name: cilium-gateway-gateway-static-addresses
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-gateway-with-one-attached-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-gateway-with-one-attached-route.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-with-one-attached-route
   name: cilium-gateway-gateway-with-one-attached-route
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-gateway-with-two-attached-routes.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-gateway-with-two-attached-routes.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: gateway-with-two-attached-routes
   name: cilium-gateway-gateway-with-two-attached-routes
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-unresolved-gateway-with-one-attached-unresolved-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-unresolved-gateway-with-one-attached-unresolved-route.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: unresolved-gateway-with-one-attached-unresolved-route
   name: cilium-gateway-unresolved-gateway-with-one-attached-unresolved-route
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/grpcroute-exact-method-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/grpcroute-exact-method-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/grpcroute-header-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/grpcroute-header-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/grpcroute-listener-hostname-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/grpcroute-listener-hostname-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backend-protocol-h2c/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backend-protocol-h2c/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backend-protocol-websocket/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backend-protocol-websocket/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-cross-namespace/output/cec-backend-namespaces.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-cross-namespace/output/cec-backend-namespaces.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: backend-namespaces
   name: cilium-gateway-backend-namespaces
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-disallowed-kind/output/cec-tlsroutes-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-disallowed-kind/output/cec-tlsroutes-only.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: tlsroutes-only
   name: cilium-gateway-tlsroutes-only
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-exact-path-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-exact-path-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-header-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-header-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-hostname-intersection/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-hostname-intersection/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-https-listener/output/cec-same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-https-listener/output/cec-same-namespace-with-https-listener.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace-with-https-listener
   name: cilium-gateway-same-namespace-with-https-listener
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-backendref-unknown-kind/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-backendref-unknown-kind/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-cross-namespace-backend-ref/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-cross-namespace-backend-ref/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-cross-namespace-parent-ref/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-cross-namespace-parent-ref/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-nonexistent-backendref/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-nonexistent-backendref/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-parentref-not-matching-listener-port/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-parentref-not-matching-listener-port/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-parentref-not-matching-section-name/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-parentref-not-matching-section-name/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-parentref-section-name-not-matching-port/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-parentref-section-name-not-matching-port/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-reference-grant/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-reference-grant/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-listener-hostname-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-listener-hostname-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-listener-port-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-listener-port-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-matching-across-routes/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-matching-across-routes/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-method-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-method-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-observed-generation-bump/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-observed-generation-bump/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-partially-invalid-via-invalid-reference-grant/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-partially-invalid-via-invalid-reference-grant/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-path-match-order/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-path-match-order/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-query-param-matching/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-query-param-matching/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-host-and-status/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-host-and-status/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-path/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-path/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-port-and-scheme/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-port-and-scheme/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-port/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-port/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-scheme/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-scheme/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-reference-grant/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-reference-grant/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-header-modifier-backend-weights/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-header-modifier-backend-weights/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-header-modifier/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-header-modifier/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-mirror/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-mirror/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-multiple-mirrors/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-multiple-mirrors/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-request-percentage-mirror/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-request-percentage-mirror/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-response-header-modifier/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-response-header-modifier/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-timeout-backend-request/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-timeout-backend-request/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-timeout-request/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-timeout-request/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-weight/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-weight/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-reference-grant/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-reference-grant/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/cec-same-namespace.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -7,11 +7,12 @@ import (
 	"maps"
 	goslices "slices"
 	"sort"
+	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
-	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/annotation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/shortener"
@@ -97,7 +98,6 @@ func NewCECTranslator(config Config) CECTranslator {
 }
 
 func (i *cecTranslator) Translate(namespace string, name string, model *model.Model) (*ciliumv2.CiliumEnvoyConfig, error) {
-
 	backendServices, err := i.desiredBackendServices(model)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,9 @@ func (i *cecTranslator) Translate(namespace string, name string, model *model.Mo
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			Labels:    i.desiredLabels(model),
+			Annotations: map[string]string{
+				annotation.CECUseOriginalSourceAddress: strconv.FormatBool(i.shouldUseOriginalSourceAddress(model)),
+			},
 		},
 		Spec: ciliumv2.CiliumEnvoyConfigSpec{
 			BackendServices: backendServices,
@@ -206,16 +208,14 @@ func (i *cecTranslator) desiredResources(m *model.Model) ([]ciliumv2.XDSResource
 	return res, nil
 }
 
-func (i *cecTranslator) desiredLabels(m *model.Model) map[string]string {
-	labels := map[string]string{}
+func (i *cecTranslator) shouldUseOriginalSourceAddress(m *model.Model) bool {
 	for _, l := range m.HTTP {
 		if l.Gamma {
-			labels[k8s.UseOriginalSourceAddressLabel] = "true"
-			return labels
+			return true
 		}
 	}
-	labels[k8s.UseOriginalSourceAddressLabel] = "false"
-	return labels
+
+	return false
 }
 
 func (i *cecTranslator) desiredNodeSelector() *slim_metav1.LabelSelector {

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_tls_sni_listener/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_tls_sni_listener/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_frontend/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_frontend/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-split-v1
   name: echo-v2
   namespace: gateway-conformance-mesh

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_ports/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_ports/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-ports
   name: echo-v1
   namespace: gateway-conformance-mesh

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_splits/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_splits/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
   labels:
-    cilium.io/use-original-source-address: "true"
     gateway.networking.k8s.io/gateway-name: mesh-split
   name: echo
   namespace: gateway-conformance-mesh

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httpexact_path_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httpexact_path_matching/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c_app_protocol/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c_app_protocol/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_request_header_modifier/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_request_header_modifier/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_response_header_modifier/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_response_header_modifier/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_cross_namespace/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_cross_namespace/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: backend-namespaces
   name: cilium-gateway-backend-namespaces
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_header_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_header_matching/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_hostname_intersection/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_hostname_intersection/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: httproute-hostname-intersection
   name: cilium-gateway-httproute-hostname-intersection
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_listener_hostname_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_listener_hostname_matching/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: httproute-listener-hostname-matching
   name: cilium-gateway-httproute-listener-hostname-matching
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching_across_routes/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching_across_routes/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_method_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_method_matching/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_query_param_matching/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_query_param_matching/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_header_modifier/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_header_modifier/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_mirror/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_mirror/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_response_header_modifier/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_response_header_modifier/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_host/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_host/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_path/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_path/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_simple_same_namespace/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_simple_same_namespace/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: same-namespace
   name: cilium-gateway-same-namespace
   namespace: gateway-conformance-infra

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/cec-output.yaml
@@ -1,7 +1,8 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   labels:
-    cilium.io/use-original-source-address: "false"
     gateway.networking.k8s.io/gateway-name: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default

--- a/operator/pkg/model/translation/ingress/testdata/complex_node_port_ingress/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/complex_node_port_ingress/output-cec.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
-  labels:
-    cilium.io/use-original-source-address: "false"
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   name: cilium-ingress-dummy-namespace-dummy-ingress
   namespace: dummy-namespace
 spec:

--- a/operator/pkg/model/translation/ingress/testdata/conformance/default_backend/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/default_backend/output-cec.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
-  labels:
-    cilium.io/use-original-source-address: "false"
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   name: cilium-ingress-random-namespace-load-balancing
   namespace: random-namespace
 spec:

--- a/operator/pkg/model/translation/ingress/testdata/conformance/host_network/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/host_network/output-cec.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
-  labels:
-    cilium.io/use-original-source-address: "false"
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   name: cilium-ingress-random-namespace-load-balancing
   namespace: random-namespace
 spec:

--- a/operator/pkg/model/translation/ingress/testdata/conformance/host_rules/no_force_https/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/host_rules/no_force_https/output-cec.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
-  labels:
-    cilium.io/use-original-source-address: "false"
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   name: cilium-ingress-random-namespace-host-rules
   namespace: random-namespace
 spec:

--- a/operator/pkg/model/translation/ingress/testdata/conformance/host_rules/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/host_rules/output-cec.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
-  labels:
-    cilium.io/use-original-source-address: "false"
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   name: cilium-ingress-random-namespace-host-rules
   namespace: random-namespace
 spec:

--- a/operator/pkg/model/translation/ingress/testdata/conformance/path_rules/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/path_rules/output-cec.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
-  labels:
-    cilium.io/use-original-source-address: "false"
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   name: cilium-ingress-random-namespace-path-rules
   namespace: random-namespace
 spec:

--- a/operator/pkg/model/translation/ingress/testdata/conformance/proxy_protocol/output-cec.yaml
+++ b/operator/pkg/model/translation/ingress/testdata/conformance/proxy_protocol/output-cec.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
-  labels:
-    cilium.io/use-original-source-address: "false"
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
   name: cilium-ingress-random-namespace-load-balancing
   namespace: random-namespace
 spec:

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -215,8 +215,9 @@ const (
 	LBIPAMSharingAcrossNamespace      = LBIPAMPrefix + "/sharing-cross-namespace"
 	LBIPAMSharingAcrossNamespaceAlias = Prefix + "/lb-ipam-sharing-cross-namespace"
 
-	CECInjectCiliumFilters = CECPrefix + "/inject-cilium-filters"
-	CECIsL7LB              = CECPrefix + "/is-l7lb"
+	CECInjectCiliumFilters      = CECPrefix + "/inject-cilium-filters"
+	CECIsL7LB                   = CECPrefix + "/is-l7lb"
+	CECUseOriginalSourceAddress = CECPrefix + "/use-original-source-address"
 )
 
 // CiliumPrefixRegex is a regex matching Cilium specific annotations.

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -972,7 +972,7 @@ func toAny(message proto.Message) *anypb.Any {
 }
 
 // UseOriginalSourceAddress returns true if the given object metadata indicates that the owner needs the Envoy listener to assume the identity of Cilium Ingress.
-// This can be an explicit label or the presence of an OwnerReference of Kind "Ingress" or "Gateway".
+// This can be an explicit annotation (or deprecated label) or the presence of an OwnerReference of Kind "Ingress" or "Gateway".
 func UseOriginalSourceAddress(meta *metav1.ObjectMeta) bool {
 	for _, owner := range meta.OwnerReferences {
 		if owner.Kind == "Ingress" || owner.Kind == "Gateway" {
@@ -980,6 +980,15 @@ func UseOriginalSourceAddress(meta *metav1.ObjectMeta) bool {
 		}
 	}
 
+	if meta.GetAnnotations() != nil {
+		if v, ok := meta.GetAnnotations()[annotation.CECUseOriginalSourceAddress]; ok {
+			if boolValue, err := strconv.ParseBool(v); err == nil {
+				return boolValue
+			}
+		}
+	}
+
+	// fallback to deprecated label
 	if meta.GetLabels() != nil {
 		if v, ok := meta.GetLabels()[k8s.UseOriginalSourceAddressLabel]; ok {
 			if boolValue, err := strconv.ParseBool(v); err == nil {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -15,6 +15,8 @@ import (
 // UseOriginalSourceAddressLabel is the k8s label that can be added to a
 // `CiliumEnvoyConfig`. This way the Cilium BPF Metadata listener filter is configured
 // to use the original source address when extracting the metadata for a request.
+//
+// Deprecated: use the corresponding annotation
 const UseOriginalSourceAddressLabel = "cilium.io/use-original-source-address"
 
 type nameLabelsGetter interface {


### PR DESCRIPTION
cec: introduce annotation to control useoriginalsourceaddress
Commit https://github.com/cilium/cilium/commit/b6bcc0c0e2a introduced the label
`cilium.io/use-original-source-address` on the CRD `CiliumEnvoyConfig` - with the
intent to have fine-grained control of whether Cilium Proxy should use
the original source address.

Using a K8s label isn't consistent with the fact that all other aspects of a
CEC are configured via K8s annotations. From the description of the commit
it looks like the intention was to add an annotation instead of the label
in the first place.

Therefore, this commit introduces a new annotation `cec.cilium.io/use-original-source-address`
and deprecates the label.