### PR TITLE
fix: create policy snapshot only for sdp

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -671,7 +671,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 
 	// Once the policy has been calculated, we can update the standalone dns proxy as well.
 	// We need to send the snapshot of the policyRules to SDP.
-	if !e.isProperty(PropertyFakeEndpoint) && !e.IsProxyDisabled() {
+	if !e.isProperty(PropertyFakeEndpoint) && !e.IsProxyDisabled() && e.proxy.IsSDPEnabled() {
 		repo := e.policyRepo
 		e.getLogger().Debug("Updating standalone DNS proxy with policy rules")
 		policyRules := repo.GetPolicySnapshot()

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -23,6 +23,7 @@ type EndpointProxy interface {
 	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
 	GetListenerProxyPort(listener string) uint16
+	IsSDPEnabled() bool
 }
 
 func (e *Endpoint) removeNetworkPolicy() {
@@ -66,4 +67,9 @@ func (f *FakeEndpointProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.
 // GetListenerProxyPort does nothing.
 func (f *FakeEndpointProxy) GetListenerProxyPort(listener string) uint16 {
 	return 0
+}
+
+// IsSDPEnabled returns false for fake proxy.
+func (f *FakeEndpointProxy) IsSDPEnabled() bool {
+	return false
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -131,6 +131,11 @@ func (r *RedirectSuiteProxy) GetListenerProxyPort(listener string) uint16 {
 	return 0
 }
 
+// IsSDPEnabled returns false for test proxy.
+func (r *RedirectSuiteProxy) IsSDPEnabled() bool {
+	return false
+}
+
 // DummyOwner implements pkg/endpoint/regeneration/Owner. Used for unit testing.
 type DummyOwner struct {
 	repo  policy.PolicyRepository

--- a/pkg/fqdn/service/cell.go
+++ b/pkg/fqdn/service/cell.go
@@ -52,22 +52,22 @@ type serverParams struct {
 }
 
 func newServer(params serverParams) *FQDNDataServer {
-	srv := NewServer(params)
 
 	if !params.Config.EnableStandaloneDNSProxy {
-		return srv
+		return nil
 	}
 
 	if !params.DaemonConfig.EnableL7Proxy {
-		srv.log.Error("Standalone DNS proxy requires L7 proxy to be enabled")
-		return srv
+		params.Logger.Error("Standalone DNS proxy requires L7 proxy to be enabled")
+		return nil
 	}
 
 	if params.DaemonConfig.ToFQDNsProxyPort == 0 || params.Config.StandaloneDNSProxyServerPort == 0 {
-		srv.log.Error("Standalone DNS proxy requires a valid port number to be set")
-		return srv
+		params.Logger.Error("Standalone DNS proxy requires a valid port number to be set")
+		return nil
 	}
 
+	srv := NewServer(params)
 	params.IPCache.AddListener(srv)
 
 	params.JobGroup.Add(job.OneShot("sdp-grpc-server", srv.ListenAndServe,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -141,7 +141,13 @@ func proxyTypeNotFoundError(proxyType types.ProxyType, listener string, ingress 
 }
 
 func (p *Proxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
-	p.dnsIntegration.sdpPolicyUpdater.UpdatePolicyRules(rules, true)
+	if p.dnsIntegration.sdpPolicyUpdater != nil {
+		p.dnsIntegration.sdpPolicyUpdater.UpdatePolicyRules(rules, true)
+	}
+}
+
+func (p *Proxy) IsSDPEnabled() bool {
+	return p.dnsIntegration != nil && p.dnsIntegration.sdpPolicyUpdater != nil && p.dnsIntegration.sdpPolicyUpdater.IsEnabled()
 }
 
 func (p *Proxy) createNewRedirect(


### PR DESCRIPTION
- Only calculate the policy rules snapshot when the standalone dns proxy is enabled. This PR adds a flag that helps us check if SDP is enabled or not. Based on that flag we calculate the snapshot and send to the grpc server.
- Also create the grpc sdp server only when the standalone dns proxy should be `enabled`

The `enabled` field indicates whether the standalone DNS proxy is enabled. This field is set to `true` only when **ALL** the following conditions are met:

| Flag/Setting | Required Value | Description |
|-------------|----------------|-------------|
| `EnableStandaloneDNSProxy` | `true` | Feature flag to enable standalone DNS proxy |
| `DaemonConfig.EnableL7Proxy` | `true` | L7 proxy must be enabled as a prerequisite |
| `DaemonConfig.ToFQDNsProxyPort` | `> 0` | Valid port for FQDN proxy |
| `Config.StandaloneDNSProxyServerPort` | `> 0` | Valid port for standalone DNS proxy server |
