### PR TITLE
cli: Add CILIUM_NAMESPACE environment variable support

### DIFF
--- a/Documentation/cmdref/cilium.md
+++ b/Documentation/cmdref/cilium.md
@@ -42,7 +42,7 @@ cilium [flags]
       --helm-release-name string   Helm release name (default "cilium")
   -h, --help                       help for cilium
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_bgp.md
+++ b/Documentation/cmdref/cilium_bgp.md
@@ -18,7 +18,7 @@ Access to BGP control plane
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_bgp_peers.md
+++ b/Documentation/cmdref/cilium_bgp_peers.md
@@ -31,7 +31,7 @@ cilium bgp peers [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_bgp_routes.md
+++ b/Documentation/cmdref/cilium_bgp_routes.md
@@ -43,7 +43,7 @@ cilium bgp routes <available | advertised> <afi> <safi> [vrouter <asn>] [peer|ne
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_clustermesh.md
+++ b/Documentation/cmdref/cilium_clustermesh.md
@@ -18,7 +18,7 @@ Multi Cluster Management
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_clustermesh_connect.md
+++ b/Documentation/cmdref/cilium_clustermesh_connect.md
@@ -27,7 +27,7 @@ cilium clustermesh connect [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_clustermesh_disable.md
+++ b/Documentation/cmdref/cilium_clustermesh_disable.md
@@ -22,7 +22,7 @@ cilium clustermesh disable [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_clustermesh_disconnect.md
+++ b/Documentation/cmdref/cilium_clustermesh_disconnect.md
@@ -24,7 +24,7 @@ cilium clustermesh disconnect [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_clustermesh_enable.md
+++ b/Documentation/cmdref/cilium_clustermesh_enable.md
@@ -24,7 +24,7 @@ cilium clustermesh enable [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_clustermesh_status.md
+++ b/Documentation/cmdref/cilium_clustermesh_status.md
@@ -25,7 +25,7 @@ cilium clustermesh status [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_completion.md
+++ b/Documentation/cmdref/cilium_completion.md
@@ -24,7 +24,7 @@ See each sub-command's help for details on how to use the generated script.
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_completion_bash.md
+++ b/Documentation/cmdref/cilium_completion_bash.md
@@ -47,7 +47,7 @@ cilium completion bash
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_completion_fish.md
+++ b/Documentation/cmdref/cilium_completion_fish.md
@@ -38,7 +38,7 @@ cilium completion fish [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_completion_powershell.md
+++ b/Documentation/cmdref/cilium_completion_powershell.md
@@ -35,7 +35,7 @@ cilium completion powershell [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_completion_zsh.md
+++ b/Documentation/cmdref/cilium_completion_zsh.md
@@ -49,7 +49,7 @@ cilium completion zsh [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_config.md
+++ b/Documentation/cmdref/cilium_config.md
@@ -18,7 +18,7 @@ Manage Configuration
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_config_delete.md
+++ b/Documentation/cmdref/cilium_config_delete.md
@@ -23,7 +23,7 @@ cilium config delete [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_config_set.md
+++ b/Documentation/cmdref/cilium_config_set.md
@@ -23,7 +23,7 @@ cilium config set [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_config_view.md
+++ b/Documentation/cmdref/cilium_config_view.md
@@ -22,7 +22,7 @@ cilium config view [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_connectivity.md
+++ b/Documentation/cmdref/cilium_connectivity.md
@@ -18,7 +18,7 @@ Connectivity troubleshooting
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_connectivity_perf.md
+++ b/Documentation/cmdref/cilium_connectivity_perf.md
@@ -50,7 +50,7 @@ cilium connectivity perf [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -128,7 +128,7 @@ cilium connectivity test [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_context.md
+++ b/Documentation/cmdref/cilium_context.md
@@ -22,7 +22,7 @@ cilium context [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_encryption.md
+++ b/Documentation/cmdref/cilium_encryption.md
@@ -18,7 +18,7 @@ Cilium encryption
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_encryption_create-key.md
+++ b/Documentation/cmdref/cilium_encryption_create-key.md
@@ -28,7 +28,7 @@ cilium encryption create-key [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_encryption_key-status.md
+++ b/Documentation/cmdref/cilium_encryption_key-status.md
@@ -28,7 +28,7 @@ cilium encryption key-status [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_encryption_rotate-key.md
+++ b/Documentation/cmdref/cilium_encryption_rotate-key.md
@@ -28,7 +28,7 @@ cilium encryption rotate-key [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_encryption_status.md
+++ b/Documentation/cmdref/cilium_encryption_status.md
@@ -31,7 +31,7 @@ cilium encryption status [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_features.md
+++ b/Documentation/cmdref/cilium_features.md
@@ -18,7 +18,7 @@ Report which features are enabled in Cilium agents
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_features_status.md
+++ b/Documentation/cmdref/cilium_features_status.md
@@ -34,7 +34,7 @@ cilium features status [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_features_summary.md
+++ b/Documentation/cmdref/cilium_features_summary.md
@@ -35,7 +35,7 @@ cilium features summary [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_hubble.md
+++ b/Documentation/cmdref/cilium_hubble.md
@@ -18,7 +18,7 @@ Hubble observability
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_hubble_disable.md
+++ b/Documentation/cmdref/cilium_hubble_disable.md
@@ -22,7 +22,7 @@ cilium hubble disable [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_hubble_enable.md
+++ b/Documentation/cmdref/cilium_hubble_enable.md
@@ -24,7 +24,7 @@ cilium hubble enable [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_hubble_port-forward.md
+++ b/Documentation/cmdref/cilium_hubble_port-forward.md
@@ -23,7 +23,7 @@ cilium hubble port-forward [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_hubble_ui.md
+++ b/Documentation/cmdref/cilium_hubble_ui.md
@@ -24,7 +24,7 @@ cilium hubble ui [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_install.md
+++ b/Documentation/cmdref/cilium_install.md
@@ -53,7 +53,7 @@ cilium install [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_multicast.md
+++ b/Documentation/cmdref/cilium_multicast.md
@@ -18,7 +18,7 @@ Manage multicast groups
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_multicast_add.md
+++ b/Documentation/cmdref/cilium_multicast_add.md
@@ -24,7 +24,7 @@ cilium multicast add [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_multicast_delete.md
+++ b/Documentation/cmdref/cilium_multicast_delete.md
@@ -24,7 +24,7 @@ cilium multicast delete [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_multicast_list.md
+++ b/Documentation/cmdref/cilium_multicast_list.md
@@ -18,7 +18,7 @@ Show the information about multicast groups
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_multicast_list_group.md
+++ b/Documentation/cmdref/cilium_multicast_list_group.md
@@ -24,7 +24,7 @@ cilium multicast list group [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_multicast_list_subscriber.md
+++ b/Documentation/cmdref/cilium_multicast_list_subscriber.md
@@ -26,7 +26,7 @@ cilium multicast list subscriber [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_status.md
+++ b/Documentation/cmdref/cilium_status.md
@@ -29,7 +29,7 @@ cilium status [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_sysdump.md
+++ b/Documentation/cmdref/cilium_sysdump.md
@@ -62,7 +62,7 @@ cilium sysdump [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_uninstall.md
+++ b/Documentation/cmdref/cilium_uninstall.md
@@ -25,7 +25,7 @@ cilium uninstall [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_upgrade.md
+++ b/Documentation/cmdref/cilium_upgrade.md
@@ -56,7 +56,7 @@ cilium upgrade [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium_version.md
+++ b/Documentation/cmdref/cilium_version.md
@@ -27,7 +27,7 @@ cilium version [flags]
       --context string             Kubernetes configuration context
       --helm-release-name string   Helm release name (default "cilium")
       --kubeconfig string          Path to the kubeconfig file
-  -n, --namespace string           Namespace Cilium is running in (default "kube-system")
+  -n, --namespace string           Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var (default "kube-system")
 ```
 
 ### SEE ALSO

--- a/cilium-cli/cli/cmd.go
+++ b/cilium-cli/cli/cmd.go
@@ -15,6 +15,8 @@ import (
 	"github.com/cilium/cilium/pkg/cmdref"
 )
 
+const ciliumNamespaceEnvVar = "CILIUM_NAMESPACE"
+
 var (
 	contextName       string
 	namespace         string
@@ -91,7 +93,12 @@ Perform a connectivity test
 	}
 
 	cmd.PersistentFlags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
-	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
+
+	defaultNamespace := "kube-system"
+	if envNamespace := os.Getenv(ciliumNamespaceEnvVar); envNamespace != "" {
+		defaultNamespace = envNamespace
+	}
+	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", defaultNamespace, "Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var")
 	cmd.PersistentFlags().StringVar(&impersonateAs, "as", "", "Username to impersonate for the operation. User could be a regular user or a service account in a namespace.")
 	cmd.PersistentFlags().StringArrayVar(&impersonateGroups, "as-group", []string{}, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups.")
 	cmd.PersistentFlags().StringVar(&helmReleaseName, "helm-release-name", "cilium", "Helm release name")


### PR DESCRIPTION
Allow users to set the default Cilium namespace via the CILIUM_NAMESPACE environment variable.

Fixes: cilium/cilium-cli#2926

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.

```release-note
CLI: Allow users to set the default Cilium namespace via the CILIUM_NAMESPACE environment variable
```