### PR TITLE
pkg/k8s: refactor to use reflect.TypeFor

### DIFF
--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -487,11 +487,7 @@ func (r *resource[T]) resourceName() string {
 		return r.opts.name
 	}
 
-	// We create a new pointer to the reconciled resource type.
-	// For example, with resource[*cilium_api_v2.CiliumNode] new(T) returns **cilium_api_v2.CiliumNode
-	// and *new(T) is nil. So we create a new pointer using reflect.New()
-	o := *new(T)
-	sourceObj := reflect.New(reflect.TypeOf(o).Elem()).Interface().(T)
+	sourceObj := reflect.New(reflect.TypeFor[T]().Elem()).Interface().(T)
 
 	gvk, err := apiutil.GVKForObject(sourceObj, scheme)
 	if err != nil {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```

### **Background**
In Go, the `reflect` package provides two similar-looking functions:

- **`reflect.TypeOf(x)`**  
  Takes a value `x` and returns its `reflect.Type`.  
  Example:  
  ```go
  t := reflect.TypeOf(123) // type: int
  ```

- **`reflect.TypeFor[T]()`** *(introduced in Go 1.22)*  
  A generic function that returns the `reflect.Type` for a type parameter `T` **without needing a value**.  
  Example:  
  ```go
  t := reflect.TypeFor[int]() // type: int
  ```

---

### **Why use `reflect.TypeFor` instead of `reflect.TypeOf`?**

1. **No value needed**  
   - `reflect.TypeOf` requires an actual value at runtime.  
     If you only know the type (not a value), you have to create a dummy value:
     ```go
     t := reflect.TypeOf((*MyStruct)(nil)).Elem()
     ```
   - `reflect.TypeFor` works directly with the type parameter:
     ```go
     t := reflect.TypeFor[MyStruct]()
     ```
     This is cleaner and avoids allocating or creating dummy values.

2. **Compile-time type safety**  
   - With `reflect.TypeOf`, the type is determined from a runtime value, so mistakes may only show up at runtime.
   - With `reflect.TypeFor`, the type is determined at compile time from the generic type parameter, so it’s safer and clearer.

3. **Better for generic code**  
   - In generic functions, you often have a type parameter `T` but no value of type `T`.  
     `reflect.TypeOf` can’t be used without creating a zero value:
     ```go
     func PrintType[T any]() {
         var zero T
         fmt.Println(reflect.TypeOf(zero))
     }
     ```
     With `reflect.TypeFor`, you can simply do:
     ```go
     func PrintType[T any]() {
         fmt.Println(reflect.TypeFor[T]())
     }
     ```

4. **Avoids unnecessary allocations**  
   - Creating a dummy value for `reflect.TypeOf` may allocate memory (especially for composite types).  
   - `reflect.TypeFor` avoids this overhead entirely.

---

### **Summary Table**

| Feature                  | `reflect.TypeOf`                  | `reflect.TypeFor` (Go 1.22+) |
|--------------------------|------------------------------------|------------------------------|
| Requires a value         | ✅ Yes                             | ❌ No                        |
| Works without allocation | ❌ Sometimes allocates             | ✅ Yes                       |
| Compile-time type safety | ❌ Runtime only                    | ✅ Compile-time              |
| Good for generics        | ❌ Needs zero value                | ✅ Directly works            |

---

✅ **Recommendation:**  
Use `reflect.TypeFor` when:
- You know the type at compile time (especially in generic code).
- You don’t have or don’t want to create a value.
- You want cleaner, safer, and allocation-free code.

Use `reflect.TypeOf` when:
- You already have a value and want its type at runtime.

---

