### PR TITLE
policy: clean up unused code

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -182,12 +182,6 @@ func (pair *IPIdentityPair) PrefixString() string {
 	return ipstr + "/" + strconv.Itoa(ones)
 }
 
-// RequiresGlobalIdentity returns true if the label combination requires a
-// global identity
-func RequiresGlobalIdentity(lbls labels.Labels) bool {
-	return ScopeForLabels(lbls) == IdentityScopeGlobal
-}
-
 // ScopeForLabels returns the identity scope to be used for the label set.
 // If all labels are either CIDR or reserved, then returns the CIDR scope.
 // Note: This assumes the caller has already called LookupReservedIdentityByLabels;

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -61,16 +61,6 @@ func TestIsReservedIdentity(t *testing.T) {
 	require.False(t, NumericIdentity(123456).IsReservedIdentity())
 }
 
-func TestRequiresGlobalIdentity(t *testing.T) {
-	prefix := netip.MustParsePrefix("0.0.0.0/0")
-	require.False(t, RequiresGlobalIdentity(labels.GetCIDRLabels(prefix)))
-
-	prefix = netip.MustParsePrefix("192.168.23.0/24")
-	require.False(t, RequiresGlobalIdentity(labels.GetCIDRLabels(prefix)))
-
-	require.True(t, RequiresGlobalIdentity(labels.NewLabelsFromModel([]string{"k8s:foo=bar"})))
-}
-
 func TestScopeForLabels(t *testing.T) {
 	tests := []struct {
 		lbls  labels.Labels

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -426,23 +426,6 @@ func AddUserDefinedNumericIdentity(identity NumericIdentity, label string) error
 	return nil
 }
 
-// DelReservedNumericIdentity deletes the given Numeric Identity from the list
-// of reservedIdentities. If the numeric identity is not between
-// UserReservedNumericIdentity and MinimalNumericIdentity it will return
-// ErrNotUserIdentity.
-// Is not safe for concurrent use.
-func DelReservedNumericIdentity(identity NumericIdentity) error {
-	if !IsUserReservedIdentity(identity) {
-		return ErrNotUserIdentity
-	}
-	label, ok := reservedIdentityNames[identity]
-	if ok {
-		delete(reservedIdentities, label)
-		delete(reservedIdentityNames, identity)
-	}
-	return nil
-}
-
 // NumericIdentity is the numeric representation of a security identity.
 //
 // Bits:

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -868,15 +868,3 @@ func parseSelectLabel(str string, delim byte) Label {
 
 	return lbl
 }
-
-// generateLabelString generates the string representation of a label with
-// the provided source, key, and value in the format "source:key=value".
-func generateLabelString(source, key, value string) string {
-	return source + ":" + key + "=" + value
-}
-
-// GenerateK8sLabelString generates the string representation of a label with
-// the provided source, key, and value in the format "LabelSourceK8s:key=value".
-func GenerateK8sLabelString(k, v string) string {
-	return generateLabelString(LabelSourceK8s, k, v)
-}

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -542,14 +542,6 @@ func BenchmarkLabel_String(b *testing.B) {
 	}
 }
 
-func BenchmarkGenerateLabelString(b *testing.B) {
-	b.ReportAllocs()
-
-	for b.Loop() {
-		generateLabelString("foo", "key", "value")
-	}
-}
-
 func TestLabel_String(t *testing.T) {
 	// with value
 	l := NewLabel("io.kubernetes.pod.namespace", "kube-system", LabelSourceK8s)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -224,14 +224,6 @@ func getAuthType(auth *api.Authentication) (bool, AuthType) {
 	}
 }
 
