### PR TITLE
docs: document request-timeout ingress annotation

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -183,11 +183,18 @@ Supported Ingress Annotations
        | ``enforce-ingress-https`` configuration
        | file setting (or ``ingressController.enforceHttps``
        | in Helm).
-       | 
+       |
        | Any host with TLS config will have redirects to
        | HTTPS configured for each match specified in the
        | Ingress.
      - unspecified
+   * - ``ingress.cilium.io/request-timeout``
+     - | Request timeout in seconds for Ingress backend HTTP requests.
+       |
+       | Note that if the annotation is present, it will override
+       | any value set by the ``ingress-default-request-timeout`` operator flag.
+       | If neither is set, defaults to ``0`` (no limit)
+     - ``0``
 
 Additionally, cloud-provider specific annotations for the LoadBalancer Service
 are supported.
@@ -334,7 +341,7 @@ Cilium's Ingress features:
 
    http
    ingress-and-network-policy
-   path-types   
+   path-types
    grpc
    tls-termination
    tls-default-certificate


### PR DESCRIPTION
Found that this annotation was not documented, and had to dive in to PRs/code to understand it. 

Relevant PR: https://github.com/cilium/cilium/pull/31693

Validation:
<img width="1268" height="1271" alt="image" src="https://github.com/user-attachments/assets/4ef400ea-193c-4991-8530-b8b74fe0ea35" />

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

```release-note
Document request-timeout ingress annotation
```
