### PR TITLE
Makefile: Fix multi codeowner detection

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -89,8 +89,8 @@ GO_TAGS_FLAGS += osusergo
 # RACE is specified.
 GOTEST_COVER_OPTS =
 
-CODEOWNERS_PATH_EVAL := $(wildcard $(ROOT_DIR)/*OWNERS*)
-CODEOWNERS_PATH ?= $(CODEOWNERS_PATH_EVAL)
+CODEOWNERS_PATH_EVAL := $(shell echo $(wildcard $(ROOT_DIR)/*OWNERS*) | tr ' ' ',')
+CODEOWNERS_PATH ?= "$(CODEOWNERS_PATH_EVAL)"
 
 # By default, just print go test output immediately to the terminal. If tparse
 # is installed, use it to format the output. Use -progress instead of -follow,


### PR DESCRIPTION
Previously when multiple code owners were specified, the extra files
would be passed as separate arguments, but the subsequent commands
expect them to be specified in the form "file1,file2". Emit them as
comma-separated values instead of space-separated.

Fixes: dda3976be23b ("Fix code owner attribution for test failures on stable branches")
Fixes: https://github.com/cilium/cilium/pull/40776
Related: https://github.com/cilium/cilium/pull/40847
