### PR TITLE
hubble: refactor the peer service as a cell

### DIFF
--- a/pkg/hubble/cell/cell.go
+++ b/pkg/hubble/cell/cell.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/hubble/parser"
 	parsercell "github.com/cilium/cilium/pkg/hubble/parser/cell"
+	peercell "github.com/cilium/cilium/pkg/hubble/peer/cell"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
@@ -52,6 +53,9 @@ var Cell = cell.Module(
 
 	// Drop event emitter flow processor
 	dropeventemitter.Cell,
+
+	// Peer service for handling peer discovery and notifications
+	peercell.Cell,
 )
 
 // The core cell group, which contains the Hubble integration and the
@@ -90,6 +94,8 @@ type hubbleParams struct {
 	GRPCMetrics          *grpc_prometheus.ServerMetrics
 	MetricsFlowProcessor metrics.FlowProcessor
 
+	PeerService peercell.PeerService
+
 	Config config
 }
 
@@ -99,7 +105,7 @@ type HubbleIntegration interface {
 }
 
 func newHubbleIntegration(params hubbleParams) (HubbleIntegration, error) {
-	h, err := new(
+	h, err := createHubbleIntegration(
 		params.IdentityAllocator,
 		params.EndpointManager,
 		params.IPCache,
@@ -114,6 +120,7 @@ func newHubbleIntegration(params hubbleParams) (HubbleIntegration, error) {
 		params.PayloadParser,
 		params.GRPCMetrics,
 		params.MetricsFlowProcessor,
+		params.PeerService,
 		params.Config,
 		params.Logger,
 	)

--- a/pkg/hubble/cell/config.go
+++ b/pkg/hubble/cell/config.go
@@ -40,6 +40,16 @@ type config struct {
 	PreferIpv6 bool `mapstructure:"hubble-prefer-ipv6"`
 }
 
+// GetListenAddress implements the HubbleConfig interface
+func (c config) GetListenAddress() string {
+	return c.ListenAddress
+}
+
+// GetPreferIPv6 implements the HubbleConfig interface
+func (c config) GetPreferIPv6() bool {
+	return c.PreferIpv6
+}
+
 var defaultConfig = config{
 	EnableHubble: false,
 	// Hubble internals (parser, ringbuffer) configuration

--- a/pkg/hubble/peer/cell/cell.go
+++ b/pkg/hubble/peer/cell/cell.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/crypto/certloader"
+	"github.com/cilium/cilium/pkg/hubble/peer"
+	"github.com/cilium/cilium/pkg/hubble/peer/serviceoption"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	nodeManager "github.com/cilium/cilium/pkg/node/manager"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+// Cell provides the Hubble peer service that handles peer discovery and notifications.
+var Cell = cell.Module(
+	"hubble-peer-service",
+	"Hubble peer service for handling peer discovery and notifications",
+
+	cell.Provide(newPeerService),
+)
+
+// HubbleConfig interface defines the configuration needed by the peer service
+type HubbleConfig interface {
+	GetListenAddress() string
+	GetPreferIPv6() bool
+}
+
+type peerServiceParams struct {
+	cell.In
+
+	Logger           *slog.Logger
+	NodeManager      nodeManager.NodeManager
+	TLSConfigPromise tlsConfigPromise `optional:"true"`
+	Config           HubbleConfig
+}
+
+type tlsConfigPromise promise.Promise[*certloader.WatchedServerConfig]
+
+// PeerService provides the Hubble peer service.
+type PeerService interface {
+	Service() *peer.Service
+}
+
+type peerServiceImpl struct {
+	service *peer.Service
+}
+
+func (p *peerServiceImpl) Service() *peer.Service {
+	return p.service
+}
+
+// getPort extracts the port from an address string.
+// Supports formats like ":4244", "localhost:4244", "[::1]:4244"
+func getPort(address string) (int, error) {
+	// Handle IPv6 addresses in brackets
+	if strings.Contains(address, "]:") {
+		parts := strings.Split(address, "]:")
+		if len(parts) == 2 {
+			return strconv.Atoi(parts[1])
+		}
+	}
+
+	// Handle regular addresses with colon
+	if strings.Contains(address, ":") {
+		parts := strings.Split(address, ":")
+		if len(parts) >= 2 {
+			return strconv.Atoi(parts[len(parts)-1])
+		}
+	}
+
+	return 0, fmt.Errorf("unable to extract port from address: %s", address)
+}
+
+func newPeerService(params peerServiceParams) (PeerService, error) {
+	var peerServiceOptions []serviceoption.Option
+
+	// Determine if TLS is enabled
+	tlsEnabled := params.TLSConfigPromise != nil
+	if !tlsEnabled {
+		peerServiceOptions = append(peerServiceOptions, serviceoption.WithoutTLSInfo())
+	}
+
+	// Set address family preference
+	if params.Config.GetPreferIPv6() {
+		peerServiceOptions = append(peerServiceOptions, serviceoption.WithAddressFamilyPreference(serviceoption.AddressPreferIPv6))
+	}
+
+	// Extract port from listen address if available
+	if addr := params.Config.GetListenAddress(); addr != "" {
+		port, err := getPort(addr)
+		if err != nil {
+			params.Logger.Warn(
+				"Hubble server will not pass port information in change notifications on exposed Hubble peer service",
+				logfields.Error, err,
+				logfields.Address, addr,
+			)
+		} else {
+			peerServiceOptions = append(peerServiceOptions, serviceoption.WithHubblePort(port))
+		}
+	}
+
+	service := peer.NewService(params.NodeManager, peerServiceOptions...)
+
+	return &peerServiceImpl{
+		service: service,
+	}, nil
+}

--- a/pkg/hubble/peer/cell/cell_test.go
+++ b/pkg/hubble/peer/cell/cell_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  string
+		expected int
+		hasError bool
+	}{
+		{
+			name:     "IPv4 with port",
+			address:  "127.0.0.1:4244",
+			expected: 4244,
+		},
+		{
+			name:     "IPv6 with port",
+			address:  "[::1]:4244",
+			expected: 4244,
+		},
+		{
+			name:     "Port only",
+			address:  ":4244",
+			expected: 4244,
+		},
+		{
+			name:     "Invalid format",
+			address:  "invalid",
+			hasError: true,
+		},
+		{
+			name:     "Invalid port",
+			address:  "localhost:abc",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, err := getPort(tt.address)
+			if tt.hasError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, port)
+			}
+		})
+	}
+}
+
+// mockHubbleConfig implements HubbleConfig interface for testing
+type mockHubbleConfig struct {
+	listenAddress string
+	preferIPv6    bool
+}
+
+func (m *mockHubbleConfig) GetListenAddress() string {
+	return m.listenAddress
+}
+
+func (m *mockHubbleConfig) GetPreferIPv6() bool {
+	return m.preferIPv6
+}
+
+func TestHubbleConfigInterface(t *testing.T) {
+	config := &mockHubbleConfig{
+		listenAddress: "0.0.0.0:4244",
+		preferIPv6:    true,
+	}
+
+	assert.Equal(t, "0.0.0.0:4244", config.GetListenAddress())
+	assert.True(t, config.GetPreferIPv6())
+}


