### PR TITLE
loadbalancer: Shrink BackendParams

### DIFF
--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"iter"
 	"strings"
+	"unsafe"
 
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
@@ -60,6 +61,19 @@ type BackendParams struct {
 	// value if never updated.
 	UnhealthyUpdatedAt time.Time
 }
+
+const maxBackendParamsSize = 160
+
+// Assert on the size of [BackendParams] to keep changes to it at check.
+// If you're adding more fields to [BackendParams] and they're most of the time
+// not set, please consider putting them behind a separate struct and referring to
+// it by pointer. This way we use less memory for the majority of use-cases.
+var _ = func() struct{} {
+	if size := unsafe.Sizeof(BackendParams{}); size > maxBackendParamsSize {
+		panic(fmt.Sprintf("BackendParams has size %d, maximum set to %d\n", size, maxBackendParamsSize))
+	}
+	return struct{}{}
+}()
 
 // Backend is a composite of the per-service backend instances that share the same
 // IP address and port.

--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -54,12 +54,11 @@ type BackendParams struct {
 	// zero value to mean that the backend is healthy.
 	Unhealthy bool
 
-	// UnhealthyUpdatedAt is the timestamp for when [Unhealthy] was last updated. Zero
-	// value if never updated.
-	UnhealthyUpdatedAt time.Time
+	// UnhealthyUpdatedAt is the timestamp for when [Unhealthy] was last updated.
+	UnhealthyUpdatedAt *time.Time
 }
 
-const maxBackendParamsSize = 128
+const maxBackendParamsSize = 110
 
 // Assert on the size of [BackendParams] to keep changes to it at check.
 // If you're adding more fields to [BackendParams] and they're most of the time

--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -36,11 +36,8 @@ type BackendParams struct {
 	// a node.
 	NodeName string
 
-	// Zone where backend is located.
-	Zone string
-
-	// ForZones where this backend should be consumed in
-	ForZones []string
+	// Optional zone information for topology-aware routing.
+	Zone *BackendZone
 
 	// ClusterID of the cluster in which the backend is located. 0 for local cluster.
 	ClusterID uint32
@@ -62,7 +59,7 @@ type BackendParams struct {
 	UnhealthyUpdatedAt time.Time
 }
 
-const maxBackendParamsSize = 160
+const maxBackendParamsSize = 128
 
 // Assert on the size of [BackendParams] to keep changes to it at check.
 // If you're adding more fields to [BackendParams] and they're most of the time
@@ -74,6 +71,23 @@ var _ = func() struct{} {
 	}
 	return struct{}{}
 }()
+
+func (bep *BackendParams) GetZone() string {
+	if bep.Zone == nil {
+		return ""
+	}
+	return bep.Zone.Zone
+}
+
+// BackendZone locates the backend to a specific zone and specifies what zones
+// the backend should be used in for topology aware routing.
+type BackendZone struct {
+	// Zone where backend is located.
+	Zone string
+
+	// ForZones where this backend should be consumed in
+	ForZones []string
+}
 
 // Backend is a composite of the per-service backend instances that share the same
 // IP address and port.

--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -167,7 +167,7 @@ func (fe *Frontend) ToModel() *models.Service {
 			Protocol:  be.Address.Protocol(),
 			Port:      be.Address.Port(),
 			NodeName:  be.NodeName,
-			Zone:      be.Zone,
+			Zone:      be.GetZone(),
 			State:     stateStr,
 			Preferred: true,
 			Weight:    &be.Weight,

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -911,7 +911,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 			}
 		}
 
