### PR TITLE
lbipam: Fix status conditions on LBIPAM pools not updating correctly

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1679,11 +1679,12 @@ func (ipam *LBIPAM) updatePoolCounts(pool *cilium_api_v2.CiliumLoadBalancerIPPoo
 		totalCounts.Used += used
 	}
 
-	if ipam.setPoolCondition(pool, ciliumPoolIPsTotalCondition, meta_v1.ConditionUnknown, "noreason", totalCounts.Total.String()) ||
-		ipam.setPoolCondition(pool, ciliumPoolIPsAvailableCondition, meta_v1.ConditionUnknown, "noreason", totalCounts.Available.String()) ||
-		ipam.setPoolCondition(pool, ciliumPoolIPsUsedCondition, meta_v1.ConditionUnknown, "noreason", strconv.FormatUint(totalCounts.Used, 10)) {
-		modifiedPoolStatus = true
-	}
+	totalChanged := ipam.setPoolCondition(pool, ciliumPoolIPsTotalCondition, meta_v1.ConditionUnknown, "noreason", totalCounts.Total.String())
+	availableChanged := ipam.setPoolCondition(pool, ciliumPoolIPsAvailableCondition, meta_v1.ConditionUnknown, "noreason", totalCounts.Available.String())
+	usedChanged := ipam.setPoolCondition(pool, ciliumPoolIPsUsedCondition, meta_v1.ConditionUnknown, "noreason", strconv.FormatUint(totalCounts.Used, 10))
+	modifiedPoolStatus = totalChanged ||
+		availableChanged ||
+		usedChanged
 
 	available, _ := new(big.Float).SetInt(totalCounts.Available).Float64()
 	ipam.metrics.AvailableIPs.WithLabelValues(pool.Name).Set(available)


### PR DESCRIPTION
When we update the counts of a pool we modify multiple fields in the status of the pool. As optimization we track to see if any modification actually happened or if the desired value was already set.

We did this by doing a logical OR of function calls. However, this means that if the first condition was changed, then we would never execute the modification of the other conditions.

By re-writing the logic so we first execute all modifications and then do the logical OR on the results we ensure that all conditions are updated correctly.

Fixes: #41536

```release-note
Fix LB-IPAM pool status not updating properly
```