### PR DESCRIPTION
hubble: refactor peer service as a cell

This commit refactors the Hubble peer service to use a cell-based architecture,
addressing the technical debt and improving modularity. The changes include:

1. Created a new peer service cell (pkg/hubble/peer/cell/cell.go):
   - Implemented a cell-based architecture for the peer service
   - Created PeerService interface that provides access to the underlying peer service
   - Implemented dependency injection for node manager and TLS configuration
   - Added proper configuration handling through HubbleConfig interface

2. Updated Hubble configuration (pkg/hubble/cell/config.go):
   - Added GetListenAddress() and GetPreferIPv6() methods to make the config implement the HubbleConfig interface
   - This allows the peer service cell to access the necessary configuration

3. Refactored hubble integration (pkg/hubble/cell/hubbleintegration.go):
   - Removed inline peer service creation
   - Updated constructor to accept PeerService dependency
   - Updated both local and TCP servers to use the injected peer service
   - Removed duplicate getPort function (now handled in peer cell)
   - Renamed function to avoid collision with builtin function

4. Updated main hubble cell (pkg/hubble/cell/cell.go):
   - Added peer cell import
   - Included peer cell in the module dependencies
   - Updated hubbleParams struct to include PeerService

5. Added comprehensive tests (pkg/hubble/peer/cell/cell_test.go):
   - Unit tests for getPort function
   - Tests for the HubbleConfig interface implementation

Fixes: #40068

Signed-off-by: Li Tangke <544720830@qq.com>