### PR TITLE
gke: Run tests concurrently

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -243,6 +243,7 @@ jobs:
           external-ip: '8.8.8.8'
           external-other-ip: '8.8.4.4'
           hubble: false
+          test-concurrency: 5
 
       - name: Set up job variables
         id: vars


### PR DESCRIPTION
Split the CLI test runs into sequential and concurrent like the other
tests, and run the concurrent tests concurrently.
