### PR TITLE
docs: Add missing dsrDispatch parameter to annotation-based DSR examples

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -774,9 +774,28 @@ annotation mode with SNAT default would look as follows:
         --set routingMode=native \\
         --set kubeProxyReplacement=true \\
         --set loadBalancer.mode=snat \\
+        --set loadBalancer.dsrDispatch=geneve \\
         --set bpf.lbModeAnnotation=true \\
         --set k8sServiceHost=${API_SERVER_IP} \\
         --set k8sServicePort=${API_SERVER_PORT}
+
+.. note::
+
+    When using annotation-based DSR mode (``bpf.lbModeAnnotation=true``), as in the previous example, you must explicitly specify the ``loadBalancer.dsrDispatch`` parameter to define how DSR packets are dispatched to backends. Valid options are ``opt``, ``ipip``, and ``geneve``.
+
+    For example, for environments where Geneve encapsulation is not suitable, you can use IPIP instead:
+
+    .. parsed-literal::
+
+        helm install cilium |CHART_RELEASE| \\
+            --namespace kube-system \\
+            --set routingMode=native \\
+            --set kubeProxyReplacement=true \\
+            --set loadBalancer.mode=snat \\
+            --set loadBalancer.dsrDispatch=ipip \\
+            --set bpf.lbModeAnnotation=true \\
+            --set k8sServiceHost=${API_SERVER_IP} \\
+            --set k8sServicePort=${API_SERVER_PORT}
 
 Annotation-based Load Balancing Algorithm Selection
 ***************************************************


### PR DESCRIPTION
Fixes: #37659
cc : @xmulligan @pchaigno 

### Description
This pull request updates the documentation for configuring a kube-proxy-free environment with DSR (Direct Server Return) enabled in annotation mode. The changes clarify the required parameters and provide examples for different DSR dispatch methods.

### Problem
Users following the annotation-based DSR documentation encounter validation errors because the required `dsrDispatch` parameter is missing from examples. When `bpf.lbModeAnnotation=true` is set without explicitly specifying `loadBalancer.dsrDispatch`, Cilium fails to start with: Invalid value for --bpf-lb-dsr-dispatch: opt

### Solution
- Added a note specifying that when using annotation-based DSR mode (`bpf.lbModeAnnotation=true`), the `loadBalancer.dsrDispatch` parameter must be explicitly defined
- Updated the existing Helm configuration example to include the missing `loadBalancer.dsrDispatch=geneve` parameter  
- Added an additional example demonstrating IPIP dispatch as an alternative
- Clarified that all dispatch methods (`opt`, `ipip`, `geneve`) work with annotation mode

### Changes Made
- Updated `Documentation/network/kubernetes/kubeproxy-free.rst` in the "Annotation-based DSR and SNAT Mode" section
- Added clear documentation note about dsrDispatch requirement