### PR TITLE
operator: manually register certwatcher metrics.

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	k8sCtrlMetrics "sigs.k8s.io/controller-runtime/pkg/certwatcher/metrics"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -70,6 +71,9 @@ func initializeMetrics(p params) {
 		metrics.WorkQueueLongestRunningProcessor,
 		metrics.WorkQueueRetries,
 	)
+
+	p.Registry.Register(k8sCtrlMetrics.ReadCertificateTotal)
+	p.Registry.Register(k8sCtrlMetrics.ReadCertificateErrors)
 
 	metrics.InitOperatorMetrics()
 	p.Registry.MustRegister(metrics.ErrorsWarnings)


### PR DESCRIPTION
These where previously included in the operator metrics
by virtue of the global registry having them registered
via the k8s controller runtime library.

Following https://github.com/cilium/cilium/commit/89f3a4317a98f4a577da337cd303e90695cab771 we
don't rely on the global registry anymore and instead
use one provided via hive.

This broke this metrics from being picked up by gather.
Instead we will now register this manually.

Fixes: #39341