### PR TITLE
refactor: Add proxy lookup handler cell for DNS policy enforcement

### DIFF
--- a/pkg/fqdn/cell/cell.go
+++ b/pkg/fqdn/cell/cell.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
+	"github.com/cilium/cilium/pkg/fqdn/lookup"
 	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/fqdn/rules"
@@ -20,6 +21,8 @@ var Cell = cell.Module(
 
 	// The FQDN NameManager stores DNS mappings.
 	namemanager.Cell,
+
+	lookup.Cell,
 
 	// The FQDN bootstrap logic
 	bootstrap.Cell,

--- a/pkg/fqdn/dnsproxy/types.go
+++ b/pkg/fqdn/dnsproxy/types.go
@@ -13,20 +13,10 @@ import (
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/spanstat"
 	"github.com/cilium/cilium/pkg/time"
 )
-
-type IPCache interface {
-	// LookupSecIDByIP is a provided callback that returns the IP's security ID
-	// from the ipcache.
-	LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool)
-
-	// LookupByIdentity is a provided callback that returns the IPs of a given security ID.
-	LookupByIdentity(nid identity.NumericIdentity) []string
-}
 
 // LookupEndpointIDByIPFunc is a provided callback that returns the endpoint ID
 // as a uint16.

--- a/pkg/fqdn/lookup/cell.go
+++ b/pkg/fqdn/lookup/cell.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lookup
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+// Cell provides the proxy lookup functionality needed by DNS proxy.
+// It is responsible for looking up security identities, endpoint information,
+// and IP mappings required for DNS policy enforcement. This cell provides
+// a ProxyLookupHandler that abstracts the lookup operations and can be
+// implemented differently for local (agent) vs remote (standalone) scenarios.
+var Cell = cell.Module(
+	"proxy-lookup-handler",
+	"Proxy Lookup functionality",
+
+	cell.Provide(NewProxyLookupHandler),
+)
+
+type ProxyLookupParams struct {
+	cell.In
+
+	IPCache         *ipcache.IPCache
+	LocalNodeStore  *node.LocalNodeStore
+	EndpointManager endpointmanager.EndpointManager
+}
+
+func NewProxyLookupHandler(params ProxyLookupParams) ProxyLookupHandler {
+	handler := &proxyLookupHandler{
+		localNodeStore:  params.LocalNodeStore,
+		endpointManager: params.EndpointManager,
+		ipCache:         params.IPCache,
+	}
+
+	return handler
+}

--- a/pkg/fqdn/lookup/endpoint.go
+++ b/pkg/fqdn/lookup/endpoint.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lookup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+type ProxyLookupHandler interface {
+	// LookupSecIDByIP is a provided callback that returns the IP's security ID
+	// from the ipcache.
+	LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool)
+
+	// LookupByIdentity is a provided callback that returns the IPs of a given security ID.
+	LookupByIdentity(nid identity.NumericIdentity) []string
+
+	// LookupRegisteredEndpoint looks up the endpoint corresponding
+	// to a given IP address. It correctly handles *all* IPs belonging to the node, not just that
+	// of the node endpoint.
+	LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error)
+}
+
+type proxyLookupHandler struct {
+	ipCache         *ipcache.IPCache
+	localNodeStore  *node.LocalNodeStore
+	endpointManager endpointmanager.EndpointManager
+}
+
+var _ ProxyLookupHandler = &proxyLookupHandler{}
+
+func (p *proxyLookupHandler) LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error) {
+	if e := p.endpointManager.LookupIP(endpointAddr); e != nil {
+		return e, e.IsHost(), nil
+	}
+
+	localNode, err := p.localNodeStore.Get(context.TODO())
+	if err != nil {
+		return nil, true, fmt.Errorf("local node has not been initialized yet: %w", err)
+	}
+
+	if localNode.IsNodeIP(endpointAddr) != "" {
+		if e := p.endpointManager.GetHostEndpoint(); e != nil {
+			return e, true, nil
+		} else {
+			return nil, true, errors.New("host endpoint has not been created yet")
+		}
+	}
+
+	return nil, false, fmt.Errorf("cannot find endpoint with IP %s", endpointAddr)
+}
+
+func (p *proxyLookupHandler) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {
+	return p.ipCache.LookupSecIDByIP(ip)
+}
+
+func (p *proxyLookupHandler) LookupByIdentity(nid identity.NumericIdentity) []string {
+	return p.ipCache.LookupByIdentity(nid)
+}


### PR DESCRIPTION
This commit introduces a new lookup cell that provides endpoint and security identity lookup functionality required by the DNS proxy for policy enforcement.

Key changes:
- Add ProxyLookupHandler interface with three core methods:
  - LookupSecIDByIP: Returns IP's security ID from ipcache
  - LookupByIdentity: Returns IPs for a given security ID
  - LookupRegisteredEndpoint: Handles endpoint lookup for any node IP
- Create lookup.Cell that provides the handler implementation
- Move lookupRegisteredEndpointFunc from bootstrap to dedicated lookup package
- Add proxyLookupHandler struct with local implementations using:
  - EndpointManager for endpoint lookups
  - IPCache for security identity operations
  - LocalNodeStore for node IP validation

This abstraction enables different implementations for local (agent) vs remote (standalone DNS proxy) scenarios while maintaining a consistent interface for DNS policy operations.