### PR TITLE
clustermesh: cli: pass every service clustermesh-apiserver IPs

### DIFF
--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -1689,7 +1689,7 @@ func getClustersFromValues(values map[string]any) (map[string]any, error) {
 
 func getCluster(ai *accessInformation, configTLS bool) (string, map[string]any) {
 	remoteCluster := map[string]any{
-		"ips":  []string{ai.ServiceIPs[0]},
+		"ips":  ai.ServiceIPs,
 		"port": ai.ServicePort,
 	}
 


### PR DESCRIPTION
See the commit description for more details

```release-note
clustermesh: cli: accept more than one service IPs (excluding when connecting to NodePort Services) when connecting to remote clustermesh-apiserver
```

Also there is some additional context here https://cilium.slack.com/archives/C06AC2H4XQ9/p1754995899479629 where we were essentially checking if `/etc/hosts` support multiple IPs and it seems to be the case in Go at least.