### PR TITLE
fix(helm): add api-server-urls as flag to agent DS config initContainer

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -477,6 +477,9 @@ spec:
         {{- if .Values.kubeConfigPath }}
         - "--k8s-kubeconfig-path={{ .Values.kubeConfigPath }}"
         {{- end }}
+        {{- if hasKey .Values.k8s "apiServerURLs" }}
+        - "--k8s-api-server-urls={{ .Values.k8s.apiServerURLs }}"
+        {{- end }}
         env:
         - name: K8S_NODE_NAME
           valueFrom:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Pass the api-server-urls Helm value as a container args to the config initContainer of the cilium-agent DaemonSet.

This will allow the config initContainer to hit apiserver correctly to build the rest of the config.

Fixes https://github.com/cilium/cilium/issues/41108

```release-note
Fix agent config initContainer unable to hit apiservers in apiServerURLs by passing as container arg
```