### PR TITLE
fix(chart): Drop NP and CNP permission in hubble UI's ClusterRole

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
@@ -15,14 +15,6 @@ metadata:
 
 rules:
 - apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - componentstatuses
@@ -39,14 +31,6 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cilium.io
-  resources:
-  - "*"
   verbs:
   - get
   - list


### PR DESCRIPTION
See description in issue #41742 :
> I observed that the ClusterRole of Hubble UI is using a wildcard permission which is not considered best practice in CIS benchmarks and > other security frameworks:
> > 5.1.3 - Minimize wildcard use in Roles and ClusterRoles (Manual)
> 
> _Links to those frameworks:_
> - https://hub.armosec.io/docs/c-0187
> - https://hub.datree.io/built-in-rules/prevent-wildcards-role-clusterrole
> - https://support.icompaas.com/support/solutions/articles/62000234737-minimize-wildcard-use-in-roles-and-clusterroles
> 
> Link to the related YAML file inside the helm chart:
> https://github.com/cilium/cilium/blob/8cb80a65ac125d20ca9a06e32962222ac98f7663/install/kubernetes/cilium/templates/hubble-ui/clusterrole.> yaml#L46-L53

In my homelab I replaced the wildcard with `ciliumnetworkpolicies` , and it seems to work, but a Hubble developer should challenge whether additional resources are consumed from kube-api in special use cases.

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #41742

```release-note
Remove NP and CNP permission in hubble UI's ClusterRole
```
