### PR TITLE
docs: fix typo in ipsec vs wireguard comparison

### DIFF
--- a/Documentation/operations/performance/benchmark.rst
+++ b/Documentation/operations/performance/benchmark.rst
@@ -283,7 +283,7 @@ throughput, WireGuard is less efficient at achieving the same throughput:
 
 .. tip::
 
-   IPsec performing better than WireGuard in in this test is unexpected in some
+   IPsec performing better than WireGuard in this test is unexpected in some
    ways. A possible explanation is that the IPsec encryption is making use of
    AES-NI instructions whereas the WireGuard implementation is not. This would
    typically lead to IPsec being more efficient when AES-NI offload is


### PR DESCRIPTION
Removes the duplicate "in".
