### PR TITLE
bpf: encrypt: align Wireguard and ESP in to-netdev program 

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1680,7 +1680,7 @@ skip_egress_gateway:
 #endif
 
 #ifdef ENABLE_NODEPORT
-	if (!ctx_snat_done(ctx) && !ctx_is_overlay(ctx) && !ctx_mark_is_wireguard(ctx)) {
+	if (!ctx_snat_done(ctx) && !ctx_is_overlay(ctx) && !ctx_mark_is_encrypted(ctx)) {
 		/*
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1403,7 +1403,7 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 
 	bpf_clear_meta(ctx);
 
-	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY || ctx_mark_is_wireguard(ctx))
+	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY || ctx_mark_is_encrypted(ctx))
 		src_sec_identity = HOST_ID;
 #ifdef ENABLE_IDENTITY_MARK
 	else if (magic == MARK_MAGIC_IDENTITY)

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1649,7 +1649,7 @@ skip_egress_gateway:
 	 * Skip redirect to the WireGuard tunnel device if the pkt has been
 	 * already encrypted.
 	 * After the packet has been encrypted, the WG tunnel device
-	 * will set the MARK_MAGIC_WG_ENCRYPTED skb mark. So, to avoid
+	 * will set the MARK_MAGIC_ENCRYPT skb mark. So, to avoid
 	 * looping forever (e.g., bpf_host@eth0 => cilium_wg0 =>
 	 * bpf_host@eth0 => ...; this happens when eth0 is used to send
 	 * encrypted WireGuard UDP packets), we check whether the mark

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -576,19 +576,6 @@ enum metric_dir {
 
 #define MARK_MAGIC_KEY_MASK		0xFF00
 
-
-/* The mark is used to indicate that the WireGuard tunnel device is done
- * encrypting a packet. The MSB invades the Kubernetes mark "space" which is
- * fine, as it's not used by K8s. See pkg/datapath/linux/linux_defaults/mark.go
- * for more details.
- *
- * NOTE: from v1.18 we reuse MARK_MAGIC_ENCRYPT for WireGuard-encrypted packets,
- * but we still need this value to handle upgrades from v1.17.
- *
- * TODO: can be removed in v1.19 in favor of MARK_MAGIC_ENCRYPT.
- */
-#define MARK_MAGIC_WG_ENCRYPTED		0x1E00
-
 /* MARK_MAGIC_HEALTH_IPIP_DONE can overlap with MARK_MAGIC_SNAT_DONE with both
  * being mutual exclusive given former is only under DSR. Used to push health
  * probe packets to ipip tunnel device & to avoid looping back.

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -255,12 +255,20 @@ static __always_inline bool ctx_is_overlay_encrypted(const struct __sk_buff *ctx
 	return (ctx->mark & MARK_MAGIC_KEY_MASK) == MARK_MAGIC_OVERLAY_ENCRYPTED;
 }
 
+static __always_inline bool ctx_mark_is_encrypted(const struct __sk_buff *ctx)
+{
+	if (!is_defined(ENABLE_WIREGUARD) && !is_defined(ENABLE_IPSEC))
+		return false;
+
+	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT;
+}
+
 static __always_inline bool ctx_mark_is_wireguard(const struct __sk_buff *ctx)
 {
 	if (!is_defined(ENABLE_WIREGUARD))
 		return false;
 
-	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT;
+	return ctx_mark_is_encrypted(ctx);
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY_COMMON

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -260,9 +260,7 @@ static __always_inline bool ctx_mark_is_wireguard(const struct __sk_buff *ctx)
 	if (!is_defined(ENABLE_WIREGUARD))
 		return false;
 
-	/* Handle upgrades from v1.17, where we still use MARK_MAGIC_WG_ENCRYPTED. */
-	return (ctx->mark & MARK_MAGIC_WG_ENCRYPTED) == MARK_MAGIC_WG_ENCRYPTED ||
-			(ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT;
+	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT;
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY_COMMON

--- a/bpf/tests/wireguard_helpers_tests.c
+++ b/bpf/tests/wireguard_helpers_tests.c
@@ -91,7 +91,7 @@ int check2(struct __ctx_buff *ctx)
 
 	assert(!ctx_mark_is_wireguard(ctx));
 
-	ctx->mark = MARK_MAGIC_WG_ENCRYPTED;
+	ctx->mark = MARK_MAGIC_ENCRYPT;
 
 	assert(ctx_mark_is_wireguard(ctx));
 


### PR DESCRIPTION
Take inspiration from Wireguard's behavior in the `to-netdev` program, and do the same for Cilium's ESP traffic.

See the individual patches for more details.