### PR TITLE
Don't enable host firewall bypass unless host firewall is enabled

### DIFF
--- a/pkg/k8s/hostfirewallbypass/bypass.go
+++ b/pkg/k8s/hostfirewallbypass/bypass.go
@@ -16,8 +16,11 @@ import (
 
 type k8sHostFirewallBypass struct{}
 
-func NewK8sHostFirewallBypass(config Params) client.ConfigureK8sClientsetDialer {
-	if config.EnableK8sHostFirewallBypass {
+func NewK8sHostFirewallBypass(params Params) client.ConfigureK8sClientsetDialer {
+	if params.DaemonConfig != nil && !params.DaemonConfig.EnableHostFirewall {
+		return nil
+	}
+	if params.LocalConfig.EnableK8sHostFirewallBypass {
 		return &k8sHostFirewallBypass{}
 	} else {
 		return nil

--- a/pkg/k8s/hostfirewallbypass/cell.go
+++ b/pkg/k8s/hostfirewallbypass/cell.go
@@ -6,6 +6,8 @@ package hostfirewallbypass
 import (
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // Provides a host firewall bypass for k8s Clientset
@@ -14,17 +16,24 @@ var Cell = cell.Module(
 	"k8s-host-firewall-bypaass",
 	"Kubernetes host firewall bypass",
 
-	cell.Config(Params{
-		EnableK8sHostFirewallBypass: false,
+	cell.Config(config{
+		EnableK8sHostFirewallBypass: true,
 	}),
 	cell.Provide(NewK8sHostFirewallBypass),
 )
 
 type Params struct {
+	cell.In
+
+	DaemonConfig *option.DaemonConfig `optional:"true"`
+	LocalConfig  config
+}
+
+type config struct {
 	EnableK8sHostFirewallBypass bool
 }
 
-func (p Params) Flags(flags *pflag.FlagSet) {
+func (p config) Flags(flags *pflag.FlagSet) {
 	enable := "enable-k8s-host-firewall-bypass"
 	flags.Bool(enable, p.EnableK8sHostFirewallBypass, "Enable bypassing host firewall for Kubernetes API server access.")
 	flags.MarkHidden(enable)


### PR DESCRIPTION
An [analysis](https://github.com/cilium/cilium/issues/40682#issuecomment-3146426530) of e2e conformance test failures reported in #40682 and attributed to #40346 (k8s host firewall bypass) being enabled by default showed that these failures appear in test jobs where IPSec is enabled. However, IPSec cannot be used with the host firewall, whereas the whole host (node) FQDN-based egress rules feature, which creates the need for a bypass, only makes sense _with_ the host firewall. This PR ensures that the bypass is not enabled unless the host firewall is enabled.

Fixes: #40682
Related: #40346