### PR TITLE
pkg/aws: paginate DescribeSecurityGroup API

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -223,7 +223,7 @@ func (c *Client) GetDetachedNetworkInterfaces(ctx context.Context, tags ipamType
 		}
 	}
 	if operatorOption.Config.AWSPaginationEnabled {
-		input.MaxResults = aws.Int32(defaults.ENIMaxResultsPerApiCall)
+		input.MaxResults = aws.Int32(defaults.AWSResultsPerApiCall)
 	}
 
 	input.Filters = append(input.Filters, ec2_types.Filter{
@@ -264,7 +264,7 @@ func (c *Client) describeNetworkInterfaces(ctx context.Context, subnets ipamType
 		},
 	}
 	if operatorOption.Config.AWSPaginationEnabled {
-		input.MaxResults = aws.Int32(defaults.ENIMaxResultsPerApiCall)
+		input.MaxResults = aws.Int32(defaults.AWSResultsPerApiCall)
 	}
 	if len(c.subnetsFilters) > 0 {
 		subnetsIDs := make([]string, 0, len(subnets))
@@ -364,7 +364,7 @@ func (c *Client) describeNetworkInterfacesFromInstances(ctx context.Context) ([]
 		ENIAttrs.NetworkInterfaceIds = enisListFromInstances
 	} else if operatorOption.Config.AWSPaginationEnabled {
 		// MaxResults is incompatible with NetworkInterfaceIds
-		ENIAttrs.MaxResults = aws.Int32(defaults.ENIMaxResultsPerApiCall)
+		ENIAttrs.MaxResults = aws.Int32(defaults.AWSResultsPerApiCall)
 	}
 
 	var result []ec2_types.NetworkInterface
@@ -924,7 +924,11 @@ func createAWSTagSlice(tags map[string]string) []ec2_types.Tag {
 
 func (c *Client) describeSecurityGroups(ctx context.Context) ([]ec2_types.SecurityGroup, error) {
 	var result []ec2_types.SecurityGroup
-	paginator := ec2.NewDescribeSecurityGroupsPaginator(c.ec2Client, &ec2.DescribeSecurityGroupsInput{})
+	input := &ec2.DescribeSecurityGroupsInput{}
+	if operatorOption.Config.AWSPaginationEnabled {
+		input.MaxResults = aws.Int32(defaults.AWSResultsPerApiCall)
+	}
+	paginator := ec2.NewDescribeSecurityGroupsPaginator(c.ec2Client, input)
 	for paginator.HasMorePages() {
 		c.limiter.Limit(ctx, DescribeSecurityGroups)
 		sinceStart := spanstat.Start()

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -363,8 +363,8 @@ const (
 	// per GC interval
 	ENIGarbageCollectionMaxPerInterval = 25
 
-	// ENIMaxResultsPerApiCall is the maximum number of ENI objects to fetch per DescribeNetworkInterfaces API call
-	ENIMaxResultsPerApiCall = 1000
+	// AWSResultsPerApiCall is the maximum number of objects to fetch per paginated API call
+	AWSResultsPerApiCall = 1000
 
 	// ParallelAllocWorkers is the default max number of parallel workers doing allocation in the operator
 	ParallelAllocWorkers = 50


### PR DESCRIPTION
We are seeing client side timeouts due to not using the paginated DescribeSecurityGroup API call. This PR sets a max results per call to 1000.

```release-note
Fix API throttling on the AWS DescribeSecurityGroups API when using the unpaginated API by passing maxResults (1000).
```