### PR TITLE
go.mod: use go 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6


### PR DESCRIPTION
So we can use `testing/synctest` without having to use a GOEXPERIMENT.

cf https://go.dev/blog/synctest and https://go.dev/doc/go1.25#new-testingsynctest-package
