### PR TITLE
clustermesh: homogenize ClusterMesh metrics based on watch store

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -371,10 +371,11 @@ Clustermesh
 =============================================== ============================================================ ========== =================================================================
 Name                                            Labels                                                       Default    Description
 =============================================== ============================================================ ========== =================================================================
-``clustermesh_global_services``                 ``source_cluster``, ``source_node_name``                     Enabled    The total number of global services in the cluster mesh
+``clustermesh_remote_cluster_services``         ``source_cluster``, ``source_node_name``, ``target_cluster`` Enabled    The total number of services per remote cluster
+``clustermesh_remote_cluster_endpoints``        ``source_cluster``, ``source_node_name``, ``target_cluster`` Enabled    The total number of endpoints per remote cluster
+``clustermesh_remote_cluster_nodes``            ``source_cluster``, ``source_node_name``, ``target_cluster`` Enabled    The total number of nodes per remote cluster
 ``clustermesh_remote_clusters``                 ``source_cluster``, ``source_node_name``                     Enabled    The total number of remote clusters meshed with the local cluster
 ``clustermesh_remote_cluster_failures``         ``source_cluster``, ``source_node_name``, ``target_cluster`` Enabled    The total number of failures related to the remote cluster
-``clustermesh_remote_cluster_nodes``            ``source_cluster``, ``source_node_name``, ``target_cluster`` Enabled    The total number of nodes in the remote cluster
 ``clustermesh_remote_cluster_last_failure_ts``  ``source_cluster``, ``source_node_name``, ``target_cluster`` Enabled    The timestamp of the last failure of the remote cluster
 ``clustermesh_remote_cluster_readiness_status`` ``source_cluster``, ``source_node_name``, ``target_cluster`` Enabled    The readiness status of the remote cluster
 =============================================== ============================================================ ========== =================================================================
@@ -866,6 +867,16 @@ Name                                                 Labels                     
 ``serviceexport_status_condition``   ``serviceexport``, ``namespace``, ``condition``, ``status``  Enabled    Status Condition of ServiceExport in the local cluster
 ``serviceimport_info``               ``serviceimport``, ``namespace``                             Enabled    Information about ServiceImport in the local cluster
 ==================================== ============================================================ ========== ===========================================================
+
+Clustermesh
+~~~~~~~~~~~
+
+============================================== ======================================= ========== ==================================================================
+Name                                           Labels                                  Default    Description
+============================================== ======================================= ========== ==================================================================
+``clustermesh_remote_cluster_services``        ``source_cluster``, ``target_cluster``  Enabled    The total number of services per remote cluster
+``clustermesh_remote_cluster_service_exports`` ``source_cluster``, ``target_cluster``  Enabled    The total number of MCS-API service exports per remote cluster
+============================================== ======================================= ========== ==================================================================
 
 
 Hubble

--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -73,7 +73,7 @@ you may perform the following steps to troubleshoot ClusterMesh issues.
 
  #. Validate that ClusterMesh is healthy running ``cilium-dbg status --all-clusters`` inside each Cilium agent::
 
-        ClusterMesh:   1/1 remote clusters ready, 10 global-services
+        ClusterMesh:   1/1 remote clusters ready
            k8s-c2: ready, 3 nodes, 25 endpoints, 8 identities, 10 services, 0 MCS-API service exports, 0 reconnections (last: never)
            └  etcd: 1/1 connected, leases=0, lock lease-ID=7c028201b53de662, has-quorum=true: https://k8s-c2.mesh.cilium.io:2379 - 3.5.4 (Leader)
            └  remote configuration: expected=true, retrieved=true, cluster-id=3, kvstoremesh=false, sync-canaries=true, service-exports=disabled

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -356,6 +356,8 @@ Bugtool Options
 
 Added Metrics
 ~~~~~~~~~~~~~
+* ``cilium_agent_clustermesh_remote_cluster_endpoints`` was added and report
+  the total number of endpoints per remote cluster in a ClusterMesh environment.
 
 Removed Metrics
 ~~~~~~~~~~~~~~~
