### PR TITLE
conformance: move Gateway API conformance test logic to Make target

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -290,45 +290,17 @@ jobs:
           GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.216@")
           echo "GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES: $GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES"
           echo "GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES: $GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES"
+          # Build test flags based on matrix
+          GATEWAY_TEST_FLAGS="--gateway-class cilium --all-features --allow-crds-mismatch"
           if [ "${{ matrix.conformance-profile }}" == "true" ]; then
-            GATEWAY_API_CONFORMANCE_TESTS=1 \
-            GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES  \
-            GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES \
-            go test \
-              -p 4 \
-              -v ./operator/pkg/gateway-api \
-              --gateway-class cilium \
-              --all-features \
-              --skip-tests "${{ steps.vars.outputs.skipped_tests }}" \
-              --allow-crds-mismatch \
-              --conformance-profiles GATEWAY-HTTP,GATEWAY-TLS,GATEWAY-GRPC,MESH-HTTP,MESH-GRPC \
-              --organization cilium \
-              --project cilium \
-              --url github.com/cilium/cilium \
-              --version main \
-              --contact https://github.com/cilium/community/blob/main/roles/Maintainers.md \
-              --report-output report.yaml \
-              -test.run "TestConformance" \
-              -test.timeout=29m \
-              -json \
-            | tparse -progress
+            GATEWAY_TEST_FLAGS="$GATEWAY_TEST_FLAGS --skip-tests \"${{ steps.vars.outputs.skipped_tests }}\" --conformance-profiles GATEWAY-HTTP,GATEWAY-TLS,GATEWAY-GRPC,MESH-HTTP,MESH-GRPC --organization cilium --project cilium --url github.com/cilium/cilium --version main --contact https://github.com/cilium/community/blob/main/roles/Maintainers.md --report-output report.yaml"
           else
-            GATEWAY_API_CONFORMANCE_TESTS=1 \
-            GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES  \
-            GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES \
-            go test \
-              -p 4 \
-              -v ./operator/pkg/gateway-api \
-              --gateway-class cilium \
-              --all-features \
-              --exempt-features "${{ steps.vars.outputs.exempt-features }}" \
-              --allow-crds-mismatch \
-              -test.run "TestConformance" \
-              -test.timeout=29m \
-              -test.skip "${{ steps.vars.outputs.skipped_tests }}" \
-              -json \
-            | tparse -progress
+            GATEWAY_TEST_FLAGS="$GATEWAY_TEST_FLAGS --exempt-features \"${{ steps.vars.outputs.exempt-features }}\" -test.skip \"${{ steps.vars.outputs.skipped_tests }}\""
           fi
+          GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES="$GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES" \
+          GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES="$GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES" \
+          GATEWAY_TEST_FLAGS="$GATEWAY_TEST_FLAGS" \
+          make gateway-api-conformance
 
       - name: Run basic CLI tests (${{ join(matrix.*, ', ') }})
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -550,8 +550,20 @@ help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writin
 	$(call print_help_line,"dev-docker-operator-*-image-debug","Build platform specific cilium-operator debug images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
 
-.PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-kvstoremesh-api generate-hubble-api generate-sdp-api install licenses-all veryclean run_bpf_tests run-builder
+.PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-kvstoremesh-api generate-hubble-api generate-sdp-api install licenses-all veryclean run_bpf_tests run-builder gateway-api-conformance
 force :;
+
+gateway-api-conformance: ## Run Gateway API conformance tests.
+	@$(ECHO_CHECK) running Gateway API conformance tests...
+	GATEWAY_API_CONFORMANCE_TESTS=1 \
+	GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES=$${GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES} \
+	GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$${GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES} \
+	$(GO) test -p 4 -v ./operator/pkg/gateway-api \
+		$(GATEWAY_TEST_FLAGS) \
+		-test.run "TestConformance" \
+		-test.timeout=29m \
+		-json \
+	| tparse -progress
 
 BPF_TEST_FILE ?= ""
 BPF_TEST_DUMP_CTX ?= ""


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Description of change

Move the Gateway API conformance test execution logic from the GitHub workflow into a reusable `gateway-api-conformance` Make target. This change:

- **Consolidates logic**: Moves duplicated `go test` command logic from workflow YAML to Makefile
- **Preserves behavior**: Maintains exact original behavior (`go test | tparse -progress`) with no functional changes
- **Improves maintainability**: Eliminates code duplication and centralizes test execution logic
- **Prepares for future enhancement**: Creates foundation for integrating with `GOTEST_FORMATTER` from `Makefile.defs` in a subsequent PR

The workflow now calls `make gateway-api-conformance` instead of executing the test pipeline inline, making it consistent with other test targets in the repository.

This is **Step 1** of a two-step approach as requested in [PR review feedback](https://github.com/cilium/cilium/pull/41038#discussion_r2268096570). 
Step 2 (separate PR) will add owner attribution by integrating with `GOTEST_FORMATTER`.

Fixes: #41029

```release-note
ci: Gateway API conformance test logic moved to reusable Make target for better maintainability.
```