### PR TITLE
bpf: Don't resolve remote cluster NodePort services at the source

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -205,7 +205,8 @@ sock4_wildcard_lookup(struct lb4_key *key __maybe_unused,
 
 	info = lookup_ip4_remote_endpoint(key->address, 0);
 	if (info && (info->sec_identity == HOST_ID ||
-		     (include_remote_hosts && identity_is_remote_node(info->sec_identity))))
+		     (include_remote_hosts && identity_is_remote_node(info->sec_identity) &&
+		      !info->flag_remote_cluster)))
 		goto wildcard_lookup;
 
 	return NULL;
@@ -742,7 +743,8 @@ sock6_wildcard_lookup(struct lb6_key *key __maybe_unused,
 
 	info = lookup_ip6_remote_endpoint(&key->address, 0);
 	if (info && (info->sec_identity == HOST_ID ||
-		     (include_remote_hosts && identity_is_remote_node(info->sec_identity))))
+		     (include_remote_hosts && identity_is_remote_node(info->sec_identity) &&
+		      !info->flag_remote_cluster)))
 		goto wildcard_lookup;
 
 	return NULL;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -297,7 +297,8 @@ struct remote_endpoint_info {
 	__u8		flag_skip_tunnel:1,
 			flag_has_tunnel_ep:1,
 			flag_ipv6_tunnel_ep:1,
-			pad2:5;
+			flag_remote_cluster:1,
+			pad2:4;
 };
 
 /*

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -117,6 +117,10 @@ type EndpointFlags struct {
 	// an overlay tunnel, regardless of Cilium's configuration.
 	flagSkipTunnel bool
 
+	// flagRemoteCluster is set when the node is in a remote cluster.
+	// It's always unset when clustermesh is disabled or for pods.
+	flagRemoteCluster bool
+
 	// Note: if you add any more flags here, be sure to update (*prefixInfo).flatten()
 	// to merge them across different resources.
 }
@@ -126,6 +130,11 @@ func (e *EndpointFlags) SetSkipTunnel(skip bool) {
 	e.flagSkipTunnel = skip
 }
 
+func (e *EndpointFlags) SetRemoteCluster(remote bool) {
+	e.isInit = true
+	e.flagRemoteCluster = remote
+}
+
 func (e EndpointFlags) IsValid() bool {
 	return e.isInit
 }
@@ -133,13 +142,17 @@ func (e EndpointFlags) IsValid() bool {
 // Uint8 encoding MUST mimic the one in pkg/maps/ipcache
 // since it will eventually get recast to it
 const (
-	FlagSkipTunnel uint8 = 1 << iota
+	FlagSkipTunnel    uint8 = 1 << iota
+	FlagRemoteCluster uint8 = 1 << 3
 )
 
 func (e EndpointFlags) Uint8() uint8 {
 	var flags uint8 = 0
 	if e.flagSkipTunnel {
-		flags = flags | FlagSkipTunnel
+		flags |= FlagSkipTunnel
+	}
+	if e.flagRemoteCluster {
+		flags |= FlagRemoteCluster
 	}
 	return flags
 }

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -144,6 +144,9 @@ func (f RemoteEndpointInfoFlags) String() string {
 	if f&FlagIPv6TunnelEndpoint != 0 {
 		flags += "ipv6tunnel,"
 	}
+	if f&FlagRemoteCluster != 0 {
+		flags += "remotecluster,"
+	}
 
 	if flags == "" {
 		return "<none>"
@@ -162,6 +165,9 @@ const (
 	// FlagIPv6TunnelEndpoint is set when the tunnel endpoint IP address
 	// is an IPv6 address.
 	FlagIPv6TunnelEndpoint
+	// FlagRemoteCluster is set when the node is in a remote cluster.
+	// It's always unset when clustermesh is disabled or for pods.
+	FlagRemoteCluster
 )
 
 // RemoteEndpointInfo implements the bpf.MapValue interface. It contains the

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -712,6 +712,11 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 			key = n.EncryptionKey
 		}
 
+		endpointFlags := ipcacheTypes.EndpointFlags{}
+		if n.Cluster != m.conf.ClusterName {
+			endpointFlags.SetRemoteCluster(true)
+		}
+
 		// We expect the node manager to have a source of either Kubernetes,
 		// CustomResource, or KVStore. Prioritize the KVStore source over the
 		// rest as it is the strongest source, i.e. only trigger datapath
@@ -743,7 +748,8 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		m.ipcache.UpsertMetadata(prefixCluster, n.Source, resource,
 			lbls,
 			ipcacheTypes.TunnelPeer{Addr: tunnelIP},
-			ipcacheTypes.EncryptKey(key))
+			ipcacheTypes.EncryptKey(key),
+			endpointFlags)
 		if nodeIdentityOverride {
 			m.ipcache.OverrideIdentity(prefixCluster, nodeLabels, n.Source, resource)
 		}
@@ -940,7 +946,7 @@ func (m *manager) podCIDREntries(source source.Source, resource ipcacheTypes.Res
 // in podCIDRsAdded.
 // Removes ipset entry associated with oldNode if it is not present in ipsetEntries.
 //
-// The removal logic in this function should mirror the upsert logic in NodeUpdated.
+// The removal logic in this function should mirror the upsert logic in nodeAddressHasTunnelIP.
 func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcacheTypes.ResourceID,
 	ipsetEntries, nodeIPsAdded, healthIPsAdded, ingressIPsAdded, podCIDRsAdded []netip.Prefix,
 ) {
@@ -992,10 +998,16 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			oldKey = oldNode.EncryptionKey
 		}
 
+		oldEndpointFlags := ipcacheTypes.EndpointFlags{}
+		if oldNode.Cluster != m.conf.ClusterName {
+			oldEndpointFlags.SetRemoteCluster(true)
+		}
+
 		m.ipcache.RemoveMetadata(oldPrefixCluster, resource,
 			oldNodeLabels,
 			ipcacheTypes.TunnelPeer{Addr: oldTunnelIP},
-			ipcacheTypes.EncryptKey(oldKey))
+			ipcacheTypes.EncryptKey(oldKey),
+			oldEndpointFlags)
 		if oldNodeIdentityOverride {
 			m.ipcache.RemoveIdentityOverride(oldPrefixCluster, oldNodeLabels, resource)
 		}


### PR DESCRIPTION
This pull request fixes a bug in clustermesh mode that causes us to redirect requests to the wrong NodePort service when the same NodePort service exists on a remote and the local clusters. The first commit adds a new ipcache flag to indicate that a node is in a remote cluster. The second commit uses the new flag to skip load balancing at the source for this case. See commits for details.

Fixes: https://github.com/cilium/cilium/issues/24692.
```release-note
Fix a bug that would cause NodePort requests to be sent to the wrong backends when using KPR and Clustermesh with two identical, non-global NodePort services on different clusters.
```