### PR TITLE
Improve logs around ipcache upserts

### DIFF
--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -361,7 +361,7 @@ func (iw *IPIdentityWatcher) OnUpdate(k storepkg.Key) {
 
 	ip := ipIDPair.PrefixString()
 	if ip == "<nil>" {
-		iw.log.Debug("Ignoring entry with nil IP")
+		iw.log.Warn("Ignoring entry with nil IP")
 		return
 	}
 

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -167,6 +167,7 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 	}
 
 	if endpoint.Networking == nil || endpoint.Networking.NodeIP == "" {
+		k.logger.Warn("NodeIP not available", logfields.Identity, id)
 		// When upgrading from an older version, the nodeIP may
 		// not be available yet in the CiliumEndpoint and we
 		// have to wait for it to be propagated
@@ -190,6 +191,11 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 	for _, port := range endpoint.NamedPorts {
 		p, err := u8proto.ParseProtocol(port.Protocol)
 		if err != nil {
+			k.logger.Error(
+				"Parsing named port protocol failed",
+				logfields.Error, err,
+				logfields.CEPName, endpoint.GetName(),
+			)
 			continue
 		}
 		k8sMeta.NamedPorts[port.Name] = ciliumTypes.PortProto{


### PR DESCRIPTION
Point of this commit is to improve observability around upserts to ipcache. Better logs allow to spot production problems much quicker

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
Improve metrics around ipcache upserts

Point of this commit is to improve observability around upserts to ipcache. Better logs allow to spot production problems much quicker