### PR TITLE
hubble: Show applied L4 network policies in hubble drop event

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -221,6 +221,7 @@ cilium-agent [flags]
       --http-stream-idle-timeout uint                             Set Envoy the amount of time that the connection manager will allow a stream to exist with no upstream or downstream activity. Default 300s (default 300)
       --hubble-disable-tls                                        Allow Hubble server to run on the given listen address without TLS. (default true)
       --hubble-drop-events                                        Emit packet drop Events related to pods (alpha)
+      --hubble-drop-events-extended                               Include L4 network policies in drop event message
       --hubble-drop-events-interval duration                      Minimum time between emitting same events (default 2m0s)
       --hubble-drop-events-reasons strings                        Drop reasons to emit events for (default [auth_required,policy_denied])
       --hubble-dynamic-metrics-config-path string                 Filepath with dynamic configuration of hubble metrics.

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -223,6 +223,7 @@ cilium-agent [flags]
       --hubble-drop-events                                        Emit packet drop Events related to pods (alpha)
       --hubble-drop-events-extended                               Include L4 network policies in drop event message
       --hubble-drop-events-interval duration                      Minimum time between emitting same events (default 2m0s)
+      --hubble-drop-events-rate-limit int                         Rate limit for the drop event emitter in events per second (0 for no rate limit) (default 1)
       --hubble-drop-events-reasons strings                        Drop reasons to emit events for (default [auth_required,policy_denied])
       --hubble-dynamic-metrics-config-path string                 Filepath with dynamic configuration of hubble metrics.
       --hubble-event-buffer-capacity int                          Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -116,6 +116,7 @@ cilium-agent hive [flags]
       --hubble-drop-events                                        Emit packet drop Events related to pods (alpha)
       --hubble-drop-events-extended                               Include L4 network policies in drop event message
       --hubble-drop-events-interval duration                      Minimum time between emitting same events (default 2m0s)
+      --hubble-drop-events-rate-limit int                         Rate limit for the drop event emitter in events per second (0 for no rate limit) (default 1)
       --hubble-drop-events-reasons strings                        Drop reasons to emit events for (default [auth_required,policy_denied])
       --hubble-dynamic-metrics-config-path string                 Filepath with dynamic configuration of hubble metrics.
       --hubble-event-buffer-capacity int                          Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -114,6 +114,7 @@ cilium-agent hive [flags]
       --http-stream-idle-timeout uint                             Set Envoy the amount of time that the connection manager will allow a stream to exist with no upstream or downstream activity. Default 300s (default 300)
       --hubble-disable-tls                                        Allow Hubble server to run on the given listen address without TLS. (default true)
       --hubble-drop-events                                        Emit packet drop Events related to pods (alpha)
+      --hubble-drop-events-extended                               Include L4 network policies in drop event message
       --hubble-drop-events-interval duration                      Minimum time between emitting same events (default 2m0s)
       --hubble-drop-events-reasons strings                        Drop reasons to emit events for (default [auth_required,policy_denied])
       --hubble-dynamic-metrics-config-path string                 Filepath with dynamic configuration of hubble metrics.

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -121,6 +121,7 @@ cilium-agent hive dot-graph [flags]
       --hubble-drop-events                                        Emit packet drop Events related to pods (alpha)
       --hubble-drop-events-extended                               Include L4 network policies in drop event message
       --hubble-drop-events-interval duration                      Minimum time between emitting same events (default 2m0s)
+      --hubble-drop-events-rate-limit int                         Rate limit for the drop event emitter in events per second (0 for no rate limit) (default 1)
       --hubble-drop-events-reasons strings                        Drop reasons to emit events for (default [auth_required,policy_denied])
       --hubble-dynamic-metrics-config-path string                 Filepath with dynamic configuration of hubble metrics.
       --hubble-event-buffer-capacity int                          Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -119,6 +119,7 @@ cilium-agent hive dot-graph [flags]
       --http-stream-idle-timeout uint                             Set Envoy the amount of time that the connection manager will allow a stream to exist with no upstream or downstream activity. Default 300s (default 300)
       --hubble-disable-tls                                        Allow Hubble server to run on the given listen address without TLS. (default true)
       --hubble-drop-events                                        Emit packet drop Events related to pods (alpha)
