### PR TITLE
Fixed broken load balancer algorithm selection in run-time for service

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -798,9 +798,16 @@ lb6_select_backend_id(struct __ctx_buff *ctx, struct lb6_key *key,
 	case LB_SELECTION_RANDOM:
 		return lb6_select_backend_id_random(ctx, key, tuple, svc);
 	default:
-		return 0;
+#if LB_SELECTION == LB_SELECTION_RANDOM
+		return lb6_select_backend_id_random(ctx, key, tuple, svc);
+#elif LB_SELECTION == LB_SELECTION_MAGLEV
+		return lb6_select_backend_id_maglev(ctx, key, tuple, svc);
+#else
+# error "Invalid load balancer backend selection algorithm!"
+#endif /* LB_SELECTION */
 	}
 }
+
 #elif LB_SELECTION == LB_SELECTION_RANDOM
 # define lb6_select_backend_id	lb6_select_backend_id_random
 #elif LB_SELECTION == LB_SELECTION_MAGLEV
@@ -1532,7 +1539,13 @@ lb4_select_backend_id(struct __ctx_buff *ctx, struct lb4_key *key,
 	case LB_SELECTION_RANDOM:
 		return lb4_select_backend_id_random(ctx, key, tuple, svc);
 	default:
-		return 0;
+#if LB_SELECTION == LB_SELECTION_RANDOM
+		return lb4_select_backend_id_random(ctx, key, tuple, svc);
+#elif LB_SELECTION == LB_SELECTION_MAGLEV
+		return lb4_select_backend_id_maglev(ctx, key, tuple, svc);
+#else
+# error "Invalid load balancer backend selection algorithm!"
+#endif /* LB_SELECTION */
 	}
 }
 #elif LB_SELECTION == LB_SELECTION_RANDOM


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

### Problem description and solution

When --bpf-lb-algorithm-annotation feature is enabled bpf code in run-time may not select load balancer algorithm for service at all. This behavior will broke all new network connections to the service if it have unknown algorithm value in service bpf map entry. This bug is stably reproducible for NodePort, HostPort, LocalRedirect service types.

This commit solves the problem as follows: in the situation where the bpf service map contains an unknown LB algorithm, it simply uses the default LB algorithm from the --bpf-lb-algorithm option.

### How to reproduce it

Cilium last version.
Configuring Cilium in ConfigMap:
```yaml
--bpf-lb-algorithm-annotation: true
--enable-node-port: true
--enable-host-port: true
```
Create pod with hostPort:
```yaml
containers:
  ports:
    - containerPort: 5678
      hostPort: 8088
```
Curl it from another pod on some node:
```bash
k exec -it curl-daemon-wjfxf -- sh
~ $ curl http://172.18.0.3:8088
curl: (7) Failed to connect to 172.18.0.3 port 8088 after 0 ms: Could not connect to server
```
From cilium monitor:
```
------------------------------------------------------------------------------
CPU 11: MARK 0xd615827e FROM 2216 from-endpoint: 74 bytes (74 captured), state unknown, , identity 29044->unknown, orig-ip 0.0.0.0
Ethernet	{Contents=[..14..] Payload=[..62..] SrcMAC=3e:d7:52:39:37:60 DstMAC=02:18:37:5d:a0:aa EthernetType=IPv4 Length=0}
IPv4	{Contents=[..20..] Payload=[..40..] Version=4 IHL=5 TOS=0 Length=60 Id=30420 Flags=DF FragOffset=0 TTL=64 Protocol=TCP Checksum=2567 SrcIP=10.244.2.216 DstIP=172.18.0.3 Options=[] Padding=[]}
TCP	{Contents=[..40..] Payload=[] SrcPort=53004 DstPort=8088(radan-http) Seq=1257134787 Ack=0 DataOffset=10 FIN=false SYN=true RST=false PSH=false ACK=false URG=false ECE=false CWR=false NS=false Window=64860 Checksum=47631 Urgent=0 Options=[..5..] Padding=[] Multipath=false}
CPU 11: MARK 0xd615827e FROM 2216 DEBUG: Conntrack lookup 1/2: src=10.244.2.216:53004 dst=172.18.0.3:8088
CPU 11: MARK 0xd615827e FROM 2216 DEBUG: Conntrack lookup 2/2: nexthdr=6 flags=4 dir=2 scope=1
CPU 11: MARK 0xd615827e FROM 2216 DEBUG: CT verdict: New, revnat=13
CPU 11: MARK 0xd615827e FROM 2216 DEBUG: Backend service lookup failed: backend_id=0
------------------------------------------------------------------------------
CPU 11: MARK 0xd615827e FROM 2216 DEBUG: 106 bytes, Delivery to ifindex 11Ethernet	{Contents=[..14..] Payload=[..94..] SrcMAC=02:18:37:5d:a0:aa DstMAC=3e:d7:52:39:37:60 EthernetType=IPv4 Length=0}
IPv4	{Contents=[..20..] Payload=[..72..] Version=4 IHL=5 TOS=0 Length=92 Id=0 Flags= FragOffset=0 TTL=64 Protocol=ICMPv4 Checksum=49344 SrcIP=172.18.0.3 DstIP=10.244.2.216 Options=[] Padding=[]}
ICMPv4	{Contents=[..8..] Payload=[..64..] TypeCode=DestinationUnreachable(Port) Checksum=43344 Id=0 Seq=0}
------------------------------------------------------------------------------
```