### PR TITLE
bgpv2: make origin attribute configurable for LB IP advertisements

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -112,6 +112,7 @@ cilium-agent [flags]
       --enable-bbr-hostns-only                                    Enable BBR only in the host network namespace.
       --enable-bgp-control-plane                                  Enable the BGP control plane.
       --enable-bgp-control-plane-status-report                    Enable the BGP control plane status reporting (default true)
+      --enable-bgp-legacy-origin-attribute                        Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-bpf-clock-probe                                    Enable BPF clock source probing for more efficient tick retrieval
       --enable-bpf-masquerade                                     Masquerade packets from endpoints leaving the host with BPF instead of iptables
       --enable-bpf-tproxy                                         Enable BPF-based proxy redirection (beta), if support available

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -55,6 +55,7 @@ cilium-agent hive [flags]
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-bbr-hostns-only                                    Enable BBR only in the host network namespace.
+      --enable-bgp-legacy-origin-attribute                        Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-drift-checker                                      Enables support for config drift checker (default true)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -61,6 +61,7 @@ cilium-agent hive dot-graph [flags]
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-bbr-hostns-only                                    Enable BBR only in the host network namespace.
+      --enable-bgp-legacy-origin-attribute                        Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-drift-checker                                      Enables support for config drift checker (default true)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -275,9 +275,17 @@
    * - :spelling:ignore:`bgpControlPlane`
      - This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs.
      - object
