### PR TITLE
Break out policy computation from endpoint pkg

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -77,6 +77,7 @@ import (
 	"github.com/cilium/cilium/pkg/nodeipamconfig"
 	"github.com/cilium/cilium/pkg/option"
 	policy "github.com/cilium/cilium/pkg/policy/cell"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
 	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/pprof"
@@ -292,6 +293,9 @@ var (
 
 		// Provides PolicyRepository (List of policy rules)
 		policy.Cell,
+
+		// Provides PolicyRecomputer (policy computation).
+		compute.Cell,
 
 		// K8s policy resource watcher cell. It depends on the half-initialized daemon which is
 		// resolved by newDaemonPromise()

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -323,11 +323,12 @@ func unloadDNSPolicies(params daemonParams) {
 			"Triggering policy recalculation to remove DNS rules due to option",
 			logfields.Option, option.DNSPolicyUnloadOnShutdown,
 		)
-		params.Policy.BumpRevision()
 		regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
 			Reason:            regeneration.ReasonDaemonConfigUpdate,
 			Message:           "unloading DNS rules on graceful shutdown",
 			RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+
+			PolicyRevisionToWaitFor: params.Policy.BumpRevision(),
 		}
 		wg := params.EndpointManager.RegenerateAllEndpoints(regenerationMetadata)
 		wg.Wait()

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/trigger"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -124,6 +125,7 @@ type configModifyEventHandlerParams struct {
 
 	Orchestrator    datapath.Orchestrator
 	Policy          policy.PolicyRepository
+	PolicyComputer  compute.PolicyRecomputer
 	EndpointManager endpointmanager.EndpointManager
 	L7Proxy         *proxy.Proxy
 }
@@ -136,6 +138,7 @@ func newConfigModifyEventHandler(params configModifyEventHandlerParams) *ConfigM
 		logger:          params.Logger,
 		orchestrator:    params.Orchestrator,
 		policy:          params.Policy,
+		computer:        params.PolicyComputer,
 		endpointManager: params.EndpointManager,
 		l7Proxy:         params.L7Proxy,
 	}
@@ -179,6 +182,7 @@ type ConfigModifyEventHandler struct {
 
 	orchestrator    datapath.Orchestrator
 	policy          policy.PolicyRepository
+	computer        compute.PolicyRecomputer
 	endpointManager endpointmanager.EndpointManager
 	l7Proxy         *proxy.Proxy
 }
@@ -186,11 +190,18 @@ type ConfigModifyEventHandler struct {
 func (h *ConfigModifyEventHandler) datapathRegen(reasons []string) {
 	reason := strings.Join(reasons, ", ")
 
+	// We expect the policy revision to have been bumped prior to this call
+	// here. All endpoints are about to be regenerated so recompute policy
+	// for all endpoints and then trigger regeneration.
+
 	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
 		Reason:            regeneration.ReasonDaemonConfigUpdate,
 		Message:           reason,
 		RegenerationLevel: regeneration.RegenerateWithDatapath,
+
+		PolicyRevisionToWaitFor: h.policy.GetRevision(),
 	}
+	h.computer.RecomputeIdentityPolicyForAllIdentities(regenerationMetadata.PolicyRevisionToWaitFor)
 	h.endpointManager.RegenerateAllEndpoints(regenerationMetadata)
 }
 

