### PR TITLE
kvstoremesh: fix regression in determining end of bootstrap phase

### DIFF
--- a/clustermesh-apiserver/kvstoremesh/cells.go
+++ b/clustermesh-apiserver/kvstoremesh/cells.go
@@ -37,6 +37,7 @@ var Cell = cell.Module(
 		}),
 		heartbeat.Cell,
 
+		cell.Provide(kvstoremesh.NewSyncWaiter),
 		cell.Invoke(func(*kvstoremesh.KVStoreMesh) {}),
 	),
 

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -748,10 +748,12 @@ func TestRemoteClusterSync(t *testing.T) {
 				clusters: make(map[string]*remoteCluster),
 			}
 			km := KVStoreMesh{
-				config: tt.config,
-				common: mockClusterMesh,
-				logger: hivetest.Logger(t),
+				config:  tt.config,
+				common:  mockClusterMesh,
+				logger:  hivetest.Logger(t),
+				started: make(chan struct{}),
 			}
+			close(km.started)
 
 			rc := &remoteCluster{
 				name:         "foo",


### PR DESCRIPTION
The KVStoreMesh bootstrap phase takes care of populating the initial state into etcd for all the target clusters, and operates under the assumption that no watchers have been established yet (the container is not marked as ready) so that higher rate limiting settings can be used to speed up the process.

However, the blamed commit broke this logic due to some shuffling, and KVStoreMesh could end up exiting the bootstrap phase too early, when synchronization did not actually complete. That's because it was no longer guaranteed that the job waiting for synchronization started after the KVStoreMesh start hook, which retrieves the list of clusters to connect to.

Let's get this fixed, moving that logic back to the leader election cell, so that it uses the appropriate job group, that depends on KVStoreMesh, and gets started only after its start hook terminated. While not being strictly necessary, let's also add an explicit check so that [*KVStoreMesh.synced] blocks until the start hook actually completed, to prevent surprises in the future.

Fixes: f3a76e9799fd ("kvstoremesh: leader election with etcd lock")