### PR TITLE
cni: Avoid lockfile leak on context timeout

### DIFF
--- a/plugins/cilium-cni/lib/deletion_queue.go
+++ b/plugins/cilium-cni/lib/deletion_queue.go
@@ -108,6 +108,7 @@ func (dc *DeletionFallbackClient) tryQueueLock() error {
 
 	err = lf.Lock(ctx, false) // get the shared lock
 	if err != nil {
+		lf.Close()
 		return fmt.Errorf("failed to acquire lock: %w", err)
 	}
 	dc.lockfile = lf


### PR DESCRIPTION
If locking a newly created lockfile ever blocked for an extended period,
this code would technically not close the corresponding file. Given that
the lockfile was just created this seems highly unlikely, but we may as
well make the logic right anyway.

Found by inspection.
