### PR TITLE
docs: include KubeCon talk showing Cilium, Prometheus & Grafana

### DIFF
--- a/Documentation/observability/grafana.rst
+++ b/Documentation/observability/grafana.rst
@@ -19,7 +19,7 @@ deployment.
 .. admonition:: Video
  :class: attention
 
-  You can also see Cilium and Grafana in action on `eCHO episode 68: Cilium & Grafana <https://www.youtube.com/watch?v=DdWksYq5Pv4>`__.
+  You can see Cilium, Prometheus and Grafana in action together in the KubeCon + CloudNativeCon talk `Effortless Open Source Observability with Cilium, Prometheus and Grafana <https://www.youtube.com/watch?v=l3zY7wHUkBA>`__.
 
 The default installation contains:
 


### PR DESCRIPTION
Link to a relevant KubeCon talk, in place of an eCHO episode (the link to which is no longer valid) 


