### PR TITLE
bgpv2: Migrate service reconciler to use svc LB tables

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -13,20 +13,22 @@ import (
 	"slices"
 
 	"github.com/cilium/hive/cell"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
-	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
 	"github.com/cilium/cilium/pkg/bgpv1/option"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
-	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
-	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
-	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	ciliumslices "github.com/cilium/cilium/pkg/slices"
+	slimmetav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	ciliumoption "github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type ServiceReconcilerOut struct {
@@ -37,45 +39,78 @@ type ServiceReconcilerOut struct {
 
 type ServiceReconcilerIn struct {
 	cell.In
+	Logger   *slog.Logger
+	JobGroup job.Group
 
-	Logger       *slog.Logger
 	PeerAdvert   *CiliumPeerAdvertisement
-	SvcDiffStore store.DiffStore[*slim_corev1.Service]
-	EPDiffStore  store.DiffStore[*k8s.Endpoints]
 	Config       option.BGPConfig
+	DaemonConfig *ciliumoption.DaemonConfig
+	Signaler     *signaler.BGPCPSignaler
+
+	DB        *statedb.DB
+	Frontends statedb.Table[*loadbalancer.Frontend]
 }
 
 type ServiceReconciler struct {
 	logger                       *slog.Logger
 	peerAdvert                   *CiliumPeerAdvertisement
 	legacyOriginAttributeEnabled bool
-	svcDiffStore                 store.DiffStore[*slim_corev1.Service]
-	epDiffStore                  store.DiffStore[*k8s.Endpoints]
+	signaler                     *signaler.BGPCPSignaler
+	db                           *statedb.DB
+	frontends                    statedb.Table[*loadbalancer.Frontend]
 	metadata                     map[string]ServiceReconcilerMetadata
 }
 
-func NewServiceReconciler(in ServiceReconcilerIn) ServiceReconcilerOut {
-	if in.SvcDiffStore == nil || in.EPDiffStore == nil {
-		return ServiceReconcilerOut{}
-	}
-
-	return ServiceReconcilerOut{
-		Reconciler: &ServiceReconciler{
-			logger:                       in.Logger,
-			peerAdvert:                   in.PeerAdvert,
-			legacyOriginAttributeEnabled: in.Config.EnableBGPLegacyOriginAttribute,
-			svcDiffStore:                 in.SvcDiffStore,
-			epDiffStore:                  in.EPDiffStore,
-			metadata:                     make(map[string]ServiceReconcilerMetadata),
-		},
-	}
+// ServiceReconcilerMetadata holds per-instance reconciler state.
+type ServiceReconcilerMetadata struct {
+	ServicePaths               ResourceAFPathsMap
+	ServiceAdvertisements      PeerAdvertisements
+	ServiceRoutePolicies       ResourceRoutePolicyMap
+	FrontendChanges            statedb.ChangeIterator[*loadbalancer.Frontend]
+	FrontendChangesInitialized bool
 }
 
-// ServiceReconcilerMetadata holds any announced service CIDRs per address family.
-type ServiceReconcilerMetadata struct {
-	ServicePaths          ResourceAFPathsMap
-	ServiceAdvertisements PeerAdvertisements
-	ServiceRoutePolicies  ResourceRoutePolicyMap
+func NewServiceReconciler(in ServiceReconcilerIn) ServiceReconcilerOut {
+	if !in.DaemonConfig.BGPControlPlaneEnabled() {
+		return ServiceReconcilerOut{}
+	}
+	r := &ServiceReconciler{
+		logger:                       in.Logger,
+		peerAdvert:                   in.PeerAdvert,
+		legacyOriginAttributeEnabled: in.Config.EnableBGPLegacyOriginAttribute,
+		signaler:                     in.Signaler,
+		db:                           in.DB,
+		frontends:                    in.Frontends,
+		metadata:                     make(map[string]ServiceReconcilerMetadata),
+	}
+	in.JobGroup.Add(
+		job.OneShot("frontend-events", r.processFrontendEvents),
+	)
+	return ServiceReconcilerOut{Reconciler: r}
+}
+
+// processFrontendEvents triggers BGP reconciliation upon frontend events (including changes in their backends)
+func (r *ServiceReconciler) processFrontendEvents(ctx context.Context, _ cell.Health) error {
+	// rate-limit reconciliation triggers to 100 milliseconds
+	limiter := rate.NewLimiter(100*time.Millisecond, 1)
+	defer limiter.Stop()
+
+	// watch for changes in the frontends table
+	_, watch := r.frontends.AllWatch(r.db.ReadTxn())
+
+	for {
+		select {
+		case <-watch:
+			// re-start the watch and emit reconciliation event
+			_, watch = r.frontends.AllWatch(r.db.ReadTxn())
+			r.signaler.Event(struct{}{})
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
+	}
 }
 
 func (r *ServiceReconciler) getMetadata(i *instance.BGPInstance) ServiceReconcilerMetadata {
@@ -98,8 +133,6 @@ func (r *ServiceReconciler) Init(i *instance.BGPInstance) error {
 	if i == nil {
 		return fmt.Errorf("BUG: service reconciler initialization with nil BGPInstance")
 	}
-	r.svcDiffStore.InitDiff(r.diffID(i))
-	r.epDiffStore.InitDiff(r.diffID(i))
 
 	r.metadata[i.Name] = ServiceReconcilerMetadata{
 		ServicePaths:          make(ResourceAFPathsMap),
@@ -111,9 +144,6 @@ func (r *ServiceReconciler) Init(i *instance.BGPInstance) error {
 
 func (r *ServiceReconciler) Cleanup(i *instance.BGPInstance) {
 	if i != nil {
-		r.svcDiffStore.CleanupDiff(r.diffID(i))
-		r.epDiffStore.CleanupDiff(r.diffID(i))
-
 		delete(r.metadata, i.Name)
 	}
 }
@@ -130,6 +160,11 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 
 	reqFullReconcile := r.modifiedServiceAdvertisements(p, desiredPeerAdverts)
 
+	// if frontend changes iterator has not been initialized yet (first reconcile), perform full reconciliation
+	if !r.getMetadata(p.BGPInstance).FrontendChangesInitialized {
+		reqFullReconcile = true
+	}
+
 	err = r.reconcileServices(ctx, p, desiredPeerAdverts, reqFullReconcile)
 
 	if err == nil && reqFullReconcile {
@@ -141,12 +176,13 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 
 func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcileParams, desiredPeerAdverts PeerAdvertisements, fullReconcile bool) error {
 	var (
-		toReconcile []*slim_corev1.Service
-		toWithdraw  []resource.Key
+		toReconcile []*loadbalancer.Service
+		toWithdraw  []loadbalancer.ServiceName
 
 		desiredSvcRoutePolicies ResourceRoutePolicyMap
 		desiredSvcPaths         ResourceAFPathsMap
 
+		rx  statedb.ReadTxn
 		err error
 	)
 
@@ -154,7 +190,7 @@ func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcilePa
 		r.logger.Debug("performing all services reconciliation")
 
 		// get all services to reconcile and to withdraw.
-		toReconcile, toWithdraw, err = r.fullReconciliationServiceList(p)
+		toReconcile, toWithdraw, rx, err = r.fullReconciliationServiceList(p)
 		if err != nil {
 			return err
 		}
@@ -163,20 +199,14 @@ func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcilePa
 
 		// get modified services to reconcile and to withdraw.
 		// Note: we should call svc diff only once in a reconcile loop.
-		toReconcile, toWithdraw, err = r.diffReconciliationServiceList(p)
+		toReconcile, rx, err = r.diffReconciliationServiceList(p)
 		if err != nil {
 			return err
 		}
 	}
 
-	// populate locally available services
-	ls, err := r.populateLocalServices(p.CiliumNode.Name)
-	if err != nil {
-		return fmt.Errorf("failed to populate local services: %w", err)
-	}
-
 	// get desired service route policies
-	desiredSvcRoutePolicies, err = r.getDesiredRoutePolicies(p, desiredPeerAdverts, toReconcile, toWithdraw, ls)
+	desiredSvcRoutePolicies, err = r.getDesiredRoutePolicies(p, desiredPeerAdverts, toReconcile, toWithdraw, rx)
 	if err != nil {
 		return err
 	}
@@ -188,7 +218,7 @@ func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcilePa
 	}
 
 	// get desired service paths
-	desiredSvcPaths, err = r.getDesiredPaths(p, desiredPeerAdverts, toReconcile, toWithdraw, ls)
+	desiredSvcPaths, err = r.getDesiredPaths(p, desiredPeerAdverts, toReconcile, toWithdraw, rx)
 	if err != nil {
 		return err
 	}
@@ -231,33 +261,31 @@ func (r *ServiceReconciler) reconcileSvcRoutePolicies(ctx context.Context, p Rec
 	return err
 }
 
-func (r *ServiceReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, toUpdate []*slim_corev1.Service, toRemove []resource.Key, ls sets.Set[resource.Key]) (ResourceRoutePolicyMap, error) {
+func (r *ServiceReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, toUpdate []*loadbalancer.Service, toRemove []loadbalancer.ServiceName, rx statedb.ReadTxn) (ResourceRoutePolicyMap, error) {
 	desiredSvcRoutePolicies := make(ResourceRoutePolicyMap)
 
 	for _, svc := range toUpdate {
-		svcKey := resource.Key{
-			Name:      svc.GetName(),
-			Namespace: svc.GetNamespace(),
-		}
+		key := resource.Key{Name: svc.Name.Name(), Namespace: svc.Name.Namespace()}
 
 		// get desired route policies for the service
-		svcRoutePolicies, err := r.getDesiredSvcRoutePolicies(desiredPeerAdverts, svc, ls)
+		svcRoutePolicies, err := r.getDesiredSvcRoutePolicies(p, desiredPeerAdverts, svc, rx)
 		if err != nil {
 			return nil, err
 		}
 
-		desiredSvcRoutePolicies[svcKey] = svcRoutePolicies
+		desiredSvcRoutePolicies[key] = svcRoutePolicies
 	}
 
-	for _, svcKey := range toRemove {
+	for _, svcName := range toRemove {
 		// for withdrawn services, we need to set route policies to nil.
-		desiredSvcRoutePolicies[svcKey] = nil
+		key := resource.Key{Name: svcName.Name(), Namespace: svcName.Namespace()}
+		desiredSvcRoutePolicies[key] = nil
 	}
 
 	return desiredSvcRoutePolicies, nil
 }
 
-func (r *ServiceReconciler) getDesiredSvcRoutePolicies(desiredPeerAdverts PeerAdvertisements, svc *slim_corev1.Service, ls sets.Set[resource.Key]) (RoutePolicyMap, error) {
+func (r *ServiceReconciler) getDesiredSvcRoutePolicies(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, svc *loadbalancer.Service, rx statedb.ReadTxn) (RoutePolicyMap, error) {
 	desiredSvcRoutePolicies := make(RoutePolicyMap)
 
 	for peer, afAdverts := range desiredPeerAdverts {
@@ -265,16 +293,20 @@ func (r *ServiceReconciler) getDesiredSvcRoutePolicies(desiredPeerAdverts PeerAd
 			agentFamily := types.ToAgentFamily(fam)
 
 			for _, advert := range adverts {
-				labelSelector, err := slim_metav1.LabelSelectorAsSelector(advert.Selector)
+				// get prefixes for the service
+				typedPrefixes, err := r.getServicePrefixes(p, svc, advert, rx)
 				if err != nil {
-					return nil, fmt.Errorf("failed constructing LabelSelector: %w", err)
+					return nil, err
 				}
-				if !labelSelector.Matches(serviceLabelSet(svc)) {
-					continue
-				}
-
-				for _, advertType := range []v2.BGPServiceAddressType{v2.BGPLoadBalancerIPAddr, v2.BGPExternalIPAddr, v2.BGPClusterIPAddr} {
-					policy, err := r.getServiceRoutePolicy(peer, agentFamily, svc, advert, advertType, ls)
+				for advertType, prefixes := range typedPrefixes {
+					if len(prefixes) == 0 {
+						continue
+					}
+					prefixesArr := prefixes.UnsortedList()
+					slices.SortFunc(prefixesArr, func(a, b netip.Prefix) int {
+						return a.Addr().Compare(b.Addr()) // NOTE: Compare for netip.Prefix us unexported as of Go 1.22 (see go.dev/issue/61642), address compare is good enough here
+					})
+					policy, err := r.getServiceRoutePolicy(peer, agentFamily, svc, prefixesArr, advert, advertType)
 					if err != nil {
 						return nil, fmt.Errorf("failed to get desired %s route policy: %w", advertType, err)
 					}
@@ -329,174 +361,104 @@ func (r *ServiceReconciler) updateServiceAdvertisementsMetadata(p ReconcileParam
 	// current metadata
 	serviceMetadata := r.getMetadata(p.BGPInstance)
 
+	serviceMetadata.ServiceAdvertisements = peerAdverts
+
 	// update ServiceAdvertisements in the metadata
-	r.setMetadata(p.BGPInstance, ServiceReconcilerMetadata{
-		ServicePaths:          serviceMetadata.ServicePaths,
-		ServiceRoutePolicies:  serviceMetadata.ServiceRoutePolicies,
-		ServiceAdvertisements: peerAdverts,
-	})
+	r.setMetadata(p.BGPInstance, serviceMetadata)
 }
 
-// Populate locally available services used for externalTrafficPolicy=local handling
-func (r *ServiceReconciler) populateLocalServices(localNodeName string) (sets.Set[resource.Key], error) {
-	ls := sets.New[resource.Key]()
+func hasLocalBackends(p ReconcileParams, fe *loadbalancer.Frontend) bool {
+	for backend := range fe.Backends {
+		if backend.NodeName == p.CiliumNode.Name && backend.State == loadbalancer.BackendStateActive {
+			return true
+		}
+	}
+	return false
+}
 
-	epList, err := r.epDiffStore.List()
+func (r *ServiceReconciler) fullReconciliationServiceList(p ReconcileParams) (toReconcile []*loadbalancer.Service, toWithdraw []loadbalancer.ServiceName, rx statedb.ReadTxn, err error) {
+	metadata := r.getMetadata(p.BGPInstance)
+
+	// re-init changes interator, so that it contains changes since the last full reconciliation
+	tx := r.db.WriteTxn(r.frontends)
+	metadata.FrontendChanges, err = r.frontends.Changes(tx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list EPs from diffstore: %w", err)
+		tx.Abort()
+		return nil, nil, nil, fmt.Errorf("error subscribing to frontends changes: %w", err)
 	}
+	rx = tx.Commit()
+	metadata.FrontendChangesInitialized = true
+	r.setMetadata(p.BGPInstance, metadata)
 
-endpointsLoop:
-	for _, eps := range epList {
-		_, exists, err := r.resolveSvcFromEndpoints(eps)
-		if err != nil {
-			// Cannot resolve service from EPs. We have nothing to do here.
-			continue
-		}
+	// the initial set of changes emits all existing frontends
+	events, _ := metadata.FrontendChanges.Next(rx)
 
-		if !exists {
-			// No service associated with this endpoint. We're not interested in this.
-			continue
-		}
-
-		svcKey := resource.Key{
-			Name:      eps.ServiceName.Name(),
-			Namespace: eps.ServiceName.Namespace(),
-		}
-
-		for _, be := range eps.Backends {
-			if !be.Conditions.IsTerminating() && be.NodeName == localNodeName {
-				// At least one endpoint is available on this node. We
-				// can add service to the local services set.
-				ls.Insert(svcKey)
-				continue endpointsLoop
-			}
-		}
+	svcMap := make(map[loadbalancer.ServiceName]*loadbalancer.Service)
+	for frontendEvent := range events {
+		frontend := frontendEvent.Object
+		svcMap[frontend.Service.Name] = frontend.Service
 	}
-
-	return ls, nil
-}
-
-func hasLocalEndpoints(svc *slim_corev1.Service, ls sets.Set[resource.Key]) bool {
-	return ls.Has(resource.Key{Name: svc.GetName(), Namespace: svc.GetNamespace()})
-}
-
-func (r *ServiceReconciler) resolveSvcFromEndpoints(eps *k8s.Endpoints) (*slim_corev1.Service, bool, error) {
-	k := resource.Key{
-		Name:      eps.ServiceName.Name(),
-		Namespace: eps.ServiceName.Namespace(),
-	}
-	return r.svcDiffStore.GetByKey(k)
-}
-
-func (r *ServiceReconciler) fullReconciliationServiceList(p ReconcileParams) (toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, err error) {
-	// re-init diff in diffstores, so that it contains only changes since the last full reconciliation.
-	r.svcDiffStore.InitDiff(r.diffID(p.BGPInstance))
-	r.epDiffStore.InitDiff(r.diffID(p.BGPInstance))
+	toReconcile = slices.Collect(maps.Values(svcMap))
 
 	// check for services which are no longer present
-	serviceAFPaths := r.getMetadata(p.BGPInstance).ServicePaths
+	serviceAFPaths := metadata.ServicePaths
 	for svcKey := range serviceAFPaths {
-		_, exists, err := r.svcDiffStore.GetByKey(svcKey)
-		if err != nil {
-			return nil, nil, fmt.Errorf("svcDiffStore.GetByKey(): %w", err)
-		}
-
+		svcName := loadbalancer.NewServiceName(svcKey.Namespace, svcKey.Name)
 		// if the service no longer exists, withdraw it
-		if !exists {
-			toWithdraw = append(toWithdraw, svcKey)
+		if _, exists := svcMap[svcName]; !exists {
+			toWithdraw = append(toWithdraw, svcName)
 		}
-	}
-
-	// check all services for advertisement
-	toReconcile, err = r.svcDiffStore.List()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list services from svcDiffstore: %w", err)
 	}
 	return
 }
 
 // diffReconciliationServiceList returns a list of services to reconcile and to withdraw when
 // performing partial (diff) service reconciliation.
-func (r *ServiceReconciler) diffReconciliationServiceList(p ReconcileParams) (toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, err error) {
-	upserted, deleted, err := r.svcDiffStore.Diff(r.diffID(p.BGPInstance))
-	if err != nil {
-		return nil, nil, fmt.Errorf("svc store diff: %w", err)
+func (r *ServiceReconciler) diffReconciliationServiceList(p ReconcileParams) (toReconcile []*loadbalancer.Service, rx statedb.ReadTxn, err error) {
+	metadata := r.getMetadata(p.BGPInstance)
+	rx = r.db.ReadTxn()
+
+	// list frontends which changed since the last reconciliation (includes frontends with just backend changed)
+	if !metadata.FrontendChangesInitialized {
+		return nil, rx, fmt.Errorf("BUG: frontend changes tracker not initialized, cannot perform diff reconciliation")
 	}
+	events, _ := metadata.FrontendChanges.Next(rx)
 
-	// For externalTrafficPolicy=local, we need to take care of
-	// the endpoint changes in addition to the service changes.
-	// Take a diff of the EPs and get affected services.
-	// Also upsert services with deleted endpoints to handle potential withdrawal.
-	epsUpserted, epsDeleted, err := r.epDiffStore.Diff(r.diffID(p.BGPInstance))
-	if err != nil {
-		return nil, nil, fmt.Errorf("EPs store diff: %w", err)
+	svcMap := make(map[loadbalancer.ServiceName]*loadbalancer.Service)
+	for frontendEvent := range events {
+		frontend := frontendEvent.Object
+		// even if the frontend was deleted, we still don't know whether whole service was deleted,
+		// so we need to perform its reconciliation instead of just withdrawal
+		svcMap[frontend.Service.Name] = frontend.Service
 	}
-
-	for _, eps := range slices.Concat(epsUpserted, epsDeleted) {
-		svc, exists, err := r.resolveSvcFromEndpoints(eps)
-		if err != nil {
-			// Cannot resolve service from EPs. We have nothing to do here.
-			continue
-		}
-
-		if !exists {
-			// No service associated with this endpoint. We're not interested in this.
-			continue
-		}
-
-		// We only need Endpoints tracking for externalTrafficPolicy=Local or internalTrafficPolicy=Local services.
-		if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal ||
-			(svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == slim_corev1.ServiceInternalTrafficPolicyLocal) {
-			upserted = append(upserted, svc)
-		}
-	}
-
-	// We may have duplicated services that changes happened for both of
-	// service and associated EPs.
-	deduped := ciliumslices.UniqueFunc(
-		upserted,
-		func(i int) resource.Key {
-			return resource.Key{
-				Name:      upserted[i].GetName(),
-				Namespace: upserted[i].GetNamespace(),
-			}
-		},
-	)
-
-	deletedKeys := make([]resource.Key, 0, len(deleted))
-	for _, svc := range deleted {
-		deletedKeys = append(deletedKeys, resource.Key{Name: svc.Name, Namespace: svc.Namespace})
-	}
-
-	return deduped, deletedKeys, nil
+	toReconcile = slices.Collect(maps.Values(svcMap))
+	return
 }
 
-func (r *ServiceReconciler) getDesiredPaths(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, ls sets.Set[resource.Key]) (ResourceAFPathsMap, error) {
+func (r *ServiceReconciler) getDesiredPaths(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, toReconcile []*loadbalancer.Service, toWithdraw []loadbalancer.ServiceName, rx statedb.ReadTxn) (ResourceAFPathsMap, error) {
+
 	desiredServiceAFPaths := make(ResourceAFPathsMap)
 	for _, svc := range toReconcile {
-		svcKey := resource.Key{
-			Name:      svc.GetName(),
-			Namespace: svc.GetNamespace(),
-		}
+		key := resource.Key{Name: svc.Name.Name(), Namespace: svc.Name.Namespace()}
 
-		afPaths, err := r.getServiceAFPaths(p, desiredPeerAdverts, svc, ls)
+		afPaths, err := r.getServiceAFPaths(p, desiredPeerAdverts, svc, rx)
 		if err != nil {
 			return nil, err
 		}
 
-		desiredServiceAFPaths[svcKey] = afPaths
+		desiredServiceAFPaths[key] = afPaths
 	}
 
-	for _, svcKey := range toWithdraw {
+	for _, svcName := range toWithdraw {
 		// for withdrawn services, we need to set paths to nil.
-		desiredServiceAFPaths[svcKey] = nil
+		key := resource.Key{Name: svcName.Name(), Namespace: svcName.Namespace()}
+		desiredServiceAFPaths[key] = nil
 	}
 
 	return desiredServiceAFPaths, nil
 }
 
-func (r *ServiceReconciler) getServiceAFPaths(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, svc *slim_corev1.Service, ls sets.Set[resource.Key]) (AFPathsMap, error) {
+func (r *ServiceReconciler) getServiceAFPaths(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, svc *loadbalancer.Service, rx statedb.ReadTxn) (AFPathsMap, error) {
 	desiredFamilyAdverts := make(AFPathsMap)
 
 	for _, peerFamilyAdverts := range desiredPeerAdverts {
@@ -505,30 +467,31 @@ func (r *ServiceReconciler) getServiceAFPaths(p ReconcileParams, desiredPeerAdve
 
 			for _, advert := range familyAdverts {
 				// get prefixes for the service
-				desiredPrefixes, err := r.getServicePrefixes(svc, advert, ls)
+				typedPrefixes, err := r.getServicePrefixes(p, svc, advert, rx)
 				if err != nil {
 					return nil, err
 				}
-
-				for _, prefix := range desiredPrefixes {
-					// we only add path corresponding to the family of the prefix.
-					if agentFamily.Afi == types.AfiIPv4 && prefix.Addr().Is4() {
-						path := types.NewPathForPrefix(prefix)
-						// For LoadBalancer IP prefixes, set origin to INCOMPLETE for legacy compatibility.
-						if r.legacyOriginAttributeEnabled && svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer && isLoadBalancerIPPrefix(svc, prefix) {
-							path = types.SetPathOriginAttrIncomplete(path)
+				for advertType, prefixes := range typedPrefixes {
+					for _, prefix := range prefixes.UnsortedList() {
+						// we only add path corresponding to the family of the prefix.
+						if agentFamily.Afi == types.AfiIPv4 && prefix.Addr().Is4() {
+							path := types.NewPathForPrefix(prefix)
+							// For LoadBalancer IP prefixes, set origin to INCOMPLETE for legacy compatibility.
+							if r.legacyOriginAttributeEnabled && advertType == v2.BGPLoadBalancerIPAddr {
+								path = types.SetPathOriginAttrIncomplete(path)
+							}
+							path.Family = agentFamily
+							addPathToAFPathsMap(desiredFamilyAdverts, agentFamily, path)
 						}
-						path.Family = agentFamily
-						addPathToAFPathsMap(desiredFamilyAdverts, agentFamily, path)
-					}
-					if agentFamily.Afi == types.AfiIPv6 && prefix.Addr().Is6() {
-						path := types.NewPathForPrefix(prefix)
-						// For LoadBalancer IP prefixes, set origin to INCOMPLETE for legacy compatibility.
-						if r.legacyOriginAttributeEnabled && svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer && isLoadBalancerIPPrefix(svc, prefix) {
-							path = types.SetPathOriginAttrIncomplete(path)
+						if agentFamily.Afi == types.AfiIPv6 && prefix.Addr().Is6() {
+							path := types.NewPathForPrefix(prefix)
+							// For LoadBalancer IP prefixes, set origin to INCOMPLETE for legacy compatibility.
+							if r.legacyOriginAttributeEnabled && advertType == v2.BGPLoadBalancerIPAddr {
+								path = types.SetPathOriginAttrIncomplete(path)
+							}
+							path.Family = agentFamily
+							addPathToAFPathsMap(desiredFamilyAdverts, agentFamily, path)
 						}
-						path.Family = agentFamily
-						addPathToAFPathsMap(desiredFamilyAdverts, agentFamily, path)
 					}
 				}
 			}
@@ -537,134 +500,117 @@ func (r *ServiceReconciler) getServiceAFPaths(p ReconcileParams, desiredPeerAdve
 	return desiredFamilyAdverts, nil
 }
 
-func (r *ServiceReconciler) getServicePrefixes(svc *slim_corev1.Service, advert v2.BGPAdvertisement, ls sets.Set[resource.Key]) ([]netip.Prefix, error) {
+func (r *ServiceReconciler) getServicePrefixes(p ReconcileParams, svc *loadbalancer.Service, advert v2.BGPAdvertisement, rx statedb.ReadTxn) (map[v2.BGPServiceAddressType]sets.Set[netip.Prefix], error) {
 	if advert.AdvertisementType != v2.BGPServiceAdvert {
 		return nil, fmt.Errorf("unexpected advertisement type: %s", advert.AdvertisementType)
 	}
-
 	if advert.Selector == nil || advert.Service == nil {
 		// advertisement has no selector or no service options, default behavior is not to match any service.
 		return nil, nil
 	}
 
-	// The vRouter has a service selector, so determine the desired routes.
-	svcSelector, err := slim_metav1.LabelSelectorAsSelector(advert.Selector)
+	// Ignore non-matching services
+	svcSelector, err := slimmetav1.LabelSelectorAsSelector(advert.Selector)
 	if err != nil {
 		return nil, fmt.Errorf("labelSelectorAsSelector: %w", err)
 	}
-
-	// Ignore non matching services.
 	if !svcSelector.Matches(serviceLabelSet(svc)) {
 		return nil, nil
 	}
 
-	var desiredRoutes []netip.Prefix
-	// Loop over the service upsertAdverts and determine the desired routes.
+	// Lookup service frontends
+	frontends := slices.Collect(statedb.ToSeq(r.frontends.List(rx, loadbalancer.FrontendByServiceName(svc.Name))))
+
+	// Loop over the service adverts and determine the desired routes
+	res := make(map[v2.BGPServiceAddressType]sets.Set[netip.Prefix])
 	for _, svcAdv := range advert.Service.Addresses {
 		switch svcAdv {
 		case v2.BGPLoadBalancerIPAddr:
-			desiredRoutes = append(desiredRoutes, r.getLBSvcPaths(svc, ls, advert)...)
+			res[svcAdv] = r.getLoadBalancerIPPaths(p, svc, frontends, advert)
 		case v2.BGPClusterIPAddr:
-			desiredRoutes = append(desiredRoutes, r.getClusterIPPaths(svc, ls, advert)...)
+			res[svcAdv] = r.getClusterIPPaths(p, frontends, advert)
 		case v2.BGPExternalIPAddr:
-			desiredRoutes = append(desiredRoutes, r.getExternalIPPaths(svc, ls, advert)...)
+			res[svcAdv] = r.getExternalIPPaths(p, frontends, advert)
 		}
 	}
-
-	return desiredRoutes, nil
+	return res, nil
 }
 
-func (r *ServiceReconciler) getExternalIPPaths(svc *slim_corev1.Service, ls sets.Set[resource.Key], advert v2.BGPAdvertisement) []netip.Prefix {
-	var desiredRoutes []netip.Prefix
-	// Ignore externalTrafficPolicy == Local && no local EPs.
-	if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal &&
-		!hasLocalEndpoints(svc, ls) {
-		return desiredRoutes
-	}
-	for _, extIP := range svc.Spec.ExternalIPs {
-		if extIP == "" {
+func (r *ServiceReconciler) getExternalIPPaths(p ReconcileParams, frontends []*loadbalancer.Frontend, advert v2.BGPAdvertisement) sets.Set[netip.Prefix] {
+	desiredRoutes := sets.New[netip.Prefix]()
+
+	for _, fe := range frontends {
+		if fe.Type != loadbalancer.SVCTypeExternalIPs {
 			continue
 		}
-		addr, err := netip.ParseAddr(extIP)
+		// Ignore externalTrafficPolicy == Local && no local EPs.
+		if fe.Service.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !hasLocalBackends(p, fe) {
+			continue
+		}
+
+		addr := fe.Address.Addr()
+		prefix, err := addr.Prefix(getServicePrefixLength(fe, advert, v2.BGPExternalIPAddr))
 		if err != nil {
 			continue
 		}
-		prefix, err := addr.Prefix(getServicePrefixLength(svc, addr, advert, v2.BGPExternalIPAddr))
-		if err != nil {
-			continue
-		}
-		desiredRoutes = append(desiredRoutes, prefix)
+		desiredRoutes.Insert(prefix)
 	}
+
 	return desiredRoutes
 }
 
-func (r *ServiceReconciler) getClusterIPPaths(svc *slim_corev1.Service, ls sets.Set[resource.Key], advert v2.BGPAdvertisement) []netip.Prefix {
-	var desiredRoutes []netip.Prefix
-	// Ignore internalTrafficPolicy == Local && no local EPs.
-	if svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == slim_corev1.ServiceInternalTrafficPolicyLocal &&
-		!hasLocalEndpoints(svc, ls) {
-		return desiredRoutes
-	}
-	if svc.Spec.ClusterIP == "" || len(svc.Spec.ClusterIPs) == 0 || svc.Spec.ClusterIP == corev1.ClusterIPNone {
-		return desiredRoutes
-	}
-	ips := sets.New[string]()
-	if svc.Spec.ClusterIP != "" {
-		ips.Insert(svc.Spec.ClusterIP)
-	}
-	for _, clusterIP := range svc.Spec.ClusterIPs {
-		if clusterIP == "" || clusterIP == corev1.ClusterIPNone {
+func (r *ServiceReconciler) getClusterIPPaths(p ReconcileParams, frontends []*loadbalancer.Frontend, advert v2.BGPAdvertisement) sets.Set[netip.Prefix] {
+	desiredRoutes := sets.New[netip.Prefix]()
+
+	for _, fe := range frontends {
+		if fe.Type != loadbalancer.SVCTypeClusterIP {
 			continue
 		}
-		ips.Insert(clusterIP)
-	}
-	for _, ip := range sets.List(ips) {
-		addr, err := netip.ParseAddr(ip)
+		// Ignore internalTrafficPolicy == Local && no local EPs.
+		if fe.Service.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !hasLocalBackends(p, fe) {
+			continue
+		}
+
+		addr := fe.Address.Addr()
+		prefix, err := addr.Prefix(getServicePrefixLength(fe, advert, v2.BGPClusterIPAddr))
 		if err != nil {
 			continue
 		}
-		prefix, err := addr.Prefix(getServicePrefixLength(svc, addr, advert, v2.BGPClusterIPAddr))
-		if err != nil {
-			continue
-		}
-		desiredRoutes = append(desiredRoutes, prefix)
+		desiredRoutes.Insert(prefix)
 	}
+
 	return desiredRoutes
 }
 
-func (r *ServiceReconciler) getLBSvcPaths(svc *slim_corev1.Service, ls sets.Set[resource.Key], advert v2.BGPAdvertisement) []netip.Prefix {
-	var desiredRoutes []netip.Prefix
-	if svc.Spec.Type != slim_corev1.ServiceTypeLoadBalancer {
-		return desiredRoutes
-	}
-	// Ignore externalTrafficPolicy == Local && no local EPs.
-	if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal &&
-		!hasLocalEndpoints(svc, ls) {
-		return desiredRoutes
-	}
+func (r *ServiceReconciler) getLoadBalancerIPPaths(p ReconcileParams, svc *loadbalancer.Service, frontends []*loadbalancer.Frontend, advert v2.BGPAdvertisement) sets.Set[netip.Prefix] {
+	desiredRoutes := sets.New[netip.Prefix]()
+
 	// Ignore service managed by an unsupported LB class.
-	if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != v2.BGPLoadBalancerClass {
-		// The service is managed by a different LB class.
+	if svc.LoadBalancerClass != nil && *svc.LoadBalancerClass != v2.BGPLoadBalancerClass {
 		return desiredRoutes
 	}
-	for _, ingress := range svc.Status.LoadBalancer.Ingress {
-		if ingress.IP == "" {
+
+	for _, fe := range frontends {
+		if fe.Type != loadbalancer.SVCTypeLoadBalancer {
 			continue
 		}
-		addr, err := netip.ParseAddr(ingress.IP)
+		// Ignore externalTrafficPolicy == Local && no local EPs.
+		if fe.Service.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !hasLocalBackends(p, fe) {
+			continue
+		}
+
+		addr := fe.Address.Addr()
+		prefix, err := addr.Prefix(getServicePrefixLength(fe, advert, v2.BGPLoadBalancerIPAddr))
 		if err != nil {
 			continue
 		}
-		prefix, err := addr.Prefix(getServicePrefixLength(svc, addr, advert, v2.BGPLoadBalancerIPAddr))
-		if err != nil {
-			continue
-		}
-		desiredRoutes = append(desiredRoutes, prefix)
+		desiredRoutes.Insert(prefix)
 	}
+
 	return desiredRoutes
 }
 
-func (r *ServiceReconciler) getServiceRoutePolicy(peer PeerID, family types.Family, svc *slim_corev1.Service, advert v2.BGPAdvertisement, advertType v2.BGPServiceAddressType, ls sets.Set[resource.Key]) (*types.RoutePolicy, error) {
+func (r *ServiceReconciler) getServiceRoutePolicy(peer PeerID, family types.Family, svc *loadbalancer.Service, svcPrefixes []netip.Prefix, advert v2.BGPAdvertisement, advertType v2.BGPServiceAddressType) (*types.RoutePolicy, error) {
 	if peer.Address == "" {
 		return nil, nil
 	}
@@ -673,22 +619,9 @@ func (r *ServiceReconciler) getServiceRoutePolicy(peer PeerID, family types.Fami
 		return nil, fmt.Errorf("failed to parse peer address: %w", err)
 	}
 
-	valid, err := checkServiceAdvertisement(advert, advertType)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check %s advertisement: %w", advertType, err)
-	}
-	if !valid {
+	// check service type is enabled in advertisement
+	if !slices.Contains(advert.Service.Addresses, advertType) {
 		return nil, nil
-	}
-
-	var svcPrefixes []netip.Prefix
-	switch advertType {
-	case v2.BGPLoadBalancerIPAddr:
-		svcPrefixes = r.getLBSvcPaths(svc, ls, advert)
-	case v2.BGPExternalIPAddr:
-		svcPrefixes = r.getExternalIPPaths(svc, ls, advert)
-	case v2.BGPClusterIPAddr:
-		svcPrefixes = r.getClusterIPPaths(svc, ls, advert)
 	}
 
 	var v4Prefixes, v6Prefixes types.PolicyPrefixMatchList
@@ -704,7 +637,7 @@ func (r *ServiceReconciler) getServiceRoutePolicy(peer PeerID, family types.Fami
 		return nil, nil
 	}
 
-	policyName := PolicyName(peer.Name, family.Afi.String(), advert.AdvertisementType, fmt.Sprintf("%s-%s-%s", svc.Name, svc.Namespace, advertType))
+	policyName := PolicyName(peer.Name, family.Afi.String(), advert.AdvertisementType, fmt.Sprintf("%s-%s-%s", svc.Name.Name(), svc.Name.Namespace(), advertType))
 	policy, err := CreatePolicy(policyName, peerAddr, v4Prefixes, v6Prefixes, advert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create %s IP route policy: %w", advertType, err)
@@ -713,51 +646,28 @@ func (r *ServiceReconciler) getServiceRoutePolicy(peer PeerID, family types.Fami
 	return policy, nil
 }
 
-func (r *ServiceReconciler) diffID(instance *instance.BGPInstance) string {
-	return fmt.Sprintf("%s-%s", r.Name(), instance.Name)
-}
-
-// checkServiceAdvertisement checks if the service advertisement is enabled in the advertisement.
-func checkServiceAdvertisement(advert v2.BGPAdvertisement, advertServiceType v2.BGPServiceAddressType) (bool, error) {
-	if advert.Service == nil {
-		return false, fmt.Errorf("advertisement has no service options")
-	}
-
-	// If selector is nil, we do not use this advertisement.
-	if advert.Selector == nil {
-		return false, nil
-	}
-
-	// check service type is enabled in advertisement
-	svcTypeEnabled := slices.Contains(advert.Service.Addresses, advertServiceType)
-	if !svcTypeEnabled {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-func serviceLabelSet(svc *slim_corev1.Service) labels.Labels {
-	svcLabels := maps.Clone(svc.Labels)
+func serviceLabelSet(svc *loadbalancer.Service) labels.Labels {
+	svcLabels := maps.Clone(svc.Labels.K8sStringMap())
 	if svcLabels == nil {
 		svcLabels = make(map[string]string)
 	}
-	svcLabels["io.kubernetes.service.name"] = svc.Name
-	svcLabels["io.kubernetes.service.namespace"] = svc.Namespace
+	svcLabels["io.kubernetes.service.name"] = svc.Name.Name()
+	svcLabels["io.kubernetes.service.namespace"] = svc.Name.Namespace()
 	return labels.Set(svcLabels)
 }
 
-func getServicePrefixLength(svc *slim_corev1.Service, addr netip.Addr, advert v2.BGPAdvertisement, addrType v2.BGPServiceAddressType) int {
+func getServicePrefixLength(fe *loadbalancer.Frontend, advert v2.BGPAdvertisement, addrType v2.BGPServiceAddressType) int {
+	addr := fe.Address.Addr()
 	length := addr.BitLen()
 
 	if addrType == v2.BGPClusterIPAddr {
 		// for iTP=Local, we always use the full prefix length
-		if svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == slim_corev1.ServiceInternalTrafficPolicyLocal {
+		if fe.Service.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
 			return length
 		}
 	} else {
 		// for eTP=Local, we always use the full prefix length
-		if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal {
+		if fe.Service.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
 			return length
 		}
 	}
@@ -770,20 +680,4 @@ func getServicePrefixLength(svc *slim_corev1.Service, addr netip.Addr, advert v2
 		length = int(*advert.Service.AggregationLengthIPv6)
 	}
 	return length
-}
-
-func isLoadBalancerIPPrefix(svc *slim_corev1.Service, prefix netip.Prefix) bool {
-	for _, ingress := range svc.Status.LoadBalancer.Ingress {
-		if ingress.IP == "" {
-			continue
-		}
-		addr, err := netip.ParseAddr(ingress.IP)
-		if err != nil {
-			continue
-		}
-		if prefix.Contains(addr) {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/bgpv1/test/testdata/svc-aggregation.txtar
+++ b/pkg/bgpv1/test/testdata/svc-aggregation.txtar
@@ -12,8 +12,8 @@ gobgp/add-server test 65010 10.99.4.211 1790
 # Configure peers on GoBGP
 gobgp/add-peer 10.99.4.212 65001
 
-# Add k8s services
-k8s/add service-1.yaml service-2.yaml service-3.yaml endpoints.yaml
+# Add k8s services and endpoints
+k8s/add service-1.yaml service-2.yaml service-3.yaml endpoints-ipv4.yaml endpoints-ipv6.yaml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement-1.yaml
@@ -274,18 +274,40 @@ status:
     - ip: 172.16.1.3
     - ip: fd00:cc:dd::3
 
--- endpoints.yaml --
+-- endpoints-ipv4.yaml --
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
   labels:
     kubernetes.io/service-name: svc3
-  name: svc3-eps1
+  name: svc3-eps-ipv4
   uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
 addressType: IPv4
 endpoints:
 - addresses:
   - 10.244.1.20
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: test-node
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpoints-ipv6.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: svc3
+  name: svc3-eps-ipv6
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd76
+addressType: IPv6
+endpoints:
+- addresses:
+  - 2001::1:20
   conditions:
     ready: true
     serving: true

--- a/pkg/bgpv1/test/testdata/svc-sharing.txtar
+++ b/pkg/bgpv1/test/testdata/svc-sharing.txtar
@@ -161,9 +161,9 @@ spec:
   ipFamilyPolicy: SingleStack
   ports:
   - name: http
-    port: 80
+    port: 8080
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   selector:
     name: echo
   sessionAffinity: None


### PR DESCRIPTION
Replace usage of Service and Endpoints diffstores (which are using k8s `Resource[T]` internally) with the service LB tables stored in StateDB. This should reduce the memory usage as well as processing needed on the BGP CP side, as the endpoints do not need to be tracked separately in BGP CP.

The change keeps the service reconciler logic within the same pattern as the it was (and with the other BGP reconcilers) - we reconcile per BGP instance, and trigger the reconciliation upon changes in the `Frontends` table (rate-limited, as service frontends and backends can emit many events on busy clusters). Each instance contains its own Frontend changes tracker.

Note: ATM, the diffstores are still in use for BGPv1, they will be removed once we remove the BGPv1 implementation.

```release-note
bgpv2: Migrate service reconciler to use loadbalancer tables in StateDB
```
