### PR TITLE
cli: run N/S and EGW disruptivity testing when XDP is enabled

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1337,8 +1337,7 @@ func (ct *ConnectivityTest) ForEachIPFamily(do func(features.IPFamily)) {
 func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 	return ct.params.IncludeConnDisruptTestNSTraffic &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&
-		(ct.Params().MultiCluster == "" || ct.Features[features.KPR].Enabled) &&
-		!ct.Features[features.KPRNodePortAcceleration].Enabled
+		(ct.Params().MultiCluster == "" || ct.Features[features.KPR].Enabled)
 }
 
 func (ct *ConnectivityTest) ShouldRunConnDisruptEgressGateway() bool {
@@ -1346,7 +1345,6 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptEgressGateway() bool {
 		ct.params.IncludeConnDisruptTestEgressGateway &&
 		ct.Features[features.EgressGateway].Enabled &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&
-		!ct.Features[features.KPRNodePortAcceleration].Enabled &&
 		ct.params.MultiCluster == ""
 }
 

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -31,6 +31,7 @@ import (
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/versioncheck"
 	"github.com/cilium/cilium/tools/testowners/codeowners"
 )
 
@@ -1423,7 +1424,8 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 	return ct.params.IncludeConnDisruptTestNSTraffic &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&
 		(ct.Params().MultiCluster == "" || ct.Features[features.KPR].Enabled) &&
-		!ct.Features[features.KPRNodePortAcceleration].Enabled
+		(!ct.Features[features.KPRNodePortAcceleration].Enabled ||
+			versioncheck.MustCompile(">=1.20.0")(ct.CiliumVersion))
 }
 
 func (ct *ConnectivityTest) ShouldRunConnDisruptL7Traffic() bool {

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1440,7 +1440,8 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptEgressGateway() bool {
 		ct.params.IncludeConnDisruptTestEgressGateway &&
 		ct.Features[features.EgressGateway].Enabled &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&
-		!ct.Features[features.KPRNodePortAcceleration].Enabled &&
+		(!ct.Features[features.KPRNodePortAcceleration].Enabled ||
+			versioncheck.MustCompile(">=1.20.0")(ct.CiliumVersion)) &&
 		ct.params.MultiCluster == ""
 }
 


### PR DESCRIPTION
These seem to pass now without causing drops.
