### PR TITLE
datapath/linux: fix comment for invalid ASSIGN_CONFIG types

### DIFF
--- a/pkg/datapath/linux/config/utils.go
+++ b/pkg/datapath/linux/config/utils.go
@@ -49,7 +49,7 @@ func assignConfig(name string, value any) string {
 	case uint64:
 		t = "__u64"
 	default:
-		return fmt.Sprintf("/* BUG: %s has invalid type for ASSIGN_CONFIG: %T/*\n", name, value)
+		return fmt.Sprintf("/* BUG: %s has invalid type for ASSIGN_CONFIG: %T*/\n", name, value)
 	}
 	return fmt.Sprintf("ASSIGN_CONFIG(%s, %s, %v);\n", t, name, value)
 }


### PR DESCRIPTION
Return a properly terminated C-style comment when `assignConfig` encounters an unsupported value type. This prevents unterminated comment blocks in generated configuration files.
