### PR TITLE
bpf: declare IP header pointer variables as __maybe_unused

### DIFF
--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -113,16 +113,12 @@ set_ipsec_encrypt(struct __ctx_buff *ctx, struct remote_endpoint_info *info,
 static __always_inline int
 do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 {
+	struct ipv6hdr __maybe_unused *ip6;
+	struct iphdr __maybe_unused *ip4;
 	void *data, *data_end;
 	__u8 protocol = 0;
 	__u16 node_id = 0;
 	bool decrypted;
-#ifdef ENABLE_IPV6
-	struct ipv6hdr *ip6;
-#endif
-#ifdef ENABLE_IPV4
-	struct iphdr *ip4;
-#endif
 
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
 

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -195,10 +195,8 @@ static __always_inline bool
 strict_allow(struct __ctx_buff *ctx, __be16 proto) {
 	struct remote_endpoint_info __maybe_unused *dest_info, __maybe_unused *src_info;
 	bool __maybe_unused in_strict_cidr = false;
+	struct iphdr __maybe_unused *ip4;
 	void *data, *data_end;
-#ifdef ENABLE_IPV4
-	struct iphdr *ip4;
-#endif
 
 	switch (proto) {
 #ifdef ENABLE_IPV4


### PR DESCRIPTION
Use `__maybe_unused` to declare IP header pointer variables instead of relying on `ENABLE_IPV{4,6}` and conditionally declaring them. This helps readability and is in line with other areas of the code.
