### PR TITLE
.github/actions: only upload files with features-tested prefix

### DIFF
--- a/.github/actions/feature-status/action.yaml
+++ b/.github/actions/feature-status/action.yaml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         ${{ inputs.cilium-cli }} features status -o markdown --output-file="feature-status.md"
-        ${{ inputs.cilium-cli }} features status -o json --output-file="${{ inputs.json-filename }}.json"
+        ${{ inputs.cilium-cli }} features status -o json --output-file="features-tested-${{ inputs.json-filename }}.json"
 
     - name: Report summary for features enabled on the agent
       if: ${{ always() }}

--- a/.github/actions/post-logic/action.yaml
+++ b/.github/actions/post-logic/action.yaml
@@ -28,7 +28,7 @@ runs:
       uses: ./.github/actions/feature-status
       with:
         title: "Summary of all features tested"
-        json-filename: "features-tested-${{ inputs.artifacts_suffix }}"
+        json-filename: "${{ inputs.artifacts_suffix }}"
 
     - name: Post-test information gathering
       if: ${{ always() && ( ( inputs.job_status == 'failure' && inputs.capture_sysdump  == 'true') || inputs.always_capture_sysdump == 'true') }}
@@ -61,7 +61,7 @@ runs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: "features-tested-${{ inputs.artifacts_suffix }}"
-        path: ./*.json
+        path: ./features-tested-*.json
 
     - name: Publish Test Results As GitHub Summary
       if: ${{ always() }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -467,7 +467,7 @@ jobs:
             docker create --name cilium-dbg quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.sha }}
             docker cp cilium-dbg:/usr/bin/cilium-dbg /usr/local/bin/cilium-dbg
             docker rm cilium-dbg
-            cilium-dbg metrics list -p cilium_feature -o json > '/host/${{ env.job_name }} (${{ matrix.focus }}).json'
+            cilium-dbg metrics list -p cilium_feature -o json > '/host/features-tested-${{ env.job_name }} (${{ matrix.focus }}).json'
 
       - name: Debug failure on VM
         # Only debug the failure on the LVH that have Cilium running as a service,
@@ -524,7 +524,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.focus }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() && runner.arch != 'ARM64' }}


### PR DESCRIPTION
When uploading the feature .json files, we should only upload the ones with this prefix.
