### PR TITLE
datapath/linux/route: Disregard MTU value when deleting routes

### DIFF
--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -308,7 +308,6 @@ func Delete(route Route) error {
 		Table:     route.Table,
 		Type:      route.Type,
 		Protocol:  netlink.RouteProtocol(route.Proto),
-		MTU:       route.MTU,
 	}
 
 	// Scope can only be specified for IPv4


### PR DESCRIPTION
When Cilium starts in tunnel mode, a route for each remote node pod CIDRs is added to the current node. For these routes, the MTU is set to 1450, to include the tunnel overhead.

If the routing mode is then changed to native and Cilium is restarted, the stale routes should be deleted at startup. Unfortunately, this is currently not happening because the MTU is set to 1500 in the deletion request, resulting in the folowing error from netlink:

msg="Unable to delete route" ... error="no such process"

In other words, the route cannot be found because the MTU value set in the deletion request is not matching the one of the installed route.

To solve this, just disregard the MTU value while deleting a route. This should still allow to correctly remove stale IPsec related routes as intended in commit 35ca979f44

Fixes: 35ca979f44 ("datapath/linux/route: Fix Delete")
Fixes: https://github.com/cilium/cilium/issues/41811

```release-note
Fix a bug that was preventing Cilium to delete stale pod CIDRs routes when changing routing mode to native
```
