### PR TITLE
shell: Prevent server error on graceful shutdown

### DIFF
--- a/pkg/shell/server/shell_server.go
+++ b/pkg/shell/server/shell_server.go
@@ -6,6 +6,7 @@ package shell
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -84,6 +85,10 @@ func (sh shell) listener(ctx context.Context, health cell.Health) error {
 	for ctx.Err() == nil {
 		conn, err := l.Accept()
 		if err != nil {
+			// If context is cancelled, the listener was closed gracefully
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return nil
+			}
 			return fmt.Errorf("accept failed: %w", err)
 		}
 		sh.jg.Add(job.OneShot(


### PR DESCRIPTION
Check context cancellation before treating accept() errors as fatal during operator, daemon, and clustermesh-apiserver shutdown. This removes these error logs on pod shutdown:

```
one-shot job errored: accept failed: accept unix /var/run/cilium/shell.sock: use of closed network connection
```