### PR TITLE
feat(sdp): Updating the ip to endpoint table for sdp

### DIFF
--- a/api/v1/standalone-dns-proxy/README.md
+++ b/api/v1/standalone-dns-proxy/README.md
@@ -11,6 +11,7 @@
     - [EndpointInfo](#standalonednsproxy-EndpointInfo)
     - [FQDNMapping](#standalonednsproxy-FQDNMapping)
     - [IdentityToEndpointMapping](#standalonednsproxy-IdentityToEndpointMapping)
+    - [IdentityToPrefixMapping](#standalonednsproxy-IdentityToPrefixMapping)
     - [PolicyState](#standalonednsproxy-PolicyState)
     - [PolicyStateResponse](#standalonednsproxy-PolicyStateResponse)
     - [UpdateMappingResponse](#standalonednsproxy-UpdateMappingResponse)
@@ -116,6 +117,22 @@ Cilium Identity ID to IP address mapping
 
 
 
+<a name="standalonednsproxy-IdentityToPrefixMapping"></a>
+
+### IdentityToPrefixMapping
+Cilium Identity ID to IP prefix mapping
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| identity | [uint32](#uint32) |  |  |
+| prefix | [bytes](#bytes) | repeated |  |
+
+
+
+
+
+
 <a name="standalonednsproxy-PolicyState"></a>
 
 ### PolicyState
@@ -128,6 +145,7 @@ and destinatione egress endpoints enforcing fqdn rules.
 | egress_l7_dns_policy | [DNSPolicy](#standalonednsproxy-DNSPolicy) | repeated |  |
 | request_id | [string](#string) |  | Random UUID based identifier which will be referenced in ACKs |
 | identity_to_endpoint_mapping | [IdentityToEndpointMapping](#standalonednsproxy-IdentityToEndpointMapping) | repeated | Identity to Endpoint mapping for the DNS server and the source identity |
+| identity_to_prefix_mapping | [IdentityToPrefixMapping](#standalonednsproxy-IdentityToPrefixMapping) | repeated | Identity to Prefix mapping for the identity |
 
 
 

--- a/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.go
+++ b/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.go
@@ -401,6 +401,7 @@ type PolicyState struct {
 	EgressL7DnsPolicy         []*DNSPolicy                 `protobuf:"bytes,1,rep,name=egress_l7_dns_policy,json=egressL7DnsPolicy,proto3" json:"egress_l7_dns_policy,omitempty"`
 	RequestId                 string                       `protobuf:"bytes,2,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`                                                     // Random UUID based identifier which will be referenced in ACKs
 	IdentityToEndpointMapping []*IdentityToEndpointMapping `protobuf:"bytes,3,rep,name=identity_to_endpoint_mapping,json=identityToEndpointMapping,proto3" json:"identity_to_endpoint_mapping,omitempty"` // Identity to Endpoint mapping for the DNS server and the source identity
+	IdentityToPrefixMapping   []*IdentityToPrefixMapping   `protobuf:"bytes,4,rep,name=identity_to_prefix_mapping,json=identityToPrefixMapping,proto3" json:"identity_to_prefix_mapping,omitempty"`       // Identity to Prefix mapping for the identity
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -452,6 +453,13 @@ func (x *PolicyState) GetRequestId() string {
 func (x *PolicyState) GetIdentityToEndpointMapping() []*IdentityToEndpointMapping {
 	if x != nil {
 		return x.IdentityToEndpointMapping
+	}
+	return nil
+}
+
+func (x *PolicyState) GetIdentityToPrefixMapping() []*IdentityToPrefixMapping {
+	if x != nil {
+		return x.IdentityToPrefixMapping
 	}
 	return nil
 }
@@ -562,6 +570,59 @@ func (x *EndpointInfo) GetIp() [][]byte {
 	return nil
 }
 
+// Cilium Identity ID to IP prefix mapping
+type IdentityToPrefixMapping struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Identity      uint32                 `protobuf:"varint,1,opt,name=identity,proto3" json:"identity,omitempty"`
+	Prefix        [][]byte               `protobuf:"bytes,2,rep,name=prefix,proto3" json:"prefix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdentityToPrefixMapping) Reset() {
+	*x = IdentityToPrefixMapping{}
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdentityToPrefixMapping) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdentityToPrefixMapping) ProtoMessage() {}
+
+func (x *IdentityToPrefixMapping) ProtoReflect() protoreflect.Message {
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdentityToPrefixMapping.ProtoReflect.Descriptor instead.
+func (*IdentityToPrefixMapping) Descriptor() ([]byte, []int) {
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *IdentityToPrefixMapping) GetIdentity() uint32 {
+	if x != nil {
+		return x.Identity
+	}
+	return 0
+}
+
+func (x *IdentityToPrefixMapping) GetPrefix() [][]byte {
+	if x != nil {
+		return x.Prefix
+	}
+	return nil
+}
+
 var File_standalone_dns_proxy_standalone_dns_proxy_proto protoreflect.FileDescriptor
 
 const file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc = "" +
@@ -589,18 +650,22 @@ const file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc = "" +
 	"\vdns_pattern\x18\x02 \x03(\tR\n" +
 	"dnsPattern\x12>\n" +
 	"\vdns_servers\x18\x03 \x03(\v2\x1d.standalonednsproxy.DNSServerR\n" +
-	"dnsServers\"\xec\x01\n" +
+	"dnsServers\"\xd6\x02\n" +
 	"\vPolicyState\x12N\n" +
 	"\x14egress_l7_dns_policy\x18\x01 \x03(\v2\x1d.standalonednsproxy.DNSPolicyR\x11egressL7DnsPolicy\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x02 \x01(\tR\trequestId\x12n\n" +
-	"\x1cidentity_to_endpoint_mapping\x18\x03 \x03(\v2-.standalonednsproxy.IdentityToEndpointMappingR\x19identityToEndpointMapping\"~\n" +
+	"\x1cidentity_to_endpoint_mapping\x18\x03 \x03(\v2-.standalonednsproxy.IdentityToEndpointMappingR\x19identityToEndpointMapping\x12h\n" +
+	"\x1aidentity_to_prefix_mapping\x18\x04 \x03(\v2+.standalonednsproxy.IdentityToPrefixMappingR\x17identityToPrefixMapping\"~\n" +
 	"\x19IdentityToEndpointMapping\x12\x1a\n" +
 	"\bidentity\x18\x01 \x01(\rR\bidentity\x12E\n" +
 	"\rendpoint_info\x18\x02 \x03(\v2 .standalonednsproxy.EndpointInfoR\fendpointInfo\".\n" +
 	"\fEndpointInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x04R\x02id\x12\x0e\n" +
-	"\x02ip\x18\x02 \x03(\fR\x02ip*\x9f\x02\n" +
+	"\x02ip\x18\x02 \x03(\fR\x02ip\"M\n" +
+	"\x17IdentityToPrefixMapping\x12\x1a\n" +
+	"\bidentity\x18\x01 \x01(\rR\bidentity\x12\x16\n" +
+	"\x06prefix\x18\x02 \x03(\fR\x06prefix*\x9f\x02\n" +
 	"\fResponseCode\x12\x1d\n" +
 	"\x19RESPONSE_CODE_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16RESPONSE_CODE_NO_ERROR\x10\x01\x12\x1e\n" +
@@ -627,7 +692,7 @@ func file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP() []byte {
 }
 
 var file_standalone_dns_proxy_standalone_dns_proxy_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_standalone_dns_proxy_standalone_dns_proxy_proto_goTypes = []any{
 	(ResponseCode)(0),                 // 0: standalonednsproxy.ResponseCode
 	(*PolicyStateResponse)(nil),       // 1: standalonednsproxy.PolicyStateResponse
@@ -638,6 +703,7 @@ var file_standalone_dns_proxy_standalone_dns_proxy_proto_goTypes = []any{
 	(*PolicyState)(nil),               // 6: standalonednsproxy.PolicyState
 	(*IdentityToEndpointMapping)(nil), // 7: standalonednsproxy.IdentityToEndpointMapping
 	(*EndpointInfo)(nil),              // 8: standalonednsproxy.EndpointInfo
+	(*IdentityToPrefixMapping)(nil),   // 9: standalonednsproxy.IdentityToPrefixMapping
 }
 var file_standalone_dns_proxy_standalone_dns_proxy_proto_depIdxs = []int32{
 	0, // 0: standalonednsproxy.PolicyStateResponse.response:type_name -> standalonednsproxy.ResponseCode
@@ -645,16 +711,17 @@ var file_standalone_dns_proxy_standalone_dns_proxy_proto_depIdxs = []int32{
 	4, // 2: standalonednsproxy.DNSPolicy.dns_servers:type_name -> standalonednsproxy.DNSServer
 	5, // 3: standalonednsproxy.PolicyState.egress_l7_dns_policy:type_name -> standalonednsproxy.DNSPolicy
 	7, // 4: standalonednsproxy.PolicyState.identity_to_endpoint_mapping:type_name -> standalonednsproxy.IdentityToEndpointMapping
-	8, // 5: standalonednsproxy.IdentityToEndpointMapping.endpoint_info:type_name -> standalonednsproxy.EndpointInfo
-	1, // 6: standalonednsproxy.FQDNData.StreamPolicyState:input_type -> standalonednsproxy.PolicyStateResponse
-	2, // 7: standalonednsproxy.FQDNData.UpdateMappingRequest:input_type -> standalonednsproxy.FQDNMapping
-	6, // 8: standalonednsproxy.FQDNData.StreamPolicyState:output_type -> standalonednsproxy.PolicyState
-	3, // 9: standalonednsproxy.FQDNData.UpdateMappingRequest:output_type -> standalonednsproxy.UpdateMappingResponse
-	8, // [8:10] is the sub-list for method output_type
-	6, // [6:8] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	9, // 5: standalonednsproxy.PolicyState.identity_to_prefix_mapping:type_name -> standalonednsproxy.IdentityToPrefixMapping
+	8, // 6: standalonednsproxy.IdentityToEndpointMapping.endpoint_info:type_name -> standalonednsproxy.EndpointInfo
+	1, // 7: standalonednsproxy.FQDNData.StreamPolicyState:input_type -> standalonednsproxy.PolicyStateResponse
+	2, // 8: standalonednsproxy.FQDNData.UpdateMappingRequest:input_type -> standalonednsproxy.FQDNMapping
+	6, // 9: standalonednsproxy.FQDNData.StreamPolicyState:output_type -> standalonednsproxy.PolicyState
+	3, // 10: standalonednsproxy.FQDNData.UpdateMappingRequest:output_type -> standalonednsproxy.UpdateMappingResponse
+	9, // [9:11] is the sub-list for method output_type
+	7, // [7:9] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_standalone_dns_proxy_standalone_dns_proxy_proto_init() }
@@ -668,7 +735,7 @@ func file_standalone_dns_proxy_standalone_dns_proxy_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc), len(file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.json.go
+++ b/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.json.go
@@ -105,3 +105,15 @@ func (msg *EndpointInfo) MarshalJSON() ([]byte, error) {
 func (msg *EndpointInfo) UnmarshalJSON(b []byte) error {
 	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
 }
+
+// MarshalJSON implements json.Marshaler
+func (msg *IdentityToPrefixMapping) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseProtoNames: true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *IdentityToPrefixMapping) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
+}

--- a/api/v1/standalone-dns-proxy/standalone-dns-proxy.proto
+++ b/api/v1/standalone-dns-proxy/standalone-dns-proxy.proto
@@ -78,6 +78,7 @@ message PolicyState {
     repeated DNSPolicy egress_l7_dns_policy = 1;
     string request_id = 2; // Random UUID based identifier which will be referenced in ACKs
     repeated IdentityToEndpointMapping identity_to_endpoint_mapping = 3; // Identity to Endpoint mapping for the DNS server and the source identity
+    repeated IdentityToPrefixMapping identity_to_prefix_mapping = 4; // Identity to Prefix mapping for the identity
 }
 
 // Cilium Identity ID to IP address mapping
@@ -90,4 +91,10 @@ message IdentityToEndpointMapping {
 message EndpointInfo {
     uint64 id = 1;
     repeated bytes ip = 2;
+}
+
+// Cilium Identity ID to IP prefix mapping
+message IdentityToPrefixMapping {
+    uint32 identity = 1;
+    repeated bytes prefix = 2;
 }

--- a/standalone-dns-proxy/pkg/client/cell.go
+++ b/standalone-dns-proxy/pkg/client/cell.go
@@ -21,19 +21,21 @@ var Cell = cell.Module(
 
 	cell.Provide(newGRPCClient),
 	cell.Provide(newDNSRulesTable),
-	cell.Provide(newIPtoIdentityTable),
+	cell.Provide(NewIPtoEndpointTable),
 )
 
 type clientParams struct {
 	cell.In
 
-	Logger        *slog.Logger
-	DB            *statedb.DB
-	DNSRulesTable statedb.RWTable[DNSRules]
-	JobGroup      job.Group
+	Logger            *slog.Logger
+	DB                *statedb.DB
+	DNSRulesTable     statedb.RWTable[DNSRules]
+	IPtoEndpointTable statedb.RWTable[IPtoEndpointInfo]
+
+	JobGroup job.Group
 }
 
 // newGRPCClient creates a new gRPC connection handler client for standalone DNS proxy
 func newGRPCClient(params clientParams) ConnectionHandler {
-	return createGRPCClient(params.Logger, params.DB, params.DNSRulesTable)
+	return createGRPCClient(params.Logger, params.DB, params.DNSRulesTable, params.IPtoEndpointTable)
 }

--- a/standalone-dns-proxy/pkg/client/cell.go
+++ b/standalone-dns-proxy/pkg/client/cell.go
@@ -22,20 +22,21 @@ var Cell = cell.Module(
 	cell.Provide(newGRPCClient),
 	cell.Provide(newDNSRulesTable),
 	cell.Provide(NewIPtoEndpointTable),
+	cell.Provide(NewPrefixToIdentityTable),
 )
 
 type clientParams struct {
 	cell.In
 
-	Logger            *slog.Logger
-	DB                *statedb.DB
-	DNSRulesTable     statedb.RWTable[DNSRules]
-	IPtoEndpointTable statedb.RWTable[IPtoEndpointInfo]
-
-	JobGroup job.Group
+	Logger                *slog.Logger
+	DB                    *statedb.DB
+	DNSRulesTable         statedb.RWTable[DNSRules]
+	IPtoEndpointTable     statedb.RWTable[IPtoEndpointInfo]
+	PrefixToIdentityTable statedb.RWTable[PrefixToIdentity]
+	JobGroup              job.Group
 }
 
 // newGRPCClient creates a new gRPC connection handler client for standalone DNS proxy
 func newGRPCClient(params clientParams) ConnectionHandler {
-	return createGRPCClient(params.Logger, params.DB, params.DNSRulesTable, params.IPtoEndpointTable)
+	return createGRPCClient(params.Logger, params.DB, params.DNSRulesTable, params.IPtoEndpointTable, params.PrefixToIdentityTable)
 }

--- a/standalone-dns-proxy/pkg/lookup/cell.go
+++ b/standalone-dns-proxy/pkg/lookup/cell.go
@@ -30,21 +30,23 @@ var Cell = cell.Module(
 type clientParams struct {
 	cell.In
 
-	Logger       *slog.Logger
-	IPToIdentity statedb.RWTable[client.IPtoEndpointInfo]
-	DB           *statedb.DB
-	JobGroup     job.Group
+	Logger           *slog.Logger
+	IPToIdentity     statedb.RWTable[client.IPtoEndpointInfo]
+	PrefixToIdentity statedb.RWTable[client.PrefixToIdentity]
+	DB               *statedb.DB
+	JobGroup         job.Group
 }
 
 func newRulesClient(params clientParams) lookup.ProxyLookupHandler {
 	r := &rulesClient{
-		logger:            params.Logger,
-		ipToIdentityTable: params.IPToIdentity,
-		db:                params.DB,
-		prefixLengths:     counter.DefaultPrefixLengthCounter(),
+		logger:                params.Logger,
+		ipToIdentityTable:     params.IPToIdentity,
+		prefixToIdentityTable: params.PrefixToIdentity,
+		db:                    params.DB,
+		prefixLengths:         counter.DefaultPrefixLengthCounter(),
 	}
 
-	params.JobGroup.Add(job.OneShot("sdp-watch-ip-endpoint-mapping", r.watchIPToEndpointTable,
+	params.JobGroup.Add(job.OneShot("sdp-watch-prefix-to-identity-mapping", r.watchPrefixToIdentityTable,
 		job.WithRetry(3, &job.ExponentialBackoff{Min: 5 * time.Second, Max: 10 * time.Second}),
 		job.WithShutdown()))
 

--- a/standalone-dns-proxy/pkg/lookup/lookup.go
+++ b/standalone-dns-proxy/pkg/lookup/lookup.go
@@ -4,21 +4,30 @@
 package lookup
 
 import (
+	"context"
 	"log/slog"
+	"net"
 	"net/netip"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 
+	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
 )
 
 type rulesClient struct {
-	Logger            *slog.Logger
-	IPtoIdentityTable statedb.RWTable[client.IPtoIdentity]
-	DB                *statedb.DB
+	logger            *slog.Logger
+	ipToIdentityTable statedb.RWTable[client.IPtoEndpointInfo]
+	db                *statedb.DB
+	// prefixLengths tracks the unique set of prefix lengths for IPv4 and
+	// IPv6 addresses in order to optimize longest prefix match lookups.
+	prefixLengths *counter.PrefixLengthCounter
 }
 
 // This is not used by the standalone DNS proxy because it is used by cilium agent to look up DNS rules
@@ -27,12 +36,98 @@ func (r *rulesClient) LookupByIdentity(nid identity.NumericIdentity) []string {
 	return []string{}
 }
 
-// Note: This is a placeholder for the actual implementation of the ProxyLookupHandler interface.
-func (r *rulesClient) LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error) {
-	return nil, false, nil
+// Note: isHost is always false because the standalone DNS proxy does not handle host endpoints yet.
+func (r *rulesClient) LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpt *endpoint.Endpoint, isHost bool, err error) {
+	prefix := netip.PrefixFrom(endpointAddr, endpointAddr.BitLen())
+	info, _, found := r.ipToIdentityTable.Get(r.db.ReadTxn(), client.IdIPToEndpointIndex.Query(prefix))
+	if !found {
+		return nil, false, nil
+	}
+	return &endpoint.Endpoint{
+		ID: uint16(info.Endpoint.ID),
+		SecurityIdentity: &identity.Identity{
+			ID: info.Endpoint.Identity,
+		},
+	}, false, nil
 }
 
-// Note: This is a placeholder for the actual implementation of the ProxyLookupHandler interface.
+// LookupSecIDByIP looks up the security ID for a given IP address
+// It is similar to ipcache.LookupSecIDByIP
 func (r *rulesClient) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {
+	if !ip.IsValid() {
+		return ipcache.Identity{}, false
+	}
+	prefix := netip.PrefixFrom(ip, ip.BitLen())
+	info, _, found := r.ipToIdentityTable.Get(r.db.ReadTxn(), client.IdIPToEndpointIndex.Query(prefix))
+	if found {
+		return ipcache.Identity{
+			ID:     info.Endpoint.Identity,
+			Source: source.Local,
+		}, true
+	}
+
+	ipv6Prefixes, ipv4Prefixes := r.prefixLengths.ToBPFData()
+	prefixes := ipv4Prefixes
+	if ip.Is6() {
+		prefixes = ipv6Prefixes
+	}
+	for _, prefixLen := range prefixes {
+		cidr, _ := ip.Prefix(prefixLen)
+		if id, ok := r.lookupPrefix(cidr); ok {
+			return id, ok
+		}
+	}
+
 	return ipcache.Identity{}, false
+}
+
+func (r *rulesClient) lookupPrefix(prefix netip.Prefix) (identity ipcache.Identity, exists bool) {
+	if _, cidr, err := net.ParseCIDR(prefix.String()); err == nil {
+		ones, bits := cidr.Mask.Size()
+		if ones == bits {
+			info, _, exists := r.ipToIdentityTable.Get(r.db.ReadTxn(), client.IdIPToEndpointIndex.Query(prefix))
+			if exists {
+				return ipcache.Identity{
+					ID:     info.Endpoint.Identity,
+					Source: source.Local,
+				}, exists
+			}
+		}
+	}
+	info, _, exists := r.ipToIdentityTable.Get(r.db.ReadTxn(), client.IdIPToEndpointIndex.Query(prefix))
+	return ipcache.Identity{
+		ID:     info.Endpoint.Identity,
+		Source: source.Local,
+	}, exists
+}
+
+func (r *rulesClient) watchIPToEndpointTable(ctx context.Context, _ cell.Health) error {
+	// listen for changes in the ipToEndpointTable
+	wtxn := r.db.WriteTxn(r.ipToIdentityTable)
+	defer wtxn.Abort()
+	changeIterator, err := r.ipToIdentityTable.Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		return err
+	}
+
+	for {
+		// Iterate over the changed objects.
+		changes, watch := changeIterator.Next(r.db.ReadTxn())
+		for change := range changes {
+			r.logger.Debug("Detected change in IP to Endpoint mapping", logfields.Object, change)
+			prefix, _ := netip.ParsePrefix(change.Object.IP.String())
+			if change.Deleted {
+				r.prefixLengths.Delete([]netip.Prefix{prefix})
+			} else {
+				r.prefixLengths.Add([]netip.Prefix{prefix})
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		}
+	}
 }

--- a/standalone-dns-proxy/pkg/lookup/lookup_test.go
+++ b/standalone-dns-proxy/pkg/lookup/lookup_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lookup
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/fqdn/lookup"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
+)
+
+func newIPTable(db *statedb.DB) statedb.RWTable[client.IPtoEndpointInfo] {
+	table, err := statedb.NewTable[client.IPtoEndpointInfo](
+		db,
+		client.IPtoEndpointTableName,
+		client.IdIPToEndpointIndex,
+	)
+	if err != nil {
+		return nil
+	}
+
+	// Pre-insert an entry for testing
+	insertIP(db, table, netip.MustParsePrefix("10.0.0.1/32"), 123, identity.NumericIdentity(5))
+	insertIP(db, table, netip.MustParsePrefix("10.0.0.0/24"), 42, identity.NumericIdentity(5))
+	return table
+}
+
+func insertIP(db *statedb.DB, table statedb.RWTable[client.IPtoEndpointInfo], ip netip.Prefix, id uint64, ident identity.NumericIdentity) {
+	w := db.WriteTxn(table)
+	table.Insert(w, client.IPtoEndpointInfo{
+		IP: ip,
+		Endpoint: client.EndpointInfo{
+			ID:       id,
+			Identity: ident,
+		},
+	})
+	w.Commit()
+}
+
+func TestLookupRegisteredEndpoint(t *testing.T) {
+	var rc lookup.ProxyLookupHandler
+	h := hive.New(
+		cell.Provide(newIPTable),
+		cell.Provide(newRulesClient),
+		cell.Invoke(func(_lh lookup.ProxyLookupHandler) {
+			rc = _lh
+		}),
+	)
+	if err := h.Start(hivetest.Logger(t), t.Context()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	ep, isHost, err := rc.LookupRegisteredEndpoint(netip.MustParseAddr("10.0.0.1"))
+	require.NoError(t, err)
+	require.NotNil(t, ep)
+	require.Equal(t, uint16(123), ep.ID)
+	require.Equal(t, identity.NumericIdentity(5), ep.SecurityIdentity.ID)
+	require.False(t, isHost)
+
+	ep, isHost, err = rc.LookupRegisteredEndpoint(netip.MustParseAddr("10.0.0.2"))
+	require.NoError(t, err)
+	require.Nil(t, ep)
+	require.False(t, isHost)
+
+	h.Stop(hivetest.Logger(t), context.TODO())
+}
+
+func TestLookupSecIDByIP(t *testing.T) {
+	var rc lookup.ProxyLookupHandler
+	h := hive.New(
+		cell.Provide(newIPTable),
+		cell.Provide(newRulesClient),
+		cell.Invoke(func(_lh lookup.ProxyLookupHandler) {
+			rc = _lh
+		}),
+	)
+	if err := h.Start(hivetest.Logger(t), t.Context()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	err := testutils.WaitUntilWithSleep(func() bool {
+		ipv6, ipv4 := rc.(*rulesClient).prefixLengths.ToBPFData()
+		return len(ipv4) == 3 && len(ipv6) == 2
+	}, 5*time.Second, 1*time.Second)
+	require.NoError(t, err)
+
+	ipv6, ipv4 := rc.(*rulesClient).prefixLengths.ToBPFData()
+	require.Equal(t, []int{32, 24, 0}, ipv4)
+	require.Equal(t, []int{128, 0}, ipv6)
+	ident_, exists := rc.LookupSecIDByIP(netip.MustParseAddr("10.0.0.1"))
+	require.True(t, exists)
+	require.Equal(t, identity.NumericIdentity(5), ident_.ID)
+
+	ident_, exists = rc.LookupSecIDByIP(netip.MustParseAddr("10.0.0.2"))
+	require.True(t, exists)
+	require.Equal(t, identity.NumericIdentity(5), ident_.ID)
+
+	ident_, exists = rc.LookupSecIDByIP(netip.MustParseAddr("10.3.0.0"))
+	require.False(t, exists)
+	require.Equal(t, identity.NumericIdentity(0), ident_.ID)
+
+	h.Stop(hivetest.Logger(t), context.TODO())
+}


### PR DESCRIPTION
- Adds the ip to endpoint info i.e identity and endpoint id in the table.
- Adds a watcher that listens for changes in the table and updates the prefixs for faster lookup.
- Lookup handlers for DNS proxy for serving the DNS req.
- Send the identity<>cidr map from the cilium agent. These cidr are not associated with
an endpoint.

Fixes: https://github.com/cilium/cilium/issues/30984
CFP: https://github.com/cilium/design-cfps/pull/54
Relevant PRs: #40982, #41507 
```release-note
feat(sdp): Updating the ip to endpoint table for sdp
```