### PR TITLE
docs: Update theme to add dark mode support :dark_sunglasses: 

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@0d7703280a1287e97f37124c1d9689e2efe03923
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@5e45810d0af338f8a7a6337b0377412ddf973dbc
 # We use semver to parse Cilium's version in the config file
 semver==3.0.1
 # Sphinx extensions


### PR DESCRIPTION
As a follow-up to an update in our sphinx_rtd_theme fork where we added support for a dark theme for the docs website, make our requirements.txt point to the new branch tip to pull the newest version of our theme.

Credits go to @UtkarshSiddhpura, and to authors of the Sphinx theme add-on he drew inspiration from, for the dark theme.

Fixes: #31391
Link: https://github.com/cilium/sphinx_rtd_theme/pull/26