### PR TITLE
.github/workflows: remove reviewers requested by auto-committer[bot]

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{
          github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
-         github.triggering_actor == 'cilium-renovate[bot]' &&
+         (github.triggering_actor == 'cilium-renovate[bot]' ||
+          github.triggering_actor == 'auto-committer[bot]') &&
          github.event.requested_reviewer.login == 'ciliumbot'
         }}
     steps:
@@ -36,12 +37,13 @@ jobs:
 
     - name: Approve PR
       # Approve the PR if all the following conditions are true:
-      # - the PR review was requested by renovate bot and
-      # - the PR was also created by renovate bot
+      # - the PR was created by renovate bot and
+      # - the PR review was requested by renovate bot or auto-committer[bot] and
       # - the requested reviewer was the trusted 'ciliumbot'
       if: ${{
            github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
-           github.triggering_actor == 'cilium-renovate[bot]' &&
+           (github.triggering_actor == 'cilium-renovate[bot]' ||
+            github.triggering_actor == 'auto-committer[bot]') &&
            github.event.requested_reviewer.login == 'ciliumbot'
           }}
       env:


### PR DESCRIPTION
The auto-committer[bot] triggers review requests when it builds and pushes the images into the PR. To prevent more notification noise for those reviewers, and if the ciliumbot is going to approve the PR, we should remove the reviewers from that PR automatically.

The core idea is basically to remove reviews requested like in here https://github.com/cilium/cilium/pull/41611#event-19606122834