### PR TITLE
gha: Disable stress testing for EGW scale workflow

### DIFF
--- a/.github/actions/cl2-modules/egw/config.yaml
+++ b/.github/actions/cl2-modules/egw/config.yaml
@@ -196,13 +196,14 @@ steps:
       udpMessageSize: {{$UDPMessageSize}}
       hasEGWPolicy: {{$CreateEGWPolicy}}
 
+# https://github.com/cilium/cilium/pull/41781
 # Run the connections stress test.
-- module:
-    path: modules/stress-test.yaml
-    params:
-      image: {{$TestImage}}
-      externalTarget: {{$ExternalTarget}}
-      instance: stress
+#- module:
+#    path: modules/stress-test.yaml
+#    params:
+#      image: {{$TestImage}}
+#      externalTarget: {{$ExternalTarget}}
+#      instance: stress
 
 - module:
     path: ../cilium-agent-pprofs.yaml

--- a/.github/actions/cl2-modules/egw/modules/stress-test.yaml
+++ b/.github/actions/cl2-modules/egw/modules/stress-test.yaml
@@ -35,7 +35,7 @@ steps:
         ExternalTarget: {{ $externalTarget }}
         ExternalTargetPort: {{ IfThenElse (ne $test "diff-port") 1338 1339 }}
         ClientConnectTimeout: "30s"
-        Stress: true
+        Stress: false
         AffinityType: {{ IfThenElse (eq $test "base") "none" ( IfThenElse (eq $test "diff-node") "antiAffinity" "affinity" ) }}
         AffinityInstance: {{ $instance }}-base
 


### PR DESCRIPTION
The scale EGW test has been broken due to the stress tests - https://github.com/cilium/cilium/actions/workflows/scale-test-egw.yaml. 
While we lose out on the coverage with respect to "max parallel connections", we can still track regressions around other [metrics](https://github.com/cilium/scaffolding/blob/d1331426ba8a3480b2392a985554fe445cf628d6/egw-scale-utils/README.md#client-pod-metrics) reported by the workflow. 