### PR TITLE
cli: require Cilium v1.15

### DIFF
--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -327,15 +327,10 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 
 	tunnelProtocol := ""
 	if cm.Data[configNameRoutingMode] == "tunnel" {
-		// Cilium v1.14 and newer
 		tunnelProtocol = "vxlan" // default for tunnel mode
 		if proto, ok := cm.Data[configNameTunnelProtocol]; ok {
 			tunnelProtocol = proto
 		}
-	} else if proto, ok := cm.Data[configNameTunnelLegacy]; ok {
-		// Cilium v1.13 and older (some v1.14 configurations might use it too)
-		// Can be removed once we drop support for v1.14
-		tunnelProtocol = proto
 	}
 
 	ai := &accessInformation{

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -24,7 +24,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 	yamlFile := templates["clientEgressTLSSNIPolicyYAML"]
 	// Test TLS SNI enforcement using an egress policy on the clients.
 	newTest(testName, ct).
-		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithCiliumVersion("!1.15.9 !1.15.10 !1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
@@ -39,7 +39,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 
 	yamlFile = templates["clientEgressTLSSNIOtherPolicyYAML"]
 	newTest(fmt.Sprintf("%s-denied", testName), ct).
-		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithCiliumVersion("!1.15.9 !1.15.10 !1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                             // L7 allow policy TLS SNI enforcement for external target
@@ -125,7 +125,7 @@ func clientEgressL7TlsSniTest(ct *check.ConnectivityTest, templates map[string]s
 	yamlFile := templates["clientEgressL7TLSSNIPolicyYAML"]
 	// Test TLS SNI enforcement using an egress policy on the clients.
 	newTest(testName, ct).
-		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithCiliumVersion("!1.15.9 !1.15.10 !1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretsOnlyFromSecretsNamespace)).
 		WithCABundleSecret().
@@ -142,7 +142,7 @@ func clientEgressL7TlsSniTest(ct *check.ConnectivityTest, templates map[string]s
 	testName = "client-egress-l7-tls-headers-other-sni"
 	yamlFile = templates["clientEgressL7TLSOtherSNIPolicyYAML"]
 	newTest(testName, ct).
-		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithCiliumVersion("!1.15.9 !1.15.10 !1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretsOnlyFromSecretsNamespace)).
 		WithCABundleSecret().

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -138,11 +138,6 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 	mode := ""
 	if st.CniChaining != nil {
 		mode = st.CniChaining.Mode
-	} else {
-		// Cilium versions prior to v1.12 do not expose the CNI chaining mode in
-		// cilium status, it's only available in the ConfigMap, which we
-		// inherit here
-		mode = result[features.CNIChaining].Mode
 	}
 
 	result[features.CNIChaining] = features.Status{

--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	"github.com/cilium/cilium/pkg/defaults"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 type requestType int
@@ -205,20 +204,11 @@ func getFilter(ctx context.Context, t *check.Test, client, clientHost *check.Pod
 }
 
 // isWgEncap checks whether packets are encapsulated before encrypting with WG.
-//
-// In v1.14, it's an opt-in, and controlled by --wireguard-encapsulate.
-// In v1.15, it's enabled, and it's not possible to opt-out.
 func isWgEncap(t *check.Test) bool {
 	if e, ok := t.Context().Feature(features.EncryptionPod); !(ok && e.Enabled && e.Mode == "wireguard") {
 		return false
 	}
 	if t, ok := t.Context().Feature(features.Tunnel); !(ok && t.Enabled) {
-		return false
-	}
-	if versioncheck.MustCompile(">=1.15.0")(t.Context().CiliumVersion) {
-		return true
-	}
-	if encap, ok := t.Context().Feature(features.WireguardEncapsulate); !(ok && encap.Enabled) {
 		return false
 	}
 

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -54,9 +54,6 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock,
 		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision, nilDetailsForService}
-	if ciliumVersion.LT(semver.MustParse("1.14.0")) {
-		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR, klogLeaderElectionFail)
-	}
 
 	envoyExternalTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalTarget))}
 	envoyExternalOtherTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalOtherTarget))}

--- a/cilium-cli/install/helm.go
+++ b/cilium-cli/install/helm.go
@@ -17,7 +17,7 @@ func (k *K8sInstaller) getHelmValues() (map[string]any, error) {
 	helmMapOpts := map[string]string{}
 
 	switch {
-	case versioncheck.MustCompile(">=1.14.0")(k.chartVersion):
+	case versioncheck.MustCompile(">=1.15.0")(k.chartVersion):
 		// TODO(aanm) to keep the previous behavior unchanged we will set the number
 		// of the operator replicas to 1. Ideally this should be the default in the helm chart
 		helmMapOpts["operator.replicas"] = "1"

--- a/cilium-cli/install/helm_test.go
+++ b/cilium-cli/install/helm_test.go
@@ -19,7 +19,7 @@ func TestK8sInstaller_getHelmValuesKind(t *testing.T) {
 	installer := K8sInstaller{
 		params:       Parameters{},
 		flavor:       k8s.Flavor{Kind: k8s.KindKind},
-		chartVersion: semver.MustParse("1.14.0"),
+		chartVersion: semver.MustParse("1.15.0"),
 	}
 	values, err := installer.getHelmValues()
 	assert.NoError(t, err)

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -451,11 +451,6 @@ func (c *Client) KVStoreMeshStatus(ctx context.Context, namespace, pod string) (
 	stdout, stderr, err := c.ExecInPodWithStderr(ctx, namespace, pod, defaults.ClusterMeshKVStoreMeshContainerName,
 		[]string{defaults.ClusterMeshBinaryName, "kvstoremesh-dbg", "status", "-o", "json"})
 	if err != nil {
-		// Cilium v1.14 has a separate kvstoremesh container, with a separate binary
-		if strings.Contains(err.Error(), "stat /usr/bin/clustermesh-apiserver: no such file or directory") {
-			return nil, ErrKVStoreMeshStatusNotImplemented
-		}
-
 		// Try to figure out if the status command is not yet supported in this version
 		stderrStr := stderr.String()
 		if strings.Contains(stderrStr, "Usage:") || strings.Contains(stderrStr, "unknown command") {

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -102,8 +102,6 @@ const (
 
 	EnableEnvoyConfig Feature = "enable-envoy-config"
 
-	WireguardEncapsulate Feature = "wireguard-encapsulate"
-
 	CiliumIPAMMode Feature = "ipam"
 
 	IPsecEnabled                  Feature = "enable-ipsec"
@@ -358,10 +356,6 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[EnableEnvoyConfig] = Status{
 		Enabled: cm.Data[string(EnableEnvoyConfig)] == "true",
-	}
-
-	fs[WireguardEncapsulate] = Status{
-		Enabled: cm.Data[string(WireguardEncapsulate)] == "true",
 	}
 
 	fs[CiliumIPAMMode] = Status{


### PR DESCRIPTION
We currently claim compatibility for Cilium v1.16 or newer. But as the Cilium CI still downgrades into v1.15, let's keep the v1.15-specific handling around for a bit longer.