### PR TITLE
fqdn: Refactor and tighten matchpattern sanitization

### DIFF
--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -5,6 +5,7 @@ package matchpattern
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -14,6 +15,10 @@ import (
 
 const allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
 
+// allowedPatternChars tests that the MatchPattern field contains only the
+// characters we want in our wildcard scheme.
+var allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9_.*]+$") // the * inside the [] is a literal *
+
 // MatchAllAnchoredPattern is the simplest pattern that match all inputs. This resulting
 // parsed regular expression is the same as an empty string regex (""), but this
 // value is easier to reason about when serializing to and from json.
@@ -22,6 +27,11 @@ const MatchAllAnchoredPattern = "(?:)"
 // MatchAllUnAnchoredPattern is the same as MatchAllAnchoredPattern, except that
 // it can be or-ed (joined with "|") with other rules, and still match all rules.
 const MatchAllUnAnchoredPattern = ".*"
+
+// MaxFQDNLength is the maximum length of a MatchName or MatchPattern statement.
+//
+// Must be kept in sync with the validator for these fields in pkg/policy/api.
+const MaxFQDNLength = 255
 
 // Validate ensures that pattern is a parsable matchPattern. It returns the
 // regexp generated when validating.
@@ -42,6 +52,13 @@ func ValidateWithoutCache(pattern string) (matcher *regexp.Regexp, err error) {
 }
 
 func prevalidate(pattern string) error {
+	if len(pattern) > MaxFQDNLength {
+		return fmt.Errorf("Invalid MatchPattern: %q. Must be <= %d characters long.", pattern, MaxFQDNLength)
+	}
+	if len(pattern) > 0 && !allowedPatternChars.MatchString(pattern) {
+		return fmt.Errorf("Invalid characters in MatchPattern: \"%s\". Only 0-9, a-z, A-Z and ., - and * characters are allowed", pattern)
+	}
+
 	pattern = strings.TrimSpace(pattern)
 	pattern = strings.ToLower(pattern)
 

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -17,10 +17,6 @@ var (
 	// allowedMatchNameChars tests that MatchName contains only valid DNS characters
 	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9_.]+$")
 
-	// allowedPatternChars tests that the MatchPattern field contains only the
-	// characters we want in our wildcard scheme.
-	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9_.*]+$") // the * inside the [] is a literal *
-
 	// FQDNMatchNameRegexString is a regex string which matches what's expected
 	// in the MatchName field in the FQDNSelector. This should be kept in-sync
 	// with the marker comment for validation. There's no way to use a Golang
@@ -103,9 +99,6 @@ func (s *FQDNSelector) sanitize() error {
 		return fmt.Errorf("Invalid characters in MatchName: \"%s\". Only 0-9, a-z, A-Z and . and - characters are allowed", s.MatchName)
 	}
 
-	if len(s.MatchPattern) > 0 && !allowedPatternChars.MatchString(s.MatchPattern) {
-		return fmt.Errorf("Invalid characters in MatchPattern: \"%s\". Only 0-9, a-z, A-Z and ., - and * characters are allowed", s.MatchPattern)
-	}
 	_, err := matchpattern.Validate(s.MatchPattern)
 	return err
 }
@@ -135,9 +128,6 @@ func (r *PortRuleDNS) Sanitize() error {
 		return fmt.Errorf("Invalid characters in MatchName: \"%s\". Only 0-9, a-z, A-Z and . and - characters are allowed", r.MatchName)
 	}
 
-	if len(r.MatchPattern) > 0 && !allowedPatternChars.MatchString(r.MatchPattern) {
-		return fmt.Errorf("Invalid characters in MatchPattern: \"%s\". Only 0-9, a-z, A-Z and ., - and * characters are allowed", r.MatchPattern)
-	}
 	_, err := matchpattern.Validate(r.MatchPattern)
 	return err
 }


### PR DESCRIPTION
Move the sanitization for match patterns in FQDNs into the function
which is fuzzed under `pkg/fqdn/matchpattern/`, and apply a pattern length
limit that matches the current k8s API limits.

Reported-by: oss-fuzz
