### PR TITLE
hubble/metrics/icmp: fix icmp6 label to correctly be ipv6.

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -389,6 +389,7 @@ As well, any remaining Operator k8s workqueue metrics that use the label ``queue
 * The metric ``workqueue_work_duration_seconds`` has been renamed and combined into ``cilium_operator_k8s_workqueue_work_duration_seconds``, the label ``queue_name`` has been renamed to ``name``.
 
 * ``k8s_client_rate_limiter_duration_seconds`` no longer has labels ``path`` and ``method``.
+* ``hubble_icmp_total`` has been fixed to correctly use ``family`` label value ``IPv6`` on ``ICMPv6`` flows instead of ``IPv4``.
 
 The following metrics:
 * ``cilium_agent_clustermesh_global_services``

--- a/pkg/hubble/metrics/icmp/handler.go
+++ b/pkg/hubble/metrics/icmp/handler.go
@@ -84,7 +84,7 @@ func (h *icmpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 	}
 
 	if icmp := l4.GetICMPv6(); icmp != nil {
-		labels := []string{"IPv4", layers.CreateICMPv6TypeCode(uint8(icmp.Type), uint8(icmp.Code)).String()}
+		labels := []string{"IPv6", layers.CreateICMPv6TypeCode(uint8(icmp.Type), uint8(icmp.Code)).String()}
 		labels = append(labels, labelValues...)
 		h.icmp.WithLabelValues(labels...).Inc()
 	}


### PR DESCRIPTION
For icmpv6 metrics, the ip family label is wrong as it always sets it to ipv4.
This just corrects that typo.

