### PR TITLE
images/builder: add python3 scapy dependency (bis)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Cilium",
-  "image": "quay.io/cilium/cilium-builder:769ce739568d824078d2cf261de649c54ecb1315@sha256:413740790b2a15ff889c4f91ac2a2dda847159f7778acf1523a196d0edbedf12",
+  "image": "quay.io/cilium/cilium-builder:975651ad3db1ae812f815a1f379afd0c3b2059a0@sha256:6175440c77403aad6ad4010133ba7deb4e21818dbf5013a1647f4d2fbfedc373",
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
   "features": {

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -46,7 +46,9 @@ RUN \
       git \
       libc6-dev \
       make \
-      ccache && \
+      ccache \
+      python3-scapy \
+      python3-jinja2 && \
     apt-get purge --auto-remove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:769ce739568d824078d2cf261de649c54ecb1315@sha256:413740790b2a15ff889c4f91ac2a2dda847159f7778acf1523a196d0edbedf12
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:975651ad3db1ae812f815a1f379afd0c3b2059a0@sha256:6175440c77403aad6ad4010133ba7deb4e21818dbf5013a1647f4d2fbfedc373
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:30803685cd0ff7897876e57fdac234a5caede8f0@sha256:551b44ea9c8e5dc6f6e8c55e8be84ad834d265f9024ed9fde8edf88abdd9424e
 #
 # cilium-envoy from github.com/cilium/proxy

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -7,7 +7,7 @@
 # $ cosign verify $IMAGE_NAME --certificate-oidc-issuer https://accounts.google.com --certificate-identity keyless@distroless.iam.gserviceaccount.com
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:627d6c5a23ad24e6bdff827f16c7b60e0289029b0c79e9f7ccd54ae3279fb45f
 ARG GOLANG_IMAGE=docker.io/library/golang:1.24.5@sha256:ef5b4be1f94b36c90385abd9b6b4f201723ae28e71acacb76d00687333c17282
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:769ce739568d824078d2cf261de649c54ecb1315@sha256:413740790b2a15ff889c4f91ac2a2dda847159f7778acf1523a196d0edbedf12
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:975651ad3db1ae812f815a1f379afd0c3b2059a0@sha256:6175440c77403aad6ad4010133ba7deb4e21818dbf5013a1647f4d2fbfedc373
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -6,7 +6,7 @@
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.24.5@sha256:ef5b4be1f94b36c90385abd9b6b4f201723ae28e71acacb76d00687333c17282
 ARG ALPINE_IMAGE=docker.io/library/alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:769ce739568d824078d2cf261de649c54ecb1315@sha256:413740790b2a15ff889c4f91ac2a2dda847159f7778acf1523a196d0edbedf12
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:975651ad3db1ae812f815a1f379afd0c3b2059a0@sha256:6175440c77403aad6ad4010133ba7deb4e21818dbf5013a1647f4d2fbfedc373
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with


### PR DESCRIPTION
Commit bda1e68cfb added the two dependencies as described in the log in `images/builder/install-builder-deps.sh`. It turns out this file is not used (at all) and hence a separate PR has been opened to remove it entirely.

> Add python3-scapy and python3-jinja2 packages to install-deps script.
> This is requirement coming from the BPF unit test scapy support PR
> (#40294).

This commit adds it as part of the builder `Dockerfile` so that scapy and jinja2 are.. there :)

Continues to be a requirement of #40294 