### PR TITLE
[v1.18] Fix IPsec startup panic in Multi-Pool IPAM mode

### DIFF
--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -368,7 +368,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 }
 
 func (n *linuxNodeHandler) enableIPSecIPv4DoLocalHost(errs error) (bool, error) {
-	if !n.subnetEncryption() {
+	if !n.subnetEncryption() && n.nodeConfig.AllocCIDRIPv4 != nil {
 		localCIDR := n.nodeConfig.AllocCIDRIPv4.IPNet
 		return true, errors.Join(errs, n.replaceNodeIPSecInRoute(localCIDR))
 	}
@@ -603,7 +603,7 @@ func (n *linuxNodeHandler) enableIPSecIPv6Do(newNode *nodeTypes.Node, nodeID uin
 }
 
 func (n *linuxNodeHandler) enableIPSecIPv6DoLocalHost(errs error) (bool, error) {
-	if !n.subnetEncryption() {
+	if !n.subnetEncryption() && n.nodeConfig.AllocCIDRIPv6 != nil {
 		localCIDR := n.nodeConfig.AllocCIDRIPv6.IPNet
 		return true, errors.Join(errs, n.replaceNodeIPSecInRoute(localCIDR))
 	}


### PR DESCRIPTION
At startup, the IPv4 and IPv6 allocation CIDRs are first initialized as nil in the InitLocalNode function from the LocalNodeStart start hook. Later in the startup sequence, the multi-pool manager watches for CiliumNode updates and reflect those in the local node status, thus updating the v4 and v6 allocation CIDRs.

When IPSec is enabled, it might be possible for the linux node handler to receive a node update before the allocation CIDRs have been set. If this happen, the IPSec subsystem tries to update the routes in the host routing table and panic while accessing the nil v4 and v6 allocation CIDRs:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x37d0675]

goroutine 423 [running]:
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).enableIPSecIPv6DoLocalHost(0xc000f6d6b0?, {0x0, 0x0})
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/ipsec.go:607 +0x55
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).enableIPsecIPv6(0xc001f9c388, 0xc003107b80, 0x5c27, 0x1, 0x0)
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/ipsec.go:621 +0x3d4
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).enableIPsec(0xc001f9c388, 0x0, 0xc003107b80, 0x5c27)
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/ipsec.go:161 +0x3a8
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).nodeUpdate(0xc001f9c388, 0x0, 0xc003107b80, 0x1)
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:504 +0xa48
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).NodeConfigurationChanged(_, {{0xc001bb3360, 0x10, 0x10}, {0xc001bb3390, 0x10, 0x10}, {0xc001e9d586, 0x10, 0x1a}, ...})
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:739 +0x51b
github.com/cilium/cilium/pkg/node/manager.(*NodeConfigNotifier).Notify(_, {{0xc001bb3360, 0x10, 0x10}, {0xc001bb3390, 0x10, 0x10}, {0xc001e9d586, 0x10, 0x1a}, ...})
	/go/src/github.com/cilium/cilium/pkg/node/manager/node_config_notifier.go:47 +0xb5
github.com/cilium/cilium/pkg/datapath/loader.(*loader).Reinitialize(0xc00053d280, {0x50c79f8, 0xc000e8f1a0}, 0xc001f8b688, {{0x49a183e, 0x4}, {0xc001c40499, 0x5}, 0x2118, 0x0, ...}, ...)
	/go/src/github.com/cilium/cilium/pkg/datapath/loader/base.go:515 +0x1e05
github.com/cilium/cilium/pkg/datapath/orchestrator.(*orchestrator).reinitialize(0xc001f6cf08, {0x50c79f8?, 0xc000e8f1a0?}, {{0x0?, 0x0?}, 0x0?}, 0xc001f8b688)
	/go/src/github.com/cilium/cilium/pkg/datapath/orchestrator/orchestrator.go:275 +0x110
github.com/cilium/cilium/pkg/datapath/orchestrator.(*orchestrator).reconciler(0xc001f6cf08, {0x50c79f8, 0xc000e8f1a0}, {0x50d1f80, 0xc0029f2600})
	/go/src/github.com/cilium/cilium/pkg/datapath/orchestrator/orchestrator.go:219 +0x725
github.com/cilium/hive/job.(*jobOneShot).start(0xc001ee2ae0, {0x50c79f8, 0xc000e8f1a0}, 0xc002613fa8?, {0x50d1f80, 0xc001ee2a80}, {{{0x0, 0x0, 0x0}}, 0xc000dc8210, ...})
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/oneshot.go:138 +0x4fd
created by github.com/cilium/hive/job.(*queuedJob).Start.func1 in goroutine 1
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/job.go:126 +0x16f
```

The commit fixes the issue checking for the allocation CIDRs to be non-nil before updating the host routing tables.

This issue only affects v1.18, where multi-pool IPAM and IPSec are both supported. This is not affecting main, since the offending logic has been changed and does not have this problem.

Observed [here](https://github.com/cilium/cilium/actions/runs/17645777107/job/50144286983) from https://github.com/cilium/cilium/pull/41631

```release-note
Fix panic at startup in IPsec subsystem with Multi-Pool IPAM mode
```
