### PR TITLE
node/manager: prevent MeshNodeSync from pruning cluster (local) nodes

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -1116,13 +1116,14 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 		return
 	}
 
-	// The ipcache is recreated from scratch on startup, no need to prune restored stale nodes.
 	if n.Source != source.Restored {
+		// The ipcache is recreated from scratch on startup, no need to prune restored stale nodes.
 		resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
 		m.removeNodeFromIPCache(entry.node, resource, nil, nil, nil, nil, nil)
-	}
 
-	m.metrics.NumNodes.Dec()
+		// We only need to decrement for nodes we've accounted for.
+		m.metrics.NumNodes.Dec()
+	}
 
 	entry.mutex.Lock()
 	delete(m.nodes, nodeIdentifier)

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -1348,43 +1348,87 @@ func TestNodeIpset(t *testing.T) {
 
 // Tests that the node manager calls delete on nodes to be pruned.
 func TestNodesStartupPruning(t *testing.T) {
-	logger := hivetest.Logger(t)
-	n1 := nodeTypes.Node{Name: "node1", Cluster: "c1", IPAddresses: []nodeTypes.Address{
+	c1Node1 := nodeTypes.Node{Name: "node1", Cluster: "c1", IPAddresses: []nodeTypes.Address{
 		{
 			Type: addressing.NodeInternalIP,
 			IP:   net.ParseIP("10.0.0.1"),
 		},
 	}}
 
-	n2 := nodeTypes.Node{Name: "node2", Cluster: "c1", IPAddresses: []nodeTypes.Address{
+	c1Node2 := nodeTypes.Node{Name: "node2", Cluster: "c1", IPAddresses: []nodeTypes.Address{
 		{
 			Type: addressing.NodeInternalIP,
 			IP:   net.ParseIP("10.0.0.2"),
 		},
 	}}
 
-	n3 := nodeTypes.Node{Name: "node3", Cluster: "c2", IPAddresses: []nodeTypes.Address{
+	c1StaleNode := nodeTypes.Node{Name: "node3", Cluster: "c1", IPAddresses: []nodeTypes.Address{
 		{
 			Type: addressing.NodeInternalIP,
 			IP:   net.ParseIP("10.0.0.3"),
 		},
 	}}
 
-	// Create a nodes.json file from the above two nodes, simulating a previous instance of the agent.
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, nodesFilename)
-	nf, err := os.Create(path)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		nf.Close()
-		os.Remove(path)
-	})
-	e := json.NewEncoder(nf)
-	require.NoError(t, e.Encode([]nodeTypes.Node{n3, n2, n1}))
-	require.NoError(t, nf.Sync())
-	require.NoError(t, nf.Close())
+	c2Node1 := nodeTypes.Node{Name: "node1", Cluster: "c2", IPAddresses: []nodeTypes.Address{
+		{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP("10.0.0.4"),
+		},
+	}}
 
-	checkNodeFileMatches := func(path string, node nodeTypes.Node) {
+	c2StaleNode := nodeTypes.Node{Name: "node2", Cluster: "c2", IPAddresses: []nodeTypes.Address{
+		{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP("10.0.0.5"),
+		},
+	}}
+
+	setupManager := func(t *testing.T, stateDir string) (*manager, *signalNodeHandler) {
+		logger := hivetest.Logger(t)
+
+		// Create a nodes.json file from the above two nodes, simulating a previous instance of the agent.
+		nodesFilePath := filepath.Join(stateDir, nodesFilename)
+		nf, err := os.Create(nodesFilePath)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			nf.Close()
+			os.Remove(nodesFilePath)
+		})
+		e := json.NewEncoder(nf)
+		require.NoError(t, e.Encode([]nodeTypes.Node{
+			c1Node1, c1Node2, c1StaleNode, c2Node1, c2StaleNode}))
+		require.NoError(t, nf.Sync())
+		require.NoError(t, nf.Close())
+
+		// Create a node manager and add only c1-node1 (local).
+		ipcacheMock := newIPcacheMock()
+		dp := newSignalNodeHandler()
+		dp.EnableNodeDeleteEvent = true
+		h, _ := cell.NewSimpleHealth()
+		mngr, err := New(logger, &option.DaemonConfig{
+			StateDir:    stateDir,
+			ClusterName: "c1",
+		}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			mngr.Stop(context.TODO())
+		})
+		mngr.Subscribe(dp)
+		mngr.NodeUpdated(c1Node1)
+
+		// Load the nodes from disk.
+		mngr.restoreNodeCheckpoint()
+		require.NoError(t, mngr.initNodeCheckpointer(time.Microsecond))
+		// We remove our test file here to be able to tell once the nodemanager has
+		// written one itself.
+		require.NoError(t, os.Remove(nodesFilePath))
+
+		return mngr, dp
+	}
+
+	checkNodeFileMatches := func(t *testing.T, stateDir string, nodes ...nodeTypes.Node) {
+		path := filepath.Join(stateDir, nodesFilename)
+
 		// Wait until the file exists. The node deletion triggers the write, hence
 		// this shouldn't take long.
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1397,59 +1441,89 @@ func TestNodesStartupPruning(t *testing.T) {
 		})
 		var nl []nodeTypes.Node
 		assert.NoError(t, json.NewDecoder(nwf).Decode(&nl))
-		assert.Len(t, nl, 1)
-		assert.Equal(t, node, nl[0])
+		assert.ElementsMatch(t, nodes, nl)
 		require.NoError(t, os.Remove(path))
 	}
 
-	// Create a node manager and add only node1.
-	ipcacheMock := newIPcacheMock()
-	dp := newSignalNodeHandler()
-	dp.EnableNodeDeleteEvent = true
-	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{
-		StateDir:    tmp,
-		ClusterName: "c1",
-	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		mngr.Stop(context.TODO())
+	t.Run("cluster nodes synced first", func(t *testing.T) {
+		stateDir := t.TempDir()
+		mngr, dp := setupManager(t, stateDir)
+
+		// Simulate cluster initial listing.
+		// Add c1 node2 and declare cluster nodes synced.
+		// This should prune c1 node3 (since it's present in the file but not in our
+		// current view).
+		mngr.NodeUpdated(c1Node2)
+		mngr.NodeSync()
+
+		select {
+		case dn := <-dp.NodeDeleteEvent:
+			expectedNode := c1StaleNode
+			expectedNode.Source = source.Restored
+			assert.Equal(t, expectedNode, dn, "should have deleted stale node c1 node3 (with source=Restored)")
+		case <-time.After(time.Second * 5):
+			t.Fatal("should have received a node deletion event for stale node c1 node3")
+		}
+
+		checkNodeFileMatches(t, stateDir, c1Node1, c1Node2)
+
+		// Simulate initial cluster mesh sync. This should prune c2 node2 (since
+		// it's present in the file but not in our current view).
+		mngr.NodeUpdated(c2Node1)
+		mngr.MeshNodeSync()
+
+		select {
+		case dn := <-dp.NodeDeleteEvent:
+			expectedNode := c2StaleNode
+			expectedNode.Source = source.Restored
+			assert.Equal(t, expectedNode, dn, "should have deleted stale node c2 node2 (with source=Restored)")
+		case <-time.After(time.Second * 5):
+			t.Fatal("should have received a node deletion event for stale node c2 node2")
+		}
+
+		checkNodeFileMatches(t, stateDir, c1Node1, c1Node2, c2Node1)
 	})
-	mngr.Subscribe(dp)
-	mngr.NodeUpdated(n1)
 
-	// Load the nodes from disk and initiate pruning. This should prune node 2
-	// (since it's present in the file but not in our current view).
-	mngr.restoreNodeCheckpoint()
-	require.NoError(t, mngr.initNodeCheckpointer(time.Microsecond))
-	// We remove our test file here to be able to tell once the nodemanager has
-	// written one itself.
-	require.NoError(t, os.Remove(path))
-	// Declare cluster nodes synced (but not clustermesh nodes)
-	mngr.NodeSync()
+	t.Run("meshed nodes synced first", func(t *testing.T) {
+		stateDir := t.TempDir()
+		mngr, dp := setupManager(t, stateDir)
 
-	select {
-	case dn := <-dp.NodeDeleteEvent:
-		n2r := n2
-		n2r.Source = source.Restored
-		assert.Equal(t, n2r, dn, "should have deleted node 2 and (with source=Restored)")
-	case <-time.After(time.Second * 5):
-		t.Fatal("should have received a node deletion event for node 2")
-	}
+		// Simulate clustermesh initial sync before cluster nodes are finished listing.
+		// Add c2 node1 and declare clustermesh nodes synced (but not cluster nodes).
+		// This should prune c2 node2 (since it's present in the file but not in our
+		// current view).
+		// Restored cluster nodes should not be pruned yet.
+		mngr.NodeUpdated(c2Node1)
+		mngr.MeshNodeSync()
 
-	checkNodeFileMatches(path, n1)
+		select {
+		case dn := <-dp.NodeDeleteEvent:
+			expectedNode := c2StaleNode
+			expectedNode.Source = source.Restored
+			assert.Equal(t, expectedNode, dn, "should have deleted stale node c2 node2 (with source=Restored)")
+		case <-time.After(time.Second * 5):
+			t.Fatal("should have received a node deletion event for stale node c2 node2")
+		}
 
-	// Allow pruning the clustermesh node.
-	mngr.MeshNodeSync()
+		// Checkpoint should have c1 node1 (local) and c2 node1 (meshed).
+		checkNodeFileMatches(t, stateDir, c1Node1, c2Node1)
 
-	select {
-	case dn := <-dp.NodeDeleteEvent:
-		n3r := n3
-		n3r.Source = source.Restored
-		assert.Equal(t, n3r, dn, "should have deleted node 3 and (with source=Restored)")
-	case <-time.After(time.Second * 5):
-		t.Fatal("should have received a node deletion event for node 3")
-	}
+		// Simulate cluster initial listing.
+		// Add c1 node2 and declare cluster nodes synced.
+		// This should prune c1 node3 (since it's present in the file but not in our
+		// current view).
+		mngr.NodeUpdated(c1Node2)
+		mngr.NodeSync()
 
-	checkNodeFileMatches(path, n1)
+		select {
+		case dn := <-dp.NodeDeleteEvent:
+			expectedNode := c1StaleNode
+			expectedNode.Source = source.Restored
+			assert.Equal(t, expectedNode, dn, "should have deleted stale node c1 node3 (with source=Restored)")
+		case <-time.After(time.Second * 5):
+			t.Fatal("should have received a node deletion event for stale node c1 node3")
+		}
+
+		checkNodeFileMatches(t, stateDir, c1Node1, c1Node2, c2Node1)
+	})
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -1482,6 +1482,9 @@ func TestNodesStartupPruning(t *testing.T) {
 		}
 
 		checkNodeFileMatches(t, stateDir, c1Node1, c1Node2, c2Node1)
+
+		assert.Equal(t, float64(2), mngr.metrics.EventsReceived.WithLabelValues("delete", string(source.Restored)).Get())
+		assert.Equal(t, float64(3), mngr.metrics.NumNodes.Get())
 	})
 
 	t.Run("meshed nodes synced first", func(t *testing.T) {
@@ -1525,5 +1528,8 @@ func TestNodesStartupPruning(t *testing.T) {
 		}
 
 		checkNodeFileMatches(t, stateDir, c1Node1, c1Node2, c2Node1)
+
+		assert.Equal(t, float64(2), mngr.metrics.EventsReceived.WithLabelValues("delete", string(source.Restored)).Get())
+		assert.Equal(t, float64(3), mngr.metrics.NumNodes.Get())
 	})
 }


### PR DESCRIPTION
Fixes an issue in NodeManager where restored cluster nodes can be pruned before the initial node listing completes.

Currently, with clustermesh, when all remote clusters have finished initial synchronization, `MeshNodeSync` is called, which considers all mesh and non-mesh nodes for pruning. If this happens before we finish listing initial cluster (local) nodes, we could end up considering the restored cluster nodes as stale for pruning. This also causes some miscounting for metrics, where for example we decrement `nodes_all_num` (in `NodeDeleted` for the synthetic delete event) for nodes we never accounted for in the first place.

This patch modifies MeshNodeSync to only consider pruning mesh nodes.

```release-note
Fixes an issue in NodeManager where restored cluster nodes can be pruned before the initial node listing completes.
```
