### PR TITLE
.github: Run CES migration tests concurrently

### DIFF
--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -202,6 +202,7 @@ jobs:
         with:
           job-name: ces-enable
           full-test: 'true'
+          test-concurrency: 5
           extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Features tested


### PR DESCRIPTION
The conn-disrupt-test-check seems to support more concurrency, and other
workflows are running multiple tests at once. If we can reliably run
more of these tests at the same time, we could further reduce the
feedback time for results from this workflow.
