### PR TITLE
Revert "loadbalancer: Keep non-serving terminating backends"

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1373,18 +1373,12 @@ Cilium's eBPF kube-proxy replacement supports graceful termination of service
 endpoint pods. The Cilium agent detects such terminating Pod events, and
 increments the metric ``k8s_terminating_endpoints_events_total``.
 
-When Cilium agent receives a Kubernetes update event that marks an endpoint as
-terminating Cilium will retain the datapath state necessary for existing connections.
-The terminating endpoint will be used as fallback for new connections only if
-1) no active endpoints exist for the service and 2) terminating endpoint has condition ``serving``
-(e.g. pod is still passing `readinessProbes <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes>`_).
-
-If ``publishNotReadyAddresses`` is set on the Service the endpoints received by Cilium
-may have both the ``ready`` and ``terminating`` conditions set. In this case Cilium follows
-kube-proxy and uses these for new connections, ignoring the ``terminating`` condition.
-
-The endpoint state is fully removed when the agent receives a Kubernetes delete
-event for the endpoint. The `Kubernetes pod termination <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination>`_
+When Cilium agent receives a Kubernetes update event for a terminating endpoint,
+the datapath state for the endpoint is removed such that it won't service new
+connections, but the endpoint's active connections are able to terminate
+gracefully. The endpoint state is fully removed when the agent receives
+a Kubernetes delete event for the endpoint. The `Kubernetes
+pod termination <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination>`_
 documentation contains more background on the behavior and configuration using ``terminationGracePeriodSeconds``.
 There are some special cases, like zero disruption during rolling updates, that require to be able to send traffic
 to Terminating Pods that are still Serving traffic during the Terminating period, the Kubernetes blog

--- a/api/v1/models/backend_address.go
+++ b/api/v1/models/backend_address.go
@@ -41,7 +41,7 @@ type BackendAddress struct {
 	Protocol string `json:"protocol,omitempty"`
 
 	// State of the backend for load-balancing service traffic
-	// Enum: ["active","terminating","terminating-not-serving","quarantined","maintenance"]
+	// Enum: ["active","terminating","quarantined","maintenance"]
 	State string `json:"state,omitempty"`
 
 	// Backend weight
@@ -82,7 +82,7 @@ var backendAddressTypeStatePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["active","terminating","terminating-not-serving","quarantined","maintenance"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["active","terminating","quarantined","maintenance"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -97,9 +97,6 @@ const (
 
 	// BackendAddressStateTerminating captures enum value "terminating"
 	BackendAddressStateTerminating string = "terminating"
-
-	// BackendAddressStateTerminatingDashNotDashServing captures enum value "terminating-not-serving"
-	BackendAddressStateTerminatingDashNotDashServing string = "terminating-not-serving"
 
 	// BackendAddressStateQuarantined captures enum value "quarantined"
 	BackendAddressStateQuarantined string = "quarantined"

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2924,7 +2924,6 @@ definitions:
         enum:
           - active
           - terminating
-          - terminating-not-serving
           - quarantined
           - maintenance
       preferred:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1824,7 +1824,6 @@ func init() {
           "enum": [
             "active",
             "terminating",
-            "terminating-not-serving",
             "quarantined",
             "maintenance"
           ]
@@ -7457,7 +7456,6 @@ func init() {
           "enum": [
             "active",
             "terminating",
-            "terminating-not-serving",
             "quarantined",
             "maintenance"
           ]

--- a/pkg/bgpv1/manager/reconciler/service.go
+++ b/pkg/bgpv1/manager/reconciler/service.go
@@ -158,7 +158,7 @@ endpointsLoop:
 		svcID := eps.ServiceName
 
 		for _, be := range eps.Backends {
-			if !be.Conditions.IsTerminating() && be.NodeName == localNodeName {
+			if !be.Terminating && be.NodeName == localNodeName {
 				// At least one endpoint is available on this node. We
 				// can make unavailable to available.
 				if _, found := ls[svcID]; !found {

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -122,8 +122,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 		},
 	}
@@ -139,8 +138,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionTerminating,
+				NodeName:    "node1",
+				Terminating: true,
 			},
 		},
 	}
@@ -156,8 +155,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -173,12 +171,10 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -194,8 +190,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 		},
 	}
@@ -211,8 +206,7 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -228,12 +222,10 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -833,8 +825,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 		},
 	}
@@ -850,8 +841,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -867,12 +857,10 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -888,8 +876,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 		},
 	}
