### PR TITLE
maps: clean up stale references to maps.h

### DIFF
--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -35,7 +35,7 @@ const (
 
 // Key implements the bpf.MapKey interface.
 //
-// Must be in sync with struct ipcache_key in <bpf/lib/maps.h>
+// Must be in sync with struct ipcache_key in bpf/...
 type Key struct {
 	Prefixlen uint32 `align:"lpm_key"`
 	ClusterID uint16 `align:"cluster_id"`

--- a/pkg/maps/l2respondermap/l2_responder_map4.go
+++ b/pkg/maps/l2respondermap/l2_responder_map4.go
@@ -114,7 +114,7 @@ func (m *l2ResponderMap) IterateWithCallback(cb IterateCallback) error {
 
 // L2ResponderKey implements the bpf.MapKey interface.
 //
-// Must be in sync with struct l2_responder_v4_key in <bpf/lib/maps.h>
+// Must be in sync with struct l2_responder_v4_key in bpf/...
 type L2ResponderKey struct {
 	IP      types.IPv4 `align:"ip4"`
 	IfIndex uint32     `align:"ifindex"`


### PR DESCRIPTION
The file was removed in https://github.com/cilium/cilium/pull/38974.