### PR TITLE
CODEOWNERS: assign Hubble metrics documentation to @cilium/hubble-metrics

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -434,6 +434,7 @@ Makefile* @cilium/build
 /Documentation/network/servicemesh/ @cilium/sig-servicemesh @cilium/docs-structure
 /Documentation/observability/ @cilium/sig-policy @cilium/docs-structure
 /Documentation/observability/hubble* @cilium/sig-hubble @cilium/docs-structure
+/Documentation/observability/metrics.rst @cilium/hubble-metrics @cilium/docs-structure
 /Documentation/operations/performance/ @cilium/sig-datapath @cilium/docs-structure
 /Documentation/operations/system_requirements.rst @cilium/sig-datapath @cilium/docs-structure
 /Documentation/operations/troubleshooting_clustermesh.rst @cilium/sig-clustermesh @cilium/docs-structure

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -95,7 +95,7 @@ option is set in the ``scrape_configs`` section:
 Hubble Metrics
 ==============
 
-While Cilium metrics allow you to monitor the state Cilium itself,
+While Cilium metrics allow you to monitor the state of Cilium itself,
 Hubble metrics on the other hand allow you to monitor the network behavior
 of your Cilium-managed Kubernetes pods with respect to connectivity and security.
 


### PR DESCRIPTION
This team is better suited to review changes to this part of the documentation.

Also fix a small typo in the docs in question while at it.

Noticed during review of https://github.com/cilium/cilium/pull/41736