### PR TITLE
feat: add clustermesh-cache-ttl flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -70,6 +70,7 @@ cilium-agent [flags]
       --cluster-health-port int                                   TCP port for cluster-wide network connectivity health API (default 4240)
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                            The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -33,6 +33,7 @@ cilium-agent hive [flags]
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                            The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -39,6 +39,7 @@ cilium-agent hive dot-graph [flags]
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                            The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-sync-timeout duration                         Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -24,6 +24,7 @@ cilium-operator-alibabacloud [flags]
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -15,6 +15,7 @@ cilium-operator-alibabacloud hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -21,6 +21,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -27,6 +27,7 @@ cilium-operator-aws [flags]
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -15,6 +15,7 @@ cilium-operator-aws hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -21,6 +21,7 @@ cilium-operator-aws hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -27,6 +27,7 @@ cilium-operator-azure [flags]
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -15,6 +15,7 @@ cilium-operator-azure hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -21,6 +21,7 @@ cilium-operator-azure hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -23,6 +23,7 @@ cilium-operator-generic [flags]
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -15,6 +15,7 @@ cilium-operator-generic hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -21,6 +21,7 @@ cilium-operator-generic hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -32,6 +32,7 @@ cilium-operator [flags]
       --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
       --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
       --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -15,6 +15,7 @@ cilium-operator hive [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -21,6 +21,7 @@ cilium-operator hive dot-graph [flags]
       --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
       --clustermesh-config string                            Path to the ClusterMesh configuration directory
       --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.

--- a/Documentation/cmdref/clustermesh-apiserver_kvstoremesh.md
+++ b/Documentation/cmdref/clustermesh-apiserver_kvstoremesh.md
@@ -14,6 +14,7 @@ clustermesh-apiserver kvstoremesh [flags]
       --api-serve-addr string                        Address to serve the KVStoreMesh API (default "localhost:9889")
       --cluster-id uint32                            Unique identifier of the cluster
       --cluster-name string                          Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration               The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-config string                    Path to the ClusterMesh configuration directory
       --controller-group-metrics strings             List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                        Enable debugging mode

--- a/Documentation/cmdref/clustermesh-apiserver_kvstoremesh_hive.md
+++ b/Documentation/cmdref/clustermesh-apiserver_kvstoremesh_hive.md
@@ -14,6 +14,7 @@ clustermesh-apiserver kvstoremesh hive [flags]
       --api-serve-addr string                        Address to serve the KVStoreMesh API (default "localhost:9889")
       --cluster-id uint32                            Unique identifier of the cluster
       --cluster-name string                          Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration               The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-config string                    Path to the ClusterMesh configuration directory
       --controller-group-metrics strings             List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                        Enable debugging mode

--- a/Documentation/cmdref/clustermesh-apiserver_kvstoremesh_hive_dot-graph.md
+++ b/Documentation/cmdref/clustermesh-apiserver_kvstoremesh_hive_dot-graph.md
@@ -20,6 +20,7 @@ clustermesh-apiserver kvstoremesh hive dot-graph [flags]
       --api-serve-addr string                        Address to serve the KVStoreMesh API (default "localhost:9889")
       --cluster-id uint32                            Unique identifier of the cluster
       --cluster-name string                          Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration               The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
       --clustermesh-config string                    Path to the ClusterMesh configuration directory
       --controller-group-metrics strings             List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                        Enable debugging mode

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -916,6 +916,10 @@
      - clustermesh-apiserver update strategy
      - object
      - ``{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}``
+   * - :spelling:ignore:`clustermesh.cacheTTL`
+     - The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked (default).
+     - string
+     - ``"0s"``
    * - :spelling:ignore:`clustermesh.config`
      - Clustermesh explicit configuration.
      - object

--- a/Documentation/network/clustermesh/services.rst
+++ b/Documentation/network/clustermesh/services.rst
@@ -204,6 +204,28 @@ clusters for the service under examination.
       Cluster1Global-->|no|Cluster1SelfCluster2Self
       Cluster2Global-->|no|Cluster1SelfCluster2Self
 
+Handling Unreachable Clusters
+#############################
+
+By default, if a remote cluster becomes unreachable, Cilium will retain the last-known service
+information in its cache. This can lead to traffic being sent to "stale" or unreachable backends.
+
+To mitigate this, you can configure a cache time-to-live (TTL). If a remote cluster's connection is
+lost and not re-established within this duration, Cilium will automatically revoke the cached data
+for that cluster. For global services, this means **Cilium will stop load-balancing to the service
+backends in the unreachable cluster**. When connectivity is re-established, the remote cluster's
+services are repopulated, and load-balancing to its backends resumes.
+
+The default value is ``"0s"``, which disables this feature and means caches are never revoked. To
+enable it, set ``clustermesh.cacheTTL`` to a duration greater than zero (e.g., ``"15m"``).
+
+.. parsed-literal::
+
+   helm upgrade cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --reuse-values \\
+     --set clustermesh.cacheTTL="15m"
+
 Limitations
 ###########
 

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -505,17 +505,18 @@ Name                                          Labels                            
 Clustermesh
 ~~~~~~~~~~~
 
-=============================================== ================== ========== =================================================================
-Name                                            Labels             Default    Description
-=============================================== ================== ========== =================================================================
-``clustermesh_remote_cluster_services``         ``target_cluster`` Enabled    The total number of services per remote cluster
-``clustermesh_remote_cluster_endpoints``        ``target_cluster`` Enabled    The total number of endpoints per remote cluster
-``clustermesh_remote_cluster_nodes``            ``target_cluster`` Enabled    The total number of nodes per remote cluster
-``clustermesh_remote_clusters``                                    Enabled    The total number of remote clusters meshed with the local cluster
-``clustermesh_remote_cluster_failures``         ``target_cluster`` Enabled    The total number of failures related to the remote cluster
-``clustermesh_remote_cluster_last_failure_ts``  ``target_cluster`` Enabled    The timestamp of the last failure of the remote cluster
-``clustermesh_remote_cluster_readiness_status`` ``target_cluster`` Enabled    The readiness status of the remote cluster
-=============================================== ================== ========== =================================================================
+================================================ ================== ========== =================================================================
+Name                                             Labels             Default    Description
+================================================ ================== ========== =================================================================
+``clustermesh_remote_cluster_services``          ``target_cluster`` Enabled    The total number of services per remote cluster
+``clustermesh_remote_cluster_endpoints``         ``target_cluster`` Enabled    The total number of endpoints per remote cluster
+``clustermesh_remote_cluster_nodes``             ``target_cluster`` Enabled    The total number of nodes per remote cluster
+``clustermesh_remote_clusters``                                     Enabled    The total number of remote clusters meshed with the local cluster
+``clustermesh_remote_cluster_failures``          ``target_cluster`` Enabled    The total number of failures related to the remote cluster
+``clustermesh_remote_cluster_last_failure_ts``   ``target_cluster`` Enabled    The timestamp of the last failure of the remote cluster
+``clustermesh_remote_cluster_readiness_status``  ``target_cluster`` Enabled    The readiness status of the remote cluster
+``clustermesh_remote_cluster_cache_revocations`` ``target_cluster`` Enabled    The total number of cache revocations related to the remote cluster
+================================================ ================== ========== =================================================================
 
 Datapath
 ~~~~~~~~
@@ -1010,16 +1011,17 @@ Name                                      Labels                                
 Clustermesh
 ~~~~~~~~~~~
 
-=============================================== ================== ========== ==================================================================
-Name                                            Labels             Default    Description
-=============================================== ================== ========== ==================================================================
-``clustermesh_remote_clusters``                                    Enabled    The total number of remote clusters meshed with the local cluster
-``clustermesh_remote_cluster_failures``         ``target_cluster`` Enabled    The total number of failures related to the remote cluster
-``clustermesh_remote_cluster_last_failure_ts``  ``target_cluster`` Enabled    The timestamp of the last failure of the remote cluster
-``clustermesh_remote_cluster_readiness_status`` ``target_cluster`` Enabled    The readiness status of the remote cluster
-``clustermesh_remote_cluster_services``         ``target_cluster`` Enabled    The total number of services per remote cluster
-``clustermesh_remote_cluster_service_exports``  ``target_cluster`` Enabled    The total number of MCS-API service exports per remote cluster
-=============================================== ================== ========== ==================================================================
+================================================= ================== ========== ====================================================================
+Name                                              Labels             Default    Description
+================================================= ================== ========== ====================================================================
+``clustermesh_remote_clusters``                                      Enabled    The total number of remote clusters meshed with the local cluster
+``clustermesh_remote_cluster_failures``           ``target_cluster`` Enabled    The total number of failures related to the remote cluster
+``clustermesh_remote_cluster_last_failure_ts``    ``target_cluster`` Enabled    The timestamp of the last failure of the remote cluster
+``clustermesh_remote_cluster_readiness_status``   ``target_cluster`` Enabled    The readiness status of the remote cluster
+``clustermesh_remote_cluster_cache_revocations``  ``target_cluster`` Enabled    The total number of cache revocations related to the remote cluster
+``clustermesh_remote_cluster_services``           ``target_cluster`` Enabled    The total number of services per remote cluster
+``clustermesh_remote_cluster_service_exports``    ``target_cluster`` Enabled    The total number of MCS-API service exports per remote cluster
+================================================= ================== ========== ====================================================================
 
 
 Hubble
@@ -1561,14 +1563,15 @@ Clustermesh
 
 Note that these metrics are not prefixed by ``clustermesh_``.
 
-=============================================== ================== ==================================================================
+=============================================== ================== ====================================================================
 Name                                            Labels             Description
-=============================================== ================== ==================================================================
+=============================================== ================== ====================================================================
 ``remote_clusters``                                                The total number of remote clusters meshed with the local cluster
 ``remote_cluster_failures``                     ``target_cluster`` The total number of failures related to the remote cluster
 ``remote_cluster_last_failure_ts``              ``target_cluster`` The timestamp of the last failure of the remote cluster
 ``remote_cluster_readiness_status``             ``target_cluster`` The readiness status of the remote cluster
-=============================================== ================== ==================================================================
+``remote_cluster_cache_revocations``            ``target_cluster`` The total number of cache revocations related to the remote cluster
+=============================================== ================== ====================================================================
 
 KVstore
 ~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -279,6 +279,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | clustermesh.apiserver.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for clustermesh-apiserver |
 | clustermesh.apiserver.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | clustermesh-apiserver update strategy |
+| clustermesh.cacheTTL | string | `"0s"` | The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked (default). |
 | clustermesh.config | object | `{"clusters":[],"domain":"mesh.cilium.io","enabled":false}` | Clustermesh explicit configuration. |
 | clustermesh.config.clusters | list | `[]` | Clusters to be peered in the mesh. @schema type: [object, array] @schema |
 | clustermesh.config.domain | string | `"mesh.cilium.io"` | Default dns domain for the Clustermesh API servers This is used in the case cluster addresses are not provided and IPs are used. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1395,6 +1395,7 @@ data:
 {{- if hasKey .Values.clustermesh "maxConnectedClusters" }}
   max-connected-clusters: {{ .Values.clustermesh.maxConnectedClusters | quote }}
 {{- end }}
+  clustermesh-cache-ttl: {{ .Values.clustermesh.cacheTTL | quote }}
   clustermesh-enable-endpoint-sync: {{ .Values.clustermesh.enableEndpointSliceSynchronization | quote }}
   clustermesh-enable-mcs-api: {{ (or .Values.clustermesh.mcsapi.enabled .Values.clustermesh.enableMCSAPISupport) | quote }}
   policy-default-local-cluster: {{ .Values.clustermesh.policyDefaultLocalCluster | quote }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -306,6 +306,7 @@ spec:
         {{- if hasKey .Values.clustermesh "maxConnectedClusters" }}
         - --max-connected-clusters={{ .Values.clustermesh.maxConnectedClusters }}
         {{- end }}
+        - --clustermesh-cache-ttl={{ .Values.clustermesh.cacheTTL }}
         - --health-port={{ .Values.clustermesh.apiserver.kvstoremesh.healthPort }}
         {{- if .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled }}
         - --prometheus-serve-addr=:{{ .Values.clustermesh.apiserver.metrics.kvstoremesh.port }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1458,6 +1458,9 @@
           },
           "type": "object"
         },
+        "cacheTTL": {
+          "type": "string"
+        },
         "config": {
           "properties": {
             "clusters": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3308,6 +3308,11 @@ clustermesh:
   # maximum allocatable cluster-local identities.
   # Supported values are 255 and 511.
   maxConnectedClusters: 255
+  # -- The time to live for the cache of a remote cluster after connectivity is
+  # lost. If the connection is not re-established within this duration, the
+  # cached data is revoked to prevent stale state. If not specified or set to
+  # 0s, the cache is never revoked (default).
+  cacheTTL: "0s"
   # -- Enable the synchronization of Kubernetes EndpointSlices corresponding to
   # the remote endpoints of appropriately-annotated global services through ClusterMesh
   enableEndpointSliceSynchronization: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3332,6 +3332,11 @@ clustermesh:
   # maximum allocatable cluster-local identities.
   # Supported values are 255 and 511.
   maxConnectedClusters: 255
+  # -- The time to live for the cache of a remote cluster after connectivity is
+  # lost. If the connection is not re-established within this duration, the
+  # cached data is revoked to prevent stale state. If not specified or set to
+  # 0s, the cache is never revoked (default).
+  cacheTTL: "0s"
   # -- Enable the synchronization of Kubernetes EndpointSlices corresponding to
   # the remote endpoints of appropriately-annotated global services through ClusterMesh
   enableEndpointSliceSynchronization: false

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -156,6 +156,7 @@ func (cm *clusterMesh) newRemoteCluster(name, path string) *remoteCluster {
 	}
 
 	rc.RemoteCluster = cm.conf.NewRemoteCluster(name, rc.status)
+	rc.ttlChecker = newTTLChecker(rc.logger, cm.conf.ClusterMeshCacheTTL, rc.RevokeCache)
 	return rc
 }
 

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -150,13 +150,18 @@ func (cm *clusterMesh) newRemoteCluster(name, path string) *remoteCluster {
 		remoteClientFactory: cm.conf.RemoteClientFactory,
 		clusterLockFactory:  newClusterLock,
 
-		metricLastFailureTimestamp: cm.conf.Metrics.LastFailureTimestamp.WithLabelValues(name),
-		metricReadinessStatus:      cm.conf.Metrics.ReadinessStatus.WithLabelValues(name),
-		metricTotalFailures:        cm.conf.Metrics.TotalFailures.WithLabelValues(name),
+		metricLastFailureTimestamp:  cm.conf.Metrics.LastFailureTimestamp.WithLabelValues(name),
+		metricReadinessStatus:       cm.conf.Metrics.ReadinessStatus.WithLabelValues(name),
+		metricTotalFailures:         cm.conf.Metrics.TotalFailures.WithLabelValues(name),
+		metricTotalCacheRevocations: cm.conf.Metrics.TotalCacheRevocations.WithLabelValues(name),
 	}
 
 	rc.RemoteCluster = cm.conf.NewRemoteCluster(name, rc.status)
-	rc.ttlChecker = newTTLChecker(rc.logger, cm.conf.ClusterMeshCacheTTL, rc.RevokeCache)
+	onExpiration := func(ctx context.Context) {
+		rc.metricTotalCacheRevocations.Inc()
+		rc.RevokeCache(ctx)
+	}
+	rc.ttlChecker = newTTLChecker(rc.logger, cm.conf.ClusterMeshCacheTTL, onExpiration)
 	return rc
 }
 

--- a/pkg/clustermesh/common/clustermesh_test.go
+++ b/pkg/clustermesh/common/clustermesh_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-type fakeRemoteCluster struct{ onRun, onStop, onRemove func(ctx context.Context) }
+type fakeRemoteCluster struct{ onRun, onStop, onRemove, onRevokeCache func(ctx context.Context) }
 
 func (f *fakeRemoteCluster) Run(ctx context.Context, _ kvstore.BackendOperations, _ types.CiliumClusterConfig, ready chan<- error) {
 	if f.onRun != nil {
@@ -39,6 +39,12 @@ func (f *fakeRemoteCluster) Run(ctx context.Context, _ kvstore.BackendOperations
 func (f *fakeRemoteCluster) Stop() {
 	if f.onStop != nil {
 		f.onStop(context.Background())
+	}
+}
+
+func (f *fakeRemoteCluster) RevokeCache(ctx context.Context) {
+	if f.onRevokeCache != nil {
+		f.onRevokeCache(ctx)
 	}
 }
 

--- a/pkg/clustermesh/common/config.go
+++ b/pkg/clustermesh/common/config.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/pflag"
@@ -21,14 +22,21 @@ import (
 type Config struct {
 	// ClusterMeshConfig is the path to the clustermesh configuration directory.
 	ClusterMeshConfig string
+
+	// ClusterMeshCacheTTL is the time to live for the cache of a remote cluster after connectivity
+	// is lost. If the connection is not re-established within this duration, the cached data is
+	// revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+	ClusterMeshCacheTTL time.Duration
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.String("clustermesh-config", def.ClusterMeshConfig, "Path to the ClusterMesh configuration directory")
+	flags.Duration("clustermesh-cache-ttl", def.ClusterMeshCacheTTL, "The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.")
 }
 
 var DefaultConfig = Config{
-	ClusterMeshConfig: "",
+	ClusterMeshConfig:   "",
+	ClusterMeshCacheTTL: 0,
 }
 
 // clusterLifecycle is the interface to implement in order to receive cluster

--- a/pkg/clustermesh/common/metrics.go
+++ b/pkg/clustermesh/common/metrics.go
@@ -17,6 +17,8 @@ type Metrics struct {
 	ReadinessStatus metric.Vec[metric.Gauge]
 	// TotalFailure tracks the number of failures when connecting to remote clusters.
 	TotalFailures metric.Vec[metric.Gauge]
+	// TotalCacheRevocations tracks the number of cache revocations for a remote cluster.
+	TotalCacheRevocations metric.Vec[metric.Gauge]
 }
 
 func MetricsProvider(subsystem string) func() Metrics {
@@ -48,6 +50,13 @@ func MetricsProvider(subsystem string) func() Metrics {
 				Subsystem: subsystem,
 				Name:      "remote_cluster_failures",
 				Help:      "The total number of failures related to the remote cluster",
+			}, []string{metrics.LabelTargetCluster}),
+
+			TotalCacheRevocations: metric.NewGaugeVec(metric.GaugeOpts{
+				Namespace: metrics.Namespace,
+				Subsystem: subsystem,
+				Name:      "remote_cluster_cache_revocations",
+				Help:      "The total number of cache revocations related to the remote cluster",
 			}, []string{metrics.LabelTargetCluster}),
 		}
 	}

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -104,9 +104,10 @@ type remoteCluster struct {
 	// for testing purposes.
 	clusterLockFactory func() *clusterLock
 
-	metricLastFailureTimestamp prometheus.Gauge
-	metricReadinessStatus      prometheus.Gauge
-	metricTotalFailures        prometheus.Gauge
+	metricLastFailureTimestamp  prometheus.Gauge
+	metricReadinessStatus       prometheus.Gauge
+	metricTotalFailures         prometheus.Gauge
+	metricTotalCacheRevocations prometheus.Gauge
 }
 
 // releaseOldConnection releases the etcd connection to a remote cluster

--- a/pkg/clustermesh/common/remote_cluster_test.go
+++ b/pkg/clustermesh/common/remote_cluster_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
@@ -108,4 +109,70 @@ func TestRemoteClusterWatchdog(t *testing.T) {
 	require.True(t, status.Ready, "Cluster status should report ready")
 	require.EqualValues(t, 2, status.NumFailures, "Cluster status should report two failures")
 	require.NotZero(t, status.LastFailure, "Cluster status should report two failures")
+}
+
+func TestRemoteClusterCacheRevokeOnTimeout(t *testing.T) {
+	client := kvstore.NewInMemoryClient(statedb.New(), "etcd")
+
+	const name = "remote-revoke-test"
+	path := filepath.Join(t.TempDir(), name)
+	writeFile(t, path, "endpoints:\n- in-memory\n")
+	require.NoError(t, clustercfg.Set(t.Context(), name, types.CiliumClusterConfig{ID: 2}, client))
+
+	ready := make(chan struct{}, 1)
+	revoked := make(chan struct{}, 1)
+
+	cm := NewClusterMesh(Configuration{
+		Logger:      hivetest.Logger(t),
+		ClusterInfo: types.ClusterInfo{ID: 255, Name: "local"},
+		NewRemoteCluster: func(name string, sf StatusFunc) RemoteCluster {
+			return &fakeRemoteCluster{
+				onRun: func(context.Context) {
+					ready <- struct{}{}
+				},
+				onRevokeCache: func(context.Context) {
+					revoked <- struct{}{}
+				},
+			}
+		},
+		Metrics: MetricsProvider("clustermesh")(),
+	})
+
+	rc := cm.(*clusterMesh).newRemoteCluster(name, path)
+
+	statusErrors := make(chan error, 1)
+	rc.remoteClientFactory = func(ctx context.Context, logger *slog.Logger, cfgpath string,
+		options kvstore.ExtraOptions) (kvstore.BackendOperations, chan error) {
+		errch := make(chan error)
+		close(errch)
+		return &fakeBackend{client, statusErrors}, errch
+	}
+
+	rc.connect()
+	t.Cleanup(rc.onStop)
+
+	select {
+	case <-ready:
+	case <-time.After(timeout):
+		t.Fatal("Remote cluster didn't turn ready for the first time")
+	}
+
+	// Configure the TTL and mock the factory to permanently fail all future connections.
+	rc.ttlChecker.ttl = 100 * time.Millisecond
+	rc.remoteClientFactory = func(ctx context.Context, logger *slog.Logger, cfgpath string,
+		options kvstore.ExtraOptions) (kvstore.BackendOperations, chan error) {
+		errCh := make(chan error, 1)
+		errCh <- errors.New("persistent connection failure")
+		return nil, errCh
+	}
+
+	// Trigger a status error to force a reconnection
+	statusErrors <- errors.New("error")
+
+	select {
+	case <-revoked:
+		// Success
+	case <-time.After(timeout):
+		t.Fatal("Cache was not revoked after timeout")
+	}
 }

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -156,6 +156,15 @@ func (rc *remoteCluster) Stop() {
 	rc.wg.Wait()
 }
 
+// RevokeCache performs a partial revocation of the remote cluster's cache, draining only remote
+// services and serviceExports. This prevents the kvstoremesh from keeping services in the kvstore
+// for clusters with potentially stale service backends. Other resources are left intact to reduce
+// churn and avoid disrupting existing connections like active IPsec security associations.
+func (rc *remoteCluster) RevokeCache(ctx context.Context) {
+	rc.services.watcher.Drain()
+	rc.serviceExports.watcher.Drain()
+}
+
 func (rc *remoteCluster) Remove(ctx context.Context) {
 	if rc.disableDrainOnDisconnection {
 		rc.logger.Warn("Remote cluster disconnected, but cached data removal is disabled. " +

--- a/pkg/clustermesh/operator/remote_cluster.go
+++ b/pkg/clustermesh/operator/remote_cluster.go
@@ -89,6 +89,14 @@ func (rc *remoteCluster) Stop() {
 	rc.synced.Stop()
 }
 
+// RevokeCache performs a partial revocation of the remote cluster's cache, draining only remote
+// services and serviceExports. This prevents the operator from maintaining state for potentially
+// stale services.
+func (rc *remoteCluster) RevokeCache(ctx context.Context) {
+	rc.remoteServices.Drain()
+	rc.remoteServiceExports.Drain()
+}
+
 func (rc *remoteCluster) Remove(context.Context) {
 	for _, clusterDeleteHook := range rc.clusterDeleteHooks {
 		clusterDeleteHook(rc.name)

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -146,6 +146,14 @@ func (rc *remoteCluster) Stop() {
 	rc.synced.Stop()
 }
 
+// RevokeCache performs a partial revocation of the remote cluster's cache, draining only remote
+// services. This prevents the agent from load-balancing to potentially stale service backends.
+// Other resources are left intact to reduce churn and avoid disrupting existing connections like
+// active IPsec security associations.
+func (rc *remoteCluster) RevokeCache(ctx context.Context) {
+	rc.remoteServices.Drain()
+}
+
 func (rc *remoteCluster) Remove(context.Context) {
 	// Draining shall occur only when the configuration for the remote cluster
 	// is removed, and not in case the agent is shutting down, otherwise we


### PR DESCRIPTION
Define a grace period for kvstore clients (cilium-agent, operator, kvstoremesh) after connectivity to a remote cluster's kvstore is detected to be lost. If the connection is not restored within this duration, all local cached data for that cluster is revoked to prevent operating on stale state.

Tested with:
```
make kind-clustermesh
make kind-clustermesh-images
make kind-install-cilium-clustermesh
```
After deleting the clustermesh-apiserver Deployment in clustermesh2, validated that kvstoremesh container in clustermesh1 removes cached clustermesh2 state from the kvstore, and cilium-agent is updated shortly thereafter. Did a similar exercise to validate that the cilium-agent cache is updated if it couldn't connect to its own clustermesh-apiserver.

Fixes: #37333

```release-note
Add flag to allow clients of Cluster Mesh to revoke cached data about a remote cluster if connectivity to the remote cluster kvstore is lost.
```
