### PR TITLE
clustermesh: helm: add support for dict type for clusters values

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -909,7 +909,7 @@
      - object
      - ``{"clusters":[],"domain":"mesh.cilium.io","enabled":false}``
    * - :spelling:ignore:`clustermesh.config.clusters`
-     - List of clusters to be peered in the mesh.
+     - Clusters to be peered in the mesh. @schema type: [object, array] @schema
      - list
      - ``[]``
    * - :spelling:ignore:`clustermesh.config.domain`

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -316,6 +316,10 @@ Helm Options
 ~~~~~~~~~~~~
 * The Helm option ``clustermesh.enableMCSAPISupport`` has been deprecated in favor of ``clustermesh.mcsapi.enabled``
   and will be removed in Cilium 1.20.
+* The Helm option ``clustermesh.config.clusters`` now support a new format based on a dict
+  in addition to the previous list format. The new format is recommended for users installing
+  Cilium ClusterMesh without Cilium CLI and could allow you to organize your clusters definition
+  in multiple Helm value files. See the Cilium Helm chart documentation or value file for more details.
 
 
 Agent Options

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -277,7 +277,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for clustermesh-apiserver |
 | clustermesh.apiserver.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | clustermesh-apiserver update strategy |
 | clustermesh.config | object | `{"clusters":[],"domain":"mesh.cilium.io","enabled":false}` | Clustermesh explicit configuration. |
-| clustermesh.config.clusters | list | `[]` | List of clusters to be peered in the mesh. |
+| clustermesh.config.clusters | list | `[]` | Clusters to be peered in the mesh. @schema type: [object, array] @schema |
 | clustermesh.config.domain | string | `"mesh.cilium.io"` | Default dns domain for the Clustermesh API servers This is used in the case cluster addresses are not provided and IPs are used. |
 | clustermesh.config.enabled | bool | `false` | Enable the Clustermesh explicit configuration. |
 | clustermesh.enableEndpointSliceSynchronization | bool | `false` | Enable the synchronization of Kubernetes EndpointSlices corresponding to the remote endpoints of appropriately-annotated global services through ClusterMesh |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -839,7 +839,7 @@ spec:
       {{- end }}
       {{- if and .Values.clustermesh.config.enabled (not (and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled )) }}
       hostAliases:
-      {{- range $cluster := .Values.clustermesh.config.clusters }}
+      {{- range $_, $cluster := (include "clustermesh-clusters" . | fromJson) }}
       {{- range $ip := $cluster.ips }}
       - ip: {{ $ip }}
         hostnames: [ "{{ $cluster.name }}.{{ $.Values.clustermesh.config.domain }}" ]

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -299,7 +299,7 @@ spec:
       {{- end }}
       {{- if and (or .Values.clustermesh.enableEndpointSliceSynchronization .Values.clustermesh.mcsapi.enabled .Values.clustermesh.enableMCSAPISupport) .Values.clustermesh.config.enabled (not (and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled )) }}
       hostAliases:
-      {{- range $cluster := .Values.clustermesh.config.clusters }}
+      {{- range $_, $cluster := (include "clustermesh-clusters" . | fromJson) }}
       {{- range $ip := $cluster.ips }}
       - ip: {{ $ip }}
         hostnames: [ "{{ $cluster.name }}.{{ $.Values.clustermesh.config.domain }}" ]

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -498,7 +498,7 @@ spec:
       {{- end }}
       {{- if and .Values.clustermesh.config.enabled .Values.clustermesh.apiserver.kvstoremesh.enabled }}
       hostAliases:
-      {{- range $cluster := .Values.clustermesh.config.clusters }}
+      {{- range $_, $cluster := (include "clustermesh-clusters" . | fromJson) }}
       {{- range $ip := $cluster.ips }}
       - ip: {{ $ip }}
         hostnames: [ "{{ $cluster.name }}.{{ $.Values.clustermesh.config.domain }}" ]

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -21,7 +21,7 @@ metadata:
 data:
   users.yaml: |
     users:
-    {{- range .Values.clustermesh.config.clusters }}
+    {{- range (include "clustermesh-clusters" . | fromJson) }}
     - name: remote-{{ .name }}
       role: remote
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
@@ -43,3 +43,25 @@ key-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client.key
 cert-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client.crt
 {{- end }}
 {{- end }}
