### PR TITLE
MAINTAINERS: Move Ian to Emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,7 +24,6 @@ to learn how to level up through the project.
  * [Gilberto Bertin] (Isovalent)
  * [Glib Smaga] (Isovalent)
  * [Hemanth Malla] (Microsoft)
- * [Ian Vernon]
  * [Jarno Rajahalme] (Isovalent)
  * [Joe Stringer] (Isovalent)
  * [John Fastabend] (Isovalent)
@@ -64,6 +63,7 @@ We would like to acknowledge previous committers and their huge contributions to
  * [Beatriz Martínez] (Isovalent)
  * [Dan Wendlandt] (Isovalent)
  * [Eloy Coto] (Red Hat)
+ * [Ian Vernon]
  * [Ilya Dmitrichenko] (Docker)
  * [Ray Bejjani]
  * [Tom Payne]


### PR DESCRIPTION
@ianvernon had a huge influence on Cilium early on in the daemon, endpoint,
policy and testing areas, and managed several of the Cilium releases.
These days he's a less involved but we appreciate his contributions to
the project and his ever-young sense of humor that continues to echo
through the community. I'm nominating him to emeritus committer
following a private discussion with him out-of-band.
