### PR TITLE
nodediscovery: Do not log error on kvstore update if context cancelled

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -182,7 +182,7 @@ func (n *NodeDiscovery) updateLocalNode(ctx context.Context, ln *node.LocalNode)
 					}
 
 					err := n.Registrar.UpdateLocalKeySync(ctx, &ln.Node)
-					if err != nil {
+					if err != nil && !errors.Is(err, context.Canceled) {
 						n.logger.Error("Unable to propagate local node change to kvstore", logfields.Error, err)
 					}
 					return err


### PR DESCRIPTION
The controller run is canceled if the controller is updated and this can happen if the local node changed while UpdateLocalKeySync() was being executed. This was seen in CI causing a failure:

```
level=error source=/go/src/github.com/cilium/cilium/pkg/nodediscovery/nodediscovery.go:186
  msg="Unable to propagate local node change to kvstore"
  module=agent.controlplane.nodediscovery
  error="request cancelled while waiting for rate limiting slot: context canceled" (1 occurrences)
```

Since it is normal for this to occur skip logging an error if the context is cancelled.