### PR TITLE
loadbalancer: Keep backends around that are terminating and not serving

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1373,12 +1373,18 @@ Cilium's eBPF kube-proxy replacement supports graceful termination of service
 endpoint pods. The Cilium agent detects such terminating Pod events, and
 increments the metric ``k8s_terminating_endpoints_events_total``.
 
-When Cilium agent receives a Kubernetes update event for a terminating endpoint,
-the datapath state for the endpoint is removed such that it won't service new
-connections, but the endpoint's active connections are able to terminate
-gracefully. The endpoint state is fully removed when the agent receives
-a Kubernetes delete event for the endpoint. The `Kubernetes
-pod termination <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination>`_
+When Cilium agent receives a Kubernetes update event that marks an endpoint as
+terminating Cilium will retain the datapath state necessary for existing connections.
+The terminating endpoint will be used as fallback for new connections only if
+1) no active endpoints exist for the service and 2) terminating endpoint has condition ``serving``
+(e.g. pod is still passing `readinessProbes <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes>`_).
+
+If ``publishNotReadyAddresses`` is set on the Service the endpoints received by Cilium
+may have both the ``ready`` and ``terminating`` conditions set. In this case Cilium follows
+kube-proxy and uses these for new connections, ignoring the ``terminating`` condition.
+
+The endpoint state is fully removed when the agent receives a Kubernetes delete
+event for the endpoint. The `Kubernetes pod termination <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination>`_
 documentation contains more background on the behavior and configuration using ``terminationGracePeriodSeconds``.
 There are some special cases, like zero disruption during rolling updates, that require to be able to send traffic
 to Terminating Pods that are still Serving traffic during the Terminating period, the Kubernetes blog

