### PR TITLE
daemon/test: explicitly wait for identities synchronization

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -168,6 +168,12 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 
 	ds.d.policy.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 
+	// Ensure that the identity allocator is synchronized before starting the
+	// actual tests, to prevent flakes caused by the goroutine started by
+	// [(*CachingIdentityAllocator).InitIdentityAllocator] still lingering
+	// around when the Hive gets stopped.
+	ds.d.identityAllocator.WaitForInitialGlobalIdentities(tb.Context())
+
 	// Reset the most common endpoint states before each test.
 	for _, s := range []string{
 		string(models.EndpointStateReady),


### PR DESCRIPTION
Ensure that the identity allocator is synchronized before starting the actual tests, to prevent flakes caused by the goroutine started by [(*CachingIdentityAllocator).InitIdentityAllocator] still lingering around when the Hive gets stopped. The proper fix would be converting the identity allocator to a cell, but that's a way more significant amount of work, so let's go for the easy fix for the moment.

Example failure that could otherwise occur:

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃   PANIC  package: github.com/cilium/cilium/daemon/cmd • TestEndpointAddReservedLabelEtcd   ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1d0 pc=0x1811979]

goroutine 589 [running]:
github.com/cilium/cilium/pkg/node.(*LocalNodeStore).Get(_, {_, _})
	/home/runner/work/cilium/cilium/pkg/node/local_node_store.go:195 +0x79
github.com/cilium/cilium/pkg/node.getLocalNode(_)
	/home/runner/work/cilium/cilium/pkg/node/address.go:46 +0x8d
github.com/cilium/cilium/pkg/node.GetIPv4(0x2?)
	/home/runner/work/cilium/cilium/pkg/node/address.go:232 +0x25
github.com/cilium/cilium/pkg/identity/cache/cell.(*identityAllocatorOwner).GetNodeSuffix(0xc002b90cc0)
	/home/runner/work/cilium/cilium/pkg/identity/cache/cell/cell.go:162 +0x89
github.com/cilium/cilium/pkg/identity/cache.(*CachingIdentityAllocator).InitIdentityAllocator.func1({0x5b360f8, 0xc002b90cc0}, 0xc00048c5b0, 0x100, 0xffff)
	/home/runner/work/cilium/cilium/pkg/identity/cache/allocator.go:253 +0x1e8
created by github.com/cilium/cilium/pkg/identity/cache.(*CachingIdentityAllocator).InitIdentityAllocator in goroutine 232
	/home/runner/work/cilium/cilium/pkg/identity/cache/allocator.go:237 +0x42b
FAIL	github.com/cilium/cilium/daemon/cmd	1.294s
```

Fixes: https://github.com/cilium/cilium/issues/40803
