### PR TITLE
ipsec: keep SPI in sync between keyCustodian and BPF map

### DIFF
--- a/pkg/datapath/linux/ipsec/cell.go
+++ b/pkg/datapath/linux/ipsec/cell.go
@@ -59,7 +59,7 @@ func (kc *keyCustodian) Start(cell.HookContext) error {
 	if err != nil {
 		return err
 	}
-	if err := SetIPSecSPI(kc.log, kc.spi); err != nil {
+	if err := kc.setIPSecSPI(kc.spi); err != nil {
 		return err
 	}
 
@@ -73,7 +73,7 @@ func (kc *keyCustodian) Start(cell.HookContext) error {
 // StartBackgroundJobs starts the keyfile watcher and stale key reclaimer jobs.
 func (kc *keyCustodian) StartBackgroundJobs(handler types.NodeHandler) error {
 	if option.Config.EnableIPSec {
-		if err := StartKeyfileWatcher(kc.log, kc.jobs, option.Config.IPSecKeyFile, handler); err != nil {
+		if err := kc.startKeyfileWatcher(option.Config.IPSecKeyFile, handler); err != nil {
 			return fmt.Errorf("failed to start IPsec keyfile watcher: %w", err)
 		}
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1173,6 +1173,7 @@ func (kc *keyCustodian) setIPSecSPI(spi uint8) error {
 		kc.log.Warn("cilium_encrypt_state map updated failed", logfields.Error, err)
 		return err
 	}
+	kc.spi = spi
 	return nil
 }
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -149,6 +149,7 @@ func TestPrivilegedLoadKeys(t *testing.T) {
 		kc := &keyCustodian{log: hivetest.Logger(t)}
 		err = kc.setIPSecSPI(spi)
 		require.NoError(t, err)
+		require.Equal(t, spi, kc.spi)
 		UnsetTestIPSecKey()
 	}
 }

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -146,7 +146,8 @@ func TestPrivilegedLoadKeys(t *testing.T) {
 		keys := bytes.NewReader(testCase)
 		_, spi, err := LoadIPSecKeys(keys)
 		require.NoError(t, err)
-		err = SetIPSecSPI(log, spi)
+		kc := &keyCustodian{log: hivetest.Logger(t)}
+		err = kc.setIPSecSPI(spi)
 		require.NoError(t, err)
 		UnsetTestIPSecKey()
 	}


### PR DESCRIPTION
The `keyCustodian.SPI()` method is used only in newDaemon to [annotate](https://github.com/cilium/cilium/blob/main/daemon/cmd/daemon.go#L636-L644) the node.
The thing is that subsequent changes to the SPI from the [ipsec job](https://github.com/cilium/cilium/blob/main/pkg/datapath/linux/ipsec/ipsec_linux.go#L1221-L1231) would cause misalignment from the SPI in the BPF map (will contain the updated one) and the one stored in the ipsec agent (will contain the old one inferred during startup). No errors as of today though.
This is just so that we don't panic if we'll start using .SPI() in other places in the future and notice a different value.