### PR TITLE
install/kubernetes: fix clustermesh-apiserver extraEnv

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -237,6 +237,9 @@ spec:
               name: cilium-config
               key: enable-k8s-endpoint-slice
               optional: true
+        {{- with .Values.clustermesh.apiserver.extraEnv }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /readyz
@@ -244,9 +247,6 @@ spec:
           {{- with .Values.clustermesh.apiserver.readinessProbe }}
           {{- toYaml . | trim | nindent 10 }}
           {{- end }}
-        {{- with .Values.clustermesh.apiserver.extraEnv }}
-        {{- toYaml . | trim | nindent 8 }}
-        {{- end }}
         ports:
         - name: apiserv-health
           containerPort: {{ .Values.clustermesh.apiserver.healthPort }}


### PR DESCRIPTION
The location of the extraEnv should be under the 'env:' section. Having it out of place, causes the yaml to be incorrectly formatted preventing the user from using this helm variable.

Fixes: a39087ea7f69 ("helm: add readinessProbe to clustermesh-apiserver")

```
Fix bug with clustermesh.apiserver.extraEnv that prevented the yaml file from being correctly generated.
```