### PR TITLE
pkg/lrp: increase coverage for the unit test.

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/testdata/address-matcher-named-ports.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address-matcher-named-ports.txtar
@@ -1,4 +1,4 @@
-# AddressMatcherLRPs with named ports, LRP resources applied in different orders
+# AddressMatcherLRPs with named and unnamed ports, LRP resources applied in different orders
 
 hive start
 
@@ -45,6 +45,21 @@ db/cmp services services-single.table
 db/cmp frontends frontends-single.table
 db/cmp backends backends-single.table
 
+# Remove the LRP.
+k8s/delete lrp-addr-single.yaml
+
+# Tables and maps should now be empty.
+* db/empty services frontends backends localredirectpolicies
+
+# Add LRP with single unnamed port to cover https://github.com/cilium/cilium/issues/41407
+k8s/add lrp-addr-unnamed.yaml
+
+# Compare tables
+db/cmp localredirectpolicies lrp-unnamed.table
+db/cmp services services-unnamed.table
+db/cmp frontends frontends-unnamed.table
+db/cmp backends backends-unnamed.table
+
 -- lrp.table --
 Name               Type     FrontendType      Frontends
 test/lrp-addr      address  addr-named-ports  169.254.169.254:5050/TCP, 169.254.169.254:5051/TCP
@@ -67,17 +82,33 @@ Address             Instances
 Name                       Type     FrontendType      Frontends
 test/lrp-addr-single       address  addr-single-port  169.254.169.254:5050/TCP
 
+-- lrp-unnamed.table --
+Name                                      Type     FrontendType      Frontends
+test/lrp-addr-unnamed                     address  addr-single-port  169.254.169.254:5050/TCP
+
 -- services-single.table --
 Name                                     Source
 test/lrp-addr-single:local-redirect      k8s
+
+-- services-unnamed.table --
+Name                                     Source
+test/lrp-addr-unnamed:local-redirect     k8s
 
 -- frontends-single.table --
 Address                    Type          ServiceName                              Backends            RedirectTo  Status
 169.254.169.254:5050/TCP   LocalRedirect test/lrp-addr-single:local-redirect      10.244.2.1:50/TCP               Done
 
+-- frontends-unnamed.table --
+Address                    Type          ServiceName                              Backends            RedirectTo  Status
+169.254.169.254:5050/TCP   LocalRedirect test/lrp-addr-unnamed:local-redirect     10.244.2.1:50/TCP               Done
+
 -- backends-single.table --
 Address             Instances
 10.244.2.1:50/TCP   test/lrp-addr-single:local-redirect
+
+-- backends-unnamed.table --
+Address             Instances
+10.244.2.1:50/TCP   test/lrp-addr-unnamed:local-redirect
 
 -- lrp-addr.yaml --
 apiVersion: "cilium.io/v2"
@@ -131,6 +162,26 @@ spec:
         name: "test"
         protocol: TCP
 
+-- lrp-addr-unnamed.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr-unnamed"
+  namespace: test
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.254"
+      toPorts:
+        - port: "5050"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "50"
+        protocol: TCP
 -- pod.yaml --
 apiVersion: v1
 kind: Pod
@@ -177,6 +228,8 @@ spec:
       image: nginx
       ports:
         - containerPort: 50
+          protocol: TCP
+        - containerPort: 51
           protocol: TCP
   nodeName: testnode
 status:


### PR DESCRIPTION
Modify the unit test to cover the case that the backend container has more than one ports. https://github.com/cilium/cilium/issues/41407.




```release-note
Modify the unit test to cover the case that the backend container has more than one ports.

```
