### PR TITLE
ci: Fix integration tests not reporting build errors in console output

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -102,6 +102,9 @@ ifneq ($(V),0)
 	GOTEST_FORMATTER_FLAGS += -follow
 endif
 ifneq ($(LOG_CODEOWNERS),)
+	# In CI environments with LOG_CODEOWNERS, always use -follow to ensure
+	# build errors are visible (GitHub issue #41158)
+	GOTEST_FORMATTER_FLAGS += -follow
 ifneq ($(shell command -v go-junit-report),)
 	JUNIT_PATH ?= junit_results.xml
 	GOTEST_FORMATTER = tee \
@@ -111,16 +114,14 @@ ifneq ($(shell command -v go-junit-report),)
 			-out "$(JUNIT_PATH)") \
 		>($(GO) run $(ROOT_DIR)/tools/testowners \
 			--code-owners=$(CODEOWNERS_PATH)) \
-		>(tparse $(GOTEST_FORMATTER_FLAGS)) \
-		>$(GO_TEST_OUT) \
-		| cat
+		/dev/stdout \
+		| tparse $(GOTEST_FORMATTER_FLAGS)
 else
 	GOTEST_FORMATTER = tee \
 		>($(GO) run $(ROOT_DIR)/tools/testowners \
 			--code-owners=$(CODEOWNERS_PATH)) \
-		>(tparse $(GOTEST_FORMATTER_FLAGS)) \
-		>$(GO_TEST_OUT) \
-		| cat
+		/dev/stdout \
+		| tparse $(GOTEST_FORMATTER_FLAGS)
 endif
 else
 	GOTEST_FORMATTER = tparse $(GOTEST_FORMATTER_FLAGS)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Description

This PR fixes an issue where CI integration tests were not displaying build error details in console output when running with `V=0` (low verbosity mode). While build errors were being captured in JUnit XML reports, they were invisible in the console output, making it difficult for developers to debug test failures.

### Problem
When `LOG_CODEOWNERS=1` and `V=0` in CI environments:
1. The `tparse` tool runs without the `-follow` flag and doesn't display `build-output` actions containing error details
2. The complex `tee` pipeline structure sent main output to `/dev/null`, then piped to `cat`, losing error visibility
3. Build errors were only visible in JUnit XML files, not in the console logs

### Solution
- **Always use `-follow` flag** when `LOG_CODEOWNERS=1` (CI environments) to ensure build errors are visible
- **Fix pipeline structure**: Changed from `>(tparse ...) >/dev/null | cat` to `| tparse ...` so tparse output reaches stdout  
- **Maintain compatibility**: Normal tests and verbose mode continue to work as expected

### Testing
- Reproduced the original issue locally
- Verified the fix shows build errors in console output
- Confirmed normal tests still work properly

Fixes: #41158

```release-note
Fix CI integration tests not showing build error details in console output when V=0
```