### PR TITLE
eni: improve logging and speed up ipam reconciliation in case of node scale-downs

### DIFF
--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -249,7 +249,6 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 
 	// An ECS instance has at least one ENI attached, no ENI found implies instance not found.
 	if enis == 0 {
-		scopedLog.Warn("Instance not found! Please delete corresponding ciliumnode if instance has already been deleted.")
 		return nil, stats, errors.New("unable to retrieve ENIs")
 	}
 

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -774,7 +774,6 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 
 	// An ec2 instance has at least one ENI attached, no ENI found implies instance not found.
 	if enis == 0 {
-		scopedLog.Warn("Instance not found! Please delete corresponding ciliumnode if instance has already been deleted.")
 		return nil, stats, fmt.Errorf("unable to retrieve ENIs")
 	}
 


### PR DESCRIPTION
(description in commits)

```release-note
eni: improve logging and speed up ipam reconciliation in case of node scale-downs
```
