### PR TITLE
k8s: In endpoint parsing reuse Backend and Ports for each address

### DIFF
--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -266,7 +266,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 	}
 
 	newEmptyEndpoints := func() *Endpoints {
-		eps := newEndpoints()
+		eps := newEndpoints(0)
 		eps.ObjectMeta = meta
 		eps.EndpointSliceID = sliceID
 		return eps


### PR DESCRIPTION
Since the ports are the same for everything in the EndpointSlice just prepare the 'Ports' map once.

Similarly for Backend as the data is the same for each address allocate it just once.

To further reduce allocations pre-allocate the hash maps.

Benchmark results with https://github.com/joamaki/cilium-lb-load-test:

Current `main` (image tag deaee71ac60ca762b78051c1ddecc67cfff89a47): 
```
Creating 1000 Services and EndpointSlices (30 backends per service, 30000 in total) in namespace cni-load-test... Finished creating resources.
Waiting 10 seconds to settle...
Recording memory usage
RSS (kB): 257724.0 (diff 55952.0)
Reachable kB: 42516.21875
Allocations: 3875906
Allocated kB: 169957.71875
CPU time seconds: 1.5099999999999998
```

This commit:
```
Creating 1000 Services and EndpointSlices (30 backends per service, 30000 in total) in namespace cni-load-test... Finished creating resources.
Waiting 10 seconds to settle...
Recording memory usage
RSS (kB): 258784.0 (diff 50344.0)
Reachable kB: 37336.3984375
Allocations: 3772102
Allocated kB: 162521.7578125
CPU time seconds: 1.4699999999999989
```

Roughly ~10% less memory allocated and reachable.


```release-note
Reduced memory usage by roughly 10% for large EndpointSlices by sharing identical objects.
```
