### PR TITLE
.github/worfklows: copy cilium-cli binary from container

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -276,12 +276,16 @@ jobs:
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
-          ci-version: ${{ needs.setup-vars.outputs.SHA }}
+          image-tag: ${{ needs.setup-vars.outputs.SHA }}
+          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
+          release-version: ${{ env.CILIUM_CLI_VERSION }}
 
       - name: Copy cilium-cli
         shell: bash
         run: |
-          cp -f /usr/local/bin/cilium ./cilium-cli-bin
+          cid=$(docker create ${{ env.CILIUM_CLI_IMAGE_REPO }}:${{ needs.setup-vars.outputs.SHA }} ls)
+          docker cp $cid:/usr/local/bin/cilium "$PWD/cilium-cli-bin"
+          docker rm $cid
 
       - name: Install helm
         shell: bash


### PR DESCRIPTION
Instead of using the cilium-cli script, that behaves as the cilium-cli binary, we will copy the binary directly from the container so that we can use it inside the VM created by LVH.

Fixes: b2ff45375ca7 (".github/workflows: simplify ginkgo workflow")

cc @viktor-kurchenko this should fix the CI on the backports.