### PR TITLE
.github/workflows: add proper suffix for scale-test-egw

### DIFF
--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -583,7 +583,7 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/post-logic
         with:
-          artifacts_suffix: "final"
+          artifacts_suffix: "final-${{ matrix.test_type }}"
           job_status: "${{ job.status }}"
           junits-directory: 'report'
           capture_sysdump: 'false'


### PR DESCRIPTION
Since the scale-test-egw is using a GH matrix the artifact suffix needs to have a matrix property. This will prevent the artifacts from colliding with the same name.

Fixes: 2f14c12884a4 (".github/workflows: add common steps for scale-test-egw")