### PR TITLE
ci: reduce gke failures

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -11,6 +11,6 @@ k8s:
     zone: us-east4-b
     vmIndex: 3
   - version: "1.33"
-    zone: us-east1-c
+    zone: us-west1-c
     vmIndex: 4
     default: true


### PR DESCRIPTION
The `conformance-gke` tests have been failing with the error message: `error dialing backend: No agent available,` as noted in the opened issue #41037. This PR changes the region, which does not completely solve the problem since the root cause is still unknown. However, after the change, the frequency of the same failure has significantly reduced.


Failures have been observed on the main and v1.18 branches, so I have tested the changes on both.


Test runs on the main branch:


[Run 16879517490](https://github.com/cilium/cilium/actions/runs/16879517490/)
[Run 16882292979](https://github.com/cilium/cilium/actions/runs/16882292979/)
[Run 16883759631](https://github.com/cilium/cilium/actions/runs/16883759631/) (contains an unrelated failure)

Test runs on the v1.18 branch:


[Run 16883023090](https://github.com/cilium/cilium/actions/runs/16883023090/)
[Run 16884801853](https://github.com/cilium/cilium/actions/runs/16884801853/) (contains an unrelated failure)

Additionally, there was a scheduled run using the old region that occurred around the same time as the tests above, and the failures were again observed:


[Run 16883921129](https://github.com/cilium/cilium/actions/runs/16883921129/)
