### PR TITLE
endpoint: reduce missed-policy-update log severity for restoring eps

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -682,7 +682,7 @@ func (e *Endpoint) UpdatePolicy(idsToRegen *set.Set[identityPkg.NumericIdentity]
 	// bump the policy revision directly (as long as we didn't miss an update somehow).
 	if !idsToRegen.Has(secID) {
 		if e.policyRevision < fromRev {
-			if e.state == StateWaitingToRegenerate {
+			if e.state == StateWaitingToRegenerate || e.state == StateRestoring {
 				// We can log this at less severity since a regeneration was already queued.
 				// This can happen if two policy updates come in quick succession, with the first
 				// affecting this endpoint and the second not.


### PR DESCRIPTION
Follow up fix for - https://github.com/cilium/cilium/commit/6380e527788f77a65de7de4d8948f6e453a56ed6#diff-2a82969e4493f485b248bb9e4f9e1487c713053ab50fac9a0f7784ede78bf4b7R667-R674
See commit message for more details.

Fixes: #36493