-		if !be.UnhealthyUpdatedAt.IsZero() {
+		if be.UnhealthyUpdatedAt != nil {
 			ops.deleteRestoredQuarantinedBackends(fe.Address, be.Address)
 		}
 
@@ -1321,7 +1321,9 @@ func (ops *BPFOps) sortedBackends(fe *loadbalancer.Frontend) []backendWithRevisi
 
 	bes := []backendWithRevision{}
 	for be, rev := range fe.Backends {
-		if be.UnhealthyUpdatedAt.IsZero() && quarantined.Has(be.Address) {
+		if be.UnhealthyUpdatedAt == nil && quarantined.Has(be.Address) {
+			// Backend was previously quarantined and we have not health checked it
+			// yet. Use the restored health until health check is performed.
 			be.Unhealthy = true
 		}
 		bes = append(bes, backendWithRevision{&be, rev})

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -1130,13 +1130,13 @@ func (ops *BPFOps) upsertBackend(id loadbalancer.BackendID, be *loadbalancer.Bac
 
 	if be.Address.AddrCluster().Is6() {
 		lbbe, err = maps.NewBackend6V3(id, be.Address.AddrCluster(), be.Address.Port(), proto,
-			be.State, ops.extCfg.GetZoneID(be.Zone))
+			be.State, ops.extCfg.GetZoneID(be.GetZone()))
 		if err != nil {
 			return err
 		}
 	} else {
 		lbbe, err = maps.NewBackend4V3(id, be.Address.AddrCluster(), be.Address.Port(), proto,
-			be.State, ops.extCfg.GetZoneID(be.Zone))
+			be.State, ops.extCfg.GetZoneID(be.GetZone()))
 		if err != nil {
 			return err
 		}

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -425,16 +425,20 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 				if be.Terminating {
 					state = loadbalancer.BackendStateTerminating
 				}
-				be := loadbalancer.BackendParams{
+				bep := loadbalancer.BackendParams{
 					Address:   l3n4Addr,
 					NodeName:  be.NodeName,
 					PortNames: portNames,
 					Weight:    loadbalancer.DefaultBackendWeight,
-					Zone:      be.Zone,
-					ForZones:  be.HintsForZones,
 					State:     state,
 				}
-				if !yield(be) {
+				if be.Zone != "" {
+					bep.Zone = &loadbalancer.BackendZone{
+						Zone:     be.Zone,
+						ForZones: be.HintsForZones,
+					}
+				}
+				if !yield(bep) {
 					break
 				}
 			}

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/annotation"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/container/cache"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -206,7 +207,7 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 			for _, port := range svc.Spec.Ports {
 				fe := loadbalancer.FrontendParams{
 					Type:        loadbalancer.SVCTypeClusterIP,
-					PortName:    loadbalancer.FEPortName(port.Name),
+					PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
 					ServiceName: name,
 					ServicePort: uint16(port.Port),
 				}
@@ -248,7 +249,7 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 
 						fe := loadbalancer.FrontendParams{
 							Type:        loadbalancer.SVCTypeNodePort,
-							PortName:    loadbalancer.FEPortName(port.Name),
+							PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
 							ServiceName: name,
 							ServicePort: uint16(port.Port),
 						}
@@ -303,7 +304,7 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 					for _, port := range svc.Spec.Ports {
 						fe := loadbalancer.FrontendParams{
 							Type:        loadbalancer.SVCTypeLoadBalancer,
-							PortName:    loadbalancer.FEPortName(port.Name),
+							PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
 							ServiceName: name,
 							ServicePort: uint16(port.Port),
 						}
@@ -340,7 +341,7 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 			for _, port := range svc.Spec.Ports {
 				fe := loadbalancer.FrontendParams{
 					Type:        loadbalancer.SVCTypeExternalIPs,
-					PortName:    loadbalancer.FEPortName(port.Name),
+					PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
 					ServiceName: name,
 					ServicePort: uint16(port.Port),
 				}

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -94,8 +94,7 @@ Address              Instances
       ],
       "Weight": 100,
       "NodeName": "nodeport-worker",
-      "Zone": "",
-      "ForZones": null,
+      "Zone": null,
       "ClusterID": 0,
       "Source": "k8s",
       "State": 0,
@@ -125,8 +124,7 @@ Address              Instances
       ],
       "Weight": 100,
       "NodeName": "nodeport-worker",
-      "Zone": "",
-      "ForZones": null,
+      "Zone": null,
       "ClusterID": 0,
       "Source": "k8s",
       "State": 0,
@@ -153,8 +151,7 @@ Address              Instances
         ],
         "Weight": 100,
         "NodeName": "nodeport-worker",
-        "Zone": "",
-        "ForZones": null,
+        "Zone": null,
         "ClusterID": 0,
         "Source": "k8s",
         "State": 0,
@@ -179,8 +176,7 @@ Address              Instances
         ],
         "Weight": 100,
         "NodeName": "nodeport-worker",
-        "Zone": "",
-        "ForZones": null,
+        "Zone": null,
         "ClusterID": 0,
         "Source": "k8s",
         "State": 0,
@@ -228,8 +224,7 @@ backends:
         - http
       weight: 100
       nodename: nodeport-worker
-      zone: ""
-      forzones: []
+      zone: null
       clusterid: 0
       source: k8s
       state: 0
@@ -254,8 +249,7 @@ backends:
         - http
       weight: 100
       nodename: nodeport-worker
-      zone: ""
-      forzones: []
+      zone: null
       clusterid: 0
       source: k8s
       state: 0
@@ -275,8 +269,7 @@ instances:
             - http
         weight: 100
         nodename: nodeport-worker
-        zone: ""
-        forzones: []
+        zone: null
         clusterid: 0
         source: k8s
         state: 0
@@ -294,8 +287,7 @@ instances:
             - http
         weight: 100
         nodename: nodeport-worker
-        zone: ""
-        forzones: []
+        zone: null
         clusterid: 0
         source: k8s
         state: 0

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -99,7 +99,7 @@ Address              Instances
       "Source": "k8s",
       "State": 0,
       "Unhealthy": false,
-      "UnhealthyUpdatedAt": "0001-01-01T00:00:00Z"
+      "UnhealthyUpdatedAt": null
     }
   ],
   "ID": 1,
@@ -129,7 +129,7 @@ Address              Instances
       "Source": "k8s",
       "State": 0,
       "Unhealthy": false,
-      "UnhealthyUpdatedAt": "0001-01-01T00:00:00Z"
+      "UnhealthyUpdatedAt": null
     }
   ],
   "ID": 2,
