### PR TITLE
vendor: Bump to StateDB v0.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v0.0.0-20250611195437-5a5dacdfb354
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.4.4
+	github.com/cilium/statedb v0.4.5
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.4.4 h1:Q3vhppnsb5RO36SzGAoEEjM7i9rZgy8p9QMHJBansfU=
-github.com/cilium/statedb v0.4.4/go.mod h1:DlxX9OQi/nM8oumUuz8VjxXUtVRiEfbfo8Ri1YWNCGI=
+github.com/cilium/statedb v0.4.5 h1:WP1xbkAdDup0wOkhRZUJG/Wh4+ZLAOgl7yIIxJ3vIEo=
+github.com/cilium/statedb v0.4.5/go.mod h1:DlxX9OQi/nM8oumUuz8VjxXUtVRiEfbfo8Ri1YWNCGI=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/vendor/github.com/cilium/statedb/index/string.go
+++ b/vendor/github.com/cilium/statedb/index/string.go
@@ -6,10 +6,12 @@ package index
 import (
 	"fmt"
 	"iter"
+	"unsafe"
 )
 
 func String(s string) Key {
-	return []byte(s)
+	// Key is never mutated, so it's safe to just cast.
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 func FromString(s string) (Key, error) {

--- a/vendor/github.com/cilium/statedb/table.go
+++ b/vendor/github.com/cilium/statedb/table.go
@@ -147,7 +147,12 @@ func (t *genTable[Obj]) tableEntry() tableEntry {
 	var entry tableEntry
 	entry.meta = t
 	entry.deleteTrackers = part.New[anyDeleteTracker]()
+
+	// A new table is initialized, as no initializers are registered.
+	entry.initialized = true
 	entry.initWatchChan = make(chan struct{})
+	close(entry.initWatchChan)
+
 	entry.indexes = make([]indexEntry, len(t.indexPositions))
 	entry.indexes[t.indexPositions[t.primaryIndexer.indexName()]] = indexEntry{part.New[object](), nil, nil, true}
 
@@ -223,10 +228,7 @@ func (t *genTable[Obj]) ToTable() Table[Obj] {
 
 func (t *genTable[Obj]) Initialized(txn ReadTxn) (bool, <-chan struct{}) {
 	table := txn.getTableEntry(t)
-	if len(table.pendingInitializers) == 0 {
-		return true, closedWatchChannel
-	}
-	return false, table.initWatchChan
+	return len(table.pendingInitializers) == 0, table.initWatchChan
 }
 
 func (t *genTable[Obj]) PendingInitializers(txn ReadTxn) []string {
@@ -239,6 +241,12 @@ func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(Writ
 		if slices.Contains(table.pendingInitializers, name) {
 			panic(fmt.Sprintf("RegisterInitializer: %q already registered", name))
 		}
+
+		if len(table.pendingInitializers) == 0 {
+			table.initialized = false
+			table.initWatchChan = make(chan struct{})
+		}
+
 		table.pendingInitializers =
 			append(slices.Clone(table.pendingInitializers), name)
 		var once sync.Once
@@ -249,6 +257,8 @@ func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(Writ
 						slices.Clone(table.pendingInitializers),
 						func(n string) bool { return n == name },
 					)
+				} else {
+					panic(fmt.Sprintf("RegisterInitializer/MarkDone: Table %q not locked for writing", t.table))
 				}
 			})
 		}

--- a/vendor/github.com/cilium/statedb/write_txn.go
+++ b/vendor/github.com/cilium/statedb/write_txn.go
@@ -354,6 +354,15 @@ func (txn *writeTxn) delete(meta TableMeta, guardRevision Revision, data any) (o
 	return obj, true, nil
 }
 
+// reset clears all fields of [writeTxn], except the ones used for statistics.
+func (txn *writeTxn) reset() {
+	txn.db = nil
+	txn.dbRoot = nil
+	txn.modifiedTables = nil
+	txn.smus = nil
+	txn.tableNames = nil
+}
+
 const (
 	// nonUniqueSeparator is the byte that delimits the secondary and primary keys.
 	// It has to be 0x00 for correct ordering, e.g. if secondary prefix is "ab",
@@ -477,7 +486,7 @@ func (txn *writeTxn) Abort() {
 		txn.tableNames,
 		time.Since(txn.acquiredAt))
 
-	*txn = writeTxn{}
+	txn.reset()
 }
 
 // Commit the transaction. Returns a ReadTxn that is the snapshot of the database at the
@@ -589,7 +598,7 @@ func (txn *writeTxn) Commit() ReadTxn {
 		txn.tableNames,
 		time.Since(txn.acquiredAt))
 
-	*txn = writeTxn{}
+	txn.reset()
 	return readTxn(root)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -319,7 +319,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.4.4
+# github.com/cilium/statedb v0.4.5
 ## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This fixes the "Last WriteTxn" in "db" command output and makes the table initializers safer to use.

https://github.com/cilium/statedb/releases/tag/v0.4.5
