### PR TITLE
node/manager: Do not prune the local node on restart

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -495,8 +495,10 @@ func (m *manager) restoreNodeCheckpoint() {
 	// separate, let whatever init needs to happen occur and once we're synced
 	// to k8s, compare the restored nodes to the live ones.
 	for _, n := range nodeCheckpoint {
-		n.Source = source.Restored
-		m.restoredNodes[n.Identity()] = n
+		if !n.IsLocal() {
+			n.Source = source.Restored
+			m.restoredNodes[n.Identity()] = n
+		}
 	}
 }
 
@@ -559,7 +561,9 @@ func (m *manager) checkpoint() error {
 	w := jsoniter.ConfigFastest.NewEncoder(bw)
 	ns := make([]nodeTypes.Node, 0, len(m.nodes))
 	for _, n := range m.nodes {
-		ns = append(ns, n.node)
+		if !n.node.IsLocal() {
+			ns = append(ns, n.node)
+		}
 	}
 	if err := w.Encode(ns); err != nil {
 		return fmt.Errorf("failed to encode node checkpoint: %w", err)


### PR DESCRIPTION
Pruning the cluster nodes is racy due to the fact that the mutex is released before NodeDeleted(). If the local node is added to the node manager after pruneClusterNodes() is called but before it has had the change to call NodeDeleted() we may see NodeAdded(<local>) followed by NodeDeleted(<local>).

Since there's no need to persist and restore the local node (it can't be deleted anyway), don't persist or restore it.

This issue likely doesn't affect the remote nodes since pruneClusterNodes() is only called after the initial sync of the CiliumNodes and re-use of a node name within the timing constraints here is not likely.

Fixes: #41543

Marked this for backports even though it's unlikely v1.18 suffers from this since https://github.com/cilium/cilium/pull/40918 was not backported, but better safe than sorry.