### PR TITLE
lbipam: widening CIDR range or updating selector of CiliumLoadBalancerIPPool does no longer reassign IPs 

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1567,13 +1567,19 @@ func (ipam *LBIPAM) revalidateAllServices(ctx context.Context) error {
 
 		return nil
 	}
-	for _, sv := range ipam.serviceStore.unsatisfied {
+
+	// We want to first revalidate all satisfied services.
+	// This helps in case when pool's CIDR was widened
+	// and we have unsatisfied services that match this pool.
+	// In this case, we want to revalidate satisfied services first,
+	// so that we can reallocate the same IPs from the newly widened CIDR.
+	for _, sv := range ipam.serviceStore.satisfied {
 		if err := revalidate(sv); err != nil {
 			return fmt.Errorf("revalidate: %w", err)
 		}
 	}
 
-	for _, sv := range ipam.serviceStore.satisfied {
+	for _, sv := range ipam.serviceStore.unsatisfied {
 		if err := revalidate(sv); err != nil {
 			return fmt.Errorf("revalidate: %w", err)
 		}

--- a/operator/pkg/lbipam/lbipam_fixture_test.go
+++ b/operator/pkg/lbipam/lbipam_fixture_test.go
@@ -33,6 +33,7 @@ const (
 	serviceAUID = types.UID("b801e1cf-9e71-455c-9bc8-52c0575c22bd")
 	serviceBUID = types.UID("b415933e-524c-4f83-8493-de2157fc736f")
 	serviceCUID = types.UID("8d820ef0-d640-497a-bc67-b05190bddee6")
+	serviceDUID = types.UID("66666666-6666-6666-6666-666666666666")
 )
 
 type fakeIPPoolClient struct {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1098,6 +1098,10 @@ const (
 
 	PoolSpec = "poolSpec"
 
+	PoolOldSpec = "poolOldSpec"
+
+	PoolNewSpec = "poolNewSpec"
+
 	PoolName = "poolName"
 
 	MaxRetries = "maxRetries"


### PR DESCRIPTION
Previously, whenever CIDR range was extended, we removed all allocations from existing ranges, created new ranges and tried reassigning IPs to new ranges. We've already tried to reuse the same IP, however as we tried first to assign IPs to "unsatisfied" services, they could steal existing IPs from other service, resulting in reallocation of IP for already "satisfied" service, while also resulting in temporary state with two different services having the same IP.

Note that this do not solve a case when CIDR range shrinks. In case of CIDR shrinking, IPs that would still be valid within a new range might get reallocated.

Related: #40358

```release-note
lbipam: widening CIDR range or updating selector of CiliumLoadBalancerIPPool does no longer reassign IPs 
```
