### PR TITLE
ipsec: fix xfrm privileged tests

### DIFF
--- a/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
@@ -26,7 +26,7 @@ func newTestableXfrmStateListCache(ttl time.Duration, clock clock.PassiveClock) 
 	}
 }
 
-func TestXfrmStateListCache(t *testing.T) {
+func TestPrivilegedXfrmStateListCache(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
 	backupOption := option.Config.EnableIPSecXfrmStateCaching
@@ -106,7 +106,7 @@ func TestXfrmStateListCache(t *testing.T) {
 	require.Empty(t, stateList)
 }
 
-func TestXfrmStateListCacheDisabled(t *testing.T) {
+func TestPrivilegedXfrmStateListCacheDisabled(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
 	backupOption := option.Config.EnableIPSecXfrmStateCaching


### PR DESCRIPTION
As in #41006, this commits adds the TestPrivileged prefix to some xfrm tests we missed to modify in the latest PR. With this, all the unparallel tests should be executed properly in CI.