### PR TITLE
k8s/client/testutils: Fix k8s/{summary,get} for objs added vie Clientset

### DIFF
--- a/pkg/k8s/client/testutils/testdata/fake.txtar
+++ b/pkg/k8s/client/testutils/testdata/fake.txtar
@@ -5,6 +5,11 @@
 
 hive/start
 
+# Test that we can retrieve the CiliumNode object added via [Clientset] in the invoke
+# of the test runner.
+k8s/get ciliumnodes test -o actual.yaml
+! empty actual.yaml
+
 # Add object for the Kubernetes and Slim clientsets
 k8s/add service.yaml
 k8s/update service.yaml
@@ -60,6 +65,7 @@ ID                                                                              
 *;/v1, Resource=services;test/echo                                                           *v1.Service                   false
 *;apiextensions.k8s.io/v1, Resource=customresourcedefinitions;/ciliumenvoyconfigs.cilium.io  *v1.CustomResourceDefinition  false
 *;cilium.io/v2, Resource=ciliumenvoyconfigs;default/cec                                      *v2.CiliumEnvoyConfig         false
+*;cilium.io/v2, Resource=ciliumnodes;/test                                                   *v2.CiliumNode                false
 *;multicluster.x-k8s.io/v1alpha1, Resource=serviceexports;/test                              *v1alpha1.ServiceExport       false
 k8s;/v1, Resource=limitranges;bar/foo                                                        *v1.LimitRange                false
 k8s;/v1, Resource=services;test/echo                                                         *v1.Service                   false
@@ -69,6 +75,7 @@ ID                                                                              
 *;/v1, Resource=services;test/echo                                                           true
 *;apiextensions.k8s.io/v1, Resource=customresourcedefinitions;/ciliumenvoyconfigs.cilium.io  true
 *;cilium.io/v2, Resource=ciliumenvoyconfigs;default/cec                                      true
+*;cilium.io/v2, Resource=ciliumnodes;/test                                                   false
 *;multicluster.x-k8s.io/v1alpha1, Resource=serviceexports;/test                              true
 k8s;/v1, Resource=limitranges;bar/foo                                                        true
 k8s;/v1, Resource=services;test/echo                                                         true
@@ -76,18 +83,22 @@ k8s;/v1, Resource=services;test/echo                                            
 -- summary.expected --
 *:
 - v1.services: 1
-- cilium.io.v2.ciliumenvoyconfigs: 1
 - apiextensions.k8s.io.v1.customresourcedefinitions: 1
+- cilium.io.v2.ciliumenvoyconfigs: 1
+- cilium.io.v2.ciliumnodes: 1
 - multicluster.x-k8s.io.v1alpha1.serviceexports: 1
+- v1.limitranges: 0
 k8s:
 - v1.services: 1
 - v1.limitranges: 1
 -- summary.empty --
 *:
 - v1.services: 0
-- cilium.io.v2.ciliumenvoyconfigs: 0
 - apiextensions.k8s.io.v1.customresourcedefinitions: 0
+- cilium.io.v2.ciliumenvoyconfigs: 0
+- cilium.io.v2.ciliumnodes: 1
 - multicluster.x-k8s.io.v1alpha1.serviceexports: 0
+- v1.limitranges: 0
 k8s:
 - v1.services: 0
 - v1.limitranges: 0


### PR DESCRIPTION
The k8s commands maintained a "seenResources" set of known object resources and this didn't include anything added via the clientset.

Fix this by looking up the known resources from the tracker.
