### PR TITLE
Cilium EndpointSlices: fix label values

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -315,9 +315,9 @@ func (c *Controller) processNextWorkItem() bool {
 	isRetried := c.handleErr(queue, err, key)
 	if err != nil {
 		if isRetried {
-			c.metrics.CiliumEndpointSliceSyncTotal.WithLabelValues(LabelOutcome, LabelValueOutcomeFail, LabelFailureType, LabelFailureTypeTransient).Inc()
+			c.metrics.CiliumEndpointSliceSyncTotal.WithLabelValues(LabelValueOutcomeFail, LabelFailureTypeTransient).Inc()
 		} else {
-			c.metrics.CiliumEndpointSliceSyncTotal.WithLabelValues(LabelOutcome, LabelValueOutcomeFail, LabelFailureType, LabelFailureTypeFatal).Inc()
+			c.metrics.CiliumEndpointSliceSyncTotal.WithLabelValues(LabelValueOutcomeFail, LabelFailureTypeFatal).Inc()
 		}
 	} else {
 		c.metrics.CiliumEndpointSliceSyncTotal.WithLabelValues(LabelValueOutcomeSuccess, "").Inc()


### PR DESCRIPTION
Follow-up to https://github.com/cilium/cilium/pull/40418

While refactoring the PR, I accidentally added the metric label names alongside the label values in `WithLabelValues()`. Normally, this function should only accept label values. This codepath was not exercised in the CI so it wasn't caught before merging the PR.

Fixes: https://github.com/cilium/cilium/issues/40801

```release-note
Cilium EndpointSlices: fix label values for the ces_sync_total metric
```
