### PR TITLE
.github/actions: fix boolean condition check in post-logic action

### DIFF
--- a/.github/actions/post-logic/action.yaml
+++ b/.github/actions/post-logic/action.yaml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Features tested
-      if: ${{ always() && inputs.capture_features_tested }}
+      if: ${{ always() && inputs.capture_features_tested == 'true' }}
       uses: ./.github/actions/feature-status
       with:
         title: "Summary of all features tested"


### PR DESCRIPTION
Fix the condition check for capture_features_tested input by explicitly comparing with 'true' string instead of relying on implicit boolean evaluation. This ensures more reliable condition handling in GitHub Actions.

Fixes: 53fd5cf59b7e (".github: de-duplicate workflows logic")