### PR TITLE
Add reusable test config workflow

### DIFF
--- a/.github/actions/cli-test-config/action.yaml
+++ b/.github/actions/cli-test-config/action.yaml
@@ -1,0 +1,79 @@
+name: 'Default CLI Test Flags'
+description: "Workflow with Cilium's CLI default test flags"
+inputs:
+  external-cidr:
+    default: "8.0.0.0/8"
+    description: "IP prefix for testing connectivity outside the cluster"
+    required: false
+  external-ip:
+    default: "8.8.4.4"
+    description: "IP address for testing connectivity outside the cluster"
+    required: false
+  external-other-ip:
+    default: "8.8.8.8"
+    description: "Extra IP address for testing connectivity outside the cluster"
+    required: false
+  external-target:
+    default: "bing.com."
+    description: "DNS name for testing connectivity outside the cluster"
+    required: false
+  flow-validation:
+    default: false
+    description: "Enable flow validation in the connectivity test"
+    required: false
+  hubble:
+    default: true
+    description: "Enable Hubble flow gathering as part of the connectivity test"
+    required: false
+  include-unsafe-tests:
+    # default: false
+    description: "Enable tests that perform operations that are unsafe in prod"
+    required: false
+  test-concurrency:
+    # default: 1
+    description: "The number of concurrent test runs to be performed"
+    required: false
+  tests:
+    description: "Comma-separated test filters to determine which tests to run"
+    required: false
+outputs:
+  test_flags:
+    description: "Generated values to be used with Cilium CLI"
+    value: ${{ steps.set-defaults.outputs.test_flags }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: set-defaults
+      shell: bash
+      run: |
+        CONNECTIVITY_TEST_DEFAULTS=("--collect-sysdump-on-failure" \
+          "--log-code-owners" \
+          "--code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS}" \
+          "--exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS}" \
+          "--external-target=${{ inputs.external-target }}" \
+          "--external-cidr=${{ inputs.external-cidr }}" \
+          "--external-ip=${{ inputs.external-ip }}" \
+          "--external-other-ip=${{ inputs.external-other-ip }}" \
+          "--hubble=${{ inputs.hubble }}" \
+        )
+
+        if [ "${{ inputs.include-unsafe-tests }}" == "true" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--include-unsafe-tests")
+        fi
+
+        if [ "${{ inputs.flow-validation }}" == "true" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--flow-validation=enabled")
+        else
+          CONNECTIVITY_TEST_DEFAULTS+=("--flow-validation=disabled")
+        fi
+
+        if [ -n "${{ inputs.test-concurrency }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--test-concurrency=${{ inputs.test-concurrency }}")
+        fi
+
+        if [ -n "${{ inputs.tests }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--test=${{ inputs.tests }}")
+        fi
+
+        echo test_flags=${CONNECTIVITY_TEST_DEFAULTS[*]} >> $GITHUB_OUTPUT

--- a/.github/actions/cli-test-config/action.yaml
+++ b/.github/actions/cli-test-config/action.yaml
@@ -3,19 +3,31 @@ description: "Workflow with Cilium's CLI default test flags"
 inputs:
   external-cidr:
     default: "8.0.0.0/8"
-    description: "IP prefix for testing connectivity outside the cluster"
+    description: "IPv4 prefix for testing connectivity outside the cluster"
+    required: false
+  external-cidrv6:
+    description: "IPv6 prefix for testing connectivity outside the cluster"
     required: false
   external-ip:
     default: "8.8.4.4"
-    description: "IP address for testing connectivity outside the cluster"
+    description: "IPv4 address for testing connectivity outside the cluster"
+    required: false
+  external-ipv6:
+    description: "IPv6 address for testing connectivity outside the cluster"
     required: false
   external-other-ip:
     default: "8.8.8.8"
-    description: "Extra IP address for testing connectivity outside the cluster"
+    description: "Extra IPv4 address for testing connectivity outside the cluster"
+    required: false
+  external-other-ipv6:
+    description: "Extra IPv6 address for testing connectivity outside the cluster"
     required: false
   external-target:
     default: "bing.com."
     description: "DNS name for testing connectivity outside the cluster"
+    required: false
+  external-other-target:
+    description: "Extra DNS name for testing connectivity outside the cluster"
     required: false
   flow-validation:
     default: false
@@ -57,6 +69,20 @@ runs:
           "--external-other-ip=${{ inputs.external-other-ip }}" \
           "--hubble=${{ inputs.hubble }}" \
         )
+
+        if [ -n "${{ inputs.external-cidrv6 }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-cidrv6=${{ inputs.external-cidrv6 }}")
+        fi
+        if [ -n "${{ inputs.external-ipv6 }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-ipv6=${{ inputs.external-ipv6 }}")
+        fi
+        if [ -n "${{ inputs.external-other-ipv6 }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-other-ipv6=${{ inputs.external-other-ipv6 }}")
+        fi
+        if [ -n "${{ inputs.external-other-target }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-other-target=${{ inputs.external-other-target }}")
+        fi
+
 
         if [ "${{ inputs.include-unsafe-tests }}" == "true" ]; then
           CONNECTIVITY_TEST_DEFAULTS+=("--include-unsafe-tests")

--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -41,7 +41,7 @@ runs:
           TEST_ARG=""
           EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic --include-conn-disrupt-test-egw"
         fi
-        ${{ inputs.cilium-cli }} connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+        ${{ inputs.cilium-cli }} connectivity test --include-unsafe-tests \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
           --conn-disrupt-test-xfrm-errors-path "./cilium-conn-disrupt-xfrm-errors" \
           --flush-ct \
@@ -50,8 +50,6 @@ runs:
           --junit-file "cilium-junits/conn-disrupt-test-${{ inputs.job-name }}.xml" \
           ${{ inputs.extra-connectivity-test-flags }} \
           --junit-property github_job_step="Run conn disrupt tests (${{ inputs.job-name }})" \
-          --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-          --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
           --test "$TEST_ARG" \
           --test-concurrency=${{ inputs.test-concurrency }} \
           --expected-xfrm-errors "+inbound_no_state" \

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -204,6 +204,12 @@ jobs:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          hubble: false
+
       - name: Set up job variables
         id: vars
         run: |
@@ -227,10 +233,9 @@ jobs:
             --helm-set=ipv6.enabled=true \
             --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16 \
             --helm-set ipam.operator.clusterPoolIPv6PodCIDRList=fd00::/104"
-          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --hubble=false --collect-sysdump-on-failure --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
+
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -198,6 +198,15 @@ jobs:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          external-target: 'amazon.com.'
+          hubble: false
+          test-concurrency: 3
+          tests: '!fqdn,!l7' # L7 policies are not supported in chaining mode.
+
       - name: Set up job variables
         id: vars
         run: |
@@ -229,12 +238,8 @@ jobs:
                                       --helm-set=cni.enableRouteMTUForCNIChaining=true"
           fi
 
-          # L7 policies are not supported in chaining mode.
-          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --test-concurrency=3 \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --hubble=false --collect-sysdump-on-failure --test '!fqdn,!l7' \
-            --external-target amazon.com. --external-ip 1.0.0.1 --external-other-ip 1.1.1.1"
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+
           # shellcheck disable=SC2046
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           # shellcheck disable=SC2046

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -279,7 +279,6 @@ jobs:
         id: e2e_config
         uses: ./.github/actions/cli-test-config
         with:
-          external-target: google.com.
           hubble: false
           include-unsafe-tests: true
           test-concurrency: 5

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -275,6 +275,15 @@ jobs:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          external-target: google.com.
+          hubble: false
+          include-unsafe-tests: true
+          test-concurrency: 5
+
       - name: Set up job variables for GHA environment
         id: vars
         run: |
@@ -374,16 +383,9 @@ jobs:
               --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.maskSize=27"
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --flow-validation=disabled \
-            --test-concurrency=5 \
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }} \
             --multi-cluster=${{ env.contextName2 }} \
