### PR TITLE
check-encryption-leak: don't skip plain-text TCP RST packets

### DIFF
--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -74,8 +74,6 @@ struct dnshdr {
 // Monitor and log plain text pod-to-pod packets passing through the bridge if:
 // 1. packet traced by proxy and at least one IP is in PodCIDR, or
 // 2. both IPs are in PodCIDR and not CiliumInternalIPs.
-// In addition, skip TCP RST packets, as they might be kernel-level packet due
-// to proxy timeout sockets (https://github.com/cilium/cilium/issues/35485).
 //
 // Shift header references to inner packet in case of encapsulation:
 // - EinV (< v1.18):  outer packet is plaintext overlay, checks must be against inner packet.
@@ -149,57 +147,55 @@ kprobe:br_forward
           (!$pod_to_pod_via_proxy && ($src_is_pod && $dst_is_pod) && (!$src_is_internal && !$dst_is_internal)) ||
           ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))
         ) {
-        if ($ip4h->protocol != PROTO_TCP || !$tcph->rst) {
-          $time = strftime("%H:%M:%S:%f", nsecs);
+        $time = strftime("%H:%M:%S:%f", nsecs);
 
-          printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+        printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+          $time, $skb,
+          ntop($ip4h->saddr),
+          ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
+          ntop($ip4h->daddr),
+          ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->dest) : 0,
+          bswap($ip4h->tot_len),
+          $ip4h->protocol,
+          $encap, $skb->encapsulation,
+          $skb->dev->ifindex,
+          $skb->dev->nd_net.net->ns.inum,
+          $src_is_pod, $src_is_internal,
+          $dst_is_pod, $dst_is_internal,
+          !!$pod_to_pod_via_proxy,
+          $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
+
+        if ($ip4h->protocol == PROTO_TCP) {
+          printf("[%s] [%p] ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
             $time, $skb,
-            ntop($ip4h->saddr),
-            ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
-            ntop($ip4h->daddr),
-            ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->dest) : 0,
-            bswap($ip4h->tot_len),
-            $ip4h->protocol,
-            $encap, $skb->encapsulation,
-            $skb->dev->ifindex,
-            $skb->dev->nd_net.net->ns.inum,
-            $src_is_pod, $src_is_internal,
-            $dst_is_pod, $dst_is_internal,
-            !!$pod_to_pod_via_proxy,
-            $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
+            $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
+            $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
+            $tcph->psh ? CH_P : CH_DOT, $tcph->rst ? CH_R : CH_DOT,
+            $tcph->syn ? CH_S : CH_DOT, $tcph->fin ? CH_F : CH_DOT,
+            bswap($tcph->seq), bswap($tcph->ack_seq));
+        }
 
-          if ($ip4h->protocol == PROTO_TCP) {
-            printf("[%s] [%p] ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
-              $time, $skb,
-              $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
-              $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
-              $tcph->psh ? CH_P : CH_DOT, $tcph->rst ? CH_R : CH_DOT,
-              $tcph->syn ? CH_S : CH_DOT, $tcph->fin ? CH_F : CH_DOT,
-              bswap($tcph->seq), bswap($tcph->ack_seq));
-          }
+        if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
+          $dns = (struct dnshdr*)($udph + 1);
+          $query = (uint8 *)($dns + 1);
+          printf("[%s] [%p] ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+            $time, $skb,
+            bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
+            bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
+            str(kptr($query)));
+        }
 
-          if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
-            $dns = (struct dnshdr*)($udph + 1);
-            $query = (uint8 *)($dns + 1);
-            printf("[%s] [%p] ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
-              $time, $skb,
-              bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
-              bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
-              str(kptr($query)));
-          }
+        if ($ip4h->protocol == PROTO_ICMP_IPV4) {
+          $frag_off = bswap($ip4h->frag_off);
 
-          if ($ip4h->protocol == PROTO_ICMP_IPV4) {
-            $frag_off = bswap($ip4h->frag_off);
-
-            printf("[%s] [%p] ↳ Detected ICMP message, IPFlags: .%c%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
-              $time, $skb,
-              ($frag_off & 0x4000) >> 14 ? CH_D : CH_DOT,
-              ($frag_off & 0x2000) >> 13 ? CH_M : CH_DOT,
-              $icmph->type,
-              $icmph->code,
-              $frag_off & 0x1FFF,
-              bswap($ip4h->id));
-          }
+          printf("[%s] [%p] ↳ Detected ICMP message, IPFlags: .%c%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
+            $time, $skb,
+            ($frag_off & 0x4000) >> 14 ? CH_D : CH_DOT,
+            ($frag_off & 0x2000) >> 13 ? CH_M : CH_DOT,
+            $icmph->type,
+            $icmph->code,
+            $frag_off & 0x1FFF,
+            bswap($ip4h->id));
         }
       }
     }
