### PR TITLE
hubble: refactor the Namespace Manager as a Cell

### DIFF
--- a/pkg/hubble/cell/cell.go
+++ b/pkg/hubble/cell/cell.go
@@ -19,6 +19,7 @@ import (
 	exportercell "github.com/cilium/cilium/pkg/hubble/exporter/cell"
 	"github.com/cilium/cilium/pkg/hubble/metrics"
 	metricscell "github.com/cilium/cilium/pkg/hubble/metrics/cell"
+	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/hubble/parser"
 	parsercell "github.com/cilium/cilium/pkg/hubble/parser/cell"
@@ -44,14 +45,17 @@ var Cell = cell.Module(
 	// Hubble flow log exporters
 	exportercell.Cell,
 
-	// Parser for Hubble flows
-	parsercell.Cell,
-
 	// Metrics server and flow processor
 	metricscell.Cell,
 
 	// Drop event emitter flow processor
 	dropeventemitter.Cell,
+
+	// Parser for Hubble flows
+	parsercell.Cell,
+
+	// Hubble flows k8s namespaces monitor
+	namespace.Cell,
 )
 
 // The core cell group, which contains the Hubble integration and the
@@ -85,7 +89,8 @@ type hubbleParams struct {
 
 	DropEventEmitter dropeventemitter.FlowProcessor
 
-	PayloadParser parser.Decoder
+	PayloadParser    parser.Decoder
+	NamespaceManager namespace.Manager
 
 	GRPCMetrics          *grpc_prometheus.ServerMetrics
 	MetricsFlowProcessor metrics.FlowProcessor
@@ -112,6 +117,7 @@ func newHubbleIntegration(params hubbleParams) (HubbleIntegration, error) {
 		params.ExporterBuilders,
 		params.DropEventEmitter,
 		params.PayloadParser,
+		params.NamespaceManager,
 		params.GRPCMetrics,
 		params.MetricsFlowProcessor,
 		params.Config,

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/hubble/monitor"
 	"github.com/cilium/cilium/pkg/hubble/observer"
+	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/hubble/parser"
 	"github.com/cilium/cilium/pkg/hubble/peer"
@@ -263,12 +264,12 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 	// for explicit ordering of known dependencies
 	observerOpts = append(observerOpts, h.observerOptions...)
 
-	namespaceManager := observer.NewNamespaceManager()
-	go namespaceManager.Run(ctx)
+	nsManager := namespace.NewManager()
+	go nsManager.Run(ctx)
 
 	hubbleObserver, err := observer.NewLocalServer(
 		h.payloadParser,
-		namespaceManager,
+		nsManager,
 		h.log,
 		observerOpts...,
 	)

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/build"
 	"github.com/cilium/cilium/pkg/hubble/container"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser"
@@ -64,13 +65,13 @@ type LocalObserverServer struct {
 	// numObservedFlows counts how many flows have been observed
 	numObservedFlows atomic.Uint64
 
-	namespaceManager NamespaceManager
+	nsManager namespace.Manager
 }
 
 // NewLocalServer returns a new local observer server.
 func NewLocalServer(
 	payloadParser parser.Decoder,
-	namespaceManager NamespaceManager,
+	nsManager namespace.Manager,
 	logger *slog.Logger,
 	options ...observeroption.Option,
 ) (*LocalObserverServer, error) {
@@ -89,14 +90,14 @@ func NewLocalServer(
 	)
 
 	s := &LocalObserverServer{
-		log:              logger,
-		ring:             container.NewRing(opts.MaxFlows),
-		events:           make(chan *observerTypes.MonitorEvent, opts.MonitorBuffer),
-		stopped:          make(chan struct{}),
-		payloadParser:    payloadParser,
-		startTime:        time.Now(),
-		namespaceManager: namespaceManager,
-		opts:             opts,
+		log:           logger,
+		ring:          container.NewRing(opts.MaxFlows),
+		events:        make(chan *observerTypes.MonitorEvent, opts.MonitorBuffer),
+		stopped:       make(chan struct{}),
+		payloadParser: payloadParser,
+		startTime:     time.Now(),
+		nsManager:     nsManager,
+		opts:          opts,
 	}
 
 	for _, f := range s.opts.OnServerInit {
@@ -251,7 +252,7 @@ func (s *LocalObserverServer) GetNodes(ctx context.Context, req *observerpb.GetN
 
 // GetNamespaces implements observerpb.ObserverClient.GetNamespaces.
 func (s *LocalObserverServer) GetNamespaces(ctx context.Context, req *observerpb.GetNamespacesRequest) (*observerpb.GetNamespacesResponse, error) {
-	return &observerpb.GetNamespacesResponse{Namespaces: s.namespaceManager.GetNamespaces()}, nil
+	return &observerpb.GetNamespacesResponse{Namespaces: s.nsManager.GetNamespaces()}, nil
 }
 
 // GetFlows implements the proto method for client requests.
@@ -661,13 +662,13 @@ func (r *eventsReader) Next(ctx context.Context) (*v1.Event, error) {
 func (s *LocalObserverServer) trackNamespaces(flow *flowpb.Flow) {
 	// track namespaces seen.
 	if srcNs := flow.GetSource().GetNamespace(); srcNs != "" {
-		s.namespaceManager.AddNamespace(&observerpb.Namespace{
+		s.nsManager.AddNamespace(&observerpb.Namespace{
 			Namespace: srcNs,
 			Cluster:   nodeTypes.GetClusterName(),
 		})
 	}
 	if dstNs := flow.GetDestination().GetNamespace(); dstNs != "" {
-		s.namespaceManager.AddNamespace(&observerpb.Namespace{
+		s.nsManager.AddNamespace(&observerpb.Namespace{
 			Namespace: dstNs,
 			Cluster:   nodeTypes.GetClusterName(),
 		})

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -24,6 +24,7 @@ import (
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	hubv1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/container"
+	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser"
@@ -35,7 +36,7 @@ import (
 )
 
 var (
-	nsManager = NewNamespaceManager()
+	nsManager = namespace.NewManager()
 )
 
 func noopParser(t *testing.T) *parser.Parser {
@@ -734,7 +735,7 @@ func TestLocalObserverServer_NodeLabels(t *testing.T) {
 
 func TestLocalObserverServer_GetNamespaces(t *testing.T) {
 	pp := noopParser(t)
-	nsManager := NewNamespaceManager()
+	nsManager := namespace.NewManager()
 	nsManager.AddNamespace(&observerpb.Namespace{
 		Namespace: "zzz",
 	})
@@ -783,7 +784,7 @@ func Benchmark_TrackNamespaces(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	nsManager := NewNamespaceManager()
+	nsManager := namespace.NewManager()
 	s, err := NewLocalServer(pp, nsManager, hivetest.Logger(b), observeroption.WithMaxFlows(container.Capacity1))
 	if err != nil {
 		b.Fatal(err)

--- a/pkg/hubble/observer/namespace/cell.go
+++ b/pkg/hubble/observer/namespace/cell.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package namespace
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+)
+
+var Cell = cell.ProvidePrivate(func(jobGroup job.Group) Manager {
+	m := NewManager()
+	jobGroup.Add(job.Timer(
+		"hubble-namespace-cleanup",
+		func(_ context.Context) error {
+			m.cleanupNamespaces()
+			return nil
+		},
+		cleanupInterval,
+	))
+	return m
+})

--- a/pkg/hubble/observer/namespace/defaults.go
+++ b/pkg/hubble/observer/namespace/defaults.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package namespace
+
+import "time"
+
+const (
+	// cleanupInterval is the interval at which the namespace list from the
+	// manager is garbage collected.
+	cleanupInterval = 5 * time.Minute
+	// namespaceTTL is the time after which a namespace is garbage collected.
+	namespaceTTL = 1 * time.Hour
+)

--- a/pkg/hubble/observer/namespace/manager.go
+++ b/pkg/hubble/observer/namespace/manager.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Hubble
 
-package observer
+package namespace
 
 import (
 	"context"
@@ -12,14 +12,12 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-var _ NamespaceManager = &namespaceManager{}
-
 const (
-	checkNamespaceAgeFrequency = 5 * time.Minute
-	namespaceTTL               = time.Hour
+	cleanupInterval = 5 * time.Minute
+	namespaceTTL    = 1 * time.Hour
 )
 
-type NamespaceManager interface {
+type Manager interface {
 	GetNamespaces() []*observerpb.Namespace
 	AddNamespace(*observerpb.Namespace)
 }
@@ -35,7 +33,7 @@ type namespaceManager struct {
 	nowFunc    func() time.Time
 }
 
-func NewNamespaceManager() *namespaceManager {
+func NewManager() *namespaceManager {
 	return &namespaceManager{
 		namespaces: make(map[string]namespaceRecord),
 		nowFunc:    time.Now,
@@ -43,7 +41,7 @@ func NewNamespaceManager() *namespaceManager {
 }
 
 func (m *namespaceManager) Run(ctx context.Context) {
-	ticker := time.NewTicker(checkNamespaceAgeFrequency)
+	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/pkg/hubble/observer/namespace/manager.go
+++ b/pkg/hubble/observer/namespace/manager.go
@@ -33,6 +33,8 @@ type namespaceManager struct {
 	nowFunc    func() time.Time
 }
 
+// NOTE: there are still a couple of places where we need to construct a
+// functional ns manager outside of Hive/Cell, i.e. testing and Hubble Relay.
 func NewManager() *namespaceManager {
 	return &namespaceManager{
 		namespaces: make(map[string]namespaceRecord),

--- a/pkg/hubble/observer/namespace/manager_test.go
+++ b/pkg/hubble/observer/namespace/manager_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Hubble
 
-package observer
+package namespace
 
 import (
 	"testing"
@@ -15,43 +15,43 @@ import (
 func TestNamespaceManager(t *testing.T) {
 	// mock time
 	currentTime := time.Time{}
-	mgr := NewNamespaceManager()
+	nsManager := NewManager()
 	// use the mocked time
-	mgr.nowFunc = func() time.Time {
+	nsManager.nowFunc = func() time.Time {
 		return currentTime
 	}
 	advanceTime := func(d time.Duration) {
 		// update our currentTime
 		currentTime = currentTime.Add(d)
 		// trigger cleanupNamespaces after we advance time to ensure it's run
-		mgr.cleanupNamespaces()
+		nsManager.cleanupNamespaces()
 	}
 
 	// we start with no namespaces
 	expected := []*observerpb.Namespace{}
-	assert.Equal(t, expected, mgr.GetNamespaces())
+	assert.Equal(t, expected, nsManager.GetNamespaces())
 
 	// add a few namespaces
 
 	// out of order, we'll verify it's sorted when we call GetNamespaces later
-	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-2"})
-	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-1"})
+	nsManager.AddNamespace(&observerpb.Namespace{Namespace: "ns-2"})
+	nsManager.AddNamespace(&observerpb.Namespace{Namespace: "ns-1"})
 
 	// namespaces that we added should be returned, sorted
 	expected = []*observerpb.Namespace{
 		{Namespace: "ns-1"},
 		{Namespace: "ns-2"},
 	}
-	assert.Equal(t, expected, mgr.GetNamespaces())
+	assert.Equal(t, expected, nsManager.GetNamespaces())
 
 	// advance the clock by 1/2 the namespaceTTL and verify our namespaces are still known
 	advanceTime(namespaceTTL / 2)
-	assert.Equal(t, expected, mgr.GetNamespaces())
+	assert.Equal(t, expected, nsManager.GetNamespaces())
 
 	// add more namespaces now that the clock has been advanced
-	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-1"})
-	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-3"})
-	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-4"})
+	nsManager.AddNamespace(&observerpb.Namespace{Namespace: "ns-1"})
+	nsManager.AddNamespace(&observerpb.Namespace{Namespace: "ns-3"})
+	nsManager.AddNamespace(&observerpb.Namespace{Namespace: "ns-4"})
 
 	// we expect all namespaces to exist, the first 2 are 30 minutes old, and the
 	// next two are 0 minutes old
@@ -61,7 +61,7 @@ func TestNamespaceManager(t *testing.T) {
 		{Namespace: "ns-3"},
 		{Namespace: "ns-4"},
 	}
-	assert.Equal(t, expected, mgr.GetNamespaces())
+	assert.Equal(t, expected, nsManager.GetNamespaces())
 
 	// advance the clock another 1/2 TTL and add a minute to push us past the TTL
 	advanceTime((namespaceTTL / 2) + time.Minute)
@@ -73,11 +73,11 @@ func TestNamespaceManager(t *testing.T) {
 		{Namespace: "ns-3"},
 		{Namespace: "ns-4"},
 	}
-	assert.Equal(t, expected, mgr.GetNamespaces())
+	assert.Equal(t, expected, nsManager.GetNamespaces())
 
 	// advance the clock another 1/2 TTL and add a minute to push us past the TTL again
 	advanceTime((namespaceTTL / 2) + time.Minute)
 
 	// no namespaces left, nothing has been refreshed
-	assert.Equal(t, []*observerpb.Namespace{}, mgr.GetNamespaces())
+	assert.Equal(t, []*observerpb.Namespace{}, nsManager.GetNamespaces())
 }

--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -16,7 +16,7 @@ import (
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	relaypb "github.com/cilium/cilium/api/v1/relay"
 	"github.com/cilium/cilium/pkg/hubble/build"
-	"github.com/cilium/cilium/pkg/hubble/observer"
+	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -205,7 +205,7 @@ func (s *Server) GetNamespaces(ctx context.Context, req *observerpb.GetNamespace
 	// results over failing on the first error
 	g := new(errgroup.Group)
 
-	namespaceManager := observer.NewNamespaceManager()
+	nsManager := namespace.NewManager()
 
 	for _, p := range s.peers.List() {
 		if !isAvailable(p.Conn) {
@@ -229,7 +229,7 @@ func (s *Server) GetNamespaces(ctx context.Context, req *observerpb.GetNamespace
 				return nil
 			}
 			for _, ns := range nsResp.GetNamespaces() {
-				namespaceManager.AddNamespace(ns)
+				nsManager.AddNamespace(ns)
 			}
 			return nil
 		})
@@ -239,7 +239,7 @@ func (s *Server) GetNamespaces(ctx context.Context, req *observerpb.GetNamespace
 		return nil, err
 	}
 
-	return &observerpb.GetNamespacesResponse{Namespaces: namespaceManager.GetNamespaces()}, nil
+	return &observerpb.GetNamespacesResponse{Namespaces: nsManager.GetNamespaces()}, nil
 }
 
 // ServerStatus implements observerpb.ObserverServer.ServerStatus by aggregating

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -28,7 +28,6 @@ import (
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/pkg/hubble/container"
 	"github.com/cilium/cilium/pkg/hubble/observer"
-	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser"
@@ -95,9 +94,8 @@ func getRandomEndpoint() *testutils.FakeEndpointInfo {
 func newHubbleObserver(t testing.TB, nodeName string, numFlows int) *observer.LocalObserverServer {
 	queueSize := numFlows
 
-	pp := noopParser(t)
-	nsManager := namespace.NewManager()
-	s, err := observer.NewLocalServer(pp, nsManager, log,
+	pp, nm := noopParser(t), testutils.NoopNamespaceManager
+	s, err := observer.NewLocalServer(pp, nm, log,
 		observeroption.WithMaxFlows(container.Capacity65535),
 		observeroption.WithMonitorBuffer(queueSize),
 	)

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -28,6 +28,7 @@ import (
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/pkg/hubble/container"
 	"github.com/cilium/cilium/pkg/hubble/observer"
+	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser"
@@ -95,8 +96,8 @@ func newHubbleObserver(t testing.TB, nodeName string, numFlows int) *observer.Lo
 	queueSize := numFlows
 
 	pp := noopParser(t)
-	nsMgr := observer.NewNamespaceManager()
-	s, err := observer.NewLocalServer(pp, nsMgr, log,
+	nsManager := namespace.NewManager()
+	s, err := observer.NewLocalServer(pp, nsManager, log,
 		observeroption.WithMaxFlows(container.Capacity65535),
 		observeroption.WithMonitorBuffer(queueSize),
 	)

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -487,3 +487,33 @@ var NoopPodMetadataGetter = FakePodMetadataGetter{
 		return nil
 	},
 }
+
+// FakeNamespaceManager is used for unit tests that need a namespace.Manager.
+type FakeNamespaceManager struct {
+	OnGetNamespaces func() []*observerpb.Namespace
+	OnAddNamespace  func(*observerpb.Namespace)
+}
+
+// GetNamespaces implements namespace.Manager.
+func (f *FakeNamespaceManager) GetNamespaces() []*observerpb.Namespace {
+	if f.OnGetNamespaces != nil {
+		return f.OnGetNamespaces()
+	}
+	panic("OnGetNamespaces not set")
+}
+
+// AddNamespace implements namespace.Manager.
+func (f *FakeNamespaceManager) AddNamespace(ns *observerpb.Namespace) {
+	if f.OnAddNamespace != nil {
+		f.OnAddNamespace(ns)
+	}
+	panic("OnAddNamespace not set")
+}
+
+// NoopNamespaceManager always return an empty namespace list.
+var NoopNamespaceManager = &FakeNamespaceManager{
+	OnGetNamespaces: func() []*observerpb.Namespace {
+		return nil
+	},
+	OnAddNamespace: func(_ *observerpb.Namespace) {},
+}


### PR DESCRIPTION
Better reviewed commit by commit.

## manual test

Use 5s for cleanup and 1m for TTL to avoid waiting too long :sweat_smile: 
```console
% sed -i -e 's/Minute/Second/;s/Hour/Minute/' pkg/hubble/observer/namespace/defaults.go

% git diff
diff --git a/pkg/hubble/observer/namespace/defaults.go b/pkg/hubble/observer/namespace/defaults.go
index 3a61e40cbf..276cd3c553 100644
--- a/pkg/hubble/observer/namespace/defaults.go
+++ b/pkg/hubble/observer/namespace/defaults.go
@@ -8,7 +8,7 @@ import "time"
 const (
        // cleanupInterval is the interval at which the namespace list from the
        // manager is garbage collected.
-       cleanupInterval = 5 * time.Minute
+       cleanupInterval = 5 * time.Second
        // namespaceTTL is the time after which a namespace is garbage collected.
-       namespaceTTL = 1 * time.Hour
+       namespaceTTL = 1 * time.Minute
 )

% make kind-image-fast
…
```

Check that the ns manager job has started, and we don't see `default` in the namespace list.

```console
% kubectl logs -n kube-system ds/cilium | grep hubble-namespacemanager
Found 2 pods, using pod/cilium-hsvh6
time=2025-09-15T11:02:41.194394455Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/cell/lifecycle.go:126 msg="Executing start hook" function="*job.groupHooks.Start (agent.controlplane.hubble.hubble-namespacemanager)"
time=2025-09-15T11:02:41.194400266Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/cell/lifecycle.go:136 msg="Start hook executed" function="*job.groupHooks.Start (agent.controlplane.hubble.hubble-namespacemanager)" duration=301ns
time=2025-09-15T11:02:41.194409813Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/cell/lifecycle.go:126 msg="Executing start hook" function="*job.queuedJob.Start (agent.controlplane.hubble.hubble-namespacemanager)"
time=2025-09-15T11:02:41.194415254Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/cell/lifecycle.go:136 msg="Start hook executed" function="*job.queuedJob.Start (agent.controlplane.hubble.hubble-namespacemanager)" duration=1.122µs
time=2025-09-15T11:02:41.194452814Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:172 msg="Starting timer job" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:02:41.194580454Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/pkg/hive/health/provider.go:89 msg="upserting health status" module=health lastLevel=none reporter-id=agent.controlplane.hubble.hubble-namespacemanager.timer-job-hubble-namespace-cleanup status="agent.controlplane.hubble.hubble-namespacemanager.timer-job-hubble-namespace-cleanup: [OK] Primed"

% kubectl exec -it -n kube-system ds/cilium -- hubble list namespaces
NAMESPACE
kube-system
local-path-storage
```

Run curl from the  `default` namespace to generate a Hubble flow, check the timestamp and that now `default` shows up in the Hubble namespace list.

```console
% kubectl run -it --rm --image=curlimages/curl curl -- curl -v cilium.io | grep Date:
If you don't see a command prompt, try pressing enter.
< Date: Mon, 15 Sep 2025 11:04:35 GMT

% kubectl exec -it -n kube-system ds/cilium -- hubble list namespaces
NAMESPACE
default
kube-system
local-path-storage
```

wait for the TTL to expire
```console
% sleep 1m
```

Now check the logs, the cleanup has been called every 5s as expected, and `default` is no longer part of the Hubble namespace list.

```console
% kubectl logs -n kube-system ds/cilium | grep hubble-namespacemanager
Found 2 pods, using pod/cilium-hsvh6
time=2025-09-15T11:02:41.194394455Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/cell/lifecycle.go:126 msg="Executing start hook" function="*job.groupHooks.Start (agent.controlplane.hubble.hubble-namespacemanager)"
time=2025-09-15T11:02:41.194400266Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/cell/lifecycle.go:136 msg="Start hook executed" function="*job.groupHooks.Start (agent.controlplane.hubble.hubble-namespacemanager)" duration=301ns
time=2025-09-15T11:02:41.194409813Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/cell/lifecycle.go:126 msg="Executing start hook" function="*job.queuedJob.Start (agent.controlplane.hubble.hubble-namespacemanager)"
time=2025-09-15T11:02:41.194415254Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/cell/lifecycle.go:136 msg="Start hook executed" function="*job.queuedJob.Start (agent.controlplane.hubble.hubble-namespacemanager)" duration=1.122µs
time=2025-09-15T11:02:41.194452814Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:172 msg="Starting timer job" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:02:41.194580454Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/pkg/hive/health/provider.go:89 msg="upserting health status" module=health lastLevel=none reporter-id=agent.controlplane.hubble.hubble-namespacemanager.timer-job-hubble-namespace-cleanup status="agent.controlplane.hubble.hubble-namespacemanager.timer-job-hubble-namespace-cleanup: [OK] Primed"
time=2025-09-15T11:02:46.194736255Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:02:46.194896046Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:02:51.195169529Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:02:51.195287971Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:02:56.195247915Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:02:56.195349486Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:01.194938294Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:01.195038753Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:06.195530597Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:06.195655722Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:11.195306537Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:11.195423527Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:16.194719133Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:16.194850139Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:21.195456088Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:21.195587836Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:26.195184058Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:26.195284757Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:31.195160733Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:31.195255611Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:36.194821705Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:36.194919198Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:41.19551726Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:41.195562094Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:46.194573183Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:46.194687277Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:51.195184689Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:51.195295427Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:56.194719922Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:03:56.194825029Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:01.19535577Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:01.195455297Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:06.194727822Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:06.194853368Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:11.195415524Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:11.195511074Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:16.195165954Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:16.195254721Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:21.195453279Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:21.195561813Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:26.194758668Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:26.19483973Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:31.194531071Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:31.1946263Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:36.194715545Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:36.194816464Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:41.194802443Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:41.194862045Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:46.195526274Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:46.195629278Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:51.195239743Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:51.195382422Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:56.194640281Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:04:56.194710173Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:01.194584758Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:01.194762713Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:06.19488027Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:06.195109461Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:11.195231224Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:11.195458801Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:16.195324959Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:16.195420208Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:21.19465752Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:21.194758109Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:26.194866203Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:26.194982412Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:31.195392999Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:31.195488969Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:36.194576556Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:36.194681173Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:41.194460976Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:41.194509918Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:46.195237037Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:46.195337165Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:51.194488317Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:184 msg="Timer job triggered" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"
time=2025-09-15T11:05:51.194590168Z level=debug source=/home/alex/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/timer.go:200 msg="Timer job finished" module=agent.controlplane.hubble.hubble-namespacemanager name=hubble-namespace-cleanup func="namespace.init.func1.1 (.../observer/namespace/cell.go:21)"

% kubectl exec -it -n kube-system ds/cilium -- hubble list namespaces
NAMESPACE
kube-system
local-path-storage
```

Closes: #40064