### PR TITLE
workflows/conformance-ginkgo: fix steps for stable branches

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -280,12 +280,19 @@ jobs:
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
-      - name: Copy cilium-cli
+      - name: Copy cilium-cli from CI docker image
+        if: ${{ env.CILIUM_CLI_VERSION == '' }}
         shell: bash
         run: |
           cid=$(docker create ${{ env.CILIUM_CLI_IMAGE_REPO }}:${{ needs.setup-vars.outputs.SHA }} ls)
           docker cp $cid:/usr/local/bin/cilium "$PWD/cilium-cli-bin"
           docker rm $cid
+
+      - name: Copy cilium-cli from released binary
+        if: ${{ env.CILIUM_CLI_VERSION != '' }}
+        shell: bash
+        run: |
+          cp /usr/local/bin/cilium "$PWD/cilium-cli-bin"
 
       - name: Install helm
         shell: bash


### PR DESCRIPTION
On stable branches we are not building cilium-cli image and therefore the CI images don't exist for the commit that we want to retrieve the cilium-cli binary from. This causes the CI to fail on stable branches. Thus, we need to add a new step that only runs when cilium-cli binary exists which permits for stable branches to run successfully.

Fixes: 8222614b1560 (".github/worfklows: copy cilium-cli binary from container")