### PR TITLE
clustermesh: update ServiceImport IPs within our service controller

### DIFF
--- a/pkg/clustermesh/mcsapi/README.md
+++ b/pkg/clustermesh/mcsapi/README.md
@@ -32,9 +32,7 @@ trigger the normal mechanism of a regular global Service. This involves for inst
 generation but also all the other clustermesh flows that are not necessarily related
 directly to MCS-API (syncing the remote endpoints to BPF maps, EndpointSliceSync, ...).
 
-There is also another controller that we use directly from the MCS-API repository
-`mcsapicontrollers.ServiceReconciler` that reports back the ClusterIP from the
-derived Service to the ServiceImport.
+The same controller will also reports back the IPs from the derived Service to the ServiceImport.
 
 To handle all the DNS aspect we rely on the multicluster CoreDNS plugin which queries
 the ServiceImport and the EndpointSlice resources, for more details about this see
@@ -86,7 +84,6 @@ flowchart TD
         `"]
 
         serviceImport -->|mcsAPIServiceReconciler| derivedService
-        derivedService -->|mcsapicontrollers.ServiceReconciler| serviceImport
 
         localService["`
         Service

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlRuntime "sigs.k8s.io/controller-runtime"
-	mcsapicontrollers "sigs.k8s.io/mcs-api/controllers"
 	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
@@ -120,16 +119,6 @@ func registerMCSAPIController(params mcsAPIParams) error {
 
 	if err := newMCSAPIEndpointSliceMirrorReconciler(params.CtrlRuntimeManager, params.Logger, params.ClusterInfo.Name).SetupWithManager(params.CtrlRuntimeManager); err != nil {
 		return fmt.Errorf("Failed to register MCSAPIEndpointSliceMirrorReconciler: %w", err)
-	}
-
-	// Upstream controller that we use as is to update the ServiceImport
-	// objects with the IPs of the derived Services.
-	svcReconciler := mcsapicontrollers.ServiceReconciler{
-		Client: params.CtrlRuntimeManager.GetClient(),
-		Log:    params.CtrlRuntimeManager.GetLogger(),
-	}
-	if err := svcReconciler.SetupWithManager(params.CtrlRuntimeManager); err != nil {
-		return fmt.Errorf("Failed to register mcsapicontrollers.ServiceReconciler: %w", err)
 	}
 
 	params.Logger.Info("Multi-Cluster Services API support enabled")

--- a/pkg/clustermesh/mcsapi/service_controller_test.go
+++ b/pkg/clustermesh/mcsapi/service_controller_test.go
@@ -142,6 +142,10 @@ var (
 				Name:      derivedName(types.NamespacedName{Name: "full-update", Namespace: "default"}),
 				Namespace: "default",
 			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP:  "42.42.42.42",
+				ClusterIPs: []string{"42.42.42.42"},
+			},
 		},
 
 		&mcsapiv1alpha1.ServiceImport{
@@ -292,6 +296,7 @@ func Test_mcsDerivedService_Reconcile(t *testing.T) {
 			err = c.Get(context.Background(), key, svcImport)
 			require.NoError(t, err)
 			require.Equal(t, keyDerived.Name, svcImport.Annotations[mcsapicontrollers.DerivedServiceAnnotation])
+			require.Equal(t, svc.Spec.ClusterIPs, svcImport.Spec.IPs)
 		}
 	})
 


### PR DESCRIPTION
Before this commit, we relied on the ServiceReconciler from the mcs-api repository. We did this assuming that we needed to wait that the ClusterIPs was generated on the Service and that it would be simpler to do on a dedicated controller which the mcs-api repository already provided.

However it turns out that when we create a Service in Kubernetes the kube-apiserver directly returns the IPs without some controller reconciling it externally which means that it is actually simpler to do in our service controller. This would also allow us to have custom logic later for instance for things related to IPFamilies/dual-stack.

The logic also have been updated to use Patch on the ServiceImport rather than Update.

```release-note
clustermesh: improve logic to report back IPs from the derived service to the ServiceImport
```
