### PR TITLE
.github/workflows: bump build-images-base timeout to 60 minutes

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -43,7 +43,7 @@ jobs:
     # Skip this workflow for repositories without credentials and branches that are created by renovate where the event type is pull_request_target
     if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
-    timeout-minutes: 45
+    timeout-minutes: 60
     environment: ${{ inputs.environment || 'release-base-images' }}
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
This GH action has been failing since it's reaching its timeout.