### PR TITLE
ICMPv6: Fix verifier error when loading on l2-less devices

### DIFF
--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -534,6 +534,10 @@ bool icmp6_ndisc_validate(struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
 	struct ethhdr *eth = ctx_data(ctx);
 	union macaddr *dmac;
 
+	/* On l2-less devices there is no MAC address, and we cannot proceed */
+	if (sizeof(struct ethhdr) != ETH_HLEN)
+		return false;
+
 	if ((void *)eth + ETH_HLEN > ctx_data_end(ctx))
 		return false;
 

--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -23,10 +23,16 @@ func lxcLoadPermutations() iter.Seq[*config.BPFLXC] {
 
 func hostLoadPermutations() iter.Seq[*config.BPFHost] {
 	return func(yield func(*config.BPFHost) bool) {
-		for permutation := range permute(2) {
+		for permutation := range permute(3) {
 			cfg := config.NewBPFHost(*config.NewNode())
 			cfg.SecctxFromIPCache = permutation[0]
 			cfg.EnableRemoteNodeMasquerade = permutation[1]
+			if permutation[2] {
+				cfg.EthHeaderLength = 0
+			} else {
+				cfg.EthHeaderLength = 14
+			}
+
 			if !yield(cfg) {
 				return
 			}


### PR DESCRIPTION
The ICMPv6 code was assuming that `ETH_HLEN` is always equal to the size of `struct ethhdr`, which is not the case on L3 devices. This leads to verifier errors when loading with l2 announcements on a L3 device.

Fixes: #41522

```release-note
Fix verifier error that occurs when enabling l2 annoucements on a l2-less device
```
