### PR TITLE
devices: increase priority of user selected device

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -611,15 +611,6 @@ func (dc *devicesController) isSelectedDevice(d *tables.Device, txn statedb.Writ
 		return false, "link not seen yet"
 	}
 
-	if len(d.Addrs) == 0 {
-		return false, "device has no addresses"
-	}
-
-	// Skip devices that don't have the required flags set.
-	if d.RawFlags&requiredIfFlagsMask == 0 {
-		return false, fmt.Sprintf("missing required flag (mask=0x%x, flags=0x%x)", requiredIfFlagsMask, d.RawFlags)
-	}
-
 	// If user specified devices or wildcards, then skip the device if it doesn't match.
 	// If the device does not match and user not requested auto detection, then skip further checks.
 	// If the device does not match and user requested auto detection, then continue to further checks.
@@ -631,6 +622,15 @@ func (dc *devicesController) isSelectedDevice(d *tables.Device, txn statedb.Writ
 		if !dc.enforceAutoDetection {
 			return false, fmt.Sprintf("not matching user filter %v", dc.filter)
 		}
+	}
+
+	if len(d.Addrs) == 0 {
+		return false, "device has no addresses"
+	}
+
+	// Skip devices that don't have the required flags set.
+	if d.RawFlags&requiredIfFlagsMask == 0 {
+		return false, fmt.Sprintf("missing required flag (mask=0x%x, flags=0x%x)", requiredIfFlagsMask, d.RawFlags)
 	}
 
 	// Skip devices that have an excluded interface flag set.

--- a/pkg/datapath/linux/testdata/device-detection-wildcard.txtar
+++ b/pkg/datapath/linux/testdata/device-detection-wildcard.txtar
@@ -1,7 +1,8 @@
 #! --devices=dummy+
 
 # Test that if the user specifies a device wildcard, then all devices not matching the wildcard
-# will be marked as non-selected.
+# will be marked as non-selected. User specified devices are selected even though they might have
+# no IP address - this is the case of dummy1.
 
 # Start the hive
 hive start
@@ -23,6 +24,8 @@ exec ip link add eth0 type dummy
 exec ip addr add 1.2.3.4/24 dev eth0
 exec ip link set eth0 up
 
+exec ip link add dummy1 type dummy
+
 # Verify selected devices. Only the one matching the wildcard is expected to be selected.
 db/cmp --grep='^(lo|dummy|eth|nonviable)' devices devices.table
 
@@ -34,3 +37,4 @@ lo          false      device
 dummy0      true       dummy
 nonviable   false      dummy
 eth0        false      dummy
+dummy1      true       dummy


### PR DESCRIPTION
The devices controller has logic to determine which devices should be selected and used for direct routing, for attaching cil_from_netdev etc. This logic unfortunately ignores devices with no IP address even though the user explicitly selected them as part of the `--devices` flag.

This breaks the possibility to use cilium_ipip4 (or v6) device, which gets created when `--enable-ipip-termination` flag is enabled and which by default has no IP. In this case the IP is not required as this only decapsulates ipip packets and looks for e.g. services during the BPF logic of `cil_from_netdev` program.

Let's make this possible.

cc @joamaki 

```release-note
devices: allow selection of devices with no IP set 
```
