### PR TITLE
hubble: Refactor drop event emitter as hive cell

### DIFF
--- a/pkg/hubble/cell/cell.go
+++ b/pkg/hubble/cell/cell.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/cgroups/manager"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/hubble/dropeventemitter"
 	exportercell "github.com/cilium/cilium/pkg/hubble/exporter/cell"
 	"github.com/cilium/cilium/pkg/hubble/metrics"
 	metricscell "github.com/cilium/cilium/pkg/hubble/metrics/cell"
@@ -23,8 +24,6 @@ import (
 	parsercell "github.com/cilium/cilium/pkg/hubble/parser/cell"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
-	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/watchers"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
@@ -50,6 +49,9 @@ var Cell = cell.Module(
 
 	// Metrics server and flow processor
 	metricscell.Cell,
+
+	// Drop event emitter flow processor
+	dropeventemitter.Cell,
 )
 
 // The core cell group, which contains the Hubble integration and the
@@ -71,8 +73,6 @@ type hubbleParams struct {
 	EndpointManager   endpointmanager.EndpointManager
 	IPCache           *ipcache.IPCache
 	CGroupManager     manager.CGroupManager
-	Clientset         k8sClient.Clientset
-	K8sWatcher        *watchers.K8sWatcher
 	NodeManager       nodeManager.NodeManager
 	NodeLocalStore    *node.LocalNodeStore
 	MonitorAgent      monitorAgent.Agent
@@ -82,6 +82,8 @@ type hubbleParams struct {
 	// NOTE: ordering is not guaranteed, do not rely on it.
 	ObserverOptions  []observeroption.Option                `group:"hubble-observer-options"`
 	ExporterBuilders []*exportercell.FlowLogExporterBuilder `group:"hubble-exporter-builders"`
+
+	DropEventEmitter dropeventemitter.FlowProcessor
 
 	PayloadParser parser.Decoder
 
@@ -102,14 +104,13 @@ func newHubbleIntegration(params hubbleParams) (HubbleIntegration, error) {
 		params.EndpointManager,
 		params.IPCache,
 		params.CGroupManager,
-		params.Clientset,
-		params.K8sWatcher,
 		params.NodeManager,
 		params.NodeLocalStore,
 		params.MonitorAgent,
 		params.TLSConfigPromise,
 		params.ObserverOptions,
 		params.ExporterBuilders,
+		params.DropEventEmitter,
 		params.PayloadParser,
 		params.GRPCMetrics,
 		params.MetricsFlowProcessor,

--- a/pkg/hubble/dropeventemitter/cell.go
+++ b/pkg/hubble/dropeventemitter/cell.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dropeventemitter
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// FlowProcessor is a wrapper for dropEventEmitter used by Hubble
+// to hook into the flow processing pipeline.
+type FlowProcessor interface {
+	ProcessFlow(ctx context.Context, flow *flowpb.Flow) error
+}
+
+var Cell = cell.Module(
+	"hubble-dropeventemitter",
+	"Emits k8s events on packet drop",
+
+	cell.Provide(newDropEventEmitter),
+	cell.Config(defaultConfig),
+)
+
+type config struct {
+	// EnableK8sDropEvents controls whether Hubble should create v1.Events for
+	// packet drops related to pods.
+	EnableK8sDropEvents bool `mapstructure:"hubble-drop-events"`
+	// K8sDropEventsInterval controls the minimum time between emitting events
+	// with the same source and destination IP.
+	K8sDropEventsInterval time.Duration `mapstructure:"hubble-drop-events-interval"`
+	// K8sDropEventsReasons controls which drop reasons to emit events for.
+	K8sDropEventsReasons []string `mapstructure:"hubble-drop-events-reasons"`
+}
+
+var defaultConfig = config{
+	EnableK8sDropEvents:   false,
+	K8sDropEventsInterval: 2 * time.Minute,
+	K8sDropEventsReasons:  []string{"auth_required", "policy_denied"},
+}
+
+func (def config) Flags(flags *pflag.FlagSet) {
+	flags.Bool("hubble-drop-events", def.EnableK8sDropEvents, "Emit packet drop Events related to pods (alpha)")
+	flags.Duration("hubble-drop-events-interval", def.K8sDropEventsInterval, "Minimum time between emitting same events")
+	flags.StringSlice("hubble-drop-events-reasons", def.K8sDropEventsReasons, "Drop reasons to emit events for")
+}
+
+func (cfg *config) normalize() {
+	// Before moving the --hubble-drop-events-reasons flag to Config, it was
+	// registered as flags.String() and parsed through viper.GetStringSlice()
+	// in Cilium's DaemonConfig. In that case, viper is handling the split of
+	// the single string value into slice and it uses white spaces as
+	// separators. See also https://github.com/cilium/cilium/pull/33699 for
+	// more context.
+	//
+	// Since it moved to Config, the --hubble-drop-events-reasons flag is
+	// registered as flags.StringSlice() allowing multiple flag invocations,
+	// and splitting values using comma as separator (see
+	// https://pkg.go.dev/github.com/spf13/pflag#StringSlice). Since the
+	// reasons themselves have no commas nor white spaces, starting to split on
+	// commas should not introduce issues but we still need to handle white
+	// spaces splitting to maintain backward compatibility.
+	if len(cfg.K8sDropEventsReasons) == 1 {
+		cfg.K8sDropEventsReasons = strings.Fields(cfg.K8sDropEventsReasons[0])
+	}
+}
+
+type params struct {
+	cell.In
+
+	Logger *slog.Logger
+
+	Lifecycle cell.Lifecycle
+
+	Clientset  k8sClient.Clientset
+	K8sWatcher *watchers.K8sWatcher
+
+	Config config
+}
+
+func newDropEventEmitter(p params) FlowProcessor {
+	if !p.Config.EnableK8sDropEvents {
+		p.Logger.Info("The Hubble packet drop events emitter is disabled")
+		return nil
+	}
+
+	p.Config.normalize()
+
+	p.Logger.Info(
+		"Building the Hubble packet drop events emitter",
+		logfields.Interval, p.Config.K8sDropEventsInterval,
+		logfields.Reasons, p.Config.K8sDropEventsReasons,
+	)
+
+	flowProcessor := new(p.Config.K8sDropEventsInterval, p.Config.K8sDropEventsReasons, p.Clientset, p.K8sWatcher)
+	p.Lifecycle.Append(cell.Hook{
+		OnStop: func(hc cell.HookContext) error {
+			flowProcessor.Shutdown()
+			return nil
+		},
+	})
+	return flowProcessor
+}

--- a/pkg/hubble/dropeventemitter/cell.go
+++ b/pkg/hubble/dropeventemitter/cell.go
@@ -46,7 +46,10 @@ type config struct {
 var defaultConfig = config{
 	EnableK8sDropEvents:   false,
 	K8sDropEventsInterval: 2 * time.Minute,
-	K8sDropEventsReasons:  []string{"auth_required", "policy_denied"},
+	K8sDropEventsReasons: []string{
+		strings.ToLower(flowpb.DropReason_AUTH_REQUIRED.String()),
+		strings.ToLower(flowpb.DropReason_POLICY_DENIED.String()),
+	},
 }
 
 func (def config) Flags(flags *pflag.FlagSet) {
@@ -102,7 +105,7 @@ func newDropEventEmitter(p params) FlowProcessor {
 		logfields.Reasons, p.Config.K8sDropEventsReasons,
 	)
 
-	flowProcessor := new(p.Config.K8sDropEventsInterval, p.Config.K8sDropEventsReasons, p.Clientset, p.K8sWatcher)
+	flowProcessor := new(p.Logger, p.Config.K8sDropEventsInterval, p.Config.K8sDropEventsReasons, p.Clientset, p.K8sWatcher)
 	p.Lifecycle.Append(cell.Hook{
 		OnStop: func(hc cell.HookContext) error {
 			flowProcessor.Shutdown()

--- a/pkg/hubble/dropeventemitter/dropeventemitter.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter.go
@@ -23,13 +23,15 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-type DropEventEmitter struct {
-	reasons    []string
-	recorder   record.EventRecorder
-	k8sWatcher watchers.CacheAccessK8SWatcher
+type dropEventEmitter struct {
+	broadcaster record.EventBroadcaster
+	recorder    record.EventRecorder
+	k8sWatcher  watchers.CacheAccessK8SWatcher
+
+	reasons []string
 }
 
-func NewDropEventEmitter(interval time.Duration, reasons []string, k8s client.Clientset, watcher watchers.CacheAccessK8SWatcher) *DropEventEmitter {
+func new(interval time.Duration, reasons []string, k8s client.Clientset, watcher watchers.CacheAccessK8SWatcher) *dropEventEmitter {
 	broadcaster := record.NewBroadcasterWithCorrelatorOptions(record.CorrelatorOptions{
 		BurstSize:            1,
 		QPS:                  1 / float32(interval.Seconds()),
@@ -39,30 +41,35 @@ func NewDropEventEmitter(interval time.Duration, reasons []string, k8s client.Cl
 	})
 	broadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: k8s.CoreV1().Events("")})
 
-	return &DropEventEmitter{
-		reasons:    reasons,
-		recorder:   broadcaster.NewRecorder(slimscheme.Scheme, v1.EventSource{Component: "cilium"}),
-		k8sWatcher: watcher,
+	return &dropEventEmitter{
+		broadcaster: broadcaster,
+		recorder:    broadcaster.NewRecorder(slimscheme.Scheme, v1.EventSource{Component: "cilium"}),
+		k8sWatcher:  watcher,
+		reasons:     reasons,
 	}
 }
 
-func (e *DropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	reason := strings.ToLower(flow.DropReasonDesc.String())
 
 	// Only handle packet drops due to policy related to a Pod
 	if flow.Verdict != flowpb.Verdict_DROPPED ||
 		!slices.Contains(e.reasons, reason) ||
-		(flow.TrafficDirection == flowpb.TrafficDirection_INGRESS &&
-			flow.Destination.PodName == "") ||
-		(flow.TrafficDirection == flowpb.TrafficDirection_EGRESS &&
-			flow.Source.PodName == "") {
+		(flow.TrafficDirection == flowpb.TrafficDirection_INGRESS && flow.Destination.PodName == "") ||
+		(flow.TrafficDirection == flowpb.TrafficDirection_EGRESS && flow.Source.PodName == "") {
 		return nil
 	}
 
 	if flow.TrafficDirection == flowpb.TrafficDirection_INGRESS {
 		message := "Incoming packet dropped (" + reason + ") from " +
-			e.endpointToString(flow.IP.Source, flow.Source) + " " +
-			e.l4protocolToString(flow.L4)
+			endpointToString(flow.IP.Source, flow.Source) + " " +
+			l4protocolToString(flow.L4)
 		e.recorder.Event(&slimv1.Pod{
 			TypeMeta: metaslimv1.TypeMeta{
 				Kind:       "Pod",
@@ -75,8 +82,8 @@ func (e *DropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 		}, v1.EventTypeWarning, "PacketDrop", message)
 	} else {
 		message := "Outgoing packet dropped (" + reason + ") to " +
-			e.endpointToString(flow.IP.Destination, flow.Destination) + " " +
-			e.l4protocolToString(flow.L4)
+			endpointToString(flow.IP.Destination, flow.Destination) + " " +
+			l4protocolToString(flow.L4)
 
 		objMeta := metaslimv1.ObjectMeta{
 			Name:      flow.Source.PodName,
@@ -101,17 +108,21 @@ func (e *DropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 	return nil
 }
 
-func (e *DropEventEmitter) endpointToString(ip string, endpoint *flowpb.Endpoint) string {
-	if endpoint.PodName != "" {
-		return endpoint.Namespace + "/" + endpoint.PodName + " (" + ip + ")"
-	} else if identity.NumericIdentity(endpoint.Identity).IsReservedIdentity() {
-		return identity.NumericIdentity(endpoint.Identity).String() + " (" + ip + ")"
-	} else {
-		return ip
-	}
+func (e *dropEventEmitter) Shutdown() {
+	e.broadcaster.Shutdown()
 }
 
-func (e *DropEventEmitter) l4protocolToString(l4 *flowpb.Layer4) string {
+func endpointToString(ip string, endpoint *flowpb.Endpoint) string {
+	if endpoint.PodName != "" {
+		return endpoint.Namespace + "/" + endpoint.PodName + " (" + ip + ")"
+	}
+	if identity.NumericIdentity(endpoint.Identity).IsReservedIdentity() {
+		return identity.NumericIdentity(endpoint.Identity).String() + " (" + ip + ")"
+	}
+	return ip
+}
+
+func l4protocolToString(l4 *flowpb.Layer4) string {
 	switch l4.Protocol.(type) {
 	case *flowpb.Layer4_TCP:
 		return "TCP/" + strconv.Itoa(int(l4.GetTCP().DestinationPort))

--- a/pkg/hubble/dropeventemitter/dropeventemitter_test.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter_test.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/identity"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -48,8 +48,7 @@ func TestEndpointToString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &DropEventEmitter{}
-			str := e.endpointToString(tt.ip, tt.endpoint)
+			str := endpointToString(tt.ip, tt.endpoint)
 			assert.Equal(t, str, tt.expect)
 		})
 	}
@@ -79,8 +78,7 @@ func TestL4protocolToString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &DropEventEmitter{}
-			str := e.l4protocolToString(tt.l4)
+			str := l4protocolToString(tt.l4)
 			assert.Equal(t, str, tt.expect)
 		})
 	}
@@ -177,7 +175,7 @@ func TestProcessFlow(t *testing.T) {
 				Events:        make(chan string, 3),
 				IncludeObject: true,
 			}
-			e := &DropEventEmitter{
+			e := &dropEventEmitter{
 				reasons:    []string{"policy_denied"},
 				recorder:   fakeRecorder,
 				k8sWatcher: &fakeK8SWatcher{},
@@ -199,8 +197,7 @@ func TestProcessFlow(t *testing.T) {
 	}
 }
 
-type fakeK8SWatcher struct {
-}
+type fakeK8SWatcher struct{}
 
 func (k *fakeK8SWatcher) GetCachedNamespace(namespace string) (*slim_corev1.Namespace, error) {
 	return nil, nil

--- a/pkg/hubble/dropeventemitter/dropeventemitter_test.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter_test.go
@@ -176,7 +176,7 @@ func TestProcessFlow(t *testing.T) {
 				IncludeObject: true,
 			}
 			e := &dropEventEmitter{
-				reasons:    []string{"policy_denied"},
+				reasons:    []flowpb.DropReason{flowpb.DropReason_POLICY_DENIED},
 				recorder:   fakeRecorder,
 				k8sWatcher: &fakeK8SWatcher{},
 			}


### PR DESCRIPTION
Behaviour changes:
- Call Shutdown() on the broadcaster to ensure we stop sending events to the event sink when the hive stops.
  - The broadcaster allows receiving a context and will shutdown itself in a goroutine when it is cancelled, but we don't do that because we need to provide the context upfront, which we can't do from a cell constructor.
- Ensure that ProcessFlow exits if the passed context is cancelled.
 
Fixes: #40061
