### PR TITLE
ctmap/gc: continue interval time on partial GC pass.

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -769,6 +769,11 @@ func GetInterval(logger *slog.Logger, actualPrevInterval, expectedPrevInterval t
 	return newInterval
 }
 
+var (
+	MinGCInterval      = defaults.ConntrackGCMinInterval
+	GCIntervalRounding = time.Second
+)
+
 func calculateInterval(prevInterval time.Duration, maxDeleteRatio float64) (interval time.Duration) {
 	interval = prevInterval
 
@@ -782,14 +787,13 @@ func calculateInterval(prevInterval time.Duration, maxDeleteRatio float64) (inte
 			maxDeleteRatio = 0.9
 		}
 		// 25%..90% => 1.3x..10x shorter
-		interval = max(time.Duration(float64(interval)*(1.0-maxDeleteRatio)).Round(time.Second), defaults.ConntrackGCMinInterval)
-
+		interval = max(time.Duration(float64(interval)*(1.0-maxDeleteRatio)).Round(GCIntervalRounding), MinGCInterval)
 	case maxDeleteRatio < 0.05:
 		// When less than 5% of entries were deleted, increase the
 		// interval. Use a simple 1.5x multiplier to start growing slowly
 		// as a new node may not be seeing workloads yet and thus the
 		// scan will return a low deletion ratio at first.
-		interval = min(time.Duration(float64(interval)*1.5).Round(time.Second), defaults.ConntrackGCMaxLRUInterval)
+		interval = min(time.Duration(float64(interval)*1.5).Round(GCIntervalRounding), defaults.ConntrackGCMaxLRUInterval)
 	}
 
 	return

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -731,16 +731,16 @@ func Exists(ipv4, ipv6 bool) bool {
 	return result
 }
 
-var cachedGCInterval time.Duration
-
 // GetInterval returns the interval adjusted based on the deletion ratio of the
