### PR TITLE
.github: remove all contents of /mnt in build images CI

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -99,9 +99,9 @@ jobs:
             echo "# Hidden files in /mnt:"
             sudo du --human-readable -- /mnt/.* 2>/dev/null
           fi
-          echo "# Removing /mnt/tmp-pv.img"
-          sudo rm -f '/mnt/tmp-pv.img'
-          sudo rm -rf '/mnt/docker-volumes'
+          echo "# Removing all contents of /mnt"
+          sudo rm -rf /mnt/*
+          sudo rm -rf /mnt/.*
 
       - name: Setup docker volumes into /mnt
         # This allows us to make use of all available disk.


### PR DESCRIPTION
As we need the /mnt directory to be empty might as well delete all files that are there instead of assuming that only a couple of files take the most amount of space.