### PR TITLE
[v1.16] envoy: Start serving listeners only after clusters have been ACKed

### DIFF
--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -93,7 +93,8 @@ func (s *xdsGRPCServer) DeltaListeners(stream envoy_service_listener.ListenerDis
 }
 
 func (s *xdsGRPCServer) StreamListeners(stream envoy_service_listener.ListenerDiscoveryService_StreamListenersServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, ListenerTypeURL)
+	// Listeners should start serving only after Clusters have been ACKed.
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, ListenerTypeURL, ClusterTypeURL)
 }
 
 func (s *xdsGRPCServer) FetchListeners(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -107,7 +108,7 @@ func (s *xdsGRPCServer) DeltaRoutes(stream envoy_service_route.RouteDiscoverySer
 }
 
 func (s *xdsGRPCServer) StreamRoutes(stream envoy_service_route.RouteDiscoveryService_StreamRoutesServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, RouteTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, RouteTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchRoutes(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -121,7 +122,7 @@ func (s *xdsGRPCServer) DeltaClusters(stream envoy_service_cluster.ClusterDiscov
 }
 
 func (s *xdsGRPCServer) StreamClusters(stream envoy_service_cluster.ClusterDiscoveryService_StreamClustersServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, ClusterTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, ClusterTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchClusters(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -135,7 +136,7 @@ func (s *xdsGRPCServer) DeltaEndpoints(stream envoy_service_endpoint.EndpointDis
 }
 
 func (s *xdsGRPCServer) StreamEndpoints(stream envoy_service_endpoint.EndpointDiscoveryService_StreamEndpointsServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, EndpointTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, EndpointTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchEndpoints(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -149,7 +150,7 @@ func (s *xdsGRPCServer) DeltaSecrets(stream envoy_service_secret.SecretDiscovery
 }
 
 func (s *xdsGRPCServer) StreamSecrets(stream envoy_service_secret.SecretDiscoveryService_StreamSecretsServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, SecretTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, SecretTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchSecrets(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -159,7 +160,7 @@ func (s *xdsGRPCServer) FetchSecrets(ctx context.Context, req *envoy_service_dis
 }
 
 func (s *xdsGRPCServer) StreamNetworkPolicies(stream cilium.NetworkPolicyDiscoveryService_StreamNetworkPoliciesServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchNetworkPolicies(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {
@@ -169,7 +170,7 @@ func (s *xdsGRPCServer) FetchNetworkPolicies(ctx context.Context, req *envoy_ser
 }
 
 func (s *xdsGRPCServer) StreamNetworkPolicyHosts(stream cilium.NetworkPolicyHostsDiscoveryService_StreamNetworkPolicyHostsServer) error {
-	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyHostsTypeURL)
+	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyHostsTypeURL, "")
 }
 
 func (s *xdsGRPCServer) FetchNetworkPolicyHosts(ctx context.Context, req *envoy_service_discovery.DiscoveryRequest) (*envoy_service_discovery.DiscoveryResponse, error) {

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -4,6 +4,7 @@
 package envoy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -79,6 +80,10 @@ var observerOnce = sync.Once{}
 
 func (cache *NPHDSCache) MarkRestorePending()   {}
 func (cache *NPHDSCache) MarkRestoreCompleted() {}
+
+func (cache *NPHDSCache) WaitForFirstAck(ctx context.Context, node string, typeURL string) {
+	// not implemented
+}
 
 // HandleResourceVersionAck is required to implement ResourceVersionAckObserver.
 // We use this to start the IP Cache listener on the first ACK so that we only

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -4,6 +4,7 @@
 package xds
 
 import (
+	"context"
 	"errors"
 
 	"github.com/sirupsen/logrus"
@@ -41,6 +42,9 @@ type ResourceVersionAckObserver interface {
 
 	// MarkRestoreCompleted clears the 'restore' state so that updates are acked normally.
 	MarkRestoreCompleted()
+
+	// WaitForFirstAck() blocks until the given node has acked the first ACK.
+	WaitForFirstAck(ctx context.Context, node string, typeURL string)
 }
 
 // AckingResourceMutatorRevertFunc is a function which reverts the effects of
@@ -106,6 +110,11 @@ type AckingResourceMutatorWrapper struct {
 	// e.g. "127.0.0.1" for the host proxy.
 	ackedVersions map[string]uint64
 
+	// ackedNodes has a channel for each node for which someone is waiting for the first ACK to
+	// be received. The channel is closed after the first ACK has been received, and set to
+	// 'nil' to avoid closing the channel more than once.
+	ackedNodes map[string]chan struct{}
+
 	// pendingCompletions is the list of updates that are pending completion.
 	pendingCompletions map[*completion.Completion]*pendingCompletion
 
@@ -133,6 +142,7 @@ func NewAckingResourceMutatorWrapper(mutator ResourceMutator) *AckingResourceMut
 	return &AckingResourceMutatorWrapper{
 		mutator:            mutator,
 		ackedVersions:      make(map[string]uint64),
+		ackedNodes:         make(map[string]chan struct{}),
 		pendingCompletions: make(map[*completion.Completion]*pendingCompletion),
 	}
 }
@@ -150,6 +160,45 @@ func (m *AckingResourceMutatorWrapper) MarkRestoreCompleted() {
 	defer m.locker.Unlock()
 
 	m.restoring = false
+}
+
+func (m *AckingResourceMutatorWrapper) WaitForFirstAck(ctx context.Context, node string, typeURL string) {
+	// No wait if there are no resources of the given type
+	if !m.mutator.HasAny(typeURL) {
+		return
+	}
+
+	m.locker.Lock()
+	ch, exists := m.ackedNodes[node]
+	// This can happen before the first request from the node is received, so we must initialize
+	// a channel here if one does not exist for the node.
+	if !exists {
+		ch = make(chan struct{})
+		m.ackedNodes[node] = ch
+	}
+	m.locker.Unlock()
+
+	logger := log.WithFields(logrus.Fields{
+		logfields.XDSClientNode: node,
+		logfields.XDSTypeURL:    typeURL,
+	})
+
+	// ch can be 'nil' to avoid closing the channel more than once. If so, the first ACK has
+	// already been received.
+	if ch == nil {
+		logger.Info("WaitForFirstAck: first ACK has already been received, no need to wait")
+		return
+	}
+
+	logger.Info("WaitForFirstAck: Waiting until first ACK has been received")
+	// wait after m.locker has been released!
+	select {
+	case <-ctx.Done():
+		logger.Info("WaitForFirstAck: canceling wait for the first ACK due to expired context")
+	case <-ch:
+		// ACK was received
+		logger.Info("WaitForFirstAck: resuming after receiving the first ACK")
+	}
 }
 
 // AddVersionCompletion adds a completion to wait for any ACK for the
@@ -172,6 +221,10 @@ func (m *AckingResourceMutatorWrapper) DeleteNode(nodeID string) {
 	defer m.locker.Unlock()
 
 	delete(m.ackedVersions, nodeID)
+	if ch, exists := m.ackedNodes[nodeID]; exists && ch != nil {
+		close(ch)
+	}
+	delete(m.ackedNodes, nodeID)
 }
 
 func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName string, resource proto.Message, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc {
@@ -354,6 +407,24 @@ func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint6
 	// node at all.
 	if previouslyAckedVersion, exists := m.ackedVersions[nodeIP]; !exists || previouslyAckedVersion < ackVersion {
 		m.ackedVersions[nodeIP] = ackVersion
+
+		// Signal reception of an ACK (exluding the version 0, or any NACKs).
+		if exists && previouslyAckedVersion < ackVersion {
+			ch, exists := m.ackedNodes[nodeIP]
+			if !exists || ch != nil {
+				log.WithFields(logrus.Fields{
+					logfields.XDSClientNode:   nodeIP,
+					logfields.XDSTypeURL:      typeURL,
+					logfields.XDSAckedVersion: ackVersion,
+				}).Info("HandleResourceVersionAck: first ACK received")
+			}
+			// nil the channel (if any) to mark the reception of the ACK
+			m.ackedNodes[nodeIP] = nil
+			if exists && ch != nil {
+				// Wake up any waiters
+				close(ch)
+			}
+		}
 	}
 
 	remainingCompletions := make(map[*completion.Completion]*pendingCompletion, len(m.pendingCompletions))

--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -193,6 +193,18 @@ func (c *Cache) Clear(typeURL string) (version uint64, updated bool) {
 	return c.version, cacheIsUpdated
 }
 
+func (c *Cache) HasAny(typeURL string) bool {
+	c.locker.Lock()
+	defer c.locker.Unlock()
+
+	for k := range c.resources {
+		if typeURL == AnyTypeURL || k.typeURL == typeURL {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Cache) GetResources(typeURL string, lastVersion uint64, nodeIP string, resourceNames []string) (*VersionedResources, error) {
 	c.locker.RLock()
 	defer c.locker.RUnlock()

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -33,6 +33,10 @@ var (
 	// a type URL from an ADS stream.
 	ErrNoADSTypeURL = errors.New("type URL is required for ADS")
 
+	// ErrMismatchingTypeURL is the error returned when receiving a request with
+	// an unexpected type URL.
+	ErrMismatchingTypeURL = errors.New("mismatching type URL")
+
 	// ErrUnknownTypeURL is the error returned when receiving a request with
 	// an unknown type URL.
 	ErrUnknownTypeURL = errors.New("unknown type URL")
@@ -129,7 +133,7 @@ func getXDSRequestFields(req *envoy_service_discovery.DiscoveryRequest) logrus.F
 }
 
 // HandleRequestStream receives and processes the requests from an xDS stream.
-func (s *Server) HandleRequestStream(ctx context.Context, stream Stream, defaultTypeURL string) error {
+func (s *Server) HandleRequestStream(ctx context.Context, stream Stream, defaultTypeURL, afterTypeURL string) error {
 	// increment stream count
 	streamID := s.lastStreamID.Add(1)
 
@@ -178,7 +182,7 @@ func (s *Server) HandleRequestStream(ctx context.Context, stream Stream, default
 		}
 	}(reqStreamLog)
 
-	return s.processRequestStream(ctx, reqStreamLog, stream, reqCh, defaultTypeURL)
+	return s.processRequestStream(ctx, reqStreamLog, stream, reqCh, defaultTypeURL, afterTypeURL)
 }
 
 // perTypeStreamState is the state maintained per resource type for each
@@ -203,7 +207,7 @@ type perTypeStreamState struct {
 
 // processRequestStream processes the requests in an xDS stream from a channel.
 func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Entry, stream Stream,
-	reqCh <-chan *envoy_service_discovery.DiscoveryRequest, defaultTypeURL string,
+	reqCh <-chan *envoy_service_discovery.DiscoveryRequest, defaultTypeURL, afterTypeURL string,
 ) error {
 	// The request state for every type URL.
 	typeStates := make([]perTypeStreamState, len(s.watchers))
@@ -261,7 +265,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 		i++
 	}
 
-	streamLog.Info("starting xDS stream processing")
+	streamLog.WithField(logfields.XDSTypeURL, defaultTypeURL).Info("starting xDS stream processing")
 
 	nodeIP := ""
 	firstRequest := true
@@ -295,6 +299,12 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 					return ErrInvalidNodeFormat
 				}
 				streamLog.WithFields(getXDSRequestFields(req)).Info("Received first request in a new xDS stream")
+
+				// delay responding to the first request until 'afterTypeURL' has
+				// been acked, if any
+				if afterTypeURL != "" {
+					s.ackObservers[afterTypeURL].WaitForFirstAck(ctx, nodeIP, afterTypeURL)
+				}
 			}
 
 			requestLog := streamLog.WithFields(getXDSRequestFields(req))
@@ -330,6 +340,11 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			if defaultTypeURL == AnyTypeURL && typeURL == "" {
 				requestLog.Error("no type URL given in ADS request")
 				return ErrNoADSTypeURL
+			}
+
+			if defaultTypeURL != AnyTypeURL && typeURL != defaultTypeURL {
+				requestLog.Error("mismatching type URL given in xDS request")
+				return ErrMismatchingTypeURL
 			}
 
 			index, exists := typeIndexes[typeURL]

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -10,8 +10,11 @@ import (
 	"testing"
 	"time"
 
+	envoy_config_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_config_tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoy_service_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,7 +103,7 @@ func TestRequestAllResources(t *testing.T) {
 	// Run the server's stream handler concurrently.
 	go func() {
 		defer close(streamDone)
-		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
 		require.NoError(t, err)
 	}()
 
@@ -223,7 +226,7 @@ func TestAck(t *testing.T) {
 	// Run the server's stream handler concurrently.
 	go func() {
 		defer close(streamDone)
-		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
 		require.NoError(t, err)
 	}()
 
@@ -344,7 +347,7 @@ func TestRequestSomeResources(t *testing.T) {
 	// Run the server's stream handler concurrently.
 	go func() {
 		defer close(streamDone)
-		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
 		require.NoError(t, err)
 	}()
 
@@ -514,7 +517,7 @@ func TestUpdateRequestResources(t *testing.T) {
 	// Run the server's stream handler concurrently.
 	go func() {
 		defer close(streamDone)
-		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
 		require.NoError(t, err)
 	}()
 
@@ -614,7 +617,7 @@ func TestRequestStaleNonce(t *testing.T) {
 	// Run the server's stream handler concurrently.
 	go func() {
 		defer close(streamDone)
-		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
 		require.NoError(t, err)
 	}()
 
@@ -740,7 +743,7 @@ func TestNAck(t *testing.T) {
 	// Run the server's stream handler concurrently.
 	go func() {
 		defer close(streamDone)
-		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
 		require.NoError(t, err)
 	}()
 
@@ -866,7 +869,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	// Run the server's stream handler concurrently.
 	go func() {
 		defer close(streamDone)
-		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
 		require.NoError(t, err)
 	}()
 
@@ -993,7 +996,7 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	// Run the server's stream handler concurrently.
 	go func() {
 		defer close(streamDone)
-		err := server.HandleRequestStream(ctx, stream, AnyTypeURL)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
 		require.NoError(t, err)
 	}()
 
@@ -1028,5 +1031,329 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	case <-ctx.Done():
 		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
 	case <-streamDone:
+	}
+}
+
+func toAny(pb proto.Message) *anypb.Any {
+	a, err := anypb.New(pb)
+	if err != nil {
+		panic(err.Error())
+	}
+	return a
+}
+
+func TestWaitForAck(t *testing.T) {
+	ListenerTypeURL := "type.googleapis.com/envoy.config.listener.v3.Listener"
+	ClusterTypeURL := "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+
+	// Test the case where the xDS server receives request for Listeners before Clusters, where
+	// we must wait responding on Listeners stream for the first ACK on the Clusters stream to
+	// have been received.
+
+	var err error
+	var resp *envoy_service_discovery.DiscoveryResponse
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+	wg := completion.NewWaitGroup(ctx)
+
+	ldsCache := NewCache()
+	ldsMutator := NewAckingResourceMutatorWrapper(ldsCache)
+	ldsStreamCtx, ldsCloseStream := context.WithCancel(ctx)
+	ldsStream := NewMockStream(ldsStreamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer ldsStream.Close()
+	ldsStreamDone := make(chan struct{})
+
+	cdsCache := NewCache()
+	cdsMutator := NewAckingResourceMutatorWrapper(cdsCache)
+	cdsStreamCtx, cdsCloseStream := context.WithCancel(ctx)
+	cdsStream := NewMockStream(cdsStreamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer cdsStream.Close()
+	cdsStreamDone := make(chan struct{})
+
+	server := NewServer(map[string]*ResourceTypeConfiguration{
+		ListenerTypeURL: {Source: ldsCache, AckObserver: ldsMutator},
+		ClusterTypeURL:  {Source: cdsCache, AckObserver: cdsMutator},
+	},
+		nil)
+
+	// Run the server's stream handlers concurrently.
+	go func() {
+		defer close(ldsStreamDone)
+		err := server.HandleRequestStream(ctx, ldsStream, ListenerTypeURL, ClusterTypeURL)
+		require.NoError(t, err)
+	}()
+	go func() {
+		defer close(cdsStreamDone)
+		err := server.HandleRequestStream(ctx, cdsStream, ClusterTypeURL, "")
+		require.NoError(t, err)
+	}()
+
+	// Create Listener with reference to a cluster
+	clusterName := "cluster1"
+
+	clusterConf := &envoy_config_cluster.Cluster{
+		Name: clusterName,
+	}
+
+	listenerConf := &envoy_config_listener.Listener{
+		Name: "listener1",
+		FilterChains: []*envoy_config_listener.FilterChain{{
+			Filters: []*envoy_config_listener.Filter{{
+				Name: "envoy.filters.network.tcp_proxy",
+				ConfigType: &envoy_config_listener.Filter_TypedConfig{
+					TypedConfig: toAny(&envoy_config_tcp.TcpProxy{
+						StatPrefix: "tcp_proxy",
+						ClusterSpecifier: &envoy_config_tcp.TcpProxy_Cluster{
+							Cluster: clusterName,
+						},
+					}),
+				},
+			}},
+		}},
+	}
+
+	cdsCallback, cdsComp := newCompCallback()
+	cdsMutator.Upsert(ClusterTypeURL, clusterConf.Name, clusterConf, []string{node0}, wg, cdsCallback)
+	require.Condition(t, isNotCompletedComparison(cdsComp))
+
+	ldsCallback, ldsComp := newCompCallback()
+	ldsMutator.Upsert(ListenerTypeURL, listenerConf.Name, listenerConf, []string{node0}, wg, ldsCallback)
+	require.Condition(t, isNotCompletedComparison(ldsComp))
+
+	// Request listener resources, with a version higher than the version currently
+	// in Cilium's cache. This happens after the server restarts but the
+	// xDS client survives and continues to request the same version.
+	// First request on a new stream has an empty ResponseNonce!
+	ldsReq := &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       ListenerTypeURL,
+		VersionInfo:   "15",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "",
+	}
+	err = ldsStream.SendRequest(ldsReq)
+	require.NoError(t, err)
+
+	// Expecting a LDS response in a goroutine
+	ldsDoneCh := make(chan struct{})
+	go func() {
+		resp, err = ldsStream.RecvResponse()
+		require.NoError(t, err)
+		require.Equal(t, resp.VersionInfo, resp.Nonce)
+		require.Condition(t, responseCheck(resp, "16", []proto.Message{listenerConf}, false, ListenerTypeURL))
+
+		// Check that the completion was not NACKed
+		require.NoError(t, ldsComp.Err())
+
+		// send LDS ACK
+		ldsReq = &envoy_service_discovery.DiscoveryRequest{
+			TypeUrl:       ListenerTypeURL,
+			VersionInfo:   "16",
+			Node:          nodes[node0],
+			ResourceNames: nil,
+			ResponseNonce: "16",
+		}
+		err = ldsStream.SendRequest(ldsReq)
+		require.NoError(t, err)
+
+		close(ldsDoneCh)
+	}()
+
+	time.Sleep(time.Millisecond)
+
+	// Request cluster resources, with a version higher than the version currently
+	// in Cilium's cache. This happens after the server restarts but the
+	// xDS client survives and continues to request the same version.
+	// First request on a new stream has an empty ResponseNonce!
+	cdsReq := &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       ClusterTypeURL,
+		VersionInfo:   "30",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "",
+	}
+	err = cdsStream.SendRequest(cdsReq)
+	require.NoError(t, err)
+
+	// Expecting a CDS response
+	resp, err = cdsStream.RecvResponse()
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "31", []proto.Message{clusterConf}, false, ClusterTypeURL))
+
+	// Check that the completion was not NACKed
+	require.NoError(t, cdsComp.Err())
+
+	// Check that LDS response has not been received before the CDS ACK is sent
+	ldsResponseReceived := false
+	select {
+	case <-ldsDoneCh:
+		ldsResponseReceived = true
+	default:
+	}
+	require.False(t, ldsResponseReceived)
+
+	// send CDS ACK
+	cdsReq = &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       ClusterTypeURL,
+		VersionInfo:   "31",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "31",
+	}
+	err = cdsStream.SendRequest(cdsReq)
+	require.NoError(t, err)
+
+	// Wait for the LDS goroutine to be done
+	select {
+	case <-ctx.Done():
+		t.Errorf("LDS goroutine did not end in time")
+	case <-ldsDoneCh:
+	}
+
+	// Wait for the ACKs to have been processed
+	err = wg.Wait()
+	require.NoError(t, err)
+
+	// Close the streams.
+	cdsCloseStream()
+
+	select {
+	case <-ctx.Done():
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", ClusterTypeURL)
+	case <-cdsStreamDone:
+	}
+
+	ldsCloseStream()
+	select {
+	case <-ctx.Done():
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", ListenerTypeURL)
+	case <-ldsStreamDone:
+	}
+}
+
+func TestWaitForAckNoClusters(t *testing.T) {
+	ListenerTypeURL := "type.googleapis.com/envoy.config.listener.v3.Listener"
+	ClusterTypeURL := "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+
+	// Test the case where the xDS server receives request for Listeners when there are no
+	// clusters. In this case the listener response must be sent without any wait.
+
+	var err error
+	var resp *envoy_service_discovery.DiscoveryResponse
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+	wg := completion.NewWaitGroup(ctx)
+
+	ldsCache := NewCache()
+	ldsMutator := NewAckingResourceMutatorWrapper(ldsCache)
+	ldsStreamCtx, ldsCloseStream := context.WithCancel(ctx)
+	ldsStream := NewMockStream(ldsStreamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer ldsStream.Close()
+	ldsStreamDone := make(chan struct{})
+
+	cdsCache := NewCache()
+	cdsMutator := NewAckingResourceMutatorWrapper(cdsCache)
+	cdsStreamCtx, cdsCloseStream := context.WithCancel(ctx)
+	cdsStream := NewMockStream(cdsStreamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer cdsStream.Close()
+	cdsStreamDone := make(chan struct{})
+
+	server := NewServer(map[string]*ResourceTypeConfiguration{
+		ListenerTypeURL: {Source: ldsCache, AckObserver: ldsMutator},
+		ClusterTypeURL:  {Source: cdsCache, AckObserver: cdsMutator},
+	},
+		nil)
+
+	// Run the server's stream handlers concurrently.
+	go func() {
+		defer close(ldsStreamDone)
+		err := server.HandleRequestStream(ctx, ldsStream, ListenerTypeURL, ClusterTypeURL)
+		require.NoError(t, err)
+	}()
+	go func() {
+		defer close(cdsStreamDone)
+		err := server.HandleRequestStream(ctx, cdsStream, ClusterTypeURL, "")
+		require.NoError(t, err)
+	}()
+
+	// Create Listener with reference to a static cluster
+	clusterName := "static_cluster"
+
+	listenerConf := &envoy_config_listener.Listener{
+		Name: "listener1",
+		FilterChains: []*envoy_config_listener.FilterChain{{
+			Filters: []*envoy_config_listener.Filter{{
+				Name: "envoy.filters.network.tcp_proxy",
+				ConfigType: &envoy_config_listener.Filter_TypedConfig{
+					TypedConfig: toAny(&envoy_config_tcp.TcpProxy{
+						StatPrefix: "tcp_proxy",
+						ClusterSpecifier: &envoy_config_tcp.TcpProxy_Cluster{
+							Cluster: clusterName,
+						},
+					}),
+				},
+			}},
+		}},
+	}
+
+	ldsCallback, ldsComp := newCompCallback()
+	ldsMutator.Upsert(ListenerTypeURL, listenerConf.Name, listenerConf, []string{node0}, wg, ldsCallback)
+	require.Condition(t, isNotCompletedComparison(ldsComp))
+
+	// Request listener resources, with a version higher than the version currently
+	// in Cilium's cache. This happens after the server restarts but the
+	// xDS client survives and continues to request the same version.
+	// First request on a new stream has an empty ResponseNonce!
+	ldsReq := &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       ListenerTypeURL,
+		VersionInfo:   "15",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "",
+	}
+	err = ldsStream.SendRequest(ldsReq)
+	require.NoError(t, err)
+
+	// Expecting a LDS response
+	resp, err = ldsStream.RecvResponse()
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "16", []proto.Message{listenerConf}, false, ListenerTypeURL))
+
+	// Check that the completion was not NACKed
+	require.NoError(t, ldsComp.Err())
+
+	// send LDS ACK
+	ldsReq = &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       ListenerTypeURL,
+		VersionInfo:   "16",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "16",
+	}
+	err = ldsStream.SendRequest(ldsReq)
+	require.NoError(t, err)
+
+	// Wait for the ACKs to have been processed
+	err = wg.Wait()
+	require.NoError(t, err)
+
+	// Close the streams.
+	cdsCloseStream()
+
+	select {
+	case <-ctx.Done():
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", ClusterTypeURL)
+	case <-cdsStreamDone:
+	}
+
+	ldsCloseStream()
+	select {
+	case <-ctx.Done():
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", ListenerTypeURL)
+	case <-ldsStreamDone:
 	}
 }

--- a/pkg/envoy/xds/set.go
+++ b/pkg/envoy/xds/set.go
@@ -86,6 +86,9 @@ type ResourceMutator interface {
 	// The returned version value is the set's version after update.
 	// This method call cannot be reverted.
 	Clear(typeURL string) (version uint64, updated bool)
+
+	// Empty returns 'true' if there are any resources of the given type
+	HasAny(typeURL string) bool
 }
 
 // ResourceSet provides read-write access to a versioned set of resources.


### PR DESCRIPTION
Author backport of #41552

[ upstream commit 39aca2ce54a7e559298f6f405fd0175801f42184 ]

Typically Envoy requests Clusters before Listeners, but when Cilium agent (re)starts the order in which the requests are received and responses provided can be random. This can lead to invalid Listener configuration, as seen by Envoy, where a non-existing cluster is referenced from the listener.

To avoid this error mode, make the Listener xDS stream start responding only after the cluster xDS stream has received the first ACK, so that all current clusters have been successfully initialized by Envoy and it is safe to refer to them from Listener configurations. The first CDS ACK is only waited for if there are clusters in the xDS cache.