### PR TITLE
CI: Fix GKE cluster creation failure due to 63-byte label limit

### DIFF
--- a/.github/actions/truncate-label/action.yml
+++ b/.github/actions/truncate-label/action.yml
@@ -1,0 +1,35 @@
+name: Truncate Label for Cloud Provider
+description: Truncates labels to meet cloud provider constraints (GKE 63-byte limit)
+inputs:
+  label:
+    description: 'The label value to truncate'
+    required: true
+  max_length:
+    description: 'Maximum length for the label (default 50 to allow for hash suffix)'
+    required: false
+    default: '50'
+outputs:
+  truncated_label:
+    description: 'The truncated label with hash suffix if needed'
+    value: ${{ steps.truncate.outputs.result }}
+runs:
+  using: composite
+  steps:
+    - name: Truncate label
+      id: truncate
+      shell: bash
+      run: |
+        LABEL="${{ inputs.label }}"
+        MAX_LENGTH="${{ inputs.max_length }}"
+
+        # Replace dots and slashes with hyphens for cloud provider compatibility
+        LABEL="${LABEL//[.\/]/-}"
+
+        # Truncate if needed and add hash for uniqueness
+        if [ ${#LABEL} -gt $MAX_LENGTH ]; then
+          HASH=$(echo "$LABEL" | sha256sum | cut -c1-8)
+          LABEL="${LABEL:0:$MAX_LENGTH}-${HASH}"
+        fi
+
+        echo "result=${LABEL}" >> $GITHUB_OUTPUT
+        echo "Truncated label: ${LABEL}"

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -228,15 +228,16 @@ jobs:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
+      - name: Truncate owner label for GKE
+        id: truncate-owner
+        uses: ./.github/actions/truncate-label
+        with:
+          label: ${{ github.event_name == 'workflow_dispatch' && inputs.PR-number || github.ref_name }}
+
       - name: Set up job variables
         id: vars
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            OWNER="${{ inputs.PR-number }}"
-          else
-            OWNER="${{ github.ref_name }}"
-            OWNER="${OWNER//[.\/]/-}"
-          fi
+          OWNER="${{ steps.truncate-owner.outputs.truncated_label }}"
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.config.index }} \

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -170,16 +170,16 @@ jobs:
           chart-dir: ./install/kubernetes/cilium
           debug: false
 
+      - name: Truncate owner label for GKE
+        id: truncate-owner
+        uses: ./.github/actions/truncate-label
+        with:
+          label: ${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request) && inputs.PR-number || github.ref_name }}
+
       - name: Set up job variables
         id: vars
         run: |
-          # shellcheck disable=SC2078
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ ${{ github.event.pull_request }} ] ; then
-            OWNER="${{ inputs.PR-number }}"
-          else
-            OWNER="${{ github.ref_name }}"
-            OWNER="${OWNER//[.\/]/-}"
-          fi
+          OWNER="${{ steps.truncate-owner.outputs.truncated_label }}"
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=cluster.name=${{ env.clusterName }}-${{ matrix.index }} \


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

## Summary

This PR fixes GKE cluster creation failures caused by branch names exceeding Google Cloud's 63-byte label value limit. The issue was specifically triggered by Renovate bot branch names like `renovate-main-go-github-com-go-viper-mapstructure-v2-vulnerability` (73 bytes).

## Changes Made

1. **Fixed GKE Workflows**: Modified `.github/workflows/conformance-gke.yaml` and `.github/workflows/net-perf-gke.yaml` to truncate long branch names to 50 characters and append an 8-character hash for uniqueness.

2. **Added Reusable Action**: Created `.github/actions/truncate-label/action.yml` for future use across other cloud provider workflows.

3. **Preserved Compatibility**: Short branch names remain unchanged, ensuring backward compatibility.

## Solution Details

- **Truncation Logic**: Branch names longer than 50 characters are truncated and a SHA256 hash suffix is added
- **Result Format**: `{first-50-chars}-{8-char-hash}` (max 59 characters, well under GKE's 63-byte limit)
- **Uniqueness**: Hash suffix prevents resource conflicts between similar long branch names
- **Examples**:
  - `renovate-main-go-github-com-go-viper-mapstructure-v2-vulnerability` → `renovate-main-go-github-com-go-viper-mapstructure--fb202bf8`
  - `main` → `main` (unchanged)

## Testing

Verified the truncation logic handles various branch name patterns correctly and stays within GKE's 63-byte label limit.

Fixes: #40251

```release-note
Fix GKE cluster creation failures when branch names exceed 63-byte label limit by implementing automatic truncation with hash-based uniqueness preservation.
```
```