### PR TITLE
Remove global metrics provider and unify workqueue metric naming

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -362,6 +362,20 @@ Removed Metrics
 Changed Metrics
 ~~~~~~~~~~~~~~~
 
+The following metrics previously had instances (i.e. for some watcher K8s resource type labels) under ``workqueue_``.
+In this release any such metrics have been renamed and combined into the correct metric name prefixed with ``cilium_operator_``.
+
+As well, any remaining Operator k8s workqueue metrics that use the label ``queue_name`` have had it renamed to 
+``name`` to be consistent with agent k8s workqueue metrics.
+
+* The metric ``workqueue_adds_total`` has been renamed and combined into to ``cilium_operator_k8s_workqueue_adds_total``, the label ``queue_name`` has been renamed to ``name``.
+* The metric ``workqueue_depth`` has been renamed and combined into ``cilium_operator_k8s_workqueue_adds_total``, the label ``queue_name`` has been renamed to ``name``.
+* The metric ``workqueue_longest_running_processor_seconds`` has been renamed and combined into ``cilium_operator_k8s_workqueue_longest_running_processor_seconds``, the label ``queue_name`` has been renamed to ``name``.
+* The metric ``workqueue_queue_duration_seconds`` has been renamed and combined into ``cilium_operator_k8s_workqueue_queue_duration_seconds``, the label ``queue_name`` has been renamed to ``name``.
+* The metric ``workqueue_retries_total`` has been renamed and combined into ``cilium_operator_k8s_workqueue_retries_total`, the label ``queue_name`` has been renamed to ``name``.
+* The metric ``workqueue_unfinished_work_seconds`` has been renamed and combined into ``cilium_operator_k8s_workqueue_unfinished_work_seconds`, the label ``queue_name`` has been renamed to ``name``.
+* The metric ``workqueue_work_duration_seconds`` has been renamed and combined into ``cilium_operator_k8s_workqueue_work_duration_seconds``, the label ``queue_name`` has been renamed to ``name``.
+
 * ``k8s_client_rate_limiter_duration_seconds`` no longer has labels ``path`` and ``method``.
 
 Deprecated Metrics

--- a/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -16,7 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/utils"
 )
 
-func CiliumSlimEndpointResource(params k8s.CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
+func CiliumSlimEndpointResource(params k8s.CiliumResourceParams, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
 	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
@@ -24,14 +25,14 @@ func CiliumSlimEndpointResource(params k8s.CiliumResourceParams, opts ...func(*m
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](params.ClientSet.CiliumV2().CiliumEndpoints(slim_corev1.NamespaceAll)),
 		opts...,
 	)
-	return resource.New[*types.CiliumEndpoint](params.Lifecycle, lw,
+	return resource.New[*types.CiliumEndpoint](params.Lifecycle, lw, mp,
 		resource.WithLazyTransform(func() runtime.Object {
 			return &cilium_api_v2.CiliumEndpoint{}
 		}, k8s.TransformToCiliumEndpoint), resource.WithCRDSync(params.CRDSyncPromise),
 	), nil
 }
 
-func CiliumNodeResource(params k8s.CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
+func CiliumNodeResource(params k8s.CiliumResourceParams, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
 	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
@@ -39,12 +40,12 @@ func CiliumNodeResource(params k8s.CiliumResourceParams, opts ...func(*metav1.Li
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](params.ClientSet.CiliumV2().CiliumNodes()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumNode](params.Lifecycle, lw,
+	return resource.New[*cilium_api_v2.CiliumNode](params.Lifecycle, lw, mp,
 		resource.WithMetric("CiliumNode"), resource.WithCRDSync(params.CRDSyncPromise),
 	), nil
 }
 
-func CiliumEndpointSliceResource(params k8s.CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
+func CiliumEndpointSliceResource(params k8s.CiliumResourceParams, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
 	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
@@ -52,7 +53,7 @@ func CiliumEndpointSliceResource(params k8s.CiliumResourceParams, opts ...func(*
 		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumEndpointSliceList](params.ClientSet.CiliumV2alpha1().CiliumEndpointSlices()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](params.Lifecycle, lw,
+	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](params.Lifecycle, lw, mp,
 		resource.WithMetric("CiliumEndpointSlice"), resource.WithCRDSync(params.CRDSyncPromise),
 	), nil
 }

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -49,9 +50,9 @@ var (
 		"Agent Kubernetes local node resources",
 
 		cell.Provide(
-			func(lc cell.Lifecycle, cs client.Clientset) (LocalNodeResource, error) {
+			func(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider) (LocalNodeResource, error) {
 				return k8s.NodeResource(
-					lc, cs,
+					lc, cs, mp,
 					func(opts *metav1.ListOptions) {
 						opts.FieldSelector = fields.ParseSelectorOrDie("metadata.name=" + nodeTypes.GetName()).String()
 					},

--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -28,7 +28,6 @@ import (
 	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	"github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/k8s/watchers/metrics"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/logging"
@@ -95,10 +94,11 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup, 
 
 	var ciliumNodeManagerQueueConfig = workqueue.TypedRateLimitingQueueConfig[string]{
 		Name:            "node_manager",
-		MetricsProvider: metrics.MetricsProvider,
+		MetricsProvider: s.workqueueMetricsProvider,
 	}
 	var kvStoreQueueConfig = workqueue.TypedRateLimitingQueueConfig[string]{
-		Name: "kvstore",
+		Name:            "kvstore",
+		MetricsProvider: s.workqueueMetricsProvider,
 	}
 
 	if operatorOption.Config.EnableMetrics {

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -47,7 +47,6 @@ import (
 	"github.com/cilium/cilium/operator/pkg/networkpolicy"
 	"github.com/cilium/cilium/operator/pkg/nodeipam"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
-	"github.com/cilium/cilium/operator/pkg/workqueuemetrics"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
 	clustercfgcell "github.com/cilium/cilium/pkg/clustermesh/clustercfg/cell"
 	"github.com/cilium/cilium/pkg/clustermesh/endpointslicesync"
@@ -240,7 +239,6 @@ var (
 			endpointslicesync.Cell,
 			mcsapi.Cell,
 			locksweeper.Cell,
-			workqueuemetrics.Cell,
 			legacyCell,
 
 			// When running in kvstore mode, the start hook of the identity GC
@@ -689,7 +687,7 @@ func (legacy *legacyOnLeader) onStart(ctx cell.HookContext) error {
 
 		if operatorOption.Config.NodesGCInterval != 0 {
 			operatorWatchers.RunCiliumNodeGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer.ciliumNodeStore,
-				operatorOption.Config.NodesGCInterval, watcherLogger)
+				operatorOption.Config.NodesGCInterval, watcherLogger, legacy.workqueueMetricsProvider)
 		}
 	}
 

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/hive/cell"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -22,7 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/utils"
 )
 
-func CiliumEndpointResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumEndpoint], error) {
+func CiliumEndpointResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumEndpoint], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -35,7 +36,7 @@ func CiliumEndpointResource(lc cell.Lifecycle, cs client.Clientset, opts ...func
 		CiliumEndpointIndexIdentity: identityIndexFunc,
 	}
 	return resource.New[*cilium_api_v2.CiliumEndpoint](
-		lc, lw, resource.WithMetric("CiliumEndpoint"), resource.WithIndexers(indexers)), nil
+		lc, lw, mp, resource.WithMetric("CiliumEndpoint"), resource.WithIndexers(indexers)), nil
 }
 
 func identityIndexFunc(obj any) ([]string, error) {
@@ -50,7 +51,7 @@ func identityIndexFunc(obj any) ([]string, error) {
 	return nil, fmt.Errorf("%w - found %T", errors.New("object is not a *cilium_api_v2.CiliumEndpoint"), obj)
 }
 
-func CiliumEndpointSliceResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
+func CiliumEndpointSliceResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -58,10 +59,10 @@ func CiliumEndpointSliceResource(lc cell.Lifecycle, cs client.Clientset, opts ..
 		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumEndpointSliceList](cs.CiliumV2alpha1().CiliumEndpointSlices()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](lc, lw, resource.WithMetric("CiliumEndpointSlice")), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](lc, lw, mp, resource.WithMetric("CiliumEndpointSlice")), nil
 }
 
-func CiliumNodeResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
+func CiliumNodeResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -69,12 +70,12 @@ func CiliumNodeResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*me
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](cs.CiliumV2().CiliumNodes()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumNode](lc, lw,
+	return resource.New[*cilium_api_v2.CiliumNode](lc, lw, mp,
 		resource.WithMetric("CiliumNode"),
 	), nil
 }
 
-func CiliumBGPClusterConfigResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumBGPClusterConfig], error) {
+func CiliumBGPClusterConfigResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumBGPClusterConfig], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -83,10 +84,10 @@ func CiliumBGPClusterConfigResource(lc cell.Lifecycle, cs client.Clientset, opts
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumBGPClusterConfigList](cs.CiliumV2().CiliumBGPClusterConfigs()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumBGPClusterConfig](lc, lw, resource.WithMetric("CiliumBGPClusterConfig")), nil
+	return resource.New[*cilium_api_v2.CiliumBGPClusterConfig](lc, lw, mp, resource.WithMetric("CiliumBGPClusterConfig")), nil
 }
 
-func CiliumBGPNodeConfigOverrideResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumBGPNodeConfigOverride], error) {
+func CiliumBGPNodeConfigOverrideResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumBGPNodeConfigOverride], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -95,10 +96,10 @@ func CiliumBGPNodeConfigOverrideResource(lc cell.Lifecycle, cs client.Clientset,
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumBGPNodeConfigOverrideList](cs.CiliumV2().CiliumBGPNodeConfigOverrides()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumBGPNodeConfigOverride](lc, lw, resource.WithMetric("CiliumBGPNodeConfigOverride")), nil
+	return resource.New[*cilium_api_v2.CiliumBGPNodeConfigOverride](lc, lw, mp, resource.WithMetric("CiliumBGPNodeConfigOverride")), nil
 }
 
-func PodResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Pod], error) {
+func PodResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Pod], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -114,14 +115,14 @@ func PodResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.Li
 		PodNodeNameIndex: PodNodeNameIndexFunc,
 	}
 
