### PR TITLE
ci: Temporarily disable go caches for privileged unit tests

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -431,7 +431,8 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host
-            make GOCACHE="/go-caches/go-build" GOMODCACHE="/go-caches/pkg" SKIP_COVERAGE=1 LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml" tests-privileged-only GO=go${{ env.go-version }}
+            # TODO: re-enable go caches (GOCACHE="/go-caches/go-build" GOMODCACHE="/go-caches/pkg") once images with larger disk size from https://github.com/cilium/little-vm-helper-images/pull/960 are in use
+            make SKIP_COVERAGE=1 LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml" tests-privileged-only GO=go${{ env.go-version }}
 
       - name: Copy Go cache to host
         id: copy-go-cache


### PR DESCRIPTION
As we are hitting disk size limits of LVH kind images, we need to temporarily disable the go caches. They can be re-enabled once images with the larger disk size from https://github.com/cilium/little-vm-helper-images/pull/960 are used.

