### PR TITLE
k8s: update heartbeat() to use `readyz` instead of `healthz`

### DIFF
--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -291,11 +291,11 @@ func (c *compositeClientset) startHeartbeat() {
 
 	heartBeat := func(ctx context.Context) error {
 		// Kubernetes does a get node of the node that kubelet is running [0]. This seems excessive in
-		// our case because the amount of data transferred is bigger than doing a Get of /healthz.
-		// For this reason we have picked to perform a get on `/healthz` instead a get of a node.
+		// our case because the amount of data transferred is bigger than doing a Get of /readyz.
+		// For this reason we have picked to perform a get on `/readyz` instead a get of a node.
 		//
 		// [0] https://github.com/kubernetes/kubernetes/blob/v1.17.3/pkg/kubelet/kubelet_node_status.go#L423
-		res := restClient.Get().Resource("healthz").Do(ctx)
+		res := restClient.Get().Resource("readyz").Do(ctx)
 		return res.Error()
 	}
 

--- a/pkg/k8s/client/client_test.go
+++ b/pkg/k8s/client/client_test.go
@@ -252,7 +252,7 @@ func Test_client(t *testing.T) {
 	// Wait until heartbeat has been seen to check that heartbeats are
 	// running.
 	err := testutils.WaitUntil(
-		func() bool { return getRequest("/healthz") != nil },
+		func() bool { return getRequest("/readyz") != nil },
 		time.Second)
 	require.NoError(t, err)
 
@@ -621,7 +621,7 @@ func Test_clientMultipleAPIServersFailedHeartbeat(t *testing.T) {
 			       "major": "1",
 			       "minor": "99"
 			}`))
-			case "/healthz":
+			case "/readyz":
 				healthServer.Store("health", "http://"+r.Host)
 			default:
 				w.Write([]byte("{}"))


### PR DESCRIPTION
The healthz endpoint of Kubernetes API server has been deprecated since Kubernetes v1.16, so update the heartBeat() function to use readyz instead.

Ref doc: https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health
