### PR TITLE
agent: Add Cilium health config cell

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -558,6 +558,7 @@ Makefile* @cilium/build
 /pkg/fswatcher/ @cilium/sig-datapath @cilium/sig-hubble
 /pkg/gops/ @cilium/sig-agent
 /pkg/health/ @cilium/sig-agent
+/pkg/healthconfig/ @cilium/sig-agent
 /pkg/hive/ @cilium/sig-foundations
 /pkg/hubble/ @cilium/sig-hubble
 /pkg/hubble/metrics @cilium/hubble-metrics

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -61,9 +61,11 @@ cilium-agent hive [flags]
       --enable-drift-checker                                      Enables support for config drift checker (default true)
       --enable-dynamic-config                                     Enables support for dynamic agent config (default true)
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
+      --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-gops                                               Enable gops server (default true)
       --enable-health-check-nodeport                              Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
+      --enable-health-checking                                    Enable connectivity health checking (default true)
       --enable-hubble                                             Enable hubble server
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format.
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -67,9 +67,11 @@ cilium-agent hive dot-graph [flags]
       --enable-drift-checker                                      Enables support for config drift checker (default true)
       --enable-dynamic-config                                     Enables support for dynamic agent config (default true)
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
+      --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-gops                                               Enable gops server (default true)
       --enable-health-check-nodeport                              Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
+      --enable-health-checking                                    Enable connectivity health checking (default true)
       --enable-hubble                                             Enable hubble server
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format.
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cilium/statedb"
 	"google.golang.org/grpc"
 
+	"github.com/cilium/cilium/pkg/healthconfig"
+
 	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/daemon/cmd/cni"
@@ -331,6 +333,9 @@ var (
 
 		// Cilium health infrastructure (host and endpoint connectivity)
 		health.Cell,
+
+		// Cilium health config
+		healthconfig.Cell,
 
 		// Cilium Status Collector
 		status.Cell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/health"
+	"github.com/cilium/cilium/pkg/healthconfig"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -132,6 +133,8 @@ type Daemon struct {
 
 	lbConfig loadbalancer.Config
 	kprCfg   kpr.KPRConfig
+
+	healthConfig healthconfig.CiliumHealthConfig
 
 	ipsecAgent datapath.IPsecAgent
 }
@@ -346,6 +349,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		ipsecAgent:        params.IPsecAgent,
 		ciliumHealth:      params.CiliumHealth,
 		endpointAPIFence:  params.EndpointAPIFence,
+		healthConfig:      params.HealthConfig,
 	}
 
 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/health"
+	"github.com/cilium/cilium/pkg/healthconfig"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
@@ -227,17 +228,11 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableEndpointRoutes, defaults.EnableEndpointRoutes, "Use per endpoint routes instead of routing via cilium_host")
 	option.BindEnv(vp, option.EnableEndpointRoutes)
 
-	flags.Bool(option.EnableHealthChecking, defaults.EnableHealthChecking, "Enable connectivity health checking")
-	option.BindEnv(vp, option.EnableHealthChecking)
-
 	flags.Bool(option.AgentHealthRequireK8sConnectivity, true, "Require Kubernetes connectivity in agent health endpoint")
 	option.BindEnv(vp, option.AgentHealthRequireK8sConnectivity)
 
 	flags.Bool(option.EnableHealthCheckLoadBalancerIP, defaults.EnableHealthCheckLoadBalancerIP, "Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs --enable-health-check-nodeport to be enabled")
 	option.BindEnv(vp, option.EnableHealthCheckLoadBalancerIP)
-
-	flags.Bool(option.EnableEndpointHealthChecking, defaults.EnableEndpointHealthChecking, "Enable connectivity health checking between virtual endpoints")
-	option.BindEnv(vp, option.EnableEndpointHealthChecking)
 
 	flags.Int(option.HealthCheckICMPFailureThreshold, defaults.HealthCheckICMPFailureThreshold, "Number of ICMP requests sent for each run of the health checker. If at least one ICMP response is received, the node or endpoint is marked as healthy.")
 	option.BindEnv(vp, option.HealthCheckICMPFailureThreshold)
@@ -1317,6 +1312,7 @@ type daemonParams struct {
 	KPRConfig           kpr.KPRConfig
 	EndpointAPIFence    endpointapi.Fence
 	IPSecConfig         datapath.IPsecConfig
+	HealthConfig        healthconfig.CiliumHealthConfig
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], legacy.DaemonInitialization) {
@@ -1516,7 +1512,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	}
 
 	bootstrapStats.healthCheck.Start()
