### PR TITLE
docs: Update theme to add dark mode support

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:7852ab8ffa34ed95a72fdd3892f8eb91b8c5c4b9@sha256:ca0d1c874ec049cbc5b340518b81b82739151c2dedd39b2f81a72b273fea06d4
+        uses: docker://quay.io/cilium/docs-builder:e008fa4f700ec5b9043f1bf2f77099b72483de23@sha256:15aa5b59ae73e66eda9de7d68e98ac3143a5ec583bc7ad738e1be3b70984f0f9
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@0d7703280a1287e97f37124c1d9689e2efe03923
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@5e45810d0af338f8a7a6337b0377412ddf973dbc
 # We use semver to parse Cilium's version in the config file
 semver==3.0.1
 # Sphinx extensions


### PR DESCRIPTION
As a follow-up to an update in our sphinx_rtd_theme fork where we added support for a dark theme for the docs website, make our requirements.txt point to the new branch tip to pull the newest version of our theme.

Credits go to @UtkarshSiddhpura, and to authors of the Sphinx theme add-on he drew inspiration from, for the dark theme.

Fixes: #31391
Link: https://github.com/cilium/sphinx_rtd_theme/pull/26

(Repost from https://github.com/cilium/cilium/pull/41172)