@@ -380,6 +382,15 @@ As well, any remaining Operator k8s workqueue metrics that use the label ``queue
 * The metric ``workqueue_work_duration_seconds`` has been renamed and combined into ``cilium_operator_k8s_workqueue_work_duration_seconds``, the label ``queue_name`` has been renamed to ``name``.
 
 * ``k8s_client_rate_limiter_duration_seconds`` no longer has labels ``path`` and ``method``.
+
+The following metrics:
+* ``cilium_agent_clustermesh_global_services``
+* ``cilium_operator_clustermesh_global_services``
+* ``cilium_operator_clustermesh_global_service_exports``
+now report per cluster metric instead of a "global" count and were renamed to respectively:
+* ``cilium_agent_clustermesh_remote_cluster_services``
+* ``cilium_operator_clustermesh_remote_cluster_services``
+* ``cilium_operator_clustermesh_remote_cluster_service_exports``
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -305,7 +305,8 @@ communicating via the proxy must reconnect to re-establish connections.
   to update your network policies.
 * Kafka Network Policy support is deprecated and will be removed in Cilium v1.20.
 * Hubble field mask support was stabilized. In the Observer gRPC API, ``GetFlowsRequest.Experimental.field_mask`` was removed in favor of ``GetFlowsRequest.field_mask``. In the Hubble CLI, the ``--experimental-field-mask`` has been renamed to ``--field-mask`` and ``--experimental-use-default-field-mask`` renamed to ``-use-default-field-mask`` (now ``true`` by default).
-
+* Cilium-agent ClusterMesh status will no longer report the global services count. When using the CLI
+  with a version lower than 1.19, the global services count will be reported as 0.
 * ``enable-remote-node-masquerade`` config option is introduced.
   To masquerade traffic to remote nodes in BPF masquerading mode,
   use the option ``enable-remote-node-masquerade: "true"``.

--- a/api/v1/models/cluster_mesh_status.go
+++ b/api/v1/models/cluster_mesh_status.go
@@ -26,9 +26,6 @@ type ClusterMeshStatus struct {
 
 	// List of remote clusters
 	Clusters []*RemoteCluster `json:"clusters"`
-
-	// Number of global services
-	NumGlobalServices int64 `json:"num-global-services,omitempty"`
 }
 
 // Validate validates this cluster mesh status

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2339,9 +2339,6 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/RemoteCluster"
-      num-global-services:
-        description: Number of global services
-        type: integer
   RemoteCluster:
     description: |-
       Status of remote cluster

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2200,10 +2200,6 @@ func init() {
           "items": {
             "$ref": "#/definitions/RemoteCluster"
           }
-        },
-        "num-global-services": {
-          "description": "Number of global services",
-          "type": "integer"
         }
       }
     },
@@ -7569,10 +7565,6 @@ func init() {
           "items": {
             "$ref": "#/definitions/RemoteCluster"
           }
-        },
-        "num-global-services": {
-          "description": "Number of global services",
-          "type": "integer"
         }
       }
     },

--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -682,15 +682,6 @@ func remoteClusterStatusToError(status *models.RemoteCluster) error {
 }
 
 func (c *ConnectivityStatus) parseAgentStatus(name string, expected []string, s *status.ClusterMeshAgentConnectivityStatus) {
-	if c.GlobalServices.Min < 0 || c.GlobalServices.Min > s.GlobalServices {
-		c.GlobalServices.Min = s.GlobalServices
-	}
-
-	if c.GlobalServices.Max < s.GlobalServices {
-		c.GlobalServices.Max = s.GlobalServices
-	}
-
-	c.GlobalServices.Avg += float64(s.GlobalServices)
 	c.Total++
 
 	ready := int64(0)

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -92,9 +92,8 @@ func NewK8sStatusCollector(client k8sImplementation, params K8sStatusParameters)
 }
 
 type ClusterMeshAgentConnectivityStatus struct {
-	GlobalServices int64
-	Clusters       map[string]*models.RemoteCluster
-	Errors         ErrorCountMap
+	Clusters map[string]*models.RemoteCluster
+	Errors   ErrorCountMap
 }
 
 // ErrClusterMeshStatusNotAvailable is a sentinel.
@@ -117,7 +116,6 @@ func (k *K8sStatusCollector) ClusterMeshConnectivity(ctx context.Context, cilium
 		return nil, ErrClusterMeshStatusNotAvailable
 	}
 
