### PR TITLE
feat(sdp): interaction flow between cells for standalone dns proxy

### DIFF
--- a/pkg/fqdn/lookup/endpoint.go
+++ b/pkg/fqdn/lookup/endpoint.go
@@ -17,7 +17,7 @@ import (
 )
 
 type ProxyLookupHandler interface {
-	// LookupSecIDByIP is a provided callback that returns the IP's security ID
+	// LookupSecIDByIP looks up the security ID for a given IP address
 	// from the ipcache.
 	LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool)
 
@@ -43,7 +43,7 @@ func (p *proxyLookupHandler) LookupRegisteredEndpoint(endpointAddr netip.Addr) (
 		return e, e.IsHost(), nil
 	}
 
-	localNode, err := p.localNodeStore.Get(context.TODO())
+	localNode, err := p.localNodeStore.Get(context.Background())
 	if err != nil {
 		return nil, true, fmt.Errorf("local node has not been initialized yet: %w", err)
 	}
@@ -56,7 +56,7 @@ func (p *proxyLookupHandler) LookupRegisteredEndpoint(endpointAddr netip.Addr) (
 		}
 	}
 
-	return nil, false, fmt.Errorf("cannot find endpoint with IP %s", endpointAddr)
+	return nil, false, fmt.Errorf("cannot find endpoint with IP %s", endpointAddr.String())
 }
 
 func (p *proxyLookupHandler) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {

--- a/pkg/fqdn/service/cell.go
+++ b/pkg/fqdn/service/cell.go
@@ -47,7 +47,7 @@ type serverParams struct {
 	DaemonConfig       *option.DaemonConfig
 	DefaultListener    listenConfig
 	DB                 *statedb.DB
-	PolicyRulesTable   statedb.RWTable[policyRules]
+	PolicyRulesTable   statedb.RWTable[PolicyRules]
 	IdentityToIPsTable statedb.RWTable[identityToIPs]
 }
 

--- a/standalone-dns-proxy/cmd/standalonednsproxy.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy.go
@@ -4,10 +4,19 @@
 package cmd
 
 import (
+	"context"
 	"log/slog"
 
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/fqdn/service"
-	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
 )
 
 type StandaloneDNSProxy struct {
@@ -16,24 +25,95 @@ type StandaloneDNSProxy struct {
 	standaloneDNSProxyServerPort uint16
 	enableL7Proxy                bool
 	enableStandaloneDNSProxy     bool
+	dnsProxier                   proxy.DNSProxier
+
+	// connHandler is the gRPC connection handler client for standalone DNS proxy
+	connHandler client.ConnectionHandler
+
+	// dnsRulesTable is the table that holds DNS rules received from the Cilium agent
+	// It is used by the DNS proxy to enforce DNS policies
+	dnsRulesTable statedb.RWTable[service.PolicyRules]
+	db            *statedb.DB
+	jobGroup      job.Group
 }
 
-// NewStandaloneDNSProxy creates a new standalone DNS proxy
-func NewStandaloneDNSProxy(logger *slog.Logger, agentCfg *option.DaemonConfig, fqdnCfg service.FQDNConfig) *StandaloneDNSProxy {
+// NewStandaloneDNSProxy creates a new StandaloneDNSProxy instance
+func NewStandaloneDNSProxy(params standaloneDNSProxyParams) *StandaloneDNSProxy {
 	return &StandaloneDNSProxy{
-		logger:                       logger,
-		enableL7Proxy:                agentCfg.EnableL7Proxy,
-		enableStandaloneDNSProxy:     fqdnCfg.EnableStandaloneDNSProxy,
-		standaloneDNSProxyServerPort: uint16(fqdnCfg.StandaloneDNSProxyServerPort),
+		logger:                       params.Logger,
+		enableL7Proxy:                params.AgentConfig.EnableL7Proxy,
+		enableStandaloneDNSProxy:     params.FQDNConfig.EnableStandaloneDNSProxy,
+		standaloneDNSProxyServerPort: uint16(params.FQDNConfig.StandaloneDNSProxyServerPort),
+		connHandler:                  params.ConnectionHandler,
+		dnsProxier:                   params.DNSProxier,
+		db:                           params.DB,
+		dnsRulesTable:                params.DNSRulesTable,
+		jobGroup:                     params.JobGroup,
 	}
 }
 
-// Note: This is intentionally left blank. The actual implementation will be added in a future commit.
-func (sdp *StandaloneDNSProxy) StopStandaloneDNSProxy() error {
+// StartStandaloneDNSProxy starts the connection management and waits for connection before starting DNS proxy
+// It also sets up the DNS rules table watcher to update the DNS proxy with the latest rules received from the Cilium agent
+func (sdp *StandaloneDNSProxy) StartStandaloneDNSProxy() error {
+	sdp.logger.Info("Starting standalone DNS proxy")
+
+	// start the connection handler
+	sdp.connHandler.StartConnection()
+
+	// Wait for the connection to be established and start the proxy, will be added in future PRs
+	// Note: This is a placeholder for the actual implementation.
+	// if err := sdp.dnsProxier.Listen(sdp.proxyPort); err != nil {
+	// 	return fmt.Errorf("error opening dns proxy socket(s): %w", err)
+	// }
+
+	sdp.jobGroup.Add(job.OneShot("sdp-watch-dns-rules", sdp.WatchDNSRulesTable,
+		job.WithRetry(3, &job.ExponentialBackoff{Min: 5 * time.Second, Max: 10 * time.Second}),
+		job.WithShutdown()))
+
+	sdp.logger.Info("Standalone DNS proxy started")
 	return nil
 }
 
-// Note: This is intentionally left blank. The actual implementation will be added in a future commit.
-func (sdp *StandaloneDNSProxy) StartStandaloneDNSProxy() error {
+// WatchDNSRulesTable watches the DNS rules table for changes and updates the DNS proxy accordingly
+func (sdp *StandaloneDNSProxy) WatchDNSRulesTable(ctx context.Context, _ cell.Health) error {
+	limiter := rate.NewLimiter(time.Second, 1)
+	defer limiter.Stop()
+
+	rulesWatch := func() <-chan struct{} {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			sdp.logger.Info("Stopping DNS rules table watcher")
+			return nil
+		case <-rulesWatch:
+			_, newWatch := sdp.dnsRulesTable.AllWatch(sdp.db.ReadTxn())
+			// Update the DNS proxy with the latest rules
+			rulesWatch = newWatch
+		}
+
+		// Limit the rate at which we send the full snapshots
+		if err := limiter.Wait(ctx); err != nil {
+			sdp.logger.Error("Failed to wait for rate limiter", logfields.Error, err)
+			return err
+		}
+	}
+}
+
+// StopStandaloneDNSProxy stops the standalone DNS proxy and cleanup resources
+func (sdp *StandaloneDNSProxy) StopStandaloneDNSProxy() error {
+	sdp.logger.Info("Stopping standalone DNS proxy")
+
+	// Stop DNS proxy first
+	sdp.dnsProxier.Cleanup()
+
+	// Stop all controllers
+	sdp.connHandler.StopConnection()
+
+	sdp.logger.Info("Standalone DNS proxy stopped")
 	return nil
 }

--- a/standalone-dns-proxy/pkg/client/cell.go
+++ b/standalone-dns-proxy/pkg/client/cell.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package client
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+)
+
+// Cell provides the gRPC connection handler client for standalone DNS proxy.
+// It is responsible for creating a client that can communicate with the Cilium agent
+// to send and receive DNS rules and responses. The client is used by the standalone DNS proxy
+// to communicate with the Cilium agent to enforce DNS policies.
+var Cell = cell.Module(
+	"sdp-grpc-client",
+	"gRPC connection handler client for standalone DNS proxy",
+
+	cell.Provide(newGRPCClient),
+	cell.Provide(newDNSRulesTable),
+	cell.Provide(newIPtoIdentityTable),
+)
+
+type clientParams struct {
+	cell.In
+
+	Logger   *slog.Logger
+	JobGroup job.Group
+}
+
+// newGRPCClient creates a new gRPC connection handler client for standalone DNS proxy
+func newGRPCClient(params clientParams) ConnectionHandler {
+	return createGRPCClient(params.Logger)
+}

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package client
+
+import (
+	"fmt"
+	"log/slog"
+	"net/netip"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+
+	"github.com/cilium/cilium/pkg/fqdn/service"
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+const (
+	DNSRulesTableName     = "sdp-dns-rules"
+	IPtoIdentityTableName = "sdp-ip-to-identity"
+)
+
+type IPtoIdentity struct {
+	IP       netip.Addr
+	Identity identity.NumericIdentity
+}
+
+var (
+	idIPToIdentityIndex = statedb.Index[IPtoIdentity, netip.Addr]{
+		Name: "ip",
+		FromObject: func(e IPtoIdentity) index.KeySet {
+			return index.NewKeySet(index.NetIPAddr(e.IP))
+		},
+		FromKey: func(key netip.Addr) index.Key {
+			return index.NetIPAddr(key)
+		},
+		FromString: index.NetIPAddrString,
+		Unique:     true,
+	}
+)
+
+func (i IPtoIdentity) TableHeader() []string {
+	return []string{
+		"IP",
+		"Identity",
+	}
+}
+
+func (i IPtoIdentity) TableRow() []string {
+	return []string{
+		i.IP.String(),
+		fmt.Sprintf("%d", i.Identity.Uint32()),
+	}
+}
+
+// ConnectionHandler defines the interface for standalone DNS proxy connection handler
+type ConnectionHandler interface {
+	// StartConnection starts the gRPC connection through a hive/job
+	// It is responsible for establishing the connection with the Cilium agent.
+	// This method is called when the standalone DNS proxy starts.
+	StartConnection()
+
+	// StopConnection stops the gRPC connection and removes all hive/job
+	// It is responsible for closing the connection with the Cilium agent.
+	StopConnection()
+
+	// NotifyOnMsg notifies the gRPC client about DNS messages received by the standalone DNS proxy
+	// This method is called by the DNS proxy when it receives a DNS message.
+	// It is responsible for sending the DNS message to the Cilium agent for further processing.
+	// Note: This method is intentionally left empty for now. And will be implemented in future PRs.
+	NotifyOnMsg() error
+}
+
+// GRPCClient  is a gRPC connection handler for standalone DNS proxy communication with Cilium agent
+type GRPCClient struct {
+	logger *slog.Logger
+}
+
+// createGRPCClient creates a new gRPC connection handler client for standalone DNS proxy
+func createGRPCClient(logger *slog.Logger) *GRPCClient {
+	return &GRPCClient{
+		logger: logger,
+	}
+}
+
+func (c *GRPCClient) StartConnection() {
+	c.logger.Info("Starting gRPC connection for standalone DNS proxy")
+	// Here we would typically start the gRPC connection to the Cilium agent.
+	// This is a placeholder for the actual implementation.
+}
+
+func (c *GRPCClient) StopConnection() {
+}
+
+// Note: This method is intentionally left empty for now. Will be implemented in future PRs.
+func (c *GRPCClient) NotifyOnMsg() error {
+	c.logger.Info("DNS message received")
+	return nil
+}
+
+// newDNSRulesTable creates a new table for storing the DNS rules and registers it with the database.
+// This table will be used to store the DNS rules for the standalone DNS proxy.
+// The standalone DNS proxy will use this table to retrieve the DNS rules and update the DNS proxy with the
+// latest rules received from the Cilium agent.
+func newDNSRulesTable(db *statedb.DB) (statedb.RWTable[service.PolicyRules], error) {
+	return statedb.NewTable(
+		db,
+		DNSRulesTableName,
+		service.PolicyRulesIndex,
+	)
+}
+
+// newIPtoIdentityTable creates a new table for storing the IP to identity mappings.
+func newIPtoIdentityTable(db *statedb.DB) (statedb.RWTable[IPtoIdentity], error) {
+	return statedb.NewTable(
+		db,
+		IPtoIdentityTableName,
+		idIPToIdentityIndex,
+	)
+}

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package client
+
+import (
+	"log/slog"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/fqdn/service"
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+func TestCreatecreateGRPCClient(t *testing.T) {
+	logger := slog.Default()
+
+	client := createGRPCClient(logger)
+
+	require.NotNil(t, client)
+}
+
+// Note: In the future PRs, the test case will be updated to actually check the dns rules table scenarios.
+func TestNewDNSRulesTable(t *testing.T) {
+	// Create a new StateDB instance
+	db := statedb.New()
+
+	// Test successful table creation
+	table, err := newDNSRulesTable(db)
+	require.NoError(t, err)
+	require.NotNil(t, table)
+
+	// Test table insertion and retrieval
+	txn := db.WriteTxn(table)
+	dnsRule := service.PolicyRules{
+		Identity: identity.NumericIdentity(100),
+		SelPol:   nil,
+	}
+	_, _, err = table.Insert(txn, dnsRule)
+	require.NoError(t, err)
+	txn.Commit()
+
+	// Read back the data
+	rtxn := db.ReadTxn()
+	rule, _, found := table.Get(rtxn, service.PolicyRulesIndex.Query(identity.NumericIdentity(100)))
+	require.True(t, found)
+	require.Equal(t, identity.NumericIdentity(100), rule.Identity)
+	require.Nil(t, rule.SelPol)
+}
+
+// Note: In the future PRs, the test case will be updated to actually check the ip<>identity mapping scenarios.
+func TestNewIPtoIdentityTable(t *testing.T) {
+	// Create a new StateDB instance
+	db := statedb.New()
+
+	// Test successful table creation
+	table, err := newIPtoIdentityTable(db)
+	require.NoError(t, err)
+	require.NotNil(t, table)
+
+	// Test table insertion and retrieval
+	txn := db.WriteTxn(table)
+	ip := netip.MustParseAddr("192.168.1.1")
+	ipToIdentity := IPtoIdentity{
+		IP:       ip,
+		Identity: identity.NumericIdentity(200),
+	}
+	_, _, err = table.Insert(txn, ipToIdentity)
+	require.NoError(t, err)
+	txn.Commit()
+
+	// Read back the data
+	rtxn := db.ReadTxn()
+	mapping, _, found := table.Get(rtxn, idIPToIdentityIndex.Query(ip))
+	require.True(t, found)
+	require.Equal(t, ip, mapping.IP)
+	require.Equal(t, identity.NumericIdentity(200), mapping.Identity)
+}

--- a/standalone-dns-proxy/pkg/lookup/cell.go
+++ b/standalone-dns-proxy/pkg/lookup/cell.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lookup
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/fqdn/lookup"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
+)
+
+// Standalone DNS Proxy lookup Client Cell is responsible for providing the lookup functionality.
+// It implements the ProxyLookupHandler interface which is used by the standalone DNS proxy to look up
+// security identities, endpoint information, and IP mappings required for DNS policy enforcement.
+// The cell
+var Cell = cell.Module(
+	"sdp-lookup-client",
+	"Lookup functionality for the standalone DNS proxy",
+
+	cell.Provide(newRulesClient),
+)
+
+type clientParams struct {
+	cell.In
+
+	Logger       *slog.Logger
+	IPToIdentity statedb.RWTable[client.IPtoIdentity]
+	DB           *statedb.DB
+}
+
+func newRulesClient(params clientParams) lookup.ProxyLookupHandler {
+	return &rulesClient{
+		Logger:            params.Logger,
+		IPtoIdentityTable: params.IPToIdentity,
+		DB:                params.DB,
+	}
+}

--- a/standalone-dns-proxy/pkg/lookup/lookup.go
+++ b/standalone-dns-proxy/pkg/lookup/lookup.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lookup
+
+import (
+	"log/slog"
+	"net/netip"
+
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
+)
+
+type rulesClient struct {
+	Logger            *slog.Logger
+	IPtoIdentityTable statedb.RWTable[client.IPtoIdentity]
+	DB                *statedb.DB
+}
+
+// This is not used by the standalone DNS proxy because it is used by cilium agent to look up DNS rules
+// from the in agent dns proxy.
+func (r *rulesClient) LookupByIdentity(nid identity.NumericIdentity) []string {
+	return []string{}
+}
+
+// Note: This is a placeholder for the actual implementation of the ProxyLookupHandler interface.
+func (r *rulesClient) LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error) {
+	return nil, false, nil
+}
+
+// Note: This is a placeholder for the actual implementation of the ProxyLookupHandler interface.
+func (r *rulesClient) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {
+	return ipcache.Identity{}, false
+}

--- a/standalone-dns-proxy/pkg/messagehandler/cell.go
+++ b/standalone-dns-proxy/pkg/messagehandler/cell.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package messagehandler
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
+)
+
+// Cell provides the DNS message handler for the standalone DNS proxy.
+// It registers the DNS message handler implementation, which processes DNS messages from the
+// DNS proxy and forwards them to the gRPC client for delivery to the Cilium agent.
+var Cell = cell.Module(
+	"sdp-message-handler",
+	"Provides DNS message handling for the standalone DNS proxy",
+
+	cell.Provide(
+		newDNSMessageHandler,
+	),
+)
+
+type clientParams struct {
+	cell.In
+
+	Logger      *slog.Logger
+	ConnHandler client.ConnectionHandler
+}
+
+// NewDNSMessageHandler creates a new DNS message handler for standalone DNS proxy
+func newDNSMessageHandler(params clientParams) messagehandler.DNSMessageHandler {
+	return &messageHandler{
+		Logger:      params.Logger,
+		ConnHandler: params.ConnHandler,
+	}
+}

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package messagehandler
+
+import (
+	"log/slog"
+	"net/netip"
+
+	"github.com/cilium/dns"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
+)
+
+type messageHandler struct {
+	Logger      *slog.Logger
+	ConnHandler client.ConnectionHandler
+}
+
+// NotifyOnDNSMsg implements messagehandler.DNSMessageHandler.
+// It is used by the standalone DNS proxy to notify the gRPC client about the DNS message.
+// Note: This is a placeholder for the actual implementation of the DNS message handler interface.
+func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddrPort netip.AddrPort, msg *dns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+	return m.ConnHandler.NotifyOnMsg()
+}
+
+// SetBindPort is not implemented for standalone DNS proxy yet. The port is set in the config map for the standalone DNS proxy.
+func (m *messageHandler) SetBindPort(uint16) {
+	m.Logger.Warn("SetBindPort is not implemented for standalone DNS proxy")
+}
+
+// UpdateOnDNSMsg is not implemented for standalone DNS proxy. The cilium agent is responsible for update the datapath based on the response from cilium agent.
+func (m *messageHandler) UpdateOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, qname string, responseIPs []netip.Addr, TTL int, stat *dnsproxy.ProxyRequestContext) {
+	m.Logger.Warn("UpdateOnDNSMsg is not implemented for standalone DNS proxy")
+}


