### PR TITLE
connectivity: Allow customization of tcpdump kill timeout

### DIFF
--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -32,7 +32,7 @@ const (
 	sniffConnectionTimeout = sniffScriptTimeout + 5*time.Second
 	// Max remote sniffer runtime to prevent lingering processes in the pod.
 	// NOTE: too low may kill tcpdump while test is running.
-	sniffKillTimeout = sniffConnectionTimeout * 4
+	SniffKillTimeout = sniffConnectionTimeout * 4
 
 	// Command executed to start the remote tcpdump in background inside a pod.
 	//
@@ -153,7 +153,8 @@ type debugLogger interface {
 // to make sure the remote sniffer is properly closed, in case [*Sniffer.Validate] has
 // not been called (e.g., expired context or error in between).
 func Sniff(ctx context.Context, name string, target *check.Pod,
-	iface string, filter string, mode Mode, dbg debugLogger,
+	iface string, filter string, mode Mode,
+	killTimeout time.Duration, dbg debugLogger,
 ) (*Sniffer, func() error, error) {
 	sniffer := &Sniffer{
 		target:   target,
@@ -184,7 +185,7 @@ func Sniff(ctx context.Context, name string, target *check.Pod,
 		PktCount:    count,
 		Filter:      filter,
 		WaitSeconds: int(sniffScriptTimeout.Seconds()),
-		KillSeconds: int(sniffKillTimeout.Seconds()),
+		KillSeconds: int(killTimeout.Seconds()),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("template execution failed: %w", err)

--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -308,7 +308,7 @@ func testNoTrafficLeak(ctx context.Context, t *check.Test, s check.Scenario,
 		snifferMode = sniff.ModeSanity
 	}
 
-	srcSniffer, cancel, err := sniff.Sniff(ctx, s.Name(), clientHost, srcIface, srcFilter, snifferMode, t)
+	srcSniffer, cancel, err := sniff.Sniff(ctx, s.Name(), clientHost, srcIface, srcFilter, snifferMode, sniff.SniffKillTimeout, t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +319,7 @@ func testNoTrafficLeak(ctx context.Context, t *check.Test, s check.Scenario,
 		dstFilter := getFilter(ctx, t, server, serverHost, client, clientHost, ipFam, reqType, wgEncap)
 		dstIface := getInterNodeIface(ctx, t, server, serverHost, client, clientHost, ipFam, wgEncap)
 
-		dstSniffer, cancel, err = sniff.Sniff(ctx, s.Name(), serverHost, dstIface, dstFilter, snifferMode, t)
+		dstSniffer, cancel, err = sniff.Sniff(ctx, s.Name(), serverHost, dstIface, dstFilter, snifferMode, sniff.SniffKillTimeout, t)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cilium-cli/connectivity/tests/encryption_v2.go
+++ b/cilium-cli/connectivity/tests/encryption_v2.go
@@ -465,7 +465,7 @@ func (s *podToPodEncryptionV2) startSniffers(ctx context.Context, t *check.Test)
 	var cancel func() error
 
 	if s.ipv4Enabled.Enabled {
-		s.clientSniffer4, cancel, err = sniff.Sniff(ctx, s.Name(), s.clientHostNS, s.clientEgressDev, s.clientFilter4, mode, t)
+		s.clientSniffer4, cancel, err = sniff.Sniff(ctx, s.Name(), s.clientHostNS, s.clientEgressDev, s.clientFilter4, mode, sniff.SniffKillTimeout, t)
 		if err != nil {
 			return fmt.Errorf("Failed to start sniffer on client: %w", err)
 		}
@@ -473,7 +473,7 @@ func (s *podToPodEncryptionV2) startSniffers(ctx context.Context, t *check.Test)
 		t.Debugf("started client tcpdump sniffer: [client: %s] [node: %s] [dev: %s] [filter: %s] [mode: %s]",
 			s.client.Pod.Name, s.client.Pod.Spec.NodeName, s.clientEgressDev, s.clientFilter4, mode)
 
-		s.serverSniffer4, cancel, err = sniff.Sniff(ctx, s.Name(), s.serverHostNS, s.serverEgressDev, s.serverFilter4, mode, t)
+		s.serverSniffer4, cancel, err = sniff.Sniff(ctx, s.Name(), s.serverHostNS, s.serverEgressDev, s.serverFilter4, mode, sniff.SniffKillTimeout, t)
 		if err != nil {
 			return fmt.Errorf("Failed to start sniffer on server: %w", err)
 		}
@@ -505,7 +505,7 @@ func (s *podToPodEncryptionV2) startSniffers(ctx context.Context, t *check.Test)
 		// write to the same pcap file and this can break validation.
 		name := fmt.Sprintf("%s-ipv6", s.Name())
 
-		s.clientSniffer6, cancel, err = sniff.Sniff(ctx, name, s.clientHostNS, s.clientEgressDev, s.clientFilter6, mode, t)
+		s.clientSniffer6, cancel, err = sniff.Sniff(ctx, name, s.clientHostNS, s.clientEgressDev, s.clientFilter6, mode, sniff.SniffKillTimeout, t)
 		if err != nil {
 			return fmt.Errorf("Failed to start sniffer on client for IPv6: %w", err)
 		}
@@ -513,7 +513,7 @@ func (s *podToPodEncryptionV2) startSniffers(ctx context.Context, t *check.Test)
 		t.Debugf("started client tcpdump sniffer for IPv6: [client: %s] [node: %s] [dev: %s] [filter: %s] [mode: %s]",
 			s.client.Pod.Name, s.client.Pod.Spec.NodeName, s.clientEgressDev, s.clientFilter6, mode)
 
-		s.serverSniffer6, cancel, err = sniff.Sniff(ctx, name, s.serverHostNS, s.serverEgressDev, s.serverFilter6, mode, t)
+		s.serverSniffer6, cancel, err = sniff.Sniff(ctx, name, s.serverHostNS, s.serverEgressDev, s.serverFilter6, mode, sniff.SniffKillTimeout, t)
 		if err != nil {
 			return fmt.Errorf("Failed to start sniffer on server for IPv6: %w", err)
 		}


### PR DESCRIPTION
This will be useful for tests that run tcpdump during the entire test.
