### PR TITLE
loadbalancer: allow HostPort for multiple protos on same port

### DIFF
--- a/pkg/loadbalancer/tests/testdata/hostport.txtar
+++ b/pkg/loadbalancer/tests/testdata/hostport.txtar
@@ -93,22 +93,27 @@ default/other-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 k8s
 -- frontends.table --
 Address           Type      Status  ServiceName                                                         Backends
 0.0.0.0:4444/TCP  HostPort  Done    default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8  10.244.1.113:80/TCP
+0.0.0.0:4444/UDP  HostPort  Done    default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8  10.244.1.113:80/UDP
 
 -- frontends2.table --
 Address           Type      Status  ServiceName                                                           Backends
 0.0.0.0:4444/TCP  HostPort  Done    default/other-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.114:80/TCP
+0.0.0.0:4444/UDP  HostPort  Done    default/other-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.114:80/UDP
 
 -- frontends3.table --
 Address           Type      Status  ServiceName                                                           Backends
 0.0.0.0:5555/TCP  HostPort  Done    default/other-app:host-port:5555:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.114:80/TCP
+0.0.0.0:5555/UDP  HostPort  Done    default/other-app:host-port:5555:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.114:80/UDP
 
 -- backends.table --
 Address             Instances 
 10.244.1.113:80/TCP default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8
+10.244.1.113:80/UDP default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8
 
 -- backends3.table --
 Address             Instances 
 10.244.1.114:80/TCP default/other-app:host-port:5555:22222222-2e9b-4c61-8454-ae81344876d8
+10.244.1.114:80/UDP default/other-app:host-port:5555:22222222-2e9b-4c61-8454-ae81344876d8
 
 -- pod.yaml --
 apiVersion: v1
@@ -130,6 +135,9 @@ spec:
     - containerPort: 80
       hostPort: 4444
       protocol: TCP
+    - containerPort: 80
+      hostPort: 4444
+      protocol: UDP
     resources: {}
     terminationMessagePath: /dev/termination-log
     terminationMessagePolicy: File
@@ -173,6 +181,9 @@ spec:
     - containerPort: 80
       hostPort: 4444
       protocol: TCP
+    - containerPort: 80
+      hostPort: 4444
+      protocol: UDP
     resources: {}
   nodeName: testnode
   restartPolicy: Always
@@ -195,25 +206,46 @@ status:
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.113:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.113:80/UDP STATE=active
 REV: ID=1 ADDR=0.0.0.0:4444
 REV: ID=2 ADDR=1.1.1.1:4444
+REV: ID=3 ADDR=0.0.0.0:4444
+REV: ID=4 ADDR=1.1.1.1:4444
 SVC: ID=1 ADDR=0.0.0.0:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
 SVC: ID=1 ADDR=0.0.0.0:4444/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
 SVC: ID=2 ADDR=1.1.1.1:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
 SVC: ID=2 ADDR=1.1.1.1:4444/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=HostPort
+SVC: ID=3 ADDR=0.0.0.0:4444/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:4444/UDP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=4 ADDR=1.1.1.1:4444/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
+SVC: ID=4 ADDR=1.1.1.1:4444/UDP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort
 -- lbmaps2.expected --
-BE: ID=2 ADDR=10.244.1.114:80/TCP STATE=active
-REV: ID=3 ADDR=0.0.0.0:4444
-REV: ID=4 ADDR=1.1.1.1:4444
-SVC: ID=3 ADDR=0.0.0.0:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
-SVC: ID=3 ADDR=0.0.0.0:4444/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
-SVC: ID=4 ADDR=1.1.1.1:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
-SVC: ID=4 ADDR=1.1.1.1:4444/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort
+BE: ID=3 ADDR=10.244.1.114:80/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.114:80/UDP STATE=active
+REV: ID=5 ADDR=0.0.0.0:4444
+REV: ID=6 ADDR=1.1.1.1:4444
+REV: ID=7 ADDR=0.0.0.0:4444
+REV: ID=8 ADDR=1.1.1.1:4444
+SVC: ID=5 ADDR=0.0.0.0:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:4444/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:4444/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
+SVC: ID=6 ADDR=1.1.1.1:4444/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=HostPort
+SVC: ID=7 ADDR=0.0.0.0:4444/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=7 ADDR=0.0.0.0:4444/UDP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=8 ADDR=1.1.1.1:4444/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
+SVC: ID=8 ADDR=1.1.1.1:4444/UDP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=HostPort
 -- lbmaps3.expected --
-BE: ID=2 ADDR=10.244.1.114:80/TCP STATE=active
-REV: ID=5 ADDR=0.0.0.0:5555
-REV: ID=6 ADDR=1.1.1.1:5555
-SVC: ID=5 ADDR=0.0.0.0:5555/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
-SVC: ID=5 ADDR=0.0.0.0:5555/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
-SVC: ID=6 ADDR=1.1.1.1:5555/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
-SVC: ID=6 ADDR=1.1.1.1:5555/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort
+BE: ID=3 ADDR=10.244.1.114:80/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.114:80/UDP STATE=active
+REV: ID=10 ADDR=1.1.1.1:5555
+REV: ID=11 ADDR=0.0.0.0:5555
+REV: ID=12 ADDR=1.1.1.1:5555
+REV: ID=9 ADDR=0.0.0.0:5555
+SVC: ID=10 ADDR=1.1.1.1:5555/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
+SVC: ID=10 ADDR=1.1.1.1:5555/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=HostPort
+SVC: ID=11 ADDR=0.0.0.0:5555/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=11 ADDR=0.0.0.0:5555/UDP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=12 ADDR=1.1.1.1:5555/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
+SVC: ID=12 ADDR=1.1.1.1:5555/UDP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=HostPort
+SVC: ID=9 ADDR=0.0.0.0:5555/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=9 ADDR=0.0.0.0:5555/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable


### PR DESCRIPTION
matching port numbers on different l4 protocol don't work as expected. this commit fixes it by grouping all ports on a pod and produces the services, backends and frontends links instead of doing it on a per port per container basis.

Fixes: #41426 

```
Allow more than one HostPort number with different protocols in a pod spec. 
```