### PR TITLE
gha: configure read actions permissions for scalability jobs

### DIFF
--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -26,6 +26,8 @@ on:
 #      - your_branch_name
 
 permissions:
+  # To be able to retrieve artifacts information
+  actions: read
   # To be able to access the repository with actions/checkout
   contents: read
   # To be able to request the JWT from GitHub's OIDC provider

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -26,6 +26,8 @@ on:
 #      - your_branch_name
 
 permissions:
+  # To be able to retrieve artifacts information
+  actions: read
   # To be able to access the repository with actions/checkout
   contents: read
   # To be able to request the JWT from GitHub's OIDC provider

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -26,6 +26,8 @@ on:
 #      - your_branch_name
 
 permissions:
+  # To be able to retrieve artifacts information
+  actions: read
   # To be able to access the repository with actions/checkout
   contents: read
   # To be able to request the JWT from GitHub's OIDC provider

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -26,6 +26,8 @@ on:
 #      - your_branch_name
 
 permissions:
+  # To be able to retrieve artifacts information
+  actions: read
   # To be able to access the repository with actions/checkout
   contents: read
   # To be able to request the JWT from GitHub's OIDC provider

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -36,6 +36,8 @@ on:
 #      - your_branch_name
 
 permissions:
+  # To be able to retrieve artifacts information
+  actions: read
   # To be able to access the repository with actions/checkout
   contents: read
   # To be able to request the JWT from GitHub's OIDC provider


### PR DESCRIPTION
The blamed commit switched the scalability jobs to use the common-post-jobs workflow, which under the hood calls the merge-artifacts action. This action performs an API call to retrieve information about the artifacts created by the current run. However, scalability jobs did not explicitly configure read access to actions information for the token, hence causing this step to fail when run in the context of private repositories. Let's get it fixed.

Fixes: a7a269049771 ("ci: resuse common-post-jobs for scalability jobs")