### PR TITLE
hubble: Skip unknown metrics instead of returning an error

### DIFF
--- a/pkg/hubble/metrics/api/registry.go
+++ b/pkg/hubble/metrics/api/registry.go
@@ -4,12 +4,14 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 // Registry holds a set of registered metric handlers
@@ -53,6 +55,11 @@ func (r *Registry) ConfigureHandlers(logger *slog.Logger, registry *prometheus.R
 	for _, metricsConfig := range enabled.Metrics {
 		h, err := r.validateAndCreateHandlerLocked(metricsConfig, &metricNames)
 		if err != nil {
+			var errM *errMetricNotExist
+			if errors.As(err, &errM) {
+				logger.Warn("Skipping unknown hubble metric", logfields.Name, errM.name)
+				continue
+			}
 			return nil, err
 		}
 		enabledHandlers = append(enabledHandlers, *h)
@@ -70,7 +77,7 @@ func (r *Registry) ValidateAndCreateHandler(metricsConfig *MetricConfig, metricN
 func (r *Registry) validateAndCreateHandlerLocked(metricsConfig *MetricConfig, metricNames *map[string]*MetricConfig) (*NamedHandler, error) {
 	plugin, ok := r.handlers[metricsConfig.Name]
 	if !ok {
-		return nil, fmt.Errorf("metric '%s' does not exist", metricsConfig.Name)
+		return nil, &errMetricNotExist{metricsConfig.Name}
 	}
 
 	if cp, ok := plugin.(PluginConflicts); ok {
@@ -88,4 +95,12 @@ func (r *Registry) validateAndCreateHandlerLocked(metricsConfig *MetricConfig, m
 	}
 
 	return &h, nil
+}
+
+type errMetricNotExist struct {
+	name string
+}
+
+func (e *errMetricNotExist) Error() string {
+	return fmt.Sprintf("metric %q does not exist", e.name)
 }

--- a/pkg/hubble/metrics/api/registry.go
+++ b/pkg/hubble/metrics/api/registry.go
@@ -51,7 +51,7 @@ func (r *Registry) ConfigureHandlers(logger *slog.Logger, registry *prometheus.R
 	var enabledHandlers []NamedHandler
 	metricNames := enabled.GetMetricNames()
 	for _, metricsConfig := range enabled.Metrics {
-		h, err := r.validateAndCreateHandlerLocked(registry, metricsConfig, &metricNames)
+		h, err := r.validateAndCreateHandlerLocked(metricsConfig, &metricNames)
 		if err != nil {
 			return nil, err
 		}
@@ -61,13 +61,13 @@ func (r *Registry) ConfigureHandlers(logger *slog.Logger, registry *prometheus.R
 	return InitHandlers(logger, registry, &enabledHandlers)
 }
 
-func (r *Registry) ValidateAndCreateHandler(registry *prometheus.Registry, metricsConfig *MetricConfig, metricNames *map[string]*MetricConfig) (*NamedHandler, error) {
+func (r *Registry) ValidateAndCreateHandler(metricsConfig *MetricConfig, metricNames *map[string]*MetricConfig) (*NamedHandler, error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	return r.validateAndCreateHandlerLocked(registry, metricsConfig, metricNames)
+	return r.validateAndCreateHandlerLocked(metricsConfig, metricNames)
 }
 
-func (r *Registry) validateAndCreateHandlerLocked(registry *prometheus.Registry, metricsConfig *MetricConfig, metricNames *map[string]*MetricConfig) (*NamedHandler, error) {
+func (r *Registry) validateAndCreateHandlerLocked(metricsConfig *MetricConfig, metricNames *map[string]*MetricConfig) (*NamedHandler, error) {
 	plugin, ok := r.handlers[metricsConfig.Name]
 	if !ok {
 		return nil, fmt.Errorf("metric '%s' does not exist", metricsConfig.Name)

--- a/pkg/hubble/metrics/api/registry_test.go
+++ b/pkg/hubble/metrics/api/registry_test.go
@@ -75,7 +75,6 @@ func (t *testHandler) ProcessFlow(ctx context.Context, p *pb.Flow) error {
 }
 
 func TestRegister(t *testing.T) {
-
 	flow1 := &pb.Flow{
 		EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
 		L7: &pb.Layer7{
@@ -97,8 +96,7 @@ func TestRegister(t *testing.T) {
 	}
 	log := hivetest.Logger(t)
 
-	t.Run("Should not register handler", func(t *testing.T) {
-
+	t.Run("Should not register non-enabled handler", func(t *testing.T) {
 		r := NewRegistry()
 
 		handler := &testHandler{}
@@ -107,12 +105,24 @@ func TestRegister(t *testing.T) {
 
 		//exhaustruct:ignore
 		handlers, err := r.ConfigureHandlers(log, nil, &Config{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		assert.Empty(t, *handlers)
+	})
+
+	t.Run("Should not register unknown handler", func(t *testing.T) {
+		r := NewRegistry()
+
+		handler := &testHandler{}
+
+		r.Register("test", &testPlugin{handler: handler})
+
+		config := &Config{Metrics: []*MetricConfig{{Name: "unknown"}}}
+		handlers, err := r.ConfigureHandlers(log, nil, config)
+		require.NoError(t, err)
 		assert.Empty(t, *handlers)
 	})
 
 	t.Run("Should register handler", func(t *testing.T) {
-
 		promRegistry := prometheus.NewRegistry()
 		options := []*ContextOptionConfig{
 			{
@@ -129,7 +139,6 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("Should remove metrics series with ContextPod", func(t *testing.T) {
-
 		promRegistry := prometheus.NewRegistry()
 		options := []*ContextOptionConfig{
 			{
@@ -172,7 +181,6 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("Should not remove metrics series with ContextWorkloadName", func(t *testing.T) {
-
 		promRegistry := prometheus.NewRegistry()
 		options := []*ContextOptionConfig{
 			{
@@ -215,7 +223,6 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("Should remove metrics series with LabelsContext", func(t *testing.T) {
-
 		promRegistry := prometheus.NewRegistry()
 		options := []*ContextOptionConfig{
 			{
@@ -254,7 +261,6 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("Should not remove metrics series with LabelsContext without namespace", func(t *testing.T) {
-
 		promRegistry := prometheus.NewRegistry()
 		options := []*ContextOptionConfig{
 			{
@@ -317,8 +323,8 @@ func initHandlers(t *testing.T, opts *ContextOptions, promRegistry *prometheus.R
 		},
 	}
 	handlers, err := r.ConfigureHandlers(log, nil, cfg)
-	assert.NoError(t, err)
-	assert.Len(t, *handlers, 1)
+	require.NoError(t, err)
+	require.Len(t, *handlers, 1)
 	assert.Equal(t, 1, (*handlers)[0].Handler.(*testHandler).InitCalled)
 	return handlers
 }

--- a/pkg/hubble/metrics/dynamic_flow_processor.go
+++ b/pkg/hubble/metrics/dynamic_flow_processor.go
@@ -153,7 +153,7 @@ func (d *DynamicFlowProcessor) onConfigReload(ctx context.Context, hash uint64, 
 }
 
 func (d *DynamicFlowProcessor) addNewMetric(reg *prometheus.Registry, cm *api.MetricConfig, metricNames map[string]*api.MetricConfig, newMetrics *[]api.NamedHandler) {
-	nh, err := api.DefaultRegistry().ValidateAndCreateHandler(reg, cm, &metricNames)
+	nh, err := api.DefaultRegistry().ValidateAndCreateHandler(cm, &metricNames)
 	if err != nil {
 		d.logger.Error(
 			"Failed to configure metrics plugin",


### PR DESCRIPTION
### Description

Skip unknown metrics when the Hubble metrics Registry configures the metric handlers. This avoids causing a fatal error from initializing the Hubble metrics cell (and therefore crashing the cilium-agent) and allow renaming and removing metrics without impact on upgrades.

This regression was introduced in Cilium 1.18 after we refactored the Hubble metrics subsystem as a Hive cell ([PR](https://github.com/cilium/cilium/pull/39549)). As part of the refactor, we are now handling the metrics initialization at cell construction time, whereas before it was done after the Hive was started.

Add a test to ensure an error is not returned when we enable an unknown metric. Also replace some assert call with require to avoid panics.

Note to reviewer: This needs to be backported to 1.18. Thanks!

Fixes: https://github.com/cilium/cilium/issues/41307

```release-note
Fix a regression where enabling unknown Hubble metrics would crash the cilium agent
```

---

### Test

Tested with the following helm options:
```yaml
hubble:
  enabled: true
  metrics:
    enabled:
      - unknown:setting=yes
      - unknownAnother:setting=no
      - dns:labelsContext=source_namespace,destination_namespace
      - drop:labelsContext=source_namespace,destination_namespace
      - tcp:labelsContext=source_namespace,destination_namespace
      - icmp:labelsContext=source_namespace,destination_namespace
      - flow:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity
      - "kafka:labelsContext=source_namespace,source_workload,destination_namespace,destination_workload,traffic_direction;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
      - "httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
```

Logs:
```
time=2025-08-25T16:18:48.383089048Z level=info msg="Starting Hubble Metrics static flow processor" module=agent.controlplane.hubble.hubble-metrics metricConfig="unknown:setting=yes unknownAnother:setting=no dns:labelsContext=source_namespace,destination_namespace drop:labelsContext=source_namespace,destination_namespace tcp:labelsContext=source_namespace,destination_namespace icmp:labelsContext=source_namespace,destination_namespace flow:labelsContext=source_namespace,destination_namespace;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity kafka:labelsContext=source_namespace,source_workload,destination_namespace,destination_workload,traffic_direction;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
time=2025-08-25T16:18:48.383149798Z level=warn msg="Skipping unknown hubble metric" module=agent.controlplane.hubble.hubble-metrics name=unknown
time=2025-08-25T16:18:48.383158673Z level=warn msg="Skipping unknown hubble metric" module=agent.controlplane.hubble.hubble-metrics name=unknownAnother
time=2025-08-25T16:18:48.383186256Z level=info msg="Configured metrics plugin" module=agent.controlplane.hubble.hubble-metrics name=dns status="labels=source_namespace,destination_namespace"
time=2025-08-25T16:18:48.383195256Z level=info msg="Configured metrics plugin" module=agent.controlplane.hubble.hubble-metrics name=drop status="labels=source_namespace,destination_namespace"
time=2025-08-25T16:18:48.383200798Z level=info msg="Configured metrics plugin" module=agent.controlplane.hubble.hubble-metrics name=tcp status="labels=source_namespace,destination_namespace"
time=2025-08-25T16:18:48.383206256Z level=info msg="Configured metrics plugin" module=agent.controlplane.hubble.hubble-metrics name=icmp status="labels=source_namespace,destination_namespace"
time=2025-08-25T16:18:48.383219339Z level=info msg="Configured metrics plugin" module=agent.controlplane.hubble.hubble-metrics name=flow status="destination=workload-name|reserved-identity,labels=source_namespace,destination_namespace,source=workload-name|reserved-identity"
time=2025-08-25T16:18:48.383235881Z level=info msg="Configured metrics plugin" module=agent.controlplane.hubble.hubble-metrics name=kafka status="destination=workload-name|reserved-identity,labels=source_namespace,source_workload,destination_namespace,destination_workload,traffic_direction,source=workload-name|reserved-identity"
time=2025-08-25T16:18:48.383260297Z level=info msg="Configured metrics plugin" module=agent.controlplane.hubble.hubble-metrics name=httpV2 status="destination=workload-name|reserved-identity,labels=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction,source=workload-name|reserved-identity,exemplars=true"
time=2025-08-25T16:18:48.664500741Z level=info msg="Starting Hubble metrics server" module=agent.controlplane.hubble.hubble-metrics address=:9965 tls=true
```