### PR TITLE
Add missing feature metrics

### DIFF
--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -28,10 +28,11 @@ type Metrics struct {
 	CPIdentityAllocation          metric.Vec[metric.Gauge]
 	CPCiliumEndpointSlicesEnabled metric.Gauge
 
-	DPMode         metric.Vec[metric.Gauge]
-	DPChaining     metric.Vec[metric.Gauge]
-	DPIP           metric.Vec[metric.Gauge]
-	DPDeviceConfig metric.Vec[metric.Gauge]
+	DPMode           metric.Vec[metric.Gauge]
+	DPChaining       metric.Vec[metric.Gauge]
+	DPIP             metric.Vec[metric.Gauge]
+	DPDeviceConfig   metric.Vec[metric.Gauge]
+	DPEndpointRoutes metric.Gauge
 
 	NPHostFirewallEnabled        metric.Gauge
 	NPLocalRedirectPolicyEnabled metric.Gauge
@@ -344,6 +345,13 @@ func NewMetrics(withDefaults bool) Metrics {
 					)
 				}(),
 			},
+		}),
+
+		DPEndpointRoutes: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Endpoint Routes enabled in the datapath",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemDP,
+			Name:      "endpoint_routes_enabled",
 		}),
 
 		NPHostFirewallEnabled: metric.NewGauge(metric.GaugeOpts{
@@ -986,6 +994,10 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 
 	deviceMode := config.DatapathMode
 	m.DPDeviceConfig.WithLabelValues(deviceMode).Add(1)
+
+	if config.EnableEndpointRoutes {
+		m.DPEndpointRoutes.Add(1)
+	}
 
 	if config.EnableHostFirewall {
 		m.NPHostFirewallEnabled.Add(1)

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -427,6 +427,17 @@ func NewMetrics(withDefaults bool) Metrics {
 					)
 				}(),
 			},
+			{
+				Name: "strict_mode_enabled", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						"true",
+						"false",
+					)
+				}(),
+			},
 		}),
 
 		ACLBKubeProxyReplacementEnabled: metric.NewGauge(metric.GaugeOpts{
@@ -1019,19 +1030,21 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 		m.NPCIDRPoliciesToNodes.WithLabelValues(mode).Add(1)
 	}
 
+	strictMode := "false"
+	if config.EnableEncryptionStrictMode {
+		strictMode = "true"
+	}
+
+	node2nodeEnabled := "false"
+	if config.EncryptNode {
+		node2nodeEnabled = "true"
+	}
+
 	if config.EnableIPSec {
-		if config.EncryptNode {
-			m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncIPSec, "true").Add(1)
-		} else {
-			m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncIPSec, "false").Add(1)
-		}
+		m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncIPSec, node2nodeEnabled, strictMode).Add(1)
 	}
 	if wgCfg.Enabled() {
-		if config.EncryptNode {
-			m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncWireGuard, "true").Add(1)
-		} else {
-			m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncWireGuard, "false").Add(1)
-		}
+		m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncWireGuard, node2nodeEnabled, strictMode).Add(1)
 	}
 
 	if kprCfg.KubeProxyReplacement == option.KubeProxyReplacementTrue {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -365,9 +365,7 @@ func NewMetrics(withDefaults bool) Metrics {
 			Name:      "kernel_version",
 		}, metric.Labels{
 			{
-				Name: "version", Values: func() metric.Values {
-					return nil
-				}(),
+				Name: "version",
 			},
 		}),
 

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -689,21 +689,25 @@ func TestUpdateEncryptionMode(t *testing.T) {
 		enableIPSec               bool
 		enableWireguard           bool
 		enableNode2NodeEncryption bool
+		enableStrictMode          bool
 
 		expectEncryptionMode      string
 		expectNode2NodeEncryption string
+		expectStrictMode          string
 	}{
 		{
 			name:                      "IPSec enabled",
 			enableIPSec:               true,
 			expectEncryptionMode:      advConnNetEncIPSec,
 			expectNode2NodeEncryption: "false",
+			expectStrictMode:          "false",
 		},
 		{
 			name:                      "IPSec disabled",
 			enableIPSec:               false,
 			expectEncryptionMode:      "",
 			expectNode2NodeEncryption: "",
+			expectStrictMode:          "",
 		},
 		{
 			name:                      "IPSec enabled w/ node2node",
@@ -711,12 +715,31 @@ func TestUpdateEncryptionMode(t *testing.T) {
 			enableNode2NodeEncryption: true,
 			expectEncryptionMode:      advConnNetEncIPSec,
 			expectNode2NodeEncryption: "true",
+			expectStrictMode:          "false",
+		},
+		{
+			name:                      "IPSec enabled w/ strict mode",
+			enableIPSec:               true,
+			enableStrictMode:          true,
+			expectEncryptionMode:      advConnNetEncIPSec,
+			expectNode2NodeEncryption: "false",
+			expectStrictMode:          "true",
+		},
+		{
+			name:                      "IPSec enabled w/ node2node and strict mode",
+			enableIPSec:               true,
+			enableNode2NodeEncryption: true,
+			enableStrictMode:          true,
+			expectEncryptionMode:      advConnNetEncIPSec,
+			expectNode2NodeEncryption: "true",
+			expectStrictMode:          "true",
 		},
 		{
 			name:                      "Wireguard enabled",
 			enableWireguard:           true,
 			expectEncryptionMode:      advConnNetEncWireGuard,
 			expectNode2NodeEncryption: "false",
+			expectStrictMode:          "false",
 		},
 		{
 			name:                      "Wireguard enabled w/ node2node",
@@ -724,6 +747,24 @@ func TestUpdateEncryptionMode(t *testing.T) {
 			enableNode2NodeEncryption: true,
 			expectEncryptionMode:      advConnNetEncWireGuard,
 			expectNode2NodeEncryption: "true",
+			expectStrictMode:          "false",
+		},
+		{
+			name:                      "Wireguard enabled w/ strict mode",
+			enableWireguard:           true,
+			enableStrictMode:          true,
+			expectEncryptionMode:      advConnNetEncWireGuard,
+			expectNode2NodeEncryption: "false",
+			expectStrictMode:          "true",
+		},
+		{
+			name:                      "Wireguard enabled w/ node2node and strict mode",
+			enableWireguard:           true,
+			enableNode2NodeEncryption: true,
+			enableStrictMode:          true,
+			expectEncryptionMode:      advConnNetEncWireGuard,
+			expectNode2NodeEncryption: "true",
+			expectStrictMode:          "true",
 		},
 	}
 
@@ -731,13 +772,14 @@ func TestUpdateEncryptionMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
-				IPAM:                   defaultIPAMModes[0],
-				EnableIPv4:             true,
-				IdentityAllocationMode: defaultIdentityAllocationModes[0],
-				DatapathMode:           defaultDeviceModes[0],
-				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
-				EnableIPSec:            tt.enableIPSec,
-				EncryptNode:            tt.enableNode2NodeEncryption,
+				IPAM:                       defaultIPAMModes[0],
+				EnableIPv4:                 true,
+				IdentityAllocationMode:     defaultIdentityAllocationModes[0],
+				DatapathMode:               defaultDeviceModes[0],
+				NodePortAcceleration:       defaultNodePortModeAccelerations[0],
+				EnableIPSec:                tt.enableIPSec,
+				EncryptNode:                tt.enableNode2NodeEncryption,
+				EnableEncryptionStrictMode: tt.enableStrictMode,
 			}
 
 			lbConfig := loadbalancer.DefaultConfig
@@ -753,14 +795,18 @@ func TestUpdateEncryptionMode(t *testing.T) {
 			// Check that only the expected mode's counter is incremented
 			for _, encMode := range defaultEncryptionModes {
 				for _, node2node := range []string{"true", "false"} {
-					counter, err := metrics.ACLBTransparentEncryption.GetMetricWithLabelValues(encMode, node2node)
-					assert.NoError(t, err)
+					for _, strictMode := range []string{"true", "false"} {
+						counter, err := metrics.ACLBTransparentEncryption.GetMetricWithLabelValues(encMode, node2node, strictMode)
+						assert.NoError(t, err)
 
-					counterValue := counter.Get()
-					if encMode == tt.expectEncryptionMode && node2node == tt.expectNode2NodeEncryption {
-						assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", encMode)
-					} else {
-						assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", encMode)
+						counterValue := counter.Get()
+						if encMode == tt.expectEncryptionMode &&
+							node2node == tt.expectNode2NodeEncryption &&
+							strictMode == tt.expectStrictMode {
+							assert.Equal(t, float64(1), counterValue, "Expected mode %s with node2node=%s and strict=%s to be incremented", encMode, node2node, strictMode)
+						} else {
+							assert.Equal(t, float64(0), counterValue, "Expected mode %s with node2node=%s and strict=%s to remain at 0", encMode, node2node, strictMode)
+						}
 					}
 				}
 			}

--- a/pkg/metrics/features/operator/cell.go
+++ b/pkg/metrics/features/operator/cell.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/operator/pkg/lbipam"
 	"github.com/cilium/cilium/operator/pkg/nodeipam"
+	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
@@ -77,9 +78,14 @@ func (p featuresParams) IsNodeIPAMEnabled() bool {
 	return p.NodeIPAM.IsEnabled()
 }
 
+func (p featuresParams) K8sVersion() string {
+	return k8sversion.Version().String()
+}
+
 type enabledFeatures interface {
 	IsIngressControllerEnabled() bool
 	IsLBIPAMEnabled() bool
 	GetLoadBalancerL7() string
 	IsNodeIPAMEnabled() bool
+	K8sVersion() string
 }

--- a/pkg/metrics/metric/metric.go
+++ b/pkg/metrics/metric/metric.go
@@ -331,6 +331,9 @@ func (l *labelSet) namesToValues() map[string]map[string]struct{} {
 func (l *labelSet) checkLabels(labels prometheus.Labels) error {
 	for name, value := range labels {
 		if lvs, ok := l.namesToValues()[name]; ok {
+			if len(lvs) == 0 {
+				continue
+			}
 			if _, ok := lvs[value]; !ok {
 				return fmt.Errorf("unexpected label vector value for label %q: value %q not defined in label range %v",
 					name, value, maps.Keys(lvs))
@@ -347,6 +350,9 @@ func (l *labelSet) checkLabelValues(lvs []string) error {
 		return fmt.Errorf("unexpected label vector length: expected %d, got %d", len(l.lbls), len(lvs))
 	}
 	for i, label := range l.lbls {
+		if len(label.Values) == 0 {
+			continue
+		}
 		if _, ok := label.Values[lvs[i]]; !ok {
 			return fmt.Errorf("unexpected label vector value for label %q: value %q not defined in label range %v",
 				label.Name, lvs[i], maps.Keys(label.Values))

--- a/pkg/version/version_unix.go
+++ b/pkg/version/version_unix.go
@@ -17,15 +17,26 @@ import (
 )
 
 func parseKernelVersion(ver string) (semver.Version, error) {
+	// Trim null bytes and whitespace that may come from C strings
+	ver = strings.TrimRight(ver, "\x00")
+	ver = strings.TrimSpace(ver)
+
 	verStrs := strings.Split(ver, ".")
 
 	// We are assuming the kernel version will be one of the following:
 	// 4.9.17-040917-generic or 4.9-040917-generic or 4-generic
-	// So as observed, the kernel value is N.N.N-m or N.N-m or N-m
-	// This implies the len(verStrs) should be between 1 and 3
+	// 6.15.8-200.fc42.x86_64 (newer format with additional dot-separated components)
+	// So as observed, the kernel value is N.N.N-m or N.N-m or N-m or N.N.N-m.additional.components
+	// This implies the len(verStrs) should be at least 1, but can be more than 3
 
-	if len(verStrs) < 1 || len(verStrs) > 3 {
+	if len(verStrs) < 1 {
 		return semver.Version{}, fmt.Errorf("unable to get kernel version from %q", ver)
+	}
+
+	// Take only the first 3 components for semantic version parsing
+	// If there are more than 3 components, we'll only use the first 3
+	if len(verStrs) > 3 {
+		verStrs = verStrs[:3]
 	}
 
 	// Given the observations, we use regular expression to extract

--- a/pkg/version/version_unix_test.go
+++ b/pkg/version/version_unix_test.go
@@ -37,6 +37,18 @@ func TestParseKernelVersion(t *testing.T) {
 		{"6.5-15-generic", mustHaveVersion(t, "6.5.0")},
 		{"6.5.2-rc8+", mustHaveVersion(t, "6.5.2")},
 		{"6-generic", mustHaveVersion(t, "6.0.0")},
+		// Test cases for versions with more than 3 dot-separated components
+		{"6.15.8-200.fc42.x86_64", mustHaveVersion(t, "6.15.8")},
+		{"5.4.0-42.46.1-generic", mustHaveVersion(t, "5.4.0")},
+		{"6.1.21-1.el9.x86_64", mustHaveVersion(t, "6.1.21")},
+		{"6.2.0-20.20.1.el9_1.x86_64", mustHaveVersion(t, "6.2.0")},
+		// Test cases with null bytes (from C strings)
+		{"6.15.8-200.fc42.x86_64\x00\x00\x00", mustHaveVersion(t, "6.15.8")},
+		{"5.4.0-generic\x00\x00\x00\x00\x00", mustHaveVersion(t, "5.4.0")},
+		// Test cases with whitespace
+		{"6.1.0-generic ", mustHaveVersion(t, "6.1.0")},
+		{" 5.15.0-generic", mustHaveVersion(t, "5.15.0")},
+		{" 6.0.0-generic ", mustHaveVersion(t, "6.0.0")},
 	}
 	for _, tt := range flagtests {
 		s, err := parseKernelVersion(tt.in)


### PR DESCRIPTION
Some features can be presented as metrics. Namely:
Kernel version
Strict encryption mode
Endpoint Routes
K8s version.

While, not as metrics but as cluster status, were added to the `cilium-cli feature summary`:
NodeLocalDNS
KubeProxy

```release-note
Add `kernel_version`, `endpoint_routes_enabled`, `strict_mode_enabled` and `kubernetes_version` feature metrics.
```