### PR TITLE
bpf: add support for delinearized ARP packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1095,6 +1095,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 	void __maybe_unused *data, *data_end;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
+	struct arp_eth __maybe_unused *arp;
 	int __maybe_unused hdrlen = 0;
 	__u8 __maybe_unused next_proto = 0;
 	__s8 __maybe_unused ext_err = 0;
@@ -1106,6 +1107,10 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 # if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER || \
      defined ENABLE_L2_ANNOUNCEMENTS
 	case bpf_htons(ETH_P_ARP):
+		if (!revalidate_data_arp_pull(ctx, &data, &data_end, &arp))
+			return send_drop_notify_error(ctx, identity,
+						      DROP_INVALID,
+						      METRIC_INGRESS);
 		send_trace_notify(ctx, obs_point, UNKNOWN_ID, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor, proto);
 		#ifdef ENABLE_L2_ANNOUNCEMENTS

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -215,6 +215,13 @@ static __always_inline __u32 get_id_from_tunnel_id(__u32 tunnel_id, __u16 proto 
 #define revalidate_data(ctx, data, data_end, ip)			\
 	revalidate_data_l3_off(ctx, data, data_end, ip, ETH_HLEN)
 
+/* arp is different from the above as we also want to pull in the payload.
+ * Returns true if 'ctx' is long enough to be valid ARP packet, false otherwise.
+ */
+#define revalidate_data_arp_pull(ctx, data, data_end, arp)		\
+	__revalidate_data_pull(ctx, data, data_end, (void **)arp,	\
+		ETH_HLEN + sizeof(struct arphdr), sizeof(**arp), true)
+
 #define ENDPOINT_KEY_IPV4 1
 #define ENDPOINT_KEY_IPV6 2
 


### PR DESCRIPTION
Internal ARP-handling functions such as those in lib/arp.h expect linearized ARP packets. However, no code exist to linearize this packet type. This means user-facing features such as L2 Announcements break easily if the kernel decides to split ARP request in chunks.

Implement revalidate_data_arp_pull() and call it the same way it is done for IPv4/IPv6 packets to prevent this from happening and keep things consistent across protocols.

Fixes: #40419

Signed-off-by: Valentine Sinitsyn <valentine.sinitsyn@gmail.com>