### PR TITLE
kvstore: fix overly verbose debug log and error message

### DIFF
--- a/pkg/kvstore/store/syncstore.go
+++ b/pkg/kvstore/store/syncstore.go
@@ -182,12 +182,12 @@ func (wss *wqSyncStore) UpsertKey(_ context.Context, k Key) error {
 	key := k.GetKeyName()
 	value, err := k.Marshal()
 	if err != nil {
-		return fmt.Errorf("failed marshaling key %q: %w", k, err)
+		return fmt.Errorf("failed marshaling key %q: %w", key, err)
 	}
 
 	prevValue, loaded := wss.state.Swap(key, value)
 	if loaded && bytes.Equal(prevValue, value) {
-		wss.log.Debug("ignoring upsert request for already up-to-date key", logfields.Key, k)
+		wss.log.Debug("ignoring upsert request for already up-to-date key", logfields.Key, key)
 	} else {
 		if !wss.synced.Load() {
 			wss.pendingSync.Store(key, struct{}{})


### PR DESCRIPTION
The debug message in the [UpsertKey] function used to pass the entire key object as logfield, possibly leading to a very verbose and/or fairly useless output (especially when the value is a byte slice). Let's get this fixed by only passing the key name (i.e., part of the key in etcd) as logfield, similarly to what already done in the other functions. And likewise for the error message in the same function, even though never expected to be triggered.