### PR TITLE
github: Apply connectivity test timeout at 20m

### DIFF
--- a/.github/actions/cli-test-config/action.yaml
+++ b/.github/actions/cli-test-config/action.yaml
@@ -48,6 +48,10 @@ inputs:
   tests:
     description: "Comma-separated test filters to determine which tests to run"
     required: false
+  timeout:
+    required: false
+    default: '20m'
+    description: 'Timeout for full connectivity test run'
 outputs:
   test_flags:
     description: "Generated values to be used with Cilium CLI"
@@ -68,6 +72,7 @@ runs:
           "--external-ip=${{ inputs.external-ip }}" \
           "--external-other-ip=${{ inputs.external-other-ip }}" \
           "--hubble=${{ inputs.hubble }}" \
+          "--timeout=${{ inputs.timeout }}" \
         )
 
         if [ -n "${{ inputs.external-cidrv6 }}" ]; then


### PR DESCRIPTION
Requires https://github.com/cilium/cilium/pull/40935
Requires https://github.com/cilium/cilium/pull/41191
    
    The goal here is to ensure that in the event of a failure condition that
    may lead to the CLI timing out (such as every test failing for the same
    reason, or some fundamental issue in the infrastructure), the CLI will
    terminate early, gather a sysdump, and return before GitHub timeouts
    kick in. This should ensure that even in such adverse situations,
    developers will have test results they can consult to identify what went
    wrong in a workflow.
    
    Taking the e2e-upgrade workflow for example, this runs twice within the
    setup-and-test job, along with a bunch of other logic to pull images,
    provision a VM, install, upgrade, downgrade and so on. Even with all of
    those other steps, it should be possible for two full runs of the CLI
    connectivity tests to complete and report failures within the 55m timer.
    
    Birol reports the following timeouts for upper quartile mean (min:sec)
    of workflow step run time after removing the upper/lower 5% of results:
    
    | workflow_name                                  | upper_quartile_mean_dur  |
    |------------------------------------------------|--------------------------|
    | Conformance GKE (ci-gke)                       | 25:00                    |
    | Conformance EKS (ci-eks)                       | 14:48                    |
    | CiliumEndpointSlice migration (ci-ces-migrate) | 14:34                    |
    | Conformance AKS (ci-aks)                       | 12:25                    |
    | Conformance Cluster Mesh (ci-clustermesh)      | 10:43                    |
    | Conformance Kind Envoy Embedded                | 10:41                    |
    | Conformance AWS-CNI (ci-awscni)                | 09:59                    |
    | Cilium E2E Upgrade (ci-e2e-upgrade)            | 09:06                    |
    | Conformance IPsec E2E (ci-ipsec-e2e)           | 08:38                    |
    | Cilium IPsec upgrade (ci-ipsec-upgrade)        | 08:00                    |
    | Conformance Kubespray (ci-kubespray)           | 01:57                    |
    | Cilium Cluster Mesh upgrade (ci-clustermesh)   | 01:24                    |
    
    There is another submission out for review that will lower the GKE
    runtime to match the other run times by introducing concurrency of test
    runs, so I have excluded that case from this calculation. Hence setting
    a 20m timeout seems reasonable to catch the vast majority of test runs.
    
    Suggested-by: @brlbil 