### PR TITLE
clustermesh: add MCS-API prometheus metrics

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -509,6 +509,7 @@ Makefile* @cilium/build
 /pkg/cleanup/ @cilium/sig-agent
 /pkg/client @cilium/api
 /pkg/clustermesh @cilium/sig-clustermesh
+/pkg/clustermesh/*/metrics* @cilium/metrics @cilium/sig-clustermesh
 /pkg/cmdref @cilium/cli
 /pkg/command/ @cilium/cli
 /pkg/common/ @cilium/sig-agent

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -854,6 +854,17 @@ Name                                                 Labels                     
 ``workqueue_retries_total``                          ``queue_name``                                 Enabled    Total number of retries handled by workqueue
 ==================================================== ============================================= ========== ===========================================================
 
+MCS-API
+~~~~~~~
+
+==================================== ============================================================ ========== ===========================================================
+Name                                                 Labels                                                    Default     Description
+==================================== ============================================================ ========== ===========================================================
+``serviceexport_info``               ``serviceexport``, ``namespace``                             Enabled    Information about ServiceExport in the local cluster
+``serviceexport_status_condition``   ``serviceexport``, ``namespace``, ``condition``, ``status``  Enabled    Status Condition of ServiceExport in the local cluster
+``serviceimport_info``               ``serviceimport``, ``namespace``                             Enabled    Information about ServiceImport in the local cluster
+==================================== ============================================================ ========== ===========================================================
+
 
 Hubble
 ------

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -123,6 +123,8 @@ func registerMCSAPIController(params mcsAPIParams) error {
 
 	params.Logger.Info("Multi-Cluster Services API support enabled")
 
+	registerMCSAPICollector(params.Logger, params.CtrlRuntimeManager.GetClient())
+
 	remoteClusterServiceSource := &remoteClusterServiceExportSource{Logger: params.Logger}
 	params.ClusterMesh.RegisterClusterServiceExportUpdateHook(remoteClusterServiceSource.onClusterServiceExportEvent)
 	params.ClusterMesh.RegisterClusterServiceExportDeleteHook(remoteClusterServiceSource.onClusterServiceExportEvent)

--- a/pkg/clustermesh/mcsapi/metrics.go
+++ b/pkg/clustermesh/mcsapi/metrics.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+func registerMCSAPICollector(logger *slog.Logger, client client.Client) {
+	operatorMetrics.Registry.MustRegister(&mcsAPICollector{
+		logger: logger,
+		client: client,
+
+		serviceExportInfo: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, "", "serviceexport_info"),
+			"Information about ServiceExport in the local cluster",
+			[]string{"serviceexport", "namespace"}, nil),
+		serviceExportStatusCondition: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, "", "serviceexport_status_condition"),
+			"Status Condition of ServiceExport in the local cluster",
+			[]string{"serviceexport", "namespace", "condition", "status"}, nil),
+		serviceImportInfo: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, "", "serviceimport_info"),
+			"Information about ServiceImport in the local cluster",
+			[]string{"serviceimport", "namespace"}, nil),
+	})
+}
+
+type mcsAPICollector struct {
+	logger *slog.Logger
+	client client.Client
+
+	serviceExportInfo            *prometheus.Desc
+	serviceExportStatusCondition *prometheus.Desc
+	serviceImportInfo            *prometheus.Desc
+}
+
+func (c *mcsAPICollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.serviceExportInfo
+	ch <- c.serviceExportStatusCondition
+	ch <- c.serviceImportInfo
+}
+
+func (c *mcsAPICollector) Collect(ch chan<- prometheus.Metric) {
+	svcExportList := mcsapiv1alpha1.ServiceExportList{}
+	err := c.client.List(context.Background(), &svcExportList)
+	if err != nil {
+		c.logger.Error("failed to list ServiceExport during metrics collection", logfields.Error, err)
+		return
+	}
+	for _, svcExport := range svcExportList.Items {
+		metric, err := prometheus.NewConstMetric(
+			c.serviceExportInfo,
+			prometheus.GaugeValue,
+			1,
+			svcExport.Name, svcExport.Namespace,
+		)
+		if err != nil {
+			c.logger.Error("Failed to generate ServiceExport metrics", logfields.Error, err)
+			return
+		}
+		ch <- metric
+		for _, condition := range svcExport.Status.Conditions {
+			metric, err := prometheus.NewConstMetric(
+				c.serviceExportStatusCondition,
+				prometheus.GaugeValue,
+				1,
+				svcExport.Name, svcExport.Namespace,
+				string(condition.Type), string(condition.Status),
+			)
+			if err != nil {
+				c.logger.Error("Failed to generate ServiceExport metrics", logfields.Error, err)
+				return
+			}
+			ch <- metric
+		}
+	}
+
+	svcImportList := mcsapiv1alpha1.ServiceImportList{}
+	err = c.client.List(context.Background(), &svcImportList)
+	if err != nil {
+		c.logger.Error("failed to list ServiceImport during metrics collection", logfields.Error, err)
+		return
+	}
+	for _, svcImport := range svcImportList.Items {
+		metric, err := prometheus.NewConstMetric(
+			c.serviceImportInfo,
+			prometheus.GaugeValue,
+			1,
+			svcImport.Name, svcImport.Namespace,
+		)
+		if err != nil {
+			c.logger.Error("Failed to generate ServiceImport metrics", logfields.Error, err)
+			return
+		}
+		ch <- metric
+	}
+}


### PR DESCRIPTION
Add initial metrics about ServiceExport and ServiceImport. This focuses on number of object created and status condition so that users may create monitoring on ServiceExport conflict for instance and when we would have ServiceImport status conditions we will be able to add metrics for those too.

It is based on similar name as kube-state-metrics, see: https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/workload/deployment-metrics.md

```release-note
clustermesh: add prometheus metrics about local ServiceExport and ServiceImport
```
