### PR TITLE
.github/workflows: only run workflows if certain files are modified

### DIFF
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -3,16 +3,54 @@ name: Conformance Kind Envoy Embedded
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
   pull_request:
-    paths-ignore:
-      - 'Documentation/**'
-      - 'test/**'
+    paths:
+      - '.github/actions/**'
+      - '.github/kind-config*.yaml'
+      - '.github/workflows/**'
+      - 'api/**'
+      - 'bpf/**'
+      - 'cilium-cli/**'
+      - 'cilium-dbg/**'
+      - 'cilium-health/**'
+      - 'daemon/**'
+      - 'hubble/**'
+      - 'hubble-relay/**'
+      - 'images/**'
+      - 'install/**'
+      - 'operator/**'
+      - 'pkg/**'
+      - 'plugins/**'
+      - 'proxylib/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile*'
+      - 'VERSION'
   push:
     branches:
       - main
       - ft/main/**
-    paths-ignore:
-      - 'Documentation/**'
-      - 'test/**'
+    paths:
+      - '.github/actions/**'
+      - '.github/kind-config*.yaml'
+      - '.github/workflows/**'
+      - 'api/**'
+      - 'bpf/**'
+      - 'cilium-cli/**'
+      - 'cilium-dbg/**'
+      - 'cilium-health/**'
+      - 'daemon/**'
+      - 'hubble/**'
+      - 'hubble-relay/**'
+      - 'images/**'
+      - 'install/**'
+      - 'operator/**'
+      - 'pkg/**'
+      - 'plugins/**'
+      - 'proxylib/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile*'
+      - 'VERSION'
 
 permissions: read-all
 

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -22,8 +22,28 @@ on:
       - main
       - ft/main/**
       - 'renovate/main-**'
-    paths-ignore:
-      - 'Documentation/**'
+    paths:
+      - '.github/actions/**'
+      - '.github/kind-config*.yaml'
+      - '.github/workflows/**'
+      - 'api/**'
+      - 'bpf/**'
+      - 'cilium-cli/**'
+      - 'cilium-dbg/**'
+      - 'cilium-health/**'
+      - 'daemon/**'
+      - 'hubble/**'
+      - 'hubble-relay/**'
+      - 'images/**'
+      - 'install/**'
+      - 'operator/**'
+      - 'pkg/**'
+      - 'plugins/**'
+      - 'proxylib/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile*'
+      - 'VERSION'
   # Run every 8 hours
   schedule:
     - cron:  '0 3/8 * * *'

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -2,11 +2,21 @@ name: K8s Network E2E tests and kube-apiserver HA
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - '.github/renovate.json5'
+      - 'Documentation/**'
+      - 'test/**'
   push:
     branches:
       - main
       - ft/main/**
+    paths-ignore:
+      - '*.md'
+      - '.github/renovate.json5'
+      - 'Documentation/**'
+      - 'test/**'
 
 permissions: read-all
 

--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -4,6 +4,8 @@ name: K8s Network Policy E2E tests
 on:
   pull_request:
     paths-ignore:
+      - '*.md'
+      - '.github/renovate.json5'
       - 'Documentation/**'
       - 'test/**'
   push:
@@ -11,6 +13,8 @@ on:
       - main
       - ft/main/**
     paths-ignore:
+      - '*.md'
+      - '.github/renovate.json5'
       - 'Documentation/**'
       - 'test/**'
   # Run every 8 hours

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -2,11 +2,27 @@ name: BPF Checks
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '.github/workflows/lint-bpf-checks.yaml'
+      - 'bpf/**'
+      - 'contrib/coccinelle/**'
+      - 'contrib/scripts/builder.sh'
+      - 'images/**'
+      - 'pkg/bpf/**'
+      - 'Makefile*'
   push:
     branches:
       - main
       - ft/main/**
+    paths:
+      - '.github/workflows/lint-bpf-checks.yaml'
+      - 'bpf/**'
+      - 'contrib/coccinelle/**'
+      - 'contrib/scripts/builder.sh'
+      - 'images/**'
+      - 'pkg/bpf/**'
+      - 'Makefile*'
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -2,11 +2,38 @@ name: Go Related Checks
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - '*.rst'
+      - '*.toml'
+      - '*.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - '.github/renovate.json5'
+      - 'Documentation/**'
+      - 'examples/**'
+      - 'AUTHORS'
+      - 'CODEOWNERS'
+      - 'LICENSE'
   push:
     branches:
       - main
       - ft/main/**
+    paths-ignore:
+      - '*.md'
+      - '*.rst'
+      - '*.toml'
+      - '*.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - '.github/renovate.json5'
+      - 'Documentation/**'
+      - 'examples/**'
+      - 'AUTHORS'
+      - 'CODEOWNERS'
+      - 'LICENSE'
+
   # Add this workflow to be triggered by merge queue events
   merge_group:
 

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -2,11 +2,21 @@ name: Smoke Test with IPv6
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - '.github/renovate.json5'
+      - 'Documentation/**'
+      - 'test/**'
   push:
     branches:
       - main
       - ft/main/**
+    paths-ignore:
+      - '*.md'
+      - '.github/renovate.json5'
+      - 'Documentation/**'
+      - 'test/**'
 
 permissions: read-all
 

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -2,11 +2,21 @@ name: Smoke Test
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - '.github/renovate.json5'
+      - 'Documentation/**'
+      - 'test/**'
   push:
     branches:
       - main
       - ft/main/**
+    paths-ignore:
+      - '*.md'
+      - '.github/renovate.json5'
+      - 'Documentation/**'
+      - 'test/**'
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
Add path filters to the workflows so that they don't need to be executed if certain files are modified in a PR. This will prevent small PRs from running workflows unnecessary.

When making PR https://github.com/cilium/cilium/pull/40948, I noticed many workflows ran unnecessarily. This PR should help avoid running those workflows for minor changes.