### PR TITLE
Docs: update fragmentation docs to reflect ipv6

### DIFF
--- a/Documentation/network/concepts/fragmentation.rst
+++ b/Documentation/network/concepts/fragmentation.rst
@@ -28,17 +28,4 @@ To check whether fragmentation occurred, check the value of the following metric
 
 If they're non-zero, it means that fragmented packets were processed.
 
-.. note::
-
-    When running Cilium with kube-proxy, fragmented NodePort traffic may break due
-    to a kernel bug where route MTU is not respected for forwarded packets. Cilium
-    fragments tracking requires the first logical fragment to arrive first. Due to the
-    kernel bug, additional fragmentation on the outer encapsulation layer may happen
-    that causes packet reordering and results in a failure in tracking the fragments.
-
-    The kernel bug has been `fixed <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=02a1b175b0e92d9e0fa5df3957ade8d733ceb6a0>`_
-    and backported to all maintained kernel versions. If you observe connectivity problems,
-    ensure that the kernel package on your nodes has been upgraded recently before
-    reporting an issue.
-
 .. include:: ../../beta.rst

--- a/Documentation/network/concepts/fragmentation.rst
+++ b/Documentation/network/concepts/fragmentation.rst
@@ -6,8 +6,8 @@
 
 .. _concepts_fragmentation:
 
-IPv4 Fragment Handling
-======================
+Fragment Handling
+=================
 
 By default, Cilium configures the eBPF datapath to perform IP fragment tracking
 to allow protocols that do not support segmentation (such as UDP) to
@@ -16,10 +16,17 @@ configured using the following options:
 
 - ``--enable-ipv4-fragment-tracking``: Enable or disable IPv4 fragment
   tracking. Enabled by default.
+- ``--enable-ipv6-fragment-tracking``: Enable or disable IPv6 fragment
+  tracking. Enabled by default.
 - ``--bpf-fragments-map-max``: Control the maximum number of active concurrent
   connections using IP fragmentation. For the defaults, see `bpf_map_limitations`.
 
-To check whether fragmentation occurred, check the value of ``cilium_bpf_map_pressure{map_name="cilium_ipv4_frag_datagrams"}`` metric. If it's non-zero, it means that fragmentation occurred.
+To check whether fragmentation occurred, check the value of the following metrics:
+
+- ``cilium_bpf_map_pressure{map_name="cilium_ipv4_frag_datagrams"}``
+- ``cilium_bpf_map_pressure{map_name="cilium_ipv6_frag_datagrams"}``
+
+If they're non-zero, it means that fragmented packets were processed.
 
 .. note::
 


### PR DESCRIPTION
We support ipv4 as well as ipv6 fragment tracking, so let's update the docs to reflect that.

