### PR TITLE
Introduce route reconciler

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -650,6 +650,7 @@ Makefile* @cilium/build
 /pkg/util/ @cilium/sig-datapath
 /pkg/version/ @cilium/sig-agent
 /pkg/versioncheck/ @cilium/sig-agent
+/pkg/wal/ @cilium/sig-foundations
 /pkg/wireguard @cilium/wireguard
 /pkg/xds/ @cilium/envoy
 /plugins/cilium-cni/ @cilium/sig-k8s

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -22,6 +22,7 @@ import (
 	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
 	"github.com/cilium/cilium/pkg/controller"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/neighbor"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/dial"
@@ -131,6 +132,7 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 		),
 		fakeDatapath.Cell,
 		neighbor.ForwardableIPCell,
+		reconciler.TableCell,
 		cell.Provide(neighbor.NewCommonTestConfig(true, false)),
 		prefilter.Cell,
 		monitorAgent.Cell,

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	dpcfg "github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
+	routeReconciler "github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/linux/utime"
 	"github.com/cilium/cilium/pkg/datapath/loader"
@@ -147,6 +148,10 @@ var Cell = cell.Module(
 	// "forwardable". The neighbor subsystem converts these IPs into neighbor entries
 	// in the kernel and ensures they are kept up to date.
 	neighbor.Cell,
+
+	// Provides the desired route table, and a reconciler that installs these desired routes
+	// into the Linux kernel routing table.
+	routeReconciler.Cell,
 )
 
 func initDatapath(rootLogger *slog.Logger, lifecycle cell.Lifecycle) {

--- a/pkg/datapath/linux/route/reconciler/cell.go
+++ b/pkg/datapath/linux/route/reconciler/cell.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+)
+
+var Cell = cell.Module(
+	"route-reconciler",
+	"Reconciles desired routes to the Linux kernel routing table",
+	TableCell,
+	cell.Provide(registerReconciler),
+	cell.Invoke(func(r reconciler.Reconciler[*DesiredRoute]) {}),
+	cell.Invoke(desiredRouteRefresher),
+)
+
+var TableCell = cell.Group(
+	cell.Provide(newDesiredRouteManager),
+	cell.ProvidePrivate(newDesiredRouteTable),
+	cell.Provide(statedb.RWTable[*DesiredRoute].ToTable),
+)

