### PR TITLE
docker: order dockerignore rules by depth to include nested targets.o

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -45,7 +45,7 @@ builder-info: ## Print information about the docker builder that will be used fo
 	@echo "Using Docker Buildx builder \"$(DOCKER_BUILDER)\" with build flags \"$(DOCKER_FLAGS)\"."
 
 # Generic rule for augmented .dockerignore files.
-GIT_IGNORE_FILES := $(shell find . -not -path "./vendor*" -name .gitignore -print)
+GIT_IGNORE_FILES := $(shell find . -not -path "./vendor*" -name .gitignore | awk -F/ '{ print NF, $$0 }' | sort -n | cut -d" " -f2-)
 .PRECIOUS: %.dockerignore
 %.dockerignore: $(GIT_IGNORE_FILES) Makefile.docker
 	@-mkdir -p $(dir $@)


### PR DESCRIPTION
In #38693 we added a new bpf program bpf/bpf_sock_term.c, and generated the Go skeleton via bpf2go. Such targets, respectively pkg/datapath/bpf/sockterm_bpf{el,be}.go, are however excluded while building docker images via `make kind-image-agent`, resulting in the error `0.456 ../pkg/datapath/bpf/sockterm_bpfel.go:198:12: pattern sockterm_bpfel.o: no matching files found`.

The generated Dockerfile.dockerignore includes the rule  _**/*.o which instructs docker to omit any .o files. But it also includes a rule !pkg/datapath/bpf/_**/*.o which says it should add them to the context. Due to the ordering the second rule does not work. It is placed before the first in the file. And once you swap it, everything works.

This commits modifies how we compute the GIT_IGNORE_FILES variable. The entire command finds all .gitignore files in the current directory and its subdirectories, excluding those within any vendor directories. It then sorts these .gitignore file paths by their "depth" in the directory structure from shallowest to deepest.

Many thanks again to @dylandreimerink  for the amazing investigation.