### PR TITLE
Remove EnableNodePort

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -24,7 +24,10 @@ inputs:
     required: false
     default: '1'
     description: 'Concurrency level to run tests'
-
+  skip-include-conn-disrupt-test-ns-traffic:
+    required: false
+    default: 'false'
+    description: 'Skip NS traffic disruption test (--include-conn-disrupt-test-ns-traffic). Can be removed after Cilium v1.20 release'
 runs:
   using: composite
   steps:
@@ -35,11 +38,17 @@ runs:
           TEST_ARG="${{ inputs.tests }}"
         else
           TEST_ARG="no-interrupted-connections"
-          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic --include-conn-disrupt-test-egw"
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw"
+          if [[ "${{ inputs.skip-include-conn-disrupt-test-ns-traffic }}" != "true" ]]; then
+            EXTRA_ARG="${EXTRA_ARG} --include-conn-disrupt-test-ns-traffic"
+          fi
         fi
         if [[ "${{ inputs.full-test }}" == "true" ]]; then
           TEST_ARG=""
-          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic --include-conn-disrupt-test-egw"
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw"
+          if [[ "${{ inputs.skip-include-conn-disrupt-test-ns-traffic }}" != "true" ]]; then
+            EXTRA_ARG="${EXTRA_ARG} --include-conn-disrupt-test-ns-traffic"
+          fi
         fi
         ${{ inputs.cilium-cli }} connectivity test --include-unsafe-tests \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \

--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -86,6 +86,7 @@
   misc: 'socketLB.enabled=false,nodePort.enabled=true,bpf.masquerade=true'
   local-redirect-policy: 'true'
   node-local-dns: 'true'
+  skip-include-conn-disrupt-test-ns-traffic: 'true'
 - name: '9'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.10-20250812.093650'

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -151,8 +151,7 @@ jobs:
             --helm-set=extraArgs[0]=\"--local-router-ipv4=169.254.23.0\" \
             --helm-set=enableIPv4Masquerade=true \
             --helm-set=bpf.masquerade=true \
-            --helm-set=ipMasqAgent.enabled=true \
-            --helm-set=nodePort.enabled=true"
+            --helm-set=ipMasqAgent.enabled=true"
 
           if [ "${{ matrix.ipFamily }}" = "dual" ]; then
             CILIUM_INSTALL_DEFAULTS="${CILIUM_INSTALL_DEFAULTS} \

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -110,34 +110,24 @@ jobs:
         include:
         - name: Without_XDP
           kube-proxy-replacement: true
-          enable-node-port: false
           bpf-lb-acceleration: disabled
           loadbalancer-mode: dedicated
           default-ingress-controller: false
         - name: With_XDP
           kube-proxy-replacement: true
-          enable-node-port: false
           bpf-lb-acceleration: native
           loadbalancer-mode: dedicated
           default-ingress-controller: false
         - name: With_Shared_LB
           kube-proxy-replacement: true
-          enable-node-port: false
           bpf-lb-acceleration: disabled
           loadbalancer-mode: shared
           default-ingress-controller: false
         - name: With_Default_Ingress_Controller
           kube-proxy-replacement: true
-          enable-node-port: false
           bpf-lb-acceleration: disabled
           loadbalancer-mode: dedicated
           default-ingress-controller: true
-        - name: Without_KPR
-          kube-proxy-replacement: false
-          enable-node-port: true
-          bpf-lb-acceleration: disabled
-          loadbalancer-mode: dedicated
-          default-ingress-controller: false
 
     steps:
       - name: Collect Workflow Telemetry
@@ -168,7 +158,6 @@ jobs:
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set kubeProxyReplacement=${{ matrix.kube-proxy-replacement }} \
-            --helm-set nodePort.enabled=${{ matrix.enable-node-port }} \
             --helm-set=ingressController.enabled=true \
             --helm-set=ingressController.loadbalancerMode=${{ matrix.loadbalancer-mode }} \
             --helm-set=ingressController.default=${{ matrix.default-ingress-controller }} \

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -119,11 +119,7 @@ jobs:
             --set-string=operator.extraEnv[3].name=KUBE_CACHE_MUTATION_DETECTOR \
             --set-string=operator.extraEnv[3].value=true \
             --set nodeinit.enabled=true \
-            --set kubeProxyReplacement=false \
-            --set socketLB.enabled=false \
-            --set externalIPs.enabled=true \
-            --set nodePort.enabled=true \
-            --set hostPort.enabled=true \
+            --set kubeProxyReplacement=true \
             --set bpf.masquerade=false \
             --set ipam.mode=kubernetes \
             --set image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -420,6 +420,7 @@ jobs:
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Start unencrypted packets check for connectivity tests after upgrade
         if: ${{ matrix.encryption != '' }}
@@ -436,6 +437,7 @@ jobs:
           job-name: cilium-upgrade-${{ matrix.name }}-sequential
           tests: 'seq-.*,!pod-to-world.*'
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Run concurrent Cilium tests
         uses: ./.github/actions/conn-disrupt-test-check
@@ -444,6 +446,7 @@ jobs:
           tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
           test-concurrency: ${{ env.test_concurrency }}
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Check for unexpected packet drops during connectivity tests
         uses: ./.github/actions/conn-disrupt-test-check
@@ -451,6 +454,7 @@ jobs:
           job-name: cilium-upgrade-${{ matrix.name }}-postcheck
           tests: 'no-unexpected-packet-drops'
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after upgrade
         if: ${{ matrix.encryption != '' }}
@@ -498,6 +502,7 @@ jobs:
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Start unencrypted packets check for connectivity tests after downgrade
         if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
@@ -514,6 +519,7 @@ jobs:
           job-name: cilium-downgrade-${{ matrix.name }}-sequential
           tests: 'seq-.*,!pod-to-world.*'
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Run concurrent Cilium tests
         if: ${{ matrix.skip-upgrade != 'true' }}
