### PR TITLE
docs/dsr: Remove IPIP example configuration

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -801,20 +801,6 @@ annotation mode with SNAT default would look as follows:
 
     When using annotation-based DSR mode (``bpf.lbModeAnnotation=true``), as in the previous example, you must explicitly specify the ``loadBalancer.dsrDispatch`` parameter to define how DSR packets are dispatched to backends. Valid options are ``opt``, ``ipip``, and ``geneve``.
 
-    For example, for environments where Geneve encapsulation is not suitable, you can use IPIP instead:
-
-    .. parsed-literal::
-
-        helm install cilium |CHART_RELEASE| \\
-            --namespace kube-system \\
-            --set routingMode=native \\
-            --set kubeProxyReplacement=true \\
-            --set loadBalancer.mode=snat \\
-            --set loadBalancer.dsrDispatch=ipip \\
-            --set bpf.lbModeAnnotation=true \\
-            --set k8sServiceHost=${API_SERVER_IP} \\
-            --set k8sServicePort=${API_SERVER_PORT}
-
 Annotation-based Load Balancing Algorithm Selection
 ***************************************************
 


### PR DESCRIPTION
This IPIP example for the DSR dispatch isn't enough to have IPIP work. It can create confusion as readers assume it's sufficient to make it work. So let's remove until we have a proper full example of how IPIP DSR dispatch might work.