### PR TITLE
metrics: fix lbipam conflicting pools metric

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1977,7 +1977,7 @@ func (ipam *LBIPAM) unmarkPool(ctx context.Context, targetPool *cilium_api_v2.Ci
 
 // initMarkPool sets the intial pool condition
 func (ipam *LBIPAM) initMarkPool(ctx context.Context, targetPool *cilium_api_v2.CiliumLoadBalancerIPPool) error {
-	if ipam.setPoolCondition(targetPool, ciliumPoolConflict, meta_v1.ConditionUnknown, "initialized", "") {
+	if ipam.setPoolCondition(targetPool, ciliumPoolConflict, meta_v1.ConditionFalse, "initialized", "") {
 		err := ipam.patchPoolStatus(ctx, targetPool)
 		if err != nil {
 			return fmt.Errorf("patchPoolStatus: %w", err)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
Created function initMarkPool which sets the ciliumPoolConflict condition to false without decrementing the cilium_operator_lbipam_conflicting_pools metric, the following call in poolOnUpsert to settleConflicts will evaluate the correct condition.

As an alternative i could pass a boolean flag to unmarkPool in which a condition will skip the part of decrementing the metric and maybe uses another reason,

https://github.com/cilium/cilium/blob/4263764ed544b6d4726a1bceb482e8b82b47ac1e/operator/pkg/lbipam/lbipam.go#L1960-L1977

at 
https://github.com/cilium/cilium/blob/4263764ed544b6d4726a1bceb482e8b82b47ac1e/operator/pkg/lbipam/lbipam.go#L1967

<details>

<summary>Outputs with the changes from this PR</summary>

```
kind@linux:~/cilium-41084$ kubectl apply -f blue-pool.yaml
ciliumloadbalancerippool.cilium.io/blue-pool created
kind@linux:~/cilium-41084$ curl -s localhost:9963/metrics | grep cilium_operator_lbipam_conflicting_pools
kind@linux:~/cilium-41084$ curl -s localhost:9963/metrics | grep cilium_operator_lbipam_conflicting_pools
# HELP cilium_operator_lbipam_conflicting_pools The number of conflicting pools
# TYPE cilium_operator_lbipam_conflicting_pools gauge
cilium_operator_lbipam_conflicting_pools 0
kind@linux:~/cilium-41084$ kubectl apply -f blue-pool.yaml
ciliumloadbalancerippool.cilium.io/blue-pool unchanged
kind@linux:~/cilium-41084$ curl -s localhost:9963/metrics | grep cilium_operator_lbipam_conflicting_pools
# HELP cilium_operator_lbipam_conflicting_pools The number of conflicting pools
# TYPE cilium_operator_lbipam_conflicting_pools gauge
cilium_operator_lbipam_conflicting_pools 0
kind@linux:~/cilium-41084$ kubectl describe ciliumloadbalancerippool blue-pool
Name:         blue-pool
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cilium.io/v2
Kind:         CiliumLoadBalancerIPPool
Metadata:
  Creation Timestamp:  2025-08-16T13:28:24Z
  Generation:          1
  Resource Version:    1402
  UID:                 e08541d6-2243-4e9b-a290-af8b2149f9e1
Spec:
  Blocks:
    Cidr:    10.0.10.0/24
    Cidr:    2004::0/112
    Start:   20.0.20.100
    Stop:    20.0.20.200
  Disabled:  false
Status:
  Conditions:
    Last Transition Time:  2025-08-16T13:28:24Z
    Message:               
    Observed Generation:   1
    Reason:                initialized
    Status:                False
    Type:                  cilium.io/PoolConflict
    Last Transition Time:  2025-08-16T13:28:24Z
    Message:               65893
    Observed Generation:   1
    Reason:                noreason
    Status:                Unknown
    Type:                  cilium.io/IPsTotal
    Last Transition Time:  2025-08-16T13:28:24Z
    Message:               65893
    Observed Generation:   1
    Reason:                noreason
    Status:                Unknown
    Type:                  cilium.io/IPsAvailable
Events:                    <none>
```
</details>

Fixes: #41084

```release-note
Fix incorrectly decrementing the metric cilium_operator_lbipam_conflicting_pools if a new Pool is added
```