### PR TITLE
daemon: conditionally disable headless service watch

### DIFF
--- a/clustermesh-apiserver/clustermesh/k8s/resources.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resources.go
@@ -28,6 +28,7 @@ var (
 		"Clustermesh-apiserver Kubernetes resources",
 
 		cell.Config(k8s.DefaultConfig),
+		cell.Provide(k8s.DefaultServiceWatchConfig),
 		cell.Config(DefaultCiliumEndpointSliceConfig),
 
 		cell.Provide(

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/util/workqueue"
 
+	envoy "github.com/cilium/cilium/pkg/envoy/config"
+
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -31,6 +33,7 @@ var (
 		"Agent Kubernetes resources",
 
 		cell.Config(k8s.DefaultConfig),
+		cell.Provide(provideK8sWatchConfig),
 		LocalNodeCell,
 		cell.Provide(
 			k8s.ServiceResource,
@@ -69,6 +72,18 @@ var (
 		),
 	)
 )
+
+// provideK8sWatchConfig creates k8s.ServiceWatchConfig with headless service watch
+// enabled only if features relying on it (Gateway API, Ingress) are enabled.
+//
+// This reduces the load on apiserver in clusters that use headless services
+// and don't use Ingress nor Gateway.
+// See: https://github.com/cilium/cilium/issues/40763
+func provideK8sWatchConfig(envoyCfg envoy.SecretSyncConfig) k8s.ServiceWatchConfig {
+	return k8s.ServiceWatchConfig{
+		EnableHeadlessServiceWatch: envoyCfg.EnableGatewayAPI || envoyCfg.EnableIngressController,
+	}
+}
 
 // LocalNodeResource is a resource.Resource[*slim_corev1.Node] but one which will only stream updates for the node object
 // associated with the node we are currently running on.

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -135,7 +135,7 @@ func LBIPPoolsResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.Metr
 
 const ServiceIndex = "service"
 
-func EndpointsResource(logger *slog.Logger, lc cell.Lifecycle, cfg k8s.Config, cs client.Clientset, mp workqueue.MetricsProvider) (resource.Resource[*k8s.Endpoints], error) {
+func EndpointsResource(logger *slog.Logger, lc cell.Lifecycle, cfg k8s.ConfigParams, cs client.Clientset, mp workqueue.MetricsProvider) (resource.Resource[*k8s.Endpoints], error) {
 	return k8s.EndpointsResourceWithIndexers(
 		logger,
 		lc,

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -31,6 +31,7 @@ var (
 		"Operator Kubernetes resources",
 
 		cell.Config(k8s.DefaultConfig),
+		cell.Provide(k8s.DefaultServiceWatchConfig),
 		cell.Provide(
 			mcsapi.ServiceExportResource,
 			EndpointsResource,

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -2571,6 +2571,7 @@ func TestLBIPAMStartupRestartShutdown(t *testing.T) {
 				EnableBGPControlPlane: true,
 			}
 		}),
+		cell.Provide(k8s.DefaultServiceWatchConfig),
 		cell.Config(k8s.DefaultConfig),
 		cell.Provide(
 			k8s.ServiceResource,
@@ -2710,6 +2711,7 @@ func TestLBIPAMRestartOnFullPool(t *testing.T) {
 			return &option.DaemonConfig{}
 		}),
 		cell.Config(k8s.DefaultConfig),
+		cell.Provide(k8s.DefaultServiceWatchConfig),
 		cell.Provide(
 			k8s.ServiceResource,
 			operator_k8s.LBIPPoolsResource,
@@ -2808,6 +2810,7 @@ func TestLBIPAMRestartOnFullPool(t *testing.T) {
 			return &option.DaemonConfig{}
 		}),
 		cell.Config(k8s.DefaultConfig),
+		cell.Provide(k8s.DefaultServiceWatchConfig),
 		cell.Provide(
 			k8s.ServiceResource,
 			operator_k8s.LBIPPoolsResource,

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -176,6 +176,8 @@ func newFixture(t testing.TB, ctx context.Context, conf fixtureConfig) (*fixture
 	f.cells = []cell.Cell{
 		cell.Config(k8sPkg.DefaultConfig),
 
+		cell.Provide(k8sPkg.DefaultServiceWatchConfig),
+
 		// service
 		cell.Provide(k8sPkg.ServiceResource),
 

--- a/pkg/bgpv1/test/script_test.go
+++ b/pkg/bgpv1/test/script_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/test/commands"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 
 	ciliumhive "github.com/cilium/cilium/pkg/hive"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -90,6 +91,8 @@ func TestPrivilegedScript(t *testing.T) {
 		h := ciliumhive.New(
 			k8sClient.FakeClientCell(),
 			daemonk8s.ResourcesCell,
+			cell.Config(envoyCfg.SecretSyncConfig{}),
+
 			metrics.Cell,
 			bgpv1.Cell,
 

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/envoy"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -75,7 +76,7 @@ type parserParams struct {
 	LocalNodeStore *node.LocalNodeStore
 
 	CecConfig   CECConfig
-	EnvoyConfig envoy.ProxyConfig
+	EnvoyConfig envoyCfg.ProxyConfig
 }
 
 func newCECResourceParser(params parserParams) *CECResourceParser {

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/envoy"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/synced"
@@ -79,7 +80,8 @@ func TestScript(t *testing.T) {
 			metrics.Cell,
 			maglev.Cell,
 			cell.Config(CECConfig{}),
-			cell.Config(envoy.ProxyConfig{}),
+			cell.Config(envoyCfg.SecretSyncConfig{}),
+			cell.Config(envoyCfg.ProxyConfig{}),
 
 			lbcell.Cell,
 

--- a/pkg/clustermesh/mcsapi/serviceexportsync_test.go
+++ b/pkg/clustermesh/mcsapi/serviceexportsync_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sFakeClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -112,6 +113,7 @@ func Test_mcsServiceExportSync_Reconcile(t *testing.T) {
 	hive := hive.New(
 		k8sFakeClient.FakeClientCell(),
 		k8s.ResourcesCell,
+		cell.Config(envoyCfg.SecretSyncConfig{}),
 		cell.Provide(ServiceExportResource),
 		cell.Provide(func() operator.MCSAPIConfig {
 			return operator.MCSAPIConfig{ClusterMeshEnableMCSAPI: true}

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/dial"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -92,6 +93,7 @@ func TestScript(t *testing.T) {
 		h := hive.New(
 			k8sClient.FakeClientCell(),
 			daemonk8s.ResourcesCell,
+			cell.Config(envoyCfg.SecretSyncConfig{}),
 			daemonk8s.TablesCell,
 			lbcell.Cell,
 

--- a/pkg/dial/resolver_test.go
+++ b/pkg/dial/resolver_test.go
@@ -60,6 +60,7 @@ func TestServiceResolver(t *testing.T) {
 		ServiceResolverCell,
 
 		cell.Config(k8s.DefaultConfig),
+		cell.Provide(k8s.DefaultServiceWatchConfig),
 		cell.Provide(k8s.ServiceResource),
 
 		cell.Invoke(func(cl_ *k8sClient.FakeClientset, resolver_ *ServiceResolver) {

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
-	"github.com/spf13/pflag"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
+	config "github.com/cilium/cilium/pkg/envoy/config"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -42,8 +42,8 @@ var Cell = cell.Module(
 
 	metrics.Metric(xds.NewXDSMetric),
 
-	cell.Config(ProxyConfig{}),
-	cell.Config(secretSyncConfig{}),
+	cell.Config(config.ProxyConfig{}),
+	cell.Config(config.SecretSyncConfig{}),
 	cell.Provide(newEnvoyXDSServer),
 	cell.Provide(newEnvoyAdminClient),
 	cell.Provide(envoypolicy.NewEnvoyL7RulesTranslator),
@@ -54,86 +54,6 @@ var Cell = cell.Module(
 	cell.Invoke(registerSecretSyncer),
 )
 
-type ProxyConfig struct {
-	DisableEnvoyVersionCheck          bool
-	ProxyPrometheusPort               int
-	ProxyAdminPort                    int
-	EnvoyLog                          string
-	EnvoyAccessLogBufferSize          uint
-	EnvoyDefaultLogLevel              string
-	EnvoyBaseID                       uint64
-	EnvoyKeepCapNetbindservice        bool
-	ProxyConnectTimeout               uint
-	ProxyInitialFetchTimeout          uint
-	ProxyGID                          uint
-	ProxyMaxRequestsPerConnection     int
-	ProxyMaxConnectionDurationSeconds int
-	ProxyIdleTimeoutSeconds           int
-	ProxyMaxConcurrentRetries         uint32
-	HTTPNormalizePath                 bool
-	HTTPRequestTimeout                uint
-	HTTPIdleTimeout                   uint
-	HTTPMaxGRPCTimeout                uint
-	HTTPRetryCount                    uint
-	HTTPRetryTimeout                  uint
-	HTTPStreamIdleTimeout             uint
-	UseFullTLSContext                 bool
-	ProxyXffNumTrustedHopsIngress     uint32
-	ProxyXffNumTrustedHopsEgress      uint32
-	EnvoyPolicyRestoreTimeout         time.Duration
-	EnvoyHTTPUpstreamLingerTimeout    int
-}
-
-func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
-	flags.Bool("disable-envoy-version-check", false, "Do not perform Envoy version check")
-	flags.Int("proxy-prometheus-port", 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
-	flags.Int("proxy-admin-port", 0, "Port to serve Envoy admin interface on.")
-	flags.Uint("envoy-access-log-buffer-size", 4096, "Envoy access log buffer size in bytes")
-	flags.String("envoy-log", "", "Path to a separate Envoy log file, if any")
-	flags.String("envoy-default-log-level", "", "Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. If not defined, the default log level of the Cilium Agent is used.")
-	flags.Uint64("envoy-base-id", 0, "Envoy base ID")
-	flags.Bool("envoy-keep-cap-netbindservice", false, "Keep capability NET_BIND_SERVICE for Envoy process")
-	flags.Uint("proxy-connect-timeout", 2, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
-	flags.Uint("proxy-initial-fetch-timeout", 30, "Time after which an xDS stream is considered timed out (in seconds)")
-	flags.Uint("proxy-gid", 1337, "Group ID for proxy control plane sockets.")
-	flags.Int("proxy-max-requests-per-connection", 0, "Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)")
-	flags.Int("proxy-max-connection-duration-seconds", 0, "Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)")
-	flags.Int("proxy-idle-timeout-seconds", 60, "Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s")
-	flags.Uint32("proxy-max-concurrent-retries", 128, "Maximum number of concurrent retries on Envoy clusters")
-	flags.Bool("http-normalize-path", true, "Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution.")
-	flags.Uint("http-request-timeout", 60*60, "Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited")
-	flags.Uint("http-idle-timeout", 0, "Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)")
-	flags.Uint("http-max-grpc-timeout", 0, "Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A \"grpc-timeout\" header may override this with a shorter value; defaults to 0 (unlimited)")
-	flags.Uint("http-retry-count", 3, "Number of retries performed after a forwarded request attempt fails")
-	flags.Uint("http-retry-timeout", 0, "Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)")
-	flags.Uint("http-stream-idle-timeout", 5*60, "Set Envoy the amount of time that the connection manager will allow a stream to exist with no upstream or downstream activity. Default 300s")
-	// This should default to false in 1.16+ (i.e., we don't implement buggy behaviour) and true in 1.15 and earlier (i.e., we keep compatibility with an existing bug).
-	flags.Bool("use-full-tls-context", false, "If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.")
-	flags.Uint32("proxy-xff-num-trusted-hops-ingress", 0, "Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.")
-	flags.Uint32("proxy-xff-num-trusted-hops-egress", 0, "Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.")
-	flags.Duration("envoy-policy-restore-timeout", 3*time.Minute, "Maxiumum time to wait for enpoint policy restoration before starting serving resources to Envoy")
-	flags.Int("envoy-http-upstream-linger-timeout", -1, "Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. "+
-		"If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.")
-}
-
-type secretSyncConfig struct {
-	EnvoySecretsNamespace string
-
-	EnableIngressController bool
-	IngressSecretsNamespace string
-
-	EnableGatewayAPI           bool
-	GatewayAPISecretsNamespace string
-}
-
-func (r secretSyncConfig) Flags(flags *pflag.FlagSet) {
-	flags.String("envoy-secrets-namespace", r.EnvoySecretsNamespace, "EnvoySecretsNamespace is the namespace having secrets used by CEC")
-	flags.Bool("enable-ingress-controller", false, "Enables Envoy secret sync for Ingress controller related TLS secrets")
-	flags.String("ingress-secrets-namespace", r.IngressSecretsNamespace, "IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller")
-	flags.Bool("enable-gateway-api", false, "Enables Envoy secret sync for Gateway API related TLS secrets")
-	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API")
-}
-
 type xdsServerParams struct {
 	cell.In
 
@@ -143,7 +63,7 @@ type xdsServerParams struct {
 	RestorerPromise    promise.Promise[endpointstate.Restorer]
 	LocalEndpointStore *LocalEndpointStore
 
-	EnvoyProxyConfig ProxyConfig
+	EnvoyProxyConfig config.ProxyConfig
 
 	// Depend on access log server to enforce init order.
 	// This ensures that the access log server is ready before it gets used by the
@@ -228,7 +148,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 	return xdsServer, nil
 }
 
-func newEnvoyAdminClient(logger *slog.Logger, envoyProxyConfig ProxyConfig) *EnvoyAdminClient {
+func newEnvoyAdminClient(logger *slog.Logger, envoyProxyConfig config.ProxyConfig) *EnvoyAdminClient {
 	return NewEnvoyAdminClientForSocket(logger, GetSocketDir(option.Config.RunDir), envoyProxyConfig.EnvoyDefaultLogLevel)
 }
 
@@ -239,7 +159,7 @@ type accessLogServerParams struct {
 	Logger             *slog.Logger
 	AccessLogger       accesslog.ProxyAccessLogger
 	LocalEndpointStore *LocalEndpointStore
-	EnvoyProxyConfig   ProxyConfig
+	EnvoyProxyConfig   config.ProxyConfig
 }
 
 func newEnvoyAccessLogServer(params accessLogServerParams) *AccessLogServer {
@@ -280,7 +200,7 @@ type versionCheckParams struct {
 	Logger           *slog.Logger
 	JobRegistry      job.Registry
 	Health           cell.Health
-	EnvoyProxyConfig ProxyConfig
+	EnvoyProxyConfig config.ProxyConfig
 	EnvoyAdminClient *EnvoyAdminClient
 }
 
@@ -360,7 +280,7 @@ type syncerParams struct {
 
 	K8sClientset client.Clientset
 
-	Config        secretSyncConfig
+	Config        config.SecretSyncConfig
 	XdsServer     XDSServer
 	SecretManager certificatemanager.SecretManager
 

--- a/pkg/envoy/config/config.go
+++ b/pkg/envoy/config/config.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package config
+
+import (
+	"github.com/cilium/cilium/pkg/time"
+
+	"github.com/spf13/pflag"
+)
+
+type ProxyConfig struct {
+	DisableEnvoyVersionCheck          bool
+	ProxyPrometheusPort               int
+	ProxyAdminPort                    int
+	EnvoyLog                          string
+	EnvoyAccessLogBufferSize          uint
+	EnvoyDefaultLogLevel              string
+	EnvoyBaseID                       uint64
+	EnvoyKeepCapNetbindservice        bool
+	ProxyConnectTimeout               uint
+	ProxyInitialFetchTimeout          uint
+	ProxyGID                          uint
+	ProxyMaxRequestsPerConnection     int
+	ProxyMaxConnectionDurationSeconds int
+	ProxyIdleTimeoutSeconds           int
+	ProxyMaxConcurrentRetries         uint32
+	HTTPNormalizePath                 bool
+	HTTPRequestTimeout                uint
+	HTTPIdleTimeout                   uint
+	HTTPMaxGRPCTimeout                uint
+	HTTPRetryCount                    uint
+	HTTPRetryTimeout                  uint
+	HTTPStreamIdleTimeout             uint
+	UseFullTLSContext                 bool
+	ProxyXffNumTrustedHopsIngress     uint32
+	ProxyXffNumTrustedHopsEgress      uint32
+	EnvoyPolicyRestoreTimeout         time.Duration
+	EnvoyHTTPUpstreamLingerTimeout    int
+}
+
+func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("disable-envoy-version-check", false, "Do not perform Envoy version check")
+	flags.Int("proxy-prometheus-port", 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
+	flags.Int("proxy-admin-port", 0, "Port to serve Envoy admin interface on.")
+	flags.Uint("envoy-access-log-buffer-size", 4096, "Envoy access log buffer size in bytes")
+	flags.String("envoy-log", "", "Path to a separate Envoy log file, if any")
+	flags.String("envoy-default-log-level", "", "Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. If not defined, the default log level of the Cilium Agent is used.")
+	flags.Uint64("envoy-base-id", 0, "Envoy base ID")
+	flags.Bool("envoy-keep-cap-netbindservice", false, "Keep capability NET_BIND_SERVICE for Envoy process")
+	flags.Uint("proxy-connect-timeout", 2, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
+	flags.Uint("proxy-initial-fetch-timeout", 30, "Time after which an xDS stream is considered timed out (in seconds)")
+	flags.Uint("proxy-gid", 1337, "Group ID for proxy control plane sockets.")
+	flags.Int("proxy-max-requests-per-connection", 0, "Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)")
+	flags.Int("proxy-max-connection-duration-seconds", 0, "Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)")
+	flags.Int("proxy-idle-timeout-seconds", 60, "Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s")
+	flags.Uint32("proxy-max-concurrent-retries", 128, "Maximum number of concurrent retries on Envoy clusters")
+	flags.Bool("http-normalize-path", true, "Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution.")
+	flags.Uint("http-request-timeout", 60*60, "Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited")
+	flags.Uint("http-idle-timeout", 0, "Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)")
+	flags.Uint("http-max-grpc-timeout", 0, "Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A \"grpc-timeout\" header may override this with a shorter value; defaults to 0 (unlimited)")
+	flags.Uint("http-retry-count", 3, "Number of retries performed after a forwarded request attempt fails")
+	flags.Uint("http-retry-timeout", 0, "Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)")
+	flags.Uint("http-stream-idle-timeout", 5*60, "Set Envoy the amount of time that the connection manager will allow a stream to exist with no upstream or downstream activity. Default 300s")
+	// This should default to false in 1.16+ (i.e., we don't implement buggy behaviour) and true in 1.15 and earlier (i.e., we keep compatibility with an existing bug).
+	flags.Bool("use-full-tls-context", false, "If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.")
+	flags.Uint32("proxy-xff-num-trusted-hops-ingress", 0, "Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.")
+	flags.Uint32("proxy-xff-num-trusted-hops-egress", 0, "Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.")
+	flags.Duration("envoy-policy-restore-timeout", 3*time.Minute, "Maxiumum time to wait for enpoint policy restoration before starting serving resources to Envoy")
+	flags.Int("envoy-http-upstream-linger-timeout", -1, "Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. "+
+		"If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.")
+}
+
+type SecretSyncConfig struct {
+	EnvoySecretsNamespace string
+
+	EnableIngressController bool
+	IngressSecretsNamespace string
+
+	EnableGatewayAPI           bool
+	GatewayAPISecretsNamespace string
+}
+
+func (r SecretSyncConfig) Flags(flags *pflag.FlagSet) {
+	flags.String("envoy-secrets-namespace", r.EnvoySecretsNamespace, "EnvoySecretsNamespace is the namespace having secrets used by CEC")
+	flags.Bool("enable-ingress-controller", false, "Enables Envoy secret sync for Ingress controller related TLS secrets")
+	flags.String("ingress-secrets-namespace", r.IngressSecretsNamespace, "IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller")
+	flags.Bool("enable-gateway-api", false, "Enables Envoy secret sync for Gateway API related TLS secrets")
+	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API")
+}

--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -68,14 +68,15 @@ func GetObjNamespaceName(obj NamespaceNameGetter) string {
 // This methods returns a ListOptions modifier which adds a label selector to
 // select all endpointSlice objects they are not from remote clusters in Cilium cluster mesh.
 // This is mostly the same behavior as kube-proxy except the cluster mesh behavior which is
-// tied to how Cilium internally works with clustermesh endpoints and that this function also doesn't ignore headless Services.
+// tied to how Cilium internally works with clustermesh endpoints and that this function doesn't ignore
+// headless Services when includeHeadlessServices is true.
 // Given label mirroring from the service objects to endpoint slice objects were introduced in Kubernetes PR 94443,
 // and released as part of Kubernetes v1.20; we can start using GetServiceAndEndpointListOptionsModifier for
 // endpoint slices when dropping support for Kubernetes v1.19 and older. We can do that since the
 // serviceProxyNameLabel label will then be mirrored to endpoint slices for services with that label.
 // We also ignore Kubernetes endpoints coming from other clusters in the Cilium clustermesh here as
 // Cilium does not rely on mirrored Kubernetes EndpointSlice for any of its functionalities.
-func GetEndpointSliceListOptionsModifier() (func(options *v1meta.ListOptions), error) {
+func GetEndpointSliceListOptionsModifier(includeHeadlessServices bool) (func(options *v1meta.ListOptions), error) {
 	nonRemoteEndpointSelector, err := labels.NewRequirement(discoveryv1.LabelManagedBy, selection.NotEquals, []string{EndpointSliceMeshControllerName})
 	if err != nil {
 		return nil, err
@@ -83,6 +84,15 @@ func GetEndpointSliceListOptionsModifier() (func(options *v1meta.ListOptions), e
 
 	labelSelector := labels.NewSelector()
 	labelSelector = labelSelector.Add(*nonRemoteEndpointSelector)
+
+	if !includeHeadlessServices {
+		nonHeadlessServiceSelector, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
+
+		if err != nil {
+			return nil, err
+		}
+		labelSelector = labelSelector.Add(*nonHeadlessServiceSelector)
+	}
 
 	return func(options *v1meta.ListOptions) {
 		options.LabelSelector = labelSelector.String()
@@ -92,12 +102,12 @@ func GetEndpointSliceListOptionsModifier() (func(options *v1meta.ListOptions), e
 // GetServiceAndEndpointListOptionsModifier returns the options modifier for service and endpoint object lists.
 // This methods returns a ListOptions modifier which adds a label selector to only
 // select services that are in context of Cilium.
-// Unlike kube-proxy Cilium does not select services/endpoints containing k8s headless service label.
+// Unlike kube-proxy Cilium also watches headless services and their endpoint slices when includeHeadlessServices is true.
 // We honor service.kubernetes.io/service-proxy-name label in the service object and only
 // handle services that match our service proxy name. If the service proxy name for Cilium
 // is an empty string, we assume that Cilium is the default service handler in which case
 // we select all services that don't have the above mentioned label.
-func GetServiceAndEndpointListOptionsModifier(k8sServiceProxy string) (func(options *v1meta.ListOptions), error) {
+func GetServiceAndEndpointListOptionsModifier(k8sServiceProxy string, includeHeadlessServices bool) (func(options *v1meta.ListOptions), error) {
 	var (
 		serviceNameSelector *labels.Requirement
 		err                 error
@@ -117,6 +127,15 @@ func GetServiceAndEndpointListOptionsModifier(k8sServiceProxy string) (func(opti
 
 	labelSelector := labels.NewSelector()
 	labelSelector = labelSelector.Add(*serviceNameSelector)
+
+	if !includeHeadlessServices {
+		nonHeadlessServiceSelector, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
+
+		if err != nil {
+			return nil, err
+		}
+		labelSelector = labelSelector.Add(*nonHeadlessServiceSelector)
+	}
 
 	return func(options *v1meta.ListOptions) {
 		options.LabelSelector = labelSelector.String()

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -1124,6 +1125,7 @@ func TestL2AnnouncerLifecycle(t *testing.T) {
 				EnableL2Announcements: true,
 			}
 		}),
+		cell.Config(envoyCfg.SecretSyncConfig{}),
 		k8sClient.FakeClientCell(),
 		k8s.ResourcesCell,
 		cell.Invoke(func(_ *L2Announcer) {}),

--- a/pkg/loadbalancer/cell/cell_test.go
+++ b/pkg/loadbalancer/cell/cell_test.go
@@ -13,6 +13,7 @@ import (
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/kpr"
@@ -30,6 +31,7 @@ func TestCell(t *testing.T) {
 	h := hive.New(
 		k8sClient.FakeClientCell(),
 		daemonk8s.ResourcesCell,
+		cell.Config(envoyCfg.SecretSyncConfig{}),
 		daemonk8s.TablesCell,
 		maglev.Cell,
 		node.LocalNodeStoreTestCell,

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -28,6 +28,7 @@ import (
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
@@ -75,6 +76,7 @@ func TestScript(t *testing.T) {
 			h := hive.New(
 				k8sClient.FakeClientCell(),
 				daemonk8s.ResourcesCell,
+				cell.Config(envoyCfg.SecretSyncConfig{}),
 				daemonk8s.TablesCell,
 				metrics.Cell,
 

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -23,6 +23,7 @@ import (
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
@@ -68,6 +69,7 @@ func TestScript(t *testing.T) {
 			h := hive.New(
 				k8sClient.FakeClientCell(),
 				daemonk8s.ResourcesCell,
+				cell.Config(envoyCfg.SecretSyncConfig{}),
 				daemonk8s.TablesCell,
 				metrics.Cell,
 

--- a/pkg/loadbalancer/repl/main.go
+++ b/pkg/loadbalancer/repl/main.go
@@ -13,6 +13,7 @@ import (
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/kpr"
@@ -87,6 +88,7 @@ var Hive = hive.New(
 	node.LocalNodeStoreTestCell,
 	metrics.Cell,
 	cell.Config(loadbalancer.TestConfig{}),
+	cell.Config(envoyCfg.SecretSyncConfig{}),
 	cell.Provide(source.NewSources),
 	cell.Provide(
 		tables.NewNodeAddressTable,

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -27,6 +27,7 @@ import (
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
@@ -78,6 +79,7 @@ func TestScript(t *testing.T) {
 				k8sClient.FakeClientCell(),
 				daemonk8s.ResourcesCell,
 				daemonk8s.TablesCell,
+				cell.Config(envoyCfg.SecretSyncConfig{}),
 
 				cell.Config(loadbalancer.TestConfig{
 					// By default 10% of the time the LBMap operations fail

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/dial"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -122,6 +123,7 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 			writer.Cell,
 			ipset.Cell,
 			k8s.ResourcesCell,
+			cell.Config(envoyCfg.SecretSyncConfig{}),
 			k8sClient.FakeClientCell(),
 			kvstore.Cell(kvstore.DisabledBackendName),
 


### PR DESCRIPTION
Previously, daemon watched headless services and headless services endpoint slices uncodnitially. This meant that even if features relying on headless services watch such as Gateway API and Ingress were not used the watch was created. This caused a increased load on apisever in clusters making use of headless services.

This patch disables the headless service watch when feature relying on it (Gateway API, Ingress) are not enabled.

Tests for the change were copied from the version prior to https://github.com/cilium/cilium/pull/28440.

Fixes: https://github.com/cilium/cilium/issues/40763

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

```release-note
Disable unnecessary headless service watching to reduce API server load in clusters not using the Gateway API or Ingress features.
```
