### PR TITLE
workflows/ipsec: yet another fix for downgrade

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -500,7 +500,7 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
       - name: Start unencrypted packets check for connectivity tests after downgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/start
         with:
           # enable the check for proxy traffic.
@@ -533,7 +533,7 @@ jobs:
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after downgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/check
 
       - name: Features tested after downgrade


### PR DESCRIPTION
In #40868, we observed no DNS traffic being recorded by the check-encryption-leaks.bt script when skipping Cilium version downgrade in IPv6-only cluster. This was true given the to-fqdn tests were run only if IPv4 was enabled. However, the fix landed in #40881 is not enough: the downgrade is skipped, but the chekc-encryption-leaks.bt script can be still run in DNS-assertion mode for clusters with IPv4-enabled. This would cause the script to throw an error if no DNS traffic is being recorded. Given we skip the whole downgrade tests, there is no guarantee that we see DNS traffic, given no CLI tests nor conn-disrupt tests run at that moment in time.

There are two possible ways to fix that:

1. activate the DNS-assertion mode only when IPv4 is enabled (already doing this) AND when downgrade is not skipped.
2. skip the whole check-encryption-leaks.bt setup for the downgrade step when we're skipping downgrade (i.e., no tests would generate such traffic).

This commit opts for (2).
An example of the issue being still present: https://github.com/cilium/cilium/actions/runs/17046381531/job/48323205922.

Fixes: #40868.