### PR TITLE
helm: Create envoy-config ConfigMap for preflight

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
@@ -1,5 +1,5 @@
 {{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
-{{- if and $envoyDS (not .Values.preflight.enabled) }}
+{{- if $envoyDS }}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
After the below PR, Cilium Envoy is part of preflight, hence the related config map is required if preflight flag is set.

Relates: #39670
Fixes: #40805

