### PR TITLE
cilium-cli: Bring back NodePort Acceleration feature detection

### DIFF
--- a/.github/actions/e2e/configs.yaml
+++ b/.github/actions/e2e/configs.yaml
@@ -58,8 +58,7 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   host-fw: 'true'
-  # Disable until https://github.com/cilium/cilium/issues/41520 is resolved
-  # lb-acceleration: 'testing-only'
+  lb-acceleration: 'testing-only'
   ingress-controller: 'true'
   bgp-control-plane: 'true'
 - name: '7'
@@ -166,8 +165,7 @@
   tunnel: 'vxlan'
   lb-mode: 'snat'
   egress-gateway: 'true'
-  # Disable until https://github.com/cilium/cilium/issues/41520 is resolved
-  # lb-acceleration: 'testing-only'
+  lb-acceleration: 'testing-only'
   ingress-controller: 'true'
 - name: '15'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -172,10 +172,15 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 				result[features.KPRSocketLB] = features.Status{Enabled: f.SocketLB.Enabled}
 				result[features.KPRSocketLBHostnsOnly] = features.Status{Enabled: f.BpfSocketLBHostnsOnly}
 			}
+			acceleration := strings.ToLower(f.NodePort.Acceleration)
+			result[features.KPRNodePortAcceleration] = features.Status{
+				Enabled: mode == "true" && acceleration != "disabled",
+				Mode:    acceleration,
+			}
 		}
 	}
 	result[features.KPR] = features.Status{
-		Enabled: mode == "true" || mode == "strict",
+		Enabled: mode == "true",
 		Mode:    mode,
 	}
 


### PR DESCRIPTION
This made to run the EGW/NS connectivity disruption tests which most likely resulted in the "FIB lookup failed" reported in \[1\].

Also, while here, change the check for [features.KPR] to check only for "true". The "strict" / "disabled" are no longer available since Cilium v1.14.

\[1\]: https://github.com/cilium/cilium/issues/41520

Fixes: 21572bb18a ("cilium-cli: Remove KPR subflags")
Fix #41520