### PR TITLE
[v1.17] bpf:tests:egressgw: fix metrics count

### DIFF
--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -156,7 +156,10 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 	entry = map_lookup_elem(&METRICS_MAP, &key);
 	if (!entry)
 		test_fatal("metrics entry not found");
-	assert(entry->count == 1);
+
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 
@@ -209,7 +212,10 @@ int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 	entry = map_lookup_elem(&METRICS_MAP, &key);
 	if (!entry)
 		test_fatal("metrics entry not found");
-	assert(entry->count == 1);
+
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 	endpoint_v4_del_entry(GATEWAY_NODE_IP);


### PR DESCRIPTION
Manual backport of
* [ ] https://github.com/cilium/cilium/pull/40338 (only the first patch applies)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 40338
```