### PR TITLE
build: Include hubble CLI directory in cilium container directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ debug: all
 
 include Makefile.defs
 
-SUBDIRS_CILIUM_CONTAINER := cilium-dbg daemon cilium-health bugtool tools/mount tools/sysctlfix plugins/cilium-cni
+SUBDIRS_CILIUM_CONTAINER := cilium-dbg daemon cilium-health bugtool hubble tools/mount tools/sysctlfix plugins/cilium-cni
 SUBDIR_OPERATOR_CONTAINER := operator
 SUBDIR_RELAY_CONTAINER := hubble-relay
 SUBDIR_CLUSTERMESH_APISERVER_CONTAINER := clustermesh-apiserver

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -184,30 +184,27 @@ CGO_ENABLED ?= 0
 GOEXPERIMENT ?=
 
 # Support CGO cross-compiling for amd64 and arm64 targets
-CGO_CC =
+GO_BUILD_ENV = CGO_ENABLED=$(CGO_ENABLED)
 CROSS_ARCH =
 ifneq ($(GOARCH),$(NATIVE_ARCH))
     CROSS_ARCH = $(GOARCH)
 endif
 ifeq ($(CROSS_ARCH),arm64)
-    CGO_CC = CC=aarch64-linux-gnu-gcc
+    GO_BUILD_ENV += CC=aarch64-linux-gnu-gcc
 else ifeq ($(CROSS_ARCH),amd64)
-    CGO_CC = CC=x86_64-linux-gnu-gcc
+    GO_BUILD_ENV += CC=x86_64-linux-gnu-gcc
 endif
 
 ifneq ($(GOARCH),)
-    CGO_CC += GOARCH=$(GOARCH)
+    GO_BUILD_ENV += GOARCH=$(GOARCH)
 endif
 
 ifneq ($(GOOS),)
-    CGO_CC += GOOS=$(GOOS)
+    GO_BUILD_ENV += GOOS=$(GOOS)
 endif
 
-
 ifneq ($(GOEXPERIMENT),)
-    GO_BUILD = GOEXPERIMENT=$(GOEXPERIMENT) CGO_ENABLED=$(CGO_ENABLED) $(CGO_CC) $(GO) build
-else
-    GO_BUILD = CGO_ENABLED=$(CGO_ENABLED) $(CGO_CC) $(GO) build
+    GO_BUILD_ENV += GOEXPERIMENT=$(GOEXPERIMENT)
 endif
 
 ifneq ($(RACE),)
@@ -240,7 +237,7 @@ ifeq ($(NOOPT),1)
     GO_BUILD_FLAGS += -gcflags="all=-N -l"
 endif
 
-GO_BUILD += $(GO_BUILD_FLAGS)
+GO_BUILD = $(GO_BUILD_ENV) $(GO) build $(GO_BUILD_FLAGS)
 
 GO_TEST = CGO_ENABLED=0 $(GO) test $(GO_TEST_FLAGS)
 GO_CLEAN = $(GO) clean $(GO_CLEAN_FLAGS)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -195,6 +195,15 @@ else ifeq ($(CROSS_ARCH),amd64)
     CGO_CC = CC=x86_64-linux-gnu-gcc
 endif
 
+ifneq ($(GOARCH),)
+    CGO_CC += GOARCH=$(GOARCH)
+endif
+
+ifneq ($(GOOS),)
+    CGO_CC += GOOS=$(GOOS)
+endif
+
+
 ifneq ($(GOEXPERIMENT),)
     GO_BUILD = GOEXPERIMENT=$(GOEXPERIMENT) CGO_ENABLED=$(CGO_ENABLED) $(CGO_CC) $(GO) build
 else

--- a/hubble/Makefile
+++ b/hubble/Makefile
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Hubble
 
+.DEFAULT_GOAL := all
+
 CURR_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include $(CURR_DIR)/../Makefile.defs
@@ -9,10 +11,8 @@ include $(CURR_DIR)/../Makefile.defs
 
 TARGET := hubble
 
+.PHONY: all
 all: $(TARGET)
-
-.PHONY: all $(TARGET) release local-release clean
-
 
 SUBDIRS_HUBBLE_CLI := .
 TARGET_DIR=.
