### PR TITLE
testutils: differentiate {Test,Benchmark}Privileged and fix benchmarks

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1436,7 +1436,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodePodCIDRsChurnIPSec(t *testing.T) 
 	}
 }
 
-func BenchmarkAll(b *testing.B) {
+func BenchmarkPrivilegedAll(b *testing.B) {
 	for _, tt := range []string{"IPv4", "IPv6", "dual"} {
 		b.Run(tt, func(b *testing.B) {
 			b.Run("BenchmarkNodeUpdate", func(b *testing.B) {

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -269,7 +269,7 @@ func BenchmarkCompileOnly(b *testing.B) {
 
 // BenchmarkReplaceDatapath compiles the datapath program, then benchmarks only
 // the loading of the program into the kernel.
-func BenchmarkReplaceDatapath(b *testing.B) {
+func BenchmarkPrivilegedReplaceDatapath(b *testing.B) {
 	ctx, cancel := context.WithTimeout(context.Background(), benchTimeout)
 	defer cancel()
 

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -55,7 +55,7 @@ func BenchmarkMapBatchLookup(b *testing.B) {
 	}
 }
 
-func Benchmark_MapUpdate(b *testing.B) {
+func BenchmarkPrivileged_MapUpdate(b *testing.B) {
 	setupCTMap(b)
 
 	m := newMap(MapNameTCP4Global+"_test", mapTypeIPv4TCPGlobal)
@@ -841,15 +841,15 @@ func populateFakeDataCTMap4(tb testing.TB, m CtMap, size int) map[*CtKey4Global]
 	return cache
 }
 
-func BenchmarkCtGcTcpXL(t *testing.B) {
+func BenchmarkPrivilegedCtGcTcpXL(t *testing.B) {
 	benchmarkCtGc(t, 1<<24) // max size
 }
 
-func BenchmarkCtGcTcpL(t *testing.B) {
+func BenchmarkPrivilegedCtGcTcpL(t *testing.B) {
 	benchmarkCtGc(t, 1<<22)
 }
 
-func BenchmarkCtGcTcpM(t *testing.B) {
+func BenchmarkPrivilegedCtGcTcpM(t *testing.B) {
 	benchmarkCtGc(t, 1<<17)
 }
 

--- a/pkg/maps/ctmap/per_cluster_ctmap_test.go
+++ b/pkg/maps/ctmap/per_cluster_ctmap_test.go
@@ -26,7 +26,7 @@ func setup(tb testing.TB) {
 	ClusterOuterMapNameTestOverride("test")
 }
 
-func BenchmarkPerClusterCTMapUpdate(b *testing.B) {
+func BenchmarkPrivilegedPerClusterCTMapUpdate(b *testing.B) {
 
 	setup(b)
 
@@ -46,7 +46,7 @@ func BenchmarkPerClusterCTMapUpdate(b *testing.B) {
 	b.StopTimer()
 }
 
-func BenchmarkPerClusterCTMapLookup(b *testing.B) {
+func BenchmarkPrivilegedPerClusterCTMapLookup(b *testing.B) {
 
 	setup(b)
 

--- a/pkg/metrics/bpf_test.go
+++ b/pkg/metrics/bpf_test.go
@@ -46,7 +46,7 @@ func TestPrivilegedGetBPFUsage(t *testing.T) {
 	assert.NotEqualValues(t, 0, usage.mapBytes)
 }
 
-func BenchmarkGetBPFUsage(b *testing.B) {
+func BenchmarkPrivilegedGetBPFUsage(b *testing.B) {
 	testutils.PrivilegedTest(b)
 	b.ReportAllocs()
 

--- a/pkg/testutils/privileged.go
+++ b/pkg/testutils/privileged.go
@@ -14,7 +14,8 @@ const (
 	integrationEnv           = "INTEGRATION_TESTS"
 	gatewayAPIConformanceEnv = "GATEWAY_API_CONFORMANCE_TESTS"
 
-	requiredPrefix = "TestPrivileged"
+	requiredTestPrefix      = "TestPrivileged"
+	requiredBenchmarkPrefix = "BenchmarkPrivileged"
 )
 
 func PrivilegedTest(tb testing.TB) {
@@ -22,8 +23,17 @@ func PrivilegedTest(tb testing.TB) {
 	testName := tb.Name()
 
 	// Check if test name has the required prefix
-	if !hasTestPrivilegedPrefix(testName) {
-		tb.Fatalf("Privileged tests must have prefix '%s' in their name, got: %s", requiredPrefix, testName)
+	switch v := tb.(type) {
+	case *testing.T:
+		if !hasPrivilegedPrefix(testName, requiredTestPrefix) {
+			tb.Fatalf("Privileged tests must have prefix '%s' in their name, got: %s", requiredTestPrefix, testName)
+		}
+	case *testing.B:
+		if !hasPrivilegedPrefix(testName, requiredBenchmarkPrefix) {
+			tb.Fatalf("Privileged benchmarks must have prefix '%s' in their name, got: %s", requiredBenchmarkPrefix, testName)
+		}
+	default:
+		tb.Fatalf("Unknown testing type %v", v)
 	}
 
 	if os.Getenv(privilegedEnv) == "" {
@@ -31,10 +41,10 @@ func PrivilegedTest(tb testing.TB) {
 	}
 }
 
-// hasTestPrivilegedPrefix checks if the test name has the TestPrivileged prefix.
+// hasPrivilegedPrefix checks if the test/benchmark name has the TestPrivileged/BenchmarkPrivileged prefix.
 // It handles both normal test functions "TestPrivileged*" and subtests that have
 // a parent test name included like "TestPrivileged*/SubTest".
-func hasTestPrivilegedPrefix(testName string) bool {
+func hasPrivilegedPrefix(testName string, requiredPrefix string) bool {
 	// Handle regular test function
 	if strings.HasPrefix(testName, requiredPrefix) {
 		return true


### PR DESCRIPTION
As of today, we identify privileged tests with the "TestPrivileged" prefix in their name. However, that doesn't hold true for benchmarks requiring privileges, which are always skipped given their prefix doesn't match "TestPrivileged".
This PR patches our current logic to introduce a new "BenchmarkPrivileged" prefix to identify such benchmarks requiring privileged access. In addition, it adjusts the prefix of all benchmarks requiring privileged with the new prefix.