### PR TITLE
.github/workflows: add variable for renovate bot username

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -406,7 +406,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{
          github.event_name == 'pull_request_target' &&
-         github.event.pull_request.user.login == 'cilium-renovate[bot]'
+         github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
         }}
     steps:
     - name: Debug
@@ -421,7 +421,7 @@ jobs:
     environment: "Trigger CI from renovate PRs"
     if: ${{
          github.event_name == 'pull_request_target' &&
-         github.event.pull_request.user.login == 'cilium-renovate[bot]'
+         github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
         }}
     steps:
       - name: Post /test comment


### PR DESCRIPTION
Since cilium-renovate[bot] is only available on cilium repository, it makes sense to make this as an variable so that this workflow can be used on Cilium forks.