### PR TITLE
clustermesh: document Kubernetes version for MCS-API CoreDNS

### DIFF
--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -18,7 +18,7 @@ Prerequisites
 You need to have a functioning Cluster Mesh setup, please follow the
 :ref:`gs_clustermesh` guide to set it up.
 
-Make sure you are running CoreDNS 1.12.2 or later.
+Make sure you are running CoreDNS 1.12.2 or later (installed by default from Kubernetes 1.35).
 
 You first need to install the required MCS-API CRDs:
 


### PR DESCRIPTION
From Kubernetes 1.35, the CoreDNS version that we need for MCS is installed by default, see:
https://github.com/kubernetes/kubernetes/pull/132288.

```release-note
clustermesh: Kubernetes 1.35 will include by default the CoreDNS version we need for MCS-API
```
