### PR TITLE
xds: optimize log message of waiting for proxy update

### DIFF
--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -2246,13 +2246,13 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 	}
 
 	if wg != nil {
-		start := time.Now()
+		logArgs := []any{logfields.Duration, time.Since(time.Now())}
 		s.logger.Debug("UpdateEnvoyResources: Waiting for proxy updates to complete...")
 		err := wg.Wait()
-		s.logger.Debug("UpdateEnvoyResources: Finished waiting for proxy updates",
-			logfields.Duration, time.Since(start),
-			logfields.Error, err,
-		)
+		if err != nil {
+			logArgs = append(logArgs, logfields.Error, err)
+		}
+		s.logger.Debug("UpdateEnvoyResources: Finished waiting for proxy updates", logArgs...)
 
 		// revert all changes in case of failure
 		if err != nil {
@@ -2314,13 +2314,13 @@ func (s *xdsServer) DeleteEnvoyResources(ctx context.Context, resources Resource
 	}
 
 	if wg != nil {
-		start := time.Now()
+		logArgs := []any{logfields.Duration, time.Since(time.Now())}
 		s.logger.Debug("DeleteEnvoyResources: Waiting for proxy updates to complete...")
 		err := wg.Wait()
-		s.logger.Debug("DeleteEnvoyResources: Finished waiting for proxy updates",
-			logfields.Duration, time.Since(start),
-			logfields.Error, err,
-		)
+		if err != nil {
+			logArgs = append(logArgs, logfields.Error, err)
+		}
+		s.logger.Debug("DeleteEnvoyResources: Finished waiting for proxy updates", logArgs...)
 
 		// revert all changes in case of failure
 		if err != nil {


### PR DESCRIPTION
Currently, the log message that indcates the end of waiting for proxy updates always contains the log field `error`, even if there wasn't any error.

```
[...] msg="UpdateEnvoyResources: Finished waiting for proxy updates" error=<nil>
```

This commit optimzes this by adding the error log field conditionally.