### PR TITLE
k8s: Skip endpoints without conditions

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -288,9 +288,16 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 	}
 
 	for i, sub := range ep.Endpoints {
+		conditions := ParseEndpointConditionsV1(sub.Conditions)
+		if conditions == 0 {
+			// Skip backends that have no conditions set as these are not ready to
+			// serve traffic.
+			continue
+		}
+
 		// Construct the backend configuration shared by all the addresses in this slice.
 		backend := &Backend{
-			Conditions: ParseEndpointConditionsV1(sub.Conditions),
+			Conditions: conditions,
 			Ports:      ports,
 		}
 

--- a/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
@@ -76,8 +76,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating3.expected lbmaps.actual
 
 # Set the first backend as not serving and second as ready+terminating .
-# First backend will be quarantined. Existing connections to
-# it won't be affected as it's still in the backends BPF map.
+# First backend will be removed.
 # The second backend will be just considered ready and its terminating
 # condition is ignored ("ready" overrides everything).
 cp endpointslice.yaml.tmpl endpointslice.yaml
@@ -146,7 +145,6 @@ Address                 Instances                                         NodeNa
 
 -- backends-terminating4.table --
 Address                 Instances                                         NodeName
-10.244.0.112:8081/TCP   test/graceful-term-svc [quarantined]              graceful-term-control-plane
 10.244.0.113:8081/TCP   test/graceful-term-svc                            graceful-term-control-plane
 
 -- service.yaml --
@@ -267,10 +265,8 @@ SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCO
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 -- lbmaps-terminating4.expected --
-BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=quarantined
 BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
 MAGLEV: ID=1 INNER=[2(1021)]
 REV: ID=1 ADDR=10.96.116.33:8081
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP


### PR DESCRIPTION
Skip endpoints in endpoint slices that have no conditions set as those are not yet ready to serve traffic. Before this they were marked quarantined which caused issues as the quarantined state was restored and not cleared until health checked (and we usually don't have a health checker). 

While we do want to keep unready endpoints around, we'll need to figure out what to mark them as that doesn't have the interaction with health checking. This is thus a temporary fix to go back to the old behavior. Opened issue https://github.com/cilium/cilium/issues/41244 to follow up on this.

Fixes: #41194
Fixes: 6f41c986bbfce ("loadbalancer: Keep non-serving terminating backends")