### PR TITLE
Add toIP to CiliumLocalRedirectPolicy redirectBackend

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -350,6 +350,7 @@ cilium-agent [flags]
       --log-opt map                                               Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
       --log-system-load                                           Enable periodic logging of system load
       --lrp-address-matcher-cidrs strings                         Limit address matches to specific CIDRs
+      --lrp-to-ip-range string                                    Limit ToIP matches to specific IP range (default "169.254.0.0/16")
       --max-connected-clusters uint32                             Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (beta)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -208,6 +208,7 @@ cilium-agent hive [flags]
       --l2-pod-announcements-interface-pattern string             Regex matching interfaces used for sending gratuitous ARP and NDP messages
       --lb-state-file string                                      Synchronize load-balancing state from the specified file
       --lrp-address-matcher-cidrs strings                         Limit address matches to specific CIDRs
+      --lrp-to-ip-range string                                    Limit ToIP matches to specific IP range (default "169.254.0.0/16")
       --max-connected-clusters uint32                             Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (beta)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -213,6 +213,7 @@ cilium-agent hive dot-graph [flags]
       --l2-pod-announcements-interface-pattern string             Regex matching interfaces used for sending gratuitous ARP and NDP messages
       --lb-state-file string                                      Synchronize load-balancing state from the specified file
       --lrp-address-matcher-cidrs strings                         Limit address matches to specific CIDRs
+      --lrp-to-ip-range string                                    Limit ToIP matches to specific IP range (default "169.254.0.0/16")
       --max-connected-clusters uint32                             Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (beta)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3092,6 +3092,10 @@
      - Enable local redirect policies.
      - bool
      - ``false``
+   * - :spelling:ignore:`localRedirectPolicies.toIPRange`
+     - Limit the allowed IP range for Local Redirect Policies for ToIP field. @schema@ type: [null, string] @schema@
+     - string
+     - ``169.254.0.0/16``
    * - :spelling:ignore:`localRedirectPolicy`
      - Enable Local Redirect Policy (deprecated, please use 'localRedirectPolicies.enabled' instead)
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -823,6 +823,7 @@ contributors across the globe, there is almost always someone available to help.
 | loadBalancer.l7.ports | list | `[]` | List of ports from service to be automatically redirected to above backend. Any service exposing one of these ports will be automatically redirected. Fine-grained control can be achieved by using the service annotation. |
 | localRedirectPolicies.addressMatcherCIDRs | string | `nil` | Limit the allowed addresses in Address Matcher rule of Local Redirect Policies to the given CIDRs. @schema@ type: [null, array] @schema@ |
 | localRedirectPolicies.enabled | bool | `false` | Enable local redirect policies. |
+| localRedirectPolicies.toIPRange | string | `169.254.0.0/16` | Limit the allowed IP range for Local Redirect Policies for ToIP field. @schema@ type: [null, string] @schema@ |
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy (deprecated, please use 'localRedirectPolicies.enabled' instead) |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -810,6 +810,10 @@ data:
   lrp-address-matcher-cidrs: {{ .Values.localRedirectPolicies.addressMatcherCIDRs | join "," | quote }}
 {{- end }}
 
