### PR TITLE
hubble: Rate-limit lost events sent from Observer server

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -231,6 +231,7 @@ cilium-agent [flags]
       --hubble-export-file-path stdout                            Filepath to write Hubble events to. By specifying stdout the flows are logged instead of written to a rotated file.
       --hubble-flowlogs-config-path string                        Filepath with configuration of hubble flowlogs
       --hubble-listen-address string                              An additional address for Hubble server to listen to, e.g. ":4244"
+      --hubble-lost-event-send-interval duration                  Interval at which lost events are sent from the Observer server, if any. (default 1s)
       --hubble-metrics string                                     List of Hubble metrics to enable.
       --hubble-metrics-server string                              Address to serve Hubble metrics on.
       --hubble-metrics-server-enable-tls                          Run the Hubble metrics server on the given listen address with TLS.

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -124,6 +124,7 @@ cilium-agent hive [flags]
       --hubble-export-file-path stdout                            Filepath to write Hubble events to. By specifying stdout the flows are logged instead of written to a rotated file.
       --hubble-flowlogs-config-path string                        Filepath with configuration of hubble flowlogs
       --hubble-listen-address string                              An additional address for Hubble server to listen to, e.g. ":4244"
+      --hubble-lost-event-send-interval duration                  Interval at which lost events are sent from the Observer server, if any. (default 1s)
       --hubble-metrics string                                     List of Hubble metrics to enable.
       --hubble-metrics-server string                              Address to serve Hubble metrics on.
       --hubble-metrics-server-enable-tls                          Run the Hubble metrics server on the given listen address with TLS.

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -129,6 +129,7 @@ cilium-agent hive dot-graph [flags]
       --hubble-export-file-path stdout                            Filepath to write Hubble events to. By specifying stdout the flows are logged instead of written to a rotated file.
       --hubble-flowlogs-config-path string                        Filepath with configuration of hubble flowlogs
       --hubble-listen-address string                              An additional address for Hubble server to listen to, e.g. ":4244"
+      --hubble-lost-event-send-interval duration                  Interval at which lost events are sent from the Observer server, if any. (default 1s)
       --hubble-metrics string                                     List of Hubble metrics to enable.
       --hubble-metrics-server string                              Address to serve Hubble metrics on.
       --hubble-metrics-server-enable-tls                          Run the Hubble metrics server on the given listen address with TLS.

