### PR TITLE
treewide: Centralize goleak options to pkg/testutils

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,6 +60,10 @@ linters:
               recommendations:
                 - github.com/cilium/dns
               reason: use the cilium fork directly to avoid replace directives in go.mod, see https://github.com/cilium/cilium/pull/27582
+          - go.uber.org/goleak:
+              recommendations:
+                - github.com/cilium/cilium/pkg/testutils
+              reason: Use testutils.Goleak* instead for the shared default options.
           - gopkg.in/check.v1:
               recommendations:
                 - testing

--- a/clustermesh-apiserver/clustermesh/users_mgmt_test.go
+++ b/clustermesh-apiserver/clustermesh/users_mgmt_test.go
@@ -14,12 +14,12 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 const (
@@ -57,8 +57,8 @@ func (f *fakeUserMgmtClient) UserEnforceAbsence(_ context.Context, name string) 
 
 func TestUsersManagement(t *testing.T) {
 	// Catch any leaked goroutines. Ignoring goroutines possibly left by other tests.
-	leakOpts := goleak.IgnoreCurrent()
-	t.Cleanup(func() { goleak.VerifyNone(t, leakOpts) })
+	leakOpts := testutils.GoleakIgnoreCurrent()
+	t.Cleanup(func() { testutils.GoleakVerifyNone(t, leakOpts) })
 
 	var client fakeUserMgmtClient
 	client.init()

--- a/clustermesh-apiserver/mcsapi-coredns-cfg/script_test.go
+++ b/clustermesh-apiserver/mcsapi-coredns-cfg/script_test.go
@@ -17,13 +17,13 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
-	"github.com/cilium/cilium/pkg/k8s/testutils"
+	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -32,17 +32,12 @@ var debug = flag.Bool("debug", false, "Enable debug logging")
 func TestScript(t *testing.T) {
 	// Catch any leaked goroutines. Ignoring goroutines possibly left by other tests.
 	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreCurrent(),
-
-			// To ignore goroutine started by the workqueue. It reports metrics
-			// on unfinished work with default tick period of 0.5s - it terminates
-			// no longer than 0.5s after the workqueue is stopped.
-			goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
+		testutils.GoleakVerifyNone(t,
+			testutils.GoleakIgnoreCurrent(),
 		)
 	})
 
-	version.Force(testutils.DefaultVersion)
+	version.Force(k8sTestutils.DefaultVersion)
 
 	var opts []hivetest.LogOption
 	if *debug {

--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -8,31 +8,31 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
-var goleakOptions = []goleak.Option{
+var goleakOptions = []testutils.GoleakOption{
 	// Ignore all the currently running goroutines spawned
 	// by prior tests or by package init() functions (like the
 	// client-go logger).
-	goleak.IgnoreCurrent(),
+	testutils.GoleakIgnoreCurrent(),
 	// Ignore goroutines started by the policy trifecta, see [newPolicyTrifecta].
-	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/identity/cache.(*identityWatcher).watch.func1"),
-	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter"),
+	testutils.GoleakIgnoreTopFunction("github.com/cilium/cilium/pkg/identity/cache.(*identityWatcher).watch.func1"),
+	testutils.GoleakIgnoreTopFunction("github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter"),
 	// Ignore goroutine started by the ipset reconciler rate limiter
-	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/rate.NewLimiter.func1"),
+	testutils.GoleakIgnoreTopFunction("github.com/cilium/cilium/pkg/rate.NewLimiter.func1"),
 }
 
 // TestAgentCell verifies that the Agent hive can be instantiated with
 // default configuration and thus the Agent hive can be inspected with
 // the hive commands and documentation can be generated from it.
 func TestAgentCell(t *testing.T) {
-	defer goleak.VerifyNone(t, goleakOptions...)
+	defer testutils.GoleakVerifyNone(t, goleakOptions...)
 	defer metrics.Reinitialize()
 
 	logging.SetLogLevelToDebug()

--- a/operator/api/health_test.go
+++ b/operator/api/health_test.go
@@ -11,20 +11,20 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/go-openapi/runtime"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/safeio"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestHealthHandlerK8sDisabled(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
-		goleak.IgnoreTopFunction("time.Sleep"),
+		testutils.GoleakIgnoreTopFunction("time.Sleep"),
 	)
 
 	rr := httptest.NewRecorder()
@@ -73,10 +73,10 @@ func TestHealthHandlerK8sDisabled(t *testing.T) {
 }
 
 func TestHealthHandlerK8sEnabled(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
-		goleak.IgnoreTopFunction("time.Sleep"),
+		testutils.GoleakIgnoreTopFunction("time.Sleep"),
 	)
 
 	rr := httptest.NewRecorder()

--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/go-openapi/runtime"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/api/v1/operator/models"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/metrics"
@@ -25,13 +24,14 @@ import (
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/safeio"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestMetricsHandlerWithoutMetrics(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
-		goleak.IgnoreTopFunction("time.Sleep"),
+		testutils.GoleakIgnoreTopFunction("time.Sleep"),
 	)
 
 	rr := httptest.NewRecorder()
@@ -94,10 +94,10 @@ func TestMetricsHandlerWithoutMetrics(t *testing.T) {
 }
 
 func TestMetricsHandlerWithMetrics(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
-		goleak.IgnoreTopFunction("time.Sleep"),
+		testutils.GoleakIgnoreTopFunction("time.Sleep"),
 	)
 
 	rr := httptest.NewRecorder()

--- a/operator/api/server_test.go
+++ b/operator/api/server_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/go-openapi/runtime/middleware"
-	"go.uber.org/goleak"
 
 	operatorApi "github.com/cilium/cilium/api/v1/operator/server"
 	clrestapi "github.com/cilium/cilium/api/v1/operator/server/restapi/cluster"
@@ -22,13 +21,14 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	ciliumMetrics "github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestAPIServerK8sDisabled(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
-		goleak.IgnoreTopFunction("time.Sleep"),
+		testutils.GoleakIgnoreTopFunction("time.Sleep"),
 	)
 
 	var testSrv Server
@@ -97,10 +97,10 @@ func TestAPIServerK8sDisabled(t *testing.T) {
 }
 
 func TestAPIServerK8sEnabled(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
-		goleak.IgnoreTopFunction("time.Sleep"),
+		testutils.GoleakIgnoreTopFunction("time.Sleep"),
 	)
 
 	var testSrv Server

--- a/operator/cmd/root_test.go
+++ b/operator/cmd/root_test.go
@@ -8,20 +8,20 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 // TestOperatorHive verifies that the Operator hive can be instantiated with
 // default configuration and thus the Operator hive can be inspected with
 // the hive commands and documentation can be generated from it.
 func TestOperatorHive(t *testing.T) {
-	defer goleak.VerifyNone(t,
+	defer testutils.GoleakVerifyNone(t,
 		// Ignore all the currently running goroutines spawned
 		// by prior tests or by package init() functions (like the
 		// client-go logger).
-		goleak.IgnoreCurrent(),
+		testutils.GoleakIgnoreCurrent(),
 	)
 
 	err := hive.New(Operator).Populate(hivetest.Logger(t))

--- a/operator/endpointgc/gc_test.go
+++ b/operator/endpointgc/gc_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sTesting "k8s.io/client-go/testing"
@@ -24,10 +23,11 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestRegisterController(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 	)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
@@ -65,7 +65,7 @@ func TestRegisterController(t *testing.T) {
 }
 
 func TestRegisterControllerOnce(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 	)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
@@ -103,7 +103,7 @@ func TestRegisterControllerOnce(t *testing.T) {
 }
 
 func TestRegisterControllerWithCRDDisabled(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 	)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"go.uber.org/goleak"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -25,14 +24,15 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestIdentitiesGC(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// To ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go
 		// init function
-		goleak.IgnoreTopFunction("time.Sleep"),
+		testutils.GoleakIgnoreTopFunction("time.Sleep"),
 	)
 
 	var clientset k8sClient.Clientset

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 
@@ -28,13 +27,8 @@ import (
 )
 
 func TestRegisterController(t *testing.T) {
-	defer goleak.VerifyNone(
-		t,
-		// To ignore goroutine started by the workqueue. It reports metrics
-		// on unfinished work with default tick period of 0.5s - it terminates
-		// no longer than 0.5s after the workqueue is stopped.
-		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
-	)
+	defer testutils.GoleakVerifyNone(t)
+
 	var fakeClient k8sClient.Clientset
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
@@ -82,12 +76,12 @@ func TestRegisterController(t *testing.T) {
 }
 
 func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// To ignore goroutine started by the workqueue. It reports metrics
 		// on unfinished work with default tick period of 0.5s - it terminates
 		// no longer than 0.5s after the workqueue is stopped.
-		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
+		testutils.GoleakIgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
 	)
 	var fakeClient k8sClient.Clientset
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]

--- a/operator/watchers/script_test.go
+++ b/operator/watchers/script_test.go
@@ -19,19 +19,19 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
-	"github.com/cilium/cilium/pkg/k8s/testutils"
+	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -40,18 +40,13 @@ var debug = flag.Bool("debug", false, "Enable debug logging")
 func TestScript(t *testing.T) {
 	// Catch any leaked goroutines.
 	t.Cleanup(func() {
-		goleak.VerifyNone(t,
+		testutils.GoleakVerifyNone(t,
 			// Ignore goroutines possibly left by other tests.
-			goleak.IgnoreCurrent(),
-
-			// Ignore goroutine started by the workqueue. It reports metrics
-			// on unfinished work with default tick period of 0.5s - it terminates
-			// no longer than 0.5s after the workqueue is stopped.
-			goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
+			testutils.GoleakIgnoreCurrent(),
 		)
 	})
 
-	version.Force(testutils.DefaultVersion)
+	version.Force(k8sTestutils.DefaultVersion)
 
 	var opts []hivetest.LogOption
 	if *debug {

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 
@@ -42,7 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/synced"
-	"github.com/cilium/cilium/pkg/k8s/testutils"
+	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -55,6 +54,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -62,9 +62,9 @@ var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
 	// Catch any leaked goroutines.
-	t.Cleanup(func() { goleak.VerifyNone(t) })
+	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
 
-	version.Force(testutils.DefaultVersion)
+	version.Force(k8sTestutils.DefaultVersion)
 	setup := func(t testing.TB, args []string) *script.Engine {
 		fakeEnvoy := &fakeEnvoySyncerAndPolicyTrigger{
 			store: resourceStore{},

--- a/pkg/clustermesh/clustercfg/clustercfg_test.go
+++ b/pkg/clustermesh/clustercfg/clustercfg_test.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 
 	"github.com/stretchr/testify/require"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 var errMock = errors.New("error")
@@ -94,7 +94,7 @@ func TestGetSetClusterConfig(t *testing.T) {
 }
 
 func TestEnforceClusterConfig(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	// Configure a short run interval for testing purposes
 	defer func(orig time.Duration) { runInterval = orig }(runInterval)

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
@@ -38,7 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
-	"github.com/cilium/cilium/pkg/k8s/testutils"
+	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -54,24 +53,22 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
-	// Catch any leaked goroutines. Ignoring goroutines possibly left by other tests.
-	leakOpts := goleak.IgnoreCurrent()
 	t.Cleanup(func() {
-		goleak.VerifyNone(t,
+		// Catch any leaked goroutines. Ignoring goroutines possibly left by other tests.
+		leakOpts := testutils.GoleakIgnoreCurrent()
+		testutils.GoleakVerifyNone(t,
 			leakOpts,
-			// Ignore workqueue metrics collection goroutine, this would otherwise be
-			// cleaned up shortly after the tests complete.
-			goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
 		)
 	})
 
-	version.Force(testutils.DefaultVersion)
+	version.Force(k8sTestutils.DefaultVersion)
 
 	var opts []hivetest.LogOption
 	if *debug {

--- a/pkg/crypto/certloader/cell_test.go
+++ b/pkg/crypto/certloader/cell_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestCell(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	// create directory structure and config inputs
@@ -84,7 +84,7 @@ func TestCell(t *testing.T) {
 
 func TestCellConfigError(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	// init hive
@@ -130,7 +130,7 @@ func TestCellConfigError(t *testing.T) {
 
 func TestCellShutdown(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	// create directory structure and config inputs
@@ -189,7 +189,7 @@ func TestCellShutdown(t *testing.T) {
 
 func TestCellDisabled(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	ctx := t.Context()

--- a/pkg/crypto/certloader/client_test.go
+++ b/pkg/crypto/certloader/client_test.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestWatchedClientConfigIsMutualTLS(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -78,7 +79,7 @@ func TestWatchedClientConfigIsMutualTLS(t *testing.T) {
 
 func TestFutureWatchedClientConfig(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -108,7 +109,7 @@ func TestFutureWatchedClientConfig(t *testing.T) {
 
 func TestNewWatchedClientConfig(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -145,7 +146,7 @@ func TestNewWatchedClientConfig(t *testing.T) {
 
 func TestNewWatchedClientConfigWithoutClientCert(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -173,7 +174,7 @@ func TestNewWatchedClientConfigWithoutClientCert(t *testing.T) {
 
 func TestWatchedClientConfigRotation(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)

--- a/pkg/crypto/certloader/server_test.go
+++ b/pkg/crypto/certloader/server_test.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestNewWatchedServerConfigErrors(t *testing.T) {
@@ -29,7 +30,7 @@ func TestNewWatchedServerConfigErrors(t *testing.T) {
 
 func TestWatchedServerConfigIsMutualTLS(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -77,7 +78,7 @@ func TestWatchedServerConfigIsMutualTLS(t *testing.T) {
 
 func TestFutureWatchedServerConfig(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -107,7 +108,7 @@ func TestFutureWatchedServerConfig(t *testing.T) {
 
 func TestNewWatchedServerConfig(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -147,7 +148,7 @@ func TestNewWatchedServerConfig(t *testing.T) {
 
 func TestWatchedServerConfigRotation(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)

--- a/pkg/crypto/certloader/watcher_test.go
+++ b/pkg/crypto/certloader/watcher_test.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestNewWatcherError(t *testing.T) {
@@ -25,7 +26,7 @@ func TestNewWatcherError(t *testing.T) {
 
 func TestNewWatcher(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -53,7 +54,7 @@ func TestNewWatcher(t *testing.T) {
 
 func TestRotation(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -96,7 +97,7 @@ func TestRotation(t *testing.T) {
 
 func TestFutureWatcherImmediately(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -127,7 +128,7 @@ func TestFutureWatcherImmediately(t *testing.T) {
 
 func TestFutureWatcher(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -169,7 +170,7 @@ func TestFutureWatcher(t *testing.T) {
 
 func TestFutureWatcherShutdownBeforeReady(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble, relay := directories(t)
@@ -193,7 +194,7 @@ func TestFutureWatcherShutdownBeforeReady(t *testing.T) {
 
 func TestKubernetesMount(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	dir, hubble := k8sDirectories(t)

--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -22,12 +22,12 @@ import (
 	"github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -44,7 +44,7 @@ Members:
 {{else}}{{end}}{{end}}`
 
 func TestManager(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	var mgr Manager
 
@@ -278,7 +278,7 @@ func TestManager(t *testing.T) {
 }
 
 func TestManagerNodeIpsetNotNeeded(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	ipsets := make(map[string]AddrSet) // mocked kernel IP sets
 	var mu lock.Mutex                  // protect the ipsets map
@@ -428,7 +428,7 @@ func TestOpsPruneEnabled(t *testing.T) {
 }
 
 func TestOpsRetry(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	var (
 		db    *statedb.DB

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 	"k8s.io/apimachinery/pkg/util/sets"
 	baseclocktest "k8s.io/utils/clock/testing"
 
@@ -27,11 +26,12 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 func TestReconciliationLoop(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	var (
 		clock   = baseclocktest.NewFakeClock(time.Now())

--- a/pkg/datapath/linux/backend_neighbors_test.go
+++ b/pkg/datapath/linux/backend_neighbors_test.go
@@ -11,20 +11,20 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/neighbor"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 func TestBackendNeighborSync(t *testing.T) {
 	// Ignore all the currently running goroutines spawned
 	// by prior tests or by package init() functions.
-	goleakOpt := goleak.IgnoreCurrent()
-	t.Cleanup(func() { goleak.VerifyNone(t, goleakOpt) })
+	goleakOpt := testutils.GoleakIgnoreCurrent()
+	t.Cleanup(func() { testutils.GoleakVerifyNone(t, goleakOpt) })
 
 	var (
 		db             *statedb.DB

--- a/pkg/datapath/linux/devices_controller_test.go
+++ b/pkg/datapath/linux/devices_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
-	"go.uber.org/goleak"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -38,15 +37,15 @@ import (
 
 func devicesControllerTestSetup(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(
+		testutils.GoleakVerifyNone(
 			t,
-			goleak.IgnoreCurrent(),
+			testutils.GoleakIgnoreCurrent(),
 			// Ignore loop() and the netlink goroutines. These are left behind as netlink library has a bug
 			// that causes it to be stuck in Recvfrom even after stop channel closes.
 			// This is fixed by https://github.com/vishvananda/netlink/pull/793, but that has not been merged.
 			// These goroutines will terminate after any route or address update.
-			goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/datapath/linux.(*devicesController).loop"),
-			goleak.IgnoreTopFunction("syscall.Syscall6"), // Recvfrom
+			testutils.GoleakIgnoreTopFunction("github.com/cilium/cilium/pkg/datapath/linux.(*devicesController).loop"),
+			testutils.GoleakIgnoreTopFunction("syscall.Syscall6"), // Recvfrom
 		)
 	})
 }

--- a/pkg/datapath/linux/sysctl/sysctl_test.go
+++ b/pkg/datapath/linux/sysctl/sysctl_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/cilium/statedb/reconciler"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -74,7 +74,7 @@ func TestFullPath(t *testing.T) {
 }
 
 func TestWaitForReconciliation(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	const paramName = "fake-parameter"
 
@@ -121,7 +121,7 @@ func TestWaitForReconciliation(t *testing.T) {
 }
 
 func TestSysctl(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	settings := [][]string{
 		{"net", "ipv4", "ip_forward"},
@@ -220,7 +220,7 @@ func TestSysctl(t *testing.T) {
 }
 
 func TestSysctlIgnoreErr(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	parameter := tables.Sysctl{Name: []string{"net", "core", "bpf_jit_enable"}, Val: "1", IgnoreErr: true}
 

--- a/pkg/dial/resolver_test.go
+++ b/pkg/dial/resolver_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 // Configure a generous timeout to prevent flakes when running in a noisy CI environment.
@@ -43,7 +43,7 @@ var (
 )
 
 func TestServiceResolver(t *testing.T) {
-	t.Cleanup(func() { goleak.VerifyNone(t) })
+	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
 
 	var (
 		tlog = hivetest.Logger(t)

--- a/pkg/dynamicconfig/script_test.go
+++ b/pkg/dynamicconfig/script_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
-	"github.com/cilium/cilium/pkg/k8s/testutils"
+	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -30,11 +30,11 @@ var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
 	// Catch any leaked goroutines.
-	t.Cleanup(func() { goleak.VerifyNone(t) })
+	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
 
 	nodeTypes.SetName("testnode")
 
-	version.Force(testutils.DefaultVersion)
+	version.Force(k8sTestutils.DefaultVersion)
 	setup := func(t testing.TB, args []string) *script.Engine {
 		h := hive.New(
 			k8sClient.FakeClientCell(),

--- a/pkg/endpointcleanup/cleanup_test.go
+++ b/pkg/endpointcleanup/cleanup_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stesting "k8s.io/client-go/testing"
@@ -30,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 var testCESs = []cilium_v2a1.CiliumEndpointSlice{
@@ -132,12 +132,7 @@ func TestGC(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer goleak.VerifyNone(
-				t,
-				// Delaying workqueues used by resource.Resource[T].Events leaks this waitingLoop goroutine.
-				// It does stop when shutting down but is not guaranteed to before we actually exit.
-				goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop"),
-			)
+			defer testutils.GoleakVerifyNone(t)
 
 			node.SetTestLocalNodeStore()
 			defer node.UnsetTestLocalNodeStore()

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestRingReader_Previous(t *testing.T) {
@@ -199,12 +199,12 @@ func TestRingReader_NextLost(t *testing.T) {
 }
 
 func TestRingReader_NextFollow(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutines started by the redirect we do from klog to logrus
-		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("io.(*pipe).read"))
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))
 	ring := NewRing(Capacity15)
 	for i := range 15 {
 		ring.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
@@ -277,12 +277,12 @@ func TestRingReader_NextFollow(t *testing.T) {
 }
 
 func TestRingReader_NextFollow_WithEmptyRing(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutines started by the redirect we do from klog to logrus
-		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("io.(*pipe).read"))
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))
 	ring := NewRing(Capacity15)
 	reader := NewRingReader(ring, ring.LastWriteParallel())
 	ctx, cancel := context.WithCancel(t.Context())

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func BenchmarkRingWrite(b *testing.B) {
@@ -711,12 +711,12 @@ func TestRingFunctionalitySerialized(t *testing.T) {
 }
 
 func TestRing_ReadFrom_Test_1(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutines started by the redirect we do from klog to logrus
-		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("io.(*pipe).read"))
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))
 	r := NewRing(Capacity15)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
@@ -772,12 +772,12 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 }
 
 func TestRing_ReadFrom_Test_2(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutines started by the redirect we do from klog to logrus
-		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("io.(*pipe).read"))
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))
 
 	r := NewRing(Capacity15)
 	if len(r.data) != 0x10 {
@@ -871,12 +871,12 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 }
 
 func TestRing_ReadFrom_Test_3(t *testing.T) {
-	defer goleak.VerifyNone(
+	defer testutils.GoleakVerifyNone(
 		t,
 		// ignore goroutines started by the redirect we do from klog to logrus
-		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("io.(*pipe).read"))
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
+		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))
 	r := NewRing(Capacity15)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +32,7 @@ import (
 	k8sFakeClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 const testTimeout = time.Minute
@@ -43,11 +43,8 @@ func TestMain(m *testing.M) {
 		// missing Event.Done() calls.
 		runtime.GC()
 	}
-	goleak.VerifyTestMain(m,
-		goleak.Cleanup(cleanup),
-		// Delaying workqueues used by resource.Resource[T].Events leaks this waitingLoop goroutine.
-		// It does stop when shutting down but is not guaranteed to before we actually exit.
-		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop"),
+	testutils.GoleakVerifyTestMain(m,
+		testutils.GoleakCleanup(cleanup),
 	)
 }
 

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -34,6 +33,7 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 type fixture struct {
@@ -1110,7 +1110,7 @@ func TestDelService(t *testing.T) {
 
 // This tests affirms that the L2 announcer behaves as expected during it lifecycle, shutting down cleanly
 func TestL2AnnouncerLifecycle(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
 
 	startCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
-	"go.uber.org/goleak"
 	"golang.org/x/sys/unix"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -129,7 +128,7 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 	require.NoError(t, h.Start(log, t.Context()), "Start")
 	t.Cleanup(func() {
 		require.NoError(t, h.Stop(log, context.Background()), "Stop")
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	// Add a backends and wait for the job to pick it up
@@ -294,7 +293,7 @@ func TestPrivilegedSocketTermination_Datapath(t *testing.T) {
 	require.NoError(t, h.Start(log, t.Context()), "Start")
 	t.Cleanup(func() {
 		require.NoError(t, h.Stop(log, context.Background()), "Stop")
-		goleak.VerifyNone(t)
+		testutils.GoleakVerifyNone(t)
 	})
 
 	namespaces := map[string]*netns.NetNS{

--- a/pkg/loadbalancer/redirectpolicy/main_test.go
+++ b/pkg/loadbalancer/redirectpolicy/main_test.go
@@ -6,19 +6,9 @@ package redirectpolicy
 import (
 	"testing"
 
-	"go.uber.org/goleak"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m,
-		// The metrics "status" collector tries to connect to the agent and leaves these
-		// around. We should refactor pkg/metrics to split it into "plain registry"
-		// and the agent specifics.
-		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
-		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
-
-		// Unfortunately we don't have a way for waiting for the workqueue's background goroutine
-		// to exit (used by pkg/k8s/resource), so we'll just need to ignore it.
-		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
-	)
+	testutils.GoleakVerifyTestMain(m)
 }

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -48,7 +47,7 @@ import (
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	version.Force(k8sTestutils.DefaultVersion)
 	nodeTypes.SetName("testnode")

--- a/pkg/loadbalancer/tests/main_test.go
+++ b/pkg/loadbalancer/tests/main_test.go
@@ -6,19 +6,9 @@ package tests
 import (
 	"testing"
 
-	"go.uber.org/goleak"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m,
-		// The metrics "status" collector tries to connect to the agent and leaves these
-		// around. We should refactor pkg/metrics to split it into "plain registry"
-		// and the agent specifics.
-		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
-		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
-
-		// Unfortunately we don't have a way for waiting for the workqueue's background goroutine
-		// to exit (used by pkg/k8s/resource), so we'll just need to ignore it.
-		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
-	)
+	testutils.GoleakVerifyTestMain(m)
 }

--- a/pkg/pprof/cell_test.go
+++ b/pkg/pprof/cell_test.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestPprofDisabled(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	var testSrv Server
 
@@ -49,7 +49,7 @@ func TestPprofDisabled(t *testing.T) {
 }
 
 func TestPprofHandlers(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer testutils.GoleakVerifyNone(t)
 
 	var testSrv Server
 

--- a/pkg/testutils/goleak.go
+++ b/pkg/testutils/goleak.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"slices"
+	"testing"
+
+	//nolint:gomodguard
+	"go.uber.org/goleak"
+)
+
+func defaultGoleakOptions() []goleak.Option {
+	return []goleak.Option{
+		// The metrics "status" collector tries to connect to the agent and leaves these
+		// around. We should refactor pkg/metrics to split it into "plain registry"
+		// and the agent specifics.
+		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+
+		// Unfortunately we don't have a way for waiting for the workqueue's background goroutine
+		// to exit (used by pkg/k8s/resource), so we'll just need to ignore it.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
+	}
+}
+
+// GoleakVerifyTestMain calls [goleak.VerifyTestMain] with our known list of
+// leaky functions to ignore. To use this:
+//
+//	func TestMain(m *testing.M) {
+//	  testutils.GoleakVerifyTestMain(m)
+//	}
+func GoleakVerifyTestMain(m *testing.M, options ...goleak.Option) {
+	goleak.VerifyTestMain(
+		m,
+		slices.Concat(defaultGoleakOptions(), options)...)
+}
+
+// GoleakVerifyNone calls [goleak.VerifyNone] with our known list of leaky
+// functions to ignore.
+func GoleakVerifyNone(t *testing.T, options ...goleak.Option) {
+	goleak.VerifyNone(
+		t,
+		slices.Concat(defaultGoleakOptions(), options)...)
+}
+
+// Aliases for the goleak options as we're forbidding the go.uber.org/goleak
+// import.
+var (
+	GoleakIgnoreTopFunction = goleak.IgnoreTopFunction
+	GoleakIgnoreAnyFunction = goleak.IgnoreAnyFunction
+	GoleakIgnoreCurrent     = goleak.IgnoreCurrent
+	GoleakCleanup           = goleak.Cleanup
+)
+
+type GoleakOption = goleak.Option

--- a/pkg/xds/experimental/client/client_test.go
+++ b/pkg/xds/experimental/client/client_test.go
@@ -22,7 +22,6 @@ import (
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/google/go-cmp/cmp"
-	"go.uber.org/goleak"
 	grpcStatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -34,6 +33,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/envoy/xds"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 const useSOTW = true
@@ -573,7 +573,7 @@ func TestRunReturnsNonRetriableErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
-					defer goleak.VerifyNone(t)
+					defer testutils.GoleakVerifyNone(t)
 
 					opts := Defaults
 					opts.RetryBackoff.Min = time.Microsecond
@@ -686,7 +686,7 @@ func TestObserve(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
-					defer goleak.VerifyNone(t)
+					defer testutils.GoleakVerifyNone(t)
 
 					opts := Defaults
 					c := NewClient(slog.Default(), sotw, &opts)
@@ -779,7 +779,7 @@ var _ grpc.ClientConnInterface = (*FakeClientConn)(nil)
 func TestClientConnectionRetry(t *testing.T) {
 	for _, retry := range []bool{true, false} {
 		t.Run(fmt.Sprintf("retry=%v", retry), func(t *testing.T) {
-			defer goleak.VerifyNone(t)
+			defer testutils.GoleakVerifyNone(t)
 
 			opts := Defaults
 			opts.RetryBackoff.Min = time.Hour
@@ -844,7 +844,7 @@ func TestAckAndNack(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
-					defer goleak.VerifyNone(t)
+					defer testutils.GoleakVerifyNone(t)
 
 					opts := Defaults
 					c := NewClient(slog.Default(), sotw, &opts)

--- a/standalone-dns-proxy/cmd/standalonednsproxy_test.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy_test.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/fqdn/service"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestStandaloneDNSProxy(t *testing.T) {
-	defer goleak.VerifyNone(t,
-		goleak.IgnoreCurrent(),
-	)
+	defer testutils.GoleakVerifyNone(t)
 
 	// Enable L7 proxy for the standalone DNS proxy
 	option.Config.EnableL7Proxy = true


### PR DESCRIPTION
This is a follow up to the goleak ignores update in https://github.com/cilium/cilium/pull/41085. Let's avoid the duplication and instead centralize the options so it's harder to get into situations where the ignores diverge when the function signatures change. E.g. what happened with `workqueue`:

```
$ git grep 'workqueue.(\*Ty'
clustermesh-apiserver/clustermesh/script_test.go:                       goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
clustermesh-apiserver/mcsapi-coredns-cfg/script_test.go:                        goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
operator/pkg/ciliumendpointslice/controller_test.go:            goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
operator/pkg/ciliumendpointslice/controller_test.go:            goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
operator/watchers/script_test.go:                       goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
pkg/clustermesh/script_test.go:                 goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
pkg/loadbalancer/redirectpolicy/main_test.go:           goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
pkg/loadbalancer/tests/main_test.go:            goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
```

Half had `workqueue.*Type` (which hasn't existed for almost a year) and half had the correct one.

```
    treewide: Enforce use of testutils.Goleak*

    Add a linter to reject use of go.uber.org/goleak in favour of
    testutils.Goleak* and switch to it treewide.

    I removed the client-go workqueue ignore from every test that mentioned it
    to instead rely on the shared option and I ran each of these test suites
    with 'stress' for 30 seconds to validate.
```

```
    testutils: Add goleak wrapper

    This wraps go.uber.org/goleak with default ignore options that a lot
    of tests repeated.

    The motivation for this is that we had a lot of tests ignoring a specific
    top function from client-go's workqueue, but its signature had changed
    over time and about half were still referring to the old one.
```