### PR TITLE
wireguard: improve detection of from-proxy traffic

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -142,10 +142,13 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	 *  encrypted.
 	 */
 	magic = ctx->mark & MARK_MAGIC_HOST_MASK;
-	if (magic == MARK_MAGIC_PROXY_INGRESS || magic == MARK_MAGIC_PROXY_EGRESS)
+	if (magic == MARK_MAGIC_PROXY_INGRESS ||
+	    magic == MARK_MAGIC_PROXY_EGRESS ||
+	    magic == MARK_MAGIC_SKIP_TPROXY)
 		goto maybe_encrypt;
 #if defined(TUNNEL_MODE)
 	/* In tunneling mode the mark might have been reset. Check TC index instead.
+	 * TODO: remove this in v1.20, once we can rely on MARK_MAGIC_SKIP_TPROXY.
 	 */
 	if (tc_index_from_ingress_proxy(ctx) || tc_index_from_egress_proxy(ctx))
 		goto maybe_encrypt;


### PR DESCRIPTION
Slightly improve the proxy datapath, so that wireguard can identity proxy-originating traffic without relying on the fragile `skb->tc_index`.
