### PR TITLE
(feat): Add hybrid routing to Cilium

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -379,8 +379,8 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	info = lookup_ip6_remote_endpoint(dst, 0);
 
 #ifdef TUNNEL_MODE
-	__u32 src_subnet_id = lookup_ip6_subnet(&ip6->saddr, 0);
-	__u32 dst_subnet_id = lookup_ip6_subnet(&ip6->daddr, 0);
+	__u32 src_subnet_id = lookup_ip6_subnet(&ip6->saddr);
+	__u32 dst_subnet_id = lookup_ip6_subnet(&ip6->daddr);
 	bool same_subnet = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
 	cilium_dbg3(ctx, DBG_TUNNEL_TRACE, src_subnet_id, dst_subnet_id, src_subnet_id);
 	cilium_dbg3(ctx, DBG_TUNNEL_TRACE, src_subnet_id, dst_subnet_id, dst_subnet_id);
@@ -825,8 +825,8 @@ skip_vtep:
 	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 
 #ifdef TUNNEL_MODE
-	__u32 src_subnet_id = lookup_ip4_subnet(ip4->saddr, 0);
-	__u32 dst_subnet_id = lookup_ip4_subnet(ip4->daddr, 0);
+	__u32 src_subnet_id = lookup_ip4_subnet(ip4->saddr);
+	__u32 dst_subnet_id = lookup_ip4_subnet(ip4->daddr);
 	bool same_subnet = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
 	if ((info && info->flag_skip_tunnel) || same_subnet)
 		goto skip_tunnel;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -514,8 +514,8 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		const union v6addr *saddr = (union v6addr *)&ip6->saddr;
 		const union v6addr *daddr = (union v6addr *)&ip6->daddr;
 		
-		__u32 src_subnet_id = lookup_ip6_subnet(saddr, 0);
-		__u32 dst_subnet_id = lookup_ip6_subnet(daddr, 0);
+		__u32 src_subnet_id = lookup_ip6_subnet(saddr);
+		__u32 dst_subnet_id = lookup_ip6_subnet(daddr);
 		bool same_subnet = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
 		info = lookup_ip6_remote_endpoint(daddr, 0);
 		if (info) {
@@ -966,8 +966,8 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	hairpin_flow = ct_state_new.loopback;
 #endif /* ENABLE_PER_PACKET_LB */
 
-	__u32 src_subnet_id = lookup_ip4_subnet(ip4->saddr, 0);
-	__u32 dst_subnet_id = lookup_ip4_subnet(ip4->daddr, 0);
+	__u32 src_subnet_id = lookup_ip4_subnet(ip4->saddr);
+	__u32 dst_subnet_id = lookup_ip4_subnet(ip4->daddr);
 	bool same_subnet = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
 	cilium_dbg3(ctx, DBG_TUNNEL_TRACE, ip4->saddr, ip4->daddr, src_subnet_id);
 	cilium_dbg3(ctx, DBG_TUNNEL_TRACE, ip4->saddr, ip4->daddr, dst_subnet_id);

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -125,6 +125,14 @@ enum {
 	DBG_SKIP_POLICY,	/**/
 	DBG_LB6_LOOPBACK_SNAT,
 	DBG_LB6_LOOPBACK_SNAT_REV,
+	DBG_SUBNET_CHECK,	/* arg1: saddr (last 4 bytes for IPv6)
+				 * arg2: daddr (last 4 bytes for IPv6)
+				 * arg3: bool (same subnet)
+				 */
+	DBG_TUNNEL_TRACE,	/* arg1: saddr (last 4 bytes for IPv6)
+				 * arg2: daddr (last 4 bytes for IPv6)
+				 * arg3: int (ret)
+				 */
 };
 
 /* Capture types */

--- a/bpf/lib/subnet.h
+++ b/bpf/lib/subnet.h
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include "common.h"
+
+#include <linux/ip.h>
+#include "ipv6.h"
+
+#define SUBNET_MAP_SIZE 1024
+
+struct subnet_key {
+	struct bpf_lpm_trie_key lpm_key;
+	__u16 cluster_id;
+	__u8 pad1;
+	__u8 family;
+	union {
+		struct {
+			__u32		ip4;
+			__u32		pad4;
+			__u32		pad5;
+			__u32		pad6;
+		};
+		union v6addr	ip6;
+	};
+} __packed;
+
+struct subnet_value {
+    __u32 identity;
+};
+
+/* Global IP -> Identity map for applying egress label-based policy */
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__type(key, struct subnet_key);
+	__type(value, struct subnet_value);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, SUBNET_MAP_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cilium_subnet_map __section_maps_btf;
+
+/* SUBNET_STATIC_PREFIX gets sizeof non-IP, non-prefix part of subnet_key */
+#define SUBNET_STATIC_PREFIX							\
+	(8 * (sizeof(struct subnet_key) - sizeof(struct bpf_lpm_trie_key)	\
+	      - sizeof(union v6addr)))
+#define SUBNET_PREFIX_LEN(PREFIX) (SUBNET_STATIC_PREFIX + (PREFIX))
+
+#define V6_CACHE_KEY_LEN (sizeof(union v6addr)*8)
+
+static __always_inline __maybe_unused __u32 
+subnet_lookup6(const void *map, const union v6addr *addr,
+		__u32 prefix, __u32 cluster_id)
+{
+    struct subnet_value *value;
+	struct subnet_key key = {
+		.lpm_key = { SUBNET_PREFIX_LEN(prefix), {} },
+		.family = ENDPOINT_KEY_IPV6,
+		.ip6 = *addr,
+	};
+
+	/* Check overflow */
+	if (cluster_id > UINT16_MAX)
+		return 0;
+
+	key.cluster_id = (__u16)cluster_id;
+
+	ipv6_addr_clear_suffix(&key.ip6, prefix);
+	value = (struct subnet_value *) map_lookup_elem(map, &key);
+    if (!value) {
+        return 0;
+    }
+    return value->identity;
+}
+
+#define V4_CACHE_KEY_LEN (sizeof(__u32)*8)
+
+static __always_inline __maybe_unused __u32
+subnet_lookup4(const void *map, __be32 addr, __u32 prefix, __u32 cluster_id)
+{
+    struct subnet_value *value;
+	struct subnet_key key = {
+		.lpm_key = { SUBNET_PREFIX_LEN(prefix), {} },
+		.family = ENDPOINT_KEY_IPV4,
+        .ip4 = addr,
+	};
+
+	/* Check overflow */
+	if (cluster_id > UINT16_MAX)
+		return 0;
+
+	key.cluster_id = (__u16)cluster_id;
+
+	key.ip4 &= GET_PREFIX(prefix);
+	value = (struct subnet_value *) map_lookup_elem(map, &key);
+    if (!value) {
+        return 0;
+    }
+	return value->identity;
+}
+
+#define lookup_ip6_subnet(addr, cluster_id) \
+	subnet_lookup6(&cilium_subnet_map, addr, V6_CACHE_KEY_LEN, cluster_id)
+#define lookup_ip4_subnet(addr, cluster_id) \
+	subnet_lookup4(&cilium_subnet_map, addr, V4_CACHE_KEY_LEN, cluster_id)

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -80,6 +80,7 @@ import (
 	"github.com/cilium/cilium/pkg/signal"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/status"
+	"github.com/cilium/cilium/pkg/subnettopology"
 	"github.com/cilium/cilium/pkg/svcrouteconfig"
 )
 
@@ -345,6 +346,9 @@ var (
 		debugapi.Cell,
 
 		svcrouteconfig.Cell,
+
+		// Subnet topology cell
+		subnettopology.Cell,
 	)
 )
 

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -417,6 +417,12 @@ spec:
           mountPath: /flowlog-config
           readOnly: true
         {{- end }}
