### PR TITLE
[v1.16] ariane-config: update path filters for e2e workflows

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -87,36 +87,36 @@ schedule:
 
 workflows:
   conformance-aks.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-aws-cni.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-clustermesh.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ipsec-e2e.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-eks.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-gateway-api.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ginkgo.yaml:
-    paths-ignore-regex: (cilium-cli|Documentation)/
+    paths-ignore-regex: (cilium-cli|Documentation|CODEOWNERS)/
   conformance-gke.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ingress.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-multi-pool.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-runtime.yaml:
-    paths-ignore-regex: (cilium-cli|Documentation|USERS.md)/
+    paths-ignore-regex: (cilium-cli|Documentation|CODEOWNERS|USERS.md)/
   integration-test.yaml:
-    paths-ignore-regex: (Documentation|USERS.md)/
+    paths-ignore-regex: (Documentation|CODEOWNERS|USERS.md)/
   tests-clustermesh-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
     paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor|USERS.md)/
   tests-e2e-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   tests-ipsec-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
+    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -99,7 +99,7 @@ workflows:
   conformance-gateway-api.yaml:
     paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ginkgo.yaml:
-    paths-ignore-regex: (cilium-cli|Documentation|CODEOWNERS)/
+    paths-ignore-regex: (cilium-cli|Documentation|CODEOWNERS|USERS.md)/
   conformance-gke.yaml:
     paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ingress.yaml:

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -87,36 +87,36 @@ schedule:
 
 workflows:
   conformance-aks.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-aws-cni.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-clustermesh.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ipsec-e2e.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-eks.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-gateway-api.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ginkgo.yaml:
-    paths-ignore-regex: (cilium-cli|Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|CODEOWNERS|USERS.md)/
   conformance-gke.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ingress.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-multi-pool.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-runtime.yaml:
-    paths-ignore-regex: (cilium-cli|Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|CODEOWNERS|USERS.md)/
   integration-test.yaml:
-    paths-ignore-regex: (Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|Documentation|CODEOWNERS|USERS.md)/
   tests-clustermesh-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
     paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor)/
   tests-e2e-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   tests-ipsec-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -99,7 +99,7 @@ workflows:
   conformance-gateway-api.yaml:
     paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ginkgo.yaml:
-    paths-ignore-regex: Documentation/
+    paths-ignore-regex: (cilium-cli|Documentation)/
   conformance-gke.yaml:
     paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ingress.yaml:
@@ -107,7 +107,7 @@ workflows:
   conformance-multi-pool.yaml:
     paths-ignore-regex: (test|Documentation|hubble)/
   conformance-runtime.yaml:
-    paths-ignore-regex: Documentation/
+    paths-ignore-regex: (cilium-cli|Documentation)/
   integration-test.yaml:
     paths-ignore-regex: Documentation/
   tests-clustermesh-upgrade.yaml:

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -87,36 +87,36 @@ schedule:
 
 workflows:
   conformance-aks.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-aws-cni.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-clustermesh.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ipsec-e2e.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-eks.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-gateway-api.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ginkgo.yaml:
     paths-ignore-regex: Documentation/
   conformance-gke.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ingress.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-multi-pool.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-runtime.yaml:
     paths-ignore-regex: Documentation/
   integration-test.yaml:
     paths-ignore-regex: Documentation/
   tests-clustermesh-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
     paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor)/
   tests-e2e-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   tests-ipsec-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -87,36 +87,36 @@ schedule:
 
 workflows:
   conformance-aks.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   conformance-aws-cni.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   conformance-clustermesh.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   conformance-ipsec-e2e.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   conformance-eks.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   conformance-gateway-api.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   conformance-ginkgo.yaml:
     paths-ignore-regex: (cilium-cli|Documentation)/
   conformance-gke.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   conformance-ingress.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   conformance-multi-pool.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   conformance-runtime.yaml:
-    paths-ignore-regex: (cilium-cli|Documentation)/
+    paths-ignore-regex: (cilium-cli|Documentation|USERS.md)/
   integration-test.yaml:
-    paths-ignore-regex: Documentation/
+    paths-ignore-regex: (Documentation|USERS.md)/
   tests-clustermesh-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
-    paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor)/
+    paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor|USERS.md)/
   tests-e2e-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/
   tests-ipsec-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble)/
+    paths-ignore-regex: (test|Documentation|hubble|USERS.md)/

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -115,7 +115,7 @@ workflows:
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
-    paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor|USERS.md)/
+    paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor)/
   tests-e2e-upgrade.yaml:
     paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
   tests-ipsec-upgrade.yaml:

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -87,36 +87,36 @@ schedule:
 
 workflows:
   conformance-aks.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   conformance-aws-cni.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   conformance-clustermesh.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   conformance-ipsec-e2e.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   conformance-eks.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   conformance-gateway-api.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   conformance-ginkgo.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation)/|(CODEOWNERS|USERS.md)$)
   conformance-gke.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   conformance-ingress.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   conformance-multi-pool.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   conformance-runtime.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation)/|(CODEOWNERS|USERS.md)$)
   integration-test.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|Documentation)/|(CODEOWNERS|USERS.md)$)
   tests-clustermesh-upgrade.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
     paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor)/
   tests-e2e-upgrade.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
   tests-ipsec-upgrade.yaml:
-    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -87,36 +87,36 @@ schedule:
 
 workflows:
   conformance-aks.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-aws-cni.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-clustermesh.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-ipsec-e2e.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-eks.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-gateway-api.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-ginkgo.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation)/|(CODEOWNERS|USERS.md)$)
   conformance-gke.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-ingress.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-multi-pool.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   conformance-runtime.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation)/|(CODEOWNERS|USERS.md)$)
   integration-test.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|Documentation)/|(CODEOWNERS|USERS.md)$)
   tests-clustermesh-upgrade.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
     paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor)/
   tests-e2e-upgrade.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)
   tests-ipsec-upgrade.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble)/|(CODEOWNERS|USERS.md|.*_test\.go)$)


### PR DESCRIPTION
Pull in a bunch of ariane-config updates to reduce the e2e burden on CI in the v1.16 branch.

* [x] #33850 (partially)
* [x] #34550 (partially)
* [x] #34605
* [x] #34894
* [x] #34931
* [x] #35334

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 34605 34894 34931 35334
```