### PR TITLE
xds: fix NACK logging after slog migration

### DIFF
--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -125,7 +125,7 @@ func (s *Server) RestoreCompleted() {
 
 func getXDSRequestFields(req *envoy_service_discovery.DiscoveryRequest) []any {
 	return []any{
-		logfields.XDSAckedVersion, req.GetVersionInfo(),
+		logfields.Version, req.GetVersionInfo(),
 		logfields.XDSTypeURL, req.GetTypeUrl(),
 		logfields.XDSNonce, req.GetResponseNonce(),
 	}
@@ -397,8 +397,6 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *slog.Logge
 				requestLog.Warn(
 					"NACK received for versions between the reported version up to the response nonce; waiting for a version update before sending again",
 					logfields.XDSDetail, detail,
-					logfields.Version, req.VersionInfo,
-					logfields.ResponseNonce, req.ResponseNonce,
 				)
 			}
 

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -395,7 +395,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *slog.Logge
 				s.metrics.IncreaseNACK(typeURL)
 				// versions after lastAppliedVersion, upto and including lastReceivedVersion are NACKed
 				requestLog.Warn(
-					"NACK received for versions after %s and up to %s; waiting for a version update before sending again",
+					"NACK received for versions between the reported version up to the response nonce; waiting for a version update before sending again",
 					logfields.XDSDetail, detail,
 					logfields.Version, req.VersionInfo,
 					logfields.ResponseNonce, req.ResponseNonce,


### PR DESCRIPTION
```
xds: fix NACK logging after slog migration
This commit fixes a log message that still contains substitutions in the
log message after the log migration.
```

```
xds: remove duplicated log variables when logging xds NACK
Currently the log message that reports an xDS NACK from envoy contains
duplicates for the version & nonce.

Therefore, this commit removes the extra log fields `responseNonce` & `version`
when logging the message because they are already part of the scoped `requestLog`.

In addition the variable `xdsAckedVersion` gets renamed to `version` because having
the word `acked` in the field for the NACK log message would be confusing.
```