### PR TITLE
tools/testowners: de-duplicate error logs

### DIFF
--- a/tools/testowners/main.go
+++ b/tools/testowners/main.go
@@ -79,6 +79,7 @@ func main() {
 		fmt.Fprintln(w, "Package\tOwner")
 	}
 	exitCode := 0
+	reportedLines := map[string]struct{}{}
 	for pkg := range failedPackages {
 		relPath := strings.TrimPrefix(pkg, "github.com/cilium/cilium/") + "/"
 		rule, err := owners.Match(relPath)
@@ -88,7 +89,10 @@ func main() {
 			if err != nil {
 				line = line + ":" + err.Error()
 			}
-			slog.Error(line)
+			if _, reported := reportedLines[line]; !reported {
+				slog.Error(line)
+				reportedLines[line] = struct{}{}
+			}
 			continue
 		}
 		owners := make([]string, 0, len(rule.Owners))


### PR DESCRIPTION
Currently, missing test owners on a particula package lead to an error of the form

    ERROR Failed to locate owner for package path=github.com/cilium/cilium/pkg/foo error="no owners defined"

potentially being reported multiple times[^1]. De-duplicate the reported error log lines to de-clutter the logs in that case.

[^1]: https://github.com/cilium/cilium/actions/runs/16586570193/job/46912960231#step:15:779
