### PR TITLE
endpoint: Avoid unnecessarily logging a warning during endpoint deletion

### DIFF
--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -304,8 +304,11 @@ func (e *Endpoint) restoreIdentity(regenerator *Regenerator) error {
 				Group: initialGlobalIdentitiesControllerGroup,
 				DoFunc: func(ctx context.Context) (err error) {
 					err = e.allocator.WaitForInitialGlobalIdentities(ctx)
-					if err != nil {
+					switch {
+					case err != nil && !errors.Is(err, context.Canceled):
 						e.getLogger().Warn("Failed while waiting for initial global identities", logfields.Error, err)
+						fallthrough
+					case err != nil:
 						return err
 					}
 					close(gotInitialGlobalIdentities)


### PR DESCRIPTION
It is possible during endpoint restoration for the endpoint to be
deleted in the middle of the process. If the endpoint restoration
process was waiting for global identities to be synced and the deletion
occurs, then the wait for the sync will be canceled. This triggers an
unnecessary warning log. To fix, detect that the endpoint is deleted
which we can tell by checking if the context was canceled.

See https://github.com/cilium/cilium/issues/40924 for more details.

Fixes: https://github.com/cilium/cilium/issues/40924
Signed-off-by: Joe Stringer <joe@cilium.io>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
