### PR TITLE
operator/pkg/lbipam: fix LoadBalancerIPPool conditions update logic

### DIFF
--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -824,6 +824,9 @@ func TestServiceDelete(t *testing.T) {
 			},
 		},
 	}
+	ipsUsed := getPoolStatusCount(fixture.GetPool("pool-a"), ciliumPoolIPsUsedCondition)
+	require.Equal(t, "0", ipsUsed)
+
 	fixture.UpsertSvc(t, svcA)
 	svcA = fixture.GetSvc("default", "service-a")
 
@@ -834,6 +837,8 @@ func TestServiceDelete(t *testing.T) {
 	if net.ParseIP(svcA.Status.LoadBalancer.Ingress[0].IP).To4() == nil {
 		t.Error("Expected service to receive a IPv4 address")
 	}
+	ipsUsed = getPoolStatusCount(fixture.GetPool("pool-a"), ciliumPoolIPsUsedCondition)
+	require.Equal(t, "1", ipsUsed)
 
 	svcIP := svcA.Status.LoadBalancer.Ingress[0].IP
 
@@ -846,6 +851,9 @@ func TestServiceDelete(t *testing.T) {
 	if _, has := fixture.lbipam.rangesStore.ranges[0].alloc.Get(netip.MustParseAddr(svcIP)); has {
 		t.Fatal("Service IP hasn't been released")
 	}
+	ipsUsed = getPoolStatusCount(fixture.GetPool("pool-a"), ciliumPoolIPsUsedCondition)
+	require.Equal(t, "0", ipsUsed)
+
 }
 
 // TestReallocOnInit tests the edge case where an existing service has an IP assigned for which there is no IP Pool.
@@ -2855,4 +2863,70 @@ func TestLBIPAMRestartOnFullPool(t *testing.T) {
 			require.Empty(t, svc.Status.LoadBalancer.Ingress)
 		}
 	}
+}
+
+func TestPoolShrink(t *testing.T) {
+	// Pool with two blocks
+	poolA := mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24", "10.0.11.0/24"})
+	fixture := mkTestFixture(t, true, true)
+	fixture.UpsertPool(t, poolA)
+
+	// Check initial state
+	p := fixture.GetPool("pool-a")
+	totalCount := getPoolStatusCount(p, ciliumPoolIPsTotalCondition)
+	require.Equal(t, "512", totalCount, "IPsTotal should be 512 initially")
+	availableCount := getPoolStatusCount(p, ciliumPoolIPsAvailableCondition)
+	require.Equal(t, "512", availableCount, "IPsAvailable should be 512 initially")
+	usedCount := getPoolStatusCount(p, ciliumPoolIPsUsedCondition)
+	require.Equal(t, "0", usedCount, "IPsUsed should be 0 initially")
+
+	// Create service to allocate one IP
+	svcA := &slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name:      "service-a",
+			Namespace: "default",
+			UID:       serviceAUID,
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type: slim_core_v1.ServiceTypeLoadBalancer,
+			IPFamilies: []slim_core_v1.IPFamily{
+				slim_core_v1.IPv4Protocol,
+			},
+		},
+	}
+	fixture.UpsertSvc(t, svcA)
+	svcA = fixture.GetSvc("default", "service-a")
+	require.Len(t, svcA.Status.LoadBalancer.Ingress, 1, "Expected service to receive exactly one ingress IP")
+
+	p = fixture.GetPool("pool-a")
+	require.Equal(t, "512", getPoolStatusCount(p, ciliumPoolIPsTotalCondition), "IPsTotal should be 512")
+	require.Equal(t, "511", getPoolStatusCount(p, ciliumPoolIPsAvailableCondition), "IPsAvailable should be 511")
+	require.Equal(t, "1", getPoolStatusCount(p, ciliumPoolIPsUsedCondition), "IPsUsed should be 1")
+
+	svcIP, err := netip.ParseAddr(svcA.Status.LoadBalancer.Ingress[0].IP)
+	require.NoError(t, err)
+	blockToKeep := "10.0.10.0/24"
+	if !netip.MustParsePrefix(blockToKeep).Contains(svcIP) {
+		blockToKeep = "10.0.11.0/24"
+	}
+
+	poolA = fixture.GetPool("pool-a")
+	poolA.Spec.Blocks = []cilium_api_v2.CiliumLoadBalancerIPPoolIPBlock{
+		{Cidr: cilium_api_v2.IPv4orIPv6CIDR(blockToKeep)},
+	}
+	fixture.UpsertPool(t, poolA)
+
+	p = fixture.GetPool("pool-a")
+	require.Equal(t, "256", getPoolStatusCount(p, ciliumPoolIPsTotalCondition), "IPsTotal should be 256")
+	require.Equal(t, "255", getPoolStatusCount(p, ciliumPoolIPsAvailableCondition), "IPsAvailable should be 255")
+	require.Equal(t, "1", getPoolStatusCount(p, ciliumPoolIPsUsedCondition), "IPsUsed should be 1")
+}
+
+func getPoolStatusCount(pool *cilium_api_v2.CiliumLoadBalancerIPPool, condType string) string {
+	for _, cond := range pool.Status.Conditions {
+		if cond.Type == condType {
+			return cond.Message
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

When deleting services that have an IP assigned from a LoadBalancerIPPool, the cilium.io/IPsUsed condition is not decremented properly. This commit adds a test for this behaviour. Additionally, when shrinking an IP pool, the IPsAvailable condition is not decremented properly. Both issues have the same root cause of setPoolCondition() being chained with ||, leading to short-circuit execution of only the conditions up to the first "true" return.

Fixes: #41321 
Fixes: #41536

```release-note
operator/pkg/lbipam: fix LoadBalancerIPPool conditions update logic
```