@@ -905,8 +892,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -922,8 +908,7 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
 				NodeName: "node2",
@@ -1483,8 +1468,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 		},
 	}
@@ -1500,8 +1484,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -1517,12 +1500,10 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -1538,8 +1519,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 		},
 	}
@@ -1555,8 +1535,7 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -1572,12 +1551,10 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName:   "node2",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node2",
 			},
 		},
 	}
@@ -2086,16 +2063,14 @@ func TestEPUpdateOnly(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+				NodeName: "node1",
 			},
 		},
 	}
 	eps1IPv4LocalUpdated := eps1IPv4Local.DeepCopy()
 	eps1IPv4LocalUpdated.Backends = map[cmtypes.AddrCluster]*k8s.Backend{
 		cmtypes.MustParseAddrCluster("10.0.0.1"): {
-			NodeName:   "node2",
-			Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
+			NodeName: "node2",
 		},
 	}
 

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -361,7 +361,7 @@ endpointsLoop:
 		}
 
 		for _, be := range eps.Backends {
-			if !be.Conditions.IsTerminating() && be.NodeName == localNodeName {
+			if !be.Terminating && be.NodeName == localNodeName {
 				// At least one endpoint is available on this node. We
 				// can add service to the local services set.
 				ls.Insert(svcKey)

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -650,12 +650,12 @@ var (
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionTerminating,
+				NodeName:    "node1",
+				Terminating: true,
 			},
 			cmtypes.MustParseAddrCluster("2001:db8:1000::1"): {
-				NodeName:   "node1",
-				Conditions: k8s.BackendConditionTerminating,
+				NodeName:    "node1",
+				Terminating: true,
 			},
 		},
 	}

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -97,58 +97,7 @@ func (in *Endpoints) DeepCopy() *Endpoints {
 	return out
 }
 
-// BackendCondition is a flag mirroring the endpoint Conditions.
-type BackendCondition uint8
-
-const (
-	// BackendConditionReady indicates that this endpoint is prepared to receive traffic,
-	// according to whatever system is managing the endpoint.
-	// More info: vendor/k8s.io/api/discovery/v1/types.go
-	// See also https://github.com/kubernetes/kubernetes/issues/108523
-	BackendConditionReady = 1 << iota
-
-	// BackendConditionServing indicates that this endpoint can serve new connections.
-	// It is meaningful to Cilium when the backend is terminating. If this condition is false
-	// then a terminating backend will not be used for new connections even as fallback
-	// when no active backends exist.
-	// More info: vendor/k8s.io/api/discovery/v1/types.go
-	// See also https://github.com/kubernetes/kubernetes/issues/108523 and
-	// https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/pkg/proxy/topology.go#L76
-	BackendConditionServing
-
-	// Terminating indicates that the endpoint is getting terminated.
-	// It will not be used for new conditions unless 1) no active backends exist
-	// and 2) this backend is serving.
-	//
-	// If [publishNotReadyAddresses] is set on a service then a backend may be
-	// both terminating and ready in which case the terminating state is ignored.
-	//
-	// More info: vendor/k8s.io/api/discovery/v1/types.go
-	// See also https://github.com/kubernetes/kubernetes/issues/108523
-	BackendConditionTerminating
-)
-
-var backendConditions = [...]string{
-	BackendConditionReady:       "ready",
-	BackendConditionServing:     "serving",
-	BackendConditionTerminating: "terminating",
-}
-
-func (bc BackendCondition) String() string {
-	var flags []string
-	for mask, str := range backendConditions {
-		if str != "" && bc&BackendCondition(mask) != 0 {
-			flags = append(flags, str)
-		}
-	}
-	return strings.Join(flags, "+")
-}
-
-func (bc BackendCondition) IsReady() bool       { return bc&BackendConditionReady != 0 }
-func (bc BackendCondition) IsServing() bool     { return bc&BackendConditionServing != 0 }
-func (bc BackendCondition) IsTerminating() bool { return bc&BackendConditionTerminating != 0 }
-
-// Backend contains all ports, conditions, and the node name of a given backend
+// Backend contains all ports, terminating state, and the node name of a given backend
 //
 // +k8s:deepcopy-gen=true
 // +deepequal-gen=false
@@ -156,7 +105,7 @@ type Backend struct {
 	Ports         map[loadbalancer.L4Addr][]string
 	NodeName      string
 	Hostname      string
-	Conditions    BackendCondition
+	Terminating   bool
 	HintsForZones []string
 	Preferred     bool
 	Zone          string
@@ -166,7 +115,7 @@ func (b *Backend) DeepEqual(other *Backend) bool {
 	return maps.EqualFunc(b.Ports, other.Ports, slices.Equal) &&
 		b.NodeName == other.NodeName &&
 		b.Hostname == other.Hostname &&
-		b.Conditions == other.Conditions &&
+		b.Terminating == other.Terminating &&
 		slices.Equal(b.HintsForZones, other.HintsForZones) &&
 		b.Preferred == other.Preferred &&
 		b.Zone == other.Zone
@@ -242,19 +191,6 @@ func ParseEndpointSliceID(es endpointSlice) EndpointSliceID {
 
 const logfieldTerminating = "terminating"
 
-func ParseEndpointConditionsV1(conditions slim_discovery_v1.EndpointConditions) (bc BackendCondition) {
-	if conditions.Ready == nil || *conditions.Ready {
-		bc |= BackendConditionReady
-	}
-	if conditions.Serving == nil || conditions.Serving != nil && *conditions.Serving {
-		bc |= BackendConditionServing
-	}
-	if conditions.Terminating != nil && *conditions.Terminating {
-		bc |= BackendConditionTerminating
-	}
-	return
-}
-
 // ParseEndpointSliceV1 parses a Kubernetes EndpointSlice resource.
 // It reads ready and terminating state of endpoints in the EndpointSlice to
 // return an EndpointSlice ID and a filtered list of Endpoints for service load-balancing.
@@ -288,10 +224,41 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 	}
 
 	for i, sub := range ep.Endpoints {
+		// ready indicates that this endpoint is prepared to receive traffic,
+		// according to whatever system is managing the endpoint. A nil value
+		// indicates an unknown state. In most cases consumers should interpret this
+		// unknown state as ready.
+		// More info: vendor/k8s.io/api/discovery/v1/types.go
+		isReady := sub.Conditions.Ready == nil || *sub.Conditions.Ready
+		// serving is identical to ready except that it is set regardless of the
+		// terminating state of endpoints. This condition should be set to true for
+		// a ready endpoint that is terminating. If nil, consumers should defer to
+		// the ready condition.
+		// More info: vendor/k8s.io/api/discovery/v1/types.go
+		isServing := (sub.Conditions.Serving == nil && isReady) || (sub.Conditions.Serving != nil && *sub.Conditions.Serving)
+		// Terminating indicates that the endpoint is getting terminated. A
+		// nil values indicates an unknown state. Ready is never true when
+		// an endpoint is terminating. Propagate the terminating endpoint
+		// state so that we can gracefully remove those endpoints.
+		// More info: vendor/k8s.io/api/discovery/v1/types.go
+		isTerminating := sub.Conditions.Terminating != nil && *sub.Conditions.Terminating
+
+		// if is not Ready allow endpoints that are Serving and Terminating
+		if !isReady {
+			// filter not Serving endpoints since those can not receive traffic
+			if !isServing {
+				logger.Debug(
+					"discarding Endpoint on EndpointSlice: not Serving",
+					logfields.Name, ep.Name,
+				)
+				continue
+			}
+		}
+
 		// Construct the backend configuration shared by all the addresses in this slice.
 		backend := &Backend{
-			Conditions: ParseEndpointConditionsV1(sub.Conditions),
-			Ports:      ports,
+			Ports:       ports,
+			Terminating: !isReady && isServing && isTerminating,
 		}
 
 		if sub.NodeName != nil {
@@ -334,7 +301,7 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 			endpoints.Backends[addrCluster] = backend
 		}
 
-		if backend.Conditions.IsTerminating() {
+		if backend.Terminating {
 			metrics.TerminatingEndpointsEvents.Inc()
 		}
 
@@ -343,7 +310,7 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 			logfields.Name, ep.Name,
 			logfields.Addresses, sub.Addresses,
 			logfields.Backend, backend,
-			logfieldTerminating, backend.Conditions.IsTerminating(),
+			logfieldTerminating, backend.Terminating,
 		)
 	}
 

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -327,9 +327,8 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 					},
-					NodeName:   nodeName,
-					Hostname:   hostname,
-					Conditions: BackendConditionReady | BackendConditionServing,
+					NodeName: nodeName,
+					Hostname: hostname,
 				}
 				return svcEP
 			},
