### PR TITLE
cilium-cli: also restart cilium-operator pods on config changes

### DIFF
--- a/cilium-cli/config/config.go
+++ b/cilium-cli/config/config.go
@@ -103,6 +103,11 @@ func (k *K8sConfig) restartPodsUponConfigChange(ctx context.Context, params Para
 		return fmt.Errorf("⚠️  unable to restart Cilium pods: %w", err)
 	}
 
+	if err := k.client.DeletePodCollection(ctx, params.Namespace,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: defaults.OperatorPodSelector}); err != nil {
+		return fmt.Errorf("⚠️  unable to restart Cilium Operator pods: %w", err)
+	}
+
 	fmt.Println("♻️  Restarted Cilium pods")
 
 	return nil


### PR DESCRIPTION
When applying a new config with `config set` we should also restart cilium-operator pods as the configuration change might be used by Cilium Operator as well.

Fixes https://github.com/cilium/cilium/issues/40888