### PR TITLE
Fix --exclude-local-address with eBPF Host-Routing

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -756,6 +756,9 @@ ct_recreate6:
 		int oif = 0;
 
 		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, false, ext_err, &oif);
+		/* Error handling for local routes - just pass the packet to the kernel stack */
+		if (ret == DROP_NO_FIB && *ext_err == BPF_FIB_LKUP_RET_NOT_FWDED)
+			goto pass_to_stack;
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV6,
 					  *dst_sec_identity, TRACE_EP_ID_UNKNOWN, oif,
@@ -1310,6 +1313,12 @@ skip_vtep:
 		int oif = 0;
 
 		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, false, ext_err, &oif);
+		/* Error handling for local routes - just pass the packet to the kernel stack */
+		if (ret == DROP_NO_FIB && *ext_err == BPF_FIB_LKUP_RET_NOT_FWDED) {
+			if (!revalidate_data(ctx, &data, &data_end, &ip4))
+				return DROP_INVALID;
+			goto pass_to_stack;
+		}
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV4,
 					  *dst_sec_identity, TRACE_EP_ID_UNKNOWN, oif,


### PR DESCRIPTION
# Description
The problem is described in detail in the original issue https://github.com/cilium/cilium/issues/41241

This PR adds error-handling logic that fixes routing for local addresses which have been passed in `--exclude-local-address`. The routing code will always attempt a FIB lookup for packets destined to these addresses and it will always fail with `BPF_FIB_LKUP_RET_NOT_FWDED` because the addresses are local. The routing code will now remediate this by passing the packet to the kernel's routing stack when encountering this scenario.

Another idea I originally had was to keep track of excluded local addresses in a separate map ( https://github.com/DataDog/cilium/commit/844f1c8c6c1c0ed47f6d58acf5acca9b2021f851 ) but this obviously introduces more complexity that the current PR.

# Testing 
Setup: deploy a pod with NLD bound to `169.254.20.10`. Set `--exclude-local-address="169.254.20.10/31"` and enable eBPF Host-Routing on the Cilium Agent.

Before the PR:
```
# dig google.com
;; communications error to 169.254.20.10#53: timed out
;; communications error to 169.254.20.10#53: timed out
[...]
```

After the PR:
```
# dig google.com
; <<>> DiG 9.18.30-0ubuntu0.20.04.2-Ubuntu <<>> google.com
;; global options: +cmd
;; Got answer:
[...]
```

Fixes: https://github.com/cilium/cilium/issues/41241

```release-note
Fix --exclude-local-address with eBPF Host-Routing
```