@@ -373,8 +372,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName:   nodeName,
-					Conditions: BackendConditionReady | BackendConditionServing,
+					NodeName: nodeName,
 				}
 				return svcEP
 			},
@@ -423,15 +421,13 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName:   nodeName,
-					Conditions: BackendConditionReady | BackendConditionServing,
+					NodeName: nodeName,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -488,22 +484,13 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Conditions: BackendConditionReady | BackendConditionServing,
-					NodeName:   nodeName,
+					NodeName: nodeName,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Conditions: BackendConditionReady | BackendConditionServing,
-				}
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.3")] = &Backend{
-					Ports: map[loadbalancer.L4Addr][]string{
-						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
-						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
-					},
-					Conditions: BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -557,22 +544,13 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName:   nodeName,
-					Conditions: BackendConditionReady | BackendConditionServing,
+					NodeName: nodeName,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Conditions: BackendConditionReady | BackendConditionServing,
-				}
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.3")] = &Backend{
-					Ports: map[loadbalancer.L4Addr][]string{
-						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
-						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
-					},
-					Conditions: BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -618,19 +596,12 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 			},
 			setupWanted: func() *Endpoints {
 				svcEP := newEmptyEndpoints()
-				be := &Backend{
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Conditions: BackendConditionReady | BackendConditionServing,
 				}
-				// nil conditions means ready & serving
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = be
-				// endpoints that are terminating should be kept regardless of other conditions.
-				be = be.DeepCopy()
-				be.Conditions = BackendConditionTerminating
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = be
 				return svcEP
 			},
 		},
