### PR TITLE
[v1.17] workflows/release: add secrets for step 4 and 5

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -216,6 +216,16 @@ jobs:
     with:
       step: "4-post-release"
       version: ${{ github.ref_name }}
+    # This is the intended behavior of GitHub Actions. Declaring entries under
+    # "secrets:" grants the called workflow permission to read
+    # CILIUM_RELEASE_BOT_PEM and CILIUM_RELEASE_BOT_APP_ID. It does not pass
+    # literal values here; the values are resolved only in the called
+    # workflow's scope. If the called workflow sets an environment
+    # (e.g., environment: TestEnvironment), environment-scoped secrets are
+    # populated there and become available to its steps.
+    secrets:
+      CILIUM_RELEASE_BOT_PEM: ${{ secrets.CILIUM_RELEASE_BOT_PEM }}
+      CILIUM_RELEASE_BOT_APP_ID: ${{ secrets.CILIUM_RELEASE_BOT_APP_ID }}
 
   call-publish-helm:
     name: Publish Helm Chart
@@ -224,3 +234,13 @@ jobs:
     with:
       step: "5-publish-helm"
       version: ${{ github.ref_name }}
+    # This is the intended behavior of GitHub Actions. Declaring entries under
+    # "secrets:" grants the called workflow permission to read
+    # CILIUM_RELEASE_BOT_PEM and CILIUM_RELEASE_BOT_APP_ID. It does not pass
+    # literal values here; the values are resolved only in the called
+    # workflow's scope. If the called workflow sets an environment
+    # (e.g., environment: TestEnvironment), environment-scoped secrets are
+    # populated there and become available to its steps.
+    secrets:
+      CILIUM_RELEASE_BOT_PEM: ${{ secrets.CILIUM_RELEASE_BOT_PEM }}
+      CILIUM_RELEASE_BOT_APP_ID: ${{ secrets.CILIUM_RELEASE_BOT_APP_ID }}


### PR DESCRIPTION
[ upstream commit 1e81d0cfb08f7a3ed8335979ce8d9f50b7ec482b ]

The build images releases need to pass the secrets to the release workflow when using reusable workflow. This way, it is possible for the child workflow to access the secrets stored on an environment.
