### PR TITLE
GKE cluster creation action

### DIFF
--- a/.github/actions/setup-gke-cluster/action.yml
+++ b/.github/actions/setup-gke-cluster/action.yml
@@ -1,0 +1,74 @@
+name: "Create GKE cluster"
+description: "Uses gcloud"
+inputs:
+  cluster-name:
+    description: "Base cluster name"
+    required: true
+  zone:
+    description: "GCP zone for the cluster"
+    required: true
+  cluster-version:
+    description: "Explicit GKE cluster version"
+    required: false
+    default: ""
+  node-taints:
+    description: "taints to apply to cluster nodes"
+    required: false
+    default: "ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute"
+  nodes:
+    description: "Number of nodes"
+    required: false
+    default: "2"
+  machine-type:
+    description: "Machine type"
+    required: false
+    default: "n2-standard-2"
+  labels:
+    description: ""
+    required: false
+    default: ""
+outputs:
+  native_cidr:
+    description: ""
+    value: ${{ steps.create-cluster.outputs.native_cidr }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: create-cluster
+      shell: bash
+      run: |
+        LABELS=""
+        VERSION=""
+        TAINTS=""
+
+        if [[ -n "${{ inputs.labels }}" ]]; then
+          LABELS="--labels ${{ inputs.labels }}"
+        fi
+
+        if [[ -n "${{ inputs.cluster-version }}" ]]; then
+          VERSION="--cluster-version ${{ inputs.cluster-version }}"
+        fi
+
+        if [[ -n "${{ inputs.node-taints }}" ]]; then
+          TAINTS="--node-taints ${{ inputs.node-taints }}"
+        fi
+
+        gcloud container clusters create "${{ inputs.cluster-name }}" \
+          --zone "${{ inputs.zone }}" \
+          --enable-ip-alias \
+          --create-subnetwork="range=/26" \
+          --cluster-ipv4-cidr="/21" \
+          --services-ipv4-cidr="/24" \
+          --image-type COS_CONTAINERD \
+          --num-nodes "${{ inputs.nodes }}" \
+          --machine-type "${{ inputs.machine-type }}" \
+          --disk-type pd-standard \
+          --disk-size 20GB \
+          --no-enable-insecure-kubelet-readonly-port \
+          $VERSION \
+          $LABELS \
+          $TAINTS
+
+        native_cidr=$(gcloud container clusters describe "${{ inputs.cluster-name }}" --zone "${{ inputs.zone }}" --format 'value(clusterIpv4Cidr)')
+        echo native_cidr=${native_cidr} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -289,25 +289,14 @@ jobs:
 
       - name: Create GKE cluster
         id: create-cluster
-        run: |
-          gcloud container clusters create ${{ env.clusterName }}-${{ matrix.config.index }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
-            --zone ${{ matrix.k8s.zone }} \
-            --cluster-version ${{ matrix.k8s.version }} \
-            --enable-ip-alias \
-            --create-subnetwork="range=/26" \
-            --cluster-ipv4-cidr="/21" \
-            --services-ipv4-cidr="/24" \
-            --image-type COS_CONTAINERD \
-            --num-nodes ${{ matrix.config.nodes || 2 }} \
-            --machine-type e2-custom-2-4096 \
-            --disk-type pd-standard \
-            --disk-size 20GB \
-            --node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute \
-            --no-enable-insecure-kubelet-readonly-port
-
-          native_cidr="$(gcloud container clusters describe ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }} --format 'value(clusterIpv4Cidr)')"
-          echo native_cidr=${native_cidr} >> $GITHUB_OUTPUT
+        uses: ./.github/actions/setup-gke-cluster
+        with:
+          cluster-name: ${{ env.clusterName }}-${{ matrix.config.index }}
+          zone: ${{ matrix.k8s.zone }}
+          cluster-version: ${{ matrix.k8s.version }}
+          nodes: ${{ matrix.config.nodes || 2 }}
+          machine-type: e2-custom-2-4096
+          labels: "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}"
 
       - name: Create ESP allow firewall rule
         if: ${{ matrix.config.type == 'tunnel-ipsec' }}

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -197,8 +197,15 @@ jobs:
 
           CILIUM_INSTALL_DEFAULTS+=" ${{ env.CILIUM_INSTALL_NET_PERF_EXTRA_ARGS }}"
 
+          NODE_TAINTS="ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute"
+
+          if [ "${{ matrix.mode }}" = "baseline" ] ; then
+            NODE_TAINTS=""
+          fi
+
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
+          echo node_taints=${NODE_TAINTS} >> $GITHUB_OUTPUT
 
       - name: Set up gcloud credentials
         id: 'auth'
@@ -225,29 +232,12 @@ jobs:
 
       - name: Create GKE cluster
         id: create-cluster
-        run: |
-          if [ "${{ matrix.mode }}" = "baseline" ] ; then
-            TAINTS=""
-          else
-            TAINTS="--node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute"
-          fi
-          gcloud container clusters create ${{ env.clusterName }}-${{ matrix.index }} \
-            --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
-            --zone ${{ env.gcp_zone }} \
-            --release-channel=stable \
-            --enable-ip-alias \
-            --create-subnetwork="range=/26" \
-            --cluster-ipv4-cidr="/21" \
-            --services-ipv4-cidr="/24" \
-            --image-type COS_CONTAINERD \
-            --num-nodes 2 \
-            --machine-type n2-standard-2 \
-            --disk-type pd-standard \
-            --disk-size 20GB \
-            ${TAINTS}
-
-          native_cidr="$(gcloud container clusters describe ${{ env.clusterName }}-${{ matrix.index }} --zone ${{ env.gcp_zone }} --format 'value(clusterIpv4Cidr)')"
-          echo native_cidr=${native_cidr} >> $GITHUB_OUTPUT
+        uses: ./.github/actions/setup-gke-cluster
+        with:
+          cluster-name: ${{ env.clusterName }}-${{ matrix.index }}
+          zone: ${{ env.gcp_zone }}
+          node-taints: ${{ steps.vars.outputs.node_taints }}
+          labels: "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}"
 
       - name: Create ESP allow firewall rule
         if: ${{ matrix.name == 'tunnel-ipsec' }}


### PR DESCRIPTION
This PR adds an action used to create GKE clusters using gcloud, and replace the manual creation in GKE workflows with this action.

Two takes were taken while making setup-gke-cluster :  
1 - Since those clusters are going to be deleted after every workflow run, no need to subscribe to a release channel (for more info about release channels in gcloud : https://cloud.google.com/kubernetes-engine/docs/how-to/release-channels)
2 - We'll always disable the insecure kubelet readonly port