### PR TITLE
Remove EnableExternalIP and EnableHostPort

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -295,7 +295,7 @@ cilium-agent [flags]
       --k8s-require-ipv6-pod-cidr                                 Require IPv6 PodCIDR to be specified in node resource
       --k8s-service-proxy-name string                             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --keep-config                                               When restoring state, keeps containers' configuration in place
-      --kube-proxy-replacement string                             Enable kube-proxy replacement (default "false")
+      --kube-proxy-replacement                                    Enable kube-proxy replacement
       --kube-proxy-replacement-healthz-bind-address string        The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
       --kvstore string                                            Key-value store type
       --kvstore-lease-ttl duration                                Time-to-live for the KVstore lease. (default 15m0s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -156,7 +156,7 @@ cilium-agent hive [flags]
       --k8s-heartbeat-timeout duration                            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                                Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                             Enable kube-proxy replacement (default "false")
+      --kube-proxy-replacement                                    Enable kube-proxy replacement
       --kube-proxy-replacement-healthz-bind-address string        The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
       --kvstore string                                            Key-value store type
       --kvstore-lease-ttl duration                                Time-to-live for the KVstore lease. (default 15m0s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -161,7 +161,7 @@ cilium-agent hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                                Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kube-proxy-replacement string                             Enable kube-proxy replacement (default "false")
+      --kube-proxy-replacement                                    Enable kube-proxy replacement
       --kube-proxy-replacement-healthz-bind-address string        The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
       --kvstore string                                            Key-value store type
       --kvstore-lease-ttl duration                                Time-to-live for the KVstore lease. (default 15m0s)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -144,7 +144,7 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 		// InstallNoConntrackIptRules can only be enabled when Cilium is
 		// running in full KPR mode as otherwise conntrack would be
 		// required for NAT operations
-		if !(kprCfg.EnableHostPort && kprCfg.EnableNodePort && kprCfg.EnableSocketLB) {
+		if !(kprCfg.EnableNodePort && kprCfg.EnableSocketLB) {
 			return fmt.Errorf("%s requires the agent to run with %s.",
 				option.InstallNoConntrackIptRules, option.KubeProxyReplacement)
 		}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -145,8 +145,8 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 		// running in full KPR mode as otherwise conntrack would be
 		// required for NAT operations
 		if !(kprCfg.EnableHostPort && kprCfg.EnableNodePort && kprCfg.EnableExternalIPs && kprCfg.EnableSocketLB) {
-			return fmt.Errorf("%s requires the agent to run with %s=%s.",
-				option.InstallNoConntrackIptRules, option.KubeProxyReplacement, option.KubeProxyReplacementTrue)
+			return fmt.Errorf("%s requires the agent to run with %s.",
+				option.InstallNoConntrackIptRules, option.KubeProxyReplacement)
 		}
 
 		if option.Config.MasqueradingEnabled() && !option.Config.EnableBPFMasquerade {
@@ -271,8 +271,8 @@ func finishKubeProxyReplacementInit(logger *slog.Logger, sysctl sysctl.Sysctl, d
 		case option.Config.IptablesMasqueradingEnabled():
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
 		// KPR=true is needed or we might rely on netfilter.
-		case kprCfg.KubeProxyReplacement != option.KubeProxyReplacementTrue:
-			msg = fmt.Sprintf("BPF host routing requires %s=%s.", option.KubeProxyReplacement, option.KubeProxyReplacementTrue)
+		case !kprCfg.KubeProxyReplacement:
+			msg = fmt.Sprintf("BPF host routing requires %s.", option.KubeProxyReplacement)
 		}
 		if msg != "" {
 			option.Config.EnableHostLegacyRouting = true

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -144,7 +144,7 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 		// InstallNoConntrackIptRules can only be enabled when Cilium is
 		// running in full KPR mode as otherwise conntrack would be
 		// required for NAT operations
-		if !(kprCfg.EnableHostPort && kprCfg.EnableNodePort && kprCfg.EnableExternalIPs && kprCfg.EnableSocketLB) {
+		if !(kprCfg.EnableHostPort && kprCfg.EnableNodePort && kprCfg.EnableSocketLB) {
 			return fmt.Errorf("%s requires the agent to run with %s.",
 				option.InstallNoConntrackIptRules, option.KubeProxyReplacement)
 		}

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -27,7 +27,7 @@ import (
 type KPRSuite struct{}
 
 type kprConfig struct {
-	kubeProxyReplacement string
+	kubeProxyReplacement bool
 
 	enableSocketLB             bool
 	enableNodePort             bool
@@ -146,7 +146,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"kpr-true",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 			},
 			kprConfig{
 				enableSocketLB:          true,
@@ -162,7 +162,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"kpr-true+ipsec",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.enableIPSec = true
 			},
 			kprConfig{
@@ -180,7 +180,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"kpr-true+no-conntrack-ipt-rules+masquerade",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.installNoConntrackIptRules = true
 				cfg.enableBPFMasquerade = true
 				cfg.enableIPv4Masquerade = true
@@ -202,7 +202,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"kpr-true+no-conntrack-ipt-rules+no-bpf-masquerade",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.installNoConntrackIptRules = true
 				cfg.enableIPv4Masquerade = true
 			},
@@ -223,7 +223,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"kpr-disabled",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementFalse
+				cfg.kubeProxyReplacement = false
 			},
 			kprConfig{
 				enableSocketLB:          false,
@@ -241,12 +241,12 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"kpr-false+no-conntrack-ipt-rules",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementFalse
+				cfg.kubeProxyReplacement = false
 				cfg.installNoConntrackIptRules = true
 				cfg.enableNodePort = true
 			},
 			kprConfig{
-				expectedErrorRegex:         ".+with kube-proxy-replacement=true.",
+				expectedErrorRegex:         ".+with kube-proxy-replacement.",
 				enableSocketLB:             false,
 				enableNodePort:             true,
 				enableHostPort:             false,
@@ -260,7 +260,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"node-port-dsr-mode+vxlan",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.VXLAN
 				cfg.nodePortMode = loadbalancer.LBModeDSR
@@ -281,7 +281,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"node-port-dsr-mode+geneve-dispatch+native-routing",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.routingMode = option.RoutingModeNative
 				cfg.tunnelProtocol = tunnel.Geneve
 				cfg.nodePortMode = loadbalancer.LBModeDSR
@@ -300,7 +300,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"node-port-dsr-mode+geneve-dispatch+geneve-routing",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.Geneve
 				cfg.nodePortMode = loadbalancer.LBModeDSR
@@ -319,7 +319,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"node-port-dsr-mode+geneve-dispatch+vxlan-routing",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.VXLAN
 				cfg.nodePortMode = loadbalancer.LBModeDSR
@@ -340,7 +340,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"node-port-hybrid-mode+geneve-dispatch+native-routing",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.routingMode = option.RoutingModeNative
 				cfg.tunnelProtocol = tunnel.Geneve
 				cfg.nodePortMode = loadbalancer.LBModeHybrid
@@ -359,7 +359,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"node-port-hybrid-mode+geneve-dispatch+geneve-routing",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.Geneve
 				cfg.nodePortMode = loadbalancer.LBModeHybrid
@@ -378,7 +378,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		{
 			"node-port-hybrid-mode+geneve-dispatch+vxlan-routing",
 			func(cfg *kprConfig) {
-				cfg.kubeProxyReplacement = option.KubeProxyReplacementTrue
+				cfg.kubeProxyReplacement = true
 				cfg.routingMode = option.RoutingModeTunnel
 				cfg.tunnelProtocol = tunnel.VXLAN
 				cfg.nodePortMode = loadbalancer.LBModeHybrid

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -32,7 +32,6 @@ type kprConfig struct {
 	enableSocketLB             bool
 	enableNodePort             bool
 	enableHostPort             bool
-	enableExternalIPs          bool
 	enableIPSec                bool
 	enableHostLegacyRouting    bool
 	installNoConntrackIptRules bool
@@ -59,7 +58,6 @@ func (cfg *kprConfig) set() (err error) {
 		EnableNodePort:       cfg.enableNodePort,
 		EnableSocketLB:       cfg.enableSocketLB,
 		EnableHostPort:       cfg.enableHostPort,
-		EnableExternalIPs:    cfg.enableExternalIPs,
 	}
 
 	cfg.kprConfig, err = kpr.NewKPRConfig(kprFlags)
@@ -111,7 +109,6 @@ func (cfg *kprConfig) verify(t *testing.T, lbConfig loadbalancer.Config, kprCfg 
 	require.Equal(t, cfg.enableSocketLB, kprCfg.EnableSocketLB)
 	require.Equal(t, cfg.enableNodePort, kprCfg.EnableNodePort)
 	require.Equal(t, cfg.enableHostPort, kprCfg.EnableHostPort)
-	require.Equal(t, cfg.enableExternalIPs, kprCfg.EnableExternalIPs)
 	require.Equal(t, cfg.enableIPSec, option.Config.EnableIPSec)
 	require.Equal(t, cfg.enableHostLegacyRouting, option.Config.EnableHostLegacyRouting)
 	require.Equal(t, cfg.installNoConntrackIptRules, option.Config.InstallNoConntrackIptRules)
@@ -152,7 +149,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          true,
 				enableNodePort:          true,
 				enableHostPort:          true,
-				enableExternalIPs:       true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -169,7 +165,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          true,
 				enableNodePort:          true,
 				enableHostPort:          true,
-				enableExternalIPs:       true,
 				enableHostLegacyRouting: false,
 				enableIPSec:             true,
 				enableSocketLBTracing:   true,
@@ -189,7 +184,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:             true,
 				enableNodePort:             true,
 				enableHostPort:             true,
-				enableExternalIPs:          true,
 				enableHostLegacyRouting:    false,
 				enableBPFMasquerade:        true,
 				enableIPv4Masquerade:       true,
@@ -211,7 +205,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:             true,
 				enableNodePort:             true,
 				enableHostPort:             true,
-				enableExternalIPs:          true,
 				enableHostLegacyRouting:    false,
 				installNoConntrackIptRules: true,
 				enableIPv4Masquerade:       true,
@@ -229,7 +222,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          false,
 				enableNodePort:          false,
 				enableHostPort:          false,
-				enableExternalIPs:       false,
 				enableIPSec:             false,
 				enableHostLegacyRouting: true,
 				enableSocketLBTracing:   false,
@@ -250,7 +242,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:             false,
 				enableNodePort:             true,
 				enableHostPort:             false,
-				enableExternalIPs:          false,
 				enableHostLegacyRouting:    false,
 				installNoConntrackIptRules: true,
 				enableSocketLBTracing:      true,
@@ -271,7 +262,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          true,
 				enableNodePort:          true,
 				enableHostPort:          true,
-				enableExternalIPs:       true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -291,7 +281,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          true,
 				enableNodePort:          true,
 				enableHostPort:          true,
-				enableExternalIPs:       true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -310,7 +299,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          true,
 				enableNodePort:          true,
 				enableHostPort:          true,
-				enableExternalIPs:       true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -330,7 +318,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          true,
 				enableNodePort:          true,
 				enableHostPort:          true,
-				enableExternalIPs:       true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -350,7 +337,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          true,
 				enableNodePort:          true,
 				enableHostPort:          true,
-				enableExternalIPs:       true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -369,7 +355,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          true,
 				enableNodePort:          true,
 				enableHostPort:          true,
-				enableExternalIPs:       true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -389,7 +374,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSocketLB:          true,
 				enableNodePort:          true,
 				enableHostPort:          true,
-				enableExternalIPs:       true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -31,7 +31,6 @@ type kprConfig struct {
 
 	enableSocketLB             bool
 	enableNodePort             bool
-	enableHostPort             bool
 	enableIPSec                bool
 	enableHostLegacyRouting    bool
 	installNoConntrackIptRules bool
@@ -57,7 +56,6 @@ func (cfg *kprConfig) set() (err error) {
 		KubeProxyReplacement: cfg.kubeProxyReplacement,
 		EnableNodePort:       cfg.enableNodePort,
 		EnableSocketLB:       cfg.enableSocketLB,
-		EnableHostPort:       cfg.enableHostPort,
 	}
 
 	cfg.kprConfig, err = kpr.NewKPRConfig(kprFlags)
@@ -108,7 +106,6 @@ func (cfg *kprConfig) verify(t *testing.T, lbConfig loadbalancer.Config, kprCfg 
 	}
 	require.Equal(t, cfg.enableSocketLB, kprCfg.EnableSocketLB)
 	require.Equal(t, cfg.enableNodePort, kprCfg.EnableNodePort)
-	require.Equal(t, cfg.enableHostPort, kprCfg.EnableHostPort)
 	require.Equal(t, cfg.enableIPSec, option.Config.EnableIPSec)
 	require.Equal(t, cfg.enableHostLegacyRouting, option.Config.EnableHostLegacyRouting)
 	require.Equal(t, cfg.installNoConntrackIptRules, option.Config.InstallNoConntrackIptRules)
@@ -148,7 +145,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				enableSocketLB:          true,
 				enableNodePort:          true,
-				enableHostPort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -164,7 +160,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				enableSocketLB:          true,
 				enableNodePort:          true,
-				enableHostPort:          true,
 				enableHostLegacyRouting: false,
 				enableIPSec:             true,
 				enableSocketLBTracing:   true,
@@ -183,7 +178,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				enableSocketLB:             true,
 				enableNodePort:             true,
-				enableHostPort:             true,
 				enableHostLegacyRouting:    false,
 				enableBPFMasquerade:        true,
 				enableIPv4Masquerade:       true,
@@ -204,7 +198,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				expectedErrorRegex:         ".+with enable-bpf-masquerade.",
 				enableSocketLB:             true,
 				enableNodePort:             true,
-				enableHostPort:             true,
 				enableHostLegacyRouting:    false,
 				installNoConntrackIptRules: true,
 				enableIPv4Masquerade:       true,
@@ -221,7 +214,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				enableSocketLB:          false,
 				enableNodePort:          false,
-				enableHostPort:          false,
 				enableIPSec:             false,
 				enableHostLegacyRouting: true,
 				enableSocketLBTracing:   false,
@@ -241,7 +233,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				expectedErrorRegex:         ".+with kube-proxy-replacement.",
 				enableSocketLB:             false,
 				enableNodePort:             true,
-				enableHostPort:             false,
 				enableHostLegacyRouting:    false,
 				installNoConntrackIptRules: true,
 				enableSocketLBTracing:      true,
@@ -261,7 +252,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				expectedErrorRegex:      "Node Port .+ mode cannot be used with .+ tunneling.",
 				enableSocketLB:          true,
 				enableNodePort:          true,
-				enableHostPort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -280,7 +270,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				enableSocketLB:          true,
 				enableNodePort:          true,
-				enableHostPort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -298,7 +287,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				enableSocketLB:          true,
 				enableNodePort:          true,
-				enableHostPort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -317,7 +305,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				expectedErrorRegex:      "Node Port .+ mode cannot be used with .+ tunneling.",
 				enableSocketLB:          true,
 				enableNodePort:          true,
-				enableHostPort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -336,7 +323,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				enableSocketLB:          true,
 				enableNodePort:          true,
-				enableHostPort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -354,7 +340,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				enableSocketLB:          true,
 				enableNodePort:          true,
-				enableHostPort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -373,7 +358,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				expectedErrorRegex:      "Node Port .+ mode cannot be used with .+ tunneling.",
 				enableSocketLB:          true,
 				enableNodePort:          true,
-				enableHostPort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},

--- a/daemon/healthz/kube_proxy_healthz.go
+++ b/daemon/healthz/kube_proxy_healthz.go
@@ -77,7 +77,7 @@ func (r config) Flags(flags *pflag.FlagSet) {
 // status HTTP endpoint exposed on addr.
 // This endpoint reports the agent health status with the timestamp.
 func registerKubeProxyHealthzHTTPService(params kubeProxyHealthParams) error {
-	if params.Config.KubeProxyReplacementHealthzBindAddress == "" || params.KPRConfig.KubeProxyReplacement == option.KubeProxyReplacementFalse {
+	if params.Config.KubeProxyReplacementHealthzBindAddress == "" || !params.KPRConfig.KubeProxyReplacement {
 		return nil
 	}
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -294,7 +294,7 @@ type OperatorConfig struct {
 
 	// KubeProxyReplacement or NodePort are required to implement cluster
 	// Ingress (or equivalent Gateway API functionality)
-	KubeProxyReplacement string
+	KubeProxyReplacement bool
 	EnableNodePort       bool
 
 	// AWS options
@@ -448,7 +448,7 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.ParallelAllocWorkers = vp.GetInt64(ParallelAllocWorkers)
 
 	// Gateways and Ingress
-	c.KubeProxyReplacement = vp.GetString(KubeProxyReplacement)
+	c.KubeProxyReplacement = vp.GetBool(KubeProxyReplacement)
 	c.EnableNodePort = vp.GetBool(EnableNodePort)
 
 	// AWS options

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -110,7 +110,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		return nil
 	}
 
-	if params.OperatorConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
+	if !params.OperatorConfig.KubeProxyReplacement &&
 		!params.OperatorConfig.EnableNodePort {
 		params.Logger.Warn("Gateway API support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -102,7 +102,7 @@ func registerReconciler(params ingressParams) error {
 		return nil
 	}
 
-	if params.OperatorConfig.KubeProxyReplacement != option.KubeProxyReplacementTrue &&
+	if !params.OperatorConfig.KubeProxyReplacement &&
 		!params.OperatorConfig.EnableNodePort {
 		params.Logger.Warn("Ingress Controller support requires either kube-proxy-replacement or enable-node-port enabled")
 		return nil

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -98,7 +98,7 @@ func TestScript(t *testing.T) {
 				},
 				func() kpr.KPRConfig {
 					return kpr.KPRConfig{
-						KubeProxyReplacement: option.KubeProxyReplacementTrue,
+						KubeProxyReplacement: true,
 						EnableNodePort:       true,
 					}
 				},

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -122,7 +122,7 @@ func TestScript(t *testing.T) {
 				func() kpr.KPRConfig {
 					return kpr.KPRConfig{
 						EnableNodePort:       true,
-						KubeProxyReplacement: option.KubeProxyReplacementTrue,
+						KubeProxyReplacement: true,
 					}
 				},
 				func() store.Factory {

--- a/pkg/datapath/tunnel/cell.go
+++ b/pkg/datapath/tunnel/cell.go
@@ -35,7 +35,7 @@ var Cell = cell.Module(
 		func(kpr kpr.KPRConfig, lbcfg loadbalancer.Config) EnablerOut {
 			return NewEnabler(
 				(kpr.EnableNodePort ||
-					kpr.KubeProxyReplacement == option.KubeProxyReplacementTrue) &&
+					kpr.KubeProxyReplacement) &&
 					lbcfg.LoadBalancerUsesDSR() &&
 					lbcfg.DSRDispatch == loadbalancer.DSRDispatchGeneve,
 				// The datapath logic takes care of the MTU overhead. So no need to

--- a/pkg/kpr/kpr.go
+++ b/pkg/kpr/kpr.go
@@ -4,8 +4,6 @@
 package kpr
 
 import (
-	"fmt"
-
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
 )
@@ -19,7 +17,7 @@ var Cell = cell.Module(
 )
 
 type KPRFlags struct {
-	KubeProxyReplacement string
+	KubeProxyReplacement bool
 	EnableSocketLB       bool `mapstructure:"bpf-lb-sock"`
 	EnableNodePort       bool
 	EnableExternalIPs    bool
@@ -27,7 +25,7 @@ type KPRFlags struct {
 }
 
 var defaultFlags = KPRFlags{
-	KubeProxyReplacement: "false",
+	KubeProxyReplacement: false,
 	EnableSocketLB:       false,
 	EnableNodePort:       false,
 	EnableExternalIPs:    false,
@@ -35,7 +33,7 @@ var defaultFlags = KPRFlags{
 }
 
 func (def KPRFlags) Flags(flags *pflag.FlagSet) {
-	flags.String("kube-proxy-replacement", def.KubeProxyReplacement, "Enable kube-proxy replacement")
+	flags.Bool("kube-proxy-replacement", def.KubeProxyReplacement, "Enable kube-proxy replacement")
 
 	flags.Bool("bpf-lb-sock", def.EnableSocketLB, "Enable socket-based LB for E/W traffic")
 
@@ -50,7 +48,7 @@ func (def KPRFlags) Flags(flags *pflag.FlagSet) {
 }
 
 type KPRConfig struct {
-	KubeProxyReplacement string
+	KubeProxyReplacement bool
 	EnableNodePort       bool
 	EnableExternalIPs    bool
 	EnableHostPort       bool
@@ -58,10 +56,6 @@ type KPRConfig struct {
 }
 
 func NewKPRConfig(flags KPRFlags) (KPRConfig, error) {
-	if flags.KubeProxyReplacement != "true" && flags.KubeProxyReplacement != "false" {
-		return KPRConfig{}, fmt.Errorf("invalid value for kube-proxy-replacement")
-	}
-
 	cfg := KPRConfig{
 		KubeProxyReplacement: flags.KubeProxyReplacement,
 		EnableNodePort:       flags.EnableNodePort,
@@ -70,7 +64,7 @@ func NewKPRConfig(flags KPRFlags) (KPRConfig, error) {
 		EnableSocketLB:       flags.EnableSocketLB,
 	}
 
-	if flags.KubeProxyReplacement == "true" {
+	if flags.KubeProxyReplacement {
 		cfg.EnableNodePort = true
 		cfg.EnableExternalIPs = true
 		cfg.EnableHostPort = true

--- a/pkg/kpr/kpr.go
+++ b/pkg/kpr/kpr.go
@@ -20,14 +20,12 @@ type KPRFlags struct {
 	KubeProxyReplacement bool
 	EnableSocketLB       bool `mapstructure:"bpf-lb-sock"`
 	EnableNodePort       bool
-	EnableHostPort       bool
 }
 
 var defaultFlags = KPRFlags{
 	KubeProxyReplacement: false,
 	EnableSocketLB:       false,
 	EnableNodePort:       false,
-	EnableHostPort:       false,
 }
 
 func (def KPRFlags) Flags(flags *pflag.FlagSet) {
@@ -37,15 +35,11 @@ func (def KPRFlags) Flags(flags *pflag.FlagSet) {
 
 	flags.Bool("enable-node-port", def.EnableNodePort, "Enable NodePort type services by Cilium")
 	flags.MarkDeprecated("enable-node-port", "The flag will be removed in v1.19. The feature will be unconditionally enabled by enabling kube-proxy-replacement")
-
-	flags.Bool("enable-host-port", def.EnableHostPort, "Enable k8s hostPort mapping feature (requires enabling enable-node-port)")
-	flags.MarkDeprecated("enable-host-port", "The flag will be removed in v1.19. The feature will be unconditionally enabled by enabling kube-proxy-replacement")
 }
 
 type KPRConfig struct {
 	KubeProxyReplacement bool
 	EnableNodePort       bool
-	EnableHostPort       bool
 	EnableSocketLB       bool
 }
 
@@ -53,19 +47,12 @@ func NewKPRConfig(flags KPRFlags) (KPRConfig, error) {
 	cfg := KPRConfig{
 		KubeProxyReplacement: flags.KubeProxyReplacement,
 		EnableNodePort:       flags.EnableNodePort,
-		EnableHostPort:       flags.EnableHostPort,
 		EnableSocketLB:       flags.EnableSocketLB,
 	}
 
 	if flags.KubeProxyReplacement {
 		cfg.EnableNodePort = true
-		cfg.EnableHostPort = true
 		cfg.EnableSocketLB = true
-	}
-
-	if !cfg.EnableNodePort {
-		// Disable features depending on NodePort
-		cfg.EnableHostPort = false
 	}
 
 	return cfg, nil

--- a/pkg/kpr/kpr.go
+++ b/pkg/kpr/kpr.go
@@ -20,7 +20,6 @@ type KPRFlags struct {
 	KubeProxyReplacement bool
 	EnableSocketLB       bool `mapstructure:"bpf-lb-sock"`
 	EnableNodePort       bool
-	EnableExternalIPs    bool
 	EnableHostPort       bool
 }
 
@@ -28,7 +27,6 @@ var defaultFlags = KPRFlags{
 	KubeProxyReplacement: false,
 	EnableSocketLB:       false,
 	EnableNodePort:       false,
-	EnableExternalIPs:    false,
 	EnableHostPort:       false,
 }
 
@@ -40,9 +38,6 @@ func (def KPRFlags) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-node-port", def.EnableNodePort, "Enable NodePort type services by Cilium")
 	flags.MarkDeprecated("enable-node-port", "The flag will be removed in v1.19. The feature will be unconditionally enabled by enabling kube-proxy-replacement")
 
-	flags.Bool("enable-external-ips", def.EnableExternalIPs, "Enable k8s service externalIPs feature (requires enabling enable-node-port)")
-	flags.MarkDeprecated("enable-external-ips", "The flag will be removed in v1.19. The feature will be unconditionally enabled by enabling kube-proxy-replacement")
-
 	flags.Bool("enable-host-port", def.EnableHostPort, "Enable k8s hostPort mapping feature (requires enabling enable-node-port)")
 	flags.MarkDeprecated("enable-host-port", "The flag will be removed in v1.19. The feature will be unconditionally enabled by enabling kube-proxy-replacement")
 }
@@ -50,7 +45,6 @@ func (def KPRFlags) Flags(flags *pflag.FlagSet) {
 type KPRConfig struct {
 	KubeProxyReplacement bool
 	EnableNodePort       bool
-	EnableExternalIPs    bool
 	EnableHostPort       bool
 	EnableSocketLB       bool
 }
@@ -59,14 +53,12 @@ func NewKPRConfig(flags KPRFlags) (KPRConfig, error) {
 	cfg := KPRConfig{
 		KubeProxyReplacement: flags.KubeProxyReplacement,
 		EnableNodePort:       flags.EnableNodePort,
-		EnableExternalIPs:    flags.EnableExternalIPs,
 		EnableHostPort:       flags.EnableHostPort,
 		EnableSocketLB:       flags.EnableSocketLB,
 	}
 
 	if flags.KubeProxyReplacement {
 		cfg.EnableNodePort = true
-		cfg.EnableExternalIPs = true
 		cfg.EnableHostPort = true
 		cfg.EnableSocketLB = true
 	}
@@ -74,7 +66,6 @@ func NewKPRConfig(flags KPRFlags) (KPRConfig, error) {
 	if !cfg.EnableNodePort {
 		// Disable features depending on NodePort
 		cfg.EnableHostPort = false
-		cfg.EnableExternalIPs = false
 	}
 
 	return cfg, nil

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -541,7 +541,7 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
 		ZoneMapper:                             cfg,
 		EnableIPv4:                             cfg.EnableIPv4,
 		EnableIPv6:                             cfg.EnableIPv6,
-		KubeProxyReplacement:                   kprCfg.KubeProxyReplacement == option.KubeProxyReplacementTrue || kprCfg.EnableNodePort,
+		KubeProxyReplacement:                   kprCfg.KubeProxyReplacement || kprCfg.EnableNodePort,
 		BPFSocketLBHostnsOnly:                  cfg.BPFSocketLBHostnsOnly,
 		EnableSocketLB:                         kprCfg.EnableSocketLB,
 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -530,9 +530,6 @@ type ExternalConfig struct {
 	EnableSocketLB                         bool
 	EnableSocketLBPodConnectionTermination bool
 	EnableHealthCheckLoadBalancerIP        bool
-
-	// The following options will be removed in v1.19
-	EnableHostPort bool
 }
 
 // NewExternalConfig maps the daemon config to [ExternalConfig].
@@ -546,7 +543,6 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
 		EnableSocketLB:                         kprCfg.EnableSocketLB,
 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,
 		EnableHealthCheckLoadBalancerIP:        cfg.EnableHealthCheckLoadBalancerIP,
-		EnableHostPort:                         kprCfg.EnableHostPort,
 	}
 }
 

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -97,7 +97,7 @@ func TestScript(t *testing.T) {
 					},
 					func() kpr.KPRConfig {
 						return kpr.KPRConfig{
-							KubeProxyReplacement: option.KubeProxyReplacementTrue,
+							KubeProxyReplacement: true,
 							EnableNodePort:       true,
 						}
 					},

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1084,7 +1084,6 @@ func TestBPFOps(t *testing.T) {
 		EnableIPv4:           true,
 		EnableIPv6:           true,
 		KubeProxyReplacement: true,
-		EnableHostPort:       true,
 	}
 
 	cfg, _ := loadbalancer.NewConfig(log, loadbalancer.DefaultUserConfig, loadbalancer.DeprecatedConfig{}, &option.DaemonConfig{})

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -93,7 +93,7 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 			},
 			func() kpr.KPRConfig {
 				return kpr.KPRConfig{
-					KubeProxyReplacement: "true",
+					KubeProxyReplacement: true,
 					EnableNodePort:       true,
 					EnableSocketLB:       true,
 				}

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -91,7 +91,7 @@ func TestScript(t *testing.T) {
 					func() kpr.KPRConfig {
 						return kpr.KPRConfig{
 							EnableNodePort:       true,
-							KubeProxyReplacement: option.KubeProxyReplacementTrue,
+							KubeProxyReplacement: true,
 						}
 					},
 					func() redirectpolicy.TestSkipLBMap {

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -166,7 +166,7 @@ func runPodReflector(ctx context.Context, health cell.Health, p reflectorParams,
 			podName := obj.Namespace + "/" + obj.Name
 			if change.Deleted {
 				rh.update(podName, nil)
-				if p.ExtConfig.EnableHostPort {
+				if p.ExtConfig.KubeProxyReplacement {
 					if err := deleteHostPort(p, txn, obj); err != nil {
 						p.Log.Error("BUG: Unexpected failure in deleteHostPort",
 							logfields.Error, err)
@@ -178,7 +178,7 @@ func runPodReflector(ctx context.Context, health cell.Health, p reflectorParams,
 					// Pod has been terminated. Clean up the HostPort already even before the Pod object
 					// has been removed to free up the HostPort for other pods.
 					rh.update(podName, nil)
-					if p.ExtConfig.EnableHostPort {
+					if p.ExtConfig.KubeProxyReplacement {
 						if err := deleteHostPort(p, txn, obj); err != nil {
 							p.Log.Error("BUG: Unexpected failure in deleteHostPort",
 								logfields.Error, err)
@@ -193,7 +193,7 @@ func runPodReflector(ctx context.Context, health cell.Health, p reflectorParams,
 						continue
 					}
 
-					if p.ExtConfig.EnableHostPort {
+					if p.ExtConfig.KubeProxyReplacement {
 						err = upsertHostPort(p.HaveNetNSCookieSupport, p.Config, p.ExtConfig, p.Log, txn, p.Writer, obj)
 					}
 					rh.update(podName, err)

--- a/pkg/loadbalancer/repl/main.go
+++ b/pkg/loadbalancer/repl/main.go
@@ -99,7 +99,7 @@ var Hive = hive.New(
 		},
 		func() kpr.KPRConfig {
 			return kpr.KPRConfig{
-				KubeProxyReplacement: option.KubeProxyReplacementTrue,
+				KubeProxyReplacement: true,
 			}
 		},
 		func(cfg loadbalancer.TestConfig) *loadbalancer.TestConfig {

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -101,7 +101,6 @@ func TestScript(t *testing.T) {
 						return kpr.KPRConfig{
 							KubeProxyReplacement: true,
 							EnableNodePort:       true,
-							EnableHostPort:       true,
 						}
 					},
 					func(ops *lbreconciler.BPFOps, lns *node.LocalNodeStore, w *writer.Writer, waitFn loadbalancer.InitWaitFunc) uhive.ScriptCmdsOut {

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -99,7 +99,7 @@ func TestScript(t *testing.T) {
 					},
 					func() kpr.KPRConfig {
 						return kpr.KPRConfig{
-							KubeProxyReplacement: option.KubeProxyReplacementTrue,
+							KubeProxyReplacement: true,
 							EnableNodePort:       true,
 							EnableHostPort:       true,
 						}

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -1062,7 +1062,7 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 		m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncWireGuard, node2nodeEnabled, strictMode).Add(1)
 	}
 
-	if kprCfg.KubeProxyReplacement == option.KubeProxyReplacementTrue {
+	if kprCfg.KubeProxyReplacement {
 		m.ACLBKubeProxyReplacementEnabled.Add(1)
 	}
 

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -817,17 +817,17 @@ func TestUpdateEncryptionMode(t *testing.T) {
 func TestUpdateKubeProxyReplacement(t *testing.T) {
 	tests := []struct {
 		name                       string
-		enableKubeProxyReplacement string
+		enableKubeProxyReplacement bool
 		expected                   float64
 	}{
 		{
 			name:                       "KubeProxyReplacement enabled",
-			enableKubeProxyReplacement: "true",
+			enableKubeProxyReplacement: true,
 			expected:                   1,
 		},
 		{
 			name:                       "KubeProxyReplacement disabled",
-			enableKubeProxyReplacement: "false",
+			enableKubeProxyReplacement: false,
 			expected:                   0,
 		},
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1093,14 +1093,6 @@ const (
 	// NodePortAccelerationBestEffort means we accelerate NodePort via native XDP in the driver (preferred), but will skip devices without driver support
 	NodePortAccelerationBestEffort = XDPModeBestEffort
 
-	// KubeProxyReplacementTrue specifies to enable all kube-proxy replacement
-	// features (might panic).
-	KubeProxyReplacementTrue = "true"
-
-	// KubeProxyReplacementFalse specifies to enable only selected kube-proxy
-	// replacement features (might panic).
-	KubeProxyReplacementFalse = "false"
-
 	// PprofAddressAgent is the default value for pprof in the agent
 	PprofAddressAgent = "localhost"
 
@@ -2112,7 +2104,7 @@ func (c *DaemonConfig) NeedEgressOnWireGuardDevice(kprCfg kpr.KPRConfig, wiregua
 
 	// Attaching cil_to_wireguard to cilium_wg0 egress is required for handling
 	// the rev-NAT xlations when encrypting KPR traffic.
-	if kprCfg.EnableNodePort && c.EnableL7Proxy && kprCfg.KubeProxyReplacement == KubeProxyReplacementTrue {
+	if kprCfg.EnableNodePort && c.EnableL7Proxy && kprCfg.KubeProxyReplacement {
 		return true
 	}
 

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -275,12 +275,9 @@ func (d *statusCollector) getCNIChainingStatus() *models.CNIChainingStatus {
 }
 
 func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *models.KubeProxyReplacement {
-	var mode string
-	switch d.statusParams.KPRConfig.KubeProxyReplacement {
-	case option.KubeProxyReplacementTrue:
+	mode := models.KubeProxyReplacementModeFalse
+	if d.statusParams.KPRConfig.KubeProxyReplacement {
 		mode = models.KubeProxyReplacementModeTrue
-	case option.KubeProxyReplacementFalse:
-		mode = models.KubeProxyReplacementModeFalse
 	}
 
 	devices, _ := datapathTables.SelectedDevices(d.statusParams.Devices, d.statusParams.DB.ReadTxn())

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -337,7 +337,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 	if d.statusParams.KPRConfig.EnableHostPort {
 		features.HostPort.Enabled = true
 	}
-	if d.statusParams.KPRConfig.EnableExternalIPs {
+	if d.statusParams.KPRConfig.KubeProxyReplacement {
 		features.ExternalIPs.Enabled = true
 	}
 	if d.statusParams.KPRConfig.EnableSocketLB {

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -334,10 +334,8 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		features.NodePort.PortMin = int64(d.statusParams.LBConfig.NodePortMin)
 		features.NodePort.PortMax = int64(d.statusParams.LBConfig.NodePortMax)
 	}
-	if d.statusParams.KPRConfig.EnableHostPort {
-		features.HostPort.Enabled = true
-	}
 	if d.statusParams.KPRConfig.KubeProxyReplacement {
+		features.HostPort.Enabled = true
 		features.ExternalIPs.Enabled = true
 	}
 	if d.statusParams.KPRConfig.EnableSocketLB {


### PR DESCRIPTION
Related #39582

Removing `EnableNodePort` is more involved due to BPF masq depending on it. Will do in a separate PR (incl. updating upgrade notes about the removal of `EnableExternalIP` and `EnableHostPort`).