### PR TITLE
endpoint: fix file descriptor leak in policy debug logging

### DIFF
--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -5,6 +5,7 @@ package endpoint
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -156,7 +157,7 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]any) {
 			}
 		}
 		lumberjackLogger := &lumberjack.Logger{
-			Filename:   filepath.Join(option.Config.StateDir, "endpoint-policy.log"),
+			Filename:   filepath.Join(option.Config.StateDir, fmt.Sprintf("endpoint-%d-policy.log", e.GetID())),
 			MaxSize:    maxSize,
 			MaxBackups: maxBackups,
 			MaxAge:     28, // days


### PR DESCRIPTION
When multiple endpoints have policy debug logging enabled, they all create separate lumberjack.Logger instances that write to the same file path (endpoint-policy.log). This causes file descriptor leaks because:

1. Each endpoint creates its own lumberjack logger with the same filename

2. When one logger rotates the file, other loggers still hold open file descriptors to the old (renamed) file

3. The old file appears as 'deleted' in lsof but continues consuming file descriptors

Fix this by making each endpoint use a unique log filename that includes the endpoint ID (endpoint-{id}-policy.log). This ensures each endpoint manages its own log file independently without interfering with others.

Fixes: baeb61facde9 ("endpoint: Add DebugPolicy option")

Fixes https://github.com/cilium/cilium/issues/39968

```release-note
Fixed a file descriptor leak that occurred when multiple endpoints had policy debug logging enabled, which could cause resource exhaustion over time.
```
