### PR TITLE
policy / hubble: fix segfault on startup when hubble enabled

### DIFF
--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -252,9 +252,7 @@ func (p *EndpointPolicy) Lookup(key Key) (MapStateEntry, RuleMeta, bool) {
 // CopyMapStateFrom copies the policy map entries from m.
 func (p *EndpointPolicy) CopyMapStateFrom(m MapStateMap) {
 	for key, entry := range m {
-		p.policyMapState.entries[key] = mapStateEntry{
-			MapStateEntry: entry,
-		}
+		p.policyMapState.entries[key] = NewMapStateEntry(entry)
 	}
 }
 


### PR DESCRIPTION
In the event that a regeneration failed, we re-populated the MapState but forgot to set the rule origin. Unfortunately, the zero value for Handle is not equivalent to nil; we must always set it explicitly.

Fixes: fe165aaa43

```release-note
Fixes a bug where the Cilium agent may segfault when starting.
```
