### PR TITLE
.github/workflows: add timeout to Install node local DNS step

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -345,13 +345,14 @@ jobs:
           mkdir -p cilium-junits
 
       - name: Install node local DNS
+        timeout-minutes: 3
         if: ${{ matrix.node-local-dns == 'true' }}
         shell: bash
         run: |
           kubedns=$(kubectl get svc kube-dns -n kube-system -o jsonpath="{.spec.clusterIP}") && sed -i "s/__PILLAR__DNS__SERVER__/$kubedns/g;" untrusted/cilium-newest/examples/kubernetes-local-redirect/node-local-dns.yaml
           sed -i "s/__PILLAR__UPSTREAM__SERVERS__/1.1.1.1/g;" untrusted/cilium-newest/examples/kubernetes-local-redirect/node-local-dns.yaml
           kubectl apply -k untrusted/cilium-newest/examples/kubernetes-local-redirect
-          kubectl rollout status -n kube-system ds/node-local-dns
+          kubectl rollout status --timeout=2m -n kube-system ds/node-local-dns
 
       - name: Prepare the bpftrace parameters
         if: ${{ matrix.encryption != '' }}


### PR DESCRIPTION
Without a timeout, this step could get stuck until the workflow timeout is reached. Thus, we add a sane timeout of 2 minutes for the step to be completed.