-	return resource.New[*slim_corev1.Pod](lc, lw,
+	return resource.New[*slim_corev1.Pod](lc, lw, mp,
 			resource.WithMetric("Pod"),
 			resource.WithIndexers(indexers),
 		),
 		nil
 }
 
-func LBIPPoolsResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumLoadBalancerIPPool], error) {
+func LBIPPoolsResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumLoadBalancerIPPool], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -129,12 +130,12 @@ func LBIPPoolsResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*met
 		utils.ListerWatcherFromTyped(cs.CiliumV2().CiliumLoadBalancerIPPools()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumLoadBalancerIPPool](lc, lw, resource.WithMetric("CiliumLoadBalancerIPPool")), nil
+	return resource.New[*cilium_api_v2.CiliumLoadBalancerIPPool](lc, lw, mp, resource.WithMetric("CiliumLoadBalancerIPPool")), nil
 }
 
 const ServiceIndex = "service"
 
-func EndpointsResource(logger *slog.Logger, lc cell.Lifecycle, cfg k8s.Config, cs client.Clientset) (resource.Resource[*k8s.Endpoints], error) {
+func EndpointsResource(logger *slog.Logger, lc cell.Lifecycle, cfg k8s.Config, cs client.Clientset, mp workqueue.MetricsProvider) (resource.Resource[*k8s.Endpoints], error) {
 	return k8s.EndpointsResourceWithIndexers(
 		logger,
 		lc,
@@ -150,6 +151,6 @@ func EndpointsResource(logger *slog.Logger, lc cell.Lifecycle, cfg k8s.Config, c
 				return []string{eps.ServiceName.String()}, nil
 			},
 		},
+		mp,
 	)
-
 }

--- a/operator/pkg/bgpv2/cell.go
+++ b/operator/pkg/bgpv2/cell.go
@@ -5,6 +5,7 @@ package bgpv2
 
 import (
 	"github.com/cilium/hive/cell"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -23,7 +24,7 @@ var Cell = cell.Module(
 	metrics.Metric(NewBGPOperatorMetrics),
 )
 
-func newSecretResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*slim_core_v1.Secret] {
+func newSecretResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*slim_core_v1.Secret] {
 	// Secret is only used for status reporting (MissingAuthSecret condition)
 	if !c.IsEnabled() || !dc.BGPControlPlaneEnabled() || !dc.EnableBGPControlPlaneStatusReport {
 		return nil
@@ -34,5 +35,5 @@ func newSecretResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonC
 	return resource.New[*slim_core_v1.Secret](
 		lc, utils.ListerWatcherFromTyped[*slim_core_v1.SecretList](
 			c.Slim().CoreV1().Secrets(dc.BGPSecretsNamespace),
-		))
+		), mp)
 }

