### PR TITLE
bpf: clean up include statements for csum.h

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -47,7 +47,6 @@
 #include "lib/lb.h"
 #include "lib/drop.h"
 #include "lib/trace.h"
-#include "lib/csum.h"
 #include "lib/srv6.h"
 #include "lib/encap.h"
 #include "lib/eps.h"

--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -10,7 +10,6 @@
 #include "eth.h"
 #include "dbg.h"
 #include "trace.h"
-#include "csum.h"
 #include "l4.h"
 #include "proxy.h"
 #include "proxy_hairpin.h"

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -17,6 +17,7 @@
 #include "signal.h"
 #include "conntrack.h"
 #include "conntrack_map.h"
+#include "csum.h"
 #include "egress_gateway.h"
 #include "eps.h"
 #include "icmp6.h"

--- a/bpf/lib/nat_46x64.h
+++ b/bpf/lib/nat_46x64.h
@@ -8,6 +8,7 @@
 #include <linux/icmpv6.h>
 
 #include "common.h"
+#include "csum.h"
 #include "ipv4.h"
 #include "ipv6.h"
 #include "eth.h"

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -17,7 +17,6 @@
 #include "egress_gateway.h"
 #include "eps.h"
 #include "conntrack.h"
-#include "csum.h"
 #include "encap.h"
 #include "identity.h"
 #include "trace.h"

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -10,7 +10,6 @@
 #include "eth.h"
 #include "dbg.h"
 #include "trace.h"
-#include "csum.h"
 #include "l3.h"
 #include "l4.h"
 


### PR DESCRIPTION
Include csum.h from all of its immediate users. This allows us to remove the include statements from various files that actually *don't* contain any low-level checksum logic.