-            --external-target=google.com. \
-            --include-unsafe-tests \
-            --collect-sysdump-on-failure \
-            --sysdump-output-filename 'cilium-sysdump-${{ matrix.name }}-<ts>'" \
+            --sysdump-output-filename 'cilium-sysdump-${{ matrix.name }}-<ts>'"
 
           if [ "${{ matrix.multipool-ipam }}" != "disabled" ]; then
             CONNECTIVITY_TEST_DEFAULTS="$CONNECTIVITY_TEST_DEFAULTS \

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -111,6 +111,13 @@ jobs:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          hubble: false
+          test-concurrency: 5
+
       - name: Set up job variables
         id: vars
         run: |
@@ -155,11 +162,7 @@ jobs:
               --helm-set=enableIPv6Masquerade=true"
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
-            --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
 
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -203,6 +203,13 @@ jobs:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          external-target: 'amazon.com.'
+          hubble: false
+
       - name: Set up job variables
         id: vars
         run: |
@@ -228,10 +235,8 @@ jobs:
             CILIUM_INSTALL_DEFAULTS+=" --helm-set eni.awsEnablePrefixDelegation=true"
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --collect-sysdump-on-failure --external-target amazon.com."
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -234,6 +234,16 @@ jobs:
         with:
           label: ${{ github.event_name == 'workflow_dispatch' && inputs.PR-number || github.ref_name }}
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          external-target: 'google.com.'
+          external-cidr: '8.0.0.0/8'
+          external-ip: '8.8.8.8'
+          external-other-ip: '8.8.4.4'
+          hubble: false
+
       - name: Set up job variables
         id: vars
         run: |
