### PR TITLE
.github/workflows: do not wait on linters form forks

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -31,10 +31,11 @@ jobs:
     name: Wait for lint checks
     uses: ./.github/workflows/wait-for-status-check.yaml
     with:
-      # Only run this job if the event is pull_request_target.
+      # Only run this job if the event is pull_request_target and if the PR
+      # is not opened from a fork.
       # This is to avoid waiting for base images on push to main or merge_group
       # events as the lint-images-base does not run on those events.
-      if: ${{ github.event_name == 'pull_request_target' }}
+      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       lint-workflows: "lint-images-base.yaml"
       timeout-minutes: 2


### PR DESCRIPTION
Fork PRs cannot update base images and require explicit approval for first-time contributors. Waiting for base image updates in these cases breaks the CI build process unnecessarily.

Skip the wait-for-base-images job when PRs are opened from forks to allow the build process to proceed normally.

Fixes: 406f3dda6530 (".github/workflows: stop build CI images until base images are built")