### PR TITLE
Allow Egress Gateway connectivity tests to run concurrently

### DIFF
--- a/cilium-cli/connectivity/builder/egress_gateway.go
+++ b/cilium-cli/connectivity/builder/egress_gateway.go
@@ -4,6 +4,8 @@
 package builder
 
 import (
+	"fmt"
+
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
@@ -16,11 +18,11 @@ func (t egressGateway) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("seq-egress-gateway", ct).
 		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
-			Name:            "cegp-sample-client",
+			Name:            fmt.Sprintf("cegp-sample-client-%d", ct.Params().TestNamespaceIndex),
 			PodSelectorKind: "client",
 		}).
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
-			Name:            "cegp-sample-echo",
+			Name:            fmt.Sprintf("cegp-sample-echo-%d", ct.Params().TestNamespaceIndex),
 			PodSelectorKind: "echo",
 		}).
 		WithIPRoutesFromOutsideToPodCIDRs().

--- a/cilium-cli/connectivity/builder/egress_gateway_excluded_cidrs.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_excluded_cidrs.go
@@ -4,6 +4,8 @@
 package builder
 
 import (
+	"fmt"
+
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
@@ -14,7 +16,7 @@ type egressGatewayExcludedCidrs struct{}
 func (t egressGatewayExcludedCidrs) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("egress-gateway-excluded-cidrs", ct).
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
-			Name:              "cegp-sample-client",
+			Name:              fmt.Sprintf("cegp-sample-client-%d", ct.Params().TestNamespaceIndex),
 			PodSelectorKind:   "client",
 			ExcludedCIDRsConf: check.ExternalNodeExcludedCIDRs,
 		}).

--- a/cilium-cli/connectivity/builder/egress_gateway_multigateway.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_multigateway.go
@@ -4,6 +4,8 @@
 package builder
 
 import (
+	"fmt"
+
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
@@ -17,12 +19,12 @@ func (t egressGatewayMultigateway) build(ct *check.ConnectivityTest, _ map[strin
 		WithCiliumVersion(">=1.18.0").
 		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
-			Name:            "cegp-sample-client",
+			Name:            fmt.Sprintf("cegp-sample-client-%d", ct.Params().TestNamespaceIndex),
 			PodSelectorKind: "client",
 			Multigateway:    true,
 		}).
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
-			Name:            "cegp-sample-echo",
+			Name:            fmt.Sprintf("cegp-sample-echo-%d", ct.Params().TestNamespaceIndex),
 			PodSelectorKind: "echo",
 			Multigateway:    true,
 		}).

--- a/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
@@ -5,6 +5,7 @@ package builder
 
 import (
 	_ "embed"
+	"fmt"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
@@ -30,11 +31,11 @@ func (t egressGatewayWithL7Policy) build(ct *check.ConnectivityTest, templates m
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).  // DNS resolution only
 		WithCiliumPolicy(templates["clientEgressL7HTTPExternalYAML"]). // L7 allow policy with HTTP introspection
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
-			Name:            "cegp-sample-client",
+			Name:            fmt.Sprintf("cegp-sample-client-%d", ct.Params().TestNamespaceIndex),
 			PodSelectorKind: "client",
 		}).
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
-			Name:            "cegp-sample-echo",
+			Name:            fmt.Sprintf("cegp-sample-echo-%d", ct.Params().TestNamespaceIndex),
 			PodSelectorKind: "echo",
 		}).
 		WithIPRoutesFromOutsideToPodCIDRs().

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -742,7 +742,12 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 					ct.Failf("%s deployment is not ready: %s", clientDeploy, err)
 				}
 			}
