### PR TITLE
ariane: allow for whitespaces after /test command

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -2,7 +2,7 @@ allowed-teams:
   - organization-members
 
 triggers:
-  /test:
+  /test\s*:
     workflows:
     - conformance-aws-cni.yaml
     - conformance-clustermesh.yaml


### PR DESCRIPTION
Related to https://github.com/cilium/cilium/pull/41154 and https://github.com/cilium/cilium/pull/41275

And Slack thread: https://cilium.slack.com/archives/C2B917YHE/p1755700884491629

