### PR TITLE
hubble: Refactor peer service as a cell

### DIFF
--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
-	"strconv"
 	"sync/atomic"
 
 	"github.com/go-openapi/strfmt"
@@ -35,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/hubble/parser"
 	"github.com/cilium/cilium/pkg/hubble/peer"
-	"github.com/cilium/cilium/pkg/hubble/peer/serviceoption"
 	"github.com/cilium/cilium/pkg/hubble/server"
 	"github.com/cilium/cilium/pkg/hubble/server/serveroption"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
@@ -83,12 +80,13 @@ type hubbleIntegration struct {
 	// exposed by the Hubble metrics server (from hubble-metrics cell).
 	grpcMetrics          *grpc_prometheus.ServerMetrics
 	metricsFlowProcessor metrics.FlowProcessor
+	peerService          *peer.Service
 
 	config config
 }
 
-// new creates and return a new hubbleIntegration.
-func new(
+// createHubbleIntegration creates and return a new hubbleIntegration.
+func createHubbleIntegration(
 	identityAllocator identitycell.CachingIdentityAllocator,
 	endpointManager endpointmanager.EndpointManager,
 	ipcache *ipcache.IPCache,
@@ -104,6 +102,7 @@ func new(
 	nsManager namespace.Manager,
 	grpcMetrics *grpc_prometheus.ServerMetrics,
 	metricsFlowProcessor metrics.FlowProcessor,
+	peerService *peer.Service,
 	config config,
 	log *slog.Logger,
 ) (*hubbleIntegration, error) {
@@ -134,6 +133,7 @@ func new(
 		nsManager:            nsManager,
 		grpcMetrics:          grpcMetrics,
 		metricsFlowProcessor: metricsFlowProcessor,
+		peerService:          peerService,
 		config:               config,
 		log:                  log,
 	}
@@ -287,32 +287,11 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 	// This server can be used by the Hubble CLI when invoked from within the
 	// cilium Pod, typically in troubleshooting scenario.
 	sockPath := "unix://" + h.config.SocketPath
-	var peerServiceOptions []serviceoption.Option
-	if !tlsEnabled {
-		peerServiceOptions = append(peerServiceOptions, serviceoption.WithoutTLSInfo())
-	}
-	if h.config.PreferIpv6 {
-		peerServiceOptions = append(peerServiceOptions, serviceoption.WithAddressFamilyPreference(serviceoption.AddressPreferIPv6))
-	}
-	if addr := h.config.ListenAddress; addr != "" {
-		port, err := getPort(h.config.ListenAddress)
-		if err != nil {
-			// TODO: bubble up the error and/or set cell health as degraded
-			h.log.Warn(
-				"Hubble server will not pass port information in change notifications on exposed Hubble peer service",
-				logfields.Error, err,
-				logfields.Address, addr,
-			)
-		} else {
-			peerServiceOptions = append(peerServiceOptions, serviceoption.WithHubblePort(port))
-		}
-	}
-	peerSvc := peer.NewService(h.nodeManager, peerServiceOptions...)
 	localSrvOpts = append(localSrvOpts,
 		serveroption.WithUnixSocketListener(h.log, sockPath),
 		serveroption.WithHealthService(),
 		serveroption.WithObserverService(hubbleObserver),
-		serveroption.WithPeerService(peerSvc),
+		serveroption.WithPeerService(h.peerService),
 		serveroption.WithInsecure(),
 		serveroption.WithGRPCUnaryInterceptor(serverVersionUnaryInterceptor()),
 		serveroption.WithGRPCStreamInterceptor(serverVersionStreamInterceptor()),
@@ -337,7 +316,6 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 	go func() {
 		<-ctx.Done()
 		localSrv.Stop()
-		peerSvc.Close()
 	}()
 
 	// configure another hubble server listening on TCP. This server is
@@ -352,7 +330,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 		options := []serveroption.Option{
 			serveroption.WithTCPListener(address),
 			serveroption.WithHealthService(),
-			serveroption.WithPeerService(peerSvc),
+			serveroption.WithPeerService(h.peerService),
 			serveroption.WithObserverService(hubbleObserver),
 			serveroption.WithGRPCUnaryInterceptor(serverVersionUnaryInterceptor()),
 			serveroption.WithGRPCStreamInterceptor(serverVersionStreamInterceptor()),
@@ -396,18 +374,6 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 	}
 
 	return hubbleObserver, nil
-}
-
-func getPort(addr string) (int, error) {
-	_, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return 0, fmt.Errorf("parse host address and port: %w", err)
-	}
-	portNum, err := strconv.Atoi(port)
-	if err != nil {
-		return 0, fmt.Errorf("parse port number: %w", err)
-	}
-	return portNum, nil
 }
 
 var serverVersionHeader = metadata.Pairs(defaults.GRPCMetadataServerVersionKey, build.ServerVersion.SemVer())

--- a/pkg/hubble/peer/cell/cell.go
+++ b/pkg/hubble/peer/cell/cell.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/hubble/peer"
+	"github.com/cilium/cilium/pkg/hubble/peer/serviceoption"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	nodeManager "github.com/cilium/cilium/pkg/node/manager"
+)
+
+// Cell provides the Hubble peer service that handles peer discovery and notifications.
+var Cell = cell.Module(
+	"hubble-peer-service",
+	"Hubble peer service for handling peer discovery and notifications",
+
+	cell.Provide(newPeerService),
+)
+
+// HubbleConfig contains the configuration needed by the peer service
+type HubbleConfig struct {
+	ListenAddress   string
+	PreferIpv6      bool
+	EnableServerTLS bool
+}
+
+type peerServiceParams struct {
+	cell.In
+
+	Logger      *slog.Logger
+	Lifecycle   cell.Lifecycle
+	NodeManager nodeManager.NodeManager
+	Config      *HubbleConfig
+	Health      cell.Health
+}
+
+// getPort extracts the port from an address string.
+// Supports formats like ":4244", "localhost:4244", "[::1]:4244"
+func getPort(addr string) (int, error) {
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0, fmt.Errorf("parse host address and port: %w", err)
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		return 0, fmt.Errorf("parse port number: %w", err)
+	}
+	return portNum, nil
+}
+
+func newPeerService(params peerServiceParams) (*peer.Service, error) {
+	var peerServiceOptions []serviceoption.Option
+
+	// Determine if TLS is disabled
+	if !params.Config.EnableServerTLS {
+		peerServiceOptions = append(peerServiceOptions, serviceoption.WithoutTLSInfo())
+	}
+
+	// Set address family preference
+	if params.Config.PreferIpv6 {
+		peerServiceOptions = append(peerServiceOptions, serviceoption.WithAddressFamilyPreference(serviceoption.AddressPreferIPv6))
+	}
+
+	// Extract port from listen address if available
+	if addr := params.Config.ListenAddress; addr != "" {
+		port, err := getPort(addr)
+		if err != nil {
+			params.Health.Degraded(
+				"Hubble server will not pass port information in change notifications on exposed Hubble peer service",
+				err,
+			)
+			params.Logger.Warn(
+				"Hubble server will not pass port information in change notifications on exposed Hubble peer service",
+				logfields.Error, err,
+				logfields.Address, addr,
+			)
+		} else {
+			peerServiceOptions = append(peerServiceOptions, serviceoption.WithHubblePort(port))
+		}
+	}
+
+	service := peer.NewService(params.NodeManager, peerServiceOptions...)
+
+	// Register stop hook to properly close the peer service
+	params.Lifecycle.Append(cell.Hook{
+		OnStop: func(cell.HookContext) error {
+			return service.Close()
+		},
+	})
+
+	return service, nil
+}

