### PR TITLE
docs: document portmap binary requirements

### DIFF
--- a/Documentation/installation/cni-chaining-portmap.rst
+++ b/Documentation/installation/cni-chaining-portmap.rst
@@ -34,6 +34,11 @@ upstream documentation:
 Deploy Cilium with the portmap plugin enabled
 =============================================
 
+Install the ``portmap`` binaries. Some Kubernetes distributions will do this for
+you, in which case you don't need to do anything. However, if ``portmap`` is not
+available on your worker nodes, you must install it into ``/opt/cni/bin/``. You
+can find binaries from the `CNI project releases page <https://github.com/containernetworking/plugins/releases>`_.
+
 .. include:: k8s-install-download-release.rst
 
 Deploy Cilium release via Helm:


### PR DESCRIPTION
Some distributions (e.g. AWS EKS clusters without AWS VPC CNI plugin) do not install the `portmap` binary on the nodes, leading to confusion when trying to use the portmap plugin. This commit documents the requirement and hints at a solution for providing binaries if needed.