@@ -236,63 +232,61 @@ kprobe:br_forward
           (!$pod_to_pod_via_proxy && ($src_is_pod && $dst_is_pod) && (!$src_is_internal && !$dst_is_internal)) ||
           ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))
         ) {
-        if ($ip6h->nexthdr != PROTO_TCP || !$tcph->rst) {
-          $time = strftime("%H:%M:%S:%f", nsecs);
+        $time = strftime("%H:%M:%S:%f", nsecs);
 
-          printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+        printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+          $time, $skb,
+          ntop($ip6h->saddr.in6_u.u6_addr8),
+          ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
+          ntop($ip6h->daddr.in6_u.u6_addr8),
+          ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->dest) : 0,
+          bswap($ip6h->payload_len),
+          $ip6h->nexthdr,
+          $encap, $skb->encapsulation,
+          $skb->dev->ifindex,
+          $skb->dev->nd_net.net->ns.inum,
+          $src_is_pod, $src_is_internal,
+          $dst_is_pod, $dst_is_internal,
+          !!$pod_to_pod_via_proxy,
+          $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
+
+        if ($ip6h->nexthdr == PROTO_TCP) {
+          printf("[%s] [%p] ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
             $time, $skb,
-            ntop($ip6h->saddr.in6_u.u6_addr8),
-            ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
-            ntop($ip6h->daddr.in6_u.u6_addr8),
-            ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->dest) : 0,
-            bswap($ip6h->payload_len),
-            $ip6h->nexthdr,
-            $encap, $skb->encapsulation,
-            $skb->dev->ifindex,
-            $skb->dev->nd_net.net->ns.inum,
-            $src_is_pod, $src_is_internal,
-            $dst_is_pod, $dst_is_internal,
-            !!$pod_to_pod_via_proxy,
-            $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
+            $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
+            $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
+            $tcph->psh ? CH_P : CH_DOT, $tcph->rst ? CH_R : CH_DOT,
+            $tcph->syn ? CH_S : CH_DOT, $tcph->fin ? CH_F : CH_DOT,
+            bswap($tcph->seq), bswap($tcph->ack_seq));
+        }
 
-          if ($ip6h->nexthdr == PROTO_TCP) {
-            printf("[%s] [%p] ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
-              $time, $skb,
-              $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
-              $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
-              $tcph->psh ? CH_P : CH_DOT, $tcph->rst ? CH_R : CH_DOT,
-              $tcph->syn ? CH_S : CH_DOT, $tcph->fin ? CH_F : CH_DOT,
-              bswap($tcph->seq), bswap($tcph->ack_seq));
+        if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
+          $dns = (struct dnshdr*)($udph + 1);
+          $query = (uint8 *)($dns + 1);
+          printf("[%s] [%p] ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+            $time, $skb,
+            bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
+            bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
+            str(kptr($query)));
+        }
+
+        if ($ip6h->nexthdr == PROTO_ICMP_IPV6 || $ip6h->nexthdr == PROTO_FRAGMENT_IPV6) {
+          $frag_id = 0;
+          $frag_off_res_m = 0;
+
+          if ($ip6h->nexthdr == PROTO_FRAGMENT_IPV6) {
+            $frag_hdr = (struct frag_hdr *)($ip6h + 1);
+            $frag_id = bswap($frag_hdr->identification);
+            $frag_off_res_m = bswap($frag_hdr->frag_off);
           }
 
-          if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
-            $dns = (struct dnshdr*)($udph + 1);
-            $query = (uint8 *)($dns + 1);
-            printf("[%s] [%p] ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
-              $time, $skb,
-              bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
-              bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
-              str(kptr($query)));
-          }
-
-          if ($ip6h->nexthdr == PROTO_ICMP_IPV6 || $ip6h->nexthdr == PROTO_FRAGMENT_IPV6) {
-            $frag_id = 0;
-            $frag_off_res_m = 0;
-
-            if ($ip6h->nexthdr == PROTO_FRAGMENT_IPV6) {
-              $frag_hdr = (struct frag_hdr *)($ip6h + 1);
-              $frag_id = bswap($frag_hdr->identification);
-              $frag_off_res_m = bswap($frag_hdr->frag_off);
-            }
-
-            printf("[%s] [%p] ↳ Detected ICMP message, IPFlags: ..%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
-              $time, $skb,
-              $frag_off_res_m & 0x0001 ? CH_M : CH_DOT,
-              $icmph->type,
-              $icmph->code,
-              $frag_off_res_m >> 3,
-              $frag_id);
-          }
+          printf("[%s] [%p] ↳ Detected ICMP message, IPFlags: ..%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
+            $time, $skb,
+            $frag_off_res_m & 0x0001 ? CH_M : CH_DOT,
+            $icmph->type,
+            $icmph->code,
+            $frag_off_res_m >> 3,
+            $frag_id);
         }
       }
     }

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -407,7 +407,7 @@ kprobe:udpv6_sendmsg /comm == "cilium-agent" || comm == "dnsproxy"/
   }
 }
 
-// Additionally trace traffic flows in which the source got masquerated.
+// Additionally trace traffic flows in which the source got masqueraded.
 // Ignore packets w/o a socket assigned or that are not traced by the proxy.
 kprobe:udp_destroy_sock
 {
@@ -425,7 +425,7 @@ kprobe:udp_destroy_sock
   delete(@trace_sk[$sk]);
 }
 
-// Additionally trace traffic flows in which the source got masquerated.
+// Additionally trace traffic flows in which the source got masqueraded.
 kprobe:__dev_queue_xmit
 {
   $skb = ((struct sk_buff *) arg0);


### PR DESCRIPTION
Starting from v1.18 the IPsec encryption policy is applied when egressing the native device. Therefore we should be able to catch stray TCP RSTs by the L7 proxy which didn't pass through cilium_host, and encrypt them as needed.

This effectively reverts
commit 09551d20aa60 ("ci: skip plain-text TCP RST packets in bpftrace").