-     - ``{"enabled":false,"routerIDAllocation":{"ipPool":"","mode":"default"},"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}``
+     - ``{"enabled":false,"legacyOriginAttribute":{"enabled":false},"routerIDAllocation":{"ipPool":"","mode":"default"},"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}``
    * - :spelling:ignore:`bgpControlPlane.enabled`
      - Enables the BGP control plane.
+     - bool
+     - ``false``
+   * - :spelling:ignore:`bgpControlPlane.legacyOriginAttribute`
+     - Legacy BGP ORIGIN attribute settings (BGPv2 only)
+     - object
+     - ``{"enabled":false}``
+   * - :spelling:ignore:`bgpControlPlane.legacyOriginAttribute.enabled`
+     - Enable/Disable advertising LoadBalancerIP routes with the legacy BGP ORIGIN attribute value INCOMPLETE (2) instead of the default IGP (0). Enable for compatibility with the legacy behavior of MetalLB integration.
      - bool
      - ``false``
    * - :spelling:ignore:`bgpControlPlane.routerIDAllocation`

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -118,8 +118,10 @@ contributors across the globe, there is almost always someone available to help.
 | bandwidthManager.bbr | bool | `false` | Activate BBR TCP congestion control for Pods |
 | bandwidthManager.bbrHostNamespaceOnly | bool | `false` | Activate BBR TCP congestion control for Pods in the host namespace only. |
 | bandwidthManager.enabled | bool | `false` | Enable bandwidth manager infrastructure (also prerequirement for BBR) |
-| bgpControlPlane | object | `{"enabled":false,"routerIDAllocation":{"ipPool":"","mode":"default"},"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
+| bgpControlPlane | object | `{"enabled":false,"legacyOriginAttribute":{"enabled":false},"routerIDAllocation":{"ipPool":"","mode":"default"},"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
+| bgpControlPlane.legacyOriginAttribute | object | `{"enabled":false}` | Legacy BGP ORIGIN attribute settings (BGPv2 only) |
+| bgpControlPlane.legacyOriginAttribute.enabled | bool | `false` | Enable/Disable advertising LoadBalancerIP routes with the legacy BGP ORIGIN attribute value INCOMPLETE (2) instead of the default IGP (0). Enable for compatibility with the legacy behavior of MetalLB integration. |
 | bgpControlPlane.routerIDAllocation | object | `{"ipPool":"","mode":"default"}` | BGP router-id allocation mode |
 | bgpControlPlane.routerIDAllocation.ipPool | string | `""` | IP pool to allocate the BGP router-id from when the mode is ip-pool. |
 | bgpControlPlane.routerIDAllocation.mode | string | `"default"` | BGP router-id allocation mode. In default mode, the router-id is derived from the IPv4 address if it is available, or else it is determined by the lower 32 bits of the MAC address. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1204,6 +1204,7 @@ data:
   enable-bgp-control-plane-status-report: {{ .Values.bgpControlPlane.statusReport.enabled | quote }}
   bgp-router-id-allocation-mode: {{ .Values.bgpControlPlane.routerIDAllocation.mode | quote }}
   bgp-router-id-allocation-ip-pool: {{ .Values.bgpControlPlane.routerIDAllocation.ipPool | quote }}
+  enable-bgp-legacy-origin-attribute: {{ .Values.bgpControlPlane.legacyOriginAttribute.enabled | quote }}
 {{- end }}
 
 {{- if .Values.pmtuDiscovery.enabled }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -463,6 +463,14 @@
         "enabled": {
           "type": "boolean"
         },
+        "legacyOriginAttribute": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
         "routerIDAllocation": {
           "properties": {
             "ipPool": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -501,6 +501,12 @@ bgpControlPlane:
     mode: "default"
     # -- IP pool to allocate the BGP router-id from when the mode is ip-pool.
     ipPool: ""
+  # -- Legacy BGP ORIGIN attribute settings (BGPv2 only)
+  legacyOriginAttribute:
+    # -- Enable/Disable advertising LoadBalancerIP routes with the legacy
+    # BGP ORIGIN attribute value INCOMPLETE (2) instead of the default IGP (0).
+    # Enable for compatibility with the legacy behavior of MetalLB integration.
+    enabled: false
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
   # the client.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -504,6 +504,12 @@ bgpControlPlane:
     mode: "default"
     # -- IP pool to allocate the BGP router-id from when the mode is ip-pool.
     ipPool: ""
+  # -- Legacy BGP ORIGIN attribute settings (BGPv2 only)
+  legacyOriginAttribute:
+    # -- Enable/Disable advertising LoadBalancerIP routes with the legacy
+    # BGP ORIGIN attribute value INCOMPLETE (2) instead of the default IGP (0).
+    # Enable for compatibility with the legacy behavior of MetalLB integration.
+    enabled: false
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
   # the client.

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/tables"
 	bgp_metrics "github.com/cilium/cilium/pkg/bgpv1/metrics"
+	bgp_option "github.com/cilium/cilium/pkg/bgpv1/option"
 	ipam_option "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -33,6 +34,9 @@ import (
 var Cell = cell.Module(
 	"bgp-control-plane",
 	"BGP Control Plane",
+
+	// Provide config so that other cells can access it
+	cell.Config(bgp_option.DefaultConfig),
 
 	// The Controller which is the entry point of the module
 	cell.Provide(agent.NewController, signaler.NewBGPCPSignaler, mode.NewConfigMode),

--- a/pkg/bgpv1/option/config.go
+++ b/pkg/bgpv1/option/config.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package option
+
+import "github.com/spf13/pflag"
+
+const (
+	// Enables advertising LoadBalancerIP routes with the BGP ORIGIN
+	// attribute set to INCOMPLETE (2), matching MetalLB’s legacy behavior,
+	// instead of the default IGP (0).
+	EnableBGPLegacyOriginAttribute = "enable-bgp-legacy-origin-attribute"
+)
+
+type BGPConfig struct {
+	// Enables LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE
+	EnableBGPLegacyOriginAttribute bool
+}
+
+var DefaultConfig = BGPConfig{
+	EnableBGPLegacyOriginAttribute: false,
+}
+
+func (def BGPConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool(EnableBGPLegacyOriginAttribute, def.EnableBGPLegacyOriginAttribute, "Enable LoadBalancerIP routes to be advertised with BGP Origin Attribute set to INCOMPLETE")
+}


### PR DESCRIPTION
Currently, the BGP Control Plane (v2) always advertises LoadBalancer IPs with origin set to IGP (0). This differs from the MetalLB integration, which uses INCOMPLETE (2). The discrepancy causes ECMP to break during migration scenarios where both integrations coexist, since upstream routers consistently prefer the IGP-originated route.

This PR introduces a new configuration option to explicitly control the origin attribute for LB IP advertisements. The option is exposed as a Helm value (`bgpControlPlane.legacyOriginAttribute.enabled`) and defaults to `false`, preserving the current behavior (IGP). Setting this option to `true` makes BGP CPv2 advertise LB IPs with origin set to INCOMPLETE, matching the MetalLB integration.

This change allows smoother migrations from MetalLB integration to BGP CPv2 without forcing disruptive behavior changes on existing clusters.

Fixes: #40944

As MetalLB integration is removed in v1.17, this feature should be backported to v1.16 and maintained in subsequent releases.

```release-note
Add option to configure BGP origin attribute for LoadBalancer IPs in BGP Control Plane v2, allowing smoother migration from MetalLB integration.
```

---
This feature can be tested using the [containerlab setup provided in contrib/containerlab/bgpv2](https://github.com/cilium/cilium/tree/main/contrib/containerlab/bgpv2).

With the feature enabled, you can confirm that the LoadBalancerIPs (20.0.10.0/32 & 20.1.10.0/32) are advertised with origin attribute set to INCOMPLETE (?) and all the other routes advertised with IGP (i) origin.
```console
$ docker exec -it clab-bgpv2-cplane-dev-service-router0 vtysh -c 'sh bgp ipv4'

BGP table version is 15, local router ID is 10.0.0.1, vrf id 0
Default local pref 100, local AS 65010
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.1.0.0/24      fd00:10:0:1::2                         0 65001 i
*> 10.1.1.0/24      fd00:10:0:2::2                         0 65001 i
*= 10.2.78.85/32    fd00:10:0:1::2                         0 65001 i
*>                  fd00:10:0:2::2                         0 65001 i
*= 10.2.99.121/32   fd00:10:0:1::2                         0 65001 i
*>                  fd00:10:0:2::2                         0 65001 i
*> 10.2.148.75/32   fd00:10:0:2::2                         0 65001 i
*= 10.2.236.67/32   fd00:10:0:1::2                         0 65001 i
*>                  fd00:10:0:2::2                         0 65001 i
*> 20.0.10.0/32     fd00:10:0:2::2                         0 65001 ?
*= 20.1.10.0/32     fd00:10:0:1::2                         0 65001 ?
*>                  fd00:10:0:2::2                         0 65001 ?
*> 192.168.100.10/32
                    fd00:10:0:2::2                         0 65001 i
*= 192.168.200.10/32
                    fd00:10:0:1::2                         0 65001 i
*>                  fd00:10:0:2::2                         0 65001 i

Displayed  10 routes and 15 total paths
```

With the feature disabled, you can confirm that all routes including the LoadBalancerIPs (20.0.10.0/32 & 20.1.10.0/32) are advertised with origin attribute set to IGP (i).
```console
$ docker exec -it clab-bgpv2-cplane-dev-service-router0 vtysh -c 'sh bgp ipv4' 

BGP table version is 15, local router ID is 10.0.0.1, vrf id 0
Default local pref 100, local AS 65010
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete
RPKI validation codes: V valid, I invalid, N Not found

   Network          Next Hop            Metric LocPrf Weight Path
*> 10.1.0.0/24      fd00:10:0:1::2                         0 65001 i
*> 10.1.1.0/24      fd00:10:0:2::2                         0 65001 i
*= 10.2.34.144/32   fd00:10:0:2::2                         0 65001 i
*>                  fd00:10:0:1::2                         0 65001 i
*> 10.2.88.200/32   fd00:10:0:2::2                         0 65001 i
*= 10.2.128.106/32  fd00:10:0:2::2                         0 65001 i
*>                  fd00:10:0:1::2                         0 65001 i
*= 10.2.166.204/32  fd00:10:0:2::2                         0 65001 i
*>                  fd00:10:0:1::2                         0 65001 i
*> 20.0.10.0/32     fd00:10:0:2::2                         0 65001 i
*= 20.1.10.0/32     fd00:10:0:2::2                         0 65001 i
*>                  fd00:10:0:1::2                         0 65001 i
*> 192.168.100.10/32
                    fd00:10:0:2::2                         0 65001 i
*= 192.168.200.10/32
                    fd00:10:0:2::2                         0 65001 i
*>                  fd00:10:0:1::2                         0 65001 i

Displayed  10 routes and 15 total paths

```

