### PR TITLE
gh: e2e-upgrade: skip even more steps when not downgrading

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -460,17 +460,18 @@ jobs:
         if: ${{ matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/check
 
-      - name: Setup conn-disrupt-test before downgrading
-        uses: ./.github/actions/conn-disrupt-test-setup
-
       - name: Features tested before downgrade
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested before downgrade"
           json-filename: "${{ env.job_name }} (${{ matrix.name }}) - before downgrade"
 
+      - name: Setup conn-disrupt-test before downgrading
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        uses: ./.github/actions/conn-disrupt-test-setup
+
       - name: Start unencrypted packets check for downgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/start
         with:
           # disable the check for proxy traffic.
@@ -478,7 +479,7 @@ jobs:
           args: ${{ steps.bpftrace-params.outputs.params }} "false" "${{ matrix.encryption }}"
 
 
-      - name: Downgrade Cilium ${{ steps.vars.outputs.downgrade_version }}
+      - name: Downgrade to Cilium ${{ steps.vars.outputs.downgrade_version }}
         if: ${{ matrix.skip-upgrade != 'true' }}
         shell: bash
         run: |
@@ -493,7 +494,7 @@ jobs:
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
       - name: Assert that no unencrypted packets are leaked during downgrade
-        if: ${{ matrix.encryption != '' }}
+        if: ${{ matrix.skip-upgrade != 'true' && matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/check
 
       - name: Test Cilium after downgrade to ${{ steps.vars.outputs.downgrade_version }}
@@ -545,6 +546,7 @@ jobs:
         uses: ./.github/actions/bpftrace/check
 
       - name: Features tested after downgrade
+        if: ${{ matrix.skip-upgrade != 'true' }}
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested after downgrade"


### PR DESCRIPTION
If we don't test the downgrade for a certain config, then we also don't need to prepare for conn-disruptivity and encryption leak tests.

And neither do we need to collect the tested features a second time.