### PR TITLE
analyze: fix race accessing `Block.predict`

### DIFF
--- a/pkg/bpf/analyze/reachability.go
+++ b/pkg/bpf/analyze/reachability.go
@@ -142,13 +142,15 @@ func Reachability(blocks *Blocks, insns asm.Instructions, variables map[string]V
 	}
 
 	live := newBitmap(uint64(blocks.count()))
+	jumps := newBitmap(uint64(blocks.count()))
 
 	// Start recursing at first block since it is always live.
-	if err := visitBlock(blocks.first(), insns, vars, live); err != nil {
+	if err := visitBlock(blocks.first(), insns, vars, live, jumps); err != nil {
 		return nil, fmt.Errorf("predicting blocks: %w", err)
 	}
 
 	blocks.l = live
+	blocks.j = jumps
 
 	return blocks, nil
 }
@@ -232,11 +234,11 @@ type mapOffset struct {
 
 // unpredictableBlock is called when the branch cannot be predicted. It visits
 // both the branch and fallthrough blocks.
-func unpredictableBlock(b *Block, insns asm.Instructions, vars map[mapOffset]VariableSpec, live bitmap) error {
-	if err := visitBlock(b.branch, insns, vars, live); err != nil {
+func unpredictableBlock(b *Block, insns asm.Instructions, vars map[mapOffset]VariableSpec, live, jumps bitmap) error {
+	if err := visitBlock(b.branch, insns, vars, live, jumps); err != nil {
 		return fmt.Errorf("visiting branch block %d: %w", b.branch.id, err)
 	}
-	if err := visitBlock(b.fthrough, insns, vars, live); err != nil {
+	if err := visitBlock(b.fthrough, insns, vars, live, jumps); err != nil {
 		return fmt.Errorf("visiting fallthrough block %d: %w", b.fthrough.id, err)
 	}
 	return nil
@@ -244,7 +246,7 @@ func unpredictableBlock(b *Block, insns asm.Instructions, vars map[mapOffset]Var
 
 // visitBlock recursively visits a block and its successors to determine
 // reachability based on the branch instructions and the provided vars.
-func visitBlock(b *Block, insns asm.Instructions, vars map[mapOffset]VariableSpec, live bitmap) error {
+func visitBlock(b *Block, insns asm.Instructions, vars map[mapOffset]VariableSpec, live, jumps bitmap) error {
 	if b == nil {
 		return nil
 	}
@@ -260,17 +262,17 @@ func visitBlock(b *Block, insns asm.Instructions, vars map[mapOffset]VariableSpe
 
 	branch := findBranch(pull)
 	if branch == nil {
-		return unpredictableBlock(b, insns, vars, live)
+		return unpredictableBlock(b, insns, vars, live, jumps)
 	}
 
 	deref := findDereference(pull, branch.Dst)
 	if deref == nil {
-		return unpredictableBlock(b, insns, vars, live)
+		return unpredictableBlock(b, insns, vars, live, jumps)
 	}
 
 	load := findMapLoad(pull, deref.Src)
 	if load == nil {
-		return unpredictableBlock(b, insns, vars, live)
+		return unpredictableBlock(b, insns, vars, live, jumps)
 	}
 
 	// TODO(tb): evalBranch doesn't currently take the deref's offset field into
@@ -278,7 +280,7 @@ func visitBlock(b *Block, insns asm.Instructions, vars map[mapOffset]VariableSpe
 	// to be more robust and remove this limitation.
 	vs := lookupVariable(load, vars)
 	if vs == nil || !vs.Constant() || vs.Size() > 8 {
-		return unpredictableBlock(b, insns, vars, live)
+		return unpredictableBlock(b, insns, vars, live, jumps)
 	}
 
 	jump, err := evalBranch(branch, vs)
@@ -288,13 +290,12 @@ func visitBlock(b *Block, insns asm.Instructions, vars map[mapOffset]VariableSpe
 
 	// If the branch is always taken, only visit the branch target.
 	if jump {
-		b.predict = 1
-		return visitBlock(b.branch, insns, vars, live)
+		jumps.set(b.id, true)
+		return visitBlock(b.branch, insns, vars, live, jumps)
 	}
 
 	// Otherwise, only visit the fallthrough target.
-	b.predict = 2
-	return visitBlock(b.fthrough, insns, vars, live)
+	return visitBlock(b.fthrough, insns, vars, live, jumps)
 }
 
 // lookupVariable retrieves the VariableSpec for the given load instruction from


### PR DESCRIPTION
https://github.com/cilium/cilium/issues/41616 found a data race in setting Block.predict. Block was never meant to be changed during reachability analysis; all bookkeeping must be done out-of-band (like the live bitmap).

This PR adds a test that reliably triggers the race (and others like it) when run with -race.

Changing visitBlock() to take a Block instead of a *Block was considered in addition, but proved too costly due to the amount of copying required.

```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/bpf/analyze
cpu: AMD Ryzen 7 3700X 8-Core Processor
                 │   old.txt   │              new.txt              │
                 │   sec/op    │   sec/op     vs base              │
ComputeBlocks-16   642.5µ ± 1%   645.0µ ± 2%       ~ (p=0.699 n=6)
Reachability-16    31.39µ ± 4%   33.83µ ± 2%  +7.78% (p=0.002 n=6)
geomean            142.0µ        147.7µ       +4.02%

                 │   old.txt    │              new.txt               │
                 │     B/op     │     B/op      vs base              │
ComputeBlocks-16   372.6Ki ± 0%   372.6Ki ± 0%  +0.01% (p=0.002 n=6)
Reachability-16    8.172Ki ± 0%   8.328Ki ± 0%  +1.91% (p=0.002 n=6)
geomean            55.18Ki        55.71Ki       +0.96%

                 │   old.txt   │               new.txt                │
                 │  allocs/op  │  allocs/op   vs base                 │
ComputeBlocks-16   8.054k ± 0%   8.054k ± 0%        ~ (p=1.000 n=6) ¹
Reachability-16     3.000 ± 0%    4.000 ± 0%  +33.33% (p=0.002 n=6)
geomean             155.4         179.5       +15.47%
¹ all samples are equal
```

Fixes: #41616