### PR TITLE
loadbalancer: Use Table[LocalNode] instead of LocalNodeStore

### DIFF
--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -366,7 +366,7 @@ func (bs *backendProcessor) process(wtxn statedb.WriteTxn, closedWatches []<-cha
 				svc.Name,
 				res.ClusterReferences,
 				svc.PortNames,
-				bs.writer.SelectBackends(bes, svc, nil))
+				bs.writer.SelectBackends(wtxn, bes, svc, nil))
 		} else {
 			// No service found (yet) and thus there are no endpoints.
 			newEndpoints = nil

--- a/pkg/clustermesh/selectbackends.go
+++ b/pkg/clustermesh/selectbackends.go
@@ -28,8 +28,8 @@ type ClusterMeshSelectBackends struct {
 	w *writer.Writer
 }
 
-func (sb ClusterMeshSelectBackends) SelectBackends(bes iter.Seq2[loadbalancer.BackendParams, statedb.Revision], svc *loadbalancer.Service, optionalFrontend *loadbalancer.Frontend) iter.Seq2[loadbalancer.BackendParams, statedb.Revision] {
-	defaultBackends := sb.w.DefaultSelectBackends(bes, svc, optionalFrontend)
+func (sb ClusterMeshSelectBackends) SelectBackends(txn statedb.ReadTxn, bes iter.Seq2[loadbalancer.BackendParams, statedb.Revision], svc *loadbalancer.Service, optionalFrontend *loadbalancer.Frontend) iter.Seq2[loadbalancer.BackendParams, statedb.Revision] {
+	defaultBackends := sb.w.DefaultSelectBackends(txn, bes, svc, optionalFrontend)
 	affinity := annotation.GetAnnotationServiceAffinity(svc)
 
 	useLocal := true

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -674,7 +674,7 @@ func TestWriter_SetSelectBackends(t *testing.T) {
 	var beAddr loadbalancer.L3n4Addr
 	beAddr.ParseFromString("2.0.0.1:80/TCP")
 
-	w.SetSelectBackendsFunc(func(bes iter.Seq2[loadbalancer.BackendParams, statedb.Revision], svc *loadbalancer.Service, fe *loadbalancer.Frontend) iter.Seq2[loadbalancer.BackendParams, statedb.Revision] {
+	w.SetSelectBackendsFunc(func(_ statedb.ReadTxn, bes iter.Seq2[loadbalancer.BackendParams, statedb.Revision], svc *loadbalancer.Service, fe *loadbalancer.Frontend) iter.Seq2[loadbalancer.BackendParams, statedb.Revision] {
 		require.NotNil(t, bes)
 		require.NotNil(t, svc)
 		require.NotNil(t, fe)

--- a/pkg/loadbalancer/writer/zones.go
+++ b/pkg/loadbalancer/writer/zones.go
@@ -8,16 +8,15 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
-	"github.com/cilium/stream"
+	"github.com/cilium/statedb"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/node"
 )
 
-// registerNodeZoneWatcher registers a background job that watches the [node.LocalNodeStore]
-// for changes to the node's topology zone. When it changes it updates the zone in [Writer]
-// and refreshes all frontends to re-select backends.
+// registerNodeZoneWatcher registers a background job that watches Table[LocalNode] and
+// refreshes the frontends with a configured TrafficDistribution to re-select backends.
 func registerNodeZoneWatcher(jg job.Group, p zoneWatcherParams) {
 	if p.Config.EnableServiceTopology {
 		jg.Add(job.OneShot("zone-watcher", zoneWatcher{p}.run))
@@ -27,9 +26,9 @@ func registerNodeZoneWatcher(jg job.Group, p zoneWatcherParams) {
 type zoneWatcherParams struct {
 	cell.In
 
-	Config         loadbalancer.Config
-	Writer         *Writer
-	LocalNodeStore *node.LocalNodeStore
+	Config loadbalancer.Config
+	Writer *Writer
+	Nodes  statedb.Table[*node.LocalNode]
 }
 
 type zoneWatcher struct {
@@ -37,14 +36,35 @@ type zoneWatcher struct {
 }
 
 func (zw zoneWatcher) run(ctx context.Context, health cell.Health) error {
-	var zone string
-	for n := range stream.ToChannel(ctx, zw.LocalNodeStore) {
-		newZone := n.Labels[corev1.LabelTopologyZone]
-		if newZone == zone {
-			continue
+	var oldZone string
+	for {
+		txn := zw.Writer.WriteTxn()
+		node, _, watch, found := zw.Nodes.GetWatch(txn, node.LocalNodeQuery)
+		updated := false
+		if found {
+			newZone := node.Labels[corev1.LabelTopologyZone]
+			if newZone != oldZone {
+				// Refresh all frontends associated with topology-aware services
+				// as the backend selection might change.
+				for fe := range zw.Writer.fes.All(txn) {
+					if fe.Service.TrafficDistribution != loadbalancer.TrafficDistributionDefault {
+						fe = fe.Clone()
+						zw.Writer.refreshFrontend(txn, fe)
+						zw.Writer.fes.Insert(txn, fe)
+						updated = true
+					}
+				}
+			}
 		}
-		zone = newZone
-		zw.Writer.updateZone(zone)
+		if updated {
+			txn.Commit()
+		} else {
+			txn.Abort()
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		}
 	}
-	return nil
 }

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -124,12 +124,12 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 			k8s.ResourcesCell,
 			k8sClient.FakeClientCell(),
 			kvstore.Cell(kvstore.DisabledBackendName),
+			node.LocalNodeStoreTestCell,
 
 			cell.Provide(
 				newWireguardAgent,
 				newWireguardConfig,
 
-				node.NewTestLocalNodeStore,
 				regeneration.NewFence,
 				tables.NewDeviceTable,
 				tables.NewNodeAddressTable,


### PR DESCRIPTION
Switch over to using Table[*node.LocalNode] to simplify looking up
the local node labels.