### PR DESCRIPTION
  This PR adds the interaction flow between cells for standalone dns proxy.
    - adds the gRPC client cell to handle communication with the Cilium agent. It receives DNS rules and IP-to-identity mappings, storing them in a local table.
    - sdp cell is responsible for initializing the gRPC client and starting the DNS proxy. It also listens for DNS rule updates and forwards them to the DNS proxy.
    - `ProxyLookupHandler` and `DNSMessageHandler` interfaces are added for sdp based on the ip<>identity table and gRPC client respectively.
The overall interaction for sdp  is like this:

```text
                                              ┌─────────────────────────┐ 
                                              │     Lookup Cell         │  
                              ┌ip<>identity ─►│  (ProxyLookupHandler)   │◄──────────┐
                              │               │ • IP→Identity lookup    │           │
                              │               └─────────────────────────┘           │
┌───────────────┐       ┌────────────────┐                                 ┌────────────────┐
│ Cilium Agent  │       │   Client Cell  │                                 │  Bootstrap Cell│
│  (External)   │       │                │                                 │                │
│               │◄─────►│ • CA connection│                                 │ • DNS Proxy    │◄───DNS Query
│               │       │ • DNSRulesTable│                                 │                │
│               │       │ • IP→Identity  │                                 └────────────────┘
└───────────────┘       └────────────────┘                                          │ ▲
                            |  ▲                                                    │ |            
                            |  │              ┌─────────────────────────┐           │ |                   
                            |  └───DNS msg────│   Message Handler Cell  │◄──DNS Msg─┘ |                  
                            │                 └─────────────────────────┘             |
                            │                                                         │
                            │                 ┌─────────────────────────┐             │
                            │                 │   SDP Parent Cell       │             │
                            └───DNS Rules──►  │    (Coordinator)        │─DNS Rules─--┘
                                              │                         │
                                              │ • Lifecycle mgmt        │
                                              └─────────────────────────┘
 ```

Note this PR has a commit that is already a part of the PR: https://github.com/cilium/cilium/pull/40882 (will rebase once merged)

Fixes: https://github.com/cilium/cilium/issues/30984
CFP: https://github.com/cilium/design-cfps/pull/54

```release-note
feat(sdp): interaction flow between cells for standalone dns proxy
```