### PR TITLE
Add missing fuzzers from cncf-fuzzing project

### DIFF
--- a/pkg/fqdn/matchpattern/fuzz_test.go
+++ b/pkg/fqdn/matchpattern/fuzz_test.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package matchpattern
+
+func FuzzMatchpatternValidate(data []byte) int {
+	_, _ = Validate(string(data))
+	return 1
+}
+
+func FuzzMatchpatternValidateWithoutCache(data []byte) int {
+	_, _ = ValidateWithoutCache(string(data))
+	return 1
+}

--- a/pkg/fqdn/matchpattern/fuzz_test.go
+++ b/pkg/fqdn/matchpattern/fuzz_test.go
@@ -2,12 +2,16 @@
 // Copyright Authors of Cilium
 package matchpattern
 
-func FuzzMatchpatternValidate(data []byte) int {
-	_, _ = Validate(string(data))
-	return 1
+import "testing"
+
+func FuzzMatchpatternValidate(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = Validate(string(data))
+	})
 }
 
-func FuzzMatchpatternValidateWithoutCache(data []byte) int {
-	_, _ = ValidateWithoutCache(string(data))
-	return 1
+func FuzzMatchpatternValidateWithoutCache(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ValidateWithoutCache(string(data))
+	})
 }

--- a/pkg/hubble/parser/fuzz_test.go
+++ b/pkg/hubble/parser/fuzz_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package parser
+
+import (
+	"log/slog"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
+)
+
+var (
+	payloads = map[int]string{
+		0: "PerfEvent",
+		1: "AgentEvent",
+		2: "LostEvent",
+	}
+)
+
+func FuzzParserDecode(data []byte) int {
+	p, err := New(slog.New(slog.DiscardHandler), nil, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return 0
+	}
+
+	f := fuzz.NewConsumer(data)
+	payloadType, err := f.GetInt()
+	if err != nil {
+		return 0
+	}
+
+	mo := &observerTypes.MonitorEvent{}
+
+	switch payloads[payloadType%len(payloads)] {
+	case "PerfEvent":
+		pe := &observerTypes.PerfEvent{}
+		f.GenerateStruct(pe)
+		mo.Payload = pe
+	case "AgentEvent":
+		ae := &observerTypes.AgentEvent{}
+		f.GenerateStruct(ae)
+		mo.Payload = ae
+	case "LostEvent":
+		le := &observerTypes.LostEvent{}
+		f.GenerateStruct(le)
+		mo.Payload = le
+	}
+	_, _ = p.Decode(mo)
+	return 0
+}

--- a/pkg/hubble/parser/fuzz_test.go
+++ b/pkg/hubble/parser/fuzz_test.go
@@ -4,6 +4,7 @@ package parser
 
 import (
 	"log/slog"
+	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
@@ -18,34 +19,35 @@ var (
 	}
 )
 
-func FuzzParserDecode(data []byte) int {
-	p, err := New(slog.New(slog.DiscardHandler), nil, nil, nil, nil, nil, nil, nil)
-	if err != nil {
-		return 0
-	}
+func FuzzParserDecode(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		p, err := New(slog.New(slog.DiscardHandler), nil, nil, nil, nil, nil, nil, nil)
+		if err != nil {
+			return
+		}
 
-	f := fuzz.NewConsumer(data)
-	payloadType, err := f.GetInt()
-	if err != nil {
-		return 0
-	}
+		f := fuzz.NewConsumer(data)
+		payloadType, err := f.GetInt()
+		if err != nil {
+			return
+		}
 
-	mo := &observerTypes.MonitorEvent{}
+		mo := &observerTypes.MonitorEvent{}
 
-	switch payloads[payloadType%len(payloads)] {
-	case "PerfEvent":
-		pe := &observerTypes.PerfEvent{}
-		f.GenerateStruct(pe)
-		mo.Payload = pe
-	case "AgentEvent":
-		ae := &observerTypes.AgentEvent{}
-		f.GenerateStruct(ae)
-		mo.Payload = ae
-	case "LostEvent":
-		le := &observerTypes.LostEvent{}
-		f.GenerateStruct(le)
-		mo.Payload = le
-	}
-	_, _ = p.Decode(mo)
-	return 0
+		switch payloads[payloadType%len(payloads)] {
+		case "PerfEvent":
+			pe := &observerTypes.PerfEvent{}
+			f.GenerateStruct(pe)
+			mo.Payload = pe
+		case "AgentEvent":
+			ae := &observerTypes.AgentEvent{}
+			f.GenerateStruct(ae)
+			mo.Payload = ae
+		case "LostEvent":
+			le := &observerTypes.LostEvent{}
+			f.GenerateStruct(le)
+			mo.Payload = le
+		}
+		_, _ = p.Decode(mo)
+	})
 }

