### PR TITLE
ipsec: don't reduce post-encrypt MTU for tunnel overhead

### DIFF
--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -106,23 +106,8 @@ func (c Configuration) Calculate(baseMTU int) RouteMTU {
 	return RouteMTU{
 		DeviceMTU:           c.getDeviceMTU(baseMTU),
 		RouteMTU:            c.getRouteMTU(baseMTU),
-		RoutePostEncryptMTU: c.getRoutePostEncryptMTU(baseMTU),
+		RoutePostEncryptMTU: c.getDeviceMTU(baseMTU),
 	}
-}
-
-// GetRoutePostEncryptMTU return the MTU to be used on the encryption routing
-// table. This is the MTU without encryption overhead and in the tunnel
-// case accounts for the tunnel overhead.
-func (c *Configuration) getRoutePostEncryptMTU(baseMTU int) int {
-	if c.encapEnabled {
-		postEncryptMTU := baseMTU - c.tunnelOverhead
-		if postEncryptMTU == 0 {
-			return EthernetMTU - c.tunnelOverhead
-		}
-		return postEncryptMTU
-
-	}
-	return c.getDeviceMTU(baseMTU)
 }
 
 // GetRouteMTU returns the MTU to be used on the network. When running in


### PR DESCRIPTION
With the switch to encrypted overlay for IPsec (in v1.18) the overlay encapsulation happens *prior* to encryption. Thus there is no more need to reduce the post-encrypt MTU to allow for subsequent overlay encapsulation.