### PR TITLE
refactor: Reimplement reflector with k8s.ListerWatcherToObservable

### DIFF
--- a/daemon/k8s/pods.go
+++ b/daemon/k8s/pods.go
@@ -89,7 +89,7 @@ var (
 // the k8s reflector. These are combined to ensure any dependency on Table[LocalPod]
 // will start after the reflector, ensuring that Start hooks can wait for the table
 // to initialize.
-func NewPodTableAndReflector(jg job.Group, db *statedb.DB, cs client.Clientset) (statedb.Table[LocalPod], error) {
+func NewPodTableAndReflector(jg job.Group, db *statedb.DB, cs client.Clientset) (statedb.RWTable[LocalPod], error) {
 	pods, err := NewPodTable(db)
 	if err != nil {
 		return nil, err

--- a/daemon/k8s/svcep_tables.go
+++ b/daemon/k8s/svcep_tables.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+)
+
+const (
+	ServiceTableName   = "k8s-services"
+	EndpointsTableName = "k8s-endpoints"
+)
+
+var (
+	// ServiceIDIndex is an index on the service's namespace and name.
+	ServiceIDIndex = statedb.Index[*slim_corev1.Service, types.NamespacedName]{
+		Name: "id",
+		FromObject: func(s *slim_corev1.Service) index.KeySet {
+			return index.NewKeySet(index.String(s.Namespace + "/" + s.Name))
+		},
+		FromKey: func(k types.NamespacedName) index.Key {
+			return index.String(k.String())
+		},
+		Unique: true,
+	}
+
+	// EndpointsIDIndex is an index on the endpoints's namespace and name.
+	EndpointsIDIndex = statedb.Index[*k8s.Endpoints, types.NamespacedName]{
+		Name: "id",
+		FromObject: func(e *k8s.Endpoints) index.KeySet {
+			return index.NewKeySet(index.String(e.Namespace + "/" + e.EndpointSliceName))
+		},
+		FromKey: func(k types.NamespacedName) index.Key {
+			return index.String(k.String())
+		},
+		Unique: true,
+	}
+
+	// EndpointsByServiceIndex is an index on the service's namespace and name.
+	EndpointsByServiceIndex = statedb.Index[*k8s.Endpoints, types.NamespacedName]{
+		Name: "service-id",
+		FromObject: func(e *k8s.Endpoints) index.KeySet {
+			return index.NewKeySet(index.String(e.ServiceName.String()))
+		},
+		FromKey: func(k types.NamespacedName) index.Key {
+			return index.String(k.String())
+		},
+		Unique: false,
+	}
+)
+
+// SvcEPTablesCell provides the statedb tables for Kubernetes services and endpoints.
+// These tables are populated directly from Kubernetes and are meant to replace the
+// existing 'resource.Resource' based caches.
+var SvcEPTablesCell = cell.Module(
+	"k8s-svcep-tables",
+	"statedb tables for Kubernetes Services and Endpoints",
+
+	cell.Provide(
+		NewServiceTable,
+		NewEndpointsTable,
+	),
+
+	cell.Invoke(registerSvcEPReflector),
+)
+
+func NewServiceTable(db *statedb.DB) (statedb.RWTable[*slim_corev1.Service], error) {
+	tbl, err := statedb.NewTable(
+		ServiceTableName,
+		ServiceIDIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return tbl, db.RegisterTable(tbl)
+}
+
+func NewEndpointsTable(db *statedb.DB) (statedb.RWTable[*k8s.Endpoints], error) {
+	tbl, err := statedb.NewTable(
+		EndpointsTableName,
+		EndpointsIDIndex,
+		EndpointsByServiceIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return tbl, db.RegisterTable(tbl)
+}
+
+type reflectorParams struct {
+	cell.In
+
+	Log       *slog.Logger
+	DB        *statedb.DB
+	Services  statedb.RWTable[*slim_corev1.Service]
+	Endpoints statedb.RWTable[*k8s.Endpoints]
+	JobGroup  job.Group
+	Clientset client.Clientset
+}
+
+func registerSvcEPReflector(p reflectorParams) {
+	if !p.Clientset.IsEnabled() {
+		return
+	}
+
+	svcLW := utils.ListerWatcherFromTyped[*slim_corev1.ServiceList](p.Clientset.Slim().CoreV1().Services(""))
+	k8s.RegisterReflector(
+		p.JobGroup,
+		p.DB,
+		k8s.ReflectorConfig[*slim_corev1.Service]{
+			Name:          "k8s-services",
+			Table:         p.Services,
+			ListerWatcher: svcLW,
+			MetricScope:   "Service",
+		},
+	)
+
+	epSliceLW := utils.ListerWatcherFromTyped[*slim_discovery_v1.EndpointSliceList](p.Clientset.Slim().DiscoveryV1().EndpointSlices(""))
+	k8s.RegisterReflector(
+		p.JobGroup,
+		p.DB,
+		k8s.ReflectorConfig[*k8s.Endpoints]{
+			Name:          "k8s-endpoints",
+			Table:         p.Endpoints,
+			ListerWatcher: epSliceLW,
+			MetricScope:   "EndpointSlice",
+			Transform: func(_ statedb.ReadTxn, obj any) (*k8s.Endpoints, bool) {
+				ep, ok := obj.(*slim_discovery_v1.EndpointSlice)
+				if !ok {
+					p.Log.Warn("svcep_tables: unexpected object type", "object", obj)
+					return nil, false
+				}
+				return k8s.ParseEndpointSliceV1(p.Log, ep), true
+			},
+		},
+	)
+}

--- a/daemon/k8s/tables.go
+++ b/daemon/k8s/tables.go
@@ -4,23 +4,28 @@
 package k8s
 
 import (
+	"github.com/cilium/cilium/pkg/k8s"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
 )
 
-// TablesCell provides a set of StateDB tables for common Kubernetes objects.
-// The tables are populated with the StateDB k8s reflector (pkg/k8s/statedb.go).
-//
-// NOTE: When adding new k8s tables make sure to provide and register from a
-// single provider to ensure reflector starts before anyone depending on the table.
-// See [NewPodTableAndReflector] for example.
+// TablesCell provides the statedb tables for Kubernetes objects.
+// It's a private cell that can be imported by other cells in this package.
 var TablesCell = cell.Module(
 	"k8s-tables",
-	"StateDB tables of Kubernetes objects",
+	"statedb tables for Kubernetes objects",
 
+	SvcEPTablesCell,
 	PodTableCell,
 	NamespaceTableCell,
+
+	cell.Provide(
+		statedb.RWTable[*slim_corev1.Service].ToTable,
+		statedb.RWTable[*k8s.Endpoints].ToTable,
+		statedb.RWTable[LocalPod].ToTable,
+	),
 )
 
 // reflectorName to use in [k8s.ReflectorConfig]. This is the name that appears

--- a/pkg/k8s/tables.go
+++ b/pkg/k8s/tables.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+)
+
+var (
+	// Services is a table of Kubernetes services.
+	Services      statedb.Table[*slim_corev1.Service]
+	servicesTable statedb.RWTable[*slim_corev1.Service]
+)
+
+func init() {
+	var err error
+	servicesTable, err = statedb.NewTable(
+		"k8s-services",
+		statedb.Index[*slim_corev1.Service, string]{
+			Name: "namespace-name",
+			FromObject: func(obj *slim_corev1.Service) index.KeySet {
+				return index.NewKeySet(index.String(obj.Namespace + "/" + obj.Name))
+			},
+			FromKey: index.String,
+			Unique:  true,
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+	Services = servicesTable
+}

--- a/pkg/loadbalancer/cell/cell_test.go
+++ b/pkg/loadbalancer/cell/cell_test.go
@@ -29,7 +29,6 @@ func TestCell(t *testing.T) {
 
 	h := hive.New(
 		k8sClient.FakeClientCell(),
-		daemonk8s.ResourcesCell,
 		daemonk8s.TablesCell,
 		maglev.Cell,
 		node.LocalNodeStoreCell,

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -74,7 +74,7 @@ func TestScript(t *testing.T) {
 		func(t testing.TB, args []string) *script.Engine {
 			h := hive.New(
 				k8sClient.FakeClientCell(),
-				daemonk8s.ResourcesCell,
+
 				daemonk8s.TablesCell,
 				metrics.Cell,
 

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -68,7 +68,6 @@ func TestScript(t *testing.T) {
 			log := hivetest.Logger(t, opts...)
 			h := hive.New(
 				k8sClient.FakeClientCell(),
-				daemonk8s.ResourcesCell,
 				daemonk8s.TablesCell,
 				metrics.Cell,
 

--- a/pkg/loadbalancer/reflectors/cell.go
+++ b/pkg/loadbalancer/reflectors/cell.go
@@ -12,7 +12,7 @@ var Cell = cell.Module(
 	"Reflects external state to load-balancing tables",
 
 	// Reflects Kubernetes Services and Endpoint(Slices) to load-balancing tables
-	K8sReflectorCell,
+	cell.Invoke(RegisterK8sReflector),
 
 	// Reflects state to load-balancing tables from a local file specified with
 	// '--lb-state-file'.

--- a/pkg/loadbalancer/reflectors/k8s_test.go
+++ b/pkg/loadbalancer/reflectors/k8s_test.go
@@ -4,67 +4,161 @@
 package reflectors
 
 import (
-	"log/slog"
-	"maps"
+	"context"
 	"testing"
+	"time"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	k8sClientTestUtils "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
-	"github.com/cilium/cilium/pkg/k8s/testutils"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	lbmaps "github.com/cilium/cilium/pkg/loadbalancer/maps"
+	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/statedb"
+
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 )
 
-var (
-	benchmarkExternalConfig = loadbalancer.ExternalConfig{
-		EnableIPv4:           true,
-		EnableIPv6:           true,
-		KubeProxyReplacement: true,
+func newService(namespace, name string) *slim_corev1.Service {
+	return &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: slim_corev1.ServiceSpec{
+			ClusterIP: "1.2.3.4",
+			Ports: []slim_corev1.ServicePort{
+				{
+					Port: 80,
+				},
+			},
+		},
 	}
-)
-
-func BenchmarkConvertService(b *testing.B) {
-	obj, err := testutils.DecodeFile("../benchmark/testdata/service.yaml")
-	if err != nil {
-		panic(err)
-	}
-	svc := obj.(*slim_corev1.Service)
-
-	for b.Loop() {
-		convertService(loadbalancer.DefaultConfig, benchmarkExternalConfig, slog.New(slog.DiscardHandler), nil, svc, source.Kubernetes)
-	}
-	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "services/sec")
 }
 
-func BenchmarkParseEndpointSlice(b *testing.B) {
-	obj, err := testutils.DecodeFile("../benchmark/testdata/endpointslice.yaml")
-	if err != nil {
-		panic(err)
+func newEndpointSlice(namespace, name, serviceName string, endpoint string) *slim_discovery_v1.EndpointSlice {
+	port := int32(80)
+	return &slim_discovery_v1.EndpointSlice{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"kubernetes.io/service-name": serviceName,
+			},
+		},
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
+		Ports: []slim_discovery_v1.EndpointPort{
+			{
+				Port: &port,
+			},
+		},
+		Endpoints: []slim_discovery_v1.Endpoint{
+			{
+				Addresses: []string{endpoint},
+			},
+		},
 	}
-	epSlice := obj.(*slim_discovery_v1.EndpointSlice)
-	logger := hivetest.Logger(b)
-
-	for b.Loop() {
-		k8s.ParseEndpointSliceV1(logger, epSlice)
-	}
-	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpointslices/sec")
 }
+func TestK8sReflector(t *testing.T) {
+	var (
+		db        *statedb.DB
+		w         *writer.Writer
+		clientset k8sClient.Clientset
+	)
 
-func BenchmarkConvertEndpoints(b *testing.B) {
-	obj, err := testutils.DecodeFile("../benchmark/testdata/endpointslice.yaml")
-	if err != nil {
-		panic(err)
-	}
-	epSlice := obj.(*slim_discovery_v1.EndpointSlice)
-	logger := hivetest.Logger(b)
-	eps := k8s.ParseEndpointSliceV1(logger, epSlice)
-	backends := maps.All(eps.Backends)
+	h := hive.New(
+		cell.Module(
+			"test-k8s-reflector",
+			"Test K8s Reflector",
 
-	for b.Loop() {
-		convertEndpoints(logger, benchmarkExternalConfig, eps.ServiceName, backends)
+			// Provide fake k8s client and the tables for services, endpoints and pods.
+			k8sClientTestUtils.FakeClientCell(),
+			daemonk8s.SvcEPTablesCell,
+			daemonk8s.PodTableCell,
+			cell.Provide(
+				statedb.RWTable[*slim_corev1.Service].ToTable,
+				statedb.RWTable[*k8s.Endpoints].ToTable,
+				statedb.RWTable[daemonk8s.LocalPod].ToTable,
+			),
+
+			// The reflector cell to test
+			Cell,
+
+			// And its dependencies
+			writer.Cell,
+			node.LocalNodeStoreCell,
+			cell.Provide(
+				func() loadbalancer.Config { return loadbalancer.Config{} },
+				func() loadbalancer.ExternalConfig { return loadbalancer.ExternalConfig{EnableIPv4: true} },
+				func() *option.DaemonConfig { return &option.DaemonConfig{} },
+				lbmaps.NetnsCookieSupportFunc,
+
+				// Dependencies for writer.Cell
+				tables.NewNodeAddressTable,
+				statedb.RWTable[tables.NodeAddress].ToTable,
+				source.NewSources,
+			),
+			cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
+
+			// Capture the created objects for the test to use
+			cell.Invoke(func(
+				db_ *statedb.DB,
+				w_ *writer.Writer,
+				cs k8sClient.Clientset,
+			) {
+				db = db_
+				w = w_
+				clientset = cs
+			}),
+		),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	log := hivetest.Logger(t)
+	err := h.Start(log, ctx)
+	require.NoError(t, err, "starting hive")
+
+	// Create a service and an endpoint slice
+	svc := newService("default", "test-svc")
+	_, err = clientset.Slim().CoreV1().Services("default").Create(ctx, svc, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	epSlice := newEndpointSlice("default", "test-svc-1", svc.Name, "10.0.0.1")
+	_, err = clientset.Slim().DiscoveryV1().EndpointSlices("default").Create(ctx, epSlice, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Wait for the reflector to process the objects and populate the LB tables.
+	require.Eventually(t, func() bool {
+		txn := db.ReadTxn()
+		return w.Backends().NumObjects(txn) > 0
+	}, 5*time.Second, 10*time.Millisecond, "backends not found")
+
+	// Check that the backend has been created correctly.
+	txn := db.ReadTxn()
+	iter := w.Backends().All(txn)
+	var be *loadbalancer.Backend
+	for b := range iter {
+		be = b
+		break
 	}
-	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpoints/sec")
+	require.NotNil(t, be, "expected a backend")
+	require.Equal(t, "10.0.0.1", be.Address.AddrCluster().String())
+
+	err = h.Stop(log, ctx)
+	require.NoError(t, err, "stopping hive")
 }

--- a/pkg/loadbalancer/repl/main.go
+++ b/pkg/loadbalancer/repl/main.go
@@ -81,7 +81,6 @@ func main() {
 
 var Hive = hive.New(
 	client.Cell,
-	daemonk8s.ResourcesCell,
 	daemonk8s.TablesCell,
 	maglev.Cell,
 	node.LocalNodeStoreCell,


### PR DESCRIPTION
Reimplement the loadbalancer reflector to use k8s.ListerWatcherToObservable, similar to pkg/k8s/statedb.go. This avoids holding objects in a cache.Store.

The implementation now waits for the initial list of services and endpoints to be synchronized before marking the tables as initialized. This avoids restoration issues where backends could be temporarily removed during startup.

HostPort has been updated to work with Table[LocalPod].

Fixes: #41065