--- a/pkg/k8s/slim/k8s/apis/labels/fuzz_test.go
+++ b/pkg/k8s/slim/k8s/apis/labels/fuzz_test.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package labels
+
+func FuzzLabelsParse(data []byte) int {
+	_, _ = Parse(string(data))
+	return 1
+}

--- a/pkg/k8s/slim/k8s/apis/labels/fuzz_test.go
+++ b/pkg/k8s/slim/k8s/apis/labels/fuzz_test.go
@@ -2,7 +2,10 @@
 // Copyright Authors of Cilium
 package labels
 
-func FuzzLabelsParse(data []byte) int {
-	_, _ = Parse(string(data))
-	return 1
+import "testing"
+
+func FuzzLabelsParse(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = Parse(string(data))
+	})
 }

--- a/pkg/labelsfilter/fuzz_test.go
+++ b/pkg/labelsfilter/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -52,7 +53,9 @@ func FuzzLabelsfilterPkg(f *testing.F) {
 
 		lbls := labels.Map2Labels(stringMap, source)
 
-		file, err := os.Create("file")
+		baseDir := t.TempDir()
+		path := filepath.Join(baseDir, "cilium_fuzz_labelsfilter")
+		file, err := os.Create(path)
 		if err != nil {
 			return
 		}
@@ -63,7 +66,7 @@ func FuzzLabelsfilterPkg(f *testing.F) {
 			return
 		}
 
-		err = ParseLabelPrefixCfg(slog.New(slog.DiscardHandler), prefixes, nodePrefixes, "file")
+		err = ParseLabelPrefixCfg(slog.New(slog.DiscardHandler), prefixes, nodePrefixes, path)
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/pkg/labelsfilter/fuzz_test.go
+++ b/pkg/labelsfilter/fuzz_test.go
@@ -7,60 +7,67 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
 	"github.com/cilium/cilium/pkg/labels"
 )
 
-func FuzzLabelsfilterPkg(data []byte) int {
-	f := fuzz.NewConsumer(data)
+func FuzzLabelsfilterPkg(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		f := fuzz.NewConsumer(data)
 
-	prefixes := make([]string, 0)
-	err := f.CreateSlice(&prefixes)
-	if err != nil {
-		return 0
-	}
-	lpc := &labelPrefixCfg{}
-	err = f.GenerateStruct(lpc)
-	if err != nil {
-		return 0
-	}
-	lpc.Version = LPCfgFileVersion
-	fileBytes, err := json.Marshal(lpc)
+		prefixes := make([]string, 0)
+		err := f.CreateSlice(&prefixes)
+		if err != nil {
+			return
+		}
+		nodePrefixes := make([]string, 0)
+		err = f.CreateSlice(&nodePrefixes)
+		if err != nil {
+			return
+		}
+		lpc := &labelPrefixCfg{}
+		err = f.GenerateStruct(lpc)
+		if err != nil {
+			return
+		}
+		lpc.Version = LPCfgFileVersion
+		fileBytes, err := json.Marshal(lpc)
 
-	if err != nil {
-		return 0
-	}
-	stringMap := make(map[string]string)
-	err = f.FuzzMap(&stringMap)
-	if err != nil {
-		return 0
-	}
+		if err != nil {
+			return
+		}
+		stringMap := make(map[string]string)
+		err = f.FuzzMap(&stringMap)
+		if err != nil {
+			return
+		}
 
-	source, err := f.GetString()
-	if err != nil {
-		return 0
-	}
+		source, err := f.GetString()
+		if err != nil {
+			return
+		}
 
-	lbls := labels.Map2Labels(stringMap, source)
+		lbls := labels.Map2Labels(stringMap, source)
 
-	file, err := os.Create("file")
-	defer file.Close()
-	if err != nil {
-		return 0
-	}
+		file, err := os.Create("file")
+		if err != nil {
+			return
+		}
+		defer file.Close()
 
-	_, err = file.Write(fileBytes)
-	if err != nil {
-		return 0
-	}
+		_, err = file.Write(fileBytes)
+		if err != nil {
+			return
+		}
 
-	err = ParseLabelPrefixCfg(slog.New(slog.DiscardHandler), prefixes, nil, "file")
-	if err != nil {
-		fmt.Println(err)
-		return 0
-	}
-	_, _ = Filter(lbls)
-	return 1
+		err = ParseLabelPrefixCfg(slog.New(slog.DiscardHandler), prefixes, nodePrefixes, "file")
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		_, _ = Filter(lbls)
+	})
 }

