### PR TITLE
[DO NOT MERGE]: panicking handler for slog

### DIFF
--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -194,6 +194,7 @@ jobs:
           export KUBERNETES_CONFORMANCE_TEST='y'
           export E2E_REPORT_DIR=${PWD}/_artifacts
           /usr/local/bin/ginkgo --nodes=10                \
+            --seed=1754416678 \
             --focus="(Netpol|NetworkPolicy)"     \
             --skip="${SKIP_FLAG}" \
             /usr/local/bin/e2e.test                       \


### PR DESCRIPTION
This is a instrumentation to see whether my hypothesis is correct and wer are affected by https://github.com/natefinch/lumberjack/issues/223

The issue is that slog.Logger.log discards handler errors, so we never se an error if we fail to close the logfile as suggested by the above issue. By wrapping the handler into a panicking variant, we'd panic instead.
