### PR TITLE
renovate: Rebase if `dont-merge/needs-rebase` label is set

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,6 +83,7 @@
     "kind/enhancement",
     "release-note/misc"
   ],
+  "rebaseLabel": "dont-merge/needs-rebase",
   "stopUpdatingLabel": "renovate/stop-updating",
   "allowedPostUpgradeCommands": [
     "^make -C install/kubernetes$",


### PR DESCRIPTION
This PR will allow renovate to automatically recognize the standard `dont-merge/needs-rebase` label and react to it by rebasing its PRs.

See https://docs.renovatebot.com/configuration-options/#rebaselabel