### PR TITLE
datapath: s/MARK_MAGIC_PROXY_TO_WORLD/MARK_MAGIC_SKIP_TPROXY

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -394,7 +394,7 @@ skip_tunnel:
 
 #if defined(ENABLE_IPSEC) && !defined(TUNNEL_MODE)
 	if (from_proxy && !identity_is_cluster(info->sec_identity))
-		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+		ctx->mark = MARK_MAGIC_SKIP_TPROXY;
 #endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
@@ -847,7 +847,7 @@ skip_tunnel:
 
 #if defined(ENABLE_IPSEC) && !defined(TUNNEL_MODE)
 	if (from_proxy && !identity_is_cluster(info->sec_identity))
-		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+		ctx->mark = MARK_MAGIC_SKIP_TPROXY;
 #endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
@@ -1748,16 +1748,16 @@ int cil_to_host(struct __ctx_buff *ctx)
 	 *
 	 * This iptables rule, created by
 	 * iptables.Manager.inboundProxyRedirectRule() is ignored by the mark
-	 * MARK_MAGIC_PROXY_TO_WORLD, in the control plane.
+	 * MARK_MAGIC_SKIP_TPROXY, in the control plane.
 	 * Technically, it is also ignored by MARK_MAGIC_ENCRYPT but reusing
 	 * this mark breaks further processing as its used in the XFRM subsystem.
 	 *
 	 * Therefore, if the packet's mark is zero, indicating it was forwarded
-	 * from 'cilium_host', mark the packet with MARK_MAGIC_PROXY_TO_WORLD
+	 * from 'cilium_host', mark the packet with MARK_MAGIC_SKIP_TPROXY
 	 * and allow it to enter the foward path once punted to stack.
 	 */
 	if (ctx->mark == 0 && THIS_INTERFACE_IFINDEX == CILIUM_NET_IFINDEX)
-		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+		ctx->mark = MARK_MAGIC_SKIP_TPROXY;
 #endif /* !TUNNEL_MODE */
 
 # ifdef ENABLE_NODEPORT

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -557,7 +557,7 @@ enum metric_dir {
  *    In the IPsec case this becomes the SPI on the wire.
  */
 #define MARK_MAGIC_HOST_MASK		0x0F00
-#define MARK_MAGIC_PROXY_TO_WORLD	0x0800
+#define MARK_MAGIC_SKIP_TPROXY		0x0800
 #define MARK_MAGIC_PROXY_EGRESS_EPID	0x0900 /* mark carries source endpoint ID */
 #define MARK_MAGIC_PROXY_INGRESS	0x0A00
 #define MARK_MAGIC_PROXY_EGRESS		0x0B00

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -598,14 +598,14 @@ func (m *Manager) inboundProxyRedirectRule(cmd string) []string {
 	// excluding traffic for the loopback device.
 	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
-	matchProxyToWorld := fmt.Sprintf("%#08x/%#08x", linux_defaults.MarkProxyToWorld, linux_defaults.RouteMarkMask)
+	matchSkipTProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MarkSkipTProxy, linux_defaults.RouteMarkMask)
 	return []string{
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
 		"-m", "socket", "--transparent",
 		"!", "-o", "lo",
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt,
-		"-m", "mark", "!", "--mark", matchProxyToWorld,
+		"-m", "mark", "!", "--mark", matchSkipTProxy,
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
 		"--set-mark", toProxyMark}

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -27,9 +27,10 @@ const (
 	// table which is between 253-255. See ip-route(8).
 	RouteTableInterfacesOffset = 10
 
-	// MarkProxyToWorld is the default mark to use to indicate that a packet
-	// from proxy needs to be sent to the world.
-	MarkProxyToWorld = 0x800
+	// MarkSkipTProxy is the default mark to use to indicate that a packet
+	// should skip tproxy-processing. This is needed for eg. traffic by transparent
+	// proxy connections which later passes through the cilium_host / cilium_net pair.
+	MarkSkipTProxy = 0x800
 
 	// RouteMarkDecrypt is the default route mark to use to indicate datapath
 	// needs to decrypt a packet.


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/37723 started making use of this flag for other types of connections. Adjust the naming to better match what it actually does.