### PR TITLE
AWS ENI: Auto-detect CIDRs from peered VPCs

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -12,6 +12,7 @@ cilium-operator-aws [flags]
 
 ```
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
+      --aws-auto-detect-peered-vpcs                          Enable auto-detection of peered VPC CIDRs (useful for excluding them from masquerading)
       --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-pagination-enabled                               Enable pagination for AWS EC2 API requests. The default page size is 1000 items. (default true)
       --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -13,6 +13,7 @@ cilium-operator [flags]
 ```
       --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
+      --aws-auto-detect-peered-vpcs                          Enable auto-detection of peered VPC CIDRs (useful for excluding them from masquerading)
       --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-pagination-enabled                               Enable pagination for AWS EC2 API requests. The default page size is 1000 items. (default true)
       --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1324,6 +1324,10 @@
      - Enable use of per endpoint routes instead of routing via the cilium_host interface.
      - bool
      - ``false``
+   * - :spelling:ignore:`eni.awsAutoDetectPeeredVPCs`
+     - Enable auto-detection of peered VPC CIDRs (useful for excluding them from masquerading)
+     - bool
+     - ``false``
    * - :spelling:ignore:`eni.awsEnablePrefixDelegation`
      - Enable ENI prefix delegation
      - bool

--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -511,6 +511,10 @@ If ``--instance-tags-filter`` is used:
 
  * ``DescribeInstances``
 
+If ``--aws-auto-detect-peered-vpcs`` is enabled:
+
+ * ``DescribeVpcPeeringConnections``
+
 *****************************
 EC2 instance types ENI limits
 *****************************

--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -32,7 +32,9 @@ Setting the routable CIDR
   in which case all destinations within that CIDR will **not** be masqueraded.
 
   In the public cloud environment, if you don't configure ``ipv4-native-routing-cidr``, 
-  Cilium will automatically detect the VPC CIDR range as the native routing range. 
+  Cilium will automatically detect the VPC CIDR range as the native routing range.
+  If you run in AWS, you can also enable the ``aws-auto-detect-peered-vpcs`` flag to
+  allow Cilium to automatically detect peered VPC CIDR ranges as well.
   Cilium does not masquerade the source address for traffic that is natively
   routable in the network, because it is possible for the endpoints to
   communicate directly without NAT.

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -381,6 +381,7 @@ contributors across the globe, there is almost always someone available to help.
 | endpointHealthChecking.enabled | bool | `true` | Enable connectivity health checking between virtual endpoints. |
 | endpointLockdownOnMapOverflow | bool | `false` | Enable endpoint lockdown on policy map overflow. |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
+| eni.awsAutoDetectPeeredVPCs | bool | `false` | Enable auto-detection of peered VPC CIDRs (useful for excluding them from masquerading) |
 | eni.awsEnablePrefixDelegation | bool | `false` | Enable ENI prefix delegation |
 | eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |
 | eni.ec2APIEndpoint | string | `""` | EC2 API endpoint to use |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -595,6 +595,9 @@ data:
 {{ if .Values.eni.gcTags }}
   eni-gc-tags: {{ .Values.eni.gcTags | toRawJson | quote }}
 {{- end }}
