### PR TITLE
redirectpolicy: Do not redirect when no local target pods exist

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/testdata/no-target-pods.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/no-target-pods.txtar
@@ -9,9 +9,9 @@ k8s/add service.yaml endpointslice.yaml
 db/cmp services services-before.table
 db/cmp frontends frontends-before.table
 
-# Add service-name based redirect. The existing frontends should not be affected
+# Add the redirects. The existing frontends should not be affected
 # by this since no local pods exist.
-k8s/add lrp-svc.yaml
+k8s/add lrp-svc.yaml lrp-addr.yaml
 db/cmp localredirectpolicies lrp.table
 db/cmp services services.table
 db/cmp frontends frontends-before.table
@@ -20,7 +20,8 @@ db/cmp frontends frontends-before.table
 k8s/add pod.yaml
 db/cmp frontends frontends.table
 
-# Removing the pod will remove the redirection.
+# Removing the pod will remove the redirections and revert
+# back to the earlier state.
 k8s/delete pod.yaml
 db/cmp frontends frontends-before.table
  
@@ -45,9 +46,27 @@ spec:
       - port: "80"
         name: "tcp"
         protocol: TCP
-      - port: "70"
-        name: "udp"
-        protocol: UDP
+
+-- lrp-addr.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.254"
+      toPorts:
+        - port: "8080"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
 
 -- pod.yaml --
 apiVersion: v1
@@ -65,9 +84,6 @@ spec:
         - containerPort: 80
           name: tcp
           protocol: TCP
-        - containerPort: 70
-          name: udp
-          protocol: UDP
   nodeName: testnode
 status:
   hostIP: 172.19.0.3
@@ -80,11 +96,6 @@ status:
   - ip: 2001::1
   qosClass: BestEffort
   startTime: "2024-07-10T16:20:42Z"
-  conditions:
-  - lastProbeTime: null
-    lastTransitionTime: '2019-07-08T09:41:59Z'
-    status: 'True'
-    type: Ready
 
 -- service.yaml --
 apiVersion: v1
@@ -93,9 +104,9 @@ metadata:
   name: echo
   namespace: test
 spec:
-  clusterIP: 169.254.169.254
+  clusterIP: 1.1.1.1
   clusterIPs:
-  - 169.254.169.254
+  - 1.1.1.1
   - 1001::1
   externalTrafficPolicy: Cluster
   internalTrafficPolicy: Cluster
@@ -108,10 +119,6 @@ spec:
     port: 8080
     protocol: TCP
     targetPort: 8080
-  - name: udp
-    port: 7070
-    protocol: UDP
-    targetPort: 7070
   selector:
     name: echo
   sessionAffinity: None
@@ -138,12 +145,10 @@ ports:
 - name: tcp
   port: 8080
   protocol: TCP
-- name: udp
-  port: 7070
-  protocol: UDP
 
 -- lrp.table --
 Name           Type     FrontendType                Frontends
+test/lrp-addr  address  addr-single-port            169.254.169.254:8080/TCP
 test/lrp-svc   service  all
 
 -- services-before.table --
@@ -152,19 +157,17 @@ test/echo                     k8s
 
 -- services.table --
 Name                          Source
-test/echo                     k8s   
+test/echo                     k8s
+test/lrp-addr:local-redirect  k8s
 test/lrp-svc:local-redirect   k8s   
 
 -- frontends-before.table --
 Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
