### PR TITLE
iptables: allow skipping conntrack on pods with hostNetwork: true

### DIFF
--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -365,6 +365,20 @@ To enable the iptables connection-tracking bypass:
              --set installNoConntrackIptablesRules=true \\
              --set kubeProxyReplacement=true
 
+If a Pod has the ``hostNetwork`` flag enabled, the ports for which connection tracking should be skipped
+must be explicitly listed using the ``network.cilium.io/no-track-host-ports`` annotation:
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      annotations:
+        network.cilium.io/no-track-host-ports: "999/tcp,8123/tcp"
+
+.. note::
+    Only UDP and TCP transport protocols are supported with the network.cilium.io/no-track-host-ports annotation at the time of writing.
+
 Hubble
 ======
 

--- a/examples/kubernetes/nginx-no-track-host-ports.yaml
+++ b/examples/kubernetes/nginx-no-track-host-ports.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+  annotations:
+    network.cilium.io/no-track-host-ports: "8080/tcp,80/tcp,443/tcp"
+spec:
+  hostNetwork: true
+  containers:
+  - image: nginx
+    imagePullPolicy: Always
+    name: nginx

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -218,6 +218,8 @@ const (
 	CECInjectCiliumFilters      = CECPrefix + "/inject-cilium-filters"
 	CECIsL7LB                   = CECPrefix + "/is-l7lb"
 	CECUseOriginalSourceAddress = CECPrefix + "/use-original-source-address"
+
+	NoTrackHostPorts = NetworkPrefix + "/no-track-host-ports"
 )
 
 // CiliumPrefixRegex is a regex matching Cilium specific annotations.

