### PR TITLE
conformance: enable Gateway API test owner attribution via GOTEST_FORMATTER

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -204,6 +204,12 @@ jobs:
           # renovate: datasource=github-releases depName=mfridman/tparse
           go install github.com/mfridman/tparse@28967170dce4f9f13de77ec857f7aed4c4294a5f # v0.12.3 (main) with -progress
 
+      - name: Install go-junit-report
+        timeout-minutes: 15
+        run: |
+          # renovate: datasource=github-releases depName=cilium/go-junit-report/v2/cmd/go-junit-report
+          go install github.com/cilium/go-junit-report/v2/cmd/go-junit-report@4cdc5c96cb4e406fccf943536b5bfcae7a0fb826 # v2.3.1
+
       - name: Install Gateway API CRDs
         run: |
           gateway_api_version=$(grep -m 1 "sigs.k8s.io/gateway-api" go.mod | awk '{print $2}' | awk -F'-' '{print (NF>2)?$NF:$0}')
@@ -296,6 +302,11 @@ jobs:
           else
             GATEWAY_TEST_FLAGS="$GATEWAY_TEST_FLAGS --exempt-features \"${{ steps.vars.outputs.exempt-features }}\" -test.skip \"${{ steps.vars.outputs.skipped_tests }}\""
           fi
+          # Create JUnit output directory and enable owner attribution
+          mkdir -p cilium-junits
+          LOG_CODEOWNERS=1 \
+          JUNIT_PATH="cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - gateway-conformance.xml" \
+          CODEOWNERS_PATH="${CILIUM_CLI_CODE_OWNERS_PATHS}" \
           GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES="$GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES" \
           GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES="$GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES" \
           GATEWAY_TEST_FLAGS="$GATEWAY_TEST_FLAGS" \

--- a/Makefile
+++ b/Makefile
@@ -575,12 +575,11 @@ gateway-api-conformance: ## Run Gateway API conformance tests.
 	GATEWAY_API_CONFORMANCE_TESTS=1 \
 	GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES=$${GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES} \
 	GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$${GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES} \
-	$(GO) test -p 4 -v ./operator/pkg/gateway-api \
+	$(GO_TEST) $(GO_TEST_FLAGS) -p 4 -v ./operator/pkg/gateway-api \
 		$(GATEWAY_TEST_FLAGS) \
 		-test.run "TestConformance" \
 		-test.timeout=29m \
-		-json \
-	| tparse -progress
+	| $(GOTEST_FORMATTER)
 
 BPF_TEST ?= ""
 BPF_TEST_DUMP_CTX ?= ""


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

### Description of change

This PR completes the Gateway API conformance test owner attribution by replacing the manual test output pipeline with the established `GOTEST_FORMATTER` from `Makefile.defs`.

**Changes:**
- Replace manual `| tparse -progress` with `| $(GOTEST_FORMATTER)` in the `gateway-api-conformance` Make target
- Use `$(GO_TEST)` and `$(GO_TEST_FLAGS)` for consistency with other test targets  
- Update workflow to set `LOG_CODEOWNERS=1` and `JUNIT_PATH` to enable owner attribution
- Add `go-junit-report` installation step to support the GOTEST_FORMATTER pipeline

**Benefits:**
- Owner attribution via `go-junit-report` when tests fail
- JUnit XML generation for CI dashboards with ownership metadata
- Console owner summary via `tools/testowners`
- Consistent formatting with other test targets in the repository
- Leverages established and tested pipeline logic from `Makefile.defs`

This builds on the previous PR(https://github.com/cilium/cilium/pull/41038) that moved the logic to a Make target and addresses reviewer feedback to avoid duplicating test output pipeline logic.

Fixes: #41029

```release-note
ci: Gateway API conformance tests now attribute failures to code owners and upload JUnit results for CI dashboards.
```