### PR TITLE
.github: fix upload artifacts for features.json

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -361,7 +361,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.index }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -344,7 +344,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.version }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -636,7 +636,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -406,7 +406,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.version }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -367,7 +367,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ join(matrix.*, '-') }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -497,7 +497,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.k8s-version }}-${{matrix.focus}}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -363,7 +363,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.config.index }}-${{ matrix.k8s.vmIndex }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -455,7 +455,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -385,7 +385,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -235,7 +235,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Upload cluster logs
         if: ${{ !success() }}

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -233,7 +233,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "features-tested-${{ matrix.ipFamily }}"
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Upload cluster logs
         if: ${{ !success() }}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -173,4 +173,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -154,7 +154,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -285,7 +285,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -464,7 +464,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.focus }}
-          path: features-tested-${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -208,7 +208,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -791,7 +791,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -811,7 +811,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -512,7 +512,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}-${{ matrix.mode }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ steps.vars.outputs.downgrade_version != '' && always() }}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -187,4 +187,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -218,4 +218,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*


### PR DESCRIPTION
With the backport of the changes made into the feature-status GitHub action, all workflows that depended on it started to fail because the backport commit changed the prefix of the file names. With this commit we make sure all workflows detect the files with the new prefix.

Fixes: fd601809893e (".github/actions: only upload files with features-tested prefix")

Fixes #41080