+        # If hybrid routing mode is enabled, add the subnet-topology-file-path
+        {{- if eq .Values.routingMode "hybrid" }}
+        - name: subnet-topology-file
+          mountPath: "/var/lib/cilium/subnet"
+          readOnly: true
+        {{- end }}
         {{- with .Values.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -1108,6 +1114,13 @@ spec:
       - name: hubble-flowlog-config
         configMap:
           name: {{ .Values.hubble.export.dynamic.config.configMapName }}
+          optional: true
+      {{- end }}
+      # If routingMode is hybrid, add the subnet-topology-file-path as configmap
+      {{- if eq .Values.routingMode "hybrid" }}
+      - name: subnet-topology-file
+        configMap:
+          name: {{ .Values.subnetTopologyConfigmapName | quote }}
           optional: true
       {{- end }}
       {{- range .Values.extraHostPathMounts }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -544,6 +544,11 @@ data:
   {{- end }}
 {{- end }}
 
+# If routingMode is hybrid, add the subnet-topology-file-path
+{{- if eq .Values.routingMode "hybrid" }}
+  subnet-topology-file-path: {{ .Values.subnetTopologyFilePath | quote }}
+{{- end }}
+
 {{- if .Values.tunnelPort }}
   tunnel-port: {{ .Values.tunnelPort | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2817,8 +2817,12 @@ underlayProtocol: ""
 #   - ""
 #   - native
 #   - tunnel
+#   - hybrid
 # @default -- `"tunnel"`
-routingMode: ""
+routingMode: "hybrid"
+# -- Subnet topology path.
+subnetTopologyFilePath: "/var/lib/cilium/subnet/subnet-topology"
+subnetTopologyConfigmapName: "subnet-topology"
 # -- Configure VXLAN and Geneve tunnel port.
 # @default -- Port 8472 for VXLAN, Port 6081 for Geneve
 tunnelPort: 0

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -446,6 +446,9 @@ const (
 	// RoutingMode enables choosing between native routing mode or tunneling mode.
 	RoutingMode = "tunnel"
 
+	// SubnetTopologyFilePath is the default path to the file containing the subnet topology
+	SubnetTopologyFilePath = "/var/run/cilium/subnet-topology"
+
 	// TunnelProtocol is the default tunneling protocol
 	TunnelProtocol = "vxlan"
 

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -104,6 +104,9 @@ const (
 	DbgL7LB
 	DbgLb6LoopbackSnat
 	DbgLb6LoopbackSnatRev
+	DbgSkipPolicy
+	DbgSameSubnetCheck
+	DbgSubnetTrace
 )
 
 // must be in sync with <bpf/lib/conntrack.h>
@@ -417,6 +420,12 @@ func (n *DebugMsg) Message(linkMonitor getters.LinkGetter) string {
 		return fmt.Sprintf("Socket assign: %s", skAssignInfo(n))
 	case DbgL7LB:
 		return fmt.Sprintf("L7 LB from %s to %s: proxy port %d", ip4Str(n.Arg1), ip4Str(n.Arg2), n.Arg3)
+	case DbgSameSubnetCheck:
+		return fmt.Sprintf("Same subnet check: src_ip=%s dst_ip=%s subnet_identity=%t",
+			ip4Str(n.Arg1), ip4Str(n.Arg2), n.Arg3 != 0)
+	case DbgSubnetTrace:
+		return fmt.Sprintf("Subnet trace: src_ip=%s dst_ip=%s subnet_id=%d",
+			ip4Str(n.Arg1), ip4Str(n.Arg2), n.Arg3)
 	default:
 		return fmt.Sprintf("Unknown message type=%d arg1=%d arg2=%d", n.SubType, n.Arg1, n.Arg2)
 	}

--- a/pkg/subnettopology/README.md
+++ b/pkg/subnettopology/README.md
@@ -1,0 +1,228 @@
+# Description
+
+This feature is an implementation of this CFP - https://github.com/cilium/design-cfps/blob/main/cilium/CFP-32810-hybrid-routing-mode.md .
+
+# Datapath changes
+
+Commit  - https://github.com/cilium/cilium/commit/4d99a9e5a50a5c89952677067b96419ab91b3baf
+
+## Key Changes
+
+### **New Subnet Map Infrastructure**
+- Added `bpf/lib/subnet.h` with a new LPM trie-based subnet map (`cilium_subnet_map`)
+- Implemented IPv4 and IPv6 subnet lookup functions with cluster ID support
+- Map stores subnet prefix → identity mappings for efficient subnet identification
+
+### **Enhanced Tunnel Skip Logic**
+- **Host datapath** (`bpf_host.c`): Extended tunnel skip conditions to include same-subnet detection
+- **Container datapath** (`bpf_lxc.c`): Modified packet handling to skip tunneling for intra-subnet traffic
+- Logic: Skip tunneling if `(existing_skip_tunnel_flag || same_subnet_detected)`
+
+### **Debug**
+- Added new debug message types:
+  - `DBG_SUBNET_CHECK`: Logs subnet comparison results
+  - `DBG_TUNNEL_TRACE`: Traces subnet ID resolution
+- Enhanced monitoring support in `pkg/monitor/datapath_debug.go` for troubleshooting
+
+# Userspace changes
+
+Commits:
+- https://github.com/anubhabMajumdar/cilium/commit/a9b1c0dc64316e1bf0588785f6052240a0369397
+- https://github.com/anubhabMajumdar/cilium/commit/508c64e2fac6df9a45809ad92510fd7173105923
+- https://github.com/anubhabMajumdar/cilium/commit/a1845f182ba6ab73f4c2a1701c3cc26c753aa072
+
+## Key Components Added
+
+### **Core Infrastructure**
+- **Hive Cell Integration**: Added `pkg/subnettopology/cell.go` with dependency injection setup
+- **Dynamic Manager**: Implemented `dynamic_manager.go` for lifecycle management and configuration synchronization
+- **File Watcher**: Created `watcher.go` for monitoring configuration file changes with MD5-based change detection
+- **Daemon Integration**: Registered subnet topology cell in `daemon/cmd/cells.go`
+
+### **eBPF Map Management**
+- **Map Abstraction**: Added `map.go` with comprehensive eBPF map management
+- **Key/Value Structures**: Implemented LPM trie-compatible data structures for subnet lookups
+- **IPv4/IPv6 Support**: Map can store both IPv4 and IPv6 keys
+
+# YAML file changes
+
+- **New Routing Mode**: Added `hybrid` as a supported routing mode option in `values.yaml`
+- **Subnet Topology Path**: Added `subnetTopologyFilePath` configuration (`/var/lib/cilium/subnet/subnet-topology`)
+- **ConfigMap Integration**: Added `subnetTopologyConfigmapName` for subnet topology configuration 
+- **Conditional Volume Mount**: Added subnet topology file mount when `routingMode` is `hybrid in `cilium-agent/daemonset.yaml`
+
+# Testing done
+
+## Single Cluster Testing
+
+### Test Environment Setup
+
+The testing was conducted on a single Azure Kubernetes Service (AKS) cluster with the following network topology:
+- **Cloud Provider**: Microsoft Azure
+- **Cluster Type**: AKS (Azure Kubernetes Service)
+- **Network Configuration**: Pod and Node subnets deployed within the same Azure Virtual Network (VNET)
+- **Subnet Architecture**: Separate subnets for pods and nodes, both residing in a single VNET to enable native routing capabilities
+
+### Cilium Installation and Configuration
+
+Cilium was deployed using a custom-built image containing the hybrid routing implementation. The installation command below shows the specific configuration parameters used:
+
+```bash
+cilium install -n kube-system cilium cilium/cilium --version v1.18.0 \
+    --set azure.resourceGroup="<RESOURCE-GROUP>" \
+    --set aksbyocni.enabled=false \
+    --set nodeinit.enabled=false \
+    --set hubble.enabled=true \
+    --set envoy.enabled=false \
+    --set cluster.id="<ID>" \
+    --set cluster.name="<NAME>" \
+    --set ipam.mode=delegated-plugin \
+    --set routingMode=hybrid
+    --set endpointRoutes.enabled=true \
+    --set enable-ipv4=true \
+    --set enableIPv4Masquerade=false \
+    --set kubeProxyReplacement=true \
+    --set kubeProxyReplacementHealthzBindAddr='0.0.0.0:<PORT>' \
+    --set extraArgs="{--local-router-ipv4=<IP>} {--install-iptables-rules=true}" \
+    --set endpointHealthChecking.enabled=false \
+    --set cni.exclusive=false \
+    --set bpf.enableTCX=false \
+    --set bpf.hostLegacyRouting=true \
+    --set l7Proxy=false \
+    --set sessionAffinity=true \
+    --set "extraVolumes[0].name=subnet-topology-file" \
+    --set "extraVolumes[0].configMap.name=subnet-topology" \
+    --set "extraVolumes[0].configMap.optional=true" \
+    --set "extraVolumeMounts[0].name=subnet-topology-file" \
+    --set "extraVolumeMounts[0].mountPath=/var/lib/cilium/subnet" \
+    --set "extraVolumeMounts[0].readOnly=true" \
+    --set subnetTopologyFilePath="/var/lib/cilium/subnet/subnet-topology" \
+    --set "extraConfig.subnet-topology-file-path"="/var/lib/cilium/subnet/subnet-topology"
+```
+
+**Key Configuration Highlights**:
+- `routingMode=hybrid`: To enable hybrid routing
+- `ipam.mode=delegated-plugin`: Uses Azure CNI for IP address management
+- `hubble.enabled=true`: Enables network flow observability for testing verification
+- `bpf.hostLegacyRouting=true`: Enables legacy routing mode for compatibility with Azure networking
+
+**Subnet topology configmap**
+
+```
+apiVersion: v1
+data:
+  subnet-topology: 10.1.1.0/24
+kind: ConfigMap
+metadata:
+  name: subnet-topology
+  namespace: kube-system
+```
+
+#### Hybrid Routing Activation and Testing
+
+**Steps Performed**:
+1. **Subnet Topology Configuration**: Applied the `subnet-topology` ConfigMap containing the subnet-to-identity mappings
+2. **eBPF Map Synchronization**: Waited for the eBPF LPM trie map to synchronize with the new subnet topology data
+3. **Flow Behavior Verification**: Monitored Hubble flows to observe the routing behavior changes
+4. **Debug Verification**: Used custom debug messages (`DBG_SUBNET_CHECK` and `DBG_TUNNEL_TRACE`) to verify internal decision-making logic
+
+**Results**:
+- ✅ Hybrid routing activated successfully
+- **Hubble Flow Observations**: Inter-node traffic within the same subnet began showing `to-stack/network` flows (native routing)
+- **Behavior Validation**: Traffic between pods in the same subnet bypassed tunneling and used direct Azure VNET routing
+- **Debug Log Verification**: Custom debug messages confirmed:
+  - Subnet identity lookups were functioning correctly
+  - Same-subnet detection logic was working as expected
+  - Tunnel bypass decisions were being made appropriately
+
+#### Dynamic Configuration Testing
+
+**Steps Performed**:
+1. **Configuration Removal**: Deleted the `subnet-topology` ConfigMap
+2. **eBPF Map Cleanup**: Waited for the eBPF map to synchronize and clear subnet topology data
+3. **Behavior Reverification**: Monitored traffic flows to confirm fallback to tunnel mode
+
+**Results**:
+- ✅ Dynamic configuration changes worked as expected
+- **Hubble Flow Observations**: After ConfigMap deletion, inter-node traffic reverted to showing `to-overlay` flows
+- **Behavior Validation**: System correctly fell back to full tunnel mode when subnet topology information was unavailable
+- **No Service Disruption**: All connectivity remained functional throughout the configuration changes
+
+## Multi-Cluster Testing (Cluster Mesh)
+
+### Test Environment Setup
+
+**Cluster Architecture**:
+- **Primary Cluster**: Single AKS cluster configured as described above
+- **Secondary Cluster**: Identical AKS cluster configuration in a separate resource group
+- **Network Connectivity**: Azure VNET peering established between the two cluster VNETs to enable cross-cluster communication
+- **Service Mesh**: Cilium Cluster Mesh enabled to provide cross-cluster service discovery and load balancing
+
+### Cluster Mesh Configuration
+
+**Steps Performed**:
+1. **Cluster Mesh Enablement**: Followed the official Cilium documentation for [Cluster Mesh setup](https://docs.cilium.io/en/stable/network/clustermesh/clustermesh/)
+2. **Cluster Connection**: Connected both clusters using the Cilium Cluster Mesh connectivity protocols
+3. **Status Verification**: Confirmed successful setup using `cilium clustermesh status` command, which reported "OK" status
+4. **Service Configuration**: Deployed the cross-cluster service example from the [official documentation](https://docs.cilium.io/en/stable/network/clustermesh/services/)
+5. **Subnet Topology Application**: Applied the `subnet-topology` ConfigMap to both clusters to enable hybrid routing across the mesh
+
+The following diagram illustrates how hybrid routing operates with this change in a multi-cluster environment:
+
+<img width="11650" height="9470" alt="hybrid-routing-diagram" src="https://github.com/user-attachments/assets/12a53efa-c037-47ec-870f-ab456124a06e" />
+
+#### Scenario 1: Cross-Cluster Communication with Same Subnet Topology
+
+**Configuration**: Both clusters configured with identical subnet topologies, simulating pods in the same logical subnet across clusters.
+
+**Observations**:
+- ✅ **Hubble Flows**: Show `to-stack/network` flows for cross-cluster communication
+- ✅ **Debug Logs**: Confirm same-subnet detection and tunnel bypass logic activation
+
+#### Scenario 2: Cross-Cluster Communication with Different Subnet Topology
+
+**Configuration**: Clusters configured with different subnet topologies, simulating pods in different logical subnets across clusters.
+
+**Observations**:
+- ✅ **Hubble Flows**: Show `to-overlay` flows for cross-cluster communication
+- ✅ **Debug Logs**: Confirm different-subnet detection and tunnel encapsulation activation
+
+#### Scenario 3: Cross-Cluster Communication with Pod Subnet and Overlay Cilium clusters
+
+**Configuration**: An Overlay cluster was added to setup in Scenario 1.
+
+**Observations**:
+- ✅ **Hubble Flows**: Show `to-overlay` flows for cross-cluster communication
+- ✅ **Debug Logs**: Confirm same as well as different-subnet detection and tunnel encapsulation activation
+
+[8_21_2025, 8_44_11 PM - Screen - Video Project 7.webm](https://github.com/user-attachments/assets/182f7404-1d52-4929-b61e-4f4fbbc8cad5)
+
+# Notes
+
+- Haven't implemented atomic read of the subnet map while making routing decision yet
+- Will remove the debug traces from data path before merging the PR
+- Missing unit tests, will add after I get some initial feedback
+- Will revert back to runnel mode as default routing option in `values.yaml`
+- Marking PR as draft. This PR will provide an overview of exactly what I am trying to achieve. Given its size and complexity, I will break it up into pieces for easier review and merging.
+
+Please ensure your pull request adheres to the following guidelines:
+
+- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
+- [ ] All code is covered by unit and/or runtime tests where feasible.
+- [x] All commits contain a well written commit description including a title,
+      description and a `Fixes: #XXX` line if the commit addresses a particular
+      GitHub issue.
+- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
+      please add the commit author[s] as reviewer[s] to this issue.
+- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
+- [ ] Provide a title or release-note blurb suitable for the release notes.
+- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
+- [ ] Thanks for contributing!
+
+<!-- Description of change -->
+
+Fixes: #issue-number
+
+```release-note
+<!-- Enter the release note text here if needed or remove this section! -->
+```

--- a/pkg/subnettopology/cell.go
+++ b/pkg/subnettopology/cell.go
@@ -1,0 +1,27 @@
+package subnettopology
+
+import (
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+)
+
+type Params struct {
+	cell.In
+
+	Logger       *slog.Logger
+	Registry     *metrics.Registry
+	Lifecycle    cell.Lifecycle
+	DaemonConfig *option.DaemonConfig
+
+	JobGroup job.Group
+}
+
+var Cell = cell.Module(
+	"subnet_topology",
+	"Provides manager for subnet topology",
+	cell.Invoke(registerDynamicManager),
+)

--- a/pkg/subnettopology/cell.go
+++ b/pkg/subnettopology/cell.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/hive/job"
 )
 
 type Params struct {
@@ -17,11 +16,16 @@ type Params struct {
 	Lifecycle    cell.Lifecycle
 	DaemonConfig *option.DaemonConfig
 
-	JobGroup job.Group
+	M *Map
 }
 
 var Cell = cell.Module(
 	"subnet_topology",
 	"Provides manager for subnet topology",
+	cell.ProvidePrivate(
+		func(reg *metrics.Registry) *Map {
+			return SubnetMap(reg)
+		},
+	),
 	cell.Invoke(registerDynamicManager),
 )

--- a/pkg/subnettopology/dynamic_manager.go
+++ b/pkg/subnettopology/dynamic_manager.go
@@ -1,0 +1,75 @@
+package subnettopology
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/workerpool"
+)
+
+type dynamicManager struct {
+	mu sync.Mutex
+
+	logger   *slog.Logger
+	filepath string
+
+	hash   uint64
+	subnet string
+
+	wp *workerpool.WorkerPool
+}
+
+func registerDynamicManager(p Params) error {
+	tm := &dynamicManager{
+		logger: p.Logger.With(
+			logfields.LogSubsys, "subnet-topology",
+		),
+		filepath: p.DaemonConfig.SubnetTopologyFilePath,
+	}
+	p.Lifecycle.Append(tm)
+	return nil
+}
+
+func (tm *dynamicManager) Start(ctx cell.HookContext) error {
+	tm.logger.Info("Starting subnet topology map")
+	if tm.filepath == "" {
+		tm.logger.Warn("No subnet topology file path configured, skipping watcher")
+		return nil
+	}
+	w := newWatcher(tm.logger, tm.filepath, tm.onUpdate)
+
+	tm.wp = workerpool.New(1)
+	if err := tm.wp.Submit("subnet-topology-watcher", w.watch); err != nil {
+		return fmt.Errorf("failed to start subnet topology watcher: %w", err)
+	}
+	return nil
+}
+
+func (tm *dynamicManager) Stop(ctx cell.HookContext) error {
+	tm.logger.Info("Stopping subnet topology map")
+	if tm.wp != nil {
+		tm.wp.Close()
+	}
+	return nil
+}
+
+func (tm *dynamicManager) onUpdate(newSubnet string, newHash uint64) error {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	if newHash == tm.hash {
+		// No change in hash, nothing to update.
+		return nil
+	}
+
+	// Sync eBPF map.
+
+	tm.logger.Info("Sync'd eBPF map")
+	tm.hash = newHash
+	tm.subnet = newSubnet
+
+	return nil
+}

--- a/pkg/subnettopology/map.go
+++ b/pkg/subnettopology/map.go
@@ -1,0 +1,164 @@
+package subnettopology
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"net"
+	"net/netip"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+const (
+	MaxEntries = 1024
+	Name       = "cilium_subnet_map"
+)
+
+type Key struct {
+	Prefixlen uint32 `align:"lpm_key"`
+	ClusterID uint16 `align:"cluster_id"`
+	Pad1      uint8  `align:"pad1"`
+	Family    uint8  `align:"family"`
+	// represents both IPv6 and IPv4 (in the lowest four bytes)
+	IP types.IPv6 `align:"$union0"`
+}
+
+func getStaticPrefixBits() uint32 {
+	staticMatchSize := unsafe.Sizeof(Key{})
+	staticMatchSize -= unsafe.Sizeof(Key{}.Prefixlen)
+	staticMatchSize -= unsafe.Sizeof(Key{}.IP)
+	return uint32(staticMatchSize) * 8
+}
+
+func (k Key) String() string {
+	var (
+		addr netip.Addr
+		ok   bool
+	)
+
+	switch k.Family {
+	case bpf.EndpointKeyIPv4:
+		addr, ok = netip.AddrFromSlice(k.IP[:net.IPv4len])
+		if !ok {
+			return "<unknown>"
+		}
+	case bpf.EndpointKeyIPv6:
+		addr = netip.AddrFrom16(k.IP)
+	default:
+		return "<unknown>"
+	}
+
+	prefixLen := int(k.Prefixlen - getStaticPrefixBits())
+	clusterID := uint32(k.ClusterID)
+
+	return cmtypes.PrefixClusterFrom(netip.PrefixFrom(addr, prefixLen), cmtypes.WithClusterID(clusterID)).String()
+}
+
+func (k *Key) New() bpf.MapKey { return &Key{} }
+
+func (k Key) Prefix() netip.Prefix {
+	var addr netip.Addr
+	prefixLen := int(k.Prefixlen - getStaticPrefixBits())
+	switch k.Family {
+	case bpf.EndpointKeyIPv4:
+		addr = netip.AddrFrom4(*(*[4]byte)(k.IP[:4]))
+	case bpf.EndpointKeyIPv6:
+		addr = netip.AddrFrom16(k.IP)
+	}
+	return netip.PrefixFrom(addr, prefixLen)
+}
+
+// getPrefixLen determines the length that should be set inside the Key so that
+// the lookup prefix is correct in the BPF map key. The specified 'prefixBits'
+// indicates the number of bits in the IP that must match to match the entry in
+// the BPF ipcache.
+func getPrefixLen(prefixBits int) uint32 {
+	return getStaticPrefixBits() + uint32(prefixBits)
+}
+
+// NewKey returns an Key based on the provided IP address, mask, and ClusterID.
+// The address family is automatically detected
+func NewKey(ip net.IP, mask net.IPMask, clusterID uint16) Key {
+	result := Key{}
+
+	ones, _ := mask.Size()
+	if ip4 := ip.To4(); ip4 != nil {
+		if mask == nil {
+			ones = net.IPv4len * 8
+		}
+		result.Prefixlen = getPrefixLen(ones)
+		result.Family = bpf.EndpointKeyIPv4
+		copy(result.IP[:], ip4)
+	} else {
+		if mask == nil {
+			ones = net.IPv6len * 8
+		}
+		result.Prefixlen = getPrefixLen(ones)
+		result.Family = bpf.EndpointKeyIPv6
+		copy(result.IP[:], ip)
+	}
+
+	result.ClusterID = clusterID
+
+	return result
+}
+
+type Value struct {
+	Identity uint32 `align:"identity"`
+}
+
+func (v *Value) String() string {
+	return fmt.Sprintf("Identity: %d", v.Identity)
+}
+
+func (v *Value) New() bpf.MapValue { return &Value{} }
+
+func NewValue(identity uint32) Value {
+	return Value{
+		Identity: identity,
+	}
+}
+
+type Map struct {
+	bpf.Map
+}
+
+func newSubnetMap(name string) *bpf.Map {
+	m := bpf.NewMap(
+		name,
+		ebpf.LPMTrie,
+		&Key{},
+		&Value{},
+		MaxEntries,
+		unix.BPF_F_NO_PREALLOC)
+	return m
+}
+
+// NewMap instantiates a Map.
+func NewSubnetMap(registry *metrics.Registry, name string) *Map {
+	return &Map{
+		Map: *newSubnetMap(name).WithCache().WithPressureMetric(registry).
+			WithEvents(option.Config.GetEventBufferConfig(name)),
+	}
+}
+
+var (
+	subnetMap *Map
+	once      = &sync.Once{}
+)
+
+func SubnetMap(registry *metrics.Registry) *Map {
+	once.Do(func() {
+		subnetMap = NewSubnetMap(registry, Name)
+	})
+	return subnetMap
+}

--- a/pkg/subnettopology/map.go
+++ b/pkg/subnettopology/map.go
@@ -25,7 +25,7 @@ const (
 
 type Key struct {
 	Prefixlen uint32 `align:"lpm_key"`
-	ClusterID uint16 `align:"cluster_id"`
+	Pad2      uint16 `align:"pad2"`
 	Pad1      uint8  `align:"pad1"`
 	Family    uint8  `align:"family"`
 	// represents both IPv6 and IPv4 (in the lowest four bytes)
@@ -58,9 +58,7 @@ func (k Key) String() string {
 	}
 
 	prefixLen := int(k.Prefixlen - getStaticPrefixBits())
-	clusterID := uint32(k.ClusterID)
-
-	return cmtypes.PrefixClusterFrom(netip.PrefixFrom(addr, prefixLen), cmtypes.WithClusterID(clusterID)).String()
+	return cmtypes.PrefixClusterFrom(netip.PrefixFrom(addr, prefixLen)).String()
 }
 
 func (k *Key) New() bpf.MapKey { return &Key{} }
@@ -85,9 +83,9 @@ func getPrefixLen(prefixBits int) uint32 {
 	return getStaticPrefixBits() + uint32(prefixBits)
 }
 
-// NewKey returns an Key based on the provided IP address, mask, and ClusterID.
+// NewKey returns an Key based on the provided IP address and mask.
 // The address family is automatically detected
-func NewKey(ip net.IP, mask net.IPMask, clusterID uint16) Key {
+func NewKey(ip net.IP, mask net.IPMask) Key {
 	result := Key{}
 
 	ones, _ := mask.Size()
@@ -106,8 +104,6 @@ func NewKey(ip net.IP, mask net.IPMask, clusterID uint16) Key {
 		result.Family = bpf.EndpointKeyIPv6
 		copy(result.IP[:], ip)
 	}
-
-	result.ClusterID = clusterID
 
 	return result
 }

--- a/pkg/subnettopology/watcher.go
+++ b/pkg/subnettopology/watcher.go
@@ -1,0 +1,77 @@
+package subnettopology
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	defaultWatchInterval = 5 * time.Second
+)
+
+type watcher struct {
+	logger   *slog.Logger
+	filePath string
+	callback func(string, uint64) error
+}
+
+func newWatcher(logger *slog.Logger, filePath string, callback func(string, uint64) error) *watcher {
+	return &watcher{
+		logger:   logger,
+		filePath: filePath,
+		callback: callback,
+	}
+}
+
+func (w *watcher) watch(ctx context.Context) error {
+	w.logger.Info("Starting subnet topology watcher")
+	ticker := time.NewTicker(defaultWatchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("Subnet topology watcher stopped")
+			return nil
+		case <-ticker.C:
+			w.reload()
+		}
+	}
+}
+
+func (w *watcher) reload() {
+	newTopology, h, err := w.parse()
+	if err != nil {
+		w.logger.Error("failed to parse config", logfields.Error, err)
+		return
+	}
+	w.callback(newTopology, h)
+}
+
+func (w *watcher) parse() (string, uint64, error) {
+	content, err := os.ReadFile(w.filePath)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to read config file: %w", err)
+	}
+	// Unmarshal the content into Config struct.
+	// Assuming a YAML format for simplicity.
+	var subnetTopology string
+	if err := yaml.Unmarshal(content, &subnetTopology); err != nil {
+		return "", 0, fmt.Errorf("failed to unmarshal config file: %w", err)
+	}
+	// Calculate the hash of the content.
+	h := calculateHash(content)
+	return subnetTopology, h, nil
+}
+
+func calculateHash(file []byte) uint64 {
+	sum := md5.Sum(file)
+	return binary.LittleEndian.Uint64(sum[0:16])
+}


### PR DESCRIPTION
# Note

I have started splitting the draft PR into smaller chunks. 
Here's the PR for the datapath - [[GH-41867][Part-1][eBPF] Add support for hybrid routing in datapath by anubhabMajumdar · Pull Request #41868 · cilium/cilium](https://github.com/cilium/cilium/pull/41868) . 

# Description

The motivation behind adding a new routing mode is discussed in this [CFP](https://github.com/cilium/design-cfps/blob/main/cilium/CFP-32810-hybrid-routing-mode.md) . This PR provides an overview for how this change will be implemented. Given the size and complexity, the changes have been grouped into logical commits. Depending on feedback, will probably create separate smaller PRs to actually merge in the changes to main.

## Overview

This feature would allow user to configure Cilium cluster(s) with multiple subnets, and benefit from both tunnel and native routing mode for maximum efficiency (no overhead of tunneling when not needed).

There's a more verbose description [here](https://github.com/cilium/cilium/pull/41405/commits/5089df7140f706cae9d0f67b37b46dc62439bb8a). It goes into much more detail about the changes and how testing was performed, along with diagram explaining the setup. 

## Motivation

1. Given that tunneling can always route a packet as long as nodes have connectivity, the entire change is designed to use tunnel as default, with exceptions built in to skip tunneling when IPs belong to same subnet.
2. The change allows users to dynamically change the subnet topology. This will help skip agent restart.
3. I have tried to adhere to existing patterns that I could identify
- the eBPF map and lookup function closely resembles the IPCache library. Will clean them up to remove fields not needed (ex - cluster ID) before merging.
- the userspace controller similarly resembles dynamic controllers like dynamic exporter in Hubble.

# Changes Overview

## Datapath

This covers all the C code changes. Files edited/added:

1. `bpf/lib/subnet.h` - This has the LPM trie based subnet map, similar to the IPCache map. Has functions for lookup.
2. `bpf_lxc.c` - Added an extra check to `skip_tunnel`. Now, skip tunneling if IPs belong to same subnet.
4. `bpf_host.c` - Added an extra check to `skip_tunnel`. Now, skip tunneling if IPs belong to same subnet.
5. Added two debug keys - `DBG_SUBNET_CHECK` and `DBG_TUNNEL_TRACE` for debugging purposes. Will remove these before merging.

## Userspace

This covers the user side code that watches, reads, parses and update the eBPF map with subnets. All files are under `pkg/subnettopology`. The pattern closely resembles other dynamic controllers like dynamic exporter, which reads a file every so many seconds and reconciles the change if it finds any.

## Configuration

This covers all changes needed to add a new option under `routing-mode`. Also. when hybrid routing mode, allow settings for both tunnel and native routing. Files edited:
1. `daemon/cmd/daemon_main.go`
2. `pkg/option/config.go`

## Install

YAML file changes to add the new hybrid routing related options.
NOTE: Will revert back to runnel mode as default routing option in `values.yaml`.

# Testing Done

I haven't added any new tests to verify this change yet. Part of the reason for this change to have a discussion here as to how this should be tested going forward. I think we would probably need to setup new infrastructure to test it in Cluster Mesh with dynamic subnets.

Here's how I have tested this change in single/multi-cluster scenarios. All testing were done on following
- **Cluster Type** - AKS
- **Networking** - Pod and Node subnets for each cluster in mesh is deployed within the same Azure Virtual Network (VNET)

## Single cluster

1. Deploy a cluster with no CNI installed. The Pod/Node CIDR is backed by two subnets belonging to same VNET
2. Install Cilium with hybrid routing. However, configure no subnets
3. Deploy a client-server on two different nodes
4. Check Hubble flows between a client-server setup. We see `to-overlay` flows on the client node.
5. Check cilium debug messages on the node to verify `same_subnet=false`.
6. Now, configure the pod subnet and check the eBPF map to see if the updates have sync'd
7. Check Hubble flows between a client-server setup. We see `to-stack/network` flows on the client node.
8. Check cilium debug messages on the node to verify `same_subnet=true`.
9. Remove the subnet config again. Repeat Steps 4 and 5.

## Cluster Mesh

1. Setup 2 clusters as above with Cilium installed. Setup VNET peering between the two VNETs. Configure subnet on both cluster with the pod CIDRs of both clusters (ex: `podcidr1,podcidr2`).
2. Setup client on one cluster and server on the other. Start traffic from client->server.
3. Check Hubble flows. We see `to-stack/network` flows on the client node.
4. Check cilium debug messages on the node to verify `same_subnet=true`.
5. Edit the subnet config to `podcidr1;podcidr2` (means no direct routing possible between two CIDR range).
6. Check Hubble flows. We see `to-overlay` flows on the client node.
7. Check cilium debug messages on the node to verify `same_subnet=false`.

# Notes

- Haven't implemented atomic read of the subnet map while making routing decision yet
- Will remove the debug traces from data path before merging the PR
- Missing unit tests, will add after I get some initial feedback
- Will revert back to runnel mode as default routing option in `values.yaml`
- Will remove the README before merging 
- Marking PR as draft. This PR will provide an overview of exactly what I am trying to achieve. Given its size and complexity, I will break it up into pieces for easier review and merging.


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