@@ -20,21 +20,21 @@ TARGET_DIR=.
 GIT_BRANCH = $(shell command -v git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD 2> /dev/null)
 GIT_HASH = $(shell command -v git >/dev/null 2>&1 && git rev-parse --short HEAD 2> /dev/null)
 
-GOOS ?=
-GOARCH ?=
-
 GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/hubble/pkg.GitBranch=$(GIT_BRANCH)" \
 					-X "github.com/cilium/cilium/hubble/pkg.GitHash=$(GIT_HASH)" \
 					-X "github.com/cilium/cilium/hubble/pkg.Version=v$(VERSION)"
 
+.PHONY: $(TARGET)
 $(TARGET):
-	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) -o $(TARGET_DIR)/$(@)$(EXT) $(SUBDIRS_HUBBLE_CLI)
+	$(GO_BUILD) -o $(TARGET_DIR)/$(@)$(EXT) $(SUBDIRS_HUBBLE_CLI)
 
+.PHONY: release
 release:
 	cd $(CURR_DIR)/../ && \
 	$(CONTAINER_ENGINE) run --rm --workdir /cilium --volume `pwd`:/cilium --user "$(shell id -u):$(shell id -g)" \
 		$(CILIUM_BUILDER_IMAGE) sh -c "$(MAKE) -C $(TARGET) local-release"
 
+.PHONY: local-release
 local-release: clean
 	set -o errexit; \
 	for OS in darwin linux windows; do \
@@ -62,5 +62,22 @@ local-release: clean
 		rm -r release/$$OS; \
 	done;
 
+.PHONY: install
+install: install-binary install-bash-completion
+
+.PHONY: install-binary
+install-binary: $(TARGET)
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+
+.PHONY: install-bash-completion
+install-bash-completion: $(TARGET)
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CONFDIR)/bash_completion.d
+	./$(TARGET) completion bash > $(TARGET)_bash_completion
+	$(QUIET)$(INSTALL) -m 0644 -T $(TARGET)_bash_completion $(DESTDIR)$(CONFDIR)/bash_completion.d/$(TARGET)
+
+.PHONY: clean
 clean:
-	rm -f $(TARGET)
+	@$(ECHO_CLEAN)
+	-$(QUIET)rm -f $(TARGET)
+	$(QUIET)$(GO_CLEAN)

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -52,11 +52,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
     # bash_completion is the same for both architectures.
     make GOARCH=${BUILDARCH} DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} PKG_BUILD=1 $(echo $MODIFIERS | tr -d '"') \
     install-bash-completion licenses-all && \
-    mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all && \
-    mkdir -p /tmp/hubble/${TARGETOS}/${TARGETARCH} && \
-    cd hubble && \
-    make GOOS=${TARGETOS} GOARCH=${TARGETARCH} $(echo $MODIFIERS | tr -d '"') && \
-    mv hubble /tmp/hubble/${TARGETOS}/${TARGETARCH}/hubble
+    mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
 # Extract debug symbols to /tmp/debug and strip the binaries if NOSTRIP is not set.
 # Use the appropriate objcopy for the target architecture.
@@ -109,8 +105,6 @@ COPY --from=cilium-envoy /usr/bin/cilium-envoy /usr/bin/cilium-envoy-starter /us
 # local unix domain socket instead of Hubble Relay.
 ENV HUBBLE_SERVER=unix:///var/run/cilium/hubble.sock
 COPY --from=builder /tmp/install/${TARGETOS}/${TARGETARCH} /
-COPY --from=builder /tmp/hubble/${TARGETOS}/${TARGETARCH}/hubble /usr/bin/hubble
-RUN /usr/bin/hubble completion bash > /etc/bash_completion.d/hubble
 WORKDIR /home/cilium
 
 ENV INITSYSTEM="SYSTEMD"


### PR DESCRIPTION
This standardizes the way the hubble CLI is built and installed in the cilium image. Standard targets are added to the hubble CLI Makefile to allow it to be built and installed along with other cilium container components.

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

```release-note
build: Include hubble CLI directory in cilium container directories
```
