### PR TITLE
Restart k8s clientset connections once datapath is set up

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -110,6 +110,7 @@ var (
 		// Provides optional configuration callback to bypass
 		// host firewall when accessing Kubernetes objects.
 		hostfirewallbypass.Cell,
+		cell.Invoke(hostfirewallbypass.RestartClientset),
 
 		// Provide the logic to map DNS names matching Kubernetes services to the
 		// corresponding ClusterIP, without depending on CoreDNS. Leveraged by etcd

--- a/pkg/datapath/fake/types/iptables_manager.go
+++ b/pkg/datapath/fake/types/iptables_manager.go
@@ -35,3 +35,9 @@ func (m *FakeIptablesManager) InstallNoTrackRules(ip netip.Addr, port uint16) {
 
 func (m *FakeIptablesManager) RemoveNoTrackRules(ip netip.Addr, port uint16) {
 }
+
+func (m *FakeIptablesManager) Initialized() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -293,6 +293,18 @@ stop:
 			} else {
 				close(req.updated)
 			}
+		case req, ok := <-params.sync:
+			if !ok {
+				break stop
+			}
+
+			if firstInit {
+				// first init not yet completed
+				updatedChs = append(updatedChs, req.updated)
+				continue
+			} else {
+				close(req.updated)
+			}
 		case <-refresher.C():
 			stateChanged = true
 		case <-ticker.C():
@@ -350,6 +362,8 @@ stop:
 	for range params.addNoTrackPod {
 	}
 	for range params.delNoTrackPod {
+	}
+	for range params.sync {
 	}
 
 	return nil

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -71,6 +71,9 @@ type IptablesManager interface {
 
 	// See comments for InstallNoTrackRules.
 	RemoveNoTrackRules(ip netip.Addr, port uint16)
+
+	// Returns a channel that is closed when initial reconciliation completes.
+	Initialized() <-chan struct{}
 }
 
 // CompilationLock is a interface over a mutex, it is used by both the loader, daemon

--- a/pkg/k8s/hostfirewallbypass/cell.go
+++ b/pkg/k8s/hostfirewallbypass/cell.go
@@ -15,7 +15,7 @@ var Cell = cell.Module(
 	"Kubernetes host firewall bypass",
 
 	cell.Config(Params{
-		EnableK8sHostFirewallBypass: false,
+		EnableK8sHostFirewallBypass: true,
 	}),
 	cell.Provide(NewK8sHostFirewallBypass),
 )


### PR DESCRIPTION
This PR attempts to fix [e2e conformance test flakiness](https://github.com/cilium/cilium/issues/40682) caused by host firewall bypass by restarting all clientset connections once the datapath is set up.

Related: #40682, #40346