### PR TITLE
proxy: Add deprecated warning for Kafka

### DIFF
--- a/Documentation/deprecated.rst
+++ b/Documentation/deprecated.rst
@@ -1,0 +1,3 @@
+.. warning::
+
+    This feature is deprecated and will be removed in a future release.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -303,6 +303,7 @@ communicating via the proxy must reconnect to re-establish connections.
   you need to take action to update your network policies to avoid this change from breaking connectivity for applications
   across different clusters. See :ref:`change_policy_default_local_cluster` for more details and migration recommendations
   to update your network policies.
+* Kafka Network Policy support is deprecated and will be removed in Cilium v1.20.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -878,7 +878,7 @@ While communicating on this port, the only API endpoints allowed will be ``GET
 Kafka (beta)
 ------------
 
-.. include:: ../../beta.rst
+.. include:: ../../deprecated.rst
 
 PortRuleKafka is a list of Kafka protocol constraints. All fields are optional,
 if all fields are empty or missing, the rule will match all Kafka messages.

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -888,7 +888,9 @@ spec:
                                   type: object
                                 type: array
                               kafka:
-                                description: Kafka-specific rules.
+                                description: |-
+                                  Kafka-specific rules.
+                                  Deprecated: This beta feature is deprecated and will be removed in a future release.
                                 items:
                                   description: |-
                                     PortRule is a list of Kafka protocol constraints. All fields are
@@ -2743,7 +2745,9 @@ spec:
                                   type: object
                                 type: array
                               kafka:
-                                description: Kafka-specific rules.
+                                description: |-
+                                  Kafka-specific rules.
+                                  Deprecated: This beta feature is deprecated and will be removed in a future release.
                                 items:
                                   description: |-
                                     PortRule is a list of Kafka protocol constraints. All fields are
@@ -4396,7 +4400,9 @@ spec:
                                     type: object
                                   type: array
                                 kafka:
-                                  description: Kafka-specific rules.
+                                  description: |-
+                                    Kafka-specific rules.
+                                    Deprecated: This beta feature is deprecated and will be removed in a future release.
                                   items:
                                     description: |-
                                       PortRule is a list of Kafka protocol constraints. All fields are
@@ -6253,7 +6259,9 @@ spec:
                                     type: object
                                   type: array
                                 kafka:
-                                  description: Kafka-specific rules.
+                                  description: |-
+                                    Kafka-specific rules.
+                                    Deprecated: This beta feature is deprecated and will be removed in a future release.
                                   items:
                                     description: |-
                                       PortRule is a list of Kafka protocol constraints. All fields are

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -891,7 +891,9 @@ spec:
                                   type: object
                                 type: array
                               kafka:
-                                description: Kafka-specific rules.
+                                description: |-
+                                  Kafka-specific rules.
+                                  Deprecated: This beta feature is deprecated and will be removed in a future release.
                                 items:
                                   description: |-
                                     PortRule is a list of Kafka protocol constraints. All fields are
@@ -2746,7 +2748,9 @@ spec:
                                   type: object
                                 type: array
                               kafka:
-                                description: Kafka-specific rules.
+                                description: |-
+                                  Kafka-specific rules.
+                                  Deprecated: This beta feature is deprecated and will be removed in a future release.
                                 items:
                                   description: |-
                                     PortRule is a list of Kafka protocol constraints. All fields are
@@ -4399,7 +4403,9 @@ spec:
                                     type: object
                                   type: array
                                 kafka:
-                                  description: Kafka-specific rules.
+                                  description: |-
+                                    Kafka-specific rules.
+                                    Deprecated: This beta feature is deprecated and will be removed in a future release.
                                   items:
                                     description: |-
                                       PortRule is a list of Kafka protocol constraints. All fields are
@@ -6256,7 +6262,9 @@ spec:
                                     type: object
                                   type: array
                                 kafka:
-                                  description: Kafka-specific rules.
+                                  description: |-
+                                    Kafka-specific rules.
+                                    Deprecated: This beta feature is deprecated and will be removed in a future release.
                                   items:
                                     description: |-
                                       PortRule is a list of Kafka protocol constraints. All fields are

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -289,6 +289,7 @@ type L7Rules struct {
 	HTTP []PortRuleHTTP `json:"http,omitempty"`
 
 	// Kafka-specific rules.
+	// Deprecated: This beta feature is deprecated and will be removed in a future release.
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:OneOf


### PR DESCRIPTION
Relates: #38224
Relates: https://github.com/cilium/cilium/pull/40757#issuecomment-3132549766


```release-note
Kafka Network Policy support is deprecated and will be removed in Cilium v1.20
```