### PR TITLE
kpr: Enhance kube-proxy replacement logging

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -46,6 +46,8 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 	if !kprCfg.EnableNodePort {
 		option.Config.EnableHostLegacyRouting = true
 	}
+	logger.Info("kube-proxy replacement starting with the following config",
+		logfields.KPRConfiguration, kprCfg)
 
 	if kprCfg.EnableNodePort {
 		if option.Config.LoadBalancerRSSv4CIDR != "" {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1803,4 +1803,6 @@ const (
 	Fraction = "fraction"
 
 	Rate = "rate"
+
+	KPRConfiguration = "kprConfiguration"
 )


### PR DESCRIPTION
improves logging for the kpr at before start up and outputs the configuration being used to follow the practice that we followed before here.
https://github.com/cilium/cilium/blob/v1.17/daemon/cmd/kube_proxy_replacement.go#L48-L52


```release-note
Log kube-proxy replacement config before starting kube-proxy replacement
```
