### PR TITLE
clustermesh: also check for valid services in export for MCS

### DIFF
--- a/pkg/clustermesh/mcsapi/serviceexportsync.go
+++ b/pkg/clustermesh/mcsapi/serviceexportsync.go
@@ -213,6 +213,9 @@ func (s *serviceExportSync) syncMCSAPIServiceSpec(
 	if !exist {
 		return s.store.DeleteKey(ctx, types.NewEmptyMCSAPIServiceSpec(s.clusterName, key.Namespace, key.Name))
 	}
+	if !checkLocalSlimSvcValidForExport(svc) {
+		return s.store.DeleteKey(ctx, types.NewEmptyMCSAPIServiceSpec(s.clusterName, key.Namespace, key.Name))
+	}
 
 	mcsAPISvcSpec := types.FromCiliumServiceToMCSAPIServiceSpec(s.clusterName, svc, svcExport)
 	return s.store.UpsertKey(ctx, mcsAPISvcSpec)


### PR DESCRIPTION
Ensure the actual export controller have the same level of checks than the controller adding the conditions. We do this by ensuring both have the same logic so that we don't get any race condition. Otherwise the export logic export the object before the import controller would update the condition to Valid=false and could theoretically still export an ExternalName service.

```release-note
clustermesh: make sure ExternalName service are not exported in MCS-API
```
