### PR TITLE
[RFC] bpf: Introduce `BENCH` test directive for BPF micro benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,6 +554,11 @@ run_bpf_tests: ## Build and run the BPF unit tests using the cilium-builder cont
 			"JUNIT_PATH=$(JUNIT_PATH)" \
 			"V=$(BPF_TEST_VERBOSE)"
 
+run_bpf_benchmarks: ## Build and run the BPF benchmarks tests using the cilium-builder container image.
+	DOCKER_ARGS=--privileged RUN_AS_ROOT=1 contrib/scripts/builder.sh \
+		$(MAKE) $(SUBMAKEOPTS) -j$(shell nproc) -C bpf/tests/ run_bench \
+			"BPF_TEST_FILE=$(BPF_TEST_FILE)"
+
 run-builder: ## Drop into a shell inside a container running the cilium-builder image.
 	DOCKER_ARGS=-it contrib/scripts/builder.sh bash
 

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -50,6 +50,7 @@ clean:
 	rm -f $(wildcard *.d)
 
 BPF_TEST_FLAGS:= $(GO_TEST_FLAGS)
+BPF_BENCH_FLAGS:=
 ifneq ($(shell id -u), 0)
 		BPF_TEST_FLAGS += -exec "sudo -E"
 endif
@@ -74,8 +75,12 @@ endif
 ifdef BPF_TEST_DUMP_CTX
     BPF_TEST_FLAGS += -dump-ctx
 endif
+ifdef BPF_TEST_BENCH
+	BPF_TEST_FLAGS += -bpf-bench
+endif
 ifdef BPF_TEST_FILE
 	BPF_TEST_FLAGS += -test $(BPF_TEST_FILE)
+	BPF_BENCH_FLAGS += -test $(BPF_TEST_FILE)
 endif
 
 run: $(TEST_OBJECTS)
@@ -83,5 +88,10 @@ run: $(TEST_OBJECTS)
 		-bpf-test-path $(ROOT_DIR)/bpf/tests \
 		$(BPF_TEST_FLAGS) \
 	| $(GOTEST_FORMATTER)
+
+run_bench: $(TEST_OBJECTS)
+	$(QUIET)$(GO) run ./bpfbench \
+		-bpf-test-path $(ROOT_DIR)/bpf/tests \
+		$(BPF_BENCH_FLAGS)
 
 -include $(TEST_OBJECTS:.o=.d)

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -1125,7 +1125,7 @@ static long snat_callback_tcp(__u32 i, struct snat_callback_ctx *ctx)
 	return ctx->err != 0;
 }
 
