### PR TITLE
pkg/loadbalancer: Fix LRP backend selection logic with named port

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -379,9 +379,14 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, ws *statedb
 				continue
 			}
 			beps = append(beps, lb.BackendParams{
-				Address:   addr.L3n4Addr,
-				State:     lb.BackendStateActive,
-				PortNames: []string{addr.portName},
+				Address: addr.L3n4Addr,
+				State:   lb.BackendStateActive,
+				PortNames: func() []string {
+					if addr.portName != "" {
+						return []string{addr.portName}
+					}
+					return []string{}
+				}(),
 			})
 		}
 	}

--- a/pkg/loadbalancer/redirectpolicy/testdata/lrp-single-multiple-ports.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/lrp-single-multiple-ports.txtar
@@ -1,0 +1,159 @@
+# Verify that local-redirect service entries are created for LRPs with single and multiple ports.
+
+hive start
+
+
+# Test case #1: LRP selected service has a single named port.
+# https://github.com/cilium/cilium/issues/41424.
+
+# Add LRP and policy selected resources
+k8s/add service.yaml lrp-backend.yaml lrp-svc.yaml
+
+# Compare statedb tables
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+# Add LRP and policy selected resources
+k8s/delete service.yaml lrp-backend.yaml lrp-svc.yaml
+
+# Compare statedb tables
+db/cmp localredirectpolicies lrp-empty.table
+db/cmp services services-empty.table
+db/cmp frontends frontends-empty.table
+
+# Test case #2: LRP selected service has a single port.
+
+# Add LRP and policy selected resources
+k8s/add service.yaml lrp-backend.yaml lrp-svc.yaml
+
+# Compare statedb tables
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+-- frontends-empty.table --
+Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
+
+-- lrp-empty.table --
+Name           Type     FrontendType                Frontends
+
+-- services-empty.table --
+Name                          Source
+
+-- frontends.table --
+Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
+192.168.10.10:8080/TCP     ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done
+
+-- lrp.table --
+Name           Type     FrontendType                Frontends
+test/lrp-svc   service  all
+
+-- services.table --
+Name                          Source
+test/echo                     k8s
+test/lrp-svc:local-redirect   k8s
+
+-- lrp-backend.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-backend
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-backend
+      image: nginx
+      ports:
+        - containerPort: 80
+          protocol: TCP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2001::1
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: 'True'
+    type: Ready
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 192.168.10.10
+  clusterIPs:
+  - 192.168.10.10
+  - 1001::1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: DualStack
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: ClusterIP
+
+-- lrp-svc.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-svc"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: echo
+      namespace: test
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        name: "tcp"
+        protocol: TCP
+
+-- service2.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 192.168.10.10
+  clusterIPs:
+  - 192.168.10.10
+  - 1001::1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: DualStack
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: ClusterIP
+

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -453,9 +453,9 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[loadba
 				continue
 			}
 			if fe != nil {
-				if fe.PortName != "" {
+				if fe.PortName != "" && len(be.PortNames) > 0 {
 					// A backend with specific port name requested. Look up what this backend
-					// is called for this service.
+					// is called for this service when the backend has multiple (named) ports.
 					if !slices.Contains(be.PortNames, string(fe.PortName)) {
 						continue
 					}


### PR DESCRIPTION
When a service frontend specifies a named port, the backend selection logic previously failed if the backend only had an unnamed port. As a result, no local-redirect service entry was created, leaving the frontend without any backends.

Before fix:

```
$ ksexec cilium-d4hwk
root@kind-worker2:/home/cilium# cilium service list
ID   Frontend               Service Type    Backend
:
10   10.96.69.44:8080/TCP   LocalRedirect ----->

kind-worker2> db/show frontends
:
Address                Type        ServiceName               PortName       Backends                                     RedirectTo                               Status   Since   Error
10.96.69.44:8080/TCP   ClusterIP   default/echo-server       http                                                        default/echo-server-lrp:local-redirect   Done     2s -------->
```

After fix:

# cilium service list
ID   Frontend               Service Type    Backend
12   10.96.23.64:8080/TCP   LocalRedirect   1 => 10.244.2.75:8080/TCP (active)

kind-worker2> db/show frontends
12   10.96.23.64:8080/TCP   LocalRedirect   1 => 10.244.2.75:8080/TCP (active)

Fixes: https://github.com/cilium/cilium/issues/41424

```release-note
Fix issue where Local Redirect Policy (LRP) services with a single named port did not create a local redirect service entry.
```
