### PR TITLE
loadbalancer/healthserver: Use external scope for backend address

### DIFF
--- a/pkg/loadbalancer/healthserver/healthserver.go
+++ b/pkg/loadbalancer/healthserver/healthserver.go
@@ -224,7 +224,7 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 									Protocol: lb.TCP,
 									Port:     port,
 								},
-								Scope: lb.ScopeInternal,
+								Scope: lb.ScopeExternal,
 							},
 							NodeName: s.nodeName,
 							State:    lb.BackendStateActive,

--- a/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
@@ -121,7 +121,7 @@ Address                 Type         ServiceName            PortName   Status  B
 [::]:30781/TCP          NodePort     test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
 [fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
 [fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
-[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP/i
+[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP
 
 -- frontends_tpcluster.table --
 Address                 Type         ServiceName            PortName   Status  Backends
@@ -134,7 +134,7 @@ Address                 Type         ServiceName            PortName   Status  B
 [::]:30781/TCP          NodePort     test/echo              http       Done    
 [fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    
 [fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    
-[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP/i
+[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP
 
 -- frontends_nohealthcheck.table --
 Address                 Type         ServiceName            PortName   Status  Backends
@@ -155,7 +155,7 @@ test/echo (http)       [fd02::1]:80/TCP
 test/echo (http)       [fd02::2]:80/TCP
 test/echo (http)       [fd02::3]:80/TCP
 test/echo (http)       [fd02::4]:80/TCP
-test/echo:healthserver [fd03::1111]:$HEALTHPORT/TCP/i
+test/echo:healthserver [fd03::1111]:$HEALTHPORT/TCP
 
 -- backends_othernode.table --
 Address           Instances              NodeName

--- a/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
@@ -121,7 +121,7 @@ Address               Type         ServiceName            PortName   Status  Bac
 0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
 10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
 172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
-172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP/i
+172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP
 
 -- frontends_tpcluster.table --
 Address               Type         ServiceName            PortName   Status  Backends
@@ -134,7 +134,7 @@ Address               Type         ServiceName            PortName   Status  Bac
 0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    
 10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    
 172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    
-172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP/i
+172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP
 
 -- frontends_nohealthcheck.table --
 Address               Type         ServiceName            PortName   Status  Backends
@@ -151,7 +151,7 @@ test/echo (http)       10.244.1.4:80/TCP
 
 -- backends.table --
 Instances              Address
-test/echo:healthserver 1.1.1.1:$HEALTHPORT/TCP/i
+test/echo:healthserver 1.1.1.1:$HEALTHPORT/TCP
 test/echo (http)       10.244.1.1:80/TCP
 test/echo (http)       10.244.1.2:80/TCP
 test/echo (http)       10.244.1.3:80/TCP


### PR DESCRIPTION
The health server backend address should not have the scope internal set as backend addresses don't really have a scope. This was causing the entry to be incorrectly pruned.
