### PR TITLE
datapath/neighbor: Reduce flakiness in Kernel ARP test

### DIFF
--- a/pkg/datapath/neighbor/test/testdata/neighbor-reconciler-kernel-arp.txtar
+++ b/pkg/datapath/neighbor/test/testdata/neighbor-reconciler-kernel-arp.txtar
@@ -42,7 +42,7 @@ db/cmp neighbors neighbors.reachable.table
 db/cmp neighbors neighbors.stale.table
 
 # Wait for the refresh to happen, which will trigger the neighbor table to change
-db/cmp neighbors neighbors.reachable.table
+db/cmp --timeout=1m neighbors neighbors.reachable.table
 
 # Assert the refresh was not due to the agent
 metrics cilium_neighbor_entry_refresh_count -o refresh-count.actual


### PR DESCRIPTION
The neighbor reconciler tests include a test which adds a neighbor entry and waits for the kernel to mark it as REACHABLE. However, the kernel does not always do this within the 5 second timeout that the db/cmp command defaults to. This commit increases the timeout to 1 minute to reduce flakiness in CI.