### PR TITLE
cilium-cli: Optimized feature detection by running cluster-wide checks once

### DIFF
--- a/cilium-cli/encrypt/status.go
+++ b/cilium-cli/encrypt/status.go
@@ -196,7 +196,7 @@ func nodeStatusFromText(str string) (models.EncryptionStatus, error) {
 func ipsecExpectedKeyCount(ciliumVersion semver.Version, cm *corev1.ConfigMap, nodeCount int) (int, error) {
 	fs := features.Set{}
 	fs.ExtractFromConfigMap(cm)
-	fs.ExtractFromVersionedConfigMap(ciliumVersion, cm)
+	fs.ExtractFromCiliumVersion(ciliumVersion)
 	if !fs[features.IPsecEnabled].Enabled {
 		return 0, nil
 	}

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -260,9 +260,8 @@ func RequireModeIsNot(feature Feature, mode string) Requirement {
 	}
 }
 
-// ExtractFromVersionedConfigMap extracts features based on Cilium version and cilium-config
-// ConfigMap.
-func (fs Set) ExtractFromVersionedConfigMap(ciliumVersion semver.Version, cm *v1.ConfigMap) {
+// ExtractFromCiliumVersion extracts features based on Cilium version.
+func (fs Set) ExtractFromCiliumVersion(ciliumVersion semver.Version) {
 	fs[PortRanges] = ExtractPortRanges(ciliumVersion)
 	fs[L7PortRanges] = ExtractL7PortRanges(ciliumVersion)
 }


### PR DESCRIPTION
This PR focuses on optimizing the `detectFeatures` function used in the setup phase of connectivity tests. Currently this function has a per-cilium-agent loop and on every iteration of this loop, it performs various feature detection checks. But the majority of those detection checks are cluster-wide and not specific to an agent. This means that the same detection logic that could run a single time instead ends up running unnecessarily once per agent.

This PR moves all those cluster-wide feature detection checks outside of the per agent loop.


Also the `ExtractFromVersionedConfigMap` function is renamed to `ExtractFromCiliumVersion` as it is not actually extracting anything from the configmap and there is already the `ExtractFromConfigMap` function that performs feature extraction from the configmap.

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!


```release-note
cilium-cli: Optimized feature detection by running cluster-wide checks once
```
