### PR TITLE
envoy: Start serving listeners only after clusters have been ACKed

### DIFF
--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -102,7 +102,8 @@ func (s *xdsGRPCServer) DeltaListeners(stream envoy_service_listener.ListenerDis
 }
 
 func (s *xdsGRPCServer) StreamListeners(stream envoy_service_listener.ListenerDiscoveryService_StreamListenersServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, ListenerTypeURL)
+	// Listeners should start serving only after Clusters have been ACKed.
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, ListenerTypeURL, ClusterTypeURL)
 }
 
 func (s *xdsGRPCServer) FetchListeners(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -116,7 +117,7 @@ func (s *xdsGRPCServer) DeltaRoutes(stream envoy_service_route.RouteDiscoverySer
 }
 
 func (s *xdsGRPCServer) StreamRoutes(stream envoy_service_route.RouteDiscoveryService_StreamRoutesServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, RouteTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, RouteTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchRoutes(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -130,7 +131,7 @@ func (s *xdsGRPCServer) DeltaClusters(stream envoy_service_cluster.ClusterDiscov
 }
 
 func (s *xdsGRPCServer) StreamClusters(stream envoy_service_cluster.ClusterDiscoveryService_StreamClustersServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, ClusterTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, ClusterTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchClusters(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -144,7 +145,7 @@ func (s *xdsGRPCServer) DeltaEndpoints(stream envoy_service_endpoint.EndpointDis
 }
 
 func (s *xdsGRPCServer) StreamEndpoints(stream envoy_service_endpoint.EndpointDiscoveryService_StreamEndpointsServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, EndpointTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, EndpointTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchEndpoints(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -158,7 +159,7 @@ func (s *xdsGRPCServer) DeltaSecrets(stream envoy_service_secret.SecretDiscovery
 }
 
 func (s *xdsGRPCServer) StreamSecrets(stream envoy_service_secret.SecretDiscoveryService_StreamSecretsServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, SecretTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, SecretTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchSecrets(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -168,7 +169,7 @@ func (s *xdsGRPCServer) FetchSecrets(ctx context.Context, req *envoy_service_dis
 }
 
 func (s *xdsGRPCServer) StreamNetworkPolicies(stream cilium.NetworkPolicyDiscoveryService_StreamNetworkPoliciesServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchNetworkPolicies(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -178,7 +179,7 @@ func (s *xdsGRPCServer) FetchNetworkPolicies(ctx context.Context, req *envoy_ser
 }
 
 func (s *xdsGRPCServer) StreamNetworkPolicyHosts(stream cilium.NetworkPolicyHostsDiscoveryService_StreamNetworkPolicyHostsServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyHostsTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyHostsTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchNetworkPolicyHosts(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -4,6 +4,7 @@
 package envoy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -81,6 +82,10 @@ var observerOnce = sync.Once{}
 func (cache *NPHDSCache) MarkRestorePending() {}
 
 func (cache *NPHDSCache) MarkRestoreCompleted() {}
+
+func (cache *NPHDSCache) WaitForFirstAck(ctx context.Context, node string, typeURL string) {
+	// not implemented
+}
 
 // HandleResourceVersionAck is required to implement ResourceVersionAckObserver.
 // We use this to start the IP Cache listener on the first ACK so that we only

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -4,6 +4,7 @@
 package xds
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -43,6 +44,9 @@ type ResourceVersionAckObserver interface {
 
 	// MarkRestoreCompleted clears the 'restore' state so that updates are acked normally.
 	MarkRestoreCompleted()
+
+	// WaitForFirstAck() blocks until the given node has acked the first ACK.
+	WaitForFirstAck(ctx context.Context, node string, typeURL string)
 }
 
 // AckingResourceMutatorRevertFunc is a function which reverts the effects of
@@ -113,6 +117,11 @@ type AckingResourceMutatorWrapper struct {
 	// e.g. "127.0.0.1" for the host proxy.
 	ackedVersions map[string]uint64
 
+	// ackedNodes has a channel for each node for which someone is waiting for the first ACK to
+	// be received. The channel is closed after the first ACK has been received, and set to
+	// 'nil' to avoid closing the channel more than once.
+	ackedNodes map[string]chan struct{}
+
 	// pendingCompletions is the list of updates that are pending completion.
 	pendingCompletions map[*completion.Completion]*pendingCompletion
 
@@ -143,6 +152,7 @@ func NewAckingResourceMutatorWrapper(logger *slog.Logger, mutator ResourceMutato
 		logger:             logger,
 		mutator:            mutator,
 		ackedVersions:      make(map[string]uint64),
+		ackedNodes:         make(map[string]chan struct{}),
 		pendingCompletions: make(map[*completion.Completion]*pendingCompletion),
 		metrics:            metrics,
 	}
@@ -161,6 +171,45 @@ func (m *AckingResourceMutatorWrapper) MarkRestoreCompleted() {
 	defer m.locker.Unlock()
 
 	m.restoring = false
+}
+
+func (m *AckingResourceMutatorWrapper) WaitForFirstAck(ctx context.Context, node string, typeURL string) {
+	// No wait if there are no resources of the given type
+	if !m.mutator.HasAny(typeURL) {
+		return
+	}
+
+	m.locker.Lock()
+	ch, exists := m.ackedNodes[node]
+	// This can happen before the first request from the node is received, so we must initialize
+	// a channel here if one does not exist for the node.
+	if !exists {
+		ch = make(chan struct{})
+		m.ackedNodes[node] = ch
+	}
+	m.locker.Unlock()
+
+	logger := m.logger.With(
+		logfields.XDSClientNode, node,
+		logfields.XDSTypeURL, typeURL,
+	)
+
+	// ch can be 'nil' to avoid closing the channel more than once. If so, the first ACK has
+	// already been received.
+	if ch == nil {
+		logger.Info("WaitForFirstAck: first ACK has already been received, no need to wait")
+		return
+	}
+
+	logger.Info("WaitForFirstAck: Waiting until first ACK has been received")
+	// wait after m.locker has been released!
+	select {
+	case <-ctx.Done():
+		logger.Info("WaitForFirstAck: canceling wait for the first ACK due to expired context")
+	case <-ch:
+		// ACK was received
+		logger.Info("WaitForFirstAck: resuming after receiving the first ACK")
+	}
 }
 
 // AddVersionCompletion adds a completion to wait for any ACK for the
@@ -206,6 +255,10 @@ func (m *AckingResourceMutatorWrapper) DeleteNode(nodeID string) {
 	defer m.locker.Unlock()
 
 	delete(m.ackedVersions, nodeID)
+	if ch, exists := m.ackedNodes[nodeID]; exists && ch != nil {
+		close(ch)
+	}
+	delete(m.ackedNodes, nodeID)
 }
 
 func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName string, resource proto.Message, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc {
@@ -388,6 +441,24 @@ func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint6
 	// node at all.
 	if previouslyAckedVersion, exists := m.ackedVersions[nodeIP]; !exists || previouslyAckedVersion < ackVersion {
 		m.ackedVersions[nodeIP] = ackVersion
+
+		// Signal reception of an ACK (exluding the version 0, or any NACKs).
+		if previouslyAckedVersion < ackVersion {
+			ch, exists := m.ackedNodes[nodeIP]
+			if !exists || ch != nil {
+				m.logger.Info("HandleResourceVersionAck: first ACK received",
+					logfields.XDSClientNode, nodeIP,
+					logfields.XDSTypeURL, typeURL,
+					logfields.XDSAckedVersion, ackVersion,
+				)
+			}
+			// nil the channel (if any) to mark the reception of the ACK
+			m.ackedNodes[nodeIP] = nil
+			if exists && ch != nil {
+				// Wake up any waiters
+				close(ch)
+			}
+		}
 	}
 
 	remainingCompletions := make(map[*completion.Completion]*pendingCompletion, len(m.pendingCompletions))

--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -212,6 +212,18 @@ func (c *Cache) Clear(typeURL string) (version uint64, updated bool) {
 	return c.version, cacheIsUpdated
 }
 
+func (c *Cache) HasAny(typeURL string) bool {
+	c.locker.Lock()
+	defer c.locker.Unlock()
+
+	for k := range c.resources {
+		if typeURL == AnyTypeURL || k.typeURL == typeURL {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Cache) GetResources(typeURL string, lastVersion uint64, nodeIP string, resourceNames []string) (*VersionedResources, error) {
 	c.locker.RLock()
 	defer c.locker.RUnlock()

--- a/pkg/envoy/xds/set.go
+++ b/pkg/envoy/xds/set.go
@@ -86,6 +86,9 @@ type ResourceMutator interface {
 	// The returned version value is the set's version after update.
 	// This method call cannot be reverted.
 	Clear(typeURL string) (version uint64, updated bool)
+
+	// Empty returns 'true' if there are any resources of the given type
+	HasAny(typeURL string) bool
 }
 
 // ResourceSet provides read-write access to a versioned set of resources.


### PR DESCRIPTION
Typically Envoy requests Clusters before Listeners, but when Cilium agent (re)starts the order in which the the requests are received and responses provided can be random. This can lead to invalid Listener configuration, as seen by Envoy, where a non-existing cluster is referenced from the listener.

To avoid this error mode, make the Listener xDS stream start responding only after the cluster xDS stream has received the first ACK, so that all current clusters have been successfully initialized by Envoy and it is safe to refer to them from Listener configurations. The first CDS ACK is only waited for if there are clusters in the xDS cache.

```release-note
The first Envoy listener xDS (LDS) response is sent only after the first ACK on Clusters has been received if there are any dynamically configured clusters.
```