-			if err := WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(),
+
+			testPods := append(
+				slices.Collect(maps.Values(ct.ClientPods())),
+				slices.Collect(maps.Values(ct.EchoPods()))...)
+
+			if err := WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), testPods,
 				func(ciliumPod Pod) ([]BPFEgressGatewayPolicyEntry, error) {
 					return ct.GetConnDisruptEgressPolicyEntries(ctx, ciliumPod)
 				}, func(ciliumPod Pod) ([]BPFEgressGatewayPolicyEntry, error) {

--- a/cilium-cli/connectivity/check/wait.go
+++ b/cilium-cli/connectivity/check/wait.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/cilium-cli/defaults"
@@ -361,12 +362,24 @@ func (e *BPFEgressGatewayPolicyEntry) matches(t BPFEgressGatewayPolicyEntry) boo
 
 // WaitForEgressGatewayBpfPolicyEntries waits for the egress gateway policy maps on each node to WaitForEgressGatewayBpfPolicyEntries
 // with the entries returned by the targetEntriesCallback
-func WaitForEgressGatewayBpfPolicyEntries(ctx context.Context, ciliumPods map[string]Pod,
+func WaitForEgressGatewayBpfPolicyEntries(ctx context.Context,
+	ciliumPods map[string]Pod,
+	testPods []Pod,
 	targetEntriesCallback func(ciliumPod Pod) ([]BPFEgressGatewayPolicyEntry, error),
 	excludeEntries func(ciliumPod Pod) ([]BPFEgressGatewayPolicyEntry, error),
 ) error {
 	w := wait.NewObserver(ctx, wait.Parameters{Timeout: 10 * time.Second})
 	defer w.Cancel()
+
+	localPodIPs := sets.New[string]()
+	for _, pod := range testPods {
+		if ip := pod.Address(features.IPFamilyV4); ip != "" {
+			localPodIPs.Insert(ip)
+		}
+		if ip := pod.Address(features.IPFamilyV6); ip != "" {
+			localPodIPs.Insert(ip)
+		}
+	}
 
 	ensureBpfPolicyEntries := func() error {
 		for _, ciliumPod := range ciliumPods {
@@ -401,6 +414,11 @@ func WaitForEgressGatewayBpfPolicyEntries(ctx context.Context, ciliumPods map[st
 			}
 
 			for _, entry := range entries {
+				// We only check for untracked entries for Pods in this test namespace that
+				// are untracked.
+				if !localPodIPs.Has(entry.SourceIP) {
+					continue
+				}
 				if !slices.ContainsFunc(targetEntries, entry.matches) {
 					return fmt.Errorf("untracked entry %+v in the egress gateway policy maps", entry)
 				}

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"maps"
 	"net"
 	"slices"
 
@@ -164,8 +165,10 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 	if ipv6Enabled && egressGatewayNodeInternalIPv6 == nil {
 		t.Fatal("Cannot get IPv6 egress gateway node internal IP")
 	}
-
-	err := check.WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
+	testPods := append(
+		slices.Collect(maps.Values(ct.ClientPods())),
+		slices.Collect(maps.Values(ct.EchoPods()))...)
+	err := check.WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), testPods, func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
 		var targetEntries []check.BPFEgressGatewayPolicyEntry
 
 		egressIP := "0.0.0.0"
@@ -453,8 +456,10 @@ func (s *egressGatewayMultigateway) Run(ctx context.Context, t *check.Test) {
 		}
 		return assignGatewayNode(epUID, sortedGatewayNodes)
 	}
-
-	err = check.WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
+	testPods := append(
+		slices.Collect(maps.Values(ct.ClientPods())),
+		slices.Collect(maps.Values(ct.EchoPods()))...)
+	err = check.WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), testPods, func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
 		var targetEntries []check.BPFEgressGatewayPolicyEntry
 
 		for _, client := range ct.ClientPods() {
@@ -673,7 +678,10 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 		t.Fatal("Cannot get egress gateway node internal IPv6")
 	}
 
-	err := check.WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
+	testPods := append(
+		slices.Collect(maps.Values(ct.ClientPods())),
+		slices.Collect(maps.Values(ct.EchoPods()))...)
+	err := check.WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), testPods, func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
 		var targetEntries []check.BPFEgressGatewayPolicyEntry
 
 		egressIP := "0.0.0.0"


### PR DESCRIPTION
This fixes assumptions for egress gateway that prevent us from running these tests concurrently, related to: github.com/cilium/cilium/pull/40103

1) Egress GW policies are global, therefore we need to have unique names for them as there is no namespace to differentiate them.
2) The untracked entry check relied on the assumption that there was only one namespace/test-instance running.  We will only do the check on known IPs going forward.