+{{- if .Values.localRedirectPolicies.toIPRange }}
+  lrp-to-ip-range: {{ .Values.localRedirectPolicies.toIPRange | quote }}
+{{- end }}
+
 {{- if .Values.ipv4NativeRoutingCIDR }}
   ipv4-native-routing-cidr: {{ .Values.ipv4NativeRoutingCIDR }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4660,6 +4660,12 @@
         },
         "enabled": {
           "type": "boolean"
+        },
+        "toIPRange": {
+          "type": [
+            "null",
+            "string"
+          ]
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2361,6 +2361,12 @@ localRedirectPolicies:
   # type: [null, array]
   # @schema@
   addressMatcherCIDRs: ~
+  # -- Limit the allowed IP range for Local Redirect Policies for ToIP field.
+  # @schema@
+  # type: [null, string]
+  # @schema@
+  # @default -- `169.254.0.0/16`
+  toIPRange: ~
 # To include or exclude matched resources from cilium identity evaluation
 # labels: ""
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2383,6 +2383,13 @@ localRedirectPolicies:
   # @schema@
   addressMatcherCIDRs: ~
 
+  # -- Limit the allowed IP range for Local Redirect Policies for ToIP field.
+  # @schema@
+  # type: [null, string]
+  # @schema@
+  # @default -- `169.254.0.0/16`
+  toIPRange: ~
+
 # To include or exclude matched resources from cilium identity evaluation
 # labels: ""
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
@@ -116,6 +116,16 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
+                  toIP:
+                    description: |-
+                      ToIP is an IP address used to override the Pod IP.
+                      This is useful when redirecting pod traffic to a DaemonSet running
+                      in the host network namespace, listening on the loopback interface or
+                      other interfaces for which Cilium cannot obtain the IP from Kubernetes.
+                    type: string
+                    x-kubernetes-validations:
+                    - message: toIP must be a valid IP address
+                      rule: isIP(self)
                   toPorts:
                     description: |-
                       ToPorts is a list of L4 ports with protocol of node local pod(s) where traffic

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
@@ -171,6 +171,10 @@ spec:
                 description: |-
                   RedirectFrontend specifies frontend configuration to redirect traffic from.
                   It can not be empty.
+                  RedirectFrontend specifies the frontend configuration. Traffic is translated
+                  only if the address family (IPv4/IPv6) matches the RedirectBackend.
+                  Translation is unsupported if families differ.
+                  Example: IPv4 services are translated only if the backend is also IPv4.
                 oneOf:
                 - properties:
                     addressMatcher: {}

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -167,6 +167,10 @@ type RedirectBackend struct {
 type CiliumLocalRedirectPolicySpec struct {
 	// RedirectFrontend specifies frontend configuration to redirect traffic from.
 	// It can not be empty.
+	// RedirectFrontend specifies the frontend configuration. Traffic is translated
+	// only if the address family (IPv4/IPv6) matches the RedirectBackend.
+	// Translation is unsupported if families differ.
+	// Example: IPv4 services are translated only if the backend is also IPv4.
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="redirectFrontend is immutable"

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -152,6 +152,14 @@ type RedirectBackend struct {
 	//
 	// +kubebuilder:validation:Required
 	ToPorts []PortInfo `json:"toPorts"`
+
+	// ToIP is an IP address used to override the Pod IP.
+	// This is useful when redirecting pod traffic to a DaemonSet running
+	// in the host network namespace, listening on the loopback interface or
+	// other interfaces for which Cilium cannot obtain the IP from Kubernetes.
+	// +kubebuilder:validation:XValidation:rule="isIP(self)", message="toIP must be a valid IP address"
+	// +kubebuilder:validation:Optional
+	ToIP string `json:"toIP,omitempty"`
 }
 
 // CiliumLocalRedirectPolicySpec specifies the configurations for redirecting traffic

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -2421,6 +2421,10 @@ func (in *RedirectBackend) DeepEqual(other *RedirectBackend) bool {
 		}
 	}
 
+	if in.ToIP != other.ToIP {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/loadbalancer/redirectpolicy/config.go
+++ b/pkg/loadbalancer/redirectpolicy/config.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	AddressMatcherCIDRsName = "lrp-address-matcher-cidrs"
+	ToIPRangeName           = "lrp-to-ip-range"
 )
 
 type Config struct {
@@ -18,10 +19,14 @@ type Config struct {
 	// AddressMatcher rule to specific CIDRs. This allows global control over
 	// what addresses can be matched over the namespaced CiliumLocalRedirectPolicies.
 	AddressMatcherCIDRs []netip.Prefix `mapstructure:"lrp-address-matcher-cidrs"`
+	// ToIPRange limits which IP addresses can be used in a ToIP rule to a specific range.
+	// This is to prevent users to use LRP to access arbitrary IPs
+	ToIPRange netip.Prefix `mapstructure:"lrp-to-ip-range"`
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.StringSlice(AddressMatcherCIDRsName, []string{}, "Limit address matches to specific CIDRs")
+	flags.String(ToIPRangeName, def.ToIPRange.String(), "Limit ToIP matches to specific IP range")
 }
 
 func (cfg Config) addressAllowed(addr netip.Addr) bool {
@@ -38,4 +43,5 @@ func (cfg Config) addressAllowed(addr netip.Addr) bool {
 
 var DefaultConfig = Config{
 	AddressMatcherCIDRs: nil,
+	ToIPRange:           netip.MustParsePrefix("169.254.0.0/16"),
 }

--- a/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
+++ b/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
@@ -316,6 +316,9 @@ func getSanitizedLocalRedirectPolicy(cfg Config, log *slog.Logger, name, namespa
 		if err != nil {
 			return nil, fmt.Errorf("invalid ToIP: %s", redirectTo.ToIP)
 		}
+		if !cfg.ToIPRange.Contains(ip) {
+			return nil, fmt.Errorf("ToIP %s is not within the allowed range %s", redirectTo.ToIP, cfg.ToIPRange)
+		}
 		backendIP = ip
 	}
 	// When a single port is specified in the LRP frontend, the protocol for frontend and

--- a/pkg/loadbalancer/redirectpolicy/testdata/lrp-ip-toip.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/lrp-ip-toip.txtar
@@ -1,0 +1,144 @@
+# Verify that local redirect policy can use the overrideIP field 
+hive start
+
+# Add LRP and then LRP-selected pod.
+k8s/add lrp-addr.yaml
+k8s/add pod.yaml
+
+# Wait for the IPv4 frontend
+db/show frontends
+* stdout '169.254.169.254:5050/TCP.*1.1.1.3:50/TCP.*Done'
+
+
+# Then add IPv6 and check tables and compare tables
+k8s/add lrp-addr-ipv6.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps.expected
+
+# Remove the ipv6 LRP.
+k8s/delete lrp-addr-ipv6.yaml
+
+# Check the BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-v4.expected
+
+# Remove the remaining policy
+k8s/delete lrp-addr.yaml
+
+# Tables and maps should now be empty.
+* db/empty services frontends backends localredirectpolicies
+
+
+-- lrp.table --
+Name               Type     FrontendType      Frontends
+test/lrp-addr      address  addr-single-port  169.254.169.254:5050/TCP
+test/lrp-addr-ipv6 address  addr-single-port  [2001::1]:5050/TCP
+
+-- services.table --
+Name                              Source
+test/lrp-addr-ipv6:local-redirect k8s
+test/lrp-addr:local-redirect      k8s
+
+-- frontends.table --
+Address                    Type          ServiceName                       Backends            RedirectTo  Status
+169.254.169.254:5050/TCP   LocalRedirect test/lrp-addr:local-redirect      1.1.1.3:50/TCP                  Done
+[2001::1]:5050/TCP         LocalRedirect test/lrp-addr-ipv6:local-redirect [2001::3]:50/TCP                Done
+
+-- backends.table --
+Address             Instances
+1.1.1.3:50/TCP      test/lrp-addr:local-redirect
+[2001::3]:50/TCP    test/lrp-addr-ipv6:local-redirect
+
+
+-- lrp-addr.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr"
+  namespace: test
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.254"
+      toPorts:
+        - port: "5050"
+          protocol: TCP
+  redirectBackend:
+    toIP: 1.1.1.3
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "50"
+        protocol: TCP
+
+-- lrp-addr-ipv6.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr-ipv6"
+  namespace: test
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "2001::1"
+      toPorts:
+        - port: "5050"
+          protocol: TCP
+  redirectBackend:
+    toIP: 2001::3
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "50"
+        protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 50
+          protocol: TCP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2002::2
+  conditions:
+  - lastProbeTime: null
+    type: Ready
+
+-- maps.expected --
+BE: ID=1 ADDR=1.1.1.3:50/TCP STATE=active
+BE: ID=2 ADDR=[2001::3]:50/TCP STATE=active
+REV: ID=1 ADDR=169.254.169.254:5050
+REV: ID=2 ADDR=[2001::1]:5050
+SVC: ID=1 ADDR=169.254.169.254:5050/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=169.254.169.254:5050/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=[2001::1]:5050/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=[2001::1]:5050/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- maps-v4.expected --
+BE: ID=1 ADDR=1.1.1.3:50/TCP STATE=active
+REV: ID=1 ADDR=169.254.169.254:5050
+SVC: ID=1 ADDR=169.254.169.254:5050/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=169.254.169.254:5050/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect


### PR DESCRIPTION
see commit message

Fixes: https://github.com/cilium/cilium/issues/41671

```release-note
Add toIP to CiliumLocalRedirectPolicy redirectBackend so it works with latest GKE metadata server
```
