### PR TITLE
Agent: Get Cilium health config from Hive

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -61,9 +61,11 @@ cilium-agent hive [flags]
       --enable-drift-checker                                      Enables support for config drift checker (default true)
       --enable-dynamic-config                                     Enables support for dynamic agent config (default true)
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
+      --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-gops                                               Enable gops server (default true)
       --enable-health-check-nodeport                              Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
+      --enable-health-checking                                    Enable connectivity health checking (default true)
       --enable-hubble                                             Enable hubble server
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format.
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -67,9 +67,11 @@ cilium-agent hive dot-graph [flags]
       --enable-drift-checker                                      Enables support for config drift checker (default true)
       --enable-dynamic-config                                     Enables support for dynamic agent config (default true)
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
+      --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-gops                                               Enable gops server (default true)
       --enable-health-check-nodeport                              Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
+      --enable-health-checking                                    Enable connectivity health checking (default true)
       --enable-hubble                                             Enable hubble server
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format.
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cilium/statedb"
 	"google.golang.org/grpc"
 
+	"github.com/cilium/cilium/pkg/healthconfig"
+
 	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/daemon/cmd/cni"
@@ -331,6 +333,9 @@ var (
 
 		// Cilium health infrastructure (host and endpoint connectivity)
 		health.Cell,
+
+		// Cilium health config
+		healthconfig.Cell,
 
 		// Cilium Status Collector
 		status.Cell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/health"
+	"github.com/cilium/cilium/pkg/healthconfig"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -119,6 +120,8 @@ type Daemon struct {
 	// healthEndpointRouting is the information required to set up the health
 	// endpoint's routing in ENI or Azure IPAM mode
 	healthEndpointRouting *linuxrouting.RoutingInfo
+
+	healthConfig healthconfig.CiliumHealthConfig
 
 	ciliumHealth health.CiliumHealthManager
 
@@ -346,6 +349,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		ipsecAgent:        params.IPsecAgent,
 		ciliumHealth:      params.CiliumHealth,
 		endpointAPIFence:  params.EndpointAPIFence,
+		healthConfig:      params.HealthConfig,
 	}
 
 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -227,17 +227,11 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableEndpointRoutes, defaults.EnableEndpointRoutes, "Use per endpoint routes instead of routing via cilium_host")
 	option.BindEnv(vp, option.EnableEndpointRoutes)
 
-	flags.Bool(option.EnableHealthChecking, defaults.EnableHealthChecking, "Enable connectivity health checking")
-	option.BindEnv(vp, option.EnableHealthChecking)
-
 	flags.Bool(option.AgentHealthRequireK8sConnectivity, true, "Require Kubernetes connectivity in agent health endpoint")
 	option.BindEnv(vp, option.AgentHealthRequireK8sConnectivity)
 
 	flags.Bool(option.EnableHealthCheckLoadBalancerIP, defaults.EnableHealthCheckLoadBalancerIP, "Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs --enable-health-check-nodeport to be enabled")
 	option.BindEnv(vp, option.EnableHealthCheckLoadBalancerIP)
-
-	flags.Bool(option.EnableEndpointHealthChecking, defaults.EnableEndpointHealthChecking, "Enable connectivity health checking between virtual endpoints")
-	option.BindEnv(vp, option.EnableEndpointHealthChecking)
 
 	flags.Int(option.HealthCheckICMPFailureThreshold, defaults.HealthCheckICMPFailureThreshold, "Number of ICMP requests sent for each run of the health checker. If at least one ICMP response is received, the node or endpoint is marked as healthy.")
 	option.BindEnv(vp, option.HealthCheckICMPFailureThreshold)
@@ -1516,10 +1510,8 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	}
 
 	bootstrapStats.healthCheck.Start()
