### PR TITLE
identity: Ensure ingress label is reserved label to be node-local

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -205,7 +205,7 @@ func ScopeForLabels(lbls labels.Labels) NumericIdentity {
 	// The ingress label is for L7 LB with cilium proxy, which is running on
 	// every node. So it's not necessary to be global identity, but local
 	// identity instead.
-	if lbls.HasIngressLabel() {
+	if lbls.IsReserved() && lbls.HasIngressLabel() {
 		return IdentityScopeLocal
 	}
 

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -116,6 +116,10 @@ func TestScopeForLabels(t *testing.T) {
 			lbls:  labels.NewLabelsFromModel([]string{"reserved:remote-node", "reserved:kube-apiserver"}),
 			scope: IdentityScopeRemoteNode,
 		},
+		{
+			lbls:  labels.NewLabelsFromModel([]string{"k8s:ingress=allowed"}),
+			scope: IdentityScopeGlobal,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
If this check is not present, then Cilium consider global identity to be
node-local if there is a label called "ingress" in the label set.

For example, a workload pod could have the label set:

```
k8s:foo=bar
k8s:ingress=allowed
```

and Cilium will incorrectly assign it a node-local identity because the
"ingress" label is present, without checking the source. Hence why we
need to add a check for the reserved source.

A unit test is added to validate this behavior.

Fixes: 226a978e50 ("identity: Allow local identity for ingress label")
Signed-off-by: Chris Tarazi <chris@isovalent.com>

---

```release-note
Fix bug where the presence of a label called "ingress" causes incorrect assignment of identities to workloads, affecting policy enforcement.
```
