### PR TITLE
cilium-cli: Validate NodePort readiness on all node IP addresses

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -2722,11 +2722,21 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			return fmt.Errorf("no client pod available")
 		}
 
-		for _, ciliumPod := range ct.ciliumPods {
-			hostIP := ciliumPod.Pod.Status.HostIP
-			for _, s := range ct.echoServices {
-				if err := WaitForNodePorts(ctx, ct, *client, hostIP, s); err != nil {
-					return err
+		// Wait for NodePorts to be ready on all node IP addresses.
+		// Tests iterate through all addresses in node.Status.Addresses[], which can include
+		// both IPv4 and IPv6 in dual-stack clusters. Validating only HostIP (typically IPv4)
+		// would leave IPv6 addresses unchecked, causing timeouts when tests try them.
+		for _, node := range ct.Nodes() {
+			for _, addr := range node.Status.Addresses {
+				// Only check IP addresses (skip DNS names, hostnames)
+				if addr.Type != slimcorev1.NodeInternalIP && addr.Type != slimcorev1.NodeExternalIP {
+					continue
+				}
+
+				for _, s := range ct.echoServices {
+					if err := WaitForNodePorts(ctx, ct, *client, addr.Address, s); err != nil {
+						return err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Description

Fixes intermittent `pod-to-local-nodeport` connectivity test failures (exit code 28 - connection timeout) in dual-stack clusters.

### Root Cause

The upfront NodePort readiness check in `deployment.go` only validated `HostIP` (one IP per node, typically IPv4), but tests iterate through all addresses in `node.Status.Addresses[]` which includes both IPv4 and IPv6 in dual-stack clusters.

This meant IPv6 NodePorts were never validated for readiness, causing timeouts when tests tried them.

### Fix

Enhance the upfront NodePort validation to check all node IP addresses (NodeInternalIP and NodeExternalIP types) instead of just HostIP. This ensures all addresses that will be tested are validated during setup.

Fixes: #39793

```release-note
Fix intermittent NodePort connectivity test timeouts in dual-stack clusters by validating NodePort readiness on all node IP addresses during test setup.
```