--- a/pkg/labelsfilter/fuzz_test.go
+++ b/pkg/labelsfilter/fuzz_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package labelsfilter
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+func FuzzLabelsfilterPkg(data []byte) int {
+	f := fuzz.NewConsumer(data)
+
+	prefixes := make([]string, 0)
+	err := f.CreateSlice(&prefixes)
+	if err != nil {
+		return 0
+	}
+	lpc := &labelPrefixCfg{}
+	err = f.GenerateStruct(lpc)
+	if err != nil {
+		return 0
+	}
+	lpc.Version = LPCfgFileVersion
+	fileBytes, err := json.Marshal(lpc)
+
+	if err != nil {
+		return 0
+	}
+	stringMap := make(map[string]string)
+	err = f.FuzzMap(&stringMap)
+	if err != nil {
+		return 0
+	}
+
+	source, err := f.GetString()
+	if err != nil {
+		return 0
+	}
+
+	lbls := labels.Map2Labels(stringMap, source)
+
+	file, err := os.Create("file")
+	defer file.Close()
+	if err != nil {
+		return 0
+	}
+
+	_, err = file.Write(fileBytes)
+	if err != nil {
+		return 0
+	}
+
+	err = ParseLabelPrefixCfg(slog.New(slog.DiscardHandler), prefixes, nil, "file")
+	if err != nil {
+		fmt.Println(err)
+		return 0
+	}
+	_, _ = Filter(lbls)
+	return 1
+}

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -32,3 +32,9 @@ compile_native_go_fuzzer github.com/cilium/cilium/pkg/monitor/format FuzzFormatE
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzAccumulateMapChange FuzzAccumulateMapChange
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzDenyPreferredInsert FuzzDenyPreferredInsert
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzResolvePolicy FuzzResolvePolicy
+
+compile_go_fuzzer github.com/cilium/cilium/pkg/labelsfilter FuzzLabelsfilterPkg fuzz_labelsfilter_pkg
+compile_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidate fuzz_matchpattern_validate
+compile_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidateWithoutCache fuzz_matchpattern_validate_without_cache
+compile_go_fuzzer github.com/cilium/cilium/pkg/hubble/parser FuzzParserDecode fuzz_parser_decode
+compile_go_fuzzer github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels FuzzLabelsParse fuzz_labels_parse

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -21,10 +21,15 @@ ln -s "$SRC"/cilium/pkg/policy/selectorcache_test{,_fuzz}.go
 
 
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/container/bitlpm FuzzUint8 FuzzUint8
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidate FuzzMatchpatternValidate
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidateWithoutCache FuzzMatchpatternValidateWithoutCache
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/fqdn/namemanager FuzzMapSelectorsToNamesLocked FuzzMapSelectorsToNamesLocked
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/hubble/parser FuzzParserDecode FuzzParserDecode
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumClusterwideNetworkPolicyParse FuzzCiliumClusterwideNetworkPolicyParse
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumNetworkPolicyParse FuzzCiliumNetworkPolicyParse
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels FuzzLabelsParse FuzzLabelsParse
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/labels FuzzNewLabels FuzzNewLabels
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/labelsfilter FuzzLabelsfilterPkg FuzzLabelsfilterPkg
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/loadbalancer FuzzJSONBackend FuzzJSONBackend
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/loadbalancer FuzzJSONFrontend FuzzJSONFrontend
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/loadbalancer FuzzJSONService FuzzJSONService
@@ -32,9 +37,3 @@ compile_native_go_fuzzer github.com/cilium/cilium/pkg/monitor/format FuzzFormatE
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzAccumulateMapChange FuzzAccumulateMapChange
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzDenyPreferredInsert FuzzDenyPreferredInsert
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzResolvePolicy FuzzResolvePolicy
-
-compile_go_fuzzer github.com/cilium/cilium/pkg/labelsfilter FuzzLabelsfilterPkg fuzz_labelsfilter_pkg
-compile_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidate fuzz_matchpattern_validate
-compile_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidateWithoutCache fuzz_matchpattern_validate_without_cache
-compile_go_fuzzer github.com/cilium/cilium/pkg/hubble/parser FuzzParserDecode fuzz_parser_decode
-compile_go_fuzzer github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels FuzzLabelsParse fuzz_labels_parse


### PR DESCRIPTION
Originally authored by @AdamKorcz, pulled from github.com/cncf/cncf-fuzzing .

This PR also converts all fuzzers to native Go fuzzers, making it easier to
reproduce fuzz results using go tooling (ie `go test -fuzz ...`).