@@ -246,10 +256,8 @@ jobs:
             --helm-set loadBalancer.l7.backend=envoy \
             --wait=false"
 
-          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --external-target google.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4"
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo hubble_enable_defaults=${HUBBLE_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -152,6 +152,12 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          include-unsafe-tests: true
+
       - name: Set up job variables
         id: vars
         run: |
@@ -166,13 +172,9 @@ jobs:
             EXTRA_CLI_FLAGS+=("\"--secondary-network-iface=eth1\"")
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="--include-unsafe-tests \
-                                      --collect-sysdump-on-failure \
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }} \
                                       --sysdump-hubble-flows-count=1000000 \
                                       --sysdump-hubble-flows-timeout=5m \
-                                      --log-code-owners \
-                                      --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-                                      --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
                                       --flush-ct \
                                       ${EXTRA_CLI_FLAGS[*]}"
 

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -368,6 +368,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: ${{ env.job_name }}-${{ matrix.name }}-post-rotate
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Start unencrypted packets check for tests
         uses: ./.github/actions/bpftrace/start

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -73,6 +73,22 @@ jobs:
           ipv6_external_target: ${{ steps.external_network.outputs.ipv6_external_target }}
           ipv6_other_external_target: ${{ steps.external_network.outputs.ipv6_other_external_target }}
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          hubble: false
+          include-unsafe-tests: true
+          test-concurrency: 5
+          external-cidr: ${{ steps.external_network.outputs.ipv4_external_cidr }}
+          external-cidrv6: ${{ steps.external_network.outputs.ipv6_external_cidr }}
+          external-ip: ${{ steps.external_network.outputs.ipv4_external_target }}
+          external-ipv6: ${{ steps.external_network.outputs.ipv6_external_target }}
+          external-other-ip: ${{ steps.external_network.outputs.ipv4_other_external_target }}
+          external-other-ipv6: ${{ steps.external_network.outputs.ipv6_other_external_target }}
+          external-other-target: ${{ steps.external_targets.outputs.other_external_target_name }}
+          external-target: ${{ steps.external_targets.outputs.external_target_name }}
+
       - name: Set up job variables
         id: vars
         run: |
@@ -88,18 +104,7 @@ jobs:
             --helm-set=envoy.enabled=false \
             --helm-set=ipv6.enabled=true \
             --wait=false"
-          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --test-concurrency=5 \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --hubble=false --collect-sysdump-on-failure \
-            --external-target=${{ steps.external_targets.outputs.external_target_name }} \
-            --external-other-target=${{ steps.external_targets.outputs.other_external_target_name }} \
-            --external-cidr=${{ steps.external_network.outputs.ipv4_external_cidr }} \
-            --external-cidrv6=${{ steps.external_network.outputs.ipv6_external_cidr }} \
-            --external-ip=${{ steps.external_network.outputs.ipv4_external_target }} \
-            --external-ipv6=${{ steps.external_network.outputs.ipv6_external_target }} \
-            --external-other-ip=${{ steps.external_network.outputs.ipv4_other_external_target }} \
-            --external-other-ipv6=${{ steps.external_network.outputs.ipv6_other_external_target }} \
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }} \
             --external-target-ca-namespace=external-target-secrets --external-target-ca-name=custom-ca \
             --external-target-ipv6-capable"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -180,15 +180,21 @@ jobs:
 
           kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=300s
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          hubble: false
+          include-unsafe-tests: true
+          test-concurrency: 5
+          tests: '!/pod-to-world'
+
       - name: Set up job variables
         id: vars
         run: |
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=cluster.name=${{ env.clusterName }}"
-          CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --test='!/pod-to-world'"
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -157,6 +157,14 @@ jobs:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          hubble: false
+          include-unsafe-tests: true
+          test-concurrency: 5
+
       - name: Set up job variables
         id: vars
         run: |
@@ -222,14 +230,10 @@ jobs:
           CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=true --helm-set=ipv6.enabled=true"
           KIND_SVC_CIDR="10.243.0.0/16,fd00:10:243::/112"
 
-          CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
+          CONNECTIVITY_TEST_DEFAULTS=" ${{ steps.e2e_config.outputs.test_flags }} \
             --sysdump-output-filename \"cilium-sysdump-${{ matrix.name }}-<ts>\" \
             --junit-file \"cilium-junits/${{ env.job_name }} ${{ matrix.name }}.xml\" \
             --junit-property github_job_step=\"Run tests ${{ matrix.name }}\" \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
