### PR TITLE
labels: enhance parseSource to support  policy rules matching endpoints with labels containing "."

### DIFF
--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -18,6 +18,7 @@ import (
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -432,8 +433,8 @@ func appendEndpoints(toCIDRSet *api.CIDRRuleSlice, endpoints []api.CIDR) {
 // appendSelector appends the service selector as a generated EndpointSelector
 func appendSelector(toEndpoints *[]api.EndpointSelector, svcSelector map[string]string, namespace string) {
 	selector := maps.Clone(svcSelector)
-	selector[labels.LabelSourceK8sKeyPrefix+k8sConst.PodNamespaceLabel] = namespace
-	endpointSelector := api.NewESFromMatchRequirements(selector, nil)
+	selector[k8sConst.PodNamespaceLabel] = namespace
+	endpointSelector := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &slim_metav1.LabelSelector{MatchLabels: selector})
 	endpointSelector.Generated = true
 
 	*toEndpoints = append(*toEndpoints, endpointSelector)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
This change adds support for matching policy rules to endpoint resources whose labels contain . or :.

Currently, any substring before a . or : is automatically treated as the "source". With this update, the code first checks whether the prefix (derived from the label delimiter) corresponds to a known resource:

If it matches a known resource → the prefix is returned as the source, and the remainder is treated as the suffix.

If it does not match a known resource → the label string is returned as-is, without splitting.

This ensures that labels containing . or : are handled correctly without incorrectly splitting on arbitrary delimiters.

Fixes: #41151

```release-note
Bugfix: allow policy rules to match endpoint labels that contain "." or ":" when referenced via toServices (CNP/CCNP).