### PR TITLE
cli/clustermesh: remove leftover global services status info

### DIFF
--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -231,7 +231,6 @@ then this will also wait for the LoadBalancer to be assigned an IP.
       - 10.168.0.89:2379
     ✅ Service "clustermesh-apiserver" of type "LoadBalancer" found
     🔌 Cluster Connections:
-    🔀 Global services: [ min:0 / avg:0.0 / max:0 ]
 
 
 Connect Clusters
@@ -267,7 +266,6 @@ The output will look something like this:
     ✅ All 2 nodes are connected to all clusters [min:1 / avg:1.0 / max:1]
     🔌 Cluster Connections:
     - cilium-cli-ci-multicluster-2-168: 2/2 configured, 2/2 connected
-    🔀 Global services: [ min:6 / avg:6.0 / max:6 ]
 
 If this step does not complete successfully, proceed to the troubleshooting
 section.

--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -629,12 +629,11 @@ type ClusterStats struct {
 }
 
 type ConnectivityStatus struct {
-	GlobalServices StatisticalStatus        `json:"global_services,omitempty"`
-	Connected      StatisticalStatus        `json:"connected,omitempty"`
-	Clusters       map[string]*ClusterStats `json:"clusters,omitempty"`
-	Total          int64                    `json:"total,omitempty"`
-	NotReady       int64                    `json:"not_ready,omitempty"`
-	Errors         status.ErrorCountMapMap  `json:"errors,omitempty"`
+	Connected StatisticalStatus        `json:"connected,omitempty"`
+	Clusters  map[string]*ClusterStats `json:"clusters,omitempty"`
+	Total     int64                    `json:"total,omitempty"`
+	NotReady  int64                    `json:"not_ready,omitempty"`
+	Errors    status.ErrorCountMapMap  `json:"errors,omitempty"`
 }
 
 func (c *ConnectivityStatus) addError(pod, cluster string, err error) {
@@ -788,10 +787,9 @@ func (k *K8sClusterMesh) determineStatusConnectivity(ctx context.Context, secret
 	collector func(ctx context.Context, ciliumPod string) (*status.ClusterMeshAgentConnectivityStatus, error),
 ) (*ConnectivityStatus, error) {
 	stats := &ConnectivityStatus{
-		GlobalServices: StatisticalStatus{Min: -1},
-		Connected:      StatisticalStatus{Min: -1},
-		Errors:         status.ErrorCountMapMap{},
-		Clusters:       map[string]*ClusterStats{},
+		Connected: StatisticalStatus{Min: -1},
+		Errors:    status.ErrorCountMapMap{},
+		Clusters:  map[string]*ClusterStats{},
 	}
 
 	// Retrieve the remote clusters to connect to from the clustermesh configuration,
@@ -831,7 +829,6 @@ func (k *K8sClusterMesh) determineStatusConnectivity(ctx context.Context, secret
 	}
 
 	if len(pods.Items) > 0 {
-		stats.GlobalServices.Avg /= float64(len(pods.Items))
 		stats.Connected.Avg /= float64(len(pods.Items))
 	}
 
@@ -960,12 +957,6 @@ func (k *K8sClusterMesh) outputConnectivityStatus(agents, kvstoremesh *Connectiv
 	} else {
 		k.Log("🔌 No cluster connected")
 	}
-
-	k.Log("")
-	k.Log("🔀 Global services: [ min:%d / avg:%.1f / max:%d ]",
-		agents.GlobalServices.Min,
-		agents.GlobalServices.Avg,
-		agents.GlobalServices.Max)
 
 	k.Log("")
 	errCount := len(agents.Errors)


### PR DESCRIPTION
The support for exposing and displaying the count of global services got dropped in the blamed commit. Let's also clean up the leftover global services status info, which otherwise always displays incorrect information.

Fixes: 3ab6ebf3f550 ("clustermesh: remove GlobalServiceCache in cilium-agent")