### PR TITLE
docs: enable debug information before first authentication in mutual auth example

### DIFF
--- a/Documentation/network/servicemesh/mutual-authentication/mutual-authentication-example.rst
+++ b/Documentation/network/servicemesh/mutual-authentication/mutual-authentication-example.rst
@@ -208,6 +208,12 @@ Update the existing rule to only allow ingress access to mutually authenticated 
 Verify Mutual Authentication
 ============================
 
+Start by enabling debug level:
+
+.. code-block:: shell-session
+
+    cilium config set debug true
+
 Re-try your connectivity tests. They should give similar results as before:
 
 .. code-block:: shell-session
@@ -218,12 +224,6 @@ Re-try your connectivity tests. They should give similar results as before:
     Access denied
 
 Verify that mutual authentication has happened by accessing the logs on the agent. 
-
-Start by enabling debug level:
-
-.. code-block:: shell-session
-
-    cilium config set debug true
 
 Examine the logs on the Cilium agent located in the same node as the *echo* Pod. 
 For brevity, you can search for some specific log messages by label:


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

In the `Mutual Authentication Example` page, enabling debug logs after running `curl` commands doesn't show the authentication flow in the debug logs when inspecting the logs afterwards. So, this adds instructions to enable cilium debug logs before the first authentication happens after enforcing mutual authentication. 
