### PR TITLE
ipcache: fix shutdown errors when controller not created

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -188,7 +188,7 @@ func TestCancellation(t *testing.T) {
 // terminationChannel returns a channel that is closed after the controller has
 // been terminated
 func (m *Manager) terminationChannel(name string) chan struct{} {
-	if c := m.lookup(name); c != nil {
+	if c := m.Lookup(name); c != nil {
 		return c.terminated
 	}
 

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -155,7 +155,7 @@ func (m *Manager) removeController(ctrl *managedController) {
 	ctrl.logger.Debug("Removed controller")
 }
 
-func (m *Manager) lookup(name string) *managedController {
+func (m *Manager) Lookup(name string) *managedController {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 	return m.lookupLocked(name)
@@ -255,7 +255,7 @@ func (m *Manager) GetStatusModel() models.ControllerStatuses {
 
 // TriggerController triggers the controller with the specified name.
 func (m *Manager) TriggerController(name string) {
-	ctrl := m.lookup(name)
+	ctrl := m.Lookup(name)
 	if ctrl == nil {
 		return
 	}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -179,7 +179,10 @@ func NewIPCache(c *Configuration) *IPCache {
 
 // Shutdown cleans up asynchronous routines associated with the IPCache.
 func (ipc *IPCache) Shutdown() error {
-	return ipc.controllers.RemoveControllerAndWait(LabelInjectorName)
+	if ipc.controllers.Lookup(LabelInjectorName) != nil {
+		return ipc.controllers.RemoveControllerAndWait(LabelInjectorName)
+	}
+	return nil
 }
 
 // RLock RLocks the IPCache's mutex.


### PR DESCRIPTION
Export controller lookup and add nil check in ipcache Shutdown() to avoid spurious "unable to find controller" errors when the daemon crashes before the ipcache-inject-labels controller is registered. This prevents noisy logs during early shutdown.

Fixes: #38842