@@ -156,7 +156,7 @@ Address              Instances
         "Source": "k8s",
         "State": 0,
         "Unhealthy": false,
-        "UnhealthyUpdatedAt": "0001-01-01T00:00:00Z"
+        "UnhealthyUpdatedAt": null
       }
     }
   ]
@@ -181,7 +181,7 @@ Address              Instances
         "Source": "k8s",
         "State": 0,
         "Unhealthy": false,
-        "UnhealthyUpdatedAt": "0001-01-01T00:00:00Z"
+        "UnhealthyUpdatedAt": null
       }
     }
   ]
@@ -229,7 +229,7 @@ backends:
       source: k8s
       state: 0
       unhealthy: false
-      unhealthyupdatedat: 0001-01-01T00:00:00Z
+      unhealthyupdatedat: null
 id: 1
 redirectto: null
 ---
@@ -254,7 +254,7 @@ backends:
       source: k8s
       state: 0
       unhealthy: false
-      unhealthyupdatedat: 0001-01-01T00:00:00Z
+      unhealthyupdatedat: null
 id: 2
 redirectto: null
 -- backends-expected.yaml --
@@ -274,7 +274,7 @@ instances:
         source: k8s
         state: 0
         unhealthy: false
-        unhealthyupdatedat: 0001-01-01T00:00:00Z
+        unhealthyupdatedat: null
 ---
 address: '[2002::2]:8080/TCP'
 instances:
@@ -292,7 +292,7 @@ instances:
         source: k8s
         state: 0
         unhealthy: false
-        unhealthyupdatedat: 0001-01-01T00:00:00Z
+        unhealthyupdatedat: null
 -- service.yaml --
 apiVersion: v1
 kind: Service

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -413,9 +413,9 @@ func (w *Writer) DefaultSelectBackends(bes iter.Seq2[loadbalancer.BackendParams,
 					fe.RedirectTo == nil &&
 					fe.Service.TrafficDistribution == loadbalancer.TrafficDistributionPreferClose {
 					thisZone := w.nodeZone.Load()
-					if len(be.ForZones) > 0 && thisZone != nil {
+					if be.Zone != nil && len(be.Zone.ForZones) > 0 && thisZone != nil {
 						// Topology-aware routing is enabled. Only use this backend if it is selected for this zone.
-						if !slices.Contains(be.ForZones, *thisZone) {
+						if !slices.Contains(be.Zone.ForZones, *thisZone) {
 							continue
 						}
 					}

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -245,13 +245,14 @@ func (w *Writer) UpdateBackendHealth(txn WriteTxn, serviceName loadbalancer.Serv
 	if inst == nil {
 		return false, loadbalancer.ErrServiceNotFound
 	}
-	if inst.Unhealthy == !healthy && !inst.UnhealthyUpdatedAt.IsZero() {
+	if inst.Unhealthy == !healthy && inst.UnhealthyUpdatedAt != nil {
 		return false, nil
 	}
 
 	be = be.Clone()
 	inst.Unhealthy = !healthy
-	inst.UnhealthyUpdatedAt = time.Now()
+	now := time.Now()
+	inst.UnhealthyUpdatedAt = &now
 	be.Instances = be.Instances.Set(loadbalancer.BackendInstanceKey{ServiceName: serviceName, SourcePriority: w.sourcePriority(inst.Source)}, *inst)
 	w.bes.Insert(txn, be)
 	return true, w.RefreshFrontends(txn, serviceName)


### PR DESCRIPTION
Move zone information into `BackendZone` and refer to it by pointer from `BackendParams` (32 bytes saved).
Refer to `UnhealthyUpdatedAt` timestamp by reference (16 bytes saved).

These combined shrink `BackendParams` size from 152 bytes to 104 bytes.

Add an init time assertion to catch additions to `BackendParams` and make the developer consider the layout.

And finally use pkg/container/cache to deduplicate FEPortName allocations.