### PR TITLE
ces: refactor and clean up 

### DIFF
--- a/operator/pkg/ciliumendpointslice/ceptocesmap.go
+++ b/operator/pkg/ciliumendpointslice/ceptocesmap.go
@@ -15,6 +15,14 @@ type CEPName resource.Key
 type CESKey resource.Key
 type CESName string
 
+// CESData contains all CES data, including endpoints.
+// CES is reconciled to have endpoints equal to CEPs mapped to it
+// and other fields set from the CESData.
+type CESData struct {
+	ceps sets.Set[CEPName]
+	ns   string
+}
+
 // CESToCEPMapping is used to map Cilium Endpoints to CiliumEndpointSlices and
 // retrieving all the Cilium Endpoints mapped to the given CiliumEndpointSlice.
 // This map is protected by lock for consistent and concurrent access.
@@ -22,24 +30,16 @@ type CESToCEPMapping struct {
 	mutex lock.RWMutex
 	// cepNameToCESName is used to map CiliumEndpoint name to CiliumEndpointSlice name.
 	cepNameToCESName map[CEPName]CESName
-	// cesNameToCEPNameSet is used to map CiliumEndpointSlice name to all CiliumEndpoints names it contains.
-	cesNameToCEPNameSet map[CESName]sets.Set[CEPName]
-	cesData             map[CESName]CESData
-}
-
-// CESData contains all CES data except endpoints.
-// CES is reconicled to have endpoints equal to CEPs mapped to it
-// and other fields set from the CESData.
-type CESData struct {
-	ns string
+	// cesNameToData is used to map CiliumEndpointSlice name to all CiliumEndpoints names it contains
+	// and the namespace associated with it
+	cesNameToData map[CESName]*CESData
 }
 
 // Creates and intializes the new CESToCEPMapping
 func newCESToCEPMapping() *CESToCEPMapping {
 	return &CESToCEPMapping{
-		cepNameToCESName:    make(map[CEPName]CESName),
-		cesNameToCEPNameSet: make(map[CESName]sets.Set[CEPName]),
-		cesData:             make(map[CESName]CESData),
+		cepNameToCESName: make(map[CEPName]CESName),
+		cesNameToData:    make(map[CESName]*CESData),
 	}
 }
 
@@ -48,14 +48,14 @@ func (c *CESToCEPMapping) insertCEP(cepName CEPName, cesName CESName) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	c.cepNameToCESName[cepName] = cesName
-	c.cesNameToCEPNameSet[cesName].Insert(cepName)
+	c.cesNameToData[cesName].ceps.Insert(cepName)
 }
 
 // Remove the CEP entry from map
 func (c *CESToCEPMapping) deleteCEP(cepName CEPName) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	c.cesNameToCEPNameSet[c.cepNameToCESName[cepName]].Delete(cepName)
+	c.cesNameToData[c.cepNameToCESName[cepName]].ceps.Delete(cepName)
 	delete(c.cepNameToCESName, cepName)
 }
 