--- a/pkg/datapath/linux/route/reconciler/manager.go
+++ b/pkg/datapath/linux/route/reconciler/manager.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type DesiredRouteManager struct {
+	db  *statedb.DB
+	tbl statedb.RWTable[*DesiredRoute]
+
+	mu     lock.Mutex
+	owners map[string]*RouteOwner
+}
+
+func newDesiredRouteManager(db *statedb.DB, tbl statedb.RWTable[*DesiredRoute]) *DesiredRouteManager {
+	return &DesiredRouteManager{
+		db:     db,
+		tbl:    tbl,
+		owners: make(map[string]*RouteOwner),
+	}
+}
+
+var (
+	ErrOwnerExists       = errors.New("owner already exists")
+	ErrOwnerDoesNotExist = errors.New("owner does not exist")
+)
+
+func (m *DesiredRouteManager) RegisterOwner(name string) (*RouteOwner, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.owners[name]; exists {
+		return nil, ErrOwnerExists
+	}
+
+	return m.newOwner(name), nil
+}
+
+func (m *DesiredRouteManager) GetOrRegisterOwner(name string) (*RouteOwner, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if owner, exists := m.owners[name]; exists {
+		return owner, nil
+	}
+
+	return m.newOwner(name), nil
+}
+
+// must be called with m.mu held
+func (m *DesiredRouteManager) newOwner(name string) *RouteOwner {
+	owner := &RouteOwner{
+		name: name,
+	}
+
+	m.owners[name] = owner
+	return owner
+}
+
+func (m *DesiredRouteManager) GetOwner(name string) (*RouteOwner, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	owner, exists := m.owners[name]
+	if !exists {
+		return nil, ErrOwnerDoesNotExist
+	}
+	return owner, nil
+}
+
+func (m *DesiredRouteManager) RemoveOwner(owner *RouteOwner) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.owners[owner.name]; !exists {
+		return ErrOwnerDoesNotExist
+	}
+	delete(m.owners, owner.name)
+
+	txn := m.db.WriteTxn(m.tbl)
+	defer txn.Abort()
+
+	for route := range m.tbl.Prefix(txn, DesiredRouteIndex.Query(DesiredRouteKey{
+		Owner: owner,
+	})) {
+		if _, _, err := m.tbl.Delete(txn, route); err != nil {
+			return err
+		}
+
+		if err := m.selectRoutes(txn, route.GetOwnerlessKey()); err != nil {
+			return err
+		}
+	}
+
+	txn.Commit()
+	return nil
+}
+
+type Initializer struct {
+	initialized func(statedb.WriteTxn)
+}
+
+func (m *DesiredRouteManager) RegisterInitializer(name string) Initializer {
+	txn := m.db.WriteTxn(m.tbl)
+	defer txn.Commit()
+
+	return Initializer{
+		initialized: m.tbl.RegisterInitializer(txn, name),
+	}
+}
+
+func (m *DesiredRouteManager) FinalizeInitializer(initializer Initializer) {
+	if initializer.initialized != nil {
+		txn := m.db.WriteTxn(m.tbl)
+		defer txn.Commit()
+		initializer.initialized(txn)
+	}
+}
+
+func (m *DesiredRouteManager) UpsertRoute(route DesiredRoute) error {
+	txn := m.db.WriteTxn(m.tbl)
+	defer txn.Abort()
+
+	if err := route.ValidateAndSetDefaults(); err != nil {
+		return err
+	}
+
+	// By default, any new route we add is not selected and does not have to be reconciled.
+	// The [selectRoutes] method will select the best route for each prefix+table.
+	route.selected = false
+	route.SetStatus(reconciler.StatusDone())
+
+	if _, _, err := m.tbl.Insert(txn, &route); err != nil {
+		return err
+	}
+
+	if err := m.selectRoutes(txn, route.GetOwnerlessKey()); err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+func (m *DesiredRouteManager) UpsertRouteWait(route DesiredRoute) error {
+	if err := m.UpsertRoute(route); err != nil {
+		return nil
+	}
+
+	return m.waitForReconciliation(route.GetFullKey())
+}
+
+func (m *DesiredRouteManager) DeleteRoute(route DesiredRoute) error {
+	txn := m.db.WriteTxn(m.tbl)
+	defer txn.Abort()
+
+	if err := route.ValidateAndSetDefaults(); err != nil {
+		return err
+	}
+
+	if _, _, err := m.tbl.Delete(txn, &route); err != nil {
+		return err
+	}
+
+	if err := m.selectRoutes(txn, route.GetOwnerlessKey()); err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+const reconciliationTimeout = 1 * time.Second
+
+func (m *DesiredRouteManager) waitForReconciliation(routeKey DesiredRouteKey) error {
+	t := time.NewTimer(reconciliationTimeout)
+	defer t.Stop()
+
+	var err error
+	for {
+		obj, _, watch, found := m.tbl.GetWatch(m.db.ReadTxn(), DesiredRouteIndex.Query(routeKey))
+		if !found {
+			return fmt.Errorf("route %s not found", routeKey)
+		}
+
+		if obj.status.Kind == reconciler.StatusKindDone {
+			// already reconciled
+			return nil
+		}
+
+		select {
+		case <-t.C:
+			return fmt.Errorf("timeout waiting for parameter %s reconciliation: %w", routeKey, err)
+		case <-watch:
+			if obj.status.Kind == reconciler.StatusKindDone {
+				return nil
+			}
+			if obj.status.Kind == reconciler.StatusKindError {
+				err = errors.New(obj.status.GetError())
+			}
+		}
+	}
+}
+
+func (m *DesiredRouteManager) selectRoutes(txn statedb.WriteTxn, key DesiredRouteKey) error {
+	// Get all routes with the same prefix and table.
+	routes := slices.Collect(statedb.ToSeq(m.tbl.List(txn, DesiredRouteTablePrefixIndex.Query(key))))
+	if len(routes) == 0 {
+		return nil // nothing to select
+	}
+
+	// Sort routes by admin distance and name, so that the first one is the
+	// one that is selected.
+	slices.SortStableFunc(routes, func(a, b *DesiredRoute) int {
+		adminDiff := int(a.AdminDistance) - int(b.AdminDistance)
+		if adminDiff == 0 {
+			if a.Owner.name < b.Owner.name {
+				return -1
+			}
+			if a.Owner.name > b.Owner.name {
+				return 1
+			}
+		}
+
+		return adminDiff
+	})
+
+	// Mark first route as selected, and all others as not selected.
+	for i, route := range routes {
+		selected := i == 0
+		if selected == route.selected {
+			continue
+		}
+
+		changed := route.SetStatus(reconciler.StatusPending())
+		changed.selected = selected
+		if _, _, err := m.tbl.Insert(txn, changed); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/datapath/linux/route/reconciler/reconciler.go
+++ b/pkg/datapath/linux/route/reconciler/reconciler.go
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/wal"
+)
+
+type RouteReconcilerMetrics *reconciler.ExpVarMetrics
+
+func registerReconciler(
+	params reconciler.Params,
+	tbl statedb.RWTable[*DesiredRoute],
+	devices statedb.Table[*tables.Device],
+	log *slog.Logger,
+	config *option.DaemonConfig,
+) (reconciler.Reconciler[*DesiredRoute], RouteReconcilerMetrics, error) {
+	metrics := reconciler.NewUnpublishedExpVarMetrics()
+	ops := newOps(params.Lifecycle, params.DB, tbl, devices, log, config)
+	rec, err := reconciler.Register(
+		params,
+		tbl,
+		(*DesiredRoute).Clone,
+		(*DesiredRoute).SetStatus,
+		(*DesiredRoute).GetStatus,
+		ops,
+		ops,
+		reconciler.WithPruning(30*time.Minute),
+		reconciler.WithMetrics(metrics),
+	)
+	return rec, metrics, err
+}
+
+func newOps(
+	lifecycle cell.Lifecycle,
+	db *statedb.DB,
+	tbl statedb.Table[*DesiredRoute],
+	devices statedb.Table[*tables.Device],
+	log *slog.Logger,
+	conf *option.DaemonConfig,
+) *ops {
+	ops := &ops{
+		db:      db,
+		tbl:     tbl,
+		devices: devices,
+		log:     log,
+
+		persistedKeys: make(map[DesiredRouteKey]struct{}),
+	}
+
+	lifecycle.Append(cell.Hook{
+		OnStart: func(hc cell.HookContext) error {
+			var err error
+			ops.handle, err = netlink.NewHandle()
+			if err != nil {
+				return err
+			}
+
+			walPath := filepath.Join(conf.StateDir, "route-reconciler.wal")
+
+			// Read all old route keys from the WAL.
+			events, err := wal.Read(walPath, func(data []byte) (reconcilerEvent, error) {
+				var key reconcilerEvent
+				if err := key.UnmarshalBinary(data); err != nil {
+					return reconcilerEvent{}, err
+				}
+				return key, nil
+			})
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					return err
+				}
+			} else {
+				for oldRouteKey, err := range events {
+					if err != nil {
+						ops.log.Error("Failed to read old route key from WAL", logfields.Error, err)
+						continue
+					}
+
+					if oldRouteKey.Deleted {
+						delete(ops.persistedKeys, oldRouteKey.Key)
+					} else {
+						ops.persistedKeys[oldRouteKey.Key] = struct{}{}
+					}
+				}
+			}
+
+			ops.wal, err = wal.NewWriter[reconcilerEvent](walPath)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		OnStop: func(hc cell.HookContext) error {
+			if ops.handle != nil {
+				ops.handle.Close()
+				ops.handle = nil
+			}
+			if ops.wal != nil {
+				ops.wal.Close()
+			}
+			return nil
+		},
+	})
+
+	return ops
+}
+
+type reconcilerEvent struct {
+	Deleted bool
+	Key     DesiredRouteKey
+}
+
+func (e reconcilerEvent) MarshalBinary() ([]byte, error) {
+	var buf []byte
+	if e.Deleted {
+		buf = append(buf, byte(1))
+	} else {
+		buf = append(buf, byte(0))
+	}
+
+	keyBuf, err := e.Key.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	buf = append(buf, keyBuf...)
+
+	return buf, nil
+}
+
+func (e *reconcilerEvent) UnmarshalBinary(data []byte) error {
+	if len(data) < 1 {
+		return nil
+	}
+
+	if data[0] == byte(1) {
+		e.Deleted = true
+	} else {
+		e.Deleted = false
+	}
+
+	if err := e.Key.UnmarshalBinary(data[1:]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type ops struct {
+	db      *statedb.DB
+	tbl     statedb.Table[*DesiredRoute]
+	devices statedb.Table[*tables.Device]
+	log     *slog.Logger
+
+	handle        *netlink.Handle
+	wal           *wal.Writer[reconcilerEvent]
+	persistedKeys map[DesiredRouteKey]struct{}
+}
+
+var errDeviceNotFound = errors.New("device no longer exists")
+
+func (ops *ops) Update(_ context.Context, rxn statedb.ReadTxn, _ statedb.Revision, obj *DesiredRoute) error {
+	// If the route is not selected, we do not need to update it.
+	if !obj.selected {
+		return nil
+	}
+
+	if obj.Device != nil {
+		// Verify that the device still exists.
+		_, _, found := ops.devices.Get(rxn, tables.DeviceIDIndex.Query(obj.Device.Index))
+		if !found {
+			return errDeviceNotFound
+		}
+	}
+
+	// Write to the WAL first, then update the route in the kernel.
+	// If we crash after writing to the WAL but before updating the route, no harm done.
+	err := ops.wal.Write(reconcilerEvent{
+		Deleted: false,
+		Key:     obj.GetOwnerlessKey(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write update event to WAL: %w", err)
+	}
+
+	return ops.handle.RouteReplace(desiredRouteToNetlinkRoute(obj))
+}
+
+func (ops *ops) Delete(_ context.Context, rxn statedb.ReadTxn, _ statedb.Revision, obj *DesiredRoute) error {
+	// If the route is not selected, we do not need to delete it.
+	if !obj.selected {
+		return nil
+	}
+
+	// First delete the route from the kernel, then write to the WAL.
+	// If we crash after deleting the route but before writing to the WAL, we will
+	// re-try the deletion on restart, which is safe.
+	err2 := ops.handle.RouteDel(desiredRouteToNetlinkRoute(obj))
+
+	err := ops.wal.Write(reconcilerEvent{
+		Deleted: true,
+		Key:     obj.GetOwnerlessKey(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write delete event to WAL: %w", err)
+	}
+
+	// Ignore "no such process" errors, which indicate that the route did not exist.
+	if err2 != nil && errors.Is(err2, syscall.ESRCH) {
+		return nil
+	}
+
+	return err2
+}
+
+func (ops *ops) UpdateBatch(ctx context.Context, txn statedb.ReadTxn, batch []reconciler.BatchEntry[*DesiredRoute]) {
+	// Filter out non-selected routes.
+	selected := make([]*reconciler.BatchEntry[*DesiredRoute], 0, len(batch))
+	for i := range batch {
+		if batch[i].Object.selected {
+			selected = append(selected, &batch[i])
+		}
+	}
+
+	// Create a list of events to write to the WAL.
+	events := make([]reconcilerEvent, 0, len(selected))
+	for _, entry := range selected {
+		events = append(events, reconcilerEvent{
+			Deleted: false,
+			Key:     entry.Object.GetOwnerlessKey(),
+		})
+	}
+
+	// Write all events to the WAL first, then process the updates.
+	if err := ops.wal.Write(events...); err != nil {
+		// If we failed to write individual entries, mark them as failed.
+		var ba wal.BatchErrors
+		if errors.As(err, &ba) {
+			for _, e := range ba {
+				selected[e.Index].Result = e.Err
+			}
+		} else {
+			// If we failed to write the entire batch, mark all entries as failed.
+			for _, entry := range selected {
+				entry.Result = err
+			}
+		}
+	}
+
+	// Process all routes we wrote to the WAL.
+	for _, entry := range selected {
+		if entry.Result != nil {
+			continue
+		}
+
+		entry.Result = ops.handle.RouteReplace(desiredRouteToNetlinkRoute(entry.Object))
+	}
+}
+
+func (ops *ops) DeleteBatch(ctx context.Context, txn statedb.ReadTxn, batch []reconciler.BatchEntry[*DesiredRoute]) {
+	// When a desired route is deleted, we need to check if there are any other desired routes
+	// with the same primary key but from a different owner. For example when there are 2
+	// desired routes one selected and one not selected, and we delete the selected one, we
+	// do not want to delete the route from the kernel, but let the update event
+	// replace it instead. Otherwise we briefly have no route installed.
+	toDelete := make([]*reconciler.BatchEntry[*DesiredRoute], 0, len(batch))
+	for i := range batch {
+		_, _, found := ops.tbl.Get(txn, DesiredRouteTablePrefixIndex.QueryFromObject(batch[i].Object))
+		if !found {
+			toDelete = append(toDelete, &batch[i])
+		}
+	}
+
+	// Delete all routes we want to delete.
+	for _, entry := range toDelete {
+		err := ops.handle.RouteDel(desiredRouteToNetlinkRoute(entry.Object))
+
+		// Ignore "no such process" errors, which indicate that the route did not exist.
+		if err != nil && errors.Is(err, syscall.ESRCH) {
+			err = nil
+		}
+
+		entry.Result = err
+	}
+
+	// Create a list of events to write to the WAL.
+	events := make([]reconcilerEvent, 0, len(toDelete))
+	for _, entry := range toDelete {
+		// If the deletion failed, do not write to the WAL.
+		if entry.Result != nil {
+			continue
+		}
+
+		events = append(events, reconcilerEvent{
+			Deleted: true,
+			Key:     entry.Object.GetOwnerlessKey(),
+		})
+	}
+
+	// Write all events to the WAL first, then process the updates.
+	if err := ops.wal.Write(events...); err != nil {
+		// If we failed to write individual entries, mark them as failed.
+		var ba wal.BatchErrors
+		if errors.As(err, &ba) {
+			for _, e := range ba {
+				toDelete[e.Index].Result = e.Err
+			}
+		} else {
+			// If we failed to write the entire batch, mark all entries as failed.
+			for _, entry := range toDelete {
+				entry.Result = err
+			}
+		}
+	}
+}
+
+func (ops *ops) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[*DesiredRoute, statedb.Revision]) error {
+	// If we have a set of keys from a previous run, we need to check if we still desire them.
+	// If not, we need to delete any route that we previously installed but no longer desire.
+	if len(ops.persistedKeys) != 0 {
+		for key := range ops.persistedKeys {
+			_, _, found := ops.tbl.Get(txn, DesiredRouteTablePrefixIndex.Query(key))
+			if !found {
+				routes, _ := safenetlink.WithRetryResult(func() ([]netlink.Route, error) {
+					//nolint:forbidigo
+					return ops.handle.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{
+						Table:    int(key.Table),
+						Dst:      netipx.PrefixIPNet(key.Prefix),
+						Priority: int(key.Priority),
+					}, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_DST|netlink.RT_FILTER_PRIORITY)
+				})
+				for _, r := range routes {
+					ops.handle.RouteDel(&r)
+				}
+			}
+		}
+
+		ops.persistedKeys = nil
+	}
+
+	// Compact the WAL, replace log with only currently selected and active routes.
+	ops.wal.Compact(func(yield func(reconcilerEvent) bool) {
+		for obj := range objects {
+			if !obj.selected {
+				continue
+			}
+			if obj.GetStatus().Kind == reconciler.StatusKindError {
+				continue
+			}
+
+			if !yield(reconcilerEvent{
+				Deleted: false,
+				Key:     obj.GetOwnerlessKey(),
+			}) {
+				return
+			}
+		}
+	})
+
+	return nil
+}
+
+func desiredRouteToNetlinkRoute(route *DesiredRoute) *netlink.Route {
+	nlRoute := &netlink.Route{
+		Table: int(route.Table),
+		Dst:   netipx.PrefixIPNet(route.Prefix),
+	}
+
+	if route.Nexthop.IsValid() {
+		nlRoute.Gw = route.Nexthop.AsSlice()
+	}
+
+	if route.Src.IsValid() {
+		nlRoute.Src = route.Src.AsSlice()
+	}
+
+	if route.Device != nil {
+		nlRoute.LinkIndex = int(route.Device.Index)
+	}
+
+	if route.MTU != 0 {
+		nlRoute.MTU = int(route.MTU)
+	}
+
+	if route.Priority != 0 {
+		nlRoute.Priority = int(route.Priority)
+	}
+
+	// Set protocol to 'kernel'. systemd-networkd, by default, will prune any routes that it did not create.
+	// Routes marked with RTPROT_KERNEL are not pruned by systemd-networkd because these are normally created by the
+	// kernel itself. We need to hide out routes amongst the kernel routes to prevent systemd-networkd from pruning them.
+	// See https://www.freedesktop.org/software/systemd/man/latest/networkd.conf.html#ManageForeignRoutingPolicyRules=
+	nlRoute.Protocol = netlink.RouteProtocol(2) // RTPROT_KERNEL
+
+	if route.Scope != SCOPE_UNIVERSE {
+		nlRoute.Scope = netlink.Scope(route.Scope)
+	} else if route.Scope == SCOPE_UNIVERSE && route.Type == RTN_LOCAL {
+		nlRoute.Scope = netlink.SCOPE_HOST
+	}
+
+	if route.Type != 0 {
+		nlRoute.Type = int(route.Type)
+	}
+
+	return nlRoute
+}

--- a/pkg/datapath/linux/route/reconciler/refresher.go
+++ b/pkg/datapath/linux/route/reconciler/refresher.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func desiredRouteRefresher(
+	jobGroup job.Group,
+	db *statedb.DB,
+	desiredRoutes statedb.RWTable[*DesiredRoute],
+	routes statedb.Table[*tables.Route],
+	devices statedb.Table[*tables.Device],
+) {
+	jobGroup.Add(job.OneShot(
+		"desired-route-refresher",
+		func(ctx context.Context, health cell.Health) error {
+			txn := db.WriteTxn(routes, devices)
+			routeIter, err := routes.Changes(txn)
+			if err != nil {
+				txn.Abort()
+				return err
+			}
+			devicesIter, err := devices.Changes(txn)
+			if err != nil {
+				txn.Abort()
+				return err
+			}
+			txn.Commit()
+
+			// Limit the rate at which the change batches are processed.
+			// A second seems like a reasonable time for refreshing neighbor entries.
+			limiter := rate.NewLimiter(1*time.Second, 1)
+			defer limiter.Stop()
+
+			for {
+				txn := db.WriteTxn(desiredRoutes)
+				routeChanges, routeWait := routeIter.Next(txn)
+				deviceChanges, deviceWait := devicesIter.Next(txn)
+
+				for routeChange := range routeChanges {
+					// Get the desired routes that match the changed route.
+					changedDesiredRoutes := desiredRoutes.List(txn, DesiredRouteTablePrefixIndex.Query(DesiredRouteKey{
+						Table:    TableID(routeChange.Object.Table),
+						Prefix:   routeChange.Object.Dst,
+						Priority: uint32(routeChange.Object.Priority),
+					}))
+
+					// Loop over any desired routes that match the changed route.
+					for desiredRoute := range changedDesiredRoutes {
+						// If the desired route is not selected, skip it.
+						if !desiredRoute.selected {
+							continue
+						}
+
+						// If the route has been deleted we always need to refresh the desired route.
+						// If the route was changed, we only need to refresh if the desired route
+						// does not equal the actual route anymore.
+						if !routeChange.Deleted && equal(desiredRoute, routeChange.Object) {
+							continue
+						}
+
+						desiredRoutes.Modify(txn, desiredRoute, func(old, new *DesiredRoute) *DesiredRoute {
+							return new.SetStatus(reconciler.StatusRefreshing())
+						})
+					}
+				}
+
+				for deviceChange := range deviceChanges {
+					// We only care about deleted devices.
+					if !deviceChange.Deleted {
+						continue
+					}
+
+					// If a device was deleted, we need to refresh any desired routes
+					// that were using this device.
+					for dr := range desiredRoutes.All(txn) {
+						if dr.Device != nil && int(dr.Device.Index) == deviceChange.Object.Index {
+							desiredRoutes.Modify(txn, dr, func(old, new *DesiredRoute) *DesiredRoute {
+								return new.SetStatus(reconciler.StatusRefreshing())
+							})
+						}
+					}
+				}
+				txn.Commit()
+
+				// Limit the rate at which we process changes.
+				limiter.Wait(ctx)
+
+				// Wait for the next change, or context cancellation.
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-routeWait:
+				case <-deviceWait:
+				}
+			}
+		},
+	))
+}
+
+func equal(desired *DesiredRoute, actual *tables.Route) bool {
+	if desired.Table != TableID(actual.Table) {
+		return false
+	}
+	if desired.Prefix != actual.Dst {
+		return false
+	}
+	if desired.Priority != uint32(actual.Priority) {
+		return false
+	}
+
+	if uint16(desired.Type) != uint16(actual.Type) {
+		return false
+	}
+	if desired.Scope != Scope(actual.Scope) {
+		return false
+	}
+	if desired.Src.Compare(actual.Src) != 0 {
+		return false
+	}
+	if desired.Nexthop.Compare(actual.Gw) != 0 {
+		return false
+	}
+	if (desired.Device == nil && actual.LinkIndex != 0) ||
+		(desired.Device != nil && int(desired.Device.Index) != actual.LinkIndex) {
+		return false
+	}
+	if desired.MTU != uint32(actual.MTU) {
+		return false
+	}
+	return true
+}

--- a/pkg/datapath/linux/route/reconciler/scripttest/reconciler_test.go
+++ b/pkg/datapath/linux/route/reconciler/scripttest/reconciler_test.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package scripttest
+
+import (
+	"fmt"
+	"maps"
+	"net/netip"
+	"os"
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+	"github.com/spf13/afero"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	ciliumhive "github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/testutils/scriptnet"
+)
+
+func TestPrivilegedScript(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	defer testutils.GoleakVerifyNone(t)
+
+	// When certain kernel modules are loaded, the kernel will by default try
+	// to create fallback devices in newly created network namespaces.
+	// Setting net.core.fb_tunnels_only_for_init=2 will prevent the kernel from
+	// creating fallback devices so we have a more predictable test environment.
+	sc := sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
+	val, _ := sc.ReadInt([]string{"net", "core", "fb_tunnels_only_for_init_net"})
+	t.Log("sysctl net.core.fb_tunnels_only_for_init_net was set to ", val)
+	if val != 2 {
+		t.Log("Setting sysctl net.core.fb_tunnels_only_for_init_net to 2")
+		sc.WriteInt([]string{"net", "core", "fb_tunnels_only_for_init_net"}, 2)
+
+		// Lets be a good citizen and clean up after ourselves.
+		t.Cleanup(func() {
+			t.Log("Resetting sysctl net.core.fb_tunnels_only_for_init_net to previous value")
+			sc.WriteInt([]string{"net", "core", "fb_tunnels_only_for_init_net"}, val)
+		})
+	}
+
+	scripttest.Test(t,
+		t.Context(),
+		func(t testing.TB, args []string) *script.Engine {
+			stateDir := t.TempDir()
+			nsManager, err := scriptnet.NewNSManager(t)
+			require.NoError(t, err, "NewNSManager")
+
+			err = nsManager.LockThreadAndInitialize(t, true)
+			require.NoError(t, err, "LockThreadAndInitialize")
+
+			var (
+				db     *statedb.DB
+				drm    *reconciler.DesiredRouteManager
+				devTbl statedb.Table[*tables.Device]
+			)
+			cells := []cell.Cell{
+				reconciler.Cell,
+				linux.DevicesControllerCell,
+				cell.Provide(func() *option.DaemonConfig {
+					return &option.DaemonConfig{
+						StateDir: stateDir,
+					}
+				}),
+				cell.Invoke(func(d *statedb.DB, m *reconciler.DesiredRouteManager, devices statedb.Table[*tables.Device]) {
+					db = d
+					drm = m
+					devTbl = devices
+				}),
+			}
+			h := ciliumhive.New(
+				cells...,
+			)
+
+			log := hivetest.Logger(t)
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+
+			maps.Copy(cmds, nsManager.Commands())
+			maps.Copy(cmds, script.DefaultCmds())
+			maps.Copy(cmds, testDesiredRouteCmds(db, drm, devTbl))
+
+			e := &script.Engine{}
+			cmds["hive/recreate"] = script.Command(
+				script.CmdUsage{
+					Summary: "Restart the hive",
+				},
+				func(s1 *script.State, s2 ...string) (script.WaitFunc, error) {
+					newHive := ciliumhive.New(cells...)
+
+					flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+					newHive.RegisterFlags(flags)
+
+					// Set some defaults
+					require.NoError(t, flags.Parse(args), "flags.Parse")
+
+					newHiveCmds, err := newHive.ScriptCommands(log)
+					if err != nil {
+						return nil, err
+					}
+
+					maps.Copy(cmds, newHiveCmds)
+					maps.Copy(cmds, testDesiredRouteCmds(db, drm, devTbl))
+
+					return nil, nil
+				},
+			)
+			e.Cmds = cmds
+
+			return e
+		}, []string{"PATH=" + os.Getenv("PATH")}, "testdata/*.txtar")
+}
+
+func testDesiredRouteCmds(db *statedb.DB, drm *reconciler.DesiredRouteManager, devTbl statedb.Table[*tables.Device]) map[string]script.Cmd {
+	initializers := make(map[string]reconciler.Initializer)
+	return map[string]script.Cmd{
+		"add-owner": script.Command(script.CmdUsage{
+			Summary: "Adds a new route owner",
+			Args:    "name",
+		}, func(state *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, script.ErrUsage
+			}
+
+			if _, err := drm.RegisterOwner(args[0]); err != nil {
+				return nil, fmt.Errorf("failed to register owner %q: %w", args, err)
+			}
+			return nil, nil
+		}),
+		"add-route": script.Command(script.CmdUsage{
+			Summary: "Adds a new route",
+			Args:    "owner route-file",
+		}, func(state *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 2 {
+				return nil, script.ErrUsage
+			}
+
+			owner, err := drm.GetOwner(args[0])
+			if err != nil {
+				return nil, fmt.Errorf("failed to get owner %q: %w", args[0], err)
+			}
+
+			routeFile, err := os.ReadFile(state.Path(args[1]))
+			if err != nil {
+				return nil, fmt.Errorf("failed to read route file %q: %w", args[1], err)
+			}
+
+			type desiredRoute struct {
+				Owner         *reconciler.RouteOwner
+				Table         reconciler.TableID
+				Prefix        netip.Prefix
+				Priority      uint32
+				AdminDistance reconciler.AdminDistance `yaml:"adminDistance"`
+				Nexthop       netip.Addr
+				Src           netip.Addr
+				Device        string
+				DeviceIfIndex int `yaml:"deviceIfIndex"`
+				MTU           uint32
+				Scope         reconciler.Scope
+				Type          reconciler.Type
+			}
+
+			var route desiredRoute
+			if err := yaml.Unmarshal(routeFile, &route); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal route file %q: %w", args[1], err)
+			}
+
+			var dev *tables.Device
+			if route.Device != "" || route.DeviceIfIndex != 0 {
+				var q statedb.Query[*tables.Device]
+				if route.Device != "" {
+					q = tables.DeviceNameIndex.Query(route.Device)
+				} else if route.DeviceIfIndex != 0 {
+					q = tables.DeviceIDIndex.Query(route.DeviceIfIndex)
+				}
+
+				var found bool
+				dev, _, found = devTbl.Get(db.ReadTxn(), q)
+				if !found {
+					if route.Device != "" {
+						return nil, fmt.Errorf("device %q not found", route.Device)
+					} else if route.DeviceIfIndex != 0 {
+						return nil, fmt.Errorf("device with index %d not found", route.DeviceIfIndex)
+					}
+				}
+			}
+
+			if err := drm.UpsertRoute(reconciler.DesiredRoute{
+				Owner:         owner,
+				Table:         route.Table,
+				Prefix:        route.Prefix,
+				Priority:      route.Priority,
+				AdminDistance: route.AdminDistance,
+				Nexthop:       route.Nexthop,
+				Device:        dev,
+				Src:           route.Src,
+				MTU:           route.MTU,
+				Scope:         route.Scope,
+				Type:          route.Type,
+			}); err != nil {
+				return nil, fmt.Errorf("failed to upsert routes for owner %q: %w", args[0], err)
+			}
+
+			return nil, nil
+		}),
+		"add-initializer": script.Command(script.CmdUsage{
+			Summary: "Adds a new route initializer",
+			Args:    "name",
+		}, func(state *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, script.ErrUsage
+			}
+
+			initializers[args[0]] = drm.RegisterInitializer(args[0])
+			return nil, nil
+		}),
+		"finish-initializer": script.Command(script.CmdUsage{
+			Summary: "Finishes a route initializer",
+			Args:    "name",
+		}, func(state *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, script.ErrUsage
+			}
+
+			initializer, found := initializers[args[0]]
+			if !found {
+				return nil, fmt.Errorf("failed to get initializer %q", args[0])
+			}
+
+			drm.FinalizeInitializer(initializer)
+			return nil, nil
+		}),
+		"remove-owner": script.Command(script.CmdUsage{
+			Summary: "Removes a route owner",
+			Args:    "name",
+		}, func(state *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, script.ErrUsage
+			}
+
+			owner, err := drm.GetOwner(args[0])
+			if err != nil {
+				return nil, fmt.Errorf("failed to get owner %q: %w", args[0], err)
+			}
+
+			if err := drm.RemoveOwner(owner); err != nil {
+				return nil, fmt.Errorf("failed to remove owner %q: %w", args[0], err)
+			}
+
+			return nil, nil
+		}),
+	}
+}