-CHECK("tc", "nat4_port_allocation")
+CHECK("tc", "nat4_port_allocation_tcp")
 int test_nat4_port_allocation_tcp_check(struct __ctx_buff *ctx)
 {
 	struct snat_callback_ctx cb_ctx = {
@@ -1256,7 +1256,7 @@ static long snat_callback_udp(__u32 i, struct snat_callback_ctx *ctx)
 	return ctx->err != 0;
 }
 
-CHECK("tc", "nat4_port_allocation")
+CHECK("tc", "nat4_port_allocation_udp")
 int test_nat4_port_allocation_udp_check(struct __ctx_buff *ctx)
 {
 	struct snat_callback_ctx cb_ctx = {

--- a/bpf/tests/bpfbench/bpf_bench.go
+++ b/bpf/tests/bpfbench/bpf_bench.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+
+	bpftest "github.com/cilium/cilium/bpf/tests/bpftest"
+
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+var (
+	testPath       = flag.String("bpf-test-path", "", "Path to the eBPF tests")
+	testFilePrefix = flag.String("test", "", "Single test file to run (without file extension)")
+)
+
+type benchmarkResult struct {
+	testing.BenchmarkResult
+	name string
+}
+
+func main() {
+	flag.Parse()
+
+	if testPath == nil || *testPath == "" {
+		fmt.Fprintf(os.Stderr, "Set -bpf-test-path to run BPF benchmarks\n")
+		os.Exit(1)
+	}
+
+	if err := rlimit.RemoveMemlock(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error removing memlock: %v", err)
+	}
+
+	var benchmarkResults []benchmarkResult
+	logger := slog.Default()
+
+	if err := bpftest.ForEachSuite(logger, *testPath, func(elfFile string, suiteSpec *ebpf.CollectionSpec) {
+		elfPath := path.Join(*testPath, elfFile)
+
+		if *testFilePrefix != "" && !strings.HasPrefix(elfFile, *testFilePrefix) {
+			return
+		}
+
+		coll, _, err := bpf.LoadCollection(logger, suiteSpec, nil)
+
+		var ve *ebpf.VerifierError
+		if errors.As(err, &ve) {
+			fmt.Fprintf(os.Stderr, "Error loading collection from %s: verifier error: %+v\n", elfPath, err)
+			return
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading collection from %s: %v\n", elfPath, err)
+			return
+		}
+
+		defer coll.Close()
+
+		suite, err := bpftest.CollectionToSuite(suiteSpec, coll)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading suite from %s: %v\n", elfPath, err)
+			return
+		}
+
+		for _, test := range suite {
+			if !test.HasBench() {
+				continue
+			}
+
+			result, err := test.Bench()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Running suite '%s' from %s: %v\n", test.Name(), elfPath, err)
+			}
+
+			benchmarkResults = append(benchmarkResults, benchmarkResult{
+				BenchmarkResult: result,
+				name:            test.Name(),
+			})
+		}
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Loading suites from %s: %v\n", *testPath, err)
+		os.Exit(1)
+	}
+
+	for _, results := range benchmarkResults {
+		fmt.Printf("%s\t%s\n", results.name, results.String())
+	}
+}

--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -7,18 +7,13 @@ package bpftests
 import (
 	"bufio"
 	"bytes"
-	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"io/fs"
-	"maps"
 	"os"
 	"path"
 	"regexp"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -28,11 +23,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/cilium/hive/hivetest"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/tools/cover"
-	"google.golang.org/protobuf/encoding/protowire"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/link"
@@ -72,10 +63,7 @@ func TestBPF(t *testing.T) {
 		t.Log(err)
 	}
 
-	entries, err := os.ReadDir(*testPath)
-	if err != nil {
-		t.Fatal("os readdir: ", err)
-	}
+	logger := hivetest.Logger(t)
 
 	var instrLog io.Writer
 	if *testInstrumentationLog != "" {
@@ -89,30 +77,23 @@ func TestBPF(t *testing.T) {
 		instrLog = buf
 		defer buf.Flush()
 	}
-
 	mergedProfiles := make([]*cover.Profile, 0)
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
+	if err := ForEachSuite(logger, *testPath, func(elfFile string, suiteSpec *ebpf.CollectionSpec) {
+		if *testFilePrefix != "" && !strings.HasPrefix(elfFile, *testFilePrefix) {
+			return
 		}
 
-		if !strings.HasSuffix(entry.Name(), ".o") {
-			continue
-		}
-
-		if *testFilePrefix != "" && !strings.HasPrefix(entry.Name(), *testFilePrefix) {
-			continue
-		}
-
-		t.Run(entry.Name(), func(t *testing.T) {
-			profiles := loadAndRunSpec(t, entry, instrLog)
+		t.Run(elfFile, func(t *testing.T) {
+			profiles := loadAndRunSpec(t, elfFile, suiteSpec, instrLog)
 			for _, profile := range profiles {
 				if len(profile.Blocks) > 0 {
 					mergedProfiles = addProfile(mergedProfiles, profile)
 				}
 			}
 		})
+	}); err != nil {
+		t.Fatal(err)
 	}
 
 	if *testCoverageReport != "" {
@@ -135,15 +116,13 @@ func TestBPF(t *testing.T) {
 	}
 }
 
-func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cover.Profile {
+func loadAndRunSpec(t *testing.T, elfFile string, spec *ebpf.CollectionSpec, instrLog io.Writer) []*cover.Profile {
 	logger := hivetest.Logger(t)
-	elfPath := path.Join(*testPath, entry.Name())
+	elfPath := path.Join(*testPath, elfFile)
 
 	if instrLog != nil {
 		fmt.Fprintln(instrLog, "===", elfPath, "===")
 	}
-
-	spec := loadAndPrepSpec(t, elfPath)
 
 	var (
 		coll            *ebpf.Collection
@@ -154,13 +133,13 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 
 	if *testCoverageReport != "" {
 		if *noTestCoverage != "" {
-			matched, err := regexp.MatchString(*noTestCoverage, entry.Name())
+			matched, err := regexp.MatchString(*noTestCoverage, elfFile)
 			if err != nil {
 				t.Fatal("test file regex matching failed:", err)
 			}
 
 			if matched {
-				t.Logf("Disabling coverage report for %s", entry.Name())
+				t.Logf("Disabling coverage report for %s", elfFile)
 			}
 
 			collectCoverage = !matched
@@ -184,49 +163,9 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 	}
 	defer coll.Close()
 
-	testNameToPrograms := make(map[string]programSet)
-
-	checkProgUnique := func(prog *ebpf.Program, testName, progType string) {
-		if prog != nil {
-			t.Fatalf(
-				"File '%s' contains duplicate %s programs for the '%s' test.",
-				elfPath,
-				progType,
-				testName,
-			)
-		}
-	}
-
-	for progName, spec := range spec.Programs {
-		match := checkProgRegex.FindStringSubmatch(spec.SectionName)
-		if len(match) == 0 {
-			continue
-		}
-
-		progs := testNameToPrograms[match[1]]
-		if match[2] == "pktgen" {
-			checkProgUnique(progs.pktgenProg, match[1], match[2])
-			progs.pktgenProg = coll.Programs[progName]
-		}
-		if match[2] == "setup" {
-			checkProgUnique(progs.setupProg, match[1], match[2])
-			progs.setupProg = coll.Programs[progName]
-		}
-		if match[2] == "check" {
-			checkProgUnique(progs.checkProg, match[1], match[2])
-			progs.checkProg = coll.Programs[progName]
-		}
-		testNameToPrograms[match[1]] = progs
-	}
-
-	for testName, progSet := range testNameToPrograms {
-		if progSet.checkProg == nil {
-			t.Fatalf(
-				"File '%s' does not contain a check program for the '%s' test.",
-				elfPath,
-				testName,
-			)
-		}
+	suite, err := CollectionToSuite(spec, coll)
+	if err != nil {
+		t.Fatalf("File '%s': %v", elfPath, err)
 	}
 
 	// Collect debug events and add them as logs of the main test
@@ -250,15 +189,14 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 		}()
 	}
 
-	// Make sure sub-tests are executed in alphabetic order, to make test results repeatable if programs rely on
-	// the order of execution.
-	testNames := slices.Sorted(maps.Keys(testNameToPrograms))
+	for _, test := range suite {
+		if !test.HasCheck() {
+			continue
+		}
 
-	// Get maps used for common mocking facilities
-	skbMdMap := coll.Maps[mockSkbMetaMap]
-
-	for _, name := range testNames {
-		t.Run(name, subTest(testNameToPrograms[name], coll.Maps[suiteResultMap], skbMdMap))
+		t.Run(test.Name(), func(t *testing.T) {
+			test.Check(t, *dumpCtx)
+		})
 	}
 
 	if globalLogReader != nil {
@@ -289,300 +227,4 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer) []*cove
 	}
 
 	return profiles
-}
-
-func loadAndPrepSpec(t *testing.T, elfPath string) *ebpf.CollectionSpec {
-	logger := hivetest.Logger(t)
-	spec, err := bpf.LoadCollectionSpec(logger, elfPath)
-	if err != nil {
-		t.Fatalf("load spec %s: %v", elfPath, err)
-	}
-
-	for _, m := range spec.Maps {
-		m.Pinning = ebpf.PinNone
-	}
-
-	for n, p := range spec.Programs {
-		switch p.Type {
-		case ebpf.XDP, ebpf.SchedACT, ebpf.SchedCLS:
-			continue
-		}
-
-		t.Logf("Skipping program '%s' of type '%s': BPF_PROG_RUN not supported", p.Name, p.Type)
-		delete(spec.Programs, n)
-	}
-
-	return spec
-}
-
-type programSet struct {
-	pktgenProg *ebpf.Program
-	setupProg  *ebpf.Program
-	checkProg  *ebpf.Program
-}
-
-var checkProgRegex = regexp.MustCompile(`[^/]+/test/([^/]+)/((?:check)|(?:setup)|(?:pktgen))`)
-
-const (
-	ResultSuccess = 1
-
-	suiteResultMap = "suite_result_map"
-	mockSkbMetaMap = "mock_skb_meta_map"
-)
-
-func subTest(progSet programSet, resultMap *ebpf.Map, skbMdMap *ebpf.Map) func(t *testing.T) {
-	return func(t *testing.T) {
-		// create ctx with the max allowed size(4k - head room - tailroom)
-		data := make([]byte, 4096-256-320)
-
-		// ctx is only used for tc programs
-		// non-empty ctx passed to non-tc programs will cause error: invalid argument
-		ctx := make([]byte, 0)
-		if progSet.checkProg.Type() == ebpf.SchedCLS {
-			// sizeof(struct __sk_buff) < 256, let's make it 256
-			ctx = make([]byte, 256)
-		}
-
-		var (
-			statusCode uint32
-			err        error
-		)
-		if progSet.pktgenProg != nil {
-			if statusCode, data, ctx, err = runBpfProgram(progSet.pktgenProg, data, ctx); err != nil {
-				t.Fatalf("error while running pktgen prog: %s", err)
-			}
-
-			if *dumpCtx {
-				t.Log("Pktgen returned status: ")
-				t.Log(statusCode)
-				t.Log("data after pktgen: ")
-				t.Log(spew.Sdump(data))
-				t.Log("ctx after pktgen: ")
-				t.Log(spew.Sdump(ctx))
-			}
-		}
-
-		if progSet.setupProg != nil {
-			if statusCode, data, ctx, err = runBpfProgram(progSet.setupProg, data, ctx); err != nil {
-				t.Fatalf("error while running setup prog: %s", err)
-			}
-
-			if *dumpCtx {
-				t.Log("Setup returned status: ")
-				t.Log(statusCode)
-				t.Log("data after setup: ")
-				t.Log(spew.Sdump(data))
-				t.Log("ctx after setup: ")
-				t.Log(spew.Sdump(ctx))
-			}
-
-			status := make([]byte, 4)
-			nl.NativeEndian().PutUint32(status, statusCode)
-			data = append(status, data...)
-		}
-
-		// Run test, input a
-		if statusCode, data, ctx, err = runBpfProgram(progSet.checkProg, data, ctx); err != nil {
-			t.Fatal("error while running check program:", err)
-		}
-
-		if *dumpCtx {
-			t.Log("Check returned status: ")
-			t.Log(statusCode)
-			t.Logf("data after check: %d", len(data))
-			t.Log(spew.Sdump(data))
-			t.Log("ctx after check: ")
-			t.Log(spew.Sdump(ctx))
-		}
-
-		// Clear map value after each test
-		defer func() {
-			for _, m := range []*ebpf.Map{resultMap, skbMdMap} {
-				if m == nil {
-					continue
-				}
-
-				var key int32
-				value := make([]byte, m.ValueSize())
-				m.Lookup(&key, &value)
-				for i := range value {
-					value[i] = 0
-				}
-				m.Update(&key, &value, ebpf.UpdateAny)
-			}
-		}()
-
-		var key int32
-		value := make([]byte, resultMap.ValueSize())
-		err = resultMap.Lookup(&key, &value)
-		if err != nil {
-			t.Fatal("error while getting suite result:", err)
-		}
-
-		// Detect the length of the result, since the proto.Unmarshal doesn't like trailing zeros.
-		valueLen := 0
-		valueC := value
-		for {
-			_, _, len := protowire.ConsumeField(valueC)
-			if len <= 0 {
-				break
-			}
-			valueLen += len
-			valueC = valueC[len:]
-		}
-
-		result := &SuiteResult{}
-		err = proto.Unmarshal(value[:valueLen], result)
-		if err != nil {
-			t.Fatal("error while unmarshalling suite result:", err)
-		}
-
-		for _, testResult := range result.Results {
-			// Remove the C-string, null-terminator.
-			name := strings.TrimSuffix(testResult.Name, "\x00")
-			t.Run(name, func(tt *testing.T) {
-				if len(testResult.TestLog) > 0 && testing.Verbose() || testResult.Status != SuiteResult_TestResult_PASS {
-					for _, log := range testResult.TestLog {
-						tt.Logf("%s", log.FmtString())
-					}
-				}
-
-				switch testResult.Status {
-				case SuiteResult_TestResult_ERROR:
-					tt.Fatal("Test failed due to unknown error in test framework")
-				case SuiteResult_TestResult_FAIL:
-					tt.Fail()
-				case SuiteResult_TestResult_SKIP:
-					tt.Skip()
-				}
-			})
-		}
-
-		if len(result.SuiteLog) > 0 && testing.Verbose() ||
-			SuiteResult_TestResult_TestStatus(statusCode) != SuiteResult_TestResult_PASS {
-			for _, log := range result.SuiteLog {
-				t.Logf("%s", log.FmtString())
-			}
-		}
-
-		switch SuiteResult_TestResult_TestStatus(statusCode) {
-		case SuiteResult_TestResult_ERROR:
-			t.Fatal("Test failed due to unknown error in test framework")
-		case SuiteResult_TestResult_FAIL:
-			t.Fail()
-		case SuiteResult_TestResult_SKIP:
-			t.SkipNow()
-		}
-	}
-}
-
-// A simplified version of fmt.Printf logic, the meaning of % specifiers changed to match the kernels printk specifiers.
-// In the eBPF code a user can for example call `test_log("expected 123, got %llu", some_val)` the %llu meaning
-// long-long-unsigned translates into a uint64, the rendered out would for example be -> 'expected 123, got 234'.
-// https://www.kernel.org/doc/Documentation/printk-formats.txt
-// https://github.com/libbpf/libbpf/blob/4eb6485c08867edaa5a0a81c64ddb23580420340/src/bpf_helper_defs.h#L152
-func (l *Log) FmtString() string {
-	var sb strings.Builder
-
-	end := len(l.Fmt)
-	argNum := 0
-
-	for i := 0; i < end; {
-		lasti := i
-		for i < end && l.Fmt[i] != '%' {
-			i++
-		}
-		if i > lasti {
-			sb.WriteString(strings.TrimSuffix(l.Fmt[lasti:i], "\x00"))
-		}
-		if i >= end {
-			// done processing format string
-			break
-		}
-
-		// Process one verb
-		i++
-
-		var spec []byte
-	loop:
-		for ; i < end; i++ {
-			c := l.Fmt[i]
-			switch c {
-			case 'd', 'i', 'u', 'x', 's':
-				spec = append(spec, c)
-				break loop
-			case 'l':
-				spec = append(spec, c)
-			default:
-				break loop
-			}
-		}
-		// Advance to to next char
-		i++
-
-		// No argument left over to print for the current verb.
-		if argNum >= len(l.Args) {
-			sb.WriteString("%!")
-			sb.WriteString(string(spec))
-			sb.WriteString("(MISSING)")
-			continue
-		}
-
-		switch string(spec) {
-		case "u":
-			fmt.Fprint(&sb, uint16(l.Args[argNum]))
-		case "d", "i", "s":
-			fmt.Fprint(&sb, int16(l.Args[argNum]))
-		case "x":
-			hb := make([]byte, 2)
-			binary.BigEndian.PutUint16(hb, uint16(l.Args[argNum]))
-			fmt.Fprint(&sb, hex.EncodeToString(hb))
-
-		case "lu":
-			fmt.Fprint(&sb, uint32(l.Args[argNum]))
-		case "ld", "li", "ls":
-			fmt.Fprint(&sb, int32(l.Args[argNum]))
-		case "lx":
-			hb := make([]byte, 4)
-			binary.BigEndian.PutUint32(hb, uint32(l.Args[argNum]))
-			fmt.Fprint(&sb, hex.EncodeToString(hb))
-
-		case "llu":
-			fmt.Fprint(&sb, uint64(l.Args[argNum]))
-		case "lld", "lli", "lls":
-			fmt.Fprint(&sb, int64(l.Args[argNum]))
-		case "llx":
-			hb := make([]byte, 8)
-			binary.BigEndian.PutUint64(hb, uint64(l.Args[argNum]))
-			fmt.Fprint(&sb, hex.EncodeToString(hb))
-
-		default:
-			sb.WriteString("%!")
-			sb.WriteString(string(spec))
-			sb.WriteString("(INVALID)")
-			continue
-		}
-
-		argNum++
-	}
-
-	return sb.String()
-}
-
-func runBpfProgram(prog *ebpf.Program, data, ctx []byte) (statusCode uint32, dataOut, ctxOut []byte, err error) {
-	dataOut = make([]byte, len(data))
-	if len(dataOut) > 0 {
-		// See comments at https://github.com/cilium/ebpf/blob/20c4d8896bdde990ce6b80d59a4262aa3ccb891d/prog.go#L563-L567
-		dataOut = make([]byte, len(data)+256+2)
-	}
-	ctxOut = make([]byte, len(ctx))
-	opts := &ebpf.RunOptions{
-		Data:       data,
-		DataOut:    dataOut,
-		Context:    ctx,
-		ContextOut: ctxOut,
-		Repeat:     1,
-	}
-	ret, err := prog.Run(opts)
-	return ret, opts.DataOut, ctxOut, err
 }

--- a/bpf/tests/bpftest/helpers.go
+++ b/bpf/tests/bpftest/helpers.go
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bpftests
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"path"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/vishvananda/netlink/nl"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+const (
+	ResultSuccess = 1
+
+	suiteResultMap = "suite_result_map"
+	mockSkbMetaMap = "mock_skb_meta_map"
+)
+
+// ForEachSuite iterates through each *.o file in dir, loads it as an
+// ebpf.CollectionSpec, unpins any maps in the ebpf.CollectionSpec, then passes
+// the file name and the final CollectionSpecit to fn for further processing.
+func ForEachSuite(logger *slog.Logger, dir string, fn func(name string, suiteSpec *ebpf.CollectionSpec)) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("reading dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		if !strings.HasSuffix(entry.Name(), ".o") {
+			continue
+		}
+
+		spec, err := loadAndPrepSuiteSpec(logger, path.Join(dir, entry.Name()))
+		if err != nil {
+			return fmt.Errorf("loading and prepping spec: %w", err)
+		}
+
+		fn(entry.Name(), spec)
+	}
+
+	return nil
+}
+
+func loadAndPrepSuiteSpec(logger *slog.Logger, elfPath string) (*ebpf.CollectionSpec, error) {
+	spec, err := bpf.LoadCollectionSpec(logger, elfPath)
+	if err != nil {
+		return nil, fmt.Errorf("load spec %s: %w", elfPath, err)
+	}
+
+	for _, m := range spec.Maps {
+		m.Pinning = ebpf.PinNone
+	}
+
+	for n, p := range spec.Programs {
+		switch p.Type {
+		case ebpf.XDP, ebpf.SchedACT, ebpf.SchedCLS:
+			continue
+		}
+
+		delete(spec.Programs, n)
+	}
+
+	return spec, nil
+}
+
+var progRegex = regexp.MustCompile(`[^/]+/test/([^/]+)/((?:check)|(?:setup)|(?:pktgen))`)
+
+// CollectionToSuite converts spec and coll into a final set of tests while
+// performing some validation:
+//
+// 1. Each test must contain a CHECK program.
+// 2. Each test must contain at most one PKTGEN/SETUP/CHECK program.
+//
+// It sorts the tests alphabetically based on their name.
+func CollectionToSuite(spec *ebpf.CollectionSpec, coll *ebpf.Collection) ([]Test, error) {
+	tests := map[string]Test{}
+
+	duplicateProgram := func(testName, progType string) error {
+		return fmt.Errorf("contains duplicate %s programs for the '%s' test", progType, testName)
+	}
+
+	for progName, spec := range spec.Programs {
+		match := progRegex.FindStringSubmatch(spec.SectionName)
+		if len(match) == 0 {
+			continue
+		}
+
+		test := tests[match[1]]
+		if match[2] == "pktgen" {
+			if test.pktgenProg != nil {
+				return nil, duplicateProgram(match[1], match[2])
+			}
+			test.pktgenProg = coll.Programs[progName]
+		}
+		if match[2] == "setup" {
+			if test.setupProg != nil {
+				return nil, duplicateProgram(match[1], match[2])
+			}
+			test.setupProg = coll.Programs[progName]
+		}
+		if match[2] == "check" {
+			if test.checkProg != nil {
+				return nil, duplicateProgram(match[1], match[2])
+			}
+			test.checkProg = coll.Programs[progName]
+		}
+		tests[match[1]] = test
+	}
+
+	for testName, test := range tests {
+		if test.checkProg == nil {
+			return nil, fmt.Errorf("does not contain a check program for the '%s' test", testName)
+		}
+	}
+
+	suite := make([]Test, len(tests))
+
+	// Make sure sub-tests are executed in alphabetic order, to make test
+	// results repeatable if programs rely on the order of execution.
+	for i, name := range slices.Sorted(maps.Keys(tests)) {
+		test := tests[name]
+		test.name = name
+		test.maps = coll.Maps
+		suite[i] = test
+	}
+
+	return suite, nil
+}
+
+// Test represents a single BPF unit test.
+type Test struct {
+	name       string
+	maps       map[string]*ebpf.Map
+	pktgenProg *ebpf.Program
+	setupProg  *ebpf.Program
+	checkProg  *ebpf.Program
+}
+
+// Name returns the name of the unit test.
+//
+// Example: CHECK("tc", "my_test") will return "my_test" as the name.
+func (tt *Test) Name() string {
+	return tt.name
+}
+
+// HasCheck returns true if this BPF unit test contains a CHECK program.
+func (tt *Test) HasCheck() bool {
+	return tt.checkProg != nil
+}
+
+// Check runs the PKTGEN, SETUP, and CHECK programs for a BPF unit test.
+func (tt *Test) Check(t *testing.T, dumpCtx bool) {
+	resultMap := tt.maps[suiteResultMap]
+	skbMdMap := tt.maps[mockSkbMetaMap]
+	// create ctx with the max allowed size(4k - head room - tailroom)
+	data := make([]byte, 4096-256-320)
+
+	// ctx is only used for tc programs
+	// non-empty ctx passed to non-tc programs will cause error: invalid argument
+	ctx := make([]byte, 0)
+	if tt.checkProg.Type() == ebpf.SchedCLS {
+		// sizeof(struct __sk_buff) < 256, let's make it 256
+		ctx = make([]byte, 256)
+	}
+
+	var (
+		statusCode uint32
+		err        error
+	)
+	if tt.pktgenProg != nil {
+		if statusCode, data, ctx, err = runBpfProgram(tt.pktgenProg, data, ctx); err != nil {
+			t.Fatalf("error while running pktgen prog: %s", err)
+		}
+
+		if dumpCtx {
+			t.Log("Pktgen returned status: ")
+			t.Log(statusCode)
+			t.Log("data after pktgen: ")
+			t.Log(spew.Sdump(data))
+			t.Log("ctx after pktgen: ")
+			t.Log(spew.Sdump(ctx))
+		}
+	}
+
+	if tt.setupProg != nil {
+		if statusCode, data, ctx, err = runBpfProgram(tt.setupProg, data, ctx); err != nil {
+			t.Fatalf("error while running setup prog: %s", err)
+		}
+
+		if dumpCtx {
+			t.Log("Setup returned status: ")
+			t.Log(statusCode)
+			t.Log("data after setup: ")
+			t.Log(spew.Sdump(data))
+			t.Log("ctx after setup: ")
+			t.Log(spew.Sdump(ctx))
+		}
+
+		status := make([]byte, 4)
+		nl.NativeEndian().PutUint32(status, statusCode)
+		data = append(status, data...)
+	}
+
+	// Run test, input a
+	if statusCode, data, ctx, err = runBpfProgram(tt.checkProg, data, ctx); err != nil {
+		t.Fatal("error while running check program:", err)
+	}
+
+	if dumpCtx {
+		t.Log("Check returned status: ")
+		t.Log(statusCode)
+		t.Logf("data after check: %d", len(data))
+		t.Log(spew.Sdump(data))
+		t.Log("ctx after check: ")
+		t.Log(spew.Sdump(ctx))
+	}
+
+	// Clear map value after each test
+	defer func() {
+		for _, m := range []*ebpf.Map{resultMap, skbMdMap} {
+			if m == nil {
+				continue
+			}
+
+			var key int32
+			value := make([]byte, m.ValueSize())
+			m.Lookup(&key, &value)
+			for i := range value {
+				value[i] = 0
+			}
+			m.Update(&key, &value, ebpf.UpdateAny)
+		}
+	}()
+
+	var key int32
+	value := make([]byte, resultMap.ValueSize())
+	err = resultMap.Lookup(&key, &value)
+	if err != nil {
+		t.Fatal("error while getting suite result:", err)
+	}
+
+	// Detect the length of the result, since the proto.Unmarshal doesn't like trailing zeros.
+	valueLen := 0
+	valueC := value
+	for {
+		_, _, len := protowire.ConsumeField(valueC)
+		if len <= 0 {
+			break
+		}
+		valueLen += len
+		valueC = valueC[len:]
+	}
+
+	result := &SuiteResult{}
+	err = proto.Unmarshal(value[:valueLen], result)
+	if err != nil {
+		t.Fatal("error while unmarshalling suite result:", err)
+	}
+
+	for _, testResult := range result.Results {
+		// Remove the C-string, null-terminator.
+		name := strings.TrimSuffix(testResult.Name, "\x00")
+		t.Run(name, func(tt *testing.T) {
+			if len(testResult.TestLog) > 0 && testing.Verbose() || testResult.Status != SuiteResult_TestResult_PASS {
+				for _, log := range testResult.TestLog {
+					tt.Logf("%s", log.FmtString())
+				}
+			}
+
+			switch testResult.Status {
+			case SuiteResult_TestResult_ERROR:
+				tt.Fatal("Test failed due to unknown error in test framework")
+			case SuiteResult_TestResult_FAIL:
+				tt.Fail()
+			case SuiteResult_TestResult_SKIP:
+				tt.Skip()
+			}
+		})
+	}
+
+	if len(result.SuiteLog) > 0 && testing.Verbose() ||
+		SuiteResult_TestResult_TestStatus(statusCode) != SuiteResult_TestResult_PASS {
+		for _, log := range result.SuiteLog {
+			t.Logf("%s", log.FmtString())
+		}
+	}
+
+	switch SuiteResult_TestResult_TestStatus(statusCode) {
+	case SuiteResult_TestResult_ERROR:
+		t.Fatal("Test failed due to unknown error in test framework")
+	case SuiteResult_TestResult_FAIL:
+		t.Fail()
+	case SuiteResult_TestResult_SKIP:
+		t.SkipNow()
+	}
+}
+
+func runBpfProgram(prog *ebpf.Program, data, ctx []byte) (statusCode uint32, dataOut, ctxOut []byte, err error) {
+	dataOut = make([]byte, len(data))
+	if len(dataOut) > 0 {
+		// See comments at https://github.com/cilium/ebpf/blob/20c4d8896bdde990ce6b80d59a4262aa3ccb891d/prog.go#L563-L567
+		dataOut = make([]byte, len(data)+256+2)
+	}
+	ctxOut = make([]byte, len(ctx))
+	opts := &ebpf.RunOptions{
+		Data:       data,
+		DataOut:    dataOut,
+		Context:    ctx,
+		ContextOut: ctxOut,
+		Repeat:     1,
+	}
+	ret, err := prog.Run(opts)
+	return ret, opts.DataOut, ctxOut, err
+}
+
+// A simplified version of fmt.Printf logic, the meaning of % specifiers changed to match the kernels printk specifiers.
+// In the eBPF code a user can for example call `test_log("expected 123, got %llu", some_val)` the %llu meaning
+// long-long-unsigned translates into a uint64, the rendered out would for example be -> 'expected 123, got 234'.
+// https://www.kernel.org/doc/Documentation/printk-formats.txt
+// https://github.com/libbpf/libbpf/blob/4eb6485c08867edaa5a0a81c64ddb23580420340/src/bpf_helper_defs.h#L152
+func (l *Log) FmtString() string {
+	var sb strings.Builder
+
+	end := len(l.Fmt)
+	argNum := 0
+
+	for i := 0; i < end; {
+		lasti := i
+		for i < end && l.Fmt[i] != '%' {
+			i++
+		}
+		if i > lasti {
+			sb.WriteString(strings.TrimSuffix(l.Fmt[lasti:i], "\x00"))
+		}
+		if i >= end {
+			// done processing format string
+			break
+		}
+
+		// Process one verb
+		i++
+
+		var spec []byte
+	loop:
+		for ; i < end; i++ {
+			c := l.Fmt[i]
+			switch c {
+			case 'd', 'i', 'u', 'x', 's':
+				spec = append(spec, c)
+				break loop
+			case 'l':
+				spec = append(spec, c)
+			default:
+				break loop
+			}
+		}
+		// Advance to to next char
+		i++
+
+		// No argument left over to print for the current verb.
+		if argNum >= len(l.Args) {
+			sb.WriteString("%!")
+			sb.WriteString(string(spec))
+			sb.WriteString("(MISSING)")
+			continue
+		}
+
+		switch string(spec) {
+		case "u":
+			fmt.Fprint(&sb, uint16(l.Args[argNum]))
+		case "d", "i", "s":
+			fmt.Fprint(&sb, int16(l.Args[argNum]))
+		case "x":
+			hb := make([]byte, 2)
+			binary.BigEndian.PutUint16(hb, uint16(l.Args[argNum]))
+			fmt.Fprint(&sb, hex.EncodeToString(hb))
+
+		case "lu":
+			fmt.Fprint(&sb, uint32(l.Args[argNum]))
+		case "ld", "li", "ls":
+			fmt.Fprint(&sb, int32(l.Args[argNum]))
+		case "lx":
+			hb := make([]byte, 4)
+			binary.BigEndian.PutUint32(hb, uint32(l.Args[argNum]))
+			fmt.Fprint(&sb, hex.EncodeToString(hb))
+
+		case "llu":
+			fmt.Fprint(&sb, uint64(l.Args[argNum]))
+		case "lld", "lli", "lls":
+			fmt.Fprint(&sb, int64(l.Args[argNum]))
+		case "llx":
+			hb := make([]byte, 8)
+			binary.BigEndian.PutUint64(hb, uint64(l.Args[argNum]))
+			fmt.Fprint(&sb, hex.EncodeToString(hb))
+
+		default:
+			sb.WriteString("%!")
+			sb.WriteString(string(spec))
+			sb.WriteString("(INVALID)")
+			continue
+		}
+
+		argNum++
+	}
+
+	return sb.String()
+}

--- a/bpf/tests/common.h
+++ b/bpf/tests/common.h
@@ -262,6 +262,7 @@ test_result_cursor = 0;
 #define PKTGEN(progtype, name) __section(progtype "/test/" name "/pktgen")
 #define SETUP(progtype, name) __section(progtype "/test/" name "/setup")
 #define CHECK(progtype, name) __section(progtype "/test/" name "/check")
+#define BENCH(progtype, name) __section(progtype "/test/" name "/bench")
 
 /* Asserts that the sum of per-cpu metrics map slots for a key equals count */
 #define assert_metrics_count(key, count) \

--- a/bpf/tests/tc_bench_example.c
+++ b/bpf/tests/tc_bench_example.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define ENABLE_EGRESS_GATEWAY
+#define ENABLE_MASQUERADE_IPV4
+#define ENABLE_MASQUERADE_IPV6
+#define ENCAP_IFINDEX 0
+
+#include "bpf_host.c"
+
+#include "lib/egressgw.h"
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+#define TO_NETDEV 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Test that a packet matching an egress gateway policy on the to-netdev
+ * program gets redirected to the gateway node.
+ */
+PKTGEN("tc", "tc_egressgw_redirect_bench_example")
+int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT,
+		});
+}
+
+BENCH("tc", "tc_egressgw_redirect_bench_example")
+int egressgw_redirect_setup(struct __ctx_buff *ctx)
+{
+	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
+	create_ct_entry(ctx, client_port(TEST_REDIRECT));
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
+				  EGRESS_IP);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+

--- a/bpf/tests/xdp_bench_example.c
+++ b/bpf/tests/xdp_bench_example.c
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/xdp.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define ENABLE_NODEPORT_ACCELERATION
+
+#define ENABLE_EGRESS_GATEWAY
+#define ENABLE_MASQUERADE
+
+#define TUNNEL_PROTOCOL		TUNNEL_PROTOCOL_VXLAN
+#define ENCAP_IFINDEX		42
+
+/* Skip ingress policy checks */
+#define USE_BPF_PROG_FOR_INGRESS_POLICY
+
+#define IPV4_DIRECT_ROUTING	v4_node_one /* gateway node */
+#define MASQ_PORT		__bpf_htons(NODEPORT_PORT_MIN_NAT + 1)
+#define DIRECT_ROUTING_IFINDEX	25
+
+#define ctx_redirect mock_ctx_redirect
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused, int ifindex __maybe_unused,
+		  __u32 flags __maybe_unused);
+
+#define fib_lookup mock_fib_lookup
+static __always_inline __maybe_unused long
+mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		__maybe_unused int plen, __maybe_unused __u32 flags);
+
+#include <bpf_xdp.c>
+
+#include "lib/egressgw.h"
+#include "lib/ipcache.h"
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused, int ifindex __maybe_unused,
+		  __u32 flags __maybe_unused)
+{
+	if (ifindex != DIRECT_ROUTING_IFINDEX)
+		return CTX_ACT_DROP;
+
+	return CTX_ACT_REDIRECT;
+}
+
+static __always_inline __maybe_unused long
+mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		__maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	params->ifindex = DIRECT_ROUTING_IFINDEX;
+
+	if (params->ipv4_dst == CLIENT_NODE_IP) {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)gateway_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)client_mac, ETH_ALEN);
+	} else {
+		return CTX_ACT_DROP;
+	}
+
+	return 0;
+}
+
+#define FROM_NETDEV	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_xdp_entry,
+	},
+};
+
+/* Test that a EgressGW reply gets RevSNATed, and forwarded to the
+ * worker node via tunnel.
+ */
+PKTGEN("xdp", "xdp_egressgw_reply_bench_example")
+int egressgw_reply_pktgen(struct __ctx_buff *ctx)
+{
+	/* Add a new NAT entry so that pktgen can figure out the correct destination port */
+	struct ipv4_ct_tuple tuple = {
+		.saddr   = CLIENT_IP,
+		.daddr   = EXTERNAL_SVC_IP,
+		.dport   = EXTERNAL_SVC_PORT,
+		.sport   = client_port(TEST_XDP_REPLY),
+		.nexthdr = IPPROTO_TCP,
+	};
+
+	struct ipv4_nat_entry nat_entry = {
+		.to_saddr = EGRESS_IP,
+		.to_sport = MASQ_PORT,
+	};
+
+	map_update_elem(&cilium_snat_v4_external, &tuple, &nat_entry, BPF_ANY);
+
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_XDP_REPLY,
+			.dir = CT_INGRESS,
+		});
+}
+
+BENCH("xdp", "xdp_egressgw_reply_bench_example")
+int egressgw_reply_setup(struct __ctx_buff *ctx)
+{
+	/* install EgressGW policy for the connection: */
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP, 0);
+
+	/* install RevSNAT entry */
+	struct ipv4_ct_tuple snat_tuple = {
+		.daddr   = EGRESS_IP,
+		.saddr   = EXTERNAL_SVC_IP,
+		.dport   = MASQ_PORT,
+		.sport   = EXTERNAL_SVC_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags   = NAT_DIR_INGRESS,
+	};
+
+	struct ipv4_nat_entry snat_entry = {
+		.to_daddr = CLIENT_IP,
+		.to_dport = client_port(TEST_XDP_REPLY),
+	};
+
+	map_update_elem(&cilium_snat_v4_external, &snat_tuple, &snat_entry, BPF_ANY);
+
+	/* install ipcache entry for the CLIENT_IP: */
+	ipcache_v4_add_entry(CLIENT_IP, 0, 0, CLIENT_NODE_IP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}

