### PR TITLE
cilium-cli: Use slim k8s packages for connectivity tests

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slimmetav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/versioncheck"
@@ -1576,7 +1577,7 @@ func (ct *ConnectivityTest) createTestConnDisruptClientDeploymentForNSTraffic(ct
 					}
 
 					// On GKE ExternalIP is not reachable from inside a cluster
-					if addr.Type == corev1.NodeExternalIP {
+					if addr.Type == slimcorev1.NodeExternalIP {
 						if f, ok := ct.Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
 							continue
 						}
@@ -1605,7 +1606,7 @@ func (ct *ConnectivityTest) createTestConnDisruptClientDeploymentForNSTraffic(ct
 
 type nodeWithType struct {
 	nodeType string
-	node     *corev1.Node
+	node     *slimcorev1.Node
 }
 
 func (ct *ConnectivityTest) getBackendNodeAndNonBackendNode(ctx context.Context) ([]nodeWithType, error) {
@@ -1658,7 +1659,7 @@ func (ct *ConnectivityTest) GetGatewayNodeInternalIP(egressGatewayNode string, i
 	}
 
 	for _, addr := range gatewayNode.Status.Addresses {
-		if addr.Type != corev1.NodeInternalIP {
+		if addr.Type != slimcorev1.NodeInternalIP {
 			continue
 		}
 

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +21,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/internal/helm"
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
+	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
 func parseBoolStatus(s string) bool {
@@ -383,12 +383,12 @@ func (ct *ConnectivityTest) ForceDisableFeature(feature features.Feature) {
 	ct.Features[feature] = features.Status{Enabled: false}
 }
 
-func canNodeRunCilium(node *corev1.Node) bool {
+func canNodeRunCilium(node *slimcorev1.Node) bool {
 	val, ok := node.ObjectMeta.Labels["cilium.io/no-schedule"]
 	return !ok || val == "false"
 }
 
-func isControlPlane(node *corev1.Node) bool {
+func isControlPlane(node *slimcorev1.Node) bool {
 	if node != nil {
 		_, ok := node.Labels["node-role.kubernetes.io/control-plane"]
 		return ok

--- a/cilium-cli/connectivity/check/peer.go
+++ b/cilium-cli/connectivity/check/peer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
 // TestPeer is the abstraction used for all peer types (pods, services, IPs,
@@ -246,7 +247,7 @@ func (s Service) FlowFilters() []*flow.FlowFilter {
 	return nil
 }
 
-func (s Service) ToNodeportService(node *corev1.Node) NodeportService {
+func (s Service) ToNodeportService(node *slimcorev1.Node) NodeportService {
 	return NodeportService{
 		Service: s,
 		Node:    node,
@@ -263,7 +264,7 @@ func (s Service) ToEchoIPService() EchoIPService {
 // It implements interface TestPeer.
 type NodeportService struct {
 	Service
-	Node *corev1.Node
+	Node *slimcorev1.Node
 }
 
 // Address returns the node IP of the wrapped Service.
@@ -273,7 +274,7 @@ func (s NodeportService) Address(family features.IPFamily) string {
 	}
 
 	for _, address := range s.Node.Status.Addresses {
-		if address.Type == corev1.NodeInternalIP {
+		if address.Type == slimcorev1.NodeInternalIP {
 			parsedAddress := net.ParseIP(address.Address)
 
 			switch family {

--- a/cilium-cli/connectivity/tests/host.go
+++ b/cilium-cli/connectivity/tests/host.go
@@ -7,10 +7,9 @@ import (
 	"context"
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
+	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
 // PodToHost sends an ICMP ping from all client Pods to all nodes
@@ -45,11 +44,11 @@ func (s *podToHost) Run(ctx context.Context, t *check.Test) {
 					}
 
 					switch {
-					case addr.Type == corev1.NodeInternalIP:
+					case addr.Type == slimcorev1.NodeInternalIP:
 						addrType = "internal-ip"
-					case addr.Type == corev1.NodeExternalIP:
+					case addr.Type == slimcorev1.NodeExternalIP:
 						addrType = "external-ip"
-					case addr.Type == corev1.NodeHostName:
+					case addr.Type == slimcorev1.NodeHostName:
 						addrType = "hostname"
 					}
 

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -8,10 +8,9 @@ import (
 	"fmt"
 	"slices"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
+	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
 // PodToService sends an HTTP request from all client Pods
@@ -205,7 +204,7 @@ func (s *podToLocalNodePort) Run(ctx context.Context, t *check.Test) {
 }
 
 func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
-	name string, pod *check.Pod, svc check.Service, node *corev1.Node,
+	name string, pod *check.Pod, svc check.Service, node *slimcorev1.Node,
 	validateFlows bool, secondaryNetwork bool) {
 
 	// Get the NodePort allocated to the Service.
@@ -215,13 +214,13 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 
 	if secondaryNetwork {
 		if t.Context().Features[features.IPv4].Enabled {
-			addrs = append(addrs, corev1.NodeAddress{
+			addrs = append(addrs, slimcorev1.NodeAddress{
 				Type:    "SecondaryNetworkIPv4",
 				Address: t.Context().SecondaryNetworkNodeIPv4()[node.Name],
 			})
 		}
 		if t.Context().Features[features.IPv6].Enabled {
-			addrs = append(addrs, corev1.NodeAddress{
+			addrs = append(addrs, slimcorev1.NodeAddress{
 				Type:    "SecondaryNetworkIPv6",
 				Address: t.Context().SecondaryNetworkNodeIPv6()[node.Name],
 			})
@@ -236,7 +235,7 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 			}
 
 			// On GKE ExternalIP is not reachable from inside a cluster
-			if addr.Type == corev1.NodeExternalIP {
+			if addr.Type == slimcorev1.NodeExternalIP {
 				if f, ok := t.Context().Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
 					continue
 				}


### PR DESCRIPTION
Use [slim](https://github.com/cilium/cilium/tree/main/pkg/k8s/slim) k8s `corev1` package for `Node`s in connectivity tests. This will reduce the memory footprint of the cilium-cli when running connectivity tests. The slim version of the `Node` object has all the fields required for the connectivity tests purpose. The connectivity tests already use slim k8s packages for other resources.

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

```release-note
cilium-cli: Use slim k8s packages for connectivity tests
```
