### PR TITLE
.actions/cilium-config: add missing extraEnv in GH action

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -90,7 +90,31 @@ runs:
             --helm-set-string=kubeProxyReplacement=${{ inputs.kpr }} \
             --helm-set=l2NeighDiscovery.enabled=true \
             --helm-set-string=encryption.ipsec.keyRotationDuration="1m" \
-            --set='${{ inputs.misc }}'"
+            --set='${{ inputs.misc }}' \
+            --set-string=extraEnv[0].name=CILIUM_FEATURE_METRICS_WITH_DEFAULTS \
+            --set-string=extraEnv[0].value=true \
+            --set-string=extraEnv[1].name=CILIUM_INVALID_METRIC_VALUE_DETECTOR \
+            --set-string=extraEnv[1].value=true \
+            --set-string=extraEnv[2].name=CILIUM_SLOG_DUP_ATTR_DETECTOR \
+            --set-string=extraEnv[2].value=true \
+            --set-string=operator.extraEnv[0].name=CILIUM_FEATURE_METRICS_WITH_DEFAULTS \
+            --set-string=operator.extraEnv[0].value=true \
+            --set-string=operator.extraEnv[1].name=CILIUM_INVALID_METRIC_VALUE_DETECTOR \
+            --set-string=operator.extraEnv[1].value=true \
+            --set-string=operator.extraEnv[2].name=CILIUM_SLOG_DUP_ATTR_DETECTOR \
+            --set-string=operator.extraEnv[2].value=true \
+            --set-string=clustermesh.apiserver.extraEnv[0].name=CILIUM_FEATURE_METRICS_WITH_DEFAULTS \
+            --set-string=clustermesh.apiserver.extraEnv[0].value=true \
+            --set-string=clustermesh.apiserver.extraEnv[1].name=CILIUM_INVALID_METRIC_VALUE_DETECTOR \
+            --set-string=clustermesh.apiserver.extraEnv[1].value=true \
+            --set-string=clustermesh.apiserver.extraEnv[2].name=CILIUM_SLOG_DUP_ATTR_DETECTOR \
+            --set-string=clustermesh.apiserver.extraEnv[2].value=true \
+            --set-string=hubble.relay.extraEnv[0].name=CILIUM_FEATURE_METRICS_WITH_DEFAULTS \
+            --set-string=hubble.relay.extraEnv[0].value=true \
+            --set-string=hubble.relay.extraEnv[1].name=CILIUM_INVALID_METRIC_VALUE_DETECTOR \
+            --set-string=hubble.relay.extraEnv[1].value=true \
+            --set-string=hubble.relay.extraEnv[2].name=CILIUM_SLOG_DUP_ATTR_DETECTOR \
+            --set-string=hubble.relay.extraEnv[2].value=true"
 
           if [ -f "${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml" ]; then
             DEFAULTS+=" --values=${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml"


### PR DESCRIPTION
This GH action is missing some extraEnv that we should run in our CI.