### PR TITLE
pkg/lrp: add PreferredIPaddresses field

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
@@ -116,6 +116,14 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
+                  preferredIPaddresses:
+                    description: |-
+                      PreferredIPAddresses is a list of IP addresses used to override the Pod IP assigned by Kubernetes.
+                      This is useful when redirecting pod traffic to a DaemonSet running in the host network namespace,
+                      listening on the loopback interface or other interfaces for which Cilium cannot obtain the IP from Kubernetes.
+                    items:
+                      type: string
+                    type: array
                   toPorts:
                     description: |-
                       ToPorts is a list of L4 ports with protocol of node local pod(s) where traffic

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -141,6 +141,12 @@ type RedirectBackend struct {
 	// +kubebuilder:validation:Required
 	LocalEndpointSelector slim_metav1.LabelSelector `json:"localEndpointSelector"`
 
+	// PreferredIPAddresses is a list of IP addresses used to override the Pod IP assigned by Kubernetes.
+	// This is useful when redirecting pod traffic to a DaemonSet running in the host network namespace,
+	// listening on the loopback interface or other interfaces for which Cilium cannot obtain the IP from Kubernetes.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Items:={Pattern=`((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))`}
+	PreferredIPaddresses []string `json:"preferredIPaddresses,omitempty"`
 	// ToPorts is a list of L4 ports with protocol of node local pod(s) where traffic
 	// is redirected to.
 	// When multiple ports are specified, the ports must be named.

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
@@ -2656,6 +2656,11 @@ func (in *PortInfo) DeepCopy() *PortInfo {
 func (in *RedirectBackend) DeepCopyInto(out *RedirectBackend) {
 	*out = *in
 	in.LocalEndpointSelector.DeepCopyInto(&out.LocalEndpointSelector)
+	if in.PreferredIPaddresses != nil {
+		in, out := &in.PreferredIPaddresses, &out.PreferredIPaddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ToPorts != nil {
 		in, out := &in.ToPorts, &out.ToPorts
 		*out = make([]PortInfo, len(*in))

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -2370,6 +2370,23 @@ func (in *RedirectBackend) DeepEqual(other *RedirectBackend) bool {
 		return false
 	}
 
+	if ((in.PreferredIPaddresses != nil) && (other.PreferredIPaddresses != nil)) || ((in.PreferredIPaddresses == nil) != (other.PreferredIPaddresses == nil)) {
+		in, other := &in.PreferredIPaddresses, &other.PreferredIPaddresses
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	if ((in.ToPorts != nil) && (other.ToPorts != nil)) || ((in.ToPorts == nil) != (other.ToPorts == nil)) {
 		in, other := &in.ToPorts, &other.ToPorts
 		if other == nil {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -734,6 +734,8 @@ const (
 	LRPLocalEndpointSelector = "lrpLocalEndpointSelector"
 
 	// LRPBackendPorts are the parsed backend ports of the Local Redirect Policy.
+	LRPPreferredIPaddresses = "lrpPreferredIPaddresses"
+	// LRPBackendPorts are the parsed backend ports of the Local Redirect Policy.
 	LRPBackendPorts = "lrpBackendPorts"
 
 	// LRPType is the type of the Local Redirect Policy.


### PR DESCRIPTION
This commit introduces a new field, PreferredIPaddresses, to the RedirectBackend struct and the corresponding CiliumLocalRedirectPolicy CRD. This field allows users to specify a list of IP addresses to override the Pod IP assigned by Kubernetes, facilitating traffic redirection to DaemonSets in the host network namespace. Additionally, updates to the controller and related functions ensure proper handling of this new field.

 Signed-off-by: Liyi Huang <liyi.huang@isovalent.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
