### PR TITLE
gha: run checkpatch check only on PR events

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -59,6 +59,7 @@ jobs:
   checkpatch:
     name: Check Patch
     runs-on: ubuntu-24.04
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Previously, the checkpatch script used to internally skip the checks when not targeting the main branch. The blamed commit bumped it to a more zealous version that runs against all target branches, and explicitly fails in case any internal command fails.

However, this check is now failing both on push and merge queue events, as the GITHUB_REF does not point to a PR. Let's prevent this by making it run on PR events only, to restore the previous behavior in this case. There's not much point in running checkpatch on already merged commits anyways; similarly, no reason for running it as part of the merge queue, given that the check is not required, and the result does not depend on whether the branch is rebased.

Fixes: 4a33221a8ddd ("checkpatch: bump checkpatch version, and minor adaptations")