### PR TITLE
pkg/default: set AddressScopeMax default value

### DIFF
--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -188,7 +188,7 @@ const (
 // lower number signifies a wider scope with RT_SCOPE_UNIVERSE (0) being
 // the widest.
 //
-// This defaults to RT_SCOPE_LINK-1 (defaults.AddressScopeMax) and can be
+// This defaults to RT_SCOPE_HOST (defaults.AddressScopeMax) and can be
 // set by the user with --local-max-addr-scope.
 type AddressScopeMax uint8
 

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -142,42 +142,6 @@ var nodeAddressTests = []struct {
 			netip.MustParseAddr("2001:db8::1"),
 		},
 	},
-	{
-
-		name: "skip-out-of-scope-addrs",
-		addrs: []DeviceAddress{
-			{
-				Addr:  netip.MustParseAddr("10.0.1.1"),
-				Scope: RT_SCOPE_UNIVERSE,
-			},
-			{
-				Addr:  netip.MustParseAddr("10.0.2.2"),
-				Scope: RT_SCOPE_LINK,
-			},
-			{
-				Addr:      netip.MustParseAddr("10.0.3.3"),
-				Secondary: true,
-				Scope:     RT_SCOPE_HOST,
-			},
-		},
-
-		// The default AddressMaxScope is set to LINK-1, so addresses with
-		// scope LINK or above are ignored (except for cilium_host addresses)
-		wantAddrs: []netip.Addr{
-			ciliumHostIP,
-			ciliumHostIPLinkScoped,
-			netip.MustParseAddr("10.0.1.1"),
-		},
-
-		wantPrimary: []netip.Addr{
-			ciliumHostIP,
-			netip.MustParseAddr("10.0.1.1"),
-		},
-
-		wantNodePort: []netip.Addr{
-			netip.MustParseAddr("10.0.1.1"),
-		},
-	},
 
 	{
 		name: "multiple",

--- a/pkg/defaults/defaults_linux.go
+++ b/pkg/defaults/defaults_linux.go
@@ -10,5 +10,5 @@ import (
 const (
 	// AddressScopeMax controls the maximum address scope for addresses to be
 	// considered local ones with HOST_ID in the ipcache
-	AddressScopeMax = int(netlink.SCOPE_LINK) - 1
+	AddressScopeMax = int(netlink.SCOPE_HOST)
 )

--- a/pkg/defaults/defaults_unspecified.go
+++ b/pkg/defaults/defaults_unspecified.go
@@ -8,6 +8,6 @@ package defaults
 const (
 	// AddressScopeMax controls the maximum address scope for addresses to be
 	// considered local ones with HOST_ID in the ipcache
-	// Use the raw value instead of constant as netlink.SCOPE_LINK is using unix.RT_SCOPE_LINK
-	AddressScopeMax = 0xfd - 1 // netlink.SCOPE_LINK - 1
+	// Use the raw value instead of constant as netlink.SCOPE_HOST is using unix.RT_SCOPE_HOST
+	AddressScopeMax = 0xfe // netlink.SCOPE_HOST
 )


### PR DESCRIPTION
see the commit message.

Move this commit to seperate PR so we can backport this one for other use cases based on discussion https://github.com/cilium/cilium/pull/41645#discussion_r2363490574
 
Fixes: https://github.com/cilium/cilium/issues/41671


```release-note
Change the default AddressScopeMax to 254(host scope) so it works with new GKE meta data server and HCP use cases.
If you need to roll back to the previous behavior, you can set --local-max-addr-scope=252 for Cilium agent
```