-	c.GlobalServices = status.ClusterMesh.NumGlobalServices
 	for _, cluster := range status.ClusterMesh.Clusters {
 		c.Clusters[cluster.Name] = cluster
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -436,8 +436,8 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 	}
 
 	if sr.ClusterMesh != nil {
-		fmt.Fprintf(w, "ClusterMesh:\t%d/%d remote clusters ready, %d global-services\n",
-			NumReadyClusters(sr.ClusterMesh.Clusters), len(sr.ClusterMesh.Clusters), sr.ClusterMesh.NumGlobalServices)
+		fmt.Fprintf(w, "ClusterMesh:\t%d/%d remote clusters ready\n",
+			NumReadyClusters(sr.ClusterMesh.Clusters), len(sr.ClusterMesh.Clusters))
 
 		verbosity := RemoteClustersStatusNotReadyOnly
 		if sd.AllClusters {

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -211,12 +211,14 @@ func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) c
 		),
 		&clusterServiceObserver{serviceMerger: cm.conf.ServiceMerger},
 		store.RWSWithOnSyncCallback(func(ctx context.Context) { close(rc.synced.services) }),
+		store.RWSWithEntriesMetric(cm.conf.Metrics.TotalServices.WithLabelValues(cm.conf.ClusterInfo.Name, cm.nodeName, rc.name)),
 	)
 
 	rc.ipCacheWatcher = ipcache.NewIPIdentityWatcher(
 		cm.conf.Logger,
 		name, cm.conf.IPCache, cm.conf.StoreFactory, source.ClusterMesh,
 		store.RWSWithOnSyncCallback(func(ctx context.Context) { close(rc.synced.ipcache) }),
+		store.RWSWithEntriesMetric(cm.conf.Metrics.TotalEndpoints.WithLabelValues(cm.conf.ClusterInfo.Name, cm.nodeName, rc.name)),
 	)
 	rc.ipCacheWatcherExtraOpts = cm.conf.IPCacheWatcherExtraOpts
 

