### PR TITLE
.github/workflows: stop build CI images until base images are built

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -19,16 +19,32 @@ permissions:
   contents: read
   # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
   id-token: write
+  # To be able to check if base images were built
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || (github.event_name == 'merge_group' && github.run_id) }}
   cancel-in-progress: true
 
 jobs:
+  wait-for-base-images:
+    name: Wait for lint checks
+    uses: ./.github/workflows/wait-for-status-check.yaml
+    with:
+      # Only run this job if the event is pull_request_target.
+      # This is to avoid waiting for base images on push to main or merge_group
+      # events as the lint-images-base does not run on those events.
+      if: ${{ github.event_name == 'pull_request_target' }}
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      lint-workflows: "lint-images-base.yaml"
+      timeout-minutes: 2
+      poll-interval: 15
+
   build-and-push-prs:
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
+    needs: wait-for-base-images
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:

--- a/.github/workflows/wait-for-status-check.yaml
+++ b/.github/workflows/wait-for-status-check.yaml
@@ -1,0 +1,122 @@
+name: Wait for Lint Checks
+
+on:
+  workflow_call:
+    inputs:
+      if:
+        description: "Condition to run the wait (true/false)"
+        type: boolean
+        default: true
+      sha:
+        description: "SHA to check for lint workflow completion"
+        required: true
+        type: string
+      lint-workflows:
+        description: "Comma-separated list of lint workflow filenames to wait for"
+        required: false
+        type: string
+        default: "lint-images-base.yaml"
+      timeout-minutes:
+        description: "Maximum time to wait for lint workflows (in minutes)"
+        required: false
+        type: number
+        default: 30
+      poll-interval:
+        description: "Polling interval in seconds"
+        required: false
+        type: number
+        default: 30
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  wait-for-lint:
+    name: Wait for lint checks
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - name: Wait for lint workflows to complete
+        if: ${{ inputs.if }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Parse input parameters
+          check_sha="${{ inputs.sha }}"
+          lint_workflows_str="${{ inputs.lint-workflows }}"
+          poll_interval="${{ inputs.poll-interval }}"
+          timeout_minutes="${{ inputs.timeout-minutes }}"
+
+          echo "Waiting for lint workflows to complete for SHA: $check_sha"
+          echo "Lint workflows to check: $lint_workflows_str"
+          echo "Poll interval: ${poll_interval}s, Timeout: ${timeout_minutes}m"
+
+          # Convert comma-separated workflows to array
+          IFS=',' read -ra lint_workflows <<< "$lint_workflows_str"
+
+          max_attempts=$((timeout_minutes * 60 / poll_interval))
+          attempt=0
+
+          while [[ $attempt -lt $max_attempts ]]; do
+            attempt=$((attempt + 1))
+            echo "Attempt $attempt/$max_attempts"
+
+            all_successful=true
+
+            for workflow in "${lint_workflows[@]}"; do
+              # Trim whitespace
+              workflow=$(echo "$workflow" | xargs)
+              echo "Checking workflow: $workflow"
+
+              # Use gh CLI to get the latest run for this workflow and commit
+              run_status=$(gh --repo ${{ github.repository }} run list --workflow "$workflow" --commit "$check_sha" --limit 1 --json status,conclusion --jq '.[0] // empty')
+
+              if [[ -z "$run_status" ]]; then
+                echo "No workflow run found for SHA $check_sha"
+                all_successful=false
+                continue
+              fi
+
+              status=$(echo "$run_status" | jq -r '.status')
+              conclusion=$(echo "$run_status" | jq -r '.conclusion')
+
+              echo "Workflow status: $status, conclusion: $conclusion"
+
+              case "$status" in
+                "completed")
+                  if [[ "$conclusion" == "success" ]]; then
+                    echo "✅ Workflow completed successfully"
+                  else
+                    echo "❌ Lint workflow $workflow failed with conclusion: $conclusion"
+                    exit 1
+                  fi
+                  ;;
+                "in_progress"|"queued")
+                  echo "⏳ Workflow is still running..."
+                  all_successful=false
+                  ;;
+                *)
+                  echo "❓ Unknown workflow status: $status"
+                  all_successful=false
+                  ;;
+              esac
+            done
+
+            if [[ "$all_successful" == "true" ]]; then
+              echo "✅ All lint workflows completed successfully!"
+              exit 0
+            fi
+
+            if [[ $attempt -lt $max_attempts ]]; then
+              echo "Waiting ${poll_interval} seconds before next check..."
+              sleep "$poll_interval"
+            fi
+          done
+
+          echo "❌ Timeout waiting for lint workflows to complete"
+          exit 1
+
+      - name: Return successful
+        if: ${{ !inputs.if }}
+        run: echo "Skipping wait as per input condition"


### PR DESCRIPTION
Add dependency on lint-images-base workflow completion before building CI images. This prevents wasting CI resources by ensuring base image validation succeeds before proceeding with expensive image builds.

Uses a reusable workflow (wait-for-status-check.yaml) that leverages the GitHub CLI to poll for lint workflow completion, avoiding unnecessary resource consumption when base image checks fail.


This will primarily be helpful in the renovate PRs where the CI is automated and it doesn't know that it needs to wait until the base images are pushed before running.

Tested failure case in https://github.com/cilium/cilium/actions/runs/17736576750/job/50399798580
Tested success case in https://github.com/cilium/cilium/actions/runs/17736615668/job/50399924868