### PR TITLE
docs: Remove references to v1.15

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v1.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v1.rst
@@ -667,17 +667,6 @@ Configure graceful restart on per-neighbor basis, as follows:
            enabled: true           # <-- enable graceful restart
            restartTimeSeconds: 120 # <-- set RestartTime
 
-.. warning::
-
-   When enabled, graceful restart capability is advertised for IPv4 and IPv6
-   address families by default. From v1.15, we have a known issue where Cilium
-   takes long time (approximately 300s) to restart route advertisement after
-   graceful restart when Cilium advertises both IPv4 and IPv6 address families,
-   but a remote peer advertises only one of them. You can work around this
-   issue by aligning the address families advertised by Cilium and remote with
-   the `families field <bgp-control-plane-address-families_>`_. You can track
-   `#30367 <https://github.com/cilium/cilium/issues/30367/>`_ for updates.
-
 Optionally, you can use the ``RestartTime`` parameter. ``RestartTime`` is the time
 advertised to the peer within which Cilium BGP control plane is expected to re-establish
 the BGP session after a restart. On expiration of ``RestartTime``, the peer removes

--- a/Documentation/network/concepts/routing.rst
+++ b/Documentation/network/concepts/routing.rst
@@ -298,9 +298,6 @@ Masquerading
 
 Load-balancing
    ClusterIP load-balancing will be performed using eBPF for all version of GKE.
-   Starting with >= GKE v1.15 or when running a Linux kernel >= 4.19, all
-   NodePort/ExternalIP/HostPort will be performed using a eBPF implementation as
-   well.
 
 Policy enforcement & visibility
    All NetworkPolicy enforcement and visibility is provided using eBPF.

--- a/Documentation/network/kubernetes/policy.rst
+++ b/Documentation/network/kubernetes/policy.rst
@@ -51,9 +51,6 @@ Known missing features for Kubernetes Network Policy:
 | ``ipBlock`` set with a pod IP | :gh-issue:`9209`  |
 +-------------------------------+-------------------+
 
-As of v1.15, ``ipBlock`` can now optionally select :ref:`node IPs <cidr_select_nodes>`. Previously,
-nodes were excluded from ``ipBlock``; see :gh-issue:`20550`.
-
 .. _CiliumNetworkPolicy:
 
 CiliumNetworkPolicy

--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -84,12 +84,6 @@ since these only have 1 or 2 IPs respectively.
 This setting only applies to blocks specified with ``.spec.blocks[].cidr`` and not to
 blocks specified with ``.spec.blocks[].start`` and ``.spec.blocks[].stop``.
 
-.. warning::
-
-  In v1.15, ``.spec.allowFirstLastIPs`` defaults to ``No``. This has changed to
-  ``Yes`` in v1.16. Please set this field explicitly if you rely on the field
-  being set to ``No``.
-
 Service Selectors
 -----------------
 

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -549,9 +549,7 @@ Once the node is known, the troubleshooting steps are as follows:
 1. Find the Cilium pod on the node experiencing the problematic policymap
    pressure and obtain a shell via ``kubectl exec``.
 2. Use ``cilium policy selectors`` to get an overview of which selectors are
-   selecting many identities. The output of this command as of Cilium v1.15
-   additionally displays the namespace and name of the policy resource of each
-   selector.
+   selecting many identities.
 3. The type of selector tells you what sort of policy rule could be having an
    impact. The three existing types of selectors are explained below, each with
    specific steps depending on the selector. See the steps below corresponding


### PR DESCRIPTION
One of these was for _GKE_ v1.15 which is ancient, but all of the other
references to v1.15 are for Cilium and are also stale. Remove them.
