### PR TITLE
operator: rework and extract legacy cilium node synchronization logic.

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -133,7 +133,7 @@ cilium-operator-alibabacloud [flags]
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -95,6 +95,7 @@ cilium-operator-alibabacloud hive [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -100,6 +100,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -141,7 +141,7 @@ cilium-operator-aws [flags]
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -95,6 +95,7 @@ cilium-operator-aws hive [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -100,6 +100,7 @@ cilium-operator-aws hive dot-graph [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -136,7 +136,7 @@ cilium-operator-azure [flags]
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -95,6 +95,7 @@ cilium-operator-azure hive [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -100,6 +100,7 @@ cilium-operator-azure hive dot-graph [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -132,7 +132,7 @@ cilium-operator-generic [flags]
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -95,6 +95,7 @@ cilium-operator-generic hive [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -100,6 +100,7 @@ cilium-operator-generic hive dot-graph [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -146,7 +146,7 @@ cilium-operator [flags]
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                            Subnets IDs (separated by commas)
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -95,6 +95,7 @@ cilium-operator hive [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -100,6 +100,7 @@ cilium-operator hive dot-graph [flags]
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/operator/cmd/allocator_test.go
+++ b/operator/cmd/allocator_test.go
@@ -93,8 +93,8 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 	}, nil, &ciliumNodeUpdateImplementation{clientset: fakeSet}, nil)
 
 	// start synchronization.
-	cns := newCiliumNodeSynchronizer(logger, fakeSet, nil, podCidrManager, false, nil)
-	if err := cns.Start(ctx, &wg, nil); err != nil {
+	cns := newCiliumNodeSynchronizer(logger, fakeSet, podCidrManager, nil)
+	if err := cns.Start(ctx, &wg); err != nil {
 		t.Fatal(err)
 	}
 

--- a/operator/cmd/allocator_test.go
+++ b/operator/cmd/allocator_test.go
@@ -12,9 +12,12 @@ import (
 	"time"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	"github.com/cilium/cilium/pkg/ipam/allocator/clusterpool/cidralloc"
 	"github.com/cilium/cilium/pkg/ipam/allocator/podcidr"
 	"github.com/cilium/cilium/pkg/ipam/cidrset"
@@ -22,7 +25,6 @@ import (
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_fake "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
-	"github.com/cilium/cilium/pkg/testutils"
 )
 
 // TestPodCIDRAllocatorOverlap tests that, on startup all nodes with assigned podCIDRs are processed so that nodes
@@ -38,7 +40,6 @@ func TestPodCIDRAllocatorOverlap(t *testing.T) {
 }
 
 func podCIDRAllocatorOverlapTestRun(t *testing.T) {
-	logger := hivetest.Logger(t)
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
@@ -48,14 +49,10 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 	// Create a new CIDR allocator
 
 	_, cidr, err := net.ParseCIDR("10.129.0.0/16")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	set, err := cidrset.NewCIDRSet(cidr, 24)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	// Create a mock APIServer client where we have 2 existing nodes, one with a PodCIDR and one without.
 	// When List'ed from the client, first node-a is returned then node-b
@@ -87,56 +84,45 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 		CiliumFakeClientset: fakeClient,
 	}
 
+	ciliumNodes, err := operatorK8s.CiliumNodeResource(hivetest.Lifecycle(t), fakeSet, nil)
+	require.NoError(t, err)
+
 	// Create a new pod manager with only our IPv4 allocator and fake client set.
 	podCidrManager := podcidr.NewNodesPodCIDRManager(hivetest.Logger(t), []cidralloc.CIDRAllocator{
 		set,
 	}, nil, &ciliumNodeUpdateImplementation{clientset: fakeSet}, nil)
 
 	// start synchronization.
-	cns := newCiliumNodeSynchronizer(logger, fakeSet, podCidrManager, nil)
-	if err := cns.Start(ctx, &wg); err != nil {
-		t.Fatal(err)
-	}
+	wg.Go(func() {
+		watchCiliumNodes(ctx, ciliumNodes, podCidrManager, true)
+	})
 
-	// Wait for the "node manager synced" signal, just like we would normally.
-	<-cns.ciliumNodeManagerQueueSynced
-
-	// Trigger the Resync after the cache sync signal
-	podCidrManager.Resync(ctx, time.Time{})
-
-	err = testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		// Get node A from the mock APIServer
 		nodeAInt, err := fakeClient.Tracker().Get(ciliumnodesResource, "", "node-a")
-		if err != nil {
-			return false
+		if !assert.NoError(c, err) {
+			return
 		}
 		nodeA := nodeAInt.(*cilium_api_v2.CiliumNode)
 
 		// Get node B from the mock APIServer
 		nodeBInt, err := fakeClient.Tracker().Get(ciliumnodesResource, "", "node-b")
-		if err != nil {
-			return false
+		if !assert.NoError(c, err) {
+			return
 		}
 		nodeB := nodeBInt.(*cilium_api_v2.CiliumNode)
 
-		if len(nodeA.Spec.IPAM.PodCIDRs) != 1 {
-			return false
+		if !assert.Len(c, nodeA.Spec.IPAM.PodCIDRs, 1) {
+			return
 		}
 
-		if len(nodeB.Spec.IPAM.PodCIDRs) != 1 {
-			return false
+		if !assert.Len(c, nodeB.Spec.IPAM.PodCIDRs, 1) {
+			return
 		}
 
-		// The PodCIDRs should be distinct.
-		if nodeA.Spec.IPAM.PodCIDRs[0] == nodeB.Spec.IPAM.PodCIDRs[0] {
-			t.Fatal("Node A and Node B are assigned overlapping PodCIDRs")
-		}
-
-		return true
-	}, 2*time.Minute)
-	if err != nil {
-		t.Fatalf("nodes have no pod CIDR: %s", err)
-	}
+		assert.NotEqual(c, nodeA.Spec.IPAM.PodCIDRs, nodeB.Spec.IPAM.PodCIDRs,
+			"Node A and Node B should not be assigned overlapping PodCIDRs")
+	}, 2*time.Minute, 10*time.Millisecond)
 }
 
 var ciliumnodesResource = schema.GroupVersionResource{Group: "cilium.io", Version: "v2", Resource: "ciliumnodes"}

--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -5,275 +5,49 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
-	"reflect"
 	"strings"
-	"sync"
+	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
-	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/informer"
-	"github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 )
 
-// ciliumNodeManagerQueueSyncedKey indicates that the caches
-// are synced. The underscore prefix ensures that it can never
-// clash with a real key, as Kubernetes does not allow object
-// names to start with an underscore.
-const ciliumNodeManagerQueueSyncedKey = "_ciliumNodeManagerQueueSynced"
-
-type ciliumNodeSynchronizer struct {
-	logger      *slog.Logger
-	clientset   k8sClient.Clientset
-	nodeManager allocator.NodeEventHandler
-
-	// ciliumNodeStore contains all CiliumNodes present in k8s.
-	ciliumNodeStore cache.Store
-
-	k8sCiliumNodesCacheSynced    chan struct{}
-	ciliumNodeManagerQueueSynced chan struct{}
-	workqueueMetricsProvider     workqueue.MetricsProvider
-}
-
-func newCiliumNodeSynchronizer(logger *slog.Logger, clientset k8sClient.Clientset, nodeManager allocator.NodeEventHandler, workqueueMetricsProvider workqueue.MetricsProvider) *ciliumNodeSynchronizer {
-	return &ciliumNodeSynchronizer{
-		logger:      logger,
-		clientset:   clientset,
-		nodeManager: nodeManager,
-
-		k8sCiliumNodesCacheSynced:    make(chan struct{}),
-		ciliumNodeManagerQueueSynced: make(chan struct{}),
-		workqueueMetricsProvider:     workqueueMetricsProvider,
-	}
-}
-
-func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup) error {
-	var (
-		nodeManagerSyncHandler func(key string) error
-		resourceEventHandler   = cache.ResourceEventHandlerFuncs{}
-	)
-
-	var ciliumNodeManagerQueueConfig = workqueue.TypedRateLimitingQueueConfig[string]{
-		Name:            "node_manager",
-		MetricsProvider: s.workqueueMetricsProvider,
-	}
-
-	if operatorOption.Config.EnableMetrics {
-		ciliumNodeManagerQueueConfig.MetricsProvider = s.workqueueMetricsProvider
-	}
-
-	var ciliumNodeManagerQueue = workqueue.NewTypedRateLimitingQueueWithConfig[string](workqueue.DefaultTypedControllerRateLimiter[string](), ciliumNodeManagerQueueConfig)
-
-	s.logger.InfoContext(ctx, "Starting to synchronize CiliumNode custom resources")
-
-	if s.nodeManager != nil {
-		nodeManagerSyncHandler = s.syncHandlerConstructor(
-			func(node *cilium_v2.CiliumNode) error {
-				s.nodeManager.Delete(node)
-				return nil
-			},
-			func(node *cilium_v2.CiliumNode) error {
-				value, ok := node.Annotations[annotation.IPAMIgnore]
-				if ok && strings.ToLower(value) == "true" {
-					return nil
-				}
-
-				// node is deep copied before it is stored in pkg/aws/eni
-				s.nodeManager.Upsert(node)
-				return nil
-			})
-	}
-
-	// If both nodeManager and KVStore are nil, then we don't need to handle
-	// any watcher events, but we will need to keep all CiliumNodes in
-	// memory because 'ciliumNodeStore' is used across the operator
-	// to get the latest state of a CiliumNode.
-	if s.nodeManager != nil {
-		resourceEventHandler = cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj any) {
-				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				if err != nil {
-					s.logger.WarnContext(ctx, "Unable to process CiliumNode Add event", logfields.Error, err)
-					return
-				}
-				if s.nodeManager != nil {
-					ciliumNodeManagerQueue.Add(key)
-				}
-			},
-			UpdateFunc: func(oldObj, newObj any) {
-				if oldNode := informer.CastInformerEvent[cilium_v2.CiliumNode](s.logger, oldObj); oldNode != nil {
-					if newNode := informer.CastInformerEvent[cilium_v2.CiliumNode](s.logger, newObj); newNode != nil {
-						if oldNode.DeepEqual(newNode) {
-							return
-						}
-						key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(newObj)
-						if err != nil {
-							s.logger.WarnContext(ctx, "Unable to process CiliumNode Update event", logfields.Error, err)
-							return
-						}
-						if s.nodeManager != nil {
-							ciliumNodeManagerQueue.Add(key)
-						}
-					} else {
-						s.logger.WarnContext(ctx,
-							"Unknown CiliumNode object type received",
-							logfields.Type, reflect.TypeOf(newNode),
-							logfields.Node, newNode,
-						)
-					}
-				} else {
-					s.logger.WarnContext(ctx,
-						"Unknown CiliumNode object type received",
-						logfields.Type, reflect.TypeOf(oldNode),
-						logfields.Node, oldNode,
-					)
-				}
-			},
-			DeleteFunc: func(obj any) {
-				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				if err != nil {
-					s.logger.WarnContext(ctx, "Unable to process CiliumNode Delete event", logfields.Error, err)
-					return
-				}
-				if s.nodeManager != nil {
-					ciliumNodeManagerQueue.Add(key)
-				}
-			},
-		}
-	}
-
-	// TODO: The operator is currently storing a full copy of the
-	// CiliumNode resource, as the resource grows, we may want to consider
-	// introducing a slim version of it.
-	var ciliumNodeInformer cache.Controller
-	s.ciliumNodeStore, ciliumNodeInformer = informer.NewInformer(
-		utils.ListerWatcherFromTyped[*cilium_v2.CiliumNodeList](s.clientset.CiliumV2().CiliumNodes()),
-		&cilium_v2.CiliumNode{},
-		0,
-		resourceEventHandler,
-		nil,
-	)
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		cache.WaitForCacheSync(ctx.Done(), ciliumNodeInformer.HasSynced)
-		close(s.k8sCiliumNodesCacheSynced)
-		ciliumNodeManagerQueue.Add(ciliumNodeManagerQueueSyncedKey)
-		s.logger.InfoContext(ctx, "CiliumNodes caches synced with Kubernetes")
-		// Only handle events if nodeManagerSyncHandler is not nil. If it is nil
-		// then there isn't any event handler set for CiliumNodes events.
-		if nodeManagerSyncHandler != nil {
-			go func() {
-				// infinite loop. run in a goroutine to unblock code execution
-				for s.processNextWorkItem(ciliumNodeManagerQueue, nodeManagerSyncHandler) {
-				}
-			}()
-		}
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		defer ciliumNodeManagerQueue.ShutDown()
-
-		ciliumNodeInformer.Run(ctx.Done())
-	}()
-
-	return nil
-}
-
-func (s *ciliumNodeSynchronizer) syncHandlerConstructor(notFoundHandler, foundHandler func(node *cilium_v2.CiliumNode) error) func(key string) error {
-	return func(key string) error {
-		_, name, err := cache.SplitMetaNamespaceKey(key)
-		if err != nil {
-			s.logger.Error("Unable to process CiliumNode event", logfields.Error, err)
-			return err
-		}
-		obj, exists, err := s.ciliumNodeStore.GetByKey(name)
-
-		// Delete handling
-		if !exists || errors.IsNotFound(err) {
-			return notFoundHandler(&cilium_v2.CiliumNode{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Name: name,
-				},
-			})
-		}
-		if err != nil {
-			s.logger.Warn("Unable to retrieve CiliumNode from watcher store", logfields.Error, err)
-			return err
-		}
-		cn, ok := obj.(*cilium_v2.CiliumNode)
-		if !ok {
-			tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-			if !ok {
-				return fmt.Errorf("couldn't get object from tombstone %T", obj)
+func watchCiliumNodes(ctx context.Context, ciliumNodes resource.Resource[*cilium_v2.CiliumNode], handler allocator.NodeEventHandler, withResync bool) {
+	// We will use CiliumNodes as the source of truth for the podCIDRs.
+	// Once the CiliumNodes are synchronized with the operator we will
+	// be able to watch for K8s Node events which they will be used
+	// to create the remaining CiliumNodes.
+	for ev := range ciliumNodes.Events(ctx) {
+		switch ev.Kind {
+		case resource.Upsert:
+			value, ok := ev.Object.Annotations[annotation.IPAMIgnore]
+			if !ok || strings.ToLower(value) != "true" {
+				handler.Upsert(ev.Object)
 			}
-			cn, ok = tombstone.Obj.(*cilium_v2.CiliumNode)
-			if !ok {
-				return fmt.Errorf("tombstone contained object that is not a *cilium_v2.CiliumNode %T", obj)
+
+		case resource.Delete:
+			handler.Delete(ev.Object)
+
+		case resource.Sync:
+			// We don't want CiliumNodes that don't have podCIDRs to be
+			// allocated with a podCIDR already being used by another node.
+			// For this reason we will call Resync after all CiliumNodes are
+			// synced with the operator to signal the node manager, since it
+			// knows all podCIDRs that are currently set in the cluster, that
+			// it can allocate podCIDRs for the nodes that don't have a podCIDR
+			// set.
+			if withResync {
+				handler.Resync(ctx, time.Time{})
 			}
 		}
-		if cn.DeletionTimestamp != nil {
-			return notFoundHandler(cn)
-		}
-		return foundHandler(cn)
+
+		ev.Done(nil)
 	}
-}
-
-// processNextWorkItem process all events from the workqueue.
-func (s *ciliumNodeSynchronizer) processNextWorkItem(queue workqueue.TypedRateLimitingInterface[string], syncHandler func(key string) error) bool {
-	key, quit := queue.Get()
-	if quit {
-		return false
-	}
-	defer queue.Done(key)
-
-	if key == ciliumNodeManagerQueueSyncedKey {
-		close(s.ciliumNodeManagerQueueSynced)
-		return true
-	}
-
-	err := syncHandler(key)
-	if err == nil {
-		// If err is nil we can forget it from the queue, if it is not nil
-		// the queue handler will retry to process this key until it succeeds.
-		if queue.NumRequeues(key) > 0 {
-			s.logger.Info("CiliumNode successfully reconciled after retries", logfields.NodeName, key)
-		}
-		queue.Forget(key)
-		return true
-	}
-
-	const silentRetries = 5
-	if queue.NumRequeues(key) < silentRetries {
-		s.logger.Info("Failed reconciling CiliumNode, will retry",
-			logfields.Error, err,
-			logfields.NodeName, key,
-		)
-	} else {
-		s.logger.Warn(
-			"Failed reconciling CiliumNode, will retry",
-			logfields.Error, err,
-			logfields.NodeName, key,
-		)
-	}
-
-	queue.AddRateLimited(key)
-
-	return true
 }
 
 type ciliumNodeUpdateImplementation struct {

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -214,9 +214,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
 	option.BindEnv(vp, operatorOption.SyncK8sServices)
 
-	flags.Bool(operatorOption.SyncK8sNodes, true, "Synchronize Kubernetes nodes to kvstore and perform CNP GC")
-	option.BindEnv(vp, operatorOption.SyncK8sNodes)
-
 	flags.Int(operatorOption.UnmanagedPodWatcherInterval, 15, "Interval to check for unmanaged kube-dns pods (0 to disable)")
 	option.BindEnv(vp, operatorOption.UnmanagedPodWatcherInterval)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -682,7 +682,7 @@ func (legacy *legacyOnLeader) onStart(ctx cell.HookContext) error {
 		}
 
 		if operatorOption.Config.NodesGCInterval != 0 {
-			operatorWatchers.RunCiliumNodeGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer.ciliumNodeStore,
+			operatorWatchers.RunCiliumNodeGC(legacy.ctx, &legacy.wg, legacy.clientset, legacy.resources.CiliumNodes,
 				operatorOption.Config.NodesGCInterval, watcherLogger, legacy.workqueueMetricsProvider)
 		}
 	}

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -49,9 +49,6 @@ const (
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices = "synchronize-k8s-services"
 
-	// SyncK8sNodes synchronizes k8s nodes into the kvstore
-	SyncK8sNodes = "synchronize-k8s-nodes"
-
 	// UnmanagedPodWatcherInterval is the interval to check for unmanaged kube-dns pods (0 to disable)
 	UnmanagedPodWatcherInterval = "unmanaged-pod-watcher-interval"
 
@@ -231,9 +228,6 @@ type OperatorConfig struct {
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices bool
 
-	// SyncK8sNodes synchronizes k8s nodes into the kvstore
-	SyncK8sNodes bool
-
 	// UnmanagedPodWatcherInterval is the interval to check for unmanaged kube-dns pods (0 to disable)
 	UnmanagedPodWatcherInterval int
 
@@ -401,7 +395,6 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.EnableMetrics = vp.GetBool(EnableMetrics)
 	c.EndpointGCInterval = vp.GetDuration(EndpointGCInterval)
 	c.SyncK8sServices = vp.GetBool(SyncK8sServices)
-	c.SyncK8sNodes = vp.GetBool(SyncK8sNodes)
 	c.UnmanagedPodWatcherInterval = vp.GetInt(UnmanagedPodWatcherInterval)
 	c.NodeCIDRMaskSizeIPv4 = vp.GetInt(NodeCIDRMaskSizeIPv4)
 	c.NodeCIDRMaskSizeIPv6 = vp.GetInt(NodeCIDRMaskSizeIPv6)

--- a/operator/pkg/kvstore/nodesgc/cell.go
+++ b/operator/pkg/kvstore/nodesgc/cell.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodesgc
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+)
+
+// Cell handles the garbage collection of stale node entries from the kvstore.
+var Cell = cell.Module(
+	"kvstore-nodes-gc",
+	"GC of stale KVStore node entries",
+
+	cell.Config(Config{Enable: true}),
+	cell.ProvidePrivate(newGC),
+	cell.Invoke(func(*gc) {}),
+)
+
+type Config struct {
+	Enable bool `mapstructure:"synchronize-k8s-nodes"`
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool("synchronize-k8s-nodes", def.Enable, "Perform GC of stale node entries from the KVStore")
+}

--- a/operator/pkg/kvstore/nodesgc/gc.go
+++ b/operator/pkg/kvstore/nodesgc/gc.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodesgc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"k8s.io/client-go/util/workqueue"
+
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
+	operatorOption "github.com/cilium/cilium/operator/option"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	nodeStore "github.com/cilium/cilium/pkg/node/store"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+var (
+	// wqRateLimiter is the rate limiter used for the working queue. It can be overridden for testing purposes.
+	wqRateLimiter = workqueue.NewTypedItemExponentialFailureRateLimiter[nodeName](1*time.Second, 120*time.Second)
+
+	// kvstoreUpsertQueueDelay is the delay before checking whether a newly observed kvstore entry should be
+	// deleted or not. It is meant to give time to the corresponding CiliumNode to be created as well before
+	// attempting deletion, as an additional safety measure in addition to checking whether a Cilium agent is
+	// running on that node. It can be overridden for testing purposes.
+	kvstoreUpsertQueueDelay = 1 * time.Minute
+)
+
+type nodeName string
+
+type gc struct {
+	logger *slog.Logger
+	jg     job.Group
+	cinfo  cmtypes.ClusterInfo
+
+	client       kvstore.Client
+	ciliumNodes  resource.Resource[*cilium_api_v2.CiliumNode]
+	pods         resource.Resource[*slim_corev1.Pod]
+	podsSelector labels.Selector
+
+	queue workqueue.TypedRateLimitingInterface[nodeName]
+}
+
+func newGC(in struct {
+	cell.In
+
+	Logger   *slog.Logger
+	JobGroup job.Group
+
+	Config      Config
+	ClusterInfo cmtypes.ClusterInfo
+
+	WQMetricsProvider workqueue.MetricsProvider
+
+	Clientset     k8sClient.Clientset
+	KVStoreClient kvstore.Client
+	StoreFactory  store.Factory
+
+	CiliumNodes resource.Resource[*cilium_api_v2.CiliumNode]
+	Pods        resource.Resource[*slim_corev1.Pod]
+}) (*gc, error) {
+	if !in.Clientset.IsEnabled() || !in.KVStoreClient.IsEnabled() || !in.Config.Enable {
+		return nil, nil
+	}
+
+	selector, err := labels.Parse(operatorOption.Config.CiliumPodLabels)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse cilium pod selector: %w", err)
+	}
+
+	g := gc{
+		logger: in.Logger,
+		jg:     in.JobGroup,
+		cinfo:  in.ClusterInfo,
+
+		client:       in.KVStoreClient,
+		ciliumNodes:  in.CiliumNodes,
+		pods:         in.Pods,
+		podsSelector: selector,
+
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			wqRateLimiter,
+			workqueue.TypedRateLimitingQueueConfig[nodeName]{
+				Name:            "kvstore-nodes",
+				MetricsProvider: in.WQMetricsProvider,
+			},
+		),
+	}
+
+	in.JobGroup.Add(
+		job.OneShot("gc", g.run),
+		job.OneShot("watch-k8s", func(ctx context.Context, health cell.Health) error {
+			health.OK("Primed")
+
+			for ev := range g.ciliumNodes.Events(ctx) {
+				switch ev.Kind {
+				case resource.Delete:
+					// Enqueue deleted CiliumNodes, to GC the corresponding kvstore
+					// entry if still present.
+					g.queue.Add(nodeName(ev.Key.Name))
+				case resource.Sync:
+					health.OK("Synced")
+				}
+
+				ev.Done(nil)
+			}
+
+			// We are terminating, shutdown the queue as well
+			health.OK("Shutting down")
+			g.queue.ShutDownWithDrain()
+			return nil
+		}),
+		job.OneShot("watch-kvstore", func(ctx context.Context, health cell.Health) error {
+			health.OK("Primed")
+			in.StoreFactory.NewWatchStore(g.cinfo.Name, nodeStore.KeyCreator, &observer{g.queue},
+				store.RWSWithOnSyncCallback(func(context.Context) { health.OK("Synced") }),
+			).Watch(ctx, g.client, path.Join(nodeStore.NodeStorePrefix, g.cinfo.Name))
+			return nil
+		}),
+	)
+
+	return &g, nil
+}
+
+func (g *gc) run(ctx context.Context, health cell.Health) error {
+	health.OK("Initializing")
+
+	ciliumNodes, err := g.ciliumNodes.Store(ctx)
+	if err != nil {
+		return fmt.Errorf("retrieving CiliumNodes store: %w", err)
+	}
+
+	pods, err := g.pods.Store(ctx)
+	if err != nil {
+		return fmt.Errorf("retrieving Pods store: %w", err)
+	}
+
+	health.OK("Initialized")
+	for g.processNextWorkItem(func(nodeName nodeName) error {
+		// Check if the CiliumNode still exists, or got recreated, as we don't
+		// need to do anything in that case.
+		if _, exists, err := ciliumNodes.GetByKey(resource.Key{Name: string(nodeName)}); err != nil {
+			return fmt.Errorf("retrieving CiliumNode %q: %w", nodeName, err)
+		} else if exists {
+			return nil
+		}
+
+		// Check if a Cilium agent is still running on the given node, and
+		// in that case retry later, because it would recognize the deletion
+		// event and recreate the kvstore entry right away. Hence, defeating
+		// the whole purpose of this GC logic, and leading to the node entry
+		// being eventually deleted by the lease expiration only.
+		found, err := pods.ByIndex(operatorK8s.PodNodeNameIndex, string(nodeName))
+		if err != nil {
+			return fmt.Errorf("retrieving pods indexed by node %q: %w", nodeName, err)
+		}
+
+		for _, pod := range found {
+			if utils.IsPodRunning(pod.Status) && g.podsSelector.Matches(labels.Set(pod.Labels)) {
+				return fmt.Errorf("delaying deletion from kvstore, as Cilium agent is still running on %q", nodeName)
+			}
+		}
+
+		key := path.Join(nodeStore.NodeStorePrefix, nodeTypes.GetKeyNodeName(g.cinfo.Name, string(nodeName)))
+		if err := g.client.Delete(ctx, key); err != nil {
+			return fmt.Errorf("deleting node from kvstore: %w", err)
+		}
+
+		g.logger.Info("Successfully deleted stale node entry from kvstore", logfields.NodeName, nodeName)
+		health.OK("Stale node entry GCed")
+		return nil
+	}) {
+	}
+
+	return nil
+}
+
+func (g *gc) processNextWorkItem(handler func(nodeName nodeName) error) bool {
+	nodeName, quit := g.queue.Get()
+	if quit {
+		return false
+	}
+
+	defer g.queue.Done(nodeName)
+
+	err := handler(nodeName)
+	if err == nil {
+		if g.queue.NumRequeues(nodeName) > 0 {
+			g.logger.Info("Successfully reconciled node after retries", logfields.NodeName, nodeName)
+		}
+		g.queue.Forget(nodeName)
+		return true
+	}
+
+	const silentRetries = 5
+	log := g.logger.Info
+	if g.queue.NumRequeues(nodeName) >= silentRetries {
+		log = g.logger.Warn
+	}
+
+	log("Failed reconciling node, will retry",
+		logfields.Error, err,
+		logfields.NodeName, nodeName,
+	)
+
+	g.queue.AddRateLimited(nodeName)
+	return true
+}
+
+type observer struct {
+	queue workqueue.TypedRateLimitingInterface[nodeName]
+}
+
+func (o *observer) OnUpdate(key store.Key) {
+	// Add the entry after a delay, as an extra safety measure, in addition to
+	// checking whether there's no Cilium pod running on that node, to prevent
+	// deleting newly created entries due to race conditions.
+	o.queue.AddAfter(nodeName(key.(*nodeTypes.Node).Name), kvstoreUpsertQueueDelay)
+}
+
+func (o *observer) OnDelete(store.NamedKey) {}

--- a/operator/pkg/kvstore/nodesgc/script_test.go
+++ b/operator/pkg/kvstore/nodesgc/script_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodesgc
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"maps"
+	"testing"
+
+	uhive "github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/util/workqueue"
+
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
+	operatorOption "github.com/cilium/cilium/operator/option"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hive"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
+func TestScript(t *testing.T) {
+	defer testutils.GoleakVerifyNone(t)
+
+	version.Force(k8sTestutils.DefaultVersion)
+
+	var opts []hivetest.LogOption
+	if *debug {
+		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+		logging.SetLogLevelToDebug()
+	}
+	log := hivetest.Logger(t, opts...)
+
+	// Override the settings for testing purposes
+	wqRateLimiter = workqueue.NewTypedItemExponentialFailureRateLimiter[nodeName](10*time.Millisecond, 10*time.Millisecond)
+	kvstoreUpsertQueueDelay = 0 * time.Second
+	operatorOption.Config.CiliumPodLabels = "k8s-app=cilium"
+
+	setup := func(t testing.TB, args []string) *script.Engine {
+		h := hive.New(
+			cell.Config(cmtypes.DefaultClusterInfo),
+
+			cell.Provide(
+				func() store.Factory { return store.NewFactory(hivetest.Logger(t), store.MetricsProvider()) },
+
+				func(db *statedb.DB) (kvstore.Client, uhive.ScriptCmdsOut) {
+					client := kvstore.NewInMemoryClient(db, "__local__")
+					return client, uhive.NewScriptCmds(kvstore.Commands(client))
+				},
+			),
+
+			k8sClient.FakeClientCell(),
+			operatorK8s.ResourcesCell,
+
+			Cell,
+		)
+
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		h.RegisterFlags(flags)
+
+		// Parse the shebang arguments in the script.
+		require.NoError(t, flags.Parse(args), "flags.Parse")
+
+		t.Cleanup(func() {
+			assert.NoError(t, h.Stop(log, context.Background()))
+		})
+
+		cmds, err := h.ScriptCommands(log)
+		require.NoError(t, err, "ScriptCommands")
+		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+
+		return &script.Engine{
+			Cmds:          cmds,
+			RetryInterval: 10 * time.Millisecond,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	scripttest.Test(t,
+		ctx,
+		setup,
+		[]string{},
+		"testdata/*.txtar")
+}

--- a/operator/pkg/kvstore/nodesgc/testdata/disabled.txtar
+++ b/operator/pkg/kvstore/nodesgc/testdata/disabled.txtar
@@ -1,0 +1,42 @@
+#! --cluster-name=foo --synchronize-k8s-nodes=false
+
+# Initialize the kvstore state with a bunch of nodes.
+kvstore/update cilium/state/nodes/v1/foo/node-1 node-1.json
+kvstore/update cilium/state/nodes/v1/foo/node-2 node-2.json
+kvstore/update cilium/state/nodes/v1/foo/node-3 node-3.json
+
+# Initialize the kubernetes state with a bunch of CiliumNodes.
+k8s/add cilium-node-1.yaml
+
+hive/start
+
+# Wait for a little bit for things to settle.
+sleep 500ms
+
+# Assert that nothing got touched, as GC is disabled.
+kvstore/list --keys-only cilium/state/nodes keys.actual
+cmp keys.actual keys.expected
+
+###
+
+-- node-1.json --
+{ "cluster": "foo", "name": "node-1" }
+
+-- node-2.json --
+{ "cluster": "foo", "name": "node-2" }
+
+-- node-3.json --
+{ "cluster": "foo", "name": "node-3" }
+
+
+-- cilium-node-1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: node-1
+
+
+-- keys.expected --
+# cilium/state/nodes/v1/foo/node-1
+# cilium/state/nodes/v1/foo/node-2
+# cilium/state/nodes/v1/foo/node-3

--- a/operator/pkg/kvstore/nodesgc/testdata/enabled.txtar
+++ b/operator/pkg/kvstore/nodesgc/testdata/enabled.txtar
@@ -1,0 +1,178 @@
+#! --cluster-name=foo
+
+# Initialize the kvstore state with a bunch of nodes.
+kvstore/update cilium/state/nodes/v1/foo/node-1 node-1.json
+kvstore/update cilium/state/nodes/v1/foo/node-2 node-2.json
+kvstore/update cilium/state/nodes/v1/foo/node-3 node-3.json
+kvstore/update cilium/state/nodes/v1/other/cluster node-other-cluster.json
+
+# Initialize the kubernetes state with a bunch of CiliumNodes and pods.
+k8s/add cilium-node-1.yaml
+k8s/add cilium-node-2.yaml
+k8s/add cilium-node-4.yaml
+
+k8s/add pod-node-1a.yaml
+k8s/add pod-node-1b.yaml
+k8s/add pod-node-3a.yaml
+k8s/add pod-node-5a.yaml
+
+hive/start
+
+# Assert that the nodes for which there's no corresponding CiliumNode are deleted.
+# Entries for other clusters should not be touched.
+kvstore/list --keys-only cilium/state/nodes keys.actual
+* cmp keys.actual keys.expected.v1
+
+# Creating a kvstore entry for a non-existing CiliumNode should cause it to be
+# immediately deleted (as we are setting the delay to 0 for testing purposes).
+kvstore/update cilium/state/nodes/v1/foo/node-3 node-3.json
+
+# Wait for garbage collection.
+kvstore/list --keys-only cilium/state/nodes keys.actual
+* cmp keys.actual keys.expected.v1
+
+# Creating a kvstore entry for an existing CiliumNode should not trigger GC.
+kvstore/update cilium/state/nodes/v1/foo/node-4 node-4.json
+
+# Wait for a bit of time so that things can settle, and ensure that the entry
+# was actually not deleted.
+sleep 50ms
+
+kvstore/list --keys-only cilium/state/nodes keys.actual
+cmp keys.actual keys.expected.v2
+
+# Deleting a CiliumNode should trigger the GC of the corresponding kvstore entry.
+k8s/delete cilium-node-2.yaml
+
+# Wait for garbage collection.
+kvstore/list --keys-only cilium/state/nodes keys.actual
+* cmp keys.actual keys.expected.v3
+
+# Deleting a CiliumNode should not trigger the GC of the corresponding kvstore
+# entry if a Cilium pod is still running.
+k8s/delete cilium-node-1.yaml
+
+# Wait for a bit of time so that things can settle, and ensure that the entry
+# was actually not deleted.
+sleep 50ms
+
+kvstore/list --keys-only cilium/state/nodes keys.actual
+cmp keys.actual keys.expected.v3
+
+# Deleting the pod should now cause the entry to be deleted.
+k8s/delete pod-node-1a.yaml
+
+# Wait for garbage collection.
+kvstore/list --keys-only cilium/state/nodes keys.actual
+* cmp keys.actual keys.expected.v4
+
+# Creating a kvstore entry for a node where Cilium is running should not trigger GC.
+kvstore/update cilium/state/nodes/v1/foo/node-5 node-5.json
+
+# Wait for a bit of time so that things can settle, and ensure that the entry
+# was actually not deleted.
+sleep 50ms
+
+kvstore/list --keys-only cilium/state/nodes keys.actual
+cmp keys.actual keys.expected.v5
+
+###
+
+-- node-1.json --
+{ "cluster": "foo", "name": "node-1" }
+
+-- node-2.json --
+{ "cluster": "foo", "name": "node-2" }
+
+-- node-3.json --
+{ "cluster": "foo", "name": "node-3" }
+
+-- node-4.json --
+{ "cluster": "foo", "name": "node-4" }
+
+-- node-5.json --
+{ "cluster": "foo", "name": "node-5" }
+
+-- node-other-cluster.json --
+{ "cluster": "other", "name": "cluster" }
+
+
+-- cilium-node-1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: node-1
+
+-- cilium-node-2.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: node-2
+
+-- cilium-node-4.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: node-4
+
+-- pod-node-1a.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cilium-42lwq
+  labels:
+    k8s-app: cilium
+    app.kubernetes.io/name: cilium-agent
+    app.kubernetes.io/part-of: cilium
+spec:
+  nodeName: node-1
+
+-- pod-node-1b.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: foobar
+spec:
+  nodeName: node-1
+
+-- pod-node-3a.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: qux
+  labels:
+    k8s-app: other
+spec:
+  nodeName: node-3
+
+-- pod-node-5a.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cilium-cl4dn
+  labels:
+    k8s-app: cilium
+spec:
+  nodeName: node-5
+
+
+-- keys.expected.v1 --
+# cilium/state/nodes/v1/foo/node-1
+# cilium/state/nodes/v1/foo/node-2
+# cilium/state/nodes/v1/other/cluster
+-- keys.expected.v2 --
+# cilium/state/nodes/v1/foo/node-1
+# cilium/state/nodes/v1/foo/node-2
+# cilium/state/nodes/v1/foo/node-4
+# cilium/state/nodes/v1/other/cluster
+-- keys.expected.v3 --
+# cilium/state/nodes/v1/foo/node-1
+# cilium/state/nodes/v1/foo/node-4
+# cilium/state/nodes/v1/other/cluster
+-- keys.expected.v4 --
+# cilium/state/nodes/v1/foo/node-4
+# cilium/state/nodes/v1/other/cluster
+-- keys.expected.v5 --
+# cilium/state/nodes/v1/foo/node-4
+# cilium/state/nodes/v1/foo/node-5
+# cilium/state/nodes/v1/other/cluster

--- a/operator/watchers/cilium_node_gc_test.go
+++ b/operator/watchers/cilium_node_gc_test.go
@@ -11,34 +11,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
 func Test_performCiliumNodeGC(t *testing.T) {
-	cns := []runtime.Object{
-		&v2.CiliumNode{
+	cns := []*v2.CiliumNode{
+		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid-node",
 			},
-		},
-		&v2.CiliumNode{
+		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "invalid-node",
 			},
-		},
-		&v2.CiliumNode{
+		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "invalid-node-with-owner-ref",
 				OwnerReferences: []metav1.OwnerReference{{}},
 			},
-		},
-		&v2.CiliumNode{
+		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "invalid-node-with-annotation",
 				Annotations: map[string]string{skipGCAnnotationKey: "true"},
@@ -46,11 +42,18 @@ func Test_performCiliumNodeGC(t *testing.T) {
 		},
 	}
 
-	fcn := fake.NewSimpleClientset(cns...).CiliumV2().CiliumNodes()
-	fCNStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	_, cs := k8sClient.NewFakeClientset(hivetest.Logger(t))
+	fcn := cs.CiliumV2().CiliumNodes()
 	for _, cn := range cns {
-		fCNStore.Add(cn)
+		_, err := fcn.Create(t.Context(), cn, metav1.CreateOptions{})
+		assert.NoError(t, err)
 	}
+
+	ciliumNodes, err := operatorK8s.CiliumNodeResource(hivetest.Lifecycle(t), cs, nil)
+	assert.NoError(t, err)
+
+	store, err := ciliumNodes.Store(t.Context())
+	assert.NoError(t, err)
 
 	interval := time.Nanosecond
 	fng := &fakeNodeGetter{
@@ -65,7 +68,7 @@ func Test_performCiliumNodeGC(t *testing.T) {
 	candidateStore := newCiliumNodeGCCandidate()
 
 	// check if the invalid node is added to GC candidate
-	err := performCiliumNodeGC(t.Context(), fcn, fCNStore, fng, interval, candidateStore, hivetest.Logger(t))
+	err = performCiliumNodeGC(t.Context(), fcn, store, fng, interval, candidateStore, hivetest.Logger(t))
 	assert.NoError(t, err)
 	assert.Len(t, candidateStore.nodesToRemove, 1)
 	_, exists := candidateStore.nodesToRemove["invalid-node"]
@@ -73,7 +76,7 @@ func Test_performCiliumNodeGC(t *testing.T) {
 
 	// check if the invalid node is actually GC-ed
 	time.Sleep(interval)
-	err = performCiliumNodeGC(t.Context(), fcn, fCNStore, fng, interval, candidateStore, hivetest.Logger(t))
+	err = performCiliumNodeGC(t.Context(), fcn, store, fng, interval, candidateStore, hivetest.Logger(t))
 	assert.NoError(t, err)
 	assert.Empty(t, candidateStore.nodesToRemove)
 	_, exists = candidateStore.nodesToRemove["invalid-node"]


### PR DESCRIPTION
Please refer to the individual commit messages for additional details. The goal of this PR is twofold. On the one hand simplifying and modernizing this legacy logic, which is now fairly complex to follow. On the other one, addressing a race condition that recently started affecting CI runs more frequently, leading to flakiness.