--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -97,14 +97,14 @@ func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, dc *
 			return resource.New[*v2.CiliumBGPClusterConfig](
 				lc, utils.ListerWatcherFromTyped[*v2.CiliumBGPClusterConfigList](
 					c.CiliumV2().CiliumBGPClusterConfigs(),
-				),
+				), nil,
 			)
 		}),
 		cell.Provide(func(lc cell.Lifecycle, c k8sClient.Clientset) resource.Resource[*v2.CiliumBGPNodeConfig] {
 			return resource.New[*v2.CiliumBGPNodeConfig](
 				lc, utils.ListerWatcherFromTyped[*v2.CiliumBGPNodeConfigList](
 					c.CiliumV2().CiliumBGPNodeConfigs(),
-				),
+				), nil,
 			)
 		}),
 
@@ -112,7 +112,7 @@ func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, dc *
 			return resource.New[*v2.CiliumBGPNodeConfigOverride](
 				lc, utils.ListerWatcherFromTyped[*v2.CiliumBGPNodeConfigOverrideList](
 					c.CiliumV2().CiliumBGPNodeConfigOverrides(),
-				),
+				), nil,
 			)
 		}),
 
@@ -120,7 +120,7 @@ func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, dc *
 			return resource.New[*v2.CiliumBGPPeerConfig](
 				lc, utils.ListerWatcherFromTyped[*v2.CiliumBGPPeerConfigList](
 					c.CiliumV2().CiliumBGPPeerConfigs(),
-				),
+				), nil,
 			)
 		}),
 
@@ -128,7 +128,7 @@ func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, dc *
 			return resource.New[*v2.CiliumNode](
 				lc, utils.ListerWatcherFromTyped[*v2.CiliumNodeList](
 					c.CiliumV2().CiliumNodes(),
-				),
+				), nil,
 			)
 		}),
 

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
@@ -50,7 +49,6 @@ func TestRegisterController(t *testing.T) {
 			}
 		}),
 		metrics.Metric(NewMetrics),
-		cell.Provide(func() workqueue.MetricsProvider { return nil }),
 		cell.Invoke(func(p params) error {
 			registerController(p)
 			return nil
@@ -104,7 +102,6 @@ func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
 			}
 		}),
 		metrics.Metric(NewMetrics),
-		cell.Provide(func() workqueue.MetricsProvider { return nil }),
 		cell.Invoke(func(p params) error {
 			registerController(p)
 			return nil

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -22,7 +22,6 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/k8s/watchers/metrics"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -62,6 +61,7 @@ type params struct {
 	CiliumIdentity      resource.Resource[*cilium_api_v2.CiliumIdentity]
 	CiliumEndpoint      resource.Resource[*cilium_api_v2.CiliumEndpoint]
 	CiliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+	MetricsProvider     workqueue.MetricsProvider
 }
 
 type Controller struct {
@@ -89,6 +89,8 @@ type Controller struct {
 	oldNSSecurityLabels map[string]labels.Labels
 
 	enqueueTimeTracker *EnqueueTimeTracker
+
+	workqueueMetricsProvider workqueue.MetricsProvider
 }
 
 func registerController(p params) {
@@ -106,18 +108,19 @@ func registerController(p params) {
 	}
 
 	cidController := &Controller{
-		logger:              p.Logger,
-		clientset:           p.Clientset,
-		namespace:           p.Namespace,
-		pod:                 p.Pod,
-		jobGroup:            p.JobGroup,
-		metrics:             p.Metrics,
-		ciliumIdentity:      p.CiliumIdentity,
-		ciliumEndpoint:      p.CiliumEndpoint,
-		ciliumEndpointSlice: p.CiliumEndpointSlice,
-		oldNSSecurityLabels: make(map[string]labels.Labels),
-		cesEnabled:          p.SharedCfg.EnableCiliumEndpointSlice,
-		enqueueTimeTracker:  &EnqueueTimeTracker{clock: clock.RealClock{}, enqueuedAt: make(map[string]time.Time)},
+		logger:                   p.Logger,
+		clientset:                p.Clientset,
+		namespace:                p.Namespace,
+		pod:                      p.Pod,
+		jobGroup:                 p.JobGroup,
+		metrics:                  p.Metrics,
+		ciliumIdentity:           p.CiliumIdentity,
+		ciliumEndpoint:           p.CiliumEndpoint,
+		ciliumEndpointSlice:      p.CiliumEndpointSlice,
+		oldNSSecurityLabels:      make(map[string]labels.Labels),
+		cesEnabled:               p.SharedCfg.EnableCiliumEndpointSlice,
+		enqueueTimeTracker:       &EnqueueTimeTracker{clock: clock.RealClock{}, enqueuedAt: make(map[string]time.Time)},
+		workqueueMetricsProvider: p.MetricsProvider,
 	}
 
 	cidController.initializeQueues()
@@ -171,7 +174,7 @@ func (c *Controller) initializeQueues() {
 		workqueue.NewTypedItemExponentialFailureRateLimiter[QueuedItem](defaultSyncBackOff, maxSyncBackOff),
 		workqueue.TypedRateLimitingQueueConfig[QueuedItem]{
 			Name:            "ciliumidentity_resource",
-			MetricsProvider: metrics.MetricsProvider,
+			MetricsProvider: c.workqueueMetricsProvider,
 		})
 }
 

--- a/operator/watchers/cilium_node_gc.go
+++ b/operator/watchers/cilium_node_gc.go
@@ -14,6 +14,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/controller"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -66,8 +67,9 @@ func (c *ciliumNodeGCCandidate) Delete(nodeName string) {
 }
 
 // RunCiliumNodeGC performs garbage collector for cilium node resource
-func RunCiliumNodeGC(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset, ciliumNodeStore cache.Store, interval time.Duration, logger *slog.Logger) {
-	nodesInit(wg, clientset.Slim(), ctx.Done(), logger)
+func RunCiliumNodeGC(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset, ciliumNodeStore cache.Store, interval time.Duration, logger *slog.Logger,
+	mp workqueue.MetricsProvider) {
+	nodesInit(wg, clientset.Slim(), ctx.Done(), mp)
 
 	// wait for k8s nodes synced is done
 	select {

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -492,7 +492,7 @@ func HandleNodeTolerationAndTaints(wg *sync.WaitGroup, clientset k8sClient.Clien
 		SetCiliumIsUpCondition: option.Config.SetCiliumIsUpCondition,
 	}
 
-	nodesInit(wg, clientset.Slim(), stopCh, logger)
+	nodesInit(wg, clientset.Slim(), stopCh, nil)
 	// ciliumPodWatcher blocks waiting for cache sync.
 	// we need to do it before starting worker threads
 	// so checkAndMarkNode has cilium-pod information.

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -6,6 +6,8 @@ package bgpv1
 import (
 	"log/slog"
 
+	"k8s.io/client-go/util/workqueue"
+
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
@@ -106,7 +108,7 @@ var Cell = cell.Module(
 	metrics.Metric(manager.NewBGPManagerMetrics),
 )
 
-func newBGPPeeringPolicyResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*v2alpha1.CiliumBGPPeeringPolicy] {
+func newBGPPeeringPolicyResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2alpha1.CiliumBGPPeeringPolicy] {
 	// Do not create this resource if the BGP Control Plane is disabled
 	if !dc.BGPControlPlaneEnabled() {
 		return nil
@@ -119,10 +121,10 @@ func newBGPPeeringPolicyResource(lc cell.Lifecycle, c client.Clientset, dc *opti
 	return resource.New[*v2alpha1.CiliumBGPPeeringPolicy](
 		lc, utils.ListerWatcherFromTyped[*v2alpha1.CiliumBGPPeeringPolicyList](
 			c.CiliumV2alpha1().CiliumBGPPeeringPolicies(),
-		), resource.WithMetric("CiliumBGPPeeringPolicy"))
+		), mp, resource.WithMetric("CiliumBGPPeeringPolicy"))
 }
 
-func newLoadBalancerIPPoolResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*v2.CiliumLoadBalancerIPPool] {
+func newLoadBalancerIPPoolResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumLoadBalancerIPPool] {
 	if !dc.BGPControlPlaneEnabled() {
 		return nil
 	}
@@ -132,10 +134,10 @@ func newLoadBalancerIPPoolResource(lc cell.Lifecycle, c client.Clientset, dc *op
 	return resource.New[*v2.CiliumLoadBalancerIPPool](
 		lc, utils.ListerWatcherFromTyped(
 			c.CiliumV2().CiliumLoadBalancerIPPools(),
-		), resource.WithMetric("CiliumLoadBalancerIPPool"))
+		), mp, resource.WithMetric("CiliumLoadBalancerIPPool"))
 }
 
-func newCiliumPodIPPoolResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*v2alpha1.CiliumPodIPPool] {
+func newCiliumPodIPPoolResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2alpha1.CiliumPodIPPool] {
 	// Do not create this resource if:
 	//   1. The BGP Control Plane is disabled.
 	//   2. Kubernetes support is disabled and the clientset cannot be used.
@@ -147,10 +149,10 @@ func newCiliumPodIPPoolResource(lc cell.Lifecycle, c client.Clientset, dc *optio
 	return resource.New[*v2alpha1.CiliumPodIPPool](
 		lc, utils.ListerWatcherFromTyped[*v2alpha1.CiliumPodIPPoolList](
 			c.CiliumV2alpha1().CiliumPodIPPools(),
-		), resource.WithMetric("CiliumPodIPPool"))
+		), mp, resource.WithMetric("CiliumPodIPPool"))
 }
 
