### PR TITLE
ctmap: improve logging of errors during ctmap GC.

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -957,7 +957,9 @@ func (e *Endpoint) garbageCollectConntrack(filter ctmap.GCFilter) {
 		}
 		defer m.Close()
 
-		e.ctMapGC.Run(m, filter)
+		if _, err := e.ctMapGC.Run(m, filter); err != nil {
+			e.getLogger().Error("failed to run endpoint ctmap gc", logfields.Error, err)
+		}
 	}
 }
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -510,7 +510,10 @@ func doGC(m *Map, filter GCFilter, next4, next6 func(GCEvent), logResults bool) 
 // It returns how many items were deleted from m.
 func GC(m *Map, filter GCFilter, next4, next6 func(GCEvent)) (int, error) {
 	if filter.RemoveExpired {
-		t, _ := timestamp.GetCTCurTime(timestamp.GetClockSourceFromOptions())
+		t, err := timestamp.GetCTCurTime(timestamp.GetClockSourceFromOptions())
+		if err != nil {
+			return 0, fmt.Errorf("failed to get current timestamp for CT: %w", err)
+		}
 		filter.Time = uint32(t)
 	}
 


### PR DESCRIPTION
* Getting ct timestamp can fail due to filesystem access. This could be very important to diagnosing issues so let's return this error and make sure we log it.

* Only suppress map not exists on initial scan, the subsequent scan should happen several minutes following this so we want to know if these are missing.