--- a/pkg/clustermesh/common/services.go
+++ b/pkg/clustermesh/common/services.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
 type GlobalService struct {
@@ -30,16 +29,12 @@ type GlobalServiceCache struct {
 	logger *slog.Logger
 	mutex  lock.RWMutex
 	byName map[types.NamespacedName]*GlobalService
-
-	// metricTotalGlobalServices is the gauge metric for total of global services
-	metricTotalGlobalServices metric.Gauge
 }
 
-func NewGlobalServiceCache(logger *slog.Logger, metricTotalGlobalServices metric.Gauge) *GlobalServiceCache {
+func NewGlobalServiceCache(logger *slog.Logger) *GlobalServiceCache {
 	return &GlobalServiceCache{
-		logger:                    logger,
-		byName:                    map[types.NamespacedName]*GlobalService{},
-		metricTotalGlobalServices: metricTotalGlobalServices,
+		logger: logger,
+		byName: map[types.NamespacedName]*GlobalService{},
 	}
 }
 
@@ -101,7 +96,6 @@ func (c *GlobalServiceCache) OnUpdate(svc *serviceStore.ClusterService) {
 			logfields.ServiceName, svc,
 			logfields.ClusterName, svc.Cluster,
 		)
-		c.metricTotalGlobalServices.Set(float64(len(c.byName)))
 	}
 
 	c.logger.Debug(
@@ -137,7 +131,6 @@ func (c *GlobalServiceCache) delete(globalService *GlobalService, clusterName st
 			logfields.ClusterName, clusterName,
 		)
 		delete(c.byName, serviceNN)
-		c.metricTotalGlobalServices.Set(float64(len(c.byName)))
 	}
 
 	return true

--- a/pkg/clustermesh/common/services_test.go
+++ b/pkg/clustermesh/common/services_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
-	"github.com/cilium/cilium/pkg/metrics"
 )
 
 type fakeUpstream struct {
@@ -32,7 +31,7 @@ func TestRemoteServiceObserver(t *testing.T) {
 	}
 	svc1 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name", IncludeExternal: false, Shared: true}
 	svc2 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name"}
-	cache := NewGlobalServiceCache(hivetest.Logger(t), metrics.NoOpGauge)
+	cache := NewGlobalServiceCache(hivetest.Logger(t))
 
 	var upstream fakeUpstream
 	observer := NewSharedServicesObserver(hivetest.Logger(t), cache, upstream.OnUpdate, upstream.OnDelete)

--- a/pkg/clustermesh/endpointslicesync/endpointslice_test.go
+++ b/pkg/clustermesh/endpointslicesync/endpointslice_test.go
@@ -31,7 +31,6 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
 const (
@@ -113,7 +112,7 @@ func Test_meshEndpointSlice_Reconcile(t *testing.T) {
 	}
 	defer hive.Stop(tlog, context.Background())
 
-	globalService := common.NewGlobalServiceCache(hivetest.Logger(t), metric.NewGauge(metric.GaugeOpts{}))
+	globalService := common.NewGlobalServiceCache(hivetest.Logger(t))
 	podInformer := newMeshPodInformer(logger, globalService)
 	nodeInformer := newMeshNodeInformer(logger)
 	controller, serviceInformer, endpointsliceInformer := newEndpointSliceMeshController(

--- a/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
@@ -26,7 +26,6 @@ import (
 
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
-	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
 const (
@@ -503,7 +502,7 @@ func Test_mcsServiceImport_Reconcile(t *testing.T) {
 		WithStatusSubresource(&mcsapiv1alpha1.ServiceImport{}).
 		WithScheme(testScheme()).
 		Build()
-	globalServiceExports := operator.NewGlobalServiceExportCache(metric.NewGauge(metric.GaugeOpts{}))
+	globalServiceExports := operator.NewGlobalServiceExportCache()
 	remoteClusterServiceSource := &remoteClusterServiceExportSource{Logger: hivetest.Logger(t)}
 	for _, svcExport := range remoteSvcImportTestFixtures {
 		globalServiceExports.OnUpdate(svcExport)

--- a/pkg/clustermesh/metrics.go
+++ b/pkg/clustermesh/metrics.go
@@ -9,11 +9,14 @@ import (
 )
 
 type Metrics struct {
-	// TotalNodes tracks the number of total nodes in a remote cluster.
+	// TotalNodes tracks the number of total nodes per remote cluster.
 	TotalNodes metric.Vec[metric.Gauge]
 
-	// TotalGlobalServices tracks the total number of global services.
-	TotalGlobalServices metric.Vec[metric.Gauge]
+	// TotalServices tracks the number of total services per remote cluster.
+	TotalServices metric.Vec[metric.Gauge]
+
+	// TotalEndpoints tracks the number of total IPs per remote cluster.
+	TotalEndpoints metric.Vec[metric.Gauge]
 }
 
 func NewMetrics() Metrics {
@@ -26,12 +29,20 @@ func NewMetrics() Metrics {
 			Help:       "The total number of nodes in the remote cluster",
 		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
 
-		TotalGlobalServices: metric.NewGaugeVec(metric.GaugeOpts{
-			ConfigName: metrics.Namespace + "_" + subsystem + "_global_services",
+		TotalServices: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_services",
 			Namespace:  metrics.Namespace,
 			Subsystem:  subsystem,
-			Name:       "global_services",
-			Help:       "The total number of global services in the cluster mesh",
-		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName}),
+			Name:       "remote_cluster_services",
+			Help:       "The total number of services in the remote cluster",
+		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
+
+		TotalEndpoints: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_endpoints",
+			Namespace:  metrics.Namespace,
+			Subsystem:  subsystem,
+			Name:       "remote_cluster_endpoints",
+			Help:       "The total number of endpoints in the remote cluster",
+		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
 	}
 }

--- a/pkg/clustermesh/operator/metrics.go
+++ b/pkg/clustermesh/operator/metrics.go
@@ -9,25 +9,25 @@ import (
 )
 
 type Metrics struct {
-	// TotalGlobalServices tracks the total number of global services.
-	TotalGlobalServices metric.Vec[metric.Gauge]
-	// TotalGlobalServiceExports tracks the total number of global service exports.
-	TotalGlobalServiceExports metric.Vec[metric.Gauge]
+	// TotalServices tracks the number of total global services per remote cluster.
+	TotalServices metric.Vec[metric.Gauge]
+	// TotalServiceExports tracks the number of total MCS-API service exports per remote cluster.
+	TotalServiceExports metric.Vec[metric.Gauge]
 }
 
 func NewMetrics() Metrics {
 	return Metrics{
-		TotalGlobalServices: metric.NewGaugeVec(metric.GaugeOpts{
+		TotalServices: metric.NewGaugeVec(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
 			Subsystem: subsystem,
-			Name:      "global_services",
-			Help:      "The total number of global services in the cluster mesh",
-		}, []string{metrics.LabelSourceCluster}),
-		TotalGlobalServiceExports: metric.NewGaugeVec(metric.GaugeOpts{
+			Name:      "remote_cluster_services",
+			Help:      "The total number of services in the remote cluster",
+		}, []string{metrics.LabelSourceCluster, metrics.LabelTargetCluster}),
+		TotalServiceExports: metric.NewGaugeVec(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
 			Subsystem: subsystem,
-			Name:      "global_service_exports",
-			Help:      "The total number of MCS-API global service exports in the cluster mesh",
-		}, []string{metrics.LabelSourceCluster}),
+			Name:      "remote_cluster_service_exports",
+			Help:      "The total number of MCS-API service exports in the remote cluster",
+		}, []string{metrics.LabelSourceCluster, metrics.LabelTargetCluster}),
 	}
 }

--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -87,17 +87,17 @@ func TestRemoteClusterStatus(t *testing.T) {
 				require.NoError(t, client.DeletePrefix(context.Background(), kvstore.BaseKeyPrefix))
 			})
 
-			metrics := NewMetrics()
 			logger := hivetest.Logger(t)
+			metrics := NewMetrics()
 			cm := clusterMesh{
-				logger:         logger,
-				storeFactory:   st,
-				globalServices: common.NewGlobalServiceCache(logger, metrics.TotalGlobalServices.WithLabelValues("foo")),
-				globalServiceExports: NewGlobalServiceExportCache(
-					metrics.TotalGlobalServiceExports.WithLabelValues("foo"),
-				),
-				cfg:       ClusterMeshConfig{ClusterMeshEnableEndpointSync: tt.clusterMeshEnableEndpointSync},
-				cfgMCSAPI: MCSAPIConfig{ClusterMeshEnableMCSAPI: tt.clusterMeshEnableMCSAPI},
+				logger:               logger,
+				clusterInfo:          types.ClusterInfo{ID: 1, Name: "cluster1", MaxConnectedClusters: 255},
+				metrics:              metrics,
+				storeFactory:         st,
+				globalServices:       common.NewGlobalServiceCache(logger),
+				globalServiceExports: NewGlobalServiceExportCache(),
+				cfg:                  ClusterMeshConfig{ClusterMeshEnableEndpointSync: tt.clusterMeshEnableEndpointSync},
+				cfgMCSAPI:            MCSAPIConfig{ClusterMeshEnableMCSAPI: tt.clusterMeshEnableMCSAPI},
 			}
 
 			// Populate the kvstore with the appropriate KV pairs
@@ -186,15 +186,15 @@ func TestRemoteClusterHooks(t *testing.T) {
 		wg.Wait()
 	})
 	logger := hivetest.Logger(t)
-	st := store.NewFactory(logger, store.MetricsProvider())
 	metrics := NewMetrics()
+	st := store.NewFactory(logger, store.MetricsProvider())
 	cm := clusterMesh{
-		logger:         logger,
-		storeFactory:   st,
-		globalServices: common.NewGlobalServiceCache(logger, metrics.TotalGlobalServices.WithLabelValues("foo")),
-		globalServiceExports: NewGlobalServiceExportCache(
-			metrics.TotalGlobalServiceExports.WithLabelValues("foo"),
-		),
+		logger:               logger,
+		clusterInfo:          types.ClusterInfo{ID: 1, Name: "cluster1", MaxConnectedClusters: 255},
+		metrics:              metrics,
+		storeFactory:         st,
+		globalServices:       common.NewGlobalServiceCache(logger),
+		globalServiceExports: NewGlobalServiceExportCache(),
 	}
 
 	clusterAddCalledCount := atomic.Uint32{}

--- a/pkg/clustermesh/operator/service_exports.go
+++ b/pkg/clustermesh/operator/service_exports.go
@@ -12,7 +12,6 @@ import (
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
 type (
@@ -28,14 +27,11 @@ type GlobalServiceExportCache struct {
 	// size is used to manage a counter of globalServiceExport
 	// as uint instead of the float of metric.Gauge as float are not reliable to count
 	size uint64
-	// metricTotalGlobalServiceExports is the gauge metric for total of global service exports
-	metricTotalGlobalServiceExports metric.Gauge
 }
 
-func NewGlobalServiceExportCache(metricTotalGlobalServiceExports metric.Gauge) *GlobalServiceExportCache {
+func NewGlobalServiceExportCache() *GlobalServiceExportCache {
 	return &GlobalServiceExportCache{
-		cache:                           ServiceExportsByNamespace{},
-		metricTotalGlobalServiceExports: metricTotalGlobalServiceExports,
+		cache: ServiceExportsByNamespace{},
 	}
 }
 
@@ -79,7 +75,6 @@ func (c *GlobalServiceExportCache) OnUpdate(svcExport *mcsapitypes.MCSAPIService
 		svcExportsByCluster = ServiceExportsByCluster{}
 		svcExportsByName[svcExport.Name] = svcExportsByCluster
 		c.size += 1
-		c.metricTotalGlobalServiceExports.Set(float64(c.size))
 	}
 
 	svcExportsByCluster[svcExport.Cluster] = svcExport
@@ -109,7 +104,6 @@ func (c *GlobalServiceExportCache) OnDelete(svcExport *mcsapitypes.MCSAPIService
 		return true
 	}
 	c.size -= 1
-	c.metricTotalGlobalServiceExports.Set(float64(c.size))
 	delete(svcExportsByName, svcExport.Name)
 
 	if len(c.cache[svcExport.Namespace]) != 0 {

--- a/pkg/clustermesh/operator/service_exports_test.go
+++ b/pkg/clustermesh/operator/service_exports_test.go
@@ -13,10 +13,7 @@ import (
 )
 
 func TestGlobalServiceExportCache(t *testing.T) {
-	metrics := NewMetrics()
-	globalServiceExports := NewGlobalServiceExportCache(
-		metrics.TotalGlobalServiceExports.WithLabelValues("foo"),
-	)
+	globalServiceExports := NewGlobalServiceExportCache()
 
 	globalServiceExports.OnUpdate(&mcsapitypes.MCSAPIServiceSpec{
 		Cluster:   "cluster1",

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/clustermesh/common"
 	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
@@ -24,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
-	"github.com/cilium/cilium/pkg/metrics"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -166,7 +164,6 @@ func TestRemoteClusterRun(t *testing.T) {
 					FeatureMetrics:        NewClusterMeshMetricsNoop(),
 					Logger:                logger,
 				},
-				globalServices: common.NewGlobalServiceCache(logger, metrics.NoOpGauge),
 				FeatureMetrics: NewClusterMeshMetricsNoop(),
 			}
 			rc := cm.NewRemoteCluster("foo", nil).(*remoteCluster)
@@ -297,7 +294,6 @@ func TestRemoteClusterClusterIDChange(t *testing.T) {
 			Logger:                logger,
 		},
 		FeatureMetrics: NewClusterMeshMetricsNoop(),
-		globalServices: common.NewGlobalServiceCache(logger, metrics.NoOpGauge),
 	}
 	rc := cm.NewRemoteCluster("foo", nil).(*remoteCluster)
 


### PR DESCRIPTION
This homogenize the ClusterMesh metrics which rely on the watch store and report per remote cluster metrics.

This also remove the usage of GlobalServiceCache in the agent which was only useful to count the number of global Service.  This count didn't accounted the local cluster and thus is misleading. While I haven't tested to what extent this improves performance, it remove managing two level of nested maps and a global lock for the cache.

Identities entries doesn't rely on the watch store and I haven't added a metrics for those here though (+ also that includes the metric `initial_sync_completed` which is available via the watch store). We should probably add those to identities as well at some point too!

See the commits for a bit more details.

Question: should we add `_total` as suffix for those metrics considering that none of the ClusterMesh metrics does that today but according to https://prometheus.io/docs/practices/naming/#metric-names we should have those in most ClusterMesh metrics??

Fixes #40771

```release-note
clustermesh: add endpoints metrics and change global service (and MCS ServiceExport) metrics to report per cluster metrics instead of a global count
```
