### PR TITLE
build-images-release: specify main branch on reusable jobs

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -220,7 +220,7 @@ jobs:
 
   call-post-release:
     name: Call Post-Release Tool
-    uses: ./.github/workflows/release.yaml
+    uses: cilium/cilium/.github/workflows/release.yaml@main
     needs: image-digests
     with:
       step: "4-post-release"
@@ -228,7 +228,7 @@ jobs:
 
   call-publish-helm:
     name: Publish Helm Chart
-    uses: ./.github/workflows/release.yaml
+    uses: cilium/cilium/.github/workflows/release.yaml@main
     needs: image-digests
     with:
       step: "5-publish-helm"


### PR DESCRIPTION
If we want to re-use the workflow from the stable branches without backporting the release script to the older branches, we need to specify the repository name and the main branch as part of the path to use.

Fixes: 0cee95bf5603 (".build-images-releases: update workflow")