### PR TITLE
loadbalancer: Fix backend state in REST API

### DIFF
--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 
 	"github.com/cilium/cilium/api/v1/models"
-
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -158,7 +157,13 @@ func (fe *Frontend) ToModel() *models.Service {
 
 	backendModel := func(be BackendParams) *models.BackendAddress {
 		addrClusterStr := be.Address.AddrCluster.String()
-		stateStr, _ := be.State.String()
+
+		state := be.State
+		if be.Unhealthy {
+			state = BackendStateQuarantined
+		}
+		stateStr, _ := state.String()
+
 		return &models.BackendAddress{
 			IP:        &addrClusterStr,
 			Protocol:  be.Address.Protocol,


### PR DESCRIPTION
The new Cilium LB controlplane introduced a new property `Unhealthy` on the backend params which allows for healthchecker extensions to report a backend as unhealthy. The LB backend selection respects the `State` & `Unhealthy` properties of the backend.

While introducing the new property, there was an oversight of `cilium-dbg service list` which still shows the backend state as `active` even though the backend is reported as `unhealthy`.

Therefore, this commit changes the LB REST API implementation to report the state of a backend as `quarantined` if `Unhealthy==true`.