### PR TITLE
hostfw: don't require a policy to allow Cilium's own overlay & wireguard traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1406,6 +1406,10 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 #endif
 
 #ifdef ENABLE_HOST_FIREWALL
+	/* Don't require HostFW policy for our own overlay traffic: */
+	if (magic == MARK_MAGIC_OVERLAY)
+		goto skip_host_firewall;
+
 	/* This was initially added for Egress GW. There it's no longer needed,
 	 * but it potentially also helps other paths (LB-to-remote-backend ?).
 	 */

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1410,6 +1410,10 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 	if (magic == MARK_MAGIC_OVERLAY)
 		goto skip_host_firewall;
 
+	/* Don't require HostFW policy for our own IPsec / WG traffic: */
+	if (ctx_mark_is_encrypted(ctx))
+		goto skip_host_firewall;
+
 	/* This was initially added for Egress GW. There it's no longer needed,
 	 * but it potentially also helps other paths (LB-to-remote-backend ?).
 	 */


### PR DESCRIPTION
Take a first stab at allowing our overlay & wireguard traffic through the HostFW, without needing a CCNP for it. This only addresses the Egress path, the Ingress path is less straight-forward.

```release-note
On egress, Cilium's own overlay and Wireguard traffic no longer requires an explicit HostFW policy.
```
