### PR TITLE
ipsec: remove dead usage of EncryptedOverlayReqID

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -69,9 +69,6 @@ const (
 
 	// DefaultReqID is the default reqid used for all IPSec rules.
 	DefaultReqID = 1
-
-	// EncryptedOverlayReqID is the reqid used for encrypting overlay traffic.
-	EncryptedOverlayReqID = 2
 )
 
 type dir string


### PR DESCRIPTION
Some cleanup missed in commit:
Commit: e202a4e10c374a802b19d03b8c3f54e4cfc3dbd9
Author: Louis DeLosSantos <louis.delos@isovalent.com>
Date:   Wed Oct 30 11:01:50 2024 -0400

    ipsec: despecify decrypted overlay

We no longer use the EncryptedOverlayReqID constant anywhere in the codebase to specify a reqid for overlay traffic. Remove this constant.

```release-note
Remove unused EncryptedOverlayReqID constant
```
