### PR TITLE
loadbalancer: break the circular dependency with clustermesh

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -298,6 +298,7 @@ jobs:
             --helm-set=clustermesh.policyDefaultLocalCluster=${{ matrix.policy-default-local-cluster }} \
             --helm-set=ciliumEndpointSlice.enabled=${{ matrix.ciliumEndpointSlice == 'enabled'}} \
             --helm-set=extraConfig.clustermesh-sync-timeout=5m \
+            --helm-set=extraConfig.lb-init-wait-timeout=4m \
             "
 
           CILIUM_INSTALL_TUNNEL=" \

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -202,6 +202,7 @@ jobs:
             --set=clustermesh.maxConnectedClusters=${{ matrix.max-connected-clusters }} \
             --set=clustermesh.config.enabled=true \
             --set=extraConfig.clustermesh-sync-timeout=10m \
+            --set=extraConfig.lb-init-wait-timeout=4m \
             --set=clustermesh.apiserver.readinessProbe.periodSeconds=1 \
             --set=clustermesh.apiserver.kvstoremesh.readinessProbe.periodSeconds=1 \
             --set=clustermesh.apiserver.updateStrategy.rollingUpdate.maxSurge=1 `# Use surge update strategy to enable clients to failover` \

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -651,11 +651,18 @@ jobs:
 
       # Perform an additional "stress" test, scaling the clustermesh-apiservers in both clusters
       # to zero replicas, and restarting all agents. Existing connections should not be disrupted.
+      # One exception to this is represented by Cilium being in charge of handling NodePort
+      # traffic, as the simultaneous restart of the clustermesh-apiserver pods in both clusters
+      # after rolling out all agents can lead to a circular dependency, as service reconciliation
+      # needs to wait on clustermesh synchronization, which requires the clustermesh-apiserver
+      # service to be reconciled to include the new backends.
       - name: Scale the clustermesh-apiserver replicas to 0
         if: ${{ !matrix.external-kvstore }}
         run: |
           kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
