### PR TITLE
ci-aks: Fix concurrency for ipsec tests

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -345,6 +345,8 @@ jobs:
       - name: Run concurrent connectivity test with IPSec (${{ join(matrix.*, ', ') }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --test-concurrency=${{ env.test_concurrency }} \
+          --test "!seq-.*" \
           --junit-file "cilium-junits/${{ env.job_name }}-concurrent-ipsec (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
 


### PR DESCRIPTION
Commit ace5b2df1f53 ("ci-aks: Run connectivity tests concurrently")
incorrectly backported the commit e02ec08dce602650a3beba6678fe7923a0a003b8
from main, resulting in this workflow not (a) filtering the concurrent
test run to only the tests that should run concurrently and (b) running
the concurrent tests concurrently.

This could cause the step in this workflow to take as much as 40m rather
than the 10m or less that is typical for this workflow when concurrency
is enabled. Fix this by adding the concurrency parameters back in.

Fixes: ace5b2df1f53 ("ci-aks: Run connectivity tests concurrently")
