### PR TITLE
.github/workflows: separate feature json files in different dirs

### DIFF
--- a/.github/actions/merge-artifacts/action.yaml
+++ b/.github/actions/merge-artifacts/action.yaml
@@ -15,6 +15,12 @@ inputs:
     required: true
     description: 'If true, the artifacts that were merged will be deleted'
     default: 'true'
+  separate-directories:
+    required: false
+    description: |
+      If true, the artifacts will be merged into separate directories.
+      If false, the artifacts will be merged into the root of the destination.
+    default: 'false'
 
 runs:
   using: composite
@@ -54,4 +60,4 @@ runs:
         pattern: ${{ inputs.pattern }}
         retention-days: 5
         delete-merged: ${{ inputs.delete-merged }}
-
+        separate-directories: ${{ inputs.separate-directories }}

--- a/.github/workflows/common-post-jobs.yaml
+++ b/.github/workflows/common-post-jobs.yaml
@@ -38,6 +38,7 @@ jobs:
           name: features-tested
           pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
+          separate-directories: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -530,6 +530,7 @@ jobs:
           name: features-tested
           pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
+          separate-directories: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -562,6 +562,7 @@ jobs:
           name: features-tested
           pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
+          separate-directories: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/cilium-cli/features/summary.go
+++ b/cilium-cli/features/summary.go
@@ -242,6 +242,8 @@ func extractZip(zipPath, destDir string) error {
 			}
 			continue
 		}
+		// Create directories
+		os.MkdirAll(filepath.Dir(destPath), os.ModePerm)
 
 		// Extract files
 		destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())


### PR DESCRIPTION
Having separate directories for the feature files allows us to distinguish each feature per each job.