### PR TITLE
bpf: Enable lower port range for NodePort with BPF IPv4 masquerade

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -146,6 +146,7 @@ cilium-agent [flags]
       --enable-ipv4                                               Enable IPv4 support (default true)
       --enable-ipv4-big-tcp                                       Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4
       --enable-ipv4-fragment-tracking                             Enable IPv4 fragments tracking for L4-based lookups (default true)
+      --enable-ipv4-masq-dual-port-range                          Enable dual port range for NodePort services (requires enabling enable-ipv4-masquerade)
       --enable-ipv4-masquerade                                    Masquerade IPv4 traffic from endpoints leaving the host (default true)
       --enable-ipv6                                               Enable IPv6 support (default true)
       --enable-ipv6-big-tcp                                       Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1244,6 +1244,10 @@
      - Enables masquerading to the source of the route for traffic leaving the node from endpoints.
      - bool
      - ``false``
+   * - :spelling:ignore:`EnableIPv4MasqueradeDualPortRange`
+     - Enables IPv4 masquerading to use a dual port range for the masquerade port.
+     - bool
+     - ``false``
    * - :spelling:ignore:`enableNonDefaultDenyPolicies`
      - Enable Non-Default-Deny policies
      - bool

--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -160,6 +160,24 @@ and ``--set ipMasqAgent.config.masqLinkLocal=false`` (or with the corresponding
 option, for IPv6) when installing Cilium via Helm to
 configure the ``ip-masq-agent`` as above.
 
+Dual-port range for masquerading
+**********************************
+
+For environments that require a large number of connections to be masqueraded,
+Cilium can be configured to use two separate port ranges for SNAT. This
+effectively increases the number of available ports for masquerading.
+
+When enabled, the following port ranges are used for SNAT:
+
+- ``1024-29999``
+- ``32768-65535``
+
+This feature can be enabled with the Helm option ``enableIPv4MasqueradeDualPortRange: true`` or the agent flag ``--enable-ipv4-masq-dual-port-range``.
+
+.. note::
+
+   This feature requires eBPF-based ipv4 masquerading to be enabled (``enable-ipv4-masquerade=true``).
+
 iptables-based
 **************
 

--- a/bpf/tests/skip_tunnel_nodeport_masq.c
+++ b/bpf/tests/skip_tunnel_nodeport_masq.c
@@ -237,8 +237,17 @@ check_ctx(const struct __ctx_buff *ctx, bool v4, bool snat)
 	if (snat) {
 		__be16 p = bpf_ntohs(l4->source);
 
+#ifdef ENABLE_DUAL_PORT_RANGE
+		bool in_range1 = (p >= NODEPORT_PORT_NAT_IPV4_RANGE1_MIN &&
+				  p <= NODEPORT_PORT_NAT_IPV4_RANGE1_MAX);
+		bool in_range2 = (p >= NODEPORT_PORT_NAT_IPV4_RANGE2_MIN &&
+				  p <= NODEPORT_PORT_NAT_IPV4_RANGE2_MAX);
+    	if (!(in_range1 || in_range2))
+        	test_fatal("src port was not snatted into the correct NodePort masquerade ranges");
+#else
 		if (p < NODEPORT_PORT_MIN_NAT || p > NODEPORT_PORT_MAX_NAT)
 			test_fatal("src port was not snatted");
+#endif
 	} else {
 		if (l4->source != SRC_PORT)
 			test_fatal("src port was changed");

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -569,6 +569,10 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		}
 	}
 
+	if option.Config.EnableIPv4MasqueradeDualPortRange && !option.Config.EnableBPFMasquerade {
+		d.logger.Error("Dual port range (--%s) requires BPF IPv4 masquerade (--%s=\"true\") to be enabled", option.EnableIPv4MasqueradeDualPortRange, option.EnableIPv4Masquerade)
+		return nil, nil, fmt.Errorf("dual port range (--%s) requires BPF IPv4 asquerade (--%s=\"true\") to be enabled", option.EnableIPv4MasqueradeDualPortRange, option.EnableIPv4Masquerade)
+	}
 	// Some of the k8s watchers rely on option flags set above (specifically
 	// EnableBPFMasquerade), so we should only start them once the flag values
 	// are set.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -550,6 +550,9 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableIPv4Masquerade, true, "Masquerade IPv4 traffic from endpoints leaving the host")
 	option.BindEnv(vp, option.EnableIPv4Masquerade)
 
