### PR TITLE
bpf/tests: allow running a single unit test (for real). BPF_TEST

### DIFF
--- a/Documentation/contributing/testing/bpf.rst
+++ b/Documentation/contributing/testing/bpf.rst
@@ -35,7 +35,7 @@ To run the tests in your local environment, execute the following command from t
 
 To run a single test, specify its name without extension. For example:
 
-    $ make run_bpf_tests BPF_TEST_FILE="xdp_nodeport_lb4_nat_lb"
+    $ make run_bpf_tests BPF_TEST="xdp_nodeport_lb4_nat_lb"
 
 Writing tests
 =============

--- a/Makefile
+++ b/Makefile
@@ -582,14 +582,14 @@ gateway-api-conformance: ## Run Gateway API conformance tests.
 		-json \
 	| tparse -progress
 
-BPF_TEST_FILE ?= ""
+BPF_TEST ?= ""
 BPF_TEST_DUMP_CTX ?= ""
 BPF_TEST_VERBOSE ?= 0
 
 run_bpf_tests: ## Build and run the BPF unit tests using the cilium-builder container image.
 	DOCKER_ARGS="--privileged -v /sys:/sys" RUN_AS_ROOT=1 contrib/scripts/builder.sh \
 		$(MAKE) $(SUBMAKEOPTS) -j$(shell nproc) -C bpf/tests/ run \
-			"BPF_TEST_FILE=$(BPF_TEST_FILE)" \
+			"BPF_TEST=$(BPF_TEST)" \
 			"BPF_TEST_DUMP_CTX=$(BPF_TEST_DUMP_CTX)" \
 			"LOG_CODEOWNERS=$(LOG_CODEOWNERS)" \
 			"JUNIT_PATH=$(JUNIT_PATH)" \

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -31,7 +31,16 @@ TRACE_PIPE_PID := $(ROOT_DIR)/bpf/tests/output/trace_pipe.pid
 
 .PHONY: all clean run $(SCAPY_HDR_TS)
 
-TEST_OBJECTS = $(patsubst %.c, %.o, $(wildcard *.c))
+ALL_TEST_OBJECTS = $(patsubst %.c, %.o, $(wildcard *.c))
+
+ifeq ($(origin BPF_TEST), undefined)
+TEST_OBJECTS = $(ALL_TEST_OBJECTS)
+else
+TEST_OBJECTS=$(shell echo $(ALL_TEST_OBJECTS) | tr ' ' '\n' | grep $(BPF_TEST).o)
+ifeq ($(strip $(TEST_OBJECTS)),)
+$(error Invalid test '$(BPF_TEST).o')
+endif
+endif
 
 all: $(TEST_OBJECTS)
 
@@ -95,8 +104,8 @@ endif
 ifdef BPF_TEST_DUMP_CTX
     BPF_TEST_FLAGS += -dump-ctx
 endif
-ifdef BPF_TEST_FILE
-	BPF_TEST_FLAGS += -test $(BPF_TEST_FILE)
+ifdef BPF_TEST
+	BPF_TEST_FLAGS += -test $(BPF_TEST)
 endif
 
 run: $(TEST_OBJECTS)

--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -64,6 +64,8 @@ func (w *testLogWriter) Write(p []byte) (n int, err error) {
 }
 
 func TestBPF(t *testing.T) {
+	ranTests := 0
+
 	if testPath == nil || *testPath == "" {
 		t.Skip("Set -bpf-test-path to run BPF tests")
 	}
@@ -113,6 +115,12 @@ func TestBPF(t *testing.T) {
 				}
 			}
 		})
+
+		ranTests++
+	}
+
+	if ranTests == 0 {
+		t.Fatal("no BPF programs found to test. Check --bpf-test-path and --test filter.")
 	}
 
 	if *testCoverageReport != "" {


### PR DESCRIPTION
Prior to this commit, bpftest had the option to run a single test (`--test`) and you could pass `BPF_TEST_FILE`:

```
make run BPF_TEST_FILE=mcast_tests
```

This had a few problems:

* When modifying headers _ALL_ objects were recompiled.
* If BPF_TEST_FLAGS was invalid, the resulting set of tests that bpftest run were 0, but bpftest was (silently) passing. Take a look at the output of this:

```
$ make run BPF_TEST_FILE=this_is_invalid
[...]
ok  	github.com/cilium/cilium/bpf/tests/bpftest	0.022s

```

This commit:

* Replaces `BPF_TEST_FILE` to `BPF_TEST` to make it a bit more usable.
* Only recompiles `BPF_TEST`.o.
* Fails if `BPF_TEST` file doesn't exist.
* bpftest fails now if no tests run.

The result is that you can now run a single test by:

```
$ make run BPF_TEST=mcast_tests
```