+
+{{- define "clustermesh-clusters" }}
+{{- $clusters := dict }}
+{{- if kindIs "map" .Values.clustermesh.config.clusters }}
+  {{- range $name, $cluster := .Values.clustermesh.config.clusters }}
+    {{- if $cluster.enabled | default true }}
+      {{- $_ := unset $cluster "enabled" }}
+      {{- $_ = set $cluster "name" $name }}
+      {{- $_ = set $clusters $name $cluster }}
+    {{- end }}
+  {{- end }}
+{{- else if kindIs "slice" .Values.clustermesh.config.clusters }}
+  {{- range $cluster := .Values.clustermesh.config.clusters }}
+    {{- if $cluster.enabled | default true }}
+      {{- $_ := set $clusters $cluster.name $cluster }}
+    {{- end }}
+  {{- end }}
+{{- else }}
+  {{- fail (printf "unknown type %s for clustermesh.config.clusters" (kindOf .Values.clustermesh.config.clusters)) }}
+{{- end }}
+{{- toJson $clusters }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -18,7 +18,7 @@ data:
   {{- $kvstoremesh := and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
   {{- $override := ternary (printf "https://clustermesh-apiserver.%s.svc:2379" (include "cilium.namespace" .)) "" $kvstoremesh }}
   {{- $local_etcd := and $kvstoremesh (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external") }}
-  {{- range .Values.clustermesh.config.clusters }}
+  {{- range (include "clustermesh-clusters" . | fromJson) }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $override $local_etcd $.Values.etcd ) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
   {{- if and (eq $override "") (.tls).cert (.tls).key }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{- range .Values.clustermesh.config.clusters }}
+  {{- range (include "clustermesh-clusters" . | fromJson) }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain "" false $.Values.etcd ) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
   {{- if and (.tls).cert (.tls).key }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1448,7 +1448,10 @@
           "properties": {
             "clusters": {
               "items": {},
-              "type": "array"
+              "type": [
+                "object",
+                "array"
+              ]
             },
             "domain": {
               "type": "string"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3287,23 +3287,50 @@ clustermesh:
     # This is used in the case cluster addresses are not provided
     # and IPs are used.
     domain: mesh.cilium.io
-    # -- List of clusters to be peered in the mesh.
+    # -- Clusters to be peered in the mesh.
+    # @schema
+    # type: [object, array]
+    # @schema
     clusters: []
+    # You can use a dict of clusters (recommended):
     # clusters:
-    # # -- Name of the cluster
+    #   # -- Name of the cluster
+    #   cluster1:
+    #     # -- Whether to enable this cluster in the mesh. Optional, defaults to true.
+    #     enabled: true
+    #     # -- Address of the cluster, use this if you created DNS records for
+    #     # the cluster Clustermesh API server.
+    #     address: cluster1.mesh.cilium.io
+    #     # -- Port of the cluster Clustermesh API server.
+    #     port: 2379
+    #     # -- IPs of the cluster Clustermesh API server, use multiple ones when
+    #     # you have multiple IPs to access the Clustermesh API server.
+    #     ips:
+    #     - 172.18.255.201
+    #     # -- base64 encoded PEM values for the cluster client certificate, private key and certificate authority.
+    #     # These fields can (and should) be omitted in case the CA is shared across clusters. In that case, the
+    #     # "remote" private key and certificate available in the local cluster are automatically used instead.
+    #     tls:
+    #       cert: ""
+    #       key: ""
+    #       caCert: ""
+    #
+    # Or alternatively you can use a list of clusters:
+    # clusters:
+    #   # -- Name of the cluster
     # - name: cluster1
-    # # -- Address of the cluster, use this if you created DNS records for
-    # # the cluster Clustermesh API server.
+    #   # -- Address of the cluster, use this if you created DNS records for
+    #   # the cluster Clustermesh API server.
     #   address: cluster1.mesh.cilium.io
-    # # -- Port of the cluster Clustermesh API server.
+    #   # -- Port of the cluster Clustermesh API server.
     #   port: 2379
-    # # -- IPs of the cluster Clustermesh API server, use multiple ones when
-    # # you have multiple IPs to access the Clustermesh API server.
+    #   # -- IPs of the cluster Clustermesh API server, use multiple ones when
+    #   # you have multiple IPs to access the Clustermesh API server.
     #   ips:
     #   - 172.18.255.201
-    # # -- base64 encoded PEM values for the cluster client certificate, private key and certificate authority.
-    # # These fields can (and should) be omitted in case the CA is shared across clusters. In that case, the
-    # # "remote" private key and certificate available in the local cluster are automatically used instead.
+    #   # -- base64 encoded PEM values for the cluster client certificate, private key and certificate authority.
+    #   # These fields can (and should) be omitted in case the CA is shared across clusters. In that case, the
+    #   # "remote" private key and certificate available in the local cluster are automatically used instead.
     #   tls:
     #     cert: ""
     #     key: ""

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3311,23 +3311,50 @@ clustermesh:
     # This is used in the case cluster addresses are not provided
     # and IPs are used.
     domain: mesh.cilium.io
-    # -- List of clusters to be peered in the mesh.
+    # -- Clusters to be peered in the mesh.
+    # @schema
+    # type: [object, array]
+    # @schema
     clusters: []
+    # You can use a dict of clusters (recommended):
     # clusters:
-    # # -- Name of the cluster
+    #   # -- Name of the cluster
+    #   cluster1:
+    #     # -- Whether to enable this cluster in the mesh. Optional, defaults to true.
+    #     enabled: true
+    #     # -- Address of the cluster, use this if you created DNS records for
+    #     # the cluster Clustermesh API server.
+    #     address: cluster1.mesh.cilium.io
+    #     # -- Port of the cluster Clustermesh API server.
+    #     port: 2379
+    #     # -- IPs of the cluster Clustermesh API server, use multiple ones when
+    #     # you have multiple IPs to access the Clustermesh API server.
+    #     ips:
+    #     - 172.18.255.201
+    #     # -- base64 encoded PEM values for the cluster client certificate, private key and certificate authority.
+    #     # These fields can (and should) be omitted in case the CA is shared across clusters. In that case, the
+    #     # "remote" private key and certificate available in the local cluster are automatically used instead.
+    #     tls:
+    #       cert: ""
+    #       key: ""
+    #       caCert: ""
+    #
+    # Or alternatively you can use a list of clusters:
+    # clusters:
+    #   # -- Name of the cluster
     # - name: cluster1
-    # # -- Address of the cluster, use this if you created DNS records for
-    # # the cluster Clustermesh API server.
+    #   # -- Address of the cluster, use this if you created DNS records for
+    #   # the cluster Clustermesh API server.
     #   address: cluster1.mesh.cilium.io
-    # # -- Port of the cluster Clustermesh API server.
+    #   # -- Port of the cluster Clustermesh API server.
     #   port: 2379
-    # # -- IPs of the cluster Clustermesh API server, use multiple ones when
-    # # you have multiple IPs to access the Clustermesh API server.
+    #   # -- IPs of the cluster Clustermesh API server, use multiple ones when
+    #   # you have multiple IPs to access the Clustermesh API server.
     #   ips:
     #   - 172.18.255.201
-    # # -- base64 encoded PEM values for the cluster client certificate, private key and certificate authority.
-    # # These fields can (and should) be omitted in case the CA is shared across clusters. In that case, the
-    # # "remote" private key and certificate available in the local cluster are automatically used instead.
+    #   # -- base64 encoded PEM values for the cluster client certificate, private key and certificate authority.
+    #   # These fields can (and should) be omitted in case the CA is shared across clusters. In that case, the
+    #   # "remote" private key and certificate available in the local cluster are automatically used instead.
     #   tls:
     #     cert: ""
     #     key: ""


### PR DESCRIPTION
This commit add initial support in Helm to pass a dict of clusters instead of a list of clusters.

This fits more to our actual usage as each name are unique and a dict can enforce that by design. It will also allows users to split their clusters in multiple helm values files as a dict allow for deep-merging helm values while you cannot do that with a list.

This also adds a enabled subkey in the clusters list which might allow for further flexibility to optionally declare but disable one cluster when merging Helm values together.

This is only the initial support and don't include the CLI support.

Related to #40796 

```release-note
clustermesh: helm: add support for dict type for `clustermesh.config.clusters` values
```
