### PR TITLE
ci: Fix Scheduled Test

### DIFF
--- a/.github/ariane-scheduled.yaml
+++ b/.github/ariane-scheduled.yaml
@@ -1,0 +1,3 @@
+tests:
+- conformance-aks.yaml
+- conformance-gke.yaml


### PR DESCRIPTION
The `conformance-aks` and `conformance-gke` tests have not been running for more than two months on the v1.17 branch. This PR fixes that issue. Related #40177 
