### PR TITLE
bpf: add REASON_MTU_ERROR_MSG forwarded metric.

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -526,6 +526,7 @@ enum {
 #define REASON_DECRYPTING			12
 #define REASON_ENCRYPTING			13
 #define REASON_LB_REVNAT_DELETE		14
+#define REASON_MTU_ERROR_MSG			15
 
 /* Lookup scope for externalTrafficPolicy=Local */
 #define LB_LOOKUP_SCOPE_EXT	0

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -539,8 +539,11 @@ ct_extract_ports6(struct __ctx_buff *ctx, struct ipv6hdr *ip6, fraginfo_t fragin
 		tuple->dport = 0;
 
 		switch (type) {
-		case ICMPV6_DEST_UNREACH:
 		case ICMPV6_PKT_TOOBIG:
+			update_metrics(ctx_full_len(ctx), ct_to_metrics_dir(dir),
+				       REASON_MTU_ERROR_MSG);
+			fallthrough;
+		case ICMPV6_DEST_UNREACH:
 		case ICMPV6_TIME_EXCEED:
 		case ICMPV6_PARAMPROB:
 			tuple->flags |= TUPLE_F_RELATED;
@@ -799,12 +802,15 @@ ct_extract_ports4(struct __ctx_buff *ctx, struct iphdr *ip4, fraginfo_t fraginfo
 		tuple->dport = 0;
 
 		switch (type) {
+		case ICMP_FRAG_NEEDED:
+			update_metrics(ctx_full_len(ctx), ct_to_metrics_dir(dir),
+				       REASON_MTU_ERROR_MSG);
+			break;
 		case ICMP_DEST_UNREACH:
 		case ICMP_TIME_EXCEEDED:
 		case ICMP_PARAMETERPROB:
 			tuple->flags |= TUPLE_F_RELATED;
 			break;
-
 		case ICMP_ECHOREPLY:
 			tuple->sport = identifier;
 			break;

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -29,6 +29,7 @@ var errors = map[uint8]string{
 	12:  "Interface Decrypting",
 	13:  "Interface Encrypting",
 	14:  "LB: sock cgroup: Reverse entry delete succeeded",
+	15:  "MTU error message",
 	130: "Invalid source mac",      // Unused
 	131: "Invalid destination mac", // Unused
 	132: "Invalid source ip",


### PR DESCRIPTION
It would be useful to have the ability to definitively detect MTU error messages (i.e. frag-needed or pkt-to-big) from icmp packets to determine if there are MTU issues occuring on the network.

Although hubble does provide metrics on this, a bpf metric is more definitive as it is not subject to hubble being enabled or buffer event drops.  As we're already examining the ICMP{4, 6} header by message type, we can trivially hook in some extra metrics counters that will enumerate any such messages. 

This hooks into the ct_extract_ports function which is used by conntrack (as well as directly by host device egress-gateway logic) to pull ct tuple information from the packet.

As this already parses icmp messages, we can add cases for mtu related message types.

The hook point to add this to the ct port lookup should provide sufficient coverage of this case in terms of metric counters, while also not introducing extra branching code paths to deal with this case.

