### PR TITLE
bpf: improve L3 device handling

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -354,7 +354,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			ret = maybe_add_l2_hdr(ctx, ep->ifindex, &l2_hdr_required);
 			if (ret != 0)
 				return ret;
-			if (l2_hdr_required && ETH_HLEN == 0) {
+			if (l2_hdr_required && THIS_IS_L3_DEV) {
 				/* l2 header is added */
 				l3_off += __ETH_HLEN;
 			}
@@ -763,7 +763,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			ret = maybe_add_l2_hdr(ctx, ep->ifindex, &l2_hdr_required);
 			if (ret != 0)
 				return ret;
-			if (l2_hdr_required && ETH_HLEN == 0) {
+			if (l2_hdr_required && THIS_IS_L3_DEV) {
 				/* l2 header is added */
 				l3_off += __ETH_HLEN;
 				if (!____revalidate_data_pull(ctx, &data, &data_end,

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -347,14 +347,14 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			return CTX_ACT_OK;
 
 #ifdef ENABLE_HOST_ROUTING
-		/* add L2 header for L2-less interface, such as cilium_wg0 */
-		if (!from_host) {
+		/* add L2 header for L2-less interface: */
+		if (!from_host && THIS_IS_L3_DEV) {
 			bool l2_hdr_required = true;
 
 			ret = maybe_add_l2_hdr(ctx, ep->ifindex, &l2_hdr_required);
 			if (ret != 0)
 				return ret;
-			if (l2_hdr_required && THIS_IS_L3_DEV) {
+			if (l2_hdr_required) {
 				/* l2 header is added */
 				l3_off += __ETH_HLEN;
 			}
@@ -756,14 +756,14 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			return CTX_ACT_OK;
 
 #ifdef ENABLE_HOST_ROUTING
-		/* add L2 header for L2-less interface, such as cilium_wg0 */
-		if (!from_host) {
+		/* add L2 header for L2-less interface: */
+		if (!from_host && THIS_IS_L3_DEV) {
 			bool l2_hdr_required = true;
 
 			ret = maybe_add_l2_hdr(ctx, ep->ifindex, &l2_hdr_required);
 			if (ret != 0)
 				return ret;
-			if (l2_hdr_required && THIS_IS_L3_DEV) {
+			if (l2_hdr_required) {
 				/* l2 header is added */
 				l3_off += __ETH_HLEN;
 				if (!____revalidate_data_pull(ctx, &data, &data_end,

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -987,6 +987,10 @@ int handle_l2_announcement(struct __ctx_buff *ctx, struct ipv6hdr *ip6)
 	int ret;
 	__u64 time;
 
+	/* Announcing L2 addresses for a L3 device makes no sense: */
+	if (THIS_IS_L3_DEV)
+		return CTX_ACT_OK;
+
 	time = config_get(RUNTIME_CONFIG_AGENT_LIVENESS);
 	if (!time)
 		return CTX_ACT_OK;

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -104,13 +104,8 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 identity, __s8 *ext_err __maybe_unused
 		ret = maybe_add_l2_hdr(ctx, ep->ifindex, &l2_hdr_required);
 		if (ret != 0)
 			return ret;
-		if (l2_hdr_required) {
+		if (l2_hdr_required)
 			l3_off += __ETH_HLEN;
-			if (!____revalidate_data_pull(ctx, &data, &data_end,
-						      (void **)&ip6, sizeof(*ip6),
-							  false, l3_off))
-				return DROP_INVALID;
-		}
 #endif
 
 		return ipv6_local_delivery(ctx, l3_off, identity, MARK_MAGIC_IDENTITY, ep,

--- a/bpf/lib/classifiers.h
+++ b/bpf/lib/classifiers.h
@@ -122,7 +122,7 @@ ctx_classify(struct __ctx_buff *ctx, __be16 proto, enum trace_point obs_point __
 		proto = ctx_get_protocol(ctx);
 
 	/* Check whether the packet comes from a L3 device (no ethernet). */
-	if (ETH_HLEN == 0)
+	if (THIS_IS_L3_DEV)
 		flags |= CLS_FLAG_L3_DEV;
 
 	/* Check if IPv6 packet. */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -105,6 +105,8 @@ union v6addr {
 #define d2 d.d2
 } __packed;
 
+#define THIS_IS_L3_DEV		(ETH_HLEN == 0)
+
 static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
 						      int l2_off, __u16 *proto)
 {
@@ -113,7 +115,7 @@ static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
 	void *data = ctx_data(ctx);
 	struct ethhdr *eth;
 
-	if (ETH_HLEN == 0) {
+	if (THIS_IS_L3_DEV) {
 		/* The packet is received on L2-less device. Determine L3
 		 * protocol from skb->protocol.
 		 */

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -33,7 +33,7 @@ maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
 		 * skip L2 addr settings.
 		 */
 		*l2_hdr_required = false;
-	} else if (ETH_HLEN == 0) {
+	} else if (THIS_IS_L3_DEV) {
 		/* The packet is going to be redirected from L3 to L2
 		 * device, so we need to create L2 header first.
 		 */

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -534,10 +534,6 @@ bool icmp6_ndisc_validate(struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
 	struct ethhdr *eth = ctx_data(ctx);
 	union macaddr *dmac;
 
-	/* On l2-less devices there is no MAC address, and we cannot proceed */
-	if (THIS_IS_L3_DEV)
-		return false;
-
 	if ((void *)eth + ETH_HLEN > ctx_data_end(ctx))
 		return false;
 

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -535,7 +535,7 @@ bool icmp6_ndisc_validate(struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
 	union macaddr *dmac;
 
 	/* On l2-less devices there is no MAC address, and we cannot proceed */
-	if (sizeof(struct ethhdr) != ETH_HLEN)
+	if (THIS_IS_L3_DEV)
 		return false;
 
 	if ((void *)eth + ETH_HLEN > ctx_data_end(ctx))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -113,7 +113,7 @@ nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 	 * Otherwise, the kernel will drop such request in
 	 * https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/core/filter.c?h=v6.7.4#n2147
 	 */
-	if (ETH_HLEN == 0) {
+	if (THIS_IS_L3_DEV) {
 		int ret;
 
 		ret = add_l2_hdr(ctx);
@@ -146,7 +146,7 @@ nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_p
 	 * Otherwise, the kernel will drop such request in
 	 * https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/core/filter.c?h=v6.7.4#n2147
 	 */
-	if (ETH_HLEN == 0) {
+	if (THIS_IS_L3_DEV) {
 		int ret;
 
 		ret = add_l2_hdr(ctx);

--- a/bpf/tests/classifiers_common.h
+++ b/bpf/tests/classifiers_common.h
@@ -44,7 +44,7 @@ ASSIGN_CONFIG(__u32, trace_payload_len_overlay, 20UL);
 static __always_inline void
 adjust_l2(struct __ctx_buff *ctx)
 {
-	if (ETH_HLEN != 0)
+	if (!THIS_IS_L3_DEV)
 		return;
 
 	void *data = (void *)(long)ctx->data;


### PR DESCRIPTION
Follow up on the discussion from https://github.com/cilium/cilium/pull/41595#discussion_r2354555785, and standardize how we check whether the current device is of L3 type.

The way we define `ETH_LEN` from within `eth.h` feels a bit brittle, but let's see.