### PR TITLE
[v1.16] ci: Revert build_commits runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build_commits:
     name: Check if build works for every commit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 180
     steps:
       - name: Collect Workflow Telemetry


### PR DESCRIPTION
Introduced as part of an automated Renovate update (b10dd2acec15f9ff42b4b4407d4a16472c6ce40c) and was not intentional: 

causes `Unable to locate package libtinfo5` error (see a [failed job](https://github.com/cilium/cilium/actions/runs/16619576312/job/47020457185)).

Major runner upgrades got enabled by #40683 and partially reverted in #40716.

