### PR TITLE
bpf: nat: rework egress path for ICMP error messages

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1878,6 +1878,7 @@ __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, fraginfo_t fr
 					 l4_off, target, trace, ext_err);
 	if (ret < 0)
 		return ret;
+	/* GH-40991: Verifier workaround for RHEL8.6 kernel: */
 	if (!state)
 		return DROP_NAT_NO_MAPPING;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2536,6 +2536,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		.reason = (enum trace_reason)CT_NEW,
 		.monitor = TRACE_PAYLOAD_LEN,
 	};
+	struct ipv4_nat_entry *state = NULL;
 	int ret, l4_off, oif = 0;
 	void *data, *data_end;
 	struct iphdr *ip4;
@@ -2589,7 +2590,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	if (unlikely(ret != CTX_ACT_OK))
 		goto drop_err;
 
-	ret = __snat_v4_nat(ctx, &tuple, fraginfo, l4_off, true,
+	ret = __snat_v4_nat(ctx, &tuple, state, fraginfo, l4_off, true,
 			    &target, TCP_SPORT_OFF, &trace, &ext_err);
 	if (IS_ERR(ret))
 		goto drop_err;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1192,6 +1192,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 		.reason = (enum trace_reason)CT_NEW,
 		.monitor = TRACE_PAYLOAD_LEN,
 	};
+	struct ipv6_nat_entry *state = NULL;
 	int ret, l4_off, oif = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -1235,7 +1236,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	if (unlikely(ret != CTX_ACT_OK))
 		goto drop_err;
 
-	ret = __snat_v6_nat(ctx, &tuple, fraginfo, l4_off, true,
+	ret = __snat_v6_nat(ctx, &tuple, state, fraginfo, l4_off, true,
 			    &target, TCP_SPORT_OFF, &trace, &ext_err);
 	if (IS_ERR(ret))
 		goto drop_err;


### PR DESCRIPTION
Some of the NAT code paths for ICMP error messages still follow an old model, where the handler contains code to apply the NAT operation for both the inner **and** outer headers.

Switch these to the new model, where the ICMP-specific code only handles the NAT operation for the inner headers. The NAT of the outer headers is deferred to the caller.

The resulting reduction in complexity unlocks https://github.com/cilium/cilium/pull/38961.
