### PR TITLE
bpf/tests: port L2 IPv6 announce to scapy and some cleanups

### DIFF
--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -75,8 +75,12 @@ default_data = "Should not change!!"
 
 ## L2 announce (v4)
 
-l2_announce_arp_req = Ether(dst=mac_bcast, src=mac_one)/ARP(op="who-has", psrc=v4_ext_one, pdst=v4_svc_one, hwsrc=mac_one, hwdst=mac_bcast)
-l2_announce_arp_reply = Ether(dst=mac_one, src=mac_two)/ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, hwsrc=mac_two, hwdst=mac_one)
+l2_announce_arp_req = Ether(dst=mac_bcast, src=mac_one)/                       \
+                      ARP(op="who-has", psrc=v4_ext_one, pdst=v4_svc_one,      \
+                          hwsrc=mac_one, hwdst=mac_bcast)
+l2_announce_arp_reply = Ether(dst=mac_one, src=mac_two)/                       \
+                        ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one,      \
+                            hwsrc=mac_two, hwdst=mac_one)
 
 ## L2 announce (v6)
 l2_announce6_ns = Ether(dst='33:33:ff:00:00:01', src=mac_one)/                 \

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -71,6 +71,15 @@ tcp_svc_three = 53
 
 default_data = "Should not change!!"
 
+# Utility functions
+def get_v6_ns_addr(v6_addr:str) -> str:
+    addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_svc_one))
+    return inet_ntop(socket.AF_INET6, addr_bytes)
+
+def v6_ns_mac(v6_addr:str) -> str:
+    addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_svc_one))
+    return in6_getnsmac(addr_bytes)
+
 # Test packet/buffer definitions
 
 ## L2 announce (v4)
@@ -83,10 +92,18 @@ l2_announce_arp_reply = Ether(dst=mac_one, src=mac_two)/                       \
                             hwsrc=mac_two, hwdst=mac_one)
 
 ## L2 announce (v6)
-l2_announce6_ns = Ether(dst='33:33:ff:00:00:01', src=mac_one)/                 \
-                  IPv6(src=v6_ext_node_one, dst=v6_svc_one, hlim=255)/         \
+
+### Calculate the IPv6 NS solicitation address
+l2_announce6_ns_mmac = v6_ns_mac(v6_svc_one)
+l2_announce6_ns_ma = get_v6_ns_addr(v6_svc_one)
+assert(l2_announce6_ns_mmac == '33:33:ff:00:00:01')
+assert(l2_announce6_ns_ma == 'ff02::1:ff00:1')
+
+l2_announce6_ns = Ether(dst=l2_announce6_ns_mmac, src=mac_one)/                \
+                  IPv6(src=v6_ext_node_one, dst=l2_announce6_ns_ma, hlim=255)/ \
                   ICMPv6ND_NS(tgt=v6_svc_one)/                                 \
-                  ICMPv6NDOptSrcLLAddr(lladdr='01:01:01:01:01:01')
+                  ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
+
 l2_announce6_na = Ether(dst=mac_one, src=mac_two)/                             \
                   IPv6(src=v6_svc_one, dst=v6_ext_node_one, hlim=255)/         \
                   ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one)/                  \

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -103,7 +103,11 @@ l2_announce6_ns = Ether(dst=l2_announce6_ns_mmac, src=mac_one)/                \
                   IPv6(src=v6_ext_node_one, dst=l2_announce6_ns_ma, hlim=255)/ \
                   ICMPv6ND_NS(tgt=v6_svc_one)/                                 \
                   ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
-
+l2_announce6_targeted_ns =                                                     \
+                  Ether(dst=mac_two, src=mac_one) /                            \
+                  IPv6(src=v6_ext_node_one, dst=v6_svc_one, hlim=255) /        \
+                  ICMPv6ND_NS(tgt=v6_svc_one) /                                \
+                  ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
 l2_announce6_na = Ether(dst=mac_one, src=mac_two)/                             \
                   IPv6(src=v6_svc_one, dst=v6_ext_node_one, hlim=255)/         \
                   ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one)/                  \

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -77,3 +77,13 @@ default_data = "Should not change!!"
 
 l2_announce_arp_req = Ether(dst=mac_bcast, src=mac_one)/ARP(op="who-has", psrc=v4_ext_one, pdst=v4_svc_one, hwsrc=mac_one, hwdst=mac_bcast)
 l2_announce_arp_reply = Ether(dst=mac_one, src=mac_two)/ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, hwsrc=mac_two, hwdst=mac_one)
+
+## L2 announce (v6)
+l2_announce6_ns = Ether(dst='33:33:ff:00:00:01', src=mac_one)/                 \
+                  IPv6(src=v6_ext_node_one, dst=v6_svc_one, hlim=255)/         \
+                  ICMPv6ND_NS(tgt=v6_svc_one)/                                 \
+                  ICMPv6NDOptSrcLLAddr(lladdr='01:01:01:01:01:01')
+l2_announce6_na = Ether(dst=mac_one, src=mac_two)/                             \
+                  IPv6(src=v6_svc_one, dst=v6_ext_node_one, hlim=255)/         \
+                  ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one)/                  \
+                  ICMPv6NDOptDstLLAddr(lladdr=mac_two)


### PR DESCRIPTION
This patchset:

* Hugely simplifies `tc_l2_announce6.c` using scapy buffers.
* Adds test coverage for targeted NSs in `tc_l2_announce6.c`. Also makes untargeted NSs use IPv6 solicited node address.
* Cleans up a bit `bpf/tests/scapy/pkt_defs.py`

Please note this PR builds on top #41017, so this PR can't be merged _before_ #41017.