@@ -523,6 +529,7 @@ jobs:
           tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
           test-concurrency: ${{ env.test_concurrency }}
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Check for unexpected packet drops during connectivity tests
         if: ${{ matrix.skip-upgrade != 'true' }}
@@ -531,6 +538,7 @@ jobs:
           job-name: cilium-upgrade-${{ matrix.name }}-postcheck
           tests: 'no-unexpected-packet-drops'
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after downgrade
         if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2879,7 +2879,7 @@
    * - :spelling:ignore:`nodePort`
      - Configure N-S k8s service loadbalancing
      - object
-     - ``{"addresses":null,"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enableHealthCheckLoadBalancerIP":false,"enabled":false}``
+     - ``{"addresses":null,"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enableHealthCheckLoadBalancerIP":false}``
    * - :spelling:ignore:`nodePort.addresses`
      - List of CIDRs for choosing which IP addresses assigned to native devices are used for NodePort load-balancing. By default this is empty and the first suitable, preferably private, IPv4 and IPv6 address assigned to each device is used.  Example:    addresses: ["192.168.1.0/24", "2001::/64"]
      - string
@@ -2898,10 +2898,6 @@
      - ``true``
    * - :spelling:ignore:`nodePort.enableHealthCheckLoadBalancerIP`
      - Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs EnableHealthCheck to be enabled
-     - bool
-     - ``false``
-   * - :spelling:ignore:`nodePort.enabled`
-     - Enable the Cilium NodePort service implementation.
      - bool
      - ``false``
    * - :spelling:ignore:`nodeSelector`

--- a/Documentation/network/clustermesh/services.rst
+++ b/Documentation/network/clustermesh/services.rst
@@ -208,8 +208,8 @@ Limitations
 ###########
 
 * Global NodePort services load balance across both local and remote backends only
-  if Cilium is configured to replace kube-proxy (either ``kubeProxyReplacement=true``
-  or ``nodePort.enabled=true``). Otherwise, only local backends are eligible for
+  if Cilium is configured to replace kube-proxy (``kubeProxyReplacement=true``).
+  Otherwise, only local backends are eligible for
   load balancing when accessed through the NodePort.
 
 * Global services accessed by a Node, or a Pod running in host network, load

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -1,8 +1,7 @@
 Prerequisites
 #############
 
-* Cilium must be configured with NodePort enabled, using
-  ``nodePort.enabled=true`` or by enabling the kube-proxy replacement with
+* Cilium must be configured with the kube-proxy replacement, using
   ``kubeProxyReplacement=true``. For more information, see :ref:`kube-proxy
   replacement <kubeproxy-free>`.
 * Cilium must be configured with the L7 proxy enabled using ``l7Proxy=true``

--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -48,8 +48,7 @@ an existing K8s cluster with Cilium installed.
 Prerequisites
 #############
 
-* Cilium must be configured with NodePort enabled, using
-  ``nodePort.enabled=true`` or by enabling the kube-proxy replacement with
+* Cilium must be configured with the kube-proxy replacement, using
   ``kubeProxyReplacement=true``. For more information, see :ref:`kube-proxy
   replacement <kubeproxy-free>`.
 * Cilium must be configured with the L7 proxy enabled using ``l7Proxy=true``

--- a/Documentation/network/servicemesh/l7-traffic-management.rst
+++ b/Documentation/network/servicemesh/l7-traffic-management.rst
@@ -16,8 +16,7 @@ and CiliumClusterwideEnvoyConfig).
 Prerequisites
 #############
 
-* Cilium must be configured with NodePort enabled, using
-  ``nodePort.enabled=true`` or by enabling the kube-proxy replacement with
+* Cilium must be configured with the kube-proxy replacement, using
   ``kubeProxyReplacement=true``. For more information, see :ref:`kube-proxy
   replacement <kubeproxy-free>`.
 

--- a/Documentation/operations/troubleshooting_servicemesh.rst
+++ b/Documentation/operations/troubleshooting_servicemesh.rst
@@ -20,17 +20,13 @@ Generic
 Manual Verification of Setup
 ----------------------------
 
- #. Validate that ``nodePort.enabled`` is true.
+ #. Validate that ``kubeProxyReplacement`` is true.
 
     .. code-block:: shell-session
 
-        $ kubectl exec -n kube-system ds/cilium -- cilium-dbg status --verbose
+        $ kubectl exec -n kube-system ds/cilium -- cilium-dbg status
         ...
-        KubeProxyReplacement Details:
-        ...
-          Services:
-          - ClusterIP:      Enabled
-          - NodePort:       Enabled (Range: 30000-32767)
+        KubeProxyReplacement:    True
         ...
 
  #. Validate that runtime the values of ``enable-envoy-config`` and ``enable-ingress-controller``

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -324,6 +324,8 @@ Removed Options
 * The previously deprecated ``--enable-session-affinity``, ``--enable-internal-traffic-policy``, and
   ``--enable-svc-source-range-check`` flags have been removed. Their corresponding features are
   enabled by default.
+* The previously deprecated ``--enable-node-port``, ``--enable-host-port``, and ``--enable-external-ips``
+  flags have been removed. To enable the corresponding features, users must set ``--kube-proxy-replacement=true``.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -422,7 +422,7 @@ func withKPRReqForMultiCluster(ct *check.ConnectivityTest, reqs ...features.Requ
 	// Skip the nodeport-related tests in the multicluster scenario if KPR is not
 	// enabled, since global nodeport services are not supported in that case.
 	if ct.Params().MultiCluster != "" {
-		reqs = append(reqs, features.RequireEnabled(features.KPRNodePort))
+		reqs = append(reqs, features.RequireEnabled(features.KPR))
 	}
 	return reqs
 }

