### PR TITLE
bpf: Rate limit socket traces based on monitor aggregation

### DIFF
--- a/Documentation/network/kubernetes/configuration.rst
+++ b/Documentation/network/kubernetes/configuration.rst
@@ -58,6 +58,13 @@ to your preferences:
   - ``maximum`` - An alias for the most aggressive aggregation level. Currently
     this is equivalent to setting ``monitor-aggregation`` to ``medium``.
 
+  When socket load-balancing is enabled, these aggregation levels also apply to
+  socket translation events:
+
+  - ``none`` - Emit all socket trace events
+  - ``lowest``/``low`` - Suppress reverse-direction (recv) socket trace events
+  - ``medium``/``maximum`` - Emit socket trace events only for connect system calls
+
 * ``monitor-aggregation-interval`` - Defines the interval to report tracing
   events. Only applicable for ``monitor-aggregation`` levels ``medium`` or higher.
   Assuming new packets are sent at least once per interval, this ensures that on

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -447,10 +447,21 @@ should consider increasing the aggregation interval or rate limiting events.
 Increase Aggregation Interval
 -----------------------------
 
-By default Cilium generates a tracing event for send packets only on every new
-connection, any time a packet contains TCP flags that have not been previously
-seen for the packet direction, and on average once per ``monitor-aggregation-interval``,
-which defaults to 5 seconds.
+By default Cilium generates tracing events according to the configured
+``monitor-aggregation`` level. For packet events, Cilium generates a tracing
+event for send packets only on every new connection, any time a packet contains
+TCP flags that have not been previously seen for the packet direction, and on
+average once per ``monitor-aggregation-interval``, which defaults to 5 seconds.
+When socket load-balancing is enabled, the same aggregation levels apply to
+socket translation events (for example, pre/post reverse translation):
+
+- ``none``: emit all socket trace events
+- ``lowest``/``low``: suppress reverse-direction (recv) socket traces
+- ``medium``/``maximum``: emit socket trace events only for connect system calls
+
+When aggregation is enabled (>= ``lowest``), socket trace emission is aligned
+to ``monitor-aggregation-interval`` using a strict cadence of approximately one
+trace per interval for active flows.
 
 Depending on your network traffic patterns, the re-emitting of trace events per
 aggregation interval can make up a large part of the total events. Increasing the

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -246,7 +246,8 @@ sock4_wildcard_lookup_full(struct lb4_key *key __maybe_unused,
 
 static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 					     struct bpf_sock_addr *ctx_full,
-					     const bool udp_only)
+					     const bool udp_only,
+					     const bool is_connect)
 {
 	union lb4_affinity_client_id id;
 	const bool in_hostns = ctx_in_hostns(ctx_full, &id.client_cookie);
@@ -286,7 +287,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 		return -EHOSTUNREACH;
 
 	send_trace_sock_notify4(ctx_full, XLATE_PRE_DIRECTION_FWD, dst_ip,
-				bpf_ntohs(dst_port));
+				bpf_ntohs(dst_port), is_connect);
 
 	/* Do not perform service translation for these services
 	 * in case of E/W traffic, but rather let the fabric
@@ -389,7 +390,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 		lb4_update_affinity_by_netns(svc, &id, backend_id);
 
 	send_trace_sock_notify4(ctx_full, XLATE_POST_DIRECTION_FWD, backend->address,
-				bpf_ntohs(backend->port));
+				bpf_ntohs(backend->port), is_connect);
 
 #ifdef ENABLE_L7_LB
 out:
@@ -416,7 +417,7 @@ int cil_sock4_connect(struct bpf_sock_addr *ctx)
 		return SYS_PROCEED;
 #endif /* ENABLE_HEALTH_CHECK */
 
-	err = __sock4_xlate_fwd(ctx, ctx, false);
+	err = __sock4_xlate_fwd(ctx, ctx, false, true);
 	if (err == -EHOSTUNREACH || err == -ENOMEM) {
 		try_set_retval(err);
 		return SYS_REJECT;
@@ -542,7 +543,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 	};
 
 	send_trace_sock_notify4(ctx_full, XLATE_PRE_DIRECTION_REV, dst_ip,
-				bpf_ntohs(dst_port));
+				bpf_ntohs(dst_port), false);
 	val = map_lookup_elem(&cilium_lb4_reverse_sk, &key);
 	if (val) {
 		struct lb4_service *svc;
@@ -567,7 +568,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 		ctx->user_ip4 = val->address;
 		ctx_set_port(ctx, val->port);
 		send_trace_sock_notify4(ctx_full, XLATE_POST_DIRECTION_REV, val->address,
-					bpf_ntohs(val->port));
+					bpf_ntohs(val->port), false);
 		return 0;
 	}
 
