### PR TITLE
node:tests: fix privileged

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -63,7 +63,7 @@ func TestPrivilegedLoadKeysNoFile(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
-func TestInvalidLoadKeys(t *testing.T) {
+func TestPrivilegedInvalidLoadKeys(t *testing.T) {
 	log := setupIPSecSuitePrivileged(t)
 
 	keys := bytes.NewReader(invalidKeysDat)
@@ -154,7 +154,7 @@ func TestPrivilegedParseSPI(t *testing.T) {
 	}
 }
 
-func TestUpsertIPSecEquals(t *testing.T) {
+func TestPrivilegedUpsertIPSecEquals(t *testing.T) {
 	log := setupIPSecSuitePrivileged(t)
 
 	_, local, err := net.ParseCIDR("1.2.3.4/16")
@@ -237,7 +237,7 @@ func TestUpsertIPSecEquals(t *testing.T) {
 //     the well-defined Encryption mark.
 //
 // 2. A state should be created with similar properties as above.
-func TestUpsertIPSecEndpointOut(t *testing.T) {
+func TestPrivilegedUpsertIPSecEndpointOut(t *testing.T) {
 	log := setupIPSecSuitePrivileged(t)
 
 	_, local, err := net.ParseCIDR("1.1.3.4/16")
@@ -358,7 +358,7 @@ func TestUpsertIPSecEndpointOut(t *testing.T) {
 //   - Template destination is the ESP tunnel IP of the local node forwarding
 //     the traffic.
 //   - A ReqID of 1
-func TestUpsertIPSecEndpointFwd(t *testing.T) {
+func TestPrivilegedUpsertIPSecEndpointFwd(t *testing.T) {
 	log := setupIPSecSuitePrivileged(t)
 
 	_, local, err := net.ParseCIDR("1.1.3.4/16")
@@ -456,7 +456,7 @@ func TestUpsertIPSecEndpointFwd(t *testing.T) {
 //     the exception that the mark match should be the TO_PROXY mark.
 //
 // 2. A state should be created with similar properties as above.
-func TestUpsertIPSecEndpointIn(t *testing.T) {
+func TestPrivilegedUpsertIPSecEndpointIn(t *testing.T) {
 	log := setupIPSecSuitePrivileged(t)
 
 	_, local, err := net.ParseCIDR("1.1.3.4/16")
@@ -561,7 +561,7 @@ func TestUpsertIPSecEndpointIn(t *testing.T) {
 	require.Equal(t, netlink.XFRM_MODE_TUNNEL, policyTmpl.Mode)
 }
 
-func TestUpsertIPSecKeyMissing(t *testing.T) {
+func TestPrivilegedUpsertIPSecKeyMissing(t *testing.T) {
 	log := setupIPSecSuitePrivileged(t)
 
 	_, local, err := net.ParseCIDR("1.1.3.4/16")
@@ -587,7 +587,7 @@ func TestUpsertIPSecKeyMissing(t *testing.T) {
 	require.ErrorContains(t, err, "unable to replace local state: global IPsec key missing")
 }
 
-func TestUpdateExistingIPSecEndpoint(t *testing.T) {
+func TestPrivilegedUpdateExistingIPSecEndpoint(t *testing.T) {
 	log := setupIPSecSuitePrivileged(t)
 
 	_, local, err := net.ParseCIDR("1.1.3.4/16")

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -697,7 +697,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(t *testing.T) {
 
 // Tests the same as TestNodeChurnXFRMLeaks, but in tunneling mode. As a
 // consequence, encrypted overlay will kick in.
-func TestNodeChurnXFRMLeaksEncryptedOverlay(t *testing.T) {
+func TestPrivilegedNodeChurnXFRMLeaksEncryptedOverlay(t *testing.T) {
 	s := setupLinuxPrivilegedIPv4OnlyTestSuite(t)
 	config := s.nodeConfigTemplate
 	config.EnableIPSec = true


### PR DESCRIPTION
This commit adds the TestPrivileged prefix to the node and ipsec linux tests.
In main this is not needed as it is already running from within a TestPrivileged
suite. While PRs related to similar fixes being backported from main https://github.com/cilium/cilium/pull/41078
and https://github.com/cilium/cilium/pull/41267 do sync up some tests, in v1.18 there were others that
needed the TestPrivileged prefix to be added. Here's the fix.

The last remaining bits will be the backport of https://github.com/cilium/cilium/pull/41279, which have not
been added to this PR for consistency with history.