### PR TITLE
ipsec: fix privileged tests

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -72,7 +72,7 @@ var (
 	log *slog.Logger
 )
 
-func TestAll(t *testing.T) {
+func TestPrivilegedAll(t *testing.T) {
 	for _, tt := range []string{"ipv4", "ipv6"} {
 		t.Run(tt, func(t *testing.T) {
 			t.Run("testInvalidLoadKeys", func(t *testing.T) {
@@ -107,7 +107,7 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func TestLoadKeysNoFile(t *testing.T) {
+func TestPrivilegedLoadKeysNoFile(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
 	_, _, err := LoadIPSecKeysFile(log, path)
@@ -137,7 +137,7 @@ func testInvalidLoadKeys(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLoadKeys(t *testing.T) {
+func TestPrivilegedLoadKeys(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
 	testCases := [][]byte{keysDat, keysNullDat, keysAeadDat, keysAeadDat256}
@@ -151,7 +151,7 @@ func TestLoadKeys(t *testing.T) {
 	}
 }
 
-func TestLoadKeysLenChange(t *testing.T) {
+func TestPrivilegedLoadKeysLenChange(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
 	keys := bytes.NewReader(append(keysDat, keysNullDat...))
@@ -159,7 +159,7 @@ func TestLoadKeysLenChange(t *testing.T) {
 	require.ErrorContains(t, err, "invalid key rotation: key length must not change")
 }
 
-func TestLoadKeysSameSPI(t *testing.T) {
+func TestPrivilegedLoadKeysSameSPI(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
 	keys := bytes.NewReader(keysSameSpiDat)
@@ -167,7 +167,7 @@ func TestLoadKeysSameSPI(t *testing.T) {
 	require.ErrorContains(t, err, "invalid SPI: changing IPSec keys requires incrementing the key id")
 }
 
-func TestParseSPI(t *testing.T) {
+func TestPrivilegedParseSPI(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
 	testCases := []struct {


### PR DESCRIPTION
This commit fixed some test name in the ipsec suite by adding the "TestPrivileged" prefix, to make sure they're executed and not skipped.