@@ -579,7 +580,7 @@ int cil_sock4_sendmsg(struct bpf_sock_addr *ctx)
 {
 	int err;
 
-	err = __sock4_xlate_fwd(ctx, ctx, true);
+	err = __sock4_xlate_fwd(ctx, ctx, true, false);
 	if (err == -EHOSTUNREACH || err == -ENOMEM) {
 		try_set_retval(err);
 		return SYS_REJECT;
@@ -779,7 +780,8 @@ sock6_wildcard_lookup_full(struct lb6_key *key __maybe_unused,
 
 static __always_inline
 int sock6_xlate_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused,
-			 const bool udp_only __maybe_unused)
+			 const bool udp_only __maybe_unused,
+			 const bool is_connect __maybe_unused)
 {
 #ifdef ENABLE_IPV4
 	struct bpf_sock_addr fake_ctx;
@@ -795,7 +797,7 @@ int sock6_xlate_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused,
 	fake_ctx.user_ip4  = addr6.p4;
 	fake_ctx.user_port = ctx_dst_port(ctx);
 
-	ret = __sock4_xlate_fwd(&fake_ctx, ctx, udp_only);
+	ret = __sock4_xlate_fwd(&fake_ctx, ctx, udp_only, is_connect);
 	if (ret < 0)
 		return ret;
 
@@ -955,7 +957,8 @@ int cil_sock6_pre_bind(struct bpf_sock_addr *ctx)
 #endif /* ENABLE_HEALTH_CHECK */
 
 static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
-					     const bool udp_only)
+					     const bool udp_only,
+					     const bool is_connect)
 {
 #ifdef ENABLE_IPV6
 	union lb6_affinity_client_id id;
@@ -988,12 +991,12 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (!svc)
 		svc = sock6_wildcard_lookup_full(&key, in_hostns);
 	if (!svc)
-		return sock6_xlate_v4_in_v6(ctx, udp_only);
+		return sock6_xlate_v4_in_v6(ctx, udp_only, is_connect);
 	if (svc->count == 0 && !lb6_svc_is_l7_loadbalancer(svc))
 		return -EHOSTUNREACH;
 
 	send_trace_sock_notify6(ctx, XLATE_PRE_DIRECTION_FWD, &key.address,
-				bpf_ntohs(dst_port));
+				bpf_ntohs(dst_port), is_connect);
 
 	if (lb6_svc_is_l7_punt_proxy(svc))
 		return SYS_PROCEED;
@@ -1059,7 +1062,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 		lb6_update_affinity_by_netns(svc, &id, backend_id);
 
 	send_trace_sock_notify6(ctx, XLATE_POST_DIRECTION_FWD, &backend->address,
-				bpf_ntohs(backend->port));
+				bpf_ntohs(backend->port), is_connect);
 
 #ifdef ENABLE_L7_LB
 out:
@@ -1075,7 +1078,7 @@ out:
 
 	return 0;
 #else
-	return sock6_xlate_v4_in_v6(ctx, udp_only);
+	return sock6_xlate_v4_in_v6(ctx, udp_only, is_connect);
 #endif /* ENABLE_IPV6 */
 }
 
@@ -1089,7 +1092,7 @@ int cil_sock6_connect(struct bpf_sock_addr *ctx)
 		return SYS_PROCEED;
 #endif /* ENABLE_HEALTH_CHECK */
 
-	err = __sock6_xlate_fwd(ctx, false);
+	err = __sock6_xlate_fwd(ctx, false, true);
 	if (err == -EHOSTUNREACH || err == -ENOMEM) {
 		try_set_retval(err);
 		return SYS_REJECT;
@@ -1141,7 +1144,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 	ctx_get_v6_address(ctx, &key.address);
 
 	send_trace_sock_notify6(ctx, XLATE_PRE_DIRECTION_REV, &key.address,
-				bpf_ntohs(dst_port));
+				bpf_ntohs(dst_port), false);
 
 	val = map_lookup_elem(&cilium_lb6_reverse_sk, &key);
 	if (val) {
@@ -1167,7 +1170,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 		ctx_set_v6_address(ctx, &val->address);
 		ctx_set_port(ctx, val->port);
 		send_trace_sock_notify6(ctx, XLATE_POST_DIRECTION_REV, &val->address,
-					bpf_ntohs(val->port));
+					bpf_ntohs(val->port), false);
 		return 0;
 	}
 #endif /* ENABLE_IPV6 */
