### PR TITLE
daemon/test: use t.Context() to fix goroutine leak in TestLocalNodeSync

### DIFF
--- a/daemon/cmd/local_node_sync_test.go
+++ b/daemon/cmd/local_node_sync_test.go
@@ -140,7 +140,7 @@ func TestLocalNodeSync(t *testing.T) {
 	require.Equal(t, "provider://foobar", local.ProviderID)
 
 	store := node.NewTestLocalNodeStore(local)
-	updates := stream.ToChannel(context.Background(), store.Observable, stream.WithBufferSize(4))
+	updates := stream.ToChannel(t.Context(), store.Observable, stream.WithBufferSize(4))
 
 	sync.SyncLocalNode(context.Background(), store)
 	require.EqualValues(t, 5, fln.done)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

The test was leaking goroutines because `context.Background()` passed to `stream.ToChannel()` is never canceled. `ToChannel()` internally uses `Multicast` which spawns goroutines that wait for context cancellation. Due to test execution order, this leak wasn't detected on the first `goleak.VerifyNone` in `TestAgentCell` but was caught on the second run. This change uses `t.Context()` instead to ensure proper cleanup.

Fixes: #40563

