### PR TITLE
egressgateway: Refactor IP family support for dual-stack

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -161,6 +161,12 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	policyMap4 := egressmap.CreatePrivatePolicyMap4(lc, nil, egressmap.DefaultPolicyConfig)
 	policyMap6 := egressmap.CreatePrivatePolicyMap6(lc, nil, egressmap.DefaultPolicyConfig)
 
+	// For testing, enable both IPv4 and IPv6
+	ipFamilySupport := IPFamilySupport{
+		IPv4: true,
+		IPv6: true,
+	}
+
 	k.manager, err = newEgressGatewayManager(Params{
 		Logger:            logger,
 		Lifecycle:         lc,
@@ -173,7 +179,7 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 		Nodes:             k.nodes,
 		Endpoints:         k.endpoints,
 		Sysctl:            k.sysctl,
-	})
+	}, ipFamilySupport)
 	require.NoError(t, err)
 	require.NotNil(t, k.manager)
 


### PR DESCRIPTION
Refactor egress gateway initialization to dynamically check IP family support based on cluster configuration and datapath capabilities. This enables proper support for dual-stack environments and provides clearer error messages when policy CIDRs don't match supported IP families.


Fixes: #38959 

