### PR TITLE
bpf/analyze backwards live instruction iterator and analysis cache

### DIFF
--- a/pkg/bpf/analyze/blocks_test.go
+++ b/pkg/bpf/analyze/blocks_test.go
@@ -40,7 +40,7 @@ func TestMakeBlocksSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.EqualValues(t, 1, b.count())
-	assert.Nil(t, b.LiveInstructions(insns))
+	assert.Nil(t, b.LiveInstructions(insns).Forward())
 
 	block := b.first()
 	assert.EqualValues(t, 0, block.id)

--- a/pkg/bpf/analyze/reachability_test.go
+++ b/pkg/bpf/analyze/reachability_test.go
@@ -39,7 +39,7 @@ func TestReachabilitySimple(t *testing.T) {
 	assert.EqualValues(t, 5, noElim.count(), "All blocks should be live")
 	assert.Equal(t, noElim.count(), noElim.countLive())
 
-	iter := noElim.LiveInstructions(obj.Program.Instructions)
+	iter := noElim.LiveInstructions(obj.Program.Instructions).Forward()
 	assert.NotNil(t, iter)
 	var found bool
 	for ins, live := range iter {
@@ -57,7 +57,7 @@ func TestReachabilitySimple(t *testing.T) {
 	assert.False(t, elim.isLive(1), "Second block with map_a reference should be dead")
 	assert.Equal(t, elim.count()-1, elim.countLive())
 
-	iter = elim.LiveInstructions(obj.Program.Instructions)
+	iter = elim.LiveInstructions(obj.Program.Instructions).Forward()
 	assert.NotNil(t, iter)
 	for ins, live := range iter {
 		if !live {

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -208,7 +208,9 @@ func LoadCollection(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *Collec
 		return nil, nil, fmt.Errorf("applying variable overrides: %w", err)
 	}
 
-	if err := removeUnusedTailcalls(logger, spec); err != nil {
+	reachabilityCache := make(map[string]*analyze.Blocks)
+
+	if err := removeUnusedTailcalls(logger, spec, reachabilityCache); err != nil {
 		return nil, nil, fmt.Errorf("removing unused tail calls: %w", err)
 	}
 
@@ -216,7 +218,7 @@ func LoadCollection(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *Collec
 		return nil, nil, fmt.Errorf("resolving tail calls: %w", err)
 	}
 
-	keep, err := removeUnusedMaps(spec, opts.Keep)
+	keep, err := removeUnusedMaps(spec, opts.Keep, reachabilityCache)
 	if err != nil {
 		return nil, nil, fmt.Errorf("pruning unused maps: %w", err)
 	}

--- a/pkg/bpf/unused_maps.go
+++ b/pkg/bpf/unused_maps.go
@@ -61,7 +61,7 @@ func removeUnusedMaps(spec *ebpf.CollectionSpec, keep *set.Set[string]) (*set.Se
 		}
 
 		// Record which maps are still referenced after reachability analysis.
-		for ins, live := range bl.LiveInstructions(prog.Instructions) {
+		for ins, live := range bl.LiveInstructions(prog.Instructions).Forward() {
 			if !ins.IsLoadFromMap() {
 				continue
 			}

--- a/pkg/bpf/unused_maps_test.go
+++ b/pkg/bpf/unused_maps_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/bpf/analyze"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -28,7 +29,7 @@ func TestPrivilegedRemoveUnusedMaps(t *testing.T) {
 	require.NoError(t, spec.Assign(&obj))
 
 	// Initially, all maps should be kept.
-	keep, err := removeUnusedMaps(spec, nil)
+	keep, err := removeUnusedMaps(spec, nil, make(map[string]*analyze.Blocks))
 	require.NoError(t, err)
 	assert.True(t, keep.Has("map_a"))
 
@@ -39,7 +40,7 @@ func TestPrivilegedRemoveUnusedMaps(t *testing.T) {
 
 	// When setting use_map_b to true, map_a should be pruned.
 	require.NoError(t, obj.UseMapB.Set(true))
-	keep, err = removeUnusedMaps(spec, nil)
+	keep, err = removeUnusedMaps(spec, nil, make(map[string]*analyze.Blocks))
 	require.NoError(t, err)
 
 	assert.False(t, keep.Has("map_a"))

--- a/pkg/bpf/unused_tailcalls_test.go
+++ b/pkg/bpf/unused_tailcalls_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf/analyze"
 )
 
 func TestRemoveUnusedTailcalls(t *testing.T) {
@@ -33,7 +35,7 @@ func TestRemoveUnusedTailcalls(t *testing.T) {
 	require.NoError(t, cpy.Assign(&obj))
 	require.NoError(t, obj.UseTailB.Set(true))
 
-	require.NoError(t, removeUnusedTailcalls(logger, cpy))
+	require.NoError(t, removeUnusedTailcalls(logger, cpy, make(map[string]*analyze.Blocks)))
 
 	assert.Contains(t, cpy.Programs, "cil_entry")
 	assert.Contains(t, cpy.Programs, "a")
@@ -49,7 +51,7 @@ func TestRemoveUnusedTailcalls(t *testing.T) {
 	require.NoError(t, cpy.Assign(&obj))
 	require.NoError(t, obj.UseTailB.Set(false))
 
-	require.NoError(t, removeUnusedTailcalls(logger, cpy))
+	require.NoError(t, removeUnusedTailcalls(logger, cpy, make(map[string]*analyze.Blocks)))
 
 	assert.Contains(t, cpy.Programs, "cil_entry")
 	assert.Contains(t, cpy.Programs, "a")


### PR DESCRIPTION
During review of #41421 a few minor improvements were mentioned which were not blocking for that initial PR. This follow-up PR adds these:

In the tail call pruning we are looking for a call instructions, and the 2 instructions above it. This was initially implemented by keeping track if indexes to allow us to look back in the slice. This depends on a number of assumptions of the iterator implementation. This PR instead introduces a copy-able iterator that can also iterate backwards which is a more elegant solution.

Secondly, since both unused tail call pruning and unused map pruning require reach-ability analysis we ended up calling `analyze.Reachability` twice. While the creation of the blocklist is cached, the evaluation of the config variable and construction of the bitmaps is not. So this PR adds a simple map to cache results.