@@ -1180,7 +1183,7 @@ int cil_sock6_sendmsg(struct bpf_sock_addr *ctx)
 {
 	int err;
 
-	err = __sock6_xlate_fwd(ctx, true);
+	err = __sock6_xlate_fwd(ctx, true, false);
 	if (err == -EHOSTUNREACH || err == -ENOMEM) {
 		try_set_retval(err);
 		return SYS_REJECT;

--- a/bpf/lib/ratelimit.h
+++ b/bpf/lib/ratelimit.h
@@ -8,6 +8,7 @@
 
 #define RATELIMIT_USAGE_ICMPV6 1
 #define RATELIMIT_USAGE_EVENTS_MAP 2
+#define RATELIMIT_USAGE_SOCKET_EVENTS_MAP 3
 
 struct ratelimit_key {
 	__u32 usage;

--- a/bpf/lib/trace_sock.h
+++ b/bpf/lib/trace_sock.h
@@ -22,6 +22,19 @@
 #include "events.h"
 #include "ratelimit.h"
 #include "sock.h"
+#include "time.h"
+
+/* Trace aggregation levels for socket traces (sock context only). */
+enum {
+	TRACE_SOCK_AGGREGATE_NONE	= 0, /* Trace every syscall */
+	TRACE_SOCK_AGGREGATE_RECV	= 1, /* Hide trace on receive syscalls */
+	TRACE_SOCK_AGGREGATE_CONNECT	= 3, /* Only trace connect syscalls */
+};
+
+/* Default monitor aggregation value when not provided by build defines. */
+#ifndef MONITOR_AGGREGATION
+#define MONITOR_AGGREGATION TRACE_SOCK_AGGREGATE_NONE
+#endif
 
 /* L4 protocol for the trace event */
 enum l4_protocol {
@@ -76,22 +89,63 @@ parse_protocol(__u32 l4_proto) {
 	}
 }
 
+/* Apply monitor aggregation mapping for socket events.
+ * Mapping mirrors packet-side behavior and documented levels:
+ * - none (0): emit all socket trace events
+ * - lowest/low (1/2): suppress reverse-direction (recv) socket traces
+ * - medium/max (3/4): only emit connect-initiated traces
+ *
+ * When aggregation is enabled (>=1), rate limiting aligns to CT_REPORT_INTERVAL.
+ */
+static __always_inline bool
+emit_trace_sock_notify(enum xlate_point xlate_point, bool is_connect)
+{
+	/* Hide reverse-direction traces starting at RX-level aggregation. */
+	if (MONITOR_AGGREGATION >= TRACE_SOCK_AGGREGATE_RECV) {
+		switch (xlate_point) {
+		case XLATE_PRE_DIRECTION_REV:
+		case XLATE_POST_DIRECTION_REV:
+			return false;
+		default:
+			break;
+		}
+	}
+
+	/* At ACTIVE_CT (3) and up, only emit for connect syscalls. */
+	if (MONITOR_AGGREGATION >= TRACE_SOCK_AGGREGATE_CONNECT)
+		if (!is_connect)
+			return false;
+
+	return true;
+}
+
 static __always_inline void
 send_trace_sock_notify4(struct __ctx_sock *ctx,
 			enum xlate_point xlate_point,
-			__u32 dst_ip, __u16 dst_port)
+			__u32 dst_ip, __u16 dst_port,
+			bool is_connect)
 {
 	struct trace_sock_notify msg __align_stack_8;
 	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
+		.usage = RATELIMIT_USAGE_SOCKET_EVENTS_MAP,
 	};
 	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
+		.topup_interval_ns = CT_REPORT_INTERVAL * NSEC_PER_SEC,
 	};
 
-	if (EVENTS_MAP_RATE_LIMIT > 0) {
-		settings.bucket_size = EVENTS_MAP_BURST_LIMIT;
-		settings.tokens_per_topup = EVENTS_MAP_RATE_LIMIT;
+	if (!emit_trace_sock_notify(xlate_point, is_connect))
+		return;
+
+	/* Rate limit socket traces when monitor aggregation is enabled.
+	 * Uses CT_REPORT_INTERVAL as the time bucket for aggregation to
+	 * align with monitor aggregation timing.
+	 */
+	if (MONITOR_AGGREGATION != TRACE_SOCK_AGGREGATE_NONE) {
+		/* One token per CT_REPORT_INTERVAL with no burst to align with
+		 * monitor aggregation semantics ("~1 per interval").
+		 */
+		settings.bucket_size = 1;
+		settings.tokens_per_topup = 1;
 		if (!ratelimit_check_and_take(&rkey, &settings))
 			return;
 	}
@@ -114,19 +168,30 @@ static __always_inline void
 send_trace_sock_notify6(struct __ctx_sock *ctx,
 			enum xlate_point xlate_point,
 			union v6addr *dst_addr,
-			__u16 dst_port)
+			__u16 dst_port,
+			bool is_connect)
 {
 	struct trace_sock_notify msg __align_stack_8;
 	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_EVENTS_MAP,
+		.usage = RATELIMIT_USAGE_SOCKET_EVENTS_MAP,
 	};
 	struct ratelimit_settings settings = {
-		.topup_interval_ns = NSEC_PER_SEC,
+		.topup_interval_ns = CT_REPORT_INTERVAL * NSEC_PER_SEC,
 	};
 
-	if (EVENTS_MAP_RATE_LIMIT > 0) {
-		settings.bucket_size = EVENTS_MAP_BURST_LIMIT;
-		settings.tokens_per_topup = EVENTS_MAP_RATE_LIMIT;
+	if (!emit_trace_sock_notify(xlate_point, is_connect))
+		return;
+
+	/* Rate limit socket traces when monitor aggregation is enabled.
+	 * Uses CT_REPORT_INTERVAL as the time bucket for aggregation to
+	 * align with monitor aggregation timing.
+	 */
+	if (MONITOR_AGGREGATION != TRACE_SOCK_AGGREGATE_NONE) {
+		/* One token per CT_REPORT_INTERVAL with no burst to align with
+		 * monitor aggregation semantics ("~1 per interval").
+		 */
+		settings.bucket_size = 1;
+		settings.tokens_per_topup = 1;
 		if (!ratelimit_check_and_take(&rkey, &settings))
 			return;
 	}
@@ -148,7 +213,8 @@ send_trace_sock_notify6(struct __ctx_sock *ctx,
 static __always_inline void
 send_trace_sock_notify4(struct __ctx_sock *ctx __maybe_unused,
 			enum xlate_point xlate_point __maybe_unused,
-			__u32 dst_ip __maybe_unused, __u16 dst_port __maybe_unused)
+			__u32 dst_ip __maybe_unused, __u16 dst_port __maybe_unused,
+			bool is_connect __maybe_unused)
 {
 }
 
@@ -156,7 +222,8 @@ static __always_inline void
 send_trace_sock_notify6(struct __ctx_sock *ctx __maybe_unused,
 			enum xlate_point xlate_point __maybe_unused,
 			union v6addr *dst_addr __maybe_unused,
-			__u16 dst_port __maybe_unused)
+			__u16 dst_port __maybe_unused,
+			bool is_connect __maybe_unused)
 {
 }
 #endif /* TRACE_SOCK_NOTIFY */

--- a/bpf/tests/host_only_socket_lb_test.c
+++ b/bpf/tests/host_only_socket_lb_test.c
@@ -91,14 +91,14 @@ int test1_check(__maybe_unused struct xdp_md *ctx)
 
 	/* If netns is not the host, then xlate should be skipped. */
 	addr.user_port = DST_PORT;
-	ret = __sock4_xlate_fwd(&addr, &addr, false);
+	ret = __sock4_xlate_fwd(&addr, &addr, false, true);
 	assert(addr.user_ip4 == v4_svc_one);
 	assert(addr.user_port == DST_PORT);
 	assert(ret == -ENXIO);
 
 	/* If netns is host, then xlate should happen. */
 	addr.user_port = DST_PORT_HOSTNS; /* see my_get_netns_cookie */
-	ret = __sock4_xlate_fwd(&addr, &addr, false);
+	ret = __sock4_xlate_fwd(&addr, &addr, false, true);
 	test_log("xlate_fwd: %d", ret);
 	test_log("ip %lx", addr.user_ip4);
 	test_log("port %d", addr.user_port);

--- a/bpf/tests/skip_lb_xlate_socket_lb.c
+++ b/bpf/tests/skip_lb_xlate_socket_lb.c
@@ -86,7 +86,7 @@ int test_sock4_xlate_fwd_skip_lb(__maybe_unused struct xdp_md *ctx)
 	/* Skip LB xlate when pod_one is connecting to v4_svc_one:tcp_svc_one. */
 	addr.user_ip4 = v4_svc_one,
 	addr.user_port = tcp_svc_one,
-	ret = __sock4_xlate_fwd(&addr, &addr, false);
+	ret = __sock4_xlate_fwd(&addr, &addr, false, true);
 	test_log("ret: %d", ret);
 	test_log("pod_one [%lx] -> svc_one [%lx]", addr.sk->src_ip4, addr.user_ip4);
 	assert(addr.user_ip4 == v4_svc_one);
@@ -96,7 +96,7 @@ int test_sock4_xlate_fwd_skip_lb(__maybe_unused struct xdp_md *ctx)
 	/* LB xlate happens when pod_one is connecting to v4_svc_two:tcp_svc_two. */
 	addr.user_ip4 = v4_svc_two;
 	addr.user_port = tcp_svc_two;
-	ret = __sock4_xlate_fwd(&addr, &addr, false);
+	ret = __sock4_xlate_fwd(&addr, &addr, false, true);
 	test_log("ret: %d", ret);
 	test_log("pod_one [%lx] -> svc_two [%lx]", addr.sk->src_ip4, addr.user_ip4);
 	assert(addr.user_ip4 == v4_pod_one);
@@ -107,7 +107,7 @@ int test_sock4_xlate_fwd_skip_lb(__maybe_unused struct xdp_md *ctx)
 	addr.sk->src_ip4 = v4_pod_two;
 	addr.user_ip4 = v4_svc_one;
 	addr.user_port = tcp_svc_one;
-	ret = __sock4_xlate_fwd(&addr, &addr, false);
+	ret = __sock4_xlate_fwd(&addr, &addr, false, true);
 	test_log("ret: %d", ret);
 	test_log("pod_two [%lx] -> svc_one [%lx]", addr.sk->src_ip4, addr.user_ip4);
 	assert(addr.user_ip4 == v4_pod_one);
@@ -162,7 +162,7 @@ int test_sock6_xlate_fwd_skip_lb(__maybe_unused struct xdp_md *ctx)
 	addr.sk->src_ip6[3] = bpf_htonl(1);
 	memcpy(addr.user_ip6, (void *)V6_SVC_ONE, 16);
 	addr.user_port = tcp_svc_one;
-	ret = __sock6_xlate_fwd(&addr, false);
+	ret = __sock6_xlate_fwd(&addr, false, true);
 	test_log("ret: %d", ret);
 	test_log("pod_one [%lx] -> svc_one [%lx]", addr.sk->src_ip6[0], addr.user_ip6[0]);
 	assert(addr.user_ip6[0] == bpf_htonl(0xfd050000));
@@ -179,7 +179,7 @@ int test_sock6_xlate_fwd_skip_lb(__maybe_unused struct xdp_md *ctx)
 	addr.sk->src_ip6[3] = bpf_htonl(1);
 	memcpy(addr.user_ip6, (void *)V6_SVC_TWO, 16);
 	addr.user_port = tcp_svc_two;
-	ret = __sock6_xlate_fwd(&addr, false);
+	ret = __sock6_xlate_fwd(&addr, false, true);
 	test_log("ret: %d", ret);
 	test_log("pod_one [%lx] -> svc_two [%lx]", addr.sk->src_ip6[0], addr.user_ip6[0]);
 	assert(addr.user_ip6[0] == bpf_htonl(0xfd040000));
@@ -196,7 +196,7 @@ int test_sock6_xlate_fwd_skip_lb(__maybe_unused struct xdp_md *ctx)
 	addr.sk->src_ip6[3] = bpf_htonl(2);
 	memcpy(addr.user_ip6, (void *)V6_SVC_ONE, 16);
 	addr.user_port = tcp_svc_one;
-	ret = __sock6_xlate_fwd(&addr, false);
+	ret = __sock6_xlate_fwd(&addr, false, true);
 	test_log("ret: %d", ret);
 	test_log("pod_two [%lx] -> svc_one [%lx]", addr.sk->src_ip6[0], addr.user_ip6[0]);
 	assert(addr.user_ip6[0] == bpf_htonl(0xfd040000));


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Description of change

Align socket translation traces with `monitor-aggregation` levels and interval (same semantics as packet events).

- lowest/low: suppress reverse-direction (recv) socket traces
- medium/maximum: emit socket traces only for connect system calls
- cadence: strict ~1 trace per `monitor-aggregation-interval` for active flows (via `CT_REPORT_INTERVAL`)
- implemented via `emit_trace_sock_notify()` and a minimal `is_connect` signal
- IPv4/IPv6 forward paths and v4-in-v6 helper updated accordingly
- docs updated to integrate socket behavior into existing monitor-aggregation sections

Fixes: #38644

```release-note
bpf: Apply monitor-aggregation semantics to socket translation events and align socket trace cadence with monitor-aggregation-interval.
```