--- a/daemon/restapi/policy.go
+++ b/daemon/restapi/policy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	policycell "github.com/cilium/cilium/pkg/policy/cell"
+	"github.com/cilium/cilium/pkg/policy/compute"
 )
 
 var policyAPICell = cell.Module(
@@ -28,8 +29,9 @@ type policyAPIHandlerParams struct {
 
 	Log *slog.Logger
 
-	Repo     policy.PolicyRepository
-	Importer policycell.PolicyImporter
+	Repo           policy.PolicyRepository
+	PolicyComputer compute.PolicyRecomputer
+	Importer       policycell.PolicyImporter
 }
 
 type policyAPIHandlers struct {

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -9,37 +9,19 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
-	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/identity/identitymanager"
-	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/testutils"
-	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
 func TestWriteInformationalComments(t *testing.T) {
-	logger := hivetest.Logger(t)
 	s := setupEndpointSuite(t)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := EndpointParams{
-		Logger:           logger,
-		EPBuildQueue:     &MockEndpointBuildQueue{},
-		Orchestrator:     s.orchestrator,
-		PolicyRepo:       s.repo,
-		IdentityManager:  identitymanager.NewIDManager(logger),
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		WgConfig:         fakeTypes.WireguardConfig{},
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-	}
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -53,25 +35,13 @@ func TestWriteInformationalComments(t *testing.T) {
 type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
-	logger := hivetest.Logger(b)
 	testutils.IntegrationTest(b)
 
 	s := setupEndpointSuite(b)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := EndpointParams{
-		Logger:           logger,
-		EPBuildQueue:     &MockEndpointBuildQueue{},
-		Orchestrator:     s.orchestrator,
-		PolicyRepo:       s.repo,
-		IdentityManager:  identitymanager.NewIDManager(logger),
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		WgConfig:         fakeTypes.WireguardConfig{},
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-	}
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(b, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -289,7 +289,7 @@ type Endpoint struct {
 
 	// policyMap is the policy related state of the datapath including
 	// reference to all policy related BPF
-	policyMap *policymap.PolicyMap
+	policyMap policymap.PolicyMap
 
 	// PolicyMapPressureUpdater updates the policymap pressure metric.
 	PolicyMapPressureUpdater policyMapPressureUpdater

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -168,7 +169,8 @@ type Endpoint struct {
 
 	epBuildQueue EndpointBuildQueue
 
-	policyRepo policy.PolicyRepository
+	policyRepo    policy.PolicyRepository
+	policyFetcher compute.PolicyRecomputer
 
 	// namedPortsGetter can get the ipcache.IPCache object.
 	namedPortsGetter NamedPortsGetter
@@ -445,6 +447,13 @@ type Endpoint struct {
 	// skipped regeneration levels.
 	skippedRegenerationLevel regeneration.DatapathRegenerationLevel
 
+	// skippedPolicyRevision is the highest PolicyRevisionToWaitFor from any regeneration
+	// event that was skipped because the endpoint was already in StateWaitingToRegenerate.
+	// The pending regeneration must wait for at least this policy revision in statedb before
+	// completing. This prevents a race where a PolicyUpdate is dropped as a duplicate while
+	// the running regen's policyRevisionToWaitFor is already satisfied by an older revision.
+	skippedPolicyRevision uint64
+
 	// DatapathConfiguration is the endpoint's datapath configuration as
 	// passed in via the plugin that created the endpoint, e.g. the CNI
 	// plugin which performed the plumbing will enable certain datapath
@@ -642,10 +651,11 @@ func createEndpoint(
 		wgConfig:           p.WgConfig,
 		ipsecConfig:        p.IPSecConfig,
 		lxcMap:             p.LxcMap,
+		localNodeStore:     p.LocalNodeStore,
 		policyMapFactory:   p.PolicyMapFactory,
 		policyRepo:         p.PolicyRepo,
+		policyFetcher:      p.PolicyFetcher,
 		namedPortsGetter:   p.NamedPortsGetter,
-		localNodeStore:     p.LocalNodeStore,
 		ID:                 ID,
 		createdAt:          time.Now(),
 		proxy:              proxy,
@@ -744,7 +754,6 @@ func CreateIngressEndpoint(p EndpointParams,
 func CreateHostEndpoint(p EndpointParams,
 	dnsRulesAPI DNSRulesAPI, proxy EndpointProxy,
 	policyDebugLog io.Writer) (*Endpoint, error) {
-
 	iface, err := safenetlink.LinkByName(defaults.HostDevice)
 	if err != nil {
 		return nil, err
@@ -982,14 +991,15 @@ func ParseEndpoint(p EndpointParams,
 		wgConfig:         p.WgConfig,
 		ipsecConfig:      p.IPSecConfig,
 		lxcMap:           p.LxcMap,
+		localNodeStore:   p.LocalNodeStore,
 		policyMapFactory: p.PolicyMapFactory,
 		namedPortsGetter: p.NamedPortsGetter,
 		policyRepo:       p.PolicyRepo,
+		policyFetcher:    p.PolicyFetcher,
 		proxy:            proxy,
 		allocator:        p.Allocator,
 		ctMapGC:          p.CTMapGC,
 		kvstoreSyncher:   p.KVStoreSynchronizer,
-		localNodeStore:   p.LocalNodeStore,
 	}
 
 	if err := ep.UnmarshalJSON(epJSON); err != nil {
@@ -2094,8 +2104,8 @@ func (e *Endpoint) UpdateLabels(ctx context.Context, sourceFilter string, identi
 	e.getLogger().Debug(
 		"Refreshing labels of endpoint",
 		logfields.SourceFilter, sourceFilter,
-		logfields.IdentityLabels, map[string]labels.Label(identityLabels),
-		logfields.InfoLabels, map[string]labels.Label(infoLabels),
+		logfields.IdentityLabels, identityLabels,
+		logfields.InfoLabels, infoLabels,
 	)
 
 	if err := e.lockAlive(); err != nil {
@@ -2154,7 +2164,7 @@ func (e *Endpoint) UpdateLabelsFrom(oldLbls, newLbls map[string]string, source s
 
 	e.getLogger().Debug(
 		"Updated endpoint with new labels",
-		logfields.Labels, map[string]labels.Label(newIdtyLabels),
+		logfields.Labels, newIdtyLabels,
 	)
 	return nil
 }
@@ -2358,6 +2368,10 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bo
 		}
 	}
 
+	// Unconditionally force policy recomputation after a new identity has been
+	// assigned.
+	e.forcePolicyComputation()
+
 	readyToRegenerate := false
 	regenMetadata := &regeneration.ExternalRegenerationMetadata{
 		Reason:            regeneration.ReasonLabelsUpdate,
@@ -2376,10 +2390,6 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bo
 	if e.ID != 0 {
 		readyToRegenerate = e.setRegenerateStateLocked(regenMetadata)
 	}
-
-	// Unconditionally force policy recomputation after a new identity has been
-	// assigned.
-	e.forcePolicyComputation()
 
 	// Trigger the sync-to-k8s-ciliumendpoint controller to sync the new
 	// endpoint's identity.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2791,3 +2791,65 @@ func (e *Endpoint) GetContainerNetnsPath() string {
 func (e *Endpoint) SetContainerNetnsPath(path string) {
 	e.containerNetnsPath = path
 }
+
+// CopyFromTemplate creates a copy of the calling Endpoint object and returns
+// it. This is used to create Endpoint objects without going through the New*()
+// code path which is useful in tests.
+func (e *Endpoint) CopyFromTemplate() *Endpoint {
+	if e == nil {
+		return nil
+	}
+
+	clone := &Endpoint{
+		DNSHistory:   e.DNSHistory,
+		DNSZombies:   e.DNSZombies,
+		ID:           e.ID,
+		IPv4:         e.IPv4,
+		IPv6:         e.IPv6,
+		K8sNamespace: e.K8sNamespace,
+		K8sPodName:   e.K8sPodName,
+
+		aliveCancel:        e.aliveCancel,
+		aliveCtx:           e.aliveCtx,
+		allocator:          e.allocator,
+		compilationLock:    e.compilationLock,
+		controllers:        e.controllers,
+		createdAt:          e.createdAt,
+		ctMapGC:            e.ctMapGC,
+		dnsRulesAPI:        e.dnsRulesAPI,
+		dockerEndpointID:   e.dockerEndpointID,
+		dockerNetworkID:    e.dockerNetworkID,
+		epBuildQueue:       e.epBuildQueue,
+		forcePolicyCompute: e.forcePolicyCompute,
+		hasBPFProgram:      e.hasBPFProgram,
+		identityManager:    e.identityManager,
+		ifIndex:            e.ifIndex,
+		ifName:             e.ifName,
+		kvstoreSyncher:     e.kvstoreSyncher,
+		loader:             e.loader,
+		lxcMap:             e.lxcMap,
+		monitorAgent:       e.monitorAgent,
+		nodeMAC:            e.nodeMAC,
+		orchestrator:       e.orchestrator,
+		policyFetcher:      e.policyFetcher,
+		policyMapFactory:   e.policyMapFactory,
+		policyRepo:         e.policyRepo,
+		proxy:              e.proxy,
+		state:              e.state,
+	}
+	clone.containerID.Store(e.containerID.Load())
+	clone.logger.Store(e.logger.Load())
+
+	clone.mutex = lock.RWMutex{}
+	clone.Options = option.NewIntOptions(&EndpointMutableOptionLibrary)
+	clone.labels = labels.NewOpLabels()
+	clone.status = NewEndpointStatus()
+	if e.controllers == nil {
+		clone.controllers = controller.NewManager()
+	}
+	clone.desiredPolicy = policy.NewEndpointPolicy(e.logger.Load(), e.policyRepo)
+	clone.realizedPolicy = clone.desiredPolicy
+	clone.initialEnvoyPolicyComputed = make(chan struct{})
+
+	return clone
+}

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -34,7 +34,7 @@ func TestGetCiliumEndpointStatus(t *testing.T) {
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
 	}
-	e, err := NewEndpointFromChangeModel(p, nil, nil, m, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, m, nil)
 	require.NoError(t, err)
 
 	status := e.GetCiliumEndpointStatus()
@@ -78,7 +78,7 @@ func TestGetCiliumEndpointStatusWithServiceAccount(t *testing.T) {
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
 	}
-	e, err := NewEndpointFromChangeModel(p, nil, nil, m, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, m, nil)
 	require.NoError(t, err)
 
 	// Create a mock pod with ServiceAccount

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
@@ -48,6 +49,7 @@ import (
 type EndpointSuite struct {
 	orchestrator datapath.Orchestrator
 	repo         policy.PolicyRepository
+	fetcher      compute.PolicyRecomputer
 	mgr          *cache.CachingIdentityAllocator
 }
 
@@ -55,11 +57,14 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 	testutils.IntegrationTest(tb)
 	logger := hivetest.Logger(tb)
 
+	idmgr := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 	s := &EndpointSuite{
 		orchestrator: &fakeTypes.FakeOrchestrator{},
-		repo:         policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop()),
+		repo:         repo,
 		mgr:          cache.NewCachingIdentityAllocator(logger, &testidentity.IdentityAllocatorOwnerMock{}, cache.NewTestAllocatorConfig()),
 	}
+	s.fetcher = compute.InstantiateCellForTesting(tb, logger, "endpoint", "setupEndpointSuite", repo, idmgr)
 
 	// GetConfig the default labels prefix filter
 	err := labelsfilter.ParseLabelPrefixCfg(logger, nil, nil, "")
@@ -81,6 +86,28 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 	})
 
 	return s
+}
+
+func createEndpointParams(tb testing.TB, o datapath.Orchestrator, r policy.PolicyRepository, fetcher compute.PolicyRecomputer) EndpointParams {
+	return EndpointParams{
+		Logger:           hivetest.Logger(tb),
+		EPBuildQueue:     &MockEndpointBuildQueue{},
+		Orchestrator:     o,
+		PolicyRepo:       r,
+		PolicyFetcher:    fetcher,
+		IdentityManager:  identitymanager.NewIDManager(hivetest.Logger(tb)),
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		WgConfig:         fakeTypes.WireguardConfig{},
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		LocalNodeStore:   node.NewTestLocalNodeStore(node.LocalNode{}),
+	}
+}
+
+func createTestEndpointParams(tb testing.TB) EndpointParams {
+	s := setupEndpointSuite(tb)
+	return createEndpointParams(tb, s.orchestrator, s.repo, s.fetcher)
 }
 
 func TestEndpointStatus(t *testing.T) {
@@ -184,45 +211,26 @@ func TestEndpointStatus(t *testing.T) {
 	require.Equal(t, "OK", eps.String())
 }
 
-func createEndpointParams(tb testing.TB, o datapath.Orchestrator, r policy.PolicyRepository) EndpointParams {
-	return EndpointParams{
-		Logger:           hivetest.Logger(tb),
-		EPBuildQueue:     &MockEndpointBuildQueue{},
-		Orchestrator:     o,
-		PolicyRepo:       r,
-		IdentityManager:  identitymanager.NewIDManager(hivetest.Logger(tb)),
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		WgConfig:         fakeTypes.WireguardConfig{},
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-		LocalNodeStore:   node.NewTestLocalNodeStore(node.LocalNode{}),
-	}
-}
-
-func createTestEndpointParams(tb testing.TB) EndpointParams {
-	s := setupEndpointSuite(tb)
-	return createEndpointParams(tb, s.orchestrator, s.repo)
-}
-
 func TestEndpointDatapathOptions(t *testing.T) {
-	m := &models.EndpointChangeRequest{
+	s := setupEndpointSuite(t)
+
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	p.Allocator = s.mgr
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, &models.EndpointChangeRequest{
 		DatapathConfiguration: &models.EndpointDatapathConfiguration{
 			DisableSipVerification: true,
 		},
-	}
-
-	p := createTestEndpointParams(t)
-	e, err := NewEndpointFromChangeModel(p, nil, nil, m, nil)
+	}, nil)
 	require.NoError(t, err)
 	require.Equal(t, option.OptionDisabled, e.Options.GetValue(option.SourceIPVerification))
 }
 
 func TestEndpointUpdateLabels(t *testing.T) {
-	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := createTestEndpointParams(t)
+	s := setupEndpointSuite(t)
 
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	model := newTestEndpointModel(100, StateWaitingForIdentity)
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -265,9 +273,11 @@ func TestEndpointUpdateLabels(t *testing.T) {
 }
 
 func TestEndpointState(t *testing.T) {
+	s := setupEndpointSuite(t)
+
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := createTestEndpointParams(t)
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 	e.Start(uint16(model.ID))
 	t.Cleanup(e.Stop)
@@ -642,6 +652,8 @@ func (n *EndpointDeadlockEvent) Handle(ifc chan any) {
 // This unit test is a bit weird - see
 // https://github.com/cilium/cilium/pull/8687 .
 func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
+	s := setupEndpointSuite(t)
+
 	// Need to modify global configuration (hooray!), change back when test is
 	// done.
 	oldQueueSize := option.Config.EndpointQueueSize
@@ -651,8 +663,8 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 	}()
 
 	model := newTestEndpointModel(12345, StateReady)
-	p := createTestEndpointParams(t)
-	ep, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	ep, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -730,9 +742,11 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 }
 
 func BenchmarkEndpointGetModel(b *testing.B) {
+	s := setupEndpointSuite(b)
+
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := createTestEndpointParams(b)
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(b, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))
@@ -773,7 +787,7 @@ func (e *Endpoint) getK8sPodLabels() labels.Labels {
 }
 
 func TestMetadataResolver(t *testing.T) {
-	p := createTestEndpointParams(t)
+	s := setupEndpointSuite(t)
 	logger := hivetest.Logger(t)
 
 	tests := []struct {
@@ -811,8 +825,10 @@ func TestMetadataResolver(t *testing.T) {
 			t.Run(fmt.Sprintf("%s (restored=%t)", tt.name, restored), func(t *testing.T) {
 				model := newTestEndpointModel(100, StateWaitingForIdentity)
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
+				p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+				p.BandwidthManager = &fakeTypes.BandwidthManager{}
 				p.KVStoreSynchronizer = kvstoreSync
-				ep, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+				ep, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 				require.NoError(t, err)
 
 				ep.K8sNamespace, ep.K8sPodName, ep.K8sUID = "bar", "foo", "uid"
@@ -833,8 +849,6 @@ func newTestEndpointModel(id int, state State) *models.EndpointChangeRequest {
 		},
 	}
 }
-
-//TODODODODO
 
 func (g fakeNodeGetter) Get(ctx context.Context) (node.LocalNode, error) {
 	return node.LocalNode{}, nil

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestPolicyLog(t *testing.T) {
+	setupEndpointSuite(t)
 	logger := hivetest.Logger(t)
 	logPath := filepath.Join(option.Config.StateDir, "endpoint-policy.log")
 	f, err := os.Create(logPath)
@@ -27,8 +28,7 @@ func TestPolicyLog(t *testing.T) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 
 	model := newTestEndpointModel(12345, StateReady)
-	p := createTestEndpointParams(t)
-	p.PolicyRepo = do.repo
+	p := createEndpointParams(t, nil, do.repo, do.fetcher)
 	ep, err := NewEndpointFromChangeModel(p, nil, nil, model, f)
 	require.NoError(t, err)
 

--- a/pkg/endpoint/params.go
+++ b/pkg/endpoint/params.go
@@ -16,6 +16,7 @@ import (
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 
 	"github.com/cilium/hive/cell"
@@ -37,6 +38,7 @@ type EndpointParams struct {
 	MonitorAgent        monitoragent.Agent
 	PolicyMapFactory    policymap.Factory
 	PolicyRepo          policy.PolicyRepository
+	PolicyFetcher       compute.PolicyRecomputer
 	Allocator           cache.IdentityAllocator
 	CTMapGC             ctmap.GCRunner
 	KVStoreSynchronizer *ipcache.IPIdentitySynchronizer

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -818,25 +818,14 @@ func (e *Endpoint) UpdatePolicy(idsToRegen *set.Set[identityPkg.NumericIdentity]
 	// If this endpoint's security ID has a policy update, we must regenerate. Otherwise,
 	// bump the policy revision directly (as long as we didn't miss an update somehow).
 	if !idsToRegen.Has(secID) {
-		if e.policyRevision < fromRev {
-			// FIXME: https://github.com/cilium/cilium/issues/36493
-			// Currently policy repository version can be bumped through multiple triggers
-			// async to each other. This can lead to out of order processing of regeneration
-			// events. Continue with endpoint regeneration to be safe but log as Info.
-			e.getLogger().Info(
-				"Endpoint missed a policy revision; triggering regeneration",
-				logfields.PolicyRevision, fromRev,
-			)
-		} else {
-			e.getLogger().Debug(
-				"Policy update is a no-op, bumping policyRevision",
-				logfields.PolicyRevision, toRev,
-			)
-			e.setPolicyRevision(toRev)
+		e.getLogger().Debug(
+			"Policy update is a no-op, bumping policyRevision",
+			logfields.PolicyRevision, toRev,
+		)
+		e.setPolicyRevision(toRev)
 
-			unlock()
-			return
-		}
+		unlock()
+		return
 	}
 
 	// Policy change affected this endpoint's identity; queue regeneration

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -33,6 +33,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
@@ -197,7 +198,6 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	}
 
 	// Copy out some values we care about, then unlock
-	forcePolicyCompute := e.forcePolicyCompute
 	securityIdentity := e.SecurityIdentity
 
 	// We are computing policy; set this to false.
@@ -221,36 +221,41 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	}
 	e.unlock()
 
-	e.getLogger().Debug("Starting policy recalculation...")
-	skipPolicyRevision := e.nextPolicyRevision
-	if forcePolicyCompute || e.desiredPolicy == nil {
-		e.getLogger().Debug("Forced policy recalculation")
-		skipPolicyRevision = 0
-	}
-
-	var selectorPolicy policy.SelectorPolicy
-	selectorPolicy, result.policyRevision, err = e.policyRepo.GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats, e.GetID())
+	e.getLogger().Debug("Fetching policy recalculation",
+		logfields.Identity, securityIdentity.ID,
+		logfields.PolicyRevision, datapathRegenCtxt.policyRevisionToWaitFor,
+	)
+	var (
+		pcr            *compute.Result
+		selectorPolicy policy.SelectorPolicy
+	)
+	// The returned policy has AddHold already called; release on error
+	// paths before DistillPolicy (which consumes the hold via insertUser).
+	pcr, err = e.waitForPolicyComputationResult(datapathRegenCtxt, securityIdentity, result)
 	if err != nil {
-		e.getLogger().Warn("Failed to calculate SelectorPolicy", logfields.Error, err)
-		return err
+		return fmt.Errorf("failed waiting for policy computation result: %w", err)
+	} else if pcr != nil {
+		selectorPolicy = pcr.NewPolicy
+		result.policyRevision = pcr.Revision
+		err = pcr.Err
 	}
+	if err != nil {
+		if selectorPolicy != nil {
+			selectorPolicy.ReleaseHold()
+		}
+		return fmt.Errorf("failed fetching policy computation result: %w", err)
+	}
+	datapathRegenCtxt.policyResult = result
 
-	// selectorPolicy is nil if skipRevision was matched.
 	if selectorPolicy == nil {
-		e.getLogger().Debug(
-			"Skipping unnecessary endpoint policy recalculation",
-			logfields.PolicyRevisionNext, e.nextPolicyRevision,
-			logfields.PolicyRevisionRepo, result.policyRevision,
-			logfields.PolicyChanged, e.nextPolicyRevision > e.policyRevision,
-		)
-		datapathRegenCtxt.policyResult = result
-		return nil
+		return err
 	}
 
 	// Add new redirects before Consume() so that all required proxy ports are available for it.
 	var desiredRedirects map[string]uint16
 	err = e.rlockAlive()
 	if err != nil {
+		selectorPolicy.ReleaseHold()
 		return err
 	}
 	// Ingress endpoint needs no redirects
@@ -283,6 +288,67 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 
 	datapathRegenCtxt.policyResult = result
 	return nil
+}
+
+var (
+	errPolicyComputationStaleRevision = errors.New("policy computation result has stale revision")
+	errPolicyComputationNotFound      = errors.New("policy computation result not found in statedb")
+)
+
+func (e *Endpoint) waitForPolicyComputationResult(
+	datapathRegenCtxt *datapathRegenerationContext,
+	securityIdentity *identity.Identity,
+	result *policyGenerateResult,
+) (*compute.Result, error) {
+	wantedRevision := datapathRegenCtxt.policyRevisionToWaitFor
+
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+
+	for {
+		computeResult, _, watch, found := e.policyFetcher.GetIdentityPolicyByIdentity(securityIdentity)
+		if found && computeResult.Revision >= wantedRevision {
+			if computeResult.NewPolicy == nil || computeResult.NewPolicy.AddHold() {
+				e.getLogger().Debug(
+					"Retrieved identity policy from statedb",
+					logfields.PolicyRevision, computeResult.Revision,
+				)
+				return &computeResult, nil
+			}
+			// AddHold failed: policy was detached by a concurrent
+			// MaybeDetach. Fall through to wait for the replacement.
+			e.getLogger().Debug(
+				"Policy was detached, waiting for replacement",
+				logfields.Identity, securityIdentity.ID,
+				logfields.PolicyRevision, computeResult.Revision,
+			)
+		} else if found {
+			e.getLogger().Debug(
+				"Policy computation result has stale revision, waiting for update",
+				logfields.Identity, securityIdentity.ID,
+				logfields.PolicyRevision, computeResult.Revision,
+				logfields.PolicyRevisionNext, wantedRevision,
+			)
+		} else {
+			e.getLogger().Debug(
+				"Policy computation result not found in statedb, waiting",
+				logfields.Identity, securityIdentity.ID,
+				logfields.PolicyRevisionNext, wantedRevision,
+			)
+		}
+
+		// Watch fires on insert/update of this identity's statedb entry.
+		select {
+		case <-watch:
+			continue
+		case <-timeout.C:
+			datapathRegenCtxt.policyResult = result
+			if found {
+				return nil, errPolicyComputationStaleRevision
+			}
+			return nil, errPolicyComputationNotFound
+		}
+	}
 }
 
 // setDesiredPolicy updates the endpoint with the results of a policy calculation.
@@ -453,6 +519,8 @@ func (e *Endpoint) regenerate(ctx *regenerationContext) (retErr error) {
 	}
 	// reset to the default lowest level
 	e.skippedRegenerationLevel = regeneration.Invalid
+
+	e.consumeSkippedPolicyRevision(ctx.datapathRegenerationContext)
 
 	e.unlock()
 
@@ -702,11 +770,24 @@ func (e *Endpoint) setRegenerateStateLocked(regenMetadata *regeneration.External
 		} else {
 			e.logStatusLocked(Other, OK, fmt.Sprintf("Skipped duplicate endpoint regeneration trigger due to %s", regenMetadata.GetRegenerationReason()))
 		}
+		// Ensures queued regen doesn't complete at an older revision.
+		if regenMetadata.PolicyRevisionToWaitFor > e.skippedPolicyRevision {
+			e.skippedPolicyRevision = regenMetadata.PolicyRevisionToWaitFor
+		}
 		regen = false
 	default:
 		regen = e.setState(StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.GetRegenerationReason()))
 	}
 	return regen
+}
+
+// consumeSkippedPolicyRevision transfers any buffered revision to ctx.
+// Must be called with e.mutex held.
+func (e *Endpoint) consumeSkippedPolicyRevision(ctx *datapathRegenerationContext) {
+	if e.skippedPolicyRevision > ctx.policyRevisionToWaitFor {
+		ctx.policyRevisionToWaitFor = e.skippedPolicyRevision
+	}
+	e.skippedPolicyRevision = 0
 }
 
 // UpdatePolicy updates the endpoint's policy.
@@ -760,9 +841,10 @@ func (e *Endpoint) UpdatePolicy(idsToRegen *set.Set[identityPkg.NumericIdentity]
 
 	// Policy change affected this endpoint's identity; queue regeneration
 	regenMetadata := &regeneration.ExternalRegenerationMetadata{
-		Reason:            regeneration.ReasonPolicyUpdate,
-		Message:           "policy rules updated",
-		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+		Reason:                  regeneration.ReasonPolicyUpdate,
+		Message:                 "policy rules updated",
+		RegenerationLevel:       regeneration.RegenerateWithoutDatapath,
+		PolicyRevisionToWaitFor: toRev,
 	}
 	regen := e.setRegenerateStateLocked(regenMetadata)
 	unlock()
@@ -856,6 +938,7 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 				e.getLogger().Error(
 					"endpoint regeneration failed",
 					logfields.Error, regenError,
+					logfields.Reason, regenMetadata.Reason,
 				)
 				hr.Degraded("Endpoint regeneration failed", regenError)
 			} else {

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -14,8 +14,10 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -23,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 )
@@ -45,9 +48,11 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	defer policy.SetPolicyEnabled(pe)
 
 	idcache := make(identity.IdentityMap, testfactor)
+	logger := hivetest.Logger(t)
 	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
 	idManager := identitymanager.NewIDManager(hivetest.Logger(t))
-	repo := policy.NewPolicyRepository(hivetest.Logger(t), fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	polComputer := compute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", "TestIncrementalUpdatesDuringPolicyGeneration", repo, idManager)
 
 	addIdentity := func(labelKeys ...string) *identity.Identity {
 		t.Helper()
@@ -73,6 +78,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 
 	ep := Endpoint{
 		policyRepo:       repo,
+		policyFetcher:    polComputer,
 		desiredPolicy:    policy.NewEndpointPolicy(hivetest.Logger(t), repo),
 		labels:           labels.NewOpLabels(),
 		SecurityIdentity: podID,
@@ -112,7 +118,8 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		},
 	}
 
-	repo.MustAddList(api.Rules{egressDenyRule})
+	_, rev := repo.MustAddList(api.Rules{egressDenyRule})
+	computePolicyForEPAndWait(t, &ep, polComputer, rev)
 
 	// Track all IDs we allocate so we can validate later that we never miss any
 	checkMutex := lock.Mutex{}
@@ -139,6 +146,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 
 	stats := new(regenerationStatistics)
 	datapathRegenCtxt := new(datapathRegenerationContext)
+	datapathRegenCtxt.policyRevisionToWaitFor = rev
 	// Continuously compute policy for the pod and ensure we never missed an incremental update.
 	for {
 		t.Log("Calculating policy...")
@@ -180,4 +188,547 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 			break
 		}
 	}
+}
+
+func computePolicyForEPAndWait(t *testing.T, ep *Endpoint, fetcher compute.PolicyRecomputer, rev uint64) {
+	t.Helper()
+
+	computedPolicyCh, err := fetcher.RecomputeIdentityPolicy(ep.SecurityIdentity, rev)
+	assert.NoError(t, err)
+	assert.NotNil(t, computedPolicyCh)
+	<-computedPolicyCh
+}
+
+// TestRemoveUserCausesRegenFailure reproduces a race where two endpoints share
+// an identity, endpoint A leaves (refcount stays >0 so no observer fires), and
+// removeUser detaches the selectorPolicy that endpoint B is about to use.
+func TestRemoveUserCausesRegenFailure(t *testing.T) {
+	pe := policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled("always")
+	defer policy.SetPolicyEnabled(pe)
+
+	logger := hivetest.Logger(t)
+	idcache := make(identity.IdentityMap)
+	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
+	idManager := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	polComputer := compute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", "TestRemoveUserCausesRegenFailure", repo, idManager)
+
+	podLbls := labels.Labels{"pod": labels.NewLabel("k8s:pod", "", "")}
+	podID, _, err := fakeAllocator.AllocateIdentity(context.Background(), podLbls, false, 0)
+	require.NoError(t, err)
+	wg := &sync.WaitGroup{}
+	repo.GetSelectorCache().UpdateIdentities(identity.IdentityMap{podID.ID: podID.LabelArray}, nil, wg)
+	wg.Wait()
+
+	idManager.Add(podID)
+
+	epA := Endpoint{
+		policyRepo:       repo,
+		policyFetcher:    polComputer,
+		desiredPolicy:    policy.NewEndpointPolicy(logger, repo),
+		labels:           labels.NewOpLabels(),
+		SecurityIdentity: podID,
+		identityManager:  idManager,
+	}
+	epA.UpdateLogger(nil)
+
+	podSelectLabel := labels.ParseSelectLabel("pod")
+	egressSelectLabel := labels.ParseSelectLabel("peer")
+	rule := &api.Rule{
+		EndpointSelector: api.NewESFromLabels(podSelectLabel),
+		EgressDeny: []api.EgressDenyRule{
+			{
+				EgressCommonRule: api.EgressCommonRule{
+					ToEndpoints: []api.EndpointSelector{
+						api.NewESFromLabels(egressSelectLabel),
+					},
+				},
+				ToPorts: []api.PortDenyRule{
+					{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: "TCP"},
+						},
+					},
+				},
+			},
+		},
+		Labels: labels.LabelArray{
+			labels.NewLabel(k8sConst.PolicyLabelName, "testRule", labels.LabelSourceAny),
+		},
+	}
+	_, rev := repo.MustAddList(api.Rules{rule})
+	computePolicyForEPAndWait(t, &epA, polComputer, rev)
+
+	statsA := new(regenerationStatistics)
+	regenCtxA := &datapathRegenerationContext{policyRevisionToWaitFor: rev}
+	err = epA.regeneratePolicy(statsA, regenCtxA)
+	require.NoError(t, err)
+	require.NotNil(t, regenCtxA.policyResult.endpointPolicy)
+
+	// Reassign so Detach() calls removeUser on the correct selectorPolicy.
+	epA.desiredPolicy = regenCtxA.policyResult.endpointPolicy
+
+	// refCount 1\u21922; no observer fires since identity is already tracked.
+	idManager.Add(podID)
+
+	epA.desiredPolicy.Ready()
+	epA.desiredPolicy.Detach(logger)
+
+	// refCount 2\u21921; policyCache.delete does NOT fire (still >0).
+	idManager.Remove(podID)
+
+	epB := Endpoint{
+		policyRepo:       repo,
+		policyFetcher:    polComputer,
+		desiredPolicy:    policy.NewEndpointPolicy(logger, repo),
+		labels:           labels.NewOpLabels(),
+		SecurityIdentity: podID,
+		identityManager:  idManager,
+	}
+	epB.UpdateLogger(nil)
+
+	statsB := new(regenerationStatistics)
+	regenCtxB := &datapathRegenerationContext{policyRevisionToWaitFor: rev}
+	err = epB.regeneratePolicy(statsB, regenCtxB)
+	require.NoError(t, err)
+	require.NotNil(t, regenCtxB.policyResult.endpointPolicy)
+
+	regenCtxB.policyResult.endpointPolicy.Ready()
+	regenCtxB.policyResult.endpointPolicy.Detach(logger)
+	idManager.Remove(podID)
+}
+
+// TestStaleStatedbEntryAfterIdentityDeleteReAdd covers the single-endpoint case
+// where identity refcount drops to 0. The DELETE handler in handlePolicyCacheEvent
+// must clean up the statedb entry even though the identity is already gone from
+// idmanager — otherwise the next endpoint for this identity reads stale detached
+// policy.
+func TestStaleStatedbEntryAfterIdentityDeleteReAdd(t *testing.T) {
+	pe := policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled("always")
+	defer policy.SetPolicyEnabled(pe)
+
+	logger := hivetest.Logger(t)
+	idcache := make(identity.IdentityMap)
+	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
+	idManager := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	polComputer := compute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", "TestStaleStatedbEntryAfterIdentityDeleteReAdd", repo, idManager)
+
+	podLbls := labels.Labels{"pod": labels.NewLabel("k8s:pod", "", "")}
+	podID, _, err := fakeAllocator.AllocateIdentity(context.Background(), podLbls, false, 0)
+	require.NoError(t, err)
+	wg := &sync.WaitGroup{}
+	repo.GetSelectorCache().UpdateIdentities(identity.IdentityMap{podID.ID: podID.LabelArray}, nil, wg)
+	wg.Wait()
+
+	idManager.Add(podID)
+
+	epA := Endpoint{
+		policyRepo:       repo,
+		policyFetcher:    polComputer,
+		desiredPolicy:    policy.NewEndpointPolicy(logger, repo),
+		labels:           labels.NewOpLabels(),
+		SecurityIdentity: podID,
+		identityManager:  idManager,
+	}
+	epA.UpdateLogger(nil)
+
+	podSelectLabel := labels.ParseSelectLabel("pod")
+	egressSelectLabel := labels.ParseSelectLabel("peer")
+	rule := &api.Rule{
+		EndpointSelector: api.NewESFromLabels(podSelectLabel),
+		EgressDeny: []api.EgressDenyRule{
+			{
+				EgressCommonRule: api.EgressCommonRule{
+					ToEndpoints: []api.EndpointSelector{
+						api.NewESFromLabels(egressSelectLabel),
+					},
+				},
+				ToPorts: []api.PortDenyRule{
+					{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: "TCP"},
+						},
+					},
+				},
+			},
+		},
+		Labels: labels.LabelArray{
+			labels.NewLabel(k8sConst.PolicyLabelName, "testRule", labels.LabelSourceAny),
+		},
+	}
+	_, rev := repo.MustAddList(api.Rules{rule})
+
+	// Observer subscribes async; wait so the DELETE event isn't lost.
+	require.Eventually(t, func() bool {
+		_, _, _, found := polComputer.GetIdentityPolicyByNumericIdentity(podID.ID)
+		return found
+	}, 5*time.Second, 10*time.Millisecond,
+		"observer must create statedb entry for identity")
+
+	computePolicyForEPAndWait(t, &epA, polComputer, rev)
+
+	res, _, _, found := polComputer.GetIdentityPolicyByNumericIdentity(podID.ID)
+	require.True(t, found)
+	require.NotNil(t, res.NewPolicy)
+	require.True(t, res.NewPolicy.AddHold())
+	res.NewPolicy.MaybeDetach()
+
+	statsA := new(regenerationStatistics)
+	regenCtxA := &datapathRegenerationContext{policyRevisionToWaitFor: rev}
+	err = epA.regeneratePolicy(statsA, regenCtxA)
+	require.NoError(t, err)
+	require.NotNil(t, regenCtxA.policyResult.endpointPolicy)
+	epA.desiredPolicy = regenCtxA.policyResult.endpointPolicy
+
+	epA.desiredPolicy.Ready()
+	epA.desiredPolicy.Detach(logger)
+	idManager.Remove(podID)
+
+	// DELETE handler must clean up statedb even when the identity is already
+	// gone from idmanager.
+	_, _, _, found = polComputer.GetIdentityPolicyByNumericIdentity(podID.ID)
+	require.False(t, found, "statedb entry must be deleted after identity removal")
+
+	idManager.Add(podID)
+
+	epB := Endpoint{
+		policyRepo:       repo,
+		policyFetcher:    polComputer,
+		desiredPolicy:    policy.NewEndpointPolicy(logger, repo),
+		labels:           labels.NewOpLabels(),
+		SecurityIdentity: podID,
+		identityManager:  idManager,
+	}
+	epB.UpdateLogger(nil)
+
+	computePolicyForEPAndWait(t, &epB, polComputer, rev)
+
+	res, _, _, found = polComputer.GetIdentityPolicyByNumericIdentity(podID.ID)
+	require.True(t, found)
+	require.NotNil(t, res.NewPolicy)
+	require.True(t, res.NewPolicy.AddHold())
+	res.NewPolicy.MaybeDetach()
+
+	statsB := new(regenerationStatistics)
+	regenCtxB := &datapathRegenerationContext{policyRevisionToWaitFor: rev}
+	err = epB.regeneratePolicy(statsB, regenCtxB)
+	require.NoError(t, err)
+	require.NotNil(t, regenCtxB.policyResult.endpointPolicy)
+
+	regenCtxB.policyResult.endpointPolicy.Ready()
+	regenCtxB.policyResult.endpointPolicy.Detach(logger)
+	idManager.Remove(podID)
+}
+
+// TestMaybeDetachRaceDuringRegeneration reproduces the TOCTOU between reading
+// a selectorPolicy from statedb and calling AddHold on it. A concurrent
+// recomputation can MaybeDetach the policy in that window, causing
+// "selector policy was detached, aborting regeneration". The fix moves
+// AddHold into the waitForPolicyComputationResult loop so that on failure
+// the loop waits on the watch channel for the replacement entry.
+func TestMaybeDetachRaceDuringRegeneration(t *testing.T) {
+	pe := policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled("always")
+	defer policy.SetPolicyEnabled(pe)
+
+	logger := hivetest.Logger(t)
+	idcache := make(identity.IdentityMap)
+	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
+	idManager := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	polComputer := compute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", "TestMaybeDetachRaceDuringRegeneration", repo, idManager)
+
+	podLbls := labels.Labels{"pod": labels.NewLabel("k8s:pod", "", "")}
+	podID, _, err := fakeAllocator.AllocateIdentity(context.Background(), podLbls, false, 0)
+	require.NoError(t, err)
+	wg := &sync.WaitGroup{}
+	repo.GetSelectorCache().UpdateIdentities(identity.IdentityMap{podID.ID: podID.LabelArray}, nil, wg)
+	wg.Wait()
+
+	idManager.Add(podID)
+
+	podSelectLabel := labels.ParseSelectLabel("pod")
+	makeRule := func(name, peer, port string) *api.Rule {
+		return &api.Rule{
+			EndpointSelector: api.NewESFromLabels(podSelectLabel),
+			EgressDeny: []api.EgressDenyRule{{
+				EgressCommonRule: api.EgressCommonRule{
+					ToEndpoints: []api.EndpointSelector{
+						api.NewESFromLabels(labels.ParseSelectLabel(peer)),
+					},
+				},
+				ToPorts: []api.PortDenyRule{{
+					Ports: []api.PortProtocol{{Port: port, Protocol: "TCP"}},
+				}},
+			}},
+			Labels: labels.LabelArray{
+				labels.NewLabel(k8sConst.PolicyLabelName, name, labels.LabelSourceAny),
+			},
+		}
+	}
+
+	_, rev1 := repo.MustAddList(api.Rules{makeRule("r1", "peer", "80")})
+	done, err := polComputer.RecomputeIdentityPolicy(podID, rev1)
+	require.NoError(t, err)
+	<-done
+
+	// Verify initial policy is live, then detach it (MaybeDetach sets
+	// superseded and detaches since there are no users or holds).
+	res, _, _, found := polComputer.GetIdentityPolicyByIdentity(podID)
+	require.True(t, found)
+	require.True(t, res.NewPolicy.AddHold())
+	res.NewPolicy.MaybeDetach()
+
+	// Recompute to get a fresh, live policy in statedb.
+	_, rev2 := repo.MustAddList(api.Rules{makeRule("r2", "peer2", "443")})
+	done, err = polComputer.RecomputeIdentityPolicy(podID, rev2)
+	require.NoError(t, err)
+	<-done
+
+	res, _, _, found = polComputer.GetIdentityPolicyByIdentity(podID)
+	require.True(t, found)
+
+	// Simulate compute.go superseding this policy before any endpoint holds it.
+	res.NewPolicy.MaybeDetach()
+	require.False(t, res.NewPolicy.AddHold(), "policy must be detached")
+
+	// After a delay, write a replacement entry so the watch loop can succeed.
+	_, rev3 := repo.MustAddList(api.Rules{makeRule("r3", "peer3", "8080")})
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		done, err := polComputer.RecomputeIdentityPolicy(podID, rev3)
+		if err == nil {
+			<-done
+		}
+	}()
+
+	// Endpoint reads the detached policy from statedb. Without the fix,
+	// AddHold fails and regeneratePolicy returns an error. With the fix,
+	// the loop waits for the replacement written by the goroutine above.
+	epB := Endpoint{
+		policyRepo:       repo,
+		policyFetcher:    polComputer,
+		desiredPolicy:    policy.NewEndpointPolicy(logger, repo),
+		labels:           labels.NewOpLabels(),
+		SecurityIdentity: podID,
+		identityManager:  idManager,
+	}
+	epB.UpdateLogger(nil)
+
+	statsB := new(regenerationStatistics)
+	regenCtxB := &datapathRegenerationContext{policyRevisionToWaitFor: rev2}
+	err = epB.regeneratePolicy(statsB, regenCtxB)
+	require.NoError(t, err)
+	require.NotNil(t, regenCtxB.policyResult.endpointPolicy)
+
+	regenCtxB.policyResult.endpointPolicy.Ready()
+	regenCtxB.policyResult.endpointPolicy.Detach(logger)
+	idManager.Remove(podID)
+}
+
+// TestSkippedPolicyRevisionPropagatedThroughDuplicateRegen reproduces a race where
+// a duplicate regen trigger drops a higher PolicyRevisionToWaitFor:
+//
+//  1. PeriodicRegeneration fires, endpoint enters StateWaitingToRegenerate (queued at rev=198)
+//  2. New policy arrives \u2192 PolicyUpdate fires with rev=199
+//  3. PolicyUpdate is SKIPPED (endpoint already waiting-to-regenerate) \u2014 rev=199 dropped
+//  4. The queued regen runs with policyRevisionToWaitFor=198; statedb returns 198 \u2192 done
+//  5. Endpoint finishes at datapathPolicyRevision=198; no regen triggered for rev=199 \u2192 stuck
+func TestSkippedPolicyRevisionPropagatedThroughDuplicateRegen(t *testing.T) {
+	pe := policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled("always")
+	defer policy.SetPolicyEnabled(pe)
+
+	logger := hivetest.Logger(t)
+	idcache := make(identity.IdentityMap)
+	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
+	idManager := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	polComputer := compute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", "TestSkippedPolicyRevisionPropagatedThroughDuplicateRegen", repo, idManager)
+
+	podLbls := labels.Labels{"pod": labels.NewLabel("k8s:pod", "", "")}
+	podID, _, err := fakeAllocator.AllocateIdentity(context.Background(), podLbls, false, 0)
+	require.NoError(t, err)
+	wg := &sync.WaitGroup{}
+	repo.GetSelectorCache().UpdateIdentities(identity.IdentityMap{podID.ID: podID.LabelArray}, nil, wg)
+	wg.Wait()
+
+	// Must precede rule additions so observer starts at rev=0 and subtests
+	// control statedb revision explicitly.
+	idManager.Add(podID)
+	require.Eventually(t, func() bool {
+		_, _, _, found := polComputer.GetIdentityPolicyByNumericIdentity(podID.ID)
+		return found
+	}, 5*time.Second, 1*time.Millisecond, "observer must compute initial statedb entry")
+
+	podSelectLabel := labels.ParseSelectLabel("pod")
+	egressSelectLabel := labels.ParseSelectLabel("peer")
+
+	makeRule := func(name string) *api.Rule {
+		return &api.Rule{
+			EndpointSelector: api.NewESFromLabels(podSelectLabel),
+			EgressDeny: []api.EgressDenyRule{{
+				EgressCommonRule: api.EgressCommonRule{
+					ToEndpoints: []api.EndpointSelector{api.NewESFromLabels(egressSelectLabel)},
+				},
+				ToPorts: []api.PortDenyRule{{Ports: []api.PortProtocol{{Port: "80", Protocol: "TCP"}}}},
+			}},
+			Labels: labels.LabelArray{
+				labels.NewLabel(k8sConst.PolicyLabelName, name, labels.LabelSourceAny),
+			},
+		}
+	}
+
+	_, rev198 := repo.MustAddList(api.Rules{makeRule("rule-198")})
+	_, rev199 := repo.MustAddList(api.Rules{makeRule("rule-199")})
+	_, rev200 := repo.MustAddList(api.Rules{makeRule("rule-200")})
+
+	newEP := func() *Endpoint {
+		ep := &Endpoint{
+			policyRepo:       repo,
+			policyFetcher:    polComputer,
+			desiredPolicy:    policy.NewEndpointPolicy(logger, repo),
+			labels:           labels.NewOpLabels(),
+			SecurityIdentity: podID,
+			identityManager:  idManager,
+			status:           NewEndpointStatus(),
+		}
+		ep.UpdateLogger(nil)
+		return ep
+	}
+
+	// triggerDuplicateSkip calls setRegenerateStateLocked under ep.mutex and returns
+	// whether the trigger was skipped (i.e., setRegenerateStateLocked returned false).
+	triggerDuplicateSkip := func(ep *Endpoint, rev uint64) (skipped bool) {
+		meta := &regeneration.ExternalRegenerationMetadata{
+			Reason:                  regeneration.ReasonPolicyUpdate,
+			RegenerationLevel:       regeneration.RegenerateWithoutDatapath,
+			PolicyRevisionToWaitFor: rev,
+		}
+		ep.unconditionalLock()
+		regen := ep.setRegenerateStateLocked(meta)
+		ep.unlock()
+		return !regen // skipped = regen was NOT triggered
+	}
+
+	// consumeSkipped calls the real production method (consumeSkippedPolicyRevision)
+	// under the endpoint mutex, exactly as regenerate() does.
+	consumeSkipped := func(ep *Endpoint, ctx *datapathRegenerationContext) {
+		ep.unconditionalLock()
+		ep.consumeSkippedPolicyRevision(ctx)
+		ep.unlock()
+	}
+
+	t.Run("BasicCaptureAndPropagate", func(t *testing.T) {
+		// PolicyUpdate for rev199 is skipped while the endpoint is queued at rev198.
+		ep := newEP()
+
+		computePolicyForEPAndWait(t, ep, polComputer, rev198)
+
+		ep.state = StateWaitingToRegenerate
+
+		require.True(t, triggerDuplicateSkip(ep, rev199))
+
+		require.Equal(t, rev199, ep.skippedPolicyRevision)
+
+		// The queued regen carries the old policyRevisionToWaitFor (rev198).
+		ctx := &datapathRegenerationContext{policyRevisionToWaitFor: rev198}
+		consumeSkipped(ep, ctx)
+
+		require.Equal(t, rev199, ctx.policyRevisionToWaitFor)
+
+		computePolicyForEPAndWait(t, ep, polComputer, rev199)
+
+		ep.state = StateRegenerating
+		require.NoError(t, ep.regeneratePolicy(new(regenerationStatistics), ctx))
+	})
+
+	t.Run("LowerRevisionNotDecremented", func(t *testing.T) {
+		// A skipped PolicyUpdate with a LOWER revision must NOT decrease skippedPolicyRevision.
+		ep := newEP()
+		ep.state = StateWaitingToRegenerate
+		ep.skippedPolicyRevision = rev199 // pre-set from a prior higher-rev skip
+
+		require.True(t, triggerDuplicateSkip(ep, rev198)) // lower revision
+		require.Equal(t, rev199, ep.skippedPolicyRevision,
+			"skippedPolicyRevision must not decrease when a lower revision is skipped")
+	})
+
+	t.Run("MultipleSkipsTracksMax", func(t *testing.T) {
+		// Multiple duplicate skips accumulate to the highest seen revision.
+		ep := newEP()
+		ep.state = StateWaitingToRegenerate
+
+		triggerDuplicateSkip(ep, rev199)
+		require.Equal(t, rev199, ep.skippedPolicyRevision)
+
+		triggerDuplicateSkip(ep, rev200)
+		require.Equal(t, rev200, ep.skippedPolicyRevision, "must track the higher revision")
+
+		triggerDuplicateSkip(ep, rev199)
+		require.Equal(t, rev200, ep.skippedPolicyRevision, "must not decrease from rev200")
+
+		ctx := &datapathRegenerationContext{policyRevisionToWaitFor: rev198}
+		consumeSkipped(ep, ctx)
+		require.Equal(t, rev200, ctx.policyRevisionToWaitFor)
+
+		computePolicyForEPAndWait(t, ep, polComputer, rev200)
+		ep.state = StateRegenerating
+		require.NoError(t, ep.regeneratePolicy(new(regenerationStatistics), ctx))
+	})
+
+	t.Run("ResetAfterConsume", func(t *testing.T) {
+		// skippedPolicyRevision must be cleared to 0 after regenerate() consumes it,
+		// so the next regen cycle starts fresh.
+		ep := newEP()
+		ep.state = StateWaitingToRegenerate
+		triggerDuplicateSkip(ep, rev199)
+		require.Equal(t, rev199, ep.skippedPolicyRevision)
+
+		ctx := &datapathRegenerationContext{policyRevisionToWaitFor: rev198}
+		consumeSkipped(ep, ctx)
+		require.Equal(t, uint64(0), ep.skippedPolicyRevision, "must be cleared after consume")
+
+		// After reset, a subsequent skip at rev198 is tracked from zero.
+		ep.state = StateWaitingToRegenerate
+		triggerDuplicateSkip(ep, rev198)
+		require.Equal(t, rev198, ep.skippedPolicyRevision,
+			"after reset, new skips are tracked from zero")
+	})
+
+	t.Run("ContextAlreadyHigher", func(t *testing.T) {
+		// If the context's policyRevisionToWaitFor is already HIGHER than
+		// skippedPolicyRevision, consumeSkippedPolicyRevision must be a no-op.
+		ep := newEP()
+		ep.state = StateWaitingToRegenerate
+		triggerDuplicateSkip(ep, rev199) // skippedPolicyRevision = rev199
+
+		ctx := &datapathRegenerationContext{policyRevisionToWaitFor: rev200} // higher
+		consumeSkipped(ep, ctx)
+		require.Equal(t, rev200, ctx.policyRevisionToWaitFor,
+			"context revision must not be lowered when skippedPolicyRevision < ctx revision")
+	})
+
+	t.Run("FreshRegenDoesNotSetSkippedRevision", func(t *testing.T) {
+		// When setRegenerateStateLocked transitions an endpoint to
+		// StateWaitingToRegenerate for the FIRST TIME (not a duplicate),
+		// skippedPolicyRevision must NOT be updated.
+		ep := newEP()
+		// ep.state is the zero value (not StateWaitingToRegenerate), so this
+		// is a fresh trigger, not a duplicate.
+		meta := &regeneration.ExternalRegenerationMetadata{
+			Reason:                  regeneration.ReasonPolicyUpdate,
+			RegenerationLevel:       regeneration.RegenerateWithoutDatapath,
+			PolicyRevisionToWaitFor: rev199,
+		}
+		ep.unconditionalLock()
+		ep.setRegenerateStateLocked(meta) // ignore return; only testing side-effect on skippedPolicyRevision
+		ep.unlock()
+
+		require.Equal(t, uint64(0), ep.skippedPolicyRevision,
+			"fresh regen trigger must not set skippedPolicyRevision")
+	})
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
@@ -67,6 +68,7 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 	s.do.idmgr = identitymanager.NewIDManager(logger)
 	s.do.repo = policy.NewPolicyRepository(logger, identityCache, nil, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), s.do.idmgr, testpolicy.NewPolicyMetricsNoop())
 	s.do.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
+	s.do.fetcher = compute.InstantiateCellForTesting(tb, logger, "endpoint", "setupRedirectSuite", s.do.repo, s.do.idmgr)
 
 	s.rsp = &RedirectSuiteProxy{
 		parserProxyPortMap: map[string]uint16{
@@ -138,8 +140,9 @@ func (r *RedirectSuiteProxy) IsSDPEnabled() bool {
 
 // DummyOwner implements pkg/endpoint/regeneration/Owner. Used for unit testing.
 type DummyOwner struct {
-	repo  policy.PolicyRepository
-	idmgr identitymanager.IDManager
+	repo    policy.PolicyRepository
+	fetcher compute.PolicyRecomputer
+	idmgr   identitymanager.IDManager
 }
 
 // GetNodeSuffix does nothing.
@@ -170,6 +173,7 @@ func (s *RedirectSuite) createTestEndpointParams(tb testing.TB) EndpointParams {
 		EPBuildQueue:     &MockEndpointBuildQueue{},
 		Orchestrator:     &fakeTypes.FakeOrchestrator{},
 		PolicyRepo:       s.do.repo,
+		PolicyFetcher:    s.do.fetcher,
 		IdentityManager:  s.do.idmgr,
 		NamedPortsGetter: testipcache.NewMockIPCache(),
 		IPSecConfig:      fakeTypes.IPsecConfig{},
@@ -201,9 +205,13 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 	return ep
 }
 
-func (s *RedirectSuite) AddRules(rules api.Rules) {
+func (s *RedirectSuite) AddRules(rules api.Rules) uint64 {
 	repo := s.do.repo.(*policy.Repository)
-	repo.MustAddList(rules)
+	orig := repo.GetRevision()
+	slice, rev := repo.MustAddList(rules)
+	affected := slice.AllIdentitySelections()
+	s.do.fetcher.UpdatePolicy(affected, orig, rev)
+	return rev
 }
 
 func (s *RedirectSuite) TearDownTest(t *testing.T) {
@@ -356,7 +364,7 @@ func TestRedirectWithDeny(t *testing.T) {
 	ep := s.NewTestEndpoint(t)
 
 	// Policy denies anything to "foo"
-	s.AddRules(api.Rules{
+	s.datapathRegenCtxt.policyRevisionToWaitFor = s.AddRules(api.Rules{
 		ruleL3DenyFoo.WithEndpointSelector(selectBar_),
 		ruleL4L7Allow.WithEndpointSelector(selectBar_),
 	})
@@ -485,7 +493,7 @@ func TestRedirectWithPriority(t *testing.T) {
 	api.TestAllowIngressListener = true
 	defer func() { api.TestAllowIngressListener = false }()
 
-	s.AddRules(api.Rules{
+	s.datapathRegenCtxt.policyRevisionToWaitFor = s.AddRules(api.Rules{
 		ruleL4AllowListener1.WithEndpointSelector(selectBar_),
 		ruleL4AllowPort80.WithEndpointSelector(selectBar_),
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
@@ -538,7 +546,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 
 	api.TestAllowIngressListener = true
 	defer func() { api.TestAllowIngressListener = false }()
-	s.AddRules(api.Rules{
+	s.datapathRegenCtxt.policyRevisionToWaitFor = s.AddRules(api.Rules{
 		ruleL4L7AllowListener1Priority1.WithEndpointSelector(selectBar_),
 		ruleL4AllowPort80.WithEndpointSelector(selectBar_),
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),

--- a/pkg/endpoint/regeneration/regeneration_context.go
+++ b/pkg/endpoint/regeneration/regeneration_context.go
@@ -73,6 +73,10 @@ type ExternalRegenerationMetadata struct {
 	RegenerationLevel DatapathRegenerationLevel
 
 	ParentContext context.Context
+
+	// PolicyRevisionToWaitFor is the policy revision is being requested to
+	// update the endpoint to.
+	PolicyRevisionToWaitFor uint64
 }
 
 func (m *ExternalRegenerationMetadata) GetRegenerationReason() string {

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -130,6 +130,8 @@ func ParseExternalRegenerationMetadata(ctx context.Context, logger *slog.Logger,
 		datapathRegenerationContext: &datapathRegenerationContext{
 			regenerationLevel: e.RegenerationLevel,
 			ctCleaned:         make(chan struct{}),
+
+			policyRevisionToWaitFor: e.PolicyRevisionToWaitFor,
 		},
 		parentContext: ctx,
 		cancelFunc:    c,
@@ -152,6 +154,10 @@ type datapathRegenerationContext struct {
 
 	policyMapSyncDone bool
 	policyMapDump     policy.MapStateMap
+
+	// policyRevisionToWaitFor is the policy revision is being requested to
+	// update the endpoint to.
+	policyRevisionToWaitFor uint64
 
 	finalizeList revert.FinalizeList
 	revertStack  revert.RevertStack

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (s *EndpointSuite) createEndpointParams(tb testing.TB) EndpointParams {
-	return createEndpointParams(tb, s.orchestrator, s.repo)
+	return createEndpointParams(tb, s.orchestrator, s.repo, s.fetcher)
 }
 
 func (s *EndpointSuite) createEndpoints(t testing.TB) ([]*Endpoint, map[uint16]*Endpoint) {
@@ -137,11 +137,7 @@ func TestReadEPsFromDirNames(t *testing.T) {
 			epsNames = append(epsNames, ep.DirectoryPath())
 		}
 	}
-	p := s.createEndpointParams(t)
-	p.Logger = logger
-	p.Orchestrator = s.orchestrator
-	p.PolicyRepo = s.repo
-	eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: p}, tmpDir, epsNames)
+	eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: s.createEndpointParams(t)}, tmpDir, epsNames)
 	require.Len(t, eps, len(epsWanted))
 
 	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })
@@ -204,11 +200,7 @@ func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 		ep.DirectoryPath(), ep.NextDirectoryPath(),
 	}
 
-	p := s.createEndpointParams(t)
-	p.Logger = logger
-	p.Orchestrator = s.orchestrator
-	p.PolicyRepo = s.repo
-	epResult, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: p}, tmpDir, epNames)
+	epResult, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: s.createEndpointParams(t)}, tmpDir, epNames)
 	require.Len(t, epResult, 1)
 
 	restoredEP := epResult[ep.ID]
@@ -261,11 +253,7 @@ func BenchmarkReadEPsFromDirNames(b *testing.B) {
 	}
 
 	for b.Loop() {
-		p := s.createEndpointParams(b)
-		p.Logger = logger
-		p.Orchestrator = s.orchestrator
-		p.PolicyRepo = s.repo
-		eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: p}, tmpDir, epsNames)
+		eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: s.createEndpointParams(b)}, tmpDir, epsNames)
 		require.Len(b, eps, len(epsWanted))
 	}
 }

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -39,13 +39,24 @@ var Cell = cell.Module(
 	"endpoint-manager",
 	"Manages the collection of local endpoints",
 
+	defaultGroup,
+	cell.Invoke(
+		registerNamespaceUpdater,
+	),
+)
+
+var TestCell = cell.Module(
+	"test-endpoint-manager",
+	"Manages the collection of local endpoints",
+
+	defaultGroup,
+)
+
+var defaultGroup = cell.Group(
 	cell.Config(defaultEndpointManagerConfig),
 	cell.Provide(newDefaultEndpointManager),
 	cell.Provide(endpoint.NewEndpointBuildQueue),
 	cell.ProvidePrivate(newEndpointSynchronizer),
-	cell.Invoke(
-		registerNamespaceUpdater,
-	),
 )
 
 type EndpointsLookup interface {

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -149,6 +149,11 @@ type EndpointManager interface {
 	// Returns immediately.
 	TriggerRegenerateAllEndpoints()
 
+	// WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
+	// this function is called to be at a given policy revision.
+	// New endpoints appearing while waiting are ignored.
+	WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error
+
 	// OverrideEndpointOpts applies the given options to all endpoints.
 	OverrideEndpointOpts(om option.OptionMap)
 

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -14,12 +14,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/api/v1/models"
-	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
-	"github.com/cilium/cilium/pkg/identity/identitymanager"
-	"github.com/cilium/cilium/pkg/maps/ctmap"
-	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
 // fakeCheck detects endpoints as unhealthy if they have an even EndpointID.
@@ -47,17 +42,7 @@ func TestMarkAndSweep(t *testing.T) {
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
 		model := newTestEndpointModel(int(id), endpoint.StateReady)
-		ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-			EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-			NamedPortsGetter: testipcache.NewMockIPCache(),
-			Allocator:        testidentity.NewMockIdentityAllocator(nil),
-			CTMapGC:          ctmap.NewFakeGCRunner(),
-			WgConfig:         &fakeTypes.WireguardConfig{},
-			IPSecConfig:      fakeTypes.IPsecConfig{},
-			Logger:           logger,
-			IdentityManager:  identitymanager.NewIDManager(logger),
-			PolicyRepo:       s.repo,
-		}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+		ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 		require.NoError(t, err)
 
 		ep.Start(uint16(model.ID))

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -832,6 +832,24 @@ func (mgr *endpointManager) initHostEndpointLabels(ctx context.Context, ep *endp
 	mgr.startNodeLabelsObserver(ln.Labels)
 }
 
+// WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
+// this function is called to be at a given policy revision.
+// New endpoints appearing while waiting are ignored.
+func (mgr *endpointManager) WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error {
+	eps := mgr.GetEndpoints()
+	for i := range eps {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-eps[i].WaitForPolicyRevision(ctx, rev, nil):
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+		}
+	}
+	return nil
+}
+
 // EndpointExists returns whether the endpoint with id exists.
 func (mgr *endpointManager) EndpointExists(id uint16) bool {
 	return mgr.LookupCiliumID(id) != nil

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -4,6 +4,8 @@
 package endpointmanager
 
 import (
+	"context"
+	"log/slog"
 	"net/netip"
 	"sync"
 	"testing"
@@ -30,6 +32,20 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 )
+
+func makeTestEndpointParams(logger *slog.Logger, repo policy.PolicyRepository) endpoint.EndpointParams {
+	return endpoint.EndpointParams{
+		Logger:           logger,
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		PolicyRepo:       repo,
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		WgConfig:         fakeTypes.WireguardConfig{},
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+	}
+}
 
 func (mgr *endpointManager) waitEndpointRemoved(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
 	mgr.unexpose(ep)
@@ -390,17 +406,7 @@ func TestLookup(t *testing.T) {
 			logger := hivetest.Logger(t)
 			mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 			if tt.cm != nil {
-				ep, err = endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-					EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-					NamedPortsGetter: testipcache.NewMockIPCache(),
-					Allocator:        testidentity.NewMockIdentityAllocator(nil),
-					CTMapGC:          ctmap.NewFakeGCRunner(),
-					WgConfig:         &fakeTypes.WireguardConfig{},
-					IPSecConfig:      fakeTypes.IPsecConfig{},
-					Logger:           logger,
-					IdentityManager:  identitymanager.NewIDManager(logger),
-					PolicyRepo:       s.repo,
-				}, nil, &endpoint.FakeEndpointProxy{}, tt.cm, nil)
+				ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, tt.cm, nil)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
 				err = mgr.expose(ep)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
@@ -425,17 +431,7 @@ func TestLookupCiliumID(t *testing.T) {
 
 	model := newTestEndpointModel(2, endpoint.StateReady)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-		PolicyRepo:       s.repo,
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		WgConfig:         &fakeTypes.WireguardConfig{},
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		Logger:           logger,
-		IdentityManager:  identitymanager.NewIDManager(logger),
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -510,17 +506,7 @@ func TestLookupCNIAttachmentID(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		WgConfig:         &fakeTypes.WireguardConfig{},
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		Logger:           logger,
-		IdentityManager:  identitymanager.NewIDManager(logger),
-		PolicyRepo:       s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, &apiv1.EndpointChangeRequest{
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, &apiv1.EndpointChangeRequest{
 		ContainerID:            "foo",
 		ContainerInterfaceName: "bar",
 	}, nil)
@@ -543,17 +529,7 @@ func TestLookupIPv4(t *testing.T) {
 
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 	model := newTestEndpointModel(4, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		WgConfig:         &fakeTypes.WireguardConfig{},
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		Logger:           logger,
-		IdentityManager:  identitymanager.NewIDManager(logger),
-		PolicyRepo:       s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -706,17 +682,7 @@ func TestLookupCEPName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-			EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-			NamedPortsGetter: testipcache.NewMockIPCache(),
-			Allocator:        testidentity.NewMockIdentityAllocator(nil),
-			CTMapGC:          ctmap.NewFakeGCRunner(),
-			WgConfig:         &fakeTypes.WireguardConfig{},
-			IPSecConfig:      fakeTypes.IPsecConfig{},
-			Logger:           logger,
-			IdentityManager:  identitymanager.NewIDManager(logger),
-			PolicyRepo:       s.repo,
-		}, nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
+		ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		tt.preTestRun(ep)
 		args := tt.setupArgs()
@@ -759,20 +725,9 @@ func TestUpdateReferences(t *testing.T) {
 	}
 	for _, tt := range tests {
 		var err error
-		logger := hivetest.Logger(t)
-		ep, err = endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-			EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-			NamedPortsGetter: testipcache.NewMockIPCache(),
-			Allocator:        testidentity.NewMockIdentityAllocator(nil),
-			CTMapGC:          ctmap.NewFakeGCRunner(),
-			WgConfig:         &fakeTypes.WireguardConfig{},
-			IPSecConfig:      fakeTypes.IPsecConfig{},
-			Logger:           logger,
-			IdentityManager:  identitymanager.NewIDManager(logger),
-			PolicyRepo:       s.repo,
-		}, nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
+		ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(hivetest.Logger(t), s.repo), nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
-		//logger := hivetest.Logger(t)
+		logger := hivetest.Logger(t)
 		mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 
 		err = mgr.expose(ep)
@@ -806,17 +761,7 @@ func TestRemove(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 	model := newTestEndpointModel(7, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		WgConfig:         &fakeTypes.WireguardConfig{},
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		Logger:           logger,
-		IdentityManager:  identitymanager.NewIDManager(logger),
-		PolicyRepo:       s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -857,6 +802,137 @@ func TestRemove(t *testing.T) {
 	}
 }
 
+func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
+	s := setupEndpointManagerSuite(t)
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+	model := newTestEndpointModel(1, endpoint.StateReady)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	require.NoError(t, err)
+
+	ep.Start(uint16(model.ID))
+	t.Cleanup(ep.Stop)
+	type args struct {
+		ctx    context.Context
+		rev    uint64
+		cancel context.CancelFunc
+	}
+	type want struct {
+		err      error
+		errCheck assert.ComparisonAssertionFunc
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWant   func() want
+		preTestRun  func()
+		postTestRun func()
+	}{
+		{
+			name: "Endpoint with revision already set",
+			preTestRun: func() {
+				ep.ID = 1
+				ep.SetPolicyRevision(5)
+				require.NoError(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				return args{
+					ctx: context.Background(),
+					rev: 5,
+				}
+			},
+			setupWant: func() want {
+				return want{
+					err:      nil,
+					errCheck: assert.EqualValues,
+				}
+			},
+			postTestRun: func() {
+				mgr.WaitEndpointRemoved(ep)
+				model := newTestEndpointModel(1, endpoint.StateReady)
+				ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				require.NoError(t, err)
+
+				ep.Start(uint16(model.ID))
+				t.Cleanup(ep.Stop)
+			},
+		},
+		{
+			name: "Context already timed out",
+			preTestRun: func() {
+				ep.ID = 1
+				ep.SetPolicyRevision(5)
+				require.NoError(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				ctx, cancel := context.WithTimeout(context.Background(), 0)
+				return args{
+					ctx:    ctx,
+					rev:    5,
+					cancel: cancel,
+				}
+			},
+			setupWant: func() want {
+				return want{
+					err:      nil,
+					errCheck: assert.NotEqualValues,
+				}
+			},
+			postTestRun: func() {
+				mgr.WaitEndpointRemoved(ep)
+				model := newTestEndpointModel(1, endpoint.StateReady)
+				ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				require.NoError(t, err)
+
+				ep.Start(uint16(model.ID))
+				t.Cleanup(ep.Stop)
+			},
+		},
+		{
+			name: "Revision is will never be set to the waiting revision",
+			preTestRun: func() {
+				ep.ID = 1
+				ep.SetPolicyRevision(4)
+				require.NoError(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				return args{
+					ctx:    ctx,
+					rev:    5,
+					cancel: cancel,
+				}
+			},
+			setupWant: func() want {
+				return want{
+					err:      nil,
+					errCheck: assert.NotEqualValues,
+				}
+			},
+			postTestRun: func() {
+				mgr.WaitEndpointRemoved(ep)
+				model := newTestEndpointModel(1, endpoint.StateReady)
+				ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				require.NoError(t, err)
+
+				ep.Start(uint16(model.ID))
+				t.Cleanup(ep.Stop)
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt.preTestRun()
+		args := tt.setupArgs()
+		want := tt.setupWant()
+		got := mgr.WaitForEndpointsAtPolicyRev(args.ctx, args.rev)
+		want.errCheck(t, want.err, got, "Test Name: %s", tt.name)
+		if args.cancel != nil {
+			args.cancel()
+		}
+		tt.postTestRun()
+	}
+}
+
 func TestMissingNodeLabelsUpdate(t *testing.T) {
 	logger := hivetest.Logger(t)
 	// Initialize label filter config.
@@ -876,18 +952,11 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	// Create host endpoint and expose it in the endpoint manager.
 	model := newTestEndpointModel(1, endpoint.StateReady)
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
-		NamedPortsGetter:    testipcache.NewMockIPCache(),
-		Allocator:           testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:             ctmap.NewFakeGCRunner(),
-		WgConfig:            &fakeTypes.WireguardConfig{},
-		IPSecConfig:         fakeTypes.IPsecConfig{},
-		Logger:              logger,
-		IdentityManager:     identitymanager.NewIDManager(logger),
-		PolicyRepo:          s.repo,
-		KVStoreSynchronizer: kvstoreSync,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := func() (*endpoint.Endpoint, error) {
+		p := makeTestEndpointParams(logger, s.repo)
+		p.KVStoreSynchronizer = kvstoreSync
+		return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	}()
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -939,18 +1008,11 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			name: "Add labels",
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
-					NamedPortsGetter:    testipcache.NewMockIPCache(),
-					Allocator:           testidentity.NewMockIdentityAllocator(nil),
-					CTMapGC:             ctmap.NewFakeGCRunner(),
-					WgConfig:            &fakeTypes.WireguardConfig{},
-					IPSecConfig:         fakeTypes.IPsecConfig{},
-					Logger:              logger,
-					IdentityManager:     identitymanager.NewIDManager(logger),
-					PolicyRepo:          s.repo,
-					KVStoreSynchronizer: kvstoreSync,
-				}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				ep, err := func() (*endpoint.Endpoint, error) {
+					p := makeTestEndpointParams(logger, s.repo)
+					p.KVStoreSynchronizer = kvstoreSync
+					return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				}()
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -981,18 +1043,11 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
-				ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
-					NamedPortsGetter:    testipcache.NewMockIPCache(),
-					Allocator:           testidentity.NewMockIdentityAllocator(nil),
-					CTMapGC:             ctmap.NewFakeGCRunner(),
-					WgConfig:            &fakeTypes.WireguardConfig{},
-					IPSecConfig:         fakeTypes.IPsecConfig{},
-					Logger:              logger,
-					IdentityManager:     identitymanager.NewIDManager(logger),
-					PolicyRepo:          s.repo,
-					KVStoreSynchronizer: kvstoreSync,
-				}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				ep, err := func() (*endpoint.Endpoint, error) {
+					p := makeTestEndpointParams(logger, s.repo)
+					p.KVStoreSynchronizer = kvstoreSync
+					return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				}()
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -1025,19 +1080,11 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-
-				ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
-					NamedPortsGetter:    testipcache.NewMockIPCache(),
-					Allocator:           testidentity.NewMockIdentityAllocator(nil),
-					CTMapGC:             ctmap.NewFakeGCRunner(),
-					WgConfig:            &fakeTypes.WireguardConfig{},
-					IPSecConfig:         fakeTypes.IPsecConfig{},
-					Logger:              logger,
-					IdentityManager:     identitymanager.NewIDManager(logger),
-					PolicyRepo:          s.repo,
-					KVStoreSynchronizer: kvstoreSync,
-				}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				ep, err := func() (*endpoint.Endpoint, error) {
+					p := makeTestEndpointParams(logger, s.repo)
+					p.KVStoreSynchronizer = kvstoreSync
+					return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				}()
 				ep.SetIsHost(true)
 				require.NoError(t, err)
 

--- a/pkg/endpointmanager/script_cmds.go
+++ b/pkg/endpointmanager/script_cmds.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/hive/script"
+	"github.com/davecgh/go-spew/spew"
+
+	endpointapi "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+func ScriptCmds(epm EndpointManager, template *endpoint.Endpoint) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"endpoint/create": script.Command(
+			script.CmdUsage{
+				Summary: "Create Endpoint",
+				Args:    "'id' 'labels'",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				allArgs := []string(args)
+				if len(allArgs) != 2 {
+					return nil, fmt.Errorf("expected two args but got %v, see usage details", len(allArgs))
+				}
+
+				num, err := strconv.Atoi(allArgs[0])
+				if err != nil {
+					return nil, fmt.Errorf("atoi: %w", err)
+				}
+
+				var labelArr []labels.Label
+				for s := range strings.SplitSeq(allArgs[1], ",") {
+					labelArr = append(labelArr, labels.ParseLabel(s))
+				}
+
+				id := &identity.Identity{
+					ID:         identity.NumericIdentity(num),
+					Labels:     labels.FromSlice(labelArr),
+					LabelArray: labels.LabelArray(labelArr),
+				}
+
+				// The following order of steps simulate adding an Endpoint the
+				// way that the Agent does.
+				ep := template.CopyFromTemplate()
+				err = epm.AddEndpoint(ep)
+				if err != nil {
+					return nil, err
+				}
+				_ = ep.UpdateLabels(s.Context(), labels.LabelSourceAny, id.Labels, nil, true)
+				// Use RegenerateIfAlive to set the endpoint state to WaitingToRegenerate.
+				_ = ep.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+					Reason:            "simulate Orchestrator",
+					RegenerationLevel: regeneration.RegenerateWithDatapath,
+					ParentContext:     s.Context(),
+				})
+				err = ep.WaitForFirstRegeneration(s.Context())
+				if err != nil {
+					return nil, err
+				}
+				<-ep.WaitForPolicyRevision(s.Context(), 1, nil)
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					return "", "", err
+				}, nil
+			},
+		),
+		"endpoint/list": script.Command(
+			script.CmdUsage{
+				Summary: "List all Endpoints",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					var sb strings.Builder
+					sb.WriteRune('[')
+					for _, ep := range epm.GetEndpointList(endpointapi.GetEndpointParams{}) {
+						sb.WriteRune('{')
+						sb.WriteString(spew.Sdump(
+							"id", ep.ID,
+							"identity", ep.Status.Identity,
+							"status", ep.Status.Policy,
+						))
+						sb.WriteRune('}')
+						sb.WriteRune(',')
+						sb.WriteRune('\n')
+					}
+					sb.WriteString("]\n")
+					return sb.String(), "", nil
+				}, nil
+			},
+		),
+		"endpoint/regen-all": script.Command(
+			script.CmdUsage{
+				Summary: "Regenerate all Endpoints",
+				Args:    "policy-rev",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				allArgs := []string(args)
+				if len(allArgs) != 1 {
+					return nil, fmt.Errorf("expected one arg but got %v, see usage details", len(allArgs))
+				}
+				rev, err := strconv.Atoi(allArgs[0])
+				if err != nil {
+					return nil, fmt.Errorf("atoi: %w", err)
+				}
+				wg := epm.RegenerateAllEndpoints(&regeneration.ExternalRegenerationMetadata{
+					Reason:            "simulate regeneration of all endpoints from script command",
+					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+					ParentContext:     s.Context(),
+
+					PolicyRevisionToWaitFor: uint64(rev),
+				})
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					wg.Wait()
+					return "", "", nil
+				}, nil
+			},
+		),
+		"endpoint/wait-all": script.Command(
+			script.CmdUsage{
+				Summary: "Wait for all Endpoints to have the given policy revision",
+				Args:    "policy-rev",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				allArgs := []string(args)
+				if len(allArgs) != 1 {
+					return nil, fmt.Errorf("expected one arg but got %v, see usage details", len(allArgs))
+				}
+				rev, err := strconv.Atoi(allArgs[0])
+				if err != nil {
+					return nil, fmt.Errorf("atoi: %w", err)
+				}
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					err = epm.WaitForEndpointsAtPolicyRev(s.Context(), uint64(rev))
+					if err != nil {
+						return "", "", fmt.Errorf("error waiting for all endpoints: %w", err)
+					}
+					return "", "", nil
+				}, nil
+			},
+		),
+	}
+}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -165,22 +165,26 @@ func (s *DNSProxyTestSuite) LookupByIdentity(nid identity.NumericIdentity) []str
 	}
 }
 
+func makeProxyTestEndpointParams(logger *slog.Logger, repo policy.PolicyRepository) endpoint.EndpointParams {
+	return endpoint.EndpointParams{
+		Logger:           logger,
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		PolicyRepo:       repo,
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		WgConfig:         fakeTypes.WireguardConfig{},
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+	}
+}
+
 func (s *DNSProxyTestSuite) LookupRegisteredEndpoint(ip netip.Addr) (*endpoint.Endpoint, bool, error) {
 	if s.restoring {
 		return nil, false, fmt.Errorf("No EPs available when restoring")
 	}
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		WgConfig:         &fakeTypes.WireguardConfig{},
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		Logger:           s.logger,
-		IdentityManager:  identitymanager.NewIDManager(s.logger),
-		PolicyRepo:       s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeProxyTestEndpointParams(s.logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	ep.Start(uint16(model.ID))
 	defer ep.Stop()
 	return ep, false, err
@@ -579,7 +583,6 @@ func assertRulesEqual(t *testing.T, da, db restore.DNSRules) {
 }
 
 func TestPrivilegedFullPathDependence(t *testing.T) {
-	logger := hivetest.Logger(t)
 	s := setupDNSProxyTestSuite(t)
 
 	// Test that we consider each of endpoint ID, destination SecID (via the
@@ -905,17 +908,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		WgConfig:         &fakeTypes.WireguardConfig{},
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		Logger:           hivetest.Logger(t),
-		IdentityManager:  identitymanager.NewIDManager(logger),
-		PolicyRepo:       s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep1, err := endpoint.NewEndpointFromChangeModel(makeProxyTestEndpointParams(hivetest.Logger(t), s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))
@@ -967,17 +960,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules for epID3
 	modelEP3 := newTestEndpointModel(int(epID3), endpoint.StateReady)
-	ep3, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		WgConfig:         &fakeTypes.WireguardConfig{},
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		Logger:           hivetest.Logger(t),
-		IdentityManager:  identitymanager.NewIDManager(logger),
-		PolicyRepo:       s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep3, err := endpoint.NewEndpointFromChangeModel(makeProxyTestEndpointParams(hivetest.Logger(t), s.repo), nil, &endpoint.FakeEndpointProxy{}, modelEP3, nil)
 	require.NoError(t, err)
 
 	ep3.Start(uint16(modelEP3.ID))
@@ -1123,7 +1106,6 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 }
 
 func TestPrivilegedRestoredEndpoint(t *testing.T) {
-	logger := hivetest.Logger(t)
 	s := setupDNSProxyTestSuite(t)
 
 	// Respond with an actual answer for the query. This also tests that the
@@ -1189,17 +1171,7 @@ func TestPrivilegedRestoredEndpoint(t *testing.T) {
 	// restore rules, set the mock to restoring state
 	s.restoring = true
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
-		NamedPortsGetter: testipcache.NewMockIPCache(),
-		Allocator:        testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:          ctmap.NewFakeGCRunner(),
-		WgConfig:         &fakeTypes.WireguardConfig{},
-		IPSecConfig:      fakeTypes.IPsecConfig{},
-		Logger:           hivetest.Logger(t),
-		IdentityManager:  identitymanager.NewIDManager(logger),
-		PolicyRepo:       s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep1, err := endpoint.NewEndpointFromChangeModel(makeProxyTestEndpointParams(hivetest.Logger(t), s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -722,6 +722,11 @@ func (sp *testSelectorPolicy) RedirectFilters() iter.Seq2[*policy.L4Filter, poli
 func (sp *testSelectorPolicy) GetSelectorSnapshot() policy.SelectorSnapshot {
 	return policy.SelectorSnapshot{}
 }
+func (sp *testSelectorPolicy) AddHold() bool       { return true }
+func (sp *testSelectorPolicy) ReleaseHold()        {}
+func (sp *testSelectorPolicy) Detach()             {}
+func (sp *testSelectorPolicy) MaybeDetach()        {}
+func (sp *testSelectorPolicy) GetRevision() uint64 { return 0 }
 
 // createSelectorCache creates a common selector cache setup used by both DNS and non-DNS policies
 func (sp *testSelectorPolicy) createSelectorCache() (policy.CachedSelector, *policy.SelectorCache) {

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -15,6 +15,8 @@ import (
 
 type IDManager interface {
 	Add(identity *identity.Identity)
+	Get(*identity.NumericIdentity) *identity.Identity
+	GetAll() []*identity.Identity
 	GetIdentityModels() []*models.IdentityEndpoints
 	Remove(identity *identity.Identity)
 	RemoveAll()
@@ -156,6 +158,35 @@ func (idm *IdentityManager) remove(identity *identity.Identity) {
 		}
 	}
 
+}
+
+// Get returns the full identity based on the numeric identity. The returned
+// identity is a pointer to a live object; do not modify!
+func (idm *IdentityManager) Get(id *identity.NumericIdentity) *identity.Identity {
+	if id == nil {
+		return nil
+	}
+
+	idm.mutex.RLock()
+	defer idm.mutex.RUnlock()
+
+	idd, exists := idm.identities[*id]
+	if !exists {
+		return nil
+	}
+	return idd.identity
+}
+
+// GetAll returns all identities from the manager. The returned slices contains
+// identities that are pointers to a live objects; do not modify!
+func (idm *IdentityManager) GetAll() []*identity.Identity {
+	idm.mutex.RLock()
+	defer idm.mutex.RUnlock()
+	ids := make([]*identity.Identity, 0, len(idm.identities))
+	for _, v := range idm.identities {
+		ids = append(ids, v.identity)
+	}
+	return ids
 }
 
 // GetIdentityModels returns the API representation of the IdentityManager.

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -4,11 +4,18 @@
 package identitymanager
 
 import (
+	"fmt"
 	"log/slog"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/hive/script"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/model"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -255,4 +262,96 @@ type IdentitiesModel []*models.IdentityEndpoints
 // in index `j`
 func (s IdentitiesModel) Less(i, j int) bool {
 	return s[i].Identity.ID < s[j].Identity.ID
+}
+
+func ScriptCmds(idm *IdentityManager) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"idm/list": script.Command(
+			script.CmdUsage{
+				Summary: "List all policies in the policy repository",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				var sb strings.Builder
+				models := idm.GetIdentityModels()
+				sb.WriteRune('[')
+				for _, m := range models {
+					sb.WriteString(strconv.FormatInt(m.Identity.ID, 10))
+					sb.WriteRune(' ')
+					sb.WriteRune('{')
+					sb.WriteString(strings.Join([]string(m.Identity.Labels), ","))
+					sb.WriteRune('}')
+					sb.WriteRune(' ')
+				}
+				sb.WriteRune(']')
+				sb.WriteRune('\n')
+
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					return sb.String(), "", nil
+				}, nil
+			},
+		),
+		"idm/add": script.Command(
+			script.CmdUsage{
+				Summary: "List all policies in the policy repository",
+				Args:    "number labels",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					allArgs := []string(args)
+					num, err := strconv.Atoi(allArgs[0])
+					if err != nil {
+						return "", "", fmt.Errorf("atoi: %w", err)
+					}
+					lstr := allArgs[1]
+
+					var labelArr []labels.Label
+					for s := range strings.SplitSeq(lstr, ",") {
+						labelArr = append(labelArr, labels.ParseLabel(s))
+					}
+
+					idm.Add(&identity.Identity{
+						ID:         identity.NumericIdentity(num),
+						Labels:     labels.FromSlice(labelArr),
+						LabelArray: labels.LabelArray(labelArr),
+					})
+					return "", "", nil
+				}, nil
+			},
+		),
+		"idm/add-from-stdout": script.Command(
+			script.CmdUsage{
+				Summary: "Add identity with the given labels and numeric value from stdout",
+				Args:    "labels",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				var wait script.WaitFunc
+
+				lines := slices.Collect(strings.Lines(s.Stdout()))
+				if len(lines) != 1 {
+					return wait, fmt.Errorf("expected stdout to contain only one line but got %v, see usage details", len(lines))
+				}
+
+				num, err := strconv.Atoi(strings.Trim(lines[0], "\n"))
+				if err != nil {
+					return wait, fmt.Errorf("atoi: %w", err)
+				}
+
+				lstr := []string(args)[0]
+				var labelArr []labels.Label
+				for s := range strings.SplitSeq(lstr, ",") {
+					labelArr = append(labelArr, labels.ParseLabel(s))
+				}
+
+				idm.Add(&identity.Identity{
+					ID:         identity.NumericIdentity(num),
+					Labels:     labels.FromSlice(labelArr),
+					LabelArray: labels.LabelArray(labelArr),
+				})
+				wait = func(s *script.State) (stdout string, stderr string, err error) {
+					return "", "", nil
+				}
+				return wait, nil
+			},
+		),
+	}
 }

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -55,34 +55,42 @@ func newIdentityManager(logger *slog.Logger) *IdentityManager {
 // already in the identity manager, the reference count for the identity is
 // incremented.
 func (idm *IdentityManager) Add(identity *identity.Identity) {
+	if identity == nil {
+		return
+	}
+
+	idm.add(identity)
+}
+
+func (idm *IdentityManager) add(identity *identity.Identity) {
 	idm.logger.Debug(
 		"Adding identity to identity manager",
 		logfields.Identity, identity,
 	)
 
 	idm.mutex.Lock()
-	defer idm.mutex.Unlock()
-	idm.add(identity)
+	added := idm.addLocked(identity)
+	idm.mutex.Unlock()
+
+	if added {
+		for o := range idm.observers {
+			o.LocalEndpointIdentityAdded(identity)
+		}
+	}
 }
 
-func (idm *IdentityManager) add(identity *identity.Identity) {
-	if identity == nil {
-		return
-	}
-
+func (idm *IdentityManager) addLocked(identity *identity.Identity) (added bool) {
 	idMeta, exists := idm.identities[identity.ID]
 	if !exists {
 		idm.identities[identity.ID] = &identityMetadata{
 			identity: identity,
 			refCount: 1,
 		}
-		for o := range idm.observers {
-			o.LocalEndpointIdentityAdded(identity)
-		}
-
+		added = true
 	} else {
 		idMeta.refCount++
 	}
+	return
 }
 
 // RemoveOldAddNew removes old from the identity manager and inserts new
@@ -91,14 +99,15 @@ func (idm *IdentityManager) add(identity *identity.Identity) {
 // This is a no-op if both identities have the same numeric ID.
 func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
 	idm.mutex.Lock()
-	defer idm.mutex.Unlock()
 
 	if old == nil && new == nil {
+		idm.mutex.Unlock()
 		return
 	}
 	// The host endpoint will always retain its reserved ID, but its labels may
 	// change so we need to update its identity.
 	if old != nil && new != nil && old.ID == new.ID && new.ID != identity.ReservedIdentityHost {
+		idm.mutex.Unlock()
 		return
 	}
 
@@ -108,8 +117,21 @@ func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
 		logfields.New, new,
 	)
 
-	idm.remove(old)
-	idm.add(new)
+	removed := idm.removeLocked(old)
+	added := idm.addLocked(new)
+
+	idm.mutex.Unlock()
+
+	if removed {
+		for o := range idm.observers {
+			o.LocalEndpointIdentityRemoved(old)
+		}
+	}
+	if added {
+		for o := range idm.observers {
+			o.LocalEndpointIdentityAdded(new)
+		}
+	}
 }
 
 // RemoveAll removes all identities.
@@ -118,7 +140,7 @@ func (idm *IdentityManager) RemoveAll() {
 	defer idm.mutex.Unlock()
 
 	for id := range idm.identities {
-		idm.remove(idm.identities[id].identity)
+		idm.removeLocked(idm.identities[id].identity)
 	}
 }
 
@@ -127,20 +149,33 @@ func (idm *IdentityManager) RemoveAll() {
 // decremented. If the identity is not in the cache, this is a no-op. If the
 // ref count becomes zero, the identity is removed from the cache.
 func (idm *IdentityManager) Remove(identity *identity.Identity) {
-	idm.logger.Debug(
-		"Removing identity from identity manager",
-		logfields.Identity, identity,
-	)
+	if identity == nil {
+		return
+	}
 
-	idm.mutex.Lock()
-	defer idm.mutex.Unlock()
 	idm.remove(identity)
 }
 
 func (idm *IdentityManager) remove(identity *identity.Identity) {
+	idm.mutex.Lock()
+	removed := idm.removeLocked(identity)
+	idm.mutex.Unlock()
+
+	if removed {
+		for o := range idm.observers {
+			o.LocalEndpointIdentityRemoved(identity)
+		}
+	}
+}
+func (idm *IdentityManager) removeLocked(identity *identity.Identity) (removed bool) {
 	if identity == nil {
 		return
 	}
+
+	idm.logger.Debug(
+		"Removing identity from identity manager",
+		logfields.Identity, identity,
+	)
 
 	idMeta, exists := idm.identities[identity.ID]
 	if !exists {
@@ -153,11 +188,9 @@ func (idm *IdentityManager) remove(identity *identity.Identity) {
 	idMeta.refCount--
 	if idMeta.refCount == 0 {
 		delete(idm.identities, identity.ID)
-		for o := range idm.observers {
-			o.LocalEndpointIdentityRemoved(identity)
-		}
+		removed = true
 	}
-
+	return
 }
 
 // Get returns the full identity based on the numeric identity. The returned

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -57,6 +57,8 @@ var Cell = cell.Module(
 		// 'reserved:kube-apiserver' label.
 		registerAPIServerBackendWatcher,
 	),
+
+	cell.Provide(func(ipc *ipcache.IPCache) ipcache.MetadataBatchAPI { return ipc }),
 )
 
 type ipCacheParams struct {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -495,6 +495,14 @@ func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
 	ipc.mutex.RUnlock()
 }
 
+type MetadataBatchAPI interface {
+	UpsertMetadataBatch(updates ...MU) (revision uint64)
+	RemoveMetadataBatch(updates ...MU) (revision uint64)
+	WaitForRevision(ctx context.Context, rev uint64) error
+}
+
+var _ MetadataBatchAPI = &IPCache{}
+
 // MU is a batched metadata update, the short name is to cut down on visual clutter.
 type MU struct {
 	Prefix   cmtypes.PrefixCluster

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -53,6 +53,7 @@ type endpointManager interface {
 	GetEndpoints() []*endpoint.Endpoint
 	GetHostEndpoint() *endpoint.Endpoint
 	GetEndpointsByPodName(string) []*endpoint.Endpoint
+	WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error
 	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
 }
 

--- a/pkg/maps/policymap/cell.go
+++ b/pkg/maps/policymap/cell.go
@@ -49,7 +49,7 @@ func (def PolicyConfig) Flags(flags *pflag.FlagSet) {
 }
 
 type Factory interface {
-	OpenEndpoint(id uint16) (*PolicyMap, error)
+	OpenEndpoint(id uint16) (PolicyMap, error)
 	RemoveEndpoint(id uint16) error
 
 	PolicyMaxEntries() int
@@ -77,7 +77,7 @@ func newFactory(logger *slog.Logger, stats *StatsMap, policyMapEntries int) *fac
 // OpenEndpoint opens (or creates) a policy for the specified endpoint, which
 // is used to govern which peer identities can communicate with the endpoint
 // protected by this map.
-func (f *factory) OpenEndpoint(id uint16) (*PolicyMap, error) {
+func (f *factory) OpenEndpoint(id uint16) (PolicyMap, error) {
 	m, err := newPolicyMap(f.logger, id, f.policyMapEntries, f.stats)
 	if err != nil {
 		return nil, err

--- a/pkg/maps/policymap/fake/map.go
+++ b/pkg/maps/policymap/fake/map.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fake
+
+import (
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+type PolicyKey = policymap.PolicyKey
+type PolicyEntry = policymap.PolicyEntry
+type PolicyEntryDump = policymap.PolicyEntryDump
+type PolicyEntriesDump = policymap.PolicyEntriesDump
+type MapStateMap = types.MapStateMap
+
+var _ policymap.PolicyMap = (*fakePolicyMap)(nil)
+
+type fakePolicyMap struct {
+	Entries map[PolicyKey]PolicyEntry
+}
+
+func NewFakePolicyMap() *fakePolicyMap {
+	return &fakePolicyMap{
+		Entries: map[PolicyKey]PolicyEntry{},
+	}
+}
+
+func (pm *fakePolicyMap) Update(key *PolicyKey, entry *PolicyEntry) error {
+	pm.Entries[*key] = *entry
+	return nil
+}
+
+func (pm *fakePolicyMap) DeleteKey(key PolicyKey) error {
+	delete(pm.Entries, key)
+	return nil
+}
+
+func (pm *fakePolicyMap) DeleteEntry(entry *PolicyEntryDump) error {
+	delete(pm.Entries, entry.Key)
+	return nil
+}
+
+func (pm *fakePolicyMap) String() string {
+	return "fakepolicymap"
+}
+
+func (pm *fakePolicyMap) Dump() (string, error) {
+	entries, err := pm.DumpToSlice()
+	if err != nil {
+		return "", err
+	}
+	return entries.String(), nil
+}
+
+func (pm *fakePolicyMap) DumpToSlice() (PolicyEntriesDump, error) {
+	entries := make(PolicyEntriesDump, 0, len(pm.Entries))
+	for key, value := range pm.Entries {
+		entries = append(entries, PolicyEntryDump{
+			Key:         key,
+			PolicyEntry: value,
+		})
+	}
+	return entries, nil
+}
+
+// Keep this up-to-date with DumpToMapStateMap() from
+// pkg/maps/policymap/policymap.go.
+func (pm *fakePolicyMap) DumpToMapStateMap() (MapStateMap, error) {
+	out := make(MapStateMap)
+	for key, val := range pm.Entries {
+		// Convert from policymap.Key to policy.Key
+		policyKey := types.KeyForDirection(trafficdirection.TrafficDirection(key.TrafficDirection)).
+			WithIdentity(identity.NumericIdentity(key.Identity)).
+			WithPortProtoPrefix(u8proto.U8proto(key.Nexthdr), key.GetDestPort(), key.GetPortPrefixLen())
+
+		// Convert from policymap.PolicyEntry to policyTypes.MapStateEntry.
+		policyVal := types.MapStateEntry{
+			Precedence:      val.Precedence,
+			ProxyPort:       val.GetProxyPort(),
+			AuthRequirement: val.AuthRequirement,
+			Cookie:          val.Cookie,
+		}.WithDeny(val.IsDeny())
+		// if policymapEntry has invalid prefix length, force update by storing as an
+		// invalid MapStateEntry
+		if !val.IsValid(&key) {
+			policyVal.Invalidate()
+		}
+		out[policyKey] = policyVal
+	}
+	return out, nil
+}
+
+func (pm *fakePolicyMap) MaxEntries() uint32 { return 1024 }
+func (pm *fakePolicyMap) Close() error       { return nil }

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -29,7 +29,7 @@ func createStatsMapForTest(maxStatsEntries int) (*StatsMap, error) {
 	return m, m.OpenOrCreate()
 }
 
-func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
+func setupPolicyMapPrivilegedTestSuite(tb testing.TB) PolicyMap {
 	testutils.PrivilegedTest(tb)
 
 	logger := hivetest.Logger(tb)
@@ -92,7 +92,7 @@ func TestPrivilegedPolicyMapDumpToSlice(t *testing.T) {
 func TestPrivilegedDeleteNonexistentKey(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 	key := newKey(trafficdirection.Ingress, 27, u8proto.TCP, 80, SinglePortPrefixLen)
-	err := testMap.Map.Delete(&key)
+	err := testMap.DeleteKey(key)
 	require.Error(t, err)
 	var errno unix.Errno
 	require.ErrorAs(t, err, &errno)

--- a/pkg/maps/policymap/statsmap_privileged_test.go
+++ b/pkg/maps/policymap/statsmap_privileged_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestPrivilegedStatMap(t *testing.T) {
-	policyMap := setupPolicyMapPrivilegedTestSuite(t)
-	require.NotNil(t, policyMap)
+	pm := setupPolicyMapPrivilegedTestSuite(t)
+	require.NotNil(t, pm)
 
-	testMap := policyMap.stats
+	testMap := (pm.(*policyMap)).stats
 	require.NotNil(t, testMap)
 
 	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/stream"
 	"github.com/spf13/pflag"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -30,6 +31,7 @@ var Cell = cell.Module(
 	cell.Provide(newPolicyRepo),
 	cell.Provide(newPolicyUpdater),
 	cell.Provide(newPolicyImporter),
+	cell.Provide(newPolicyCacheOut),
 	cell.Provide(newIdentityUpdater),
 	cell.Provide(newIPCacher),
 	cell.Config(defaultConfig),
@@ -100,6 +102,10 @@ func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
 	})
 
 	return policyRepo
+}
+
+func newPolicyCacheOut(r policy.PolicyRepository) stream.Observable[policy.PolicyCacheChange] {
+	return r.PolicyCacheObservable()
 }
 
 type policyUpdaterParams struct {

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
 
@@ -113,6 +114,7 @@ type policyUpdaterParams struct {
 
 	Logger           *slog.Logger
 	PolicyRepository policy.PolicyRepository
+	PolicyComputer   compute.PolicyRecomputer
 	EndpointManager  endpointmanager.EndpointManager
 }
 
@@ -120,7 +122,5 @@ func newPolicyUpdater(params policyUpdaterParams) *policy.Updater {
 	// policyUpdater: forces policy recalculation on all endpoints.
 	// Called for various events, such as named port changes
 	// or certain identity updates.
-	policyUpdater := policy.NewUpdater(params.Logger, params.PolicyRepository, params.EndpointManager)
-
-	return policyUpdater
+	return policy.NewUpdater(params.Logger, params.PolicyRepository, params.PolicyComputer, params.EndpointManager)
 }

--- a/pkg/policy/cell/identity_updater.go
+++ b/pkg/policy/cell/identity_updater.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -42,6 +43,7 @@ type identityAllocatorParams struct {
 	Log              *slog.Logger
 	Registry         job.Registry
 	PolicyRepository policy.PolicyRepository
+	PolicyComputer   compute.PolicyRecomputer
 	EPManager        endpointmanager.EndpointManager
 	Health           cell.Health
 	Metrics          *identityUpdaterMetrics
@@ -54,6 +56,7 @@ type identityAllocatorParams struct {
 type identityUpdater struct {
 	logger    *slog.Logger
 	policy    policy.PolicyRepository
+	computer  compute.PolicyRecomputer
 	epmanager endpointmanager.EndpointManager
 
 	identityHandlers []identity.UpdateIdentities
@@ -82,6 +85,7 @@ func newIdentityUpdater(params identityAllocatorParams) IdentityUpdater {
 	i := &identityUpdater{
 		logger:    params.Log,
 		policy:    params.PolicyRepository,
+		computer:  params.PolicyComputer,
 		epmanager: params.EPManager,
 		pending: batch{
 			done: make(chan struct{}),
@@ -220,7 +224,7 @@ func (i *identityUpdater) doUpdatePolicyMaps(ctx context.Context) error {
 	// We mutated a selector, we must regenerate.
 	if q.forcePolicyRegen {
 		i.logger.Info("Incremental policy update mutated identities. Forcing policy recalculation.")
-		i.policy.BumpRevision()
+		i.computer.RecomputeIdentityPolicyForAllIdentities(i.policy.BumpRevision())
 		i.epmanager.TriggerRegenerateAllEndpoints()
 	}
 

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -50,7 +50,7 @@ type policyImporterParams struct {
 	MonitorAgent    agent.Agent
 }
 
-type policyImporter struct {
+type Importer struct {
 	log          *slog.Logger
 	repo         policy.PolicyRepository
 	computer     compute.PolicyRecomputer
@@ -81,7 +81,7 @@ type epmanager interface {
 }
 
 func newPolicyImporter(cfg policyImporterParams) PolicyImporter {
-	i := &policyImporter{
+	i := &Importer{
 		log:          cfg.Log,
 		repo:         cfg.Repo,
 		computer:     cfg.PolicyComputer,
@@ -104,7 +104,12 @@ func newPolicyImporter(cfg policyImporterParams) PolicyImporter {
 	return i
 }
 
-func (i *policyImporter) UpdatePolicy(u *policytypes.PolicyUpdate) {
+// ResourceIDAnonymous is the anonymous ipcache resource used as a placeholder
+// for policies that allocate CIDRs but do not have an owning resource.
+// (This is only used for policies created by the local API).
+const ResourceIDAnonymous = "policy/anonymous"
+
+func (i *Importer) UpdatePolicy(u *policytypes.PolicyUpdate) {
 	i.q <- u
 }
 
@@ -121,7 +126,7 @@ func concat(buf []*policytypes.PolicyUpdate, in *policytypes.PolicyUpdate) []*po
 // to be allocated.
 //
 // It returns the set of stale prefixes that should be deallocated after policy updates are complete.
-func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policytypes.PolicyUpdate) (toPrune map[ipcachetypes.ResourceID][]netip.Prefix) {
+func (i *Importer) updatePrefixes(ctx context.Context, updates []*policytypes.PolicyUpdate) (toPrune map[ipcachetypes.ResourceID][]netip.Prefix) {
 	if i.ipc == nil {
 		return
 	}
@@ -207,7 +212,7 @@ func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policyty
 }
 
 // prunePrefixes removes the CIDR labels from the given set of (resource, prefix) pairs.
-func (i *policyImporter) prunePrefixes(prunePrefixes map[ipcachetypes.ResourceID][]netip.Prefix) {
+func (i *Importer) prunePrefixes(prunePrefixes map[ipcachetypes.ResourceID][]netip.Prefix) {
 	if i.ipc == nil {
 		return
 	}
@@ -236,7 +241,7 @@ func (i *policyImporter) prunePrefixes(prunePrefixes map[ipcachetypes.ResourceID
 // It also handles prefix allocation in the ipcache when the supplied rules rely on
 // CIDR identities.
 // (Does not actually return error, just to satisfy the Job signature)
-func (i *policyImporter) processUpdates(ctx context.Context, updates []*policytypes.PolicyUpdate) error {
+func (i *Importer) processUpdates(ctx context.Context, updates []*policytypes.PolicyUpdate) error {
 	if len(updates) == 0 {
 		return nil
 	}

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/monitor/agent"
 	monitorapi "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
@@ -43,6 +44,7 @@ type policyImporterParams struct {
 	Config   Config
 
 	Repo            policy.PolicyRepository
+	PolicyComputer  compute.PolicyRecomputer
 	EndpointManager endpointmanager.EndpointManager
 	IPCache         IPCacher
 	MonitorAgent    agent.Agent
@@ -51,6 +53,7 @@ type policyImporterParams struct {
 type policyImporter struct {
 	log          *slog.Logger
 	repo         policy.PolicyRepository
+	computer     compute.PolicyRecomputer
 	epm          epmanager
 	ipc          IPCacher
 	monitorAgent agent.Agent
@@ -81,6 +84,7 @@ func newPolicyImporter(cfg policyImporterParams) PolicyImporter {
 	i := &policyImporter{
 		log:          cfg.Log,
 		repo:         cfg.Repo,
+		computer:     cfg.PolicyComputer,
 		epm:          cfg.EndpointManager,
 		ipc:          cfg.IPCache,
 		monitorAgent: cfg.MonitorAgent,
@@ -317,6 +321,7 @@ func (i *policyImporter) processUpdates(ctx context.Context, updates []*policyty
 	// Unaffected endpoints can merely have their policy revision set.
 	i.log.Debug("Policy repository updates complete, triggering endpoint updates",
 		logfields.PolicyRevision, endRevision)
+	i.computer.UpdatePolicy(*idsToRegen, startRevision, endRevision)
 	if i.epm != nil {
 		i.epm.UpdatePolicy(idsToRegen, startRevision, endRevision)
 	}

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -5,14 +5,18 @@ package policycell
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"log/slog"
 	"net/netip"
+	"os"
 	"slices"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	"github.com/cilium/hive/script"
 	"github.com/cilium/stream"
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/set"
@@ -20,14 +24,18 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/monitor/agent"
 	monitorapi "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/compute"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
+	policyutils "github.com/cilium/cilium/pkg/policy/utils"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -360,5 +368,110 @@ func truncate[T any](xs iter.Seq[T], maxLen int) iter.Seq[T] {
 				return
 			}
 		}
+	}
+}
+
+func PolicyImporterScriptCmds(p *Importer) map[string]script.Cmd {
+	parse := func(s *script.State, args []string, del bool) (api.Rules, ipcachetypes.ResourceID, error) {
+		file := args[0]
+
+		b, err := os.ReadFile(s.Path(file))
+		if err != nil {
+			b, err = os.ReadFile(file)
+		}
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read %s: %w", file, err)
+		}
+		obj, _, err := testutils.DecodeObjectGVK(b)
+		if err != nil {
+			return nil, "", fmt.Errorf("decode: %w", err)
+		}
+		robj, _ := testutils.DecodeObject(b)
+		objMeta, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, "", fmt.Errorf("accessor: %w", err)
+		}
+
+		var (
+			rules      api.Rules
+			resourceID ipcachetypes.ResourceID
+		)
+		if objMeta.GetNamespace() == "" {
+			ccnp := robj.(*v2.CiliumClusterwideNetworkPolicy)
+			rules, err = ccnp.Parse(p.log, "")
+			if err != nil {
+				return nil, "", fmt.Errorf("ccnp parse: %w", err)
+			}
+			resourceID = ipcachetypes.NewResourceID(
+				ipcachetypes.ResourceKindCNP,
+				ccnp.ObjectMeta.Namespace,
+				ccnp.ObjectMeta.Name,
+			)
+		} else {
+			cnp := robj.(*v2.CiliumNetworkPolicy)
+			rules, err = cnp.Parse(p.log, "")
+			if err != nil {
+				return nil, "", fmt.Errorf("cnp parse: %w", err)
+			}
+			resourceID = ipcachetypes.NewResourceID(
+				ipcachetypes.ResourceKindCNP,
+				cnp.ObjectMeta.Namespace,
+				cnp.ObjectMeta.Name,
+			)
+		}
+
+		if del {
+			return nil, resourceID, nil
+		}
+		return rules, resourceID, nil
+	}
+
+	return map[string]script.Cmd{
+		"policy/import": script.Command(
+			script.CmdUsage{
+				Summary: "Import a policy change",
+				Args:    "'policy'",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				rules, resourceID, err := parse(s, []string(args), false)
+				if err != nil {
+					return nil, err
+				}
+				dc := make(chan uint64, 1)
+				p.UpdatePolicy(&policytypes.PolicyUpdate{
+					Rules:    policyutils.RulesToPolicyEntries(rules),
+					Source:   source.CustomResource,
+					Resource: resourceID,
+					DoneChan: dc,
+				})
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					rev := <-dc
+					return fmt.Sprintf("Imported policy change, rev=%d\n", rev), "", nil
+				}, nil
+			},
+		),
+		"policy/remove": script.Command(
+			script.CmdUsage{
+				Summary: "Remove a policy",
+				Args:    "'policy'",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				rules, resourceID, err := parse(s, []string(args), true)
+				if err != nil {
+					return nil, err
+				}
+				dc := make(chan uint64, 1)
+				p.UpdatePolicy(&policytypes.PolicyUpdate{
+					Rules:    policyutils.RulesToPolicyEntries(rules),
+					Source:   source.CustomResource,
+					Resource: resourceID,
+					DoneChan: dc,
+				})
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					rev := <-dc
+					return fmt.Sprintf("Removed policy, rev=%d\n", rev), "", nil
+				}, nil
+			},
+		),
 	}
 }

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -99,7 +99,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 	repo := policy.NewPolicyRepository(logger, ids, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 	polComputer := compute.InstantiateCellForTesting(t, logger, "policy-cell", "TestAddReplaceRemoveRule", repo, idmgr)
 
-	pi := &policyImporter{
+	pi := &Importer{
 		log:      logger,
 		repo:     repo,
 		computer: polComputer,

--- a/pkg/policy/compute/cell.go
+++ b/pkg/policy/compute/cell.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/stream"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+// Cell provides the IdentityPolicyRecomputer as a hive cell.
+var Cell = cell.Module(
+	"identity-policy-computer",
+	"Handles policy computation per identity",
+
+	cell.ProvidePrivate(NewPolicyComputationTable),
+	cell.Provide(
+		func(params Params) PolicyRecomputer {
+			return NewIdentityPolicyComputer(params)
+		},
+		statedb.RWTable[Result].ToTable,
+	),
+)
+
+func NewIdentityPolicyComputer(params Params) *IdentityPolicyComputer {
+	obj := &IdentityPolicyComputer{
+		db:  params.DB,
+		tbl: params.Table,
+
+		repo:      params.Repo,
+		idmanager: params.IDManager,
+
+		logger: params.Logger,
+
+		policyCacheEvents: params.PolicyCacheEvents,
+	}
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			params.JobGroup.Add(
+				job.Observer[policy.PolicyCacheChange](
+					"policy-cache-observer",
+					obj.handlePolicyCacheEvent,
+					obj.policyCacheEvents,
+				),
+			)
+			return nil
+		},
+		OnStop: func(cell.HookContext) error { return nil },
+	})
+	return obj
+}
+
+// IdentityPolicyComputer handles policy computation for specific identities.
+type IdentityPolicyComputer struct {
+	logger *slog.Logger
+
+	db  *statedb.DB
+	tbl statedb.RWTable[Result]
+
+	repo      policy.PolicyRepository
+	idmanager identitymanager.IDManager
+
+	policyCacheEvents stream.Observable[policy.PolicyCacheChange]
+}
+
+type Params struct {
+	cell.In
+
+	Lifecycle cell.Lifecycle
+	Logger    *slog.Logger
+	JobGroup  job.Group
+
+	DB    *statedb.DB
+	Table statedb.RWTable[Result]
+
+	Repo      policy.PolicyRepository
+	IDManager identitymanager.IDManager
+
+	PolicyCacheEvents stream.Observable[policy.PolicyCacheChange]
+}
+
+func InstantiateCellForTesting(tb testing.TB, logger *slog.Logger, id, desc string, repo policy.PolicyRepository, idmgr identitymanager.IDManager) PolicyRecomputer {
+	tb.Helper()
+
+	var pc PolicyRecomputer
+
+	h := hive.New(
+		cell.Module(id, desc,
+			cell.Invoke(
+				func(c_ PolicyRecomputer) error {
+					pc = c_
+					return nil
+				},
+			),
+
+			cell.ProvidePrivate(func() (policy.PolicyRepository, stream.Observable[policy.PolicyCacheChange]) {
+				return repo, repo.PolicyCacheObservable()
+			}),
+			cell.ProvidePrivate(func() identitymanager.IDManager { return idmgr }),
+
+			cell.Provide(
+				func(params Params) PolicyRecomputer {
+					return NewIdentityPolicyComputer(params)
+				},
+			),
+			cell.Provide(NewPolicyComputationTable),
+			cell.Provide(statedb.RWTable[Result].ToTable),
+		),
+	)
+
+	if err := h.Start(logger, context.Background()); err != nil {
+		tb.Fatalf("failed to start hive: %v", err)
+	}
+	tb.Cleanup(func() {
+		if err := h.Stop(logger, context.Background()); err != nil {
+			tb.Fatalf("failed to stop hive: %v", err)
+		}
+	})
+
+	return pc
+}

--- a/pkg/policy/compute/compute.go
+++ b/pkg/policy/compute/compute.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+type PolicyRecomputer interface {
+	RecomputeIdentityPolicy(identity *identity.Identity, toRev uint64) (<-chan struct{}, error)
+	RecomputeIdentityPolicyForAllIdentities(toRev uint64) (*statedb.WatchSet, error)
+	UpdatePolicy(idsToRegen set.Set[identity.NumericIdentity], fromRev, toRev uint64)
+	GetIdentityPolicyByNumericIdentity(identity identity.NumericIdentity) (Result, statedb.Revision, <-chan struct{}, bool)
+	GetIdentityPolicyByIdentity(identity *identity.Identity) (Result, statedb.Revision, <-chan struct{}, bool)
+}
+
+type Result struct {
+	Identity             identity.NumericIdentity
+	NewPolicy, OldPolicy policy.SelectorPolicy
+	Revision             uint64
+	NeedsRelease         bool
+	Err                  error
+}
+
+func (r *IdentityPolicyComputer) UpdatePolicy(idsToRegen set.Set[identity.NumericIdentity], _, toRev uint64) {
+	for id := range idsToRegen.Members() {
+		if idd := r.idmanager.Get(&id); idd != nil {
+			_, _ = r.RecomputeIdentityPolicy(idd, toRev)
+		} else {
+			r.logger.Debug("Policy recomputation skipped due to non-local identity", logfields.Identity, id)
+		}
+	}
+}
+
+// RecomputeIdentityPolicy recomputes the policy for a specific identity.
+func (r *IdentityPolicyComputer) RecomputeIdentityPolicy(identity *identity.Identity, toRev uint64) (<-chan struct{}, error) {
+	r.logger.Debug(
+		"Recomputing policy for identity",
+		logfields.Identity, identity,
+		logfields.PolicyRevision, toRev,
+	)
+
+	ch := make(chan struct{}, 1)
+	go func() {
+		defer close(ch)
+
+		res := Result{Identity: identity.ID}
+
+		// ReadTxn avoids holding the table lock during expensive computation.
+		obj, _, found := r.tbl.Get(r.db.ReadTxn(), PolicyComputationByIdentity(identity.ID))
+		if found && obj.Revision >= toRev {
+			return
+		}
+
+		// Compute policy without holding any transaction. This can be
+		// expensive for policies that read Kubernetes secrets (TLS).
+		res.NewPolicy, res.Revision, res.OldPolicy, res.NeedsRelease, res.Err = r.repo.ComputeSelectorPolicy(identity, toRev)
+
+		// Acquire WriteTxn only for the insert so the statedb watch
+		// channel fires promptly, unblocking endpoint regeneration.
+		wtxn := r.db.WriteTxn(r.tbl)
+		obj, _, found = r.tbl.Get(wtxn, PolicyComputationByIdentity(identity.ID))
+		if found && obj.Revision >= res.Revision {
+			wtxn.Abort()
+			return
+		}
+		_, _, err := r.tbl.Insert(wtxn, res)
+		if err != nil {
+			wtxn.Abort()
+			r.logger.Error("Failed to write into statedb policy computation table",
+				logfields.Error, err,
+				logfields.Identity, identity.ID,
+				logfields.PolicyRevision, toRev,
+			)
+			return
+		}
+		wtxn.Commit()
+
+		r.logger.Debug(
+			"Policy recomputation completed",
+			logfields.Identity, identity,
+			logfields.PolicyRevision, toRev,
+		)
+
+		if res.OldPolicy != nil && res.NeedsRelease {
+			res.OldPolicy.MaybeDetach()
+		}
+	}()
+
+	r.logger.Debug(
+		"Policy recomputation scheduled",
+		logfields.Identity, identity,
+		logfields.PolicyRevision, toRev,
+	)
+
+	return ch, nil
+}
+
+// RecomputeIdentityPolicyForAllIdentities recomputes policy for all local identities.
+func (r *IdentityPolicyComputer) RecomputeIdentityPolicyForAllIdentities(toRev uint64) (*statedb.WatchSet, error) {
+	ws := statedb.NewWatchSet()
+
+	r.logger.Info("Recomputing policy for all identities")
+	for _, id := range r.idmanager.GetAll() {
+		if ch, err := r.RecomputeIdentityPolicy(id, toRev); err != nil {
+			return nil, err
+		} else {
+			ws.Add(ch)
+		}
+	}
+	return ws, nil
+}
+
+func (r *IdentityPolicyComputer) GetIdentityPolicyByNumericIdentity(identity identity.NumericIdentity) (Result, statedb.Revision, <-chan struct{}, bool) {
+	return r.tbl.GetWatch(r.db.ReadTxn(), PolicyComputationByIdentity(identity))
+}
+
+func (r *IdentityPolicyComputer) GetIdentityPolicyByIdentity(identity *identity.Identity) (Result, statedb.Revision, <-chan struct{}, bool) {
+	if identity == nil {
+		return Result{}, 0, nil, false
+	}
+	return r.GetIdentityPolicyByNumericIdentity(identity.ID)
+}
+
+func (r *IdentityPolicyComputer) handlePolicyCacheEvent(ctx context.Context, event policy.PolicyCacheChange) error {
+	r.logger.Debug("Handle policy cache event", logfields.Identity, event.ID)
+
+	// Handle DELETE first — the identity may already be removed from the manager
+	// by the time we process this event, but we still need to clean up statedb.
+	if event.Kind == policy.PolicyChangeDelete {
+		wtxn := r.db.WriteTxn(r.tbl)
+		obj, _, found := r.tbl.Get(wtxn, PolicyComputationByIdentity(event.ID))
+		if !found {
+			wtxn.Abort()
+			return nil
+		}
+		_, _, err := r.tbl.Delete(wtxn, obj)
+		if err != nil {
+			wtxn.Abort()
+			return fmt.Errorf("failed to delete from statedb policy computation table: %w", err)
+		}
+		wtxn.Commit()
+		return nil
+	}
+
+	identity := r.idmanager.Get(&event.ID)
+	if identity == nil {
+		return nil
+	}
+
+	if event.Kind == policy.PolicyChangeInsert {
+		_, err := r.RecomputeIdentityPolicy(identity, 0)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/policy/compute/compute_test.go
+++ b/pkg/policy/compute/compute_test.go
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/cilium/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/testutils"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+)
+
+// TestWatchChannelFiresOnUpdate verifies statedb watch channels fire correctly
+// when entries are created or updated via the production code paths.
+func TestWatchChannelFiresOnUpdate(t *testing.T) {
+	testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
+
+	t.Run("not found then created", func(t *testing.T) {
+		_, _, computer := fixture(t)
+
+		targetID := identity.NumericIdentity(7)
+
+		_, _, watch, found := computer.GetIdentityPolicyByIdentity(
+			&identity.Identity{ID: targetID},
+		)
+		require.False(t, found)
+		require.NotNil(t, watch)
+
+		done, err := computer.RecomputeIdentityPolicy(
+			&identity.Identity{ID: targetID}, 1,
+		)
+		require.NoError(t, err)
+		<-done
+
+		select {
+		case <-watch:
+		case <-time.After(time.Second):
+			t.Fatal("watch channel not closed after key creation")
+		}
+
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(
+			&identity.Identity{ID: targetID},
+		)
+		require.True(t, found)
+		assert.Equal(t, targetID, obj.Identity)
+	})
+
+	t.Run("stale revision then updated", func(t *testing.T) {
+		db, table, computer := fixture(t)
+
+		targetID := identity.NumericIdentity(10)
+
+		done, err := computer.RecomputeIdentityPolicy(
+			&identity.Identity{ID: targetID}, 1,
+		)
+		require.NoError(t, err)
+		<-done
+
+		obj, _, watch, found := computer.GetIdentityPolicyByNumericIdentity(targetID)
+		require.True(t, found)
+		require.NotNil(t, watch)
+
+		select {
+		case <-watch:
+			t.Fatal("watch channel closed before any update")
+		default:
+		}
+
+		// Direct WriteTxn because RecomputeIdentityPolicy can't bump revision
+		// without a real repo (revision always comes from the repo, which is 0 in tests).
+		wtxn := db.WriteTxn(table)
+		_, _, err = table.Insert(wtxn, Result{Identity: targetID, Revision: obj.Revision + 1})
+		require.NoError(t, err)
+		wtxn.Commit()
+
+		select {
+		case <-watch:
+		case <-time.After(time.Second):
+			t.Fatal("watch channel not closed after revision update")
+		}
+
+		obj, _, _, found = computer.GetIdentityPolicyByNumericIdentity(targetID)
+		require.True(t, found)
+		assert.Equal(t, uint64(1), obj.Revision)
+	})
+
+	t.Run("watch loop with spurious wakes from concurrent writes", func(t *testing.T) {
+		// Concurrent writes to unrelated identities cause spurious watch
+		// wake-ups. The loop must never accept a wrong identity's data.
+		db, table, computer := fixture(t)
+
+		targetID := identity.NumericIdentity(20)
+		wantedRevision := uint64(3)
+
+		done, err := computer.RecomputeIdentityPolicy(
+			&identity.Identity{ID: targetID}, 1,
+		)
+		require.NoError(t, err)
+		<-done
+
+		type loopResult struct {
+			obj        Result
+			found      bool
+			iterations int64
+		}
+		resultCh := make(chan loopResult, 1)
+		go func() {
+			timeout := time.NewTimer(2 * time.Second)
+			defer timeout.Stop()
+			var iters int64
+			for {
+				iters++
+				obj, _, watch, found := computer.GetIdentityPolicyByNumericIdentity(targetID)
+				if found && obj.Revision >= wantedRevision {
+					resultCh <- loopResult{obj: obj, found: true, iterations: iters}
+					return
+				}
+				if found {
+					require.Equal(t, targetID, obj.Identity)
+				}
+				select {
+				case <-watch:
+					continue
+				case <-timeout.C:
+					resultCh <- loopResult{found: false, iterations: iters}
+					return
+				}
+			}
+		}()
+
+		noiseDone := make(chan struct{})
+		go func() {
+			defer close(noiseDone)
+			for i := identity.NumericIdentity(100); i < 110; i++ {
+				wtxn := db.WriteTxn(table)
+				table.Insert(wtxn, Result{Identity: i, Revision: 1})
+				wtxn.Commit()
+				time.Sleep(5 * time.Millisecond)
+			}
+		}()
+
+		time.Sleep(30 * time.Millisecond)
+		for _, rev := range []uint64{2, 3} {
+			wtxn := db.WriteTxn(table)
+			_, _, err := table.Insert(wtxn, Result{Identity: targetID, Revision: rev})
+			require.NoError(t, err)
+			wtxn.Commit()
+			time.Sleep(5 * time.Millisecond)
+		}
+
+		<-noiseDone
+
+		select {
+		case r := <-resultCh:
+			require.True(t, r.found)
+			assert.Equal(t, targetID, r.obj.Identity)
+			assert.GreaterOrEqual(t, r.obj.Revision, wantedRevision)
+			t.Logf("loop completed in %d iterations", r.iterations)
+		case <-time.After(2 * time.Second):
+			t.Fatal("endpoint goroutine did not receive result in time")
+		}
+	})
+}
+
+func TestRecomputeIdentityPolicy(t *testing.T) {
+	testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
+	db, table, computer := fixture(t)
+	assert.NotNil(t, db)
+	assert.NotNil(t, table)
+
+	init, err := computer.RecomputeIdentityPolicy(&identity.Identity{ID: identity.NumericIdentity(4)}, 0)
+	assert.NoError(t, err)
+	<-init
+
+	ch := make(chan struct{})
+	var (
+		wg     sync.WaitGroup
+		result Result
+	)
+	wg.Add(1)
+	once := sync.Once{}
+	go func() {
+		defer wg.Done()
+
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			var (
+				found bool
+				watch <-chan struct{}
+			)
+			res, _, watch, found := computer.GetIdentityPolicyByNumericIdentity(identity.NumericIdentity(1))
+			if found {
+				result = res
+				return
+			}
+			once.Do(func() { close(ch) })
+			select {
+			case <-ticker.C:
+			case <-watch:
+			}
+		}
+	}()
+
+	<-ch
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ch, err := computer.RecomputeIdentityPolicy(&identity.Identity{ID: identity.NumericIdentity(1)}, 0)
+		assert.NoError(t, err)
+		<-ch
+	}()
+
+	wg.Wait()
+
+	assert.Equal(t, identity.NumericIdentity(1), result.Identity)
+}
+
+func fixture(t *testing.T) (*statedb.DB, statedb.RWTable[Result], PolicyRecomputer) {
+	t.Helper()
+
+	logger := hivetest.Logger(t)
+	idmgr := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+
+	var (
+		db       *statedb.DB
+		table    statedb.RWTable[Result]
+		computer PolicyRecomputer
+	)
+
+	h := hive.New(
+		cell.Module("test", "test",
+			cell.Invoke(
+				func(t statedb.RWTable[Result], db_ *statedb.DB, c_ PolicyRecomputer) error {
+					table = t
+					db = db_
+					computer = c_
+					return nil
+				},
+			),
+
+			cell.ProvidePrivate(func() (policy.PolicyRepository, stream.Observable[policy.PolicyCacheChange]) {
+				return repo, repo.PolicyCacheObservable()
+			}),
+			cell.ProvidePrivate(func() identitymanager.IDManager { return idmgr }),
+
+			cell.Provide(
+				func(params Params) PolicyRecomputer {
+					return NewIdentityPolicyComputer(params)
+				},
+			),
+			cell.ProvidePrivate(NewPolicyComputationTable),
+		),
+	)
+
+	if err := h.Start(logger, context.Background()); err != nil {
+		t.Fatalf("failed to start hive: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Stop(logger, context.Background()); err != nil {
+			t.Fatalf("failed to stop hive: %v", err)
+		}
+	})
+
+	assert.NotNil(t, db)
+	assert.NotNil(t, table)
+	assert.NotNil(t, computer)
+
+	return db, table, computer
+}

--- a/pkg/policy/compute/script_cmds.go
+++ b/pkg/policy/compute/script_cmds.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"github.com/cilium/hive/script"
+)
+
+func PolicyComputerScriptCmds(pc *IdentityPolicyComputer) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"policy/compute-all": script.Command(
+			script.CmdUsage{
+				Summary: "Recompute policy for all idenities",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				// TODO: Maybe add a flag to control whether to bump the revision or not.
+				ws, err := pc.RecomputeIdentityPolicyForAllIdentities(pc.repo.GetRevision())
+				if err != nil {
+					return nil, err
+				}
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					_, err = ws.Wait(s.Context(), 0)
+					return "", "", err
+				}, nil
+			},
+		),
+	}
+}

--- a/pkg/policy/compute/table.go
+++ b/pkg/policy/compute/table.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"strconv"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+func NewPolicyComputationTable(db *statedb.DB) (statedb.RWTable[Result], statedb.Index[Result, identity.NumericIdentity], error) {
+	tbl, err := statedb.NewTable(
+		db,
+		"policy-computations",
+		PolicyComputationNameIndex,
+	)
+	return tbl, PolicyComputationNameIndex, err
+}
+
+var (
+	PolicyComputationNameIndex = statedb.Index[Result, identity.NumericIdentity]{
+		Name: "numeric-identity",
+		FromObject: func(r Result) index.KeySet {
+			return index.NewKeySet(index.Uint32(uint32(r.Identity)))
+		},
+		FromKey:    func(i identity.NumericIdentity) index.Key { return index.Uint32(uint32(i)) },
+		FromString: index.Uint32String,
+		Unique:     true,
+	}
+
+	PolicyComputationByIdentity = PolicyComputationNameIndex.Query
+)
+
+func (Result) TableHeader() []string {
+	return []string{"Identity", "NewPolicy", "OldPolicy", "Revision", "NeedsRelease", "Err"}
+}
+
+func (r Result) TableRow() []string {
+	var serr string
+	if r.Err != nil {
+		serr = r.Err.Error()
+	}
+	var newRev uint64
+	if r.NewPolicy != nil {
+		newRev = r.NewPolicy.GetRevision()
+	}
+	var oldRev uint64
+	if r.OldPolicy != nil {
+		oldRev = r.OldPolicy.GetRevision()
+	}
+	return []string{
+		r.Identity.String(),
+		strconv.FormatUint(newRev, 10),
+		strconv.FormatUint(oldRev, 10),
+		strconv.FormatUint(r.Revision, 10),
+		strconv.FormatBool(r.NeedsRelease),
+		serr,
+	}
+}

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -124,10 +124,10 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 // is still referring to the old identity.
 //
 // Must be called with repo.Mutex held for reading.
-func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, bool, error) {
+func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, *selectorPolicy, bool, error) {
 	cip, ok := cache.lookup(identity)
 	if !ok {
-		return nil, false, fmt.Errorf("SelectorPolicy not found in cache for ID %d", identity.ID)
+		return nil, nil, false, fmt.Errorf("SelectorPolicy not found in cache for ID %d", identity.ID)
 	}
 
 	// As long as UpdatePolicy() is triggered from endpoint
@@ -144,18 +144,16 @@ func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, e
 
 	// Don't resolve policy if it was already done for this or later revision.
 	if selPolicy := cip.getPolicy(); selPolicy != nil && selPolicy.Revision >= cache.repo.GetRevision() {
-		return selPolicy, false, nil
+		return selPolicy, nil, false, nil
 	}
 
 	// Resolve the policies, which could fail
 	selPolicy, err := cache.repo.resolvePolicyLocked(identity)
 	if err != nil {
-		return nil, false, err
+		return nil, nil, false, err
 	}
 
-	cip.setPolicy(selPolicy, endpointID)
-
-	return selPolicy, true, nil
+	return selPolicy, cip.setPolicy(selPolicy, endpointID), true, nil
 }
 
 // LocalEndpointIdentityAdded creates a SelectorPolicy cache entry for the
@@ -238,10 +236,11 @@ func (cip *cachedSelectorPolicy) getPolicy() *selectorPolicy {
 // the endpoint that initiated the old selector policy detach. Since detach
 // can trigger endpoint regenerations of all it users, this ensures
 // that endpoints do not continuously update themselves.
-func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) {
+func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) *selectorPolicy {
 	oldPolicy := cip.policy.Swap(policy)
 	if oldPolicy != nil {
 		// Release the references the previous policy holds on the selector cache.
 		oldPolicy.detach(false, endpointID)
 	}
+	return oldPolicy
 }

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -286,15 +286,8 @@ func (cip *cachedSelectorPolicy) getPolicy() *selectorPolicy {
 }
 
 // setPolicy updates the reference to the SelectorPolicy that is cached.
-// Calls Detach() on the old policy, if any. It passes the endpointID of
-// the endpoint that initiated the old selector policy detach. Since detach
-// can trigger endpoint regenerations of all it users, this ensures
-// that endpoints do not continuously update themselves.
+// Callers are responsible for detaching the old policy as appropriate.
 func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) *selectorPolicy {
 	oldPolicy := cip.policy.Swap(policy)
-	if oldPolicy != nil {
-		// Release the references the previous policy holds on the selector cache.
-		oldPolicy.detach(false, endpointID)
-	}
 	return oldPolicy
 }

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -4,6 +4,7 @@
 package policy
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -11,11 +12,15 @@ import (
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/lock"
+
+	"github.com/cilium/stream"
 )
 
 // policyCache represents a cache of resolved policies for identities.
 type policyCache struct {
 	lock.Mutex
+	// Used to implement the stream.Observable interface.
+	stream.Observable[PolicyCacheChange]
 
 	// repo is a circular reference back to the Repository, but as
 	// we create only one Repository and one PolicyCache for each
@@ -23,13 +28,21 @@ type policyCache struct {
 	// collected.
 	repo     *Repository
 	policies map[identityPkg.NumericIdentity]*cachedSelectorPolicy
+
+	// emitChange is used with the observable embedded in this struct.
+	emitChange func(PolicyCacheChange)
 }
 
 // newPolicyCache creates a new cache of SelectorPolicy.
 func newPolicyCache(repo *Repository, idmgr identitymanager.IDManager) *policyCache {
+	mcast, emit, _ := stream.Multicast[PolicyCacheChange]()
 	cache := &policyCache{
+		Observable: mcast,
+
 		repo:     repo,
 		policies: make(map[identityPkg.NumericIdentity]*cachedSelectorPolicy),
+
+		emitChange: emit,
 	}
 	if idmgr != nil {
 		idmgr.Subscribe(cache)
@@ -84,6 +97,7 @@ func (cache *policyCache) insert(identity *identityPkg.Identity) *cachedSelector
 		cip = newCachedSelectorPolicy(identity)
 		cache.policies[identity.ID] = cip
 	}
+	cache.emitChange(PolicyCacheChange{Kind: PolicyChangeInsert, ID: identity.ID})
 	return cip
 }
 
@@ -107,6 +121,7 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 			selPolicy.detach(true, 0)
 		}
 	}
+	cache.emitChange(PolicyCacheChange{Kind: PolicyChangeDelete, ID: identity.ID})
 	return ok
 }
 
@@ -166,6 +181,45 @@ func (cache *policyCache) LocalEndpointIdentityAdded(identity *identityPkg.Ident
 // specified Identity.
 func (cache *policyCache) LocalEndpointIdentityRemoved(identity *identityPkg.Identity) {
 	cache.delete(identity)
+}
+
+// Implements stream.Observable. Replays initial state as a sequence of adds.
+func (cache *policyCache) Observe(ctx context.Context, next func(PolicyCacheChange), complete func(error)) {
+	cache.Lock()
+	defer cache.Unlock()
+
+	for id := range cache.policies {
+		select {
+		case <-ctx.Done():
+			complete(ctx.Err())
+			return
+		default:
+		}
+		next(PolicyCacheChange{Kind: PolicyChangeInsert, ID: id})
+	}
+
+	select {
+	case <-ctx.Done():
+		complete(ctx.Err())
+		return
+	default:
+	}
+	next(PolicyCacheChange{Kind: PolicyChangeSync})
+
+	cache.Observable.Observe(ctx, next, complete)
+}
+
+type PolicyChangeKind string
+
+const (
+	PolicyChangeSync   PolicyChangeKind = "sync"
+	PolicyChangeInsert PolicyChangeKind = "Insert"
+	PolicyChangeDelete PolicyChangeKind = "delete"
+)
+
+type PolicyCacheChange struct {
+	Kind PolicyChangeKind
+	ID   identityPkg.NumericIdentity
 }
 
 // getAuthTypes returns the AuthTypes required by the policy between the localID and remoteID, if

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -93,13 +93,13 @@ func TestCachePopulation(t *testing.T) {
 	cip1 := cache.insert(identity1)
 
 	// Calculate the policy and observe that it's cached
-	policy1, updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
+	policy1, _, updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.True(t, updated)
-	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
+	_, _, updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.False(t, updated)
-	policy3, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
+	policy3, _, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NotNil(t, policy1)
 	require.Same(t, policy1, policy3)
 	cip2, ok := cache.lookup(identity1)
@@ -109,17 +109,17 @@ func TestCachePopulation(t *testing.T) {
 	// Remove the identity and observe that it is no longer available
 	cacheCleared := cache.delete(identity1)
 	require.True(t, cacheCleared)
-	_, _, err = cache.updateSelectorPolicy(identity1, ep1.Id)
+	_, _, _, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.Error(t, err)
 
 	// Attempt to update policy for non-cached endpoint and observe failure
 	ep3 := testutils.NewTestEndpoint(t)
 	ep3.SetIdentity(1234, true)
-	_, _, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+	_, _, _, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
 	require.Error(t, err)
 
 	cache.insert(ep3.GetSecurityIdentity())
-	policy4, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+	policy4, _, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
 
 	// policy4 must be different from ep1, ep2
 	require.NoError(t, err)
@@ -132,9 +132,9 @@ func TestCachePopulation(t *testing.T) {
 	idp1 := policy5.getPolicy()
 	require.Nil(t, idp1)
 
-	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.GetID())
-	require.NoError(t, err)
+	_, _, updated, err = cache.updateSelectorPolicy(identity1, ep1.GetID())
 	require.True(t, updated)
+	require.NoError(t, err)
 
 	idp1 = policy5.getPolicy()
 	require.NotNil(t, idp1)
@@ -142,13 +142,13 @@ func TestCachePopulation(t *testing.T) {
 	identity3 := ep3.GetSecurityIdentity()
 	policy6 := cache.insert(identity3)
 	require.NotEqual(t, policy5, policy6)
-	idp3, updated, err := cache.updateSelectorPolicy(identity3, ep3.GetID())
+	idp3, _, updated, err := cache.updateSelectorPolicy(identity3, ep3.GetID())
 	require.NoError(t, err)
 	require.False(t, updated)
 	require.Equal(t, idp1, idp3)
 
 	repo.revision.Store(43)
-	idp3, updated, err = cache.updateSelectorPolicy(identity3, ep3.GetID())
+	idp3, _, updated, err = cache.updateSelectorPolicy(identity3, ep3.GetID())
 	require.NoError(t, err)
 	require.True(t, updated)
 	idp1 = policy5.getPolicy()

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1298,11 +1298,47 @@ type L4PolicyMap struct {
 	NamedPortMap map[string]*L4Filter
 	// RangePortMap is a map of all L4Filters indexed by their port-
 	// protocol.
-	RangePortMap map[portProtoKey]*L4Filter
+	RangePortMap rangePortMap
 	// RangePortIndex is an index of all L4Filters so that
 	// L4Filters that have overlapping port ranges can be looked up
 	// by with a single port.
 	RangePortIndex *bitlpm.UintTrie[uint32, map[portProtoKey]struct{}]
+}
+
+type rangePortMap map[portProtoKey]*L4Filter
+
+func (r rangePortMap) MarshalJSON() ([]byte, error) {
+	if len(r) == 0 {
+		return []byte{'{', '}'}, nil
+	}
+
+	first := true
+	buffer := bytes.NewBufferString("{")
+	for ppk, filter := range r {
+		if !first {
+			buffer.WriteRune(',')
+		}
+		first = false
+
+		buffer.WriteRune('"')
+		buffer.WriteString(strconv.FormatUint(uint64(ppk.Port), 10))
+		buffer.WriteRune('-')
+		buffer.WriteString(strconv.FormatUint(uint64(ppk.EndPort), 10))
+		buffer.WriteRune('/')
+		buffer.WriteString(strconv.FormatUint(uint64(ppk.Proto), 10))
+		buffer.WriteRune('"')
+
+		buffer.WriteRune(':')
+
+		b, err := json.Marshal(filter)
+		if err != nil {
+			return nil, err
+		}
+		buffer.Write(b)
+	}
+	buffer.WriteRune('}')
+
+	return buffer.Bytes(), nil
 }
 
 func parsePortProtocol(port, protocol string) (uint16, uint8) {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1516,6 +1516,14 @@ type L4Policy struct {
 	mutex lock.RWMutex
 	users map[*EndpointPolicy]struct{}
 
+	// holdCount prevents detachment between policy fetch and insertUser registration.
+	holdCount int
+
+	// superseded is set when this policy has been replaced by a newer one.
+	// shouldDetachLocked only performs full detachment for superseded policies,
+	// preventing premature detachment of policies still current in statedb.
+	superseded bool
+
 	// detachedTime can be used for users that don't need to grab the lock.
 	detachedTime atomic.Pointer[time.Time]
 }
@@ -1530,11 +1538,64 @@ func NewL4Policy(revision uint64) L4Policy {
 	}
 }
 
+// addHold prevents detachment between policy fetch and insertUser.
+// Returns false if already detached.
+func (l4 *L4Policy) addHold() bool {
+	l4.mutex.Lock()
+	defer l4.mutex.Unlock()
+	if l4.users == nil {
+		return false
+	}
+	l4.holdCount++
+	return true
+}
+
+// releaseHold decrements the hold count, detaching the policy if no users
+// or holds remain. Used on error paths when insertUser will not be called.
+func (l4 *L4Policy) releaseHold(selectorCache *SelectorCache) {
+	l4.mutex.Lock()
+	if l4.holdCount > 0 {
+		l4.holdCount--
+	}
+	needsDetach := l4.shouldDetachLocked()
+	l4.mutex.Unlock()
+
+	if needsDetach {
+		l4.finishDetach(selectorCache)
+	}
+}
+
+// shouldDetachLocked marks the policy as detached (users=nil) if no users,
+// holds, or active references remain. Returns true if the caller must call
+// finishDetach after releasing l4.mutex.
+//
+// The superseded check prevents premature detachment when removeUser drains
+// a policy that is still the current statedb entry — without it, removeUser
+// would create a permanently stale entry that traps endpoints in a regen loop.
+//
+// Must be called with l4.mutex held.
+func (l4 *L4Policy) shouldDetachLocked() bool {
+	if l4.holdCount == 0 && l4.users != nil && len(l4.users) == 0 && l4.superseded {
+		l4.users = nil
+		l4.detachedTime.Store(ptr.To(time.Now()))
+		return true
+	}
+	return false
+}
+
+// finishDetach removes cached selectors from the SelectorCache.
+// Must be called WITHOUT l4.mutex held (takes sc.mutex internally).
+func (l4 *L4Policy) finishDetach(selectorCache *SelectorCache) {
+	l4.Ingress.Detach(selectorCache)
+	l4.Egress.Detach(selectorCache)
+}
+
 // insertUser adds a user to the L4Policy so that incremental
 // updates of the L4Policy may be forwarded to the users of it.
 // May not call into SelectorCache, as SelectorCache is locked during this call.
-func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
+func (l4 *L4Policy) insertUser(user *EndpointPolicy, selectorCache *SelectorCache) {
 	l4.mutex.Lock()
+	defer l4.mutex.Unlock()
 
 	// 'users' is set to nil when the policy is detached. This
 	// happens to the old policy when it is being replaced with a
@@ -1557,21 +1618,26 @@ func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 		})
 	}
 
-	l4.mutex.Unlock()
+	// Release hold; detach impossible here (user count >= 1 or already detached).
+	if l4.holdCount > 0 {
+		l4.holdCount--
+	}
 }
 
 // removeUser removes a user that no longer needs incremental updates
-// from the L4Policy.
-func (l4 *L4Policy) removeUser(user *EndpointPolicy) {
-	// 'users' is set to nil when the policy is detached. This
-	// happens to the old policy when it is being replaced with a
-	// new one, or when the last endpoint using this policy is
-	// removed.
+// from the L4Policy. It detaches the policy if this was the last user
+// and there are no outstanding holds.
+func (l4 *L4Policy) removeUser(user *EndpointPolicy, selectorCache *SelectorCache) {
 	l4.mutex.Lock()
 	if l4.users != nil {
 		delete(l4.users, user)
 	}
+	needsDetach := l4.shouldDetachLocked()
 	l4.mutex.Unlock()
+
+	if needsDetach {
+		l4.finishDetach(selectorCache)
+	}
 }
 
 // AccumulateMapChanges distributes the given changes to the registered users.
@@ -1701,26 +1767,34 @@ func (l4Policy *L4Policy) SyncMapChanges(l4 *L4Filter, txn SelectorSnapshot) {
 // Note that the L4Policy itself is not modified in any way, so that it may still
 // be used concurrently.
 func (l4 *L4Policy) detach(selectorCache *SelectorCache, isDelete bool, endpointID uint64) {
-	l4.Ingress.Detach(selectorCache)
-	l4.Egress.Detach(selectorCache)
+	if isDelete {
+		l4.Ingress.Detach(selectorCache)
+		l4.Egress.Detach(selectorCache)
+		l4.mutex.Lock()
+		defer l4.mutex.Unlock()
+		l4.users = nil
+		l4.detachedTime.Store(ptr.To(time.Now()))
+		return
+	}
 
+	// Notify existing users to regenerate so they migrate to the new policy.
 	l4.mutex.Lock()
-	defer l4.mutex.Unlock()
-	// If this detach is a delete there is no reason to initiate
-	// a regenerate.
-	if !isDelete {
-		for ePolicy := range l4.users {
-			if endpointID != ePolicy.PolicyOwner.GetID() {
-				go ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
-					Reason:            regeneration.ReasonSelectorPolicyStale,
-					Message:           "selector policy has changed because of another endpoint with the same identity",
-					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
-				})
-			}
+	for ePolicy := range l4.users {
+		if endpointID != ePolicy.PolicyOwner.GetID() {
+			go ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+				Reason:            regeneration.ReasonSelectorPolicyStale,
+				Message:           "selector policy has changed because of another endpoint with the same identity",
+				RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+			})
 		}
 	}
-	l4.users = nil
-	l4.detachedTime.Store(ptr.To(time.Now()))
+	l4.superseded = true
+	needsDetach := l4.shouldDetachLocked()
+	l4.mutex.Unlock()
+
+	if needsDetach {
+		l4.finishDetach(selectorCache)
+	}
 }
 
 // Attach makes all the L4Filters to point back to the L4Policy that contains them.

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -4,7 +4,6 @@
 package policy
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -27,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/policy/utils"
+	testcertificatemanager "github.com/cilium/cilium/pkg/testutils/certificatemanager"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 )
 
@@ -78,7 +78,7 @@ func newTestData(tb testing.TB, logger *slog.Logger) *testData {
 		identityManager:   idMgr,
 		sc:                testNewSelectorCache(tb, logger, nil),
 		subjectSc:         testNewSelectorCache(tb, logger, nil),
-		repo:              NewPolicyRepository(logger, nil, &fakeCertificateManager{}, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
+		repo:              NewPolicyRepository(logger, nil, &testcertificatemanager.Fake{}, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
 		idSet:             set.NewSet[identity.NumericIdentity](),
 		testPolicyContext: &testPolicyContextType{logger: logger},
 	}
@@ -2788,22 +2788,4 @@ func TestDefaultAllowL7Rules(t *testing.T) {
 			require.True(t, anyPerSelectorPolicy, "Should have at least one PerSelectorPolicy")
 		})
 	}
-}
-
-type fakeCertificateManager struct{}
-
-const (
-	fakeCA         = "fake ca"
-	fakePublicKey  = "fake public key"
-	fakePrivateKey = "fake private key"
-)
-
-func (_ *fakeCertificateManager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, inlineSecrets bool, err error) {
-	name := tlsCtx.Secret.Name
-	public = fakePublicKey + " " + name
-	private = fakePrivateKey + " " + name
-	ca = fakeCA + " " + name
-
-	inlineSecrets = true
-	return
 }

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -7,20 +7,28 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"iter"
+	"log/slog"
 	"math/rand/v2"
 	"slices"
 	"sort"
 	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/testutils"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -644,4 +652,191 @@ func BenchmarkEvaluateL4PolicyMapState(b *testing.B) {
 			}
 		}
 	})
+}
+
+// TestHoldCountRealCodePath validates that holdCount prevents premature detachment
+// when multiple endpoints share a selectorPolicy through DistillPolicy.
+func TestHoldCountRealCodePath(t *testing.T) {
+	repo := NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo.revision.Store(1)
+	cache := repo.policyCache
+
+	ep1 := testutils.NewTestEndpoint(t)
+	identity1 := ep1.GetSecurityIdentity()
+
+	cache.insert(identity1)
+
+	policy, _, _, err := cache.updateSelectorPolicy(identity1, ep1.Id)
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+
+	require.Equal(t, 0, policy.L4Policy.holdCount, "policy should have no holds after updateSelectorPolicy")
+
+	logger := hivetest.Logger(t)
+	existingOwner := newTestPolicyOwner(100, logger)
+
+	held := policy.AddHold()
+	require.True(t, held, "AddHold should succeed on live policy")
+	require.Equal(t, 1, policy.L4Policy.holdCount, "hold should be added")
+
+	existingPolicy := policy.DistillPolicy(logger, existingOwner, nil)
+
+	require.Equal(t, 0, policy.L4Policy.holdCount, "hold should be released after DistillPolicy")
+	require.Len(t, policy.L4Policy.users, 1, "should have 1 user")
+
+	ownerA := newTestPolicyOwner(200, logger)
+	ownerB := newTestPolicyOwner(300, logger)
+
+	require.True(t, policy.AddHold())
+	require.True(t, policy.AddHold())
+	require.Equal(t, 2, policy.L4Policy.holdCount)
+
+	policyA := policy.DistillPolicy(logger, ownerA, nil)
+	require.NotNil(t, policyA)
+	require.Equal(t, 1, policy.L4Policy.holdCount, "one hold should remain for B")
+	require.Len(t, policy.L4Policy.users, 2, "should have existing user + A")
+
+	require.NotSame(t, existingPolicy, policyA, "each endpoint should have its own EndpointPolicy")
+	require.NotSame(t, existingOwner.PreviousMapState(), ownerA.PreviousMapState(), "each endpoint should have its own MapState")
+
+	policy.removeUser(existingPolicy)
+	require.Equal(t, 1, policy.L4Policy.holdCount, "B's hold still outstanding")
+	require.Len(t, policy.L4Policy.users, 1, "should have only A")
+
+	policy.removeUser(policyA)
+
+	// B's outstanding hold prevents detachment even though users is empty.
+	require.Equal(t, 1, policy.L4Policy.holdCount)
+	require.NotNil(t, policy.L4Policy.users)
+	require.Empty(t, policy.L4Policy.users)
+
+	policyB := policy.DistillPolicy(logger, ownerB, nil)
+	require.NotNil(t, policyB)
+	require.NotSame(t, policyB, policyA, "B should have its own EndpointPolicy")
+	require.NotSame(t, ownerB.PreviousMapState(), ownerA.PreviousMapState(), "B should have its own MapState")
+
+	require.Equal(t, 0, policy.L4Policy.holdCount, "B's hold released after DistillPolicy")
+	require.NotNil(t, policy.L4Policy.users, "policy should not be detached")
+	require.Len(t, policy.L4Policy.users, 1, "B should have registered successfully")
+}
+
+// TestAddHoldRejectsDetachedPolicy verifies AddHold returns false on a policy
+// that was detached by MaybeDetach, preventing the regen loop where DistillPolicy
+// fires RegenerateIfAlive on a dead policy.
+func TestAddHoldRejectsDetachedPolicy(t *testing.T) {
+	repo := NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo.revision.Store(1)
+	cache := repo.policyCache
+	logger := hivetest.Logger(t)
+
+	ep := testutils.NewTestEndpoint(t)
+	identity := ep.GetSecurityIdentity()
+	cache.insert(identity)
+
+	repo.mutex.RLock()
+	P, _, _, err := cache.updateSelectorPolicy(identity, 0)
+	repo.mutex.RUnlock()
+	require.NoError(t, err)
+	require.NotNil(t, P.L4Policy.users, "P should be live")
+
+	repo.BumpRevision()
+	repo.mutex.RLock()
+	Q, old, _, err := cache.updateSelectorPolicy(identity, 0)
+	repo.mutex.RUnlock()
+	require.NoError(t, err)
+	require.Same(t, P, old)
+	require.NotSame(t, P, Q)
+
+	old.MaybeDetach()
+	require.Nil(t, P.L4Policy.users, "P should be detached")
+
+	// Endpoint tries to use stale (detached) P.
+	regenOwner := newRegenTrackingOwner(100, logger)
+	held := P.AddHold()
+	if held {
+		P.DistillPolicy(logger, regenOwner, nil)
+	}
+
+	require.False(t, held, "AddHold must reject detached policy")
+	require.Never(t, func() bool {
+		return regenOwner.regenCount.Load() > 0
+	}, 200*time.Millisecond, 10*time.Millisecond,
+		"RegenerateIfAlive must not fire on detached policy")
+
+	// Live policy Q works normally.
+	held = Q.AddHold()
+	require.True(t, held)
+
+	safeOwner := newRegenTrackingOwner(200, logger)
+	epPolicy := Q.DistillPolicy(logger, safeOwner, nil)
+	require.NotNil(t, epPolicy)
+	require.Len(t, Q.L4Policy.users, 1, "endpoint registered on Q")
+	require.Equal(t, int32(0), safeOwner.regenCount.Load(),
+		"no spurious regen when using live policy")
+}
+
+// testPolicyOwner provides a PolicyOwner implementation for tests that need
+// per-endpoint state (logger, previousState).
+type testPolicyOwner struct {
+	id            uint64
+	previousState *MapState
+	logger        *slog.Logger
+}
+
+func newTestPolicyOwner(id uint64, logger *slog.Logger) *testPolicyOwner {
+	return &testPolicyOwner{
+		id:            id,
+		previousState: &MapState{},
+		logger:        logger,
+	}
+}
+
+func (t *testPolicyOwner) GetID() uint64 { return t.id }
+
+func (t *testPolicyOwner) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, _ iter.Seq[identity.NumericIdentity]) uint16 {
+	return 0
+}
+
+func (t *testPolicyOwner) PolicyDebug(msg string, attrs ...any) {
+	if t.logger != nil {
+		t.logger.Debug(msg, attrs...)
+	}
+}
+
+func (t *testPolicyOwner) IsHost() bool { return false }
+
+func (t *testPolicyOwner) PreviousMapState() *MapState {
+	return t.previousState
+}
+
+func (t *testPolicyOwner) RegenerateIfAlive(meta *regeneration.ExternalRegenerationMetadata) <-chan bool {
+	ch := make(chan bool, 1)
+	ch <- false
+	close(ch)
+	return ch
+}
+
+// regenTrackingOwner extends testPolicyOwner with an atomic regen counter
+// to detect when RegenerateIfAlive is fired (the regen loop trigger).
+type regenTrackingOwner struct {
+	testPolicyOwner
+	regenCount atomic.Int32
+}
+
+func newRegenTrackingOwner(id uint64, logger *slog.Logger) *regenTrackingOwner {
+	return &regenTrackingOwner{
+		testPolicyOwner: testPolicyOwner{
+			id:            id,
+			previousState: &MapState{},
+			logger:        logger,
+		},
+	}
+}
+
+func (t *regenTrackingOwner) RegenerateIfAlive(meta *regeneration.ExternalRegenerationMetadata) <-chan bool {
+	t.regenCount.Add(1)
+	ch := make(chan bool, 1)
+	ch <- false
+	close(ch)
+	return ch
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -552,7 +552,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	stats.SelectorPolicyCalculation().Start()
 	// This may call back in to the (locked) repository to generate the
 	// selector policy
-	sp, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
+	sp, _, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
 	stats.SelectorPolicyCalculation().EndError(err)
 
 	// If we hit cache, reset the statistics.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -36,13 +36,18 @@ type PolicyRepository interface {
 	GetAuthTypes(localID identity.NumericIdentity, remoteID identity.NumericIdentity) AuthTypes
 	GetEnvoyHTTPRules(l7Rules *api.L7Rules, ns string) (*cilium.HttpNetworkPolicyRules, bool)
 
-	// GetSelectorPolicy computes the SelectorPolicy for a given identity.
+	// GetSelectorPolicy computes the SelectorPolicy for a given identity. It
+	// is only used in unit tests.
 	//
 	// It returns nil if skipRevision is >= than the already calculated version.
 	// This is used to skip policy calculation when a certain revision delta is
 	// known to not affect the given identity. Pass a skipRevision of 0 to force
 	// calculation.
 	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error)
+
+	// ComputeSelectorPolicy computes the SelectorPolicy for a given identity,
+	// if it needs recomputing.
+	ComputeSelectorPolicy(id *identity.Identity, skipRevision uint64) (SelectorPolicy, uint64, SelectorPolicy, bool, error)
 
 	// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
 	GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy
@@ -529,7 +534,8 @@ func (rules ruleSlice) addDefaultRule(subject *identity.Identity, peers types.Se
 	})
 }
 
-// GetSelectorPolicy computes the SelectorPolicy for a given identity.
+// GetSelectorPolicy computes the SelectorPolicy for a given identity. It is
+// only used in unit tests.
 //
 // It returns nil if skipRevision is >= than the already calculated version.
 // This is used to skip policy calculation when a certain revision delta is
@@ -561,6 +567,21 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	}
 
 	return sp, rev, err
+}
+
+// ComputeSelectorPolicy computes the SelectorPolicy for a given identity, if
+// it needs recomputing.
+func (r *Repository) ComputeSelectorPolicy(id *identity.Identity, skipRevision uint64) (SelectorPolicy, uint64, SelectorPolicy, bool, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	rev := r.GetRevision()
+	sp, old, release, err := r.policyCache.updateSelectorPolicy(id, 0)
+	if err != nil {
+		return nil, 0, nil, release, err
+	}
+
+	return sp, rev, old, release, err
 }
 
 // ReplaceByResource replaces all rules by resource, returning the complete set of affected endpoints.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
+	"github.com/cilium/stream"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -58,6 +59,8 @@ type PolicyRepository interface {
 	Iterate(f func(rule *types.PolicyEntry))
 	ReplaceByResource(rules types.PolicyEntries, resource ipcachetypes.ResourceID) (affectedIDs *set.Set[identity.NumericIdentity], rev uint64, oldRevCnt int)
 	Search() (types.PolicyEntries, uint64)
+
+	PolicyCacheObservable() stream.Observable[PolicyCacheChange]
 }
 
 type GetPolicyStatistics interface {
@@ -633,4 +636,8 @@ func (p *Repository) GetPolicySnapshot() map[identity.NumericIdentity]SelectorPo
 	defer p.mutex.RUnlock()
 
 	return p.policyCache.GetPolicySnapshot()
+}
+
+func (p *Repository) PolicyCacheObservable() stream.Observable[PolicyCacheChange] {
+	return p.policyCache
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -561,8 +561,11 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	stats.SelectorPolicyCalculation().Start()
 	// This may call back in to the (locked) repository to generate the
 	// selector policy
-	sp, _, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
+	sp, old, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
 	stats.SelectorPolicyCalculation().EndError(err)
+	if old != nil {
+		old.detach(false, endpointID)
+	}
 
 	// If we hit cache, reset the statistics.
 	if !updated {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -5,12 +5,18 @@ package policy
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"maps"
+	"os"
+	"strconv"
 	"sync/atomic"
 
+	"github.com/cilium/hive/script"
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	"github.com/cilium/stream"
+	"github.com/davecgh/go-spew/spew"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -21,6 +27,8 @@ import (
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -643,4 +651,89 @@ func (p *Repository) GetPolicySnapshot() map[identity.NumericIdentity]SelectorPo
 
 func (p *Repository) PolicyCacheObservable() stream.Observable[PolicyCacheChange] {
 	return p.policyCache
+}
+
+func RepositoryScriptCmds(p *Repository) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"policyrepo/list": script.Command(
+			script.CmdUsage{
+				Summary: "List all policies in the policy repository",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					policies := p.GetRulesList()
+					return string(policies.Policy), "", nil
+				}, nil
+			},
+		),
+		"policyrepo/selectorcache": script.Command(
+			script.CmdUsage{
+				Summary: "List all policies in the policy repository",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					model := p.GetSelectorCache().GetModel()
+					return spew.Sprint(model), "", nil
+				}, nil
+			},
+		),
+		"policyrepo/add": script.Command(
+			script.CmdUsage{
+				Summary: "Add a policy to the policy repository",
+				Args:    "'policy'",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					file := []string(args)[0]
+
+					b, err := os.ReadFile(s.Path(file))
+					if err != nil {
+						b, err = os.ReadFile(file)
+					}
+					if err != nil {
+						return "", "", fmt.Errorf("failed to read %s: %w", file, err)
+					}
+					obj, _, err := testutils.DecodeObjectGVK(b)
+					if err != nil {
+						return "", "", fmt.Errorf("decode: %w", err)
+					}
+					robj, _ := testutils.DecodeObject(b)
+					objMeta, err := meta.Accessor(obj)
+					if err != nil {
+						return "", "", fmt.Errorf("accessor: %w", err)
+					}
+
+					var (
+						rules api.Rules
+						rev   uint64
+					)
+					if objMeta.GetNamespace() == "" {
+						ccnp := robj.(*v2.CiliumClusterwideNetworkPolicy)
+						rules, err = ccnp.Parse(p.logger, "")
+						if err != nil {
+							return "", "", fmt.Errorf("ccnp parse: %w", err)
+						}
+					} else {
+						cnp := robj.(*v2.CiliumNetworkPolicy)
+						rules, err = cnp.Parse(p.logger, "")
+						if err != nil {
+							return "", "", fmt.Errorf("cnp parse: %w", err)
+						}
+					}
+					_, rev = p.MustAddList(rules)
+					return fmt.Sprintf("Added rules, revision=%d\n", rev), "", nil
+				}, nil
+			},
+		),
+		"policyrepo/bump-revision": script.Command(
+			script.CmdUsage{
+				Summary: "Bump revision of the policy repository",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					return "Bumped revision to " + strconv.FormatUint(p.BumpRevision(), 10) + "\n", "", nil
+				}, nil
+			},
+		),
+	}
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -163,6 +163,11 @@ type SelectorPolicy interface {
 
 	// GetSelectorSnapshot returns a selector snapshot if available and valid
 	GetSelectorSnapshot() SelectorSnapshot
+	AddHold() bool
+	ReleaseHold()
+	Detach()
+	MaybeDetach()
+	GetRevision() uint64
 }
 
 // selectorPolicy is a structure which contains the resolved policy for a
@@ -285,16 +290,48 @@ func newSelectorPolicy(selectorCache *SelectorCache) *selectorPolicy {
 	}
 }
 
+func (p *selectorPolicy) AddHold() bool {
+	return p.L4Policy.addHold()
+}
+
+func (p *selectorPolicy) ReleaseHold() {
+	if p == nil {
+		return
+	}
+	p.L4Policy.releaseHold(p.SelectorCache)
+}
+
+func (p *selectorPolicy) MaybeDetach() {
+	if p == nil {
+		return
+	}
+	p.L4Policy.mutex.Lock()
+	p.L4Policy.superseded = true
+	needsDetach := p.L4Policy.shouldDetachLocked()
+	p.L4Policy.mutex.Unlock()
+
+	if needsDetach {
+		p.L4Policy.finishDetach(p.SelectorCache)
+	}
+}
+
 // insertUser adds a user to the L4Policy so that incremental
 // updates of the L4Policy may be fowarded.
 func (p *selectorPolicy) insertUser(user *EndpointPolicy) {
-	p.L4Policy.insertUser(user)
+	p.L4Policy.insertUser(user, p.SelectorCache)
 }
 
 // removeUser removes a user from the L4Policy so the EndpointPolicy
 // can be freed when not needed any more
 func (p *selectorPolicy) removeUser(user *EndpointPolicy) {
-	p.L4Policy.removeUser(user)
+	p.L4Policy.removeUser(user, p.SelectorCache)
+}
+
+func (p *selectorPolicy) Detach() {
+	if p == nil {
+		return
+	}
+	p.detach(true, 0)
 }
 
 // detach releases resources held by a selectorPolicy to enable
@@ -555,6 +592,13 @@ func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, PerSelectorPolic
 			p.L4Policy.Egress.forEachRedirectFilter(yield)
 		}
 	}
+}
+
+func (p *selectorPolicy) GetRevision() uint64 {
+	if p == nil {
+		return 0
+	}
+	return p.Revision
 }
 
 func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, PerSelectorPolicyTuple) bool) bool {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"slices"
 
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
 
@@ -204,6 +206,16 @@ func (rules ruleSlice) AsPolicyEntries() types.PolicyEntries {
 		policyRules = append(policyRules, &r.PolicyEntry)
 	}
 	return policyRules
+}
+
+func (rules ruleSlice) AllIdentitySelections() set.Set[identity.NumericIdentity] {
+	ids := set.NewSet[identity.NumericIdentity]()
+	for _, r := range rules {
+		for _, id := range r.getSubjects() {
+			ids.Insert(id)
+		}
+	}
+	return ids
 }
 
 // traceState is an internal structure used to collect information

--- a/pkg/policy/test/script_test.go
+++ b/pkg/policy/test/script_test.go
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"maps"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+	apiv1 "github.com/cilium/cilium/api/v1/models"
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
+	datapathfaketypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/datapath/loader"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	identitycache "github.com/cilium/cilium/pkg/identity/cache/cell"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/ipcache"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/k8s/synced"
+	testk8s "github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/lxcmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	fakepolicymap "github.com/cilium/cilium/pkg/maps/policymap/fake"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/monitor/agent"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	policycell "github.com/cilium/cilium/pkg/policy/cell"
+	"github.com/cilium/cilium/pkg/policy/compute"
+	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/testutils"
+	testcertificatemanager "github.com/cilium/cilium/pkg/testutils/certificatemanager"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	testmonitor "github.com/cilium/cilium/pkg/testutils/monitor"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
+func TestScript(t *testing.T) {
+	defer testutils.GoleakVerifyNone(t)
+
+	version.Force(testk8s.DefaultVersion)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	var opts []hivetest.LogOption
+	if *debug {
+		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+		logging.SetLogLevelToDebug()
+	}
+
+	var idmgr identitymanager.IDManager
+	var allocator cache.IdentityAllocator
+	var epm endpointmanager.EndpointManager
+	var p policy.PolicyRepository
+	var c compute.PolicyRecomputer
+	var importer policycell.PolicyImporter
+	var templateEP *endpoint.Endpoint
+	log := hivetest.Logger(t, opts...)
+	scripttest.Test(t,
+		ctx,
+		func(t testing.TB, args []string) *script.Engine {
+			h := hive.New(
+				k8sClient.FakeClientCell(),
+				daemonk8s.ResourcesCell,
+				metrics.Cell,
+
+				cell.Provide(
+					func() *option.DaemonConfig {
+						return &option.DaemonConfig{
+							EnableIPv4: true,
+							EnableIPv6: true,
+						}
+					},
+				),
+
+				cell.Invoke(
+					func(client_ *k8sClient.FakeClientset, p_ policy.PolicyRepository, idmgr_ identitymanager.IDManager,
+						alloc_ cache.IdentityAllocator, c_ compute.PolicyRecomputer,
+						i_ policycell.PolicyImporter, epm_ endpointmanager.EndpointManager) error {
+						p = p_
+						idmgr = idmgr_
+						allocator = alloc_
+						c = c_
+						importer = i_
+						epm = epm_
+
+						option.Config.IdentityAllocationMode = option.IdentityAllocationModeCRD
+						defer func() { option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore }()
+
+						// Init the identity allocator.
+						<-allocator.(*cache.CachingIdentityAllocator).InitIdentityAllocator(client_, nil)
+
+						p.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
+
+						var err error
+						templateEP, err = endpoint.NewEndpointFromChangeModel(
+							endpoint.EndpointParams{
+								Logger:              log,
+								EPBuildQueue:        endpoint.NewEndpointBuildQueue(),
+								Loader:              &datapathfaketypes.FakeLoader{},
+								Orchestrator:        &datapathfaketypes.FakeOrchestrator{},
+								CompilationLock:     loader.NewCompilationLock(),
+								IdentityManager:     idmgr,
+								MonitorAgent:        &testmonitor.TestMonitorAgent{},
+								PolicyMapFactory:    &fakePolicyMapFactory{},
+								PolicyRepo:          p,
+								PolicyFetcher:       c,
+								NamedPortsGetter:    testipcache.NewMockIPCache(),
+								Allocator:           allocator,
+								CTMapGC:             ctmap.NewFakeGCRunner(),
+								KVStoreSynchronizer: ipcache.NewIPIdentitySynchronizer(log, kvstore.SetupDummy(t, kvstore.DisabledBackendName)),
+								LocalNodeStore:      node.NewTestLocalNodeStore(node.LocalNode{}),
+								LxcMap:              &fakeLXCMap{},
+							},
+							&fakeDNSAPI{},
+							&endpoint.FakeEndpointProxy{},
+							&apiv1.EndpointChangeRequest{
+								ContainerID:            "foo",
+								ContainerInterfaceName: "bar",
+								State:                  models.NewEndpointState(models.EndpointStateWaitingDashForDashIdentity),
+							},
+							t.Output(),
+						)
+
+						return err
+					},
+				),
+
+				cell.ProvidePrivate(func() certificatemanager.CertificateManager {
+					return &testcertificatemanager.Fake{}
+				}),
+				cell.ProvidePrivate(func() cmtypes.ClusterInfo {
+					return cmtypes.DefaultClusterInfo
+				}),
+				cell.ProvidePrivate(func() envoypolicy.EnvoyL7RulesTranslator {
+					return envoypolicy.NewEnvoyL7RulesTranslator(log, nil)
+				}),
+				cell.ProvidePrivate(func() types.PolicyMetrics {
+					return testpolicy.NewPolicyMetricsNoop()
+				}),
+				cell.ProvidePrivate(func() agent.Agent {
+					return &testmonitor.TestMonitorAgent{}
+				}),
+				cell.ProvidePrivate(func() synced.CacheStatus {
+					ch := make(chan struct{}, 1)
+					ch <- struct{}{}
+					return ch
+				}),
+				cell.ProvidePrivate(func() *ipcache.IPCache {
+					return ipcache.NewIPCache(&ipcache.Configuration{
+						Context:           t.Context(),
+						Logger:            log,
+						IdentityAllocator: allocator,
+						IdentityUpdater:   &mockUpdater{},
+					})
+				}),
+				cell.ProvidePrivate(regeneration.NewFence),
+				cell.ProvidePrivate(func() promise.Promise[endpointstate.Restorer] {
+					return &fakeRestorer{}
+				}),
+				identitymanager.Cell,
+				identitycache.Cell,
+				policycell.Cell,
+				endpointmanager.TestCell,
+				node.LocalNodeStoreTestCell,
+
+				cell.Provide(
+					func(params compute.Params) compute.PolicyRecomputer {
+						return compute.NewIdentityPolicyComputer(params)
+					},
+				),
+				cell.ProvidePrivate(compute.NewPolicyComputationTable),
+			)
+
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			h.RegisterFlags(flags)
+
+			t.Cleanup(func() {
+				for _, ep := range epm.GetEndpoints() {
+					epm.RemoveEndpoint(ep, endpoint.DeleteConfig{})
+				}
+				assert.NoError(t, h.Stop(log, context.TODO()))
+			})
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+			maps.Insert(cmds, maps.All(script.DefaultCmds()))
+			maps.Insert(cmds, maps.All(compute.PolicyComputerScriptCmds(c.(*compute.IdentityPolicyComputer))))
+			maps.Insert(cmds, maps.All(policy.RepositoryScriptCmds(p.(*policy.Repository))))
+			maps.Insert(cmds, maps.All(identitymanager.ScriptCmds(idmgr.(*identitymanager.IdentityManager))))
+			maps.Insert(cmds, maps.All(cache.ScriptCmds(allocator.(*cache.CachingIdentityAllocator))))
+			maps.Insert(cmds, maps.All(policycell.PolicyImporterScriptCmds(importer.(*policycell.Importer))))
+			maps.Insert(cmds, maps.All(endpointmanager.ScriptCmds(epm, templateEP)))
+			return &script.Engine{
+				Cmds:          cmds,
+				RetryInterval: 10 * time.Millisecond,
+			}
+		}, []string{}, "testdata/*.txtar")
+}
+
+type fakeDNSAPI struct{}
+
+func (*fakeDNSAPI) GetDNSRules(epID uint16) restore.DNSRules { return nil }
+func (*fakeDNSAPI) RemoveRestoredDNSRules(epID uint16)       {}
+
+type fakePolicyMapFactory struct{}
+
+func (*fakePolicyMapFactory) OpenEndpoint(id uint16) (policymap.PolicyMap, error) {
+	return fakepolicymap.NewFakePolicyMap(), nil
+}
+func (*fakePolicyMapFactory) RemoveEndpoint(id uint16) error { return nil }
+func (*fakePolicyMapFactory) PolicyMaxEntries() int          { return 0 }
+func (*fakePolicyMapFactory) StatsMaxEntries() int           { return 0 }
+
+type fakeLXCMap struct{}
+
+func (*fakeLXCMap) WriteEndpoint(f lxcmap.EndpointFrontend) error                        { return nil }
+func (*fakeLXCMap) SyncHostEntry(addr netip.Addr) (bool, error)                          { return false, nil }
+func (*fakeLXCMap) DeleteEntry(addr netip.Addr) error                                    { return nil }
+func (*fakeLXCMap) DeleteElement(logger *slog.Logger, f lxcmap.EndpointFrontend) []error { return nil }
+func (*fakeLXCMap) Dump(hash map[string][]string) error                                  { return nil }
+func (*fakeLXCMap) DumpToMap() (map[netip.Addr]lxcmap.EndpointInfo, error)               { return nil, nil }
+
+type mockUpdater struct{}
+
+func (m *mockUpdater) UpdateIdentities(_, _ identity.IdentityMap) <-chan struct{} {
+	out := make(chan struct{})
+	close(out)
+	return out
+}
+
+type fakeRestorer struct{}
+
+func (r *fakeRestorer) Await(context.Context) (endpointstate.Restorer, error) {
+	return r, nil
+}
+
+func (r *fakeRestorer) WaitForEndpointRestoreWithoutRegeneration(_ context.Context) error {
+	return nil
+}
+
+func (r *fakeRestorer) WaitForEndpointRestore(_ context.Context) error {
+	return nil
+}
+
+func (r *fakeRestorer) WaitForInitialPolicy(_ context.Context) error {
+	return nil
+}

--- a/pkg/policy/test/testdata/test.txtar
+++ b/pkg/policy/test/testdata/test.txtar
@@ -1,0 +1,88 @@
+hive/start
+db/show health
+
+# Initialize state: create host and health endpoints.
+identity/allocate reserved:host,reserved:kube-apiserver
+identity/allocate reserved:health
+endpoint/create 1 reserved:host,reserved:kube-apiserver
+endpoint/create 4 reserved:health
+
+# Import initial policy. Neither host nor health endpoint should have their
+# policy recomputed as this policy does not select them.
+k8s/add policy.yaml
+policy/import policy.yaml
+
+# Create first real endpoint selected by policy.yaml. Policy computation for
+# this endpoint should be at 2 now.
+env id1_labels=k8s:io.kubernetes.pod.namespace=default,k8s:foo=bar
+identity/allocate ${id1_labels}
+env --from-stdout id1
+endpoint/create ${id1} ${id1_labels}
+
+# Create second real endpoint selected by policy.yaml. Policy computation for
+# this endpoint should be at 2.
+env id2_labels=k8s:io.kubernetes.pod.namespace=default,k8s:baz=bar
+identity/allocate ${id2_labels}
+env --from-stdout id2
+endpoint/create ${id2} ${id2_labels}
+
+# Remove initial policy. Policy revision should be at 3.
+policy/remove policy.yaml
+
+# Add new policy that does not select foo=bar endpoint. Policy computation of
+# all identities should stay at 3 (doesn't bump if there is no need to
+# recompute), but the repo revision and endpoints' revision should be at 4.
+policy/import allow-env-prod.yaml
+
+# Wait until all endpoints' revision is at 4 which means they have consumed the
+# latest computation of revision 3.
+endpoint/wait-all 4
+
+# Perform assertion that all endpoints with a non-reserved identity (not host /
+# health) are still at policy revision 3.
+db/show --columns Identity,Revision policy-computations
+stdout host.+1
+stdout health.+1
+stdout ${id1}.+3
+stdout ${id2}.+3
+
+-- policy.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: "policy"
+  namespace: "default"
+spec:
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+      - matchLabels: {}
+    - toEndpoints:
+      - matchLabels:
+          "k8s:io.kubernetes.pod.namespace": kube-system
+          "k8s:k8s-app": kube-dns
+      toPorts:
+      - ports:
+        - port: "53"
+          protocol: "UDP"
+        rules:
+          dns:
+          - matchPattern: "*"
+    - toFQDNs:
+      - matchPattern: "*"
+      - matchPattern: "ifconfig.co"
+    - toCIDR:
+      - "1.1.1.1/32"
+
+-- allow-env-prod.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: "allow-env-prod"
+  namespace: "default"
+spec:
+  endpointSelector:
+    matchLabels:
+      env: prod
+  egress:
+  - {}

--- a/pkg/policy/trigger.go
+++ b/pkg/policy/trigger.go
@@ -6,6 +6,8 @@ package policy
 import (
 	"log/slog"
 
+	"github.com/cilium/statedb"
+
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -15,30 +17,36 @@ import (
 // all cached policies. This is done when an additional resource
 // used in policy calculation has changed.
 func (u *Updater) TriggerPolicyUpdates(reason string) {
-	u.repo.BumpRevision()
+	u.computer.RecomputeIdentityPolicyForAllIdentities(u.repo.BumpRevision())
 	u.logger.Info("Triggering full policy recalculation and regeneration of all endpoints", logfields.Reason, reason)
 	u.regen.TriggerRegenerateAllEndpoints()
 }
 
 // NewUpdater returns a new Updater instance to handle triggering policy
 // updates ready for use.
-func NewUpdater(logger *slog.Logger, r PolicyRepository, regen regenerator) *Updater {
+func NewUpdater(logger *slog.Logger, r PolicyRepository, c computer, regen regenerator) *Updater {
 	return &Updater{
-		logger: logger,
-		regen:  regen,
-		repo:   r,
+		logger:   logger,
+		regen:    regen,
+		repo:     r,
+		computer: c,
 	}
 }
 
 // Updater is responsible for triggering policy updates, in order to perform
 // policy recalculation.
 type Updater struct {
-	logger *slog.Logger
-	repo   PolicyRepository
-	regen  regenerator
+	logger   *slog.Logger
+	repo     PolicyRepository
+	computer computer
+	regen    regenerator
 }
 
 type regenerator interface {
 	// RegenerateAllEndpoints should trigger a regeneration of all endpoints.
 	TriggerRegenerateAllEndpoints()
+}
+
+type computer interface {
+	RecomputeIdentityPolicyForAllIdentities(toRev uint64) (*statedb.WatchSet, error)
 }

--- a/pkg/testutils/certificatemanager/certmanager.go
+++ b/pkg/testutils/certificatemanager/certmanager.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testcertificatemanager
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+const (
+	fakeCA         = "fake ca"
+	fakePublicKey  = "fake public key"
+	fakePrivateKey = "fake private key"
+)
+
+func (_ *Fake) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, inlineSecrets bool, err error) {
+	name := tlsCtx.Secret.Name
+	public = fakePublicKey + " " + name
+	private = fakePrivateKey + " " + name
+	ca = fakeCA + " " + name
+
+	inlineSecrets = true
+	return
+}
+
+type Fake struct{}

--- a/pkg/testutils/monitor/agent.go
+++ b/pkg/testutils/monitor/agent.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testmonitor
+
+import (
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/monitor/agent/consumer"
+	"github.com/cilium/cilium/pkg/monitor/agent/listener"
+)
+
+type TestMonitorAgent struct{}
+
+func (*TestMonitorAgent) AttachToEventsMap(nPages int) error                       { return nil }
+func (*TestMonitorAgent) SendEvent(typ int, event any) error                       { return nil }
+func (*TestMonitorAgent) RegisterNewListener(newListener listener.MonitorListener) {}
+func (*TestMonitorAgent) RemoveListener(ml listener.MonitorListener)               {}
+func (*TestMonitorAgent) RegisterNewConsumer(newConsumer consumer.MonitorConsumer) {}
+func (*TestMonitorAgent) RemoveConsumer(mc consumer.MonitorConsumer)               {}
+func (*TestMonitorAgent) State() *models.MonitorStatus                             { return nil }

--- a/pkg/ztunnel/xds/xds_server_test.go
+++ b/pkg/ztunnel/xds/xds_server_test.go
@@ -168,6 +168,10 @@ func (m *MockEndpointManager) TriggerRegenerateAllEndpoints() {
 	panic("MockEndpointManager.TriggerRegenerateAllEndpoints not implemented")
 }
 
+func (m *MockEndpointManager) WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error {
+	panic("MockEndpointManager.WaitForEndpointsAtPolicyRev not implemented")
+}
+
 func (m *MockEndpointManager) OverrideEndpointOpts(om option.OptionMap) {
 	panic("MockEndpointManager.OverrideEndpointOpts not implemented")
 }


### PR DESCRIPTION
Review commit-by-commit. It is a long PR, but many of the commits are preparatory.

For convenience, here are the main meaty commits:

> ```
> policy/compute: Add policy computation cell
> 
> This cell is responsible for computing policies (specifically
> SelectorPolicy objects) per identity. In future commits, this cell will
> take over the policy computation logic from the endpoint and the
> endpoint will simply fetch the (latest) computed policy that is stored
> in a statedb table (policy-computations).
> ```

> ```
> endpoint: Plumb policy computer
> 
> Now the policy computation code inside the endpoint regeneration logic
> will simply read from the policy-computations table containing the
> most-recently computed SelectorPolicy object.
> 
> The biggest change to the endpoint logic is the new mechanism to wait
> for the relevant policy computation to appear in the statedb table (with
> the correct revision). For now, this is a hardcoded time-limited retry
> where if it fails to find the relevant entry in the statedb table, then
> the regeneration will fail. The regeneration controller will retry upon
> failure automatically which will retry the fetch of the statedb table.
> 
> Another impact of this commit is that the endpoints that are not
> affected by a policy change will not need to be regenerated, unlike
> before.
> ```

---

Depends on:

* https://github.com/cilium/hive/pull/58
* https://github.com/cilium/statedb/pull/106

Fixes: https://github.com/cilium/cilium/issues/7515
