### PR TITLE
workflows/ipsec: Fix leak detection for IPv6-only in e2e downgrade

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -481,7 +481,7 @@ jobs:
         with:
           # enable the check for proxy traffic.
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
-          args: ${{ steps.bpftrace-params.outputs.params }} "true" "${{ matrix.encryption }}"
+          args: ${{ steps.bpftrace-params.outputs.params }} "${{ matrix.ipv4 != 'false' }}" "${{ matrix.encryption }}"
 
       - name: Run sequential Cilium tests
         if: ${{ matrix.skip-upgrade != 'true' }}


### PR DESCRIPTION
Commit 8dc7793ba0da ("workflows/ipsec: Skip bpftrace DNS check if IPv4 is disabled") fixed the leak detection when running on an IPv6-only cluster. We forgot to disable bpftrace DNS checks for IPv6-only clusters in the "after downgrade" step. This commit should fix it.

Discussion https://github.com/cilium/cilium/pull/40412#discussion_r2192261747.

Fixes: #40868