--- a/pkg/datapath/linux/route/reconciler/scripttest/testdata/manager.txtar
+++ b/pkg/datapath/linux/route/reconciler/scripttest/testdata/manager.txtar
@@ -1,0 +1,68 @@
+netns/create otherns
+
+link/add veth0 veth --peername eth0 --peerns otherns
+link/add veth1 veth --peername eth1 --peerns otherns
+
+addr/add 192.168.1.1/24 veth0
+addr/add 192.168.1.0/24 --netns otherns eth0
+addr/add 192.168.2.1/24 veth1
+addr/add 192.168.2.0/24 --netns otherns eth1
+
+link/set lo up
+link/set veth0 up
+link/set eth0 --netns otherns up
+link/set veth1 up
+link/set eth1 --netns otherns up
+
+hive start
+db/initialized
+
+# Add two owners, owner 2 has higher priority (lower number)
+add-owner owner1
+add-owner owner2
+
+# Add routes for the same prefix but different devices
+add-route owner1 route1.yaml
+add-route owner2 route2.yaml
+
+# Route from owner2 should be selected
+db/cmp desired-routes desired-routes-both.table
+
+# Selected route should be present in the kernel
+route/list --table=2000
+* cmp stdout route2.txt
+
+# Remove owner2, route from owner1 should be selected
+remove-owner owner2
+db/cmp desired-routes desired-routes-owner1.table
+
+# Route from owner1 should be present in the kernel
+route/list --table=2000
+* cmp stdout route1.txt
+
+# Stop hive properly
+hive/stop
+
+-- route1.yaml --
+table: 2000
+prefix: "10.2.3.4/32"
+adminDistance: 101
+device: veth0
+
+-- route2.yaml --
+table: 2000
+prefix: "10.2.3.4/32"
+adminDistance: 100
+device: veth1
+
+-- desired-routes-both.table --
+Owner    Table   Prefix        Priority   AD    Selected   Nexthop   Src    Device      MTU    Scope      Type  
+owner1   2000    10.2.3.4/32   none       101   false      none      none   veth0 (2)   none   universe   unspec
+owner2   2000    10.2.3.4/32   none       100   true       none      none   veth1 (3)   none   universe   unspec
+-- desired-routes-owner1.table --
+Owner    Table   Prefix        Priority   AD    Selected   Nexthop   Src    Device      MTU    Scope      Type  
+owner1   2000    10.2.3.4/32   none       101   true       none      none   veth0 (2)   none   universe   unspec
+-- route1.txt --
+10.2.3.4/32 dev veth0 scope universe table 2000
+-- route2.txt --
+10.2.3.4/32 dev veth1 scope universe table 2000

--- a/pkg/datapath/linux/route/reconciler/scripttest/testdata/persistance.txtar
+++ b/pkg/datapath/linux/route/reconciler/scripttest/testdata/persistance.txtar
@@ -1,0 +1,69 @@
+netns/create otherns
+
+link/add veth0 veth --peername eth0 --peerns otherns
+link/add veth1 veth --peername eth1 --peerns otherns
+
+addr/add 192.168.1.1/24 veth0
+addr/add 192.168.1.0/24 --netns otherns eth0
+addr/add 192.168.2.1/24 veth1
+addr/add 192.168.2.0/24 --netns otherns eth1
+
+link/set lo up
+link/set veth0 up
+link/set eth0 --netns otherns up
+link/set veth1 up
+link/set eth1 --netns otherns up
+
+hive start
+db/initialized
+
+# Create a owner and two routes
+add-owner owner1
+add-route owner1 route1.yaml
+add-route owner1 route2.yaml
+
+# Make sure the routes are installed before we re-create the hive
+route/list --table=2000
+* cmp stdout routes-before.txt
+
+# Stop and re-create the hive to simulate a restart
+hive stop
+hive/recreate
+
+# Add initializer for the owner before starting the hive
+add-initializer owner1
+
+# Start the hive so the device table is populated
+hive start
+
+# Re-create the owner, but only one route
+add-owner owner1
+add-route owner1 route1.yaml
+
+# Mark initializer as finished so pruning can proceed
+finish-initializer owner1
+
+# We should have route 1 but not route 2
+route/list --table=2000
+* cmp stdout routes-after.txt
+
+# Stop hive properly
+hive/stop
+
+-- route1.yaml --
+table: 2000
+prefix: "10.2.3.4/32"
+adminDistance: 100
+device: veth0
+
+-- route2.yaml --
+table: 2000
+prefix: "10.2.3.5/32"
+adminDistance: 100
+device: veth0
+
+-- routes-before.txt --
+10.2.3.4/32 dev veth0 scope universe table 2000
+10.2.3.5/32 dev veth0 scope universe table 2000
+-- routes-after.txt --
+10.2.3.4/32 dev veth0 scope universe table 2000

--- a/pkg/datapath/linux/route/reconciler/scripttest/testdata/priority.txtar
+++ b/pkg/datapath/linux/route/reconciler/scripttest/testdata/priority.txtar
@@ -1,0 +1,67 @@
+link/add eth0 dummy
+link/add eth1 dummy
+
+addr/add 192.168.1.1/24 eth0
+addr/add 192.168.2.1/24 eth1
+
+link/set lo up
+link/set eth0 up
+link/set eth1 up
+
+hive start
+db/initialized
+
+add-owner owner1
+
+# Same owner+table+prefix+priority replace old route (same primary key)
+add-route owner1 eth0-200-101.yaml
+add-route owner1 eth1-200-100.yaml
+db/cmp desired-routes expected-desired-1.table
+
+# Same table+prefix+priority, different owner: only one route selected lowest AD wins
+add-owner owner2
+add-route owner2 eth0-200-101.yaml
+db/cmp desired-routes expected-desired-2.table
+
+# Same table+prefix, different priority: both routes selected
+remove-owner owner2
+add-owner owner2
+add-route owner2 eth0-201-101.yaml
+db/cmp desired-routes expected-desired-3.table
+
+# Compare installed routes
+route/list --table=2000
+* cmp stdout expected-routes.txt
+
+-- eth0-200-101.yaml --
+table: 2000
+prefix: "10.2.3.4/32"
+adminDistance: 101
+priority: 200
+device: eth0
+-- eth1-200-100.yaml --
+table: 2000
+prefix: "10.2.3.4/32"
+adminDistance: 100
+priority: 200
+device: eth1
+-- eth0-201-101.yaml --
+table: 2000
+prefix: "10.2.3.4/32"
+adminDistance: 101
+priority: 201
+device: eth0
+-- expected-desired-1.table --
+Owner    Table   Prefix        Priority   AD    Selected   Device  
+owner1   2000    10.2.3.4/32   200        100   true       eth1 (3)
+-- expected-desired-2.table --
+Owner    Table   Prefix        Priority   AD    Selected   Device  
+owner1   2000    10.2.3.4/32   200        100   true       eth1 (3)
+owner2   2000    10.2.3.4/32   200        101   false      eth0 (2)
+-- expected-desired-3.table --
+Owner    Table   Prefix        Priority   AD    Selected   Device  
+owner1   2000    10.2.3.4/32   200        100   true       eth1 (3)
+owner2   2000    10.2.3.4/32   201        101   true       eth0 (2)
+-- expected-routes.txt --
+10.2.3.4/32 dev eth1 scope universe table 2000 priority 200
+10.2.3.4/32 dev eth0 scope universe table 2000 priority 201

--- a/pkg/datapath/linux/route/reconciler/scripttest/testdata/refresher.txtar
+++ b/pkg/datapath/linux/route/reconciler/scripttest/testdata/refresher.txtar
@@ -1,0 +1,51 @@
+netns/create otherns
+
+link/add veth0 veth --peername eth0 --peerns otherns
+link/add veth1 veth --peername eth1 --peerns otherns
+
+addr/add 192.168.1.1/24 veth0
+addr/add 192.168.1.0/24 --netns otherns eth0
+addr/add 192.168.2.1/24 veth1
+addr/add 192.168.2.0/24 --netns otherns eth1
+
+link/set lo up
+link/set veth0 up
+link/set eth0 --netns otherns up
+link/set veth1 up
+link/set eth1 --netns otherns up
+
+hive start
+db/initialized
+
+add-owner owner1
+add-route owner1 route1.yaml
+
+# Wait until the route is reconciled
+route/list --table=2000
+* cmp stdout route1.txt
+
+# Delete the route
+route/del --table=2000 10.2.3.4/32
+
+# It should be re-added
+route/list --table=2000
+* cmp stdout route1.txt
+
+# modify the route to add mtu
+route/replace --table=2000 --mtu=1000 --dev veth1 --proto kernel 10.2.3.4/32
+
+# It should be reverted back
+route/list --table=2000
+* cmp stdout route1.txt
+
+# Stop hive properly
+hive/stop
+
+-- route1.yaml --
+table: 2000
+prefix: "10.2.3.4/32"
+adminDistance: 100
+device: veth1
+
+-- route1.txt --
+10.2.3.4/32 dev veth1 scope universe table 2000