-	if option.Config.EnableHealthChecking {
-		if err := d.ciliumHealth.Init(d.ctx, d.healthEndpointRouting, cleaner.cleanupFuncs.Add); err != nil {
-			return fmt.Errorf("failed to initialize cilium health: %w", err)
-		}
+	if err := d.ciliumHealth.Init(d.ctx, d.healthEndpointRouting, cleaner.cleanupFuncs.Add); err != nil {
+		return fmt.Errorf("failed to initialize cilium health: %w", err)
 	}
 	bootstrapStats.healthCheck.End(true)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/health"
+	"github.com/cilium/cilium/pkg/healthconfig"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
@@ -1279,6 +1280,7 @@ type daemonParams struct {
 	IPCache             *ipcache.IPCache
 	DirReadStatus       policyDirectory.DirectoryWatcherReadStatus
 	CiliumHealth        health.CiliumHealthManager
+	HealthConfig        healthconfig.CiliumHealthConfig
 	ClusterMesh         *clustermesh.ClusterMesh
 	MonitorAgent        monitorAgent.Agent
 	DB                  *statedb.DB

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -237,7 +237,7 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily, fromK8s,
 func (d *Daemon) allocateHealthIPs() error {
 	bootstrapStats.healthCheck.Start()
 	defer bootstrapStats.healthCheck.End(true)
-	if !option.Config.EnableHealthChecking || !option.Config.EnableEndpointHealthChecking {
+	if !d.healthConfig.IsHealthCheckingEnabled() || !d.healthConfig.IsEndpointHealthCheckingEnabled() {
 		return nil
 	}
 	var healthIPv4, healthIPv6 net.IP

--- a/daemon/cmd/local_node_sync.go
+++ b/daemon/cmd/local_node_sync.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/healthconfig"
+
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -37,6 +39,7 @@ type localNodeSynchronizerParams struct {
 	K8sLocalNode       agentK8s.LocalNodeResource
 	K8sCiliumLocalNode agentK8s.LocalCiliumNodeResource
 	IPsecConfig        datapath.IPsecConfig
+	HealthConfig       healthconfig.CiliumHealthConfig
 }
 
 // localNodeSynchronizer performs the bootstrapping of the LocalNodeStore,
@@ -214,7 +217,8 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 			}
 		}
 
-		if ini.Config.EnableHealthChecking && ini.Config.EnableEndpointHealthChecking {
+		if ini.localNodeSynchronizerParams.HealthConfig.IsHealthCheckingEnabled() &&
+			ini.localNodeSynchronizerParams.HealthConfig.IsEndpointHealthCheckingEnabled() {
 			if ini.Config.EnableIPv4 {
 				node.IPv4HealthIP = net.ParseIP(k8sCiliumNode.Spec.HealthAddressing.IPv4)
 			}

--- a/pkg/health/health_manager.go
+++ b/pkg/health/health_manager.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/healthconfig"
+
 	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/controller"
@@ -62,6 +64,8 @@ type ciliumHealthManager struct {
 
 	ctrlMgr      *controller.Manager
 	ciliumHealth *CiliumHealth
+
+	healthConfig healthconfig.CiliumHealthConfig
 }
 
 type ciliumHealthParams struct {
@@ -77,6 +81,7 @@ type ciliumHealthParams struct {
 	EndpointCreator endpointcreator.EndpointCreator
 	EndpointManager endpointmanager.EndpointManager
 	K8sClientSet    k8sClient.Clientset
+	Config          healthconfig.CiliumHealthConfig
 }
 
 func newCiliumHealthManager(params ciliumHealthParams) CiliumHealthManager {
@@ -90,12 +95,16 @@ func newCiliumHealthManager(params ciliumHealthParams) CiliumHealthManager {
 		endpointCreator: params.EndpointCreator,
 		endpointManager: params.EndpointManager,
 		k8sClientSet:    params.K8sClientSet,
+		healthConfig:    params.Config,
 	}
 
 	return h
 }
 
 func (h *ciliumHealthManager) Init(ctx context.Context, routingInfo *linuxrouting.RoutingInfo, addCleanerFunc func(newFunc func())) error {
+	if !h.healthConfig.IsEndpointHealthCheckingEnabled() {
+		return nil
+	}
 	// Launch cilium-health in the same process (and namespace) as cilium.
 	h.logger.Info("Launching Cilium health daemon")
 	ch, err := h.launchCiliumNodeHealth(h.healthSpec, h.loader.HostDatapathInitialized())
@@ -106,7 +115,7 @@ func (h *ciliumHealthManager) Init(ctx context.Context, routingInfo *linuxroutin
 	h.ciliumHealth = ch
 
 	// If endpoint health checking is disabled, the virtual endpoint does not need to be launched
-	if !option.Config.EnableEndpointHealthChecking {
+	if !h.healthConfig.IsEndpointHealthCheckingEnabled() {
 		return nil
 	}
 

--- a/pkg/healthconfig/cell.go
+++ b/pkg/healthconfig/cell.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package healthconfig
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+)
+
+const (
+	EnableHealthCheckingName         = "enable-health-checking"
+	EnableEndpointHealthCheckingName = "enable-endpoint-health-checking"
+)
+
+// Cell provides the Cilium health config.
+var Cell = cell.Module(
+	"cilium-health-config",
+	"Cilium health config",
+	cell.Config[CiliumHealthConfig](defaultConfig),
+)
+
+type Config struct {
+	EnableHealthChecking         bool `mapstructure:"enable-health-checking"`
+	EnableEndpointHealthChecking bool `mapstructure:"enable-endpoint-health-checking"`
+}
+
+var defaultConfig = Config{
+	EnableHealthChecking:         true,
+	EnableEndpointHealthChecking: true,
+}
+
+type CiliumHealthConfig interface {
+	cell.Flagger
+	IsHealthCheckingEnabled() bool
+	IsEndpointHealthCheckingEnabled() bool
+}
+
+func (c Config) IsHealthCheckingEnabled() bool {
+	return c.EnableHealthChecking
+}
+
+func (c Config) IsEndpointHealthCheckingEnabled() bool {
+	return c.EnableEndpointHealthChecking
+}
+
+func (c Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool(EnableHealthCheckingName, c.EnableHealthChecking, "Enable connectivity health checking")
+	flags.Bool(EnableEndpointHealthCheckingName, c.EnableEndpointHealthChecking, "Enable connectivity health checking between virtual endpoints")
+}

--- a/pkg/healthconfig/healthconfig_test.go
+++ b/pkg/healthconfig/healthconfig_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package healthconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func Test_healthConfig(t *testing.T) {
+	var hc CiliumHealthConfig
+	hive := hive.New(
+		Cell,
+		cell.Invoke(func(cfg CiliumHealthConfig) { hc = cfg }),
+	)
+
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	hive.RegisterFlags(flags)
+	flags.Set("enable-health-checking", "true")
+	flags.Set("enable-endpoint-health-checking", "true")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	tlog := hivetest.Logger(t)
+	require.NoError(t, hive.Start(tlog, ctx))
+
+	require.True(t, hc.IsHealthCheckingEnabled())
+	require.True(t, hc.IsEndpointHealthCheckingEnabled())
+}


### PR DESCRIPTION
Global configurations can not be completely removed as there are some non-modularized modules (e.g., IPAM) that still reference them.

Signed-off-by: Aditi Ghag [aditi@cilium.io](mailto:aditi@cilium.io)