### PR TITLE
aws: fix bug for iterate the wrong subnets

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -959,7 +959,7 @@ func (n *Node) getEffectiveIPLimits(eni *eniTypes.ENI, limits int) (leftoverPref
 
 // findSubnetInSameRouteTableWithNodeSubnet returns the subnet with the most addresses
 // that is in the same route table as the node's subnet to make sure the pod traffic
-// leaving secondary interfaces will be routed as the primary interface.
+// leaving secondary interfaces is routed in the same way as the primary interface.
 func (n *Node) findSubnetInSameRouteTableWithNodeSubnet() *ipamTypes.Subnet {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
@@ -976,15 +976,13 @@ func (n *Node) findSubnetInSameRouteTableWithNodeSubnet() *ipamTypes.Subnet {
 
 	for _, routeTable := range n.manager.routeTables {
 		if _, ok := routeTable.Subnets[nodeSubnetID]; ok && routeTable.VirtualNetworkID == n.k8sObj.Spec.ENI.VpcID {
-			for _, subnetID := range n.k8sObj.Spec.ENI.SubnetIDs {
+			for subnetID := range routeTable.Subnets {
 				if subnetID == nodeSubnetID {
 					continue
 				}
-				if _, ok := routeTable.Subnets[subnetID]; ok {
-					subnet := n.manager.subnets[subnetID]
-					if bestSubnet == nil || subnet.AvailableAddresses > bestSubnet.AvailableAddresses {
-						bestSubnet = subnet
-					}
+				subnet := n.manager.subnets[subnetID]
+				if (bestSubnet == nil || subnet.AvailableAddresses > bestSubnet.AvailableAddresses) && subnet.AvailabilityZone == n.k8sObj.Spec.ENI.AvailabilityZone {
+					bestSubnet = subnet
 				}
 			}
 		}
@@ -994,7 +992,7 @@ func (n *Node) findSubnetInSameRouteTableWithNodeSubnet() *ipamTypes.Subnet {
 }
 
 // checkSubnetInSameRouteTableWithNodeSubnet checks if the given subnet is in the same route table as the node's subnet
-// to make sure the pod traffic leaving secondary interfaces will be routed as the primary interface.
+// to make sure the pod traffic leaving secondary interfaces is routed in the same way as the primary interface.
 func (n *Node) checkSubnetInSameRouteTableWithNodeSubnet(subnet *ipamTypes.Subnet) bool {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()

--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -53,13 +53,14 @@ func Test_findSubnetInSameRouteTableWithNodeSubnet(t *testing.T) {
 			Subnets: map[string]struct{}{
 				"subnet-1": {},
 				"subnet-2": {},
+				"subnet-3": {},
 			},
 		},
 		"rt-2": &ipamTypes.RouteTable{
 			ID:               "rt-2",
 			VirtualNetworkID: "vpc-2",
 			Subnets: map[string]struct{}{
-				"subnet-3": {},
+				"subnet-4": {},
 			},
 		},
 	}
@@ -68,9 +69,9 @@ func Test_findSubnetInSameRouteTableWithNodeSubnet(t *testing.T) {
 		k8sObj: &v2.CiliumNode{
 			Spec: v2.NodeSpec{
 				ENI: types.ENISpec{
-					VpcID:        "vpc-1",
-					NodeSubnetID: "subnet-1",
-					SubnetIDs:    []string{"subnet-1", "subnet-2", "subnet-3"},
+					VpcID:            "vpc-1",
+					NodeSubnetID:     "subnet-1",
+					AvailabilityZone: "us-east-1a",
 				},
 			},
 		},
@@ -79,14 +80,22 @@ func Test_findSubnetInSameRouteTableWithNodeSubnet(t *testing.T) {
 				"subnet-1": {
 					ID:                 "subnet-1",
 					AvailableAddresses: 10,
+					AvailabilityZone:   "us-east-1a",
 				},
 				"subnet-2": {
 					ID:                 "subnet-2",
 					AvailableAddresses: 20,
+					AvailabilityZone:   "us-east-1a",
 				},
 				"subnet-3": {
 					ID:                 "subnet-3",
+					AvailableAddresses: 25,
+					AvailabilityZone:   "us-east-1b",
+				},
+				"subnet-4": {
+					ID:                 "subnet-4",
 					AvailableAddresses: 15,
+					AvailabilityZone:   "us-east-1a",
 				},
 			},
 			routeTables: routeTableMap,


### PR DESCRIPTION
`n.k8sObj.Spec.ENI.SubnetIDs` is read from custom CNI config where `for _, subnetID := range n.k8sObj.Spec.ENI.SubnetIDs` should read all subnets in the route table with the node's subnet.

Here is the example of the ENI spec block where the `SubnetIDs` is empty.

```
eni:
  availability-zone: us-east-1d
  disable-prefix-delegation: false
  first-interface-index: 0
  instance-type: m5.large
  node-subnet-id: subnet-0a8316618efd8ca86
  use-primary-address: false
  vpc-id: vpc-0101a04a3c189edb5
```




```release-note
Fix bug in ENI routing where Cilium would chose the wrong subnet for routing traffic on secondary interfaces
```
