### PR TITLE
bpf/lib/ipv4: handle ipv4_is_in_subnet safely

### DIFF
--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -82,7 +82,17 @@ static __always_inline int ipv4_hdrlen(const struct iphdr *ip4)
 static __always_inline bool ipv4_is_in_subnet(__be32 addr,
 					      __be32 subnet, int prefixlen)
 {
-	return (addr & bpf_htonl(~((1 << (32 - prefixlen)) - 1))) == subnet;
+	__u32 mask;
+
+	/* normalize prefixlen into [0,32] */
+	if (prefixlen <= 0)
+		mask = 0U;
+	else if (prefixlen >= 32)
+		mask = ~0U;
+	else
+		mask = (~0U) << (32 - prefixlen);
+
+	return (addr & bpf_htonl(mask)) == subnet;
 }
 
 #ifdef ENABLE_IPV4_FRAGMENTS

--- a/bpf/tests/ipv4_is_in_subnet_test.c
+++ b/bpf/tests/ipv4_is_in_subnet_test.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "node_config.h"
+#include "lib/ipv4.h"
+
+CHECK("tc", "ipv4_is_in_subnet_prefix0")
+int ipv4_is_in_subnet_prefix0(void)
+{
+test_init();
+	__be32 addr = bpf_htonl(0x12345678);
+	__be32 subnet = 0;
+
+	/* Any address is in 0.0.0.0/0 */
+	assert(ipv4_is_in_subnet(addr, subnet, 0));
+
+	/* Non-zero subnet with /0 should not match */
+	subnet = bpf_htonl(0x01000000);
+	assert(!ipv4_is_in_subnet(addr, subnet, 0));
+
+	test_finish();
+}


### PR DESCRIPTION
Add an explicit check for prefixlen == 0 that returns whether the subnet itself is 0, bypassing any shifts. For other prefix lengths, compute the IPv4 mask using 32-bit (~0U) << (32 - prefixlen), which makes the intent explicit and avoids architecture-dependent long shifts.
Include a dedicated unit test.
