### PR TITLE
.github: fix upload artifacts for features.json

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -387,7 +387,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.index }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -355,7 +355,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.version }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -674,7 +674,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -377,7 +377,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ join(matrix.*, '-') }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -412,7 +412,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.version }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -379,7 +379,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ join(matrix.*, '-') }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -499,7 +499,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.k8s-version }}-${{matrix.focus}}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -375,7 +375,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.config.index }}-${{ matrix.k8s.vmIndex }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -458,7 +458,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -428,7 +428,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -228,7 +228,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Upload cluster logs
         if: ${{ !success() }}

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -226,7 +226,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "features-tested-${{ matrix.ipFamily }}"
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Upload cluster logs
         if: ${{ !success() }}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -174,4 +174,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -181,7 +181,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -288,7 +288,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -461,7 +461,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.focus }}
-          path: features-tested-${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() && runner.arch != 'ARM64' }}

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -222,7 +222,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.conformance-profile }}-${{ matrix.crd-channel }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -232,7 +232,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -818,7 +818,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -531,7 +531,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -484,7 +484,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested-${{ matrix.name }}-${{ matrix.mode }}
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ steps.vars.outputs.downgrade_version != '' && always() }}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -182,4 +182,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -238,4 +238,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: features-tested
-          path: ${{ env.job_name }}*.json
+          path: features-tested-*


### PR DESCRIPTION
With the backport of the changes made into the feature-status GitHub action, all workflows that depended on it started to fail because the backport commit changed the prefix of the file names. With this commit we make sure all workflows detect the files with the new prefix.

Fixes: 3029d2b70d77 (".github/actions: only upload files with features-tested prefix")

Fixes #41080
