### PR TITLE
datapath: Use go 1.23 timers

### DIFF
--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -322,15 +322,7 @@ stop:
 
 			// Reset the timer so that it gets triggered again after fullReconciliationInterval,
 			// to avoid introducing unnecessary churn in case a full reconciliation was already
-			// triggered due to other reasons. The Stop and select steps can be dropped once
-			// switching to using go v1.23: https://go.dev/wiki/Go123Timer
-			if !refresher.Stop() {
-				select {
-				case <-ticker.C():
-				default:
-				}
-			}
-
+			// triggered due to other reasons.
 			refresher.Reset(fullReconciliationInterval)
 		}
 	}


### PR DESCRIPTION
This is a followup to #34661. Now that cilium uses go 1.24, it is safe to remove the pre-go1.23 workaround for timer reset. See https://go.dev/wiki/Go123Timer

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

```release-note
datapath: Use go 1.23 timers
```
