### PR TITLE
ci: filter runner upgrade for old stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -677,6 +677,26 @@
     {
       "enabled": false,
       "matchFileNames": [
+        ".github/workflows/lint-build-commits.yaml"
+      ],
+      "matchDepTypes": [
+        "github-runner",
+      ],
+      "matchPackageNames": [
+        "ubuntu",
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "matchBaseBranches": [
+        "v1.17",
+        "v1.16",
+        "v1.15"
+      ]
+    },
+    {
+      "enabled": false,
+      "matchFileNames": [
         ".github/workflows/documentation.yaml"
       ],
       "matchDepTypes": [


### PR DESCRIPTION
This is for .github/workflows/lint-build-commits.yaml only Since I'm not sure libtinfo6 won't be a problem for older stable branches, let's not push our luck and not upgrade the runner for versions older than 1.18.