### PR TITLE
ipam: Register k8s sync metrics for cluster-pool

### DIFF
--- a/pkg/ipam/allocator/clusterpool/clusterpool.go
+++ b/pkg/ipam/allocator/clusterpool/clusterpool.go
@@ -66,7 +66,7 @@ func (a *AllocatorOperator) Init(ctx context.Context, logger *slog.Logger, reg *
 }
 
 // Start kicks of Operator allocation.
-func (a *AllocatorOperator) Start(ctx context.Context, updater ipam.CiliumNodeGetterUpdater, _ *metrics.Registry) (allocator.NodeEventHandler, error) {
+func (a *AllocatorOperator) Start(ctx context.Context, updater ipam.CiliumNodeGetterUpdater, reg *metrics.Registry) (allocator.NodeEventHandler, error) {
 	a.logger.Info(
 		"Starting ClusterPool IP allocator",
 		logfields.IPv4CIDRs, operatorOption.Config.ClusterPoolIPv4CIDR,
@@ -78,7 +78,9 @@ func (a *AllocatorOperator) Start(ctx context.Context, updater ipam.CiliumNodeGe
 	)
 
 	if operatorOption.Config.EnableMetrics {
-		iMetrics = ipamMetrics.NewTriggerMetrics(metrics.Namespace, "k8s_sync")
+		triggerMetrics := ipamMetrics.NewTriggerMetrics(metrics.Namespace, "k8s_sync")
+		triggerMetrics.Register(reg)
+		iMetrics = triggerMetrics
 	} else {
 		iMetrics = &ipamMetrics.NoOpMetricsObserver{}
 	}


### PR DESCRIPTION
In cluster-pool IPAM mode the allocator creates a metrics set related to the activity of the internal trigger. Specifically, the trigger is called (and the related metrics are updated) each time the internal status of the CiliumNode, including the allocated pod CIDRs, is synced to k8s.  There is however an issue, since the metrics are not correctly registered to the metrics registry, therefore they are not actually available.

This commit registers the metrics so that they can be correctly exposed and visible with the `cilium-operator-generic metrics list` command.

---

In a kind cluster, with `--enable-metrics` passed to the operator

Before:

```
$ kubectl -n kube-system exec -ti deploy/cilium-operator -- cilium-operator-generic metrics list | grep "ipam_k8s_sync"
<empty>
```

After:

```
$ kubectl -n kube-system exec -ti deploy/cilium-operator -- cilium-operator-generic metrics list | grep "ipam_k8s_sync"
cilium_operator_ipam_k8s_sync_duration_seconds                                                                                                   0.000107
cilium_operator_ipam_k8s_sync_folds                                                                                                              2.000000
cilium_operator_ipam_k8s_sync_latency_seconds                                                                                                    1.000271
cilium_operator_ipam_k8s_sync_queued_total                                                                                                       3.000000
```

```release-note
Register cluster-pool IPAM metrics related to CiliumNode synchronization with k8s
```
