### PR TITLE
metrics: skip health metrics collection when healthchecking is disabled

### DIFF
--- a/pkg/metrics/status_test.go
+++ b/pkg/metrics/status_test.go
@@ -139,15 +139,32 @@ func Test_statusCollector_Collect(t *testing.T) {
 			expectedCount:        5,
 			expectedMetric:       expectedStatusMetric,
 		},
+		{
+			name:           "check status metrics without health checking",
+			healthResponse: sampleHealthResponse,
+			expectedCount:  3, // Only non-health metrics: controllers_failing, ip_addresses (IPv4 + IPv6)
+			expectedMetric: `# HELP cilium_controllers_failing Number of failing controllers
+# TYPE cilium_controllers_failing gauge
+cilium_controllers_failing 1
+# HELP cilium_ip_addresses Number of allocated IP addresses
+# TYPE cilium_ip_addresses gauge
+cilium_ip_addresses{family="ipv4"} 3
+cilium_ip_addresses{family="ipv6"} 3
+`,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Log("Test :", tt.name)
+		var connectivityClient connectivityStatusGetter
+		if tt.connectivityResponse != nil {
+			connectivityClient = &fakeConnectivityClient{
+				response: tt.connectivityResponse,
+			}
+		}
 		collector := newStatusCollectorWithClients(logger, &fakeDaemonClient{
 			response: tt.healthResponse,
-		}, &fakeConnectivityClient{
-			response: tt.connectivityResponse,
-		})
+		}, connectivityClient)
 
 		// perform static checks such as prometheus naming convention, number of labels matching, etc
 		lintProblems, err := testutil.CollectAndLint(collector)


### PR DESCRIPTION
Currently, disabling agent health checks with `--enable-health-checking=false`, causes a lot of error logs like

> Error while getting cilium-health status: Get "http://localhost/v1beta/status": dial unix /var/run/cilium/health.sock: connect: no such file or directory

This PR updates the agent metrics collection logic to skip collecting health related metrics if health checking is disabled.

```release-note
Fix bug that would cause error messages when disabling agent health checks
```