### PR TITLE
node: Set Cluster, Skip equal nodes

### DIFF
--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -118,6 +119,7 @@ func TestScript(t *testing.T) {
 					},
 				),
 				node.LocalNodeStoreTestCell,
+				cell.Provide(func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} }),
 				cell.Invoke(func(lns_ *node.LocalNodeStore) { lns = lns_ }),
 			),
 			tableCells,

--- a/pkg/dial/resolver_test.go
+++ b/pkg/dial/resolver_test.go
@@ -184,6 +184,7 @@ func TestServiceBackendResolver(t *testing.T) {
 		writer.Cell,
 
 		cell.Provide(
+			func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
 			ServiceBackendResolverFactory("test1"),
 
 			func() *option.DaemonConfig { return &option.DaemonConfig{} },

--- a/pkg/loadbalancer/benchmark/benchmark.go
+++ b/pkg/loadbalancer/benchmark/benchmark.go
@@ -25,6 +25,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -539,6 +540,9 @@ func testHive(maps lbmaps.LBMaps,
 			node.LocalNodeStoreTestCell,
 
 			cell.Provide(
+				func() cmtypes.ClusterInfo {
+					return cmtypes.ClusterInfo{}
+				},
 				func() loadbalancer.Config {
 					return loadbalancer.Config{
 						UserConfig:  loadbalancer.DefaultUserConfig,

--- a/pkg/loadbalancer/cell/cell_test.go
+++ b/pkg/loadbalancer/cell/cell_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
@@ -38,8 +39,9 @@ func TestCell(t *testing.T) {
 		metrics.Cell,
 		kpr.Cell,
 		Cell,
-		cell.Provide(source.NewSources),
 		cell.Provide(
+			func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
+			source.NewSources,
 			tables.NewNodeAddressTable,
 			statedb.RWTable[tables.NodeAddress].ToTable,
 			func() *option.DaemonConfig {

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -86,6 +86,7 @@ func TestScript(t *testing.T) {
 				maglev.Cell,
 				node.LocalNodeStoreTestCell,
 				cell.Provide(
+					func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
 					func(cfg loadbalancer.TestConfig) *loadbalancer.TestConfig { return &cfg },
 					tables.NewNodeAddressTable,
 					statedb.RWTable[tables.NodeAddress].ToTable,

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
@@ -78,6 +79,7 @@ func TestScript(t *testing.T) {
 				node.LocalNodeStoreTestCell,
 				maglev.Cell,
 				cell.Provide(
+					func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
 					source.NewSources,
 					func() *loadbalancer.TestConfig { return &loadbalancer.TestConfig{} },
 					tables.NewNodeAddressTable,

--- a/pkg/loadbalancer/repl/main.go
+++ b/pkg/loadbalancer/repl/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
@@ -89,8 +90,9 @@ var Hive = hive.New(
 	metrics.Cell,
 	cell.Config(loadbalancer.TestConfig{}),
 	cell.Config(envoyCfg.SecretSyncConfig{}),
-	cell.Provide(source.NewSources),
 	cell.Provide(
+		func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
+		source.NewSources,
 		tables.NewNodeAddressTable,
 		statedb.RWTable[tables.NodeAddress].ToTable,
 		func() *option.DaemonConfig {

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
@@ -89,6 +90,7 @@ func TestScript(t *testing.T) {
 				maglev.Cell,
 				node.LocalNodeStoreTestCell,
 				cell.Provide(
+					func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
 					func(cfg loadbalancer.TestConfig) *loadbalancer.TestConfig { return &cfg },
 					tables.NewNodeAddressTable,
 					statedb.RWTable[tables.NodeAddress].ToTable,

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -18,8 +18,9 @@ import (
 	"github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
-	"github.com/cilium/cilium/pkg/clustermesh/types"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/kpr"
@@ -27,8 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
-
-	"k8s.io/utils/ptr"
 )
 
 type testParams struct {
@@ -50,6 +49,7 @@ func fixture(t testing.TB) (p testParams) {
 		node.LocalNodeStoreTestCell,
 		Cell,
 		cell.Provide(
+			func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
 			func() *option.DaemonConfig { return &option.DaemonConfig{} },
 			tables.NewNodeAddressTable,
 			statedb.RWTable[tables.NodeAddress].ToTable,
@@ -66,10 +66,10 @@ func fixture(t testing.TB) (p testParams) {
 	return p
 }
 
-func intToAddr(i int) types.AddrCluster {
+func intToAddr(i int) cmtypes.AddrCluster {
 	var addr [4]byte
 	binary.BigEndian.PutUint32(addr[:], 0x0100_0000+uint32(i))
-	addrCluster, _ := types.AddrClusterFromIP(addr[:])
+	addrCluster, _ := cmtypes.AddrClusterFromIP(addr[:])
 	return addrCluster
 }
 

--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/source"
@@ -43,12 +44,13 @@ var LocalNodeStoreCell = cell.Module(
 type LocalNodeStoreParams struct {
 	cell.In
 
-	Logger    *slog.Logger
-	Lifecycle cell.Lifecycle
-	Sync      LocalNodeSynchronizer
-	DB        *statedb.DB
-	Nodes     statedb.RWTable[*LocalNode]
-	Jobs      job.Group
+	Logger      *slog.Logger
+	Lifecycle   cell.Lifecycle
+	Sync        LocalNodeSynchronizer
+	DB          *statedb.DB
+	Nodes       statedb.RWTable[*LocalNode]
+	Jobs        job.Group
+	ClusterInfo cmtypes.ClusterInfo
 }
 
 // LocalNodeStore is the canonical owner for the local node object and provides
@@ -69,7 +71,9 @@ func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, error) {
 	params.Nodes.Insert(wtxn,
 		&LocalNode{
 			Node: types.Node{
-				Name: types.GetName(),
+				Name:      types.GetName(),
+				Cluster:   params.ClusterInfo.Name,
+				ClusterID: params.ClusterInfo.ID,
 				// Explicitly initialize the labels and annotations maps, so that
 				// we don't need to always check for nil values.
 				Labels:      make(map[string]string),
@@ -86,6 +90,9 @@ func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, error) {
 		OnStart: func(ctx cell.HookContext) error {
 			wtxn := params.DB.WriteTxn(params.Nodes)
 			n, _, _ := params.Nodes.Get(wtxn, LocalNodeQuery)
+			// Delete the initial one as name might change.
+			params.Nodes.Delete(wtxn, n)
+
 			n = n.DeepCopy()
 			err := params.Sync.InitLocalNode(ctx, n)
 			params.Nodes.Insert(wtxn, n)
@@ -184,11 +191,17 @@ func (s *LocalNodeStore) Update(update func(*LocalNode)) {
 	if !found {
 		panic("BUG: No local node exists")
 	}
+	orig := ln
 	ln = ln.DeepCopy()
 	update(ln)
 	if ln.Local == nil {
 		panic("BUG: Updated LocalNode has nil Local")
 	}
+	if orig.Fullname() != ln.Fullname() {
+		// Name or cluster has changed, delete first to remove it from the name index.
+		s.nodes.Delete(txn, orig)
+	}
+
 	s.nodes.Insert(txn, ln)
 }
 

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	. "github.com/cilium/cilium/pkg/node"
 )
@@ -78,6 +79,12 @@ func TestLocalNodeStore(t *testing.T) {
 	hive := hive.New(
 		LocalNodeStoreCell,
 
+		cell.Provide(func() cmtypes.ClusterInfo {
+			return cmtypes.ClusterInfo{
+				Name: "test",
+				ID:   1,
+			}
+		}),
 		cell.Provide(func() LocalNodeSynchronizer { return ts }),
 		cell.Invoke(observe),
 		cell.Invoke(update),

--- a/pkg/xds/experimental/client/cell_test.go
+++ b/pkg/xds/experimental/client/cell_test.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/node"
-
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-
 	discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	core_v1 "k8s.io/api/core/v1"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/node"
 )
 
 func TestCell_SuccessfullyRunClient(t *testing.T) {
@@ -26,6 +26,7 @@ func TestCell_SuccessfullyRunClient(t *testing.T) {
 		cell.Provide(NewInsecureGRPCOptionsProvider),
 		node.LocalNodeStoreTestCell,
 		Cell,
+		cell.Provide(func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} }),
 		cell.Invoke(func(localNodeStore *node.LocalNodeStore) {
 			localNodeStore.Update(func(n *node.LocalNode) {
 				hLog.Info("Update localNodeStore")


### PR DESCRIPTION
First commit sets the cluster name in the initial local node object so we won't end up with two objects in `Table[LocalNode]`'s name index (one with cluster, one without). This didn't cause issues since we only accessed via the "local" index thus far, but would've caused issues in the future when `Table[LocalNode]` becomes `Table[Node]`.

Second commit adds `DeepEqual` check to `LocalNodeStore.Update` to avoid inserting identical objects and waking up observers for no reason.