### PR TITLE
loadbalancer: Raise default retry duration to 1 second

### DIFF
--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -464,7 +464,7 @@ func NewConfig(log *slog.Logger, userConfig UserConfig, deprecatedConfig Depreca
 }
 
 var DefaultUserConfig = UserConfig{
-	RetryBackoffMin:           50 * time.Millisecond,
+	RetryBackoffMin:           time.Second,
 	RetryBackoffMax:           time.Minute,
 	LBMapEntries:              DefaultLBMapMaxEntries,
 	LBPressureMetricsInterval: 5 * time.Minute,


### PR DESCRIPTION
The 50ms minimum retry leads to very high load if there are many entries that do not fit into the LB BPF maps.

Since the probability of a BPF syscall failing without maps being full is very unlikely, raise default to 1 second to avoid excessive load in situations where BPF maps overflow.

This was found during benchmarking when I accidentally added ~150000 backends, so 90k more than fit in the map. If there's only few entries that overflow than even with the 50ms minimum retry the load is minimal, so it's more of a "fix for extremes". Marking for backport to v1.18 as this is still useful to change.