### PR TITLE
ci: simplify scheduled test

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -97,6 +97,13 @@ triggers:
     workflows:
     - tests-ces-migrate.yaml
 
+schedule:
+  nightly:
+    workflows:
+    - conformance-aks.yaml
+    - conformance-gateway-api.yaml
+    - conformance-gke.yaml
+
 workflows:
   conformance-aks.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)

--- a/.github/ariane-scheduled.yaml
+++ b/.github/ariane-scheduled.yaml
@@ -1,4 +1,0 @@
-tests:
-- conformance-aks.yaml
-- conformance-gateway-api.yaml
-- conformance-gke.yaml


### PR DESCRIPTION
We run required tests on a schedule, with the list derived from `ariane-config.yaml.`
However, there are tests that we want to run on a schedule but that are not required. For these, we added the `ariane-scheduled.yaml` file.
This PR simplifies the logic by adding a schedule section to `ariane-config.yaml` and modifies the workflow accordingly.

Related PRs #41261 #41264 #41265 Not required, but would be nice to have them merged together. 

```upstream-prs
 41261
```