### PR TITLE
ci: Fix CI-Fuzz Build failures

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/fuzz_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/fuzz_test.go
@@ -4,10 +4,10 @@
 package v2
 
 import (
+	"log/slog"
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"github.com/cilium/hive/hivetest"
 )
 
 func FuzzCiliumNetworkPolicyParse(f *testing.F) {
@@ -16,7 +16,7 @@ func FuzzCiliumNetworkPolicyParse(f *testing.F) {
 		r := &CiliumNetworkPolicy{}
 		ff.GenerateStruct(r)
 		clusterName, _ := ff.GetString()
-		_, _ = r.Parse(hivetest.Logger(t), clusterName)
+		_, _ = r.Parse(slog.New(slog.DiscardHandler), clusterName)
 	})
 }
 
@@ -26,6 +26,6 @@ func FuzzCiliumClusterwideNetworkPolicyParse(f *testing.F) {
 		r := &CiliumClusterwideNetworkPolicy{}
 		ff.GenerateStruct(r)
 		clusterName, _ := ff.GetString()
-		_, _ = r.Parse(hivetest.Logger(t), clusterName)
+		_, _ = r.Parse(slog.New(slog.DiscardHandler), clusterName)
 	})
 }

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -4,10 +4,10 @@
 package policy
 
 import (
+	"log/slog"
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	"github.com/cilium/hive/hivetest"
 
 	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
@@ -31,19 +31,20 @@ func FuzzResolvePolicy(f *testing.F) {
 			return
 		}
 
-		td := newTestData(hivetest.Logger(t)).withIDs(ruleTestIDs)
+		logger := slog.New(slog.DiscardHandler)
+		td := newTestData(logger).withIDs(ruleTestIDs)
 		td.repo.mustAdd(r)
 		sp, err := td.repo.resolvePolicyLocked(idA)
 		if err != nil {
 			return
 		}
-		sp.DistillPolicy(hivetest.Logger(t), &EndpointInfo{ID: uint64(idA.ID)}, nil)
+		sp.DistillPolicy(logger, &EndpointInfo{ID: uint64(idA.ID)}, nil)
 	})
 }
 
 func FuzzDenyPreferredInsert(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		keys := emptyMapState(hivetest.Logger(t))
+		keys := emptyMapState(slog.New(slog.DiscardHandler))
 		key := Key{}
 		entry := NewMapStateEntry(types.AllowEntry())
 		ff := fuzz.NewConsumer(data)
@@ -84,7 +85,7 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		}
 		key := KeyForDirection(dir).WithPortProto(proto, port)
 		value := newMapStateEntry(NilRuleOrigin, proxyPort, 0, deny, NoAuthRequirement)
-		policyMaps := MapChanges{}
+		policyMaps := MapChanges{logger: slog.New(slog.DiscardHandler)}
 		policyMaps.AccumulateMapChanges(adds, deletes, []Key{key}, value)
 		policyMaps.SyncMapChanges(versioned.LatestTx)
 	})

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -15,7 +15,6 @@ printf "package policy\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testin
 go mod tidy && go mod vendor
 mv $SRC/cilium/pkg/policy/distillery_test.go $SRC/cilium/pkg/policy/distillery_test_fuzz.go
 mv $SRC/cilium/pkg/policy/l4_filter_test.go $SRC/cilium/pkg/policy/l4_filter_test_fuzz.go
-mv $SRC/cilium/pkg/policy/policy_test.go $SRC/cilium/pkg/policy/policy_test_fuzz.go
 mv $SRC/cilium/pkg/policy/mapstate_test.go $SRC/cilium/pkg/policy/mapstate_test_fuzz.go
 mv $SRC/cilium/pkg/policy/repository_test.go $SRC/cilium/pkg/policy/repository_test_fuzz.go
 mv $SRC/cilium/pkg/policy/resolve_test.go $SRC/cilium/pkg/policy/resolve_test_fuzz.go

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -23,10 +23,11 @@ mv $SRC/cilium/pkg/policy/resolve_deny_test.go $SRC/cilium/pkg/policy/resolve_de
 mv $SRC/cilium/pkg/policy/rule_test.go $SRC/cilium/pkg/policy/rule_test_fuzz.go
 mv $SRC/cilium/pkg/policy/selectorcache_test.go $SRC/cilium/pkg/policy/selectorcache_test_fuzz.go
 
+
 compile_go_fuzzer github.com/cilium/cilium/test/fuzzing Fuzz fuzz gofuzz
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/monitor/format FuzzFormatEvent FuzzFormatEvent
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumNetworkPolicyParse FuzzCiliumNetworkPolicyParse
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumClusterwideNetworkPolicyParse FuzzCiliumClusterwideNetworkPolicyParse
-compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzResolveEgressPolicy FuzzResolveEgressPolicy
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzResolvePolicy FuzzResolvePolicy
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzDenyPreferredInsert FuzzDenyPreferredInsert
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzAccumulateMapChange FuzzAccumulateMapChange

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -15,6 +15,7 @@ printf "package policy\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testin
 go mod tidy && go mod vendor
 mv $SRC/cilium/pkg/policy/distillery_test.go $SRC/cilium/pkg/policy/distillery_test_fuzz.go
 mv $SRC/cilium/pkg/policy/l4_filter_test.go $SRC/cilium/pkg/policy/l4_filter_test_fuzz.go
+mv $SRC/cilium/pkg/policy/l4_test.go $SRC/cilium/pkg/policy/l4_test_fuzz.go
 mv $SRC/cilium/pkg/policy/mapstate_test.go $SRC/cilium/pkg/policy/mapstate_test_fuzz.go
 mv $SRC/cilium/pkg/policy/repository_test.go $SRC/cilium/pkg/policy/repository_test_fuzz.go
 mv $SRC/cilium/pkg/policy/resolve_test.go $SRC/cilium/pkg/policy/resolve_test_fuzz.go


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

This PR causes all fuzzers to build successfully (tested locally using my fork of oss-fuzz here: https://github.com/lomackie/oss-fuzz/commit/e59bb05d58b5d1623592efa25f591c75c856d77c). I'm not entirely sure if it will build perfectly in CI but this workflow was green a few commits ago (doesn't account for any of the cncf-fuzzing changes - but those can fail without the build failing): https://github.com/cilium/cilium/actions/runs/16532943538

Linked PRs:
- https://github.com/cncf/cncf-fuzzing/pull/557 - this got merged in instantly 😅 perhaps I should have left it in draft
  - As I mentioned in the PR description a large number of these fuzzers haven't built successfully in a long time
  - Additionally these builds can fail without causing the CI to fail, compared to the ones in this repo which have `set -e` - is that intended behaviour?
  - Does it make sense to keep fuzzing proxylib now that it's moved to a different repo?
- https://github.com/google/oss-fuzz/pull/13746 - pulls in the proxy source for the proxylib build

Given there are now going to be more fuzzers running which haven't run for a while I'd expect to see a bunch of tests failing, I can't see the original failure in the linked issue as the build logs have expired, but I'm assuming this resolving just the build errors is okay, and the tests themselves are a separate issue.

Fixes: #37885