@@ -680,14 +651,13 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Conditions: BackendConditionServing | BackendConditionTerminating,
+					Terminating: true,
 				}
 				return svcEP
 			},
@@ -734,7 +704,6 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Conditions: BackendConditionReady | BackendConditionServing | BackendConditionTerminating,
 				}
 				return svcEP
 			},
@@ -750,11 +719,19 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 							{
 								Conditions: slim_discovery_v1.EndpointConditions{
 									Ready:       func() *bool { a := false; return &a }(),
-									Serving:     func() *bool { a := false; return &a }(),
 									Terminating: func() *bool { a := true; return &a }(),
 								},
 								Addresses: []string{
 									"172.0.0.1",
+								},
+							},
+							{
+								Conditions: slim_discovery_v1.EndpointConditions{
+									Ready:       func() *bool { a := false; return &a }(),
+									Terminating: func() *bool { a := true; return &a }(),
+								},
+								Addresses: []string{
+									"172.0.0.2",
 								},
 							},
 						},
@@ -775,13 +752,6 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 			},
 			setupWanted: func() *Endpoints {
 				svcEP := newEmptyEndpoints()
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
-					Ports: map[loadbalancer.L4Addr][]string{
-						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
-						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
-					},
-					Conditions: BackendConditionTerminating,
-				}
 				return svcEP
 			},
 		},
@@ -831,15 +801,20 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 			},
 			setupWanted: func() *Endpoints {
 				svcEP := newEmptyEndpoints()
-				be := &Backend{
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Conditions: BackendConditionServing | BackendConditionTerminating,
+					Terminating: true,
 				}
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = be
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = be
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
+					Ports: map[loadbalancer.L4Addr][]string{
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
+					},
+					Terminating: true,
+				}
 				return svcEP
 			},
 		},
