### PR TITLE
GHA: Node without Cilium for GKE workflows

### DIFF
--- a/.github/actions/cli-test-config/action.yaml
+++ b/.github/actions/cli-test-config/action.yaml
@@ -29,6 +29,9 @@ inputs:
   external-other-target:
     description: "Extra DNS name for testing connectivity outside the cluster"
     required: false
+  external-target-fake-dns:
+    description: "Use DNS override for external targets in wildcard tests"
+    required: false
   flow-validation:
     default: false
     description: "Enable flow validation in the connectivity test"
@@ -83,6 +86,10 @@ runs:
           CONNECTIVITY_TEST_DEFAULTS+=("--external-other-target=${{ inputs.external-other-target }}")
         fi
 
+
+        if [ "${{ inputs.external-target-fake-dns }}" == "true" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-target-fake-dns")
+        fi
 
         if [ "${{ inputs.include-unsafe-tests }}" == "true" ]; then
           CONNECTIVITY_TEST_DEFAULTS+=("--include-unsafe-tests")

--- a/.github/actions/cli-test-config/action.yaml
+++ b/.github/actions/cli-test-config/action.yaml
@@ -29,6 +29,12 @@ inputs:
   external-other-target:
     description: "Extra DNS name for testing connectivity outside the cluster"
     required: false
+  external-target-ca-namespace:
+    description: "Namespace of the CA secret for the external target"
+    required: false
+  external-target-ca-name:
+    description: "Name of the CA secret for the external target"
+    required: false
   external-target-fake-dns:
     description: "Use DNS override for external targets in wildcard tests"
     required: false
@@ -84,6 +90,12 @@ runs:
         fi
         if [ -n "${{ inputs.external-other-target }}" ]; then
           CONNECTIVITY_TEST_DEFAULTS+=("--external-other-target=${{ inputs.external-other-target }}")
+        fi
+        if [ -n "${{ inputs.external-target-ca-namespace }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-target-ca-namespace=${{ inputs.external-target-ca-namespace }}")
+        fi
+        if [ -n "${{ inputs.external-target-ca-name }}" ]; then
+          CONNECTIVITY_TEST_DEFAULTS+=("--external-target-ca-name=${{ inputs.external-target-ca-name }}")
         fi
 
 

--- a/.github/actions/generic-external-targets/action.sh
+++ b/.github/actions/generic-external-targets/action.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+TARGETNAME=nginx.external.svc.cluster.local
+OTHERTARGETNAME=nginx.external-other.svc.cluster.local
+
+# Create a private key for the self signed CA
+openssl genrsa 2048 > ca-key.pem
+
+# Create a self signed CA certificate
+openssl req -new -x509 -nodes -days 365 \
+    -key ca-key.pem \
+    -subj "/O=Cilium/CN=Cilium CA" \
+    -out ca-cert.pem
+
+# Create a secret with the CA certificate, will be used by L7 tests as trused CA for
+# connections between Envoy and our external services
+kubectl create ns external-target-secrets
+kubectl -n external-target-secrets create secret generic custom-ca --from-file=ca.crt=ca-cert.pem
+
+# Create a cerificate signing request and private key for external services
+# Note only the primary external target is in the common name.
+openssl req -newkey rsa:2048 -nodes \
+    -keyout external-service.cilium.key \
+    -subj "/CN=$TARGETNAME" \
+    -out external-service.cilium.req.pem
+
+# Figure out the addresses of the external nodes.
+IP4TARGET="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+IP4OTHERTARGET="$(kubectl get nodes -o jsonpath='{.items[1].status.addresses[?(@.type=="InternalIP")].address}')"
+
+# Create a config file to tell openssl how to turn the signing request into a certificate
+# Make sure the key usage is such that we can use the cert for HTTPS traffic.
+# Also make sure both domain names are in the subjectAltName so the certificate works for
+# both external services and the IP addresses without domain name.
+cat > v3.ext << EOF
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+keyUsage               = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment, keyAgreement, keyCertSign
+subjectAltName         = DNS:$OTHERTARGETNAME, DNS:$TARGETNAME, DNS:fake.external.first.target, DNS:fake.external.second.target, IP:$IP4TARGET, IP:$IP4OTHERTARGET
+EOF
+
+# Turn the certificate signing request into a certificate, signed by our CA
+openssl x509 -req -days 365 -set_serial 01 \
+    -in external-service.cilium.req.pem \
+    -out external-service.cilium.crt \
+    -extfile v3.ext \
+    -CA ca-cert.pem \
+    -CAkey ca-key.pem
+
+# Start the external targets.
+mapfile -t NODES_WITHOUT_CILIUM < <(kubectl get nodes -l cilium.io/no-schedule=true -o name | sed 's@^node/@@')
+
+kubectl create ns external
+NGINX_CERT_BASE64="$(base64 -w0 external-service.cilium.crt)" \
+NGINX_KEY_BASE64="$(base64 -w0 external-service.cilium.key)" \
+EXTERNAL_NODE="${NODES_WITHOUT_CILIUM[0]}" \
+envsubst '$NGINX_CERT_BASE64 $NGINX_KEY_BASE64 $EXTERNAL_NODE' < "$(dirname "$0")/nginx-external.yaml" | kubectl -n external apply -f -
+
+kubectl create ns external-other
+NGINX_CERT_BASE64="$(base64 -w0 external-service.cilium.crt)" \
+NGINX_KEY_BASE64="$(base64 -w0 external-service.cilium.key)" \
+EXTERNAL_NODE="${NODES_WITHOUT_CILIUM[1]}" \
+envsubst '$NGINX_CERT_BASE64 $NGINX_KEY_BASE64 $EXTERNAL_NODE' < "$(dirname "$0")/nginx-external.yaml" | kubectl -n external-other apply -f -
+
+kubectl -n external rollout status daemonset nginx --timeout 60s
+kubectl -n external-other rollout status daemonset nginx --timeout 60s
+
+echo "ipv4_external_target=$IP4TARGET" >> $GITHUB_OUTPUT
+echo "ipv4_other_external_target=$IP4OTHERTARGET" >> $GITHUB_OUTPUT
+echo "external_target_name=$TARGETNAME" >> $GITHUB_OUTPUT
+echo "other_external_target_name=$OTHERTARGETNAME" >> $GITHUB_OUTPUT

--- a/.github/actions/generic-external-targets/action.yaml
+++ b/.github/actions/generic-external-targets/action.yaml
@@ -1,0 +1,24 @@
+name: Add external targets to a generic cluster
+description: |
+  Deploy hostns pods on the node without Cilium to be used as external targets
+  for cilium-cli connectivity tests.
+outputs:
+  ipv4_external_target:
+    description: "IPv4 address of the first external target"
+    value: ${{ steps.add_targets.outputs.ipv4_external_target }}
+  ipv4_other_external_target:
+    description: "IPv4 address of the second external target"
+    value: ${{ steps.add_targets.outputs.ipv4_other_external_target }}
+  external_target_name:
+    description: "Domain name of the first external target"
+    value: ${{ steps.add_targets.outputs.external_target_name }}
+  other_external_target_name:
+    description: "Domain name of the second external target"
+    value: ${{ steps.add_targets.outputs.other_external_target_name }}
+runs:
+  using: composite
+  steps:
+    - id: add_targets
+      shell: bash
+      run: |
+        bash .github/actions/generic-external-targets/action.sh

--- a/.github/actions/generic-external-targets/nginx-external.yaml
+++ b/.github/actions/generic-external-targets/nginx-external.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-external-config
+data:
+  nginx.conf: |
+    user  nginx;
+    worker_processes  auto;
+
+    error_log  /var/log/nginx/error.log notice;
+    pid        /var/run/nginx.pid;
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /var/log/nginx/access.log  main;
+
+        sendfile        on;
+
+        keepalive_timeout  65;
+
+        server {
+            listen              80;
+            listen              [::]:80;
+            listen              443 ssl;
+            listen              [::]:443 ssl;
+            server_name         _;
+            ssl_certificate     /etc/nginx/ssl/external-service.cilium.crt;
+            ssl_certificate_key /etc/nginx/ssl/external-service.cilium.key;
+            ssl_protocols       TLSv1.2 TLSv1.3;
+            ssl_ciphers         HIGH:!aNULL:!MD5;
+
+            location / {
+                root   /usr/share/nginx/html;
+                index  index.html index.htm;
+            }
+
+            error_page   500 502 503 504  /50x.html;
+            location = /50x.html {
+                root   /usr/share/nginx/html;
+            }
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-external-certs
+binaryData:
+  external-service.cilium.crt: $NGINX_CERT_BASE64
+  external-service.cilium.key: $NGINX_KEY_BASE64
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        cilium.io/no-schedule: "true"
+        kubernetes.io/hostname: "$EXTERNAL_NODE"
+      tolerations:
+      - key: "ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready"
+        operator: "Equal"
+        value: "true"
+        effect: "NoExecute"
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: nginx
+        image: nginx:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - name: config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: certs
+          mountPath: /etc/nginx/ssl/
+      volumes:
+      - name: config
+        configMap:
+          name: nginx-external-config
+      - name: certs
+        configMap:
+          name: nginx-external-certs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  clusterIP: None
+  selector:
+    app: nginx
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 80
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 443

--- a/.github/actions/setup-gke-cluster/action.yml
+++ b/.github/actions/setup-gke-cluster/action.yml
@@ -75,7 +75,7 @@ runs:
           --cluster-ipv4-cidr="/21" \
           --services-ipv4-cidr="/24" \
           --image-type COS_CONTAINERD \
-          --num-nodes "${{ inputs.nodes }}" \
+          --num-nodes "$(( ${{ inputs.nodes }} + 2 ))" \
           --machine-type "${{ inputs.machine-type }}" \
           --disk-type pd-standard \
           --disk-size 20GB \
@@ -88,3 +88,6 @@ runs:
 
         native_cidr=$(gcloud container clusters describe "${{ inputs.cluster-name }}" --zone "${{ inputs.zone }}" --format 'value(clusterIpv4Cidr)')
         echo native_cidr=${native_cidr} >> $GITHUB_OUTPUT
+
+        mapfile -t nodes_without_cilium < <(kubectl get nodes -o name | head -n 2)
+        kubectl patch "${nodes_without_cilium[@]}" --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -453,7 +453,8 @@ jobs:
         id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} ${{ matrix.config.cilium-install-opts }} \
-          --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }}
+          --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }} \
+          --nodes-without-cilium
 
       - name: Wait for Cilium to be ready
         run: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -316,17 +316,6 @@ jobs:
         with:
           label: ${{ github.event_name == 'workflow_dispatch' && inputs.PR-number || github.ref_name }}
 
