### PR TITLE
pkg/container/set: Fix string method with single element

### DIFF
--- a/pkg/container/set/set.go
+++ b/pkg/container/set/set.go
@@ -34,7 +34,7 @@ func (s Set[T]) Len() int {
 
 func (s Set[T]) String() string {
 	if s.single != nil {
-		return fmt.Sprintf("%v", s.single)
+		return fmt.Sprintf("%v", *s.single)
 	}
 	res := ""
 	for m := range s.members {

--- a/pkg/container/set/set_test.go
+++ b/pkg/container/set/set_test.go
@@ -5,6 +5,7 @@ package set
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -274,4 +275,43 @@ func TestSet(t *testing.T) {
 		}
 	}
 	require.True(t, set2.Empty())
+}
+
+func TestSet_String(t *testing.T) {
+	tests := []struct {
+		name             string
+		intSet           Set[int]
+		expected         string
+		expectedElements []string
+	}{
+		{
+			name:     "returns empty string on empty set",
+			intSet:   NewSet[int](),
+			expected: "",
+		},
+		{
+			name:     "returns single set element as string",
+			intSet:   NewSet(1),
+			expected: "1",
+		},
+		{
+			name:             "returns multi-element set as string",
+			intSet:           NewSet(1, 2, 3),
+			expectedElements: []string{"1", "2", "3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := tt.intSet.String()
+			if tt.expected != "" {
+				require.Equal(t, tt.expected, output)
+			} else if tt.expectedElements != nil {
+				for _, e := range tt.expectedElements {
+					require.Contains(t, output, e)
+					require.Len(t, strings.Split(output, ","), len(tt.expectedElements))
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes an issue with the Set String() method when used with a single element Set. The issue is that it would previously return the memory address instead of the value of the element.

Fixes: #41495

```release-note
pkg/container/set: Fixes string method with single element
```