--- a/contrib/scripts/check-fipsonly.sh
+++ b/contrib/scripts/check-fipsonly.sh
@@ -5,6 +5,7 @@
 set -eu
 
 EXCLUDED_DIRS=(
+    "bpf/tests/bpfbench"
     "cilium-health/responder"
     "contrib/examples/statedb"
     "contrib/examples/statedb_k8s"


### PR DESCRIPTION
Recently, I added the [`BENCH` probe type](https://bpftrace.org/docs/pre-release/language#bench) to bpftrace (https://github.com/bpftrace/bpftrace/pull/4343) for implementing BPF micro benchmarks. I thought that something similar could be handy in Cilium as an extension to the BPF unit test framework for benchmarking various programs, gauging the performance effects of BPF changes, etc. and wondered if others would find it useful. Micro benchmarks are never the full picture when it comes to performance, but still, it could be a nice tool.

So,

Introduce `BENCH` for implementing BPF micro benchmarks. bpftest (`make run_bpf_tests`) ignores `BENCH` programs; they are only executed when running bpfbench (`make run_bpf_benchmarks`). If a `PKTGEN` program is
defined, it is run before the `BENCH` program to generate its input, but `SETUP` and `CHECK` programs are ignored.

```
jordan@t14:~/code/cilium$ make run_bpf_benchmarks
DOCKER_ARGS=--privileged RUN_AS_ROOT=1 contrib/scripts/builder.sh \
	make  -j16 -C bpf/tests/ run_bench \
		"BPF_TEST_FILE="""
make: Entering directory '/go/src/github.com/cilium/cilium/bpf/tests'
go run ./bpfbench \
	-bpf-test-path /go/src/github.com/cilium/cilium/bpf/tests \

tc_egressgw_redirect_bench_example	 1000000	      1328 ns/op
make: Leaving directory '/go/src/github.com/cilium/cilium/bpf/tests'
```

As part of this change, refactor bpf_test.go a bit to extract the useful bits and make them reusable to bpfbench. I considered just putting everything inside bpf_test.go, maybe piggybacking on top of Go's `Benchmark*`s somehow, but found this approach unworkable. This lead me down the path of implementing benchmarking as a separate tool and making some of the functionality shared between bpftest and bpfbench. I would have liked to use `tparse` for output formatting, but at present it doesn't support reporting for benchmarks, so the output is currently quite raw.(Coincidentally, https://github.com/mfridman/tparse/issues/67 was reported by @joestringer a few years ago, but alas, it has not yet been implemented)