### PR TITLE
fix: drop ipv4 wildcard when ipv6 wildcard present on node health check

### DIFF
--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -458,20 +458,20 @@ func getAddresses(logger *slog.Logger) []string {
 	addresses := make([]string, 0, 2)
 
 	if option.Config.EnableIPv4 {
-		if ipv4 := node.GetInternalIPv4(logger); ipv4 != nil {
-			addresses = append(addresses, ipv4.String())
+		if ip := node.GetInternalIPv4(logger); ip != nil {
+			addresses = append(addresses, ip.String())
 		} else {
-			// if Get ipv4 fails, then listen on all ipv4 addr.
-			addresses = append(addresses, "0.0.0.0")
+			// if Get ipv4 fails, then listen on all addresses.
+			return nil
 		}
 	}
 
 	if option.Config.EnableIPv6 {
-		if ipv6 := node.GetInternalIPv6(logger); ipv6 != nil {
-			addresses = append(addresses, ipv6.String())
+		if ip := node.GetInternalIPv6(logger); ip != nil {
+			addresses = append(addresses, ip.String())
 		} else {
-			// if Get ipv6 fails, then listen on all ipv6 addr.
-			addresses = append(addresses, "::")
+			// if Get ipv6 fails, then listen on all addresses.
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Previously, on dual stack clusters node health check, if there's no internal ip for IPv4 and IPv6 stacks configured, health check will attempt to bind for both IPv4 wildcard (0.0.0.0) and IPv6 wildcard (::) ips. Unless IPV6_V6ONLY flag is set (defaults to value of /proc/sys/net/ipv6/bindv6only which in turn defaults to false) ipv6 wildcard will bind for both v4 and v6 stacks resulting in bind error due to address being already in use.

This commit checks for ipv4 and ipv6 wildcards and in case drops ipv4 one if both are present

Fixes: #41402

```release-note
Fix failing node health check on dual stack cluster if NodeInternalIPs are not configured for both families.
```
