### PR TITLE
redirectpolicy: Forget watch set on deletion

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -152,6 +152,7 @@ func (c *lrpController) run(ctx context.Context, health cell.Health) error {
 				cleanup(wtxn)
 			}
 			delete(cleanupFuncs, lrpID)
+			delete(watchSets, lrpID)
 			if c.p.LRPMetrics != nil {
 				c.p.LRPMetrics.DelLRPConfig(lrpID)
 			}
@@ -274,7 +275,7 @@ func (c *lrpController) processRedirectPolicy(wtxn writer.WriteTxn, lrpID lb.Ser
 			matchingPods = append(matchingPods, getPodInfo(pod))
 		}
 	}
-	c.updateRedirectBackends(wtxn, ws, lrp, matchingPods)
+	c.updateRedirectBackends(wtxn, lrp, matchingPods)
 	c.updateSkipLB(wtxn, ws, lrp, matchingPods)
 	c.updateRedirects(wtxn, ws, cleanup, lrp, matchingPods)
 
@@ -356,7 +357,7 @@ func (c *lrpController) updateRedirects(wtxn writer.WriteTxn, ws *statedb.WatchS
 	return cleanup
 }
 
-func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, ws *statedb.WatchSet, lrp *LocalRedirectPolicy, pods []podInfo) {
+func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalRedirectPolicy, pods []podInfo) {
 	portNameMatches := func(portName string) bool {
 		for bePortName := range lrp.BackendPortsByPortName {
 			if string(bePortName) == strings.ToLower(portName) {
@@ -576,6 +577,7 @@ func (c *lrpController) frontendsToSkip(txn statedb.ReadTxn, ws *statedb.WatchSe
 	feAddrs := []lb.L3n4Addr{}
 	fes, watch := c.p.Writer.Frontends().ListWatch(txn, lb.FrontendByServiceName(targetName))
 	ws.Add(watch)
+
 	for fe := range fes {
 		if lrp.LRPType == lrpConfigTypeAddr || fe.RedirectTo != nil {
 			feAddrs = append(feAddrs, fe.Address)

--- a/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
@@ -45,6 +45,18 @@ db/cmp localredirectpolicies lrp-fixed.table
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.actual maps-v4.expected
 
+# Policy can be deleted and added back and we'll get to same state
+k8s/delete lrp-addr.yaml
+
+# Policy and service table is now empty
+* db/empty localredirectpolicies services
+
+# Adding it back gets us to the same state as before
+k8s/add lrp-addr.yaml
+db/cmp localredirectpolicies lrp-fixed.table
+db/cmp services services-ipv4.table
+db/cmp frontends frontends-ipv4.table
+
 # Remove the remaining policy
 k8s/delete lrp-addr.yaml
 
@@ -68,10 +80,18 @@ Name                              Source
 test/lrp-addr-ipv6:local-redirect k8s
 test/lrp-addr:local-redirect      k8s   
 
+-- services-ipv4.table --
+Name                              Source
+test/lrp-addr:local-redirect      k8s   
+
 -- frontends.table --
 Address                    Type          ServiceName                       Backends            RedirectTo  Status
 169.254.169.254:8080/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:80/TCP               Done
 [2001::1]:8080/TCP         LocalRedirect test/lrp-addr-ipv6:local-redirect [2002::2]:80/TCP                Done
+
+-- frontends-ipv4.table --
+Address                    Type          ServiceName                       Backends            RedirectTo  Status
+169.254.169.253:8080/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:80/TCP               Done
 
 -- backends.table --
 Address             Instances

--- a/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
@@ -53,6 +53,19 @@ sed 'name: "foo"' 'name: "tcp"' lrp-svc.yaml
 k8s/update lrp-svc.yaml
 db/cmp frontends frontends.table
 
+# Policy can be deleted and added back and we'll get to same state
+k8s/delete lrp-svc.yaml
+
+# Policy table is now empty
+* db/empty localredirectpolicies
+db/cmp services services-before.table
+
+# Adding it back gets us to the same state as before
+k8s/add lrp-svc.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+
 # Removing policy reverts (but we'll get new backend id)
 k8s/delete lrp-svc.yaml
 db/cmp services services-before.table
@@ -160,8 +173,8 @@ SVC: ID=7 ADDR=[1001::1]:7070/UDP SLOT=1 BEID=11 COUNT=0 QCOUNT=0 FLAGS=LocalRed
 SVC: ID=8 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
 SVC: ID=8 ADDR=[1001::1]:8080/TCP SLOT=1 BEID=12 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
 -- maps-after.expected --
-BE: ID=16 ADDR=10.244.1.1:7070/UDP STATE=active
-BE: ID=17 ADDR=10.244.1.1:8080/TCP STATE=active
+BE: ID=22 ADDR=10.244.1.1:7070/UDP STATE=active
+BE: ID=23 ADDR=10.244.1.1:8080/TCP STATE=active
 REV: ID=5 ADDR=169.254.169.254:7070
 REV: ID=6 ADDR=169.254.169.254:8080
 REV: ID=7 ADDR=[1001::1]:7070
@@ -169,9 +182,9 @@ REV: ID=8 ADDR=[1001::1]:8080
 SVC: ID=0 ADDR=169.254.169.254:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=5 ADDR=169.254.169.254:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=5 ADDR=169.254.169.254:7070/UDP SLOT=1 BEID=16 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=169.254.169.254:7070/UDP SLOT=1 BEID=22 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=6 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=6 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=17 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=23 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=7 ADDR=[1001::1]:7070/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=8 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 -- lrp-svc.yaml --


### PR DESCRIPTION
When an orphan LRP was deleted we didn't forget the WatchSet for it. This was then reused when an LRP with the same name was added back.

This didn't cause actual problems since the WatchSet contained a watch channel for the LRP itself which was removed and thus the channel was closed and we processed the new LRP. So this commit just makes sure we don't hold onto the old watch channels.

Extend the tests to remove and add a policy to test this edge case even though it wasn't broken.