-	if option.Config.EnableHealthChecking {
+	if d.healthConfig.IsHealthCheckingEnabled() {
 		if err := d.ciliumHealth.Init(d.ctx, d.healthEndpointRouting, cleaner.cleanupFuncs.Add); err != nil {
 			return fmt.Errorf("failed to initialize cilium health: %w", err)
 		}

--- a/pkg/health/health_connectivity_node.go
+++ b/pkg/health/health_connectivity_node.go
@@ -56,7 +56,7 @@ func (h *ciliumHealthManager) launchCiliumNodeHealth(spec *healthApi.Spec, initi
 		HealthAPISpec: spec,
 	}
 
-	ch.server, err = server.NewServer(h.logger, config)
+	ch.server, err = server.NewServer(h.logger, config, h.healthConfig.IsActiveHealthCheckingEnabled())
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate cilium-health server: %w", err)
 	}

--- a/pkg/healthconfig/cell.go
+++ b/pkg/healthconfig/cell.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package healthconfig
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+)
+
+const (
+	EnableHealthCheckingName         = "enable-health-checking"
+	EnableEndpointHealthCheckingName = "enable-endpoint-health-checking"
+)
+
+// Cell provides the Cilium health config.
+var Cell = cell.Module(
+	"cilium-health-config",
+	"Cilium health config",
+	cell.Config[CiliumHealthConfig](defaultConfig),
+)
+
+type Config struct {
+	EnableHealthChecking         bool `mapstructure:"enable-health-checking"`
+	EnableEndpointHealthChecking bool `mapstructure:"enable-endpoint-health-checking"`
+}
+
+var defaultConfig = Config{
+	EnableHealthChecking:         true,
+	EnableEndpointHealthChecking: true,
+}
+
+type CiliumHealthConfig interface {
+	cell.Flagger
+	// IsHealthCheckingEnabled checks whether health server API and active health checks are enabled
+	IsHealthCheckingEnabled() bool
+	// IsEndpointHealthCheckingEnabled checks whether enables active checks to virtual health endpoints are enabled
+	IsEndpointHealthCheckingEnabled() bool
+}
+
+func (c Config) IsHealthCheckingEnabled() bool {
+	return c.EnableHealthChecking
+}
+
+func (c Config) IsEndpointHealthCheckingEnabled() bool {
+	return c.EnableEndpointHealthChecking
+}
+
+func (c Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool(EnableHealthCheckingName, c.EnableHealthChecking, "Enable connectivity health checking")
+	flags.Bool(EnableEndpointHealthCheckingName, c.EnableEndpointHealthChecking, "Enable connectivity health checking between virtual endpoints")
+}

--- a/pkg/healthconfig/cell.go
+++ b/pkg/healthconfig/cell.go
@@ -36,6 +36,8 @@ type CiliumHealthConfig interface {
 	IsHealthCheckingEnabled() bool
 	// IsEndpointHealthCheckingEnabled checks whether enables active checks to virtual health endpoints are enabled
 	IsEndpointHealthCheckingEnabled() bool
+	// IsActiveHealthCheckingEnabled checks whether periodic active health checks are enabled
+	IsActiveHealthCheckingEnabled() bool
 }
 
 func (c Config) IsHealthCheckingEnabled() bool {
@@ -44,6 +46,10 @@ func (c Config) IsHealthCheckingEnabled() bool {
 
 func (c Config) IsEndpointHealthCheckingEnabled() bool {
 	return c.EnableEndpointHealthChecking
+}
+
+func (c Config) IsActiveHealthCheckingEnabled() bool {
+	return true
 }
 
 func (c Config) Flags(flags *pflag.FlagSet) {

--- a/pkg/healthconfig/healthconfig_test.go
+++ b/pkg/healthconfig/healthconfig_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package healthconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_healthConfig(t *testing.T) {
+	var hc CiliumHealthConfig
+	hive := hive.New(
+		Cell,
+		cell.Invoke(func(cfg CiliumHealthConfig) { hc = cfg }),
+	)
+
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	hive.RegisterFlags(flags)
+	flags.Set(EnableHealthCheckingName, "false")
+	flags.Set(EnableEndpointHealthCheckingName, "false")
+
+	tlog := hivetest.Logger(t)
+	require.NoError(t, hive.Start(tlog, context.Background()))
+
+	require.False(t, hc.IsHealthCheckingEnabled())
+	require.False(t, hc.IsEndpointHealthCheckingEnabled())
+}


### PR DESCRIPTION
This change moves the Cilium health configurations to a Hive cell, and paves the way for future extensions. 

A separate cell is introduced instead of adding the configurations directly to the Cilium health cell, because other dependency modules (such as IPAM) also reference them. These modules are not yet modularized, and the Cilium health cell itself depends on them.

Replacing other global usages of the health configurations is done in a separate PR - https://github.com/cilium/cilium/pull/41637
