### PR TITLE
loadbalancer: fix connectivity for host network pods

### DIFF
--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -159,6 +159,10 @@ func runPodReflector(ctx context.Context, health cell.Health, p reflectorParams,
 	processBuffer := func(txn writer.WriteTxn, buf iter.Seq2[types.NamespacedName, statedb.Change[daemonK8s.LocalPod]]) {
 		for _, change := range buf {
 			obj := change.Object.Pod
+			if obj.Spec.HostNetwork {
+				continue
+			}
+
 			podName := obj.Namespace + "/" + obj.Name
 			if change.Deleted {
 				rh.update(podName, nil)


### PR DESCRIPTION
Skip creating HostPort service in loadbalancer for host network pods.

We saw a regression with the disabling of the legacy load balancer control plane (#39915) with loss of connectivity to localhost:port for a host networking pod. In the legacy load balancer, 

the function that updates service mappings:
https://github.com/cilium/cilium/blob/f413ee6ace2be8e3a5059ab306fdf846b676c10c/pkg/k8s/watchers/pod.go#L542

is not called for hostnetwork pods:
https://github.com/cilium/cilium/blob/f413ee6ace2be8e3a5059ab306fdf846b676c10c/pkg/k8s/watchers/pod.go#L791-L797

This PR reverts this to the original behavior with the new control plane.

<!-- Description of change -->

Fixes: #40721

```release-note
fix: skip creating hostport mapping for host network pods
```
