### PR TITLE
bpf: fix ICMPv6 NS (no llopt) csum and move IPv6 NDP unit tests to scapy

### DIFF
--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -13,6 +13,8 @@
 #include "lib/ipcache.h"
 #include "lib/endpoint.h"
 
+#include "scapy.h"
+
 #define FROM_NETDEV 0
 
 ASSIGN_CONFIG(union macaddr, interface_mac, {.addr = mac_two_addr})
@@ -47,115 +49,6 @@ struct test_args {
 	} __packed icmp_opt;
 };
 
-/* Generics */
-static __always_inline
-int __ipv6_from_netdev_ns_pktgen(struct __ctx_buff *ctx,
-				 struct test_args *args)
-{
-	struct pktgen builder;
-	struct icmp6hdr *l4;
-	void *data;
-
-	pktgen__init(&builder, ctx);
-
-	l4 = pktgen__push_ipv6_icmp6_packet(&builder, args->mac_src,
-					    args->mac_dst,
-					    (__u8 *)&args->ip_src,
-					    (__u8 *)&args->ip_dst,
-					    ICMP6_NS_MSG_TYPE);
-	if (!l4)
-		return TEST_ERROR;
-
-	data = pktgen__push_data(&builder, (__u8 *)&args->icmp_ns_addr,
-				 IPV6_ALEN);
-	if (!data)
-		return TEST_ERROR;
-
-	if (args->llsrc_opt) {
-		data = pktgen__push_data(&builder, (__u8 *)&args->icmp_opt,
-					 ICMP6_ND_OPT_LEN);
-	}
-
-	pktgen__finish(&builder);
-	return 0;
-}
-
-static __always_inline
-int __ipv6_from_netdev_ns_check(const struct __ctx_buff *ctx,
-				struct test_args *args)
-{
-	void *data;
-	void *data_end;
-	__u32 *status_code;
-	struct ethhdr *l2;
-	struct ipv6hdr *l3;
-	struct icmp6hdr *l4;
-	void *target_addr, *opt;
-
-	test_init();
-
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(*status_code) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == args->status_code);
-
-	l2 = data + sizeof(*status_code);
-
-	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
-		test_fatal("l2 out of bounds");
-
-	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
-		test_fatal("l2 proto hasn't been set to ETH_P_IPV6");
-
-	if (memcmp(l2->h_source, (__u8 *)args->mac_src, ETH_ALEN) != 0)
-		test_fatal("Incorrect mac_src");
-
-	if (memcmp(l2->h_dest, (__u8 *)args->mac_dst, ETH_ALEN) != 0)
-		test_fatal("Incorrect mac_dst");
-
-	l3 = (void *)l2 + sizeof(struct ethhdr);
-
-	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
-		test_fatal("l3 out of bounds");
-
-	if (memcmp((__u8 *)&l3->saddr, (__u8 *)&args->ip_src, IPV6_ALEN) != 0)
-		test_fatal("Incorrect ip_src");
-
-	if (memcmp((__u8 *)&l3->daddr, (__u8 *)&args->ip_dst, IPV6_ALEN) != 0)
-		test_fatal("Incorrect ip_dst");
-
-	l4 = (void *)l3 + sizeof(struct ipv6hdr);
-
-	if ((void *)l4 + sizeof(struct icmp6hdr) > data_end)
-		test_fatal("l4 out of bounds");
-
-	if (l4->icmp6_type != args->icmp_type)
-		test_fatal("Invalid ICMP type");
-
-	target_addr = (void *)l4 + sizeof(struct icmp6hdr);
-	if ((void *)target_addr + IPV6_ALEN > data_end)
-		test_fatal("Target addr out of bounds");
-
-	if (memcmp(target_addr, (__u8 *)&args->icmp_ns_addr, IPV6_ALEN) != 0)
-		test_fatal("Incorrect icmp6 payload target addr");
-
-	if (args->llsrc_opt) {
-		opt = target_addr + IPV6_ALEN;
-
-		if ((void *)opt + ICMP6_ND_OPT_LEN > data_end)
-			test_fatal("llsrc_opt out of bounds");
-
-		if (memcmp(opt, (__u8 *)&args->icmp_opt, ICMP6_ND_OPT_LEN) != 0)
-			test_fatal("Incorrect icmp6 payload type/length or target_lladdr");
-	}
-
-	test_finish();
-}
-
 /*
  * These tests make sure that ND packets directed to a Pod IP are answered
  * directly from BPF.
@@ -170,56 +63,18 @@ int __ipv6_from_netdev_ns_pod_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-static __always_inline
-void __ipv6_from_netdev_ns_pod_pktgen_args(struct test_args *args,
-					   bool llsrc_opt)
-{
-	__u8 llsrc_mac[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
-
-	memcpy((__u8 *)args->mac_src, (__u8 *)mac_one, ETH_ALEN);
-	memcpy((__u8 *)args->mac_dst, (__u8 *)mac_two, ETH_ALEN);
-
-	memcpy((__u8 *)&args->ip_src, (__u8 *)v6_pod_one, IPV6_ALEN);
-	memcpy((__u8 *)&args->ip_dst, (__u8 *)v6_pod_two, IPV6_ALEN);
-
-	memcpy((__u8 *)&args->icmp_ns_addr, (__u8 *)v6_pod_three, IPV6_ALEN);
-
-	args->llsrc_opt = llsrc_opt;
-	args->icmp_opt.type = 0x1;
-	args->icmp_opt.length = 0x1;
-	memcpy((__u8 *)args->icmp_opt.llsrc_mac, (__u8 *)llsrc_mac, ETH_ALEN);
-}
-
-static __always_inline
-void __ipv6_from_netdev_ns_pod_check_args(struct test_args *args,
-					  bool llsrc_opt)
-{
-	union macaddr node_mac = THIS_INTERFACE_MAC;
-
-	args->status_code = CTX_ACT_REDIRECT;
-
-	memcpy((__u8 *)args->mac_src, (__u8 *)&node_mac.addr, ETH_ALEN);
-	memcpy((__u8 *)args->mac_dst, (__u8 *)mac_one, ETH_ALEN);
-
-	memcpy((__u8 *)&args->ip_src, (__u8 *)v6_pod_three, IPV6_ALEN);
-	memcpy((__u8 *)&args->ip_dst, (__u8 *)v6_pod_one, IPV6_ALEN);
-
-	args->icmp_type = ICMP6_NA_MSG_TYPE;
-	memcpy((__u8 *)&args->icmp_ns_addr, (__u8 *)v6_pod_three, IPV6_ALEN);
-
-	args->llsrc_opt = llsrc_opt;
-	args->icmp_opt.type = 0x2;
-	args->icmp_opt.length = 0x1;
-	memcpy((__u8 *)args->icmp_opt.llsrc_mac, (__u8 *)&node_mac, ETH_ALEN);
-}
-
 PKTGEN("tc", "011_ipv6_from_netdev_ns_pod")
 int ipv6_from_netdev_ns_pod_pktgen(struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	struct pktgen builder;
 
-	__ipv6_from_netdev_ns_pod_pktgen_args(&args, true);
-	return __ipv6_from_netdev_ns_pktgen(ctx, &args);
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(V6_NDP_POD_NS_LLOPT, v6_ndp_pod_ns_llopt);
+	BUILDER_PUSH_BUF(builder, V6_NDP_POD_NS_LLOPT);
+
+	pktgen__finish(&builder);
+	return 0;
 }
 
 SETUP("tc", "011_ipv6_from_netdev_ns_pod")
@@ -231,19 +86,44 @@ int ipv6_from_netdev_ns_pod_setup(struct __ctx_buff *ctx)
 CHECK("tc", "011_ipv6_from_netdev_ns_pod")
 int ipv6_from_netdev_ns_pod_check(const struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	void *data;
+	void *data_end;
+	__u32 *status_code;
 
-	__ipv6_from_netdev_ns_pod_check_args(&args, true);
-	return __ipv6_from_netdev_ns_check(ctx, &args);
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	BUF_DECL(V6_NDP_POD_NA_LLOPT, v6_ndp_pod_na_llopt);
+
+	ASSERT_CTX_BUF_OFF("pod_na_ns_llopt_ok", "Ether", ctx, sizeof(__u32),
+			   V6_NDP_POD_NA_LLOPT,
+			   sizeof(BUF(V6_NDP_POD_NA_LLOPT)));
+	test_finish();
+
+	return 0;
 }
 
 PKTGEN("tc", "011_ipv6_from_netdev_ns_pod_noopt")
 int ipv6_from_netdev_ns_pod_pktgen_noopt(struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	struct pktgen builder;
 
-	__ipv6_from_netdev_ns_pod_pktgen_args(&args, false);
-	return __ipv6_from_netdev_ns_pktgen(ctx, &args);
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(V6_NDP_POD_NS, v6_ndp_pod_ns);
+	BUILDER_PUSH_BUF(builder, V6_NDP_POD_NS);
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP("tc", "011_ipv6_from_netdev_ns_pod_noopt")
@@ -255,10 +135,29 @@ int ipv6_from_netdev_ns_pod_setup_noopt(struct __ctx_buff *ctx)
 CHECK("tc", "011_ipv6_from_netdev_ns_pod_noopt")
 int ipv6_from_netdev_ns_pod_check_noopt(const struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	void *data;
+	void *data_end;
+	__u32 *status_code;
 
-	__ipv6_from_netdev_ns_pod_check_args(&args, false);
-	return __ipv6_from_netdev_ns_check(ctx, &args);
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	/* Note we always return NA with llopt */
+	BUF_DECL(V6_NDP_POD_NA_LLOPT_NS_NOOPT, v6_ndp_pod_na_llopt);
+	ASSERT_CTX_BUF_OFF("pod_na_ns_noopt_ok", "Ether", ctx, sizeof(__u32),
+			   V6_NDP_POD_NA_LLOPT_NS_NOOPT,
+			   sizeof(BUF(V6_NDP_POD_NA_LLOPT_NS_NOOPT)));
+	test_finish();
+
+	return 0;
 }
 
 /* Bcast NS */
