### PR TITLE
node/manager: TestNodesStartupPruning poll state

### DIFF
--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -4,6 +4,7 @@
 package manager
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1427,20 +1428,22 @@ func TestNodesStartupPruning(t *testing.T) {
 	checkNodeFileMatches := func(t *testing.T, stateDir string, nodes ...nodeTypes.Node) {
 		path := filepath.Join(stateDir, nodesFilename)
 
-		// Wait until the file exists. The node deletion triggers the write, hence
-		// this shouldn't take long.
+		var prevBytes []byte
+
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.FileExists(c, path)
-		}, time.Second, 10*time.Millisecond)
-		nwf, err := os.Open(path)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			nwf.Close()
-		})
-		var nl []nodeTypes.Node
-		assert.NoError(t, json.NewDecoder(nwf).Decode(&nl))
-		assert.ElementsMatch(t, nodes, nl)
-		require.NoError(t, os.Remove(path))
+			checkpointBytes, err := os.ReadFile(path)
+			assert.NoError(c, err)
+
+			if bytes.Equal(checkpointBytes, prevBytes) {
+				c.FailNow()
+			}
+
+			prevBytes = checkpointBytes
+
+			var nl []nodeTypes.Node
+			assert.NoError(c, json.Unmarshal(checkpointBytes, &nl))
+			assert.ElementsMatch(c, nodes, nl)
+		}, time.Second*2, 100*time.Millisecond)
 	}
 
 	t.Run("cluster nodes synced first", func(t *testing.T) {


### PR DESCRIPTION
Fixes CI flake #41550

With multiple NodeUpdate/NodeDelete events firing at once, the order that the state will be committed to the file is non-determisitc.

Instead of deleting the checkpoint file and waiting for the correct state to be written back, we poll the file, reading until the correct state is found or timeout.

Stress test:
```
 I  ~/w/c/p/f/41550 pr/fix/41550• 1.8s ❱ go test -count=1 -run "TestNodesStartupPruning" ./pkg/node/manager/...
ok      github.com/cilium/cilium/pkg/node/manager       0.430s
I  ~/w/c/p/f/41550 41550• 21.1s ❱ stress -count=1000 -p=32 go test -v -count=1 -run "TestNodesStartupPruning" ./pkg/node/manager/...
5s: 1 runs so far, 0 failures, 32 active
10s: 33 runs so far, 0 failures, 32 active
15s: 65 runs so far, 0 failures, 32 active
20s: 97 runs so far, 0 failures, 32 active
25s: 128 runs so far, 0 failures, 32 active
30s: 160 runs so far, 0 failures, 32 active
35s: 192 runs so far, 0 failures, 32 active
40s: 223 runs so far, 0 failures, 32 active
45s: 255 runs so far, 0 failures, 32 active
50s: 287 runs so far, 0 failures, 32 active
55s: 316 runs so far, 0 failures, 32 active
1m0s: 345 runs so far, 0 failures, 32 active
1m5s: 374 runs so far, 0 failures, 32 active
1m10s: 402 runs so far, 0 failures, 32 active
1m15s: 426 runs so far, 0 failures, 32 active
1m20s: 455 runs so far, 0 failures, 32 active
1m25s: 485 runs so far, 0 failures, 32 active
1m30s: 513 runs so far, 0 failures, 32 active
1m35s: 543 runs so far, 0 failures, 32 active
1m40s: 575 runs so far, 0 failures, 32 active
1m45s: 607 runs so far, 0 failures, 32 active
1m50s: 639 runs so far, 0 failures, 32 active
1m55s: 671 runs so far, 0 failures, 32 active
2m0s: 701 runs so far, 0 failures, 32 active
2m5s: 730 runs so far, 0 failures, 32 active
2m10s: 760 runs so far, 0 failures, 32 active
2m15s: 789 runs so far, 0 failures, 32 active
2m20s: 811 runs so far, 0 failures, 32 active
2m25s: 842 runs so far, 0 failures, 32 active
2m30s: 869 runs so far, 0 failures, 32 active
2m35s: 897 runs so far, 0 failures, 32 active
2m40s: 929 runs so far, 0 failures, 32 active
2m45s: 959 runs so far, 0 failures, 32 active
2m49s: 1000 runs total, 0 failures
```