### PR TITLE
metrics/features: Fix counter metrics to use Set() instead of Add()

### DIFF
--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -984,13 +984,13 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 			networkMode = networkModeOverlayGENEVE
 		}
 	}
-	m.DPMode.WithLabelValues(networkMode).Add(1)
+	m.DPMode.WithLabelValues(networkMode).Set(1)
 
 	ipamMode := config.IPAMMode()
-	m.CPIPAM.WithLabelValues(ipamMode).Add(1)
+	m.CPIPAM.WithLabelValues(ipamMode).Set(1)
 
 	chainingMode := params.GetChainingMode()
-	m.DPChaining.WithLabelValues(chainingMode).Add(1)
+	m.DPChaining.WithLabelValues(chainingMode).Set(1)
 
 	var ip string
 	switch {
@@ -1001,48 +1001,48 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 	case config.IPv6Enabled():
 		ip = networkIPv6
 	}
-	m.DPIP.WithLabelValues(ip).Add(1)
+	m.DPIP.WithLabelValues(ip).Set(1)
 
 	identityAllocationMode := config.IdentityAllocationMode
-	m.CPIdentityAllocation.WithLabelValues(identityAllocationMode).Add(1)
+	m.CPIdentityAllocation.WithLabelValues(identityAllocationMode).Set(1)
 
 	if config.EnableCiliumEndpointSlice {
-		m.CPCiliumEndpointSlicesEnabled.Add(1)
+		m.CPCiliumEndpointSlicesEnabled.Set(1)
 	}
 
 	deviceMode := config.DatapathMode
-	m.DPDeviceConfig.WithLabelValues(deviceMode).Add(1)
+	m.DPDeviceConfig.WithLabelValues(deviceMode).Set(1)
 
 	if config.EnableEndpointRoutes {
-		m.DPEndpointRoutes.Add(1)
+		m.DPEndpointRoutes.Set(1)
 	}
 
 	// Get kernel version - this would need to be implemented to detect actual kernel version
 	kernelVersion, err := version.GetKernelVersion()
 	if err != nil || kernelVersion.String() == "" {
-		m.DPKernelVersion.WithLabelValues(kernelVersionUnknown).Add(1)
+		m.DPKernelVersion.WithLabelValues(kernelVersionUnknown).Set(1)
 	} else if kernelVersion.String() != "" {
-		m.DPKernelVersion.WithLabelValues(kernelVersion.String()).Add(1)
+		m.DPKernelVersion.WithLabelValues(kernelVersion.String()).Set(1)
 	}
 
 	if config.EnableHostFirewall {
-		m.NPHostFirewallEnabled.Add(1)
+		m.NPHostFirewallEnabled.Set(1)
 	}
 
 	if config.EnableLocalRedirectPolicy {
-		m.NPLocalRedirectPolicyEnabled.Add(1)
+		m.NPLocalRedirectPolicyEnabled.Set(1)
 	}
 
 	if params.IsMutualAuthEnabled() {
-		m.NPMutualAuthEnabled.Add(1)
+		m.NPMutualAuthEnabled.Set(1)
 	}
 
 	if config.EnableNonDefaultDenyPolicies {
-		m.NPNonDefaultDenyEnabled.Add(1)
+		m.NPNonDefaultDenyEnabled.Set(1)
 	}
 
 	for _, mode := range config.PolicyCIDRMatchMode {
-		m.NPCIDRPoliciesToNodes.WithLabelValues(mode).Add(1)
+		m.NPCIDRPoliciesToNodes.WithLabelValues(mode).Set(1)
 	}
 
 	strictMode := "false"
@@ -1056,40 +1056,40 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 	}
 
 	if config.EnableIPSec {
-		m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncIPSec, node2nodeEnabled, strictMode).Add(1)
+		m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncIPSec, node2nodeEnabled, strictMode).Set(1)
 	}
 	if wgCfg.Enabled() {
-		m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncWireGuard, node2nodeEnabled, strictMode).Add(1)
+		m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncWireGuard, node2nodeEnabled, strictMode).Set(1)
 	}
 
 	if kprCfg.KubeProxyReplacement {
-		m.ACLBKubeProxyReplacementEnabled.Add(1)
+		m.ACLBKubeProxyReplacementEnabled.Set(1)
 	}
 