--- a/api/v1/models/backend_address.go
+++ b/api/v1/models/backend_address.go
@@ -41,7 +41,7 @@ type BackendAddress struct {
 	Protocol string `json:"protocol,omitempty"`
 
 	// State of the backend for load-balancing service traffic
-	// Enum: ["active","terminating","quarantined","maintenance"]
+	// Enum: ["active","terminating","terminating-not-serving","quarantined","maintenance"]
 	State string `json:"state,omitempty"`
 
 	// Backend weight
@@ -82,7 +82,7 @@ var backendAddressTypeStatePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["active","terminating","quarantined","maintenance"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["active","terminating","terminating-not-serving","quarantined","maintenance"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -97,6 +97,9 @@ const (
 
 	// BackendAddressStateTerminating captures enum value "terminating"
 	BackendAddressStateTerminating string = "terminating"
+
+	// BackendAddressStateTerminatingDashNotDashServing captures enum value "terminating-not-serving"
+	BackendAddressStateTerminatingDashNotDashServing string = "terminating-not-serving"
 
 	// BackendAddressStateQuarantined captures enum value "quarantined"
 	BackendAddressStateQuarantined string = "quarantined"

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2924,6 +2924,7 @@ definitions:
         enum:
           - active
           - terminating
+          - terminating-not-serving
           - quarantined
           - maintenance
       preferred:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1824,6 +1824,7 @@ func init() {
           "enum": [
             "active",
             "terminating",
+            "terminating-not-serving",
             "quarantined",
             "maintenance"
           ]
@@ -7456,6 +7457,7 @@ func init() {
           "enum": [
             "active",
             "terminating",
+            "terminating-not-serving",
             "quarantined",
             "maintenance"
           ]

--- a/pkg/bgpv1/manager/reconciler/service.go
+++ b/pkg/bgpv1/manager/reconciler/service.go
@@ -158,7 +158,7 @@ endpointsLoop:
 		svcID := eps.ServiceName
 
 		for _, be := range eps.Backends {
-			if !be.Terminating && be.NodeName == localNodeName {
+			if !be.Conditions.IsTerminating() && be.NodeName == localNodeName {
 				// At least one endpoint is available on this node. We
 				// can make unavailable to available.
 				if _, found := ls[svcID]; !found {

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -122,7 +122,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -138,8 +139,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:    "node1",
-				Terminating: true,
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionTerminating,
 			},
 		},
 	}
@@ -155,7 +156,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -171,10 +173,12 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -190,7 +194,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -206,7 +211,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -222,10 +228,12 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -825,7 +833,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -841,7 +850,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -857,10 +867,12 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -876,7 +888,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -892,7 +905,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -908,7 +922,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
 				NodeName: "node2",
@@ -1468,7 +1483,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1484,7 +1500,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1500,10 +1517,12 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1519,7 +1538,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1535,7 +1555,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1551,10 +1572,12 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -2063,14 +2086,16 @@ func TestEPUpdateOnly(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
 	eps1IPv4LocalUpdated := eps1IPv4Local.DeepCopy()
 	eps1IPv4LocalUpdated.Backends = map[cmtypes.AddrCluster]*k8s.Backend{
 		cmtypes.MustParseAddrCluster("10.0.0.1"): {
-			NodeName: "node2",
+			NodeName:   "node2",
+			Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 		},
 	}
 

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -361,7 +361,7 @@ endpointsLoop:
 		}
 
 		for _, be := range eps.Backends {
-			if !be.Terminating && be.NodeName == localNodeName {
+			if !be.Conditions.IsTerminating() && be.NodeName == localNodeName {
 				// At least one endpoint is available on this node. We
 				// can add service to the local services set.
 				ls.Insert(svcKey)

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -650,12 +650,12 @@ var (
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:    "node1",
-				Terminating: true,
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionTerminating,
 			},
 			cmtypes.MustParseAddrCluster("2001:db8:1000::1"): {
-				NodeName:    "node1",
-				Terminating: true,
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionTerminating,
 			},
 		},
 	}

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -185,6 +185,12 @@ type bpfOpsParams struct {
 	NodeAddresses  statedb.Table[tables.NodeAddress]
 }
 
+const (
+	logfieldActiveCount      = "active-count"
+	logfieldTerminatingCount = "terminating-count"
+	logfieldInactiveCount    = "inactive-count"
+)
+
 func newBPFOps(p bpfOpsParams) *BPFOps {
 	ops := &BPFOps{
 		cfg:       p.Config,
@@ -873,7 +879,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 
 		if ops.needsUpdate(be.Address, be.Revision) {
 			ops.log.Debug("Update backend",
-				logfields.Backend, be,
+				logfields.Backend, be.BackendParams,
 				logfields.ID, beID,
 				logfields.Address, be.Address,
 			)
@@ -1016,7 +1022,10 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 		logfields.Type, fe.Type,
 		logfields.ProxyRedirect, fe.Service.ProxyRedirect,
 		logfields.Address, fe.Address,
-		logfields.Count, backendCount)
+		logfields.Count, backendCount,
+		logfieldActiveCount, activeCount,
+		logfieldTerminatingCount, terminatingCount,
+		logfieldInactiveCount, inactiveCount)
 	if err := ops.upsertMaster(svcKey, svcVal, fe, activeCount, inactiveCount); err != nil {
 		return fmt.Errorf("upsert service master: %w", err)
 	}

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -432,9 +432,32 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					}
 				}
 
-				state := loadbalancer.BackendStateActive
-				if be.Terminating {
+				var state loadbalancer.BackendState
+				switch {
+				case be.Conditions.IsReady():
+					// A backend that is ready (regardless of serving and terminating) is considered
+					// active. We may see backends that are ready+terminating if 'PublishNotReadyAddresses'
+					// is true. While it would be more logical to set this as terminating, we're following
+					// kube-proxy here and considering it as an active backend and not ignoring it even when
+					// other active backends are available.
+					//
+					// See also kube-proxy implementation at:
+					// https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/pkg/proxy/topology.go#L61
+					state = loadbalancer.BackendStateActive
+				case be.Conditions.IsTerminating() && !be.Conditions.IsServing():
+					// A backend that is terminating and not serving should not be used for load-balancing
+					// even if it's the only backend. A terminating backend is kept in the BPF maps until
+					// fully removed to avoid disrupting connections.
+					state = loadbalancer.BackendStateTerminatingNotServing
+				case be.Conditions.IsTerminating():
+					// A backend that is terminating and serving can still be used for new connections
+					// when no active backends are available. A terminating backend is kept in the BPF maps until
+					// fully removed to avoid disrupting connections.
 					state = loadbalancer.BackendStateTerminating
+				default:
+					// In all other cases we mark the backend as quarantined. Existing connections
+					// are not disrupted until the backend is actually deleted.
+					state = loadbalancer.BackendStateQuarantined
 				}
 				bep := loadbalancer.BackendParams{
 					Address:   l3n4Addr,

--- a/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
@@ -8,10 +8,12 @@ hive start
 
 # Start with two backends that are both active.
 cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$TERM1' 'false' endpointslice.yaml
 replace '$READY1' 'true' endpointslice.yaml
-replace '$TERM2' 'false' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
+replace '$TERM1' 'false' endpointslice.yaml
 replace '$READY2' 'true' endpointslice.yaml
+replace '$SERVING2' 'true' endpointslice.yaml
+replace '$TERM2' 'false' endpointslice.yaml
 
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
@@ -25,10 +27,12 @@ lb/maps-dump lbmaps.actual
 # Set the first backend as terminating. The second backend
 # will now serve the traffic.
 cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$TERM1' 'true' endpointslice.yaml
 replace '$READY1' 'false' endpointslice.yaml
-replace '$TERM2' 'false' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
+replace '$TERM1' 'true' endpointslice.yaml
 replace '$READY2' 'true' endpointslice.yaml
+replace '$SERVING2' 'true' endpointslice.yaml
+replace '$TERM2' 'false' endpointslice.yaml
 k8s/update endpointslice.yaml
 db/cmp backends backends-terminating1.table
 
@@ -40,10 +44,12 @@ lb/maps-dump lbmaps.actual
 # are now active backends the terminating backends are used
 # instead.
 cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$TERM1' 'true' endpointslice.yaml
 replace '$READY1' 'false' endpointslice.yaml
-replace '$TERM2' 'true' endpointslice.yaml
+replace '$TERM1' 'true' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
 replace '$READY2' 'false' endpointslice.yaml
+replace '$TERM2' 'true' endpointslice.yaml
+replace '$SERVING2' 'true' endpointslice.yaml
 k8s/update endpointslice.yaml
 db/cmp frontends frontends-terminating2.table
 db/cmp backends backends-terminating2.table
@@ -51,6 +57,43 @@ db/cmp backends backends-terminating2.table
 # Check BPF maps
 lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating2.expected lbmaps.actual
+
+# Set the second backend as terminating AND not serving.
+# This now won't be used as a fallback.
+cp endpointslice.yaml.tmpl endpointslice.yaml
+replace '$READY1' 'false' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
+replace '$TERM1' 'true' endpointslice.yaml
+replace '$READY2' 'false' endpointslice.yaml
+replace '$SERVING2' 'false' endpointslice.yaml
+replace '$TERM2' 'true' endpointslice.yaml
+k8s/update endpointslice.yaml
+db/cmp frontends frontends-terminating3.table
+db/cmp backends backends-terminating3.table
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-terminating3.expected lbmaps.actual
+
+# Set the first backend as not serving and second as ready+terminating .
+# First backend will be quarantined. Existing connections to
+# it won't be affected as it's still in the backends BPF map.
+# The second backend will be just considered ready and its terminating
+# condition is ignored ("ready" overrides everything).
+cp endpointslice.yaml.tmpl endpointslice.yaml
+replace '$READY1' 'false' endpointslice.yaml
+replace '$SERVING1' 'false' endpointslice.yaml
+replace '$TERM1' 'false' endpointslice.yaml
+replace '$READY2' 'true' endpointslice.yaml
+replace '$SERVING2' 'false' endpointslice.yaml
+replace '$TERM2' 'true' endpointslice.yaml
+k8s/update endpointslice.yaml
+db/cmp frontends frontends-terminating4.table
+db/cmp backends backends-terminating4.table
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-terminating4.expected lbmaps.actual
 
 # Cleanup
 k8s/delete service.yaml endpointslice.yaml
@@ -73,6 +116,14 @@ Address                 Type        ServiceName              Status  Backends
 Address                 Type        ServiceName              Status  Backends
 10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
 
+-- frontends-terminating3.table --
+Address                 Type        ServiceName              Status  Backends
+10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
+
+-- frontends-terminating4.table --
+Address                 Type        ServiceName              Status  Backends
+10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
+
 -- backends.table --
 Address                 Instances                NodeName
 10.244.0.112:8081/TCP   test/graceful-term-svc   graceful-term-control-plane
@@ -87,6 +138,16 @@ Address                 Instances                              NodeName
 Address                 Instances                             NodeName
 10.244.0.112:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
 10.244.0.113:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
+
+-- backends-terminating3.table --
+Address                 Instances                                         NodeName
+10.244.0.112:8081/TCP   test/graceful-term-svc [terminating]              graceful-term-control-plane
+10.244.0.113:8081/TCP   test/graceful-term-svc [terminating-not-serving]  graceful-term-control-plane
+
+-- backends-terminating4.table --
+Address                 Instances                                         NodeName
+10.244.0.112:8081/TCP   test/graceful-term-svc [quarantined]              graceful-term-control-plane
+10.244.0.113:8081/TCP   test/graceful-term-svc                            graceful-term-control-plane
 
 -- service.yaml --
 apiVersion: v1
@@ -146,7 +207,7 @@ endpoints:
   - 10.244.0.112
   conditions:
     ready: $READY1
-    serving: true
+    serving: $SERVING1
     terminating: $TERM1
   nodeName: graceful-term-control-plane
   targetRef:
@@ -159,7 +220,7 @@ endpoints:
   - 10.244.0.113
   conditions:
     ready: $READY2
-    serving: true
+    serving: $SERVING2
     terminating: $TERM2
   nodeName: graceful-term-control-plane
   targetRef:
@@ -197,3 +258,19 @@ REV: ID=1 ADDR=10.96.116.33:8081
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+-- lbmaps-terminating3.expected --
+BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=terminating
+BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=terminating
+MAGLEV: ID=1 INNER=[1(1021)]
+REV: ID=1 ADDR=10.96.116.33:8081
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+-- lbmaps-terminating4.expected --
+BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=quarantined
+BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
+MAGLEV: ID=1 INNER=[2(1021)]
+REV: ID=1 ADDR=10.96.116.33:8081
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP


### PR DESCRIPTION
This fixes handling of terminating endpoints that are marked as not serving. These were skipped by `ParseEndpointSliceV1` which lead to them being removed from the backend BPF maps and disrupting connections too early when a terminating pod stopped signalling readiness (conditions became `{ready: false, serving: false, terminating: true}`. 

To fix this we:
1) introduce `BackendStateTerminatingNotServing` for terminating backends that are to be kept in BPF maps, but not load-balanced to.
2) remove the skipping of non-serving backends from `ParseEndpointSliceV1`. In case the conditions are the unexpected `{ready: false, serving: false, terminating: false}` the backend is simply quarantined.

```release-note
Kubernetes endpoints that are terminating are retained in the backends BPF state regardless of the "serving" condition to avoid connection disruptions when a pod no longer signals readiness to process new connections.
```