### PR TITLE
redirectpolicy: Always OpenOrCreate SkipLB map to avoid loader race

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/skiplb.go
+++ b/pkg/loadbalancer/redirectpolicy/skiplb.go
@@ -385,9 +385,6 @@ func newSkipLBMap(p skiplbmapParams) (out bpf.MapOut[lbmaps.SkipLBMap], err erro
 
 	p.Lifecycle.Append(cell.Hook{
 		OnStart: func(cell.HookContext) error {
-			if !p.NetNSCookieSupport() {
-				return nil
-			}
 			return m.OpenOrCreate()
 		},
 		OnStop: func(cell.HookContext) error {

--- a/pkg/testutils/goleak.go
+++ b/pkg/testutils/goleak.go
@@ -22,6 +22,7 @@ func defaultGoleakOptions() []goleak.Option {
 		// Unfortunately we don't have a way for waiting for the workqueue's background goroutine
 		// to exit (used by pkg/k8s/resource), so we'll just need to ignore it.
 		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Typed[...]).updateUnfinishedWorkLoop"),
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType[...]).waitingLoop"),
 	}
 }
 


### PR DESCRIPTION
The BPF programs will contain the SkipLB map definition regardless of whether this is used or not. This can cause flakes in CI if the loader races loading endpoint programs in parallel and each of those are trying to pin the skiplb maps. To avoid this always open and pin the skiplb maps.

The error in logs was:

```
level=error msg="Error while reloading endpoint BPF program" ...
  error="loading eBPF collection into the kernel: map cilium_skip_lb6: pin map to .../cilium_skip_lb6: file exists"
```

The second commit adds an ignore for yet another workqueue goroutine that we can't wait for and which we hit in CI as part of this PR.