### PR TITLE
.github/conformance: fix concurrency group for ipsec

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -77,7 +77,7 @@ concurrency:
     ${{ github.workflow }}
     ${{ github.event_name }}
     ${{
-      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'schedule' && format('{0}-{1}', github.sha, 'aks')) ||
       (github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.event.inputs.PR-number, 'aks'))
     }}
   cancel-in-progress: true

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -80,7 +80,7 @@ concurrency:
     ${{ github.workflow }}
     ${{ github.event_name }}
     ${{
-      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'schedule' && format('{0}-{1}', github.sha, 'eks')) ||
       (github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.event.inputs.PR-number, 'eks'))
     }}
   cancel-in-progress: true

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -77,7 +77,7 @@ concurrency:
     ${{ github.workflow }}
     ${{ github.event_name }}
     ${{
-      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'schedule' && format('{0}-{1}', github.sha, 'gke')) ||
       (github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.event.inputs.PR-number, 'gke'))
     }}
   cancel-in-progress: true


### PR DESCRIPTION
For scheduled workflows events, the reusable workflow will also receive that event type which causes the concurrency to conflict with other workflows. To prevent this bug, we must suffix each concurrency group with the workflow name.

Fixes: 1337c87c9955 ("Add vanilla cloud-provider configs for conformance tests")