### PR TITLE
ci: simplify scheduled test

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -80,6 +80,11 @@ triggers:
     workflows:
     - net-perf-gke.yaml
 
+schedule:
+  nightly:
+    workflows:
+    - conformance-gke.yaml
+
 workflows:
   conformance-aks.yaml:
     paths-ignore-regex: (test|Documentation)/


### PR DESCRIPTION
We run required tests on a schedule, with the list derived from `ariane-config.yaml.`
However, there are tests that we want to run on a schedule but that are not required. For these, we added the `ariane-scheduled.yaml` file.
This PR simplifies the logic by adding a schedule section to `ariane-config.yaml` and modifies the workflow accordingly.

Related PRs #41261 #41262 #41265 Not required, but would be nice to have them merged together. 

```upstream-prs
 41261
```