### PR TITLE
datapath: strictly require even more BPF functionality (remaining changes)

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -16,8 +16,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -1201,13 +1199,6 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 	if option.Config.EnableIPv6FragmentsTracking {
 		if !option.Config.EnableIPv6 {
 			option.Config.EnableIPv6FragmentsTracking = false
-		}
-	}
-
-	if option.Config.EnableBPFTProxy {
-		if probes.HaveProgramHelper(logger, ebpf.SchedCLS, asm.FnSkAssign) != nil {
-			option.Config.EnableBPFTProxy = false
-			logger.Info("Disabled support for BPF TProxy due to missing kernel support for socket assign (Linux 5.7 or later)")
 		}
 	}
 

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -199,12 +199,6 @@ func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer
 		// be v4-in-v6 connections even if the agent has v6 support disabled.
 		probes.HaveIPv6Support()
 
-		if option.Config.EnableMKE {
-			if probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnGetCgroupClassid) != nil {
-				return fmt.Errorf("BPF kube-proxy replacement under MKE with --%s needs kernel 5.7 or newer", option.EnableMKE)
-			}
-		}
-
 		option.Config.EnableSocketLBPeer = true
 		if option.Config.EnableIPv4 {
 			if err := probes.HaveAttachType(ebpf.CGroupSockAddr, ebpf.AttachCgroupInet4GetPeername); err != nil {

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -204,8 +204,7 @@ func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer
 		probes.HaveIPv6Support()
 
 		if option.Config.EnableMKE {
-			if probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnGetCgroupClassid) != nil ||
-				probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnGetNetnsCookie) != nil {
+			if probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnGetCgroupClassid) != nil {
 				return fmt.Errorf("BPF kube-proxy replacement under MKE with --%s needs kernel 5.7 or newer", option.EnableMKE)
 			}
 		}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -223,13 +223,6 @@ func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer
 				return fmt.Errorf("BPF host-reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer: %w", err)
 			}
 		}
-
-		if option.Config.EnableSocketLBTracing {
-			if probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnPerfEventOutput) != nil {
-				option.Config.EnableSocketLBTracing = false
-				logger.Info("Disabling socket-LB tracing as it requires kernel 5.7 or newer")
-			}
-		}
 	} else {
 		option.Config.EnableSocketLBTracing = false
 		option.Config.EnableSocketLBPodConnectionTermination = false

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -174,10 +174,6 @@ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, 
 func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, sysctl sysctl.Sysctl) error {
 
 	if kprCfg.KubeProxyReplacement {
-		if probes.HaveProgramHelper(logger, ebpf.SchedCLS, asm.FnFibLookup) != nil {
-			return fmt.Errorf("BPF NodePort services needs kernel 4.17.0 or newer")
-		}
-
 		if err := checkNodePortAndEphemeralPortRanges(lbConfig, sysctl); err != nil {
 			return err
 		}

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -111,6 +111,10 @@ func CheckRequirements(log *slog.Logger) error {
 			return errors.New("Require support for bpf_get_cgroup_classid() (Linux 5.7.0 or newer)")
 		}
 
+		if probes.HaveProgramHelper(log, ebpf.CGroupSockAddr, asm.FnPerfEventOutput) != nil {
+			return errors.New("Require support for bpf_perf_event_output() (Linux 5.7.0 or newer)")
+		}
+
 		if probes.HaveProgramHelper(log, ebpf.SchedCLS, asm.FnCsumLevel) != nil {
 			return errors.New("Require support for bpf_csum_level() (Linux 5.8.0 or newer)")
 		}

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -107,6 +107,10 @@ func CheckRequirements(log *slog.Logger) error {
 			return errors.New("Require support for bpf_sk_assign() (Linux 5.7.0 or newer)")
 		}
 
+		if probes.HaveProgramHelper(log, ebpf.CGroupSockAddr, asm.FnGetCgroupClassid) != nil {
+			return errors.New("Require support for bpf_get_cgroup_classid() (Linux 5.7.0 or newer)")
+		}
+
 		if probes.HaveProgramHelper(log, ebpf.SchedCLS, asm.FnCsumLevel) != nil {
 			return errors.New("Require support for bpf_csum_level() (Linux 5.8.0 or newer)")
 		}

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -98,6 +98,10 @@ func CheckRequirements(log *slog.Logger) error {
 			return errors.New("Require support for bpf_jiffies64 (Linux 5.6.0 or newer)")
 		}
 
+		if probes.HaveBatchAPI() != nil {
+			return errors.New("Require support for BPF_MAP_LOOKUP_BATCH (Linux 5.6.0 or newer)")
+		}
+
 		if probes.HaveProgramHelper(log, ebpf.CGroupSock, asm.FnGetNetnsCookie) != nil ||
 			probes.HaveProgramHelper(log, ebpf.CGroupSockAddr, asm.FnGetNetnsCookie) != nil {
 			return errors.New("Require support for bpf_get_netns_cookie() (Linux 5.7.0 or newer)")

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -71,6 +71,10 @@ func CheckRequirements(log *slog.Logger) error {
 			return errors.New("Require support for bpf_get_current_cgroup_id() (Linux 4.18 or newer)")
 		}
 
+		if probes.HaveProgramHelper(log, ebpf.SchedCLS, asm.FnFibLookup) != nil {
+			return errors.New("Require support for bpf_fib_lookup() (Linux 4.18 or newer)")
+		}
+
 		if probes.HaveDeadCodeElim() != nil {
 			return errors.New("Require support for dead code elimination (Linux 5.1 or newer)")
 		}

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -103,6 +103,10 @@ func CheckRequirements(log *slog.Logger) error {
 			return errors.New("Require support for bpf_get_netns_cookie() (Linux 5.7.0 or newer)")
 		}
 
+		if probes.HaveProgramHelper(log, ebpf.SchedCLS, asm.FnSkAssign) != nil {
+			return errors.New("Require support for bpf_sk_assign() (Linux 5.7.0 or newer)")
+		}
+
 		if probes.HaveProgramHelper(log, ebpf.SchedCLS, asm.FnCsumLevel) != nil {
 			return errors.New("Require support for bpf_csum_level() (Linux 5.8.0 or newer)")
 		}

--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/stream"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
-	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/nat"
@@ -128,14 +127,6 @@ type params struct {
 }
 
 func newStats(params params) (*Stats, error) {
-	if err := probes.HaveBatchAPI(); err != nil {
-		if errors.Is(err, probes.ErrNotSupported) {
-			params.Logger.Info("nat-stats is not supported", logfields.Error, err)
-			return nil, nil
-		}
-		params.Logger.Error("could not probe for nat-stats feature", logfields.Error, err)
-	}
-
 	if params.Config.NATMapStatInterval == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
Following https://github.com/cilium/cilium/pull/39384 and https://github.com/cilium/cilium/pull/39524, this moves all the remaining probes for old BPF functionality into the startup path.
