### PR TITLE
pkg/ipam: fix nil dereference during pool shrink operation

### DIFF
--- a/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -156,6 +156,9 @@ func (p *PoolAllocator) updateCIDRSets(isV6 bool, cidrSets []cidralloc.CIDRAlloc
 
 	// delete CIDR set for CIDRs not present in the new CIDRs
 	for i, oldCIDR := range cidrSets {
+		if oldCIDR == nil {
+			continue
+		}
 		exists := slices.ContainsFunc(newCIDRs, oldCIDR.IsClusterCIDR)
 		if !exists {
 			cidrSets[i] = nil


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

When shrinking a CiliumPodIPPool the operator could crash with a nil pointer dereference in updateCIDRSets.  The loop deletes entries from the slice it is iterating over, leaving behind nil slots that are dereferenced in the next iteration. This change skips over nil items in the slice. It also introduces a new unit test for this behaviour.

Fixes: #41197

```release-note
pkg/ipam: fix nil dereference during pool shrink operation
```
