### PR TITLE
Only pull the aws resources from its own VPC

### DIFF
--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -722,7 +722,7 @@ func (e *API) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap
 	return instances, nil
 }
 
-func (e *API) GetVpcs(ctx context.Context) (ipamTypes.VirtualNetworkMap, error) {
+func (e *API) GetVpcs(ctx context.Context, vpcID string) (ipamTypes.VirtualNetworkMap, error) {
 	vpcs := ipamTypes.VirtualNetworkMap{}
 
 	e.mutex.RLock()
@@ -734,7 +734,7 @@ func (e *API) GetVpcs(ctx context.Context) (ipamTypes.VirtualNetworkMap, error) 
 	return vpcs, nil
 }
 
-func (e *API) GetSubnets(ctx context.Context) (ipamTypes.SubnetMap, error) {
+func (e *API) GetSubnets(ctx context.Context, vpcID string) (ipamTypes.SubnetMap, error) {
 	subnets := ipamTypes.SubnetMap{}
 
 	e.mutex.RLock()
@@ -746,7 +746,7 @@ func (e *API) GetSubnets(ctx context.Context) (ipamTypes.SubnetMap, error) {
 	return subnets, nil
 }
 
-func (e *API) GetRouteTables(ctx context.Context) (ipamTypes.RouteTableMap, error) {
+func (e *API) GetRouteTables(ctx context.Context, vpcID string) (ipamTypes.RouteTableMap, error) {
 	routeTables := ipamTypes.RouteTableMap{}
 
 	e.mutex.RLock()
@@ -783,7 +783,7 @@ func (e *API) TagENI(ctx context.Context, eniID string, eniTags map[string]strin
 	return fmt.Errorf("Unable to find ENI with ID %s", eniID)
 }
 
-func (e *API) GetSecurityGroups(ctx context.Context) (types.SecurityGroupMap, error) {
+func (e *API) GetSecurityGroups(ctx context.Context, vpcID string) (types.SecurityGroupMap, error) {
 	securityGroups := types.SecurityGroupMap{}
 
 	e.mutex.RLock()

--- a/pkg/aws/ec2/mock/mock_test.go
+++ b/pkg/aws/ec2/mock/mock_test.go
@@ -77,7 +77,7 @@ func TestMock(t *testing.T) {
 	}
 	api.UpdateSecurityGroups([]*types.SecurityGroup{sg1, sg2})
 
-	sgMap, err := api.GetSecurityGroups(t.Context())
+	sgMap, err := api.GetSecurityGroups(t.Context(), "")
 	require.NoError(t, err)
 	require.Equal(t, types.SecurityGroupMap{"sg1": sg1, "sg2": sg2}, sgMap)
 }
@@ -179,7 +179,7 @@ func TestGetRouteTables(t *testing.T) {
 		routeTables,
 	)
 
-	tables, err := api.GetRouteTables(t.Context())
+	tables, err := api.GetRouteTables(t.Context(), "")
 	require.NoError(t, err)
 	require.Len(t, tables, 2)
 

--- a/pkg/aws/eni/instances_test.go
+++ b/pkg/aws/eni/instances_test.go
@@ -11,6 +11,7 @@ import (
 
 	ec2mock "github.com/cilium/cilium/pkg/aws/ec2/mock"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	metadataMock "github.com/cilium/cilium/pkg/aws/metadata/mock"
 	"github.com/cilium/cilium/pkg/aws/types"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 )
@@ -207,8 +208,8 @@ func iteration2(t *testing.T, api *ec2mock.API, mngr *InstancesManager) {
 func TestGetSubnet(t *testing.T) {
 	api := ec2mock.NewAPI(subnets, vpcs, securityGroups, routeTables)
 	require.NotNil(t, api)
-
-	mngr, err := NewInstancesManager(hivetest.Logger(t), api)
+	metadataMockapi, _ := metadataMock.NewMetadataMock()
+	mngr, err := NewInstancesManager(hivetest.Logger(t), api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -246,8 +247,8 @@ func TestGetSubnet(t *testing.T) {
 func TestFindSubnetByIDs(t *testing.T) {
 	api := ec2mock.NewAPI(subnets2, vpcs, securityGroups, routeTables)
 	require.NotNil(t, api)
-
-	mngr, err := NewInstancesManager(hivetest.Logger(t), api)
+	metadataMockapi, _ := metadataMock.NewMetadataMock()
+	mngr, err := NewInstancesManager(hivetest.Logger(t), api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -286,8 +287,8 @@ func TestFindSubnetByIDs(t *testing.T) {
 func TestFindSubnetByTags(t *testing.T) {
 	api := ec2mock.NewAPI(subnets, vpcs, securityGroups, routeTables)
 	require.NotNil(t, api)
-
-	mngr, err := NewInstancesManager(hivetest.Logger(t), api)
+	metadataMockapi, _ := metadataMock.NewMetadataMock()
+	mngr, err := NewInstancesManager(hivetest.Logger(t), api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -324,7 +325,8 @@ func TestGetSecurityGroupByTags(t *testing.T) {
 	api := ec2mock.NewAPI(subnets, vpcs, securityGroups, routeTables)
 	require.NotNil(t, api)
 
-	mngr, err := NewInstancesManager(hivetest.Logger(t), api)
+	metadataMockapi, _ := metadataMock.NewMetadataMock()
+	mngr, err := NewInstancesManager(hivetest.Logger(t), api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -16,6 +16,7 @@ import (
 	operatorOption "github.com/cilium/cilium/operator/option"
 	ec2mock "github.com/cilium/cilium/pkg/aws/ec2/mock"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	metadataMock "github.com/cilium/cilium/pkg/aws/metadata/mock"
 	"github.com/cilium/cilium/pkg/aws/types"
 	"github.com/cilium/cilium/pkg/ipam"
 	metricsmock "github.com/cilium/cilium/pkg/ipam/metrics/mock"
@@ -67,8 +68,9 @@ var (
 			},
 		},
 	}
-	k8sapi     = &k8sMock{}
-	metricsapi = metricsmock.NewMockMetrics()
+	k8sapi             = &k8sMock{}
+	metricsapi         = metricsmock.NewMockMetrics()
+	metadataMockapi, _ = metadataMock.NewMetadataMock()
 )
 
 func setup(tb testing.TB) {
@@ -83,7 +85,7 @@ func TestGetNodeNames(t *testing.T) {
 	setup(t)
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
@@ -113,7 +115,7 @@ func TestNodeManagerGet(t *testing.T) {
 	setup(t)
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
@@ -144,7 +146,7 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 	const instanceID = "i-testNodeManagerDefaultAllocation-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -190,7 +192,7 @@ func TestNodeManagerPrefixDelegation(t *testing.T) {
 
 	pdTestSubnet := *testSubnet
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{&pdTestSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -261,7 +263,7 @@ func TestNodeManagerENIWithSGTags(t *testing.T) {
 	const instanceID = "i-testNodeManagerDefaultAllocation-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -323,7 +325,7 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 	const instanceID = "i-testNodeManagerMinAllocate20-1"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -381,7 +383,7 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	const instanceID = "i-testNodeManagerMinAllocateAndPreallocate-1"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -448,7 +450,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 
 	operatorOption.Config.ExcessIPReleaseDelay = 2
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -552,7 +554,7 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 	const instanceID = "i-testNodeManagerDefaultAllocation-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -622,7 +624,7 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	const instanceID = "i-testNodeManagerExceedENICapacity-1"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -682,7 +684,7 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 	}
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet, testSubnet2}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -748,7 +750,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	}
 
 	ec2api := ec2mock.NewAPI(subnets, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instancesManager, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instancesManager, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instancesManager)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instancesManager, k8sapi, metricsapi, 10, false, false)
@@ -819,7 +821,7 @@ func TestNodeManagerInstanceNotRunning(t *testing.T) {
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
 	metricsMock := metricsmock.NewMockMetrics()
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -866,7 +868,7 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	const instanceID = "i-testInstanceBeenDeleted-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -927,7 +929,7 @@ func TestNodeManagerStaticIP(t *testing.T) {
 	const instanceID = "i-testNodeManagerStaticIP-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -973,7 +975,7 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 	const instanceID = "i-testNodeManagerStaticIPAlreadyAssociated-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -1008,7 +1010,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet1, testSubnet2, testSubnet3}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, routeTables)
 	ec2api.SetDelay(ec2mock.AllOperations, delay)
 	ec2api.SetLimiter(rateLimit, burst)
-	instances, err := NewInstancesManager(hivetest.Logger(b), ec2api)
+	instances, err := NewInstancesManager(hivetest.Logger(b), ec2api, metadataMockapi)
 	require.NoError(b, err)
 	require.NotNil(b, instances)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(b), instances, k8sapi, metricsapi, 10, false, false)

--- a/pkg/aws/eni/node_stat_test.go
+++ b/pkg/aws/eni/node_stat_test.go
@@ -43,7 +43,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 		k8sObj: cn,
 		manager: &InstancesManager{
 			instances:    im,
-			api:          mockEC2API,
+			ec2api:       mockEC2API,
 			limitsGetter: limitsGetter,
 		},
 		enis: map[string]eniTypes.ENI{"eni-a": {}},

--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -11,13 +11,15 @@ import (
 
 	ec2mock "github.com/cilium/cilium/pkg/aws/ec2/mock"
 	"github.com/cilium/cilium/pkg/aws/eni/types"
+	metadataMock "github.com/cilium/cilium/pkg/aws/metadata/mock"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
 func TestGetMaximumAllocatableIPv4(t *testing.T) {
 	api := ec2mock.NewAPI(nil, nil, nil, nil)
-	instances, err := NewInstancesManager(hivetest.Logger(t), api)
+	metadataMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(hivetest.Logger(t), api, metadataMock)
 	require.NoError(t, err)
 	n := &Node{
 		rootLogger: hivetest.Logger(t),
@@ -210,7 +212,8 @@ func TestIsPrefixDelegated(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			api := ec2mock.NewAPI(nil, nil, nil, nil)
-			instances, err := NewInstancesManager(hivetest.Logger(t), api)
+			metadataMock, _ := metadataMock.NewMetadataMock()
+			instances, err := NewInstancesManager(hivetest.Logger(t), api, metadataMock)
 			require.NoError(t, err)
 			n := &Node{
 				rootLogger: hivetest.Logger(t),

--- a/pkg/aws/metadata/mock/metadata_mock.go
+++ b/pkg/aws/metadata/mock/metadata_mock.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mock
+
+import "github.com/cilium/cilium/pkg/aws/metadata"
+
+type metadataMock struct {
+}
+
+func NewMetadataMock() (*metadataMock, error) {
+	return &metadataMock{}, nil
+}
+
+// GetInstanceMetadata returns required AWS metadatas
+func (m *metadataMock) GetInstanceMetadata() (metadata.MetaDataInfo, error) {
+	return metadata.MetaDataInfo{}, nil
+}

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -15,6 +15,7 @@ import (
 	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	ec2shim "github.com/cilium/cilium/pkg/aws/ec2"
 	"github.com/cilium/cilium/pkg/aws/eni"
+	"github.com/cilium/cilium/pkg/aws/metadata"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
@@ -128,7 +129,11 @@ func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 	} else {
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
-	instances, err := eni.NewInstancesManager(a.rootLogger, a.client)
+	imds, err := metadata.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize metadata client: %w", err)
+	}
+	instances, err := eni.NewInstancesManager(a.rootLogger, a.client, imds)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize ENI instances manager: %w", err)
 	}

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -381,12 +381,16 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 	case ipamOption.IPAMENI:
 		// set ENI field in the node only when the ENI ipam is specified
 		nodeResource.Spec.ENI = eniTypes.ENISpec{}
-		instanceID, instanceType, availabilityZone, vpcID, subnetID, err := metadata.GetInstanceMetadata()
+		imds, err := metadata.NewClient()
+		if err != nil {
+			logging.Fatal(n.logger, "Unable to create metadata client", logfields.Error, err)
+		}
+		info, err := imds.GetInstanceMetadata()
 		if err != nil {
 			logging.Fatal(n.logger, "Unable to retrieve InstanceID of own EC2 instance", logfields.Error, err)
 		}
 
-		if instanceID == "" {
+		if info.InstanceID == "" {
 			return errors.New("InstanceID of own EC2 instance is empty")
 		}
 
@@ -397,7 +401,7 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		// the PreAllocate value, so to ensure that the agent and the Operator
 		// are not conflicting with each other, we must have similar logic to
 		// determine the appropriate value to place inside the resource.
-		nodeResource.Spec.ENI.VpcID = vpcID
+		nodeResource.Spec.ENI.VpcID = info.VPCID
 		nodeResource.Spec.ENI.FirstInterfaceIndex = aws.Int(defaults.ENIFirstInterfaceIndex)
 		nodeResource.Spec.ENI.UsePrimaryAddress = aws.Bool(defaults.UseENIPrimaryAddress)
 		nodeResource.Spec.ENI.DisablePrefixDelegation = aws.Bool(defaults.ENIDisableNodeLevelPD)
@@ -454,10 +458,10 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 			nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
 		}
 
-		nodeResource.Spec.InstanceID = instanceID
-		nodeResource.Spec.ENI.InstanceType = instanceType
-		nodeResource.Spec.ENI.AvailabilityZone = availabilityZone
-		nodeResource.Spec.ENI.NodeSubnetID = subnetID
+		nodeResource.Spec.InstanceID = info.InstanceID
+		nodeResource.Spec.ENI.InstanceType = info.InstanceType
+		nodeResource.Spec.ENI.AvailabilityZone = info.AvailabilityZone
+		nodeResource.Spec.ENI.NodeSubnetID = info.SubnetID
 
 	case ipamOption.IPAMAzure:
 		if ln.Local.ProviderID == "" {


### PR DESCRIPTION
This PR will make aws operator to read the metadata info to get its own VPC ID and use it as filter before it pulls the aws vpc/subnet/route/security group so it can reduce the cpu/memory and other potential issues(like too many responds causing ec2 client timeout etc)

With this PR, we will see the that we only sync one VPC
```
time=2025-09-20T03:16:59.21773155Z level=info msg="Synchronized ENI information" module=operator.operator-controlplane.leader-lifecycle.legacy-cell subsys=eni numInstances=9 numVPCs=1 numSubnets=6 numRouteTables=3 numSecurityGroups=4
```
without this PR, in the same AWS account, we can see that we sync other resources from other VPCs

```
time=2025-09-20T03:21:32.90667992Z level=info msg="Synchronized ENI information" module=operator.operator-controlplane.leader-lifecycle.legacy-cell subsys=eni numInstances=9 numVPCs=6 numSubnets=29 numRouteTables=14 numSecurityGroups=23
```


Fixes: https://github.com/cilium/cilium/issues/41392

```release-note
aws operator pulls its own VPC resources based on its own vpc id
```