@@ -85,23 +85,31 @@ func (c *CESToCEPMapping) countCEPs() int {
 func (c *CESToCEPMapping) countCEPsInCES(ces CESName) int {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	return c.cesNameToCEPNameSet[ces].Len()
+
+	if cesData, ok := c.cesNameToData[ces]; ok {
+		return cesData.ceps.Len()
+	}
+	return 0
 }
 
 // Return CEP Names mapped to the given CES
 func (c *CESToCEPMapping) getCEPsInCES(ces CESName) []CEPName {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	return c.cesNameToCEPNameSet[ces].UnsortedList()
+
+	if cesData, ok := c.cesNameToData[ces]; ok {
+		return cesData.ceps.UnsortedList()
+	}
+	return nil
 }
 
 // Initializes mapping structure for CES
 func (c *CESToCEPMapping) insertCES(cesName CESName, ns string) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	c.cesNameToCEPNameSet[cesName] = sets.New[CEPName]()
-	c.cesData[cesName] = CESData{
-		ns: ns,
+	c.cesNameToData[cesName] = &CESData{
+		ceps: sets.New[CEPName](),
+		ns:   ns,
 	}
 }
 
@@ -109,14 +117,13 @@ func (c *CESToCEPMapping) insertCES(cesName CESName, ns string) {
 func (c *CESToCEPMapping) deleteCES(cesName CESName) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	delete(c.cesNameToCEPNameSet, cesName)
-	delete(c.cesData, cesName)
+	delete(c.cesNameToData, cesName)
 }
 
 func (c *CESToCEPMapping) hasCESName(cesName CESName) bool {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	_, ok := c.cesNameToCEPNameSet[cesName]
+	_, ok := c.cesNameToData[cesName]
 	return ok
 }
 
@@ -124,26 +131,28 @@ func (c *CESToCEPMapping) hasCESName(cesName CESName) bool {
 func (c *CESToCEPMapping) getCESCount() int {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	return len(c.cesNameToCEPNameSet)
+	return len(c.cesNameToData)
 }
 
 // Return names of all CESs.
 func (c *CESToCEPMapping) getAllCESs() []CESName {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	cess := make([]CESName, 0, len(c.cesNameToCEPNameSet))
-	for ces := range c.cesNameToCEPNameSet {
+	cess := make([]CESName, 0, len(c.cesNameToData))
+	for ces := range c.cesNameToData {
 		cess = append(cess, ces)
 	}
 	return cess
 }
 
-// Return the CES data
-func (c *CESToCEPMapping) getCESData(name CESName) CESData {
+// Return the namespace of the given CES
+func (c *CESToCEPMapping) getCESNamespace(name CESName) string {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	data := c.cesData[name]
-	return data
+	if cesData, ok := c.cesNameToData[name]; ok {
+		return cesData.ns
+	}
+	return ""
 }
 
 func (ces CESKey) key() resource.Key {

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -62,7 +62,7 @@ type Controller struct {
 	// Manager is used to create and maintain a local datastore. Manager watches for
 	// cilium endpoint changes and enqueues/dequeues the cilium endpoint changes in CES.
 	// It maintains the desired state of the CESs in dataStore
-	manager      operations
+	manager      *cesManager
 	maxCEPsInCES int
 
 	// workqueue is used to sync CESs with the api-server. this will rate-limit the

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -30,7 +30,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, log).(*cesManager)
+	m := newCESManager(2, log)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -116,7 +116,7 @@ func (c *cesManager) getLargestAvailableCESForNamespace(ns string) CESName {
 	selectedCES := CESName("")
 	for _, ces := range c.mapping.getAllCESs() {
 		cepCount := c.mapping.countCEPsInCES(ces)
-		if cepCount < c.maxCEPsInCES && cepCount > largestCEPCount && c.mapping.getCESData(ces).ns == ns {
+		if cepCount < c.maxCEPsInCES && cepCount > largestCEPCount && c.mapping.getCESNamespace(ces) == ns {
 			selectedCES = ces
 			largestCEPCount = cepCount
 			if largestCEPCount == c.maxCEPsInCES-1 {
@@ -140,8 +140,8 @@ func (c *cesManager) getCEPCountInCES(ces CESName) int {
 	return c.mapping.countCEPsInCES(ces)
 }
 
-func (c *cesManager) getCESData(ces CESName) CESData {
-	return c.mapping.getCESData(ces)
+func (c *cesManager) getCESNamespace(ces CESName) string {
+	return c.mapping.getCESNamespace(ces)
 }
 
 func (c *cesManager) getCEPinCES(ces CESName) []CEPName {

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -17,21 +17,6 @@ var (
 	sequentialLetters = []rune("bcdfghjklmnpqrstvwxyz2456789")
 )
 
-// operations is an interface to all operations that a CES manager can perform.
-type operations interface {
-	// External APIs to Insert/Remove CEP in local dataStore
-	UpdateCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) []CESKey
-	RemoveCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) CESKey
-
-	initializeMappingForCES(ces *cilium_v2.CiliumEndpointSlice) CESName
-	initializeMappingCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ns string, ces CESName)
-
-	getCEPCountInCES(ces CESName) int
-	getCEPinCES(ces CESName) []CEPName
-	getCESData(ces CESName) CESData
-	isCEPinCES(cep CEPName, ces CESName) bool
-}
-
 // cesManager is used to batch CEP into a CES, based on FirstComeFirstServe. If a new CEP
 // is inserted, then the CEP is queued in any one of the available CES. CEPs are
 // inserted into CESs without any preference or any priority.
@@ -48,7 +33,7 @@ type cesManager struct {
 
 // newCESManager creates and initializes a new FirstComeFirstServe based CES
 // manager, in this mode CEPs are batched based on FirstComeFirtServe algorithm.
-func newCESManager(maxCEPsInCES int, logger *slog.Logger) operations {
+func newCESManager(maxCEPsInCES int, logger *slog.Logger) *cesManager {
 	return &cesManager{
 		logger:       logger,
 		mapping:      newCESToCEPMapping(),

--- a/operator/pkg/ciliumendpointslice/manager_test.go
+++ b/operator/pkg/ciliumendpointslice/manager_test.go
@@ -22,13 +22,13 @@ func getCEP(name string, id int64) *capi_v2a1.CoreCiliumEndpoint {
 func TestFCFSManager(t *testing.T) {
 	log := hivetest.Logger(t)
 	t.Run("Test adding new CEP to map", func(*testing.T) {
-		m := newCESManager(2, log).(*cesManager)
+		m := newCESManager(2, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		assert.Equal(t, 1, m.mapping.getCESCount(), "Total number of CESs allocated is 1")
 		assert.Equal(t, 1, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test creating enough CESs", func(*testing.T) {
-		m := newCESManager(2, log).(*cesManager)
+		m := newCESManager(2, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c3", 0), "ns")
@@ -38,7 +38,7 @@ func TestFCFSManager(t *testing.T) {
 		assert.Equal(t, 5, m.mapping.countCEPs(), "Total number of CEPs inserted is 5")
 	})
 	t.Run("Test keeping the CEPs from different namespaces in different CESs", func(*testing.T) {
-		m := newCESManager(5, log).(*cesManager)
+		m := newCESManager(5, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns1")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns2")
 		m.UpdateCEPMapping(getCEP("c3", 0), "ns3")
@@ -48,14 +48,14 @@ func TestFCFSManager(t *testing.T) {
 		assert.Equal(t, 5, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test keeping the same mapping", func(*testing.T) {
-		m := newCESManager(2, log).(*cesManager)
+		m := newCESManager(2, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c1", 5), "ns")
 		assert.Equal(t, 1, m.mapping.getCESCount(), "Total number of CESs allocated is 1")
 		assert.Equal(t, 1, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test reusing CES", func(*testing.T) {
-		m := newCESManager(2, log).(*cesManager)
+		m := newCESManager(2, log)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns")
 		m.RemoveCEPMapping(getCEP("c1", 0), "ns")

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -25,7 +25,7 @@ type reconciler struct {
 	logger     *slog.Logger
 	client     clientset.CiliumV2alpha1Interface
 	context    context.Context
-	cesManager operations
+	cesManager *cesManager
 	cepStore   resource.Store[*cilium_v2.CiliumEndpoint]
 	cesStore   resource.Store[*cilium_v2a1.CiliumEndpointSlice]
 	metrics    *Metrics
@@ -35,7 +35,7 @@ type reconciler struct {
 func newReconciler(
 	ctx context.Context,
 	client clientset.CiliumV2alpha1Interface,
-	cesMgr operations,
+	cesMgr *cesManager,
 	logger *slog.Logger,
 	ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint],
 	ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice],

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -89,8 +89,7 @@ func (r *reconciler) reconcileCESCreate(cesName CESName) (err error) {
 		Endpoints: make([]cilium_v2a1.CoreCiliumEndpoint, 0, len(ceps)),
 	}
 
-	cesData := r.cesManager.getCESData(cesName)
-	newCES.Namespace = cesData.ns
+	newCES.Namespace = r.cesManager.getCESNamespace(cesName)
 
 	for _, cepName := range ceps {
 		ccep := r.getCoreEndpointFromStore(cepName)
@@ -163,9 +162,9 @@ func (r *reconciler) reconcileCESUpdate(cesName CESName, cesObj *cilium_v2a1.Cil
 	)
 
 	cesEqual := cepInserted == 0 && cepUpdated == 0 && cepRemoved == 0
-	data := r.cesManager.getCESData(cesName)
-	if updatedCES.Namespace != data.ns {
-		updatedCES.Namespace = data.ns
+	ns := r.cesManager.getCESNamespace(cesName)
+	if updatedCES.Namespace != ns {
+		updatedCES.Namespace = ns
 		cesEqual = false
 	}
 

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -25,7 +25,7 @@ import (
 func TestReconcileCreate(t *testing.T) {
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, hivetest.Logger(t)).(*cesManager)
+	m := newCESManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics
@@ -84,7 +84,7 @@ func TestReconcileCreate(t *testing.T) {
 func TestReconcileUpdate(t *testing.T) {
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, hivetest.Logger(t)).(*cesManager)
+	m := newCESManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics
@@ -149,7 +149,7 @@ func TestReconcileUpdate(t *testing.T) {
 func TestReconcileDelete(t *testing.T) {
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, hivetest.Logger(t)).(*cesManager)
+	m := newCESManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics
@@ -208,7 +208,7 @@ func TestReconcileDelete(t *testing.T) {
 func TestReconcileNoop(t *testing.T) {
 	var r *reconciler
 	var fakeClient *k8sClient.FakeClientset
-	m := newCESManager(2, hivetest.Logger(t)).(*cesManager)
+	m := newCESManager(2, hivetest.Logger(t))
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	var cesMetrics *Metrics


### PR DESCRIPTION
- Replace usage of map[T]struct{} with sets.Set
- Remove unused CES manager interface (since Identity mode has been removed)
- Refactor ceptocesmap to simplify local state

Breaking out some commits from original PR #38388 for convenience :)

```release-note
ces: refactor and clean up
```
