### PR TITLE
.github/workflows: print open file descriptors

### DIFF
--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -215,6 +215,7 @@ jobs:
             echo "cilium-agent($p) has $num file descriptors open"
             if [ "$num" -gt "500" ]; then
               echo "cilium-agent($p) has more than 500 file descriptors (potential leak)"
+              sudo lsof -p $p
               exit 1
             fi
           done


### PR DESCRIPTION
There's a check that counts the number of file descriptors open by Cilium. We should present them and to check if it's a potential leak.