--- a/pkg/datapath/linux/route/reconciler/table.go
+++ b/pkg/datapath/linux/route/reconciler/table.go
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+)
+
+var _ statedb.TableWritable = &DesiredRoute{}
+
+type DesiredRouteKey struct {
+	Owner    *RouteOwner
+	Table    TableID
+	Prefix   netip.Prefix
+	Priority uint32
+}
+
+func (k DesiredRouteKey) Key() index.Key {
+	var key []byte
+	if k.Owner != nil {
+		key = index.String(k.Owner.name)
+		// Owner name is variable, insert a 0x00 byte to separate it from the rest of the key.
+		key = append(key, 0x00)
+	}
+
+	if k.Table != 0 {
+		key = append(key, index.Uint32(uint32(k.Table))...)
+	}
+
+	if k.Prefix.IsValid() {
+		key = append(key, index.NetIPAddr(k.Prefix.Addr())...)
+		key = append(key, uint8(k.Prefix.Bits()))
+	}
+
+	if k.Priority != 0 {
+		key = append(key, index.Uint32(k.Priority)...)
+	}
+
+	return key
+}
+
+func (k DesiredRouteKey) String() string {
+	parts := []string{k.Owner.String(), k.Table.String(), k.Prefix.String()}
+	if k.Priority != 0 {
+		parts = append(parts, strconv.FormatUint(uint64(k.Priority), 10))
+	}
+	return strings.Join(parts, ":")
+}
+
+var desiredRouteKeyBinaryVersion = 1
+
+func (k DesiredRouteKey) MarshalBinary() ([]byte, error) {
+	var (
+		buf []byte
+		tmp [4]byte
+	)
+
+	buf = append(buf, byte(desiredRouteKeyBinaryVersion))
+
+	binary.LittleEndian.PutUint32(tmp[:], uint32(k.Table))
+	buf = append(buf, tmp[:]...)
+
+	addrBuf, err := k.Prefix.Addr().MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	buf = append(buf, byte(len(addrBuf)))
+	buf = append(buf, addrBuf...)
+	buf = append(buf, byte(k.Prefix.Bits()))
+
+	binary.LittleEndian.PutUint32(tmp[:], k.Priority)
+	buf = append(buf, tmp[:]...)
+
+	return buf, nil
+}
+
+func (k *DesiredRouteKey) UnmarshalBinary(data []byte) error {
+	if len(data) < 10 { // Minimum length: 1 (version) + 4 (table) + 1 (addr len) + 4 (priority)
+		return fmt.Errorf("data too short to unmarshal DesiredRouteKey")
+	}
+
+	if data[0] != byte(desiredRouteKeyBinaryVersion) {
+		return fmt.Errorf("unsupported DesiredRouteKey version: %d", data[0])
+	}
+	data = data[1:]
+
+	k.Table = TableID(binary.LittleEndian.Uint32(data[0:4]))
+	data = data[4:]
+
+	addrLen := int(data[0])
+	data = data[1:]
+	if len(data) < addrLen+1+4 { // addr + 1 (prefix bits) + 4 (priority)
+		return fmt.Errorf("data too short to unmarshal DesiredRouteKey")
+	}
+	addr, ok := netip.AddrFromSlice(data[0:addrLen])
+	if !ok {
+		return fmt.Errorf("failed to unmarshal IP address")
+	}
+	prefixBits := int(data[addrLen])
+	k.Prefix = netip.PrefixFrom(addr, prefixBits)
+	data = data[addrLen+1:]
+
+	k.Priority = binary.LittleEndian.Uint32(data[0:4])
+
+	return nil
+}
+
+type DesiredRoute struct {
+	// Composite primary key for the route.
+	Owner    *RouteOwner
+	Table    TableID
+	Prefix   netip.Prefix
+	Priority uint32
+
+	// The administrative distance of the route, lower values are preferred.
+	AdminDistance AdminDistance
+	// If true, the route is selected for installation, a calculated property.
+	selected bool
+
+	// Optional, if [netip.Addr.IsValid] then nexthop is specified.
+	Nexthop netip.Addr
+	// Optional, if [netip.Addr.IsValid] then source address is specified.
+	Src netip.Addr
+	// Optional, non-nil if device is specified.
+	Device *tables.Device
+	// Optional, if 0 no MTU is specified.
+	MTU uint32
+	// Optional, if 0 no scope is specified.
+	Scope Scope
+	// Optional, if 0 no type is specified.
+	Type Type
+
+	status reconciler.Status
+}
+
+func (dr *DesiredRoute) GetFullKey() DesiredRouteKey {
+	return DesiredRouteKey{
+		Owner:    dr.Owner,
+		Table:    dr.Table,
+		Prefix:   dr.Prefix,
+		Priority: dr.Priority,
+	}
+}
+
+func (dr *DesiredRoute) GetOwnerlessKey() DesiredRouteKey {
+	return DesiredRouteKey{
+		Table:    dr.Table,
+		Prefix:   dr.Prefix,
+		Priority: dr.Priority,
+	}
+}
+
+func (dr *DesiredRoute) TableHeader() []string {
+	return []string{
+		"Owner",
+		"Table",
+		"Prefix",
+		"Priority",
+		"AD",
+		"Selected",
+		"Nexthop",
+		"Src",
+		"Device",
+		"MTU",
+		"Scope",
+		"Type",
+		"Status",
+	}
+}
+
+func (dr *DesiredRoute) TableRow() []string {
+	row := []string{
+		dr.Owner.String(),
+		dr.Table.String(),
+		dr.Prefix.String(),
+	}
+
+	if dr.Priority == 0 {
+		row = append(row, "none")
+	} else {
+		row = append(row, strconv.FormatUint(uint64(dr.Priority), 10))
+	}
+
+	row = append(row, strconv.FormatUint(uint64(dr.AdminDistance), 10))
+	row = append(row, strconv.FormatBool(dr.selected))
+
+	if !dr.Nexthop.IsValid() {
+		row = append(row, "none")
+	} else {
+		row = append(row, dr.Nexthop.String())
+	}
+
+	if !dr.Src.IsValid() {
+		row = append(row, "none")
+	} else {
+		row = append(row, dr.Src.String())
+	}
+
+	if dr.Device == nil {
+		row = append(row, "none")
+	} else {
+		row = append(row, dr.Device.Name+" ("+strconv.Itoa(dr.Device.Index)+")")
+	}
+
+	if dr.MTU == 0 {
+		row = append(row, "none")
+	} else {
+		row = append(row, strconv.FormatUint(uint64(dr.MTU), 10))
+	}
+
+	row = append(row, dr.Scope.String())
+	row = append(row, dr.Type.String())
+	row = append(row, dr.status.String())
+
+	return row
+}
+
+func (dr *DesiredRoute) GetStatus() reconciler.Status {
+	return dr.status
+}
+
+func (dr *DesiredRoute) SetStatus(s reconciler.Status) *DesiredRoute {
+	ndr := dr.Clone()
+	ndr.status = s
+	return ndr
+}
+
+func (dr *DesiredRoute) Clone() *DesiredRoute {
+	dr2 := *dr
+	return &dr2
+}
+
+func (dr *DesiredRoute) ValidateAndSetDefaults() error {
+	if dr.Owner == nil {
+		return fmt.Errorf("route must have an owner")
+	}
+
+	if !dr.Prefix.Addr().IsValid() {
+		return fmt.Errorf("route must have a valid prefix")
+	}
+
+	if dr.AdminDistance == 0 {
+		return fmt.Errorf("route must have a non-zero admin distance")
+	}
+
+	// When not specified, the route should be added to the main table.
+	if dr.Table == 0 {
+		dr.Table = TableMain
+	}
+
+	return nil
+}
+
+var (
+	DesiredRouteIndex = statedb.Index[*DesiredRoute, DesiredRouteKey]{
+		Name: "id",
+		FromObject: func(d *DesiredRoute) index.KeySet {
+			return index.NewKeySet(d.GetFullKey().Key())
+		},
+		FromKey: DesiredRouteKey.Key,
+		FromString: func(s string) (index.Key, error) {
+			parts := strings.Split(s, ":")
+			if len(parts) > 3 {
+				return nil, fmt.Errorf("bad key, expected \"owner[:table[:prefix[:priority]]]\", got %s", s)
+			}
+
+			var key DesiredRouteKey
+			if len(parts) >= 2 {
+				if err := key.Table.FromString(parts[1]); err != nil {
+					return nil, fmt.Errorf("bad key, expected \"owner[:table[:prefix[:priority]]]\", got %s: %w", s, err)
+				}
+			}
+
+			if len(parts) >= 3 {
+				var err error
+				key.Prefix, err = netip.ParsePrefix(parts[2])
+				if err != nil {
+					return nil, fmt.Errorf("bad key, expected \"owner[:table[:prefix[:priority]]]\", got %s: %w", s, err)
+				}
+			}
+
+			if len(parts) >= 4 {
+				prio, err := strconv.ParseUint(parts[3], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("bad key, expected \"owner[:table[:prefix[:priority]]]\", got %s: %w", s, err)
+				}
+				key.Priority = uint32(prio)
+			}
+
+			return key.Key(), nil
+		},
+		Unique: true,
+	}
+
+	DesiredRouteTablePrefixIndex = statedb.Index[*DesiredRoute, DesiredRouteKey]{
+		Name: "table-prefix",
+		FromObject: func(d *DesiredRoute) index.KeySet {
+			return index.NewKeySet(d.GetOwnerlessKey().Key())
+		},
+		FromKey: func(key DesiredRouteKey) index.Key {
+			key.Owner = nil // Owner is not part of the key for this index
+			return key.Key()
+		},
+		FromString: func(s string) (index.Key, error) {
+			// The string is expected to be in the format "table:prefix[:priority]"
+			parts := strings.Split(s, ":")
+
+			var key DesiredRouteKey
+			if err := key.Table.FromString(parts[0]); err != nil {
+				return nil, fmt.Errorf("bad key, expected \"table:prefix:priority\", got %s: %w", s, err)
+			}
+
+			if len(parts) < 2 {
+				return key.Key(), nil
+			}
+
+			var err error
+			key.Prefix, err = netip.ParsePrefix(parts[1])
+			if err != nil {
+				return nil, err
+			}
+
+			if len(parts) < 3 {
+				return key.Key(), nil
+			}
+
+			prio, err := strconv.ParseUint(parts[2], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("bad key, expected \"table:prefix:priority\", got %s: %w", s, err)
+			}
+			key.Priority = uint32(prio)
+
+			return key.Key(), nil
+		},
+		Unique: false,
+	}
+
+	DesiredRouteTableDeviceIndex = statedb.Index[*DesiredRoute, int]{
+		Name: "device",
+		FromObject: func(obj *DesiredRoute) index.KeySet {
+			if obj.Device == nil {
+				return index.NewKeySet()
+			}
+			return index.NewKeySet(index.Int(obj.Device.Index))
+		},
+		FromKey: func(key int) index.Key {
+			return index.Int(key)
+		},
+		Unique: false,
+	}
+)
+
+func newDesiredRouteTable(db *statedb.DB) (statedb.RWTable[*DesiredRoute], error) {
+	return statedb.NewTable(
+		db,
+		"desired-routes",
+		DesiredRouteIndex,
+		DesiredRouteTablePrefixIndex,
+		DesiredRouteTableDeviceIndex,
+	)
+}

--- a/pkg/datapath/linux/route/reconciler/types.go
+++ b/pkg/datapath/linux/route/reconciler/types.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"fmt"
+	"strconv"
+
+	"go.yaml.in/yaml/v3"
+)
+
+type AdminDistance int
+
+const (
+	// AdminDistanceDefault is the default administrative distance for routes
+	// emitted by Cilium itself.
+	AdminDistanceDefault AdminDistance = 100
+)
+
+type RouteOwner struct {
+	name string
+}
+
+var _ yaml.Unmarshaler = (*RouteOwner)(nil)
+
+func (o *RouteOwner) UnmarshalYAML(value *yaml.Node) error {
+	type routeOwner struct {
+		Name string
+	}
+
+	var r routeOwner
+	err := value.Decode(&r)
+	o.name = r.Name
+	return err
+}
+
+func (o *RouteOwner) String() string {
+	return o.name
+}
+
+type TableID uint32
+
+const (
+	TableMain  TableID = 254
+	TableLocal TableID = 255
+)
+
+var _ yaml.Unmarshaler = (*TableID)(nil)
+
+func (t *TableID) UnmarshalYAML(value *yaml.Node) error {
+	var tableName string
+	if err := value.Decode(&tableName); err != nil {
+		return err
+	}
+
+	if err := t.FromString(tableName); err != nil {
+		return fmt.Errorf("failed to parse table ID %q: %w", tableName, err)
+	}
+
+	return nil
+}
+
+func (t *TableID) FromString(s string) error {
+	switch s {
+	case "main":
+		*t = TableMain
+	case "local":
+		*t = TableLocal
+	default:
+		table, err := strconv.ParseUint(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid table ID %q: %w", s, err)
+		}
+		*t = TableID(table)
+	}
+	return nil
+}
+
+func (t TableID) String() string {
+	switch t {
+	case TableMain:
+		return "main (" + strconv.Itoa(int(t)) + ")"
+	case TableLocal:
+		return "local (" + strconv.Itoa(int(t)) + ")"
+	}
+
+	return strconv.Itoa(int(t))
+}
+
+type Scope uint8
+
+const (
+	SCOPE_UNIVERSE Scope = 0
+	SCOPE_SITE     Scope = 200
+	SCOPE_LINK     Scope = 253
+	SCOPE_HOST     Scope = 254
+	SCOPE_NOWHERE  Scope = 255
+)
+
+var _ yaml.Unmarshaler = (*Scope)(nil)
+
+func (s *Scope) UnmarshalYAML(value *yaml.Node) error {
+	var scopeName string
+	if err := value.Decode(&scopeName); err != nil {
+		return err
+	}
+
+	if err := s.FromString(scopeName); err != nil {
+		return fmt.Errorf("failed to parse scope %q: %w", scopeName, err)
+	}
+
+	return nil
+}
+
+func (s *Scope) FromString(scopeName string) error {
+	switch scopeName {
+	case "universe":
+		*s = SCOPE_UNIVERSE
+	case "site":
+		*s = SCOPE_SITE
+	case "link":
+		*s = SCOPE_LINK
+	case "host":
+		*s = SCOPE_HOST
+	case "nowhere":
+		*s = SCOPE_NOWHERE
+	default:
+		scope, err := strconv.ParseUint(scopeName, 10, 8)
+		if err != nil {
+			return fmt.Errorf("invalid scope %q: %w", scopeName, err)
+		}
+		*s = Scope(scope)
+	}
+	return nil
+}
+
+func (s Scope) String() string {
+	switch s {
+	case SCOPE_UNIVERSE:
+		return "universe"
+	case SCOPE_SITE:
+		return "site"
+	case SCOPE_LINK:
+		return "link"
+	case SCOPE_HOST:
+		return "host"
+	case SCOPE_NOWHERE:
+		return "nowhere"
+	default:
+		return "unknown (" + strconv.Itoa(int(s)) + ")"
+	}
+}
+
+type Type uint8
+
+const (
+	RTN_UNSPEC Type = 0x0
+	// a gateway or direct route
+	RTN_UNICAST Type = 0x1
+	// packets matching a local route are sent up the network stack as destined for the local host
+	RTN_LOCAL Type = 0x2
+	// a local broadcast route (sent as a broadcast)
+	RTN_BROADCAST Type = 0x3
+	// a local broadcast route (sent as a unicast)
+	RTN_ANYCAST Type = 0x4
+	// a multicast route
+	RTN_MULTICAST Type = 0x5
+	// packets matching a blackhole route are silently dropped
+	RTN_BLACKHOLE Type = 0x6
+	// packets matching an unreachable route are dropped and an ICMP unreachable message is sent
+	RTN_UNREACHABLE Type = 0x7
+	// packets matching a prohibited route are dropped and an ICMP administratively prohibited message is sent
+	RTN_PROHIBIT Type = 0x8
+	// packets matching a throw route cause a lookup error
+	RTN_THROW Type = 0x9
+	// stateless NAT route
+	RTN_NAT Type = 0xa
+)
+
+var _ yaml.Unmarshaler = (*Type)(nil)
+
+func (t *Type) UnmarshalYAML(value *yaml.Node) error {
+	var typeName string
+	if err := value.Decode(&typeName); err != nil {
+		return err
+	}
+
+	if err := t.FromString(typeName); err != nil {
+		return fmt.Errorf("failed to parse type %q: %w", typeName, err)
+	}
+
+	return nil
+}
+
+func (t *Type) FromString(typeName string) error {
+	switch typeName {
+	case "unspec":
+		*t = RTN_UNSPEC
+	case "unicast":
+		*t = RTN_UNICAST
+	case "local":
+		*t = RTN_LOCAL
+	case "broadcast":
+		*t = RTN_BROADCAST
+	case "anycast":
+		*t = RTN_ANYCAST
+	case "multicast":
+		*t = RTN_MULTICAST
+	case "blackhole":
+		*t = RTN_BLACKHOLE
+	case "unreachable":
+		*t = RTN_UNREACHABLE
+	case "prohibit":
+		*t = RTN_PROHIBIT
+	case "throw":
+		*t = RTN_THROW
+	case "nat":
+		*t = RTN_NAT
+	default:
+		typeValue, err := strconv.ParseUint(typeName, 10, 8)
+		if err != nil {
+			return fmt.Errorf("invalid type %q: %w", typeName, err)
+		}
+		*t = Type(typeValue)
+	}
+	return nil
+}
+
+func (t Type) String() string {
+	switch t {
+	case RTN_UNSPEC:
+		return "unspec"
+	case RTN_UNICAST:
+		return "unicast"
+	case RTN_LOCAL:
+		return "local"
+	case RTN_BROADCAST:
+		return "broadcast"
+	case RTN_ANYCAST:
+		return "anycast"
+	case RTN_MULTICAST:
+		return "multicast"
+	case RTN_BLACKHOLE:
+		return "blackhole"
+	case RTN_UNREACHABLE:
+		return "unreachable"
+	case RTN_PROHIBIT:
+		return "prohibit"
+	case RTN_THROW:
+		return "throw"
+	case RTN_NAT:
+		return "nat"
+	default:
+		return fmt.Sprintf("unknown (%d)", t)
+	}
+}

--- a/pkg/datapath/linux/testdata/device-controller-tables.txtar
+++ b/pkg/datapath/linux/testdata/device-controller-tables.txtar
@@ -97,39 +97,39 @@ Destination   Source   Gateway   LinkIndex   Table   Scope   Priority
 
 -- routes_dummy0.table --
 Destination      Source        Gateway   Table   Scope   Priority
-192.168.0.1/32   192.168.0.1             255     254     0
+192.168.0.1/32   192.168.0.1             local   host    0
 
 -- routes_dummy01.table --
-Destination        Source        Gateway         Table   Scope   Priority
-0.0.0.0/0                        192.168.1.254   254     0       0
-192.168.1.0/24     192.168.1.1                   254     253     0
-192.168.1.253/32                                 254     253     0
-192.168.1.254/32                                 254     253     0
-192.168.0.1/32     192.168.0.1                   255     254     0
-192.168.1.1/32     192.168.1.1                   255     254     0
-192.168.1.2/32     192.168.1.1                   255     254     0
-192.168.1.255/32   192.168.1.1                   255     253     0
-ff00::/8                                         255     0       256
+Destination        Source        Gateway         Table   Scope      Priority
+0.0.0.0/0                        192.168.1.254   main    universe   0
+192.168.1.0/24     192.168.1.1                   main    link       0
+192.168.1.253/32                                 main    link       0
+192.168.1.254/32                                 main    link       0
+192.168.0.1/32     192.168.0.1                   local   host       0
+192.168.1.1/32     192.168.1.1                   local   host       0
+192.168.1.2/32     192.168.1.1                   local   host       0
+192.168.1.255/32   192.168.1.1                   local   link       0
+ff00::/8                                         local   universe   256
 
 -- routes_table254_link3_254.table --
 Destination        Source   Gateway   Table   Scope   Priority
-192.168.1.254/32                      254     253
+192.168.1.254/32                      main    link
 -- routes_table254_link3_all.table --
