### PR TITLE
bgpv2: Avoid modifying CiliumBGPPeerConfig in resource store

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/neighbor.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor.go
@@ -403,7 +403,7 @@ func (r *NeighborReconciler) getPeerConfig(peerConfig *v2.PeerConfigReference) (
 		return nil, exists, err
 	}
 
-	conf = &config.Spec
+	conf = config.Spec.DeepCopy() // copy to not ever modify config in store in SetDefaults()
 	conf.SetDefaults()
 	return conf, true, nil
 }


### PR DESCRIPTION
Modifying an object in the resource store is forbidden and cause a panic.