-      - name: Get connectivity test flags
-        id: e2e_config
-        uses: ./.github/actions/cli-test-config
-        with:
-          external-target: 'google.com.'
-          external-cidr: '8.0.0.0/8'
-          external-ip: '8.8.8.8'
-          external-other-ip: '8.8.4.4'
-          hubble: false
-          test-concurrency: 5
-
       - name: Set up job variables
         id: vars
         run: |
@@ -361,14 +350,7 @@ jobs:
               --helm-set egressGateway.enabled=true"
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
-          if [[ "${{ matrix.config.kpr }}" == "true" ]]; then
-            CONNECTIVITY_TEST_DEFAULTS+=" --test '!pod-to-host'"
-          fi
-
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
-          echo hubble_enable_defaults=${HUBBLE_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
-          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
 
@@ -433,6 +415,12 @@ jobs:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
           kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
+      - name: Copy scripts to trusted directory
+        run: |
+          mkdir -p ../cilium-base-branch/.github/actions
+          cp -a .github/actions/generic-external-targets ../cilium-base-branch/.github/actions/
+          cp -a .github/actions/cli-test-config ../cilium-base-branch/.github/actions/
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -461,6 +449,44 @@ jobs:
           cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods -n kube-system
 
+      - name: Add external targets to kind cluster
+        uses: ./../cilium-base-branch/.github/actions/generic-external-targets
+        id: external_targets
+
+      - name: Determine the CIDR of fake external targets
+        id: external_cidr
+        run: |
+          ZONE=${{ matrix.k8s.zone }}
+          REGION=${ZONE%-?}
+          SUBNET=$(gcloud container clusters describe ${{ env.clusterName }}-${{ matrix.config.index }} --zone "$ZONE" --format 'value(subnetwork)')
+          CIDR=$(gcloud compute networks subnets describe "$SUBNET" --region "$REGION" --format 'value(ipCidrRange)')
+          echo "ipv4_external_cidr=$CIDR" >> $GITHUB_OUTPUT
+
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./../cilium-base-branch/.github/actions/cli-test-config
+        with:
+          external-target: ${{ steps.external_targets.outputs.external_target_name }}
+          external-other-target: ${{ steps.external_targets.outputs.other_external_target_name }}
+          external-cidr: ${{ steps.external_cidr.outputs.ipv4_external_cidr }}
+          external-ip: ${{ steps.external_targets.outputs.ipv4_external_target }}
+          external-other-ip: ${{ steps.external_targets.outputs.ipv4_other_external_target }}
+          external-target-ca-namespace: external-target-secrets
+          external-target-ca-name: custom-ca
+          external-target-fake-dns: true
+          hubble: false
+          test-concurrency: 5
+
+      - name: Set up job variables for connectivity tests
+        id: vars-conn
+        run: |
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+          if [[ "${{ matrix.config.kpr }}" == "true" ]]; then
+            CONNECTIVITY_TEST_DEFAULTS+=" --test '!pod-to-host'"
+          fi
+
+          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
+
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits
@@ -468,7 +494,7 @@ jobs:
       - name: Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})
         id: run-tests
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          cilium connectivity test ${{ steps.vars-conn.outputs.connectivity_test_defaults }} \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})"
 

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -420,6 +420,8 @@ jobs:
           mkdir -p ../cilium-base-branch/.github/actions
           cp -a .github/actions/generic-external-targets ../cilium-base-branch/.github/actions/
           cp -a .github/actions/cli-test-config ../cilium-base-branch/.github/actions/
