### PR TITLE
loadbalancer: Fix handling of non-VIP IPMode services

### DIFF
--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -282,7 +282,8 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 		// LoadBalancer
 		if svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer && expType.CanExpose(slim_corev1.ServiceTypeLoadBalancer) {
 			for _, ip := range svc.Status.LoadBalancer.Ingress {
-				if ip.IP == "" {
+				if ip.IP == "" ||
+					(ip.IPMode != nil && *ip.IPMode != slim_corev1.LoadBalancerIPModeVIP) /* KEP-1860, skip non-VIP */ {
 					continue
 				}
 

--- a/pkg/loadbalancer/tests/testdata/loadbalancer.txtar
+++ b/pkg/loadbalancer/tests/testdata/loadbalancer.txtar
@@ -31,6 +31,11 @@ k8s/delete service.yaml
 * db/empty services frontends backends
 * lb/maps-empty
 
+# Check that LoadBalancer IPs with IPMode other than VIP are skipped. 
+sed '#ipMode:' 'ipMode:' service.yaml
+k8s/add service.yaml endpointslice.yaml
+db/cmp frontends frontends_ipmode_proxy.table
+
 #####
 
 -- addrv4.yaml --
@@ -58,6 +63,11 @@ Address               Type         ServiceName   PortName   Status  Backends
 0.0.0.0:30781/TCP     NodePort     test/echo     http       Done        
 10.96.50.104:80/TCP   ClusterIP    test/echo     http       Done        
 172.16.1.1:80/TCP     LoadBalancer test/echo     http       Done
+
+-- frontends_ipmode_proxy.table --
+Address               Type         ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort     test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.50.104:80/TCP   ClusterIP    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
 
 -- backends.table --
 Address             Instances            NodeName
@@ -116,6 +126,7 @@ status:
   loadBalancer:
     ingress:
     - ip: 172.16.1.1
+      #ipMode: Proxy
 
 -- endpointslice.yaml --
 apiVersion: discovery.k8s.io/v1


### PR DESCRIPTION
This fixes a regression in which the IPMode field was not correctly processed for 'LoadBalancer` services leading to such services having IPMode set to 'Proxy' not being skipped by Cilium as expected (KEP-1860).

Fixes: #40913

```release-note
Fix skipping of LoadBalancer services when IPMode is not set to VIP (KEP-1860)
```
