### PR TITLE
daemon: remove useless error log

### DIFF
--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -342,7 +342,7 @@ func (c *cniConfigManager) setupCNIConfFile() (err error) {
 		)
 	} else {
 		if err != nil && !os.IsNotExist(err) {
-			c.logger.Debug(
+			c.logger.Info(
 				"Failed to read existing CNI configuration file",
 				logfields.Error, err,
 				logfields.Destination, dest,
@@ -354,7 +354,6 @@ func (c *cniConfigManager) setupCNIConfFile() (err error) {
 		}
 		c.logger.Info(
 			"Wrote CNI configuration file",
-			logfields.Error, err,
 			logfields.Destination, dest,
 		)
 	}


### PR DESCRIPTION
Remove the error log in Wrote CNI configuration cuz it only could be "open /host/etc/cni/net.d/05-cilium.conflist: no such file or directory" when cilium-agent startup at the first time. 

See the comments below for detailed explanation:
```go
		if err != nil && !os.IsNotExist(err) { // If it's other errors, it should be logged at here (debug level).
			c.logger.Debug(
				"Failed to read existing CNI configuration file",
				logfields.Error, err,
				logfields.Destination, dest,
			)
		}
		if err := renameio.WriteFile(dest, contents, 0600); err != nil { // If write failed, will return error, will not go to the following code; If no error, the err variable is shadowed, the following err variable will use the previous err variable.
			return fmt.Errorf("failed to write CNI configuration file at %s: %w", dest, err)
		}
		c.logger.Info(
			"Wrote CNI configuration file",
			logfields.Error, err, // Error here must be the NotExist error (usually startup first time), it's meaningless, may even be misleading, should be removed
			logfields.Destination, dest,
		)

```

Logging example:
```txt
time=2025-08-13T01:36:48.119502555Z level=info source=/go/src/github.com/cilium/cilium/daemon/cmd/cni/config.go:355 msg="Wrote CNI configuration file" module=agent.infra.cni-config error="open /host/etc/cni/net.d/05-cilium.conflist: no such file or directory" destination=/host/etc/cni/net.d/05-cilium.conflist
```
