### PR TITLE
redirectpolicy: Fix race in marking desired-skiplbs initialized

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -169,8 +169,10 @@ func (c *lrpController) run(ctx context.Context, health cell.Health) error {
 				if chanIsClosed(fesInitWatch) {
 					// Mark desired SkipLBs as initialized to allow pruning
 					c.desiredSkipLBInit(wtxn)
+
+					// All initializers marked done, we can stop tracking these.
+					initWatches = nil
 				}
-				initWatches = nil
 			}
 		}
 


### PR DESCRIPTION
The desired-skiplbs table may not have been correctly marked initialized in cases where multiple initializers to the frontends table existed. This would've prevented the skiplbmap from being pruned by the reconciler.

Fix is easy: keep the 'initWatches' non-nil until we've marked the table initialized.

```release-note
Fix race condition preventing the skiplbmap BPF map from sometimes being pruned after restart.
```