### PR TITLE
bpf/tests/scapy: show pkt diffs on assertion failures and improve outputs

### DIFF
--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -43,22 +43,29 @@
 		void *__data = (void *)(long)(CTX)->data;			\
 		void *__data_end = (void *)(long)(CTX)->data_end;		\
 		__data += OFF;							\
+		bool ok = true;							\
+		__u16 _len = LEN;						\
+										\
 		if (__data + (LEN) > __data_end) {				\
-			test_log("CTX size - offset < LEN " __FILE__ ":"	\
-				 LINE_STRING);					\
-			test_fail_now();					\
+			ok = false;						\
+			_len = (__u16)(data_end - __data);			\
+			test_log("CTX len (%d) - offset (%d) < LEN (%d)",	\
+				 _len + OFF, OFF, LEN);				\
 		}								\
 		if (sizeof(BUF(BUF_NAME)) < (LEN)) {				\
-			test_log("BUF size < LEN " __FILE__ ":" LINE_STRING);	\
-			test_fail_now();					\
+			ok = false;						\
+			test_log("Buffer '" #BUF_NAME "' of len (%d) < LEN"	\
+				 " (%d)", sizeof(BUF(BUF_NAME)), LEN);		\
 		}								\
-		if (memcmp(__data, &BUF(BUF_NAME), LEN) != 0) {			\
+		if (ok && memcmp(__data, &BUF(BUF_NAME), LEN) != 0) {		\
+			ok = false;						\
 			test_log("CTX and buffer '" #BUF_NAME			\
-				 "' mismatch " __FILE__ ":"			\
-				LINE_STRING);					\
+				 "' content mismatch ");			\
+		}								\
+		if (!ok) {							\
 			hexdump_len_off(__FILE__ ":" LINE_STRING " assert '"	\
 					NAME "' FAILED! Got (ctx)",		\
-					FIRST_LAYER, CTX, LEN, OFF);		\
+					FIRST_LAYER, CTX, _len, OFF);		\
 			scapy_hexdump(__FILE__ ":" LINE_STRING " assert '"	\
 				      NAME "' FAILED! Expected (buf)",		\
 				      FIRST_LAYER, &BUF(BUF_NAME)[0],		\


### PR DESCRIPTION
This small patchset improves:

* `trace_diff_pkts.py` by:
   * Showing the diff between the expected packet and the one received, (potentially) field by field. This is done
       _after_ dumping both packets.
   * Print pkt lengths in bytes as part of dumping the packets.
   * Changes formatting to make it easier to read.
* `ASSERT_CTX_BUF_OFF` by:
    * Unconditionally dumping packets, even when lengths mismatch.
    * Adds useful info in the assert message (e.g. sizes).
    
### Before this patch series

<details>
<summary>Example of CTX len < LEN</summary>

```
time=2025-08-13T16:02:22.755411559+02:00 level=info msg="Initializing dissection cache..."
--- FAIL: TestBPF (14.12s)
    --- FAIL: TestBPF/tc_l2_announcement.o (0.07s)
        --- FAIL: TestBPF/tc_l2_announcement.o/1_happy_path (0.00s)
            bpf_test.go:457: tc_l2_announcement.c:150: CTX size - offset < LEN tc_l2_announcement.c:150
        bpf_test.go:62: -> 1: [error]
FAIL
FAIL	github.com/cilium/cilium/bpf/tests/bpftest	14.144s
FAIL
```

</details>

<details>
<summary>Example of buffer length < LEN:</summary>
    
```
--- FAIL: TestBPF (14.51s)
    --- FAIL: TestBPF/tc_l2_announcement.o (0.08s)
        --- FAIL: TestBPF/tc_l2_announcement.o/1_happy_path (0.00s)
            bpf_test.go:457: tc_l2_announcement.c:150: CTX and buffer 'EXPECTED_ARP_REP' mismatch tc_l2_announcement.c:150
        bpf_test.go:62: -> 1: [error]
FAIL
FAIL	github.com/cilium/cilium/bpf/tests/bpftest	14.533s
FAIL
=== Start tc_l2_announcement.c:150 'arp_rep_ok' ===
--- Expected ---
###[ Ethernet ]### 
  dst       = de:ad:be:ef:de:ef
  src       = 13:37:13:37:13:37
  type      = 0x9000

--- Got ---
###[ Ethernet ]### 
  dst       = de:ad:be:ef:de:ef
  src       = 13:37:13:37:13:37
  type      = ARP

===  End  tc_l2_announcement.c:150 'arp_rep_ok' ===
```

</details>

### After:

Simple diff:

```
--- FAIL: TestBPF (15.31s)
    --- FAIL: TestBPF/tc_l2_announcement.o (0.07s)
        --- FAIL: TestBPF/tc_l2_announcement.o/1_happy_path (0.00s)
            bpf_test.go:457: tc_l2_announcement.c:150: CTX and buffer 'EXPECTED_ARP_REP' content mismatch 
        bpf_test.go:62: -> 1: [error]
FAIL
FAIL	github.com/cilium/cilium/bpf/tests/bpftest	15.344s
FAIL
=== START tc_l2_announcement.c:150 'arp_rep_ok' ===
>>> Expected (len: 42 bytes) <<<
###[ Ethernet ]### 
  dst       = de:ad:be:ef:de:ef
  src       = 31:41:59:26:35:89
  type      = ARP
###[ ARP ]### 
     hwtype    = Ethernet (10Mb)
     ptype     = IPv4
     hwlen     = 6
     plen      = 4
     op        = is-at
     hwsrc     = 13:37:13:37:13:37
     psrc      = 172.16.10.1
     hwdst     = de:ad:be:ef:de:ef
     pdst      = 0.0.0.53

>>> Got (len: 42 bytes) <<<
###[ Ethernet ]### 
  dst       = de:ad:be:ef:de:ef
  src       = 13:37:13:37:13:37
  type      = ARP
###[ ARP ]### 
     hwtype    = Ethernet (10Mb)
     ptype     = IPv4
     hwlen     = 6
     plen      = 4
     op        = is-at
     hwsrc     = 13:37:13:37:13:37
     psrc      = 172.16.10.1
     hwdst     = de:ad:be:ef:de:ef
     pdst      = 110.0.11.1

>>> Diff <<<
  --- a/pkt (Expected)
  +++ b/pkt (Got)

  - [ Ether ].src: 31:41:59:26:35:89
  + [ Ether ].src: 13:37:13:37:13:37
  - [ Ether ][ ARP ].pdst: 0.0.0.53
  + [ Ether ][ ARP ].pdst: 110.0.11.1

=== END tc_l2_announcement.c:150 'arp_rep_ok' ===
```

<details>
<summary>Example of CTX len < LEN</summary>

```
    --- FAIL: TestBPF (14.35s)
        --- FAIL: TestBPF/tc_l2_announcement.o (0.07s)
            --- FAIL: TestBPF/tc_l2_announcement.o/1_happy_path (0.00s)
                bpf_test.go:457: tc_l2_announcement.c:150: CTX len (46) - offset (4) < LEN (65)
            bpf_test.go:62: -> 1: [error]
    FAIL
    FAIL    github.com/cilium/cilium/bpf/tests/bpftest      14.372s
    FAIL
    === START tc_l2_announcement.c:150 'arp_rep_ok' ===
    >>> Expected (len: 65 bytes) <<<
      dst       = de:ad:be:ef:de:ef
      src       = 13:37:13:37:13:37
      type      = IPv4
         version   = 4
         ihl       = 5
         tos       = 0x0
         len       = 51
         id        = 1
         flags     =
         frag      = 0
         ttl       = 64
         proto     = tcp
         chksum    = 0x7cc2
         src       = 127.0.0.1
         dst       = 127.0.0.1
         \options   \
            sport     = ftp_data
            dport     = http
            seq       = 0
            ack       = 0
            dataofs   = 5
            reserved  = 0
            flags     = S
            window    = 8192
            chksum    = 0x1fa3
            urgptr    = 0
            options   = []
               load      = 'Hello world'
    
    >>> Got (len: 42 bytes) <<<
      dst       = de:ad:be:ef:de:ef
      src       = 13:37:13:37:13:37
      type      = ARP
         hwtype    = Ethernet (10Mb)
         ptype     = IPv4
         hwlen     = 6
         plen      = 4
         op        = is-at
         hwsrc     = 13:37:13:37:13:37
         psrc      = 172.16.10.1
         hwdst     = de:ad:be:ef:de:ef
         pdst      = 110.0.11.1
    
    >>> Diff <<<
      --- a/pkt (Expected)
      +++ b/pkt (Got)
    
      - [ Ether ].type: 2048
      + [ Ether ].type: 2054
      - [ Ether ][ IP ].options: []
      - [ Ether ][ IP ].version: 4
      - [ Ether ][ IP ].ihl: 5
      - [ Ether ][ IP ].tos: 0
      - [ Ether ][ IP ].len: 51
      - [ Ether ][ IP ].id: 1
      - [ Ether ][ IP ].flags:
      - [ Ether ][ IP ].frag: 0
      - [ Ether ][ IP ].ttl: 64
      - [ Ether ][ IP ].proto: 6
      - [ Ether ][ IP ].chksum: 31938
      - [ Ether ][ IP ].src: 127.0.0.1
      - [ Ether ][ IP ].dst: 127.0.0.1
      - [ Ether ][ IP ][ TCP ].sport: 20
      - [ Ether ][ IP ][ TCP ].dport: 80
      - [ Ether ][ IP ][ TCP ].seq: 0
      - [ Ether ][ IP ][ TCP ].ack: 0
      - [ Ether ][ IP ][ TCP ].dataofs: 5
      - [ Ether ][ IP ][ TCP ].reserved: 0
      - [ Ether ][ IP ][ TCP ].flags: S
      - [ Ether ][ IP ][ TCP ].window: 8192
      - [ Ether ][ IP ][ TCP ].chksum: 8099
      - [ Ether ][ IP ][ TCP ].urgptr: 0
      - [ Ether ][ IP ][ TCP ].options: []
      - [ Ether ][ IP ][ TCP ][ Raw ].load: b'Hello world'
      + [ Ether ][ ARP ].hwtype: 1
      + [ Ether ][ ARP ].ptype: 2048
      + [ Ether ][ ARP ].hwlen: 6
      + [ Ether ][ ARP ].plen: 4
      + [ Ether ][ ARP ].op: 2
      + [ Ether ][ ARP ].hwsrc: 13:37:13:37:13:37
      + [ Ether ][ ARP ].psrc: 172.16.10.1
      + [ Ether ][ ARP ].hwdst: de:ad:be:ef:de:ef
      + [ Ether ][ ARP ].pdst: 110.0.11.1
    
    === END tc_l2_announcement.c:150 'arp_rep_ok' ===
```

</details>

<details>
<summary>Example of buffer length < LEN:</summary>
    
```
    --- FAIL: TestBPF (14.42s)
        --- FAIL: TestBPF/tc_l2_announcement.o (0.07s)
            --- FAIL: TestBPF/tc_l2_announcement.o/1_happy_path (0.00s)
                bpf_test.go:457: tc_l2_announcement.c:151: Buffer 'EXPECTED_ARP_REP' of len (14) < LEN (42)
            bpf_test.go:62: -> 1: [error]
    FAIL
    FAIL    github.com/cilium/cilium/bpf/tests/bpftest      14.444s
    FAIL
    === START tc_l2_announcement.c:151 'arp_rep_ok' ===
    >>> Expected (len: 14 bytes) <<<
      dst       = de:ad:be:ef:de:ef
      src       = 13:37:13:37:13:37
      type      = 0x9000
    
    >>> Got (len: 42 bytes) <<<
      dst       = de:ad:be:ef:de:ef
      src       = 13:37:13:37:13:37
      type      = ARP
         hwtype    = Ethernet (10Mb)
         ptype     = IPv4
         hwlen     = 6
         plen      = 4
         op        = is-at
         hwsrc     = 13:37:13:37:13:37
         psrc      = 172.16.10.1
         hwdst     = de:ad:be:ef:de:ef
         pdst      = 110.0.11.1
    
    >>> Diff <<<
      --- a/pkt (Expected)
      +++ b/pkt (Got)
    
      - [ Ether ].type: 36864
      + [ Ether ].type: 2054
      + [ Ether ][ ARP ].hwtype: 1
      + [ Ether ][ ARP ].ptype: 2048
      + [ Ether ][ ARP ].hwlen: 6
      + [ Ether ][ ARP ].plen: 4
      + [ Ether ][ ARP ].op: 2
      + [ Ether ][ ARP ].hwsrc: 13:37:13:37:13:37
      + [ Ether ][ ARP ].psrc: 172.16.10.1
      + [ Ether ][ ARP ].hwdst: de:ad:be:ef:de:ef
      + [ Ether ][ ARP ].pdst: 110.0.11.1
    
    === END tc_l2_announcement.c:151 'arp_rep_ok' ===
```

</details>