### PR TITLE
Add conntrack support for IP options

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -775,7 +775,7 @@ struct ipv4_ct_tuple {
 } __packed;
 
 struct ct_entry {
-	__u64 reserved0;	/* unused since v1.16 */
+	__u64 ip_trace_id;
 	__u64 backend_id;
 	__u64 packets;
 	__u64 bytes;

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -525,7 +525,7 @@ func (k *CtKey6Global) GetTupleKey() tuple.TupleKey {
 
 // CtEntry represents an entry in the connection tracking table.
 type CtEntry struct {
-	Reserved0 uint64 `align:"reserved0"`
+	IpTraceId uint64 `align:"ip_trace_id"`
 	BackendID uint64 `align:"backend_id"`
 	Packets   uint64 `align:"packets"`
 	Bytes     uint64 `align:"bytes"`


### PR DESCRIPTION
Feature introduces support for storing and retrieving a trace_id in the BPF conntrack table, using the recently-supported IP options to create persistent tracing information.

## Motivation
Return packets don't copy IP options from the original packet. Therefore, we lose the trace ID for return packets. This lets us restore the packet trace ID without incurring a high complexity that comes with re-injecting ip options into packets. 

## Implementation Details
   - The ct_entry struct (in both C and Go) is extended to include a trace_id field.
   - On new connection creation (ct_create4), the trace_id is extracted from the packet's IP options and saved into the conntrack entry.
   - During a conntrack lookup (__ct_lookup), if a matching entry contains a trace_id, it is restored into the packet's context.
   - This functionality is currently limited to IPv4, as IPv6 does not have equivalent IP option support.

This allows for the trace ID to persist for the duration of the connection, providing a stable identifier for debugging.