### PR TITLE
multicast: do not assign to nil node config map

### DIFF
--- a/pkg/maps/multicast/subscribermap.go
+++ b/pkg/maps/multicast/subscribermap.go
@@ -106,7 +106,7 @@ func NewGroupV4Map(in ParamsIn) ParamsOut {
 		return out
 	}
 
-	out.NodeDefines["ENABLE_MULTICAST"] = "1"
+	out.NodeDefines = defines.Map{"ENABLE_MULTICAST": "1"}
 
 	groupMap := NewGroupV4OuterMap(in.Logger, GroupOuter4MapName)
 


### PR DESCRIPTION
See commit message for details

Fixes: #40830 

```release-note
multicast: fix nil assignment to node configuration cell.Out map
```