+          cp -a .github/actions/post-logic ../cilium-base-branch/.github/actions/
+          cp -a .github/actions/gke-clean-esp-rule ../cilium-base-branch/.github/actions/
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
@@ -500,7 +502,7 @@ jobs:
 
       - name: Run common post steps
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}
-        uses: ./.github/actions/post-logic
+        uses: ./../cilium-base-branch/.github/actions/post-logic
         with:
           artifacts_suffix: "gke-${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ matrix.config.type }}, ${{ inputs.UID }})"
           job_status: "${{ job.status }}"
@@ -508,7 +510,7 @@ jobs:
 
       - name: Clean up ESP allow firewall rule
         if: ${{ always() && matrix.config.ipsec == true }}
-        uses: ./.github/actions/gke-clean-esp-rule
+        uses: ./../cilium-base-branch/.github/actions/gke-clean-esp-rule
         with:
           cluster_name: ${{ env.clusterName }}-${{ matrix.config.index }}
           cluster_zone: ${{ matrix.k8s.zone }}

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -284,8 +284,8 @@ jobs:
         if: ${{ matrix.mode != 'baseline' }}
         id: install-cilium
         run: |
-          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }}
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }}
+          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }} --nodes-without-cilium
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }} --nodes-without-cilium
 
       - name: Wait for Cilium to be ready
         if: ${{ matrix.mode != 'baseline' }}