-          kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
+          if [ "${{ matrix.kube-proxy }}" != "none" ]; then
+            kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
+          fi
 
       - name: Rollout Cilium agents in both clusters
         run: |

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
+	"github.com/cilium/cilium/pkg/dial"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -28,6 +29,10 @@ var Cell = cell.Module(
 	cell.Provide(
 		common.DefaultRemoteClientFactory,
 		NewClusterMesh,
+	),
+
+	cell.ProvidePrivate(
+		dial.ServiceBackendResolverFactory("clustermesh"),
 	),
 
 	// Convert concrete objects into more restricted interfaces used by clustermesh.

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -64,6 +64,9 @@ type Configuration struct {
 	// ServiceResolver, if not nil, is used to create a custom dialer for service resolution.
 	ServiceResolver *dial.ServiceResolver
 
+	// ServiceBackendResolver, if not nil, is used to perform service to backend resolution.
+	ServiceBackendResolver *dial.ServiceBackendResolver
+
 	// IPCacheWatcherExtraOpts returns extra options for watching ipcache entries.
 	IPCacheWatcherExtraOpts IPCacheWatcherOptsFn `optional:"true"`
 
@@ -150,6 +153,9 @@ func NewClusterMesh(lifecycle cell.Lifecycle, c Configuration) *ClusterMesh {
 		Resolvers: func() (out []dial.Resolver) {
 			if c.ServiceResolver != nil {
 				out = append(out, c.ServiceResolver)
+			}
+			if c.ServiceBackendResolver != nil {
+				out = append(out, c.ServiceBackendResolver)
 			}
 			return out
 		}(),

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -146,7 +146,13 @@ func NewClusterMesh(lifecycle cell.Lifecycle, c Configuration) *ClusterMesh {
 		ClusterInfo:                  c.ClusterInfo,
 		RemoteClientFactory:          c.RemoteClientFactory,
 		ClusterSizeDependantInterval: c.ClusterSizeDependantInterval,
-		ServiceResolver:              c.ServiceResolver,
+
+		Resolvers: func() (out []dial.Resolver) {
+			if c.ServiceResolver != nil {
+				out = append(out, c.ServiceResolver)
+			}
+			return out
+		}(),
 
 		NewRemoteCluster: cm.NewRemoteCluster,
 

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -45,8 +45,8 @@ type Configuration struct {
 	// ClusterSizeDependantInterval allows to calculate intervals based on cluster size.
 	ClusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc
 
-	// ServiceResolver, if not nil, is used to create a custom dialer for service resolution.
-	ServiceResolver *dial.ServiceResolver
+	// Resolvers, if provided, are used to create a custom dialer to connect to etcd.
+	Resolvers []dial.Resolver
 
 	// Metrics holds the different clustermesh metrics.
 	Metrics Metrics
@@ -143,12 +143,7 @@ func (cm *clusterMesh) newRemoteCluster(name, path string) *remoteCluster {
 		configPath:                   path,
 		clusterSizeDependantInterval: cm.conf.ClusterSizeDependantInterval,
 
-		resolvers: func() []dial.Resolver {
-			if cm.conf.ServiceResolver != nil {
-				return []dial.Resolver{cm.conf.ServiceResolver}
-			}
-			return nil
-		}(),
+		resolvers: cm.conf.Resolvers,
 
 		controllers:                    controller.NewManager(),
 		remoteConnectionControllerName: fmt.Sprintf("remote-etcd-%s", name),

--- a/pkg/clustermesh/operator/clustermesh.go
+++ b/pkg/clustermesh/operator/clustermesh.go
@@ -19,6 +19,7 @@ import (
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
+	"github.com/cilium/cilium/pkg/dial"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -112,8 +113,13 @@ func newClusterMesh(lc cell.Lifecycle, params clusterMeshParams) (*clusterMesh, 
 		ClusterInfo:         params.ClusterInfo,
 		RemoteClientFactory: params.RemoteClientFactory,
 		NewRemoteCluster:    cm.newRemoteCluster,
-		ServiceResolver:     params.ServiceResolver,
-		Metrics:             params.CommonMetrics,
+		Resolvers: func() (out []dial.Resolver) {
+			if params.ServiceResolver != nil {
+				out = append(out, params.ServiceResolver)
+			}
+			return out
+		}(),
+		Metrics: params.CommonMetrics,
 	})
 
 	lc.Append(cm.common)

--- a/pkg/dial/resolver.go
+++ b/pkg/dial/resolver.go
@@ -6,16 +6,25 @@ package dial
 import (
 	"context"
 	"fmt"
+	"iter"
+	"math/rand/v2"
 	"net/netip"
+	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
 	"k8s.io/apimachinery/pkg/types"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // ServiceResolverCell provides a ServiceResolver instance to map DNS names
@@ -114,4 +123,131 @@ func ServiceURLToNamespacedName(host string) (types.NamespacedName, error) {
 	}
 
 	return types.NamespacedName{Namespace: tokens[1], Name: tokens[0]}, nil
+}
+
+var _ Resolver = (*ServiceBackendResolver)(nil)
+
+type ServiceBackendResolver struct {
+	db        *statedb.DB
+	frontends statedb.Table[*loadbalancer.Frontend]
+
+	ignoredInitializers []string
+
+	// affinityCache is leveraged to preserve backend affinity when the resolver
+	// is invoked multiple times for the same frontend. Indeed, this resolver is
+	// intended to be used for the clustermesh-apiserver service, and each sidecar
+	// etcd replica is different (from an etcd standpoint, even if they eventually
+	// contain the same data), and connecting to a different one means that we need
+	// to do a full synchronization again, which is expensive. We do not explicitly
+	// collect stale entries, as we only ever expect a single one in the vast
+	// majority of scenarios (and a handful at most in the others).
+	mu            lock.Mutex
+	affinityCache map[loadbalancer.L3n4Addr]loadbalancer.L3n4Addr
+}
+
+func ServiceBackendResolverFactory(ignoredInitializers ...string) func(db *statedb.DB, fes statedb.Table[*loadbalancer.Frontend]) *ServiceBackendResolver {
+	return func(db *statedb.DB, fes statedb.Table[*loadbalancer.Frontend]) *ServiceBackendResolver {
+		return &ServiceBackendResolver{
+			db: db, frontends: fes,
+			ignoredInitializers: ignoredInitializers,
+			affinityCache:       make(map[loadbalancer.L3n4Addr]loadbalancer.L3n4Addr),
+		}
+	}
+}
+
+func (sr *ServiceBackendResolver) Resolve(ctx context.Context, host, port string) (string, string) {
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return host, port
+	}
+
+	po, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return host, port
+	}
+
+	if err := sr.waitForInit(ctx); err != nil {
+		return host, port
+	}
+
+	fe := loadbalancer.NewL3n4Addr(
+		loadbalancer.TCP, cmtypes.AddrClusterFrom(addr, 0),
+		uint16(po), loadbalancer.ScopeExternal,
+	)
+
+	got := sr.resolve(fe)
+	if got == nil {
+		return host, port
+	}
+
+	return got.Addr().String(), strconv.FormatInt(int64(got.Port()), 10)
+}
+
+func (sr *ServiceBackendResolver) waitForInit(ctx context.Context) error {
+	init, wait := sr.frontends.Initialized(sr.db.ReadTxn())
+	if init {
+		return nil
+	}
+
+	for {
+		// We cannot just wait on full initialization of the table, as the
+		// purpose of this resolver is to break a circular dependency that
+		// would prevent it. Hence, let's periodically check the pending
+		// initializers, and proceed if only expected ones are remaining.
+		if initialized := !slices.ContainsFunc(
+			sr.frontends.PendingInitializers(sr.db.ReadTxn()),
+			func(init string) bool { return !slices.Contains(sr.ignoredInitializers, init) },
+		); initialized {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-wait:
+			return nil
+
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func (sr *ServiceBackendResolver) resolve(addr loadbalancer.L3n4Addr) (got *loadbalancer.L3n4Addr) {
+	fe, _, found := sr.frontends.Get(sr.db.ReadTxn(), loadbalancer.FrontendByAddress(addr))
+	if !found {
+		return nil
+	}
+
+	bes := statedb.Collect(
+		statedb.Map(
+			statedb.Filter(
+				iter.Seq2[loadbalancer.BackendParams, statedb.Revision](fe.Backends),
+				func(bep loadbalancer.BackendParams) bool {
+					return bep.State == loadbalancer.BackendStateActive && !bep.Unhealthy
+				},
+			),
+			func(bep loadbalancer.BackendParams) loadbalancer.L3n4Addr {
+				return bep.Address
+			},
+		),
+	)
+
+	if len(bes) == 0 {
+		return nil
+	}
+
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	// Preserve affinity, in case the backend is still available
+	prev, ok := sr.affinityCache[addr]
+	if ok && slices.Contains(bes, prev) {
+		return &prev
+	}
+
+	// Pick a random backend otherwise, and store it for future lookups
+	idx := rand.IntN(len(bes))
+	sr.affinityCache[addr] = bes[idx]
+	return &bes[idx]
 }

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -39,6 +39,8 @@ const (
 	// we start reconciling towards the BPF maps. This reduces the probability that load-balancing is scaled
 	// down temporarily due to not yet seeing all backends.
 	//
+	// The delay happens only when existing BPF state existed.
+	//
 	// We must not wait forever for initialization though due to potential interdependencies between load-balancing
 	// data sources. For example we might depend on Kubernetes data to connect to the ClusterMesh api-server and
 	// thus may need to first reconcile the Kubernetes services to connect to ClusterMesh (if endpoints have changed
@@ -94,17 +96,26 @@ func newBPFReconciler(p reconciler.Params, g job.Group, cfg loadbalancer.Config,
 	g.Add(
 		job.OneShot("start-reconciler", func(ctx context.Context, health cell.Health) error {
 			defer close(started)
-			// We give a short grace period for initializers to finish populating the initial contents
-			// of the tables to avoid scaling down load-balancing due to e.g. seeing services before
-			// the endpoint slices.
-			health.OK("Waiting for load-balancing tables to initialize")
-			_, initWatch := w.Frontends().Initialized(p.DB.ReadTxn())
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-initWatch:
-			case <-time.After(initGracePeriod):
+
+			if len(ops.restoredServiceIDs) > 0 {
+				// We give a short grace period for initializers to finish populating the initial contents
+				// of the tables to avoid scaling down load-balancing due to e.g. seeing backends from k8s
+				// much earlier than from ClusterMesh for the same service.
+				//
+				// We only do this if we restored data from BPF maps as only in that scenario we could
+				// be scaling down. This way we also don't introduce an unnecessary delay to connecting
+				// to the ClusterMesh api-server if it connects via a k8s service.
+				health.OK("Waiting for load-balancing tables to initialize")
+				_, initWatch := w.Frontends().Initialized(p.DB.ReadTxn())
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-initWatch:
+				case <-time.After(initGracePeriod):
+					p.Log.Warn("Timed out waiting for load-balancing state to initialize, proceeding with reconciliation")
+				}
 			}
+
 			health.OK("Starting")
 			if err := rlc.Start(p.Log, ctx); err != nil {
 				return err

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -45,7 +45,7 @@ const (
 	// data sources. For example we might depend on Kubernetes data to connect to the ClusterMesh api-server and
 	// thus may need to first reconcile the Kubernetes services to connect to ClusterMesh (if endpoints have changed
 	// while agent was down).
-	initGracePeriod = 10 * time.Second
+	initGracePeriod = 1 * time.Minute
 )
 
 func newBPFReconciler(p reconciler.Params, g job.Group, cfg loadbalancer.Config, ops *BPFOps, fes statedb.Table[*loadbalancer.Frontend], w *writer.Writer) (reconciler.Reconciler[*loadbalancer.Frontend], error) {

--- a/pkg/loadbalancer/zz_generated.deepequal.go
+++ b/pkg/loadbalancer/zz_generated.deepequal.go
@@ -133,6 +133,9 @@ func (in *UserConfig) DeepEqual(other *UserConfig) bool {
 	if in.EnableServiceTopology != other.EnableServiceTopology {
 		return false
 	}
+	if in.InitWaitTimeout != other.InitWaitTimeout {
+		return false
+	}
 
 	return true
 }


### PR DESCRIPTION
Please refer to the individual commits for additional details.

```release-note
clustermesh: fix regression possibly causing cross-cluster connections disruption if the clustermesh-apiserver is restarted at the same time as Cilium agents. 
```