+{{- if .Values.eni.awsAutoDetectPeeredVPCs }}
+  aws-auto-detect-peered-vpcs: "true"
+{{- end }}
 
 {{- if .Values.azure.enabled }}
   enable-endpoint-routes: "true"

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1909,6 +1909,9 @@
     },
     "eni": {
       "properties": {
+        "awsAutoDetectPeeredVPCs": {
+          "type": "boolean"
+        },
         "awsEnablePrefixDelegation": {
           "type": "boolean"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1128,6 +1128,8 @@ eni:
   # -- Filter via AWS EC2 Instance tags (k=v) which will dictate which AWS EC2 Instances
   # are going to be used to create new ENIs
   instanceTagsFilter: []
+  # -- Enable auto-detection of peered VPC CIDRs (useful for excluding them from masquerading)
+  awsAutoDetectPeeredVPCs: false
 # fragmentTracking enables IPv4 fragment tracking support in the datapath.
 # fragmentTracking: true
 gke:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1138,6 +1138,8 @@ eni:
   # -- Filter via AWS EC2 Instance tags (k=v) which will dictate which AWS EC2 Instances
   # are going to be used to create new ENIs
   instanceTagsFilter: []
+  # -- Enable auto-detection of peered VPC CIDRs (useful for excluding them from masquerading)
+  awsAutoDetectPeeredVPCs: false
 # fragmentTracking enables IPv4 fragment tracking support in the datapath.
 # fragmentTracking: true
 gke:

--- a/operator/cmd/provider_aws_flags.go
+++ b/operator/cmd/provider_aws_flags.go
@@ -53,5 +53,8 @@ func (hook *awsFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.Vi
 	flags.Bool(operatorOption.AWSPaginationEnabled, true, "Enable pagination for AWS EC2 API requests. The default page size is 1000 items.")
 	option.BindEnv(vp, operatorOption.AWSPaginationEnabled)
 
+	flags.Bool(operatorOption.AWSAutoDetectPeeredVPCs, false, "Enable auto-detection of peered VPC CIDRs (useful for excluding them from masquerading)")
+	option.BindEnv(vp, operatorOption.AWSAutoDetectPeeredVPCs)
+
 	vp.BindPFlags(flags)
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -131,6 +131,9 @@ const (
 	// node
 	AWSUsePrimaryAddress = "aws-use-primary-address"
 
+	// AWSAutoDetectPeeredVPCs enables auto-detection of peered VPC CIDRs (useful for excluding them from masquerading)
+	AWSAutoDetectPeeredVPCs = "aws-auto-detect-peered-vpcs"
+
 	// Azure options
 
 	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
@@ -335,6 +338,9 @@ type OperatorConfig struct {
 	// e.g. "ec2-fips.us-west-1.amazonaws.com" to use a FIPS endpoint in the us-west-1 region.
 	EC2APIEndpoint string
 
+	// AWSAutoDetectPeeredVPCs enables auto-detection of peered VPC CIDRs (useful for excluding them from masquerading)
+	AWSAutoDetectPeeredVPCs bool
+
 	// Azure options
 
 	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
@@ -460,6 +466,7 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.ExcessIPReleaseDelay = vp.GetInt(ExcessIPReleaseDelay)
 	c.ENIGarbageCollectionInterval = vp.GetDuration(ENIGarbageCollectionInterval)
 	c.AWSPaginationEnabled = vp.GetBool(AWSPaginationEnabled)
+	c.AWSAutoDetectPeeredVPCs = vp.GetBool(AWSAutoDetectPeeredVPCs)
 
 	// Azure options
 

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -276,4 +276,7 @@ type AwsVPC struct {
 
 	// CIDRs is the list of CIDR ranges associated with the VPC
 	CIDRs []string `json:"cidrs,omitempty"`
+
+	// PeeredCIDRs is the list of IPv4 CIDR ranges from peered VPCs
+	PeeredCIDRs []string `json:"peered-cidrs,omitempty"`
 }

--- a/pkg/aws/eni/types/zz_generated.deepcopy.go
+++ b/pkg/aws/eni/types/zz_generated.deepcopy.go
@@ -32,6 +32,11 @@ func (in *AwsVPC) DeepCopyInto(out *AwsVPC) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PeeredCIDRs != nil {
+		in, out := &in.PeeredCIDRs, &out.PeeredCIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -55,6 +55,23 @@ func (in *AwsVPC) DeepEqual(other *AwsVPC) bool {
 		}
 	}
 
+	if ((in.PeeredCIDRs != nil) && (other.PeeredCIDRs != nil)) || ((in.PeeredCIDRs == nil) != (other.PeeredCIDRs == nil)) {
+		in, other := &in.PeeredCIDRs, &other.PeeredCIDRs
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	return true
 }
 

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -777,6 +777,8 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 				if a.conf.IPv4NativeRoutingCIDR != nil {
 					result.CIDRs = append(result.CIDRs, a.conf.IPv4NativeRoutingCIDR.String())
 				}
+				// Add auto-detected peered VPCs
+				result.CIDRs = append(result.CIDRs, eni.VPC.PeeredCIDRs...)
 				// If the ip-masq-agent is enabled, get the CIDRs that are not masqueraded.
 				// Note that the resulting ip rules will not be dynamically regenerated if the
 				// ip-masq-agent configuration changes.

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -439,6 +439,9 @@ type VirtualNetwork struct {
 
 	// IPv6CIDRs is the list of IPv6 CIDR ranges associated with the VPC
 	IPv6CIDRs []string
+
+	// PeeredCIDRs is the list of IPv4 CIDR ranges from peered VPCs
+	PeeredCIDRs []string
 }
 
 // VirtualNetworkMap indexes virtual networks by their ID

--- a/pkg/ipam/types/zz_generated.deepcopy.go
+++ b/pkg/ipam/types/zz_generated.deepcopy.go
@@ -448,6 +448,11 @@ func (in *VirtualNetwork) DeepCopyInto(out *VirtualNetwork) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PeeredCIDRs != nil {
+		in, out := &in.PeeredCIDRs, &out.PeeredCIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -574,6 +574,23 @@ func (in *VirtualNetwork) DeepEqual(other *VirtualNetwork) bool {
 		}
 	}
 
+	if ((in.PeeredCIDRs != nil) && (other.PeeredCIDRs != nil)) || ((in.PeeredCIDRs == nil) != (other.PeeredCIDRs == nil)) {
+		in, other := &in.PeeredCIDRs, &other.PeeredCIDRs
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	return true
 }
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -711,6 +711,12 @@ spec:
                             id:
                               description: / ID is the ID of a VPC
                               type: string
+                            peered-cidrs:
+                              description: PeeredCIDRs is the list of IPv4 CIDR ranges
+                                from peered VPCs
+                              items:
+                                type: string
+                              type: array
                             primary-cidr:
                               description: PrimaryCIDR is the primary CIDR of the
                                 VPC


### PR DESCRIPTION
# Description
This PR adds a new feature to the AWS Cilium Operator which allows it to auto-detect peered VPC CIDRs. This information can then be used by the Agent when setting up masquerading ip rules in order to exclude peered VPC traffic from being masqueraded.

More context around why that could be needed: https://github.com/cilium/cilium/issues/39806#issuecomment-3144087053 

Since this change requires users to grant a new IAM permission (`ec2:DescribeVpcPeeringConnections`), it is gated behind a flag (`--aws-auto-detect-peered-vpcs`)

# Testing
Deployed this PR with `--aws-auto-detect-peered-vpcs=true` to a test AWS account with 4 VPCs and 25 peering connections.
The Operator was running in a VPC which has 95 peered CIDRs in total across all connections. The Operator automatically detected them and coalesced them into 28 entries:
```
 $ kubectl get ciliumnode $NODE -o yaml | yq '.status.eni.enis[].vpc.peered-cidrs'
- 10.2.80.0/20
- 10.12.48.0/20
- 10.116.0.0/16
- 10.117.32.0/19
- 10.117.64.0/20
- 10.117.80.0/26
- 10.117.80.64/28
- 10.117.80.96/27
- 10.117.80.128/25
- 10.117.81.0/24
- 10.117.82.0/23
- 10.117.85.0/24
- 10.117.86.0/27
- 10.117.0.0/16
- 10.118.0.0/17
- 10.118.128.0/19
- 10.255.200.0/28
- 100.70.0.0/18
- 100.70.64.0/19
- 100.71.0.0/16
- 100.75.0.0/18
- 100.75.64.0/21
- 100.77.0.0/16
- 100.80.0.0/13
- 100.128.0.0/13
- 172.20.0.0/16
- 172.26.192.0/20
``` 

I then checked a pod which had masquerading enabled and verified that its ip rules were updated with these auto-detected CIDRs (`10.128.0.0/13` is the primary VPC CIDR, all others are peered ones):
```
# ip rule | grep "10.130.86.196"
111: from 10.130.86.196 to 10.2.80.0/20 lookup 11
111: from 10.130.86.196 to 10.12.48.0/20 lookup 11
111: from 10.130.86.196 to 10.116.0.0/16 lookup 11
111: from 10.130.86.196 to 10.117.32.0/19 lookup 11
111: from 10.130.86.196 to 10.117.64.0/20 lookup 11
111: from 10.130.86.196 to 10.117.80.0/26 lookup 11
111: from 10.130.86.196 to 10.117.80.64/28 lookup 11
111: from 10.130.86.196 to 10.117.80.96/27 lookup 11
111: from 10.130.86.196 to 10.117.80.128/25 lookup 11
111: from 10.130.86.196 to 10.117.81.0/24 lookup 11
111: from 10.130.86.196 to 10.117.82.0/23 lookup 11
111: from 10.130.86.196 to 10.117.85.0/24 lookup 11
111: from 10.130.86.196 to 10.117.86.0/27 lookup 11
111: from 10.130.86.196 to 10.117.0.0/16 lookup 11
111: from 10.130.86.196 to 10.118.0.0/17 lookup 11
111: from 10.130.86.196 to 10.118.128.0/19 lookup 11
111: from 10.130.86.196 to 10.128.0.0/13 lookup 11
111: from 10.130.86.196 to 10.255.200.0/28 lookup 11
111: from 10.130.86.196 to 100.70.0.0/18 lookup 11
111: from 10.130.86.196 to 100.70.64.0/19 lookup 11
111: from 10.130.86.196 to 100.71.0.0/16 lookup 11
111: from 10.130.86.196 to 100.75.0.0/18 lookup 11
111: from 10.130.86.196 to 100.75.64.0/21 lookup 11
111: from 10.130.86.196 to 100.77.0.0/16 lookup 11
111: from 10.130.86.196 to 100.80.0.0/13 lookup 11
111: from 10.130.86.196 to 100.128.0.0/13 lookup 11
111: from 10.130.86.196 to 172.20.0.0/16 lookup 11
111: from 10.130.86.196 to 172.26.192.0/20 lookup 11
```
Note: AFAICT there shouldn't be limits on the number of `ip rules` which can be created so the fact that there are that many shouldn't be an issue

I also know that the code which retrieves these CIDRs and coalesces them is not necessarily super optimized but users shouldn't have that many of them. Moreover, it's still pretty fast - when I timed it in our environment, the API call + the parsing + the coalescing took ~100-150ms on average.

```release-note
AWS ENI: add new flag --aws-auto-detect-peered-vpcs to enable auto-detection of peered VPC CIDRs (useful for excluding them from masquerading)
```
