### PR TITLE
gha: Correct k8s version for f12-datapath-service-ns-misc

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -247,7 +247,7 @@ exclude:
   - k8s-version: "1.32"
     focus: "f11-datapath-service-ns-tc"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.32"
     focus: "f12-datapath-service-ns-misc"
 
   - k8s-version: "1.32"


### PR DESCRIPTION
Fixes: e471a29bedae04a5581db3c6e0816e28e7f630f4