+	flags.Bool(option.EnableIPv4MasqueradeDualPortRange, false, fmt.Sprintf("Enable dual port range for NodePort services (requires enabling %s)", option.EnableIPv4Masquerade))
+	option.BindEnv(vp, option.EnableIPv4MasqueradeDualPortRange)
+
 	flags.Bool(option.EnableIPv6Masquerade, true, "Masquerade IPv6 traffic from endpoints leaving the host")
 	option.BindEnv(vp, option.EnableIPv6Masquerade)
 
@@ -1288,6 +1291,10 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 				),
 			)
 		}
+	}
+
+	if option.Config.EnableIPv4MasqueradeDualPortRange && !option.Config.EnableIPv4Masquerade {
+		logging.Fatal(logger, "Dual port range for IPv4 masquerading requires IPv4 masquerading to be enabled")
 	}
 }
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -540,6 +540,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			if option.Config.EnableIPv4Masquerade {
 				cDefinesMap["ENABLE_MASQUERADE_IPV4"] = "1"
 
+				if option.Config.EnableIPv4MasqueradeDualPortRange {
+					cDefinesMap["ENABLE_IPV4_MASQ_DUAL_PORT_RANGE"] = "1"
+				}
+
 				// ip-masq-agent depends on bpf-masq
 				var excludeCIDR *cidr.CIDR
 				if option.Config.EnableIPMasqAgent {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -222,6 +222,9 @@ const (
 	// EnableNodePort enables NodePort services implemented by Cilium in BPF
 	EnableNodePort = "enable-node-port"
 
+	// EnableDualPortRange enables the dual port range feature for NodePort SNAT.
+	EnableIPv4MasqueradeDualPortRange = "enable-ipv4-masq-dual-port-range"
+
 	// NodePortAcceleration indicates whether NodePort should be accelerated
 	// via XDP ("none", "generic", "native", or "best-effort")
 	NodePortAcceleration = "node-port-acceleration"
@@ -1472,11 +1475,13 @@ type DaemonConfig struct {
 
 	// Masquerade specifies whether or not to masquerade packets from endpoints
 	// leaving the host.
-	EnableIPv4Masquerade        bool
-	EnableIPv6Masquerade        bool
-	EnableBPFMasquerade         bool
-	EnableMasqueradeRouteSource bool
-	EnableIPMasqAgent           bool
+	EnableIPv4Masquerade              bool
+	EnableIPv6Masquerade              bool
+	EnableBPFMasquerade               bool
+	EnableMasqueradeRouteSource       bool
+	EnableIPv4MasqueradeDualPortRange bool
+	EnableIPMasqAgent                 bool
+	IPMasqAgentConfigPath             string
 
 	EnableBPFClockProbe    bool
 	EnableEgressGateway    bool
@@ -2645,6 +2650,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.EnableNat46X64Gateway = vp.GetBool(EnableNat46X64Gateway)
 	c.EnableIPv4Masquerade = vp.GetBool(EnableIPv4Masquerade) && c.EnableIPv4
 	c.EnableIPv6Masquerade = vp.GetBool(EnableIPv6Masquerade) && c.EnableIPv6
+	c.EnableIPv4MasqueradeDualPortRange = vp.GetBool(EnableIPv4MasqueradeDualPortRange)
 	c.EnableBPFMasquerade = vp.GetBool(EnableBPFMasquerade)
 	c.EnableMasqueradeRouteSource = vp.GetBool(EnableMasqueradeRouteSource)
 	c.EnablePMTUDiscovery = vp.GetBool(EnablePMTUDiscovery)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible. 
TESTED: 
[PoC_ OSS Cilium Node Port Range Change.pdf](https://github.com/user-attachments/files/21845803/PoC_.OSS.Cilium.Node.Port.Range.Change.pdf)
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

This change introduces support for a dual SNAT port range for eBPF NodePort masquerading on IPv4 to increase the number of available source ports and mitigate port exhaustion.

Previously, the eBPF based masquerade was limited to a single, hardcoded upper port range (e.g., 32768-60999) for NodePort SNAT. This could lead to source port exhaustion on nodes handling a high volume of connections.

This implementation introduces a new boolean flag, `enable-ipv4-masq-dual-port-range`. When enabled, the eBPF datapath will randomly select a source port from one of two ranges: a new lower range (1024-29999) and the existing upper range (32768-65535). This effectively doubles the number of available ports.

Fixes: #23604

```release-note
eBPF based masquerade for NodePort (IPv4) now supports a dual SNAT port range to increase port availability. The feature is configurable via the `enable-ipv4-masq-dual-port-range` flag.
```
