### PR TITLE
feat(clustermesh): Implement namespace watcher infrastructure for glo…

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -195,6 +195,7 @@ spec:
         {{- end }}
         - --cluster-name=$(CLUSTER_NAME)
         - --cluster-id=$(CLUSTER_ID)
+        - --clustermesh-default-global-namespace=$(CLUSTERMESH_DEFAULT_GLOBAL_NAMESPACE)
         - --kvstore-opt=etcd.config=/var/lib/cilium/etcd-config.yaml
         - --kvstore-opt=etcd.qps=20
         - --kvstore-opt=etcd.bootstrapQps=10000
@@ -334,6 +335,12 @@ spec:
             configMapKeyRef:
               name: cilium-config
               key: cluster-id
+        - name: CLUSTERMESH_DEFAULT_GLOBAL_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: clustermesh-default-global-namespace
+              optional: true
         {{- with .Values.clustermesh.apiserver.kvstoremesh.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -218,6 +218,9 @@ const (
 	CECInjectCiliumFilters      = CECPrefix + "/inject-cilium-filters"
 	CECIsL7LB                   = CECPrefix + "/is-l7lb"
 	CECUseOriginalSourceAddress = CECPrefix + "/use-original-source-address"
+
+	// GlobalNamespace is the annotation used to mark namespaces for global export in ClusterMesh
+	GlobalNamespace = ClusterMeshPrefix + "/global"
 )
 
 // CiliumPrefixRegex is a regex matching Cilium specific annotations.

--- a/pkg/clustermesh/common/namespacewatcher/cell.go
+++ b/pkg/clustermesh/common/namespacewatcher/cell.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package namespacewatcher
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+)
+
+// NamespaceWatcherParams provides the dependencies for the namespace watcher.
+type NamespaceWatcherParams struct {
+	cell.In
+
+	Logger     *slog.Logger
+	JobGroup   job.Group
+	Namespaces resource.Resource[*slim_corev1.Namespace]
+	Config     Config
+}
+
+// Cell provides namespace-based export control for ClusterMesh.
+// The Config must be provided externally by the calling module.
+var Cell = cell.Module(
+	"namespace-watcher",
+	"Namespace-based export control for ClusterMesh",
+
+	cell.Provide(newGlobalNamespaceTracker),
+)
+
+// newGlobalNamespaceTracker creates and registers the namespace watcher.
+// The config parameter is provided externally by the calling module.
+func newGlobalNamespaceTracker(params NamespaceWatcherParams) GlobalNamespaceTracker {
+	// Ensure required dependencies are available
+	if params.Namespaces == nil {
+		params.Logger.Error("namespace resource is required for namespace watcher")
+		return nil
+	}
+
+	watcher := NewNamespaceWatcher(params.Logger, params.Config, params.Namespaces)
+
+	params.JobGroup.Add(
+		job.OneShot(
+			"namespace-watcher",
+			func(ctx context.Context, _ cell.Health) error {
+				for event := range params.Namespaces.Events(ctx) {
+					event.Done(nil)
+
+					switch event.Kind {
+					case resource.Sync:
+						params.Logger.Info("Initial list of namespaces successfully received from Kubernetes")
+					case resource.Upsert:
+						watcher.updateNamespace(event.Object)
+					case resource.Delete:
+						watcher.deleteNamespace(event.Object)
+					}
+				}
+				return nil
+			},
+		),
+	)
+
+	return watcher
+}

--- a/pkg/clustermesh/common/namespacewatcher/watcher.go
+++ b/pkg/clustermesh/common/namespacewatcher/watcher.go
@@ -1,0 +1,480 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package namespacewatcher
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// NewAlwaysGlobalTracker returns a tracker that always considers all namespaces as global.
+// This is used for backward compatibility when namespace filtering is not enabled.
+func NewAlwaysGlobalTracker() GlobalNamespaceTracker {
+	return &alwaysGlobalTracker{}
+}
+
+// alwaysGlobalTracker is used for backward compatibility when namespace watching is not enabled
+type alwaysGlobalTracker struct{}
+
+func (d *alwaysGlobalTracker) IsGlobalNamespace(namespace string) bool        { return true }
+func (d *alwaysGlobalTracker) GetGlobalNamespaces() sets.Set[string]          { return sets.New[string]() }
+func (d *alwaysGlobalTracker) RegisterProcessor(processor NamespaceProcessor) {}
+func (d *alwaysGlobalTracker) IsFilteringActive() bool                        { return false }
+func (d *alwaysGlobalTracker) IsGlobalService(obj interface {
+	GetAnnotations() map[string]string
+	GetNamespace() string
+}) bool {
+	return annotation.GetAnnotationIncludeExternal(obj)
+}
+func (d *alwaysGlobalTracker) IsSharedGlobalService(obj interface {
+	GetAnnotations() map[string]string
+	GetNamespace() string
+}) bool {
+	return d.IsGlobalService(obj) && annotation.GetAnnotationShared(obj)
+}
+
+// GlobalNamespaceTracker tracks which namespaces are marked as global for ClusterMesh export.
+type GlobalNamespaceTracker interface {
+	// IsGlobalNamespace returns true if the given namespace should be exported globally.
+	// Returns true by default for backwards compatibility if no specific configuration exists.
+	IsGlobalNamespace(namespace string) bool
+
+	// GetGlobalNamespaces returns the set of namespaces that are currently marked as global.
+	GetGlobalNamespaces() sets.Set[string]
+
+	// RegisterProcessor registers a processor that will be notified when namespace status changes
+	RegisterProcessor(processor NamespaceProcessor)
+
+	// IsFilteringActive returns true if namespace-based filtering is currently active
+	IsFilteringActive() bool
+
+	// IsGlobalService checks if a service is global considering both
+	// the service annotation and namespace filtering when active.
+	IsGlobalService(obj interface {
+		GetAnnotations() map[string]string
+		GetNamespace() string
+	}) bool
+
+	// IsSharedGlobalService checks if a service is both global and shared
+	IsSharedGlobalService(obj interface {
+		GetAnnotations() map[string]string
+		GetNamespace() string
+	}) bool
+}
+
+// NamespaceProcessor handles processing when namespace global status changes
+type NamespaceProcessor interface {
+	ProcessNamespaceChange(namespace string, isGlobal bool)
+	// GetAllNamespaces returns all namespaces that have resources in this processor's resource index
+	GetAllNamespaces() []string
+}
+
+const (
+	// OptClusterMeshDefaultGlobalNamespace is the name of the clustermesh-default-global-namespace option
+	OptClusterMeshDefaultGlobalNamespace = "clustermesh-default-global-namespace"
+)
+
+// Config configures the namespace watcher behavior.
+type Config struct {
+	// DefaultGlobalNamespace determines the default behavior for namespaces when
+	// namespace-based filtering is active (i.e., when at least one namespace is annotated).
+	// When true, namespaces are global by default unless annotated with clustermesh.cilium.io/global=false.
+	// When false, namespaces are local by default unless annotated with clustermesh.cilium.io/global=true.
+	DefaultGlobalNamespace bool `mapstructure:"clustermesh-default-global-namespace"`
+}
+
+// Flags implements cell.Flagger to register the clustermesh-default-global-namespace flag.
+func (cfg Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool(OptClusterMeshDefaultGlobalNamespace, cfg.DefaultGlobalNamespace,
+		"Default behavior for namespaces when namespace-based filtering is active. "+
+			"When true, namespaces are global by default unless annotated with 'clustermesh.cilium.io/global=false'. "+
+			"When false, namespaces are local by default unless annotated with 'clustermesh.cilium.io/global=true'.")
+}
+
+type namespaceWatcher struct {
+	logger            *slog.Logger
+	config            Config
+	mu                lock.RWMutex
+	namespaceResource resource.Resource[*slim_corev1.Namespace]
+
+	// Processors for handling namespace changes
+	processors []NamespaceProcessor
+}
+
+// NewNamespaceWatcher creates a new namespace watcher that tracks global namespaces.
+func NewNamespaceWatcher(logger *slog.Logger, config Config, namespaceResource resource.Resource[*slim_corev1.Namespace]) *namespaceWatcher {
+
+	return &namespaceWatcher{
+		logger:            logger,
+		config:            config,
+		namespaceResource: namespaceResource,
+	}
+}
+
+func (nw *namespaceWatcher) RegisterProcessor(processor NamespaceProcessor) {
+	nw.mu.Lock()
+	defer nw.mu.Unlock()
+	nw.processors = append(nw.processors, processor)
+}
+
+// getAllNamespacesFromProcessors gets all namespaces from all registered processors
+func (nw *namespaceWatcher) getAllNamespacesFromProcessors() []string {
+	allNamespaces := sets.New[string]()
+
+	// Collect namespaces from all processors
+	for _, processor := range nw.processors {
+		namespaces := processor.GetAllNamespaces()
+		for _, ns := range namespaces {
+			allNamespaces.Insert(ns)
+		}
+	}
+
+	return allNamespaces.UnsortedList()
+}
+
+// isNamespaceAnnotated checks if a namespace has the global annotation by querying the resource store
+func (nw *namespaceWatcher) isNamespaceAnnotated(namespace string) bool {
+	ctx := context.Background()
+	store, err := nw.namespaceResource.Store(ctx)
+	if err != nil {
+		return false
+	}
+
+	ns, exists, err := store.GetByKey(resource.Key{Name: namespace})
+	if err != nil || !exists {
+		return false
+	}
+
+	_, hasAnnotation := annotation.Get(ns, annotation.GlobalNamespace)
+	return hasAnnotation
+}
+
+// isNamespaceGlobalByAnnotation checks if a namespace is marked as global by its annotation
+func (nw *namespaceWatcher) isNamespaceGlobalByAnnotation(namespace string) bool {
+	ctx := context.Background()
+	store, err := nw.namespaceResource.Store(ctx)
+	if err != nil {
+		return false
+	}
+
+	ns, exists, err := store.GetByKey(resource.Key{Name: namespace})
+	if err != nil || !exists {
+		return false
+	}
+
+	annotationValue, hasAnnotation := annotation.Get(ns, annotation.GlobalNamespace)
+	if !hasAnnotation {
+		return false
+	}
+
+	return annotationValue == "true"
+}
+
+// isFilteringActive checks if namespace-based filtering is currently active by checking if any namespace has the annotation
+func (nw *namespaceWatcher) isFilteringActive() bool {
+	ctx := context.Background()
+	store, err := nw.namespaceResource.Store(ctx)
+	if err != nil {
+		return false
+	}
+
+	// List all namespaces and check if any have the annotation
+	allNamespaces := store.List()
+	for _, ns := range allNamespaces {
+		if _, hasAnnotation := annotation.Get(ns, annotation.GlobalNamespace); hasAnnotation {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (nw *namespaceWatcher) IsGlobalNamespace(namespace string) bool {
+	nw.mu.RLock()
+	defer nw.mu.RUnlock()
+
+	// If namespace-based filtering is not active (no annotated namespaces),
+	// all namespaces are global for backwards compatibility
+	if !nw.isFilteringActive() {
+		return true
+	}
+
+	// If the namespace is explicitly annotated, use the annotation value
+	if nw.isNamespaceAnnotated(namespace) {
+		return nw.isNamespaceGlobalByAnnotation(namespace)
+	}
+
+	// For non-annotated namespaces when filtering is active, use the default behavior
+	return nw.config.DefaultGlobalNamespace
+}
+
+func (nw *namespaceWatcher) IsFilteringActive() bool {
+	nw.mu.RLock()
+	defer nw.mu.RUnlock()
+	return nw.isFilteringActive()
+}
+
+func (nw *namespaceWatcher) GetGlobalNamespaces() sets.Set[string] {
+	nw.mu.RLock()
+	defer nw.mu.RUnlock()
+
+	// If namespace-based filtering is not active, return empty set to indicate all namespaces are global
+	if !nw.isFilteringActive() {
+		return sets.New[string]()
+	}
+
+	// When filtering is active, collect all global namespaces from the resource store
+	result := sets.New[string]()
+
+	ctx := context.Background()
+	store, err := nw.namespaceResource.Store(ctx)
+	if err != nil {
+		return result
+	}
+
+	// List all namespaces and check which ones are global
+	allNamespaces := store.List()
+	for _, ns := range allNamespaces {
+		annotationValue, hasAnnotation := annotation.Get(ns, annotation.GlobalNamespace)
+		if hasAnnotation {
+			if annotationValue == "true" {
+				result.Insert(ns.Name)
+			}
+		} else if nw.config.DefaultGlobalNamespace {
+			// Non-annotated namespaces are global if the default is true
+			result.Insert(ns.Name)
+		}
+	}
+
+	return result
+}
+
+func (nw *namespaceWatcher) IsGlobalService(obj interface {
+	GetAnnotations() map[string]string
+	GetNamespace() string
+}) bool {
+	// First check if service has the global annotation
+	if !annotation.GetAnnotationIncludeExternal(obj) {
+		return false
+	}
+
+	// If namespace filtering is active, also check if service is in a global namespace
+	if nw.IsFilteringActive() {
+		if !nw.IsGlobalNamespace(obj.GetNamespace()) {
+			// Service is marked as global but not in a global namespace
+			return false
+		}
+	}
+
+	return true
+}
+
+func (nw *namespaceWatcher) IsSharedGlobalService(obj interface {
+	GetAnnotations() map[string]string
+	GetNamespace() string
+}) bool {
+	// Service must be global first
+	if !nw.IsGlobalService(obj) {
+		return false
+	}
+
+	// Then check if it's also shared
+	return annotation.GetAnnotationShared(obj)
+}
+
+func (nw *namespaceWatcher) processNamespaceChange(processors []NamespaceProcessor, namespace string, isGlobal bool) {
+
+	// Normal operation: process asynchronously
+	for _, processor := range processors {
+		go processor.ProcessNamespaceChange(namespace, isGlobal)
+	}
+
+}
+
+func (nw *namespaceWatcher) updateNamespace(ns *slim_corev1.Namespace) {
+	// Check if namespace has the global annotation
+	annotationValue, hasAnnotation := annotation.Get(ns, annotation.GlobalNamespace)
+
+	nw.mu.Lock()
+
+	// Capture the previous state by querying the resource store
+	wasAnnotated := nw.isNamespaceAnnotated(ns.Name)
+	wasGlobal := nw.isNamespaceGlobalByAnnotation(ns.Name)
+	wasFilteringActive := nw.isFilteringActive()
+
+	var processors = make([]NamespaceProcessor, len(nw.processors))
+	copy(processors, nw.processors)
+
+	nw.mu.Unlock()
+
+	// Calculate current global status after the namespace update
+	// We need to check the current filtering state and annotation status
+	isFilteringActiveNow := hasAnnotation || nw.hasOtherAnnotatedNamespaces(ns.Name)
+	isGlobal := nw.calculateGlobalStatus(ns.Name, hasAnnotation, annotationValue, isFilteringActiveNow)
+
+	// Check if this specific namespace's status changed
+	wasGlobalWithOldLogic := wasAnnotated && wasGlobal || (!wasAnnotated && nw.config.DefaultGlobalNamespace)
+	needsProcessing := (wasGlobalWithOldLogic != isGlobal)
+
+	// Check if we transitioned from filtering active to inactive (backfill case)
+	transitionedToInactive := wasFilteringActive && !isFilteringActiveNow
+
+	// Check if we transitioned from filtering inactive to active (cleanup case)
+	transitionedToActive := !wasFilteringActive && isFilteringActiveNow
+
+	if needsProcessing {
+		nw.logger.Info("Namespace global status changed",
+			logfields.K8sNamespace, ns.Name,
+			logfields.IsGlobal, isGlobal,
+			logfields.HasAnnotation, hasAnnotation,
+			logfields.FilteringActive, isFilteringActiveNow,
+		)
+
+		// Process the namespace change directly without acquiring additional locks
+		nw.processNamespaceChange(processors, ns.Name, isGlobal)
+	}
+
+	// Handle the edge case: if we transitioned from filtering active to inactive,
+	// we need to backfill all namespaces as they all become global now
+	if transitionedToInactive {
+		// Get all namespaces from resource indexes
+		namespacesToBackfill := nw.getAllNamespacesFromProcessors()
+
+		nw.logger.Info("Namespace filtering deactivated, backfilling all namespaces as global",
+			logfields.NamespacesToBackfill, len(namespacesToBackfill),
+		)
+
+		for _, namespaceName := range namespacesToBackfill {
+			// Skip the namespace we already processed above to avoid double processing
+			if namespaceName != ns.Name {
+				nw.processNamespaceChange(processors, namespaceName, true)
+			}
+		}
+	}
+
+	// Handle the edge case: if we transitioned from filtering inactive to active,
+	// we need to remove resources from all non-global namespaces
+	if transitionedToActive {
+		// Get all namespaces from resource indexes
+		namespacesToCleanup := nw.getAllNamespacesFromProcessors()
+
+		nw.logger.Info("Namespace filtering activated, cleaning up non-global namespaces",
+			logfields.NamespacesToCleanup, len(namespacesToCleanup),
+		)
+
+		for _, namespaceName := range namespacesToCleanup {
+			// Skip the namespace we already processed above to avoid double processing
+			if namespaceName != ns.Name {
+				// Check if this namespace should now be considered global
+				shouldBeGlobal := nw.calculateGlobalStatusForNamespace(namespaceName, true)
+				if !shouldBeGlobal {
+					// This namespace is not global, so remove its resources from etcd
+					nw.processNamespaceChange(processors, namespaceName, false)
+				}
+			}
+		}
+	}
+}
+
+// hasOtherAnnotatedNamespaces checks if there are any other namespaces (besides the given one) that have annotations
+func (nw *namespaceWatcher) hasOtherAnnotatedNamespaces(excludeNamespace string) bool {
+	ctx := context.Background()
+	store, err := nw.namespaceResource.Store(ctx)
+	if err != nil {
+		return false
+	}
+
+	allNamespaces := store.List()
+	for _, ns := range allNamespaces {
+		if ns.Name != excludeNamespace {
+			if _, hasAnnotation := annotation.Get(ns, annotation.GlobalNamespace); hasAnnotation {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// calculateGlobalStatus determines if a namespace should be global based on its annotation and filtering state
+func (nw *namespaceWatcher) calculateGlobalStatus(namespace string, hasAnnotation bool, annotationValue string, filteringActive bool) bool {
+	if !filteringActive {
+		return true // All namespaces are global when filtering is not active
+	}
+
+	if hasAnnotation {
+		return annotationValue == "true"
+	}
+
+	return nw.config.DefaultGlobalNamespace
+}
+
+// calculateGlobalStatusForNamespace determines if a namespace should be global when filtering is active
+func (nw *namespaceWatcher) calculateGlobalStatusForNamespace(namespace string, filteringActive bool) bool {
+	if !filteringActive {
+		return true
+	}
+
+	if nw.isNamespaceAnnotated(namespace) {
+		return nw.isNamespaceGlobalByAnnotation(namespace)
+	}
+
+	return nw.config.DefaultGlobalNamespace
+}
+
+func (nw *namespaceWatcher) deleteNamespace(ns *slim_corev1.Namespace) {
+	nw.mu.Lock()
+
+	// Capture the previous state by querying the resource store before deletion
+	wasAnnotated := nw.isNamespaceAnnotated(ns.Name)
+	wasGlobal := nw.isNamespaceGlobalByAnnotation(ns.Name)
+	wasFilteringActive := nw.isFilteringActive()
+
+	// Copy processors while holding the lock
+	var processors = make([]NamespaceProcessor, len(nw.processors))
+	copy(processors, nw.processors)
+
+	nw.mu.Unlock()
+
+	// Check if this namespace was global (either explicitly or by default)
+	needsProcessing := wasAnnotated && wasGlobal || (!wasAnnotated && nw.config.DefaultGlobalNamespace)
+
+	// Check if we transitioned from filtering active to inactive (backfill case)
+	// This happens when the deleted namespace was the last one with annotations
+	transitionedToInactive := wasFilteringActive && !nw.hasOtherAnnotatedNamespaces(ns.Name)
+
+	// If this namespace was global (either explicitly or by default), process removal
+	if needsProcessing {
+		nw.logger.Info("Namespace deleted, removing from global set",
+			logfields.K8sNamespace, ns.Name,
+		)
+
+		nw.processNamespaceChange(processors, ns.Name, false)
+	}
+
+	// Handle the edge case: if we transitioned from filtering active to inactive,
+	// we need to backfill all remaining namespaces as they all become global now
+	if transitionedToInactive {
+		// Get all namespaces from resource indexes
+		namespacesToBackfill := nw.getAllNamespacesFromProcessors()
+
+		nw.logger.Info("Namespace filtering deactivated due to namespace deletion, backfilling all remaining namespaces as global",
+			logfields.NamespacesToBackfill, len(namespacesToBackfill),
+			logfields.DeletedNamespace, ns.Name,
+		)
+
+		for _, namespaceName := range namespacesToBackfill {
+			nw.processNamespaceChange(processors, namespaceName, true)
+		}
+	}
+}

--- a/pkg/clustermesh/common/namespacewatcher/watcher_test.go
+++ b/pkg/clustermesh/common/namespacewatcher/watcher_test.go
@@ -1,0 +1,515 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package namespacewatcher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+const (
+	// GlobalNamespaceAnnotation defines the annotation key for marking namespaces as global
+	GlobalNamespaceAnnotation = "clustermesh.cilium.io/global"
+)
+
+// MockNamespaceProcessor implements NamespaceProcessor for testing
+type MockNamespaceProcessor struct {
+	namespaceChanges map[string]bool
+	allNamespaces    []string
+}
+
+func (m *MockNamespaceProcessor) ProcessNamespaceChange(namespace string, isGlobal bool) {
+	if m.namespaceChanges == nil {
+		m.namespaceChanges = make(map[string]bool)
+	}
+	m.namespaceChanges[namespace] = isGlobal
+}
+
+func (m *MockNamespaceProcessor) GetAllNamespaces() []string {
+	return m.allNamespaces
+}
+
+func (m *MockNamespaceProcessor) SetAllNamespaces(namespaces []string) {
+	m.allNamespaces = namespaces
+}
+
+func (m *MockNamespaceProcessor) GetNamespaceChanges() map[string]bool {
+	return m.namespaceChanges
+}
+
+func (m *MockNamespaceProcessor) ClearChanges() {
+	m.namespaceChanges = make(map[string]bool)
+}
+
+// createTestNamespace creates a test namespace with optional global annotation
+func createTestNamespace(name string, isGlobal *bool) *slim_corev1.Namespace {
+	ns := &slim_corev1.Namespace{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if isGlobal != nil {
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+		if *isGlobal {
+			ns.Annotations[GlobalNamespaceAnnotation] = "true"
+		} else {
+			ns.Annotations[GlobalNamespaceAnnotation] = "false"
+		}
+	}
+
+	return ns
+}
+
+// mockNamespaceResource creates a simple mock resource for testing namespace watcher in isolation
+type mockNamespaceResource struct {
+	namespaces map[string]*slim_corev1.Namespace
+}
+
+func newMockNamespaceResource(namespaces ...*slim_corev1.Namespace) *mockNamespaceResource {
+	r := &mockNamespaceResource{
+		namespaces: make(map[string]*slim_corev1.Namespace),
+	}
+	for _, ns := range namespaces {
+		r.namespaces[ns.Name] = ns
+	}
+	return r
+}
+
+func (m *mockNamespaceResource) Store(ctx context.Context) (resource.Store[*slim_corev1.Namespace], error) {
+	return &mockNamespaceStore{namespaces: m.namespaces}, nil
+}
+
+func (m *mockNamespaceResource) Events(ctx context.Context, opts ...resource.EventsOpt) <-chan resource.Event[*slim_corev1.Namespace] {
+	// For basic testing, we don't need events
+	ch := make(chan resource.Event[*slim_corev1.Namespace])
+	close(ch)
+	return ch
+}
+
+func (m *mockNamespaceResource) Observe(ctx context.Context, next func(resource.Event[*slim_corev1.Namespace]), complete func(error)) {
+	// Basic implementation for stream.Observable interface
+	complete(nil)
+}
+
+type mockNamespaceStore struct {
+	namespaces map[string]*slim_corev1.Namespace
+}
+
+func (m *mockNamespaceStore) GetByKey(key resource.Key) (*slim_corev1.Namespace, bool, error) {
+	ns, exists := m.namespaces[key.Name]
+	return ns, exists, nil
+}
+
+func (m *mockNamespaceStore) Get(obj *slim_corev1.Namespace) (*slim_corev1.Namespace, bool, error) {
+	return m.GetByKey(resource.Key{Name: obj.Name})
+}
+
+func (m *mockNamespaceStore) List() []*slim_corev1.Namespace {
+	var result []*slim_corev1.Namespace
+	for _, ns := range m.namespaces {
+		result = append(result, ns)
+	}
+	return result
+}
+
+func (m *mockNamespaceStore) IterKeys() resource.KeyIter {
+	// Simple implementation for testing
+	return &mockKeyIterator{}
+}
+
+func (m *mockNamespaceStore) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	return nil, nil // Not needed for basic testing
+}
+
+func (m *mockNamespaceStore) ByIndex(indexName, indexedValue string) ([]*slim_corev1.Namespace, error) {
+	return nil, nil // Not needed for basic testing
+}
+
+func (m *mockNamespaceStore) CacheStore() cache.Store {
+	return nil // Not needed for basic testing
+}
+
+type mockKeyIterator struct{}
+
+func (m *mockKeyIterator) Next() bool        { return false }
+func (m *mockKeyIterator) Key() resource.Key { return resource.Key{} }
+
+// createNamespaceWatcher creates a namespace watcher for isolated testing
+func createNamespaceWatcher(t *testing.T, config Config, namespaces ...*slim_corev1.Namespace) (GlobalNamespaceTracker, *MockNamespaceProcessor) {
+	logger := hivetest.Logger(t)
+
+	// Create namespace watcher with config
+	mockResource := newMockNamespaceResource(namespaces...)
+	watcher := NewNamespaceWatcher(logger, config, mockResource)
+
+	// Create and register mock processor
+	mockProcessor := &MockNamespaceProcessor{}
+	watcher.RegisterProcessor(mockProcessor)
+
+	return watcher, mockProcessor
+}
+
+func TestNamespaceWatcherInitialization(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         Config
+		expectedGlobal bool
+	}{
+		{
+			name:           "default-global-true",
+			config:         Config{DefaultGlobalNamespace: true},
+			expectedGlobal: true,
+		},
+		{
+			name:           "default-global-false",
+			config:         Config{DefaultGlobalNamespace: false},
+			expectedGlobal: true, // Backwards compatibility mode
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker, _ := createNamespaceWatcher(t, tt.config)
+
+			// Test initial state - no filtering should be active
+			assert.False(t, tracker.IsFilteringActive(), "Filtering should not be active initially")
+
+			// Test backwards compatibility - all namespaces should be global when no annotations exist
+			assert.True(t, tracker.IsGlobalNamespace("any-namespace"), "All namespaces should be global in backwards compatibility mode")
+
+			// Test that GetGlobalNamespaces returns empty set (indicating all namespaces are global)
+			globalNs := tracker.GetGlobalNamespaces()
+			assert.Equal(t, 0, globalNs.Len(), "GetGlobalNamespaces should return empty set when filtering is inactive")
+		})
+	}
+}
+
+func TestNamespaceAnnotationProcessing(t *testing.T) {
+	tests := []struct {
+		name                    string
+		config                  Config
+		namespace               *slim_corev1.Namespace
+		expectedGlobal          bool
+		expectedFilteringActive bool
+	}{
+		{
+			name:                    "global-annotation-true",
+			config:                  Config{DefaultGlobalNamespace: false},
+			namespace:               createTestNamespace("test-ns", &[]bool{true}[0]),
+			expectedGlobal:          true,
+			expectedFilteringActive: true,
+		},
+		{
+			name:                    "global-annotation-false",
+			config:                  Config{DefaultGlobalNamespace: true},
+			namespace:               createTestNamespace("test-ns", &[]bool{false}[0]),
+			expectedGlobal:          false,
+			expectedFilteringActive: true,
+		},
+		{
+			name:                    "no-annotation-default-true",
+			config:                  Config{DefaultGlobalNamespace: true},
+			namespace:               createTestNamespace("test-ns", nil),
+			expectedGlobal:          true,
+			expectedFilteringActive: false,
+		},
+		{
+			name:                    "no-annotation-default-false",
+			config:                  Config{DefaultGlobalNamespace: false},
+			namespace:               createTestNamespace("test-ns", nil),
+			expectedGlobal:          true, // Backwards compatibility when no filtering active
+			expectedFilteringActive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker, _ := createNamespaceWatcher(t, tt.config, tt.namespace)
+
+			assert.Equal(t, tt.expectedFilteringActive, tracker.IsFilteringActive(), "Filtering active state should match expectation")
+			assert.Equal(t, tt.expectedGlobal, tracker.IsGlobalNamespace(tt.namespace.Name), "Namespace global state should match expectation")
+		})
+	}
+}
+
+func TestNamespaceWatcherProcessorRegistration(t *testing.T) {
+	config := Config{DefaultGlobalNamespace: false}
+	tracker, processor1 := createNamespaceWatcher(t, config)
+
+	// Register additional processors
+	processor2 := &MockNamespaceProcessor{}
+	processor3 := &MockNamespaceProcessor{}
+
+	tracker.RegisterProcessor(processor2)
+	tracker.RegisterProcessor(processor3)
+
+	// Since we can't directly access updateNamespace from the interface,
+	// we'll test the basic registration functionality
+	assert.NotNil(t, processor1, "First processor should be registered")
+	assert.NotNil(t, processor2, "Second processor should be registered")
+	assert.NotNil(t, processor3, "Third processor should be registered")
+}
+
+func TestGetGlobalNamespaces(t *testing.T) {
+	config := Config{DefaultGlobalNamespace: false}
+
+	ns1 := createTestNamespace("global-ns", &[]bool{true}[0])
+	ns2 := createTestNamespace("local-ns", &[]bool{false}[0])
+	ns3 := createTestNamespace("default-ns", nil)
+
+	tracker, _ := createNamespaceWatcher(t, config, ns1, ns2, ns3)
+
+	globalNs := tracker.GetGlobalNamespaces()
+	expected := sets.New("global-ns") // Only explicitly global namespace
+	assert.Equal(t, expected, globalNs, "Should return only explicitly global namespaces")
+
+	// Test with default global = true
+	config2 := Config{DefaultGlobalNamespace: true}
+	tracker2, _ := createNamespaceWatcher(t, config2, ns1, ns2, ns3)
+
+	globalNs2 := tracker2.GetGlobalNamespaces()
+	expected2 := sets.New("global-ns", "default-ns") // Global + default
+	assert.Equal(t, expected2, globalNs2, "Should return global and default namespaces when DefaultGlobalNamespace=true")
+}
+
+func TestNamespaceWatcherEdgeCases(t *testing.T) {
+	t.Run("empty-namespace-name", func(t *testing.T) {
+		config := Config{DefaultGlobalNamespace: false}
+		tracker, _ := createNamespaceWatcher(t, config)
+
+		// Should handle empty namespace name gracefully
+		assert.True(t, tracker.IsGlobalNamespace(""), "Should handle empty namespace name")
+	})
+
+	t.Run("special-characters-in-namespace", func(t *testing.T) {
+		config := Config{DefaultGlobalNamespace: false}
+		specialNs := createTestNamespace("test-ns.with-special_chars", &[]bool{true}[0])
+		tracker, _ := createNamespaceWatcher(t, config, specialNs)
+
+		assert.True(t, tracker.IsFilteringActive(), "Should work with special characters")
+		assert.True(t, tracker.IsGlobalNamespace("test-ns.with-special_chars"), "Should handle special characters in namespace names")
+	})
+}
+
+func TestComprehensiveBackwardsCompatibility(t *testing.T) {
+	// Test that the namespace watcher maintains backwards compatibility behavior
+	scenarios := []struct {
+		name                 string
+		defaultGlobal        bool
+		hasAnnotatedNS       bool
+		expectedFiltering    bool
+		expectedGlobalForAny bool
+	}{
+		{
+			name:                 "no-annotations-default-true",
+			defaultGlobal:        true,
+			hasAnnotatedNS:       false,
+			expectedFiltering:    false,
+			expectedGlobalForAny: true,
+		},
+		{
+			name:                 "no-annotations-default-false",
+			defaultGlobal:        false,
+			hasAnnotatedNS:       false,
+			expectedFiltering:    false,
+			expectedGlobalForAny: true,
+		},
+		{
+			name:                 "with-annotations-default-true",
+			defaultGlobal:        true,
+			hasAnnotatedNS:       true,
+			expectedFiltering:    true,
+			expectedGlobalForAny: true, // Because default is true
+		},
+		{
+			name:                 "with-annotations-default-false",
+			defaultGlobal:        false,
+			hasAnnotatedNS:       true,
+			expectedFiltering:    true,
+			expectedGlobalForAny: false, // Because default is false and filtering is active
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			config := Config{DefaultGlobalNamespace: scenario.defaultGlobal}
+
+			var namespaces []*slim_corev1.Namespace
+			if scenario.hasAnnotatedNS {
+				namespaces = append(namespaces, createTestNamespace("annotated-ns", &[]bool{true}[0]))
+			}
+
+			tracker, _ := createNamespaceWatcher(t, config, namespaces...)
+
+			assert.Equal(t, scenario.expectedFiltering, tracker.IsFilteringActive(), "Filtering state should match expectation")
+			assert.Equal(t, scenario.expectedGlobalForAny, tracker.IsGlobalNamespace("any-namespace"), "Global namespace behavior should match expectation")
+		})
+	}
+}
+
+// Test service objects for IsGlobalService and IsSharedGlobalService methods
+type testService struct {
+	annotations map[string]string
+	namespace   string
+}
+
+func (ts *testService) GetAnnotations() map[string]string {
+	return ts.annotations
+}
+
+func (ts *testService) GetNamespace() string {
+	return ts.namespace
+}
+
+func TestIsGlobalService(t *testing.T) {
+	config := Config{DefaultGlobalNamespace: false}
+
+	// Create a namespace that is global
+	globalNs := createTestNamespace("global-ns", &[]bool{true}[0])
+	localNs := createTestNamespace("local-ns", &[]bool{false}[0])
+
+	tracker, _ := createNamespaceWatcher(t, config, globalNs, localNs)
+
+	tests := []struct {
+		name     string
+		service  *testService
+		expected bool
+	}{
+		{
+			name: "global-service-in-global-namespace",
+			service: &testService{
+				annotations: map[string]string{"service.cilium.io/global": "true"},
+				namespace:   "global-ns",
+			},
+			expected: true,
+		},
+		{
+			name: "global-service-in-local-namespace",
+			service: &testService{
+				annotations: map[string]string{"service.cilium.io/global": "true"},
+				namespace:   "local-ns",
+			},
+			expected: false, // Should fail because namespace is local
+		},
+		{
+			name: "local-service-in-global-namespace",
+			service: &testService{
+				annotations: map[string]string{},
+				namespace:   "global-ns",
+			},
+			expected: false, // Should fail because service is not annotated as global
+		},
+		{
+			name: "local-service-in-local-namespace",
+			service: &testService{
+				annotations: map[string]string{},
+				namespace:   "local-ns",
+			},
+			expected: false, // Should fail both checks
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tracker.IsGlobalService(tt.service)
+			assert.Equal(t, tt.expected, result, "IsGlobalService should match expectation")
+		})
+	}
+}
+
+func TestIsSharedGlobalService(t *testing.T) {
+	config := Config{DefaultGlobalNamespace: false}
+
+	// Create a namespace that is global
+	globalNs := createTestNamespace("global-ns", &[]bool{true}[0])
+
+	tracker, _ := createNamespaceWatcher(t, config, globalNs)
+
+	tests := []struct {
+		name     string
+		service  *testService
+		expected bool
+	}{
+		{
+			name: "shared-global-service",
+			service: &testService{
+				annotations: map[string]string{
+					"service.cilium.io/global": "true",
+					"service.cilium.io/shared": "true",
+				},
+				namespace: "global-ns",
+			},
+			expected: true,
+		},
+		{
+			name: "global-service-default-shared",
+			service: &testService{
+				annotations: map[string]string{"service.cilium.io/global": "true"},
+				namespace:   "global-ns",
+			},
+			expected: true, // Should be shared by default
+		},
+		{
+			name: "explicitly-not-shared-global-service",
+			service: &testService{
+				annotations: map[string]string{
+					"service.cilium.io/global": "true",
+					"service.cilium.io/shared": "false",
+				},
+				namespace: "global-ns",
+			},
+			expected: false, // Explicitly not shared
+		},
+		{
+			name: "local-service",
+			service: &testService{
+				annotations: map[string]string{"service.cilium.io/shared": "true"},
+				namespace:   "global-ns",
+			},
+			expected: false, // Not global, so can't be shared
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tracker.IsSharedGlobalService(tt.service)
+			assert.Equal(t, tt.expected, result, "IsSharedGlobalService should match expectation")
+		})
+	}
+}
+
+func TestAlwaysGlobalTracker(t *testing.T) {
+	tracker := NewAlwaysGlobalTracker()
+
+	// Should always return true for backwards compatibility
+	assert.True(t, tracker.IsGlobalNamespace("any-namespace"), "Always global tracker should always return true")
+	assert.False(t, tracker.IsFilteringActive(), "Always global tracker should not be filtering")
+	assert.Equal(t, 0, tracker.GetGlobalNamespaces().Len(), "Always global tracker should return empty set")
+
+	// Test service methods
+	globalService := &testService{
+		annotations: map[string]string{"service.cilium.io/global": "true"},
+		namespace:   "any-ns",
+	}
+	localService := &testService{
+		annotations: map[string]string{},
+		namespace:   "any-ns",
+	}
+
+	assert.True(t, tracker.IsGlobalService(globalService), "Should respect global annotation")
+	assert.False(t, tracker.IsGlobalService(localService), "Should respect missing global annotation")
+	assert.True(t, tracker.IsSharedGlobalService(globalService), "Global service should be shared by default")
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1807,4 +1807,16 @@ const (
 	Fraction = "fraction"
 
 	Rate = "rate"
+
+	IsGlobal = "isGlobal"
+
+	HasAnnotation = "hasAnnotation"
+
+	FilteringActive = "filteringActive"
+
+	NamespacesToCleanup = "namespacesToCleanup"
+
+	NamespacesToBackfill = "namespacesToBackfill"
+
+	DeletedNamespace = "deletedNamespace"
 )


### PR DESCRIPTION
This PR introduces the foundational namespace watcher infrastructure required for [CFP-39876](https://github.com/cilium/design-cfps/pull/74) 

Major elements included:
- pkg/clustermesh/namespace_watcher.go - Core namespace tracking logic
- pkg/clustermesh/namespace_watcher_cell.go - Hive cell integration
- pkg/clustermesh/cell.go - Cell registration
- pkg/annotation/k8s.go - GlobalNamespace annotation constant
- pkg/annotation/clustermesh.go - Namespace filtering helper

Draft [PR](https://github.com/cilium/cilium/pull/41096/) with E2E changes for the linked CFP 

