### PR TITLE
loadbalancer: Fixes to test flakes

### DIFF
--- a/pkg/loadbalancer/reconciler/cmds.go
+++ b/pkg/loadbalancer/reconciler/cmds.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/statedb/reconciler"
 
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type scriptCommandsParams struct {
@@ -18,6 +19,7 @@ type scriptCommandsParams struct {
 	Config     loadbalancer.Config
 	TestConfig *loadbalancer.TestConfig `optional:"true"`
 	Reconciler reconciler.Reconciler[*loadbalancer.Frontend]
+	BPFOps     *BPFOps
 }
 
 func scriptCommands(p scriptCommandsParams) hive.ScriptCmdsOut {
@@ -25,8 +27,14 @@ func scriptCommands(p scriptCommandsParams) hive.ScriptCmdsOut {
 		"lb/prune": script.Command(
 			script.CmdUsage{Summary: "Trigger pruning of load-balancing BPF maps"},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				count := p.BPFOps.pruneCount.Load()
 				p.Reconciler.Prune()
-				return nil, nil
+
+				// Wait for prune to happen
+				for s.Context().Err() != nil || p.BPFOps.pruneCount.Load() <= count {
+					time.Sleep(10 * time.Millisecond)
+				}
+				return nil, s.Context().Err()
 			},
 		),
 	}

--- a/pkg/loadbalancer/redirectpolicy/main_test.go
+++ b/pkg/loadbalancer/redirectpolicy/main_test.go
@@ -10,5 +10,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m,
+		// The metrics "status" collector tries to connect to the agent and leaves these
+		// around. We should refactor pkg/metrics to split it into "plain registry"
+		// and the agent specifics.
+		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+
+		// Unfortunately we don't have a way for waiting for the workqueue's background goroutine
+		// to exit (used by pkg/k8s/resource), so we'll just need to ignore it.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
+	)
 }

--- a/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
@@ -29,10 +29,13 @@ db/cmp frontends frontends.table
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.actual maps.expected
 
-# Remove and re-add the service we're redirecting to check that it's
-# reprocessed.
+# Remove service and endpoints. Only the backends for pseudo-service should be present.
 k8s/delete service.yaml endpointslice.yaml
 db/cmp services services-no-echo.table
+db/cmp backends backends-only-redirects.table
+
+# Re-add the service we're redirecting to check that it's
+# reprocessed.
 k8s/add service.yaml endpointslice.yaml
 db/cmp localredirectpolicies lrp.table
 db/cmp services services.table
@@ -95,6 +98,13 @@ Address                    Type        ServiceName   PortName   Backends        
 169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done
 [1001::1]:7070/UDP         ClusterIP   test/echo     udp        [2001::1]:70/UDP      test/lrp-svc:local-redirect   Done
 [1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                            Done
+
+-- backends-only-redirects.table --
+Address             Instances                           Shadows   NodeName
+10.244.2.1:70/UDP   test/lrp-svc:local-redirect (udp)
+10.244.2.1:80/TCP   test/lrp-svc:local-redirect (tcp)
+[2001::1]:70/UDP    test/lrp-svc:local-redirect (udp)
+[2001::1]:80/TCP    test/lrp-svc:local-redirect (tcp)
 
 -- maps-before.expected --
 BE: ID=1 ADDR=10.244.1.1:7070/UDP STATE=active

--- a/pkg/loadbalancer/tests/main_test.go
+++ b/pkg/loadbalancer/tests/main_test.go
@@ -17,8 +17,8 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
 		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
 
-		// Unfortunately we don't have a way for waiting for the DelayingWorkQueue's background goroutine
+		// Unfortunately we don't have a way for waiting for the workqueue's background goroutine
 		// to exit (used by pkg/k8s/resource), so we'll just need to ignore it.
-		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType[...]).waitingLoop"),
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
 	)
 }

--- a/pkg/loadbalancer/tests/testdata/migrate-any-proto.txtar
+++ b/pkg/loadbalancer/tests/testdata/migrate-any-proto.txtar
@@ -22,6 +22,10 @@ k8s/delete service.yaml endpointslice.yaml
 * db/empty services frontends backends
 * lb/maps-empty
 
+# Force a prune to make sure it won't run while we restore
+# data.
+lb/prune
+
 # Restore with protocol changed to ANY.
 lb/maps-restore --any-proto
 

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -18,7 +18,6 @@ import (
 var Cell = cell.Module("metrics", "Metrics",
 	// Provide registry to hive, but also invoke if case no cells decide to use as dependency
 	cell.Provide(NewAgentRegistry),
-	Metric(NewLegacyMetrics),
 	cell.Config(defaultRegistryConfig),
 	cell.Config(defaultSamplerConfig),
 	cell.Provide(
@@ -32,6 +31,7 @@ var Cell = cell.Module("metrics", "Metrics",
 // and without pulling in the legacy metrics.
 var AgentCell = cell.Group(
 	Cell,
+	Metric(NewLegacyMetrics),
 	cell.Invoke(
 		func(logger *slog.Logger, reg *Registry) {
 			// Register the agent status and BPF metrics.


### PR DESCRIPTION
- Make the lb/prune command wait for the pruning to happen to avoid potential races with the `test/bpfops-reset`
- Add a mutex to BPFOps so `test/bpfops-reset` and `test/bpfops-summary` don't race with operations
- Update the goleak ignores after the client-go library was bumped and function names changed
- Fix a flake in redirectpolicy's service.txtar causing ID re-use when backend deletion wasn't waited for
- Revert the change to `metrics.Cell` and move the `NewLegacyMetrics` back into `metrics.AgentCell`. This fixes test failure when run with `-race`.