### PR TITLE
.github: fix upload artifacts for features.json

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -453,7 +453,7 @@ jobs:
             exit 0
           fi
           find . -type f -iname 'feature-status-*.json' | while IFS= read -r file; do
-            mv "\$file" "./${{ env.job_name }}-\${file##*/feature-status-}"
+            mv "\$file" "./feature-status-${{ env.job_name }}-\${file##*/feature-status-}"
           done
           EOF
           chmod +x run-in-lvm.sh


### PR DESCRIPTION
With the changes made into the feature-status GitHub action, all workflows that depended on it started to fail because the commit changed the prefix of the file names. This commit fixes the conformance-ginkgo test since it was creating the features .json file without the feature-status prefix.

Fixes: deaee71ac60c (".github/actions: only upload files with features-tested prefix")