### PR TITLE
feat(sdp): Updating DNS rules in Standalone DNS proxy

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/netip"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -29,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/proxy/ipfamily"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -189,6 +191,46 @@ type restoredIPRule struct {
 
 // map from EP IPs to *Endpoint
 type restoredEPs map[netip.Addr]*endpoint.Endpoint
+
+// DNSServerIdentity contains the identities of the DNS servers and used to
+// determine if a DNS request is allowed or not from standalone DNS proxy.
+// It adheres the interface policy.CachedSelector and reuses the
+// in agent dns proxy filtering path.
+type DNSServerIdentity struct {
+	Identities identity.NumericIdentitySlice
+}
+
+func (d DNSServerIdentity) Selects(_ *versioned.VersionHandle, identity identity.NumericIdentity) bool {
+	return slices.Contains(d.Identities, identity)
+}
+
+func (d DNSServerIdentity) String() string {
+	identityStrings := make([]string, len(d.Identities))
+	for i, id := range d.Identities {
+		identityStrings[i] = strconv.FormatUint(uint64(id), 10)
+	}
+	return strings.Join(identityStrings, ",")
+}
+
+// Not being used in the standalone dns proxy path
+func (d DNSServerIdentity) IsWildcard() bool {
+	return false
+}
+
+// Not being used in the standalone dns proxy path
+func (d DNSServerIdentity) IsNone() bool {
+	return false
+}
+
+// Not being used in the standalone dns proxy path
+func (d DNSServerIdentity) GetSelections(_ *versioned.VersionHandle) identity.NumericIdentitySlice {
+	return d.Identities
+}
+
+// Not being used in the standalone dns proxy path
+func (d DNSServerIdentity) GetMetadataLabels() labels.LabelArray {
+	return nil
+}
 
 // asIPRule returns a new restore.IPRule representing the rules, including the provided IP map.
 func asIPRule(r *regexp.Regexp, IPs map[restore.RuleIPOrCIDR]struct{}) restore.IPRule {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/netip"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -30,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/proxy/ipfamily"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -191,46 +189,6 @@ type restoredIPRule struct {
 
 // map from EP IPs to *Endpoint
 type restoredEPs map[netip.Addr]*endpoint.Endpoint
-
-// DNSServerIdentity contains the identities of the DNS servers and used to
-// determine if a DNS request is allowed or not from standalone DNS proxy.
-// It adheres the interface policy.CachedSelector and reuses the
-// in agent dns proxy filtering path.
-type DNSServerIdentity struct {
-	Identities identity.NumericIdentitySlice
-}
-
-func (d DNSServerIdentity) Selects(_ *versioned.VersionHandle, identity identity.NumericIdentity) bool {
-	return slices.Contains(d.Identities, identity)
-}
-
-func (d DNSServerIdentity) String() string {
-	identityStrings := make([]string, len(d.Identities))
-	for i, id := range d.Identities {
-		identityStrings[i] = strconv.FormatUint(uint64(id), 10)
-	}
-	return strings.Join(identityStrings, ",")
-}
-
-// Not being used in the standalone dns proxy path
-func (d DNSServerIdentity) IsWildcard() bool {
-	return false
-}
-
-// Not being used in the standalone dns proxy path
-func (d DNSServerIdentity) IsNone() bool {
-	return false
-}
-
-// Not being used in the standalone dns proxy path
-func (d DNSServerIdentity) GetSelections(_ *versioned.VersionHandle) identity.NumericIdentitySlice {
-	return d.Identities
-}
-
-// Not being used in the standalone dns proxy path
-func (d DNSServerIdentity) GetMetadataLabels() labels.LabelArray {
-	return nil
-}
 
 // asIPRule returns a new restore.IPRule representing the rules, including the provided IP map.
 func asIPRule(r *regexp.Regexp, IPs map[restore.RuleIPOrCIDR]struct{}) restore.IPRule {

--- a/standalone-dns-proxy/cmd/root.go
+++ b/standalone-dns-proxy/cmd/root.go
@@ -105,7 +105,7 @@ type standaloneDNSProxyParams struct {
 	JobGroup          job.Group
 	ConnectionHandler client.ConnectionHandler
 	DNSProxier        proxy.DNSProxier
-	DNSRulesTable     statedb.RWTable[service.PolicyRules]
+	DNSRulesTable     statedb.RWTable[client.DNSRules]
 	DB                *statedb.DB
 }
 

--- a/standalone-dns-proxy/cmd/standalonednsproxy_test.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy_test.go
@@ -4,15 +4,39 @@
 package cmd
 
 import (
+	"context"
+	"net/netip"
 	"testing"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
+	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/fqdn/service"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/lookup"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/messagehandler"
+)
+
+var (
+	epID1        = uint32(111)
+	epID2        = uint32(222)
+	epID3        = uint32(333)
+	dstID1       = identity.NumericIdentity(1001)
+	dstPort53UDP = restore.MakeV2PortProto(53, u8proto.UDP)
 )
 
 func TestStandaloneDNSProxy(t *testing.T) {
@@ -30,4 +54,147 @@ func TestStandaloneDNSProxy(t *testing.T) {
 
 	err := h.Populate(hivetest.Logger(t))
 	assert.NoError(t, err, "Populate()")
+}
+
+func setupTestEnv(t *testing.T) *StandaloneDNSProxy {
+	var sdp *StandaloneDNSProxy
+	h := hive.New(
+		cell.Module(
+			"test-standalone-dns-proxy",
+			"Test standalone DNS proxy",
+			cell.Config(service.DefaultConfig),
+			client.Cell,
+			bootstrap.Cell,
+			lookup.Cell,
+			messagehandler.Cell,
+			cell.Provide(
+				func() *option.DaemonConfig {
+					return &option.DaemonConfig{
+						EnableL7Proxy:    true,
+						ToFQDNsProxyPort: 1001,
+					}
+				},
+				NewStandaloneDNSProxy,
+			)),
+		cell.Invoke(func(_s *StandaloneDNSProxy) {
+			sdp = _s
+		}))
+
+	hive.AddConfigOverride(
+		h,
+		func(cfg *service.FQDNConfig) {
+			cfg.EnableStandaloneDNSProxy = true
+			cfg.StandaloneDNSProxyServerPort = 1000
+		})
+	tlog := hivetest.Logger(t)
+	if err := h.Start(tlog, t.Context()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	t.Cleanup(func() {
+		// Stop the server
+		if err := h.Stop(tlog, context.TODO()); err != nil {
+			t.Fatalf("failed to stop: %s", err)
+		}
+	})
+	return sdp
+}
+
+func addDataToDNSTable(t *testing.T, sdp *StandaloneDNSProxy, epID uint32, pp restore.PortProto, serverID identity.NumericIdentitySlice, patterns []string) {
+	t.Helper()
+	wtxn := sdp.db.WriteTxn(sdp.dnsRulesTable)
+	defer wtxn.Abort()
+	var pat []api.PortRuleDNS
+	for _, pattern := range patterns {
+		pat = append(pat, api.PortRuleDNS{
+			MatchPattern: pattern,
+		})
+	}
+	dnsRule := make(policy.L7DataMap)
+	dnsRule[&dnsproxy.DNSServerIdentity{Identities: serverID}] = &policy.PerSelectorPolicy{
+		L7Rules: api.L7Rules{
+			DNS: pat,
+		},
+	}
+	_, _, err := sdp.dnsRulesTable.Insert(wtxn, client.DNSRules{
+		EndpointID: epID,
+		PortProto:  pp,
+		DNSRule:    dnsRule,
+	})
+	require.NoError(t, err, "failed to insert DNSRules")
+	wtxn.Commit()
+}
+
+func check(t *testing.T, sdp *StandaloneDNSProxy, epID uint32, pp restore.PortProto, dstID identity.NumericIdentity, q string, expect bool) {
+	t.Helper()
+	allowed, err := sdp.dnsProxier.(*dnsproxy.DNSProxy).CheckAllowed(uint64(epID), pp, dstID, netip.Addr{}, q)
+	require.NoError(t, err)
+	if expect {
+		require.True(t, allowed, "expected allow %s", q)
+	} else {
+		require.False(t, allowed, "expected deny %s", q)
+	}
+}
+
+func TestUpdateDNSRules(t *testing.T) {
+	sdp := setupTestEnv(t)
+	sdp.StartStandaloneDNSProxy()
+	defer sdp.StopStandaloneDNSProxy()
+
+	// single pattern single server allow/deny other ep
+	addDataToDNSTable(t, sdp, epID1, dstPort53UDP, identity.NumericIdentitySlice{dstID1}, []string{"cilium.io."})
+	err := testutils.WaitUntilWithSleep(func() bool {
+		rules, err := sdp.dnsProxier.GetRules(versioned.Latest(), uint16(epID1))
+		return err == nil && len(rules) != 0
+	}, 5*time.Second, time.Millisecond*500)
+	require.NoError(t, err, "failed to get rules for endpoint")
+
+	check(t, sdp, epID1, dstPort53UDP, dstID1, "cilium.io.", true)
+	check(t, sdp, epID1, dstPort53UDP, dstID1, "ciliumXio.", false)
+	check(t, sdp, epID2, dstPort53UDP, dstID1, "cilium.io.", false)
+	check(t, sdp, epID1, dstPort53UDP, dstID1, "ciliumXio.", false)
+
+	// No patterns means allow all
+	addDataToDNSTable(t, sdp, epID2, dstPort53UDP, identity.NumericIdentitySlice{dstID1}, []string{})
+	err = testutils.WaitUntilWithSleep(func() bool {
+		rules, err := sdp.dnsProxier.GetRules(versioned.Latest(), uint16(epID2))
+		return err == nil && len(rules) != 0
+	}, 5*time.Second, time.Millisecond*500)
+	require.NoError(t, err, "failed to get rules for endpoint")
+	check(t, sdp, epID2, dstPort53UDP, dstID1, "cilium.io.", true)
+	check(t, sdp, epID2, dstPort53UDP, dstID1, "example.com.", true)
+	check(t, sdp, epID3, dstPort53UDP, dstID1, "anything.test.", false)
+
+	// multiple patterns single server
+	addDataToDNSTable(t, sdp, epID3, dstPort53UDP, identity.NumericIdentitySlice{dstID1}, []string{"example.*", "cilium.io."})
+	err = testutils.WaitUntilWithSleep(func() bool {
+		rules, err := sdp.dnsProxier.GetRules(versioned.Latest(), uint16(epID3))
+		return err == nil && len(rules) != 0
+	}, 5*time.Second, time.Millisecond*500)
+	require.NoError(t, err, "failed to get rules for endpoint")
+	check(t, sdp, epID3, dstPort53UDP, dstID1, "cilium.io.", true)
+	check(t, sdp, epID3, dstPort53UDP, dstID1, "example.com.", true)
+	check(t, sdp, epID3, dstPort53UDP, dstID1, "test.example.com.", false)
+}
+
+func TestUpdateDNSRulesRevert(t *testing.T) {
+	sdp := setupTestEnv(t)
+
+	pp := restore.MakeV2PortProto(53, u8proto.UDP)
+	addDataToDNSTable(t, sdp, epID1, pp, identity.NumericIdentitySlice{dstID1}, []string{"cilium.io."})
+	addDataToDNSTable(t, sdp, epID2, pp, identity.NumericIdentitySlice{dstID1}, []string{"example.com."})
+	rules := sdp.dnsRulesTable.All(sdp.db.ReadTxn())
+	err := sdp.updateDNSRules(rules)
+	require.NoError(t, err)
+	check(t, sdp, epID1, pp, dstID1, "cilium.io.", true)
+	check(t, sdp, epID2, pp, dstID1, "example.com.", true)
+
+	// Now add a invalid regex to check the revert
+	addDataToDNSTable(t, sdp, epID1, pp, identity.NumericIdentitySlice{dstID1}, []string{"example.com."})
+	addDataToDNSTable(t, sdp, epID2, pp, identity.NumericIdentitySlice{dstID1}, []string{"(?<=a)"})
+	rules = sdp.dnsRulesTable.All(sdp.db.ReadTxn())
+	err = sdp.updateDNSRules(rules)
+	require.Error(t, err)
+	check(t, sdp, epID1, pp, dstID1, "cilium.io.", true)
+	check(t, sdp, epID2, pp, dstID1, "example.com.", true)
 }

--- a/standalone-dns-proxy/cmd/standalonednsproxy_test.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy_test.go
@@ -111,7 +111,7 @@ func addDataToDNSTable(t *testing.T, sdp *StandaloneDNSProxy, epID uint32, pp re
 		})
 	}
 	dnsRule := make(policy.L7DataMap)
-	dnsRule[&dnsproxy.DNSServerIdentity{Identities: serverID}] = &policy.PerSelectorPolicy{
+	dnsRule[&client.DNSServerIdentity{Identities: serverID}] = &policy.PerSelectorPolicy{
 		L7Rules: api.L7Rules{
 			DNS: pat,
 		},

--- a/standalone-dns-proxy/pkg/client/cell.go
+++ b/standalone-dns-proxy/pkg/client/cell.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
 )
 
 // Cell provides the gRPC connection handler client for standalone DNS proxy.
@@ -26,11 +27,13 @@ var Cell = cell.Module(
 type clientParams struct {
 	cell.In
 
-	Logger   *slog.Logger
-	JobGroup job.Group
+	Logger        *slog.Logger
+	DB            *statedb.DB
+	DNSRulesTable statedb.RWTable[DNSRules]
+	JobGroup      job.Group
 }
 
 // newGRPCClient creates a new gRPC connection handler client for standalone DNS proxy
 func newGRPCClient(params clientParams) ConnectionHandler {
-	return createGRPCClient(params.Logger)
+	return createGRPCClient(params.Logger, params.DB, params.DNSRulesTable)
 }

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -6,13 +6,21 @@ package client
 import (
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/netip"
 
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
 
-	"github.com/cilium/cilium/pkg/fqdn/service"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/u8proto"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
 )
 
 const (
@@ -20,12 +28,34 @@ const (
 	IPtoIdentityTableName = "sdp-ip-to-identity"
 )
 
+func DNSRulesCompositeKey(epID uint32, pp restore.PortProto) uint64 {
+	return (uint64(epID) << 32) | uint64(pp)
+}
+
+type DNSRules struct {
+	EndpointID uint32
+	PortProto  restore.PortProto
+	DNSRule    policy.L7DataMap
+}
+
 type IPtoIdentity struct {
 	IP       netip.Addr
 	Identity identity.NumericIdentity
 }
 
 var (
+	DNSRulesIndex = statedb.Index[DNSRules, uint64]{
+		Name: "id",
+		FromObject: func(e DNSRules) index.KeySet {
+			return index.NewKeySet(index.Uint64(DNSRulesCompositeKey(e.EndpointID, e.PortProto)))
+		},
+		FromKey: func(key uint64) index.Key {
+			return index.Uint64(key)
+		},
+		FromString: index.Uint64String,
+		Unique:     true,
+	}
+
 	idIPToIdentityIndex = statedb.Index[IPtoIdentity, netip.Addr]{
 		Name: "ip",
 		FromObject: func(e IPtoIdentity) index.KeySet {
@@ -38,6 +68,27 @@ var (
 		Unique:     true,
 	}
 )
+
+// TableHeader implements statedb.TableWritable.
+func (p DNSRules) TableHeader() []string {
+	return []string{"EndpointID", "PortProto", "DNS Rules"}
+}
+
+// TableRow implements statedb.TableWritable.
+func (p DNSRules) TableRow() []string {
+	var dnsRules string
+	for _, sel := range p.DNSRule {
+		if sel != nil && sel.L7Rules.DNS != nil {
+			dnsRules += fmt.Sprintf("%v|", sel.L7Rules.DNS)
+		}
+
+	}
+	return []string{
+		fmt.Sprintf("%d", p.EndpointID),
+		p.PortProto.String(),
+		dnsRules,
+	}
+}
 
 func (i IPtoIdentity) TableHeader() []string {
 	return []string{
@@ -68,18 +119,23 @@ type ConnectionHandler interface {
 	// This method is called by the DNS proxy when it receives a DNS message.
 	// It is responsible for sending the DNS message to the Cilium agent for further processing.
 	// Note: This method is intentionally left empty for now. And will be implemented in future PRs.
-	NotifyOnMsg() error
+	NotifyOnMsg(msg *pb.FQDNMapping) error
 }
 
 // GRPCClient  is a gRPC connection handler for standalone DNS proxy communication with Cilium agent
 type GRPCClient struct {
 	logger *slog.Logger
+
+	db            *statedb.DB
+	dnsRulesTable statedb.RWTable[DNSRules]
 }
 
 // createGRPCClient creates a new gRPC connection handler client for standalone DNS proxy
-func createGRPCClient(logger *slog.Logger) *GRPCClient {
+func createGRPCClient(logger *slog.Logger, db *statedb.DB, dnsRulesTable statedb.RWTable[DNSRules]) *GRPCClient {
 	return &GRPCClient{
-		logger: logger,
+		logger:        logger,
+		db:            db,
+		dnsRulesTable: dnsRulesTable,
 	}
 }
 
@@ -87,13 +143,16 @@ func (c *GRPCClient) StartConnection() {
 	c.logger.Info("Starting gRPC connection for standalone DNS proxy")
 	// Here we would typically start the gRPC connection to the Cilium agent.
 	// This is a placeholder for the actual implementation.
+
+	// Adding a dummy call to updatePolicyState to avoid unused method warning.
+	c.updatePolicyState(&pb.PolicyState{})
 }
 
 func (c *GRPCClient) StopConnection() {
 }
 
 // Note: This method is intentionally left empty for now. Will be implemented in future PRs.
-func (c *GRPCClient) NotifyOnMsg() error {
+func (c *GRPCClient) NotifyOnMsg(msg *pb.FQDNMapping) error {
 	c.logger.Info("DNS message received")
 	return nil
 }
@@ -102,11 +161,11 @@ func (c *GRPCClient) NotifyOnMsg() error {
 // This table will be used to store the DNS rules for the standalone DNS proxy.
 // The standalone DNS proxy will use this table to retrieve the DNS rules and update the DNS proxy with the
 // latest rules received from the Cilium agent.
-func newDNSRulesTable(db *statedb.DB) (statedb.RWTable[service.PolicyRules], error) {
+func newDNSRulesTable(db *statedb.DB) (statedb.RWTable[DNSRules], error) {
 	return statedb.NewTable(
 		db,
 		DNSRulesTableName,
-		service.PolicyRulesIndex,
+		DNSRulesIndex,
 	)
 }
 
@@ -117,4 +176,88 @@ func newIPtoIdentityTable(db *statedb.DB) (statedb.RWTable[IPtoIdentity], error)
 		IPtoIdentityTableName,
 		idIPToIdentityIndex,
 	)
+}
+
+// updatePolicyState processes the received PolicyState message and updates the DNSRules/IPToIdentity table accordingly.
+func (c *GRPCClient) updatePolicyState(state *pb.PolicyState) error {
+	err := c.updateDNSRules(state.GetEgressL7DnsPolicy())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// updateDNSRules updates the DNS rules table with the received DNS policies.
+func (c *GRPCClient) updateDNSRules(rules []*pb.DNSPolicy) error {
+	wtxn := c.db.WriteTxn(c.dnsRulesTable)
+	defer wtxn.Abort()
+
+	// Clear existing entries as we are replacing the entire mapping with the given snapshot.
+	err := c.dnsRulesTable.DeleteAll(wtxn)
+	if err != nil {
+		c.logger.Error("Failed to clear existing DNS rules", logfields.Error, err)
+		return err
+	}
+
+	// create a mapping of endpointID to PortProto to L7DataMap, similar to what DNS proxy expects
+	endpointIdToRule := make(map[uint32]map[restore.PortProto]policy.L7DataMap)
+	for _, rule := range rules {
+		portProtoToServerIdentity := make(map[restore.PortProto]identity.NumericIdentitySlice)
+		for _, dnsServer := range rule.GetDnsServers() {
+			pp := restore.MakeV2PortProto(uint16(dnsServer.GetDnsServerPort()), u8proto.U8proto(dnsServer.GetDnsServerProto()))
+			portProtoToServerIdentity[pp] = append(portProtoToServerIdentity[pp], identity.NumericIdentity(dnsServer.GetDnsServerIdentity()))
+		}
+
+		portProtoToDNSrules := make(map[restore.PortProto]policy.L7DataMap)
+		for portProto, identities := range portProtoToServerIdentity {
+			dnsRulesSlice := make([]api.PortRuleDNS, 0, len(rule.GetDnsPattern()))
+			for _, pat := range rule.GetDnsPattern() {
+				dnsRulesSlice = append(dnsRulesSlice, api.PortRuleDNS{
+					MatchPattern: pat,
+				})
+			}
+			cs := make(policy.L7DataMap)
+			if len(dnsRulesSlice) == 0 {
+				cs[&dnsproxy.DNSServerIdentity{Identities: identities}] = nil
+
+			} else {
+				cs[&dnsproxy.DNSServerIdentity{Identities: identities}] = &policy.PerSelectorPolicy{
+					L7Rules: api.L7Rules{
+						DNS: dnsRulesSlice,
+					},
+				}
+			}
+			portProtoToDNSrules[portProto] = cs
+		}
+		// Process each DNS policy rule
+		epId := rule.GetSourceEndpointId()
+		if _, ok := endpointIdToRule[epId]; !ok {
+			endpointIdToRule[epId] = make(map[restore.PortProto]policy.L7DataMap)
+		}
+
+		for portProto, cs := range portProtoToDNSrules {
+			if _, ok := endpointIdToRule[epId][portProto]; !ok {
+				endpointIdToRule[epId][portProto] = make(policy.L7DataMap)
+			}
+
+			maps.Copy(endpointIdToRule[epId][portProto], cs)
+		}
+	}
+
+	for epId, portProtoToRules := range endpointIdToRule {
+		for portProto, rules := range portProtoToRules {
+			dnsRule := DNSRules{
+				EndpointID: epId,
+				PortProto:  portProto,
+				DNSRule:    rules,
+			}
+			if _, _, err := c.dnsRulesTable.Insert(wtxn, dnsRule); err != nil {
+				c.logger.Error("Failed to insert DNS rule into table", logfields.Error, err)
+				return err
+			}
+		}
+	}
+	wtxn.Commit()
+
+	return nil
 }

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -8,51 +8,253 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/statedb"
-
-	"github.com/cilium/cilium/pkg/fqdn/service"
+	"github.com/cilium/cilium/pkg/container/versioned"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/u8proto"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
 )
 
 func TestCreatecreateGRPCClient(t *testing.T) {
 	logger := slog.Default()
 
-	client := createGRPCClient(logger)
+	client := createGRPCClient(logger, nil, nil)
 
 	require.NotNil(t, client)
 }
 
-// Note: In the future PRs, the test case will be updated to actually check the dns rules table scenarios.
-func TestNewDNSRulesTable(t *testing.T) {
-	// Create a new StateDB instance
-	db := statedb.New()
+func assertDNSRules(t *testing.T, c *GRPCClient, epID uint32, pp restore.PortProto, expServerIDs []uint32, expPatterns []string) {
+	t.Helper()
+	rtxn := c.db.ReadTxn()
+	ck := DNSRulesCompositeKey(epID, pp)
+	row, _, found := c.dnsRulesTable.Get(rtxn, DNSRulesIndex.Query(ck))
+	require.True(t, found, "no DNSRules for ep=%d portProto=%v", epID, pp)
 
-	// Test successful table creation
-	table, err := newDNSRulesTable(db)
-	require.NoError(t, err)
-	require.NotNil(t, table)
-
-	// Test table insertion and retrieval
-	txn := db.WriteTxn(table)
-	dnsRule := service.PolicyRules{
-		Identity:    identity.NumericIdentity(100),
-		PolicyRules: nil,
+	var gotIDs []uint32
+	var gotPatterns []string
+	for k, v := range row.DNSRule {
+		for _, id := range k.GetSelections(versioned.Latest()) {
+			gotIDs = append(gotIDs, id.Uint32())
+		}
+		if v != nil {
+			for _, r := range v.L7Rules.DNS {
+				if r.MatchPattern != "" {
+					gotPatterns = append(gotPatterns, r.MatchPattern)
+				}
+			}
+		}
 	}
-	_, _, err = table.Insert(txn, dnsRule)
-	require.NoError(t, err)
-	txn.Commit()
-
-	// Read back the data
-	rtxn := db.ReadTxn()
-	rule, _, found := table.Get(rtxn, service.PolicyRulesIndex.Query(identity.NumericIdentity(100)))
-	require.True(t, found)
-	require.Equal(t, identity.NumericIdentity(100), rule.Identity)
-	require.Nil(t, rule.PolicyRules)
+	require.ElementsMatch(t, expServerIDs, gotIDs, "server IDs mismatch")
+	require.ElementsMatch(t, expPatterns, gotPatterns, "patterns mismatch")
 }
 
-// Note: In the future PRs, the test case will be updated to actually check the ip<>identity mapping scenarios.
+func TestUpdateDNSRules(t *testing.T) {
+	db := statedb.New()
+	table, err := newDNSRulesTable(db)
+	require.NoError(t, err)
+
+	logger := hivetest.Logger(t)
+	c := &GRPCClient{
+		logger:        logger,
+		db:            db,
+		dnsRulesTable: table,
+	}
+
+	pp53 := restore.MakeV2PortProto(53, u8proto.UDP)
+	pp54 := restore.MakeV2PortProto(54, u8proto.TCP)
+
+	tests := []struct {
+		name   string
+		input  []*pb.DNSPolicy
+		checks []struct {
+			epID      uint32
+			pp        restore.PortProto
+			serverIDs []uint32
+			patterns  []string
+		}
+	}{
+		{
+			name: "single pattern single server",
+			input: []*pb.DNSPolicy{
+				{
+					SourceEndpointId: 100,
+					DnsPattern:       []string{"example.com"},
+					DnsServers: []*pb.DNSServer{{
+						DnsServerPort:     53,
+						DnsServerProto:    uint32(u8proto.UDP),
+						DnsServerIdentity: 200,
+					}},
+				},
+			},
+			checks: []struct {
+				epID      uint32
+				pp        restore.PortProto
+				serverIDs []uint32
+				patterns  []string
+			}{
+				{100, pp53, []uint32{200}, []string{"example.com"}},
+			},
+		},
+		{
+			name: "multiple patterns single server",
+			input: []*pb.DNSPolicy{
+				{
+					SourceEndpointId: 101,
+					DnsPattern:       []string{"a.com", "b.com"},
+					DnsServers: []*pb.DNSServer{{
+						DnsServerPort:     54,
+						DnsServerProto:    uint32(u8proto.TCP),
+						DnsServerIdentity: 210,
+					}},
+				},
+			},
+			checks: []struct {
+				epID      uint32
+				pp        restore.PortProto
+				serverIDs []uint32
+				patterns  []string
+			}{
+				{101, pp54, []uint32{210}, []string{"a.com", "b.com"}},
+			},
+		},
+		{
+			name: "multiple servers same policy",
+			input: []*pb.DNSPolicy{
+				{
+					SourceEndpointId: 102,
+					DnsPattern:       []string{"group.com"},
+					DnsServers: []*pb.DNSServer{
+						{DnsServerPort: 53, DnsServerProto: uint32(u8proto.UDP), DnsServerIdentity: 220},
+						{DnsServerPort: 53, DnsServerProto: uint32(u8proto.UDP), DnsServerIdentity: 221},
+					},
+				},
+			},
+			checks: []struct {
+				epID      uint32
+				pp        restore.PortProto
+				serverIDs []uint32
+				patterns  []string
+			}{
+				{102, pp53, []uint32{220, 221}, []string{"group.com"}},
+			},
+		},
+		{
+			name: "multiple policies different servers",
+			input: []*pb.DNSPolicy{
+				{
+					SourceEndpointId: 103,
+					DnsPattern:       []string{"one.com"},
+					DnsServers: []*pb.DNSServer{
+						{DnsServerPort: 53, DnsServerProto: uint32(u8proto.UDP), DnsServerIdentity: 230},
+					},
+				},
+				{
+					SourceEndpointId: 103,
+					DnsPattern:       []string{"two.com"},
+					DnsServers: []*pb.DNSServer{
+						{DnsServerPort: 53, DnsServerProto: uint32(u8proto.UDP), DnsServerIdentity: 231},
+					},
+				},
+			},
+			checks: []struct {
+				epID      uint32
+				pp        restore.PortProto
+				serverIDs []uint32
+				patterns  []string
+			}{
+				{103, pp53, []uint32{230, 231}, []string{"one.com", "two.com"}},
+			},
+		},
+		{
+			name: "different ports same endpoint",
+			input: []*pb.DNSPolicy{
+				{
+					SourceEndpointId: 104,
+					DnsPattern:       []string{"p53.com"},
+					DnsServers: []*pb.DNSServer{
+						{DnsServerPort: 53, DnsServerProto: uint32(u8proto.UDP), DnsServerIdentity: 240},
+					},
+				},
+				{
+					SourceEndpointId: 104,
+					DnsPattern:       []string{"p54.com"},
+					DnsServers: []*pb.DNSServer{
+						{DnsServerPort: 54, DnsServerProto: uint32(u8proto.TCP), DnsServerIdentity: 241},
+					},
+				},
+			},
+			checks: []struct {
+				epID      uint32
+				pp        restore.PortProto
+				serverIDs []uint32
+				patterns  []string
+			}{
+				{104, pp53, []uint32{240}, []string{"p53.com"}},
+				{104, pp54, []uint32{241}, []string{"p54.com"}},
+			},
+		},
+		{
+			name: "empty patterns single server (nil policy entry)",
+			input: []*pb.DNSPolicy{
+				{
+					SourceEndpointId: 110,
+					// DnsPattern omitted -> len==0 => nil policy value stored
+					DnsServers: []*pb.DNSServer{{
+						DnsServerPort:     53,
+						DnsServerProto:    uint32(u8proto.UDP),
+						DnsServerIdentity: 2100,
+					}},
+				},
+			},
+			checks: []struct {
+				epID      uint32
+				pp        restore.PortProto
+				serverIDs []uint32
+				patterns  []string
+			}{
+				{110, pp53, []uint32{2100}, []string{}}, // expect no patterns
+			},
+		},
+		{
+			name: "No dns server identity",
+			input: []*pb.DNSPolicy{
+				{
+					SourceEndpointId: 110,
+					DnsPattern:       []string{"p53.com"},
+					DnsServers: []*pb.DNSServer{{
+						DnsServerPort:  53,
+						DnsServerProto: uint32(u8proto.UDP),
+					}},
+				},
+			},
+			checks: []struct {
+				epID      uint32
+				pp        restore.PortProto
+				serverIDs []uint32
+				patterns  []string
+			}{
+				{110, pp53, []uint32{0}, []string{"p53.com"}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.updateDNSRules(tc.input)
+			require.NoError(t, err)
+
+			for _, chk := range tc.checks {
+				assertDNSRules(t, c, chk.epID, chk.pp, chk.serverIDs, chk.patterns)
+			}
+		})
+	}
+}
+
 func TestNewIPtoIdentityTable(t *testing.T) {
 	// Create a new StateDB instance
 	db := statedb.New()

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
@@ -5,6 +5,7 @@ package messagehandler
 
 import (
 	"log/slog"
+	"net"
 	"net/netip"
 
 	"github.com/cilium/dns"
@@ -12,8 +13,11 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
 )
 
 type messageHandler struct {
@@ -23,9 +27,37 @@ type messageHandler struct {
 
 // NotifyOnDNSMsg implements messagehandler.DNSMessageHandler.
 // It is used by the standalone DNS proxy to notify the gRPC client about the DNS message.
-// Note: This is a placeholder for the actual implementation of the DNS message handler interface.
 func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddrPort netip.AddrPort, msg *dns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
-	return m.ConnHandler.NotifyOnMsg()
+	qname, responseIPs, TTL, _, rcode, _, _, err := dnsproxy.ExtractMsgDetails(msg)
+	if err != nil {
+		m.Logger.Error("Cannot extract DNS message details", logfields.Error, err)
+		return err
+	}
+	var ips [][]byte
+	for _, i := range responseIPs {
+		ips = append(ips, []byte(i.String()))
+	}
+
+	sourceIp, _, err := net.SplitHostPort(epIPPort)
+	if err != nil {
+		m.Logger.Error("Failed to split IP:Port", logfields.Error, err)
+		return err
+	}
+
+	sourceIdentity, err := ep.GetSecurityIdentity()
+	if err != nil {
+		m.Logger.Error("Failed to get security identity", logfields.Error, err)
+		return err
+	}
+	message := &pb.FQDNMapping{
+		Fqdn:           qname,
+		RecordIp:       ips,
+		Ttl:            TTL,
+		SourceIp:       []byte(sourceIp),
+		SourceIdentity: uint32(sourceIdentity.ID),
+		ResponseCode:   uint32(rcode),
+	}
+	return m.ConnHandler.NotifyOnMsg(message)
 }
 
 // SetBindPort is not implemented for standalone DNS proxy yet. The port is set in the config map for the standalone DNS proxy.

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler_test.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package messagehandler
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/dns"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/time"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+type mockConnHandler struct {
+	last *pb.FQDNMapping
+}
+
+func (m *mockConnHandler) NotifyOnMsg(msg *pb.FQDNMapping) error {
+	m.last = msg
+	return nil
+}
+
+func (m *mockConnHandler) StartConnection() {}
+
+func (m *mockConnHandler) StopConnection() {}
+
+func newTestHandler(t *testing.T) (*messageHandler, *mockConnHandler, *endpoint.Endpoint) {
+	t.Helper()
+
+	// Minimal endpoint instance with a security identity.
+	ep := &endpoint.Endpoint{
+		SecurityIdentity: &identity.Identity{
+			ID: identity.NumericIdentity(111),
+		},
+	}
+	mc := &mockConnHandler{}
+	h := &messageHandler{
+		Logger:      hivetest.Logger(t),
+		ConnHandler: mc,
+	}
+	return h, mc, ep
+}
+
+func buildResponseMsg() *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+	m.Response = true
+	m.Answer = append(m.Answer,
+		&dns.A{
+			Hdr: dns.RR_Header{
+				Name:   "example.com.",
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			A: net.IPv4(1, 2, 3, 4),
+		},
+		&dns.AAAA{
+			Hdr: dns.RR_Header{
+				Name:   "example.com.",
+				Rrtype: dns.TypeAAAA,
+				Class:  dns.ClassINET,
+				Ttl:    100,
+			},
+			AAAA: net.ParseIP("2001:db8::1"),
+		},
+	)
+	return m
+}
+
+func TestNotifyOnDNSMsg(t *testing.T) {
+	type testCase struct {
+		name      string
+		msg       *dns.Msg
+		epIPPort  string
+		server    string
+		expectErr bool
+	}
+
+	tests := []testCase{
+		{
+			name:      "success",
+			msg:       buildResponseMsg(),
+			epIPPort:  "10.1.1.10:5353",
+			server:    "8.8.8.8:53",
+			expectErr: false,
+		},
+		{
+			name:      "invalid message no question",
+			msg:       &dns.Msg{},
+			epIPPort:  "10.1.1.10:5353",
+			server:    "1.1.1.1:53",
+			expectErr: true,
+		},
+		{
+			name:      "invalid source ip:port",
+			msg:       buildResponseMsg(),
+			epIPPort:  "bad-format",
+			server:    "8.8.4.4:53",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, mc, ep := newTestHandler(t)
+			serverAP := netip.MustParseAddrPort(tc.server)
+			err := h.NotifyOnDNSMsg(time.Now(), ep, tc.epIPPort, 0, serverAP, tc.msg, "udp", true, &dnsproxy.ProxyRequestContext{})
+			if tc.expectErr {
+				require.Error(t, err, "expected error")
+			} else {
+				require.NoError(t, err, "expected no error")
+				require.NotNil(t, mc.last, "expected mapping")
+				require.Equal(t, "example.com.", mc.last.Fqdn)
+				require.Equal(t, uint32(100), mc.last.Ttl)
+				require.Equal(t, "10.1.1.10", string(mc.last.SourceIp))
+				require.Equal(t, uint32(111), mc.last.SourceIdentity)
+				require.Equal(t, uint32(0), mc.last.ResponseCode)
+				require.ElementsMatch(t, [][]byte{[]byte("1.2.3.4"), []byte("2001:db8::1")}, mc.last.RecordIp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Updates the DNS rules received from cilium agent in the dns proxy.(It tries to follow the same path as that of in agent dns proxy)
- Also updates the `NotifyOnDNSMsg` to send back the fqdn mapping to cilium agent

Fixes: https://github.com/cilium/cilium/issues/30984
CFP: https://github.com/cilium/design-cfps/pull/54
Relevant PRs: https://github.com/cilium/cilium/pull/40982, https://github.com/cilium/cilium/pull/41507

```release-note
feat(sdp): Updating DNS rules in Standalone DNS proxy
```