--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -600,6 +600,8 @@ that happened before the events were captured by Hubble.
 | source | [LostEventSource](#flow-LostEventSource) |  | source is the location where events got lost. |
 | num_events_lost | [uint64](#uint64) |  | num_events_lost is the number of events that haven been lost at source. |
 | cpu | [google.protobuf.Int32Value](#google-protobuf-Int32Value) |  | cpu on which the event was lost if the source of lost events is PERF_EVENT_RING_BUFFER. |
+| first | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | first is the timestamp of the first event that was lost. |
+| last | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | last is the timestamp of the last event that was lost. |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -4050,7 +4050,11 @@ type LostEvent struct {
 	NumEventsLost uint64 `protobuf:"varint,2,opt,name=num_events_lost,json=numEventsLost,proto3" json:"num_events_lost,omitempty"`
 	// cpu on which the event was lost if the source of lost events is
 	// PERF_EVENT_RING_BUFFER.
-	Cpu           *wrapperspb.Int32Value `protobuf:"bytes,3,opt,name=cpu,proto3" json:"cpu,omitempty"`
+	Cpu *wrapperspb.Int32Value `protobuf:"bytes,3,opt,name=cpu,proto3" json:"cpu,omitempty"`
+	// first is the timestamp of the first event that was lost.
+	First *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=first,proto3" json:"first,omitempty"`
+	// last is the timestamp of the last event that was lost.
+	Last          *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=last,proto3" json:"last,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4102,6 +4106,20 @@ func (x *LostEvent) GetNumEventsLost() uint64 {
 func (x *LostEvent) GetCpu() *wrapperspb.Int32Value {
 	if x != nil {
 		return x.Cpu
+	}
+	return nil
+}
+
+func (x *LostEvent) GetFirst() *timestamppb.Timestamp {
+	if x != nil {
+		return x.First
+	}
+	return nil
+}
+
+func (x *LostEvent) GetLast() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Last
 	}
 	return nil
 }
@@ -5346,11 +5364,13 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\"L\n" +
 	"\tIPTraceID\x12\x19\n" +
 	"\btrace_id\x18\x01 \x01(\x04R\atraceId\x12$\n" +
-	"\x0eip_option_type\x18\x02 \x01(\rR\fipOptionType\"\x91\x01\n" +
+	"\x0eip_option_type\x18\x02 \x01(\rR\fipOptionType\"\xf3\x01\n" +
 	"\tLostEvent\x12-\n" +
 	"\x06source\x18\x01 \x01(\x0e2\x15.flow.LostEventSourceR\x06source\x12&\n" +
 	"\x0fnum_events_lost\x18\x02 \x01(\x04R\rnumEventsLost\x12-\n" +
-	"\x03cpu\x18\x03 \x01(\v2\x1b.google.protobuf.Int32ValueR\x03cpu\"\xfe\x04\n" +
+	"\x03cpu\x18\x03 \x01(\v2\x1b.google.protobuf.Int32ValueR\x03cpu\x120\n" +
+	"\x05first\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x05first\x12.\n" +
+	"\x04last\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x04last\"\xfe\x04\n" +
 	"\n" +
 	"AgentEvent\x12(\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x14.flow.AgentEventTypeR\x04type\x123\n" +
@@ -5825,31 +5845,33 @@ var file_flow_flow_proto_depIdxs = []int32{
 	38, // 57: flow.HTTP.headers:type_name -> flow.HTTPHeader
 	11, // 58: flow.LostEvent.source:type_name -> flow.LostEventSource
 	60, // 59: flow.LostEvent.cpu:type_name -> google.protobuf.Int32Value
-	12, // 60: flow.AgentEvent.type:type_name -> flow.AgentEventType
-	45, // 61: flow.AgentEvent.unknown:type_name -> flow.AgentEventUnknown
-	46, // 62: flow.AgentEvent.agent_start:type_name -> flow.TimeNotification
-	47, // 63: flow.AgentEvent.policy_update:type_name -> flow.PolicyUpdateNotification
-	48, // 64: flow.AgentEvent.endpoint_regenerate:type_name -> flow.EndpointRegenNotification
-	49, // 65: flow.AgentEvent.endpoint_update:type_name -> flow.EndpointUpdateNotification
-	50, // 66: flow.AgentEvent.ipcache_update:type_name -> flow.IPCacheNotification
-	52, // 67: flow.AgentEvent.service_upsert:type_name -> flow.ServiceUpsertNotification
-	53, // 68: flow.AgentEvent.service_delete:type_name -> flow.ServiceDeleteNotification
-	57, // 69: flow.TimeNotification.time:type_name -> google.protobuf.Timestamp
-	61, // 70: flow.IPCacheNotification.old_identity:type_name -> google.protobuf.UInt32Value
-	51, // 71: flow.ServiceUpsertNotification.frontend_address:type_name -> flow.ServiceUpsertNotificationAddr
-	51, // 72: flow.ServiceUpsertNotification.backend_addresses:type_name -> flow.ServiceUpsertNotificationAddr
-	14, // 73: flow.DebugEvent.type:type_name -> flow.DebugEventType
-	22, // 74: flow.DebugEvent.source:type_name -> flow.Endpoint
-	61, // 75: flow.DebugEvent.hash:type_name -> google.protobuf.UInt32Value
-	61, // 76: flow.DebugEvent.arg1:type_name -> google.protobuf.UInt32Value
-	61, // 77: flow.DebugEvent.arg2:type_name -> google.protobuf.UInt32Value
-	61, // 78: flow.DebugEvent.arg3:type_name -> google.protobuf.UInt32Value
-	60, // 79: flow.DebugEvent.cpu:type_name -> google.protobuf.Int32Value
-	80, // [80:80] is the sub-list for method output_type
-	80, // [80:80] is the sub-list for method input_type
-	80, // [80:80] is the sub-list for extension type_name
-	80, // [80:80] is the sub-list for extension extendee
-	0,  // [0:80] is the sub-list for field type_name
+	57, // 60: flow.LostEvent.first:type_name -> google.protobuf.Timestamp
+	57, // 61: flow.LostEvent.last:type_name -> google.protobuf.Timestamp
+	12, // 62: flow.AgentEvent.type:type_name -> flow.AgentEventType
+	45, // 63: flow.AgentEvent.unknown:type_name -> flow.AgentEventUnknown
+	46, // 64: flow.AgentEvent.agent_start:type_name -> flow.TimeNotification
+	47, // 65: flow.AgentEvent.policy_update:type_name -> flow.PolicyUpdateNotification
+	48, // 66: flow.AgentEvent.endpoint_regenerate:type_name -> flow.EndpointRegenNotification
+	49, // 67: flow.AgentEvent.endpoint_update:type_name -> flow.EndpointUpdateNotification
+	50, // 68: flow.AgentEvent.ipcache_update:type_name -> flow.IPCacheNotification
+	52, // 69: flow.AgentEvent.service_upsert:type_name -> flow.ServiceUpsertNotification
+	53, // 70: flow.AgentEvent.service_delete:type_name -> flow.ServiceDeleteNotification
+	57, // 71: flow.TimeNotification.time:type_name -> google.protobuf.Timestamp
+	61, // 72: flow.IPCacheNotification.old_identity:type_name -> google.protobuf.UInt32Value
+	51, // 73: flow.ServiceUpsertNotification.frontend_address:type_name -> flow.ServiceUpsertNotificationAddr
+	51, // 74: flow.ServiceUpsertNotification.backend_addresses:type_name -> flow.ServiceUpsertNotificationAddr
+	14, // 75: flow.DebugEvent.type:type_name -> flow.DebugEventType
+	22, // 76: flow.DebugEvent.source:type_name -> flow.Endpoint
+	61, // 77: flow.DebugEvent.hash:type_name -> google.protobuf.UInt32Value
+	61, // 78: flow.DebugEvent.arg1:type_name -> google.protobuf.UInt32Value
+	61, // 79: flow.DebugEvent.arg2:type_name -> google.protobuf.UInt32Value
+	61, // 80: flow.DebugEvent.arg3:type_name -> google.protobuf.UInt32Value
+	60, // 81: flow.DebugEvent.cpu:type_name -> google.protobuf.Int32Value
+	82, // [82:82] is the sub-list for method output_type
+	82, // [82:82] is the sub-list for method input_type
+	82, // [82:82] is the sub-list for extension type_name
+	82, // [82:82] is the sub-list for extension extendee
+	0,  // [0:82] is the sub-list for field type_name
 }
 
 func init() { file_flow_flow_proto_init() }

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -210,7 +210,7 @@ enum TraceObservationPoint {
     // TO_CRYPTO indicates network packets are transmitted towards the crypto
     // process for encryption.
     TO_CRYPTO = 13;
-    
+
 }
 
 enum TraceReason {
@@ -757,6 +757,10 @@ message LostEvent {
     // cpu on which the event was lost if the source of lost events is
     // PERF_EVENT_RING_BUFFER.
     google.protobuf.Int32Value cpu = 3;
+    // first is the timestamp of the first event that was lost.
+    google.protobuf.Timestamp first = 4;
+    // last is the timestamp of the last event that was lost.
+    google.protobuf.Timestamp last = 5;
 }
 
 // AgentEventType is the type of agent event. These values are shared with type

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -964,6 +964,10 @@ data:
   # Capacity of the buffer to store recent events.
   hubble-event-buffer-capacity: {{ .Values.hubble.eventBufferCapacity | quote }}
 {{- end }}
+{{- if hasKey .Values.hubble "lostEventSendInterval" }}
+  # Interval to send lost events from Observer server.
+  hubble-lost-event-send-interval: {{ include "validateDuration" .Values.hubble.lostEventSendInterval | quote }}
+{{- end }}
 {{- if or .Values.hubble.metrics.enabled .Values.hubble.metrics.dynamic.enabled}}
   # Address to expose Hubble metrics (e.g. ":7070"). Metrics server will be disabled if this
   # field is not set.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1223,6 +1223,9 @@ hubble:
   #   2047, 4095, 8191, 16383, 32767, 65535
   # eventBufferCapacity: "4095"
 
+  # -- The interval at which Hubble will send out lost events from the Observer server, if any.
+  # lostEventSendInterval: 1s
+
   # -- Hubble metrics configuration.
   # See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics
   # for more comprehensive documentation about Hubble metrics.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1233,6 +1233,9 @@ hubble:
   #   2047, 4095, 8191, 16383, 32767, 65535
   # eventBufferCapacity: "4095"
 
+  # -- The interval at which Hubble will send out lost events from the Observer server, if any.
+  # lostEventSendInterval: 1s
+
   # -- Hubble metrics configuration.
   # See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics
   # for more comprehensive documentation about Hubble metrics.
@@ -2157,7 +2160,7 @@ localRedirectPolicy: false
 localRedirectPolicies:
   # -- Enable local redirect policies.
   enabled: false
-  
+
   # -- Limit the allowed addresses in Address Matcher rule of
   # Local Redirect Policies to the given CIDRs.
   # @schema@
@@ -2933,7 +2936,7 @@ operator:
   # @schema
   # type: [null, array]
   # @schema
-  tolerations: 
+  tolerations:
     - key: "node-role.kubernetes.io/control-plane"
       operator: Exists
     - key: "node-role.kubernetes.io/master" #deprecated

--- a/pkg/counter/range.go
+++ b/pkg/counter/range.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package counter
+
+import (
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// RangeCount represents a monotonically increasing count along with the first and last time it was
+// incremented.
+type RangeCount struct {
+	Count uint64
+	First time.Time
+	Last  time.Time
+}
+
+// RangeCounter is a simple counter that tracks a count and a time interval.
+type RangeCounter struct {
+	count RangeCount
+}
+
+// NewRangeCounter creates a new RangeCounter.
+func NewRangeCounter() *RangeCounter {
+	return &RangeCounter{}
+}
+
+// Increment increments the counter and updates the time range.
+func (c *RangeCounter) Increment(now time.Time) {
+	if c.count.Count == 0 || c.count.First.After(now) {
+		c.count.First = now
+	}
+	if c.count.Count == 0 || c.count.Last.Before(now) {
+		c.count.Last = now
+	}
+	c.count.Count++
+}
+
+// Peek returns the current count.
+func (c *RangeCounter) Peek() RangeCount {
+	return c.count
+}
+
+// Clear clears the counter and returns the existing count.
+func (c *RangeCounter) Clear() RangeCount {
+	count := c.count
+	c.count = RangeCount{}
+	return count
+}
+
+// IntervalRangeCounter is a specialized RangeCounter that provides a IsElapsed() method to check if
+// the time interval has elapsed since the first increment.
+type IntervalRangeCounter struct {
+	RangeCounter
+	interval time.Duration
+}
+
+// NewIntervalRangeCounter creates a new IntervalRangeCounter with the specified interval.
+func NewIntervalRangeCounter(interval time.Duration) *IntervalRangeCounter {
+	return &IntervalRangeCounter{
+		RangeCounter: RangeCounter{},
+		interval:     interval,
+	}
+}
+
+// IsElapsed checks if the duration since the first increment until now exceeds the configured
+// interval. It always returns false when the counter is empty as a "start time" is required as base
+// to compute the interval.
+func (c *IntervalRangeCounter) IsElapsed(now time.Time) bool {
+	if c.count.Count == 0 {
+		return false
+	}
+	return now.Sub(c.count.First) >= c.interval
+}

--- a/pkg/counter/range_test.go
+++ b/pkg/counter/range_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package counter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRangeCounter(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(-1 * time.Second)
+	later := now.Add(1 * time.Second)
+
+	counter := NewRangeCounter()
+	require.NotNil(t, counter, "Expected counter to be initialized")
+
+	counter.Increment(now)
+	require.Equal(t, uint64(1), counter.count.Count, "Expected count to be 1")
+	require.Equal(t, now, counter.count.First, "Expected first time to be now")
+	require.Equal(t, now, counter.count.Last, "Expected last time to be now")
+
+	counter.Increment(later)
+	require.Equal(t, uint64(2), counter.count.Count, "Expected count to be 2")
+	require.Equal(t, now, counter.count.First, "Expected first time to be now")
+	require.Equal(t, later, counter.count.Last, "Expected last time to be now + 1s")
+
+	count := counter.Clear()
+	require.Equal(t, uint64(2), count.Count, "Expected cleared count to be 2")
+	require.Equal(t, now, count.First, "Expected cleared first time to be now")
+	require.Equal(t, now.Add(1*time.Second), count.Last, "Expected cleared last time to be now + 1s")
+
+	count = counter.Clear()
+	require.Equal(t, uint64(0), count.Count, "Expected second cleared count to be 0")
+	require.Equal(t, time.Time{}, count.First, "Expected second cleared first time to be zero")
+	require.Equal(t, time.Time{}, count.Last, "Expected second cleared last time to be zero")
+
+	counter.Increment(now)
+	counter.Increment(earlier)
+	counter.Increment(later)
+	require.Equal(t, uint64(3), counter.count.Count, "Expected count to be 3 after increments")
+	require.Equal(t, earlier, counter.count.First, "Expected first time to be earlier")
+	require.Equal(t, later, counter.count.Last, "Expected last time to be later")
+}
+
+func TestIntervalRangeCounter(t *testing.T) {
+	interval := 2 * time.Second
+	now := time.Now()
+
+	counter := NewIntervalRangeCounter(interval)
+	require.NotNil(t, counter, "Expected counter to be initialized")
+
+	require.False(t, counter.IsElapsed(now.Add(-2*interval)), "Expected IsElapsed to return false when count is not incremented")
+	require.False(t, counter.IsElapsed(now), "Expected IsElapsed to return false when count is not incremented")
+	require.False(t, counter.IsElapsed(now.Add(2*interval)), "Expected IsElapsed to return false when count is not incremented")
+
+	counter.Increment(now)
+	require.False(t, counter.IsElapsed(now.Add(-2*interval)), "Expected IsElapsed to return false when first time is in the future")
+	require.False(t, counter.IsElapsed(now), "Expected IsElapsed to return false when first time is now")
+	require.True(t, counter.IsElapsed(now.Add(2*interval)), "Expected IsElapsed to return true when first time is past the interval")
+}

--- a/pkg/hubble/cell/config.go
+++ b/pkg/hubble/cell/config.go
@@ -14,6 +14,7 @@ import (
 	hubbleDefaults "github.com/cilium/cilium/pkg/hubble/defaults"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type config struct {
@@ -28,6 +29,9 @@ type config struct {
 	// MonitorEvents specifies Cilium monitor events for Hubble to observe. By
 	// default, Hubble observes all monitor events.
 	MonitorEvents []string `mapstructure:"hubble-monitor-events"`
+	// LostEventSendInterval specifies the interval at which lost events are
+	// sent from the Observer server, if any.
+	LostEventSendInterval time.Duration `mapstructure:"hubble-lost-event-send-interval"`
 
 	// SocketPath specifies the UNIX domain socket for Hubble server to listen
 	// to.
@@ -43,9 +47,10 @@ type config struct {
 var defaultConfig = config{
 	EnableHubble: false,
 	// Hubble internals (parser, ringbuffer) configuration
-	EventBufferCapacity: observeroption.Default.MaxFlows.AsInt(),
-	EventQueueSize:      0, // see getDefaultMonitorQueueSize()
-	MonitorEvents:       []string{},
+	EventBufferCapacity:   observeroption.Default.MaxFlows.AsInt(),
+	EventQueueSize:        0, // see getDefaultMonitorQueueSize()
+	MonitorEvents:         []string{},
+	LostEventSendInterval: hubbleDefaults.LostEventSendInterval,
 	// Hubble local server configuration
 	SocketPath: hubbleDefaults.SocketPath,
 	// Hubble TCP server configuration
@@ -64,6 +69,7 @@ func (def config) Flags(flags *pflag.FlagSet) {
 			strings.Join(monitorAPI.AllMessageTypeNames(), " "),
 		),
 	)
+	flags.Duration("hubble-lost-event-send-interval", def.LostEventSendInterval, "Interval at which lost events are sent from the Observer server, if any.")
 	// Hubble local server configuration
 	flags.String("hubble-socket-path", def.SocketPath, "Set hubble's socket path to listen for connections")
 	// Hubble TCP server configuration

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -277,7 +277,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 		return nil, fmt.Errorf("failed to initialize observer server: %w", err)
 	}
 	go hubbleObserver.Start()
-	h.monitorAgent.RegisterNewConsumer(monitor.NewConsumer(hubbleObserver))
+	h.monitorAgent.RegisterNewConsumer(monitor.NewConsumer(hubbleObserver, h.config.LostEventSendInterval))
 
 	tlsEnabled := h.tlsConfigPromise != nil
 

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -243,6 +243,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 	observerOpts = append(observerOpts,
 		observeroption.WithMaxFlows(maxFlows),
 		observeroption.WithMonitorBuffer(h.config.EventQueueSize),
+		observeroption.WithLostEventSendInterval(h.config.LostEventSendInterval),
 	)
 
 	// register exporters

--- a/pkg/hubble/defaults/defaults.go
+++ b/pkg/hubble/defaults/defaults.go
@@ -3,7 +3,11 @@
 
 package defaults
 
-import ciliumDefaults "github.com/cilium/cilium/pkg/defaults"
+import (
+	"time"
+
+	ciliumDefaults "github.com/cilium/cilium/pkg/defaults"
+)
 
 const (
 	// ServerPort is the default port for hubble server when a provided
@@ -30,4 +34,9 @@ const (
 	// SocketPath is the path to the UNIX domain socket exposing the Hubble API
 	// to clients locally.
 	SocketPath = ciliumDefaults.RuntimePath + "/hubble.sock"
+
+	// LostEventSendInterval is the default interval at which lost events are sent
+	// from the Observer server, if any. The default of 1s matches Hubble
+	// Relay's SortBufferDrainTimeout.
+	LostEventSendInterval = 1 * time.Second
 )

--- a/pkg/hubble/monitor/consumer.go
+++ b/pkg/hubble/monitor/consumer.go
@@ -29,12 +29,12 @@ type Observer interface {
 
 // consumer implements monitorConsumer.MonitorConsumer
 type consumer struct {
-	uuider        *bufuuid.Generator
-	observer      Observer
-	numEventsLost uint64
-	lostLock      lock.Mutex
-	logLimiter    logging.Limiter
+	uuider   *bufuuid.Generator
+	observer Observer
 
+	lostLock               lock.Mutex
+	numEventsLost          uint64
+	logLimiter             logging.Limiter
 	cachedLostNotification *observerTypes.MonitorEvent
 
 	metricLostPerfEvents     prometheus.Counter
@@ -44,10 +44,9 @@ type consumer struct {
 // NewConsumer returns an initialized pointer to consumer.
 func NewConsumer(observer Observer) monitorConsumer.MonitorConsumer {
 	mc := &consumer{
-		uuider:        bufuuid.New(),
-		observer:      observer,
-		numEventsLost: 0,
-		logLimiter:    logging.NewLimiter(30*time.Second, 1),
+		uuider:     bufuuid.New(),
+		observer:   observer,
+		logLimiter: logging.NewLimiter(30*time.Second, 1),
 
 		metricLostPerfEvents: metrics.LostEvents.WithLabelValues(
 			strings.ToLower(flowpb.LostEventSource_PERF_EVENT_RING_BUFFER.String())),

--- a/pkg/hubble/monitor/consumer.go
+++ b/pkg/hubble/monitor/consumer.go
@@ -129,11 +129,13 @@ func (c *consumer) trySendLostEventLocked(ts time.Time) {
 		return
 	}
 
+	count := c.lostEventCounter.Peek()
 	lostEvent := c.newEvent(ts, func() any {
 		return &observerTypes.LostEvent{
 			Source:        observerTypes.LostEventSourceEventsQueue,
-			NumLostEvents: c.lostEventCounter.Peek().Count,
-			// TODO: add timestamp range to LostEvent
+			NumLostEvents: count.Count,
+			First:         count.First,
+			Last:          count.Last,
 		}
 	})
 

--- a/pkg/hubble/monitor/consumer.go
+++ b/pkg/hubble/monitor/consumer.go
@@ -11,6 +11,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/bufuuid"
+	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/hubble/metrics"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/lock"
@@ -27,26 +28,28 @@ type Observer interface {
 	GetLogger() *slog.Logger
 }
 
-// consumer implements monitorConsumer.MonitorConsumer
+var _ monitorConsumer.MonitorConsumer = (*consumer)(nil)
+
+// consumer is a monitor consumer that sends events to an Observer.
 type consumer struct {
 	uuider   *bufuuid.Generator
 	observer Observer
 
-	lostLock               lock.Mutex
-	numEventsLost          uint64
-	logLimiter             logging.Limiter
-	cachedLostNotification *observerTypes.MonitorEvent
+	lostLock         lock.Mutex
+	lostEventCounter *counter.IntervalRangeCounter
+	logLimiter       logging.Limiter
 
 	metricLostPerfEvents     prometheus.Counter
 	metricLostObserverEvents prometheus.Counter
 }
 
-// NewConsumer returns an initialized pointer to consumer.
-func NewConsumer(observer Observer) monitorConsumer.MonitorConsumer {
+// NewConsumer returns a new consumer that sends events to the provided Observer.
+func NewConsumer(observer Observer, lostEventSendInterval time.Duration) *consumer {
 	mc := &consumer{
-		uuider:     bufuuid.New(),
-		observer:   observer,
-		logLimiter: logging.NewLimiter(30*time.Second, 1),
+		uuider:           bufuuid.New(),
+		observer:         observer,
+		lostEventCounter: counter.NewIntervalRangeCounter(lostEventSendInterval),
+		logLimiter:       logging.NewLimiter(30*time.Second, 1),
 
 		metricLostPerfEvents: metrics.LostEvents.WithLabelValues(
 			strings.ToLower(flowpb.LostEventSource_PERF_EVENT_RING_BUFFER.String())),
@@ -56,98 +59,7 @@ func NewConsumer(observer Observer) monitorConsumer.MonitorConsumer {
 	return mc
 }
 
-// sendEventQueueLostEvents tries to send the current value of the lost events
-// counter to the observer. If it succeeds to enqueue a notification, it
-// resets the counter. Returns a boolean indicating whether the notification
-// has been successfully sent.
-func (c *consumer) sendNumLostEvents() bool {
-	c.lostLock.Lock()
-	defer c.lostLock.Unlock()
-	// check again, in case multiple
-	// routines contended the lock
-	if c.numEventsLost == 0 {
-		return true
-	}
-
-	if c.cachedLostNotification == nil {
-		c.cachedLostNotification = c.newEvent(func() any {
-			return &observerTypes.LostEvent{
-				Source:        observerTypes.LostEventSourceEventsQueue,
-				NumLostEvents: c.numEventsLost,
-			}
-		})
-	} else {
-		c.cachedLostNotification.Timestamp = time.Now()
-		c.cachedLostNotification.Payload.(*observerTypes.LostEvent).NumLostEvents = c.numEventsLost
-	}
-
-	select {
-	case c.observer.GetEventsChannel() <- c.cachedLostNotification:
-		// We now now safely reset the counter, as at this point have
-		// successfully notified the observer about the amount of events
-		// that were lost since the previous LostEvent message. Similarly,
-		// we reset the cached notification, so that a new one is created
-		// the next time.
-		c.numEventsLost = 0
-		c.cachedLostNotification = nil
-		return true
-	default:
-		// We do not need to bump the numEventsLost counter here, as we will
-		// try to send a new LostEvent notification again during the next
-		// invocation of sendEvent
-		return false
-	}
-}
-
-// sendEvent enqueues an event in the observer. If this is not possible, it
-// keeps a counter of lost events, which it will regularly try to send to the
-// observer as well
-func (c *consumer) sendEvent(payloader func() any) {
-	if c.numEventsLost > 0 {
-		if !c.sendNumLostEvents() {
-			// We just failed sending the lost notification, hence it doesn't
-			// make sense to try and send the actual event, as we'll most
-			// likely fail as well.
-			c.countDroppedEvent()
-			return
-		}
-	}
-
-	select {
-	case c.observer.GetEventsChannel() <- c.newEvent(payloader):
-	default:
-		c.countDroppedEvent()
-	}
-}
-
-func (c *consumer) newEvent(payloader func() any) *observerTypes.MonitorEvent {
-	ev := &observerTypes.MonitorEvent{
-		Timestamp: time.Now(),
-		NodeName:  nodeTypes.GetAbsoluteNodeName(),
-		Payload:   payloader(),
-	}
-
-	c.uuider.NewInto(&ev.UUID)
-	return ev
-}
-
-// countDroppedEvent logs that the events channel is full
-// and counts how many messages it has lost.
-func (c *consumer) countDroppedEvent() {
-	c.lostLock.Lock()
-	defer c.lostLock.Unlock()
-	if c.numEventsLost == 0 && c.logLimiter.Allow() {
-		c.observer.GetLogger().
-			Warn(
-				"hubble events queue is full: dropping messages; consider increasing the queue size (hubble-event-queue-size) or provisioning more CPU",
-				logfields.RelatedMetric, "hubble_lost_events_total",
-			)
-	}
-	c.numEventsLost++
-	c.metricLostObserverEvents.Inc()
-}
-
-// NotifyAgentEvent implements monitorConsumer.MonitorConsumer
+// NotifyAgentEvent implements monitorConsumer.MonitorConsumer.
 func (c *consumer) NotifyAgentEvent(typ int, message any) {
 	c.sendEvent(func() any {
 		return &observerTypes.AgentEvent{
@@ -157,7 +69,7 @@ func (c *consumer) NotifyAgentEvent(typ int, message any) {
 	})
 }
 
-// NotifyPerfEvent implements monitorConsumer.MonitorConsumer
+// NotifyPerfEvent implements monitorConsumer.MonitorConsumer.
 func (c *consumer) NotifyPerfEvent(data []byte, cpu int) {
 	c.sendEvent(func() any {
 		return &observerTypes.PerfEvent{
@@ -167,7 +79,7 @@ func (c *consumer) NotifyPerfEvent(data []byte, cpu int) {
 	})
 }
 
-// NotifyPerfEventLost implements monitorConsumer.MonitorConsumer
+// NotifyPerfEventLost implements monitorConsumer.MonitorConsumer.
 func (c *consumer) NotifyPerfEventLost(numLostEvents uint64, cpu int) {
 	c.sendEvent(func() any {
 		return &observerTypes.LostEvent{
@@ -177,4 +89,73 @@ func (c *consumer) NotifyPerfEventLost(numLostEvents uint64, cpu int) {
 		}
 	})
 	c.metricLostPerfEvents.Inc()
+}
+
+// sendEvent enqueues an event in the observer. If this is not possible, it
+// keeps a counter of lost events, which it will try to send at most once per
+// configured interval, and on every call to sendEvent until it succeeds.
+func (c *consumer) sendEvent(payloader func() any) {
+	c.lostLock.Lock()
+	defer c.lostLock.Unlock()
+
+	now := time.Now()
+	c.trySendLostEventLocked(now)
+
+	select {
+	case c.observer.GetEventsChannel() <- c.newEvent(now, payloader):
+	default:
+		c.incrementLostEventLocked(now)
+	}
+}
+
+func (c *consumer) newEvent(ts time.Time, payloader func() any) *observerTypes.MonitorEvent {
+	ev := &observerTypes.MonitorEvent{
+		Timestamp: ts,
+		NodeName:  nodeTypes.GetAbsoluteNodeName(),
+		Payload:   payloader(),
+	}
+
+	c.uuider.NewInto(&ev.UUID)
+	return ev
+}
+
+// trySendLostEventLocked tries to send a lost event as needed. If it succeeds, it clears the
+// lost event counter, otherwise it does nothing so we keep the existing count. It assumes that
+// the caller holds c.lostLock.
+func (c *consumer) trySendLostEventLocked(ts time.Time) {
+	// check if we should send a lost event
+	shouldSend := c.lostEventCounter.IsElapsed(ts)
+	if !shouldSend {
+		return
+	}
+
+	lostEvent := c.newEvent(ts, func() any {
+		return &observerTypes.LostEvent{
+			Source:        observerTypes.LostEventSourceEventsQueue,
+			NumLostEvents: c.lostEventCounter.Peek().Count,
+			// TODO: add timestamp range to LostEvent
+		}
+	})
+
+	select {
+	case c.observer.GetEventsChannel() <- lostEvent:
+		// only clear the counter if we successfully sent the lost event
+		c.lostEventCounter.Clear()
+	default:
+	}
+}
+
+// incrementLostEventLocked increments the lost event counter. It also logs a warning message if the
+// counter was previously empty and the log limiter allows it. It assumes that the caller holds
+// c.lostLock.
+func (c *consumer) incrementLostEventLocked(ts time.Time) {
+	if c.lostEventCounter.Peek().Count == 0 && c.logLimiter.Allow() {
+		c.observer.GetLogger().
+			Warn(
+				"hubble events queue is full: dropping messages; consider increasing the queue size (hubble-event-queue-size) or provisioning more CPU",
+				logfields.RelatedMetric, "hubble_lost_events_total",
+			)
+	}
+	c.lostEventCounter.Increment(ts)
+	c.metricLostObserverEvents.Inc()
 }

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -347,7 +347,8 @@ nextEvent:
 					LostEvents: &flowpb.LostEvent{
 						Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
 						NumEventsLost: count.Count,
-						// TODO: add timestamp range to LostEvent
+						First:         timestamppb.New(count.First),
+						Last:          timestamppb.New(count.Last),
 					},
 				},
 			}

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -289,20 +289,6 @@ func (s *LocalObserverServer) GetFlows(
 	start := time.Now()
 	ring := s.GetRingBuffer()
 
-	i := uint64(0)
-	if log.Enabled(context.Background(), slog.LevelDebug) {
-		defer func() {
-			log.Debug(
-				"GetFlows finished",
-				logfields.NumberOfFlows, i,
-				logfields.BufferSize, ring.Cap(),
-				logfields.Whitelist, logFilters(req.Whitelist),
-				logfields.Blacklist, logFilters(req.Blacklist),
-				logfields.Took, time.Since(start),
-			)
-		}()
-	}
-
 	ringReader, err := newRingReader(ring, req, whitelist, blacklist)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
@@ -314,6 +300,19 @@ func (s *LocalObserverServer) GetFlows(
 	eventsReader, err := newEventsReader(ringReader, req, log, whitelist, blacklist)
 	if err != nil {
 		return err
+	}
+
+	if log.Enabled(context.Background(), slog.LevelDebug) {
+		defer func() {
+			log.Debug(
+				"GetFlows finished",
+				logfields.NumberOfFlows, eventsReader.eventCount,
+				logfields.BufferSize, ring.Cap(),
+				logfields.Whitelist, logFilters(req.Whitelist),
+				logfields.Blacklist, logFilters(req.Blacklist),
+				logfields.Took, time.Since(start),
+			)
+		}()
 	}
 
 	fm := req.GetFieldMask()
@@ -329,7 +328,7 @@ func (s *LocalObserverServer) GetFlows(
 	}
 
 nextEvent:
-	for ; ; i++ {
+	for {
 		e, err := eventsReader.Next(ctx)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
@@ -408,18 +407,6 @@ func (s *LocalObserverServer) GetAgentEvents(
 	log := s.GetLogger()
 	ring := s.GetRingBuffer()
 
-	i := uint64(0)
-	if log.Enabled(context.Background(), slog.LevelDebug) {
-		defer func() {
-			log.Debug(
-				"GetAgentEvents finished",
-				logfields.NumberOfAgentEvents, i,
-				logfields.BufferSize, ring.Cap(),
-				logfields.Took, time.Since(start),
-			)
-		}()
-	}
-
 	ringReader, err := newRingReader(ring, req, whitelist, blacklist)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
@@ -433,7 +420,18 @@ func (s *LocalObserverServer) GetAgentEvents(
 		return err
 	}
 
-	for ; ; i++ {
+	if log.Enabled(context.Background(), slog.LevelDebug) {
+		defer func() {
+			log.Debug(
+				"GetAgentEvents finished",
+				logfields.NumberOfAgentEvents, eventsReader.eventCount,
+				logfields.BufferSize, ring.Cap(),
+				logfields.Took, time.Since(start),
+			)
+		}()
+	}
+
+	for {
 		e, err := eventsReader.Next(ctx)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
@@ -476,18 +474,6 @@ func (s *LocalObserverServer) GetDebugEvents(
 	log := s.GetLogger()
 	ring := s.GetRingBuffer()
 
-	i := uint64(0)
-	if log.Enabled(context.Background(), slog.LevelDebug) {
-		defer func() {
-			log.Debug(
-				"GetDebugEvents finished",
-				logfields.NumberOfDebugEvents, i,
-				logfields.BufferSize, ring.Cap(),
-				logfields.Took, time.Since(start),
-			)
-		}()
-	}
-
 	ringReader, err := newRingReader(ring, req, whitelist, blacklist)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
@@ -501,7 +487,18 @@ func (s *LocalObserverServer) GetDebugEvents(
 		return err
 	}
 
-	for ; ; i++ {
+	if log.Enabled(context.Background(), slog.LevelDebug) {
+		defer func() {
+			log.Debug(
+				"GetDebugEvents finished",
+				logfields.NumberOfDebugEvents, eventsReader.eventCount,
+				logfields.BufferSize, ring.Cap(),
+				logfields.Took, time.Since(start),
+			)
+		}()
+	}
+
+	for {
 		e, err := eventsReader.Next(ctx)
 		if err != nil {
 			if errors.Is(err, io.EOF) {

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -18,6 +18,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/cilium/pkg/counter"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/build"
 	"github.com/cilium/cilium/pkg/hubble/container"
@@ -327,8 +328,34 @@ func (s *LocalObserverServer) GetFlows(
 		mask.Alloc(flow.ProtoReflect())
 	}
 
+	// Setup a counter to rate-limit sending lost events to at most
+	// once every s.opts.LostEventSendInterval.
+	lostEventCounter := counter.NewIntervalRangeCounter(s.opts.LostEventSendInterval)
+
 nextEvent:
 	for {
+		now := time.Now()
+
+		if lostEventCounter.IsElapsed(now) {
+			// IsElapsed always returns false if the counter is empty, therefore
+			// we can trust that count is non-zero.
+			count := lostEventCounter.Clear()
+			resp := &observerpb.GetFlowsResponse{
+				Time:     timestamppb.New(now),
+				NodeName: nodeTypes.GetAbsoluteNodeName(),
+				ResponseTypes: &observerpb.GetFlowsResponse_LostEvents{
+					LostEvents: &flowpb.LostEvent{
+						Source:        flowpb.LostEventSource_HUBBLE_RING_BUFFER,
+						NumEventsLost: count.Count,
+						// TODO: add timestamp range to LostEvent
+					},
+				},
+			}
+			if err = server.Send(resp); err != nil {
+				return err
+			}
+		}
+
 		e, err := eventsReader.Next(ctx)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
@@ -369,12 +396,21 @@ nextEvent:
 			// when a query asks for 20 events, then lost events should not be
 			// accounted for as they are not events per se but an indication
 			// that some event was lost).
-			resp = &observerpb.GetFlowsResponse{
-				Time:     e.Timestamp,
-				NodeName: nodeTypes.GetAbsoluteNodeName(),
-				ResponseTypes: &observerpb.GetFlowsResponse_LostEvents{
-					LostEvents: ev,
-				},
+
+			// We only want to rate-limit lost events that originate from the
+			// Hubble ring buffer. Other lost events should be rate-limited closer to
+			// the emitting source, if needed.
+			switch ev.Source {
+			case flowpb.LostEventSource_HUBBLE_RING_BUFFER:
+				lostEventCounter.Increment(now)
+			default:
+				resp = &observerpb.GetFlowsResponse{
+					Time:     e.Timestamp,
+					NodeName: nodeTypes.GetAbsoluteNodeName(),
+					ResponseTypes: &observerpb.GetFlowsResponse_LostEvents{
+						LostEvents: ev,
+					},
+				}
 			}
 		}
 
@@ -547,15 +583,23 @@ var (
 	_ genericRequest = (*observerpb.GetDebugEventsRequest)(nil)
 )
 
-// eventsReader reads flows using a RingReader. It applies the GetFlows request
+// eventsReader reads events using a RingReader. It applies the request
 // criteria (blacklist, whitelist, follow, ...) before returning events.
 type eventsReader struct {
-	ringReader           *container.RingReader
+	ringReader *container.RingReader
+
+	// request criteria
 	whitelist, blacklist filters.FilterFuncs
 	maxEvents            uint64
 	follow, timeRange    bool
-	eventCount           uint64
 	since, until         *time.Time
+
+	// eventCount is updated by the reader user to keep track of how many
+	// successful reads happened. This is because the reader does not know
+	// the underlying Event type the user is looking for. When maxEvents is
+	// non-zero, we use this counter to infer when the limit is reached from
+	// Next() and return io.EOF.
+	eventCount uint64
 }
 
 // newEventsReader creates a new eventsReader that uses the given RingReader to

--- a/pkg/hubble/observer/types/types.go
+++ b/pkg/hubble/observer/types/types.go
@@ -61,4 +61,8 @@ type LostEvent struct {
 	NumLostEvents uint64
 	// CPU is the cpu number if for events lost in the perf ring buffer
 	CPU int
+	// First is the timestamp of the first event that was lost
+	First time.Time
+	// Last is the timestamp of the last event that was lost
+	Last time.Time
 }

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -171,13 +171,20 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 			return nil, errors.ErrUnknownEventType
 		}
 	case *observerTypes.LostEvent:
-		ev.Event = &pb.LostEvent{
+		lostEvent := &pb.LostEvent{
 			Source:        lostEventSourceToProto(payload.Source),
 			NumEventsLost: payload.NumLostEvents,
 			Cpu: &wrapperspb.Int32Value{
 				Value: int32(payload.CPU),
 			},
 		}
+		if !payload.First.IsZero() {
+			lostEvent.First = timestamppb.New(payload.First)
+		}
+		if !payload.Last.IsZero() {
+			lostEvent.Last = timestamppb.New(payload.Last)
+		}
+		ev.Event = lostEvent
 		return ev, nil
 	case nil:
 		return ev, errors.ErrEmptyData


### PR DESCRIPTION
### Description

This PR introduces rate-limiting for lost events sent from the Hubble Observer.

Lost events are emitted from 3 places in Cilium whenever we are not able to forward events:
- PERF_EVENT_RING_BUFFER
  - Here we are ignoring `PERF_EVENT_RING_BUFFER` on purpose as these are emitted by the kernel.
  - They should be rare, and if happening, hint at the agent itself being heavily CPU starved, therefore not being able to progress altogether.
- OBSERVER_EVENTS_QUEUE
  - Emitted by the monitor consumer when it can't push events to the Observer.
- HUBBLE_RING_BUFFER
  - Emitted by the ring buffer when the Observer can't read fast enough from the buffer and events are being overwritten.

We update the monitor consumer to keep a counter of lost events, which we increment whenever we can't send an event on the Observer events channel. We will try to send a lost event at most once per configured interval if the counter is positive. If we can't send the event, we will retry on every subsequent send until we succeed. We clear the counter whenever we succeed to send the lost event.

We do similarly in the Observer server where we increment the counter whenever we receive a `HUBBLE_RING_BUFFER` lost event, and we forward any other lost events, as they should have been rate-limited already downstream. We try to send lost events before reading from the ring buffer.

Additionally, we update the flow.LostEvent API type and add two new Timestamp fields: `First` and `Last`, to keep track of the lost events time range. The Hubble CLI is also updated to print this time range if set.

The counter used by both systems above is abstracted away as a new type `RangeCounter` which takes care of updating a time range internally on increment. To provide the rate-limiting capabilities using an interval, we introduce a specialized counter `IntervalRangeCounter` that can answer whether the interval has elapsed (using `IsElapsed()`) since the first lost event was recorded.

Fixes: https://github.com/cilium/cilium/issues/34981

```release-note
Rate-limit lost events sent from the Hubble Observer
```

### Test

With some custom code to sleep in an OnMonitorEvent hook at regular intervals, I can simulate dropped events for observer:
```
$ hubble observe -P --tls --tls-allow-insecure -f | grep -i lost
Aug 25 20:09:59.167 EVENTS LOST: OBSERVER_EVENTS_QUEUE CPU(0) 125 (first: Aug 25 20:09:54.156, last: Aug 25 20:09:59.162)
Aug 25 20:10:09.297 EVENTS LOST: OBSERVER_EVENTS_QUEUE CPU(0) 106 (first: Aug 25 20:10:04.236, last: Aug 25 20:10:09.166)
Aug 25 20:10:19.298 EVENTS LOST: OBSERVER_EVENTS_QUEUE CPU(0) 119 (first: Aug 25 20:10:14.156, last: Aug 25 20:10:19.169)
Aug 25 20:10:29.296 EVENTS LOST: OBSERVER_EVENTS_QUEUE CPU(0) 105 (first: Aug 25 20:10:24.982, last: Aug 25 20:10:29.159)
Aug 25 20:10:39.297 EVENTS LOST: OBSERVER_EVENTS_QUEUE CPU(0) 120 (first: Aug 25 20:10:34.159, last: Aug 25 20:10:39.234)
Aug 25 20:10:49.300 EVENTS LOST: OBSERVER_EVENTS_QUEUE CPU(0) 110 (first: Aug 25 20:10:44.980, last: Aug 25 20:10:49.158)
```

It seems a bit more complicated to simulate for HUBBLE_RING_BUFFER, still trying to figure it out..
EDIT: In the end, I forced the ring buffer to emit only lost events to simulate hard conditions and could exercise the lost event counter:
```
$ hubble observe -P --tls --tls-allow-insecure -f
Aug 26 20:59:44.571 EVENTS LOST: HUBBLE_RING_BUFFER CPU(0) 61658 (first: Aug 26 20:59:43.568, last: Aug 26 20:59:44.567)
Aug 26 20:59:45.571 EVENTS LOST: HUBBLE_RING_BUFFER CPU(0) 40793 (first: Aug 26 20:59:44.571, last: Aug 26 20:59:45.571)
Aug 26 20:59:46.571 EVENTS LOST: HUBBLE_RING_BUFFER CPU(0) 48383 (first: Aug 26 20:59:45.571, last: Aug 26 20:59:46.571)
```