### PR TITLE
github: netpol-e2e: re-raise FD count to 5000

### DIFF
--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -213,8 +213,8 @@ jobs:
           for p in $(pidof cilium-agent); do
             num=$(sudo lsof -p $p | wc -l)
             echo "cilium-agent($p) has $num file descriptors open"
-            if [ "$num" -gt "500" ]; then
-              echo "cilium-agent($p) has more than 500 file descriptors (potential leak)"
+            if [ "$num" -gt "5000" ]; then
+              echo "cilium-agent($p) has more than 5000 file descriptors (potential leak)"
               sudo lsof -p $p
               exit 1
             fi


### PR DESCRIPTION
When the FD leak detector was ported from a ginkgo test to a Github Workflow, we lost an order of magnitude - causing flakes. The underlying **[issue](https://github.com/cilium/cilium/issues/39968)** is being addressed, but this deflakes CI for now without making things worse.

Fixes: eb05e5b83b (test/runtime: Move fd leak detector to conformance-k8s-kind)
