### PR TITLE
pkg/ciliumidentity: refactor tests and export helper functions

### DIFF
--- a/operator/pkg/ciliumendpointslice/testutils/test_utils.go
+++ b/operator/pkg/ciliumendpointslice/testutils/test_utils.go
@@ -9,6 +9,14 @@ import (
 	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
+var (
+	NodeIPs = map[string]string{
+		"node1": "10.0.0.0",
+		"node2": "10.0.0.1",
+		"node3": "10.0.0.2",
+	}
+)
+
 func CreateManagerEndpoint(name string, identity int64) capi_v2a1.CoreCiliumEndpoint {
 	return capi_v2a1.CoreCiliumEndpoint{
 		Name:       name,

--- a/operator/pkg/ciliumidentity/testutils/test_utils.go
+++ b/operator/pkg/ciliumidentity/testutils/test_utils.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package cidtestutils
+
+import (
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	"github.com/cilium/cilium/pkg/identity/key"
+	capi_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	idbackend "github.com/cilium/cilium/pkg/k8s/identitybackend"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+func NewCID(id string, lbs map[string]string) *capi_v2.CiliumIdentity {
+	secLbs := key.GetCIDKeyFromLabels(maps.Clone(lbs), labels.LabelSourceK8s).GetAsMap()
+	selectedLabels := idbackend.SelectK8sLabels(secLbs)
+
+	return &capi_v2.CiliumIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   id,
+			Labels: selectedLabels,
+		},
+		SecurityLabels: secLbs,
+	}
+}
+
+func NewCIDWithNamespace(id string, pod *slim_corev1.Pod, namespace *slim_corev1.Namespace) *capi_v2.CiliumIdentity {
+	lbs := k8sUtils.SanitizePodLabels(pod.ObjectMeta.Labels, namespace, "", "")
+	return NewCID(id, lbs)
+}
+
+func NewPod(name, namespace string, lbs map[string]string, node string) *slim_corev1.Pod {
+	return &slim_corev1.Pod{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      lbs,
+			Annotations: nil,
+		},
+		Spec: slim_corev1.PodSpec{
+			NodeName: node,
+		},
+		Status: slim_corev1.PodStatus{
+			HostIP: cestest.NodeIPs[node],
+			PodIPs: []slim_corev1.PodIP{
+				{IP: "172.0.0.1"},
+				{IP: "2001:db8::1"},
+			},
+		},
+	}
+}
+
+func NewNamespace(name string, lbs map[string]string) *slim_corev1.Namespace {
+	if lbs == nil {
+		lbs = make(map[string]string)
+	}
+	lbs["kubernetes.io/metadata.name"] = name
+
+	return &slim_corev1.Namespace{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:   name,
+			Labels: lbs,
+		},
+	}
+}


### PR DESCRIPTION
PR refactors ciliumidentity package to export test helpers and functions that will be used in the future.

Breaking out some commits from original PR #38388 for convenience :)

```release-note
refactor ciliumidentity tests and export helper functions
```
