### PR TITLE
daemon/test: use t.Context() to fix goroutine leak in TestLocalNodeSync

### DIFF
--- a/daemon/cmd/local_node_sync_test.go
+++ b/daemon/cmd/local_node_sync_test.go
@@ -140,7 +140,7 @@ func TestLocalNodeSync(t *testing.T) {
 	require.Equal(t, "provider://foobar", local.ProviderID)
 
 	store := node.NewTestLocalNodeStore(local)
-	updates := stream.ToChannel(context.Background(), store.Observable, stream.WithBufferSize(4))
+	updates := stream.ToChannel(t.Context(), store.Observable, stream.WithBufferSize(4))
 
 	sync.SyncLocalNode(context.Background(), store)
 	require.EqualValues(t, 5, fln.done)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
