### PR TITLE
gateway-api: Fix incorrect `Owns` call in refactor

### DIFF
--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -151,7 +152,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.Endpoints{})
+		Owns(&discoveryv1.EndpointSlice{})
 
 	if tlsRouteEnabled {
 		// Watch TLSRoute linked to Gateway


### PR DESCRIPTION
This commit fixes an `Owns` call that was updated
to use EndpointSlice (instead of Endpoint) in

This change was missed in the refactor in #41323.
