### PR TITLE
loadbalancer: Remove restoration of quarantined state

### DIFF
--- a/pkg/loadbalancer/tests/testdata/quarantined.txtar
+++ b/pkg/loadbalancer/tests/testdata/quarantined.txtar
@@ -94,7 +94,6 @@ lb/maps-dump maps.actual
 
 # The quarantined restored state is clean now.
 test/bpfops-summary
-stdout 'restoredQuarantines: 0'
 stdout 'restoredServiceIDs: 0'
 stdout 'restoredBackendIDs: 0'
 


### PR DESCRIPTION
Since https://github.com/cilium/cilium/pull/41092 now marks backends unhealthy until they've been health checked there's no need to restore the quarantined state of backends on restart since they'll anyway start out unhealthy until they've been health checked again.