@@ -874,7 +849,6 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 					},
-					Conditions:    BackendConditionReady | BackendConditionServing,
 					HintsForZones: []string{"testing"},
 				}
 				return svcEP
@@ -910,7 +884,6 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 					},
-					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -381,14 +381,12 @@ const (
 // Valid transition states for a backend -
 // BackendStateActive -> BackendStateTerminating, BackendStateQuarantined, BackendStateMaintenance
 // BackendStateTerminating -> No valid state transition
-// BackendStateTerminatingNotServing -> No valid state transition
 // BackendStateQuarantined -> BackendStateActive, BackendStateTerminating
 // BackendStateMaintenance -> BackendStateActive
 //
 // Sources setting the states -
 // BackendStateActive - Kubernetes events, service API
 // BackendStateTerminating - Kubernetes events
-// BackendStateTerminatingNotServing - Kubernetes events
 // BackendStateQuarantined - service API
 // BackendStateMaintenance - service API
 const (
@@ -397,15 +395,9 @@ const (
 	// Backends in this state can be health-checked.
 	BackendStateActive BackendState = iota
 	// BackendStateTerminating refers to the terminating backend state so that
-	// it can be gracefully removed. Backend in this state can be used as a fallback
-	// if no active backends exist.
+	// it can be gracefully removed.
 	// Backends in this state won't be health-checked.
 	BackendStateTerminating
-	// BackendStateTerminatingNotServing refers to the terminating backend state
-	// for a backend that can be gracefully removed but cannot be used as fallback.
-	// Backends in this state won't be health-checked. In the BPF backend map this
-	// is the same as [BackendStateTerminating].
-	BackendStateTerminatingNotServing
 	// BackendStateQuarantined refers to the backend state when it's unreachable,
 	// and will not be selected for load-balancing traffic.
 	// Backends in this state can be health-checked.
@@ -436,7 +428,7 @@ func NewBackendFlags(state BackendState) BackendStateFlags {
 	switch state {
 	case BackendStateActive:
 		flags = BackendStateActiveFlag
-	case BackendStateTerminating, BackendStateTerminatingNotServing:
+	case BackendStateTerminating:
 		flags = BackendStateTerminatingFlag
 	case BackendStateQuarantined:
 		flags = BackendStateQuarantinedFlag
@@ -678,8 +670,6 @@ func (state BackendState) String() (string, error) {
 		return models.BackendAddressStateActive, nil
 	case BackendStateTerminating:
 		return models.BackendAddressStateTerminating, nil
-	case BackendStateTerminatingNotServing:
-		return models.BackendAddressStateTerminatingDashNotDashServing, nil
 	case BackendStateQuarantined:
 		return models.BackendAddressStateQuarantined, nil
 	case BackendStateMaintenance:

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -185,12 +185,6 @@ type bpfOpsParams struct {
 	NodeAddresses  statedb.Table[tables.NodeAddress]
 }
 
-const (
-	logfieldActiveCount      = "active-count"
-	logfieldTerminatingCount = "terminating-count"
-	logfieldInactiveCount    = "inactive-count"
-)
-
 func newBPFOps(p bpfOpsParams) *BPFOps {
 	ops := &BPFOps{
 		cfg:       p.Config,
@@ -879,7 +873,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 
 		if ops.needsUpdate(be.Address, be.Revision) {
 			ops.log.Debug("Update backend",
-				logfields.Backend, be.BackendParams,
+				logfields.Backend, be,
 				logfields.ID, beID,
 				logfields.Address, be.Address,
 			)
@@ -1022,10 +1016,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 		logfields.Type, fe.Type,
 		logfields.ProxyRedirect, fe.Service.ProxyRedirect,
 		logfields.Address, fe.Address,
-		logfields.Count, backendCount,
-		logfieldActiveCount, activeCount,
-		logfieldTerminatingCount, terminatingCount,
-		logfieldInactiveCount, inactiveCount)
+		logfields.Count, backendCount)
 	if err := ops.upsertMaster(svcKey, svcVal, fe, activeCount, inactiveCount); err != nil {
 		return fmt.Errorf("upsert service master: %w", err)
 	}

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -432,32 +432,9 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					}
 				}
 
-				var state loadbalancer.BackendState
-				switch {
-				case be.Conditions.IsReady():
-					// A backend that is ready (regardless of serving and terminating) is considered
-					// active. We may see backends that are ready+terminating if 'PublishNotReadyAddresses'
-					// is true. While it would be more logical to set this as terminating, we're following
-					// kube-proxy here and considering it as an active backend and not ignoring it even when
-					// other active backends are available.
-					//
-					// See also kube-proxy implementation at:
-					// https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/pkg/proxy/topology.go#L61
-					state = loadbalancer.BackendStateActive
-				case be.Conditions.IsTerminating() && !be.Conditions.IsServing():
-					// A backend that is terminating and not serving should not be used for load-balancing
-					// even if it's the only backend. A terminating backend is kept in the BPF maps until
-					// fully removed to avoid disrupting connections.
-					state = loadbalancer.BackendStateTerminatingNotServing
-				case be.Conditions.IsTerminating():
-					// A backend that is terminating and serving can still be used for new connections
-					// when no active backends are available. A terminating backend is kept in the BPF maps until
-					// fully removed to avoid disrupting connections.
+				state := loadbalancer.BackendStateActive
+				if be.Terminating {
 					state = loadbalancer.BackendStateTerminating
-				default:
-					// In all other cases we mark the backend as quarantined. Existing connections
-					// are not disrupted until the backend is actually deleted.
-					state = loadbalancer.BackendStateQuarantined
 				}
 				bep := loadbalancer.BackendParams{
 					Address:   l3n4Addr,

--- a/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
@@ -8,12 +8,10 @@ hive start
 
 # Start with two backends that are both active.
 cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$READY1' 'true' endpointslice.yaml
-replace '$SERVING1' 'true' endpointslice.yaml
 replace '$TERM1' 'false' endpointslice.yaml
-replace '$READY2' 'true' endpointslice.yaml
-replace '$SERVING2' 'true' endpointslice.yaml
+replace '$READY1' 'true' endpointslice.yaml
 replace '$TERM2' 'false' endpointslice.yaml
+replace '$READY2' 'true' endpointslice.yaml
 
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
@@ -27,12 +25,10 @@ lb/maps-dump lbmaps.actual
 # Set the first backend as terminating. The second backend
 # will now serve the traffic.
 cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$READY1' 'false' endpointslice.yaml
-replace '$SERVING1' 'true' endpointslice.yaml
 replace '$TERM1' 'true' endpointslice.yaml
-replace '$READY2' 'true' endpointslice.yaml
-replace '$SERVING2' 'true' endpointslice.yaml
+replace '$READY1' 'false' endpointslice.yaml
 replace '$TERM2' 'false' endpointslice.yaml
+replace '$READY2' 'true' endpointslice.yaml
 k8s/update endpointslice.yaml
 db/cmp backends backends-terminating1.table
 
@@ -44,12 +40,10 @@ lb/maps-dump lbmaps.actual
 # are now active backends the terminating backends are used
 # instead.
 cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$READY1' 'false' endpointslice.yaml
 replace '$TERM1' 'true' endpointslice.yaml
-replace '$SERVING1' 'true' endpointslice.yaml
-replace '$READY2' 'false' endpointslice.yaml
+replace '$READY1' 'false' endpointslice.yaml
 replace '$TERM2' 'true' endpointslice.yaml
-replace '$SERVING2' 'true' endpointslice.yaml
+replace '$READY2' 'false' endpointslice.yaml
 k8s/update endpointslice.yaml
 db/cmp frontends frontends-terminating2.table
 db/cmp backends backends-terminating2.table
@@ -57,43 +51,6 @@ db/cmp backends backends-terminating2.table
 # Check BPF maps
 lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating2.expected lbmaps.actual
-
-# Set the second backend as terminating AND not serving.
-# This now won't be used as a fallback.
-cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$READY1' 'false' endpointslice.yaml
-replace '$SERVING1' 'true' endpointslice.yaml
-replace '$TERM1' 'true' endpointslice.yaml
-replace '$READY2' 'false' endpointslice.yaml
-replace '$SERVING2' 'false' endpointslice.yaml
-replace '$TERM2' 'true' endpointslice.yaml
-k8s/update endpointslice.yaml
-db/cmp frontends frontends-terminating3.table
-db/cmp backends backends-terminating3.table
-
-# Check BPF maps
-lb/maps-dump lbmaps.actual
-* cmp lbmaps-terminating3.expected lbmaps.actual
-
-# Set the first backend as not serving and second as ready+terminating .
-# First backend will be quarantined. Existing connections to
-# it won't be affected as it's still in the backends BPF map.
-# The second backend will be just considered ready and its terminating
-# condition is ignored ("ready" overrides everything).
-cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$READY1' 'false' endpointslice.yaml
-replace '$SERVING1' 'false' endpointslice.yaml
-replace '$TERM1' 'false' endpointslice.yaml
-replace '$READY2' 'true' endpointslice.yaml
-replace '$SERVING2' 'false' endpointslice.yaml
-replace '$TERM2' 'true' endpointslice.yaml
-k8s/update endpointslice.yaml
-db/cmp frontends frontends-terminating4.table
-db/cmp backends backends-terminating4.table
-
-# Check BPF maps
-lb/maps-dump lbmaps.actual
-* cmp lbmaps-terminating4.expected lbmaps.actual
 
 # Cleanup
 k8s/delete service.yaml endpointslice.yaml
@@ -116,14 +73,6 @@ Address                 Type        ServiceName              Status  Backends
 Address                 Type        ServiceName              Status  Backends
 10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
 
--- frontends-terminating3.table --
-Address                 Type        ServiceName              Status  Backends
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
-
--- frontends-terminating4.table --
-Address                 Type        ServiceName              Status  Backends
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
-
 -- backends.table --
 Address                 Instances                NodeName
 10.244.0.112:8081/TCP   test/graceful-term-svc   graceful-term-control-plane
@@ -138,16 +87,6 @@ Address                 Instances                              NodeName
 Address                 Instances                             NodeName
 10.244.0.112:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
 10.244.0.113:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
-
--- backends-terminating3.table --
-Address                 Instances                                         NodeName
-10.244.0.112:8081/TCP   test/graceful-term-svc [terminating]              graceful-term-control-plane
-10.244.0.113:8081/TCP   test/graceful-term-svc [terminating-not-serving]  graceful-term-control-plane
-
--- backends-terminating4.table --
-Address                 Instances                                         NodeName
-10.244.0.112:8081/TCP   test/graceful-term-svc [quarantined]              graceful-term-control-plane
-10.244.0.113:8081/TCP   test/graceful-term-svc                            graceful-term-control-plane
 
 -- service.yaml --
 apiVersion: v1
@@ -207,7 +146,7 @@ endpoints:
   - 10.244.0.112
   conditions:
     ready: $READY1
-    serving: $SERVING1
+    serving: true
     terminating: $TERM1
   nodeName: graceful-term-control-plane
   targetRef:
@@ -220,7 +159,7 @@ endpoints:
   - 10.244.0.113
   conditions:
     ready: $READY2
-    serving: $SERVING2
+    serving: true
     terminating: $TERM2
   nodeName: graceful-term-control-plane
   targetRef:
@@ -258,19 +197,3 @@ REV: ID=1 ADDR=10.96.116.33:8081
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
--- lbmaps-terminating3.expected --
-BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=terminating
-BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=terminating
-MAGLEV: ID=1 INNER=[1(1021)]
-REV: ID=1 ADDR=10.96.116.33:8081
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
--- lbmaps-terminating4.expected --
-BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=quarantined
-BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
-MAGLEV: ID=1 INNER=[2(1021)]
-REV: ID=1 ADDR=10.96.116.33:8081
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP


### PR DESCRIPTION
This reverts commit 6f41c986bbfceae31fde143b0e029970d343b83c.

Related: #41194

ci-ginkgo has been failing consistently and it seems to have started with this commit.
