### PR TITLE
datapath/neighbor: ignore EINVAL on NeighSet for next hop entries

### DIFF
--- a/pkg/datapath/neighbor/neighbor_reconciler.go
+++ b/pkg/datapath/neighbor/neighbor_reconciler.go
@@ -141,7 +141,11 @@ func (ops *ops) Update(ctx context.Context, rx statedb.ReadTxn, _ statedb.Revisi
 		}
 		if err := ops.funcsGetter.Get().NeighSet(&neighInit); err != nil {
 			// EINVAL is expected (see above)
-			return fmt.Errorf("next hop insert failed for %+v: %w", neighInit, err)
+			if errors.Is(err, unix.EINVAL) {
+				return nil
+			}
+
+			return fmt.Errorf("next hop initial insert failed for %+v: %w", neighInit, err)
 		}
 	}
 	if err := ops.funcsGetter.Get().NeighSet(&neigh); err != nil {


### PR DESCRIPTION
When adding a next hop neighbor entry, it is expected that the kernel returns EINVAL in some cases. However, we were still returning an error in those cases which caused the reconciler to constantly retry adding the entry.

While functionality is not broken, we do ARP requests more often then we should, and the constant failing causes a lot of noise in the error logs and health system.

```release-note
Ignore expected error in neighbor reconciliation
```