--- a/pkg/hubble/peer/cell/cell_test.go
+++ b/pkg/hubble/peer/cell/cell_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  string
+		expected int
+		hasError bool
+	}{
+		{
+			name:     "IPv4 with port",
+			address:  "127.0.0.1:4244",
+			expected: 4244,
+		},
+		{
+			name:     "IPv6 with port",
+			address:  "[::1]:4244",
+			expected: 4244,
+		},
+		{
+			name:     "Port only",
+			address:  ":4244",
+			expected: 4244,
+		},
+		{
+			name:     "Invalid format",
+			address:  "invalid",
+			hasError: true,
+		},
+		{
+			name:     "Invalid port",
+			address:  "localhost:abc",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, err := getPort(tt.address)
+			if tt.hasError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, port)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Description of change -->
This commit refactors the Hubble peer service to use a cell-based architecture, addressing the technical debt and improving modularity. The changes include:

1. Created a new peer service cell (pkg/hubble/peer/cell/cell.go):
   - Implemented a cell-based architecture for the peer service

2. Refactored hubble integration (pkg/hubble/cell/hubbleintegration.go):
   - Removed inline peer service creation
   - Removed duplicate getPort function (now handled in peer cell)
   - Renamed function to avoid collision with builtin function

3. Updated main hubble cell (pkg/hubble/cell/cell.go)

4. Added comprehensive tests (pkg/hubble/peer/cell/cell_test.go:
   - Unit tests for getPort function

Fixes: #40068

## Release note
```release-note
misc: Refactored Hubble peer service to use a Hive cell.
```