-	m.ACLBNodePortConfig.WithLabelValues(lbConfig.LBMode, lbConfig.LBAlgorithm, config.NodePortAcceleration).Add(1)
+	m.ACLBNodePortConfig.WithLabelValues(lbConfig.LBMode, lbConfig.LBAlgorithm, config.NodePortAcceleration).Set(1)
 
 	if config.EnableBGPControlPlane {
-		m.ACLBBGPEnabled.Add(1)
+		m.ACLBBGPEnabled.Set(1)
 	}
 
 	if config.EnableEgressGateway {
-		m.ACLBEgressGatewayEnabled.Add(1)
+		m.ACLBEgressGatewayEnabled.Set(1)
 	}
 
 	if params.IsBandwidthManagerEnabled() {
-		m.ACLBBandwidthManagerEnabled.Add(1)
+		m.ACLBBandwidthManagerEnabled.Set(1)
 	}
 
 	if config.EnableSCTP {
-		m.ACLBSCTPEnabled.Add(1)
+		m.ACLBSCTPEnabled.Set(1)
 	}
 
 	if config.EnableVTEP {
-		m.ACLBVTEPEnabled.Add(1)
+		m.ACLBVTEPEnabled.Set(1)
 	}
 
 	if config.EnableEnvoyConfig {
-		m.ACLBCiliumEnvoyConfigEnabled.Add(1)
+		m.ACLBCiliumEnvoyConfigEnabled.Set(1)
 	}
 
 	var bigTCPProto string
@@ -1103,24 +1103,24 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 	}
 
 	if bigTCPProto != "" {
-		m.ACLBBigTCPEnabled.WithLabelValues(bigTCPProto).Add(1)
+		m.ACLBBigTCPEnabled.WithLabelValues(bigTCPProto).Set(1)
 	}
 
 	if config.EnableL2Announcements {
-		m.ACLBL2LBEnabled.Add(1)
+		m.ACLBL2LBEnabled.Set(1)
 	}
 
 	if params.IsL2PodAnnouncementEnabled() {
-		m.ACLBL2PodAnnouncementEnabled.Add(1)
+		m.ACLBL2PodAnnouncementEnabled.Set(1)
 	}
 
 	if config.ExternalEnvoyProxy {
-		m.ACLBExternalEnvoyProxyEnabled.WithLabelValues(advConnExtEnvoyProxyStandalone).Add(1)
+		m.ACLBExternalEnvoyProxyEnabled.WithLabelValues(advConnExtEnvoyProxyStandalone).Set(1)
 	} else {
-		m.ACLBExternalEnvoyProxyEnabled.WithLabelValues(advConnExtEnvoyProxyEmbedded).Add(1)
+		m.ACLBExternalEnvoyProxyEnabled.WithLabelValues(advConnExtEnvoyProxyEmbedded).Set(1)
 	}
 
 	if params.IsDynamicConfigSourceKindNodeConfig() {
-		m.ACLBCiliumNodeConfigEnabled.Add(1)
+		m.ACLBCiliumNodeConfigEnabled.Set(1)
 	}
 }

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -82,21 +82,21 @@ type featureMetrics interface {
 
 func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
 	if config.EnableGatewayAPI {
-		m.ACLBGatewayAPIEnabled.Add(1)
+		m.ACLBGatewayAPIEnabled.Set(1)
 	}
 	if params.IsIngressControllerEnabled() {
-		m.ACLBIngressControllerEnabled.Add(1)
+		m.ACLBIngressControllerEnabled.Set(1)
 	}
 	if params.IsLBIPAMEnabled() {
-		m.ACLBIPAMEnabled.Add(1)
+		m.ACLBIPAMEnabled.Set(1)
 	}
 	if params.GetLoadBalancerL7() != "" {
-		m.ACLBL7AwareTrafficManagementEnabled.Add(1)
+		m.ACLBL7AwareTrafficManagementEnabled.Set(1)
 	}
 	if params.IsNodeIPAMEnabled() {
-		m.ACLBNodeIPAMEnabled.Add(1)
+		m.ACLBNodeIPAMEnabled.Set(1)
 	}
 	if k8sVersionStr := params.K8sVersion(); k8sVersionStr != "" {
-		m.CPKubernetesVersion.WithLabelValues(k8sVersionStr).Add(1)
+		m.CPKubernetesVersion.WithLabelValues(k8sVersionStr).Set(1)
 	}
 }


### PR DESCRIPTION
Replace Add(1) with Set(1) for all feature metrics in both daemon and operator components. These metrics represent boolean feature states that should be set to 1 when enabled, not incremented. Using Add(1) causes metrics to accumulate over time and produce incorrect values when the metrics are updated multiple times, leading to misleading monitoring data.