### PR TITLE
refactor: cleanups in unparallel tests and replace netlink with safenetlink 

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -476,7 +476,8 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 				r.Src, _ = netip.AddrFromSlice(u.Src)
 				r.Gw, _ = netip.AddrFromSlice(u.Gw)
 
-				if u.Type == unix.RTM_NEWROUTE {
+				switch u.Type {
+				case unix.RTM_NEWROUTE:
 					_, _, err := dc.params.RouteTable.Insert(txn, &r)
 					if err != nil {
 						dc.log.Warn("Failed to insert route",
@@ -484,7 +485,7 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 							logfields.Route, r,
 						)
 					}
-				} else if u.Type == unix.RTM_DELROUTE {
+				case unix.RTM_DELROUTE:
 					_, _, err := dc.params.RouteTable.Delete(txn, &r)
 					if err != nil {
 						dc.log.Warn("Failed to delete route",
@@ -515,7 +516,8 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 				}
 				n.IPAddr, _ = netip.AddrFromSlice(u.IP)
 
-				if u.Type == unix.RTM_NEWNEIGH {
+				switch u.Type {
+				case unix.RTM_NEWNEIGH:
 					_, _, err := dc.params.NeighborTable.Insert(txn, &n)
 					if err != nil {
 						dc.log.Warn("Failed to insert neighbor",
@@ -523,7 +525,7 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 							logfields.Neighbor, n,
 						)
 					}
-				} else if u.Type == unix.RTM_DELNEIGH {
+				case unix.RTM_DELNEIGH:
 					_, _, err := dc.params.NeighborTable.Delete(txn, &n)
 					if err != nil {
 						dc.log.Warn("Failed to delete neighbor",

--- a/pkg/datapath/linux/ipsec/cell.go
+++ b/pkg/datapath/linux/ipsec/cell.go
@@ -55,7 +55,7 @@ func (kc *keyCustodian) Start(cell.HookContext) error {
 	}
 
 	var err error
-	kc.authKeySize, kc.spi, err = LoadIPSecKeysFile(kc.log, option.Config.IPSecKeyFile)
+	kc.authKeySize, kc.spi, err = LoadIPSecKeysFile(option.Config.IPSecKeyFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/testutils"
 )
@@ -234,7 +235,7 @@ func testUpsertIPSecEquals(t *testing.T) {
 	require.NoError(t, err)
 
 	// Let's check that state was not added as source and destination are the same
-	result, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	result, err := safenetlink.XfrmStateList(netlink.FAMILY_ALL)
 	require.NoError(t, err)
 	require.Empty(t, result)
 
@@ -258,7 +259,7 @@ func testUpsertIPSecEquals(t *testing.T) {
 	require.NoError(t, err)
 
 	// Let's check that state was not added as source and destination are the same
-	result, err = netlink.XfrmStateList(netlink.FAMILY_ALL)
+	result, err = safenetlink.XfrmStateList(netlink.FAMILY_ALL)
 	require.NoError(t, err)
 	require.Empty(t, result)
 }

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -110,13 +110,13 @@ func TestPrivilegedAll(t *testing.T) {
 func TestPrivilegedLoadKeysNoFile(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
-	_, _, err := LoadIPSecKeysFile(log, path)
+	_, _, err := LoadIPSecKeysFile(path)
 	require.True(t, os.IsNotExist(err))
 }
 
 func testInvalidLoadKeys(t *testing.T) {
 	keys := bytes.NewReader(invalidKeysDat)
-	_, _, err := LoadIPSecKeys(log, keys)
+	_, _, err := LoadIPSecKeys(keys)
 	require.Error(t, err)
 
 	params := &IPSecParameters{
@@ -143,7 +143,7 @@ func TestPrivilegedLoadKeys(t *testing.T) {
 	testCases := [][]byte{keysDat, keysNullDat, keysAeadDat, keysAeadDat256}
 	for _, testCase := range testCases {
 		keys := bytes.NewReader(testCase)
-		_, spi, err := LoadIPSecKeys(log, keys)
+		_, spi, err := LoadIPSecKeys(keys)
 		require.NoError(t, err)
 		err = SetIPSecSPI(log, spi)
 		require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestPrivilegedLoadKeysLenChange(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
 	keys := bytes.NewReader(append(keysDat, keysNullDat...))
-	_, _, err := LoadIPSecKeys(log, keys)
+	_, _, err := LoadIPSecKeys(keys)
 	require.ErrorContains(t, err, "invalid key rotation: key length must not change")
 }
 
@@ -163,7 +163,7 @@ func TestPrivilegedLoadKeysSameSPI(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
 	keys := bytes.NewReader(keysSameSpiDat)
-	_, _, err := LoadIPSecKeys(log, keys)
+	_, _, err := LoadIPSecKeys(keys)
 	require.ErrorContains(t, err, "invalid SPI: changing IPSec keys requires incrementing the key id")
 }
 
@@ -183,7 +183,7 @@ func TestPrivilegedParseSPI(t *testing.T) {
 		{"0", 0, 0, true},
 	}
 	for _, tc := range testCases {
-		spi, off, err := parseSPI(log, tc.input)
+		spi, off, err := parseSPI(tc.input)
 		if spi != tc.expSPI {
 			t.Fatalf("For input %q, expected SPI %d, but got %d", tc.input, tc.expSPI, spi)
 		}

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 
@@ -135,7 +136,7 @@ func TestPrivilegedXfrmStateListCacheDisabled(t *testing.T) {
 }
 
 func cleanIPSecStatesAndPolicies(t *testing.T) {
-	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	xfrmStateList, err := safenetlink.XfrmStateList(netlink.FAMILY_ALL)
 	if err != nil {
 		t.Fatalf("Can't list XFRM states: %v", err)
 	}
@@ -147,7 +148,7 @@ func cleanIPSecStatesAndPolicies(t *testing.T) {
 
 	}
 
-	xfrmPolicyList, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
+	xfrmPolicyList, err := safenetlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	if err != nil {
 		t.Fatalf("Can't list XFRM policies: %v", err)
 	}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -761,10 +761,10 @@ func (s *linuxPrivilegedBaseTestSuite) testNodeChurnXFRMLeaksWithConfig(t *testi
 	err = linuxNodeHandler.NodeAdd(node)
 	require.NoError(t, err)
 
-	states, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	states, err := safenetlink.XfrmStateList(netlink.FAMILY_ALL)
 	require.NoError(t, err)
 	require.NotEmpty(t, states)
-	policies, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
+	policies, err := safenetlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	require.NoError(t, err)
 	require.NotEqual(t, 0, countXFRMPolicies(policies))
 
@@ -772,10 +772,10 @@ func (s *linuxPrivilegedBaseTestSuite) testNodeChurnXFRMLeaksWithConfig(t *testi
 	err = linuxNodeHandler.NodeDelete(node)
 	require.NoError(t, err)
 
-	states, err = netlink.XfrmStateList(netlink.FAMILY_ALL)
+	states, err = safenetlink.XfrmStateList(netlink.FAMILY_ALL)
 	require.NoError(t, err)
 	require.Empty(t, states)
-	policies, err = netlink.XfrmPolicyList(netlink.FAMILY_ALL)
+	policies, err = safenetlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	require.NoError(t, err)
 	require.Equal(t, 0, countXFRMPolicies(policies))
 }
@@ -1174,7 +1174,7 @@ func lookupIPSecInRoutes(t *testing.T, family int, extDev string, prefixes []*ci
 }
 
 func lookupIPSecXFRMPoliciesOut(t *testing.T, family int, prefixes []*cidr.CIDR) {
-	policies, err := netlink.XfrmPolicyList(family)
+	policies, err := safenetlink.XfrmPolicyList(family)
 	require.NoError(t, err)
 
 	var zero *cidr.CIDR

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -736,7 +736,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaksSubnetMode(t *testi
 func (s *linuxPrivilegedBaseTestSuite) testNodeChurnXFRMLeaksWithConfig(t *testing.T, config datapath.LocalNodeConfiguration) {
 	log := hivetest.Logger(t)
 	keys := bytes.NewReader([]byte("6+ rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n"))
-	_, _, err := ipsec.LoadIPSecKeys(log, keys)
+	_, _, err := ipsec.LoadIPSecKeys(keys)
 	require.NoError(t, err)
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
@@ -1260,7 +1260,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodePodCIDRsChurnIPSec(t *testing.T) 
 	option.Config.BootIDFile = "/proc/sys/kernel/random/boot_id"
 
 	keys := bytes.NewReader([]byte("6+ rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n"))
-	_, _, err = ipsec.LoadIPSecKeys(log, keys)
+	_, _, err = ipsec.LoadIPSecKeys(keys)
 	require.NoError(t, err)
 
 	// set "local_node" as the local node name

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -76,17 +76,6 @@ func setup(tb testing.TB, family string) *linuxPrivilegedBaseTestSuite {
 const (
 	dummyHostDeviceName     = "dummy_host"
 	dummyExternalDeviceName = "dummy_external"
-
-	baseTime = 2500
-	mcastNum = 6
-)
-
-var (
-	baseIPv4Time = []string{"net", "ipv4", "neigh", "default", "base_reachable_time_ms"}
-	baseIPv6Time = []string{"net", "ipv6", "neigh", "default", "base_reachable_time_ms"}
-
-	mcastNumIPv4 = []string{"net", "ipv4", "neigh", "default", "mcast_solicit"}
-	mcastNumIPv6 = []string{"net", "ipv6", "neigh", "default", "mcast_solicit"}
 )
 
 func setupLinuxPrivilegedBaseTestSuite(tb testing.TB, addressing datapath.NodeAddressing, enableIPv6, enableIPv4 bool) *linuxPrivilegedBaseTestSuite {

--- a/pkg/maps/encrypt/encrypt.go
+++ b/pkg/maps/encrypt/encrypt.go
@@ -84,15 +84,3 @@ func MapUpdateContext(ctxID uint32, keyID uint8) error {
 	}
 	return encryptMap.Update(k, v)
 }
-
-// MapUpdateContextWithMap updates the encrypt state with ctxID to use the new keyID
-// with the map as its argument.
-//
-// This is primarily used in tests.
-func MapUpdateContextWithMap(m *bpf.Map, ctxID uint32, keyID uint8) error {
-	k := newEncryptKey(ctxID)
-	v := &EncryptValue{
-		encryptKeyID: keyID,
-	}
-	return m.Update(k, v)
-}


### PR DESCRIPTION
This PR is mostly just to please `golangci-lint run` and editor linters.
Please refer to commits.