-169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.1.1:7070/UDP                                 Done
-169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done
-[1001::1]:7070/UDP         ClusterIP   test/echo     udp                                                            Done
+1.1.1.1:8080/TCP           ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done
 [1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                            Done
 
 -- frontends.table --
-Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
-169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.2.1:70/UDP     test/lrp-svc:local-redirect   Done
-169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
-[1001::1]:7070/UDP         ClusterIP   test/echo     udp        [2001::1]:70/UDP      test/lrp-svc:local-redirect   Done
-[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done
+Address                  Type          ServiceName                  PortName   Backends              RedirectTo                    Status
+1.1.1.1:8080/TCP         ClusterIP     test/echo                    tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
+169.254.169.254:8080/TCP LocalRedirect test/lrp-addr:local-redirect            10.244.2.1:80/TCP                                   Done
+[1001::1]:8080/TCP       ClusterIP     test/echo                    tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done

--- a/pkg/loadbalancer/redirectpolicy/testdata/no-target-pods.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/no-target-pods.txtar
@@ -1,0 +1,170 @@
+# Regression test for https://github.com/cilium/cilium/issues/41450 where
+# a service was incorrectly redirected to a LRP service without backends when
+# no matching local target pods existed.
+
+hive/start
+
+# Add services and endpoints.
+k8s/add service.yaml endpointslice.yaml
+db/cmp services services-before.table
+db/cmp frontends frontends-before.table
+
+# Add service-name based redirect. The existing frontends should not be affected
+# by this since no local pods exist.
+k8s/add lrp-svc.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends-before.table
+
+# Add a pod. The frontends should now be redirected.
+k8s/add pod.yaml
+db/cmp frontends frontends.table
+
+# Removing the pod will remove the redirection.
+k8s/delete pod.yaml
+db/cmp frontends frontends-before.table
+ 
+# -----
+
+-- lrp-svc.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-svc"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: echo
+      namespace: test
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        name: "tcp"
+        protocol: TCP
+      - port: "70"
+        name: "udp"
+        protocol: UDP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: tcp
+          protocol: TCP
+        - containerPort: 70
+          name: udp
+          protocol: UDP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2001::1
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: '2019-07-08T09:41:59Z'
+    status: 'True'
+    type: Ready
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 169.254.169.254
+  clusterIPs:
+  - 169.254.169.254
+  - 1001::1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: DualStack
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: udp
+    port: 7070
+    protocol: UDP
+    targetPort: 7070
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: tcp
+  port: 8080
+  protocol: TCP
+- name: udp
+  port: 7070
+  protocol: UDP
+
+-- lrp.table --
+Name           Type     FrontendType                Frontends
+test/lrp-svc   service  all
+
+-- services-before.table --
+Name                          Source
+test/echo                     k8s   
+
+-- services.table --
+Name                          Source
+test/echo                     k8s   
+test/lrp-svc:local-redirect   k8s   
+
+-- frontends-before.table --
+Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
+169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.1.1:7070/UDP                                 Done
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done
+[1001::1]:7070/UDP         ClusterIP   test/echo     udp                                                            Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                            Done
+
+-- frontends.table --
+Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
+169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.2.1:70/UDP     test/lrp-svc:local-redirect   Done
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
+[1001::1]:7070/UDP         ClusterIP   test/echo     udp        [2001::1]:70/UDP      test/lrp-svc:local-redirect   Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -237,6 +237,13 @@ func (w *Writer) UpsertFrontend(txn WriteTxn, params loadbalancer.FrontendParams
 	return w.upsertFrontendParams(txn, params, svc)
 }
 
+func (w *Writer) DeleteFrontend(txn WriteTxn, addr loadbalancer.L3n4Addr) {
+	fe, _, found := w.fes.Get(txn, loadbalancer.FrontendByAddress(addr))
+	if found {
+		w.fes.Delete(txn, fe)
+	}
+}
+
 func (w *Writer) UpdateBackendHealth(txn WriteTxn, serviceName loadbalancer.ServiceName, backend loadbalancer.L3n4Addr, healthy bool) (bool, error) {
 	be, _, ok := w.bes.Get(txn, loadbalancer.BackendByAddress(backend))
 	if !ok {


### PR DESCRIPTION
 The local redirection should only be in effect when local target pods are available. Fix the issue by only setting the redirect when the LRP service has associated backends.


```release-note
Fix issue in Local Redirect Policies where traffic was dropped when no local pods were available to be redirected to. In these scenarios the traffic should have been processed as if the Local Redirect Policy did not exist.
```