### PR TITLE
ipam/multipool: respect ipam-cilium-node-update-rate for CiliumNode updates

### DIFF
--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -263,7 +263,7 @@ func newMultiPoolManager(logger *slog.Logger, conf *option.DaemonConfig, node ag
 
 	k8sController := controller.NewManager()
 	k8sUpdater, err := trigger.NewTrigger(trigger.Parameters{
-		MinInterval: 15 * time.Second,
+		MinInterval: conf.IPAMCiliumNodeUpdateRate,
 		TriggerFunc: func(reasons []string) {
 			k8sController.TriggerController(multiPoolControllerName)
 		},


### PR DESCRIPTION
Replace hardcoded 15s trigger MinInterval with `conf.IPAMCiliumNodeUpdateRate` in multi-pool IPAM.


```release-note
IPAM (MultiPool): Honor ipam-cilium-node-update-rate for CiliumNode updates (was hardcoded to 15s by default). Default remains 15s.
```
