### PR TITLE
ci: add conformance-race

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -14,6 +14,7 @@ triggers:
     - conformance-ingress.yaml
     - conformance-kpr.yaml
     - conformance-multi-pool.yaml
+    - conformance-race.yaml
     - conformance-runtime.yaml
     - integration-test.yaml
     - tests-clustermesh-upgrade.yaml
@@ -26,6 +27,9 @@ triggers:
   /ci-awscni:
     workflows:
     - conformance-aws-cni.yaml
+  /ci-conformance-race(\s+(?:all-tests=true))?:
+    workflows:
+    - conformance-race.yaml
   /ci-clustermesh:
     workflows:
     - conformance-clustermesh.yaml
@@ -135,6 +139,8 @@ workflows:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
   conformance-multi-pool.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
+  conformance-race.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md)$)
   conformance-runtime.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md)$)
   integration-test.yaml:

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -2,6 +2,31 @@ name: Conformance Ginkgo (ci-ginkgo)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  workflow_call:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+        type: string
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+        type: string
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+        type: string
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+        type: string
+      is-workflow-call:
+        description: "Distinguish if it's a workflow_call event."
+        required: false
+        type: boolean
+        default: true
+
   workflow_dispatch:
     inputs:
       PR-number:
@@ -17,9 +42,11 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
+
+
   # Run every 8 hours
   schedule:
-    - cron:  '0 1/8 * * *'
+    - cron: '0 1/8 * * *'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -36,15 +63,21 @@ permissions:
 concurrency:
   # Structure:
   # - Workflow name
+  #   For workflow_call events, this is the name of the *parent* workflow.
   # - Event type
   # - A unique identifier depending on event type:
   #   - schedule: SHA
-  #   - workflow_dispatch: PR number
+  #   - workflow_dispatch: PR number.
+  # The 'ginkgo' string added to both schedule and workflow_dispatch ensures
+  # that for workflow_call events it doesn't conflict with other potential
+  # parallel workflow_call done to other workflows from the same parent
+  # workflow. As otherwise the group name would be identical.
   #
   # This structure ensures a unique concurrency group name is generated for each
   # type of testing, such that re-runs will cancel the previous run.
   group: |
     ${{ github.workflow }}
+    ginkgo
     ${{ github.event_name }}
     ${{
       (github.event_name == 'schedule' && github.sha) ||
@@ -69,6 +102,8 @@ jobs:
       SHA: ${{ steps.vars.outputs.SHA }}
       context-ref: ${{ steps.vars.outputs.context-ref }}
       owner: ${{ steps.vars.outputs.owner }}
+      detect-race: ${{ steps.vars.outputs.detect-race }}
+      image_tag_suffix: ${{ steps.vars.outputs.image_tag_suffix }}
     steps:
       - name: Set up job variables
         id: vars
@@ -84,9 +119,17 @@ jobs:
             OWNER="${OWNER//[.\/]/-}"
           fi
 
+          DETECT_RACE=$(echo '${{ inputs.extra-args }}' | jq -r '."detect-race" // false | tostring')
+          IMAGE_TAG_SUFFIX=""
+          if [ "${DETECT_RACE}" = "true" ]; then
+            IMAGE_TAG_SUFFIX="-race"
+          fi
+
           echo SHA=${SHA} >> $GITHUB_OUTPUT
           echo context-ref=${CONTEXT_REF} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
+          echo detect-race=${DETECT_RACE} >> $GITHUB_OUTPUT
+          echo image_tag_suffix=${IMAGE_TAG_SUFFIX} >> $GITHUB_OUTPUT
 
   commit-status-start:
     name: Commit Status Start
@@ -174,7 +217,7 @@ jobs:
       - name: Wait for images
         uses: ./.github/actions/wait-for-images
         with:
-          SHA: ${{ inputs.SHA || github.sha }}
+          SHA: ${{ inputs.SHA || github.sha }}${{ needs.setup-vars.outputs.image_tag_suffix }}
 
   generate-matrix:
     name: Generate Job Matrix from YAMLs
@@ -224,7 +267,25 @@ jobs:
             '.include |= map(select(.["k8s-version"] as $k | $prs[] | select($k == .))) + $focus[0].include |
             . + {"k8s-version": $prs} |
             .focus = $focus[0].focus | .exclude = $focus[0].exclude' \
-            main-k8s-versions.json> /tmp/merged.json
+            main-k8s-versions.json > /tmp/merged.json
+
+          # Parse flags from inputs and optionally restrict the matrix.
+          DETECT_RACE="${{ needs.setup-vars.outputs.detect-race }}"
+          ALL_TESTS=$(echo '${{ inputs.extra-args }}' | jq -r '."all-tests" // false | tostring')
+          if [ "${DETECT_RACE}" = "true" ] && [ "${ALL_TESTS}" != "true" ]; then
+            echo "::notice::Restricting matrix to focus 'f04-agent-policy-multi-node-1' (all-tests!=true) for quick data race detection on PRs."
+            jq '
+              # Keep only k8s-version entries and the single desired focus
+              .include |= map(select(has("k8s-version") or (.focus == "f04-agent-policy-multi-node-1"))) |
+              .focus = ["f04-agent-policy-multi-node-1"] |
+              # Drop the last k8s-version and remove matching include entries
+              ( .["k8s-version"] | if (type=="array" and length>0) then .[-1] else empty end ) as $last |
+              .["k8s-version"] |= (if (type=="array" and length>0) then .[0:-1] else . end) |
+              .include |= map(select((has("k8s-version") | not) or (.["k8s-version"] != $last)))
+            ' /tmp/merged.json > /tmp/merged.filtered.json
+            mv /tmp/merged.filtered.json /tmp/merged.json
+          fi
+
           echo "Generated matrix:"
           cat /tmp/merged.json
           echo "matrix=$(jq -c . < /tmp/merged.json)" >> $GITHUB_OUTPUT
@@ -409,17 +470,22 @@ jobs:
             # GitHub actions do not support IPv6 connectivity to outside
             # world.
             export CILIUM_NO_IPV6_OUTSIDE=true
+            # Race detection variables - only set when race detection is enabled
+            if [[ "${{ needs.setup-vars.outputs.detect-race }}" == "true" ]]; then
+              export RACE=1
+              export LOCKDEBUG=1
+            fi
             echo "/root/go/bin/ginkgo \
              --focus=\"${{ matrix.cliFocus }}\" \
              --skip=\"${{ matrix.cliSkip }}\" \
              --seed=1679952881 \
              -v -- \
              -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
-             -cilium.tag=${{ needs.setup-vars.outputs.SHA }}  \
+             -cilium.tag=${{ needs.setup-vars.outputs.SHA }}${{ needs.setup-vars.outputs.image_tag_suffix }}  \
              -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
-             -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }} \
+             -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }}${{ needs.setup-vars.outputs.image_tag_suffix }} \
              -cilium.hubble-relay-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-             -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }} \
