### PR TITLE
cni: reduce timeout on deletion to 1.5s

### DIFF
--- a/plugins/cilium-cni/lib/deletion_queue.go
+++ b/plugins/cilium-cni/lib/deletion_queue.go
@@ -41,7 +41,7 @@ type DeletionFallbackClient struct {
 
 // the timeout for connecting and obtaining the lock
 // the default of 30 seconds is too long; kubelet will time us out before then
-const timeoutSeconds = 10
+const timeoutDuration = 1500 * time.Millisecond
 
 // the maximum number of queued deletions allowed, to protect against kubelet insanity
 const maxDeletionFiles = 256
@@ -72,7 +72,7 @@ func (dc *DeletionFallbackClient) tryConnect() error {
 		return nil
 	}
 
-	c, err := dc.newCiliumClientFn(timeoutSeconds * time.Second)
+	c, err := dc.newCiliumClientFn(timeoutDuration)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (dc *DeletionFallbackClient) tryQueueLock() (*lockfile.Lockfile, error) {
 		return nil, fmt.Errorf("failed to open lockfile %s: %w", dc.deleteQueueLockfile, err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutSeconds*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
 	defer cancel()
 
 	err = lf.Lock(ctx, false) // get the shared lock


### PR DESCRIPTION
When kubelet enables graceful shutdown, and set shutdowngraceperiod to default value(30), long deletion timeout in cilium-cni could lead to containerd cannot finish StopPodSandbox before it is killed. As a result, kubelet cannot remove the pod from kube-api server, and the pod is leaked. 

<!-- Description of change -->
Reducing timeout to 1.5s (3 * rest API timeout 500 ms) can ensure StopPod Sandbox can be finished before kubelet and containedd are terminated. 

Fixes: #40931 
