### PR TITLE
[v1.17] ci,gke: apply allow ESP firewall rules for GKE cluster nodes

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -276,6 +276,27 @@ jobs:
             --node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute \
             --no-enable-insecure-kubelet-readonly-port
 
+      - name: Create ESP allow firewall rule
+        if: ${{ matrix.config.type == 'tunnel-ipsec' }}
+        run: |
+          cluster_name=${{ env.clusterName }}-${{ matrix.config.index }}
+          cluster_zone=${{ matrix.k8s.zone }}
+          hash=$(gcloud container clusters describe $cluster_name --zone=$cluster_zone --format="value(id)")
+          hash="${hash:0:8}"
+          echo $hash
+          cluster_node_target_tag=gke-${cluster_name}-${hash}-node
+          echo $cluster_node_target_tag
+          firewall_rule_name=gke-${cluster_name}-${hash}-allow-esp
+
+          gcloud compute firewall-rules create $firewall_rule_name \
+            --network default \
+            --direction INGRESS \
+            --action ALLOW \
+            --rules esp \
+            --priority 1000 \
+            --source-ranges 0.0.0.0/0 \
+            --target-tags $cluster_node_target_tag
+
       - name: Get cluster credentials
         run: |
           gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }}
@@ -346,6 +367,18 @@ jobs:
           cilium status
           cilium sysdump --output-filename cilium-sysdump-final-${{ matrix.k8s.version }}-${{ matrix.config.index }}-${{ matrix.config.type }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+
+      - name: Clean up ESP allow firewall rule
+        if: ${{ matrix.config.type == 'tunnel-ipsec' }}
+        run: |
+          cluster_name=${{ env.clusterName }}-${{ matrix.config.index }}
+          cluster_zone=${{ matrix.k8s.zone }}
+          hash=$(gcloud container clusters describe $cluster_name --zone=$cluster_zone --format="value(id)")
+          hash="${hash:0:8}"
+          firewall_rule_name=gke-${cluster_name}-${hash}-allow-esp
+
+          gcloud compute firewall-rules delete --quiet $firewall_rule_name
+        shell: bash {0} # Disable default fail-fast behavior so that all commands run independently
 
       - name: Clean up GKE
         if: ${{ always() }}


### PR DESCRIPTION
[ upstream commit e5077d85d6ab628404e55052eea0e30dfb690ab4 ]

In v1.18 Cilium moves to utilizing VXLAN-in-ESP traffic by default.

This means traffic between nodes is now ESP and no longer VXLAN when IPsec is enabled.

GKE, by default, does not allow ESP traffic between GKE nodes.

Therefore, create a ESP allow firewall rule which targets just the cluster nodes.