-func newSecretResource(logger *slog.Logger, lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*slim_core_v1.Secret] {
+func newSecretResource(logger *slog.Logger, lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*slim_core_v1.Secret] {
 	// Do not create this resource if the BGP Control Plane is disabled
 	if !dc.BGPControlPlaneEnabled() {
 		return nil
@@ -169,10 +171,10 @@ func newSecretResource(logger *slog.Logger, lc cell.Lifecycle, c client.Clientse
 	return resource.New[*slim_core_v1.Secret](
 		lc, utils.ListerWatcherFromTyped[*slim_core_v1.SecretList](
 			c.Slim().CoreV1().Secrets(dc.BGPSecretsNamespace),
-		))
+		), mp)
 }
 
-func newBGPNodeConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*v2.CiliumBGPNodeConfig] {
+func newBGPNodeConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumBGPNodeConfig] {
 	// Do not create this resource if the BGP Control Plane is disabled
 	if !dc.BGPControlPlaneEnabled() {
 		return nil
@@ -185,10 +187,10 @@ func newBGPNodeConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.
 	return resource.New[*v2.CiliumBGPNodeConfig](
 		lc, utils.ListerWatcherFromTyped[*v2.CiliumBGPNodeConfigList](
 			c.CiliumV2().CiliumBGPNodeConfigs(),
-		), resource.WithMetric("CiliumBGPNodeConfig"))
+		), mp, resource.WithMetric("CiliumBGPNodeConfig"))
 }
 
-func newBGPPeerConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*v2.CiliumBGPPeerConfig] {
+func newBGPPeerConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumBGPPeerConfig] {
 	// Do not create this resource if the BGP Control Plane is disabled
 	if !dc.BGPControlPlaneEnabled() {
 		return nil
@@ -201,10 +203,10 @@ func newBGPPeerConfigResource(lc cell.Lifecycle, c client.Clientset, dc *option.
 	return resource.New[*v2.CiliumBGPPeerConfig](
 		lc, utils.ListerWatcherFromTyped[*v2.CiliumBGPPeerConfigList](
 			c.CiliumV2().CiliumBGPPeerConfigs(),
-		), resource.WithMetric("CiliumBGPPeerConfig"))
+		), mp, resource.WithMetric("CiliumBGPPeerConfig"))
 }
 
-func newBGPAdvertisementResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*v2.CiliumBGPAdvertisement] {
+func newBGPAdvertisementResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig, mp workqueue.MetricsProvider) resource.Resource[*v2.CiliumBGPAdvertisement] {
 	// Do not create this resource if the BGP Control Plane is disabled
 	if !dc.BGPControlPlaneEnabled() {
 		return nil
@@ -217,5 +219,5 @@ func newBGPAdvertisementResource(lc cell.Lifecycle, c client.Clientset, dc *opti
 	return resource.New[*v2.CiliumBGPAdvertisement](
 		lc, utils.ListerWatcherFromTyped[*v2.CiliumBGPAdvertisementList](
 			c.CiliumV2().CiliumBGPAdvertisements(),
-		), resource.WithMetric("CiliumBGPAdvertisement"))
+		), mp, resource.WithMetric("CiliumBGPAdvertisement"))
 }

--- a/pkg/bgpv1/manager/store/diffstore_test.go
+++ b/pkg/bgpv1/manager/store/diffstore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"k8s.io/apimachinery/pkg/watch"
 	k8sTesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/hive"
