### PR TITLE
operator/bgpv2: Avoid race in TestRouterIDAllocation test

### DIFF
--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -1568,14 +1568,16 @@ func TestRouterIDAllocation(t *testing.T) {
 				}
 				assert.Equal(c, tt.InitExpectedRouterIDs, InitNodesRouterIDs)
 			}, TestTimeout, 100*time.Millisecond)
-			// cleanup the cluster configs
-			if tt.FinalClusterConfigs != nil {
-				for _, clusterConfig := range tt.FinalClusterConfigs {
-					config := clusterConfig
-					upsertBGPCC(req, ctx, f, config)
-				}
-			}
+
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				// NOTE: upserting cluster configs in "eventually" to workaround race between
+				// resource.Events and resource.Store, where store can contain outdated resource
+				// version even after receiving an event for the new version.
+				if tt.FinalClusterConfigs != nil {
+					for _, clusterConfig := range tt.FinalClusterConfigs {
+						upsertBGPCC(req, ctx, f, clusterConfig)
+					}
+				}
 				NodeConfigs, err := f.bgpnClient.List(ctx, meta_v1.ListOptions{})
 				if !assert.NoError(c, err) {
 					return


### PR DESCRIPTION
Workaround conceptual race between resource.Events and resource.Store, where store can contain outdated resource version even after receiving an event for the new version. In this case, after upserting a change in BGPCC, the old version of BGPCC was present in the store during the reconciliation triggered by this change in about 2% of the test runs.

Before:
```
2m0s: 481 runs so far, 7 failures (1.46%), 8 active
```

After:
```
5m0s: 1085 runs so far, 0 failures, 8 active
```

Fixes: https://github.com/cilium/cilium/issues/41497
