### PR TITLE
plugins: Fix cilium-cni build for `kind-image-fast`

### DIFF
--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -10,6 +10,7 @@ TARGET := cilium-cni
 .PHONY: all
 all: $(TARGET)
 
+.PHONY: $(TARGET)
 $(TARGET):
 	@$(ECHO_GO)
 	$(QUIET)$(GO_BUILD) -o $@


### PR DESCRIPTION
This commit makes the cilium-cni binary a PHONY make target again, since it depends on various source files in the tree. Without this change, the `cilium-cni` binary is never rebuilt, which breaks `make kind-image-fast` and other workflows.

Fixes: 118497fc349b ("plugins: Remove unused CNI config file")
