### PR TITLE
contrib: don't create UID 0 files on run_bpf_tests

### DIFF
--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -4,6 +4,8 @@ set -eu
 
 cd "$(dirname "$0")/../.."
 
+CMD="$@"
+
 CILIUM_BUILDER_IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_IMAGE=' | cut -d '=' -f 2)
 
 GO=""
@@ -21,6 +23,10 @@ fi
 if [ -z "${RUN_AS_ROOT:-}" ]; then
     USER_OPTION="--user $(id -u):$(id -g)"
     USER_PATH="$HOME"
+    MOUNT_CILIUM="-v ${PWD}:/go/src/github.com/cilium/cilium"
+else
+    MOUNT_CILIUM="-v ${PWD}:/ro/go/src/github.com/cilium/cilium"
+    CMD="mkdir -p /go/src/github.com/cilium/ && cp -R /ro/go/src/github.com/cilium/cilium/. /go/src/github.com/cilium/cilium/ && ${CMD}"
 fi
 
 MOUNT_GOCACHE_DIR=""
@@ -54,8 +60,8 @@ docker run --rm \
 	$MOUNT_GOCACHE_DIR \
 	$MOUNT_GOMODCACHE_DIR \
 	$MOUNT_CCACHE_DIR \
-	-v "$PWD":/go/src/github.com/cilium/cilium \
+	${MOUNT_CILIUM} \
 	-w /go/src/github.com/cilium/cilium \
 	${DOCKER_ARGS:+"$DOCKER_ARGS"} \
 	"$CILIUM_BUILDER_IMAGE" \
-	"$@"
+	bash -c "${CMD}"


### PR DESCRIPTION
Prior to this commit, running `make run_bpf_tests` was running BPF unit tests as root (`RUN_AS_ROOT=1`) with the whole cilium/ folder mapped into the container.

This was problematic because:

1. Compilation objects (e.g. *.o) were left in the `bpf/tests/` folder.
2. Objects had been - potentially - compiled with a different toolchain than the host's one.

After exploring several options (e.g. using an overlayFS, which doesn't work in all situations), this commit uses the "most compatible" option when running with `RUN_AS_ROOT=1`, by mounting `PWD` (cilium copy) as RO (`/ro/go/...`) in the container and copying to `/go/...`

This increases ~20-30 sec (~16%) in my local machine the `make run_bpf_tests`, see 3 runs with an w/o this patch:

* With:

```
Iteration 1:

real	3m30,324s
user	0m0,228s
sys	0m1,611s

Iteration 2:

real	3m21,137s
user	0m0,293s
sys	0m0,248s

Iteration 3:

real	3m19,920s
user	0m0,250s
sys	0m0,268s
```

* Without:

```
Iteration 1:

real	3m5,191s
user	0m0,191s
sys	0m0,434s

Iteration 2:

real	2m55,528s
user	0m0,162s
sys	0m0,247s

Iteration 3:

real	3m0,467s
user	0m0,196s
sys	0m0,197s
```