+      --hubble-drop-events-extended                               Include L4 network policies in drop event message
       --hubble-drop-events-interval duration                      Minimum time between emitting same events (default 2m0s)
       --hubble-drop-events-reasons strings                        Drop reasons to emit events for (default [auth_required,policy_denied])
       --hubble-dynamic-metrics-config-path string                 Filepath with dynamic configuration of hubble metrics.

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -647,3 +647,19 @@ func (e *Endpoint) ApplyUserLabelChanges(lbls labels.Labels) (add, del labels.La
 func (e *Endpoint) GetStatusModel() []*models.EndpointStatusChange {
 	return e.status.GetModel()
 }
+
+// GetRealizedL4PolicyRuleOriginModel returns the realized L4 policy of the endpoint.
+func (e *Endpoint) GetRealizedL4PolicyRuleOriginModel() (policy *models.L4Policy, policyRevision uint64, err error) {
+	if e == nil {
+		return
+	}
+	err = e.lockAlive()
+	if err != nil {
+		return
+	}
+	defer e.unlock()
+	if e.realizedPolicy == nil {
+		return
+	}
+	return e.realizedPolicy.SelectorPolicy.L4Policy.GetRuleOriginModel(), e.policyRevision, nil
+}

--- a/pkg/hubble/dropeventemitter/cell.go
+++ b/pkg/hubble/dropeventemitter/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -41,6 +42,8 @@ type config struct {
 	K8sDropEventsInterval time.Duration `mapstructure:"hubble-drop-events-interval"`
 	// K8sDropEventsReasons controls which drop reasons to emit events for.
 	K8sDropEventsReasons []string `mapstructure:"hubble-drop-events-reasons"`
+	// EnableK8sDropEventsExtended controls if L4 network policies are included in event message
+	EnableK8sDropEventsExtended bool `mapstructure:"hubble-drop-events-extended"`
 }
 
 var defaultConfig = config{
@@ -50,12 +53,14 @@ var defaultConfig = config{
 		strings.ToLower(flowpb.DropReason_AUTH_REQUIRED.String()),
 		strings.ToLower(flowpb.DropReason_POLICY_DENIED.String()),
 	},
+	EnableK8sDropEventsExtended: false,
 }
 
 func (def config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("hubble-drop-events", def.EnableK8sDropEvents, "Emit packet drop Events related to pods (alpha)")
 	flags.Duration("hubble-drop-events-interval", def.K8sDropEventsInterval, "Minimum time between emitting same events")
 	flags.StringSlice("hubble-drop-events-reasons", def.K8sDropEventsReasons, "Drop reasons to emit events for")
+	flags.Bool("hubble-drop-events-extended", def.EnableK8sDropEventsExtended, "Include L4 network policies in drop event message")
 }
 
 func (cfg *config) normalize() {
@@ -89,6 +94,8 @@ type params struct {
 	K8sWatcher *watchers.K8sWatcher
 
 	Config config
+
+	EndpointsLookup endpointmanager.EndpointsLookup
 }
 
 func newDropEventEmitter(p params) FlowProcessor {
@@ -103,9 +110,10 @@ func newDropEventEmitter(p params) FlowProcessor {
 		"Building the Hubble packet drop events emitter",
 		logfields.Interval, p.Config.K8sDropEventsInterval,
 		logfields.Reasons, p.Config.K8sDropEventsReasons,
+		logfields.CiliumNetworkPolicy, p.Config.EnableK8sDropEventsExtended,
 	)
 
-	flowProcessor := new(p.Logger, p.Config.K8sDropEventsInterval, p.Config.K8sDropEventsReasons, p.Clientset, p.K8sWatcher)
+	flowProcessor := new(p.Logger, p.Config.K8sDropEventsInterval, p.Config.K8sDropEventsReasons, p.Config.EnableK8sDropEventsExtended, p.Clientset, p.K8sWatcher, p.EndpointsLookup)
 	p.Lifecycle.Append(cell.Hook{
 		OnStop: func(hc cell.HookContext) error {
 			flowProcessor.Shutdown()

--- a/pkg/hubble/dropeventemitter/dropeventemitter.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter.go
@@ -15,7 +15,11 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	client "github.com/cilium/cilium/pkg/k8s/client"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	metaslimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -25,15 +29,24 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-type dropEventEmitter struct {
-	broadcaster record.EventBroadcaster
-	recorder    record.EventRecorder
-	k8sWatcher  watchers.CacheAccessK8SWatcher
-
-	reasons []flowpb.DropReason
+type endpointsLookup interface {
+	LookupCiliumID(id uint16) *endpoint.Endpoint
 }
 
-func new(log *slog.Logger, interval time.Duration, reasons []string, k8s client.Clientset, watcher watchers.CacheAccessK8SWatcher) *dropEventEmitter {
+type endpointInterface interface {
+	GetRealizedL4PolicyRuleOriginModel() (policy *models.L4Policy, policyRevision uint64, err error)
+}
+
+type dropEventEmitter struct {
+	broadcaster     record.EventBroadcaster
+	recorder        record.EventRecorder
+	k8sWatcher      watchers.CacheAccessK8SWatcher
+	showPolicies    bool
+	reasons         []flowpb.DropReason
+	endpointsLookup endpointsLookup
+}
+
+func new(log *slog.Logger, interval time.Duration, reasons []string, showPolicies bool, k8s client.Clientset, watcher watchers.CacheAccessK8SWatcher, endpointsLookup endpointsLookup) *dropEventEmitter {
 	broadcaster := record.NewBroadcasterWithCorrelatorOptions(record.CorrelatorOptions{
 		BurstSize:            1,
 		QPS:                  1 / float32(interval.Seconds()),
@@ -53,10 +66,12 @@ func new(log *slog.Logger, interval time.Duration, reasons []string, k8s client.
 	}
 
 	return &dropEventEmitter{
-		broadcaster: broadcaster,
-		recorder:    broadcaster.NewRecorder(slimscheme.Scheme, v1.EventSource{Component: "cilium"}),
-		k8sWatcher:  watcher,
-		reasons:     rs,
+		broadcaster:     broadcaster,
+		recorder:        broadcaster.NewRecorder(slimscheme.Scheme, v1.EventSource{Component: "cilium"}),
+		k8sWatcher:      watcher,
+		reasons:         rs,
+		showPolicies:    showPolicies,
+		endpointsLookup: endpointsLookup,
 	}
 }
 
@@ -76,15 +91,29 @@ func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 	}
 
 	reason := strings.ToLower(flow.DropReasonDesc.String())
+
+	typeMeta := metaslimv1.TypeMeta{
+		Kind:       "Pod",
+		APIVersion: "v1",
+	}
+
 	if flow.TrafficDirection == flowpb.TrafficDirection_INGRESS {
 		message := "Incoming packet dropped (" + reason + ") from " +
 			endpointToString(flow.IP.Source, flow.Source) + " " +
-			l4protocolToString(flow.L4)
+			l4protocolToString(flow.L4) + "."
+
+		if e.showPolicies {
+			policies, err := e.dropEventPoliciesToString(flow)
+			if err != nil {
+				return err
+			}
+			if policies != "" {
+				message += " " + policies
+			}
+		}
+
 		e.recorder.Event(&slimv1.Pod{
-			TypeMeta: metaslimv1.TypeMeta{
-				Kind:       "Pod",
-				APIVersion: "v1",
-			},
+			TypeMeta: typeMeta,
 			ObjectMeta: metaslimv1.ObjectMeta{
 				Name:      flow.Destination.PodName,
 				Namespace: flow.Destination.Namespace,
@@ -93,7 +122,17 @@ func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 	} else {
 		message := "Outgoing packet dropped (" + reason + ") to " +
 			endpointToString(flow.IP.Destination, flow.Destination) + " " +
-			l4protocolToString(flow.L4)
+			l4protocolToString(flow.L4) + "."
+
+		if e.showPolicies {
+			policies, err := e.dropEventPoliciesToString(flow)
+			if err != nil {
+				return err
+			}
+			if policies != "" {
+				message += " " + policies
+			}
+		}
 
 		objMeta := metaslimv1.ObjectMeta{
 			Name:      flow.Source.PodName,
@@ -106,10 +145,7 @@ func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 			}
 		}
 		podObj := slimv1.Pod{
-			TypeMeta: metaslimv1.TypeMeta{
-				Kind:       "Pod",
-				APIVersion: "v1",
-			},
+			TypeMeta:   typeMeta,
 			ObjectMeta: objMeta,
 		}
 		e.recorder.Event(&podObj, v1.EventTypeWarning, "PacketDrop", message)
@@ -150,4 +186,92 @@ func l4protocolToString(l4 *flowpb.Layer4) string {
 		return "VRRP"
 	}
 	return ""
+}
+
+func (e *dropEventEmitter) getLocalEndpoint(flow *flowpb.Flow) *endpoint.Endpoint {
+	var endpointID uint16
+	if flow.TrafficDirection == flowpb.TrafficDirection_INGRESS {
+		endpointID = uint16(flow.Destination.ID)
+	} else {
+		endpointID = uint16(flow.Source.ID)
+	}
+	return e.endpointsLookup.LookupCiliumID(endpointID)
+}
+
+func getPolicyRulesFromEndpoint(direction flowpb.TrafficDirection, ep endpointInterface) ([]*models.PolicyRule, uint64, error) {
+	if ep == nil {
+		return nil, 0, nil
+	}
+	realizedPolicy, policyRevision, err := ep.GetRealizedL4PolicyRuleOriginModel()
+	if err != nil || realizedPolicy == nil {
+		return nil, 0, err
+	}
+	if direction == flowpb.TrafficDirection_INGRESS {
+		return realizedPolicy.Ingress, policyRevision, nil
+	}
+	return realizedPolicy.Egress, policyRevision, nil
+}
+
+func parsePolicyRules(l4Rules []*models.PolicyRule, policyRevision uint64) (networkPolicies set.Set[string], clusterwideNetworkPolicies set.Set[string]) {
+	for _, rules := range l4Rules {
+		if rules == nil {
+			continue
+		}
+		for _, policyLabels := range rules.DerivedFromRules {
+			policy := utils.GetPolicyFromLabels(policyLabels, policyRevision)
+			if policy == nil {
+				continue
+			}
+			if policy.Namespace == "" {
+				clusterwideNetworkPolicies.Insert(policy.Kind + "/" + policy.Name)
+				continue
+			}
+			networkPolicies.Insert(policy.Kind + "/" + policy.Name)
+		}
+	}
+	return
+}
+
+func parsePolicyCorrelation(direction flowpb.TrafficDirection, ingressDeniedBy []*flowpb.Policy, egressDeniedBy []*flowpb.Policy) (networkPolicies set.Set[string], clusterwideNetworkPolicies set.Set[string]) {
+	var policies []*flowpb.Policy
+	if direction == flowpb.TrafficDirection_INGRESS {
+		policies = ingressDeniedBy
+	} else {
+		policies = egressDeniedBy
+	}
+	for _, policy := range policies {
+		if policy.Namespace == "" {
+			clusterwideNetworkPolicies.Insert(policy.Kind + "/" + policy.Name)
+			continue
+		}
+		networkPolicies.Insert(policy.Kind + "/" + policy.Name)
+	}
+	return
+}
+
+func (e *dropEventEmitter) dropEventPoliciesToString(flow *flowpb.Flow) (string, error) {
+	var parts []string
+	prefix := "Denied by"
+	var networkPolicies, clusterwideNetworkPolicies set.Set[string]
+	// If the drop event is caused by a deny policy, policy correlation will identify the denying policy.
+	if flow.DropReasonDesc == flowpb.DropReason_POLICY_DENY {
+		networkPolicies, clusterwideNetworkPolicies = parsePolicyCorrelation(flow.TrafficDirection, flow.IngressDeniedBy, flow.EgressDeniedBy)
+	}
+	// If the drop event is not caused by a direct deny policy or policy correlation is turned off,
+	// show all applied network policies.
+	if networkPolicies.Empty() && clusterwideNetworkPolicies.Empty() {
+		prefix = "Applied"
+		flowPolicyRules, policyRevision, err := getPolicyRulesFromEndpoint(flow.TrafficDirection, e.getLocalEndpoint(flow))
+		if err != nil {
+			return "", err
+		}
+		networkPolicies, clusterwideNetworkPolicies = parsePolicyRules(flowPolicyRules, policyRevision)
+	}
+	if !networkPolicies.Empty() {
+		parts = append(parts, prefix+" policies: "+networkPolicies.String()+".")
+	}
+	if !clusterwideNetworkPolicies.Empty() {
+		parts = append(parts, prefix+" clusterwide policies: "+clusterwideNetworkPolicies.String()+".")
+	}
+	return strings.Join(parts, " "), nil
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1841,4 +1841,6 @@ const (
 	ReloadKeypairError = "reloadKeypairError"
 
 	ReloadCAError = "reloadCAError"
+
+	ExtendedMessage = "extendedMessage"
 )

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -5,19 +5,17 @@ package correlation
 
 import (
 	"log/slog"
-	"strings"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/identity"
-	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
-	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -223,39 +221,7 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 
 func toProto(info policyTypes.PolicyCorrelationInfo) (policies []*flowpb.Policy) {
 	for model := range labels.ModelsFromLabelArrayListString(info.RuleLabels) {
-		policies = append(policies, policyFromModel(model, info))
+		policies = append(policies, utils.GetPolicyFromLabels(model, info.Revision))
 	}
 	return policies
-}
-
-// policyFromModel derives and sets fields in the flow policy from the label set array and policy
-// correlation information.
-//
-// This function supports namespaced and cluster-scoped resources.
-func policyFromModel(model []string, info policyTypes.PolicyCorrelationInfo) *flowpb.Policy {
-	f := &flowpb.Policy{
-		Labels:   model,
-		Revision: info.Revision,
-	}
-
-	for _, lbl := range model {
-		if lbl, isK8sLabel := strings.CutPrefix(lbl, string(source.Kubernetes)+":"); isK8sLabel {
-			if key, value, found := strings.Cut(lbl, "="); found {
-				switch key {
-				case k8sConst.PolicyLabelName:
-					f.Name = value
-				case k8sConst.PolicyLabelNamespace:
-					f.Namespace = value
-				case k8sConst.PolicyLabelDerivedFrom:
-					f.Kind = value
-				default:
-					if f.Kind != "" && f.Name != "" && f.Namespace != "" {
-						return f
-					}
-				}
-			}
-		}
-	}
-
-	return f
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1782,6 +1782,7 @@ func (l4 *L4Policy) HasProxylibRedirect() bool {
 	return l4 != nil && l4.redirectTypes&redirectTypeProxylib == redirectTypeProxylib
 }
 
+// GetModel returns the API model of the L4 policy.
 func (l4 *L4Policy) GetModel() *models.L4Policy {
 	if l4 == nil {
 		return nil
@@ -1814,6 +1815,44 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 		}
 		egress = append(egress, &models.PolicyRule{
 			Rule:             v.Marshal(),
+			DerivedFromRules: derivedFrom.GetModel(),
+		})
+		return true
+	})
+
+	return &models.L4Policy{
+		Ingress: ingress,
+		Egress:  egress,
+	}
+}
+
+// GetRuleOriginModel returns the API model of the L4 policy with the rule origins only.
+func (l4 *L4Policy) GetRuleOriginModel() *models.L4Policy {
+	if l4 == nil {
+		return nil
+	}
+
+	ingress := []*models.PolicyRule{}
+	l4.Ingress.PortRules.ForEach(func(v *L4Filter) bool {
+		derivedFrom := labels.LabelArrayList{}
+		for _, rules := range v.RuleOrigin {
+			lal := rules.GetLabelArrayList()
+			derivedFrom.MergeSorted(lal)
+		}
+		ingress = append(ingress, &models.PolicyRule{
+			DerivedFromRules: derivedFrom.GetModel(),
+		})
+		return true
+	})
+
+	egress := []*models.PolicyRule{}
+	l4.Egress.PortRules.ForEach(func(v *L4Filter) bool {
+		derivedFrom := labels.LabelArrayList{}
+		for _, rules := range v.RuleOrigin {
+			lal := rules.GetLabelArrayList()
+			derivedFrom.MergeSorted(lal)
+		}
+		egress = append(egress, &models.PolicyRule{
 			DerivedFromRules: derivedFrom.GetModel(),
 		})
 		return true


### PR DESCRIPTION
Adds option to show blocking or applied network policies in `hubble` k8s drop events. This allows for faster diagnostic of this type of event. Also, adds rate limiting for the drop event emitter to limit the resource usage of this feature.

The feature has been placed behind a flag for now. But, in our experience it can be very useful. So it could be turned on by default or the flag could be removed altogether.

This is also intended to help move this feature to beta #33975.

## How it works

When a drop event occurs, the correlation results are parsed to detect if the drop was due to a specific deny policy. If the correlation results are empty, all applied network policies are shown. The emitter will query the endpoint manager to retrieve the applied L4 rules. Those rules are then parsed and shown as either namespaced or clusterwide network policies.

## Result

The following is an example of a dropevent with the feature turned off:
```
Outgoing packet dropped (policy_denied) to 8.8.8.8 ICMPv4.
Incoming packet dropped (policy_denied) from remote-node (1.2.3.4) TCP/8080.
```

With the feature turned off we get something like this:
```
Outgoing packet dropped (policy_deny) to 8.8.8.8 ICMPv4. Denied by policies: deny-icmp.
Outgoing packet dropped (policy_denied) to 8.8.8.8 ICMPv4. Applied policies: namespaced-cnp. Applied clusterwide policies: cluster-cnp-1, cluster-cnp-2.
Incoming packet dropped (policy_denied) from remote-node (1.2.3.4) TCP/8080. Applied policies: namespaced-cnp. Applied clusterwide policies: cluster-cnp-1, cluster-cnp-2.
```

## Performance Analysis

To assess the CPU impact without rate limiting, we deployed this change on one of our machines and subjected it to deliberate packet drops with varying rates.

The values in the table below correspond to average CPU usage in `mcores`. Idle CPU core usage = around `58 mcores`

| Configuration | 100 pkt/s | 500 pkt/s | 1000 pkt/s | Event message |
|--------|--------|--------|--------|--------|
| No events | 102.62 | 111.42 | 152.42 | N/A |
| Dropevents | 106.63 | 178.82 | 275.13 | Outgoing packet dropped (policy_denied) to 8.8.8.8 ICMPv4. |
| Dropevents + extended (Policy Deny) | 108.9 | 166.92 | 253.15 | Outgoing packet dropped (policy_deny) to 8.8.4.4 ICMPv4. Denied by policies: alex-custom-cnp. |
| Dropevents + extended (Policy Denied) | 136.66 | 253.74 | 430.9 | Outgoing packet dropped (policy_denied) to 8.8.8.8 ICMPv4. Applied policies: alex-custom-cnp. Applied clusterwide policies: ... |

This shows a slight impact from this feature. However, the packet drop rates used here exceed those typically observed on production machines under normal conditions.

With rate limiting turned on, performance is stable across packet drop rates.

## Release note
```release-note
Hubble v1.Events drop message now supports displaying applied L4 network policies
```
