### PR TITLE
cli: add l7proxy check to policy-local-cluster-egress

### DIFF
--- a/cilium-cli/connectivity/builder/policy_local_cluster.go
+++ b/cilium-cli/connectivity/builder/policy_local_cluster.go
@@ -21,6 +21,7 @@ func (t policyLocalCluster) build(ct *check.ConnectivityTest, templates map[stri
 		WithCiliumPolicy(clientEgressToEchoNoClusterPolicyYAML).
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).
 		WithScenarios(tests.PodToPod()).
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if !ct.Features[features.PolicyDefaultLocalCLuster].Enabled {
 				return check.ResultOK, check.ResultOK


### PR DESCRIPTION
<!-- Description of change -->
### Issue
#39786 introduces a new test policy-local-cluster-egress that deploys DNS-only CNP (client-egress-only-dns) and does not check if l7 is enabled. This test is failing for clusters without l7 proxy, as the policy is still applied

`level=warn msg="Unable to add CiliumNetworkPolicy" module=agent.controlplane.policy-k8s-watcher ciliumNetworkPolicyName=client-egress-only-dns k8sApiVersion="" k8sNamespace=cilium-test-1 error="Invalid CiliumNetworkPolicy spec: L7 policy is not supported since L7 proxy is not enabled"`

### Fix
Adding a check for l7 proxy enablement. Skip this test if the cluster does not have l7 enabled. 
Same as #40549 

```release-note
Add l7 proxy check to policy-local-cluster-egress connectivity test
```
