### PR TITLE
checkpatch: Update image digest

### DIFF
--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -49,7 +49,7 @@ force:
 # TODO: revert addition of ignore MACRO_ARG_REUSE below once cilium-checkpatch
 # image is updated to ignore it.
 #
-CHECKPATCH_IMAGE := quay.io/cilium/cilium-checkpatch:1755701578-b97bd7a@sha256:edc094e3c306bbf9b9481f5a99aa6e8e00539cd1f4f7f7f4ffefeeabb0ff88b5
+CHECKPATCH_IMAGE := quay.io/cilium/cilium-checkpatch:1755701578-b97bd7a@sha256:5c4df794425e29962aac25fd5c005fd39d737232121688ba8d08878f4815b232
 ifneq ($(CHECKPATCH_DEBUG),)
   # Run script with "bash -x"
   CHECKPATCH_IMAGE_AND_ENTRY := \


### PR DESCRIPTION
More details in https://github.com/cilium/image-tools/issues/385

---

The `image-tools` CI is supposed to only build an image if there isn't already a tag for the last commit that changed that image directory on quay.io.

There seems to have been an issue with this check in [this job](https://github.com/cilium/image-tools/actions/runs/17178799757/job/48738420427) for the `checkpatch` image causing the job to fail to check for the existing tag, assume it didn't exist and proceed to rebuild it:

> /usr/local/bin/crane
> 2025/08/23 18:59:33 HEAD request failed, falling back on GET: error getting credentials - err: exit status 1, out: `ANY_REGISTRY_USERNAME is not set`
> Error: error getting credentials - err: exit status 1, out: `ANY_REGISTRY_USERNAME is not set`
> error: crane returned 1
> quay.io/cilium/cilium-checkpatch:1755701578-b97bd7a doesn't exist

With the `1755701578-b97bd7a` tag rebuilt and repushed, quay.io must have garbage collected the previous image digest with the same tag, causing pulls of the previous digest for that tag to start failing ([example](https://github.com/cilium/cilium/actions/runs/17182063773/job/48745850927?pr=41345#step:3:16)):

> docker: Error response from daemon: manifest for quay.io/cilium/cilium-checkpatch@sha256:edc094e3c306bbf9b9481f5a99aa6e8e00539cd1f4f7f7f4ffefeeabb0ff88b5 not found: manifest unknown: manifest unknown
