### PR TITLE
gh: e2e-upgrade: temporarily disable XDP for config 6 and 14

### DIFF
--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -58,7 +58,8 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   host-fw: 'true'
-  lb-acceleration: 'testing-only'
+  # Disable until https://github.com/cilium/cilium/issues/41520 is resolved
+  # lb-acceleration: 'testing-only'
   ingress-controller: 'true'
   bgp-control-plane: 'true'
 - name: '7'
@@ -165,7 +166,8 @@
   tunnel: 'vxlan'
   lb-mode: 'snat'
   egress-gateway: 'true'
-  lb-acceleration: 'testing-only'
+  # Disable until https://github.com/cilium/cilium/issues/41520 is resolved
+  # lb-acceleration: 'testing-only'
   ingress-controller: 'true'
 - name: '15'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/41380 seems to have introduced a regression, when XDP needs to perform L2 resolution for hand-crafted VXLAN traffic. Disable XDP to cure the CI flakes, until the root cause has been identified.

This works around https://github.com/cilium/cilium/issues/41520.