--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -41,6 +41,7 @@ cilium connectivity test [flags]
       --external-target string                                     Domain name to use as external target in connectivity tests (default "one.one.one.one.")
       --external-target-ca-name string                             Name of the CA secret for the external target. (default "cabundle")
       --external-target-ca-namespace string                        Namespace of the CA secret for the external target.
+      --external-target-fake-dns                                   Use DNS override for external targets in wildcard tests
       --external-target-ipv6-capable                               External target is IPv6 capable
       --flow-validation string                                     Enable Hubble flow validation { disabled | warning | strict } (default "warning")
       --force-deploy                                               Force re-deploying test artifacts

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -40,7 +40,7 @@ func newCmdConnectivity(hooks api.Hooks) *cobra.Command {
 }
 
 var params = check.Parameters{
-	ExternalDeploymentPort: 8080,
+	ExternalDeploymentPort: 8090,
 	EchoServerHostPort:     4000,
 	Writer:                 os.Stdout,
 	SysdumpOptions: sysdump.Options{

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -153,6 +153,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Timestamp, "timestamp", "t", false, "Show timestamp in messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
 	cmd.Flags().BoolVar(&params.ExternalTargetIPv6Capable, "external-target-ipv6-capable", false, "External target is IPv6 capable")
+	cmd.Flags().BoolVar(&params.ExternalTargetFakeDNS, "external-target-fake-dns", false, "Use DNS override for external targets in wildcard tests")
 	cmd.Flags().StringVar(&params.ExternalTarget, "external-target", "one.one.one.one.", "Domain name to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalOtherTarget, "external-other-target", "k8s.io.", "Domain name to use as a second external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalTargetCANamespace, "external-target-ca-namespace", "", "Namespace of the CA secret for the external target.")

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/builder/manifests/template"
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
@@ -393,16 +394,26 @@ func renderTemplates(clusterNameLocal, clusterNameRemote string, param check.Par
 		templates["clientEgressToCIDRK8sPolicyKNPYAML"] = clientEgressToCIDRK8sPolicyYAML
 	}
 
+	fakeExternalTarget1 := tests.FakeExternalTarget1
+	fakeExternalTarget2 := tests.FakeExternalTarget2
+	if !param.ExternalTargetFakeDNS {
+		fakeExternalTarget1 = param.ExternalTarget
+		fakeExternalTarget2 = param.ExternalOtherTarget
+	}
 	renderedTemplates := map[string]string{}
 	for key, temp := range templates {
 		val, err := template.Render(temp, struct {
 			check.Parameters
-			ClusterNameLocal  string
-			ClusterNameRemote string
+			ClusterNameLocal        string
+			ClusterNameRemote       string
+			FakeExternalTarget      string
+			FakeExternalOtherTarget string
 		}{
-			Parameters:        param,
-			ClusterNameLocal:  clusterNameLocal,
-			ClusterNameRemote: clusterNameRemote,
+			Parameters:              param,
+			ClusterNameLocal:        clusterNameLocal,
+			ClusterNameRemote:       clusterNameRemote,
+			FakeExternalTarget:      fakeExternalTarget1,
+			FakeExternalOtherTarget: fakeExternalTarget2,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to render template %s: %w", key, err)

--- a/cilium-cli/connectivity/builder/client_egress_l7.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7.go
@@ -33,7 +33,12 @@ func clientEgressL7Test(ct *check.ConnectivityTest, templates map[string]string,
 		WithCiliumPolicy(templates[templateName]).                    // L7 allow policy with HTTP introspection
 		WithScenarios(
 			tests.PodToPod(),
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
+			tests.PodToWorld(
+				ct.Params().ExternalTargetIPv6Capable,
+				false,
+				tests.WithRetryDestPort(80),
+				tests.WithRetryPodLabel("other", "client"),
+			),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.

--- a/cilium-cli/connectivity/builder/client_egress_l7_named_port.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_named_port.go
@@ -20,7 +20,12 @@ func (t clientEgressL7NamedPort) build(ct *check.ConnectivityTest, templates map
 		WithCiliumPolicy(templates["clientEgressL7HTTPNamedPortPolicyYAML"]). // L7 allow policy with HTTP introspection (named port)
 		WithScenarios(
 			tests.PodToPod(),
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),
+			tests.PodToWorld(
+				ct.Params().ExternalTargetIPv6Capable,
+				false,
+				tests.WithRetryDestPort(80),
+				tests.WithRetryPodLabel("other", "client"),
+			),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -30,7 +30,11 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		WithScenarios(
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryAll())).
+			tests.PodToWorld(
+				ct.Params().ExternalTargetIPv6Capable,
+				false,
+				tests.WithRetryAll(),
+			)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -47,9 +51,12 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithCiliumVersion("!1.15.9 !1.15.10 !1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
-		WithCiliumPolicy(yamlFile).                                             // L7 allow policy TLS SNI enforcement for external target
-		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).           // DNS resolution only
-		WithScenarios(tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable)). // External Target is not allowed
+		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
+		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
+		WithScenarios(tests.PodToWorld(                               // External Target is not allowed
+			ct.Params().ExternalTargetIPv6Capable,
+			false,
+		)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				// SSL error as another external target (e.g. cilium.io) SNI is not allowed
@@ -75,7 +82,11 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		WithScenarios(
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryAll())).
+			tests.PodToWorld(
+				ct.Params().ExternalTargetIPv6Capable,
+				ct.Params().ExternalTargetFakeDNS,
+				tests.WithRetryAll(),
+			)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -91,7 +102,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		WithScenarios(tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable)).
+		WithScenarios(tests.PodToWorld2(
+			ct.Params().ExternalTargetIPv6Capable,
+			ct.Params().ExternalTargetFakeDNS,
+		)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				// SSL error as another external target (e.g. cilium.io) SNI is not allowed
@@ -109,7 +123,11 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		WithScenarios(
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryAll())).
+			tests.PodToWorld(
+				ct.Params().ExternalTargetIPv6Capable,
+				ct.Params().ExternalTargetFakeDNS,
+				tests.WithRetryAll(),
+			)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -125,7 +143,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		WithScenarios(tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable)).
+		WithScenarios(tests.PodToWorld2(
+			ct.Params().ExternalTargetIPv6Capable,
+			ct.Params().ExternalTargetFakeDNS,
+		)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				// SSL error as another external target (e.g. cilium.io) SNI is not allowed
@@ -143,7 +164,11 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		WithScenarios(
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryAll())).
+			tests.PodToWorld(
+				ct.Params().ExternalTargetIPv6Capable,
+				ct.Params().ExternalTargetFakeDNS,
+				tests.WithRetryAll(),
+			)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				return check.ResultOK, check.ResultNone
@@ -159,7 +184,10 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		WithScenarios(tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable)).
+		WithScenarios(tests.PodToWorld2(
+			ct.Params().ExternalTargetIPv6Capable,
+			ct.Params().ExternalTargetFakeDNS,
+		)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				// SSL error as another external target (e.g. cilium.io) SNI is not allowed

--- a/cilium-cli/connectivity/builder/dns_only.go
+++ b/cilium-cli/connectivity/builder/dns_only.go
@@ -18,7 +18,10 @@ func (t dnsOnly) build(ct *check.ConnectivityTest, templates map[string]string) 
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithScenarios(
 			tests.PodToPod(), // connects to other Pods directly, no DNS
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable), // resolves set domain-name defaults to one.one.one.one
+			tests.PodToWorld( // resolves set domain-name defaults to one.one.one.one
+				ct.Params().ExternalTargetIPv6Capable,
+				false,
+			),
 		).
 		WithExpectations(func(_ *check.Action) (egress check.Result, ingress check.Result) {
 			return check.ResultDropCurlTimeout, check.ResultNone

--- a/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-double-wildcard.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-double-wildcard.yaml
@@ -13,4 +13,4 @@ specs:
       - port: "443"
         protocol: "TCP"
       serverNames:
-      - "{{ trimSuffix (generateDNSMatchPatternWithWildcard .ExternalTarget .ExternalOtherTarget "any-prefix") "." }}"
+      - "{{ trimSuffix (generateDNSMatchPatternWithWildcard .FakeExternalTarget .FakeExternalOtherTarget "any-prefix") "." }}"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-random-wildcard.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-random-wildcard.yaml
@@ -13,4 +13,4 @@ specs:
       - port: "443"
         protocol: "TCP"
       serverNames:
-      - "{{ trimSuffix (generateDNSMatchPatternWithWildcard .ExternalTarget .ExternalOtherTarget "random") "." }}"
+      - "{{ trimSuffix (generateDNSMatchPatternWithWildcard .FakeExternalTarget .FakeExternalOtherTarget "random") "." }}"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-wildcard.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-wildcard.yaml
@@ -13,4 +13,4 @@ specs:
       - port: "443"
         protocol: "TCP"
       serverNames:
-      - "{{ trimSuffix (generateDNSMatchPatternWithWildcard .ExternalTarget .ExternalOtherTarget "subdomain-prefix") "." }}"
+      - "{{ trimSuffix (generateDNSMatchPatternWithWildcard .FakeExternalTarget .FakeExternalOtherTarget "subdomain-prefix") "." }}"

--- a/cilium-cli/connectivity/builder/no_policies.go
+++ b/cilium-cli/connectivity/builder/no_policies.go
@@ -17,7 +17,11 @@ func (t noPolicies) build(ct *check.ConnectivityTest, _ map[string]string) {
 			tests.ClientToClient(),
 			tests.PodToService(),
 			tests.PodToHostPort(),
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryAll()),
+			tests.PodToWorld(
+				ct.Params().ExternalTargetIPv6Capable,
+				false,
+				tests.WithRetryAll(),
+			),
 			tests.PodToHost(),
 			tests.HostToPod(),
 			tests.PodToCIDR(tests.WithRetryAll()),

--- a/cilium-cli/connectivity/builder/to_entities_world.go
+++ b/cilium-cli/connectivity/builder/to_entities_world.go
@@ -36,7 +36,11 @@ func toEntitiesWorldTest(ct *check.ConnectivityTest, portRanges bool) {
 	// This policy allows UDP to kube-dns and port 80 TCP to all 'world' endpoints.
 	newTest(testName, ct).
 		WithCiliumPolicy(policyYAML).
-		WithScenarios(tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryDestPort(80))).
+		WithScenarios(tests.PodToWorld(
+			ct.Params().ExternalTargetIPv6Capable,
+			false,
+			tests.WithRetryDestPort(80),
+		)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 80 {
 				return check.ResultOK, check.ResultNone

--- a/cilium-cli/connectivity/builder/to_fqdns.go
+++ b/cilium-cli/connectivity/builder/to_fqdns.go
@@ -20,8 +20,15 @@ func (t toFqdns) build(ct *check.ConnectivityTest, templates map[string]string) 
 		WithCiliumPolicy(templates["clientEgressToFQDNsPolicyYAML"]).
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).
 		WithScenarios(
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryDestPort(80)),
-			tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable), // resolves to ExternalOtherTarget
+			tests.PodToWorld(
+				ct.Params().ExternalTargetIPv6Capable,
+				false,
+				tests.WithRetryDestPort(80),
+			),
+			tests.PodToWorld2( // resolves to ExternalOtherTarget
+				ct.Params().ExternalTargetIPv6Capable,
+				false,
+			),
 		).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
@@ -64,8 +71,15 @@ func (t toFqdnsWithProxy) build(ct *check.ConnectivityTest, templates map[string
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithScenarios(
-			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, tests.WithRetryDestPort(80)),
-			tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable), // resolves to ExternalOtherTarget
+			tests.PodToWorld(
+				ct.Params().ExternalTargetIPv6Capable,
+				false,
+				tests.WithRetryDestPort(80),
+			),
+			tests.PodToWorld2( // resolves to ExternalOtherTarget
+				ct.Params().ExternalTargetIPv6Capable,
+				false,
+			),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Address(features.IPFamilyAny) == ct.Params().ExternalOtherTarget {

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -92,6 +92,7 @@ type Parameters struct {
 	NamespaceLabels           map[string]string
 	NamespaceAnnotations      map[string]string
 	ExternalTargetIPv6Capable bool
+	ExternalTargetFakeDNS     bool
 	ExternalTarget            string
 	ExternalOtherTarget       string
 	ExternalCIDRv4            string

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -811,7 +811,22 @@ func (ct *ConnectivityTest) detectNodesWithoutCiliumIPs() error {
 	return nil
 }
 
+func (ct *ConnectivityTest) requiresStaticRoutes() bool {
+	if f, ok := ct.Feature(features.Flavor); ok && f.Enabled {
+		switch f.Mode {
+		case "gke", "aks", "eks":
+			return false
+		}
+	}
+	return true
+}
+
 func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.Context, verb string) error {
+	if !ct.requiresStaticRoutes() {
+		ct.Debugf("Skipping modifying static route on nodes without Cilium, cloud platform has pod connectivity")
+		return nil
+	}
+
 	for _, e := range ct.params.PodCIDRs {
 		for withoutCilium := range ct.nodesWithoutCilium {
 			pod := ct.hostNetNSPodsByNode[withoutCilium]

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1386,7 +1386,6 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	}
 
 	if !ct.params.SingleNode || ct.params.MultiCluster != "" {
-
 		_, err = ct.clients.dst.GetService(ctx, ct.params.TestNamespace, echoOtherNodeDeploymentName, metav1.GetOptions{})
 		svc := newService(echoOtherNodeDeploymentName, map[string]string{"name": echoOtherNodeDeploymentName}, serviceLabels, "http", 8080, ct.Params().ServiceType)
 		if ct.params.MultiCluster != "" {
@@ -1479,7 +1478,9 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				}
 			}
 		}
+	}
 
+	if ct.Features[features.NodeWithoutCilium].Enabled {
 		_, err = ct.clients.src.GetDaemonSet(ctx, ct.params.TestNamespace, hostNetNSDeploymentNameNonCilium, metav1.GetOptions{})
 		if err != nil {
 			ct.Logf("✨ [%s] Deploying %s daemonset...", hostNetNSDeploymentNameNonCilium, ct.clients.src.ClusterName())
@@ -1504,52 +1505,50 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			}
 		}
 
-		if ct.Features[features.NodeWithoutCilium].Enabled {
-			_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, echoExternalNodeDeploymentName, metav1.GetOptions{})
+		_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, echoExternalNodeDeploymentName, metav1.GetOptions{})
+		if err != nil {
+			ct.Logf("✨ [%s] Deploying echo-external-node deployment...", ct.clients.src.ClusterName())
+			// in case if test concurrency is > 1 port must be unique for each test namespace
+			port := ct.Params().ExternalDeploymentPort
+			echoExternalDeployment := newDeployment(deploymentParameters{
+				Name:           echoExternalNodeDeploymentName,
+				Kind:           kindEchoExternalNodeName,
+				Port:           port,
+				NamedPort:      fmt.Sprintf("http-%d", port),
+				HostPort:       port,
+				Image:          ct.params.JSONMockImage,
+				Labels:         map[string]string{"external": "echo"},
+				Annotations:    ct.params.DeploymentAnnotations.Match(echoExternalNodeDeploymentName),
+				NodeSelector:   map[string]string{"cilium.io/no-schedule": "true"},
+				ReadinessProbe: newLocalReadinessProbe(port, "/"),
+				HostNetwork:    true,
+				Tolerations: append(
+					[]corev1.Toleration{
+						{Operator: corev1.TolerationOpExists},
+					},
+					ct.params.GetTolerations()...,
+				),
+			})
+			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(echoExternalNodeDeploymentName), metav1.CreateOptions{})
 			if err != nil {
-				ct.Logf("✨ [%s] Deploying echo-external-node deployment...", ct.clients.src.ClusterName())
-				// in case if test concurrency is > 1 port must be unique for each test namespace
-				port := ct.Params().ExternalDeploymentPort
-				echoExternalDeployment := newDeployment(deploymentParameters{
-					Name:           echoExternalNodeDeploymentName,
-					Kind:           kindEchoExternalNodeName,
-					Port:           port,
-					NamedPort:      fmt.Sprintf("http-%d", port),
-					HostPort:       port,
-					Image:          ct.params.JSONMockImage,
-					Labels:         map[string]string{"external": "echo"},
-					Annotations:    ct.params.DeploymentAnnotations.Match(echoExternalNodeDeploymentName),
-					NodeSelector:   map[string]string{"cilium.io/no-schedule": "true"},
-					ReadinessProbe: newLocalReadinessProbe(port, "/"),
-					HostNetwork:    true,
-					Tolerations: append(
-						[]corev1.Toleration{
-							{Operator: corev1.TolerationOpExists},
-						},
-						ct.params.GetTolerations()...,
-					),
-				})
-				_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(echoExternalNodeDeploymentName), metav1.CreateOptions{})
-				if err != nil {
-					return fmt.Errorf("unable to create service account %s: %w", echoExternalNodeDeploymentName, err)
-				}
-				_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, echoExternalDeployment, metav1.CreateOptions{})
-				if err != nil {
-					return fmt.Errorf("unable to create deployment %s: %w", echoExternalNodeDeploymentName, err)
-				}
-
-				svc := newService(echoExternalNodeDeploymentName,
-					map[string]string{"name": echoExternalNodeDeploymentName, "kind": kindEchoExternalNodeName},
-					map[string]string{"kind": kindEchoExternalNodeName}, "http", port, "ClusterIP")
-				svc.Spec.ClusterIP = corev1.ClusterIPNone
-				_, err := ct.clients.src.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
-				if err != nil {
-					return fmt.Errorf("unable to create service %s: %w", echoExternalNodeDeploymentName, err)
-				}
+				return fmt.Errorf("unable to create service account %s: %w", echoExternalNodeDeploymentName, err)
 			}
-		} else {
-			ct.Infof("Skipping tests that require a node Without Cilium")
+			_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, echoExternalDeployment, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create deployment %s: %w", echoExternalNodeDeploymentName, err)
+			}
+
+			svc := newService(echoExternalNodeDeploymentName,
+				map[string]string{"name": echoExternalNodeDeploymentName, "kind": kindEchoExternalNodeName},
+				map[string]string{"kind": kindEchoExternalNodeName}, "http", port, "ClusterIP")
+			svc.Spec.ClusterIP = corev1.ClusterIPNone
+			_, err := ct.clients.src.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create service %s: %w", echoExternalNodeDeploymentName, err)
+			}
 		}
+	} else {
+		ct.Infof("Skipping tests that require a node Without Cilium")
 	}
 
 	// Create one Ingress service for echo deployment
@@ -3022,7 +3021,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	// The host-netns-non-cilium DaemonSet is created in the source cluster only, also in case of multi-cluster tests.
-	if !ct.params.SingleNode || ct.params.MultiCluster != "" {
+	if ct.Features[features.NodeWithoutCilium].Enabled {
 		if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.Params().TestNamespace, hostNetNSDeploymentNameNonCilium); err != nil {
 			return err
 		}


### PR DESCRIPTION
```release-note
Use fake external targets on nodes without Cilium in GKE CI workflows for better stability.
```