### PR TITLE
.github: fix removal of all files in /mnt

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -99,9 +99,8 @@ jobs:
             echo "# Hidden files in /mnt:"
             sudo du --human-readable -- /mnt/.* 2>/dev/null
           fi
-          echo "# Removing all contents of /mnt"
-          sudo rm -rf /mnt/*
-          sudo rm -rf /mnt/.*
+          echo "# Removing all contents of /mnt except /mnt/swapfile"
+          sudo find /mnt -mindepth 1 ! -path /mnt/swapfile -exec rm -rf {} + || true
 
       - name: Setup docker volumes into /mnt
         # This allows us to make use of all available disk.


### PR DESCRIPTION
Use find to ignore swapfile and avoid error in case of permission denied.

Fixes: 0cd21f97a78d (".github: remove all contents of /mnt in build images CI")