### PR TITLE
docs: improve metrics documentation with Helm configuration instructions

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -358,7 +358,7 @@ Exported Metrics
 ^^^^^^^^^^^^^^^^
 
 Configuring Metrics with Helm
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When installing or upgrading Cilium using Helm, you can configure which metrics
 are enabled or disabled using the ``prometheus.metrics`` option. This allows you


### PR DESCRIPTION
This PR improves the metrics documentation by adding comprehensive Helm configuration instructions to the Exported Metrics section.
Fixes the issue where metrics documentation lacked instructions on how to configure metrics using Helm prometheus.metrics option.


Fixes: #21450

```release-note
Add Helm configuration instructions for Cilium metrics in the documentation.
```

