### PR TITLE
multipool: add support for matching pods to PodIPPools via label selectors

### DIFF
--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -207,6 +207,10 @@ const (
 	// ignore the given CiliumNode object
 	IPAMIgnore = IPAMPrefix + "/ignore"
 
+	// IPAMRequirePoolMatch is the annotation used to prevent fallback to the
+	// default pool when no pool selectors match. Can be set on pods or namespaces.
+	IPAMRequirePoolMatch = IPAMPrefix + "/require-pool-match"
+
 	LBIPAMIPsKey     = LBIPAMPrefix + "/ips"
 	LBIPAMIPKeyAlias = Prefix + "/lb-ipam-ips"
 

--- a/pkg/ipam/allocator/multipool/allocator.go
+++ b/pkg/ipam/allocator/multipool/allocator.go
@@ -59,6 +59,7 @@ func (a *Allocator) UpsertPool(ctx context.Context, pool *cilium_v2alpha1.Cilium
 		logfields.IPv4MaskSize, ipv4MaskSize,
 		logfields.IPv6CIDRs, ipv6CIDRs,
 		logfields.IPv6MaskSize, ipv6MaskSize,
+		logfields.Selector, pool.Spec.PodSelector,
 	)
 
 	return a.poolAlloc.UpsertPool(

--- a/pkg/ipam/cell/cell.go
+++ b/pkg/ipam/cell/cell.go
@@ -17,6 +17,7 @@ import (
 	ipamapi "github.com/cilium/cilium/pkg/ipam/api"
 	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
 	"github.com/cilium/cilium/pkg/ipmasq"
+	k8sResources "github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/mtu"
@@ -32,6 +33,7 @@ var Cell = cell.Module(
 
 	cell.Provide(newIPAddressManager),
 	cell.Provide(newIPAMAPIHandler),
+	cell.Provide(k8sResources.CiliumPodIPPoolResource),
 
 	// IPAM metadata manager, determines which IPAM pool a pod should allocate from
 	ipamMetadata.Cell,

--- a/pkg/ipam/metadata/manager.go
+++ b/pkg/ipam/metadata/manager.go
@@ -4,16 +4,27 @@
 package metadata
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
+	"sync/atomic"
 
 	"github.com/cilium/statedb"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/ipam"
+	consts "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_labels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -22,6 +33,8 @@ type ManagerStoppedError struct{}
 func (m *ManagerStoppedError) Error() string {
 	return "ipam-metadata-manager has been stopped"
 }
+
+var ErrManagerPoolsNotSynced = errors.New("ipam-metadata-manager has not synced all pod IP pools yet")
 
 type ResourceNotFound struct {
 	Resource  string
@@ -57,6 +70,23 @@ type manager struct {
 	db         *statedb.DB
 	pods       statedb.Table[k8s.LocalPod]
 	namespaces statedb.Table[k8s.Namespace]
+
+	// compiledPools is a map of pools and their selectors that have been compiled
+	// from CiliumPodIPPool resources. It is protected by a RWMutex.
+	// TODO: Use stateDB instead https://github.com/cilium/cilium/pull/41688#discussion_r2371642168
+	compiledPools map[string]compiledPool
+	poolMu        lock.RWMutex
+	// poolsSynced shows whether the manager has received a Sync event from the poolInformer.
+	// GetIPPoolForPod will return an error until the poolInformer has received a Sync event.
+	poolsSynced atomic.Bool
+}
+
+type compiledPool struct {
+	name              string
+	podSelector       slim_labels.Selector
+	namespaceSelector slim_labels.Selector
+	hasV4             bool
+	hasV6             bool
 }
 
 func splitK8sPodName(owner string) (namespace, name string, ok bool) {
@@ -93,6 +123,9 @@ func determinePoolByAnnotations(annotations map[string]string, family ipam.Famil
 }
 
 func (m *manager) GetIPPoolForPod(owner string, family ipam.Family) (pool string, err error) {
+	if !m.poolsSynced.Load() {
+		return "", ErrManagerPoolsNotSynced
+	}
 	if family != ipam.IPv6 && family != ipam.IPv4 {
 		return "", fmt.Errorf("invalid IP family: %s", family)
 	}
@@ -100,7 +133,7 @@ func (m *manager) GetIPPoolForPod(owner string, family ipam.Family) (pool string
 	namespace, name, ok := splitK8sPodName(owner)
 	if !ok {
 		m.logger.Debug(
-			"IPAM metadata request for invalid pod name, falling back to default pool",
+			"pool selector: IPAM metadata request for invalid pod name, falling back to default pool",
 			logfields.Owner, owner,
 		)
 		return ipam.PoolDefault().String(), nil
@@ -113,17 +146,187 @@ func (m *manager) GetIPPoolForPod(owner string, family ipam.Family) (pool string
 	if !found {
 		return "", &ResourceNotFound{Resource: "Pod", Namespace: namespace, Name: name}
 	} else if ippool, ok := determinePoolByAnnotations(pod.Annotations, family); ok {
+		m.logger.Debug("pool selector: found pool by pod annotation",
+			logfields.Owner, owner,
+			logfields.K8sNamespace, namespace,
+			logfields.Name, name,
+			logfields.PoolName, ippool,
+		)
 		return ippool, nil
 	}
 
 	// Check annotation on namespace
 	podNamespace, _, found := m.namespaces.Get(txn, k8s.NamespaceIndex.Query(namespace))
 	if !found {
+		m.logger.Debug("pool selector: namespace not found",
+			logfields.Owner, owner,
+			logfields.K8sNamespace, namespace,
+		)
 		return "", &ResourceNotFound{Resource: "Namespace", Name: namespace}
 	} else if ippool, ok := determinePoolByAnnotations(podNamespace.Annotations, family); ok {
+		m.logger.Debug("pool selector: found pool by namespace annotation",
+			logfields.Owner, owner,
+			logfields.K8sNamespace, namespace,
+			logfields.PoolName, ippool,
+		)
 		return ippool, nil
 	}
 
-	// Fallback to default pool
-	return ipam.PoolDefault().String(), nil
+	podLabels := maps.Clone(pod.Labels)
+	if podLabels == nil {
+		podLabels = make(map[string]string)
+	}
+	// Add synthetic fields for selectors
+	podLabels[consts.PodNamespaceLabel] = namespace
+	podLabels[consts.PodNameLabel] = name
+
+	var matches []string
+	m.poolMu.RLock()
+	for _, cp := range m.compiledPools {
+		if family == ipam.IPv4 && !cp.hasV4 {
+			continue
+		}
+		if family == ipam.IPv6 && !cp.hasV6 {
+			continue
+		}
+		// Check if pod matches the pool's podSelector (if specified)
+		podMatches := cp.podSelector == nil || cp.podSelector.Matches(labels.Set(podLabels))
+
+		// Check if namespace matches the pool's namespaceSelector (if specified)
+		namespaceMatches := cp.namespaceSelector == nil || cp.namespaceSelector.Matches(labels.Set(podNamespace.Labels))
+
+		if podMatches && namespaceMatches {
+			matches = append(matches, cp.name)
+		}
+	}
+	m.poolMu.RUnlock()
+
+	switch len(matches) {
+	case 0:
+		// Check if pod or namespace requires pool match
+		podRequiresMatch := pod.Annotations[annotation.IPAMRequirePoolMatch] == "true"
+		namespaceRequiresMatch := podNamespace.Annotations[annotation.IPAMRequirePoolMatch] == "true"
+		if podRequiresMatch || namespaceRequiresMatch {
+			var annotationLocation string
+			if podRequiresMatch {
+				annotationLocation = "pod"
+			} else {
+				annotationLocation = "namespace"
+			}
+			return "", fmt.Errorf("no matching CiliumPodIPPool found for pod %s (family=%s) and require-pool-match annotation is set on %s", owner, family, annotationLocation)
+		}
+		// Fallback to default pool
+		m.logger.Debug("pool selector: no matches, falling back to default pool",
+			logfields.Owner, owner,
+		)
+		return ipam.PoolDefault().String(), nil
+	case 1:
+		m.logger.Debug("pool selector: found matching pool",
+			logfields.Owner, owner,
+			logfields.PoolName, matches[0],
+		)
+		return matches[0], nil
+	default:
+		// If multiple pools match, fail the allocation
+		m.logger.Error("pool selector: multiple pools matched; refusing to choose a pool",
+			logfields.Owner, owner,
+			logfields.Matches, matches,
+		)
+		return "", fmt.Errorf("multiple CiliumPodIPPools match pod %s (family=%s): %v", owner, family, matches)
+	}
+}
+
+// handlePoolEvent handles individual CiliumPodIPPool events and maintains internal selector state.
+func (m *manager) handlePoolEvent(ctx context.Context, event resource.Event[*cilium_v2alpha1.CiliumPodIPPool]) error {
+	defer func() {
+		event.Done(nil)
+	}()
+
+	switch event.Kind {
+	case resource.Sync:
+		m.logger.Debug("pool watcher: pools synced")
+		m.poolsSynced.Store(true)
+		return nil
+	case resource.Upsert:
+		m.compilePool(event.Object)
+	case resource.Delete:
+		m.deleteCompiledPool(event.Object.Name)
+	}
+
+	m.logger.Debug("pool watcher: handled new pool event",
+		logfields.PoolName, event.Object.Name,
+		logfields.CompiledPools, m.getCompiledPools())
+	return nil
+}
+
+func (m *manager) compilePool(p *cilium_v2alpha1.CiliumPodIPPool) {
+	// Compile selectors
+	var podSelector slim_labels.Selector
+	var namespaceSelector slim_labels.Selector
+
+	hasPodSelector := p.Spec.PodSelector != nil
+	hasNamespaceSelector := p.Spec.NamespaceSelector != nil
+	if !hasPodSelector && !hasNamespaceSelector {
+		m.logger.Debug("pool watcher: pool has no pod or namespace selectors; ignoring",
+			logfields.PoolName, p.Name,
+		)
+		m.deleteCompiledPool(p.Name)
+		return
+	}
+	if hasPodSelector {
+		sel, err := slim_meta_v1.LabelSelectorAsSelector(p.Spec.PodSelector)
+		if err != nil {
+			m.logger.Error("pool watcher: failed to compile podSelector for CiliumPodIPPool; ignoring selector",
+				logfields.PoolName, p.Name,
+				logfields.Error, err)
+			return
+		}
+		podSelector = sel
+	}
+
+	if hasNamespaceSelector {
+		sel, err := slim_meta_v1.LabelSelectorAsSelector(p.Spec.NamespaceSelector)
+		if err != nil {
+			m.logger.Error("pool watcher: failed to compile namespaceSelector for CiliumPodIPPool; ignoring selector",
+				logfields.PoolName, p.Name,
+				logfields.Error, err)
+			return
+		}
+		namespaceSelector = sel
+	}
+
+	cp := compiledPool{
+		name:              p.Name,
+		podSelector:       podSelector,
+		namespaceSelector: namespaceSelector,
+		hasV4:             p.Spec.IPv4 != nil,
+		hasV6:             p.Spec.IPv6 != nil,
+	}
+
+	m.setCompiledPool(cp)
+}
+
+func (m *manager) setCompiledPool(p compiledPool) {
+	m.poolMu.Lock()
+	m.compiledPools[p.name] = p
+	m.poolMu.Unlock()
+}
+
+func (m *manager) deleteCompiledPool(name string) {
+	m.poolMu.Lock()
+	delete(m.compiledPools, name)
+	m.poolMu.Unlock()
+}
+
+func (m *manager) getCompiledPool(name string) (compiledPool, bool) {
+	m.poolMu.RLock()
+	defer m.poolMu.RUnlock()
+	cp, ok := m.compiledPools[name]
+	return cp, ok
+}
+
+func (m *manager) getCompiledPools() map[string]compiledPool {
+	m.poolMu.RLock()
+	defer m.poolMu.RUnlock()
+	return maps.Clone(m.compiledPools)
 }

--- a/pkg/ipam/metadata/manager_test.go
+++ b/pkg/ipam/metadata/manager_test.go
@@ -4,19 +4,33 @@
 package metadata
 
 import (
+	"context"
 	"errors"
+	"log/slog"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/ipam"
+	consts "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sresource "github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_labels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
+
+func selectorFromLabels(labels map[string]string) slim_labels.Selector {
+	sel, _ := slim_meta_v1.LabelSelectorAsSelector(&slim_meta_v1.LabelSelector{MatchLabels: labels})
+	return sel
+}
 
 func TestManager_GetIPPoolForPod(t *testing.T) {
 	db := statedb.New()
@@ -25,11 +39,13 @@ func TestManager_GetIPPoolForPod(t *testing.T) {
 	namespaces, err := k8s.NewNamespaceTable(db)
 	require.NoError(t, err, "NewNamespaceTable")
 	m := &manager{
-		logger:     hivetest.Logger(t),
-		db:         db,
-		namespaces: namespaces,
-		pods:       pods,
+		logger:      hivetest.Logger(t),
+		db:          db,
+		namespaces:  namespaces,
+		pods:        pods,
+		poolsSynced: atomic.Bool{},
 	}
+	m.poolsSynced.Store(true)
 
 	txn := db.WriteTxn(pods, namespaces)
 	newPod := func(namespace, name string, annotations map[string]string) k8s.LocalPod {
@@ -197,6 +213,438 @@ func TestManager_GetIPPoolForPod(t *testing.T) {
 	}
 }
 
+func TestManager_handlePoolEvent_UpsertAndDelete(t *testing.T) {
+	db := statedb.New()
+	pods, err := k8s.NewPodTable(db)
+	require.NoError(t, err)
+	namespaces, err := k8s.NewNamespaceTable(db)
+	require.NoError(t, err)
+
+	m := &manager{
+		logger:        hivetest.Logger(t),
+		db:            db,
+		namespaces:    namespaces,
+		pods:          pods,
+		poolsSynced:   atomic.Bool{},
+		compiledPools: map[string]compiledPool{},
+	}
+
+	ctx := t.Context()
+
+	// Create ipv4 pool with selector
+	p1 := &v2alpha1api.CiliumPodIPPool{
+		ObjectMeta: v1.ObjectMeta{Name: "p1"},
+		Spec: v2alpha1api.IPPoolSpec{
+			IPv4:        &v2alpha1api.IPv4PoolSpec{},
+			PodSelector: &slim_meta_v1.LabelSelector{MatchLabels: map[string]string{"team": "blue"}},
+		},
+	}
+	// poolsSynced is false, should not compile pool
+	_, err = m.GetIPPoolForPod("p1", ipam.IPv4)
+	require.ErrorIs(t, err, ErrManagerPoolsNotSynced)
+	err = m.handlePoolEvent(ctx, k8sresource.Event[*v2alpha1api.CiliumPodIPPool]{Kind: k8sresource.Sync, Object: p1, Done: func(error) {}})
+	require.NoError(t, err)
+	// pool should be marked as synced now
+	pool, err := m.GetIPPoolForPod("p1", ipam.IPv4)
+	require.NoError(t, err)
+	require.Equal(t, "default", pool)
+
+	err = m.handlePoolEvent(ctx, k8sresource.Event[*v2alpha1api.CiliumPodIPPool]{Kind: k8sresource.Upsert, Object: p1, Done: func(error) {}})
+	require.NoError(t, err)
+	cp, ok := m.getCompiledPool("p1")
+	require.True(t, ok, "p1 should be present in compiledPools")
+	require.True(t, cp.hasV4)
+	require.False(t, cp.hasV6)
+	require.NotNil(t, cp.podSelector)
+
+	// remove selector
+	p1NoSel := &v2alpha1api.CiliumPodIPPool{ObjectMeta: v1.ObjectMeta{Name: "p1"}, Spec: v2alpha1api.IPPoolSpec{IPv4: &v2alpha1api.IPv4PoolSpec{}}}
+	err = m.handlePoolEvent(ctx, k8sresource.Event[*v2alpha1api.CiliumPodIPPool]{Kind: k8sresource.Upsert, Object: p1NoSel, Done: func(error) {}})
+	require.NoError(t, err)
+	_, exists := m.getCompiledPool("p1")
+	require.False(t, exists, "p1 should have been removed from compiledPools")
+
+	// add it back and delete it again
+	err = m.handlePoolEvent(ctx, k8sresource.Event[*v2alpha1api.CiliumPodIPPool]{Kind: k8sresource.Upsert, Object: p1, Done: func(error) {}})
+	require.NoError(t, err)
+	cp, ok = m.getCompiledPool("p1")
+	require.True(t, ok, "p1 should be added back to compiledPools")
+
+	err = m.handlePoolEvent(ctx, k8sresource.Event[*v2alpha1api.CiliumPodIPPool]{Kind: k8sresource.Delete, Object: p1, Done: func(error) {}})
+	require.NoError(t, err)
+	_, exists = m.getCompiledPool("p1")
+	require.False(t, exists, "p1 should have been removed from compiledPools")
+}
+
+func TestManager_handlePoolEvent_BadSelectorIgnored(t *testing.T) {
+	db := statedb.New()
+	pods, err := k8s.NewPodTable(db)
+	require.NoError(t, err)
+	namespaces, err := k8s.NewNamespaceTable(db)
+	require.NoError(t, err)
+
+	m := &manager{
+		logger:        hivetest.Logger(t),
+		db:            db,
+		namespaces:    namespaces,
+		pods:          pods,
+		compiledPools: make(map[string]compiledPool),
+	}
+	m.poolsSynced.Store(true)
+
+	ctx := context.Background()
+
+	// selector with In operator and empty value
+	badSel := &slim_meta_v1.LabelSelector{
+		MatchExpressions: []slim_meta_v1.LabelSelectorRequirement{{
+			Key:      "k",
+			Operator: slim_meta_v1.LabelSelectorOpIn,
+			Values:   []string{},
+		}},
+	}
+	bad := &v2alpha1api.CiliumPodIPPool{
+		ObjectMeta: v1.ObjectMeta{Name: "bad"},
+		Spec: v2alpha1api.IPPoolSpec{
+			IPv4:        &v2alpha1api.IPv4PoolSpec{},
+			PodSelector: badSel,
+		},
+	}
+
+	done := func(err error) {
+		require.NoError(t, err, "handlePoolEvent should not return errors")
+	}
+
+	err = m.handlePoolEvent(ctx, k8sresource.Event[*v2alpha1api.CiliumPodIPPool]{Kind: k8sresource.Upsert, Object: bad, Done: done})
+	require.NoError(t, err)
+
+	// bad selector should be ignored and not compiled
+	_, ok := m.getCompiledPool("bad")
+	require.False(t, ok, "bad selector should be ignored and not compiled")
+
+	// bad namespace selector should also trigger error via Done and not be compiled
+	badNsSel := &slim_meta_v1.LabelSelector{
+		MatchExpressions: []slim_meta_v1.LabelSelectorRequirement{{
+			Key:      "ns-k",
+			Operator: slim_meta_v1.LabelSelectorOpIn,
+			Values:   []string{},
+		}},
+	}
+	badNS := &v2alpha1api.CiliumPodIPPool{
+		ObjectMeta: v1.ObjectMeta{Name: "bad-ns"},
+		Spec: v2alpha1api.IPPoolSpec{
+			IPv4:              &v2alpha1api.IPv4PoolSpec{},
+			NamespaceSelector: badNsSel,
+		},
+	}
+	err = m.handlePoolEvent(ctx, k8sresource.Event[*v2alpha1api.CiliumPodIPPool]{Kind: k8sresource.Upsert, Object: badNS, Done: done})
+	require.NoError(t, err)
+	_, ok = m.getCompiledPool("bad-ns")
+	require.False(t, ok, "bad namespace selector should be ignored and not compiled")
+}
+
+func TestManager_SelectorBasedMatching(t *testing.T) {
+	db := statedb.New()
+	pods, err := k8s.NewPodTable(db)
+	require.NoError(t, err)
+	namespaces, err := k8s.NewNamespaceTable(db)
+	require.NoError(t, err)
+
+	m := &manager{
+		logger:        hivetest.Logger(t),
+		db:            db,
+		namespaces:    namespaces,
+		pods:          pods,
+		compiledPools: make(map[string]compiledPool),
+	}
+	m.poolsSynced.Store(true)
+
+	txn := db.WriteTxn(pods, namespaces)
+
+	pods.Insert(txn, k8s.LocalPod{Pod: &slim_core_v1.Pod{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Namespace: "namespace",
+			Name:      "pod",
+			Labels: map[string]string{
+				"app": "foo",
+			},
+		},
+	}})
+	namespaces.Insert(txn, k8s.Namespace{Name: "namespace"})
+	txn.Commit()
+
+	selSynthetic, err := slim_meta_v1.LabelSelectorAsSelector(&slim_meta_v1.LabelSelector{
+		MatchLabels: map[string]string{
+			consts.PodNamespaceLabel: "namespace",
+			consts.PodNameLabel:      "pod",
+		},
+	})
+	require.NoError(t, err)
+
+	m.compiledPools = map[string]compiledPool{
+		"pool-v4": {name: "poolv4", podSelector: selectorFromLabels(map[string]string{"app": "foo"}), hasV4: true, hasV6: false},
+		"pool-v6": {name: "poolv6", podSelector: selectorFromLabels(map[string]string{"app": "foo"}), hasV4: false, hasV6: true},
+	}
+
+	pool, err := m.GetIPPoolForPod("namespace/pod", ipam.IPv4)
+	require.NoError(t, err)
+	require.Equal(t, "poolv4", pool)
+
+	pool, err = m.GetIPPoolForPod("namespace/pod", ipam.IPv6)
+	require.NoError(t, err)
+	require.Equal(t, "poolv6", pool)
+
+	m.compiledPools = map[string]compiledPool{
+		"pool-syn": {name: "pool-syn", podSelector: selSynthetic, hasV4: true, hasV6: true},
+	}
+
+	pool, err = m.GetIPPoolForPod("namespace/pod", ipam.IPv4)
+	require.NoError(t, err)
+	require.Equal(t, "pool-syn", pool)
+}
+
+func TestManager_SelectorMultipleMatches_Error(t *testing.T) {
+	db := statedb.New()
+	pods, err := k8s.NewPodTable(db)
+	require.NoError(t, err)
+	namespaces, err := k8s.NewNamespaceTable(db)
+	require.NoError(t, err)
+
+	m := &manager{
+		logger:     hivetest.Logger(t),
+		db:         db,
+		namespaces: namespaces,
+		pods:       pods,
+	}
+	m.poolsSynced.Store(true)
+
+	txn := db.WriteTxn(pods, namespaces)
+	pods.Insert(txn, k8s.LocalPod{Pod: &slim_core_v1.Pod{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Namespace: "namespace",
+			Name:      "pod",
+			Labels:    map[string]string{"team": "blue"},
+		},
+	}})
+	namespaces.Insert(txn, k8s.Namespace{Name: "namespace"})
+	txn.Commit()
+
+	m.compiledPools = map[string]compiledPool{
+		"p1": {name: "p1", podSelector: selectorFromLabels(map[string]string{"team": "blue"}), hasV4: true, hasV6: false},
+		"p2": {name: "p2", podSelector: selectorFromLabels(map[string]string{"team": "blue"}), hasV4: true, hasV6: false},
+	}
+
+	// Verify pools are configured
+	poolCount := len(m.compiledPools)
+	require.Equal(t, 2, poolCount, "should have 2 pools configured")
+
+	pool, err := m.GetIPPoolForPod("namespace/pod", ipam.IPv4)
+	require.Error(t, err)
+	require.Empty(t, pool)
+	require.Contains(t, err.Error(), "multiple CiliumPodIPPools match")
+}
+
+func TestManager_PodAnnotationOverridesSelector(t *testing.T) {
+	db := statedb.New()
+	pods, err := k8s.NewPodTable(db)
+	require.NoError(t, err)
+	namespaces, err := k8s.NewNamespaceTable(db)
+	require.NoError(t, err)
+
+	m := &manager{
+		logger:     hivetest.Logger(t),
+		db:         db,
+		namespaces: namespaces,
+		pods:       pods,
+	}
+	m.poolsSynced.Store(true)
+
+	txn := db.WriteTxn(pods, namespaces)
+	pods.Insert(txn, k8s.LocalPod{Pod: &slim_core_v1.Pod{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Namespace:   "namespace",
+			Name:        "pod",
+			Labels:      map[string]string{"team": "red"},
+			Annotations: map[string]string{annotation.IPAMPoolKey: "annot-pool"},
+		},
+	}})
+	namespaces.Insert(txn, k8s.Namespace{Name: "namespace"})
+	txn.Commit()
+
+	// selector matches but superceded by annotation
+	selRed, err := slim_meta_v1.LabelSelectorAsSelector(&slim_meta_v1.LabelSelector{MatchLabels: map[string]string{"team": "red"}})
+	require.NoError(t, err)
+	m.compiledPools = map[string]compiledPool{
+		"selector-pool": {name: "selector-pool", podSelector: selRed, hasV4: true, hasV6: true},
+	}
+
+	pool, err := m.GetIPPoolForPod("namespace/pod", ipam.IPv4)
+	require.NoError(t, err)
+	require.Equal(t, "annot-pool", pool)
+}
+
+func TestManager_NamespaceAnnotationOverridesSelector(t *testing.T) {
+	db := statedb.New()
+	pods, err := k8s.NewPodTable(db)
+	require.NoError(t, err)
+	namespaces, err := k8s.NewNamespaceTable(db)
+	require.NoError(t, err)
+
+	m := &manager{
+		logger:     hivetest.Logger(t),
+		db:         db,
+		namespaces: namespaces,
+		pods:       pods,
+	}
+	m.poolsSynced.Store(true)
+
+	txn := db.WriteTxn(pods, namespaces)
+	pods.Insert(txn, k8s.LocalPod{Pod: &slim_core_v1.Pod{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Namespace: "namespace", Name: "pod",
+			Labels: map[string]string{"tier": "backend"},
+		},
+	}})
+	namespaces.Insert(txn, k8s.Namespace{
+		Name:        "namespace",
+		Annotations: map[string]string{annotation.IPAMPoolKey: "ns-pool"},
+	})
+	txn.Commit()
+
+	// selector matches but superceded by namespace annotation
+	selBackend, err := slim_meta_v1.LabelSelectorAsSelector(&slim_meta_v1.LabelSelector{MatchLabels: map[string]string{"tier": "backend"}})
+	require.NoError(t, err)
+	m.compiledPools = map[string]compiledPool{
+		"green-pool": {name: "green-pool", podSelector: selBackend, hasV4: true, hasV6: true},
+	}
+
+	pool, err := m.GetIPPoolForPod("namespace/pod", ipam.IPv4)
+	require.NoError(t, err)
+	require.Equal(t, "ns-pool", pool)
+}
+
+func TestManager_NoSelectorNoMatch(t *testing.T) {
+	db := statedb.New()
+	pods, err := k8s.NewPodTable(db)
+	require.NoError(t, err)
+	namespaces, err := k8s.NewNamespaceTable(db)
+	require.NoError(t, err)
+	m := &manager{
+		logger:     hivetest.Logger(t),
+		db:         db,
+		namespaces: namespaces,
+		pods:       pods,
+	}
+	m.poolsSynced.Store(true)
+
+	m.compiledPools = map[string]compiledPool{
+		"nomatch": {name: "nomatch", podSelector: selectorFromLabels(map[string]string{"team": "nomatch"}), hasV4: true, hasV6: true},
+	}
+
+	// Add pod and namespace
+	pod := k8s.LocalPod{Pod: &slim_core_v1.Pod{
+		ObjectMeta: slim_meta_v1.ObjectMeta{Name: "test", Namespace: "namespace", Labels: map[string]string{"tier": "backend"}},
+	}}
+	ns := k8s.Namespace{Name: "namespace"}
+	txn := db.WriteTxn(pods, namespaces)
+	pods.Insert(txn, pod)
+	namespaces.Insert(txn, ns)
+	txn.Commit()
+
+	// Should fall back to default
+	pool, err := m.GetIPPoolForPod("namespace/test", ipam.IPv4)
+	require.NoError(t, err)
+	require.Equal(t, "default", pool)
+}
+
+func TestManager_RequirePoolMatchAnnotation(t *testing.T) {
+	db := statedb.New()
+	pods, err := k8s.NewPodTable(db)
+	require.NoError(t, err)
+	namespaces, err := k8s.NewNamespaceTable(db)
+	require.NoError(t, err)
+	m := &manager{
+		logger:     hivetest.Logger(t),
+		db:         db,
+		namespaces: namespaces,
+		pods:       pods,
+	}
+	m.compiledPools = map[string]compiledPool{}
+	m.poolsSynced.Store(true)
+
+	t.Run("pod annotation blocks default fallback", func(t *testing.T) {
+		// Add pod with require-pool-match annotation
+		pod := k8s.LocalPod{Pod: &slim_core_v1.Pod{
+			ObjectMeta: slim_meta_v1.ObjectMeta{
+				Name:        "pod",
+				Namespace:   "default",
+				Annotations: map[string]string{annotation.IPAMRequirePoolMatch: "true"},
+			},
+		}}
+		txn := db.WriteTxn(pods, namespaces)
+		pods.Insert(txn, pod)
+
+		// Add namespace without annotation
+		ns := k8s.Namespace{Name: "default"}
+		namespaces.Insert(txn, ns)
+		txn.Commit()
+
+		// Should return error instead of default
+		_, err := m.GetIPPoolForPod("default/pod", ipam.IPv4)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no matching CiliumPodIPPool found")
+		require.Contains(t, err.Error(), "require-pool-match annotation is set")
+	})
+
+	t.Run("namespace annotation blocks default fallback", func(t *testing.T) {
+		// Add pod without annotation
+		pod := k8s.LocalPod{Pod: &slim_core_v1.Pod{
+			ObjectMeta: slim_meta_v1.ObjectMeta{
+				Name:      "pod2",
+				Namespace: "strict-ns",
+			},
+		}}
+		txn := db.WriteTxn(pods, namespaces)
+		pods.Insert(txn, pod)
+
+		// Add namespace with require-pool-match annotation
+		ns := k8s.Namespace{
+			Name:        "strict-ns",
+			Annotations: map[string]string{annotation.IPAMRequirePoolMatch: "true"},
+		}
+		namespaces.Insert(txn, ns)
+		txn.Commit()
+
+		// Should return error instead of default
+		_, err := m.GetIPPoolForPod("strict-ns/pod2", ipam.IPv4)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no matching CiliumPodIPPool found")
+		require.Contains(t, err.Error(), "require-pool-match annotation is set")
+	})
+
+	t.Run("annotation false allows default fallback", func(t *testing.T) {
+		// Add pod with annotation set to false
+		pod := k8s.LocalPod{Pod: &slim_core_v1.Pod{
+			ObjectMeta: slim_meta_v1.ObjectMeta{
+				Name:        "pod3",
+				Namespace:   "namespace",
+				Annotations: map[string]string{annotation.IPAMRequirePoolMatch: "false"},
+			},
+		}}
+		txn := db.WriteTxn(pods, namespaces)
+		pods.Insert(txn, pod)
+
+		// Add namespace
+		ns := k8s.Namespace{Name: "namespace"}
+		namespaces.Insert(txn, ns)
+		txn.Commit()
+
+		// Should fall back to default
+		pool, err := m.GetIPPoolForPod("namespace/pod3", ipam.IPv4)
+		require.NoError(t, err)
+		require.Equal(t, "default", pool)
+	})
+}
+
 func TestDefaultManager_DefaultPool(t *testing.T) {
 	defaultPoolManager := defaultIPPoolManager{}
 
@@ -207,4 +655,108 @@ func TestDefaultManager_DefaultPool(t *testing.T) {
 	ipv6Pool, err := defaultPoolManager.GetIPPoolForPod("", ipam.IPv6)
 	require.NoError(t, err)
 	require.Equal(t, ipam.PoolDefault(), ipam.Pool(ipv6Pool))
+}
+
+func TestNamespaceSelector(t *testing.T) {
+	db := statedb.New()
+	pools, err := k8s.NewPodTable(db)
+	require.NoError(t, err, "NewPodTable")
+	namespaces, err := k8s.NewNamespaceTable(db)
+	require.NoError(t, err, "NewNamespaceTable")
+
+	m := &manager{
+		logger:        slog.Default(),
+		db:            db,
+		namespaces:    namespaces,
+		pods:          pools,
+		compiledPools: make(map[string]compiledPool),
+	}
+	m.poolsSynced.Store(true)
+
+	// Create dev/prod namespaces and pods
+	w := db.WriteTxn(namespaces, pools)
+	namespaces.Insert(w, k8s.Namespace{
+		Name:   "dev",
+		Labels: map[string]string{"env": "dev"},
+	})
+	namespaces.Insert(w, k8s.Namespace{
+		Name:   "prod",
+		Labels: map[string]string{"env": "prod"},
+	})
+	pools.Insert(w, k8s.LocalPod{Pod: &slim_core_v1.Pod{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Namespace: "dev", Name: "pod", Labels: map[string]string{"app": "web"},
+		},
+	}})
+	pools.Insert(w, k8s.LocalPod{Pod: &slim_core_v1.Pod{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Namespace: "prod", Name: "pod", Labels: map[string]string{"app": "web"},
+		},
+	}})
+	w.Commit()
+
+	t.Run("match by namespace only", func(t *testing.T) {
+		m.compiledPools = make(map[string]compiledPool)
+		m.setCompiledPool(compiledPool{
+			name:              "dev-pool",
+			namespaceSelector: selectorFromLabels(map[string]string{"env": "dev"}),
+			hasV4:             true,
+		})
+
+		pool, err := m.GetIPPoolForPod("dev/pod", ipam.IPv4)
+		require.NoError(t, err)
+		assert.Equal(t, "dev-pool", pool)
+
+		pool, err = m.GetIPPoolForPod("prod/pod", ipam.IPv4)
+		require.NoError(t, err)
+		require.Equal(t, ipam.PoolDefault().String(), pool)
+	})
+
+	t.Run("match by pod and namespace", func(t *testing.T) {
+		m.compiledPools = make(map[string]compiledPool)
+		m.setCompiledPool(compiledPool{
+			name:              "dev-web-pool",
+			podSelector:       selectorFromLabels(map[string]string{"app": "web"}),
+			namespaceSelector: selectorFromLabels(map[string]string{"env": "dev"}),
+			hasV4:             true,
+		})
+
+		pool, err := m.GetIPPoolForPod("dev/pod", ipam.IPv4)
+		require.NoError(t, err)
+		assert.Equal(t, "dev-web-pool", pool)
+
+		pool, err = m.GetIPPoolForPod("prod/pod", ipam.IPv4)
+		require.NoError(t, err)
+		assert.Equal(t, ipam.PoolDefault().String(), pool)
+	})
+
+	t.Run("require-pool-match on namespace blocks fallback", func(t *testing.T) {
+		m.compiledPools = make(map[string]compiledPool)
+
+		// Add a restricted namespace/pod
+		w := db.WriteTxn(namespaces, pools)
+		namespaces.Insert(w, k8s.Namespace{
+			Name:        "restricted",
+			Annotations: map[string]string{annotation.IPAMRequirePoolMatch: "true"},
+		})
+		// Pod with no labels
+		pools.Insert(w, k8s.LocalPod{Pod: &slim_core_v1.Pod{
+			ObjectMeta: slim_meta_v1.ObjectMeta{
+				Namespace: "restricted", Name: "pod", Labels: map[string]string{},
+			},
+		}})
+		w.Commit()
+
+		m.setCompiledPool(compiledPool{
+			name:              "prod-pool",
+			namespaceSelector: selectorFromLabels(map[string]string{"env": "prod"}),
+			hasV4:             true,
+		})
+
+		// should not fallback to default due to ns annotation
+		_, err := m.GetIPPoolForPod("restricted/pod", ipam.IPv4)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no matching CiliumPodIPPool found")
+		assert.Contains(t, err.Error(), "require-pool-match annotation is set on namespace")
+	})
 }

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumpodippools.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumpodippools.yaml
@@ -86,6 +86,135 @@ spec:
                 - cidrs
                 - maskSize
                 type: object
+              namespaceSelector:
+                description: |-
+                  NamespaceSelector selects the set of Namespaces that are eligible to use
+                  this pool. If both PodSelector and NamespaceSelector are specified, a Pod
+                  must match both selectors to be eligible for IP allocation from this pool.
+
+                  If NamespaceSelector is empty, the pool can be used by Pods in any namespace
+                  (subject to PodSelector constraints).
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podSelector:
+                description: |-
+                  PodSelector selects the set of Pods that are eligible to receive IPs from
+                  this pool when neither the Pod nor its Namespace specify an explicit
+                  `ipam.cilium.io/*` annotation.
+
+                  The selector can match on regular Pod labels and on the following synthetic
+                  labels that Cilium adds for convenience:
+
+                  io.kubernetes.pod.namespace – the Pod's namespace
+                  io.kubernetes.pod.name      – the Pod's name
+
+                  A single Pod must not match more than one pool for the same IP family.
+                  If multiple pools match, IP allocation fails for that Pod and a warning event
+                  is emitted in the namespace of the Pod.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
             type: object
         required:
         - spec

--- a/pkg/k8s/apis/cilium.io/v2alpha1/ippool_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/ippool_types.go
@@ -3,7 +3,11 @@
 
 package v2alpha1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
 
 // +genclient
 // +genclient:nonNamespaced
@@ -34,6 +38,33 @@ type IPPoolSpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	IPv6 *IPv6PoolSpec `json:"ipv6"`
+
+	// PodSelector selects the set of Pods that are eligible to receive IPs from
+	// this pool when neither the Pod nor its Namespace specify an explicit
+	// `ipam.cilium.io/*` annotation.
+	//
+	// The selector can match on regular Pod labels and on the following synthetic
+	// labels that Cilium adds for convenience:
+	//
+	// io.kubernetes.pod.namespace – the Pod's namespace
+	// io.kubernetes.pod.name      – the Pod's name
+	//
+	// A single Pod must not match more than one pool for the same IP family.
+	// If multiple pools match, IP allocation fails for that Pod and a warning event
+	// is emitted in the namespace of the Pod.
+	//
+	// +kubebuilder:validation:Optional
+	PodSelector *slimv1.LabelSelector `json:"podSelector,omitempty"`
+
+	// NamespaceSelector selects the set of Namespaces that are eligible to use
+	// this pool. If both PodSelector and NamespaceSelector are specified, a Pod
+	// must match both selectors to be eligible for IP allocation from this pool.
+	//
+	// If NamespaceSelector is empty, the pool can be used by Pods in any namespace
+	// (subject to PodSelector constraints).
+	//
+	// +kubebuilder:validation:Optional
+	NamespaceSelector *slimv1.LabelSelector `json:"namespaceSelector,omitempty"`
 }
 
 type IPv4PoolSpec struct {

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
@@ -2045,6 +2045,16 @@ func (in *IPPoolSpec) DeepCopyInto(out *IPPoolSpec) {
 		*out = new(IPv6PoolSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PodSelector != nil {
+		in, out := &in.PodSelector, &out.PodSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.NamespaceSelector != nil {
+		in, out := &in.NamespaceSelector, &out.NamespaceSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -1634,6 +1634,22 @@ func (in *IPPoolSpec) DeepEqual(other *IPPoolSpec) bool {
 		}
 	}
 
+	if (in.PodSelector == nil) != (other.PodSelector == nil) {
+		return false
+	} else if in.PodSelector != nil {
+		if !in.PodSelector.DeepEqual(other.PodSelector) {
+			return false
+		}
+	}
+
+	if (in.NamespaceSelector == nil) != (other.NamespaceSelector == nil) {
+		return false
+	} else if in.NamespaceSelector != nil {
+		if !in.NamespaceSelector.DeepEqual(other.NamespaceSelector) {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -526,6 +526,12 @@ const (
 	// EndpointSelector is a selector for Endpoints
 	EndpointSelector = "EndpointSelector"
 
+	// PodSelector is a selector for Pods
+	PodSelector = "PodSelector"
+
+	// NamespaceSelector is a selector for Namespaces
+	NamespaceSelector = "NamespaceSelector"
+
 	// Path is a filesystem path. It can be a file or directory.
 	// Note: pkg/proxy/accesslog points to this variable so be careful when
 	// changing the value
@@ -1812,4 +1818,10 @@ const (
 
 	// CESFeatureEnabled indicates whether CiliumEndpointSlice feature is enabled.
 	CESFeatureEnabled = "cesEnabled"
+
+	// Matches is a list of pools that match a pod.
+	Matches = "matches"
+
+	// CompiledPools is a map of pools that use podSelectors
+	CompiledPools = "compiledPools"
 )


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This change adds a podSelector field to the CiliumPodIPPool CRD. A CiliumPodIPPool informer is added to the IPAM manager, which watches and compiles the podSelectors of pools for later lookup.

In manager.GetIPPoolForPod, if the ipam annotation is not found on the pod or its namespace, the pod is matched against all podSelectors to find a matching IP pool.

If a pod matches multiple selectors, allocation fails and emits an event to the pod's namespace.

Tests are added for happy path and invalid or conflicting selectors. Documentation is added for the new behaviour. Debug logging is also generally improved.

```release-note
multipool: add support for matching pods to PodIPPools via label selectors
```
