### PR TITLE
helm: improve k8sServiceHost automatic lookup function

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -131,12 +131,16 @@ To override the namespace and configMap when using `auto`:
 {{- define "k8sServiceHost" }}
   {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
   {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}
-  {{- if and (eq .Values.k8sServiceHost "auto") (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
+  {{- if eq .Values.k8sServiceHost "auto" }}
     {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
-    {{- $kubeconfig := get $configmap.data "kubeconfig" }}
-    {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
-    {{- $uri := (split "https://" $k8sServer)._1 | trim }}
-    {{- (split ":" $uri)._0 | quote }}
+    {{- if $configmap }}
+      {{- $kubeconfig := get $configmap.data "kubeconfig" }}
+      {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
+      {{- $uri := (split "https://" $k8sServer)._1 | trim }}
+      {{- (split ":" $uri)._0 | quote }}
+    {{- else }}
+      {{- fail (printf "ConfigMap %s/%s not found, please create it or set k8sServiceHost to a valid value" $configmapNamespace $configmapName) }}
+    {{- end }}
   {{- else }}
     {{- .Values.k8sServiceHost | quote }}
   {{- end }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

In some edge-case scenarios, the chart gets installed before the cluster info ConfigMap has been created or populated. In such cases cilium gets deployed with an erroneous value ("auto") as the k8s service host and fails to start. The helm install operation won't fail immediately, but it will timeout eventually and get rolled back. This makes remediation difficult, specially with large install timeouts, which are often used on larger clusters.

With this change, if the k8s host auto discovery is requested in the chart values (by setting "auto" in `.Values.k8sServiceHost`), the chart will immediately fail to get installed if it can't find the cluster info ConfigMap, and the installer will be forced to retry the chart installation.