-Destination        Source        Gateway         Table   Scope   Priority
-0.0.0.0/0                        192.168.1.254   254     0       0
-192.168.1.0/24     192.168.1.1                   254     253     0
-192.168.1.253/32                                 254     253     0
-192.168.1.254/32                                 254     253     0
+Destination        Source        Gateway         Table   Scope      Priority
+0.0.0.0/0                        192.168.1.254   main    universe   0
+192.168.1.0/24     192.168.1.1                   main    link       0
+192.168.1.253/32                                 main    link       0
+192.168.1.254/32                                 main    link       0
 -- routes_link3.table --
-Destination        Source        Gateway         Table   Scope   Priority
-192.168.1.254/32                                 254     253     0
-192.168.1.253/32                                 254     253     0
-192.168.1.0/24     192.168.1.1                   254     253     0
-0.0.0.0/0                        192.168.1.254   254     0       0
-192.168.1.1/32     192.168.1.1                   255     254     0
-192.168.1.2/32     192.168.1.1                   255     254     0
-192.168.1.255/32   192.168.1.1                   255     253     0
-ff00::/8                                         255     0       0
+Destination        Source        Gateway         Table   Scope      Priority
+192.168.1.254/32                                 main    link       0
+192.168.1.253/32                                 main    link       0
+192.168.1.0/24     192.168.1.1                   main    link       0
+0.0.0.0/0                        192.168.1.254   main    universe   0
+192.168.1.1/32     192.168.1.1                   local   host       0
+192.168.1.2/32     192.168.1.1                   local   host       0
+192.168.1.255/32   192.168.1.1                   local   link       0
+ff00::/8                                         local   universe   0
 -- routes_placeholder --
 
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -517,10 +517,8 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfig
 	}
 
 	// Reinstall proxy rules for any running proxies if needed
