### PR TITLE
Allow setting Envoy runtime configs

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1592,6 +1592,10 @@
      - Roll out cilium envoy pods automatically when configmap is updated.
      - bool
      - ``false``
+   * - :spelling:ignore:`envoy.runtime`
+     - Envoy runtime configs. ref: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/runtime#arch-overview-runtime
+     - object
+     - ``{}``
    * - :spelling:ignore:`envoy.securityContext.capabilities.envoy`
      - Capabilities for the ``cilium-envoy`` container. Even though granted to the container, the cilium-envoy-starter wrapper drops all capabilities after forking the actual Envoy process. ``NET_BIND_SERVICE`` is the only capability that can be passed to the Envoy process by setting ``envoy.securityContext.capabilities.keepNetBindService=true`` (in addition to granting the capability to the container). Note: In case of embedded envoy, the capability must  be granted to the cilium-agent container.
      - list

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -448,6 +448,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.readinessProbe.periodSeconds | int | `30` | interval between checks of the readiness probe |
 | envoy.resources | object | `{}` | Envoy resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | envoy.rollOutPods | bool | `false` | Roll out cilium envoy pods automatically when configmap is updated. |
+| envoy.runtime | object | `{}` | Envoy runtime configs. ref: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/runtime#arch-overview-runtime |
 | envoy.securityContext.capabilities.envoy | list | `["NET_ADMIN","SYS_ADMIN"]` | Capabilities for the `cilium-envoy` container. Even though granted to the container, the cilium-envoy-starter wrapper drops all capabilities after forking the actual Envoy process. `NET_BIND_SERVICE` is the only capability that can be passed to the Envoy process by setting `envoy.securityContext.capabilities.keepNetBindService=true` (in addition to granting the capability to the container). Note: In case of embedded envoy, the capability must  be granted to the cilium-agent container. |
 | envoy.securityContext.capabilities.keepCapNetBindService | bool | `false` | Keep capability `NET_BIND_SERVICE` for Envoy process. |
 | envoy.securityContext.privileged | bool | `false` | Run the pod with elevated privileges |

--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
@@ -304,3 +304,10 @@ admin:
   address:
     pipe:
       path: "/var/run/cilium/envoy/sockets/admin.sock"
+layered_runtime:
+  layers:
+  {{- with .Values.envoy.runtime }}
+  - name: static_layer
+    static_layer:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2385,6 +2385,9 @@
         "rollOutPods": {
           "type": "boolean"
         },
+        "runtime": {
+          "type": "object"
+        },
         "securityContext": {
           "properties": {
             "capabilities": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2697,6 +2697,10 @@ envoy:
       metricRelabelings: ~
     # -- Serve prometheus metrics for cilium-envoy on the configured port
     port: "9964"
+  # -- Envoy runtime configs.
+  # ref: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/runtime#arch-overview-runtime
+  runtime: {}
+  #   re2.max_program_size.error_level: 200
 # -- Enable/Disable use of node label based identity
 nodeSelectorLabels: false
 # To include or exclude matched resources from cilium node identity evaluation

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2718,6 +2718,11 @@ envoy:
     # -- Serve prometheus metrics for cilium-envoy on the configured port
     port: "9964"
 
+  # -- Envoy runtime configs.
+  # ref: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/runtime#arch-overview-runtime
+  runtime: {}
+  #   re2.max_program_size.error_level: 200
+
 # -- Enable/Disable use of node label based identity
 nodeSelectorLabels: false
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Envoy [runtime configs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/runtime#arch-overview-runtime) are a kind of feature flags that can be used for various Envoy settings. One particularly useful one would be controlling the maximum complexity of RE2 regexps with the `re2.max_program_size.error_level` runtime config.

Before this PR, setting runtime configs would require overriding the bootstrap configmap completely. With this change we would just have to provide the Helm values file with:

```
envoy:
  runtime:
    re2.max_program_size.error_level: 200
```


```release-note
Added the possibility to set envoy runtime configs during install.
```
