### PR TITLE
ci: Re-enable go caches for privileged tests

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -274,7 +274,7 @@ jobs:
           cpu: 4
           # renovate: datasource=github-tags depName=cilium/little-vm-helper
           lvh-version: "v0.0.26"
-          mem: 12G
+          mem: 14G
 
       # Load Ginkgo build from GitHub
       - name: Load ${{ matrix.focus }} Ginkgo build from GitHub

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -425,9 +425,8 @@ jobs:
             go${{ env.go-version}} install github.com/cilium/go-junit-report/v2/cmd/go-junit-report@cc2d3acf69eeefab6f9a23ad61b175cd1d570623 # v2.3.0
             # Use go cache and module cache from the host that is shared with the VM.
             mkdir -p /go-caches
-            # TODO: re-enable go caches below once images with larger disk size from https://github.com/cilium/little-vm-helper-images/pull/960 are in use
-            # tar --use-compress-program=zstd -xpf /host/go-build-cache.tar.zst --same-owner -C /go-caches || true
-            # tar --use-compress-program=zstd -xpf /host/go-mod-cache.tar.zst --same-owner -C /go-caches || true
+            tar --use-compress-program=zstd -xpf /host/go-build-cache.tar.zst --same-owner -C /go-caches || true
+            tar --use-compress-program=zstd -xpf /host/go-mod-cache.tar.zst --same-owner -C /go-caches || true
             ls -la /go-caches/go-build || true
 
       - name: Privileged unit tests
@@ -439,8 +438,7 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host
-            # TODO: re-enable go caches (GOCACHE="/go-caches/go-build" GOMODCACHE="/go-caches/pkg") once images with larger disk size from https://github.com/cilium/little-vm-helper-images/pull/960 are in use
-            make SKIP_COVERAGE=1 LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml" tests-privileged-only GO=go${{ env.go-version }}
+            make GOCACHE="/go-caches/go-build" GOMODCACHE="/go-caches/pkg" SKIP_COVERAGE=1 LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml" tests-privileged-only GO=go${{ env.go-version }}
 
       - name: Copy Go cache to host
         id: copy-go-cache


### PR DESCRIPTION
Since c27d53f49bf481e691a2493fd0e45778ad550091 we use 30 GB disk size for LVH images in ci-runtime, so we can re-enable go caches for privileged tests.

Also bumps VM RAM size, as /tmp filesystem which gets 50% of the RAM size is running out of space in some test runs.