### PR TITLE
cilium-cli: Prevent panic in `node-to-node-encryption` connectivity test

### DIFF
--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -452,6 +452,14 @@ func (s *nodeToNodeEncryption) Run(ctx context.Context, t *check.Test) {
 	clientHost := t.Context().HostNetNSPodsByNode()[client.Pod.Spec.NodeName]
 	// serverHost is a pod running in a remote node's host netns.
 	serverHost := t.Context().HostNetNSPodsByNode()[server.Pod.Spec.NodeName]
+
+	if clientHost.Pod == nil {
+		t.Fatalf("Could not find host network namespace pod on client node %s", client.Pod.Spec.NodeName)
+	}
+	if serverHost.Pod == nil {
+		t.Fatalf("Could not find host network namespace pod on server node %s", server.Pod.Spec.NodeName)
+	}
+
 	assertNoLeaks, _ := t.Context().Features.MatchRequirements(s.reqs...)
 
 	if !assertNoLeaks {


### PR DESCRIPTION
The `node-to-node-encryption` test currently panics when run on a cluster with node encryption disabled, see logs bellow.

This PR adds safeguards to properly fail with an appropriate error message in the situation that currently panics.

Note: I guess the[ feature detection](https://github.com/cilium/cilium/blob/c0649fbdbf1d33fc532e9281c08b34db36d7d984/cilium-cli/connectivity/tests/encryption.go#L429-L441) should prevent ending up in this situation by skipping this test. In my case the feature detection produces:
```
🐛 Detected features:
[...]
🐛   encryption-node: Disabled:node-role.kubernetes.io/control-plane
```

But as a first step, this PR replaces the panic by a clean failure.

Panic logs:

```sh
$ cilium version
cilium-cli: v0.18.7 compiled with go1.25.0 on darwin/arm64

$ cilium connectivity test --test=node-to-node-encryption --debug
[...]
  [-] Scenario [node-to-node-encryption/node-to-node-encryption]
[=] [cilium-test-1] Test [node-to-node-encryption] [59/123]
  🐛 node-to-node-encryption test running in sanity mode, expecting unencrypted packets
  🐛 Finalizing Test node-to-node-encryption
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x3c8 pc=0x1067f077c]

goroutine 1697 [running]:
github.com/cilium/cilium/cilium-cli/connectivity/check.Pod.Address({0x0, 0x0, {0x0, 0x0}, {0x0, 0x0}, 0x0, 0x0}, 0x1)
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/check/peer.go:109 +0x3c
github.com/cilium/cilium/cilium-cli/connectivity/tests.getFilter({0x1097d8718, 0x14000f86ac0}, 0x14000ea0f20, 0x14001592300, 0x14001592400, 0x140015924c0, 0x140015924c0, 0x1, 0x1, 0x0)
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/tests/encryption.go:171 +0x75c
github.com/cilium/cilium/cilium-cli/connectivity/tests.testNoTrafficLeak({0x1097d8718, 0x14000f86ac0}, 0x14000ea0f20, {0x1097c3630, 0x14000a40a80}, 0x14001592300, 0x140015924c0, 0x14001592400, 0x140015924c0, 0x1, ...)
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/tests/encryption.go:303 +0xb0
github.com/cilium/cilium/cilium-cli/connectivity/tests.(*nodeToNodeEncryption).Run.func1(0x1)
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/tests/encryption.go:481 +0x8c
github.com/cilium/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).ForEachIPFamily(0x14000878a88, 0xb0?, 0x14000d51c30)
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/check/context.go:1326 +0x260
github.com/cilium/cilium/cilium-cli/connectivity/check.(*Test).ForEachIPFamily(0x14000ea0f20, 0x14000d51c30)
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/check/test.go:916 +0xac
github.com/cilium/cilium/cilium-cli/connectivity/tests.(*nodeToNodeEncryption).Run(0x14000a40a80, {0x1097d8718, 0x14000f86ac0}, 0x14000ea0f20)
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/tests/encryption.go:472 +0x6fc
github.com/cilium/cilium/cilium-cli/connectivity/check.(*Test).Run(0x14000ea0f20, {0x1097d8718, 0x14000f86ac0}, 0x3b)
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/check/test.go:397 +0x45c
github.com/cilium/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).Run.func1()
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/check/context.go:455 +0x68
created by github.com/cilium/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).Run in goroutine 1567
        /cilium/vendor/github.com/cilium/cilium/cilium-cli/connectivity/check/context.go:449 +0x90
```
