### PR TITLE
workflows/integration-test: fix Go cache architecture-specific restoration

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -168,7 +168,6 @@ jobs:
           key: ${{ runner.os }}-go-integration-test-cache-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-integration-test-cache-${{ runner.arch }}-
-            ${{ runner.os }}-go-integration-test-cache-
 
       - name: Set clang directory
         id: set_clang_dir


### PR DESCRIPTION
Prevent GitHub runners from different architectures from restoring cache from other architectures. Cross-architecture cache restoration causes both amd64 and arm64 build artifacts to be loaded on a single runner, leading to disk space exhaustion with errors like:

    compile: writing output: write $WORK/b3076/_pkg_.a: no space left on device
    github.com/aliyun/alibaba-cloud-sdk-go/sdk/internal: mkdir /tmp/go-build2367015974/b3083/: no space left on device

This occurred because cache cleanup happens on schedule, and during cache recreation, the arm64 runner would pick up the amd64 cache (or vice versa), resulting in "no space left on device" errors when trying to build for one of architectures on the same runner using both caches.

The fix ensures each architecture maintains its own isolated cache space by including the runner architecture in the cache key.

Fixes: 86061ff6ae13 (".github/{integration,conformance}: use caches to speed up compilation")

Fixes: #41157