### PR TITLE
[v1.17] ci: Revert build_commits runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build_commits:
     name: Check if build works for every commit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 180
     steps:
       - name: Collect Workflow Telemetry


### PR DESCRIPTION
 Introduced as part of an automated Renovate update (87eeb2198556ac33f1566da328fa0809f718a0bc) and was not intentional: 

causes `Unable to locate package libtinfo5` error ([example job](https://github.com/cilium/cilium/actions/runs/16617736896/job/47014304769)).

Major runner upgrades got enabled by #40683 and partially reverted in #40716.