+             -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }}${{ needs.setup-vars.outputs.image_tag_suffix }} \
              -cilium.kubeconfig=/root/.kube/config \
              -cilium.operator-suffix=-ci ${{ env.CILIUM_GINKGO_EXTRA_ARGS }}"
 
@@ -429,11 +495,11 @@ jobs:
                --ginkgo.seed=1679952881 \
                --ginkgo.v -- \
                -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
-               -cilium.tag=${{ needs.setup-vars.outputs.SHA }}  \
+               -cilium.tag=${{ needs.setup-vars.outputs.SHA }}${{ needs.setup-vars.outputs.image_tag_suffix }}  \
                -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
-               -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }} \
+               -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }}${{ needs.setup-vars.outputs.image_tag_suffix }} \
                -cilium.hubble-relay-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-               -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }} \
+               -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }}${{ needs.setup-vars.outputs.image_tag_suffix }} \
                -cilium.kubeconfig=/root/.kube/config \
                -cilium.operator-suffix=-ci ${{ env.CILIUM_GINKGO_EXTRA_ARGS }}
 
@@ -497,7 +563,7 @@ jobs:
 
   merge-upload-and-status:
     name: Merge Upload and Status
-    if: ${{ always() }}
+    if: ${{ always() && !inputs.is-workflow-call }}
     needs: setup-and-test
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit

--- a/.github/workflows/conformance-race.yaml
+++ b/.github/workflows/conformance-race.yaml
@@ -1,0 +1,109 @@
+name: Conformance Race Detection (ci-conformance-race)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+
+  # Run daily at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Parent concurrency group name to avoid deadlock with child workflows
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    parent
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  prepare-extra-args:
+    name: Prepare extra-args
+    runs-on: ubuntu-24.04
+    outputs:
+      extra-args: ${{ steps.merge.outputs.extra-args }}
+    steps:
+      - name: Merge extra-args with "detect-race"
+        id: merge
+        run: |
+          ARGS='${{ inputs.extra-args }}'
+          echo "extra-args=$(echo "${ARGS}" | jq -c '. + {"detect-race": true}')" >> "$GITHUB_OUTPUT"
+
+  conformance-ginkgo-race:
+    name: Conformance Ginkgo with Race Detection
+    needs: prepare-extra-args
+    uses: ./.github/workflows/conformance-ginkgo.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: ${{ needs.prepare-extra-args.outputs.extra-args }}
+
+  merge-upload-and-status:
+    name: Merge Upload and Status
+    if: ${{ always() }}
+    needs: conformance-ginkgo-race
+    uses: ./.github/workflows/common-post-jobs.yaml
+    secrets: inherit
+    with:
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      sha: ${{ inputs.SHA || github.sha }}
+      result: ${{ needs.conformance-ginkgo-race.result }}

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -261,6 +261,15 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 			flows := getFlowsFromRelay(fmt.Sprintf(
 				"--last 1 --type trace:from-endpoint --from-pod %s/%s --to-fqdn %s",
 				namespaceForTest, appPods[helpers.App2], fqdnTarget))
+			var newFlows []*observerpb.GetFlowsResponse
+			for i := range flows {
+				// Ignore lost events, as they are not relevant to this test.
+				if flows[i].GetLostEvents() != nil {
+					continue
+				}
+				newFlows = append(newFlows, flows[i])
+			}
+			flows = newFlows
 			Expect(flows).To(HaveLen(1))
 			Expect(flows[0].GetFlow().Destination.Identity).To(BeNumerically(">=", identity.MinimalNumericIdentity))
 		})


### PR DESCRIPTION
This PR introduces a new workflow for running the CI tests with race
detection enabled. The goal is to start this effort by doing having a
dedicated workflow that will perform a workflow_call on existing
workflows but with race detection enabled.

In order to have a smoke test on the race detection, we will run just
one cli focus for each PR. This will hopefully catch race condition
introduced in PRs before the changes are merged into main.

If we want to run all tests with race detection enabled, we need to
trigger them with:
`/ci-conformance-race all-tests=true`