@@ -272,37 +171,19 @@ int __ipv6_from_netdev_ns_pod_setup_mcast(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-static __always_inline
-void __ipv6_from_netdev_ns_pod_pktgen_mcast_args(struct test_args *args,
-						 bool llsrc_opt)
-{
-	__u8 llsrc_mac[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
-
-	memcpy((__u8 *)args->mac_src, (__u8 *)mac_one, ETH_ALEN);
-
-	ipv6_sol_mc_mac_set((union v6addr *)v6_pod_three,
-			    (union macaddr *)args->mac_dst);
-
-	memcpy((__u8 *)&args->ip_src, (__u8 *)v6_pod_one, IPV6_ALEN);
-
-	ipv6_sol_mc_addr_set((union v6addr *)v6_pod_three, &args->ip_dst);
-
-	memcpy((__u8 *)&args->icmp_ns_addr, (__u8 *)v6_pod_three, IPV6_ALEN);
-
-	args->llsrc_opt = llsrc_opt;
-	args->icmp_opt.type = 0x1;
-	args->icmp_opt.length = 0x1;
-	memcpy((__u8 *)args->icmp_opt.llsrc_mac, (__u8 *)llsrc_mac, ETH_ALEN);
-}
-
-
 PKTGEN("tc", "012_ipv6_from_netdev_ns_pod_mcast")
 int ipv6_from_netdev_ns_pod_pktgen_mcast(struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	struct pktgen builder;
 
-	__ipv6_from_netdev_ns_pod_pktgen_mcast_args(&args, true);
-	return __ipv6_from_netdev_ns_pktgen(ctx, &args);
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(V6_NDP_POD_NS_MCAST_LLOPT, v6_ndp_pod_ns_mcast_llopt);
+	BUILDER_PUSH_BUF(builder, V6_NDP_POD_NS_MCAST_LLOPT);
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP("tc", "012_ipv6_from_netdev_ns_pod_mcast")
@@ -314,19 +195,44 @@ int ipv6_from_netdev_ns_pod_setup_mcast(struct __ctx_buff *ctx)
 CHECK("tc", "012_ipv6_from_netdev_ns_pod_mcast")
 int ipv6_from_netdev_ns_pod_check_mcast(const struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	void *data;
+	void *data_end;
+	__u32 *status_code;
 
-	__ipv6_from_netdev_ns_pod_check_args(&args, true);
-	return __ipv6_from_netdev_ns_check(ctx, &args);
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	/* Note we always return NA with llopt */
+	BUF_DECL(V6_NDP_POD_NA_MCAST_NS_NOOPT, v6_ndp_pod_na_llopt);
+	ASSERT_CTX_BUF_OFF("pod_na_ns_mcast_ok", "Ether", ctx, sizeof(__u32),
+			   V6_NDP_POD_NA_MCAST_NS_NOOPT,
+			   sizeof(BUF(V6_NDP_POD_NA_MCAST_NS_NOOPT)));
+	test_finish();
+
+	return 0;
 }
 
 PKTGEN("tc", "012_ipv6_from_netdev_ns_pod_mcast_noopt")
 int ipv6_from_netdev_ns_pod_pktgen_mcast_noopt(struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	struct pktgen builder;
 
-	__ipv6_from_netdev_ns_pod_pktgen_mcast_args(&args, false);
-	return __ipv6_from_netdev_ns_pktgen(ctx, &args);
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(V6_NDP_POD_NS_MCAST, v6_ndp_pod_ns_mcast);
+	BUILDER_PUSH_BUF(builder, V6_NDP_POD_NS_MCAST);
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP("tc", "012_ipv6_from_netdev_ns_pod_mcast_noopt")
@@ -338,10 +244,30 @@ int ipv6_from_netdev_ns_pod_setup_mcast_noopt(struct __ctx_buff *ctx)
 CHECK("tc", "012_ipv6_from_netdev_ns_pod_mcast_noopt")
 int ipv6_from_netdev_ns_pod_check_mcast_noopt(const struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	void *data;
+	void *data_end;
+	__u32 *status_code;
 
-	__ipv6_from_netdev_ns_pod_check_args(&args, false);
-	return __ipv6_from_netdev_ns_check(ctx, &args);
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	/* Note we always return NA with llopt */
+	BUF_DECL(V6_NDP_POD_NA_MCAST_LLOPT, v6_ndp_pod_na_llopt);
+	ASSERT_CTX_BUF_OFF("pod_na_ns_mcast_noopt_ok", "Ether", ctx,
+			   sizeof(__u32),
+			   V6_NDP_POD_NA_MCAST_LLOPT,
+			   sizeof(BUF(V6_NDP_POD_NA_MCAST_LLOPT)));
+	test_finish();
+
+	return 0;
 }
 
 /*
@@ -359,45 +285,20 @@ int __ipv6_from_netdev_ns_node_ip_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-static __always_inline
-void __ipv6_from_netdev_ns_node_ip_pktgen_args(struct test_args *args,
-					       bool llsrc_opt)
-{
-	__u8 llsrc_mac[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
-
-	memcpy((__u8 *)args->mac_src, (__u8 *)mac_one, ETH_ALEN);
-	memcpy((__u8 *)args->mac_dst, (__u8 *)mac_two, ETH_ALEN);
-
-	memcpy((__u8 *)&args->ip_src, (__u8 *)v6_pod_one, IPV6_ALEN);
-	memcpy((__u8 *)&args->ip_dst, (__u8 *)v6_pod_two, IPV6_ALEN);
-
-	memcpy((__u8 *)&args->icmp_ns_addr, (__u8 *)&v6_node_one, IPV6_ALEN);
-
-	args->icmp_type = ICMP6_NS_MSG_TYPE;
-
-	args->llsrc_opt = llsrc_opt;
-	args->icmp_opt.type = 0x1;
-	args->icmp_opt.length = 0x1;
-	memcpy((__u8 *)args->icmp_opt.llsrc_mac, (__u8 *)llsrc_mac, ETH_ALEN);
-}
-
-static __always_inline
-void __ipv6_from_netdev_ns_node_ip_check_args(struct test_args *args,
-					      bool llsrc_opt)
-{
-	/* Pkt is unmodified */
-	__ipv6_from_netdev_ns_node_ip_pktgen_args(args, llsrc_opt);
-	args->status_code = CTX_ACT_OK;
-}
-
 /* With LL SRC option */
 PKTGEN("tc", "0211_ipv6_from_netdev_ns_node_ip")
 int ipv6_from_netdev_ns_node_ip_pktgen(struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	struct pktgen builder;
 
-	__ipv6_from_netdev_ns_node_ip_pktgen_args(&args, true);
-	return __ipv6_from_netdev_ns_pktgen(ctx, &args);
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(V6_NDP_NODE_NS_LLOPT, v6_ndp_node_ns_llopt);
+	BUILDER_PUSH_BUF(builder, V6_NDP_NODE_NS_LLOPT);
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP("tc", "0211_ipv6_from_netdev_ns_node_ip")
@@ -409,20 +310,46 @@ int ipv6_from_netdev_ns_node_ip_setup(struct __ctx_buff *ctx)
 CHECK("tc", "0211_ipv6_from_netdev_ns_node_ip")
 int ipv6_from_netdev_ns_node_ip_check(const struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	void *data;
+	void *data_end;
+	__u32 *status_code;
 
-	__ipv6_from_netdev_ns_node_ip_check_args(&args, true);
-	return __ipv6_from_netdev_ns_check(ctx, &args);
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Packet should not be modified */
+	BUF_DECL(V6_NDP_NODE_NS_LLOPT_PASS, v6_ndp_node_ns_llopt);
+	ASSERT_CTX_BUF_OFF("node_ns_pass", "Ether", ctx,
+			   sizeof(__u32),
+			   V6_NDP_NODE_NS_LLOPT_PASS,
+			   sizeof(BUF(V6_NDP_NODE_NS_LLOPT_PASS)));
+	test_finish();
+
+	return 0;
 }
 
 /* Without LL SRC option */
 PKTGEN("tc", "0212_ipv6_from_netdev_ns_node_ip_noopt")
 int ipv6_from_netdev_ns_node_ip_pktgen_noopt(struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	struct pktgen builder;
 
-	__ipv6_from_netdev_ns_node_ip_pktgen_args(&args, false);
-	return __ipv6_from_netdev_ns_pktgen(ctx, &args);
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(V6_NDP_NODE_NS, v6_ndp_node_ns);
+	BUILDER_PUSH_BUF(builder, V6_NDP_NODE_NS);
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP("tc", "0212_ipv6_from_netdev_ns_node_ip_noopt")
@@ -434,10 +361,30 @@ int ipv6_from_netdev_ns_node_ip_setup_noopt(struct __ctx_buff *ctx)
 CHECK("tc", "0212_ipv6_from_netdev_ns_node_ip_noopt")
 int ipv6_from_netdev_ns_node_ip_check_noopt(const struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	void *data;
+	void *data_end;
+	__u32 *status_code;
 
-	__ipv6_from_netdev_ns_node_ip_check_args(&args, false);
-	return __ipv6_from_netdev_ns_check(ctx, &args);
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Packet should not be modified */
+	BUF_DECL(V6_NDP_NODE_NS_PASS, v6_ndp_node_ns);
+	ASSERT_CTX_BUF_OFF("node_ns_pass", "Ether", ctx,
+			   sizeof(__u32),
+			   V6_NDP_NODE_NS_PASS,
+			   sizeof(BUF(V6_NDP_NODE_NS_PASS)));
+	test_finish();
+
+	return 0;
 }
 
 /* Bcast NS */
@@ -451,47 +398,19 @@ int __ipv6_from_netdev_ns_node_ip_setup_mcast(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-static __always_inline
-void __ipv6_from_netdev_ns_node_ip_pktgen_mcast_args(struct test_args *args,
-						     bool llsrc_opt)
-{
-	__u8 llsrc_mac[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
-
-	memcpy((__u8 *)args->mac_src, (__u8 *)mac_one, ETH_ALEN);
-
-	ipv6_sol_mc_mac_set((union v6addr *)v6_pod_one,
-			    (union macaddr *)args->mac_dst);
-
-	memcpy((__u8 *)&args->ip_src, (__u8 *)v6_pod_one, IPV6_ALEN);
-
-	ipv6_sol_mc_addr_set((union v6addr *)v6_pod_one, &args->ip_dst);
-
-	memcpy((__u8 *)&args->icmp_ns_addr, (__u8 *)&v6_node_one, IPV6_ALEN);
-
-	args->icmp_type = ICMP6_NS_MSG_TYPE;
-
-	args->llsrc_opt = llsrc_opt;
-	args->icmp_opt.type = 0x1;
-	args->icmp_opt.length = 0x1;
-	memcpy((__u8 *)args->icmp_opt.llsrc_mac, (__u8 *)llsrc_mac, ETH_ALEN);
-}
-
-static __always_inline
-void __ipv6_from_netdev_ns_node_ip_check_mcast_args(struct test_args *args,
-						    bool llsrc_opt)
-{
-	/* Pkt is unmodified */
-	__ipv6_from_netdev_ns_node_ip_pktgen_mcast_args(args, llsrc_opt);
-	args->status_code = CTX_ACT_OK;
-}
-
 PKTGEN("tc", "022_ipv6_from_netdev_ns_node_ip_mcast")
 int ipv6_from_netdev_ns_node_ip_pktgen_mcast(struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	struct pktgen builder;
 
-	__ipv6_from_netdev_ns_node_ip_pktgen_mcast_args(&args, true);
-	return __ipv6_from_netdev_ns_pktgen(ctx, &args);
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(V6_NDP_NODE_NS_MCAST_LLOPT, v6_ndp_node_ns_mcast_llopt);
+	BUILDER_PUSH_BUF(builder, V6_NDP_NODE_NS_MCAST_LLOPT);
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP("tc", "022_ipv6_from_netdev_ns_node_ip_mcast")
@@ -503,19 +422,45 @@ int ipv6_from_netdev_ns_node_ip_setup_mcast(struct __ctx_buff *ctx)
 CHECK("tc", "022_ipv6_from_netdev_ns_node_ip_mcast")
 int ipv6_from_netdev_ns_node_ip_check_mcast(const struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	void *data;
+	void *data_end;
+	__u32 *status_code;
 
-	__ipv6_from_netdev_ns_node_ip_check_mcast_args(&args, true);
-	return __ipv6_from_netdev_ns_check(ctx, &args);
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Packet should not be modified */
+	BUF_DECL(V6_NDP_NODE_NS_MCAST_LLOPT_PASS, v6_ndp_node_ns_mcast_llopt);
+	ASSERT_CTX_BUF_OFF("node_ns_mcast_pass", "Ether", ctx,
+			   sizeof(__u32),
+			   V6_NDP_NODE_NS_MCAST_LLOPT_PASS,
+			   sizeof(BUF(V6_NDP_NODE_NS_MCAST_LLOPT_PASS)));
+	test_finish();
+
+	return 0;
 }
 
 PKTGEN("tc", "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
 int ipv6_from_netdev_ns_node_ip_pktgen_mcast_noopt(struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	struct pktgen builder;
 
-	__ipv6_from_netdev_ns_node_ip_pktgen_mcast_args(&args, false);
-	return __ipv6_from_netdev_ns_pktgen(ctx, &args);
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(V6_NDP_NODE_NS_MCAST, v6_ndp_node_ns_mcast);
+	BUILDER_PUSH_BUF(builder, V6_NDP_NODE_NS_MCAST);
+
+	pktgen__finish(&builder);
+
+	return 0;
 }
 
 SETUP("tc", "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
@@ -527,8 +472,28 @@ int ipv6_from_netdev_ns_node_ip_setup_mcast_noopt(struct __ctx_buff *ctx)
 CHECK("tc", "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
 int ipv6_from_netdev_ns_node_ip_check_mcast_noopt(const struct __ctx_buff *ctx)
 {
-	struct test_args args = {0};
+	void *data;
+	void *data_end;
+	__u32 *status_code;
 
-	__ipv6_from_netdev_ns_node_ip_check_mcast_args(&args, false);
-	return __ipv6_from_netdev_ns_check(ctx, &args);
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Packet should not be modified */
+	BUF_DECL(V6_NDP_NODE_NS_MCAST_PASS, v6_ndp_node_ns_mcast);
+	ASSERT_CTX_BUF_OFF("node_ns_mcast_noopt_pass", "Ether", ctx,
+			   sizeof(__u32),
+			   V6_NDP_NODE_NS_MCAST_PASS,
+			   sizeof(BUF(V6_NDP_NODE_NS_MCAST_PASS)));
+	test_finish();
+
+	return 0;
 }

--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -50,6 +50,26 @@ struct test_args {
 };
 
 /*
+ * Generic
+ */
+static __always_inline
+bool __check_ret_code(const struct __ctx_buff *ctx, const __u32 exp_rc)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		return false;
+
+	status_code = data;
+	return *status_code == exp_rc;
+}
+
+/*
  * These tests make sure that ND packets directed to a Pod IP are answered
  * directly from BPF.
  */
@@ -86,20 +106,9 @@ int ipv6_from_netdev_ns_pod_setup(struct __ctx_buff *ctx)
 CHECK("tc", "011_ipv6_from_netdev_ns_pod")
 int ipv6_from_netdev_ns_pod_check(const struct __ctx_buff *ctx)
 {
-	void *data;
-	void *data_end;
-	__u32 *status_code;
-
 	test_init();
 
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(*status_code) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_REDIRECT);
+	assert(__check_ret_code(ctx, CTX_ACT_REDIRECT));
 
 	BUF_DECL(V6_NDP_POD_NA_LLOPT, v6_ndp_pod_na_llopt);
 
@@ -135,20 +144,9 @@ int ipv6_from_netdev_ns_pod_setup_noopt(struct __ctx_buff *ctx)
 CHECK("tc", "011_ipv6_from_netdev_ns_pod_noopt")
 int ipv6_from_netdev_ns_pod_check_noopt(const struct __ctx_buff *ctx)
 {
-	void *data;
-	void *data_end;
-	__u32 *status_code;
-
 	test_init();
 
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(*status_code) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_REDIRECT);
+	assert(__check_ret_code(ctx, CTX_ACT_REDIRECT));
 
 	/* Note we always return NA with llopt */
 	BUF_DECL(V6_NDP_POD_NA_LLOPT_NS_NOOPT, v6_ndp_pod_na_llopt);
@@ -195,20 +193,9 @@ int ipv6_from_netdev_ns_pod_setup_mcast(struct __ctx_buff *ctx)
 CHECK("tc", "012_ipv6_from_netdev_ns_pod_mcast")
 int ipv6_from_netdev_ns_pod_check_mcast(const struct __ctx_buff *ctx)
 {
-	void *data;
-	void *data_end;
-	__u32 *status_code;
-
 	test_init();
 
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(*status_code) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_REDIRECT);
+	assert(__check_ret_code(ctx, CTX_ACT_REDIRECT));
 
 	/* Note we always return NA with llopt */
 	BUF_DECL(V6_NDP_POD_NA_MCAST_NS_NOOPT, v6_ndp_pod_na_llopt);
@@ -244,20 +231,9 @@ int ipv6_from_netdev_ns_pod_setup_mcast_noopt(struct __ctx_buff *ctx)
 CHECK("tc", "012_ipv6_from_netdev_ns_pod_mcast_noopt")
 int ipv6_from_netdev_ns_pod_check_mcast_noopt(const struct __ctx_buff *ctx)
 {
-	void *data;
-	void *data_end;
-	__u32 *status_code;
-
 	test_init();
 
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(*status_code) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_REDIRECT);
+	assert(__check_ret_code(ctx, CTX_ACT_REDIRECT));
 
 	/* Note we always return NA with llopt */
 	BUF_DECL(V6_NDP_POD_NA_MCAST_LLOPT, v6_ndp_pod_na_llopt);
@@ -310,20 +286,9 @@ int ipv6_from_netdev_ns_node_ip_setup(struct __ctx_buff *ctx)
 CHECK("tc", "0211_ipv6_from_netdev_ns_node_ip")
 int ipv6_from_netdev_ns_node_ip_check(const struct __ctx_buff *ctx)
 {
-	void *data;
-	void *data_end;
-	__u32 *status_code;
-
 	test_init();
 
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(*status_code) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_OK);
+	assert(__check_ret_code(ctx, CTX_ACT_OK));
 
 	/* Packet should not be modified */
 	BUF_DECL(V6_NDP_NODE_NS_LLOPT_PASS, v6_ndp_node_ns_llopt);
@@ -361,20 +326,9 @@ int ipv6_from_netdev_ns_node_ip_setup_noopt(struct __ctx_buff *ctx)
 CHECK("tc", "0212_ipv6_from_netdev_ns_node_ip_noopt")
 int ipv6_from_netdev_ns_node_ip_check_noopt(const struct __ctx_buff *ctx)
 {
-	void *data;
-	void *data_end;
-	__u32 *status_code;
-
 	test_init();
 
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(*status_code) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_OK);
+	assert(__check_ret_code(ctx, CTX_ACT_OK));
 
 	/* Packet should not be modified */
 	BUF_DECL(V6_NDP_NODE_NS_PASS, v6_ndp_node_ns);
@@ -422,20 +376,9 @@ int ipv6_from_netdev_ns_node_ip_setup_mcast(struct __ctx_buff *ctx)
 CHECK("tc", "022_ipv6_from_netdev_ns_node_ip_mcast")
 int ipv6_from_netdev_ns_node_ip_check_mcast(const struct __ctx_buff *ctx)
 {
-	void *data;
-	void *data_end;
-	__u32 *status_code;
-
 	test_init();
 
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(*status_code) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_OK);
+	assert(__check_ret_code(ctx, CTX_ACT_OK));
 
 	/* Packet should not be modified */
 	BUF_DECL(V6_NDP_NODE_NS_MCAST_LLOPT_PASS, v6_ndp_node_ns_mcast_llopt);
@@ -472,20 +415,9 @@ int ipv6_from_netdev_ns_node_ip_setup_mcast_noopt(struct __ctx_buff *ctx)
 CHECK("tc", "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
 int ipv6_from_netdev_ns_node_ip_check_mcast_noopt(const struct __ctx_buff *ctx)
 {
-	void *data;
-	void *data_end;
-	__u32 *status_code;
-
 	test_init();
 
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(*status_code) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_OK);
+	assert(__check_ret_code(ctx, CTX_ACT_OK));
 
 	/* Packet should not be modified */
 	BUF_DECL(V6_NDP_NODE_NS_MCAST_PASS, v6_ndp_node_ns_mcast);

--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -15,6 +15,8 @@
 
 #define FROM_NETDEV 0
 
+ASSIGN_CONFIG(union macaddr, interface_mac, {.addr = mac_two_addr})
+
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(key_size, sizeof(__u32));

--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -40,15 +40,15 @@
  */
 #define ASSERT_CTX_BUF_OFF(NAME, FIRST_LAYER, CTX, OFF, BUF_NAME, LEN)		\
 	do {									\
-		void *__data = (void *)(long)(CTX)->data;			\
-		void *__data_end = (void *)(long)(CTX)->data_end;		\
-		__data += OFF;							\
+		void *__DATA = (void *)(long)(CTX)->data;			\
+		void *__DATA_END = (void *)(long)(CTX)->data_end;		\
+		__DATA += OFF;							\
 		bool ok = true;							\
 		__u16 _len = LEN;						\
 										\
-		if (__data + (LEN) > __data_end) {				\
+		if (__DATA + (LEN) > __DATA_END) {				\
 			ok = false;						\
-			_len = (__u16)(data_end - __data);			\
+			_len = (__u16)(__DATA_END - __DATA);			\
 			test_log("CTX len (%d) - offset (%d) < LEN (%d)",	\
 				 _len + OFF, OFF, LEN);				\
 		}								\
@@ -57,7 +57,7 @@
 			test_log("Buffer '" #BUF_NAME "' of len (%d) < LEN"	\
 				 " (%d)", sizeof(BUF(BUF_NAME)), LEN);		\
 		}								\
-		if (ok && memcmp(__data, &BUF(BUF_NAME), LEN) != 0) {		\
+		if (ok && memcmp(__DATA, &BUF(BUF_NAME), LEN) != 0) {		\
 			ok = false;						\
 			test_log("CTX and buffer '" #BUF_NAME			\
 				 "' content mismatch ");			\

--- a/bpf/tests/scapy/README.md
+++ b/bpf/tests/scapy/README.md
@@ -90,10 +90,12 @@ Replace values with the constants defined in `pkt_defs.py` (e.g.MACs, IPs). Add
 any new value necessary in `pkt_defs.py`:
 
 ```
-l2_announce6_ns = Ether(dst=l2_announce6_ns_mmac, src=mac_one)/                \
-                  IPv6(src=v6_ext_node_one, dst=l2_announce6_ns_ma, hlim=255)/ \
-                  ICMPv6ND_NS(tgt=v6_svc_one)/                                 \
-                  ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
+l2_announce6_ns = (
+    Ether(dst=l2_announce6_ns_mmac, src=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=l2_announce6_ns_ma, hlim=255) /
+    ICMPv6ND_NS(tgt=v6_svc_one) /
+    ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
+)
 ```
 
 Run the test and adjust the scapy packet until it passes.
@@ -104,10 +106,12 @@ If the expected packet in the `_check` function is different than the injected,
 define the new packet. You can take as reference the injected packet.
 
 ```
-l2_announce6_na = Ether(dst=mac_one, src=mac_two)/                             \
-                  IPv6(src=v6_svc_one, dst=v6_ext_node_one, hlim=255)/         \
-                  ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one)/                  \
-                  ICMPv6NDOptDstLLAddr(lladdr=mac_two)
+l2_announce6_na = (
+    Ether(dst=mac_one, src=mac_two) /
+    IPv6(src=v6_svc_one, dst=v6_ext_node_one, hlim=255) /
+    ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one) /
+    ICMPv6NDOptDstLLAddr(lladdr=mac_two)
+)
 ```
 
 Add the `ASSERT_CTX_BUF_*()` after the current assertions but before

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -72,43 +72,54 @@ tcp_svc_three = 53
 default_data = "Should not change!!"
 
 # Utility functions
-def get_v6_ns_addr(v6_addr:str) -> str:
-    addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_svc_one))
+def v6_get_ns_addr(v6_addr:str) -> str:
+    addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_addr))
     return inet_ntop(socket.AF_INET6, addr_bytes)
 
-def v6_ns_mac(v6_addr:str) -> str:
-    addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_svc_one))
+def v6_get_ns_mac(v6_addr:str) -> str:
+    addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_addr))
     return in6_getnsmac(addr_bytes)
 
 # Test packet/buffer definitions
 
 ## L2 announce (v4)
+l2_announce_arp_req = (
+    Ether(dst=mac_bcast, src=mac_one) /
+    ARP(op="who-has", psrc=v4_ext_one, pdst=v4_svc_one, \
+        hwsrc=mac_one, hwdst=mac_bcast)
+)
 
-l2_announce_arp_req = Ether(dst=mac_bcast, src=mac_one)/                       \
-                      ARP(op="who-has", psrc=v4_ext_one, pdst=v4_svc_one,      \
-                          hwsrc=mac_one, hwdst=mac_bcast)
-l2_announce_arp_reply = Ether(dst=mac_one, src=mac_two)/                       \
-                        ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one,      \
-                            hwsrc=mac_two, hwdst=mac_one)
+l2_announce_arp_reply = (
+    Ether(dst=mac_one, src=mac_two) /
+    ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, \
+        hwsrc=mac_two, hwdst=mac_one)
+)
 
 ## L2 announce (v6)
 
 ### Calculate the IPv6 NS solicitation address
-l2_announce6_ns_mmac = v6_ns_mac(v6_svc_one)
-l2_announce6_ns_ma = get_v6_ns_addr(v6_svc_one)
+l2_announce6_ns_mmac = v6_get_ns_mac(v6_svc_one)
+l2_announce6_ns_ma = v6_get_ns_addr(v6_svc_one)
 assert(l2_announce6_ns_mmac == '33:33:ff:00:00:01')
 assert(l2_announce6_ns_ma == 'ff02::1:ff00:1')
 
-l2_announce6_ns = Ether(dst=l2_announce6_ns_mmac, src=mac_one)/                \
-                  IPv6(src=v6_ext_node_one, dst=l2_announce6_ns_ma, hlim=255)/ \
-                  ICMPv6ND_NS(tgt=v6_svc_one)/                                 \
-                  ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
-l2_announce6_targeted_ns =                                                     \
-                  Ether(dst=mac_two, src=mac_one) /                            \
-                  IPv6(src=v6_ext_node_one, dst=v6_svc_one, hlim=255) /        \
-                  ICMPv6ND_NS(tgt=v6_svc_one) /                                \
-                  ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
-l2_announce6_na = Ether(dst=mac_one, src=mac_two)/                             \
-                  IPv6(src=v6_svc_one, dst=v6_ext_node_one, hlim=255)/         \
-                  ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one)/                  \
-                  ICMPv6NDOptDstLLAddr(lladdr=mac_two)
+l2_announce6_ns = (
+    Ether(dst=l2_announce6_ns_mmac, src=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=l2_announce6_ns_ma, hlim=255) /
+    ICMPv6ND_NS(tgt=v6_svc_one) /
+    ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
+)
+
+l2_announce6_targeted_ns = (
+    Ether(dst=mac_two, src=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one, hlim=255) /
+    ICMPv6ND_NS(tgt=v6_svc_one) /
+    ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
+)
+
+l2_announce6_na = (
+    Ether(dst=mac_one, src=mac_two) /
+    IPv6(src=v6_svc_one, dst=v6_ext_node_one, hlim=255) /
+    ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one) /
+    ICMPv6NDOptDstLLAddr(lladdr=mac_two)
+)

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -82,6 +82,70 @@ def v6_get_ns_mac(v6_addr:str) -> str:
 
 # Test packet/buffer definitions
 
+## IPv6 ndp from netdev
+### Pod NS/NA
+v6_ndp_pod_ns = (
+    Ether(dst=mac_two, src=mac_one) /
+    IPv6(dst=v6_pod_two, src=v6_pod_one, hlim=255) /
+    ICMPv6ND_NS(tgt=v6_pod_three)
+)
+
+v6_ndp_pod_ns_llopt = (
+    v6_ndp_pod_ns /
+    ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
+)
+
+v6_ndp_pod_na_llopt = (
+    Ether(dst=mac_one, src=mac_two) /
+    IPv6(dst=v6_pod_one, src=v6_pod_three, hlim=255) /
+    ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_pod_three) /
+    ICMPv6NDOptDstLLAddr(lladdr=mac_two)
+)
+
+v6_ndp_pod_ns_mmac = v6_get_ns_mac(v6_pod_three)
+v6_ndp_pod_ns_ma = v6_get_ns_addr(v6_pod_three)
+assert(v6_ndp_pod_ns_mmac == '33:33:ff:00:00:03')
+assert(v6_ndp_pod_ns_ma == 'ff02::1:ff00:3')
+
+v6_ndp_pod_ns_mcast = (
+    Ether(dst=v6_ndp_pod_ns_mmac, src=mac_one) /
+    IPv6(dst=v6_ndp_pod_ns_ma, src=v6_pod_one, hlim=255) /
+    ICMPv6ND_NS(tgt=v6_pod_three)
+)
+
+v6_ndp_pod_ns_mcast_llopt = (
+    v6_ndp_pod_ns_mcast /
+    ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
+)
+
+### Node NS/NA
+v6_ndp_node_ns = (
+    Ether(dst=mac_two, src=mac_one) /
+    IPv6(dst=v6_pod_two, src=v6_pod_one, hlim=255) /
+    ICMPv6ND_NS(tgt=v6_node_one)
+)
+
+v6_ndp_node_ns_llopt = (
+    v6_ndp_node_ns /
+    ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
+)
+
+v6_ndp_node_ns_mmac = v6_get_ns_mac(v6_node_one)
+v6_ndp_node_ns_ma = v6_get_ns_addr(v6_node_one)
+assert(v6_ndp_node_ns_mmac == '33:33:ff:00:00:01')
+assert(v6_ndp_node_ns_ma == 'ff02::1:ff00:1')
+
+v6_ndp_node_ns_mcast = (
+    Ether(dst=v6_ndp_node_ns_mmac, src=mac_one) /
+    IPv6(dst=v6_ndp_node_ns_ma, src=v6_pod_one, hlim=255) /
+    ICMPv6ND_NS(tgt=v6_node_one)
+)
+
+v6_ndp_node_ns_mcast_llopt = (
+    v6_ndp_node_ns_mcast /
+    ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
+)
+
 ## L2 announce (v4)
 l2_announce_arp_req = (
     Ether(dst=mac_bcast, src=mac_one) /


### PR DESCRIPTION
```
2c056dde51 bpf/test: more cleanups on IPv6 NDP test
26f34665b4 bpf/tests: adapt IPv6 NDP to scapy
8ad328cb2c bpf/scapy: fix ASSERT data vs __data
b55c0846e3 bpf/lib: fix ICMPv6 csum for non-llsrc opt NS
c123030ab3 bpf/tests: fix NULL iface MAC on ipv6 ND tests
e20e3aab44 bpf/scapy: misc fixes (v6 utils, formatting)
```

```release-note
Fix checksum calculation on ICMPv6 NA when NS don't have llsrc option.
```