### PR TITLE
v1.18 manual backport of L7 IPv6 SNAT fix

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -732,22 +732,22 @@ func (m *Manager) installStaticProxyRules() error {
 			return err
 		}
 
-		// No conntrack for proxy return traffic that is heading to cilium_host
+		// No conntrack for proxy return traffic that is heading to lxc+
 		if err := ip6tables.runProg([]string{
 			"-t", "raw",
 			"-A", ciliumOutputRawChain,
-			"-o", defaults.HostDevice,
+			"-o", "lxc+",
 			"-m", "mark", "--mark", matchProxyReply,
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 			"-j", "CT", "--notrack"}); err != nil {
 			return err
 		}
 
-		// No conntrack for proxy upstream traffic that is heading to lxc+
+		// No conntrack for proxy return traffic that is heading to cilium_host
 		if err := ip6tables.runProg([]string{
 			"-t", "raw",
 			"-A", ciliumOutputRawChain,
-			"-o", "lxc+",
+			"-o", defaults.HostDevice,
 			"-m", "mark", "--mark", matchProxyReply,
 			"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 			"-j", "CT", "--notrack"}); err != nil {


### PR DESCRIPTION
v1.18 manual backport of L7 IPv6 SNAT fix

 - [ ] #41034 -- iptables: Fix IPv6 SNAT for L7 proxy upstream traffic (@gentoo-root)

Backporting manually to speed up unblocking the CI at https://github.com/cilium/cilium/pull/39662. Currently, two upgrade-downgrade tests in ci-e2e-upgrade fail at the downgrade stage due to the bugfix missing from the 1.18 version.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
41034
```
