### PR TITLE
clustermesh: add back GlobalServiceCache usage in the agent

### DIFF
--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/clustermesh/common"
 	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
@@ -165,6 +166,7 @@ func TestRemoteClusterRun(t *testing.T) {
 					Logger:                logger,
 				},
 				FeatureMetrics: NewClusterMeshMetricsNoop(),
+				globalServices: common.NewGlobalServiceCache(logger),
 			}
 			rc := cm.NewRemoteCluster("foo", nil).(*remoteCluster)
 			ready := make(chan error)
@@ -294,6 +296,7 @@ func TestRemoteClusterClusterIDChange(t *testing.T) {
 			Logger:                logger,
 		},
 		FeatureMetrics: NewClusterMeshMetricsNoop(),
+		globalServices: common.NewGlobalServiceCache(logger),
 	}
 	rc := cm.NewRemoteCluster("foo", nil).(*remoteCluster)
 

--- a/pkg/clustermesh/testdata/clusterservice.txtar
+++ b/pkg/clustermesh/testdata/clusterservice.txtar
@@ -33,6 +33,17 @@ kvstore/delete cilium/state/services/v1/cluster2/test/echo
 db/cmp backends backends-3.table
 db/cmp frontends frontends-with-clusterservice-3.table
 
+# Marking the cluster service as not shared causes the remote backends to be removed
+cp clusterservice3.json clusterservice3_v2.json
+sed '"shared": true' '"shared": false' clusterservice3_v2.json
+kvstore/update cilium/state/services/v1/cluster3/test/echo clusterservice3_v2.json
+db/cmp frontends frontends.table
+
+# Switch back for next test
+kvstore/update cilium/state/services/v1/cluster3/test/echo clusterservice3.json
+db/cmp backends backends-3.table
+db/cmp frontends frontends-with-clusterservice-3.table
+
 # Removing the last cluster service gets us back to starting point
 kvstore/delete cilium/state/services/v1/cluster3/test/echo
 db/cmp frontends frontends.table


### PR DESCRIPTION
This partially revert this 3ab6ebf3f5500c3b8c1f68c334ce4051bd2caa88 that was removing the GlobalServiceCache in the agent so that we have a consistent behavior in the operator and the agents. For instance, the GlobalServiceCache ignored ClusterService with a shared=false value and while this isn't set anywhere like, doing something different in the agent and operator might lead to even more difference in the future.