### PR TITLE
Avoid disabling trace when Socket LB is enabled only for Host namespace

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -152,9 +152,6 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 				option.InstallNoConntrackIptRules, option.EnableBPFMasquerade)
 		}
 	}
-	if option.Config.BPFSocketLBHostnsOnly {
-		option.Config.EnableSocketLBTracing = false
-	}
 
 	if !kprCfg.EnableSocketLB {
 		option.Config.EnableSocketLBTracing = false


### PR DESCRIPTION
Socket LB trace is on by default so NAT events can be monitored using 'cilium-dbg monitor -v', but it is disabled when Socket LB is only enabled for host namespace using the flag socketLB.hostNamespaceOnly=true. Trace is disabled even if explicitly setting the trace flag during installation.

This patch prevents the trace from being disabled when socket LB is enabled for host namespace only.

Fixes: #40932

```release-note
Cilium monitor now shows Socket LB trace events when Socket LB is enabled for host namespace only
```
