### PR TITLE
vendor,treewide: Bump to StateDB v0.5.0 and update API usage

### DIFF
--- a/contrib/examples/statedb/example.go
+++ b/contrib/examples/statedb/example.go
@@ -19,7 +19,7 @@ type Example struct {
 }
 
 // TableHeader defines how cilium-dbg displays the header
-func (e *Example) TableHeader() []string {
+func (e Example) TableHeader() []string {
 	return []string{
 		"ID",
 		"CreatedAt",
@@ -27,7 +27,7 @@ func (e *Example) TableHeader() []string {
 }
 
 // TableRow defines how cilium-dbg displays a row
-func (e *Example) TableRow() []string {
+func (e Example) TableRow() []string {
 	return []string{
 		strconv.FormatUint(e.ID, 10),
 		e.CreatedAt.String(),
@@ -58,14 +58,11 @@ var (
 
 // NewExampleTable creates the table and registers it.
 func NewExampleTable(db *statedb.DB) (statedb.RWTable[Example], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		TableName,
 		idIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }
 
 // Cell provides the Table[Example] and registers a controller to populate

--- a/contrib/examples/statedb_k8s/pods.go
+++ b/contrib/examples/statedb_k8s/pods.go
@@ -33,14 +33,21 @@ var (
 
 // NewPodTable creates the pod table and registers it.
 func NewPodTable(db *statedb.DB) (statedb.RWTable[*v1.Pod], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTableAny(
+		db,
 		PodTableName,
+		podTableHeader,
+		podTableRow,
 		podNameIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
+}
+
+func podTableHeader() []string {
+	return []string{"Namespace", "Name"}
+}
+
+func podTableRow(pod *v1.Pod) []string {
+	return []string{pod.Namespace, pod.Name}
 }
 
 // PodListerWatcher is the lister watcher for pod objects. This is separately

--- a/daemon/k8s/namespaces.go
+++ b/daemon/k8s/namespaces.go
@@ -93,14 +93,11 @@ func NewNamespaceTableAndReflector(jg job.Group, db *statedb.DB, cs client.Clien
 }
 
 func NewNamespaceTable(db *statedb.DB) (statedb.RWTable[Namespace], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		NamespaceTableName,
 		NamespaceIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }
 
 func namespaceReflectorConfig(cs client.Clientset, namespaces statedb.RWTable[Namespace]) k8s.ReflectorConfig[Namespace] {

--- a/daemon/k8s/pods.go
+++ b/daemon/k8s/pods.go
@@ -109,14 +109,11 @@ func PodByName(namespace, name string) statedb.Query[LocalPod] {
 }
 
 func NewPodTable(db *statedb.DB) (statedb.RWTable[LocalPod], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		PodTableName,
 		PodNameIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }
 
 func podReflectorConfig(cs client.Clientset, pods statedb.RWTable[LocalPod]) k8s.ReflectorConfig[LocalPod] {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v0.0.0-20250731144630-28e7a35ed227
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.4.5
+	github.com/cilium/statedb v0.5.0
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.4.5 h1:WP1xbkAdDup0wOkhRZUJG/Wh4+ZLAOgl7yIIxJ3vIEo=
-github.com/cilium/statedb v0.4.5/go.mod h1:DlxX9OQi/nM8oumUuz8VjxXUtVRiEfbfo8Ri1YWNCGI=
+github.com/cilium/statedb v0.5.0 h1:GZtOa1QynwoIpf4j46+gF+CtOJzJAt8d94o92kOMK8M=
+github.com/cilium/statedb v0.5.0/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/agent/mode"
@@ -102,8 +101,6 @@ var Cell = cell.Module(
 		func(*agent.Controller) {},
 		// Register the bgp_metrics collector
 		bgp_metrics.RegisterCollector,
-		// Register statedb tables
-		statedb.RegisterTable[*tables.BGPReconcileError],
 	),
 
 	metrics.Metric(manager.NewBGPManagerMetrics),

--- a/pkg/bgpv1/manager/manager_test.go
+++ b/pkg/bgpv1/manager/manager_test.go
@@ -461,10 +461,7 @@ func TestStatedbReconcileErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := statedb.New()
-			reconcileErrTbl, err := tables.NewBGPReconcileErrorTable()
-			require.NoError(t, err)
-
-			err = db.RegisterTable(reconcileErrTbl)
+			reconcileErrTbl, err := tables.NewBGPReconcileErrorTable(db)
 			require.NoError(t, err)
 
 			testInstances := make(map[string]*instance.BGPInstance)

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
@@ -112,7 +112,6 @@ func newCRDStatusFixture(ctx context.Context, req *require.Assertions, l *slog.L
 				f.reconciler = out.Reconciler.(*StatusReconciler)
 				f.reconciler.reconcileInterval = 100 * time.Millisecond
 			}),
-		cell.Invoke(statedb.RegisterTable[*tables.BGPReconcileError]),
 		cell.Invoke(func(db *statedb.DB, table statedb.RWTable[*tables.BGPReconcileError]) {
 			f.db = db
 			f.reconcileErrTbl = table

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
@@ -791,21 +791,13 @@ func setupStateDB(routes []*tables.Route) (*statedb.DB, error) {
 	if len(routes) == 0 {
 		return db, nil
 	}
-	routeTable, err := tables.NewRouteTable()
+	routeTable, err := tables.NewRouteTable(db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default gateway table: %w", err)
 	}
-	deviceTable, err := tables.NewDeviceTable()
+	deviceTable, err := tables.NewDeviceTable(db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create device table: %w", err)
-	}
-	err = db.RegisterTable(routeTable)
-	if err != nil {
-		return nil, fmt.Errorf("failed to register default gateway table: %w", err)
-	}
-	err = db.RegisterTable(deviceTable)
-	if err != nil {
-		return nil, fmt.Errorf("failed to register device table: %w", err)
 	}
 	txn := db.WriteTxn(routeTable, deviceTable)
 	for _, r := range routes {

--- a/pkg/bgpv1/manager/tables/errors.go
+++ b/pkg/bgpv1/manager/tables/errors.go
@@ -83,8 +83,9 @@ var (
 	}
 )
 
-func NewBGPReconcileErrorTable() (statedb.RWTable[*BGPReconcileError], error) {
+func NewBGPReconcileErrorTable(db *statedb.DB) (statedb.RWTable[*BGPReconcileError], error) {
 	return statedb.NewTable(
+		db,
 		"bgp-reconcile-errors",
 		BGPReconcileErrorIndex,
 		BGPReconcileErrorInstance,

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
-	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	k8sTesting "k8s.io/client-go/testing"
@@ -172,26 +171,6 @@ func newFixture(t testing.TB, ctx context.Context, conf fixtureConfig) (*fixture
 	f.fakeClientSet.CiliumFakeClientset.Tracker().Add(&conf.policy)
 	f.fakeClientSet.SlimFakeClientset.Tracker().Add(&conf.secret)
 
-	// Create route and device tables
-	routeTable, err := tables.NewRouteTable()
-	require.NoError(t, err)
-
-	deviceTable, err := tables.NewDeviceTable()
-	require.NoError(t, err)
-
-	// Create a cell that registers the tables with the StateDB
-	registerTablesCell := cell.Module(
-		"register-tables",
-		"Registers the route and device tables with the StateDB",
-		cell.Invoke(func(db *statedb.DB) {
-			err := db.RegisterTable(routeTable)
-			require.NoError(t, err)
-
-			err = db.RegisterTable(deviceTable)
-			require.NoError(t, err)
-		}),
-	)
-
 	// Construct a new Hive with mocked out dependency cells.
 	f.cells = []cell.Cell{
 		cell.Config(k8sPkg.DefaultConfig),
@@ -221,18 +200,13 @@ func newFixture(t testing.TB, ctx context.Context, conf fixtureConfig) (*fixture
 			return f.fakeClientSet
 		}),
 
-		// Register the tables with the StateDB
-		registerTablesCell,
-
-		// Provide route table
-		cell.Provide(func() statedb.Table[*tables.Route] {
-			return routeTable.ToTable()
-		}),
-
-		// Provide device table
-		cell.Provide(func() statedb.Table[*tables.Device] {
-			return deviceTable.ToTable()
-		}),
+		// Provide route and device tables
+		cell.Provide(
+			tables.NewRouteTable,
+			tables.NewDeviceTable,
+			statedb.RWTable[*tables.Route].ToTable,  // Table[*Route]
+			statedb.RWTable[*tables.Device].ToTable, // Table[*Device]
+		),
 		// daemon config
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -106,7 +106,6 @@ func TestScript(t *testing.T) {
 					return &loadbalancer.TestConfig{}
 				},
 			),
-			cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 
 			// cecResourceParser and its friends.
 			cell.Group(

--- a/pkg/ciliumenvoyconfig/tables.go
+++ b/pkg/ciliumenvoyconfig/tables.go
@@ -122,15 +122,12 @@ var (
 )
 
 func NewCECTable(db *statedb.DB) (statedb.RWTable[*CEC], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		CECTableName,
 		cecNameIndex,
 		cecServiceIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }
 
 type EnvoyResourceOrigin string
@@ -310,9 +307,9 @@ func (r *EnvoyResource) TableRow() []string {
 		r.showListeners(),
 		r.showEndpoints(),
 		r.showReferences(),
-		string(r.Status.Kind),
+		r.Status.Kind.String(),
 		duration.HumanDuration(time.Since(r.Status.UpdatedAt)),
-		r.Status.Error,
+		r.Status.GetError(),
 	}
 }
 
@@ -346,13 +343,10 @@ var (
 )
 
 func NewEnvoyResourcesTable(db *statedb.DB) (statedb.RWTable[*EnvoyResource], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		EnvoyResourcesTableName,
 		envoyResourceNameIndex,
 		envoyResourceOriginIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }

--- a/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
@@ -14,7 +14,7 @@ cmp actual.json cec-expected.json
 
 db/show envoy-resources --format=json --out=actual.json
 sed '"updated-at":.*' '"updated-at": <redacted>,' actual.json
-sed '"id":.*' '"id": <redacted>' actual.json
+sed '"id":.*' '"id": <redacted>,' actual.json
 cmp actual.json envoy-resources-expected.json
 
 ##### 
@@ -182,9 +182,9 @@ spec:
     "Name": "echo"
   },
   "Status": {
-    "kind": "Done",
     "updated-at": <redacted>,
-    "id": <redacted>
+    "id": <redacted>,
+    "kind": "Done"
   },
   "Resources": {
     "Listeners": null,
@@ -266,9 +266,9 @@ spec:
     "Name": "envoy-lb-listener"
   },
   "Status": {
-    "kind": "Done",
     "updated-at": <redacted>,
-    "id": <redacted>
+    "id": <redacted>,
+    "kind": "Done"
   },
   "Resources": {
     "Listeners": [

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -135,7 +135,6 @@ func TestScript(t *testing.T) {
 					return nil
 				},
 			),
-			cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 
 			cell.Provide(func(db *statedb.DB) (kvstore.Client, uhive.ScriptCmdsOut) {
 				client := kvstore.NewInMemoryClient(db, "__all__")

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -86,12 +86,6 @@ var Cell = cell.Module(
 	datapath.NodeAddressingCell,
 	tables.DirectRoutingDeviceCell,
 
-	cell.Invoke(
-		statedb.RegisterTable[*tables.Device],
-		statedb.RegisterTable[*tables.L2AnnounceEntry],
-		statedb.RegisterTable[*tables.Route],
-	),
-
 	tunnel.Cell,
 	cell.Provide(fakeDevices),
 	link.Cell,

--- a/pkg/datapath/gneigh/processor_test.go
+++ b/pkg/datapath/gneigh/processor_test.go
@@ -130,9 +130,6 @@ func fixture(t *testing.T, c *Config) (
 		),
 
 		cell.Invoke(
-			// Register the devices table, required for it to work.
-			statedb.RegisterTable[*tables.Device],
-
 			func(dbParam *statedb.DB, devicesParam statedb.RWTable[*tables.Device], procParam *processor) {
 				db = dbParam
 				devices = devicesParam

--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -378,8 +378,7 @@ func TestOpsPruneEnabled(t *testing.T) {
 	fakeLogger := slog.New(slog.DiscardHandler)
 
 	db := statedb.New()
-	table, _ := statedb.NewTable("ipsets", tables.IPSetEntryIndex)
-	require.NoError(t, db.RegisterTable(table))
+	table, _ := statedb.NewTable(db, "ipsets", tables.IPSetEntryIndex)
 
 	txn := db.WriteTxn(table)
 	table.Insert(txn, &tables.IPSetEntry{

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -56,7 +56,6 @@ func TestReconciliationLoop(t *testing.T) {
 			db = db_
 			devices = devices_
 			store = store_
-			db.RegisterTable(devices_)
 			health = health_.NewScope("iptables-reconciler-test")
 			params = &reconcilerParams{
 				clock:          clock,

--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -40,8 +40,6 @@ var Cell = cell.Module(
 		tables.NewL2AnnounceTable,
 		statedb.RWTable[*tables.L2AnnounceEntry].ToTable,
 	),
-	cell.Invoke(statedb.RegisterTable[*tables.L2AnnounceEntry]),
-
 	cell.Invoke(NewL2ResponderReconciler),
 	cell.Provide(newNeighborNetlink),
 )

--- a/pkg/datapath/l2responder/l2responder_test.go
+++ b/pkg/datapath/l2responder/l2responder_test.go
@@ -48,7 +48,6 @@ func newFixture(t testing.TB) *fixture {
 		),
 
 		cell.Invoke(
-			statedb.RegisterTable[*tables.L2AnnounceEntry],
 			func(d *statedb.DB, lc cell.Lifecycle, h cell.Health, t statedb.RWTable[*tables.L2AnnounceEntry], j job.Group) {
 				db = d
 				tbl = t

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -49,11 +49,6 @@ var DevicesControllerCell = cell.Module(
 		tables.NewRouteTable,
 		tables.NewNeighborTable,
 	),
-	cell.Invoke(
-		statedb.RegisterTable[*tables.Device],
-		statedb.RegisterTable[*tables.Route],
-		statedb.RegisterTable[*tables.Neighbor],
-	),
 
 	cell.Provide(
 		newDevicesController,

--- a/pkg/datapath/linux/sysctl/sysctl.go
+++ b/pkg/datapath/linux/sysctl/sysctl.go
@@ -78,7 +78,6 @@ func newReconcilingSysctl(
 	fs afero.Fs,
 	_ reconciler.Reconciler[*tables.Sysctl], // needed to enforce the correct hive ordering
 ) Sysctl {
-	db.RegisterTable(settings)
 	return &reconcilingSysctl{db, settings, fs, cfg.ProcFs}
 }
 
@@ -342,7 +341,7 @@ func (sysctl *reconcilingSysctl) waitForReconciliation(name []string) error {
 				return nil
 			}
 			if obj.Status.Kind == reconciler.StatusKindError {
-				err = errors.New(obj.Status.Error)
+				err = errors.New(obj.Status.GetError())
 			}
 		}
 	}

--- a/pkg/datapath/linux/sysctl/sysctl_test.go
+++ b/pkg/datapath/linux/sysctl/sysctl_test.go
@@ -84,13 +84,7 @@ func TestWaitForReconciliation(t *testing.T) {
 	)
 
 	hive := hive.New(
-		cell.Provide(func(db *statedb.DB) (statedb.RWTable[*tables.Sysctl], statedb.Index[*tables.Sysctl, reconciler.StatusKind], error) {
-			return tables.NewSysctlTable(db)
-		}),
-		cell.Invoke(func(db *statedb.DB, settings statedb.RWTable[*tables.Sysctl]) {
-			db.RegisterTable(settings)
-		}),
-
+		cell.Provide(tables.NewSysctlTable),
 		cell.Invoke(func(statedb *statedb.DB, tb statedb.RWTable[*tables.Sysctl]) {
 			db = statedb
 			settings = tb

--- a/pkg/datapath/neighbor/desired_neighbor.go
+++ b/pkg/datapath/neighbor/desired_neighbor.go
@@ -80,7 +80,7 @@ func (dn *DesiredNeighbor) TableRow() []string {
 	return []string{
 		dn.IP.String(),
 		fmt.Sprintf("%d", dn.IfIndex),
-		string(dn.Status.Kind),
+		dn.Status.Kind.String(),
 	}
 }
 
@@ -97,13 +97,9 @@ var (
 )
 
 func newDesiredNeighborTable(db *statedb.DB) (statedb.RWTable[*DesiredNeighbor], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		"desired-neighbors",
 		DesiredNeighborIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	return tbl, db.RegisterTable(tbl)
 }

--- a/pkg/datapath/neighbor/forwardable_ip.go
+++ b/pkg/datapath/neighbor/forwardable_ip.go
@@ -95,6 +95,7 @@ var (
 // Return the read-only table for consumption, and the [ForwardableIPManager] for modification.
 func newForwardableIPTable(db *statedb.DB, config *CommonConfig) (*ForwardableIPManager, statedb.Table[*ForwardableIP], error) {
 	tbl, err := statedb.NewTable(
+		db,
 		"forwardable-ip",
 		ForwardableIPIndex,
 	)
@@ -107,8 +108,7 @@ func newForwardableIPTable(db *statedb.DB, config *CommonConfig) (*ForwardableIP
 			table:  tbl,
 			config: config,
 		},
-		tbl,
-		db.RegisterTable(tbl)
+		tbl, nil
 }
 
 // ForwardableIPManager manages modification of the ForwardableIP table.

--- a/pkg/datapath/tables/bandwidth_qdisc.go
+++ b/pkg/datapath/tables/bandwidth_qdisc.go
@@ -73,12 +73,9 @@ var (
 )
 
 func NewBandwidthQDiscTable(db *statedb.DB) (statedb.RWTable[*BandwidthQDisc], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		BandwidthQDiscTableName,
 		BandwidthQDiscIndex,
 	)
-	if err == nil {
-		err = db.RegisterTable(tbl)
-	}
-	return tbl, err
 }

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -45,8 +45,9 @@ var (
 	}
 )
 
-func NewDeviceTable() (statedb.RWTable[*Device], error) {
+func NewDeviceTable(db *statedb.DB) (statedb.RWTable[*Device], error) {
 	return statedb.NewTable(
+		db,
 		"devices",
 		DeviceIDIndex,
 		DeviceNameIndex,

--- a/pkg/datapath/tables/direct_routing_device_test.go
+++ b/pkg/datapath/tables/direct_routing_device_test.go
@@ -52,7 +52,6 @@ func TestDirectRoutingDevice(t *testing.T) {
 		),
 		DirectRoutingDeviceCell,
 		cell.Invoke(
-			statedb.RegisterTable[*Device],
 			func(db_ *statedb.DB, table statedb.RWTable[*Device], dev DirectRoutingDevice) {
 				db = db_
 				devicesTable = table
@@ -183,7 +182,6 @@ func TestDirectRoutingDevice_withConfig(t *testing.T) {
 				),
 				DirectRoutingDeviceCell,
 				cell.Invoke(
-					statedb.RegisterTable[*Device],
 					func(db_ *statedb.DB, table_ statedb.RWTable[*Device], dev DirectRoutingDevice) {
 						db = db_
 						devicesTable = table_

--- a/pkg/datapath/tables/ipset.go
+++ b/pkg/datapath/tables/ipset.go
@@ -45,14 +45,11 @@ var IPSetEntryIndex = statedb.Index[*IPSetEntry, IPSetEntryKey]{
 }
 
 func NewIPSetTable(db *statedb.DB) (statedb.RWTable[*IPSetEntry], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		IPSetsTableName,
 		IPSetEntryIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }
 
 func (s *IPSetEntry) TableHeader() []string {

--- a/pkg/datapath/tables/l2_announce.go
+++ b/pkg/datapath/tables/l2_announce.go
@@ -69,8 +69,9 @@ var (
 	}
 )
 
-func NewL2AnnounceTable() (statedb.RWTable[*L2AnnounceEntry], error) {
+func NewL2AnnounceTable(db *statedb.DB) (statedb.RWTable[*L2AnnounceEntry], error) {
 	return statedb.NewTable(
+		db,
 		"l2-announce",
 		L2AnnounceIDIndex,
 		L2AnnounceOriginIndex,

--- a/pkg/datapath/tables/neighbor.go
+++ b/pkg/datapath/tables/neighbor.go
@@ -75,8 +75,9 @@ var (
 	}
 )
 
-func NewNeighborTable() (statedb.RWTable[*Neighbor], error) {
+func NewNeighborTable(db *statedb.DB) (statedb.RWTable[*Neighbor], error) {
 	return statedb.NewTable(
+		db,
 		"neighbors",
 		NeighborIDIndex,
 		NeighborLinkIndex,

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -169,8 +169,9 @@ var (
 	)
 )
 
-func NewNodeAddressTable() (statedb.RWTable[NodeAddress], error) {
+func NewNodeAddressTable(db *statedb.DB) (statedb.RWTable[NodeAddress], error) {
 	return statedb.NewTable(
+		db,
 		NodeAddressTableName,
 		NodeAddressIndex,
 		NodeAddressDeviceNameIndex,
@@ -231,10 +232,6 @@ type nodeAddressController struct {
 // that depends on Table[NodeAddress] and allows it to populate it before
 // it is accessed.
 func newNodeAddressController(p nodeAddressControllerParams) (tbl statedb.Table[NodeAddress], err error) {
-	if err := p.DB.RegisterTable(p.NodeAddresses); err != nil {
-		return nil, err
-	}
-
 	n := nodeAddressController{nodeAddressControllerParams: p}
 	n.register()
 	return n.NodeAddresses, nil

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -807,8 +807,6 @@ func fixture(t *testing.T, addressScopeMax int, beforeStart func(*hive.Hive)) (*
 			devices = d
 			nodeAddrs = na
 			localNodeStore = lns
-			db.RegisterTable(d)
-			db.RegisterTable(r)
 		}),
 
 		// option.DaemonConfig needed for AddressMaxScope. This flag will move into NodeAddressConfig
@@ -1101,9 +1099,6 @@ func TestNodeAddressFromRoute(t *testing.T) {
 					devices = d
 					routes = r
 					nodeAddrs = na
-
-					db.RegisterTable(d)
-					db.RegisterTable(r)
 				}),
 			)
 

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -67,8 +67,9 @@ var (
 	}
 )
 
-func NewRouteTable() (statedb.RWTable[*Route], error) {
+func NewRouteTable(db *statedb.DB) (statedb.RWTable[*Route], error) {
 	return statedb.NewTable(
+		db,
 		"routes",
 		RouteIDIndex,
 		RouteLinkIndex,

--- a/pkg/datapath/tables/sysctl.go
+++ b/pkg/datapath/tables/sysctl.go
@@ -29,6 +29,7 @@ var (
 
 func NewSysctlTable(db *statedb.DB) (statedb.RWTable[*Sysctl], statedb.Index[*Sysctl, reconciler.StatusKind], error) {
 	tbl, err := statedb.NewTable(
+		db,
 		SysctlTableName,
 		SysctlNameIndex,
 		SysctlStatusIndex,

--- a/pkg/dial/resolver_test.go
+++ b/pkg/dial/resolver_test.go
@@ -192,8 +192,6 @@ func TestServiceBackendResolver(t *testing.T) {
 			func() kpr.KPRConfig { return kpr.KPRConfig{} },
 		),
 
-		cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
-
 		cell.Invoke(func(wr_ *writer.Writer, resolver_ *ServiceBackendResolver) {
 			wr = wr_
 			resolver = resolver_

--- a/pkg/dynamicconfig/table.go
+++ b/pkg/dynamicconfig/table.go
@@ -75,16 +75,12 @@ func (d DynamicConfig) TableRow() []string {
 }
 
 func NewConfigTable(db *statedb.DB) (statedb.RWTable[DynamicConfig], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		TableName,
 		keyIndex,
 		keyNameIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	return tbl, db.RegisterTable(tbl)
 }
 
 func RegisterConfigMapReflector(jobGroup job.Group, db *statedb.DB, rcs []k8s.ReflectorConfig[DynamicConfig], c Config) error {

--- a/pkg/dynamiclifecycle/table.go
+++ b/pkg/dynamiclifecycle/table.go
@@ -122,15 +122,12 @@ func newDynamicFeature(name DynamicFeatureName, deps []DynamicFeatureName, hooks
 
 func newDynamicFeatureTable(p tableParams) (statedb.RWTable[*DynamicFeature], error) {
 	tbl, err := statedb.NewTable(
+		p.DB,
 		TableName,
 		featureIndex,
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	if err := p.DB.RegisterTable(tbl); err != nil {
-		return tbl, err
 	}
 
 	if err := initializeTable(p, tbl); err != nil {

--- a/pkg/hive/health/cell.go
+++ b/pkg/hive/health/cell.go
@@ -49,14 +49,9 @@ var (
 )
 
 func newTablesPrivate(db *statedb.DB) (statedb.RWTable[types.Status], error) {
-	statusTable, err := statedb.NewTable(TableName,
+	return statedb.NewTable(
+		db,
+		TableName,
 		PrimaryIndex,
 		LevelIndex)
-	if err != nil {
-		return nil, err
-	}
-	if err := db.RegisterTable(statusTable); err != nil {
-		return nil, err
-	}
-	return statusTable, nil
 }

--- a/pkg/k8s/client/testutils/object_tracker.go
+++ b/pkg/k8s/client/testutils/object_tracker.go
@@ -57,11 +57,8 @@ type statedbObjectTracker struct {
 }
 
 func newStateDBObjectTracker(db *statedb.DB, log *slog.Logger) (*statedbObjectTracker, error) {
-	tbl, err := statedb.NewTable("k8s-object-tracker", objectIndex)
+	tbl, err := statedb.NewTable(db, "k8s-object-tracker", objectIndex)
 	if err != nil {
-		return nil, err
-	}
-	if err := db.RegisterTable(tbl); err != nil {
 		return nil, err
 	}
 	return &statedbObjectTracker{

--- a/pkg/k8s/resource/statedb_test.go
+++ b/pkg/k8s/resource/statedb_test.go
@@ -32,14 +32,17 @@ var (
 )
 
 func newNodesTable(db *statedb.DB) (statedb.RWTable[*corev1.Node], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTableAny(
+		db,
 		"nodes",
+		func() []string {
+			return []string{"Name"}
+		},
+		func(node *corev1.Node) []string {
+			return []string{node.Name}
+		},
 		nodeNameIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }
 
 func TestStateDBTableEventStream(t *testing.T) {

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -57,7 +57,6 @@ func newFixture(t testing.TB) *fixture {
 	hive.New(
 		cell.Provide(tables.NewL2AnnounceTable),
 		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], h_ cell.Health, j job.Registry, jg_ job.Group) {
-			d.RegisterTable(t)
 			db = d
 			tbl = t
 			jr = j
@@ -1119,9 +1118,7 @@ func TestL2AnnouncerLifecycle(t *testing.T) {
 	h := hive.New(
 		Cell,
 		cell.Provide(tables.NewL2AnnounceTable),
-		cell.Invoke(statedb.RegisterTable[*tables.L2AnnounceEntry]),
 		cell.Provide(tables.NewDeviceTable, statedb.RWTable[*tables.Device].ToTable),
-		cell.Invoke(statedb.RegisterTable[*tables.Device]),
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{
 				EnableL2Announcements: true,

--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -318,13 +318,10 @@ var (
 )
 
 func NewBackendsTable(db *statedb.DB) (statedb.RWTable[*Backend], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		BackendTableName,
 		backendAddrIndex,
 		backendServiceIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }

--- a/pkg/loadbalancer/benchmark/benchmark.go
+++ b/pkg/loadbalancer/benchmark/benchmark.go
@@ -451,7 +451,7 @@ func checkTables(db *statedb.DB, writer *writer.Writer, svcs []*slim_corev1.Serv
 				if fe.PortName != loadbalancer.FEPortName(want.Spec.Ports[0].Name) {
 					err = errors.Join(err, fmt.Errorf("Incorrect port name for frontend #%06d, got %v, want %v", i, fe.PortName, loadbalancer.FEPortName(want.Spec.Ports[0].Name)))
 				}
-				if fe.Status.Kind != "Done" {
+				if fe.Status.Kind != reconciler.StatusKindDone {
 					err = errors.Join(err, fmt.Errorf("Incorrect status for frontend #%06d, got %v, want %v", i, fe.Status.Kind, "Done"))
 				}
 				backends := slices.Collect(statedb.ToSeq(iter.Seq2[loadbalancer.BackendParams, statedb.Revision](fe.Backends)))
@@ -594,7 +594,6 @@ func testHive(maps lbmaps.LBMaps,
 				source.NewSources,
 			),
 			cell.Invoke(func(db *statedb.DB, nodeAddrs statedb.RWTable[tables.NodeAddress]) {
-				db.RegisterTable(nodeAddrs)
 				txn := db.WriteTxn(nodeAddrs)
 
 				for _, addr := range nodePortAddrs {

--- a/pkg/loadbalancer/cell/cell_test.go
+++ b/pkg/loadbalancer/cell/cell_test.go
@@ -44,7 +44,6 @@ func TestCell(t *testing.T) {
 				return &option.DaemonConfig{}
 			},
 		),
-		cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 	)
 	require.NoError(t, h.Populate(hivetest.Logger(t)))
 }

--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -117,9 +117,9 @@ func (fe *Frontend) TableRow() []string {
 		string(fe.PortName),
 		showBackends(fe.Backends),
 		redirectTo,
-		string(fe.Status.Kind),
+		fe.Status.Kind.String(),
 		duration.HumanDuration(time.Since(fe.Status.UpdatedAt)),
-		fe.Status.Error,
+		fe.Status.GetError(),
 	}
 }
 
@@ -241,13 +241,10 @@ const (
 )
 
 func NewFrontendsTable(cfg Config, db *statedb.DB) (statedb.RWTable[*Frontend], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		FrontendTableName,
 		frontendAddressIndex,
 		frontendServiceIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -103,8 +103,6 @@ func TestScript(t *testing.T) {
 						}
 					},
 				),
-
-				cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 			)
 
 			flags := pflag.NewFlagSet("", pflag.ContinueOnError)

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1073,8 +1073,8 @@ func TestBPFOps(t *testing.T) {
 
 	// Insert node addrs used for NodePort/HostPort
 	db := statedb.New()
-	nodeAddrs, _ := tables.NewNodeAddressTable()
-	require.NoError(t, db.RegisterTable(nodeAddrs))
+	nodeAddrs, err := tables.NewNodeAddressTable(db)
+	require.NoError(t, err)
 	wtxn := db.WriteTxn(nodeAddrs)
 	for _, n := range nodePortAddrs {
 		na := tables.NodeAddress{

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -102,7 +102,6 @@ func TestScript(t *testing.T) {
 						return &fakeSkipLBMap{}
 					},
 				),
-				cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 			)
 
 			flags := pflag.NewFlagSet("", pflag.ContinueOnError)

--- a/pkg/loadbalancer/redirectpolicy/skiplb.go
+++ b/pkg/loadbalancer/redirectpolicy/skiplb.go
@@ -154,7 +154,7 @@ func (dsl *desiredSkipLB) TableRow() []string {
 		dsl.LRPID.String(),
 		strings.Join(skipRedirects, ", "),
 		cookie,
-		string(dsl.Status.Kind),
+		dsl.Status.Kind.String(),
 		duration.HumanDuration(time.Since(dsl.Status.UpdatedAt)),
 	}
 }
@@ -186,15 +186,12 @@ var (
 )
 
 func newDesiredSkipLBTable(db *statedb.DB) (statedb.RWTable[*desiredSkipLB], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		"desired-skiplbmap",
 		desiredSkipLBPodIndex,
 		desiredSkipLBLRPIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }
 
 type skiplbOps struct {

--- a/pkg/loadbalancer/redirectpolicy/table.go
+++ b/pkg/loadbalancer/redirectpolicy/table.go
@@ -62,16 +62,13 @@ var (
 )
 
 func NewLRPTable(db *statedb.DB) (statedb.RWTable[*LocalRedirectPolicy], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		LRPTableName,
 		lrpIDIndex,
 		lrpServiceIndex,
 		lrpAddressIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }
 
 type lrpListerWatcher cache.ListerWatcher

--- a/pkg/loadbalancer/repl/main.go
+++ b/pkg/loadbalancer/repl/main.go
@@ -106,6 +106,5 @@ var Hive = hive.New(
 			return &cfg
 		},
 	),
-	cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 	lbcell.Cell,
 )

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -287,12 +287,9 @@ const (
 )
 
 func NewServicesTable(cfg Config, db *statedb.DB) (statedb.RWTable[*Service], error) {
-	tbl, err := statedb.NewTable(
+	return statedb.NewTable(
+		db,
 		ServiceTableName,
 		serviceNameIndex,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return tbl, db.RegisterTable(tbl)
 }

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -112,7 +112,6 @@ func TestScript(t *testing.T) {
 						return uhive.NewScriptCmds(testCommands{w, lns, ops, waitFn}.cmds())
 					},
 				),
-				cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 
 				lbcell.Cell,
 			)

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -20,7 +20,7 @@ db/show services -f json -o services-actual.json
 cmp services-actual.json services-expected.json
 db/show frontends -f json -o frontends-actual.json
 sed '"updated-at":.*' '"updated-at": <redacted>,' frontends-actual.json
-sed '"id":.*' '"id": <redacted>' frontends-actual.json
+sed '"id":.*' '"id": <redacted>,' frontends-actual.json
 cmp frontends-actual.json frontends-expected.json
 db/show backends -f json -o backends-actual.json
 cmp backends-actual.json backends-expected.json
@@ -82,9 +82,9 @@ Address              Instances
   "PortName": "http",
   "ServicePort": 80,
   "Status": {
-    "kind": "Done",
     "updated-at": <redacted>,
-    "id": <redacted>
+    "id": <redacted>,
+    "kind": "Done"
   },
   "Backends": [
     {
@@ -112,9 +112,9 @@ Address              Instances
   "PortName": "http",
   "ServicePort": 80,
   "Status": {
-    "kind": "Done",
     "updated-at": <redacted>,
-    "id": <redacted>
+    "id": <redacted>,
+    "kind": "Done"
   },
   "Backends": [
     {
@@ -215,9 +215,9 @@ frontendparams:
     portname: http
     serviceport: 80
 status:
-    kind: Done
     updated-at: <redacted>
     id: <redacted>
+    kind: Done
 backends:
     - address: 10.244.1.1:8080/TCP
       portnames:
@@ -240,9 +240,9 @@ frontendparams:
     portname: http
     serviceport: 80
 status:
-    kind: Done
     updated-at: <redacted>
     id: <redacted>
+    kind: Done
 backends:
     - address: '[2002::2]:8080/TCP'
       portnames:

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -56,7 +56,6 @@ func fixture(t testing.TB) (p testParams) {
 			source.NewSources,
 			func() kpr.KPRConfig { return kpr.KPRConfig{} },
 		),
-		cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 		cell.Invoke(func(p_ testParams) { p = p_ }),
 	)
 

--- a/pkg/maps/bwmap/cell.go
+++ b/pkg/maps/bwmap/cell.go
@@ -28,7 +28,6 @@ var Cell = cell.Module(
 		newThrottleMap,
 	),
 	cell.Invoke(
-		statedb.RegisterTable[Edt],
 		registerReconciler,
 		bpf.RegisterTablePressureMetricsJob[Edt, throttleMap],
 	),

--- a/pkg/maps/bwmap/table.go
+++ b/pkg/maps/bwmap/table.go
@@ -84,8 +84,9 @@ func NewEdt(endpointID uint16, direction uint8, bytesPerSecond uint64, prio uint
 	}
 }
 
-func NewEdtTable() (statedb.RWTable[Edt], error) {
+func NewEdtTable(db *statedb.DB) (statedb.RWTable[Edt], error) {
 	return statedb.NewTable(
+		db,
 		EdtTableName,
 		EdtIDIndex,
 	)

--- a/pkg/maps/nat/stats/cell.go
+++ b/pkg/maps/nat/stats/cell.go
@@ -108,12 +108,5 @@ var (
 )
 
 func newTables(db *statedb.DB) (statedb.RWTable[NatMapStats], error) {
-	statusTable, err := statedb.NewTable(TableName, Index)
-	if err != nil {
-		return nil, err
-	}
-	if err := db.RegisterTable(statusTable); err != nil {
-		return nil, err
-	}
-	return statusTable, nil
+	return statedb.NewTable(db, TableName, Index)
 }

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -25,7 +25,7 @@ var Cell = cell.Module(
 	"mtu",
 	"MTU discovery",
 
-	cell.ProvidePrivate(newTable),
+	cell.ProvidePrivate(NewMTUTable),
 	cell.Provide(
 		statedb.RWTable[RouteMTU].ToTable,
 		newForCell,
@@ -39,19 +39,6 @@ type MTU interface {
 	GetRouteMTU() int
 	GetRoutePostEncryptMTU() int
 	IsEnableRouteMTUForCNIChaining() bool
-}
-
-func newTable(db *statedb.DB) (statedb.RWTable[RouteMTU], error) {
-	tbl, err := NewMTUTable()
-	if err != nil {
-		return nil, err
-	}
-
-	if err := db.RegisterTable(tbl); err != nil {
-		return nil, err
-	}
-
-	return tbl, nil
 }
 
 type mtuParams struct {

--- a/pkg/mtu/table.go
+++ b/pkg/mtu/table.go
@@ -23,8 +23,9 @@ var (
 	}
 )
 
-func NewMTUTable() (statedb.RWTable[RouteMTU], error) {
+func NewMTUTable(db *statedb.DB) (statedb.RWTable[RouteMTU], error) {
 	return statedb.NewTable(
+		db,
 		"mtu",
 		MTURouteIndex,
 	)

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -1004,7 +1004,6 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 		}),
 		cell.Provide(tables.NewDeviceTable),                   // Provide statedb.RWTable[*tables.Device]
 		cell.Provide(statedb.RWTable[*tables.Device].ToTable), // Provide statedb.Table[*tables.Device] from RW table
-		cell.Invoke(statedb.RegisterTable[*tables.Device]),
 		cell.Module("node_manager", "Node Manager", cell.Provide(New)),
 		cell.Invoke(fn),
 	)

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -185,8 +185,6 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 			),
 
 			cell.Invoke(
-				statedb.RegisterTable[tables.NodeAddress],
-				statedb.RegisterTable[*tables.Device],
 				func(a types.WireguardAgent, n *nodediscovery.NodeDiscovery, s *node.LocalNodeStore, u nodeManager.NodeManager, i *ipcache.IPCache, c k8sSynced.CacheStatus) {
 					wgAgent = a.(*Agent)
 					nodeDiscovery = n

--- a/vendor/github.com/cilium/statedb/any_table.go
+++ b/vendor/github.com/cilium/statedb/any_table.go
@@ -137,13 +137,9 @@ func (t AnyTable) Changes(txn WriteTxn) (anyChangeIterator, error) {
 }
 
 func (t AnyTable) TableHeader() []string {
-	zero := t.Meta.proto()
-	if tw, ok := zero.(TableWritable); ok {
-		return tw.TableHeader()
-	}
-	return nil
+	return t.Meta.tableHeader()
 }
 
-func (t AnyTable) Proto() any {
-	return t.Meta.proto()
+func (t AnyTable) TableRow(obj any) []string {
+	return t.Meta.tableRowAny(obj)
 }

--- a/vendor/github.com/cilium/statedb/part/iterator.go
+++ b/vendor/github.com/cilium/statedb/part/iterator.go
@@ -48,7 +48,7 @@ func (it *Iterator[T]) Next() (key []byte, value T, ok bool) {
 			it.next = append(it.next, node.children())
 		}
 		if leaf := node.getLeaf(); leaf != nil {
-			key = leaf.key
+			key = leaf.fullKey()
 			value = leaf.value
 			ok = true
 			return

--- a/vendor/github.com/cilium/statedb/script.go
+++ b/vendor/github.com/cilium/statedb/script.go
@@ -66,7 +66,7 @@ func DBCmd(db *DB) script.Cmd {
 				"one    1",
 				"two    2",
 				"",
-				"> db/prefix -index=id example o",
+				"> db/prefix --index=id example o",
 				"Name   X",
 				"one    1",
 				"",
@@ -82,8 +82,8 @@ func DBCmd(db *DB) script.Cmd {
 			fmt.Fprintf(w, "Name\tObject count\tZombie objects\tIndexes\tInitializers\tGo type\tLast WriteTxn\n")
 			for _, tbl := range tbls {
 				idxs := strings.Join(tbl.Indexes(), ", ")
-				fmt.Fprintf(w, "%s\t%d\t%d\t%s\t%v\t%T\t%s\n",
-					tbl.Name(), tbl.NumObjects(txn), tbl.numDeletedObjects(txn), idxs, tbl.PendingInitializers(txn), tbl.proto(), tbl.getAcquiredInfo())
+				fmt.Fprintf(w, "%s\t%d\t%d\t%s\t%v\t%s\t%s\n",
+					tbl.Name(), tbl.NumObjects(txn), tbl.numDeletedObjects(txn), idxs, tbl.PendingInitializers(txn), tbl.typeName(), tbl.getAcquiredInfo())
 			}
 			w.Flush()
 			return nil, nil
@@ -106,6 +106,9 @@ func InitializedCmd(db *DB) script.Cmd {
 				"This command is useful in tests where you might need to wait",
 				"for e.g. a background reflector to have started watching before",
 				"inserting objects.",
+			},
+			AutocompleteArgs: func(_ *script.State, before []string, cur string) []string {
+				return autocompleteTableName(db, before, cur)
 			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
@@ -158,6 +161,49 @@ func InitializedCmd(db *DB) script.Cmd {
 	)
 }
 
+func autocompleteTableName(db *DB, before []string, cur string) []string {
+	var suggestions []string
+	for _, tbl := range db.GetTables(db.ReadTxn()) {
+		if cur == "" || strings.HasPrefix(tbl.Name(), cur) {
+			suggestions = append(suggestions, tbl.Name())
+		}
+	}
+	slices.Sort(suggestions)
+	return suggestions
+}
+
+func autocompleteColumnNames(db *DB, args []string, cur string) []string {
+	if len(args) < 1 {
+		return nil
+	}
+
+	tbl, _, err := getTable(db, args[0])
+	if err != nil {
+		return nil
+	}
+
+	parts := strings.Split(cur, ",")
+
+	var suggestions []string
+	for _, col := range tbl.TableHeader() {
+		if cur == "" {
+			suggestions = append(suggestions, col)
+			continue
+		}
+
+		if slices.Contains(parts, col) {
+			// Already specified, skip.
+			continue
+		}
+
+		if strings.HasPrefix(col, parts[len(parts)-1]) {
+			newList := append(parts[:len(parts)-1], col)
+			suggestions = append(suggestions, strings.Join(newList, ","))
+		}
+	}
+	return suggestions
+}
+
 func ShowCmd(db *DB) script.Cmd {
 	return script.Command(
 		script.CmdUsage{
@@ -173,11 +219,28 @@ func ShowCmd(db *DB) script.Cmd {
 				"a file instead with the -o flag.",
 				"",
 				"By default the table is shown in the table format.",
-				"For YAML use '-format=yaml' and for JSON use '-format=json'",
+				"For YAML use '--format=yaml' and for JSON use '--format=json'",
 				"",
-				"To only show specific columns use the '-columns' flag. The",
+				"To only show specific columns use the '--columns' flag. The",
 				"columns are as specified by 'TableHeader()' method.",
 				"This flag is only supported with 'table' formatting.",
+			},
+			AutocompleteArgs: func(_ *script.State, before []string, cur string) []string {
+				// Only complete table names
+				if len(before) > 0 {
+					return nil
+				}
+
+				return autocompleteTableName(db, before, cur)
+			},
+			AutocompleteFlag: func(state *script.State, args []string, flag, cur string) []string {
+				switch flag {
+				case "format":
+					return []string{"table", "yaml", "json"}
+				case "columns":
+					return autocompleteColumnNames(db, args, cur)
+				}
+				return nil
 			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
@@ -235,13 +298,21 @@ func CompareCmd(db *DB) script.Cmd {
 				"The comparison is retried until a timeout (1s default).",
 				"",
 				"The file should be formatted in the same style as",
-				"the output from 'db/show -format=table'. Indentation",
+				"the output from 'db/show --format=table'. Indentation",
 				"does not matter as long as header is aligned with the data.",
 				"",
 				"Not all columns need to be specified. Remove the columns",
 				"from the file you do not want compared.",
 				"",
-				"The rows can be filtered with the -grep flag.",
+				"The rows can be filtered with the --grep flag.",
+			},
+			AutocompleteArgs: func(_ *script.State, before []string, cur string) []string {
+				// Only complete table names
+				if len(before) > 0 {
+					return nil
+				}
+
+				return autocompleteTableName(db, before, cur)
 			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
@@ -358,6 +429,14 @@ func EmptyCmd(db *DB) script.Cmd {
 		script.CmdUsage{
 			Summary: "Assert that given table(s) are empty",
 			Args:    "table",
+			AutocompleteArgs: func(_ *script.State, before []string, cur string) []string {
+				// Only complete table names
+				if len(before) > 0 {
+					return nil
+				}
+
+				return autocompleteTableName(db, before, cur)
+			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
 			txn := db.ReadTxn()
@@ -384,6 +463,14 @@ func InsertCmd(db *DB) script.Cmd {
 				"Insert one or more objects into a table. The input files",
 				"are expected to be YAML.",
 			},
+			AutocompleteArgs: func(_ *script.State, before []string, cur string) []string {
+				// Only complete table names
+				if len(before) > 0 {
+					return nil
+				}
+
+				return autocompleteTableName(db, before, cur)
+			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
 			return insertOrDelete(true, db, s, args...)
@@ -400,6 +487,14 @@ func DeleteCmd(db *DB) script.Cmd {
 				"Delete one or more objects from the table. The input files",
 				"are expected to be YAML and need to specify enough of the",
 				"object to construct the primary key",
+			},
+			AutocompleteArgs: func(_ *script.State, before []string, cur string) []string {
+				// Only complete table names
+				if len(before) > 0 {
+					return nil
+				}
+
+				return autocompleteTableName(db, before, cur)
 			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
@@ -519,6 +614,23 @@ func queryCmd(db *DB, query int, summary string, detail []string) script.Cmd {
 				fs.Bool("delete", false, "Delete all matching objects")
 			},
 			Detail: detail,
+			AutocompleteArgs: func(_ *script.State, before []string, cur string) []string {
+				// Only complete table names
+				if len(before) > 0 {
+					return nil
+				}
+
+				return autocompleteTableName(db, before, cur)
+			},
+			AutocompleteFlag: func(state *script.State, args []string, flag, cur string) []string {
+				switch flag {
+				case "format":
+					return []string{"table", "yaml", "json"}
+				case "columns":
+					return autocompleteColumnNames(db, args, cur)
+				}
+				return nil
+			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
 			return runQueryCmd(query, db, s, args)
@@ -626,6 +738,14 @@ func WatchCmd(db *DB) script.Cmd {
 				"Watch a table for changes. Streams each insert or delete",
 				"that happens to the table.",
 			},
+			AutocompleteArgs: func(_ *script.State, before []string, cur string) []string {
+				// Only complete table names
+				if len(before) > 0 {
+					return nil
+				}
+
+				return autocompleteTableName(db, before, cur)
+			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
 			if len(args) < 1 {
@@ -691,7 +811,7 @@ func firstOfSeq2[A, B any](it iter.Seq2[A, B]) iter.Seq2[A, B] {
 
 func writeObjects(tbl *AnyTable, it iter.Seq2[any, Revision], w io.Writer, columns []string, format string) error {
 	if len(columns) > 0 && format != "table" {
-		return fmt.Errorf("-columns not supported with non-table formats")
+		return fmt.Errorf("--columns not supported with non-table formats")
 	}
 	switch format {
 	case "yaml":
@@ -746,7 +866,7 @@ func writeObjects(tbl *AnyTable, it iter.Seq2[any, Revision], w io.Writer, colum
 		fmt.Fprintf(tw, "%s\n", strings.Join(header, "\t"))
 
 		for obj := range it {
-			row := takeColumns(obj.(TableWritable).TableRow(), idxs)
+			row := takeColumns(tbl.TableRow(obj), idxs)
 			fmt.Fprintf(tw, "%s\n", strings.Join(row, "\t"))
 		}
 		return tw.Flush()

--- a/vendor/github.com/cilium/statedb/types.go
+++ b/vendor/github.com/cilium/statedb/types.go
@@ -249,11 +249,13 @@ type tableInternal interface {
 	secondary() map[string]anyIndexer      // Secondary indexers (if any)
 	sortableMutex() internal.SortableMutex // The sortable mutex for locking the table for writing
 	anyChanges(txn WriteTxn) (anyChangeIterator, error)
-	proto() any                             // Returns the zero value of 'Obj', e.g. the prototype
+	typeName() string                       // Returns the 'Obj' type as string
 	unmarshalYAML(data []byte) (any, error) // Unmarshal the data into 'Obj'
 	numDeletedObjects(txn ReadTxn) int      // Number of objects in graveyard
 	acquired(*writeTxn)
 	getAcquiredInfo() string
+	tableHeader() []string
+	tableRowAny(any) []string
 }
 
 type ReadTxn interface {
@@ -397,7 +399,7 @@ type Indexer[Obj any] interface {
 }
 
 // TableWritable is a constraint for objects that implement tabular
-// pretty-printing. Used in "cilium-dbg statedb" sub-commands.
+// pretty-printing. Used by the "db" script commands to render a table.
 type TableWritable interface {
 	// TableHeader returns the header columns that are independent of the
 	// object.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -322,7 +322,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.4.5
+# github.com/cilium/statedb v0.5.0
 ## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This bumps to StateDB v0.5.0. The treewide changes are due to: 

1) RegisterTable is gone and NewTable takes DB as argument and registers for you 
2) TableWritable is now a constraint on the object type

See https://github.com/cilium/statedb/releases/tag/v0.5.0 for full list of changes.

This also brings tab completion in hive script for StateDB commands (thanks @dylandreimerink)! This is for now available
in script tests (or in `pkg/loadbalancer/repl` if you want to try it) with the Cilium Shell support coming later.