-	if option.Config.EnableL7Proxy {
-		if err := p.ReinstallRoutingRules(ctx, lnc.RouteMTU, lnc.EnableIPSec); err != nil {
-			return err
-		}
+	if err := p.ReinstallRoutingRules(ctx, lnc.RouteMTU, lnc.EnableIPSec); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -5,10 +5,10 @@ package loader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/netip"
 	"path/filepath"
 	"slices"
@@ -17,13 +17,12 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
 	"github.com/vishvananda/netlink"
-	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/config"
-	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
-	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	routeReconciler "github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
@@ -84,6 +83,10 @@ type loader struct {
 	compilationLock    datapath.CompilationLock
 	configWriter       datapath.ConfigWriter
 	nodeConfigNotifier *manager.NodeConfigNotifier
+
+	db           *statedb.DB
+	devices      statedb.Table[*tables.Device]
+	routeManager *routeReconciler.DesiredRouteManager
 }
 
 type Params struct {
@@ -95,6 +98,9 @@ type Params struct {
 	CompilationLock    datapath.CompilationLock
 	ConfigWriter       datapath.ConfigWriter
 	NodeConfigNotifier *manager.NodeConfigNotifier
+	RouteManager       *routeReconciler.DesiredRouteManager
+	DB                 *statedb.DB
+	Devices            statedb.Table[*tables.Device]
 
 	// Force map initialisation before loader. You should not use these otherwise.
 	// Some of the entries in this slice may be nil.
@@ -112,26 +118,46 @@ func newLoader(p Params) *loader {
 		compilationLock:    p.CompilationLock,
 		configWriter:       p.ConfigWriter,
 		nodeConfigNotifier: p.NodeConfigNotifier,
+		routeManager:       p.RouteManager,
+
+		db:      p.DB,
+		devices: p.Devices,
 	}
 }
 
-func upsertEndpointRoute(logger *slog.Logger, ep datapath.Endpoint, ip net.IPNet) error {
-	endpointRoute := route.Route{
-		Prefix: ip,
-		Device: ep.InterfaceName(),
-		Scope:  netlink.SCOPE_LINK,
-		Proto:  linux_defaults.RTProto,
+func upsertEndpointRoute(logger *slog.Logger, db *statedb.DB, devices statedb.Table[*tables.Device], rm *routeReconciler.DesiredRouteManager, ep datapath.Endpoint, ip netip.Prefix) error {
+	owner, err := rm.GetOrRegisterOwner("endpoint/" + ep.StringID())
+	if err != nil {
+		return fmt.Errorf("getting or registering owner for endpoint %s: %w", ep.StringID(), err)
 	}
 
-	return route.Upsert(logger, endpointRoute)
-}
+	epDev, _, found := devices.Get(db.ReadTxn(), tables.DeviceIDIndex.Query(ep.GetIfIndex()))
+	if !found {
+		return fmt.Errorf("device %d not found for endpoint %s", ep.GetIfIndex(), ep.StringID())
+	}
 
-func removeEndpointRoute(ep datapath.Endpoint, ip net.IPNet) error {
-	return route.Delete(route.Route{
-		Prefix: ip,
-		Device: ep.InterfaceName(),
-		Scope:  netlink.SCOPE_LINK,
+	return rm.UpsertRoute(routeReconciler.DesiredRoute{
+		Owner:         owner,
+		Prefix:        ip,
+		Table:         routeReconciler.TableMain,
+		AdminDistance: routeReconciler.AdminDistanceDefault,
+
+		Device: epDev,
+		Scope:  routeReconciler.SCOPE_LINK,
 	})
+}
+
+func removeEndpointRoute(ep datapath.Endpoint, rm *routeReconciler.DesiredRouteManager) error {
+	owner, err := rm.GetOwner("endpoint/" + ep.StringID())
+	if err != nil {
+		if errors.Is(err, routeReconciler.ErrOwnerDoesNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("getting route owner for endpoint %s: %w", ep.StringID(), err)
+	}
+
+	return rm.RemoveOwner(owner)
 }
 
 func bpfMasqAddrs(ifName string, cfg *datapath.LocalNodeConfiguration) (masq4, masq6 netip.Addr) {
@@ -629,7 +655,7 @@ func endpointRewrites(ep datapath.EndpointConfiguration, lnc *datapath.LocalNode
 //
 // spec is modified by the method and it is the callers responsibility to copy
 // it if necessary.
-func reloadEndpoint(logger *slog.Logger, ep datapath.Endpoint, lnc *datapath.LocalNodeConfiguration, spec *ebpf.CollectionSpec) error {
+func reloadEndpoint(logger *slog.Logger, db *statedb.DB, devices statedb.Table[*tables.Device], rm *routeReconciler.DesiredRouteManager, ep datapath.Endpoint, lnc *datapath.LocalNodeConfiguration, spec *ebpf.CollectionSpec) error {
 	device := ep.InterfaceName()
 
 	co, renames := endpointRewrites(ep, lnc)
@@ -696,14 +722,14 @@ func reloadEndpoint(logger *slog.Logger, ep datapath.Endpoint, lnc *datapath.Loc
 			logfields.Interface, device,
 		)
 		if ip := ep.IPv4Address(); ip.IsValid() {
-			if err := upsertEndpointRoute(logger, ep, *netipx.AddrIPNet(ip)); err != nil {
+			if err := upsertEndpointRoute(logger, db, devices, rm, ep, netip.PrefixFrom(ip, ip.BitLen())); err != nil {
 				scopedLog.Warn("Failed to upsert route",
 					logfields.Error, err,
 				)
 			}
 		}
 		if ip := ep.IPv6Address(); ip.IsValid() {
-			if err := upsertEndpointRoute(logger, ep, *netipx.AddrIPNet(ip)); err != nil {
+			if err := upsertEndpointRoute(logger, db, devices, rm, ep, netip.PrefixFrom(ip, ip.BitLen())); err != nil {
 				scopedLog.Warn("Failed to upsert route",
 					logfields.Error, err,
 				)
@@ -887,7 +913,7 @@ func (l *loader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, lnc *
 
 	// Reload an lxc endpoint program.
 	stats.BpfLoadProg.Start()
-	err = reloadEndpoint(l.logger, ep, lnc, spec)
+	err = reloadEndpoint(l.logger, l.db, l.devices, l.routeManager, ep, lnc, spec)
 	stats.BpfLoadProg.End(err == nil)
 	return hash, err
 }
@@ -896,11 +922,11 @@ func (l *loader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, lnc *
 func (l *loader) Unload(ep datapath.Endpoint) {
 	if ep.RequireEndpointRoute() {
 		if ip := ep.IPv4Address(); ip.IsValid() {
-			removeEndpointRoute(ep, *netipx.AddrIPNet(ip))
+			removeEndpointRoute(ep, l.routeManager)
 		}
 
 		if ip := ep.IPv6Address(); ip.IsValid() {
-			removeEndpointRoute(ep, *netipx.AddrIPNet(ip))
+			removeEndpointRoute(ep, l.routeManager)
 		}
 	}
 

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -350,7 +350,7 @@ func (n *nodeAddressController) reconcile() (<-chan struct{}, <-chan struct{}) {
 		// We are only interested in local routes, which are used for IPs that are assigned
 		// to the host (e.g. on GCE). These routes are in the local table, have host scope,
 		// and have no source address.
-		if route.Scope != uint8(RT_SCOPE_HOST) || route.Src.IsValid() {
+		if route.Scope != RT_SCOPE_HOST || route.Src.IsValid() {
 			continue
 		}
 

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -1110,7 +1110,7 @@ func TestNodeAddressFromRoute(t *testing.T) {
 			route := &Route{
 				LinkIndex: testDevice.Index,
 				Dst:       routeBasedPrefix,
-				Scope:     uint8(RT_SCOPE_HOST),
+				Scope:     RT_SCOPE_HOST,
 				Table:     RT_TABLE_LOCAL,
 			}
 			if tc.customizeRoute != nil {

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -104,11 +104,13 @@ type Route struct {
 	Table     RouteTable
 	LinkIndex int
 
-	Scope    uint8
+	Type     RouteType
+	Scope    RouteScope
 	Dst      netip.Prefix
 	Src      netip.Addr
 	Gw       netip.Addr
 	Priority int
+	MTU      int
 }
 
 func (r *Route) DeepCopy() *Route {
@@ -127,7 +129,9 @@ func (*Route) TableHeader() []string {
 		"Source",
 		"Gateway",
 		"LinkIndex",
+		"MTU",
 		"Table",
+		"Type",
 		"Scope",
 		"Priority",
 	}
@@ -143,13 +147,21 @@ func (r *Route) TableRow() []string {
 		}
 		return addr.String()
 	}
+
+	mtu := ""
+	if r.MTU != 0 {
+		mtu = fmt.Sprintf("%d", r.MTU)
+	}
+
 	return []string{
 		r.Dst.String(),
 		showAddr(r.Src),
 		showAddr(r.Gw),
 		fmt.Sprintf("%d", r.LinkIndex),
-		fmt.Sprintf("%d", r.Table),
-		fmt.Sprintf("%d", r.Scope),
+		mtu,
+		r.Table.String(),
+		r.Type.String(),
+		r.Scope.String(),
 		fmt.Sprintf("%d", r.Priority),
 	}
 }
@@ -177,6 +189,7 @@ var (
 
 type (
 	RouteScope uint8
+	RouteType  uint16
 	RouteTable uint32
 )
 
@@ -194,4 +207,81 @@ const (
 	RT_TABLE_MAIN     = RouteTable(0xfe)
 	RT_TABLE_LOCAL    = RouteTable(0xff)
 	RT_TABLE_MAX      = RouteTable(0xffffffff)
+	RTN_UNSPEC        = RouteType(0)
+	RTN_UNICAST       = RouteType(1)
+	RTN_LOCAL         = RouteType(2)
+	RTN_BROADCAST     = RouteType(3)
+	RTN_ANYCAST       = RouteType(4)
+	RTN_MULTICAST     = RouteType(5)
+	RTN_BLACKHOLE     = RouteType(6)
+	RTN_UNREACHABLE   = RouteType(7)
+	RTN_PROHIBIT      = RouteType(8)
+	RTN_THROW         = RouteType(9)
+	RTN_NAT           = RouteType(10)
+	RTN_XRESOLVE      = RouteType(11)
 )
+
+func (table RouteTable) String() string {
+	switch table {
+	case RT_TABLE_UNSPEC:
+		return "unspec"
+	case RT_TABLE_COMPAT:
+		return "compat"
+	case RT_TABLE_DEFAULT:
+		return "default"
+	case RT_TABLE_MAIN:
+		return "main"
+	case RT_TABLE_LOCAL:
+		return "local"
+	default:
+		return fmt.Sprintf("%d", table)
+	}
+}
+
+func (scope RouteScope) String() string {
+	switch scope {
+	case RT_SCOPE_UNIVERSE:
+		return "universe"
+	case RT_SCOPE_SITE:
+		return "site"
+	case RT_SCOPE_LINK:
+		return "link"
+	case RT_SCOPE_HOST:
+		return "host"
+	case RT_SCOPE_NOWHERE:
+		return "nowhere"
+	default:
+		return fmt.Sprintf("%d", scope)
+	}
+}
+
+func (typ RouteType) String() string {
+	switch typ {
+	case RTN_UNSPEC:
+		return "unspec"
+	case RTN_UNICAST:
+		return "unicast"
+	case RTN_LOCAL:
+		return "local"
+	case RTN_BROADCAST:
+		return "broadcast"
+	case RTN_ANYCAST:
+		return "anycast"
+	case RTN_MULTICAST:
+		return "multicast"
+	case RTN_BLACKHOLE:
+		return "blackhole"
+	case RTN_UNREACHABLE:
+		return "unreachable"
+	case RTN_PROHIBIT:
+		return "prohibit"
+	case RTN_THROW:
+		return "throw"
+	case RTN_NAT:
+		return "nat"
+	case RTN_XRESOLVE:
+		return "xresolve"
+	default:
+		return fmt.Sprintf("%d", typ)
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -8,8 +8,12 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/cilium/statedb"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -34,6 +38,8 @@ const (
 
 // Proxy maintains state about redirects
 type Proxy struct {
+	enabled bool
+
 	// mutex is the lock required when modifying any proxy datastructure
 	mutex lock.RWMutex
 
@@ -51,31 +57,44 @@ type Proxy struct {
 
 	// proxyPorts manages proxy port allocation
 	proxyPorts *proxyports.ProxyPorts
+
+	db               *statedb.DB
+	devices          statedb.Table[*tables.Device]
+	routeOwner       *reconciler.RouteOwner
+	routeInitializer reconciler.Initializer
+	routeManager     *reconciler.DesiredRouteManager
 }
 
 func createProxy(
+	enabled bool,
 	logger *slog.Logger,
 	localNodeStore *node.LocalNodeStore,
 	proxyPorts *proxyports.ProxyPorts,
 	envoyIntegration *envoyProxyIntegration,
 	dnsIntegration *dnsProxyIntegration,
-) *Proxy {
+	db *statedb.DB,
+	devices statedb.Table[*tables.Device],
+	routeManager *reconciler.DesiredRouteManager,
+) (*Proxy, error) {
+	routeOwner, err := routeManager.RegisterOwner("proxy")
+	if err != nil {
+		return nil, fmt.Errorf("unable to register route owner: %w", err)
+	}
+
 	return &Proxy{
+		enabled:          enabled,
 		logger:           logger,
 		localNodeStore:   localNodeStore,
 		redirects:        make(map[string]RedirectImplementation),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
 		proxyPorts:       proxyPorts,
-	}
-}
-
-func (p *Proxy) ReinstallRoutingRules(ctx context.Context, mtu int, ipsecEnabled bool) error {
-	ln, err := p.localNodeStore.Get(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve local node: %w", err)
-	}
-	return ReinstallRoutingRules(p.logger, ln, mtu, ipsecEnabled)
+		db:               db,
+		devices:          devices,
+		routeOwner:       routeOwner,
+		routeInitializer: routeManager.RegisterInitializer("proxy"),
+		routeManager:     routeManager,
+	}, nil
 }
 
 func (p *Proxy) GetListenerProxyPort(listener string) uint16 {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -8,13 +8,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/hive/job"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/completion"
 	datapath "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/proxyports"
 	"github.com/cilium/cilium/pkg/time"
@@ -22,6 +25,13 @@ import (
 )
 
 func proxyForTest(t *testing.T) *Proxy {
+	var drm *reconciler.DesiredRouteManager
+	hive.New(
+		reconciler.TableCell,
+		cell.Invoke(func(m *reconciler.DesiredRouteManager) {
+			drm = m
+		}),
+	).Populate(hivetest.Logger(t))
 	fakeIPTablesManager := &datapath.FakeIptablesManager{}
 	ppConfig := proxyports.ProxyPortsConfig{
 		ProxyPortrangeMin:          10000,
@@ -29,7 +39,8 @@ func proxyForTest(t *testing.T) *Proxy {
 		RestoredProxyPortsAgeLimit: 0,
 	}
 	pp := proxyports.NewProxyPorts(hivetest.Logger(t), ppConfig, fakeIPTablesManager)
-	p := createProxy(hivetest.Logger(t), nil, pp, nil, nil)
+	p, err := createProxy(true, hivetest.Logger(t), nil, pp, nil, nil, nil, nil, drm)
+	require.NoError(t, err)
 
 	p.proxyPorts.Trigger = job.NewTrigger(job.WithDebounce(10 * time.Second))
 	return p

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -4,19 +4,22 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
+	"net/netip"
 	"syscall"
 
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -32,29 +35,18 @@ var (
 		Table:    linux_defaults.RouteTableToProxy,
 		Protocol: linux_defaults.RTProto,
 	}
-
-	// Default IPv4 route for local delivery.
-	route4 = route.Route{
-		Table:  linux_defaults.RouteTableToProxy,
-		Type:   route.RTN_LOCAL,
-		Local:  net.IPv4zero,
-		Device: "lo",
-		Proto:  linux_defaults.RTProto,
-	}
-
-	// Default IPv6 route for local delivery.
-	route6 = route.Route{
-		Table:  linux_defaults.RouteTableToProxy,
-		Type:   route.RTN_LOCAL,
-		Local:  net.IPv6zero,
-		Device: "lo",
-		Proto:  linux_defaults.RTProto,
-	}
 )
 
 // ReinstallRoutingRules ensures the presence of routing rules and tables needed
-// to route packets to and from the L7 proxy.
-func ReinstallRoutingRules(logger *slog.Logger, localNode node.LocalNode, mtu int, ipsecEnabled bool) error {
+// to route packets to and from the L7 proxy. Or removes rules if the proxy is disabled.
+func (p *Proxy) ReinstallRoutingRules(ctx context.Context, mtu int, ipsecEnabled bool) error {
+	defer p.routeManager.FinalizeInitializer(p.routeInitializer)
+
+	localNode, err := p.localNodeStore.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve local node: %w", err)
+	}
+
 	fromIngressProxy, fromEgressProxy := requireFromProxyRoutes(ipsecEnabled)
 
 	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
@@ -62,31 +54,42 @@ func ReinstallRoutingRules(logger *slog.Logger, localNode node.LocalNode, mtu in
 		mtu = 0
 	}
 
-	if option.Config.EnableIPv4 {
-		if err := installToProxyRoutesIPv4(logger); err != nil {
+	rxn := p.db.ReadTxn()
+	hostDevice, _, hostDeviceFound := p.devices.Get(rxn, tables.DeviceNameIndex.Query(defaults.HostDevice))
+	lo, _, loFound := p.devices.Get(rxn, tables.DeviceNameIndex.Query("lo"))
+
+	if option.Config.EnableIPv4 && p.enabled {
+		if !loFound {
+			return fmt.Errorf("failed to get loopback device")
+		}
+		if err := installToProxyRoutesIPv4(lo, p.routeManager, p.routeOwner); err != nil {
 			return err
 		}
 
 		if fromIngressProxy || fromEgressProxy {
-			if err := installFromProxyRoutesIPv4(logger, localNode.GetCiliumInternalIP(false), defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
+			if !hostDeviceFound {
+				return fmt.Errorf("failed to get host device %s", defaults.HostDevice)
+			}
+			internalIP, _ := netipx.FromStdIP(localNode.GetCiliumInternalIP(false))
+			if err := installFromProxyRoutesIPv4(p.routeManager, p.routeOwner, internalIP, hostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
 				return err
 			}
 		} else {
-			if err := removeFromProxyRoutesIPv4(); err != nil {
+			if err := removeFromProxyRulesIPv4(); err != nil {
 				return err
 			}
 		}
 	} else {
-		if err := removeToProxyRoutesIPv4(); err != nil {
+		if err := removeToProxyRulesIPv4(); err != nil {
 			return err
 		}
-		if err := removeFromProxyRoutesIPv4(); err != nil {
+		if err := removeFromProxyRulesIPv4(); err != nil {
 			return err
 		}
 	}
 
-	if option.Config.EnableIPv6 {
-		if err := installToProxyRoutesIPv6(logger); err != nil {
+	if option.Config.EnableIPv6 && p.enabled {
+		if err := installToProxyRulesIPv6(lo, p.routeManager, p.routeOwner); err != nil {
 			return err
 		}
 
@@ -95,19 +98,23 @@ func ReinstallRoutingRules(logger *slog.Logger, localNode node.LocalNode, mtu in
 			if err != nil {
 				return err
 			}
-			if err := installFromProxyRoutesIPv6(logger, ipv6, defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
+			if !hostDeviceFound {
+				return fmt.Errorf("failed to get host device %s", defaults.HostDevice)
+			}
+			netIP, _ := netipx.FromStdIP(ipv6)
+			if err := installFromProxyRoutesIPv6(p.routeOwner, p.routeManager, netIP, hostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
 				return err
 			}
 		} else {
-			if err := removeFromProxyRoutesIPv6(); err != nil {
+			if err := removeFromProxyRulesIPv6(); err != nil {
 				return err
 			}
 		}
 	} else {
-		if err := removeToProxyRoutesIPv6(); err != nil {
+		if err := removeToProxyRulesIPv6(); err != nil {
 			return err
 		}
-		if err := removeFromProxyRoutesIPv6(); err != nil {
+		if err := removeFromProxyRulesIPv6(); err != nil {
 			return err
 		}
 	}
@@ -138,8 +145,18 @@ func getCiliumNetIPv6() (net.IP, error) {
 
 // installToProxyRoutesIPv4 configures routes and rules needed to redirect ingress
 // packets to the proxy.
-func installToProxyRoutesIPv4(logger *slog.Logger) error {
-	if err := route.Upsert(logger, route4); err != nil {
+func installToProxyRoutesIPv4(loDevice *tables.Device, routeManager *reconciler.DesiredRouteManager, routeOwner *reconciler.RouteOwner) error {
+	route4 := reconciler.DesiredRoute{
+		Owner:         routeOwner,
+		Table:         linux_defaults.RouteTableToProxy,
+		Prefix:        netip.MustParsePrefix("0.0.0.0/0"),
+		AdminDistance: reconciler.AdminDistanceDefault,
+		Type:          reconciler.RTN_LOCAL,
+		Src:           netip.AddrFrom4([4]byte{}),
+		Device:        loDevice,
+	}
+
+	if err := routeManager.UpsertRouteWait(route4); err != nil {
 		return fmt.Errorf("inserting ipv4 proxy route %v: %w", route4, err)
 	}
 	if err := route.ReplaceRule(toProxyRule); err != nil {
@@ -149,22 +166,29 @@ func installToProxyRoutesIPv4(logger *slog.Logger) error {
 	return nil
 }
 
-// removeToProxyRoutesIPv4 ensures routes and rules for proxy traffic are removed.
-func removeToProxyRoutesIPv4() error {
+// removeToProxyRulesIPv4 ensures routes and rules for proxy traffic are removed.
+func removeToProxyRulesIPv4() error {
 	if err := route.DeleteRule(netlink.FAMILY_V4, toProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
 		return fmt.Errorf("removing ipv4 proxy routing rule: %w", err)
-	}
-	if err := route.DeleteRouteTable(linux_defaults.RouteTableToProxy, netlink.FAMILY_V4); err != nil {
-		return fmt.Errorf("removing ipv4 proxy route table: %w", err)
 	}
 
 	return nil
 }
 
-// installToProxyRoutesIPv6 configures routes and rules needed to redirect ingress
+// installToProxyRulesIPv6 configures routes and rules needed to redirect ingress
 // packets to the proxy.
-func installToProxyRoutesIPv6(logger *slog.Logger) error {
-	if err := route.Upsert(logger, route6); err != nil {
+func installToProxyRulesIPv6(loDevice *tables.Device, routeManager *reconciler.DesiredRouteManager, routeOwner *reconciler.RouteOwner) error {
+	route6 := reconciler.DesiredRoute{
+		Owner:         routeOwner,
+		Table:         linux_defaults.RouteTableToProxy,
+		Prefix:        netip.MustParsePrefix("::/0"),
+		AdminDistance: reconciler.AdminDistanceDefault,
+		Type:          route.RTN_LOCAL,
+		Src:           netip.AddrFrom16([16]byte{}),
+		Device:        loDevice,
+	}
+
+	if err := routeManager.UpsertRouteWait(route6); err != nil {
 		return fmt.Errorf("inserting ipv6 proxy route %v: %w", route6, err)
 	}
 	if err := route.ReplaceRuleIPv6(toProxyRule); err != nil {
@@ -174,15 +198,12 @@ func installToProxyRoutesIPv6(logger *slog.Logger) error {
 	return nil
 }
 
-// removeToProxyRoutesIPv6 ensures routes and rules for proxy traffic are removed.
-func removeToProxyRoutesIPv6() error {
+// removeToProxyRulesIPv6 ensures routes and rules for proxy traffic are removed.
+func removeToProxyRulesIPv6() error {
 	if err := route.DeleteRule(netlink.FAMILY_V6, toProxyRule); err != nil {
 		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.EAFNOSUPPORT) {
 			return fmt.Errorf("removing ipv6 proxy routing rule: %w", err)
 		}
-	}
-	if err := route.DeleteRouteTable(linux_defaults.RouteTableToProxy, netlink.FAMILY_V6); err != nil {
-		return fmt.Errorf("removing ipv6 proxy route table: %w", err)
 	}
 
 	return nil
@@ -210,23 +231,33 @@ var (
 
 // installFromProxyRoutesIPv4 configures routes and rules needed to redirect ingress
 // packets from the proxy.
-func installFromProxyRoutesIPv4(logger *slog.Logger, ipv4 net.IP, device string, fromIngressProxy, fromEgressProxy bool, mtu int) error {
-	fromProxyToCiliumHostRoute4 := route.Route{
-		Table: linux_defaults.RouteTableFromProxy,
-		Prefix: net.IPNet{
-			IP:   ipv4,
-			Mask: net.CIDRMask(32, 32),
-		},
+func installFromProxyRoutesIPv4(
+	routeManager *reconciler.DesiredRouteManager,
+	routeOwner *reconciler.RouteOwner,
+	ipv4 netip.Addr,
+	device *tables.Device,
+	fromIngressProxy, fromEgressProxy bool,
+	mtu int,
+) error {
+	prefix, _ := ipv4.Prefix(ipv4.BitLen())
+	fromProxyToCiliumHostRoute4 := reconciler.DesiredRoute{
+		Owner:         routeOwner,
+		Table:         linux_defaults.RouteTableFromProxy,
+		Prefix:        prefix,
+		AdminDistance: reconciler.AdminDistanceDefault,
+
 		Device: device,
-		Type:   route.RTN_LOCAL,
-		Proto:  linux_defaults.RTProto,
+		Scope:  reconciler.Scope(netlink.SCOPE_LINK),
 	}
-	fromProxyDefaultRoute4 := route.Route{
-		Table:   linux_defaults.RouteTableFromProxy,
-		Nexthop: &ipv4,
+	fromProxyDefaultRoute4 := reconciler.DesiredRoute{
+		Owner:         routeOwner,
+		Table:         linux_defaults.RouteTableFromProxy,
+		Prefix:        netip.MustParsePrefix("0.0.0.0/0"),
+		AdminDistance: reconciler.AdminDistanceDefault,
+
+		Nexthop: ipv4,
 		Device:  device,
-		Proto:   linux_defaults.RTProto,
-		MTU:     mtu,
+		MTU:     uint32(mtu),
 	}
 
 	if fromIngressProxy {
@@ -239,26 +270,23 @@ func installFromProxyRoutesIPv4(logger *slog.Logger, ipv4 net.IP, device string,
 			return fmt.Errorf("inserting ipv4 from egress proxy routing rule %v: %w", fromEgressProxyRule, err)
 		}
 	}
-	if err := route.Upsert(logger, fromProxyToCiliumHostRoute4); err != nil {
+	if err := routeManager.UpsertRouteWait(fromProxyToCiliumHostRoute4); err != nil {
 		return fmt.Errorf("inserting ipv4 from proxy to cilium_host route %v: %w", fromProxyToCiliumHostRoute4, err)
 	}
-	if err := route.Upsert(logger, fromProxyDefaultRoute4); err != nil {
+	if err := routeManager.UpsertRouteWait(fromProxyDefaultRoute4); err != nil {
 		return fmt.Errorf("inserting ipv4 from proxy default route %v: %w", fromProxyDefaultRoute4, err)
 	}
 
 	return nil
 }
 
-// removeFromProxyRoutesIPv4 ensures routes and rules for traffic from the proxy are removed.
-func removeFromProxyRoutesIPv4() error {
+// removeFromProxyRulesIPv4 ensures routes and rules for traffic from the proxy are removed.
+func removeFromProxyRulesIPv4() error {
 	if err := route.DeleteRule(netlink.FAMILY_V4, fromIngressProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
 		return fmt.Errorf("removing ipv4 from ingress proxy routing rule: %w", err)
 	}
 	if err := route.DeleteRule(netlink.FAMILY_V4, fromEgressProxyRule); err != nil && !errors.Is(err, syscall.ENOENT) {
 		return fmt.Errorf("removing ipv4 from egress proxy routing rule: %w", err)
-	}
-	if err := route.DeleteRouteTable(linux_defaults.RouteTableFromProxy, netlink.FAMILY_V4); err != nil {
-		return fmt.Errorf("removing ipv4 from proxy route table: %w", err)
 	}
 
 	return nil
@@ -266,23 +294,33 @@ func removeFromProxyRoutesIPv4() error {
 
 // installFromProxyRoutesIPv6 configures routes and rules needed to redirect ingress
 // packets from the proxy.
-func installFromProxyRoutesIPv6(logger *slog.Logger, ipv6 net.IP, device string, fromIngressProxy, fromEgressProxy bool, mtu int) error {
-	fromProxyToCiliumHostRoute6 := route.Route{
-		Table: linux_defaults.RouteTableFromProxy,
-		Prefix: net.IPNet{
-			IP:   ipv6,
-			Mask: net.CIDRMask(128, 128),
-		},
+func installFromProxyRoutesIPv6(
+	routeOwner *reconciler.RouteOwner,
+	routeManager *reconciler.DesiredRouteManager,
+	ipv6 netip.Addr,
+	device *tables.Device,
+	fromIngressProxy, fromEgressProxy bool,
+	mtu int,
+) error {
+	prefix, _ := ipv6.Prefix(ipv6.BitLen())
+	fromProxyToCiliumHostRoute6 := reconciler.DesiredRoute{
+		Owner:         routeOwner,
+		Table:         linux_defaults.RouteTableFromProxy,
+		Prefix:        prefix,
+		AdminDistance: reconciler.AdminDistanceDefault,
+
 		Device: device,
-		Proto:  linux_defaults.RTProto,
 	}
 
-	fromProxyDefaultRoute6 := route.Route{
-		Table:   linux_defaults.RouteTableFromProxy,
-		Nexthop: &ipv6,
+	fromProxyDefaultRoute6 := reconciler.DesiredRoute{
+		Owner:         routeOwner,
+		Table:         linux_defaults.RouteTableFromProxy,
+		Prefix:        netip.MustParsePrefix("::/0"),
+		AdminDistance: reconciler.AdminDistanceDefault,
+
+		Nexthop: ipv6,
 		Device:  device,
-		Proto:   linux_defaults.RTProto,
-		MTU:     mtu,
+		MTU:     uint32(mtu),
 	}
 
 	if fromIngressProxy {
@@ -295,18 +333,18 @@ func installFromProxyRoutesIPv6(logger *slog.Logger, ipv6 net.IP, device string,
 			return fmt.Errorf("inserting ipv6 from egress proxy routing rule %v: %w", fromEgressProxyRule, err)
 		}
 	}
-	if err := route.Upsert(logger, fromProxyToCiliumHostRoute6); err != nil {
+	if err := routeManager.UpsertRouteWait(fromProxyToCiliumHostRoute6); err != nil {
 		return fmt.Errorf("inserting ipv6 from proxy to cilium_host route %v: %w", fromProxyToCiliumHostRoute6, err)
 	}
-	if err := route.Upsert(logger, fromProxyDefaultRoute6); err != nil {
+	if err := routeManager.UpsertRouteWait(fromProxyDefaultRoute6); err != nil {
 		return fmt.Errorf("inserting ipv6 from proxy default route %v: %w", fromProxyDefaultRoute6, err)
 	}
 
 	return nil
 }
 
-// removeFromProxyRoutesIPv6 ensures routes and rules for traffic from the proxy are removed.
-func removeFromProxyRoutesIPv6() error {
+// removeFromProxyRulesIPv6 ensures routes and rules for traffic from the proxy are removed.
+func removeFromProxyRulesIPv6() error {
 	if err := route.DeleteRule(netlink.FAMILY_V6, fromIngressProxyRule); err != nil {
 		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.EAFNOSUPPORT) {
 			return fmt.Errorf("removing ipv6 from ingress proxy routing rule: %w", err)
@@ -316,9 +354,6 @@ func removeFromProxyRoutesIPv6() error {
 		if !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.EAFNOSUPPORT) {
 			return fmt.Errorf("removing ipv6 from egress proxy routing rule: %w", err)
 		}
-	}
-	if err := route.DeleteRouteTable(linux_defaults.RouteTableFromProxy, netlink.FAMILY_V6); err != nil {
-		return fmt.Errorf("removing ipv6 from proxy route table: %w", err)
 	}
 
 	return nil

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -4,18 +4,28 @@
 package proxy
 
 import (
+	"expvar"
 	"net"
+	"net/netip"
 	"slices"
 	"testing"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+
+	"github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
@@ -43,14 +53,56 @@ func filterDefaultRouteIPv6(t *testing.T, rt []netlink.Route) netlink.Route {
 func TestPrivilegedRoutes(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
+	newHive := func(t *testing.T, routeManager **reconciler.DesiredRouteManager, reconcilerMetrics *reconciler.RouteReconcilerMetrics) *hive.Hive {
+		t.Helper()
+		return hive.New(
+			linux.DevicesControllerCell,
+			reconciler.Cell,
+			cell.Provide(func() *option.DaemonConfig {
+				return &option.DaemonConfig{
+					StateDir: t.TempDir(),
+				}
+			}),
+			cell.Invoke(func(routeManagerp *reconciler.DesiredRouteManager, metrics reconciler.RouteReconcilerMetrics) {
+				*routeManager = routeManagerp
+				*reconcilerMetrics = metrics
+			}),
+		)
+	}
+
+	loDevice := &tables.Device{
+		Name:  "lo",
+		Index: 1,
+	}
+
 	t.Run("IPv4", func(t *testing.T) {
 		t.Run("toProxy", func(t *testing.T) {
 			ns := netns.NewNetNS(t)
 			logger := hivetest.Logger(t)
 
 			ns.Do(func() error {
+				var (
+					routeManager      *reconciler.DesiredRouteManager
+					reconcilerMetrics reconciler.RouteReconcilerMetrics
+				)
+				h := newHive(t, &routeManager, &reconcilerMetrics)
+				err := h.Start(logger, t.Context())
+				require.NoError(t, err, "start hive")
+
+				defer func() {
+					err := h.Stop(logger, t.Context())
+					require.NoError(t, err, "stop hive")
+				}()
+
+				loLink, err := safenetlink.LinkByName(loDevice.Name)
+				require.NoError(t, err, "get loopback link")
+				netlink.LinkSetUp(loLink)
+
+				owner, err := routeManager.RegisterOwner("test-proxy")
+				require.NoError(t, err, "register route owner")
+
 				// Install routes and rules the first time.
-				assert.NoError(t, installToProxyRoutesIPv4(logger))
+				assert.NoError(t, installToProxyRoutesIPv4(loDevice, routeManager, owner))
 
 				rules, err := route.ListRules(netlink.FAMILY_V4, &toProxyRule)
 				assert.NoError(t, err)
@@ -63,10 +115,28 @@ func TestPrivilegedRoutes(t *testing.T) {
 				assert.Len(t, rt, 1)
 
 				// Ensure idempotence.
-				assert.NoError(t, installToProxyRoutesIPv4(logger))
+				assert.NoError(t, installToProxyRoutesIPv4(loDevice, routeManager, owner))
+
+				recCount := reconcilerMetrics.ReconciliationCountVar.Get("route-reconciler").(*expvar.Int).Value()
 
 				// Remove routes installed before.
-				assert.NoError(t, removeToProxyRoutesIPv4())
+				assert.NoError(t, removeToProxyRulesIPv4())
+				assert.NoError(t, routeManager.RemoveOwner(owner))
+
+				// Wait for the reconciler to process the deletions.
+				tick := time.NewTicker(100 * time.Millisecond)
+			loop:
+				for {
+					select {
+					case <-t.Context().Done():
+						t.Fatal("timeout waiting for toProxy routes and rules to be removed")
+					case <-tick.C:
+						if reconcilerMetrics.ReconciliationCountVar.Get("route-reconciler").(*expvar.Int).Value() > recCount {
+							tick.Stop()
+							break loop
+						}
+					}
+				}
 
 				rules, err = route.ListRules(netlink.FAMILY_V4, &toProxyRule)
 				assert.NoError(t, err)
@@ -83,10 +153,26 @@ func TestPrivilegedRoutes(t *testing.T) {
 		})
 
 		t.Run("fromProxy", func(t *testing.T) {
-			testIPv4 := net.ParseIP("1.2.3.4")
+			testIPv4 := netip.MustParseAddr("1.2.3.4")
 			ns := netns.NewNetNS(t)
 			logger := hivetest.Logger(t)
 			ns.Do(func() error {
+				var (
+					routeManager      *reconciler.DesiredRouteManager
+					reconcilerMetrics reconciler.RouteReconcilerMetrics
+				)
+				h := newHive(t, &routeManager, &reconcilerMetrics)
+				err := h.Start(logger, t.Context())
+				require.NoError(t, err, "start hive")
+
+				defer func() {
+					err := h.Stop(logger, t.Context())
+					require.NoError(t, err, "stop hive")
+				}()
+
+				owner, err := routeManager.RegisterOwner("test-proxy")
+				require.NoError(t, err, "register route owner")
+
 				// create test device
 				ifName := "dummy"
 				dummy := &netlink.Dummy{
@@ -94,11 +180,20 @@ func TestPrivilegedRoutes(t *testing.T) {
 						Name: ifName,
 					},
 				}
-				err := netlink.LinkAdd(dummy)
+				err = netlink.LinkAdd(dummy)
 				assert.NoError(t, err)
 
+				assert.NoError(t, netlink.LinkSetUp(dummy))
+
+				dummyLink, err := safenetlink.LinkByName(ifName)
+				assert.NoError(t, err)
+				dummyDevice := &tables.Device{
+					Name:  dummyLink.Attrs().Name,
+					Index: dummyLink.Attrs().Index,
+				}
+
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv4(logger, testIPv4, ifName, true, true, defaultMTU))
+				assert.NoError(t, installFromProxyRoutesIPv4(routeManager, owner, testIPv4, dummyDevice, true, true, defaultMTU))
 
 				rules, err := route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -115,14 +210,18 @@ func TestPrivilegedRoutes(t *testing.T) {
 				assert.Equal(t, defaultMTU, defaultRoute.MTU)
 
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv4(logger, testIPv4, ifName, true, true, defaultMTU))
+				assert.NoError(t, installFromProxyRoutesIPv4(routeManager, owner, testIPv4, dummyDevice, true, true, defaultMTU))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromProxyRoutesIPv4())
+				assert.NoError(t, removeFromProxyRulesIPv4())
+				assert.NoError(t, routeManager.RemoveOwner(owner))
+
+				owner, err = routeManager.RegisterOwner("test-proxy")
+				require.NoError(t, err, "register route owner")
 
 				// Install routes and rules with non-default MTU -- this would happen with
 				// IPSec enabled and both ingress and egress policies in-place.
-				assert.NoError(t, installFromProxyRoutesIPv4(logger, testIPv4, ifName, true, true, withOverheadMTU))
+				assert.NoError(t, installFromProxyRoutesIPv4(routeManager, owner, testIPv4, dummyDevice, true, true, withOverheadMTU))
 
 				// Re-list the from proxy (2005) routing table, expect a single entry.
 				rt, err = safenetlink.RouteListFiltered(netlink.FAMILY_V4,
@@ -134,8 +233,26 @@ func TestPrivilegedRoutes(t *testing.T) {
 				defaultRoute = filterDefaultRouteIPv4(t, rt)
 				assert.Equal(t, withOverheadMTU, defaultRoute.MTU)
 
+				recCount := reconcilerMetrics.ReconciliationCountVar.Get("route-reconciler").(*expvar.Int).Value()
+
 				// Remove installed routes.
-				assert.NoError(t, removeFromProxyRoutesIPv4())
+				assert.NoError(t, removeFromProxyRulesIPv4())
+				assert.NoError(t, routeManager.RemoveOwner(owner))
+
+				// Wait for the reconciler to process the deletions.
+				tick := time.NewTicker(100 * time.Millisecond)
+			loop:
+				for {
+					select {
+					case <-t.Context().Done():
+						t.Fatal("timeout waiting for toProxy routes and rules to be removed")
+					case <-tick.C:
+						if reconcilerMetrics.ReconciliationCountVar.Get("route-reconciler").(*expvar.Int).Value() > recCount {
+							tick.Stop()
+							break loop
+						}
+					}
+				}
 
 				rules, err = route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -158,8 +275,26 @@ func TestPrivilegedRoutes(t *testing.T) {
 			logger := hivetest.Logger(t)
 
 			ns.Do(func() error {
+				var routeManager *reconciler.DesiredRouteManager
+				var reconcilerMetrics reconciler.RouteReconcilerMetrics
+				h := newHive(t, &routeManager, &reconcilerMetrics)
+				err := h.Start(logger, t.Context())
+				require.NoError(t, err, "start hive")
+
+				defer func() {
+					err := h.Stop(logger, t.Context())
+					require.NoError(t, err, "stop hive")
+				}()
+
+				loLink, err := safenetlink.LinkByName(loDevice.Name)
+				require.NoError(t, err, "get loopback link")
+				netlink.LinkSetUp(loLink)
+
+				owner, err := routeManager.RegisterOwner("test-proxy")
+				require.NoError(t, err, "register route owner")
+
 				// Install routes and rules the first time.
-				assert.NoError(t, installToProxyRoutesIPv6(logger))
+				assert.NoError(t, installToProxyRulesIPv6(loDevice, routeManager, owner))
 
 				rules, err := route.ListRules(netlink.FAMILY_V6, &toProxyRule)
 				assert.NoError(t, err)
@@ -172,10 +307,28 @@ func TestPrivilegedRoutes(t *testing.T) {
 				assert.Len(t, rt, 1)
 
 				// Ensure idempotence.
-				assert.NoError(t, installToProxyRoutesIPv6(logger))
+				assert.NoError(t, installToProxyRulesIPv6(loDevice, routeManager, owner))
+
+				recCount := reconcilerMetrics.ReconciliationCountVar.Get("route-reconciler").(*expvar.Int).Value()
 
 				// Remove routes installed before.
-				assert.NoError(t, removeToProxyRoutesIPv6())
+				assert.NoError(t, removeToProxyRulesIPv6())
+				assert.NoError(t, routeManager.RemoveOwner(owner))
+
+				// Wait for the reconciler to process the deletions.
+				tick := time.NewTicker(100 * time.Millisecond)
+			loop:
+				for {
+					select {
+					case <-t.Context().Done():
+						t.Fatal("timeout waiting for toProxy routes and rules to be removed")
+					case <-tick.C:
+						if reconcilerMetrics.ReconciliationCountVar.Get("route-reconciler").(*expvar.Int).Value() > recCount {
+							tick.Stop()
+							break loop
+						}
+					}
+				}
 
 				rules, err = route.ListRules(netlink.FAMILY_V6, &toProxyRule)
 				assert.NoError(t, err)
@@ -192,11 +345,27 @@ func TestPrivilegedRoutes(t *testing.T) {
 		})
 
 		t.Run("fromProxy", func(t *testing.T) {
-			testIPv6 := net.ParseIP("2001:db08:0bad:cafe:600d:bee2:0bad:cafe")
+			testIPv6 := netip.MustParseAddr("2001:db08:0bad:cafe:600d:bee2:0bad:cafe")
 			ns := netns.NewNetNS(t)
 			logger := hivetest.Logger(t)
 
 			ns.Do(func() error {
+				var (
+					routeManager      *reconciler.DesiredRouteManager
+					reconcilerMetrics reconciler.RouteReconcilerMetrics
+				)
+				h := newHive(t, &routeManager, &reconcilerMetrics)
+				err := h.Start(logger, t.Context())
+				require.NoError(t, err, "start hive")
+
+				defer func() {
+					err := h.Stop(logger, t.Context())
+					require.NoError(t, err, "stop hive")
+				}()
+
+				owner, err := routeManager.RegisterOwner("test-proxy")
+				require.NoError(t, err, "register route owner")
+
 				// create test device
 				ifName := "dummy"
 				dummy := &netlink.Dummy{
@@ -204,11 +373,19 @@ func TestPrivilegedRoutes(t *testing.T) {
 						Name: ifName,
 					},
 				}
-				err := netlink.LinkAdd(dummy)
+				err = netlink.LinkAdd(dummy)
 				assert.NoError(t, err)
+				assert.NoError(t, netlink.LinkSetUp(dummy))
+
+				dummyLink, err := safenetlink.LinkByName(ifName)
+				assert.NoError(t, err)
+				dummyDevice := &tables.Device{
+					Name:  dummyLink.Attrs().Name,
+					Index: dummyLink.Attrs().Index,
+				}
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv6(logger, testIPv6, ifName, true, true, defaultMTU))
+				assert.NoError(t, installFromProxyRoutesIPv6(owner, routeManager, testIPv6, dummyDevice, true, true, defaultMTU))
 
 				rules, err := route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -225,14 +402,18 @@ func TestPrivilegedRoutes(t *testing.T) {
 				assert.Equal(t, defaultMTU, defaultRoute.MTU)
 
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv6(logger, testIPv6, ifName, true, true, defaultMTU))
+				assert.NoError(t, installFromProxyRoutesIPv6(owner, routeManager, testIPv6, dummyDevice, true, true, defaultMTU))
 
 				// Remove routes installed before.
-				assert.NoError(t, removeFromProxyRoutesIPv6())
+				assert.NoError(t, removeFromProxyRulesIPv6())
+				assert.NoError(t, routeManager.RemoveOwner(owner))
+
+				owner, err = routeManager.RegisterOwner("test-proxy")
+				require.NoError(t, err, "register route owner")
 
 				// Install routes and rules with non-default MTU -- this would happen with
 				// IPSec enabled and both ingress and egress policies in-place.
-				assert.NoError(t, installFromProxyRoutesIPv6(logger, testIPv6, ifName, true, true, withOverheadMTU))
+				assert.NoError(t, installFromProxyRoutesIPv6(owner, routeManager, testIPv6, dummyDevice, true, true, withOverheadMTU))
 
 				// Re-list the from proxy (2005) routing table, expect a single entry.
 				rt, err = safenetlink.RouteListFiltered(netlink.FAMILY_V6,
@@ -244,8 +425,26 @@ func TestPrivilegedRoutes(t *testing.T) {
 				defaultRoute = filterDefaultRouteIPv6(t, rt)
 				assert.Equal(t, withOverheadMTU, defaultRoute.MTU)
 
+				recCount := reconcilerMetrics.ReconciliationCountVar.Get("route-reconciler").(*expvar.Int).Value()
+
 				// Remove installed routes.
-				assert.NoError(t, removeFromProxyRoutesIPv6())
+				assert.NoError(t, removeFromProxyRulesIPv6())
+				assert.NoError(t, routeManager.RemoveOwner(owner))
+
+				// Wait for the reconciler to process the deletions.
+				tick := time.NewTicker(100 * time.Millisecond)
+			loop:
+				for {
+					select {
+					case <-t.Context().Done():
+						t.Fatal("timeout waiting for toProxy routes and rules to be removed")
+					case <-tick.C:
+						if reconcilerMetrics.ReconciliationCountVar.Get("route-reconciler").(*expvar.Int).Value() > recCount {
+							tick.Stop()
+							break loop
+						}
+					}
+				}
 
 				rules, err = route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)

--- a/pkg/wal/wal.go
+++ b/pkg/wal/wal.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package wal
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"iter"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type Event interface {
+	encoding.BinaryMarshaler
+}
+
+// Read reads all events from the WAL at logPath using the provided unmarshaller function.
+func Read[T Event](logPath string, unmarshaller func(data []byte) (T, error)) (iter.Seq2[T, error], error) {
+	file, err := os.OpenFile(logPath, os.O_RDONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &lvReader{r: file}
+	return func(yield func(T, error) bool) {
+		defer file.Close()
+
+		for data := range r.Events() {
+			e, err := unmarshaller(data)
+			if !yield(e, err) {
+				return
+			}
+		}
+	}, nil
+}
+
+type Writer[T Event] struct {
+	logPath string
+
+	mu  lock.Mutex
+	log *os.File
+}
+
+// NewWriter creates a new WAL writer for events of type T at the specified logPath.
+// The log file is created if it does not exist, and truncated if it does.
+func NewWriter[T Event](logPath string) (*Writer[T], error) {
+	w := &Writer[T]{
+		logPath: logPath,
+	}
+
+	// Open the log file, create it if it doesn't exist, and truncate it to start fresh.
+	if log, err := w.open(logPath, true); err != nil {
+		return nil, err
+	} else {
+		w.log = log
+	}
+
+	return w, nil
+}
+
+func (w *Writer[T]) open(path string, truncate bool) (*os.File, error) {
+	flags := os.O_WRONLY | os.O_CREATE | os.O_APPEND
+	if truncate {
+		flags |= os.O_TRUNC
+	}
+
+	log, err := os.OpenFile(path, flags, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	return log, nil
+}
+
+type BatchError struct {
+	Index int
+	Err   error
+}
+
+func (be BatchError) Error() string {
+	return strconv.Itoa(be.Index) + ": " + be.Err.Error()
+}
+
+type BatchErrors []BatchError
+
+func (be BatchErrors) Error() string {
+	var builder strings.Builder
+	for i, e := range be {
+		if i > 0 {
+			builder.WriteString("; ")
+		}
+		builder.WriteString(e.Error())
+	}
+	return builder.String()
+}
+
+// Write appends an event to the WAL. Data is flushed to disk before returning.
+func (w *Writer[T]) Write(e ...T) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.log == nil {
+		return fmt.Errorf("wal closed")
+	}
+
+	var ba BatchErrors
+	for i, e := range e {
+		data, err := e.MarshalBinary()
+		if err != nil {
+			ba = append(ba, BatchError{Index: i, Err: err})
+			continue
+		}
+
+		lv := &lvWriter{w: w.log}
+		if err := lv.Write(data); err != nil {
+			ba = append(ba, BatchError{Index: i, Err: err})
+			continue
+		}
+	}
+
+	// Ensure the data is flushed to disk.
+	if err := w.log.Sync(); err != nil {
+		return err
+	}
+
+	if len(ba) > 0 {
+		return ba
+	}
+	return nil
+}
+
+// Compact rewrites the WAL to contain only the provided events, removing any redundant or obsolete entries.
+func (w *Writer[T]) Compact(all iter.Seq[T]) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Create a new temporary log file.
+	tmpPath := w.logPath + ".tmp"
+	tmpLog, err := w.open(tmpPath, true)
+	if err != nil {
+		return err
+	}
+
+	// Write all events to the temporary log file.
+	lv := &lvWriter{w: tmpLog}
+	for e := range all {
+		data, err := e.MarshalBinary()
+		if err != nil {
+			tmpLog.Close()
+			os.Remove(tmpLog.Name())
+			return err
+		}
+
+		if err := lv.Write(data); err != nil {
+			tmpLog.Close()
+			os.Remove(tmpLog.Name())
+			return err
+		}
+	}
+
+	// Ensure the temporary log file is flushed to disk.
+	if err := tmpLog.Sync(); err != nil {
+		tmpLog.Close()
+		os.Remove(tmpLog.Name())
+		return err
+	}
+
+	// Close the temporary log file.
+	if err := tmpLog.Close(); err != nil {
+		os.Remove(tmpLog.Name())
+		return err
+	}
+
+	// Close the current log file.
+	if err := w.close(); err != nil {
+		return err
+	}
+
+	// Replace the current log file with the temporary log file.
+	if err := os.Rename(tmpPath, w.logPath); err != nil {
+		return err
+	}
+
+	// Re-open the log file for appending.
+	log, err := w.open(w.logPath, false)
+	if err != nil {
+		return err
+	}
+	w.log = log
+	return nil
+}
+
+func (w *Writer[T]) close() error {
+	var err error
+	if w.log != nil {
+		err = w.log.Close()
+		w.log = nil
+	}
+	return err
+}
+
+func (w *Writer[T]) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.close()
+}
+
+// Length-Value writer
+type lvWriter struct {
+	w io.Writer
+}
+
+func (w *lvWriter) Write(e []byte) error {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(e)))
+	n, err := w.w.Write(buf[:])
+	if err != nil {
+		return err
+	}
+	if n != len(buf) {
+		return io.ErrShortWrite
+	}
+
+	_, err = io.Copy(w.w, bytes.NewReader(e))
+	return err
+}
+
+// Length-Value reader
+type lvReader struct {
+	r io.Reader
+}
+
+func (r *lvReader) Events() iter.Seq[[]byte] {
+	return func(yield func([]byte) bool) {
+		for {
+			var buf [8]byte
+			n, err := r.r.Read(buf[:])
+			if err != nil {
+				return
+			}
+			if n != len(buf) {
+				return
+			}
+
+			dataLen := int(binary.LittleEndian.Uint64(buf[:]))
+			if dataLen == 0 {
+				if !yield([]byte{}) {
+					return
+				}
+				continue
+			}
+
+			dataBuf := make([]byte, dataLen)
+			var read int
+			for {
+				n, err = r.r.Read(dataBuf[read:])
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					return
+				}
+				if n == 0 {
+					return
+				}
+				read += n
+				if read >= dataLen {
+					break
+				}
+			}
+			if !yield(dataBuf) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/wal/wal_test.go
+++ b/pkg/wal/wal_test.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package wal
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestEvent struct {
+	ID   byte
+	Data []byte
+}
+
+func (e *TestEvent) MarshalBinary() ([]byte, error) {
+	var buf []byte
+	buf = append(buf, e.ID)
+	buf = append(buf, []byte(e.Data)...)
+	return buf, nil
+}
+
+func (e *TestEvent) UnmarshalBinary(data []byte) error {
+	if len(data) < 1 {
+		return fmt.Errorf("data too short")
+	}
+	e.ID = data[0]
+	e.Data = data[1:]
+	return nil
+}
+
+func UnmarshalTestEvent(data []byte) (*TestEvent, error) {
+	var e TestEvent
+	if err := e.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+func TestHappyPath(t *testing.T) {
+	logPath := t.TempDir() + "/test.wal"
+
+	w, err := NewWriter[*TestEvent](logPath)
+	if err != nil {
+		t.Fatalf("failed to create WAL: %v", err)
+	}
+
+	events := []*TestEvent{
+		{ID: 1, Data: []byte("event1")},
+		{ID: 2, Data: []byte("event2")},
+		{ID: 3, Data: []byte("event3")},
+	}
+
+	for _, event := range events {
+		if err := w.Write(event); err != nil {
+			t.Fatalf("failed to write event: %v", err)
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close WAL: %v", err)
+	}
+
+	iter, err := Read(logPath, UnmarshalTestEvent)
+	if err != nil {
+		t.Fatalf("failed to read WAL: %v", err)
+	}
+
+	var readEvents []*TestEvent
+	for e, err := range iter {
+		if err != nil {
+			t.Fatalf("failed to read event: %v", err)
+		}
+		readEvents = append(readEvents, e)
+	}
+	assert.Equal(t, events, readEvents, "read events do not match written events")
+}
+
+type TestEventV2 struct {
+	Delete bool
+	Key    byte
+	Data   []byte
+}
+
+func (e *TestEventV2) MarshalBinary() ([]byte, error) {
+	var buf []byte
+	if e.Delete {
+		buf = append(buf, 1)
+	} else {
+		buf = append(buf, 0)
+	}
+	buf = append(buf, e.Key)
+	buf = append(buf, []byte(e.Data)...)
+	return buf, nil
+}
+
+func (e *TestEventV2) UnmarshalBinary(data []byte) error {
+	if len(data) < 2 {
+		return fmt.Errorf("data too short")
+	}
+	if data[0] == 1 {
+		e.Delete = true
+	} else {
+		e.Delete = false
+	}
+	e.Key = data[1]
+	e.Data = data[2:]
+	return nil
+}
+
+func UnmarshalTestEventV2(data []byte) (*TestEventV2, error) {
+	var e TestEventV2
+	if err := e.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+func TestCompact(t *testing.T) {
+	logPath := t.TempDir() + "/test.wal"
+
+	w, err := NewWriter[*TestEventV2](logPath)
+	if err != nil {
+		t.Fatalf("failed to create WAL: %v", err)
+	}
+
+	events := []*TestEventV2{
+		{Delete: false, Key: 1, Data: []byte("value1-abc")},
+		{Delete: false, Key: 2, Data: []byte("value2-abc")},
+		{Delete: false, Key: 1, Data: []byte("value1-def")},
+		{Delete: true, Key: 2},
+		{Delete: false, Key: 3, Data: []byte("value3-ghi")},
+	}
+
+	for _, event := range events {
+		if err := w.Write(event); err != nil {
+			t.Fatalf("failed to write event: %v", err)
+		}
+	}
+
+	postCompEvents := []*TestEventV2{
+		{Delete: false, Key: 1, Data: []byte("value1-def")},
+		{Delete: false, Key: 3, Data: []byte("value3-ghi")},
+	}
+	if err := w.Compact(func(yield func(*TestEventV2) bool) {
+		for _, e := range postCompEvents {
+			if !yield(e) {
+				break
+			}
+		}
+	}); err != nil {
+		t.Fatalf("failed to compact WAL: %v", err)
+	}
+
+	err = w.Write(&TestEventV2{Delete: false, Key: 4, Data: []byte("value4-jkl")})
+	assert.NoError(t, err, "failed to write event after compaction")
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close WAL: %v", err)
+	}
+
+	iter, err := Read(logPath, UnmarshalTestEventV2)
+	if err != nil {
+		t.Fatalf("failed to read WAL: %v", err)
+	}
+
+	var readEvents []*TestEventV2
+	for e, err := range iter {
+		if err != nil {
+			t.Fatalf("failed to read event: %v", err)
+		}
+		readEvents = append(readEvents, e)
+	}
+
+	expectedEvents := []*TestEventV2{
+		{Delete: false, Key: 1, Data: []byte("value1-def")},
+		{Delete: false, Key: 3, Data: []byte("value3-ghi")},
+		{Delete: false, Key: 4, Data: []byte("value4-jkl")},
+	}
+	assert.Equal(t, expectedEvents, readEvents, "read events do not match compacted events")
+}
+
+type SmallReadsReader struct {
+	data []byte
+}
+
+func (r *SmallReadsReader) Read(p []byte) (int, error) {
+	l := len(p)
+	if l > 8 {
+		l = 8
+	}
+	if l > len(r.data) {
+		l = len(r.data)
+	}
+
+	copy(p, r.data[:l])
+	r.data = r.data[l:]
+	if len(r.data) == 0 {
+		return l, io.EOF
+	}
+	return l, nil
+}
+
+func TestLVReaderWriter(t *testing.T) {
+	var buf bytes.Buffer
+
+	msgs := [][]byte{
+		[]byte("hello"),
+		[]byte("world"),
+		[]byte("this is a test"),
+	}
+
+	w := &lvWriter{w: &buf}
+	for _, msg := range msgs {
+		if err := w.Write(msg); err != nil {
+			t.Fatalf("failed to write data: %v", err)
+		}
+	}
+
+	reader := &SmallReadsReader{data: buf.Bytes()}
+	lvReader := &lvReader{r: reader}
+	readMsgs := slices.Collect(lvReader.Events())
+	assert.Equal(t, msgs, readMsgs, "read messages do not match written messages")
+}

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -19,6 +19,7 @@ import (
 	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/neighbor"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
@@ -83,6 +84,7 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 		kvstore.Cell(kvstore.DisabledBackendName),
 		fakeDatapath.Cell,
 		neighbor.ForwardableIPCell,
+		reconciler.TableCell,
 		cell.Provide(neighbor.NewCommonTestConfig(true, false)),
 		prefilter.Cell,
 		monitorAgent.Cell,


### PR DESCRIPTION
This PR introduces the desired route manager, table, and reconciler.

We have a number of features which create/update/delete routes. Usually
our logic creates such routes once and does not revisit them. If for
whatever reason routes are removed or modified outside of our control,
we don't recover until the agent restarts and the code paths that added
them are re-executed.

To increase the robustness of Cilium we want to actively reconcile our
desired state to the actual state of the linux routing kernel.

We achieve this by adding a table to store desired routes. Components
which wish to install routes write to this table instead of using
netlink directly. Access to the table is gated by the desired route
manager.

Every desired route has an "owner". Owners can be registered at the
manager. An owner does not represent a 1:1 mapping to a component but
rather a logical grouping of routes that share a common lifecycle such
as routes for an endpoint, node, feature.
When an owner is removed all of its routes are also removed. Each owner
has a admin-distance number, if two owners ever add routes with the same
table, prefix, and priority then the admin-distance of the owner will
determine which of the routes is "selected" to actually be installed.

A generic reconciler is used to reconcile the desired routes into the
kernel. All routes are always inserted as proto: kernel, since SystemD's
NetworkD by default removes any route not marked as such.
This is unfortunate as it means we cannot easily track which routes
were created by us and which were not without some sort of external
tracking. While the agent is active our desired state table serves as
this tracking mechanism, but it is not persistent across restarts.
So we use a WAL (Write-Ahead-Log) to persist the keys of all routes
we have installed. On startup we replay this WAL to restore knowledge
of routes we "own", and upon the first pruning we remove any routes
from the routing table we no longer desire to be there and did install
in a previous run.

While the generic reconcile periodically refreshes all routes, however
this is just time based. Since missing critical routes could cause
connectivity issues we want to restore any missing or modified routes
as soon as we can. The desire route refresher component monitors the
kernel routing table (via the stateDB table) for modifications or
deletions of routes owned by the reconciler, and trigger the reconciler
to fix/reinstall any missing or modified routes. This created a sort
of control loop.

Fixes: #38285

```release-note
Add reconciliation of routes
```
