### PR TITLE
pkg/bpf/collection: Temporarily don't error on unused maps

### DIFF
--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -401,9 +401,10 @@ func LoadCollection(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *Collec
 
 	if logger.Enabled(context.Background(), slog.LevelDebug) {
 		if err := verifyUnusedMaps(coll, keep); err != nil {
-			return nil, nil, fmt.Errorf("verifying unused maps: %w", err)
+			logger.Debug(fmt.Sprintf("verifying unused maps: %v", err))
+		} else {
+			logger.Debug("Verified no unused maps after loading Collection")
 		}
-		logger.Debug("Verified no unused maps after loading Collection")
 	}
 
 	// Collect Maps that need their bpffs pins replaced. Pull out Map objects


### PR DESCRIPTION
When we introduced the new unused map pruning logic we added a verification step which, after loading, confirms we did everything as expected. This works by reading back the loaded program instructions.

However, on GKE the process of reading back the instructions fails inside of cilium/ebpf logic. To unblock CI until the root cause can be resolved, let us not throw an error in the verification step.

See https://github.com/cilium/cilium/issues/41245
