### PR TITLE
bpf: Add BPF tests for extended IP protocols support in pods

### DIFF
--- a/bpf/tests/lxc_extended_protocols.c
+++ b/bpf/tests/lxc_extended_protocols.c
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4			1
+
+#define CLIENT_IP		v4_pod_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define SERVER_IP		v4_ext_one
+#define SERVER_PORT		__bpf_htons(222)
+
+#define NODE_IP			v4_node_one
+
+#define DST_IP			v4_ext_one
+#define DST_IP2			v4_ext_two
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *server_mac = mac_two;
+static volatile const __u8 *node_mac = mac_three;
+static volatile const __u8 *dst_mac = mac_four;
+
+#include "bpf_lxc.c"
+
+ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = v4_pod_one})
+ASSIGN_CONFIG(bool, enable_extended_ip_protocols, true);
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+#define FROM_CONTAINER 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+/* Send an IGMP packet from pod to IGMP destination (allow all egress policy).
+ *
+ */
+PKTGEN("tc", "lxc_igmp_egress")
+int lxc_igmp_egress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct igmphdr *igmp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	igmp = pktgen__push_ipv4_igmp_packet(&builder,
+					     (__u8 *)client_mac, (__u8 *)server_mac,
+					     CLIENT_IP, DST_IP,
+					     IGMP_HOST_MEMBERSHIP_REPORT);
+	if (!igmp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "lxc_igmp_egress")
+int lxc_igmp_egress_setup(struct __ctx_buff *ctx)
+{
+	policy_add_egress_allow_all_entry();
+	endpoint_v4_add_entry(CLIENT_IP, 0, 0, ENDPOINT_F_HOST, LXC_ID,
+			      0, (__u8 *)client_mac, (__u8 *)client_mac);
+	ipcache_v4_add_entry(CLIENT_IP, 0, LXC_ID, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "lxc_igmp_egress")
+int lxc_igmp_egress_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Check for egress CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = DST_IP,
+		.saddr   = CLIENT_IP,
+		.dport   = 0,
+		.sport   = 0,
+		.nexthdr = IPPROTO_IGMP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 1);
+
+	policy_delete_egress_entry();
+
+	test_finish();
+}
+
+/* Send an IGMP packet from pod to IGMP destination.
+ *
+ * The packet is allowed by the egress policy.
+ */
+PKTGEN("tc", "lxc_igmp_egress_policy")
+int lxc_igmp_egress_policy_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct igmphdr *igmp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	igmp = pktgen__push_ipv4_igmp_packet(&builder,
+					     (__u8 *)client_mac, (__u8 *)server_mac,
+					     CLIENT_IP, DST_IP2,
+					     IGMP_HOST_MEMBERSHIP_REPORT);
+	if (!igmp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "lxc_igmp_egress_policy")
+int lxc_igmp_egress_policy_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(CLIENT_IP, 0, 0, ENDPOINT_F_HOST, LXC_ID,
+			      0, (__u8 *)client_mac, (__u8 *)client_mac);
+	ipcache_v4_add_entry(CLIENT_IP, 0, LXC_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+	policy_add_egress_allow_entry(0, IPPROTO_IGMP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "lxc_igmp_egress_policy")
+int lxc_igmp_egress_policy_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Check for egress CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = DST_IP2,
+		.saddr   = CLIENT_IP,
+		.dport   = 0,
+		.sport   = 0,
+		.nexthdr = IPPROTO_IGMP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 1);
+
+	policy_delete_egress_entry();
+
+	test_finish();
+}
+
+/* Send an IGMP packet from pod to IGMP destination.
+ *
+ * The packet is denied by the egress policy.
+ */
+PKTGEN("tc", "lxc_igmp_egress_policy_deny")
+int lxc_igmp_egress_policy_deny_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct igmphdr *igmp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	igmp = pktgen__push_ipv4_igmp_packet(&builder,
+					     (__u8 *)client_mac, (__u8 *)server_mac,
+					     CLIENT_IP, DST_IP2,
+					     IGMP_HOST_MEMBERSHIP_REPORT);
+	if (!igmp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "lxc_igmp_egress_policy_deny")
+int lxc_igmp_egress_policy_deny_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(CLIENT_IP, 0, 0, ENDPOINT_F_HOST, LXC_ID,
+			      0, (__u8 *)client_mac, (__u8 *)client_mac);
+	ipcache_v4_add_entry(CLIENT_IP, 0, LXC_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+	policy_add_entry(true, 0, IPPROTO_IGMP, 0, true, LPM_PROTO_PREFIX_BITS);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "lxc_igmp_egress_policy_deny")
+int lxc_igmp_egress_policy_deny_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_DROP);
+
+	policy_delete_egress_entry();
+
+	test_finish();
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR adds BPF unit tests for extended IP protocols support in pod traffic

## Implementation

Created `bpf/tests/lxc_extended_protocols.c` with three IGMP egress test scenarios:
- IGMP traffic with allow-all policy (should pass)
- IGMP traffic with explicit allow policy (should pass) 
- IGMP traffic with explicit deny policy (should be dropped)

The tests follow the same pattern as the existing host firewall tests in `hostfw_extended_protocols.c`, using:
- `PKTGEN` programs to generate IGMP packets via `pktgen__push_ipv4_igmp_packet()`
- `SETUP` programs to configure policies and enable `enable_extended_ip_protocols`
- `CHECK` programs to verify packet processing results and conntrack entries

## Implementation Details

The tests follow established patterns from `hostfw_extended_protocols.c`:

**Code patterns used:**
- `PKTGEN` programs generate test packets using `pktgen__push_ipv4_igmp_packet()` 
- `SETUP` programs configure policies via `policy_add_egress_allow_entry()` and enable `enable_extended_ip_protocols`
- `CHECK` programs validate packet processing and conntrack entries with zero ports for extended protocols
- Three test scenarios mirror the host firewall approach: allow-all, explicit allow, explicit deny

**Key implementation choices:**
- Focus on IGMP only (matching the original host firewall BPF tests scope)
- Target `bpf_lxc` program entry points (`cil_from_container`) for pod traffic
- Use existing `pktgen` helpers and policy functions from the test framework
- Validate conntrack behavior specific to extended IP protocols (sport=0, dport=0)

## Testing

**Build validation:** Tests compile and integrate successfully with Cilium's build system. Validated via `make kind-image` deployment to kind clusters where IGMP policies now work correctly.

**Testing limitation:** Unable to execute BPF tests locally on macOS due to kernel differences. The BPF test framework requires Linux kernel features not available on macOS. Unsure how to properly run BPF tests within kind cluster environment.

The tests will validate IGMP protocol handling in the pod datapath once the extended IP protocols feature is enabled, providing the missing pod-level test coverage that complements the existing host firewall tests.

Fixes: #40229

```release-note
Add BPF unit tests for extended IP protocols support in pod traffic. The tests validate IGMP protocol handling in the bpf_lxc datapath, providing missing test coverage to complement existing host firewall tests.
```