-            --flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
-            --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8 \
             --namespace-annotations=ipam.cilium.io/ip-pool=cilium-test-pool \
             --deployment-pod-annotations='{ \
                 \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -112,6 +112,10 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+
       - name: Set up job variables
         id: vars
         run: |
@@ -120,6 +124,10 @@ jobs:
           else
             SHA="${{ github.sha }}"
           fi
+
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+
+          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
       - name: Create kind cluster
@@ -194,6 +202,7 @@ jobs:
         with:
           job-name: ces-enable
           full-test: 'true'
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Features tested
         uses: ./.github/actions/feature-status

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -170,6 +170,13 @@ jobs:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/cilium-newest/install/kubernetes/cilium
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          hubble: false
+          include-unsafe-tests: true
+
       - name: Set up job variables
         id: vars
         run: |
@@ -213,10 +220,7 @@ jobs:
           # Run only a limited subset of tests to reduce the amount of time
           # required. The full suite is run in conformance-clustermesh.
           CONNECTIVITY_TEST_DEFAULTS=" \
-            --hubble=false \
-            --flow-validation=disabled \
-            --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
-            --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
+            ${{ steps.e2e_config.outputs.test_flags }} \
             --test='no-interrupted-connections' \
             --test='no-unexpected-packet-drops' \
             --test='check-log-errors' \
@@ -228,7 +232,7 @@ jobs:
             --test='cluster-entity-multi-cluster/' \
             --test='!/pod-to-world' \
             --test='!/pod-to-cidr' \
-            --collect-sysdump-on-failure"
+          "
 
           CILIUM_INSTALL_ENCRYPTION=""
           if [ "${{ matrix.encryption }}" != "disabled" ]; then

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -155,6 +155,10 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+
       - name: Set up job variables
         id: vars
         run: |
@@ -177,7 +181,8 @@ jobs:
             EXTRA_CLI_FLAGS+=("\"--expected-drop-reasons=+Traffic is unencrypted\"")
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="${EXTRA_CLI_FLAGS[*]}"
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }} \
+                                      ${EXTRA_CLI_FLAGS[*]}"
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 
           CONCURRENT_CONNECTIVITY_TESTS="!seq-.*"

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -157,6 +157,10 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+
       - name: Set up job variables
         id: vars
         run: |
@@ -199,6 +203,9 @@ jobs:
             CONCURRENT_CONNECTIVITY_TESTS="!(seq-.*|pod-to-world.*|pod-to-cidr)"
           fi
           echo concurrent_connectivity_tests=${CONCURRENT_CONNECTIVITY_TESTS} >> $GITHUB_OUTPUT
+
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 
       - name: Checkout pull request branch (NOT TRUSTED)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -393,6 +400,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-precheck
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Run sequential tests after upgrading (${{ join(matrix.*, ', ') }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -400,6 +408,7 @@ jobs:
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-sequential
           tests: ${{ steps.vars.outputs.sequential_connectivity_tests }}
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Run concurrent tests after upgrading (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -408,6 +417,7 @@ jobs:
           job-name: cilium-upgrade-${{ matrix.name }}-concurrent
           tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
           test-concurrency: ${{ env.test_concurrency }}
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Assert that no unencrypted packets are leaked during Cilium upgrade
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -450,6 +460,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-precheck
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Run sequential tests after downgrading (${{ join(matrix.*, ', ') }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -457,6 +468,7 @@ jobs:
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-sequential
           tests: ${{ steps.vars.outputs.sequential_connectivity_tests }}
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Run concurrent tests after downgrading (${{ matrix.name }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -465,6 +477,7 @@ jobs:
           job-name: cilium-downgrade-${{ matrix.name }}-concurrent
           tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
           test-concurrency: ${{ env.test_concurrency }}
+          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Assert that no unencrypted packets are leaked during Cilium downgrade
         if: ${{ steps.vars.outputs.downgrade_version != '' }}


### PR DESCRIPTION
Add 'cli-test-config', a reusable workflow for defining the flags to pass to
Cilium connectivity tests which should allow the tests to more consistently
pass the common flags (like parameters for code owners, sysdumps, timeouts).

This enables much easier extension of testing flags to apply CI-wide, like in https://github.com/cilium/cilium/pull/40957 .

The goal for this PR is just to centralize the configuration, but I could
imagine future PRs taking this further to centralize all of the CLI test runs
across both conn-disrupt-test and regular test runs. I've left that out of
scope for this PR as the main goal I want to achieve is #40957.