### PR TITLE
hubble: allow overrrides if building from outside the tree

### DIFF
--- a/hubble/Makefile
+++ b/hubble/Makefile
@@ -7,7 +7,7 @@ CURR_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include $(CURR_DIR)/../Makefile.defs
 # Add the ability to override variables
--include Makefile.override
+-include $(CURR_DIR)/Makefile.override
 
 TARGET := hubble
 


### PR DESCRIPTION
After commit 9695b5979772 ("Support triggering Makefiles from outside the tree"), the overrides to the hubble build are no longer considered if hubble is built from outside the tree. Fix that by sourcing Makefile.override from $(CURR_DIR), like other includes Makefiles.

Fixes: 9695b5979772 ("Support triggering Makefiles from outside the tree")