--- a/cilium-cli/connectivity/builder/echo_ingress_l7.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_l7.go
@@ -66,7 +66,7 @@ func (t echoIngressL7) build(ct *check.ConnectivityTest, _ map[string]string) {
 				}
 				ok, _ = ct.Features.MatchRequirements(
 					features.RequireEnabled(features.Tunnel),
-					features.RequireEnabled(features.KPRMode),
+					features.RequireEnabled(features.KPR),
 				)
 				return !ok
 			}

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1337,7 +1337,7 @@ func (ct *ConnectivityTest) ForEachIPFamily(hasNetworkPolicies bool, do func(fea
 func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 	return ct.params.IncludeConnDisruptTestNSTraffic &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&
-		(ct.Params().MultiCluster == "" || ct.Features[features.KPRNodePort].Enabled) &&
+		(ct.Params().MultiCluster == "" || ct.Features[features.KPR].Enabled) &&
 		!ct.Features[features.KPRNodePortAcceleration].Enabled
 }
 

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -166,31 +166,14 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 	if kpr := st.KubeProxyReplacement; kpr != nil {
 		mode = strings.ToLower(kpr.Mode)
 		if f := kpr.Features; f != nil {
-			if f.ExternalIPs != nil {
-				result[features.KPRExternalIPs] = features.Status{Enabled: f.ExternalIPs.Enabled}
-			}
-			if f.HostPort != nil {
-				result[features.KPRHostPort] = features.Status{Enabled: f.HostPort.Enabled}
-			}
-			if f.NodePort != nil {
-				result[features.KPRNodePort] = features.Status{Enabled: f.NodePort.Enabled}
-				acceleration := strings.ToLower(f.NodePort.Acceleration)
-				result[features.KPRNodePortAcceleration] = features.Status{
-					Enabled: mode != "false" && acceleration != "disabled",
-					Mode:    mode,
-				}
-			}
-			if f.SessionAffinity != nil {
-				result[features.KPRSessionAffinity] = features.Status{Enabled: f.SessionAffinity.Enabled}
-			}
 			if f.SocketLB != nil {
 				result[features.KPRSocketLB] = features.Status{Enabled: f.SocketLB.Enabled}
 				result[features.KPRSocketLBHostnsOnly] = features.Status{Enabled: f.BpfSocketLBHostnsOnly}
 			}
 		}
 	}
-	result[features.KPRMode] = features.Status{
-		Enabled: mode != "false" && mode != "disabled",
+	result[features.KPR] = features.Status{
+		Enabled: mode == "true" || mode == "strict",
 		Mode:    mode,
 	}
 

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -286,7 +286,7 @@ func (s *outsideToNodePort) Run(ctx context.Context, t *check.Test) {
 	// With kube-proxy doing N/S LB it is not possible to see the original client
 	// IP, as iptables rules do the LB SNAT/DNAT before the packet hits any
 	// of Cilium's datapath BPF progs. So, skip the flow validation in that case.
-	status, ok := t.Context().Feature(features.KPRNodePort)
+	status, ok := t.Context().Feature(features.KPR)
 	validateFlows := ok && status.Enabled
 
 	for _, svc := range t.Context().EchoServices() {

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -28,14 +28,10 @@ const (
 	TunnelPort         Feature = "tunnel-port"
 	EndpointRoutes     Feature = "endpoint-routes"
 
-	KPRMode                 Feature = "kpr-mode"
-	KPRExternalIPs          Feature = "kpr-external-ips"
-	KPRHostPort             Feature = "kpr-hostport"
+	KPR                     Feature = "kpr"
 	KPRSocketLB             Feature = "kpr-socket-lb"
 	KPRSocketLBHostnsOnly   Feature = "kpr-socket-lb-hostns-only"
-	KPRNodePort             Feature = "kpr-nodeport"
 	KPRNodePortAcceleration Feature = "kpr-nodeport-acceleration"
-	KPRSessionAffinity      Feature = "kpr-session-affinity"
 
 	BPFLBExternalClusterIP Feature = "bpf-lb-external-clusterip"
 
@@ -197,7 +193,7 @@ func (fs Set) DeriveFeatures() error {
 		Enabled: (fs[CNIChaining].Enabled && fs[CNIChaining].Mode == "portmap" &&
 			// cilium/cilium#12541: Host firewall doesn't work with portmap CNI chaining
 			!fs[HostFirewall].Enabled) ||
-			fs[KPRHostPort].Enabled,
+			fs[KPR].Enabled,
 	}
 
 	return nil

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -269,7 +269,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		return nil, nil, fmt.Errorf("unable to initialize kube-proxy replacement options: %w", err)
 	}
 
-	ctmap.InitMapInfo(params.MetricsRegistry, option.Config.EnableIPv4, option.Config.EnableIPv6, params.KPRConfig.EnableNodePort)
+	ctmap.InitMapInfo(params.MetricsRegistry, option.Config.EnableIPv4, option.Config.EnableIPv6, params.KPRConfig.KubeProxyReplacement || option.Config.EnableBPFMasquerade)
 
 	identity.IterateReservedIdentities(func(_ identity.NumericIdentity, _ *identity.Identity) {
 		metrics.Identity.WithLabelValues(identity.ReservedIdentityType).Inc()
@@ -533,9 +533,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 		var err error
 		switch {
-		case !params.KPRConfig.EnableNodePort:
-			err = fmt.Errorf("BPF masquerade requires NodePort (--%s=\"true\")",
-				option.EnableNodePort)
 		case len(option.Config.MasqueradeInterfaces) > 0:
 			err = fmt.Errorf("BPF masquerade does not allow to specify devices via --%s (use --%s instead)",
 				option.MasqueradeInterfaces, option.Devices)

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -198,7 +198,7 @@ func (d *Daemon) initMaps() error {
 	}
 
 	ipv4Nat, ipv6Nat := nat.GlobalMaps(d.metricsRegistry, option.Config.EnableIPv4,
-		option.Config.EnableIPv6, d.kprCfg.EnableNodePort)
+		option.Config.EnableIPv6, d.kprCfg.KubeProxyReplacement || option.Config.EnableBPFMasquerade)
 	if ipv4Nat != nil {
 		if err := ipv4Nat.Create(); err != nil {
 			return fmt.Errorf("initializing ipv4nat map: %w", err)
@@ -210,11 +210,13 @@ func (d *Daemon) initMaps() error {
 		}
 	}
 
-	if d.kprCfg.EnableNodePort {
+	if d.kprCfg.KubeProxyReplacement {
 		if err := neighborsmap.InitMaps(option.Config.EnableIPv4,
 			option.Config.EnableIPv6); err != nil {
 			return fmt.Errorf("initializing neighbors map: %w", err)
 		}
+	}
+	if d.kprCfg.KubeProxyReplacement || option.Config.EnableBPFMasquerade {
 		if err := nat.CreateRetriesMaps(option.Config.EnableIPv4,
 			option.Config.EnableIPv6); err != nil {
 			return fmt.Errorf("initializing NAT retries map: %w", err)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -43,11 +43,11 @@ import (
 // if this function cannot determine the strictness an error is returned and the boolean
 // is false. If an error is returned the boolean is of no meaning.
 func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, tunnelConfig tunnel.Config, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.WireguardConfig) error {
-	if !kprCfg.EnableNodePort {
+	if !kprCfg.KubeProxyReplacement {
 		option.Config.EnableHostLegacyRouting = true
 	}
 
-	if kprCfg.EnableNodePort {
+	if kprCfg.KubeProxyReplacement {
 		if option.Config.LoadBalancerRSSv4CIDR != "" {
 			ip, cidr, err := net.ParseCIDR(option.Config.LoadBalancerRSSv4CIDR)
 			if ip.To4() == nil {
@@ -144,7 +144,7 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 		// InstallNoConntrackIptRules can only be enabled when Cilium is
 		// running in full KPR mode as otherwise conntrack would be
 		// required for NAT operations
-		if !(kprCfg.EnableNodePort && kprCfg.EnableSocketLB) {
+		if !(kprCfg.KubeProxyReplacement && kprCfg.EnableSocketLB) {
 			return fmt.Errorf("%s requires the agent to run with %s.",
 				option.InstallNoConntrackIptRules, option.KubeProxyReplacement)
 		}
@@ -171,7 +171,7 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 // the running kernel.
 func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, sysctl sysctl.Sysctl) error {
 
-	if kprCfg.EnableNodePort {
+	if kprCfg.KubeProxyReplacement {
 		if probes.HaveProgramHelper(logger, ebpf.SchedCLS, asm.FnFibLookup) != nil {
 			return fmt.Errorf("BPF NodePort services needs kernel 4.17.0 or newer")
 		}

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -30,7 +30,6 @@ type kprConfig struct {
 	kubeProxyReplacement bool
 
 	enableSocketLB             bool
-	enableNodePort             bool
 	enableIPSec                bool
 	enableHostLegacyRouting    bool
 	installNoConntrackIptRules bool
@@ -54,7 +53,6 @@ func (cfg *kprConfig) set() (err error) {
 
 	kprFlags := kpr.KPRFlags{
 		KubeProxyReplacement: cfg.kubeProxyReplacement,
-		EnableNodePort:       cfg.enableNodePort,
 		EnableSocketLB:       cfg.enableSocketLB,
 	}
 
@@ -105,7 +103,6 @@ func (cfg *kprConfig) verify(t *testing.T, lbConfig loadbalancer.Config, kprCfg 
 		}
 	}
 	require.Equal(t, cfg.enableSocketLB, kprCfg.EnableSocketLB)
-	require.Equal(t, cfg.enableNodePort, kprCfg.EnableNodePort)
 	require.Equal(t, cfg.enableIPSec, option.Config.EnableIPSec)
 	require.Equal(t, cfg.enableHostLegacyRouting, option.Config.EnableHostLegacyRouting)
 	require.Equal(t, cfg.installNoConntrackIptRules, option.Config.InstallNoConntrackIptRules)
@@ -144,7 +141,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			},
 			kprConfig{
 				enableSocketLB:          true,
-				enableNodePort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -159,7 +155,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			},
 			kprConfig{
 				enableSocketLB:          true,
-				enableNodePort:          true,
 				enableHostLegacyRouting: false,
 				enableIPSec:             true,
 				enableSocketLBTracing:   true,
@@ -177,7 +172,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			},
 			kprConfig{
 				enableSocketLB:             true,
-				enableNodePort:             true,
 				enableHostLegacyRouting:    false,
 				enableBPFMasquerade:        true,
 				enableIPv4Masquerade:       true,
@@ -197,7 +191,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				expectedErrorRegex:         ".+with enable-bpf-masquerade.",
 				enableSocketLB:             true,
-				enableNodePort:             true,
 				enableHostLegacyRouting:    false,
 				installNoConntrackIptRules: true,
 				enableIPv4Masquerade:       true,
@@ -213,7 +206,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			},
 			kprConfig{
 				enableSocketLB:          false,
-				enableNodePort:          false,
 				enableIPSec:             false,
 				enableHostLegacyRouting: true,
 				enableSocketLBTracing:   false,
@@ -227,13 +219,11 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			func(cfg *kprConfig) {
 				cfg.kubeProxyReplacement = false
 				cfg.installNoConntrackIptRules = true
-				cfg.enableNodePort = true
 			},
 			kprConfig{
 				expectedErrorRegex:         ".+with kube-proxy-replacement.",
 				enableSocketLB:             false,
-				enableNodePort:             true,
-				enableHostLegacyRouting:    false,
+				enableHostLegacyRouting:    true,
 				installNoConntrackIptRules: true,
 				enableSocketLBTracing:      true,
 			},
@@ -251,7 +241,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				expectedErrorRegex:      "Node Port .+ mode cannot be used with .+ tunneling.",
 				enableSocketLB:          true,
-				enableNodePort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -269,7 +258,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			},
 			kprConfig{
 				enableSocketLB:          true,
-				enableNodePort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -286,7 +274,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			},
 			kprConfig{
 				enableSocketLB:          true,
-				enableNodePort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -304,7 +291,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				expectedErrorRegex:      "Node Port .+ mode cannot be used with .+ tunneling.",
 				enableSocketLB:          true,
-				enableNodePort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -322,7 +308,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			},
 			kprConfig{
 				enableSocketLB:          true,
-				enableNodePort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -339,7 +324,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			},
 			kprConfig{
 				enableSocketLB:          true,
-				enableNodePort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},
@@ -357,7 +341,6 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				expectedErrorRegex:      "Node Port .+ mode cannot be used with .+ tunneling.",
 				enableSocketLB:          true,
-				enableNodePort:          true,
 				enableHostLegacyRouting: false,
 				enableSocketLBTracing:   true,
 			},

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -769,13 +769,12 @@ contributors across the globe, there is almost always someone available to help.
 | nat46x64Gateway | object | `{"enabled":false}` | Configure standalone NAT46/NAT64 gateway |
 | nat46x64Gateway.enabled | bool | `false` | Enable RFC6052-prefixed translation |
 | nodeIPAM.enabled | bool | `false` | Configure Node IPAM ref: https://docs.cilium.io/en/stable/network/node-ipam/ |
-| nodePort | object | `{"addresses":null,"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enableHealthCheckLoadBalancerIP":false,"enabled":false}` | Configure N-S k8s service loadbalancing |
+| nodePort | object | `{"addresses":null,"autoProtectPortRange":true,"bindProtection":true,"enableHealthCheck":true,"enableHealthCheckLoadBalancerIP":false}` | Configure N-S k8s service loadbalancing |
 | nodePort.addresses | string | `nil` | List of CIDRs for choosing which IP addresses assigned to native devices are used for NodePort load-balancing. By default this is empty and the first suitable, preferably private, IPv4 and IPv6 address assigned to each device is used.  Example:    addresses: ["192.168.1.0/24", "2001::/64"]  |
 | nodePort.autoProtectPortRange | bool | `true` | Append NodePort range to ip_local_reserved_ports if clash with ephemeral ports is detected. |
 | nodePort.bindProtection | bool | `true` | Set to true to prevent applications binding to service ports. |
 | nodePort.enableHealthCheck | bool | `true` | Enable healthcheck nodePort server for NodePort services |
 | nodePort.enableHealthCheckLoadBalancerIP | bool | `false` | Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs EnableHealthCheck to be enabled |
-| nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for cilium-agent. |
 | nodeSelectorLabels | bool | `false` | Enable/Disable use of node label based identity |
 | nodeinit.affinity | object | `{}` | Affinity for cilium-nodeinit |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -796,9 +796,6 @@ data:
 {{- end }}
 
 {{- if hasKey .Values "nodePort" }}
-{{- if eq $kubeProxyReplacement "false" }}
-  enable-node-port: {{ .Values.nodePort.enabled | quote }}
-{{- end }}
 {{- if hasKey .Values.nodePort "range" }}
   node-port-range: {{ get .Values.nodePort "range" | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4355,9 +4355,6 @@
         },
         "enableHealthCheckLoadBalancerIP": {
           "type": "boolean"
-        },
-        "enabled": {
-          "type": "boolean"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2275,8 +2275,6 @@ loadBalancer:
     algorithm: round_robin
 # -- Configure N-S k8s service loadbalancing
 nodePort:
-  # -- Enable the Cilium NodePort service implementation.
-  enabled: false
   # -- Port range to use for NodePort services.
   # range: "30000,32767"
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2294,8 +2294,6 @@ loadBalancer:
     algorithm: round_robin
 # -- Configure N-S k8s service loadbalancing
 nodePort:
-  # -- Enable the Cilium NodePort service implementation.
-  enabled: false
   # -- Port range to use for NodePort services.
   # range: "30000,32767"
 

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -267,10 +267,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.KubeProxyReplacement)
 	option.BindEnv(vp, option.KubeProxyReplacement)
 
-	flags.Bool(option.EnableNodePort, false, "Enable NodePort type services by Cilium")
-	flags.MarkHidden(option.EnableNodePort)
-	option.BindEnv(vp, option.EnableNodePort)
-
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(vp, option.EnablePolicy)
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -183,10 +183,6 @@ const (
 	// is used to provide hints for misconfiguration.
 	KubeProxyReplacement = "kube-proxy-replacement"
 
-	// EnableNodePort is equivalent to the cilium-agent option, and
-	// is used to provide hints for misconfiguration.
-	EnableNodePort = "enable-node-port"
-
 	// CiliumK8sNamespace is the namespace where Cilium pods are running.
 	CiliumK8sNamespace = "cilium-pod-namespace"
 
@@ -292,10 +288,9 @@ type OperatorConfig struct {
 	// IPAMAutoCreateCiliumPodIPPools contains pre-defined IP pools to be auto-created on startup.
 	IPAMAutoCreateCiliumPodIPPools map[string]string
 
-	// KubeProxyReplacement or NodePort are required to implement cluster
+	// KubeProxyReplacement is required to implement cluster
 	// Ingress (or equivalent Gateway API functionality)
 	KubeProxyReplacement bool
-	EnableNodePort       bool
 
 	// AWS options
 
@@ -449,7 +444,6 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 
 	// Gateways and Ingress
 	c.KubeProxyReplacement = vp.GetBool(KubeProxyReplacement)
-	c.EnableNodePort = vp.GetBool(EnableNodePort)
 
 	// AWS options
 

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -110,9 +110,8 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		return nil
 	}
 
-	if !params.OperatorConfig.KubeProxyReplacement &&
-		!params.OperatorConfig.EnableNodePort {
-		params.Logger.Warn("Gateway API support requires either kube-proxy-replacement or enable-node-port enabled")
+	if !params.OperatorConfig.KubeProxyReplacement {
+		params.Logger.Warn("Gateway API support requires kube-proxy-replacement enabled")
 		return nil
 	}
 

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -102,9 +102,8 @@ func registerReconciler(params ingressParams) error {
 		return nil
 	}
 
-	if !params.OperatorConfig.KubeProxyReplacement &&
-		!params.OperatorConfig.EnableNodePort {
-		params.Logger.Warn("Ingress Controller support requires either kube-proxy-replacement or enable-node-port enabled")
+	if !params.OperatorConfig.KubeProxyReplacement {
+		params.Logger.Warn("Ingress Controller support requires kube-proxy-replacement enabled")
 		return nil
 	}
 

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -99,7 +99,6 @@ func TestScript(t *testing.T) {
 				func() kpr.KPRConfig {
 					return kpr.KPRConfig{
 						KubeProxyReplacement: true,
-						EnableNodePort:       true,
 					}
 				},
 				func() *loadbalancer.TestConfig {

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -118,7 +118,6 @@ func TestScript(t *testing.T) {
 				},
 				func() kpr.KPRConfig {
 					return kpr.KPRConfig{
-						EnableNodePort:       true,
 						KubeProxyReplacement: true,
 					}
 				},

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -349,7 +349,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["NODEPORT_NEIGH6_SIZE"] = fmt.Sprintf("%d", option.Config.NeighMapEntriesGlobal)
 	cDefinesMap["NODEPORT_NEIGH4_SIZE"] = fmt.Sprintf("%d", option.Config.NeighMapEntriesGlobal)
 
-	if h.kprCfg.EnableNodePort {
+	if h.kprCfg.KubeProxyReplacement {
 		if option.Config.EnableHealthDatapath {
 			cDefinesMap["ENABLE_HEALTH_CHECK"] = "1"
 		}
@@ -433,7 +433,9 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if !option.Config.EnableHostLegacyRouting {
 			cDefinesMap["ENABLE_HOST_ROUTING"] = "1"
 		}
+	}
 
+	if h.kprCfg.KubeProxyReplacement || option.Config.EnableBPFMasquerade {
 		cDefinesMap["NODEPORT_PORT_MIN"] = fmt.Sprintf("%d", cfg.LBConfig.NodePortMin)
 		cDefinesMap["NODEPORT_PORT_MAX"] = fmt.Sprintf("%d", cfg.LBConfig.NodePortMax)
 		cDefinesMap["NODEPORT_PORT_MIN_NAT"] = fmt.Sprintf("%d", cfg.LBConfig.NodePortMax+1)
@@ -520,47 +522,47 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["SNAT_MAPPING_IPV6_SIZE"] = fmt.Sprintf("%d", option.Config.NATMapEntriesGlobal)
 	cDefinesMap["SNAT_COLLISION_RETRIES"] = fmt.Sprintf("%d", nat.SnatCollisionRetries)
 
-	if h.kprCfg.EnableNodePort {
-		if option.Config.EnableBPFMasquerade {
-			if option.Config.EnableIPv4Masquerade {
-				cDefinesMap["ENABLE_MASQUERADE_IPV4"] = "1"
+	if option.Config.EnableBPFMasquerade {
+		cDefinesMap["ENABLE_NODEPORT"] = "1"
 
-				// ip-masq-agent depends on bpf-masq
-				var excludeCIDR *cidr.CIDR
-				if option.Config.EnableIPMasqAgent {
-					cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV4"] = "1"
+		if option.Config.EnableIPv4Masquerade {
+			cDefinesMap["ENABLE_MASQUERADE_IPV4"] = "1"
 
-					// native-routing-cidr is optional with ip-masq-agent and may be nil
-					excludeCIDR = option.Config.IPv4NativeRoutingCIDR
-				} else {
-					excludeCIDR = cfg.NativeRoutingCIDRIPv4
-				}
+			// ip-masq-agent depends on bpf-masq
+			var excludeCIDR *cidr.CIDR
+			if option.Config.EnableIPMasqAgent {
+				cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV4"] = "1"
 
-				if excludeCIDR != nil {
-					cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR"] =
-						fmt.Sprintf("%#x", byteorder.NetIPv4ToHost32(excludeCIDR.IP))
-					ones, _ := excludeCIDR.Mask.Size()
-					cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR_LEN"] = fmt.Sprintf("%d", ones)
-				}
+				// native-routing-cidr is optional with ip-masq-agent and may be nil
+				excludeCIDR = option.Config.IPv4NativeRoutingCIDR
+			} else {
+				excludeCIDR = cfg.NativeRoutingCIDRIPv4
 			}
-			if option.Config.EnableIPv6Masquerade {
-				cDefinesMap["ENABLE_MASQUERADE_IPV6"] = "1"
 
-				var excludeCIDR *cidr.CIDR
-				if option.Config.EnableIPMasqAgent {
-					cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV6"] = "1"
+			if excludeCIDR != nil {
+				cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR"] =
+					fmt.Sprintf("%#x", byteorder.NetIPv4ToHost32(excludeCIDR.IP))
+				ones, _ := excludeCIDR.Mask.Size()
+				cDefinesMap["IPV4_SNAT_EXCLUSION_DST_CIDR_LEN"] = fmt.Sprintf("%d", ones)
+			}
+		}
+		if option.Config.EnableIPv6Masquerade {
+			cDefinesMap["ENABLE_MASQUERADE_IPV6"] = "1"
 
-					excludeCIDR = option.Config.IPv6NativeRoutingCIDR
-				} else {
-					excludeCIDR = cfg.NativeRoutingCIDRIPv6
-				}
+			var excludeCIDR *cidr.CIDR
+			if option.Config.EnableIPMasqAgent {
+				cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV6"] = "1"
 
-				if excludeCIDR != nil {
-					extraMacrosMap["IPV6_SNAT_EXCLUSION_DST_CIDR"] = excludeCIDR.IP.String()
-					fw.WriteString(FmtDefineAddress("IPV6_SNAT_EXCLUSION_DST_CIDR", excludeCIDR.IP))
-					extraMacrosMap["IPV6_SNAT_EXCLUSION_DST_CIDR_MASK"] = excludeCIDR.Mask.String()
-					fw.WriteString(FmtDefineAddress("IPV6_SNAT_EXCLUSION_DST_CIDR_MASK", excludeCIDR.Mask))
-				}
+				excludeCIDR = option.Config.IPv6NativeRoutingCIDR
+			} else {
+				excludeCIDR = cfg.NativeRoutingCIDRIPv6
+			}
+
+			if excludeCIDR != nil {
+				extraMacrosMap["IPV6_SNAT_EXCLUSION_DST_CIDR"] = excludeCIDR.IP.String()
+				fw.WriteString(FmtDefineAddress("IPV6_SNAT_EXCLUSION_DST_CIDR", excludeCIDR.IP))
+				extraMacrosMap["IPV6_SNAT_EXCLUSION_DST_CIDR_MASK"] = excludeCIDR.Mask.String()
+				fw.WriteString(FmtDefineAddress("IPV6_SNAT_EXCLUSION_DST_CIDR_MASK", excludeCIDR.Mask))
 			}
 		}
 	}

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -187,7 +187,7 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 		}...)
 	}
 
-	if !ms.kprCfg.EnableNodePort {
+	if !ms.kprCfg.KubeProxyReplacement && !option.Config.EnableBPFMasquerade {
 		maps = append(maps, []string{"cilium_snat_v4_external", "cilium_snat_v6_external"}...)
 	}
 

--- a/pkg/datapath/tunnel/cell.go
+++ b/pkg/datapath/tunnel/cell.go
@@ -34,8 +34,7 @@ var Cell = cell.Module(
 		// handled here, as the corresponding logic has not yet been modularized).
 		func(kpr kpr.KPRConfig, lbcfg loadbalancer.Config) EnablerOut {
 			return NewEnabler(
-				(kpr.EnableNodePort ||
-					kpr.KubeProxyReplacement) &&
+				kpr.KubeProxyReplacement &&
 					lbcfg.LoadBalancerUsesDSR() &&
 					lbcfg.DSRDispatch == loadbalancer.DSRDispatchGeneve,
 				// The datapath logic takes care of the MTU overhead. So no need to

--- a/pkg/kpr/kpr.go
+++ b/pkg/kpr/kpr.go
@@ -19,39 +19,32 @@ var Cell = cell.Module(
 type KPRFlags struct {
 	KubeProxyReplacement bool
 	EnableSocketLB       bool `mapstructure:"bpf-lb-sock"`
-	EnableNodePort       bool
 }
 
 var defaultFlags = KPRFlags{
 	KubeProxyReplacement: false,
 	EnableSocketLB:       false,
-	EnableNodePort:       false,
 }
 
 func (def KPRFlags) Flags(flags *pflag.FlagSet) {
 	flags.Bool("kube-proxy-replacement", def.KubeProxyReplacement, "Enable kube-proxy replacement")
 
 	flags.Bool("bpf-lb-sock", def.EnableSocketLB, "Enable socket-based LB for E/W traffic")
-
-	flags.Bool("enable-node-port", def.EnableNodePort, "Enable NodePort type services by Cilium")
-	flags.MarkDeprecated("enable-node-port", "The flag will be removed in v1.19. The feature will be unconditionally enabled by enabling kube-proxy-replacement")
 }
 
 type KPRConfig struct {
 	KubeProxyReplacement bool
-	EnableNodePort       bool
 	EnableSocketLB       bool
 }
 
 func NewKPRConfig(flags KPRFlags) (KPRConfig, error) {
+	//nolint:staticcheck
 	cfg := KPRConfig{
 		KubeProxyReplacement: flags.KubeProxyReplacement,
-		EnableNodePort:       flags.EnableNodePort,
 		EnableSocketLB:       flags.EnableSocketLB,
 	}
 
 	if flags.KubeProxyReplacement {
-		cfg.EnableNodePort = true
 		cfg.EnableSocketLB = true
 	}
 

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -538,7 +538,7 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
 		ZoneMapper:                             cfg,
 		EnableIPv4:                             cfg.EnableIPv4,
 		EnableIPv6:                             cfg.EnableIPv6,
-		KubeProxyReplacement:                   kprCfg.KubeProxyReplacement || kprCfg.EnableNodePort,
+		KubeProxyReplacement:                   kprCfg.KubeProxyReplacement,
 		BPFSocketLBHostnsOnly:                  cfg.BPFSocketLBHostnsOnly,
 		EnableSocketLB:                         kprCfg.EnableSocketLB,
 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -98,7 +98,6 @@ func TestScript(t *testing.T) {
 					func() kpr.KPRConfig {
 						return kpr.KPRConfig{
 							KubeProxyReplacement: true,
-							EnableNodePort:       true,
 						}
 					},
 				),

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -93,7 +93,6 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 			func() kpr.KPRConfig {
 				return kpr.KPRConfig{
 					KubeProxyReplacement: true,
-					EnableNodePort:       true,
 					EnableSocketLB:       true,
 				}
 			},

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -89,7 +89,6 @@ func TestScript(t *testing.T) {
 					},
 					func() kpr.KPRConfig {
 						return kpr.KPRConfig{
-							EnableNodePort:       true,
 							KubeProxyReplacement: true,
 						}
 					},

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -100,7 +100,6 @@ func TestScript(t *testing.T) {
 					func() kpr.KPRConfig {
 						return kpr.KPRConfig{
 							KubeProxyReplacement: true,
-							EnableNodePort:       true,
 						}
 					},
 					func(ops *lbreconciler.BPFOps, lns *node.LocalNodeStore, w *writer.Writer, waitFn loadbalancer.InitWaitFunc) uhive.ScriptCmdsOut {

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -122,8 +122,8 @@ type CtMapRecord struct {
 
 // InitMapInfo builds the information about different CT maps for the
 // combination of L3/L4 protocols.
-func InitMapInfo(registry *metrics.Registry, v4, v6, nodeport bool) {
-	global4Map, global6Map := nat.GlobalMaps(registry, v4, v6, nodeport)
+func InitMapInfo(registry *metrics.Registry, v4, v6, natRequired bool) {
+	global4Map, global6Map := nat.GlobalMaps(registry, v4, v6, natRequired)
 	global4MapLock := &lock.Mutex{}
 	global6MapLock := &lock.Mutex{}
 

--- a/pkg/maps/nat/cell.go
+++ b/pkg/maps/nat/cell.go
@@ -22,7 +22,7 @@ import (
 var ErrMapDisabled = fmt.Errorf("nat map is disabled")
 
 // Cell exposes global nat maps via Hive. These maps depend on
-// the final state of EnableNodePort, thus the maps are currently
+// the final state of EnableBPFMasquerade, thus the maps are currently
 // provided as promises.
 // TODO: Once we have a way of finalizing this config prior to runtime
 // we'll want to provide these using bpf.MapOut[T] (GH: #32557)
@@ -42,7 +42,7 @@ var Cell = cell.Module(
 				if err != nil {
 					return fmt.Errorf("failed to wait for config promise: %w", err)
 				}
-				if !kprCfg.EnableNodePort {
+				if !kprCfg.KubeProxyReplacement && !cfg.EnableBPFMasquerade {
 					res4.Reject(fmt.Errorf("nat IPv4: %w", ErrMapDisabled))
 					res6.Reject(fmt.Errorf("nat IPv6: %w", ErrMapDisabled))
 					return nil
@@ -79,7 +79,14 @@ var Cell = cell.Module(
 				return nil
 			},
 			OnStop: func(hc cell.HookContext) error {
-				if !kprCfg.EnableNodePort {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+				defer cancel()
+				cfg, err := cfgPromise.Await(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to wait for config promise: %w", err)
+				}
+
+				if !kprCfg.KubeProxyReplacement && !cfg.EnableBPFMasquerade {
 					return nil
 				}
 

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -388,8 +388,8 @@ func DeleteSwappedMapping6(m *Map, tk tuple.TupleKey) error {
 }
 
 // GlobalMaps returns all global NAT maps.
-func GlobalMaps(registry *metrics.Registry, ipv4, ipv6, nodeport bool) (ipv4Map, ipv6Map *Map) {
-	if !nodeport {
+func GlobalMaps(registry *metrics.Registry, ipv4, ipv6, natRequired bool) (ipv4Map, ipv6Map *Map) {
+	if !natRequired {
 		return
 	}
 	if ipv4 {
@@ -426,8 +426,8 @@ func maxEntries() int {
 }
 
 // RetriesMaps returns the maps that contain the histograms of the number of retries.
-func RetriesMaps(ipv4, ipv6, nodeport bool) (ipv4RetriesMap, ipv6RetriesMap RetriesMap) {
-	if !nodeport {
+func RetriesMaps(ipv4, ipv6, natRequired bool) (ipv4RetriesMap, ipv6RetriesMap RetriesMap) {
+	if !natRequired {
 		return
 	}
 	if ipv4 {

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -97,7 +97,7 @@ func Enable(logger *slog.Logger, sysctl sysctl.Sysctl, kprCfg kpr.KPRConfig) err
 			enabled[GetPeerName4] = true
 		}
 
-		if kprCfg.EnableNodePort && option.Config.NodePortBindProtection {
+		if kprCfg.KubeProxyReplacement && option.Config.NodePortBindProtection {
 			enabled[PostBind4] = true
 		}
 
@@ -119,7 +119,7 @@ func Enable(logger *slog.Logger, sysctl sysctl.Sysctl, kprCfg kpr.KPRConfig) err
 			enabled[GetPeerName6] = true
 		}
 
-		if kprCfg.EnableNodePort && option.Config.NodePortBindProtection {
+		if kprCfg.KubeProxyReplacement && option.Config.NodePortBindProtection {
 			enabled[PostBind6] = true
 		}
 

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -303,7 +303,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		Nat46X64:              &models.KubeProxyReplacementFeaturesNat46X64{},
 		BpfSocketLBHostnsOnly: d.statusParams.DaemonConfig.BPFSocketLBHostnsOnly,
 	}
-	if d.statusParams.KPRConfig.EnableNodePort {
+	if d.statusParams.KPRConfig.KubeProxyReplacement {
 		features.NodePort.Enabled = true
 		features.NodePort.Mode = strings.ToUpper(d.statusParams.LBConfig.LBMode)
 		switch d.statusParams.LBConfig.DSRDispatch {
@@ -359,7 +359,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		}
 		features.Nat46X64.Service = svc
 	}
-	if d.statusParams.KPRConfig.EnableNodePort {
+	if d.statusParams.KPRConfig.KubeProxyReplacement {
 		if d.statusParams.LBConfig.AlgorithmAnnotation {
 			features.Annotations = append(features.Annotations, annotation.ServiceLoadBalancingAlgorithm)
 		}


### PR DESCRIPTION
In order to use NodePort BPF (or other KPR sub-features, such as HostPort), users must enable KPR.

BPF masq no longer requires NodePort BPF. However, `ENABLE_NODEPORT` is passed to the datapath when BPF masq is true and KPR=false. This enables the LB wildcard lookup. As we don't provision NodePort services in the BPF service maps when KPR=false, the wildcard lookup is no-op. We could consider adding a new define (`ENABLE_NODEPORT_ONLY_FOR_MASQ`), but that would introduce quite a few changes in the datapath. I'd rather suggest to tackle #13732 instead.

Fix #39882
Fix #39582

```release-note
NodePort functionality is now enabled when --kube-proxy-replacement is enabled. The --enable-nodeport flag has been removed. 
```