### PR TITLE
GH-40627: Add retries for client-egress-tls* tests

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -30,7 +30,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
 		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld(false)).
+		WithScenarios(tests.PodToWorld(false, tests.WithRetryAll())).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -63,7 +63,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
 		// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-		WithScenarios(tests.PodToWorld(false)).
+		WithScenarios(tests.PodToWorld(false, tests.WithRetryAll())).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -99,7 +99,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 			WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 			// TODO: Reenable IPv6 for this test once the kernel with the bugfix is released:
 			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
-			WithScenarios(tests.PodToWorld(false)).
+			WithScenarios(tests.PodToWorld(false, tests.WithRetryAll())).
 			WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 				if a.Destination().Port() == 443 {
 					return check.ResultOK, check.ResultNone

--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -307,9 +307,11 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 			a.Debugf("retrying command %s due to inconclusive results", cmdStr)
 			continue
 		} else if err != nil {
+			// Log the output, errOutput and error only if the command failed.
+			a.Debugf("Command %q output: %s errOutput: %s err: %s", cmdStr, a.cmdOutput, errOutput.String(), err.Error())
 			exitCode, _ := a.extractExitCode(err)
 			if exitCode == ExitInvalidCode {
-				a.Debugf("retrying command %s to to command execution error", cmdStr)
+				a.Debugf("retrying command %s due to command execution error", cmdStr)
 				continue
 			}
 		}


### PR DESCRIPTION
Ref: https://github.com/cilium/cilium/issues/40627

Adding this to enable retries for cilium egress tls tests. While fixing this [bug](https://github.com/cilium/cilium/issues/37724) , the upgrade e2e tests fails for this particular scenario randomly (the same test passes and fails in different runs). 

The test is only failing during upgrade. And the test is failing consistently (though it passes occasionally). What I was trying to determine if there is an issue with syncing the policy to the eBPF map which was causing curl failures. Given the test pass consistently on retry, I think either

- the client-egress-sni* test is flaky and retry is the correct way to go, or
- there is an existing bug in L7 that this change exposes

Raising this PR to add retries for this failure to facilitate checking in the policy fix, while investigation continues for the test failure bug. In the course of the investigation, if any other reason is determined for the failure, this change can be reverted back.

Please refer to the [bug](https://github.com/cilium/cilium/issues/40627) for more details of the investigation and subsequent discussion. 

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: [#issue-number](https://github.com/cilium/cilium/issues/40627)

