### PR TITLE
v1.18 backports 2025-07-25

### DIFF
--- a/Documentation/network/servicemesh/istio.rst
+++ b/Documentation/network/servicemesh/istio.rst
@@ -17,6 +17,26 @@ This document covers the following common aspects of Cilium's integration with I
 * Istio configuration
 * Demo application
 
+.. note::
+
+   You can run Cilium with Istio in two ways:
+
+   1. **With kube-proxy present (recommended):**
+
+      - Set ``kubeProxyReplacement: false`` (the default).
+      - Cilium does not fully replace kube-proxy; kube-proxy continues to handle ClusterIP routing.
+      - This is the recommended setup for using Istio with minimal disruption, particularly in sidecar or ambient mode.
+
+   2. **With kube-proxy removed (full replacement):**
+
+      - Set ``kubeProxyReplacement: true``, ``socketLB.hostNamespaceOnly: true``, and ``cni.exclusive: false``.
+      - These settings prevent Cilium’s socket-based load balancing from interfering with Istio’s proxying.
+      - kube-proxy can be removed in this mode, but these configurations are required to ensure compatibility.
+
+   In summary, you can run Istio with Cilium and kube-proxy by setting ``kubeProxyReplacement: false`` (the default and recommended for most Istio installs);
+   or you can run without kube-proxy by setting ``kubeProxyReplacement: true``, but you must carefully configure Cilium to avoid conflicts with Istio.
+
+
 Cilium Configuration
 ====================
 

--- a/pkg/loadbalancer/healthserver/healthserver.go
+++ b/pkg/loadbalancer/healthserver/healthserver.go
@@ -224,7 +224,7 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 									Protocol: lb.TCP,
 									Port:     port,
 								},
-								Scope: lb.ScopeInternal,
+								Scope: lb.ScopeExternal,
 							},
 							NodeName: s.nodeName,
 							State:    lb.BackendStateActive,

--- a/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
@@ -121,7 +121,7 @@ Address                 Type         ServiceName            PortName   Status  B
 [::]:30781/TCP          NodePort     test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
 [fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
 [fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    [fd02::1]:80/TCP, [fd02::2]:80/TCP
-[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP/i
+[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP
 
 -- frontends_tpcluster.table --
 Address                 Type         ServiceName            PortName   Status  Backends
@@ -134,7 +134,7 @@ Address                 Type         ServiceName            PortName   Status  B
 [::]:30781/TCP          NodePort     test/echo              http       Done    
 [fd00::aaaa]:80/TCP     ClusterIP    test/echo              http       Done    
 [fd01::bbbb]:80/TCP     LoadBalancer test/echo              http       Done    
-[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP/i
+[fd01::bbbb]:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    [fd03::1111]:$HEALTHPORT/TCP
 
 -- frontends_nohealthcheck.table --
 Address                 Type         ServiceName            PortName   Status  Backends
@@ -155,7 +155,7 @@ test/echo (http)       [fd02::1]:80/TCP
 test/echo (http)       [fd02::2]:80/TCP
 test/echo (http)       [fd02::3]:80/TCP
 test/echo (http)       [fd02::4]:80/TCP
-test/echo:healthserver [fd03::1111]:$HEALTHPORT/TCP/i
+test/echo:healthserver [fd03::1111]:$HEALTHPORT/TCP
 
 -- backends_othernode.table --
 Address           Instances              NodeName

--- a/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
@@ -121,7 +121,7 @@ Address               Type         ServiceName            PortName   Status  Bac
 0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
 10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
 172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
-172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP/i
+172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP
 
 -- frontends_tpcluster.table --
 Address               Type         ServiceName            PortName   Status  Backends
@@ -134,7 +134,7 @@ Address               Type         ServiceName            PortName   Status  Bac
 0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    
 10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    
 172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    
-172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP/i
+172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP
 
 -- frontends_nohealthcheck.table --
 Address               Type         ServiceName            PortName   Status  Backends
@@ -151,7 +151,7 @@ test/echo (http)       10.244.1.4:80/TCP
 
 -- backends.table --
 Instances              Address
-test/echo:healthserver 1.1.1.1:$HEALTHPORT/TCP/i
+test/echo:healthserver 1.1.1.1:$HEALTHPORT/TCP
 test/echo (http)       10.244.1.1:80/TCP
 test/echo (http)       10.244.1.2:80/TCP
 test/echo (http)       10.244.1.3:80/TCP

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -159,6 +159,10 @@ func runPodReflector(ctx context.Context, health cell.Health, p reflectorParams,
 	processBuffer := func(txn writer.WriteTxn, buf iter.Seq2[types.NamespacedName, statedb.Change[daemonK8s.LocalPod]]) {
 		for _, change := range buf {
 			obj := change.Object.Pod
+			if obj.Spec.HostNetwork {
+				continue
+			}
+
 			podName := obj.Namespace + "/" + obj.Name
 			if change.Deleted {
 				rh.update(podName, nil)


### PR DESCRIPTION
v1.18 backports 2025-07-25

 - [ ] #40572 -- docs: clarify kubeProxyReplacement and kube-proxy requirements for Istio integration (@RayyanSeliya)
 - [x] #40720 -- loadbalancer/healthserver: Use external scope for backend address (@joamaki)
 - [ ] #40722 -- loadbalancer: fix connectivity for host network pods (@jshr-w)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
40572 40720 40722
```
