### PR TITLE
pkg/labels: Fix missing source field in policy labels

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -395,5 +395,17 @@ func ParseToCiliumLabels(namespace, name string, uid types.UID, ruleLbs labels.L
 	}
 
 	policyLbls := GetPolicyLabels(namespace, name, uid, resourceType)
-	return append(policyLbls, ruleLbs...).Sort()
+
+	// Ensure user-defined labels have consistent source
+	userLbls := make(labels.LabelArray, len(ruleLbs))
+	for i, lbl := range ruleLbs {
+		if lbl.Source == "" {
+			// If source is empty, set it to unspec
+			userLbls[i] = labels.NewLabel(lbl.Key, lbl.Value, labels.LabelSourceUnspec)
+		} else {
+			userLbls[i] = lbl
+		}
+	}
+
+	return append(policyLbls, userLbls...).Sort()
 }

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -754,6 +754,68 @@ func TestParseToCiliumLabels(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "parse labels with empty source",
+			args: args{
+				name:      "test-policy",
+				namespace: "default",
+				uid:       uuid,
+				ruleLbs: labels.LabelArray{
+					{
+						Key:    "policy-comment",
+						Value:  "allow all traffic inside namespace",
+						Source: "",
+					},
+					{
+						Key:    "team",
+						Value:  "platform",
+						Source: labels.LabelSourceUnspec,
+					},
+					{
+						Key:    "explicit-source",
+						Value:  "test",
+						Source: "custom",
+					},
+				},
+			},
+			want: labels.LabelArray{
+				{
+					Key:    "explicit-source",
+					Value:  "test",
+					Source: "custom",
+				},
+				{
+					Key:    "io.cilium.k8s.policy.derived-from",
+					Value:  "CiliumNetworkPolicy",
+					Source: labels.LabelSourceK8s,
+				},
+				{
+					Key:    "io.cilium.k8s.policy.name",
+					Value:  "test-policy",
+					Source: labels.LabelSourceK8s,
+				},
+				{
+					Key:    "io.cilium.k8s.policy.namespace",
+					Value:  "default",
+					Source: labels.LabelSourceK8s,
+				},
+				{
+					Key:    "io.cilium.k8s.policy.uid",
+					Value:  string(uuid),
+					Source: labels.LabelSourceK8s,
+				},
+				{
+					Key:    "policy-comment",
+					Value:  "allow all traffic inside namespace",
+					Source: labels.LabelSourceUnspec,
+				},
+				{
+					Key:    "team",
+					Value:  "platform",
+					Source: labels.LabelSourceUnspec,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		got := ParseToCiliumLabels(tt.args.namespace, tt.args.name, tt.args.uid, tt.args.ruleLbs)

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -387,8 +387,7 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 			},
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
-				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
-				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
+				lbls := utils.ParseToCiliumLabels("production", "db", uuid, labels.ParseLabelArray("foo=bar"))
 				r.MustAddList(policyapi.Rules{
 					policyapi.NewRule().
 						WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Description

This PR fixes an issue where CiliumNetworkPolicy labels with empty `source` fields were not being assigned a default source value, causing issues in policy debugging and Hubble flow exports.

### Problem
When parsing CiliumNetworkPolicy labels from YAML like:
```yaml
labels:
- key: policy-comment
  value: allow all traffic inside namespace
```

Labels with empty source fields were passed through without any default source assignment, resulting in:
- `cilium-dbg policy get` showing empty source fields: `"source": ""`
- Hubble flow exports showing labels starting with `:` instead of `unspec:` (e.g., `:policy-comment=allow all traffic inside namespace`)
- Policy correlation and debugging difficulties

### Root Cause
The `ParseToCiliumLabels` function in `pkg/k8s/apis/cilium.io/utils/utils.go` was not handling labels with empty source fields. Since CNP `Parse` can be called directly from the policy directory watcher (not just from Kubernetes resources), we cannot assume the label source is always `k8s`.

### Solution
- Modified `ParseToCiliumLabels()` to convert empty source fields to `LabelSourceUnspec` ("unspec")
- Labels with `unspec` source remain as `unspec` (unchanged)
- Labels with explicit sources (k8s, custom, etc.) are preserved as-is
- Added comprehensive unit tests to verify the correct source assignment behavior

### Main idea
Labels with empty source will be set to 'unspec' and will be internally handled as `LabelSourceAny` when required for matching. This ensures consistent behavior across both Kubernetes-sourced policies and directory watcher-sourced policies.

### Testing
- All existing tests pass
- New test case "parse labels with empty source" verifies correct behavior
- Labels now correctly appear as `"unspec:policy-comment=allow all traffic inside namespace"`

Fixes: #40912

```release-note
Fix CiliumNetworkPolicy labels without explicit source field defaulting to empty string instead of "unspec", resolving issues in policy debugging and Hubble flow exports.
```