--- a/pkg/datapath/fake/types/iptables_manager.go
+++ b/pkg/datapath/fake/types/iptables_manager.go
@@ -35,3 +35,9 @@ func (m *FakeIptablesManager) InstallNoTrackRules(ip netip.Addr, port uint16) {
 
 func (m *FakeIptablesManager) RemoveNoTrackRules(ip netip.Addr, port uint16) {
 }
+
+func (m *FakeIptablesManager) AddNoTrackHostPorts(namespace, name string, ports []string) {
+}
+
+func (m *FakeIptablesManager) RemoveNoTrackHostPorts(namespace, name string) {
+}

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -130,7 +130,7 @@ func (c *customChain) doAdd(prog runnable) error {
 	return nil
 }
 
-func (c *customChain) add(ipv4, ipv6 bool) error {
+func (c *customChain) add(ipv4, ipv6 bool, ip4tables, ip6tables iptablesInterface) error {
 	if ipv4 {
 		if err := c.doAdd(ip4tables); err != nil {
 			return err
@@ -162,7 +162,7 @@ func (c *customChain) doRename(prog runnable, newName string) error {
 	return nil
 }
 
-func (c *customChain) rename(ipv4, ipv6 bool, name string) error {
+func (c *customChain) rename(ipv4, ipv6 bool, name string, ip4tables, ip6tables iptablesInterface) error {
 	if ipv4 {
 		if err := c.doRename(ip4tables, name); err != nil {
 			return err
@@ -201,7 +201,7 @@ func (c *customChain) doRemove(prog iptablesInterface) error {
 	return nil
 }
 
-func (c *customChain) remove(ipv4, ipv6 bool) error {
+func (c *customChain) remove(ipv4, ipv6 bool, ip4tables, ip6tables iptablesInterface) error {
 	if ipv4 {
 		if err := c.doRemove(ip4tables); err != nil {
 			return err
@@ -233,7 +233,7 @@ func (c *customChain) doInstallFeeder(prog iptablesInterface, prepend bool) erro
 	return nil
 }
 
-func (c *customChain) installFeeder(ipv4, ipv6, prepend bool) error {
+func (c *customChain) installFeeder(ipv4, ipv6, prepend bool, ip4tables, ip6tables iptablesInterface) error {
 	if ipv4 {
 		if err := c.doInstallFeeder(ip4tables, prepend); err != nil {
 			return err

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -406,6 +406,8 @@ func newIptablesManager(p params) datapath.IptablesManager {
 				iptMgr.doInstallProxyRules,
 				iptMgr.installNoTrackRules,
 				iptMgr.removeNoTrackRules,
+				iptMgr.setNoTrackHostPorts,
+				iptMgr.removeNoTrackHostPorts,
 			)
 		}),
 	)

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -128,6 +128,8 @@ func reconciliationLoop(
 	updateProxyRules func(proxyPort uint16, name string) error,
 	installNoTrackRules func(addr netip.Addr, port uint16) error,
 	removeNoTrackRules func(addr netip.Addr, port uint16) error,
+	addNoTrackHostPorts func(currentState noTrackHostPortsByPod, podName podAndNameSpace, ports []string) error,
+	removeNoTrackHostPorts func(currentState noTrackHostPortsByPod, podName podAndNameSpace) error,
 ) error {
 	// The minimum interval between reconciliation attempts
 	const minReconciliationInterval = 200 * time.Millisecond
@@ -142,9 +144,10 @@ func reconciliationLoop(
 	fullLogLimiter := logging.NewLimiter(10*time.Second, 3)
 
 	state := desiredState{
-		installRules: installIptRules,
-		proxies:      make(map[string]proxyInfo),
-		noTrackPods:  sets.New[noTrackPodInfo](),
+		installRules:     installIptRules,
+		proxies:          make(map[string]proxyInfo),
+		noTrackPods:      sets.New[noTrackPodInfo](),
+		noTrackHostPorts: make(noTrackHostPortsByPod),
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -299,6 +302,53 @@ stop:
 			} else {
 				close(req.updated)
 			}
+
+		case req, ok := <-params.addNoTrackHostPorts:
+			if !ok {
+				break stop
+			}
+
+			if firstInit {
+				stateChanged = true
+				updatedChs = append(updatedChs, req.updated)
+				continue
+			}
+
+			if err := addNoTrackHostPorts(state.noTrackHostPorts, req.info.podKey, req.info.ports); err != nil {
+				if partialLogLimiter.Allow() {
+					log.Error("failed to set up no-track-host-ports, will retry a full reconciliation", logfields.Error, err)
+				}
+
+				// incremental rules update failed, schedule a full iptables reconciliation
+				stateChanged = true
+				updatedChs = append(updatedChs, req.updated)
+			} else {
+				close(req.updated)
+			}
+
+		case req, ok := <-params.delNoTrackHostPorts:
+			if !ok {
+				break stop
+			}
+
+			if firstInit {
+				stateChanged = true
+				updatedChs = append(updatedChs, req.updated)
+				continue
+			}
+
+			if err := removeNoTrackHostPorts(state.noTrackHostPorts, req.info); err != nil {
+				if partialLogLimiter.Allow() {
+					log.Error("failed to remove no-track-host-ports, will retry a full reconciliation", logfields.Error, err)
+				}
+
+				// incremental rules update failed, schedule a full iptables reconciliation
+				stateChanged = true
+				updatedChs = append(updatedChs, req.updated)
+			} else {
+				close(req.updated)
+			}
+
 		case <-refresher.C():
 			stateChanged = true
 		case <-ticker.C():
@@ -348,6 +398,10 @@ stop:
 	for range params.addNoTrackPod {
 	}
 	for range params.delNoTrackPod {
+	}
+	for range params.addNoTrackHostPorts {
+	}
+	for range params.delNoTrackHostPorts {
 	}
 
 	return nil

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -24,10 +24,11 @@ import (
 type desiredState struct {
 	installRules bool
 
-	devices       sets.Set[string]
-	localNodeInfo localNodeInfo
-	proxies       map[string]proxyInfo
-	noTrackPods   sets.Set[noTrackPodInfo]
+	devices          sets.Set[string]
+	localNodeInfo    localNodeInfo
+	proxies          map[string]proxyInfo
+	noTrackPods      sets.Set[noTrackPodInfo]
+	noTrackHostPorts noTrackHostPortsByPod
 }
 
 type localNodeInfo struct {
@@ -110,6 +111,11 @@ type proxyInfo struct {
 type noTrackPodInfo struct {
 	ip   netip.Addr
 	port uint16
+}
+
+type noTrackHostPortsPodInfo struct {
+	podKey podAndNameSpace
+	ports  []string
 }
 
 func reconciliationLoop(

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -71,6 +71,11 @@ type IptablesManager interface {
 
 	// See comments for InstallNoTrackRules.
 	RemoveNoTrackRules(ip netip.Addr, port uint16)
+
+	// AddNoTrackHostPorts/RemoveNoTrackHostPort are explicitly called when a pod has a valid "no-track-host-ports" annotation.
+	// causes iptables notrack rules to be added/removed so CT is skipped for pods using host networking on the requested ports.
+	AddNoTrackHostPorts(namespace, name string, ports []string)
+	RemoveNoTrackHostPorts(namespace, name string)
 }
 
 // CompilationLock is a interface over a mutex, it is used by both the loader, daemon

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -88,6 +88,11 @@ type ipcacheManager interface {
 	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool)
 }
 
+type hostNetworkManager interface {
+	AddNoTrackHostPorts(namespace, name string, ports []string)
+	RemoveNoTrackHostPorts(namespace, name string)
+}
+
 type K8sWatcher struct {
 	logger           *slog.Logger
 	resourceGroupsFn func(logger *slog.Logger, cfg WatcherConfiguration) (resourceGroups, waitForCachesOnly []string)

--- a/pkg/loadbalancer/errors.go
+++ b/pkg/loadbalancer/errors.go
@@ -13,4 +13,7 @@ var (
 	// ErrFrontendConflict occurs when a frontend is being upserted but it already
 	// exists and is owned by a different service.
 	ErrFrontendConflict = errors.New("frontend already owned by another service")
+
+	// ErrInvalidL4Addr occurs when L4AddrFromString attempts to parse a malformed L4Addr string
+	ErrInvalidL4Addr = errors.New("invalid l4 addr format. expected <proto>/<port>")
 )

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -777,6 +777,27 @@ func (l L4Addr) String() string {
 	return fmt.Sprintf("%d/%s", l.Port, l.Protocol)
 }
 
+// L4AddrFromString returns a L4Addr from its string representation.
+func L4AddrFromString(s string) (L4Addr, error) {
+	splitted := strings.Split(s, "/")
+
+	if len(splitted) != 2 {
+		return L4Addr{}, fmt.Errorf("%w for %s", ErrInvalidL4Addr, s)
+	}
+
+	proto, err := NewL4Type(strings.ToUpper(splitted[1]))
+	if err != nil {
+		return L4Addr{}, fmt.Errorf("%w for %s", err, splitted[0])
+	}
+
+	portUInt64, err := strconv.ParseUint(splitted[0], 10, 16)
+	if err != nil {
+		return L4Addr{}, fmt.Errorf("%s is not a valid port number. %w", splitted[1], err)
+	}
+
+	return NewL4Addr(proto, uint16(portUInt64)), nil
+}
+
 // L3n4Addr is an unique L3+L4 address and scope (for traffic policies).
 type L3n4Addr unique.Handle[l3n4AddrRep]
 


### PR DESCRIPTION
pods serving connections in the host network namespace might exhibit lower than expected performance under high load due to CT. this PR allows an operator to specify l4 protocol ports for which they want to skip CT when a pod is deployed in the host ns, avoiding the performance cost of connection tracking.

```release-note
Allow bypassing conntrack in pods with hostNetwork: true
```
