### PR TITLE
policy: fix agent crash due to policy cache update-delete race

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -60,6 +60,13 @@ func TestCacheManagement(t *testing.T) {
 	deleted := cache.delete(identity)
 	require.False(t, deleted)
 
+	// Insert directly to cache and delete the entry.
+	csp := cache.lookupOrCreate(identity)
+	require.NotNil(t, csp)
+	require.Nil(t, csp.getPolicy())
+	removed := cache.delete(identity)
+	require.True(t, removed)
+
 	// Insert identity twice. Should be the same policy.
 	policy1, updated, err := cache.updateSelectorPolicy(identity, ep1.Id)
 	require.NoError(t, err)


### PR DESCRIPTION
See commit message for more details.

Relevant crash stack trace.
```
2025-08-04T00:40:52.104526177Z panic: runtime error: invalid memory address or nil pointer dereference
2025-08-04T00:40:52.104914523Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x28fea25]
2025-08-04T00:40:52.104925173Z 
2025-08-04T00:40:52.105147488Z goroutine 378 [running]:
2025-08-04T00:40:52.105285226Z github.com/cilium/cilium/pkg/policy.(*selectorPolicy).detach(...)
2025-08-04T00:40:52.105461936Z 	/go/src/github.com/cilium/cilium/pkg/policy/resolve.go:290
2025-08-04T00:40:52.105590045Z github.com/cilium/cilium/pkg/policy.(*policyCache).delete(0xc0015f2840, 0xc00a9fc4c0)
2025-08-04T00:40:52.105937734Z 	/go/src/github.com/cilium/cilium/pkg/policy/distillery.go:73 +0xc5
2025-08-04T00:40:52.106142488Z github.com/cilium/cilium/pkg/policy.(*policyCache).LocalEndpointIdentityRemoved(0xc00a9fc4c0?, 0x4e5f7d0?)
2025-08-04T00:40:52.106267340Z 	/go/src/github.com/cilium/cilium/pkg/policy/distillery.go:128 +0x13
2025-08-04T00:40:52.106565598Z github.com/cilium/cilium/pkg/identity/identitymanager.(*IdentityManager).remove(0xc000fd65a0, 0xc00a9fc4c0)
2025-08-04T00:40:52.106652430Z 	/go/src/github.com/cilium/cilium/pkg/identity/identitymanager/manager.go:155 +0x16a
2025-08-04T00:40:52.107387694Z github.com/cilium/cilium/pkg/identity/identitymanager.(*IdentityManager).RemoveOldAddNew(0xc000fd65a0, 0xc00a9fc4c0, 0xc00a72cac0)
2025-08-04T00:40:52.107506195Z 	/go/src/github.com/cilium/cilium/pkg/identity/identitymanager/manager.go:109 +0x185
2025-08-04T00:40:52.107905230Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).SetIdentity(0xc001948f08, 0xc00a72cac0, 0x0?)
2025-08-04T00:40:52.107919347Z 	/go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:1080 +0xb5
2025-08-04T00:40:52.108031977Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).identityLabelsChanged(0xc001948f08, {0x55fcab0, 0x8c5d640})
2025-08-04T00:40:52.108347346Z 	/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:2305 +0xaa5
2025-08-04T00:40:52.109019978Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runIdentityResolver(0xc001948f08, {0x55fcab0, 0x8c5d640}, 0x0, 0x6fc23ac00)
2025-08-04T00:40:52.109152971Z 	/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:2151 +0x47b
2025-08-04T00:40:52.109494860Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).ModifyIdentityLabels(0xc001948f08, {0x4e5f6e3, 0x3}, 0xc0085e9830, 0xc0085e98f0, 0x6fc23ac00)
2025-08-04T00:40:52.109637957Z 	/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1973 +0x493
2025-08-04T00:40:52.110190490Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).UpdateLabelsFrom(0xc001948f08, 0xc0090ca120, 0xba7e0c6bd8ea023e?, {0x4e5f6e3, 0x3})
2025-08-04T00:40:52.110411623Z 	/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:2103 +0xc5
2025-08-04T00:40:52.110517080Z github.com/cilium/cilium/pkg/endpointmanager.(*endpointManager).updateHostEndpointLabels(0xc000f96380, 0xc0090ca120, 0xc0085e9500)
2025-08-04T00:40:52.110668543Z 	/go/src/github.com/cilium/cilium/pkg/endpointmanager/host.go:62 +0x56
2025-08-04T00:40:52.111712839Z github.com/cilium/cilium/pkg/endpointmanager.(*endpointManager).startNodeLabelsObserver.func1({0xc00171d3e0, {{0xc002ca6420, 0xc}, {0xc001c96c50, 0x7}, {0xc0034123c0, 0x4, 0x4}, 0xc003892ae8, {0x0, ...}, ...}, ...})
2025-08-04T00:40:52.111993688Z 	/go/src/github.com/cilium/cilium/pkg/endpointmanager/host.go:43 +0x632
2025-08-04T00:40:52.112400258Z github.com/cilium/stream.Multicast[...].func1()
2025-08-04T00:40:52.112413462Z 	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/stream/sources.go:205 +0x1fd
2025-08-04T00:40:52.112881452Z github.com/cilium/cilium/pkg/node.(*LocalNodeStore).Update(0xc000f26780, 0xc003655f80)
2025-08-04T00:40:52.113486146Z 	/go/src/github.com/cilium/cilium/pkg/node/local_node_store.go:221 +0x13d
2025-08-04T00:40:52.113732046Z github.com/cilium/cilium/daemon/cmd.(*localNodeSynchronizer).SyncLocalNode(0xc000f263c0, {0x55fd3c8?, 0xc000dc3950?}, 0xc000f26780)
2025-08-04T00:40:52.113922582Z 	/go/src/github.com/cilium/cilium/daemon/cmd/local_node_sync.go:91 +0x289
2025-08-04T00:40:52.114098431Z github.com/cilium/cilium/pkg/node.NewLocalNodeStore.func1.1()
2025-08-04T00:40:52.114193037Z 	/go/src/github.com/cilium/cilium/pkg/node/local_node_store.go:150 +0x31
2025-08-04T00:40:52.114366832Z created by github.com/cilium/cilium/pkg/node.NewLocalNodeStore.func1 in goroutine 1
2025-08-04T00:40:52.114454466Z 	/go/src/github.com/cilium/cilium/pkg/node/local_node_store.go:149 +0x37b
```

This crash is related to a race condition between endpoint policy computation and node identity update(due to labels change). Currently when host endpoint identity labels are updated we generate a new cached selector policy. The old cached selector policy is removed from the policy cache and a new selector policy is expected to be created when endpoint regeneration happens. In this case the policy cache and corresponding cached selector policy is updated in two steps:
1. lookupOrCreate new cached selector policy in policy cache
2. Resolve the selector policy and set it in cached selector policy

```go
func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, bool, error) {
	cip := cache.lookupOrCreate(identity) // 1. Create new cached selector policy in policy cache

	cip.Lock()
	defer cip.Unlock()

	if selPolicy := cip.getPolicy(); selPolicy != nil && selPolicy.Revision >= cache.repo.GetRevision() {
		return selPolicy, false, nil
	}

	selPolicy, err := cache.repo.resolvePolicyLocked(identity)
	if err != nil {
		return nil, false, err
	}

	cip.setPolicy(selPolicy, endpointID) // 2. Set resolved selector policy in cached selector policy instance from policy cache. 

	return selPolicy, true, nil
}
```

This selector policy resolution for the endpoint is done as part of endpoint regeneration, which is asynchronous to node identity update handler.
If between step 1 and 2 a new host endpoint labels change is processed, we will attempt to first remove the old cached selector policy from the policy cache. This will cause a nil pointer dereference since the underlying selector policy is nil.

```go
func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
	cache.Lock()
	defer cache.Unlock()
	cip, ok := cache.policies[identity.ID]
	if ok {
		delete(cache.policies, identity.ID)
		cip.getPolicy().detach(true, 0) // getPolicy() returns nil.
	}
	return ok
}
```

To reproduce the issue we can add an artificial delay and trigger two host endpoint labels updates.

```diff
diff --git a/pkg/policy/distillery.go b/pkg/policy/distillery.go
index ea4ff9dec9..f8bd110dc3 100644
--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -5,6 +5,7 @@ package policy

 import (
        "sync/atomic"
+       "time"

        "github.com/cilium/cilium/pkg/container/versioned"
        identityPkg "github.com/cilium/cilium/pkg/identity"
@@ -89,6 +90,8 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, bool, error) {
        cip := cache.lookupOrCreate(identity)

+       time.Sleep(5 * time.Second)
+
        // As long as UpdatePolicy() is triggered from endpoint
        // regeneration, it's possible for two endpoints with the
        // *same* identity to race to update the policy here. Such
```

```bash
kubectl label nodes kind-worker test-label=value
sleep 1 // To make sure host endpoint regeneration is triggered and we reach our sleep.
kubectl label nodes kind-worker test-label-
```

Since policy cache operation to create new cached selector policy doesn't assume underlying selector policy is set, we shouldn't make this assumption in `delete` operation as well.
Adding a simple nil pointer check should fix the issue. I will create a PR.
