### PR TITLE
renovate: Fix go-github exclusion rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -385,7 +385,7 @@
       // Disable major updates for go-github as those require updating import paths
       "enabled": false,
       "matchPackageNames": [
-        "github.com/google/go-github",
+        "github.com/google/go-github/v*",
       ],
       "matchUpdateTypes": [
         "major",


### PR DESCRIPTION
This week's renovate update (#40897) tried and failed to upgrade `google/go-github` because of how this module's major version is included in the module import path.

Automated major upgrades for this module were supposed to be disabled by #40326, but that PR did not actually work as expected as it configured `github.com/google/go-github` in `matchPackageNames` which only does an exact module name match and does not match the actual module name which includes the module major version.

This PR fixes the logic by configuring this `matchPackageNames` with a glob pattern.

Relevant renovate documentations on exact string matches, glob patterns and regex in `matchPackageNames`: https://docs.renovatebot.com/string-pattern-matching/

Note: for a followup, instead of disabling major upgrades for this module, we could consider instead configuring renovate with a `postUpgradeTasks` to `sed` the module import string to use the new major version.

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!



```release-note
renovate: Fix go-github exclusion rule
```
