### PR TITLE
gamma: support group "core" in GAMMA service parent ref check

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -40,6 +40,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		logfields.Controller, gamma,
 		logfields.Resource, req.NamespacedName,
 	)
+	scopedLog.InfoContext(ctx, "Reconciling GAMMA service")
 
 	// Step 1: Retrieve the Service
 	originalSvc := &corev1.Service{}
@@ -72,6 +73,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	if len(httpRouteList.Items) == 0 {
+		scopedLog.InfoContext(ctx, "No referencing HTTPRoute found")
 		return controllerruntime.Success()
 	}
 

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -37,7 +37,7 @@ func IsGateway(parent gatewayv1.ParentReference) bool {
 
 func IsGammaService(parent gatewayv1.ParentReference) bool {
 	return parent.Kind != nil && *parent.Kind == kindService &&
-		parent.Group != nil && *parent.Group == corev1.GroupName
+		parent.Group != nil && (*parent.Group == corev1.GroupName || *parent.Group == "core")
 }
 
 func IsGammaServiceEqual(parent gatewayv1.ParentReference, gammaService *corev1.Service, objNamespace string) bool {

--- a/operator/pkg/gateway-api/helpers/types_test.go
+++ b/operator/pkg/gateway-api/helpers/types_test.go
@@ -61,6 +61,16 @@ func TestIsGammaService(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "service kind with group core",
+			args: args{
+				parent: gatewayv1.ParentReference{
+					Kind:  ptr.To[gatewayv1.Kind]("Service"),
+					Group: ptr.To[gatewayv1.Group]("core"),
+				},
+			},
+			want: true,
+		},
+		{
 			name: "something else",
 			args: args{
 				parent: gatewayv1.ParentReference{


### PR DESCRIPTION
```
gamma: support group "core" in GAMMA service parent ref check

Currently, checking whether a Route parentref references a GAMMA service
doesn't support the case where the group of the K8s Service is defined as `core`.
(Historically it can either be defined as empty string (``) or `core`)

Hence the documented example from the Gateway API site isn't working as expected:
https://gateway-api.sigs.k8s.io/mesh/#connecting-routes-and-services

Therefore, this commit adds support for both cases.
```

```
gamma: improve logging of GAMMA reconciler

This commit adds to helpful log messages to the GAMMA reconciler.

One that indicates the start of the reconciliation and the other one that
no HTTPRoute has been found that references the GAMMA K8s Service.
```

I thought that's it's worth to improve the logging as this would have ease debugging this issue in the first place. 