-// last run
-func GetInterval(logger *slog.Logger, actualPrevInterval time.Duration, maxDeleteRatio float64) time.Duration {
+// last run.
+//   - actualPrevInterval 	= actual time elapsed since last GC.
+//   - expectedPrevInterval 	= Is the last computed interval, which we expected to
+//     wait *unless* a signal caused early pass. If this is set to zero then we use gc starting interval.
+func GetInterval(logger *slog.Logger, actualPrevInterval, expectedPrevInterval time.Duration, maxDeleteRatio float64) time.Duration {
 	if val := option.Config.ConntrackGCInterval; val != time.Duration(0) {
 		return val
 	}
 
-	expectedPrevInterval := cachedGCInterval
 	adjustedDeleteRatio := maxDeleteRatio
 	if expectedPrevInterval == time.Duration(0) {
 		expectedPrevInterval = defaults.ConntrackGCStartingInterval
@@ -791,8 +791,6 @@ func calculateInterval(prevInterval time.Duration, maxDeleteRatio float64) (inte
 		// scan will return a low deletion ratio at first.
 		interval = min(time.Duration(float64(interval)*1.5).Round(time.Second), defaults.ConntrackGCMaxLRUInterval)
 	}
-
-	cachedGCInterval = interval
 
 	return
 }

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -110,6 +110,14 @@ func New(params parameters) *GC {
 	return gc
 }
 
+// A full GC pass is when we perform GC on any and all
+// enabled IP families.
+// Partial passes can happen as a result of datapath
+// signals on particular families (i.e. ct or nat).
+func (gc *GC) isFullGC(ipv4, ipv6 bool) bool {
+	return ipv4 == gc.ipv4 && ipv6 == gc.ipv6
+}
+
 // Enable enables the connection tracking garbage collection.
 func (gc *GC) Enable() {
 	gc.enable(gc.runGC, true)
@@ -129,6 +137,7 @@ func (gc *GC) enable(
 		ipv6 := gc.ipv6
 		triggeredBySignal := false
 		var gcPrev time.Time
+		var forceFullGCTTL time.Time
 		var cachedGCInterval time.Duration
 		for {
 			var (
@@ -189,14 +198,33 @@ func (gc *GC) enable(
 				maxDeleteRatio, success = runGC(ipv4, ipv6, triggeredBySignal, gcFilter)
 			}
 
-			// Mark the CT GC as over in each EP DNSZombies instance, if we did a *full* GC run
 			interval := ctmap.GetInterval(gc.logger, gcInterval, cachedGCInterval, maxDeleteRatio)
-			if success && ipv4 == gc.ipv4 && ipv6 == gc.ipv6 {
+			if success && gc.isFullGC(ipv4, ipv6) {
+				// Mark the CT GC as over in each EP DNSZombies instance, if we did a *full* GC run
+				nextGCTime := time.Now().Add(interval)
 				for _, e := range eps {
-					e.MarkCTGCTime(gcStart, time.Now().Add(interval))
+					e.MarkCTGCTime(gcStart, nextGCTime)
+				}
+
+				forceFullGCTTL = time.Now().Add(interval)
+				// full pass so we reset our cached GC interval.
+				cachedGCInterval = interval
+			} else if !initialScan {
+				// If we did not succeed, or it wasn't a full pass then we take the
+				// minimum of the new interval and any remaining time on the last interval
+				// clock - effectively running out the clock of the previous interval.
+				// This is because in a partial GC pass one of the IP families has not been
+				// tended to, so to avoid potentially starving GC on one of the IP families
+				// we do this to ensure it is eventually run.
+				forceInterval := max(0, time.Until(forceFullGCTTL))
+				if forceInterval < interval {
+					interval = forceInterval
+				} else {
+					// partial pass, but the new interval is less than any leftover ttl so
+					// we cache this as well.
+					cachedGCInterval = interval
 				}
 			}
-			cachedGCInterval = interval
 
 			if initialScan {
 				close(initialScanComplete)

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -122,6 +122,7 @@ func (gc *GC) Enable() {
 		ipv6 := gc.ipv6
 		triggeredBySignal := false
 		var gcPrev time.Time
+		var cachedGCInterval time.Duration
 		for {
 			var (
 				maxDeleteRatio float64
@@ -182,12 +183,13 @@ func (gc *GC) Enable() {
 			}
 
 			// Mark the CT GC as over in each EP DNSZombies instance, if we did a *full* GC run
-			interval := ctmap.GetInterval(gc.logger, gcInterval, maxDeleteRatio)
+			interval := ctmap.GetInterval(gc.logger, gcInterval, cachedGCInterval, maxDeleteRatio)
 			if success && ipv4 == gc.ipv4 && ipv6 == gc.ipv6 {
 				for _, e := range eps {
 					e.MarkCTGCTime(gcStart, time.Now().Add(interval))
 				}
 			}
+			cachedGCInterval = interval
 
 			if initialScan {
 				close(initialScanComplete)

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -112,6 +112,13 @@ func New(params parameters) *GC {
 
 // Enable enables the connection tracking garbage collection.
 func (gc *GC) Enable() {
+	gc.enable(gc.runGC, true)
+}
+
+func (gc *GC) enable(
+	runGC func(ipv4, ipv6, triggeredBySignal bool, filter ctmap.GCFilter) (maxDeleteRatio float64, success bool),
+	runMapPressureDaemon bool,
+) {
 	var (
 		initialScan         = true
 		initialScanComplete = make(chan struct{})
@@ -179,7 +186,7 @@ func (gc *GC) Enable() {
 
 			if len(eps) > 0 || initialScan {
 				gc.logger.Info("Starting GC of connection tracking", logfields.First, initialScan)
-				maxDeleteRatio, success = gc.runGC(ipv4, ipv6, triggeredBySignal, gcFilter)
+				maxDeleteRatio, success = runGC(ipv4, ipv6, triggeredBySignal, gcFilter)
 			}
 
 			// Mark the CT GC as over in each EP DNSZombies instance, if we did a *full* GC run
@@ -253,13 +260,15 @@ func (gc *GC) Enable() {
 		}
 	}()
 
-	// Wait until after initial scan is complete prior to starting ctmap metrics controller.
-	go func() {
-		<-initialScanComplete
-		gc.logger.Info("Initial scan of connection tracking completed, starting ctmap pressure metrics controller")
-		// Not supporting BPF map pressure for local CT maps as of yet.
-		ctmap.CalculateCTMapPressure(gc.controllerManager, gc.metricsRegistry, ctmap.GlobalMaps(gc.ipv4, gc.ipv6)...)
-	}()
+	if runMapPressureDaemon {
+		// Wait until after initial scan is complete prior to starting ctmap metrics controller.
+		go func() {
+			<-initialScanComplete
+			gc.logger.Info("Initial scan of connection tracking completed, starting ctmap pressure metrics controller")
+			// Not supporting BPF map pressure for local CT maps as of yet.
+			ctmap.CalculateCTMapPressure(gc.controllerManager, gc.metricsRegistry, ctmap.GlobalMaps(gc.ipv4, gc.ipv6)...)
+		}()
+	}
 }
 
 func (gc *GC) Run(m *ctmap.Map, filter ctmap.GCFilter) (int, error) {

--- a/pkg/maps/ctmap/gc/gc_test.go
+++ b/pkg/maps/ctmap/gc/gc_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gc
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/signal"
+)
+
+// TestGCEnable tests the overall *flow* of ctmap GC scheduling
+// while abstracting out the underlying garbage collection logic.
+func TestGCEnableDualStack(t *testing.T) {
+	gc := &GC{
+		ipv4:             true,
+		ipv6:             true,
+		logger:           slog.Default(),
+		endpointsManager: &fakeEPM{},
+		signalHandler: SignalHandler{
+			signals: make(chan SignalData),
+			manager: &fakeSignalMan{},
+		},
+	}
+
+	// start GC
+
+	var ipv4Passes atomic.Int32
+	var dualPasses atomic.Int32
+
+	reset := func() {
+		ipv4Passes.Store(0)
+		dualPasses.Store(0)
+	}
+
+	returnRatio := 0.1 // low -> high next interval
+	option.Config.ConntrackGCMaxInterval = time.Millisecond * 500
+	gc.enable(func(ipv4, ipv6, triggeredBySignal bool, filter ctmap.GCFilter) (maxDeleteRatio float64, success bool) {
+		if ipv4 {
+			ipv4Passes.Add(1)
+			if ipv6 {
+				dualPasses.Add(1)
+			}
+		}
+		return returnRatio, true
+	}, false)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, int(dualPasses.Load()))
+		assert.Equal(c, 1, int(ipv4Passes.Load()))
+	}, time.Second, time.Millisecond*10, "initial pass should be full pass")
+
+	gc.signalHandler.signals <- SignalProtoV4
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, int(dualPasses.Load()))
+		assert.Equal(c, 2, int(ipv4Passes.Load())) // This will only do ipv4 based pass.
+	}, time.Second, time.Millisecond*10, "we should receive a signal based ipv4 pass now")
+
+	reset()
+
+	feedSignals := func(ctx context.Context, sigs ...SignalData) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.Context().Done():
+				return
+			case <-time.After(time.Millisecond * 50):
+				for _, s := range sigs {
+					gc.signalHandler.signals <- s
+				}
+			}
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// feed ipv4 signals to simulate high pressure on *one* ip family.
+	go feedSignals(ctx, SignalProtoV4)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NotZero(c, dualPasses.Load())
+	}, time.Second, time.Millisecond*10, "Despite high signal load, ipv6 should not be starved")
+
+	cancel()
+	reset()
+
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+	// feed ipv4 signals to simulate high pressure on *one* ip family.
+	go feedSignals(ctx, SignalProtoV6)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NotZero(c, dualPasses.Load())
+	}, time.Second, time.Millisecond*10, "Despite high signal load, ipv4 should not be starved")
+
+	cancel()
+	reset()
+
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+	// feed ipv4 signals to simulate high pressure on *one* ip family.
+	go feedSignals(ctx, SignalProtoV6, SignalProtoV4)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NotZero(c, dualPasses.Load())
+	}, time.Second, time.Millisecond*10, "Should start full pass")
+}
+
+type fakeEPM struct{}
+
+func (f *fakeEPM) GetEndpoints() []*endpoint.Endpoint {
+	return []*endpoint.Endpoint{{
+		DNSZombies: fqdn.NewDNSZombieMappings(slog.Default(), 0, 0),
+	}}
+}
+
+type fakeSignalMan struct{}
+
+// RegisterHandler must be called during initialization of the cells using signals.
+func (f *fakeSignalMan) RegisterHandler(handler signal.SignalHandler, signals ...signal.SignalType) error {
+	return nil
+}
+
+func (f *fakeSignalMan) MuteSignals(signals ...signal.SignalType) error {
+	return nil
+}
+
+func (f *fakeSignalMan) UnmuteSignals(signals ...signal.SignalType) error {
+	return nil
+}


### PR DESCRIPTION
When {ipv4,ipv6} specific signals are sent from the datapath to indicate conditions such as high ctmap or snat pressure we may invoke a ipv4 or ipv6 *only* gc pass.
Currently this will also reset the gc interval by recomputing the next interval.

Under a situation where a lot of ipv4/ipv6 specific signals are being sent this may a starvation condition such that the other family never has a chance to be run since before the interval time can finish the loop is woken up by another signal.

To prevent this, if the GC was a "partial" pass (i.e. not including all *enabled* ip families), then we will continue waiting from where the previous timer left off.  Following a full GC pass we will just recompute the interval as normal (doesn't matter if the full pass was caused by the timer or a signal).

Addresses: #40820
