### PR TITLE
v1.18 Backports 2025-08-01

### DIFF
--- a/operator/watchers/testdata/servicesync.txtar
+++ b/operator/watchers/testdata/servicesync.txtar
@@ -73,7 +73,7 @@ k8s/update service.yaml
 kvstore/list -o json cilium/state/services services.actual
 * empty services.actual
 
-# 10. Toggle the global annotation back. The shared annotation is not neeeded.
+# 10. Toggle the global annotation back. The shared annotation is not needed.
 # Service should be added again.
 sed 'service.cilium.io/shared: "true"' 'placeholder: "true"' service.yaml
 sed 'service.cilium.io/global: "false"' 'service.cilium.io/global: "true"' service.yaml
@@ -90,6 +90,21 @@ k8s/update service.yaml
 # Wait for synchronization
 kvstore/list -o json cilium/state/services services.actual
 * empty services.actual
+
+# 12. Validate the export of services with unnamed ports.
+sed 'service.cilium.io/shared: "false"' 'service.cilium.io/shared: "true"' service.yaml
+sed http "" service.yaml
+sed http "" endpointslice.yaml
+
+k8s/update service.yaml
+k8s/update endpointslice.yaml
+
+cp services-4.expected services-5.expected
+sed http '' services-5.expected
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/services services.actual
+* cmp services.actual services-5.expected
 
 # ----
 

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -208,11 +208,7 @@ func ParseEndpoints(ep *slim_corev1.Endpoints) *Endpoints {
 
 			for _, port := range sub.Ports {
 				lbPort := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
-				if port.Name != "" {
-					backend.Ports[lbPort] = append(backend.Ports[lbPort], port.Name)
-				} else {
-					backend.Ports[lbPort] = nil
-				}
+				backend.Ports[lbPort] = append(backend.Ports[lbPort], port.Name)
 			}
 		}
 	}
@@ -302,11 +298,7 @@ func ParseEndpointSliceV1Beta1(ep *slim_discovery_v1beta1.EndpointSlice) *Endpoi
 			for _, port := range ep.Ports {
 				name, lbPort, ok := parseEndpointPortV1Beta1(port)
 				if ok {
-					if name != "" {
-						backend.Ports[lbPort] = append(backend.Ports[lbPort], name)
-					} else {
-						backend.Ports[lbPort] = nil
-					}
+					backend.Ports[lbPort] = append(backend.Ports[lbPort], name)
 				}
 			}
 		}
@@ -437,11 +429,7 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 			for _, port := range ep.Ports {
 				name, lbPort, ok := parseEndpointPortV1(port)
 				if ok {
-					if name != "" {
-						backend.Ports[lbPort] = append(backend.Ports[lbPort], name)
-					} else {
-						backend.Ports[lbPort] = nil
-					}
+					backend.Ports[lbPort] = append(backend.Ports[lbPort], name)
 				}
 			}
 			if sub.Hints != nil && (*sub.Hints).ForZones != nil {

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -403,6 +403,15 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					continue
 				}
 
+				// Filter out the unnamed port, if present
+				if idx := slices.Index(portNames, ""); idx != -1 {
+					if len(portNames) == 1 {
+						portNames = nil
+					} else {
+						portNames = slices.Concat(portNames[:idx], portNames[idx+1:])
+					}
+				}
+
 				state := loadbalancer.BackendStateActive
 				if be.Terminating {
 					state = loadbalancer.BackendStateTerminating


### PR DESCRIPTION
 * [ ] #40848 (@giorio94)
    * :information_source: Extended the same changes to the parsing of Endpoint and EndpointSliceV1Beta1 types, whose support had already been removed in the main branch.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 40848
```
