### PR TITLE
bpf: use redirect_neigh() for punting reply traffic to parent interface

### DIFF
--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -357,23 +357,8 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 				return ret;
 
 			if (ret != DROP_CT_UNKNOWN_PROTO &&
-			    ct_is_reply4(get_ct_map4(&tuple), &tuple)) {
-				/* Look up the parent interface's MAC address and set it as the
-				 * source MAC address of the packet. We will assume the destination
-				 * MAC address is still correct. This assumption only holds if the
-				 * current and parent interfaces are on the same L2 network such as
-				 * in EKS.
-				 */
-				union macaddr smac = NATIVE_DEV_MAC_BY_IFINDEX(ep->parent_ifindex);
-
-				if (eth_store_saddr_aligned(ctx, smac.addr, 0) < 0)
-					return DROP_WRITE_ERROR;
-
-				/* For EKS we don't have to rewrite the dmac. Once we require a 5.10
-				 * kernel, this can turn into bpf_redirect_neigh() for robustness.
-				 */
-				return ctx_redirect(ctx, ep->parent_ifindex, 0);
-			}
+			    ct_is_reply4(get_ct_map4(&tuple), &tuple))
+				return redirect_neigh(ep->parent_ifindex, NULL, 0, 0);
 		}
 	}
 

--- a/bpf/tests/eni_nlb_symetric_routing_host.c
+++ b/bpf/tests/eni_nlb_symetric_routing_host.c
@@ -27,7 +27,7 @@
 #define NODE_MAC mac_two
 #define LOCAL_BACKEND_MAC mac_three
 
-#define ctx_redirect mock_ctx_redirect
+#define redirect_neigh mock_redirect_neigh
 
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
@@ -37,8 +37,10 @@ struct {
 } redirect_ifindex_map __section_maps_btf;
 
 static __always_inline __maybe_unused int
-mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
-		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+mock_redirect_neigh(int ifindex,
+		    __maybe_unused struct bpf_redir_neigh *params,
+		    __maybe_unused int plen,
+		    __maybe_unused __u32 flags)
 {
 	__u32 key = 0;
 	__u32 *value = map_lookup_elem(&redirect_ifindex_map, &key);


### PR DESCRIPTION
In https://github.com/cilium/cilium/pull/35298#discussion_r1832352132 we discussed that this code path should eventually use redirect_neigh() for more robustness, once all supported kernels offered this helper.

As the v1.18 Cilium release requires a v5.10 kernel (or newer), we can now unconditionally assume that bpf_redirect_neigh() is available. Use it.