### PR TITLE
Lower log level for Cloud/AWS data fetches

### DIFF
--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -560,7 +560,9 @@ func (n *Node) createInterface(ctx context.Context, a *AllocationAction) (create
 	toAllocate, errCondition, err := n.ops.CreateInterface(ctx, a, n.logger.Load())
 	if err != nil {
 		n.manager.metricsAPI.AllocationAttempt(createInterfaceAndAllocateIP, errCondition, string(a.PoolID), metrics.SinceInSeconds(start))
-		n.logger.Load().Warn(
+		// IP Allocation can fail due to outdated information (cloud provider APIs are eventually consistent) about the available capacity.
+		// Since we eventually recover from this, use log level info. For more details see https://github.com/cilium/cilium/issues/36428
+		n.logger.Load().Info(
 			"Unable to create interface on instance",
 			logfields.Error, err,
 		)
@@ -950,7 +952,9 @@ func (n *Node) handleIPAllocation(ctx context.Context, a *maintenanceAction) (in
 		}
 
 		n.manager.metricsAPI.AllocationAttempt(allocateIP, failed, string(a.allocation.PoolID), metrics.SinceInSeconds(start))
-		n.logger.Load().Warn(
+		// IP Allocation can fail due to outdated information (cloud provider APIs are eventually consistent) about the available capacity.
+		// Since we eventually recover from this, use log level info. For more details see https://github.com/cilium/cilium/issues/36428
+		n.logger.Load().Info(
 			"Unable to assign additional IPs to interface, will create new interface",
 			logfields.Error, err,
 			logfields.SelectedInterface, a.allocation.InterfaceID,


### PR DESCRIPTION
Lowering the log severity from warn to info for cases where stale data is received from AWS. As discussed in https://github.com/cilium/cilium/issues/36428 and https://github.com/cilium/cilium/pull/41278, stale metadata can cause temporary IP calculation issues, but the operator is expected to eventually reconcile correctly. These warnings have been observed to cause CI failures, despite being ok  in  Datadog's environment




Fixes: #36428

```release-note
lower log severity for stale metadata to avoid CI issue
```
