### PR TITLE
endpointsynchronizer: suppress warning log when endpoint is terminating

### DIFF
--- a/pkg/endpointmanager/endpointsynchronizer.go
+++ b/pkg/endpointmanager/endpointsynchronizer.go
@@ -204,6 +204,11 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 
 						// continue the execution so we update the endpoint
 						// status immediately upon endpoint creation
+
+					case errors.Is(err, context.Canceled):
+						// Do not log a warning in case of errors due to the
+						// endpoint being terminated.
+						return nil
 					default:
 						scopedLog.Warn("Error getting CEP", logfields.Error, err)
 						return err


### PR DESCRIPTION
We sometimes see CI failures caused by warnings along the lines of:

>  msg="Error getting CEP" [...] error="Get \"https://10.245.0.1:443/apis/cilium.io/v2/namespaces/.../ciliumendpoints/...?resourceVersion=0\": context canceled"

In case the get operation gets interrupted because the endpoint is terminating, and the controller's context gets canceled. Let's silence them, as completely legitimate, so that they don't get flagged causing failures.

Fixes: https://github.com/cilium/cilium/issues/41683