### PR TITLE
bpf: Fix handling of encrypted packets in `bpf_host`

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1272,7 +1272,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 	 * ignore the return value from do_decrypt.
 	 */
 	do_decrypt(ctx, proto);
-	if (ctx->mark == MARK_MAGIC_DECRYPT)
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT)
 		return CTX_ACT_OK;
 #endif
 	ret = tcx_early_hook(ctx, proto);


### PR DESCRIPTION
This pull request fixes an issue for encrypted packets arriving in `bpf_host`. When checking that they are encrypted using the packet mark, we shouldn't expect the mark to be equal to `MARK_MAGIC_DECRYPT`. Instead, we should check that the `MARK_MAGIC_DECRYPT` bit is set.

This issue isn't affecting anything today, but will once we support IPsec + BPF Host Routing.

Fixes: https://github.com/cilium/cilium/pull/31193.