-// getAuthType returns the AuthType of the L4Filter.
-func (a *PerSelectorPolicy) getAuthType() (bool, AuthType) {
-	if a == nil {
-		return false, types.AuthTypeDisabled
-	}
-	return getAuthType(a.Authentication)
-}
-
 // GetAuthRequirement returns the AuthRequirement of the L4Filter.
 func (a *PerSelectorPolicy) getAuthRequirement() AuthRequirement {
 	if a == nil {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -601,15 +601,6 @@ type ChangeState struct {
 	old     mapStateMap // Old values of all modified or deleted keys, if not nil
 }
 
-// NewRevertState returns an empty ChangeState suitable for reverting MapState changes.
-// The private 'old' field is initialized so that old state can be restored if need be.
-func NewRevertState() ChangeState {
-	return ChangeState{
-		Adds: make(Keys),
-		old:  make(mapStateMap),
-	}
-}
-
 func (c *ChangeState) Empty() bool {
 	return len(c.Adds)+len(c.Deletes)+len(c.old) == 0
 }

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -163,7 +163,7 @@ func TestCreateL4Filter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
-			explicit, authType := sp.getAuthType()
+			explicit, authType := getAuthType(sp.Authentication)
 			require.False(t, explicit)
 			require.Equal(t, AuthTypeDisabled, authType)
 			require.Equal(t, redirectTypeEnvoy, sp.redirectType())
@@ -173,7 +173,7 @@ func TestCreateL4Filter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
-			explicit, authType := sp.getAuthType()
+			explicit, authType := getAuthType(sp.Authentication)
 			require.False(t, explicit)
 			require.Equal(t, AuthTypeDisabled, authType)
 			require.Equal(t, redirectTypeEnvoy, sp.redirectType())
@@ -207,7 +207,7 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
-			explicit, authType := sp.getAuthType()
+			explicit, authType := getAuthType(sp.Authentication)
 			require.True(t, explicit)
 			require.Equal(t, AuthTypeDisabled, authType)
 			require.Equal(t, redirectTypeEnvoy, sp.redirectType())
@@ -217,7 +217,7 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
-			explicit, authType := sp.getAuthType()
+			explicit, authType := getAuthType(sp.Authentication)
 			require.True(t, explicit)
 			require.Equal(t, AuthTypeDisabled, authType)
 			require.Equal(t, redirectTypeEnvoy, sp.redirectType())

--- a/pkg/policy/origin.go
+++ b/pkg/policy/origin.go
@@ -130,16 +130,6 @@ func (ro ruleOrigin) Merge(other ruleOrigin) ruleOrigin {
 
 var NilRuleOrigin = newRuleOrigin(RuleMeta{labels: "[]"})
 
-type testOrigin map[CachedSelector]labels.LabelArrayList
-
-func OriginForTest(m testOrigin) map[CachedSelector]ruleOrigin {
-	res := make(map[CachedSelector]ruleOrigin, len(m))
-	for cs, lbls := range m {
-		res[cs] = makeRuleOrigin(lbls, nil)
-	}
-	return res
-}
-
 // stringLabels is an interned labels.LabelArray.String()
 type stringLabels unique.Handle[labels.LabelArrayListString]
 

--- a/pkg/policy/origin_test.go
+++ b/pkg/policy/origin_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 )
 
+func OriginForTest(m map[CachedSelector]labels.LabelArrayList) map[CachedSelector]ruleOrigin {
+	res := make(map[CachedSelector]ruleOrigin, len(m))
+	for cs, lbls := range m {
+		res[cs] = makeRuleOrigin(lbls, nil)
+	}
+	return res
+}
+
 func TestRuleOrigin(t *testing.T) {
 	lbls1 := labels.NewLabelsFromSortedList("k8s:a=1;k8s:b=1").LabelArray()
 	lbls2 := labels.NewLabelsFromSortedList("k8s:a=2;k8s:b=2").LabelArray()

--- a/pkg/policy/proxyid.go
+++ b/pkg/policy/proxyid.go
@@ -7,9 +7,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/cilium/cilium/pkg/policy/trafficdirection"
-	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // ProxyStatsKey returns a key for endpoint's proxy stats, which may aggregate stats from multiple
@@ -57,11 +54,6 @@ func ProxyID(endpointID uint16, ingress bool, protocol string, port uint16, list
 	str.WriteString(listener)
 
 	return str.String()
-}
-
-// ProxyIDFromKey returns a unique string to identify a proxy mapping.
-func ProxyIDFromKey(endpointID uint16, key Key, listener string) string {
-	return ProxyID(endpointID, key.TrafficDirection() == trafficdirection.Ingress, u8proto.U8proto(key.Nexthdr).String(), key.DestPort, listener)
 }
 
 // ParseProxyID parses a proxy ID returned by ProxyID and returns its components.


### PR DESCRIPTION
Remove some unused code from the policy/identity subsystems. See individual commits for reference to the commits removing the last usage.