### PR TITLE
helm: Correct and simplify the port logic for Agent

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -251,17 +251,19 @@ spec:
         resources:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
-        {{- if or .Values.prometheus.enabled (or .Values.hubble.metrics.enabled .Values.hubble.metrics.dynamic.enabled) }}
         ports:
+        {{- if .Values.hubble.enabled }}
         - name: peer-service
           containerPort: {{ .Values.hubble.peerService.targetPort }}
           hostPort: {{ .Values.hubble.peerService.targetPort }}
           protocol: TCP
+        {{- end }}
         {{- if .Values.prometheus.enabled }}
         - name: prometheus
           containerPort: {{ .Values.prometheus.port }}
           hostPort: {{ .Values.prometheus.port }}
           protocol: TCP
+        {{- end }}
         {{- if and .Values.envoy.prometheus.enabled (not $envoyDS) }}
         - name: envoy-metrics
           containerPort: {{ .Values.envoy.prometheus.port }}
@@ -274,13 +276,11 @@ spec:
           hostPort: {{ .Values.envoy.debug.admin.port }}
           protocol: TCP
         {{- end }}
-        {{- end }}
         {{- if or .Values.hubble.metrics.enabled .Values.hubble.metrics.dynamic.enabled }}
         - name: hubble-metrics
           containerPort: {{ .Values.hubble.metrics.port }}
           hostPort: {{ .Values.hubble.metrics.port }}
           protocol: TCP
-        {{- end }}
         {{- end }}
         securityContext:
           {{- if .Values.securityContext.privileged }}


### PR DESCRIPTION
The current implementation is based on the below global conditions, which makes it hard to maintain, and prone to error

- .Values.prometheus.enabled, or
- .Values.hubble.metrics.enabled .Values.hubble.metrics.dynamic.enabled

This commit is to split out the condition per port, so that it's easier to understand and maintain.

Relates: https://github.com/cilium/cilium/pull/39281/files#r2259643455

