### PR TITLE
ci: regex update variable runners

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -863,6 +863,15 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+lvh-version: \"(?<currentValue>.*)\""
       ]
+    },
+    {
+      "fileMatch": [".github/workflows/.*\\.ya?ml$"],
+      "matchStrings": [
+        "['\"]ubuntu-(?<currentValue>[0-9]{2}\\.[0-9]{2})['\"]"
+      ],
+      "datasourceTemplate": "github-runners",
+      "depNameTemplate": "ubuntu",
+      "packageNameTemplate": "ubuntu"
     }
   ]
 }


### PR DESCRIPTION
In this commit we add a regex to update github runner labels that are substituted if a github var isn't defined. 
Example : ` runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }} `
Not covered by default through renovate base config cf https://docs.renovatebot.com/modules/manager/github-actions/#non-support-of-variables

Local logs (after downgrading runner for `build-images-ci.yaml`) :
```
"deps": [
 {
   "depName": "ubuntu",
   "packageName": "ubuntu",
   "currentValue": "22.04",
   "datasource": "github-runners",
   "replaceString": "'ubuntu-22.04'",
   "updates": [
     {
       "bucket": "latest",
       "newVersion": "24.04",
       "newValue": "24.04",
       "newMajor": 24,
       "newMinor": 4,
       "newPatch": null,
       "updateType": "major",
       "isBreaking": true,
       "branchName": "renovate/all-github-action"
     }
   ],
   "versioning": "docker",
   "warnings": [],
   "sourceUrl": "https://github.com/actions/runner-images",
   "currentVersion": "22.04",
   "isSingleVersion": true,
   "fixedVersion": "22.04"
 }
],
"matchStrings": ["['\"]ubuntu-(?<currentValue>[0-9]{2}\\.[0-9]{2})['\"]"],
"depNameTemplate": "ubuntu",
"packageNameTemplate": "ubuntu",
"datasourceTemplate": "github-runners",
"packageFile": ".github/workflows/build-images-ci.yaml"
},
```