### PR TITLE
renovate: Allow updates of images from the `image-tools` repo

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -635,6 +635,22 @@
       }
     },
     {
+      // The images from the image-tools repository have a timestamp-based versioning scheme, see https://github.com/cilium/image-tools/pull/286
+      "matchPackageNames": [
+        "quay.io/cilium/cilium-bpftool",
+        "quay.io/cilium/ca-certificates",
+        "quay.io/cilium/cilium-checkpatch",
+        "quay.io/cilium/image-compilers",
+        "quay.io/cilium/iptables",
+        "quay.io/cilium/cilium-llvm",
+        "quay.io/cilium/image-maker",
+        "quay.io/cilium/network-perf",
+        "quay.io/cilium/startup-script",
+        "quay.io/cilium/image-tester",
+      ],
+      "versioning": "regex:^(?<major>\\d+)-[a-f0-9]{7}$",
+    },
+    {
       "matchDepNames": [
         "quay.io/cilium/cilium-envoy"
       ],


### PR DESCRIPTION
The image-tools repository switched to a timestamp based versioning scheme for its images with https://github.com/cilium/image-tools/pull/286 in order to allow renovate to start managing the updates of those images. But renovate is not able to properly manage those as it does not recognize their versioning scheme.

This PR adds a renovate package rule for those images with a custom [versioning](https://docs.renovatebot.com/modules/versioning/) config.

I tested it in a test repo and renovate managed to detect the dependency and update it:

<img width="735" height="186" alt="image" src="https://github.com/user-attachments/assets/b53554df-d851-477d-96e6-a304c67ccff0" />