### PR TITLE
ci: simplify scheduled test

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -96,6 +96,13 @@ triggers:
     workflows:
     - tests-ces-migrate.yaml
 
+schedule:
+  nightly:
+    workflows:
+    - conformance-aks.yaml
+    - conformance-gateway-api.yaml
+    - conformance-gke.yaml
+
 workflows:
   conformance-aks.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)

--- a/.github/ariane-scheduled.yaml
+++ b/.github/ariane-scheduled.yaml
@@ -1,4 +1,0 @@
-tests:
-- conformance-aks.yaml
-- conformance-gateway-api.yaml
-- conformance-gke.yaml

--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -53,7 +53,7 @@ jobs:
           SHA=$(git rev-parse ${REF})
           readarray workflows < <((
             yq '.triggers["/test"].workflows[]' .github/ariane-config.yaml
-            yq '.tests[]' .github/ariane-scheduled.yaml
+            yq '.schedule.nightly.workflows[]' .github/ariane-config.yaml
           ) | sort -u)
 
           for workflow in "${workflows[@]}"; do


### PR DESCRIPTION
We run required tests on a schedule, with the list derived from `ariane-config.yaml.`
However, there are tests that we want to run on a schedule but that are not required. For these, we added #40177 the `ariane-scheduled.yaml` file.
This PR simplifies the logic by adding a schedule section to `ariane-config.yaml` and modifies the workflow accordingly.

Related PRs #41262 #41264 #41265 Not required, but would be nice to have them merged together. 