### PR TITLE
Add TESTOWNERS file

### DIFF
--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -1,0 +1,678 @@
+# Code owners are used by the Cilium community to consolidate common knowledge
+# into teams that can provide consistent and actionable feedback to
+# contributors. This section will describe groups of teams and suggestions
+# about the focus areas for review.
+#
+# The primary motivation for these teams is to provide structure around review
+# processes to ensure that contributors know how to reach out to community
+# members to conduct discussions, ensure contributions meet the expectations of
+# the community, and align on the direction of proposed changes. Furthermore,
+# while these teams are primarily drawn upon to provide review on specific pull
+# requests, they are also encouraged to self-organize around how to make
+# improvements to their areas of the Cilium project over time.
+#
+# Any committer may self-nominate to code owner teams. Reach out to the core
+# team on the #committers channel in Slack to coordinate. Committers do not
+# require expert knowledge in an area in order to join a code owner team,
+# only a willingness to engage in discussions and learn about the area.
+#
+# Project-wide
+# ++++++++++++
+#
+# These code owners may provide feedback for Pull Requests submitted to any
+# repository in the Cilium project:
+#
+# - @cilium/api:
+#   Ensure the backwards-compatibility of Cilium REST and gRPC APIs, excluding
+#   Hubble which is owned by @cilium/sig-hubble-api.
+# - @cilium/build:
+#   Provide feedback on languages and scripting used for build and packaging
+#   system: Make, Shell, Docker.
+# - @cilium/cli:
+#   Provide user experience feedback on changes to Command-Line Interfaces.
+#   These owners are a stand-in for the user community to bring a user
+#   perspective to the review process. Consider how information is presented,
+#   consistency of flags and options.
+# - @cilium/ci-structure:
+#   Provide guidance around the best use of Cilium project continuous
+#   integration and testing infrastructure, including GitHub actions, VM
+#   helpers, testing frameworks, etc.
+# - @cilium/community:
+#   Maintain files that refer to Cilium community users such as USERS.md.
+# - @cilium/contributing:
+#   Encourage practices that ensure an inclusive contributor community. Review
+#   tooling and scripts used by contributors.
+# - @cilium/docs-structure:
+#   Ensure the consistency and layout of documentation. General feedback on the
+#   use of Sphinx, how to communicate content clearly to the community. This
+#   code owner is not expected to validate the technical correctness of
+#   submissions. Correctness is typically handled by another code owner group
+#   which is also assigned to any given piece of documentation.
+# - @cilium/sig-foundations:
+#   Review changes to the core libraries and provide guidance to overall
+#   software architecture.
+# - @cilium/github-sec:
+#   Responsible for maintaining the security of repositories in the Cilium
+#   project by maintaining best practices for workflow usage, for instance
+#   preventing malicious use of GitHub actions.
+# - @cilium/helm:
+#   Provide input on the way that Helm can be used to configure features. These
+#   owners are a stand-in for the user community to bring a user perspective to
+#   the review process. Ensure that Helm changes are defined in manners that
+#   will be forward-compatible for upgrade and follow best practices for
+#   deployment (for example, being GitOps-friendly).
+# - @cilium/sig-hubble-api:
+#   Review Hubble API changes related to gRPC endpoints.
+#   The team ensures that API changes are backward
+#   compatible or that a new API version is created for backward incompatible
+#   changes.
+# - @cilium/metrics:
+#   Provide recommendations about the types, names and labels for metrics to
+#   follow best practices. This includes considering the cardinality impact of
+#   metrics being added or extended.
+# - @cilium/release-managers:
+#   Review files related to releases like AUTHORS and VERSION.
+# - @cilium/security:
+#   Provide feedback on changes that could have security implications for Cilium,
+#   and maintain security-related documentation.
+# - @cilium/vendor:
+#   Review vendor updates for software dependencies to check for any potential
+#   upstream breakages / incompatibilities. Discourage the use of unofficial
+#   forks of upstream libraries if they are actively maintained.
+#
+# Repository Owners
+# +++++++++++++++++
+#
+# The following code owners are responsible for a range of general feedback for
+# contributions to specific repositories:
+#
+# - @cilium/sig-hubble:
+#   Review all Cilium and Hubble code related to observing system events,
+#   exporting those via gRPC protocols outside the node and outside the
+#   cluster. those event channels, for example via TLS.
+# - @cilium/hubble-metrics:
+#   Review code related to Hubble metrics, ensure changes in exposed metrics are
+#   consistent and not breaking without careful consideration.
+# - @cilium/hubble-ui:
+#   Maintain the Hubble UI graphical interface.
+# - @cilium/tetragon:
+#   Review of all Tetragon code, both for Go and C (for eBPF).
+#
+# The teams above are responsible for reviewing the majority of contributions
+# to the corresponding repositories. Additionally, there are "maintainer" teams
+# listed below which may not be responsible for overall code review for a
+# repository, but they have administrator access to the repositories and so
+# they can assist with configuring GitHub repository settings, secrets, and
+# related processes. For the full codeowners for individual repositories, see
+# the CODEOWNERS file in the corresponding repository.
+#
+# - @cilium/cilium-cli-maintainers
+# - @cilium/cilium-maintainers
+# - @cilium/cilium-packer-ci-build-maintainers
+# - @cilium/ebpf-lib-maintainers
+# - @cilium/hubble-maintainers
+# - @cilium/image-tools-maintainers
+# - @cilium/metallb-maintainers
+# - @cilium/openshift-terraform-maintainers
+# - @cilium/proxy-maintainers
+# - @cilium/tetragon-maintainers
+#
+# Cloud Integrations
+# ++++++++++++++++++
+#
+# The following codeowner groups provide insight into the integrations with
+# specific cloud providers:
+#
+# - @cilium/alibabacloud
+# - @cilium/aws
+# - @cilium/azure
+#
+# Cilium Internals
+# ++++++++++++++++
+#
+# The following codeowner groups cover more specific knowledge about Cilium
+# Agent internals or the way that particular Cilium features interact with
+# external software and protocols:
+#
+# - @cilium/docker:
+#   Maintain the deprecated docker-plugin.
+# - @cilium/endpoint:
+#   Provide background on how the Cilium Endpoint package fits into the overall
+#   agent architecture, relationship with generation of policy / datapath
+#   constructs, serialization and restore from disk.
+# - @cilium/envoy:
+#   Maintain the L7 proxy integration with Envoy. This includes the
+#   configurations for Envoy via xDS protocols as well as the extensible
+#   proxylib framework for Go-based layer 7 filters.
+# - @cilium/egress-gateway:
+#   Maintain the egress gateway control plane and datapath logic.
+# - @cilium/fqdn:
+#   Maintain the L7 DNS proxy integration.
+# - @cilium/ipcache:
+#   Provide background on how the userspace IPCache structure fits into the
+#   overall agent architecture, ordering constraints with respect to network
+#   policies and encryption. Handle the relationship between Kubernetes state
+#   and datapath state as it pertains to remote peers.
+# - @cilium/ipsec:
+#   Maintain the kernel IPsec configuration and related eBPF logic to ensure
+#   traffic is correctly encrypted.
+# - @cilium/kvstore:
+#   Review Cilium interactions with key-value stores, particularly etcd.
+#   Understand the client libraries used by Cilium for sharing state between
+#   nodes and clusters.
+# - @cilium/loader:
+#   Maintain the tooling that allows eBPF programs to be loaded into the
+#   kernel: LLVM, bpftool, use of cilium/ebpf for loading programs in the
+#   agent, ELF templating, etc.
+# - @cilium/operator:
+#   Review operations that occur once per cluster via the Cilium Operator
+#   component. Take care of the corresponding garbage collection and leader
+#   election logic.
+# - @cilium/proxy:
+#   Review low-level implementations used to redirect L7 traffic to the actual
+#   proxy implementations (FQDN, Envoy, ...).
+# - @cilium/sig-agent:
+#   Provide Cilium (agent) general Go review. Internal architecture, core data
+#   structures and daemon startup.
+# - @cilium/sig-bgp:
+#   Review changes to our BGP integration.
+# - @cilium/sig-clustermesh:
+#   Ensure the reliability of state sharing between clusters to ensure that
+#   each cluster maintains a separate fault domain.
+# - @cilium/sig-datapath:
+#   Provide feedback on all eBPF code changes, use of the kernel APIs for
+#   configuring the networking and socket layers. Coordination of kernel
+#   subsystems such as xfrm (IPsec), iptables / nftables, tc. Maintain the
+#   control plane layers that populate most eBPF maps; account for endianness
+#   and system architecture impacts on the datapath code.
+# - @cilium/sig-encryption
+#   Review control and data plane logic related with encryption (IPSec and
+#   WireGuard).
+# - @cilium/sig-hubble:
+#   Review all Cilium and Hubble code related to observing system events,
+#   exporting those via gRPC protocols outside the node and outside the
+#   cluster. Ensure the security of those event channels, for example via TLS.
+# - @cilium/sig-ipam:
+#   Coordinate the implementation between all of the IP Address Management
+#   modes, provide awareness/insight into IP resource exhaustion and garbage
+#   collection concerns.
+# - @cilium/sig-k8s:
+#   Provide input on all interactions with Kubernetes, both for standard
+#   resources and CRDs. Ensure best practices are followed for the coordination
+#   of clusterwide state in order to minimize memory usage.
+# - @cilium/sig-lb:
+#   Maintain the layers necessary to coordinate all load balancing
+#   configurations within the agent control plane, including Services,
+#   ClusterIP, NodePorts, Maglev, local redirect policies, and
+#   NAT46/NAT64.
+# - @cilium/sig-policy:
+#   Ensure consistency of semantics for all network policy representations.
+#   Responsible for all policy logic from Kubernetes down to eBPF policymap
+#   entries, including all intermediate layers such as the Policy Repository,
+#   SelectorCache, PolicyCache, CachedSelectorPolicy, EndpointPolicy, etc.
+# - @cilium/sig-scalability:
+#   Maintain scalability and performance tests. Provide input on scalability
+#   and performance related changes.
+# - @cilium/sig-servicemesh:
+#   Provide input on the way that Service Mesh constructs such as Gateway API
+#   are converted into lower-level constructs backed by eBPF or Envoy
+#   configurations. Maintain the CRDs necessary for Service Mesh functionality.
+# - @cilium/wireguard:
+#   Maintain the kernel WireGuard configuration and datapath impacts related to
+#   ensuring traffic is encrypted correctly when WireGuard mode is enabled.
+#
+# END_CODEOWNERS_DOCS
+#
+# The following filepaths should be sorted so that more specific paths occur
+# after the less specific paths, otherwise the ownership for the specific paths
+# is not properly picked up in Github.
+/AUTHORS @cilium/release-managers
+/CODE_OF_CONDUCT.md @cilium/contributing
+/CODEOWNERS @cilium/contributing
+/CONTRIBUTING.md @cilium/contributing
+/.authors.aux @cilium/contributing
+/.clomonitor.yml @cilium/contributing
+/.devcontainer @cilium/ci-structure
+/.gitattributes @cilium/contributing
+/.github/ @cilium/github-sec @cilium/ci-structure
+/.github/*.md @cilium/contributing
+/.github/assets/ @cilium/contributing
+/.github/ISSUE_TEMPLATE/ @cilium/contributing
+/.github/ariane-config.yaml @cilium/github-sec @cilium/ci-structure
+/.github/renovate.json5 @cilium/github-sec @cilium/ci-structure
+/.github/actions/ @cilium/github-sec @cilium/ci-structure
+/.github/actions/bpftrace/ @cilium/sig-encryption @cilium/github-sec @cilium/ci-structure
+/.github/actions/e2e/*ipsec* @cilium/ipsec @cilium/github-sec @cilium/ci-structure
+/.github/actions/kvstore/ @cilium/sig-clustermesh @cilium/kvstore @cilium/github-sec @cilium/ci-structure
+/.github/workflows/ @cilium/github-sec @cilium/ci-structure
+/.github/workflows/auto-approve.yaml @cilium/cilium-maintainers
+/.github/workflows/*cilium-cli*.yaml @cilium/cli @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*clustermesh*.yaml @cilium/sig-clustermesh @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*datapath*.yaml @cilium/sig-datapath @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*gateway-api*.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*hubble*.yaml @cilium/sig-hubble @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*ipsec*.yaml @cilium/ipsec @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*ingress*.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure
+/.github/actions/cl2-modules/ @cilium/sig-scalability
+/.github/workflows/*scale*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*perf*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
+/.github/workflows/conformance-aks.yaml @cilium/azure @cilium/ipsec @cilium/github-sec @cilium/ci-structure
+/.github/workflows/conformance-aws-cni.yaml @cilium/aws @cilium/github-sec @cilium/ci-structure
+/.github/workflows/conformance-eks.yaml @cilium/aws @cilium/ipsec @cilium/github-sec @cilium/ci-structure
+/.github/workflows/conformance-kind-proxy-embedded.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure
+/.github/workflows/tests-ces-migrate.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
+/.gitignore @cilium/contributing
+/.golangci.yaml @cilium/ci-structure
+/.mailmap @cilium/release-managers
+/.nvim @cilium/contributing
+/.vscode @cilium/contributing
+/api/ @cilium/api
+/api/v1/Makefile @cilium/sig-hubble-api
+/api/v1/Makefile.protoc @cilium/sig-hubble-api
+/api/v1/flow/ @cilium/sig-hubble-api
+/api/v1/health/ @cilium/api @cilium/sig-agent
+/api/v1/observer/ @cilium/sig-hubble-api
+/api/v1/operator/ @cilium/api @cilium/operator
+/api/v1/peer/ @cilium/sig-hubble-api
+/api/v1/recorder/ @cilium/sig-hubble-api
+/api/v1/relay/ @cilium/sig-hubble-api
+Makefile* @cilium/build
+/bpf/ @cilium/sig-datapath
+/bpf/bpf_wireguard.c @cilium/wireguard @cilium/sig-datapath
+/bpf/custom/Makefile* @cilium/build @cilium/loader
+/bpf/include/bpf/tailcall.h @cilium/loader
+/bpf/include/bpf/config @cilium/loader
+/bpf/lib/auth.h @cilium/sig-datapath @cilium/sig-servicemesh
+/bpf/lib/drop_reasons.h @cilium/sig-hubble
+/bpf/lib/egress_gateway.h @cilium/egress-gateway
+/bpf/lib/encrypt.h @cilium/ipsec
+/bpf/lib/policy.h @cilium/sig-datapath @cilium/sig-policy
+/bpf/lib/proxy.h @cilium/proxy @cilium/sig-datapath
+/bpf/lib/wireguard.h @cilium/wireguard @cilium/sig-datapath
+/bpf/Makefile* @cilium/loader
+/bpf/node_config.h @cilium/loader
+/bugtool/ @cilium/cli
+/cilium-dbg/ @cilium/cli
+/cilium-dbg/cmd/encrypt* @cilium/ipsec @cilium/cli
+/cilium-dbg/cmd/preflight_k8s_valid_cnp.go @cilium/sig-k8s
+/cilium-cli/ @cilium/cli
+/cilium-cli/bgp/ @cilium/sig-bgp
+/cilium-cli/cmd/ @cilium/cli
+/cilium-cli/clustermesh/ @cilium/sig-clustermesh
+/cilium-cli/connectivity/ @cilium/ci-structure
+/cilium-cli/connectivity/check/frr.go @cilium/sig-bgp
+/cilium-cli/connectivity/check/ipcache.go @cilium/ipcache
+/cilium-cli/connectivity/check/manifests/egress-gateway-policy.yaml @cilium/egress-gateway
+/cilium-cli/connectivity/check/metrics*.go @cilium/metrics
+/cilium-cli/connectivity/check/policy.go @cilium/sig-policy
+/cilium-cli/connectivity/builder/** @cilium/ci-structure
+/cilium-cli/connectivity/builder/all_ingress_deny_from_outside.go @cilium/sig-encryption
+/cilium-cli/connectivity/builder/bgp_control_plane.go @cilium/sig-bgp
+/cilium-cli/connectivity/builder/client_egress.go @cilium/sig-policy
+/cilium-cli/connectivity/builder/client_egress_l7*.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/client_egress_tls_sni.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/client_egress_to_cidr*.go @cilium/sig-policy
+/cilium-cli/connectivity/builder/client_egress_to_echo*.go @cilium/sig-policy
+/cilium-cli/connectivity/builder/cluster_entity_multi_cluster.go @cilium/sig-clustermesh
+/cilium-cli/connectivity/builder/dns_only.go @cilium/fqdn
+/cilium-cli/connectivity/builder/echo_ingress.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/echo_ingress_auth_always_fail.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/echo_ingress_from_other_client_deny.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/echo_ingress_from_outside.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/echo_ingress_knp.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/echo_ingress_l7.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/echo_ingress_l7_named_port.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/echo_ingress_mutual_auth_spiffe.go @cilium/sig-servicemesh
+/cilium-cli/connectivity/builder/egress_gateway.go @cilium/egress-gateway
+/cilium-cli/connectivity/builder/egress_gateway_excluded_cidrs.go @cilium/egress-gateway
+/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go @cilium/egress-gateway
+/cilium-cli/connectivity/builder/local_redirect_policy.go @cilium/sig-lb
+/cilium-cli/connectivity/builder/no_ipsec_xfrm_errors.go @cilium/sig-encryption
+/cilium-cli/connectivity/builder/node_to_node_encryption.go @cilium/sig-encryption
+/cilium-cli/connectivity/builder/pod_to_pod_encryption.go @cilium/sig-encryption
+/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go @cilium/sig-encryption
+/cilium-cli/connectivity/perf/** @cilium/sig-scalability
+/cilium-cli/connectivity/tests/bgp.go @cilium/sig-bgp
+/cilium-cli/connectivity/tests/clustermesh-endpointslice-sync.go @cilium/sig-clustermesh
+/cilium-cli/connectivity/tests/egressgateway.go @cilium/egress-gateway
+/cilium-cli/connectivity/tests/encryption.go @cilium/sig-encryption
+/cilium-cli/connectivity/tests/encryption_v2.go @cilium/sig-encryption
+/cilium-cli/connectivity/tests/errors.go @cilium/sig-agent @cilium/sig-datapath
+/cilium-cli/connectivity/tests/from-cidr.go @cilium/sig-policy
+/cilium-cli/connectivity/tests/health.go @cilium/sig-agent
+/cilium-cli/connectivity/tests/host.go @cilium/sig-agent
+/cilium-cli/connectivity/tests/ipsec_xfrm.go @cilium/ipsec
+/cilium-cli/connectivity/tests/lrp.go @cilium/sig-lb
+/cilium-cli/connectivity/tests/pod.go @cilium/sig-agent
+/cilium-cli/connectivity/tests/service.go @cilium/sig-lb
+/cilium-cli/connectivity/tests/to-cidr.go @cilium/sig-policy
+/cilium-cli/connectivity/tests/upgrade.go @cilium/sig-datapath
+/cilium-cli/connectivity/tests/world.go @cilium/proxy
+/cilium-cli/encrypt/ @cilium/sig-encryption
+/cilium-cli/hubble/ @cilium/sig-hubble
+/cilium-cli/install/ @cilium/cli @cilium/helm
+/cilium-cli/install/azure.go @cilium/azure
+/cilium-cli/k8s/ @cilium/sig-k8s
+/cilium-health/ @cilium/sig-agent
+/cilium-health/cmd/ @cilium/sig-agent @cilium/cli
+/clustermesh-apiserver @cilium/sig-clustermesh
+/contrib/ @cilium/contributing
+/contrib/containerlab/ @cilium/sig-bgp
+/contrib/coccinelle/ @cilium/sig-datapath
+/contrib/scripts/portgen.py @cilium/sig-datapath
+/contrib/scripts/check-datapathconfig.sh @cilium/loader
+/daemon/ @cilium/sig-agent
+/daemon/cmd/datapath.go @cilium/sig-datapath
+/daemon/cmd/endpoint* @cilium/endpoint
+/daemon/cmd/kube_proxy* @cilium/sig-datapath
+/daemon/cmd/bootstrap_statistics.go @cilium/metrics
+/daemon/cmd/policy* @cilium/sig-policy
+/daemon/cmd/state.go @cilium/endpoint
+/daemon/cmd/cells*.go @cilium/sig-foundations
+/Documentation/ @cilium/docs-structure
+/Documentation/_static/ @cilium/docs-structure
+/Documentation/api.rst @cilium/sig-agent @cilium/docs-structure
+/Documentation/beta.rst @cilium/docs-structure
+/Documentation/reference-guides/bpf/ @cilium/sig-datapath @cilium/docs-structure
+/Documentation/reference-guides/xfrm/ @cilium/ipsec @cilium/docs-structure
+/Documentation/check-build.sh @cilium/docs-structure
+/Documentation/check-cmdref.sh @cilium/docs-structure
+/Documentation/check-crd-compat-table.sh @cilium/docs-structure
+/Documentation/check-examples.sh @cilium/docs-structure
+/Documentation/check-helmvalues.sh @cilium/docs-structure
+/Documentation/cmdref/
+/Documentation/community/community.rst @cilium/contributing
+/Documentation/community/governance.rst @cilium/contributing
+/Documentation/community/roadmap.rst @cilium/contributing @cilium/docs-structure
+/Documentation/contributing/ @cilium/contributing @cilium/docs-structure
+/Documentation/conf.py @cilium/docs-structure
+/Documentation/configuration/index.rst @cilium/docs-structure
+/Documentation/contributing/ @cilium/contributing @cilium/docs-structure
+/Documentation/contributing/development/reviewers_committers/review_vendor.rst @cilium/vendor
+/Documentation/contributing/testing/scalability.rst @cilium/sig-scalability
+/Documentation/crdlist.rst
+/Documentation/Dockerfile @cilium/docs-structure
+/Documentation/gettingstarted/demo.rst @cilium/docs-structure
+/Documentation/gettingstarted/gettinghelp.rst @cilium/contributing @cilium/docs-structure
+/Documentation/glossary.rst @cilium/docs-structure
+/Documentation/helm-values.rst
+/Documentation/images/re-request-review.png @cilium/contributing @cilium/docs-structure
+/Documentation/index.rst @cilium/docs-structure
+/Documentation/installation/alibabacloud* @cilium/alibabacloud @cilium/docs-structure
+/Documentation/installation/aws* @cilium/aws @cilium/docs-structure
+/Documentation/installation/cni-chaining-aws-cni.rst @cilium/aws @cilium/docs-structure
+/Documentation/installation/cni-chaining-azure-cni.rst @cilium/azure @cilium/docs-structure
+/Documentation/installation/kind-configure.rst @cilium/docs-structure
+/Documentation/internals/index.rst @cilium/docs-structure
+/Documentation/internals/cilium_operator.rst @cilium/operator @cilium/docs-structure
+/Documentation/internals/hubble.rst @cilium/sig-hubble @cilium/docs-structure
+/Documentation/images/bpf* @cilium/sig-datapath @cilium/docs-structure
+/Documentation/images/hubble_getflows.png @cilium/sig-hubble @cilium/docs-structure
+/Documentation/Makefile @cilium/docs-structure
+/Documentation/network/bgp* @cilium/sig-bgp @cilium/docs-structure
+/Documentation/network/clustermesh/ @cilium/sig-clustermesh @cilium/docs-structure
+/Documentation/network/concepts/fragmentation.rst @cilium/sig-datapath @cilium/docs-structure
+/Documentation/network/concepts/ipam/ @cilium/sig-ipam @cilium/docs-structure
+/Documentation/network/concepts/ipam/azure* @cilium/sig-ipam @cilium/azure @cilium/docs-structure
+/Documentation/network/concepts/ipam/eni* @cilium/sig-ipam @cilium/aws @cilium/docs-structure
+/Documentation/network/concepts/masquerading.rst @cilium/sig-datapath @cilium/docs-structure
+/Documentation/network/ebpf/ @cilium/sig-datapath @cilium/docs-structure
+/Documentation/network/egress-gateway-toc.rst @cilium/egress-gateway @cilium/docs-structure
+/Documentation/network/egress-gateway/ @cilium/egress-gateway @cilium/docs-structure
+/Documentation/network/kubernetes/ @cilium/sig-k8s @cilium/docs-structure
+/Documentation/network/kubernetes/bandwidth-manager.rst @cilium/sig-datapath @cilium/docs-structure
+/Documentation/network/kubernetes/ipam* @cilium/sig-ipam @cilium/docs-structure
+/Documentation/network/kubernetes/kubeproxy-free.rst @cilium/sig-lb @cilium/docs-structure
+/Documentation/network/kubernetes/local-redirect-policy.rst @cilium/sig-lb @cilium/docs-structure
+/Documentation/network/kubernetes/ciliumendpointslice.rst @cilium/sig-scalability @cilium/docs-structure
+/Documentation/network/lb-ipam.rst @cilium/sig-lb @cilium/docs-structure
+/Documentation/network/multicast.rst @cilium/sig-datapath @cilium/docs-structure
+/Documentation/network/servicemesh/ @cilium/sig-servicemesh @cilium/docs-structure
+/Documentation/observability/ @cilium/sig-policy @cilium/docs-structure
+/Documentation/observability/hubble* @cilium/sig-hubble @cilium/docs-structure
+/Documentation/operations/performance/ @cilium/sig-datapath @cilium/docs-structure
+/Documentation/operations/system_requirements.rst @cilium/sig-datapath @cilium/docs-structure
+/Documentation/operations/troubleshooting_clustermesh.rst @cilium/sig-clustermesh @cilium/docs-structure
+/Documentation/overview/component-overview.rst @cilium/docs-structure
+/Documentation/overview/intro.rst @cilium/docs-structure
+/Documentation/requirements.txt @cilium/docs-structure
+/Documentation/security/http.rst @cilium/sig-policy @cilium/docs-structure
+/Documentation/security/images/cilium_threat_model* @cilium/security @cilium/docs-structure
+/Documentation/security/network/encryption-ipsec.rst @cilium/ipsec @cilium/docs-structure
+/Documentation/security/network/encryption-wireguard.rst @cilium/wireguard @cilium/docs-structure
+/Documentation/security/network/proxy/ @cilium/proxy @cilium/docs-structure
+/Documentation/security/policy-creation.rst @cilium/sig-policy @cilium/docs-structure
+/Documentation/security/policy/ @cilium/sig-policy @cilium/docs-structure
+/Documentation/security/threat-model.rst @cilium/security @cilium/docs-structure
+/Documentation/spelling_wordlist.txt @cilium/docs-structure
+/Documentation/update-cmdref.sh @cilium/docs-structure
+/Documentation/update-spelling_wordlist.sh @cilium/docs-structure
+/Documentation/yaml.config @cilium/docs-structure
+/examples/ @cilium/docs-structure
+/examples/hubble/ @cilium/sig-hubble
+/examples/kubernetes-egress-gateway/ @cilium/egress-gateway
+/examples/kubernetes/ @cilium/sig-k8s
+/examples/kubernetes/clustermesh/ @cilium/sig-clustermesh
+/examples/minikube/ @cilium/sig-k8s
+/examples/policies/kubernetes/clustermesh/ @cilium/sig-clustermesh
+/FURTHER_READINGS.rst @cilium/docs-structure
+/hack/ @cilium/contributing
+/hubble/ @cilium/sig-hubble
+/hubble-relay/ @cilium/sig-hubble
+/images @cilium/build
+/images/builder/install-protoc.sh @cilium/sig-hubble-api
+/images/builder/install-protoplugins.sh @cilium/sig-hubble-api
+/images/builder/update-cilium-builder-image.sh @cilium/github-sec
+/images/hubble-relay @cilium/sig-hubble
+/images/runtime/update-cilium-runtime-image.sh @cilium/github-sec
+/install/kubernetes/ @cilium/sig-k8s @cilium/helm
+/install/kubernetes/cilium/**/cilium-envoy @cilium/sig-k8s @cilium/helm @cilium/envoy @cilium/sig-servicemesh
+/install/kubernetes/cilium/**/spire @cilium/sig-k8s @cilium/helm @cilium/sig-servicemesh
+/install/kubernetes/cilium/templates/clustermesh* @cilium/sig-k8s @cilium/helm @cilium/sig-clustermesh
+/install/kubernetes/cilium/templates/hubble* @cilium/sig-k8s @cilium/helm @cilium/sig-hubble
+/LICENSE @cilium/contributing
+/MAINTAINERS.md @cilium/contributing
+/netlify.toml @cilium/ci-structure
+/operator/ @cilium/operator
+/operator/doublewrite @cilium/metrics
+/operator/pkg/bgpv2 @cilium/sig-bgp
+/operator/pkg/ciliumendpointslice @cilium/sig-scalability
+/operator/pkg/ciliumenvoyconfig @cilium/sig-servicemesh
+/operator/pkg/controller-runtime @cilium/envoy @cilium/sig-servicemesh
+/operator/pkg/gateway-api @cilium/sig-servicemesh
+/operator/pkg/ingress @cilium/sig-servicemesh
+/operator/pkg/lbipam @cilium/sig-lb
+/operator/pkg/model @cilium/sig-servicemesh
+/operator/pkg/networkpolicy @cilium/sig-policy
+/operator/pkg/secretsync @cilium/envoy @cilium/sig-servicemesh
+/pkg/act/ @cilium/sig-datapath @cilium/metrics
+/pkg/annotation @cilium/sig-k8s
+/pkg/alibabacloud/ @cilium/alibabacloud
+/pkg/alignchecker/ @cilium/sig-datapath @cilium/loader
+/pkg/allocator/ @cilium/kvstore
+/pkg/api/ @cilium/api
+/pkg/auth/ @cilium/sig-servicemesh
+/pkg/aws/ @cilium/aws
+/pkg/azure/ @cilium/azure
+/pkg/backoff/ @cilium/sig-agent
+/pkg/bufuuid/ @cilium/sig-scalability
+/pkg/bgpv1/ @cilium/sig-bgp
+/pkg/bpf/ @cilium/loader
+/pkg/byteorder/ @cilium/sig-datapath @cilium/api
+/pkg/cgroups/ @cilium/sig-datapath
+/pkg/cidr/ @cilium/sig-agent
+/pkg/ciliumenvoyconfig/ @cilium/envoy @cilium/sig-servicemesh
+/pkg/cleanup/ @cilium/sig-agent
+/pkg/client @cilium/api
+/pkg/clustermesh @cilium/sig-clustermesh
+/pkg/cmdref @cilium/cli
+/pkg/command/ @cilium/cli
+/pkg/common/ @cilium/sig-agent
+/pkg/common/ipsec/ @cilium/ipsec
+/pkg/comparator/ @cilium/sig-agent
+/pkg/completion/ @cilium/proxy
+/pkg/components/ @cilium/sig-agent
+/pkg/container/ @cilium/sig-foundations
+/pkg/container/bitlpm/ @cilium/ipcache @cilium/sig-policy
+/pkg/container/set/ @cilium/sig-policy
+/pkg/controller @cilium/sig-agent
+/pkg/counter @cilium/sig-datapath
+/pkg/crypto/certificatemanager @cilium/envoy @cilium/sig-servicemesh
+/pkg/crypto/certloader @cilium/sig-hubble
+/pkg/datapath/ @cilium/sig-datapath
+/pkg/datapath/fake/ipsec.go @cilium/ipsec
+/pkg/datapath/ipcache/ @cilium/ipcache
+/pkg/datapath/linux/config/ @cilium/loader
+/pkg/datapath/linux/ipsec/ @cilium/ipsec
+/pkg/datapath/linux/ipsec/xfrm_collector* @cilium/ipsec @cilium/metrics
+/pkg/datapath/linux/ipsec.go @cilium/ipsec
+/pkg/datapath/linux/probes/ @cilium/loader
+/pkg/datapath/linux/requirements.go @cilium/loader
+/pkg/datapath/loader/ @cilium/loader
+/pkg/datapath/types/ipsec.go @cilium/ipsec
+/pkg/datapath/types/loader.go @cilium/loader
+/pkg/datapath/sockets/ @cilium/sig-lb
+/pkg/defaults @cilium/sig-agent
+/pkg/debug @cilium/sig-agent
+/pkg/dial @cilium/sig-agent
+/pkg/driftchecker @cilium/sig-foundations
+/pkg/dynamicconfig @cilium/sig-foundations
+/pkg/ebpf @cilium/sig-datapath
+/pkg/egressgateway/ @cilium/egress-gateway
+/pkg/endpoint/ @cilium/endpoint
+/pkg/endpointcleanup/ @cilium/endpoint
+/pkg/endpointmanager/ @cilium/endpoint
+/pkg/endpointstate/ @cilium/endpoint
+/pkg/envoy/ @cilium/envoy
+/pkg/eventqueue/ @cilium/sig-agent
+/pkg/dynamiclifecycle/ @cilium/sig-foundations
+/pkg/flowdebug/ @cilium/proxy
+/pkg/fqdn/ @cilium/fqdn
+/pkg/fswatcher/ @cilium/sig-datapath @cilium/sig-hubble
+/pkg/gops/ @cilium/sig-agent
+/pkg/health/ @cilium/sig-agent
+/pkg/hive/ @cilium/sig-foundations
+/pkg/hubble/ @cilium/sig-hubble
+/pkg/hubble/metrics @cilium/hubble-metrics
+/pkg/iana/ @cilium/sig-agent
+/pkg/identity @cilium/sig-policy
+/pkg/identity/restoration @cilium/sig-policy @cilium/ipcache
+/pkg/idpool/ @cilium/kvstore
+/pkg/ip/ @cilium/sig-agent
+/pkg/ipalloc/ @cilium/sig-ipam
+/pkg/ipam/ @cilium/sig-ipam
+/pkg/ipam/allocator/alibabacloud/ @cilium/sig-ipam @cilium/alibabacloud
+/pkg/ipam/allocator/aws/ @cilium/sig-ipam @cilium/aws
+/pkg/ipam/allocator/azure/ @cilium/sig-ipam @cilium/azure
+/pkg/ipam/allocator/clusterpool/ @cilium/sig-ipam @cilium/operator
+/pkg/ipcache/ @cilium/ipcache
+/pkg/ipmasq @cilium/sig-agent
+/pkg/k8s/ @cilium/sig-k8s
+/pkg/k8s/apis/cilium.io/client/crds/v2/ @cilium/sig-k8s
+/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml @cilium/egress-gateway
+/pkg/k8s/apis/cilium.io/v2/cegp_types.go @cilium/egress-gateway
+/pkg/k8s/apis/cilium.io/v2/ @cilium/api @cilium/sig-k8s
+/pkg/kpr/ @cilium/sig-lb
+/pkg/kvstore/ @cilium/kvstore
+/pkg/kvstore/etcdinit @cilium/sig-clustermesh @cilium/kvstore
+/pkg/l2announcer/ @cilium/sig-agent
+/pkg/labels @cilium/sig-policy @cilium/api
+/pkg/labelsfilter @cilium/sig-policy
+/pkg/launcher @cilium/sig-agent
+/pkg/loadbalancer @cilium/sig-lb
+/pkg/loadinfo/ @cilium/sig-agent
+/pkg/lock @cilium/sig-agent
+/pkg/logging/ @cilium/sig-agent
+/pkg/mac @cilium/sig-datapath
+/pkg/maglev @cilium/sig-lb
+/pkg/maps/ @cilium/sig-datapath
+/pkg/maps/egressmap @cilium/egress-gateway
+/pkg/mcastmanager @cilium/sig-datapath
+/pkg/metrics @cilium/metrics
+/pkg/monitor @cilium/sig-datapath
+/pkg/monitor/api @cilium/api @cilium/sig-datapath
+/pkg/monitor/datapath_trace.go @cilium/sig-datapath @cilium/sig-hubble
+/pkg/monitor/format @cilium/cli @cilium/sig-datapath
+/pkg/monitor/payload @cilium/api @cilium/sig-datapath
+/pkg/mountinfo @cilium/sig-datapath
+/pkg/mtu @cilium/sig-datapath
+/pkg/multicast @cilium/sig-datapath
+/pkg/murmur3/ @cilium/sig-datapath
+/pkg/netns/ @cilium/sig-datapath @cilium/sig-k8s
+/pkg/node @cilium/sig-agent
+/pkg/node/neighbordiscovery @cilium/sig-agent @cilium/sig-datapath
+/pkg/nodediscovery/ @cilium/sig-agent
+/pkg/option @cilium/sig-agent @cilium/cli
+/pkg/pidfile @cilium/sig-agent
+/pkg/policy @cilium/sig-policy
+/pkg/policy/api/ @cilium/api
+/pkg/policy/groups/aws/ @cilium/sig-policy @cilium/aws
+/pkg/policy/k8s @cilium/sig-policy
+/pkg/pprof @cilium/sig-foundations
+/pkg/promise @cilium/sig-foundations
+/pkg/proxy/ @cilium/proxy
+/pkg/proxy/accesslog/record.go @cilium/proxy @cilium/api
+/pkg/proxy/dns.go @cilium/proxy @cilium/fqdn
+/pkg/proxy/envoyproxy.go @cilium/proxy @cilium/envoy
+/pkg/rate/ @cilium/sig-agent
+/pkg/rate/metrics @cilium/metrics
+/pkg/recorder @cilium/sig-datapath
+/pkg/resiliency @cilium/sig-agent
+/pkg/revert/ @cilium/sig-agent
+/pkg/safeio @cilium/sig-agent
+/pkg/safetime/ @cilium/sig-agent
+/pkg/shell @cilium/sig-foundations
+/pkg/shortener @cilium/sig-foundations @cilium/sig-k8s
+/pkg/signal @cilium/sig-datapath
+/pkg/slices @cilium/sig-foundations
+/pkg/socketlb @cilium/loader
+/pkg/source @cilium/ipcache
+/pkg/spanstat/ @cilium/sig-agent
+/pkg/status/ @cilium/sig-agent
+/pkg/testutils/ @cilium/ci-structure
+/pkg/testutils/scriptnet @cilium/sig-foundations
+/pkg/time @cilium/sig-agent
+/pkg/trigger/ @cilium/sig-agent
+/pkg/tuple @cilium/sig-datapath
+/pkg/types/ @cilium/sig-datapath
+/pkg/u8proto/ @cilium/sig-agent
+/pkg/util/ @cilium/sig-datapath
+/pkg/version/ @cilium/sig-agent
+/pkg/versioncheck/ @cilium/sig-agent
+/pkg/wireguard @cilium/wireguard
+/pkg/xds/ @cilium/envoy
+/plugins/cilium-cni/ @cilium/sig-k8s
+/plugins/cilium-docker/ @cilium/docker
+/README.rst @cilium/docs-structure
+/SECURITY.md @cilium/contributing
+/SECURITY-INSIGHTS.yml @cilium/security
+/stable.txt @cilium/release-managers
+/test/ @cilium/ci-structure
+/test/Makefile* @cilium/ci-structure @cilium/build
+# Service handling tests
+/test/k8s/services.go @cilium/sig-lb @cilium/ci-structure
+# Datapath tests
+/test/k8s/bandwidth.go @cilium/sig-datapath @cilium/ci-structure
+/test/k8s/datapath_configuration.go @cilium/sig-datapath @cilium/ci-structure
+/test/verifier @cilium/loader @cilium/ci-structure
+# Policy tests
+/test/k8s/net_policies.go @cilium/sig-policy @cilium/ci-structure
+/test/runtime/net_policies.go @cilium/sig-policy @cilium/ci-structure
+# Hubble/monitoring tests
+/test/k8s/hubble.go @cilium/sig-hubble @cilium/ci-structure
+/test/runtime/monitor.go @cilium/sig-hubble @cilium/ci-structure
+# L7 proxy tests
+/test/k8s/fqdn.go @cilium/fqdn @cilium/ci-structure
+/test/k8s/kafka_policies.go @cilium/envoy @cilium/ci-structure
+/test/runtime/fqdn.go @cilium/fqdn @cilium/ci-structure
+# BIG TCP tests
+/test/bigtcp @cilium/sig-datapath @cilium/ci-structure
+# Misc. tests
+/tools/dpgen @cilium/loader
+/tools/ @cilium/contributing
+/USERS.md @cilium/community
+/go.sum @cilium/vendor
+/go.mod @cilium/vendor
+/vendor/ @cilium/vendor
+/VERSION @cilium/release-managers
+/.clang-format @cilium/contributing


### PR DESCRIPTION
The upstream commit dda3976be23b ("Fix code owner attribution for test
failures on stable branches") recently updated the tree to detect and
use the TESTOWNERS file to determine ownership for test failures on
stable branches. While the backport for this is pending, the TESTOWNERS
file is not yet prepared on that branch. This commit does exactly that.

This introduces the TESTOWNERS file to be the same as the CODEOWNERS
file prior to the v1.18 branch point, which is to say at commit
cdf8de6724fe ("CODEOWNERS: move pkg/logging to sig-agent").

In conjunction with #40847, this should make the v1.18 branch behave correctly
with respect to #40583.
