### PR TITLE
helm: Support extending cilium-agent dnsPolicy as downstream packager

### DIFF
--- a/install/kubernetes/cilium/templates/_extensions.tpl
+++ b/install/kubernetes/cilium/templates/_extensions.tpl
@@ -13,6 +13,15 @@ Allow packagers to add extra volumes to cilium-agent.
 {{- end }}
 
 {{/*
+Allow packagers to set dnsPolicy for cilium-agent.
+*/}}
+{{- define "cilium-agent.dnsPolicy" }}
+{{- if .Values.dnsPolicy }}
+dnsPolicy: {{ .Values.dnsPolicy }}
+{{- end }}
+{{- end }}
+
+{{/*
 Intentionally empty to allow downstream chart packagers to add extra
 containers to hubble-relay without having to modify the deployment manifest
 directly.

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -820,9 +820,7 @@ spec:
       automountServiceAccountToken: {{ .Values.serviceAccounts.cilium.automount }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       hostNetwork: true
-      {{- if .Values.dnsPolicy }}
-      dnsPolicy: {{ .Values.dnsPolicy }}
-      {{- end }}
+      {{- include "cilium-agent.dnsPolicy" . | nindent 6 }}
       {{- if (eq .Values.scheduling.mode "anti-affinity")  }}
       {{- with .Values.affinity }}
       affinity:


### PR DESCRIPTION
We want to repackage the cilium chart and set the dnsPolicy programmatically based on additional helm values and templates.

Add a new extension template: `cilium-agent.dnsPolicy` that is included in the cilium-agent daemonset and can be overridden by downstream packagers with custom handling.

```release-note
Support extending cilium-agent dnsPolicy as a downstream packager
```
