### PR TITLE
loadbalancer/writer: add support for SetIsServiceHealthCheckedFunc

### DIFF
--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -56,6 +56,9 @@ type Frontend struct {
 	// Backends associated with the frontend.
 	Backends BackendsSeq2
 
+	// HealthCheckBackends associated with the frontend that includes the ones that should be health checked.
+	HealthCheckBackends BackendsSeq2
+
 	// ID is the identifier allocated to this frontend. Used as the key
 	// in the services BPF map. This field is populated by the reconciler
 	// and is initially set to zero. It can be considered valid only when

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -102,6 +102,22 @@ Address              Instances
       "UnhealthyUpdatedAt": null
     }
   ],
+  "HealthCheckBackends": [
+    {
+      "Address": "10.244.1.1:8080/TCP",
+      "PortNames": [
+        "http"
+      ],
+      "Weight": 100,
+      "NodeName": "nodeport-worker",
+      "Zone": null,
+      "ClusterID": 0,
+      "Source": "k8s",
+      "State": 0,
+      "Unhealthy": false,
+      "UnhealthyUpdatedAt": null
+    }
+  ],
   "ID": 1,
   "RedirectTo": null
 }
@@ -117,6 +133,22 @@ Address              Instances
     "id": <redacted>
   },
   "Backends": [
+    {
+      "Address": "[2002::2]:8080/TCP",
+      "PortNames": [
+        "http"
+      ],
+      "Weight": 100,
+      "NodeName": "nodeport-worker",
+      "Zone": null,
+      "ClusterID": 0,
+      "Source": "k8s",
+      "State": 0,
+      "Unhealthy": false,
+      "UnhealthyUpdatedAt": null
+    }
+  ],
+  "HealthCheckBackends": [
     {
       "Address": "[2002::2]:8080/TCP",
       "PortNames": [
@@ -230,6 +262,18 @@ backends:
       state: 0
       unhealthy: false
       unhealthyupdatedat: null
+healthcheckbackends:
+    - address: 10.244.1.1:8080/TCP
+      portnames:
+        - http
+      weight: 100
+      nodename: nodeport-worker
+      zone: null
+      clusterid: 0
+      source: k8s
+      state: 0
+      unhealthy: false
+      unhealthyupdatedat: null
 id: 1
 redirectto: null
 ---
@@ -244,6 +288,18 @@ status:
     updated-at: <redacted>
     id: <redacted>
 backends:
+    - address: '[2002::2]:8080/TCP'
+      portnames:
+        - http
+      weight: 100
+      nodename: nodeport-worker
+      zone: null
+      clusterid: 0
+      source: k8s
+      state: 0
+      unhealthy: false
+      unhealthyupdatedat: null
+healthcheckbackends:
     - address: '[2002::2]:8080/TCP'
       portnames:
         - http

--- a/pkg/loadbalancer/tests/testdata/quarantined.txtar
+++ b/pkg/loadbalancer/tests/testdata/quarantined.txtar
@@ -9,12 +9,29 @@ hive/start
 metrics -s reconciler_prune_count -o metrics.actual
 * grep 'prune_count.*1' metrics.actual
 
+# Mark service as health checked
+test/set-is-service-healthchecked service.cilium.io/health-checked
+
 # Add our test service and backends.
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp backends backends_healthy1.table
 
-# Mark the backend as unhealthy (for this service)
+# Check BPF maps
+lb/maps-dump maps.actual
+* grep 'SLOT=0.*COUNT=0 QCOUNT=0' maps_init.expected
+* cmp maps.actual maps_init.expected
+
+# Report health of first backend as healthy (explicitly - due to SetIsServiceHealthchecked)
+test/update-backend-health test/echo 10.244.1.1:80/TCP true
+db/cmp backends backends_healthy1.table
+
+# Check BPF maps
+lb/maps-dump maps.actual
+* grep 'SLOT=0.*COUNT=1 QCOUNT=0' maps0.expected
+* cmp maps.actual maps0.expected
+
+# Mark the second backend as unhealthy (for this service)
 test/update-backend-health test/echo 10.244.1.2:80/TCP false
 db/cmp backends backends_unhealthy.table
 
@@ -40,6 +57,11 @@ test/bpfops-reset
 k8s/add endpointslice2.yaml
 db/cmp backends backends_healthy2.table
 k8s/add service.yaml
+
+# Report health of all backends
+test/update-backend-health test/echo 10.244.1.1:80/TCP true
+test/update-backend-health test/echo 10.244.1.2:80/TCP false
+test/update-backend-health test/echo 10.244.1.3:80/TCP true
 
 # Wait for reconciliation.
 db/show frontends --columns=Address,Status -o frontends.actual
@@ -76,6 +98,14 @@ stdout 'restoredQuarantines: 0'
 stdout 'restoredServiceIDs: 0'
 stdout 'restoredBackendIDs: 0'
 
+-- maps_init.expected --
+REV: ID=1 ADDR=10.96.50.104:80
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- maps0.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 -- maps1.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
 BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
@@ -128,6 +158,8 @@ kind: Service
 metadata:
   name: echo
   namespace: test
+  annotations:
+    service.cilium.io/health-checked: "true"
 spec:
   clusterIP: 10.96.50.104
   clusterIPs:


### PR DESCRIPTION
The current loadbalancer controlplane always initializes new `BackendParams`
with its default value `Unhealthy=false`. This leads to potential issues that
backendselection for a given service doesn't respect the circumstance that there might be
service health check implementations that should report the backend health
state before exposing that service backend via statedb `frontend` to other modules.

Therefore, this commit introduces a new hook `SetIsServiceHealthCheckedFunc` to the
loadbalancer `Writer`. Service health checking modules can use this hook to
mark that a given service is health checked. Backendselection for a service will use
that hook and only include a backend to a health-checked service frontend if the
health state for the backend has already been reported once. This prevents prematurely
exposing unhealthy backends (or their incorrect health status) to other modules.