### PR TITLE
Fixes: #37805 configuration of IP families on ingress controller

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -48,6 +48,13 @@ spec:
   {{- if and .Values.ingressController.service.externalTrafficPolicy (not .Values.ingressController.hostNetwork.enabled) }}
   externalTrafficPolicy: {{ .Values.ingressController.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.ingressController.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ingressController.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- with .Values.ingressController.service.ipFamilies }}
+  ipFamilies:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Endpoints

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -990,6 +990,22 @@ ingressController:
     # Valid values are "Cluster" and "Local".
     # ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy
     externalTrafficPolicy: Cluster
+    # @schema
+    # type: [null, string]
+    # @schema
+    # -- Configures the service's supported IP family policy.
+    # Valid values are:
+    #     SingleStack: Single-stack service. The control plane allocates a cluster IP for the Service, using the first configured service cluster IP range.
+    #     PreferDualStack: Allocates IPv4 and IPv6 cluster IPs for the Service.
+    #     RequireDualStack: Allocates Service .spec.ClusterIPs from both IPv4 and IPv6 address ranges.
+    # ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
+    ipFamilyPolicy: ~
+    # @schema
+    # type: [null, array]
+    # @schema
+    # -- Sets the families that should be supported and the order in which they should be applied to ClusterIP as well.
+    # Valid values are "IPv4" and/or "IPv6"
+    ipFamilies: []
   # Host Network related configuration
   hostNetwork:
     # -- Configure whether the Envoy listeners should be exposed on the host network.


### PR DESCRIPTION
<!-- Description of change -->
Fixes #37805.

IP families cannot currently be setted on ingress contrller service. In dual stack environment it means that service can be only accessible on IPv4 and not IPv6.

Allowing that means dual stack is fully functionnal with ingress controller.
```release-note
chart: add configuration of IP families for ingress controller service
```
