### PR TITLE
Adding a note about intra-node pod-to-pod encryption.

### DIFF
--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -294,6 +294,14 @@ options:
 
   Egress Gateway replies are not encrypted when XDP Acceleration is enabled.
 
+.. error::
+    Cilium does not support intra-node pod-to-pod encryption. Traffic between
+    pods on the same node is never encrypted, regardless of whether node-to-node
+    encryption is enabled or not.
+    If your goal is to encrypt all traffic between pods, regardless of whether
+    they run on the same or different nodes, for compliance reasons this will likely
+    not be sufficient.
+
 Which traffic is encrypted
 ==========================
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.

- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Our team recently evaluated Cilium as a potential solution to a problem introduced by a compliance auditors.
TLDR: All the traffic between pods including intra-node pod-to-pod traffic must be fully encrypted.
If a bad actor manages to take control of one of the cluster nodes, traffic within that node must be encrypted.
This doesn't introduce any additional layer of security and could be partially mitigated by introducing mTLS.
However, it is an important requirement and must be implemented to pass the audit.
There are other alternative CNIs and service-meshes that offer this.
Hopefully, a small remark will save someone else some time in the future.

Fixes: #issue-number
```release-note
```
