### PR TITLE
metrics: remove labels from client_rate_limiter

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -542,7 +542,7 @@ Kubernetes Rest Client
 Name                                          Labels                                        Default    Description
 ============================================= ============================================= ========== ===========================================================
 ``k8s_client_api_latency_time_seconds``       ``path``, ``method``                          Enabled    Duration of processed API calls labeled by path and method
-``k8s_client_rate_limiter_duration_seconds``  ``path``, ``method``                          Enabled    Kubernetes client rate limiter latency in seconds. Broken down by path and method
+``k8s_client_rate_limiter_duration_seconds``                                                Enabled    Kubernetes client rate limiter latency in seconds.
 ``k8s_client_api_calls_total``                ``host``, ``method``, ``return_code``         Enabled    Number of API calls made to kube-apiserver labeled by host, method and return code
 ============================================= ============================================= ========== ===========================================================
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -347,6 +347,7 @@ Removed Metrics
 Changed Metrics
 ~~~~~~~~~~~~~~~
 
+* ``k8s_client_rate_limiter_duration_seconds`` no longer has labels ``path`` and ``method``.
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/pkg/k8s/watchers/metrics/metrics.go
+++ b/pkg/k8s/watchers/metrics/metrics.go
@@ -95,7 +95,7 @@ func (*requestLatencyAdapter) Observe(_ context.Context, verb string, u url.URL,
 type rateLimiterLatencyAdapter struct{}
 
 func (c *rateLimiterLatencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
-	metrics.KubernetesAPIRateLimiterLatency.WithLabelValues(u.Path, verb).Observe(latency.Seconds())
+	metrics.KubernetesAPIRateLimiterLatency.WithLabelValues().Observe(latency.Seconds())
 }
 
 // resultAdapter implements the ResultMetric interface from k8s client-go package

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1009,9 +1009,9 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Namespace:  Namespace,
 			Subsystem:  SubsystemK8sClient,
 			Name:       "rate_limiter_duration_seconds",
-			Help:       "Kubernetes client rate limiter latency in seconds. Broken down by path and method.",
+			Help:       "Kubernetes client rate limiter latency in seconds.",
 			Buckets:    []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 60.0},
-		}, []string{LabelPath, LabelMethod}),
+		}, []string{}),
 
 		KubernetesAPICallsTotal: metric.NewCounterVec(metric.CounterOpts{
 			ConfigName: Namespace + "_" + SubsystemK8sClient + "_api_calls_total",


### PR DESCRIPTION
Metric cilium_k8s_client_rate_limiter_duration_seconds is the metric with the highest cardinality. To reduce cardinality, let's remove path and method. These two labels are not really useful, as throttling is on client level and not per resource or verb.

```release-note
metrics: cilium_k8s_client_rate_limiter_duration_seconds no longer has labels path and method
```
