### PR TITLE
containerlab/bgpv2: update Cilium version and add local build in Makefile

### DIFF
--- a/contrib/containerlab/bgpv2/multi-homing/Makefile
+++ b/contrib/containerlab/bgpv2/multi-homing/Makefile
@@ -1,13 +1,24 @@
-# version of cilium to deploy
-VERSION ?= v1.16.0
+VERSION ?= $(shell curl -s https://raw.githubusercontent.com/cilium/cilium/main/stable.txt)
+
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+KIND_CLUSTER_NAME ?= bgpv2-cplane-dev-multi-homing
+
 
 deploy:
 	kind create cluster --config cluster.yaml
 	sudo containerlab -t topo.yaml deploy
 	# create secret for bgp
 	kubectl -n kube-system create secret generic --type=string bgp-auth-secret --from-literal=password=cilium123
-	# install cilium
-	helm install cilium -n kube-system cilium/cilium --version $(VERSION) -f values.yaml
+	if [ "$(VERSION)" = "local" ]; then \
+		$(MAKE) -C $(ROOT_DIR) kind-image KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME); \
+		helm install cilium -n kube-system $(ROOT_DIR)/install/kubernetes/cilium/ -f values.yaml \
+			--set image.override="localhost:5000/cilium/cilium-dev:local"  \
+			--set image.pullPolicy=Never \
+			--set operator.image.override="localhost:5000/cilium/operator-generic:local" \
+			--set operator.image.pullPolicy=Never; \
+	else \
+		helm install cilium -n kube-system cilium/cilium --version $(VERSION) -f values.yaml; \
+	fi
 	cilium status --wait --namespace kube-system
 
 destroy:

--- a/contrib/containerlab/bgpv2/pod-ip-pool/Makefile
+++ b/contrib/containerlab/bgpv2/pod-ip-pool/Makefile
@@ -1,5 +1,6 @@
-# version of cilium to deploy
-VERSION ?= v1.16.0
+VERSION ?= $(shell curl -s https://raw.githubusercontent.com/cilium/cilium/main/stable.txt)
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+KIND_CLUSTER_NAME ?= bgpv2-cplane-dev-pod-ip-pool
 
 deploy:
 	kind create cluster --config cluster.yaml
@@ -9,7 +10,16 @@ deploy:
 	# create secret for bgp
 	kubectl -n kube-system create secret generic --type=string bgp-auth-secret --from-literal=password=cilium123
 	# install cilium
-	helm install cilium -n kube-system cilium/cilium --version $(VERSION) -f values.yaml
+	if [ "$(VERSION)" = "local" ]; then \
+		$(MAKE) -C $(ROOT_DIR) kind-image KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME); \
+		helm install cilium -n kube-system $(ROOT_DIR)/install/kubernetes/cilium/ -f values.yaml \
+			--set image.override="localhost:5000/cilium/cilium-dev:local"  \
+			--set image.pullPolicy=Never \
+			--set operator.image.override="localhost:5000/cilium/operator-generic:local" \
+			--set operator.image.pullPolicy=Never; \
+	else \
+		helm install cilium -n kube-system cilium/cilium --version $(VERSION) -f values.yaml; \
+	fi
 
 destroy:
 	sudo containerlab -t topo.yaml destroy -c

--- a/contrib/containerlab/bgpv2/service/Makefile
+++ b/contrib/containerlab/bgpv2/service/Makefile
@@ -1,4 +1,8 @@
-VERSION ?= v1.16.0
+VERSION ?= $(shell curl -s https://raw.githubusercontent.com/cilium/cilium/main/stable.txt)
+
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+KIND_CLUSTER_NAME ?= bgpv2-cplane-dev-service
+
 
 deploy:
 	kind create cluster --config cluster.yaml
@@ -8,7 +12,16 @@ deploy:
 	# create secret for bgp
 	kubectl -n kube-system create secret generic --type=string bgp-auth-secret --from-literal=password=cilium123
 	# install cilium
-	helm install cilium -n kube-system cilium/cilium --version $(VERSION) -f values.yaml
+	if [ "$(VERSION)" = "local" ]; then \
+		$(MAKE) -C $(ROOT_DIR) kind-image KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME); \
+		helm install cilium -n kube-system $(ROOT_DIR)/install/kubernetes/cilium/ -f values.yaml \
+			--set image.override="localhost:5000/cilium/cilium-dev:local"  \
+			--set image.pullPolicy=Never \
+			--set operator.image.override="localhost:5000/cilium/operator-generic:local" \
+			--set operator.image.pullPolicy=Never; \
+	else \
+		helm install cilium -n kube-system cilium/cilium --version $(VERSION) -f values.yaml; \
+	fi
 	cilium status --wait --namespace kube-system
 
 destroy:


### PR DESCRIPTION
Replaced the hardcoded Cilium version with a dynamic retrieval from the official repository in the Makefiles for multi-homing, pod IP pool, and service configurations in `containerlab/bgpv2`. Enhanced the deployment logic to handle local image installations, allowing for better flexibility in development environments.


```release-note
Update makefile in containerlab/bgpv2 from hardcode to dynamic stable version and new logic to handle local image for  development environments.
```
