### PR TITLE
bpf: fix invalid escape sequence '\(' warning

### DIFF
--- a/bpf/tests/scapy/trace_diff_pkts.py
+++ b/bpf/tests/scapy/trace_diff_pkts.py
@@ -14,7 +14,7 @@ def parse_asserts(filename: str) -> List[Dict]:
     Parses asserts in the log file.
 
     Expected assert log format:
-       '... bpf_trace_printk: (file):(linenum) assert '(assert_name)' FAILED! (Got|Expected) ... : pkt_hex \((first_layer)\)[(bytes)]'
+       '... bpf_trace_printk: (file):(linenum) assert '(assert_name)' FAILED! (Got|Expected) ... : pkt_hex ((first_layer))[(bytes)]'
     Example:
        'bpftest.test-1515316 [001] b..11 102260.946507: bpf_trace_printk: tc_l2_announcement.c:164 assert 'arp_rep_only_ok' FAILED! Got (ctx): pkt_hex ARP[0001080006040002133713371337ac100a01deadbeefdeef6e000b01]'
 

--- a/bpf/tools/log2scapy.py
+++ b/bpf/tools/log2scapy.py
@@ -13,7 +13,7 @@ def parse_pkts(filename: str) -> List[Dict]:
     Parses packet hexdump log entries in the trace_pipe log.
 
     Expected hexdump log format:
-       '(context) pkt_hex \((first_layer)\)[(bytes)]'
+       '(context) pkt_hex ((first_layer))[(bytes)]'
     Example:
        'bpftest.test-1515316 [001] b..11 102260.946440: bpf_trace_printk: tc_l2_announcement.c:93 no_entry: pkt_hex Ether[ffffffffffffdeadbeefdeef08060001080006040001deadbeefdeef6e000b01ffffffffffffac100a01]'
 


### PR DESCRIPTION
Fix Python/Scapy warnings on comments due to invalid escape sequence:

```
bpf/tests/../tools/log2scapy.py:12: SyntaxWarning: invalid escape sequence '\('
  """
Parsed 2 pkts...
```

in both `bpf/tools/log2scapy.py` and `bpf/tests/scapy/trace_diff_pkts.py`.

p.s. Python3 linting might be a good idea...
