### PR TITLE
envoy: Allow stream timeout to be disabled

### DIFF
--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -363,6 +363,8 @@ type OperatorConfig struct {
 	ProxyIdleTimeoutSeconds int
 
 	// ProxyStreamIdleTimeoutSeconds is the stream idle timeout for the proxy to upstream cluster
+	// A value of 0 will completely disable the connection manager stream idle timeout.
+	// A value of -1 will ignore the stream idle timeout and use whatever is default in Envoy (currently 300s).
 	ProxyStreamIdleTimeoutSeconds int
 
 	// CiliumK8sNamespace is the namespace where Cilium pods are running.
@@ -416,9 +418,6 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 		c.ProxyIdleTimeoutSeconds = DefaultProxyIdleTimeoutSeconds
 	}
 	c.ProxyStreamIdleTimeoutSeconds = vp.GetInt(ProxyStreamIdleTimeoutSeconds)
-	if c.ProxyStreamIdleTimeoutSeconds == 0 {
-		c.ProxyStreamIdleTimeoutSeconds = DefaultProxyStreamIdleTimeoutSeconds
-	}
 	c.CiliumPodLabels = vp.GetString(CiliumPodLabels)
 	c.TaintSyncWorkers = vp.GetInt(TaintSyncWorkers)
 	c.RemoveCiliumNodeTaints = vp.GetBool(RemoveCiliumNodeTaints)

--- a/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
+++ b/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
@@ -34,12 +34,13 @@ func newCiliumEnvoyConfigReconciler(c client.Client, logger *slog.Logger, defaul
 		client: c,
 		logger: logger,
 
-		algorithm:          defaultAlgorithm,
-		ports:              ports,
-		maxRetries:         maxRetries,
-		idleTimeoutSeconds: idleTimeoutSeconds,
-		enableIpv4:         enableIpv4,
-		enableIpv6:         enableIpv6,
+		algorithm:                defaultAlgorithm,
+		ports:                    ports,
+		maxRetries:               maxRetries,
+		idleTimeoutSeconds:       idleTimeoutSeconds,
+		streamIdleTimeoutSeconds: streamIdleTimeoutSeconds,
+		enableIpv4:               enableIpv4,
+		enableIpv6:               enableIpv6,
 	}
 }
 

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -285,7 +285,7 @@ func (i *cecTranslator) listenerMutators(m *model.Model) []ListenerMutator {
 		res = append(res, withHostNetworkPort(m, i.Config.IPConfig.IPv4Enabled, i.Config.IPConfig.IPv6Enabled))
 	}
 
-	if i.Config.ListenerConfig.StreamIdleTimeoutSeconds > 0 {
+	if i.Config.ListenerConfig.StreamIdleTimeoutSeconds > -1 {
 		res = append(res, WithStreamIdleTimeout(i.Config.ListenerConfig.StreamIdleTimeoutSeconds))
 	}
 


### PR DESCRIPTION
This commit is to allow to have stream timeout to be disabled (i.e. the value of zero). Additionally, this commit is to pass the value for L7 LB service, which is missed in original PR.

Fixes: 93018d28b4197fc556e26c24c3ed369b8cc812b6


