### PR TITLE
envoy: Add config for websocket upgrades

### DIFF
--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -395,7 +395,10 @@ func (s *xdsServer) getHttpFilterChainProto(clusterName string, tls bool, isIngr
 	}
 
 	hcmConfig := &envoy_config_http.HttpConnectionManager{
-		StatPrefix:        "proxy",
+		StatPrefix: "proxy",
+		UpgradeConfigs: []*envoy_config_http.HttpConnectionManager_UpgradeConfig{
+			{UpgradeType: "websocket"},
+		},
 		UseRemoteAddress:  &wrapperspb.BoolValue{Value: true},
 		SkipXffAppend:     true,
 		XffNumTrustedHops: xffNumTrustedHops,


### PR DESCRIPTION
Adding config for websocket upgrades allows Envoy HTTP filter to pass-through websocket upgrades, while having no effect on non-websocket connections.

Fixes: #11672

```release-note
Cilium now configures Envoy to allow websocket connections to be passed through with HTTP policies.
```
