### PR TITLE
[Please don't merge this PR] This PR is for validation of E2E test itself.

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -517,6 +517,10 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 	}
 
 	/* Amend the L3 checksum due to changing the addresses. */
+	/* With a patch that moves this part before the L4 header processing,
+	 * E2E tests failed. I want to determine whether the tests are broken
+	 * or the patch itself is inappropriate.
+	 */
 	if (ipv4_csum_update_by_diff(ctx, l3_off, sum) < 0)
 		return DROP_CSUM_L3;
 


### PR DESCRIPTION
With the patch that moves this part before the L4 header processing, E2E tests failed.
https://github.com/cilium/cilium/pull/41551
 I want to determine whether the tests are broken or the patch itself is inappropriate.