### PR TITLE
controller: make RemoveControllerAndWait tolerate missing controller

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -20,7 +20,33 @@ func TestUpdateRemoveController(t *testing.T) {
 	mngr := NewManager()
 	mngr.UpdateController("test", ControllerParams{})
 	require.NoError(t, mngr.RemoveController("test"))
-	require.Error(t, mngr.RemoveController("not-exits"))
+}
+
+func TestRemoveControllerNotFound(t *testing.T) {
+	mngr := NewManager()
+
+	err := mngr.RemoveController("not-exists")
+	require.ErrorIs(t, err, errControllerNotFound)
+}
+
+func TestRemoveControllerEmptyMap(t *testing.T) {
+	var mngr Manager
+
+	err := mngr.RemoveController("not-exists")
+	require.ErrorIs(t, err, errControllerMapEmpty)
+}
+
+func TestRemoveControllerAndWaitNotFound(t *testing.T) {
+	mngr := NewManager()
+
+	require.NoError(t, mngr.RemoveControllerAndWait("not-exists"))
+}
+
+func TestRemoveControllerAndWaitEmptyMap(t *testing.T) {
+	var mngr Manager
+
+	err := mngr.RemoveControllerAndWait("not-exists")
+	require.ErrorIs(t, err, errControllerMapEmpty)
 }
 
 func TestCreateController(t *testing.T) {


### PR DESCRIPTION
controller: make RemoveControllerAndWait tolerate missing controller

Fixes: https://github.com/cilium/cilium/issues/38842
Related: #41272

```release-note
controller: avoid spurious errors when RemoveControllerAndWait is invoked when the controller does not exist
```
