### PR TITLE
loadbalancer: Fix topology-aware routing safe-guards

### DIFF
--- a/pkg/loadbalancer/tests/testdata/topology-aware.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware.txtar
@@ -16,29 +16,43 @@ db/cmp services services.table
 k8s/add endpointslice.yaml endpointslice2.yaml
 
 # With zone set to 'foo' and topology-awareness enabled, we should
-# only select backen 10.244.1.1.
+# only select backend 10.244.1.1 which has 'foo' in its ForZones.
 db/cmp backends backends.table 
-db/cmp frontends frontends.table
+db/cmp frontends frontends-foo.table
 
 # Move the node to a different zone which won't match ForZones.
+# Now we'll fall back to selecting all backends.
+# (safeguard #5 at https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#safeguards)
 test/set-node-labels topology.kubernetes.io/zone=baz
-db/cmp frontends frontends-no-backends.table
+db/cmp frontends frontends-all.table
 
 # Move to another zone which isn't backend's own zone but mentioned in
 # ForZones.
 test/set-node-labels topology.kubernetes.io/zone=bar
-db/cmp frontends frontends.table
+db/cmp frontends frontends-foo.table
 
-# Remove the topology-mode annotation. Both backends should now be selected.
+# Remove the zone hints from one of the endpointslices. We'll again
+# fall back to selecting all backends.
+# (safeguard #4 at https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#safeguards)
+cp endpointslice2.yaml endpointslice2-no-hints.yaml
+sed 'forZones:' 'notForZones:' endpointslice2-no-hints.yaml
+k8s/update endpointslice2-no-hints.yaml
+db/cmp frontends frontends-all.table
+
+# Revert back to selecting backends with foo zone.
+k8s/update endpointslice2.yaml
+db/cmp frontends frontends-foo.table
+
+# Remove the topology-mode annotation. All backends should now be selected.
 sed 'topology-mode' 'topology-nope' service.yaml
 k8s/update service.yaml
-db/cmp frontends frontends-no-topo.table
+db/cmp frontends frontends-all.table
 
 # Set 'trafficDistribution' and check that this results in identical behavior
 # to topology-mode.
 sed '#trafficD' 'trafficD' service.yaml
 k8s/update service.yaml
-db/cmp frontends frontends.table
+db/cmp frontends frontends-foo.table
 
 #####
 
@@ -46,15 +60,15 @@ db/cmp frontends frontends.table
 Name        Source   PortNames  TrafficPolicy  Flags
 test/echo   k8s      http=80    Cluster        TrafficDistribution=PreferClose
 
--- frontends.table --
+-- frontends-foo.table --
 Address               Type        ServiceName   PortName   Status  Backends
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP
 
--- frontends-no-backends.table --
+-- frontends-none.table --
 Address               Type        ServiceName   PortName   Status   Backends
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done
 
--- frontends-no-topo.table --
+-- frontends-all.table --
 Address               Type        ServiceName   PortName   Status  Backends
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.2.1:80/TCP
 

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -389,6 +389,31 @@ func (w *Writer) DefaultSelectBackends(bes iter.Seq2[loadbalancer.BackendParams,
 		}
 	}
 
+	// Check whether the [BackendParams.ForZones] hints should be consulted when
+	// selecting a backend.
+	checkZoneHints := false
+	thisZone := w.nodeZone.Load()
+	if w.config.EnableServiceTopology &&
+		thisZone != nil &&
+		fe != nil && fe.RedirectTo == nil &&
+		fe.Service.TrafficDistribution == loadbalancer.TrafficDistributionPreferClose {
+		// Topology-aware routing enabled. See if we can find any backends fitting
+		// for our zone. If we don't find any we fall back to default behaviour.
+		// https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#safeguards
+		candidatesFound, missingHints := false, false
+		for be := range bes {
+			if be.Zone != nil && len(be.Zone.ForZones) > 0 {
+				if !candidatesFound && slices.Contains(be.Zone.ForZones, *thisZone) {
+					candidatesFound = true
+				}
+			} else {
+				missingHints = true
+				break
+			}
+		}
+		checkZoneHints = candidatesFound && !missingHints
+	}
+
 	return func(yield func(loadbalancer.BackendParams, statedb.Revision) bool) {
 		for be, rev := range bes {
 			if fe != nil && fe.Address.Protocol() != be.Address.Protocol() {
@@ -409,18 +434,10 @@ func (w *Writer) DefaultSelectBackends(bes iter.Seq2[loadbalancer.BackendParams,
 					continue
 				}
 			}
+			if checkZoneHints && !slices.Contains(be.Zone.ForZones, *thisZone) {
+				continue
+			}
 			if fe != nil {
-				if w.config.EnableServiceTopology &&
-					fe.RedirectTo == nil &&
-					fe.Service.TrafficDistribution == loadbalancer.TrafficDistributionPreferClose {
-					thisZone := w.nodeZone.Load()
-					if be.Zone != nil && len(be.Zone.ForZones) > 0 && thisZone != nil {
-						// Topology-aware routing is enabled. Only use this backend if it is selected for this zone.
-						if !slices.Contains(be.Zone.ForZones, *thisZone) {
-							continue
-						}
-					}
-				}
 				if fe.PortName != "" {
 					// A backend with specific port name requested. Look up what this backend
 					// is called for this service.


### PR DESCRIPTION
Cilium's topology-aware implementation did not correctly implement the following safe guards [1]:

4. If no fitting backend found for current zone us backends from all zones
5. Use all backends if one or more endpoints did not have zone hints

It did correctly implement:
(1. insufficient endpoints (endpointslice controller responsibility) 
(2. unbalanced allocation (endpointslice controller responsibility)
3. Use all backends if local node missing zone label

This is fixed by doing an additional iteration over the backends to check
4. and 5. before trying to apply the zone hints.

[1]: https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#enabling-topology-aware-routing.

Fixes: e35c099d60bf ("experimental: Implement support for topology-aware routing")
Fixes: #41022

```release-note
Add missing safeguards to topology-aware routing: use all backends when no suitable one matching the zone hints are found or a backend exists without a zone hint.
```
