### PR TITLE
clustermesh: fix propagation of services with unnamed ports

### DIFF
--- a/operator/watchers/testdata/servicesync.txtar
+++ b/operator/watchers/testdata/servicesync.txtar
@@ -73,7 +73,7 @@ k8s/update service.yaml
 kvstore/list -o json cilium/state/services services.actual
 * empty services.actual
 
-# 10. Toggle the global annotation back. The shared annotation is not neeeded.
+# 10. Toggle the global annotation back. The shared annotation is not needed.
 # Service should be added again.
 sed 'service.cilium.io/shared: "true"' 'placeholder: "true"' service.yaml
 sed 'service.cilium.io/global: "false"' 'service.cilium.io/global: "true"' service.yaml
@@ -90,6 +90,21 @@ k8s/update service.yaml
 # Wait for synchronization
 kvstore/list -o json cilium/state/services services.actual
 * empty services.actual
+
+# 12. Validate the export of services with unnamed ports.
+sed 'service.cilium.io/shared: "false"' 'service.cilium.io/shared: "true"' service.yaml
+sed http "" service.yaml
+sed http "" endpointslice.yaml
+
+k8s/update service.yaml
+k8s/update endpointslice.yaml
+
+cp services-4.expected services-5.expected
+sed http '' services-5.expected
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/services services.actual
+* cmp services.actual services-5.expected
 
 # ----
 

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -287,11 +287,7 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 			for _, port := range ep.Ports {
 				name, lbPort, ok := parseEndpointPortV1(port)
 				if ok {
-					if name != "" {
-						backend.Ports[lbPort] = append(backend.Ports[lbPort], name)
-					} else {
-						backend.Ports[lbPort] = nil
-					}
+					backend.Ports[lbPort] = append(backend.Ports[lbPort], name)
 				}
 			}
 			if sub.Hints != nil && (*sub.Hints).ForZones != nil {

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -421,6 +421,15 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					continue
 				}
 
+				// Filter out the unnamed port, if present
+				if idx := slices.Index(portNames, ""); idx != -1 {
+					if len(portNames) == 1 {
+						portNames = nil
+					} else {
+						portNames = slices.Concat(portNames[:idx], portNames[idx+1:])
+					}
+				}
+
 				state := loadbalancer.BackendStateActive
 				if be.Terminating {
 					state = loadbalancer.BackendStateTerminating


### PR DESCRIPTION
The blamed commit reworked the storage of port information as part of the k8s.Backends structure, with the goal of reducing allocations. However, unnamed ports are handled differently, which down the line broke the propagation of services via clustermesh, when associated with unnamed ports, as incorrectly ignored.

Let's get this fixed by uniforming the handling, and adding appropriate filtering to remove the unnamed port entry where appropriate, to preserve the existing behavior. Additionally, let's extend the service synchronization script test, to prevent future regressions.

Fixes: 12ae78bbb2ab ("k8s,loadbalancer: Optimize 'k8s.Backend.Ports' to reduce allocations")

```release-note
clustermesh: fix regression preventing global services with unnamed ports from including remote backends
```