@@ -61,11 +62,11 @@ func newDiffStoreFixture() *DiffStoreFixture {
 
 	// Construct a new Hive with faked out dependency cells.
 	fixture.hive = hive.New(
-		cell.Provide(func(lc cell.Lifecycle, c k8sClient.Clientset) resource.Resource[*slimv1.Service] {
+		cell.Provide(func(lc cell.Lifecycle, c k8sClient.Clientset, mp workqueue.MetricsProvider) resource.Resource[*slimv1.Service] {
 			return resource.New[*slimv1.Service](
 				lc, utils.ListerWatcherFromTyped[*slimv1.ServiceList](
 					c.Slim().CoreV1().Services(""),
-				),
+				), mp,
 			)
 		}),
 

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -15,6 +15,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	k8sTesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 
 	daemon_k8s "github.com/cilium/cilium/daemon/k8s"
@@ -185,11 +186,11 @@ func newFixture(t testing.TB, ctx context.Context, conf fixtureConfig) (*fixture
 		cell.Provide(k8sPkg.LBIPPoolsResource),
 
 		// cilium node
-		cell.Provide(func(lc cell.Lifecycle, c k8sClient.Clientset) daemon_k8s.LocalCiliumNodeResource {
+		cell.Provide(func(lc cell.Lifecycle, c k8sClient.Clientset, mp workqueue.MetricsProvider) daemon_k8s.LocalCiliumNodeResource {
 			store := resource.New[*cilium_api_v2.CiliumNode](
 				lc, utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](
 					c.CiliumV2().CiliumNodes(),
-				),
+				), mp,
 			)
 			f.ciliumNode = store
 			return store

--- a/pkg/clustermesh/mcsapi/serviceexportsync.go
+++ b/pkg/clustermesh/mcsapi/serviceexportsync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
 	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
@@ -25,7 +26,7 @@ import (
 )
 
 // ServiceExportResource builds the Resource[ServiceExport] object.
-func ServiceExportResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) resource.Resource[*mcsapiv1alpha1.ServiceExport] {
+func ServiceExportResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) resource.Resource[*mcsapiv1alpha1.ServiceExport] {
 	if !cs.IsEnabled() {
 		return nil
 	}
@@ -34,7 +35,7 @@ func ServiceExportResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(
 		utils.ListerWatcherFromTyped(cs.MulticlusterV1alpha1().ServiceExports("")),
 		opts...,
 	)
-	return resource.New[*mcsapiv1alpha1.ServiceExport](lc, lw, resource.WithMetric("ServiceExport"))
+	return resource.New[*mcsapiv1alpha1.ServiceExport](lc, lw, mp, resource.WithMetric("ServiceExport"))
 }
 
 // ServiceExportSyncCallback represents a callback that, if provided, is executed

--- a/pkg/egressgateway/resource.go
+++ b/pkg/egressgateway/resource.go
@@ -5,6 +5,7 @@ package egressgateway
 
 import (
 	"github.com/cilium/hive/cell"
+	"k8s.io/client-go/util/workqueue"
 
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -14,10 +15,10 @@ import (
 
 type Policy = v2.CiliumEgressGatewayPolicy
 
-func newPolicyResource(lc cell.Lifecycle, c client.Clientset) resource.Resource[*Policy] {
+func newPolicyResource(lc cell.Lifecycle, c client.Clientset, mp workqueue.MetricsProvider) resource.Resource[*Policy] {
 	if !c.IsEnabled() {
 		return nil
 	}
-	lw := utils.ListerWatcherFromTyped[*v2.CiliumEgressGatewayPolicyList](c.CiliumV2().CiliumEgressGatewayPolicies())
-	return resource.New[*Policy](lc, lw)
+	lw := utils.ListerWatcherFromTyped(c.CiliumV2().CiliumEgressGatewayPolicies())
+	return resource.New[*Policy](lc, lw, mp)
 }

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/hive/health"
 	"github.com/cilium/cilium/pkg/hive/health/types"
+	watcherMetrics "github.com/cilium/cilium/pkg/k8s/watchers/metrics"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -75,6 +76,10 @@ func New(cells ...cell.Cell) *Hive {
 				return reg.NewGroup(h, lc, job.WithLogger(l))
 			},
 		),
+
+		// Provides workqueue metrics provider, used by all k8s resource constructors. This will
+		// also be needed by a very large number of tests so we choose to include it by default.
+		watcherMetrics.Cell,
 	)
 
 	// Scope logging and health by module ID.

--- a/pkg/k8s/resource/example/main.go
+++ b/pkg/k8s/resource/example/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/workerpool"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -59,19 +60,19 @@ var resourcesCell = cell.Module(
 	"Kubernetes Pod and Service resources",
 
 	cell.Provide(
-		func(lc cell.Lifecycle, c client.Clientset) resource.Resource[*corev1.Pod] {
+		func(lc cell.Lifecycle, c client.Clientset, mp workqueue.MetricsProvider) resource.Resource[*corev1.Pod] {
 			if !c.IsEnabled() {
 				return nil
 			}
 			lw := utils.ListerWatcherFromTyped[*corev1.PodList](c.CoreV1().Pods(""))
-			return resource.New[*corev1.Pod](lc, lw, resource.WithMetric("Pod"))
+			return resource.New[*corev1.Pod](lc, lw, mp, resource.WithMetric("Pod"))
 		},
-		func(lc cell.Lifecycle, c client.Clientset) resource.Resource[*corev1.Service] {
+		func(lc cell.Lifecycle, c client.Clientset, mp workqueue.MetricsProvider) resource.Resource[*corev1.Service] {
 			if !c.IsEnabled() {
 				return nil
 			}
 			lw := utils.ListerWatcherFromTyped[*corev1.ServiceList](c.CoreV1().Services(""))
-			return resource.New[*corev1.Service](lc, lw, resource.WithMetric("Service"))
+			return resource.New[*corev1.Service](lc, lw, mp, resource.WithMetric("Service"))
 		},
 	),
 )

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -303,8 +303,8 @@ func TestResource_RepeatedDelete(t *testing.T) {
 
 	hive := hive.New(
 		cell.Provide(
-			func(lc cell.Lifecycle) resource.Resource[*corev1.Node] {
-				return resource.New[*corev1.Node](lc, &lw)
+			func(lc cell.Lifecycle, mp workqueue.MetricsProvider) resource.Resource[*corev1.Node] {
+				return resource.New[*corev1.Node](lc, &lw, nil)
 			}),
 
 		cell.Invoke(func(r resource.Resource[*corev1.Node]) {
@@ -477,7 +477,7 @@ func TestResource_WithTransform(t *testing.T) {
 			func() k8sClient.Clientset { return cs },
 			func(lc cell.Lifecycle, c k8sClient.Clientset) resource.Resource[*StrippedNode] {
 				lw := utils.ListerWatcherFromTyped[*corev1.NodeList](c.CoreV1().Nodes())
-				return resource.New[*StrippedNode](lc, lw, resource.WithTransform(strip))
+				return resource.New[*StrippedNode](lc, lw, nil, resource.WithTransform(strip))
 			}),
 
 		cell.Invoke(func(r resource.Resource[*StrippedNode]) {
@@ -543,7 +543,7 @@ func TestResource_WithoutIndexers(t *testing.T) {
 		cell.Provide(
 			func(lc cell.Lifecycle, cs k8sClient.Clientset) resource.Resource[*corev1.Node] {
 				lw := utils.ListerWatcherFromTyped[*corev1.NodeList](cs.CoreV1().Nodes())
-				return resource.New[*corev1.Node](lc, lw)
+				return resource.New[*corev1.Node](lc, lw, nil)
 			},
 		),
 
@@ -662,7 +662,7 @@ func TestResource_WithIndexers(t *testing.T) {
 			func(lc cell.Lifecycle, cs k8sClient.Clientset) resource.Resource[*corev1.Node] {
 				lw := utils.ListerWatcherFromTyped[*corev1.NodeList](cs.CoreV1().Nodes())
 				return resource.New[*corev1.Node](
-					lc, lw,
+					lc, lw, nil,
 					resource.WithIndexers(cache.Indexers{indexName: indexFunc}),
 				)
 			},
@@ -755,7 +755,7 @@ func TestResource_Retries(t *testing.T) {
 		cell.Provide(func() k8sClient.Clientset { return cs }),
 		cell.Provide(func(lc cell.Lifecycle, c k8sClient.Clientset) resource.Resource[*corev1.Node] {
 			nodesLW := utils.ListerWatcherFromTyped[*corev1.NodeList](c.CoreV1().Nodes())
-			return resource.New[*corev1.Node](lc, nodesLW)
+			return resource.New[*corev1.Node](lc, nodesLW, nil)
 		}),
 		cell.Invoke(func(r resource.Resource[*corev1.Node]) {
 			nodes = r
@@ -957,7 +957,7 @@ func BenchmarkResource(b *testing.B) {
 
 	hive := hive.New(
 		cell.Provide(func(lc cell.Lifecycle) resource.Resource[*corev1.Node] {
-			return resource.New[*corev1.Node](lc, lw)
+			return resource.New[*corev1.Node](lc, lw, nil)
 		}),
 		cell.Invoke(func(r resource.Resource[*corev1.Node]) {
 			nodes = r
@@ -1071,6 +1071,6 @@ func TestResource_SkippedDonePanics(t *testing.T) {
 var nodesResource = cell.Provide(
 	func(lc cell.Lifecycle, c k8sClient.Clientset) resource.Resource[*corev1.Node] {
 		lw := utils.ListerWatcherFromTyped[*corev1.NodeList](c.CoreV1().Nodes())
-		return resource.New[*corev1.Node](lc, lw)
+		return resource.New[*corev1.Node](lc, lw, nil)
 	},
 )

--- a/pkg/k8s/resource/statedb_test.go
+++ b/pkg/k8s/resource/statedb_test.go
@@ -60,6 +60,7 @@ func TestStateDBTableEventStream(t *testing.T) {
 		func(k resource.Key) statedb.Query[*corev1.Node] {
 			return nodeNameIndex.Query(k.String())
 		},
+		nil,
 	)
 
 	// No sync event before initialized

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -15,6 +15,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/identity/key"
@@ -85,14 +86,15 @@ func GetIdentitiesByKeyFunc(keyFunc func(map[string]string) allocator.AllocatorK
 type CiliumResourceParams struct {
 	cell.In
 
-	Logger         *slog.Logger
-	Lifecycle      cell.Lifecycle
-	ClientSet      client.Clientset
-	CRDSyncPromise promise.Promise[synced.CRDSync] `optional:"true"`
+	Logger          *slog.Logger
+	Lifecycle       cell.Lifecycle
+	ClientSet       client.Clientset
+	CRDSyncPromise  promise.Promise[synced.CRDSync] `optional:"true"`
+	MetricsProvider workqueue.MetricsProvider
 }
 
 // ServiceResource builds the Resource[Service] object.
-func ServiceResource(lc cell.Lifecycle, cfg Config, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Service], error) {
+func ServiceResource(lc cell.Lifecycle, cfg Config, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Service], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -108,13 +110,13 @@ func ServiceResource(lc cell.Lifecycle, cfg Config, cs client.Clientset, opts ..
 		append(opts, optsModifier)...,
 	)
 	return resource.New[*slim_corev1.Service](
-		lc, lw,
+		lc, lw, mp,
 		resource.WithMetric("Service"),
 		resource.WithIndexers(indexers),
 	), nil
 }
 
-func NodeResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Node], error) {
+func NodeResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Node], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -122,7 +124,7 @@ func NodeResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.L
 		utils.ListerWatcherFromTyped[*slim_corev1.NodeList](cs.Slim().CoreV1().Nodes()),
 		opts...,
 	)
-	return resource.New[*slim_corev1.Node](lc, lw, resource.WithMetric("Node")), nil
+	return resource.New[*slim_corev1.Node](lc, lw, mp, resource.WithMetric("Node")), nil
 }
 
 func CiliumNodeResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNode], error) {
@@ -133,13 +135,13 @@ func CiliumNodeResource(params CiliumResourceParams, opts ...func(*metav1.ListOp
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](params.ClientSet.CiliumV2().CiliumNodes()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumNode](params.Lifecycle, lw,
+	return resource.New[*cilium_api_v2.CiliumNode](params.Lifecycle, lw, params.MetricsProvider,
 		resource.WithMetric("CiliumNode"),
 		resource.WithCRDSync(params.CRDSyncPromise), // optional, can be nil
 	), nil
 }
 
-func NamespaceResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Namespace], error) {
+func NamespaceResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Namespace], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -147,7 +149,7 @@ func NamespaceResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*met
 		utils.ListerWatcherFromTyped[*slim_corev1.NamespaceList](cs.Slim().CoreV1().Namespaces()),
 		opts...,
 	)
-	return resource.New[*slim_corev1.Namespace](lc, lw, resource.WithMetric("Namespace")), nil
+	return resource.New[*slim_corev1.Namespace](lc, lw, mp, resource.WithMetric("Namespace")), nil
 }
 
 func LBIPPoolsResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumLoadBalancerIPPool], error) {
@@ -158,7 +160,7 @@ func LBIPPoolsResource(params CiliumResourceParams, opts ...func(*metav1.ListOpt
 		utils.ListerWatcherFromTyped(params.ClientSet.CiliumV2().CiliumLoadBalancerIPPools()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumLoadBalancerIPPool](params.Lifecycle, lw, resource.WithMetric("CiliumLoadBalancerIPPool"), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2.CiliumLoadBalancerIPPool](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumLoadBalancerIPPool"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func CiliumIdentityResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumIdentity], error) {
@@ -174,10 +176,10 @@ func CiliumIdentityResource(params CiliumResourceParams, opts ...func(*metav1.Li
 		ByKeyIndex: GetIdentitiesByKeyFunc((&key.GlobalIdentity{}).PutKeyFromMap),
 	}
 
-	return resource.New[*cilium_api_v2.CiliumIdentity](params.Lifecycle, lw, resource.WithMetric("CiliumIdentityList"), resource.WithIndexers(indexers), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2.CiliumIdentity](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumIdentityList"), resource.WithIndexers(indexers), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func NetworkPolicyResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_networkingv1.NetworkPolicy], error) {
+func NetworkPolicyResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_networkingv1.NetworkPolicy], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -185,7 +187,7 @@ func NetworkPolicyResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(
 		utils.ListerWatcherFromTyped[*slim_networkingv1.NetworkPolicyList](cs.Slim().NetworkingV1().NetworkPolicies("")),
 		opts...,
 	)
-	return resource.New[*slim_networkingv1.NetworkPolicy](lc, lw, resource.WithMetric("NetworkPolicy")), nil
+	return resource.New[*slim_networkingv1.NetworkPolicy](lc, lw, mp, resource.WithMetric("NetworkPolicy")), nil
 }
 
 func CiliumNetworkPolicyResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumNetworkPolicy], error) {
@@ -196,7 +198,7 @@ func CiliumNetworkPolicyResource(params CiliumResourceParams, opts ...func(*meta
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNetworkPolicyList](params.ClientSet.CiliumV2().CiliumNetworkPolicies("")),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumNetworkPolicy](params.Lifecycle, lw, resource.WithMetric("CiliumNetworkPolicy"), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2.CiliumNetworkPolicy](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumNetworkPolicy"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func CiliumClusterwideNetworkPolicyResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumClusterwideNetworkPolicy], error) {
@@ -207,7 +209,7 @@ func CiliumClusterwideNetworkPolicyResource(params CiliumResourceParams, opts ..
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumClusterwideNetworkPolicyList](params.ClientSet.CiliumV2().CiliumClusterwideNetworkPolicies()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumClusterwideNetworkPolicy](params.Lifecycle, lw, resource.WithMetric("CiliumClusterwideNetworkPolicy"), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2.CiliumClusterwideNetworkPolicy](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumClusterwideNetworkPolicy"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func CiliumCIDRGroupResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumCIDRGroup], error) {
@@ -218,7 +220,7 @@ func CiliumCIDRGroupResource(params CiliumResourceParams, opts ...func(*metav1.L
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumCIDRGroupList](params.ClientSet.CiliumV2().CiliumCIDRGroups()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumCIDRGroup](params.Lifecycle, lw, resource.WithMetric("CiliumCIDRGroup"), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2.CiliumCIDRGroup](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumCIDRGroup"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func CiliumPodIPPoolResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool], error) {
@@ -229,7 +231,7 @@ func CiliumPodIPPoolResource(params CiliumResourceParams, opts ...func(*metav1.L
 		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumPodIPPoolList](params.ClientSet.CiliumV2alpha1().CiliumPodIPPools()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumPodIPPool](params.Lifecycle, lw, resource.WithMetric("CiliumPodIPPool"), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumPodIPPool](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumPodIPPool"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func CiliumBGPPeeringPolicyResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumBGPPeeringPolicy], error) {
@@ -241,7 +243,7 @@ func CiliumBGPPeeringPolicyResource(params CiliumResourceParams, opts ...func(*m
 		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumBGPPeeringPolicyList](params.ClientSet.CiliumV2alpha1().CiliumBGPPeeringPolicies()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumBGPPeeringPolicy](params.Lifecycle, lw, resource.WithMetric("CiliumBGPPeeringPolicies"), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumBGPPeeringPolicy](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumBGPPeeringPolicies"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func CiliumBGPNodeConfigResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumBGPNodeConfig], error) {
@@ -253,7 +255,7 @@ func CiliumBGPNodeConfigResource(params CiliumResourceParams, opts ...func(*meta
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumBGPNodeConfigList](params.ClientSet.CiliumV2().CiliumBGPNodeConfigs()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumBGPNodeConfig](params.Lifecycle, lw, resource.WithMetric("CiliumBGPNodeConfig"), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2.CiliumBGPNodeConfig](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumBGPNodeConfig"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func CiliumBGPAdvertisementResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumBGPAdvertisement], error) {
@@ -265,7 +267,7 @@ func CiliumBGPAdvertisementResource(params CiliumResourceParams, opts ...func(*m
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumBGPAdvertisementList](params.ClientSet.CiliumV2().CiliumBGPAdvertisements()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumBGPAdvertisement](params.Lifecycle, lw, resource.WithMetric("CiliumBGPAdvertisement"), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2.CiliumBGPAdvertisement](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumBGPAdvertisement"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
 func CiliumBGPPeerConfigResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumBGPPeerConfig], error) {
@@ -277,14 +279,14 @@ func CiliumBGPPeerConfigResource(params CiliumResourceParams, opts ...func(*meta
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumBGPPeerConfigList](params.ClientSet.CiliumV2().CiliumBGPPeerConfigs()),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumBGPPeerConfig](params.Lifecycle, lw, resource.WithMetric("CiliumBGPPeerConfig"), resource.WithCRDSync(params.CRDSyncPromise)), nil
+	return resource.New[*cilium_api_v2.CiliumBGPPeerConfig](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumBGPPeerConfig"), resource.WithCRDSync(params.CRDSyncPromise)), nil
 }
 
-func EndpointsResource(logger *slog.Logger, lc cell.Lifecycle, cfg Config, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*Endpoints], error) {
-	return EndpointsResourceWithIndexers(logger, lc, cfg, cs, nil, opts...)
+func EndpointsResource(logger *slog.Logger, lc cell.Lifecycle, cfg Config, cs client.Clientset, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*Endpoints], error) {
+	return EndpointsResourceWithIndexers(logger, lc, cfg, cs, nil, mp, opts...)
 }
 
-func EndpointsResourceWithIndexers(logger *slog.Logger, lc cell.Lifecycle, cfg Config, cs client.Clientset, indexers cache.Indexers, opts ...func(*metav1.ListOptions)) (resource.Resource[*Endpoints], error) {
+func EndpointsResourceWithIndexers(logger *slog.Logger, lc cell.Lifecycle, cfg Config, cs client.Clientset, indexers cache.Indexers, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*Endpoints], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
@@ -303,6 +305,7 @@ func EndpointsResourceWithIndexers(logger *slog.Logger, lc cell.Lifecycle, cfg C
 	return resource.New[*Endpoints](
 		lc,
 		lw,
+		mp,
 		resource.WithLazyTransform(lw.getSourceObj, func(i any) (any, error) {
 			return transformEndpoint(logger, i)
 		}),
@@ -367,7 +370,7 @@ func transformEndpoint(logger *slog.Logger, obj any) (any, error) {
 // to initialize it before the first access.
 // To reflect this, the node.LocalNodeStore dependency is explicitly requested in the function
 // signature.
-func CiliumSlimEndpointResource(params CiliumResourceParams, _ *node.LocalNodeStore, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
+func CiliumSlimEndpointResource(params CiliumResourceParams, _ *node.LocalNodeStore, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
 	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
@@ -380,7 +383,7 @@ func CiliumSlimEndpointResource(params CiliumResourceParams, _ *node.LocalNodeSt
 			return ciliumEndpointLocalPodIndexFunc(params.Logger, obj)
 		},
 	}
-	return resource.New[*types.CiliumEndpoint](params.Lifecycle, lw,
+	return resource.New[*types.CiliumEndpoint](params.Lifecycle, lw, params.MetricsProvider,
 		resource.WithLazyTransform(func() k8sRuntime.Object {
 			return &cilium_api_v2.CiliumEndpoint{}
 		}, TransformToCiliumEndpoint),
@@ -416,7 +419,7 @@ func ciliumEndpointLocalPodIndexFunc(logger *slog.Logger, obj any) ([]string, er
 // to initialize it before the first access.
 // To reflect this, the node.LocalNodeStore dependency is explicitly requested in the function
 // signature.
-func CiliumEndpointSliceResource(params CiliumResourceParams, _ *node.LocalNodeStore, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
+func CiliumEndpointSliceResource(params CiliumResourceParams, _ *node.LocalNodeStore, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
 	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
@@ -429,7 +432,7 @@ func CiliumEndpointSliceResource(params CiliumResourceParams, _ *node.LocalNodeS
 			return ciliumEndpointSliceLocalPodIndexFunc(params.Logger, obj)
 		},
 	}
-	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](params.Lifecycle, lw,
+	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](params.Lifecycle, lw, params.MetricsProvider,
 		resource.WithMetric("CiliumEndpointSlice"),
 		resource.WithIndexers(indexers),
 		resource.WithCRDSync(params.CRDSyncPromise),

--- a/pkg/k8s/watchers/metrics/cell.go
+++ b/pkg/k8s/watchers/metrics/cell.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"github.com/cilium/hive/cell"
+	"k8s.io/client-go/util/workqueue"
+)
+
+var Cell = cell.Module(
+	"k8s-workqueue-metrics",
+	"K8s workqueue metrics provider",
+	cell.Provide(func() workqueue.MetricsProvider {
+		return &workqueueMetricsProvider{}
+	}),
+)

--- a/pkg/k8s/watchers/metrics/metrics.go
+++ b/pkg/k8s/watchers/metrics/metrics.go
@@ -40,19 +40,7 @@ func init() {
 	k8s_metrics.RequestLatency = registerOps.RequestLatency
 	k8s_metrics.RateLimiterLatency = registerOps.RateLimiterLatency
 	k8s_metrics.RequestResult = registerOps.RequestResult
-
-	// Note: Workqueues should have the metric provider set directly
-	// via the [TypedRateLimitingQueueConfig.MetricsProvider] field.
-	// The workqueue.SetProvider call is inherently prone to breaking
-	// (see: above commment), however we will still attempt to register
-	// it for the sake of posterity.
-	workqueue.SetProvider(MetricsProvider)
 }
-
-// MetricsProvider is the global metrics provider for k8s controller runtime
-// watcher work queues. This should be set directly in TypedRateLimitingQueueConfig
-// when configuring work queues.
-var MetricsProvider = workqueueMetricsProvider{}
 
 type workqueueMetricsProvider struct{}
 

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/util/workqueue"
 
 	daemon_k8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -51,14 +52,15 @@ var Cell = cell.Module(
 	cell.Invoke(func(*L2Announcer) {}), // register and start L2 announcer
 )
 
-func l2AnnouncementPolicyResource(lc cell.Lifecycle, cs k8sClient.Clientset) (resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy], error) {
+func l2AnnouncementPolicyResource(lc cell.Lifecycle, cs k8sClient.Clientset,
+	mp workqueue.MetricsProvider) (resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
 	}
 	lw := utils.ListerWatcherFromTyped(
 		cs.CiliumV2alpha1().CiliumL2AnnouncementPolicies(),
 	)
-	return resource.New[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy](lc, lw, resource.WithMetric("CiliumL2AnnouncementPolicy")), nil
+	return resource.New[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy](lc, lw, mp, resource.WithMetric("CiliumL2AnnouncementPolicy")), nil
 }
 
 type l2AnnouncerParams struct {


### PR DESCRIPTION
The way we registered the k8s global work-queue metrics has always been prone to breaking, as it depended on the specific ordering of evaluation of init functions, as is explained in this comment:

https://github.com/cilium/cilium/blob/6c82bc435a276edb8d14e2b119ba612808060021/pkg/k8s/watchers/metrics.go#L20-L31

This was already causing problems in the Operator resulting in missing metrics when trying to move the `watchers/metrics.go` file to a separate package.  Clearly trying to trick Go into evaluating our init funcs before a code libraries wasn't a good approach moving forward.

As a result, recent changes have moved operator related workqueue configs to explicitly define the provider via a global variable.  This fixes the problem of the `init()` registry race condition but it results in some Operator workqueue metrics now being prefixed with the agent metrics namespace (i.e. `cilium_`).  Previously this was broken as well as because metrics registered via the global registry were not registered with the cilium prefix many such metrics were missing the `cilium_` prefix, leading to inconsistent metric naming.

This follows up those changes and takes another step in cleaning all this up by removing the global MetricsProvider and explicitly passing a Hive provided one to each workqueue (i.e. notably, many of the resource watchers use these to setup K8s object events).  The result is a wide refactor requiring a lot of fixed tests and addition of MetricsProvider to a lot of Hive constructor parameters - thus the separate pull request.

https://github.com/cilium/cilium/pull/40884/files#diff-8b8e02278a63139306486adc431761b5b2dd9847df5559f95acd90d9a921fb6bL44-L49

```release-note
Fix operator k8s workqueue metrics to use correct prefix of cilium_operator_workqueue_<metric> 
```
