### PR TITLE
cilium-cli, netns: fix golangci-lint 2.5.0 errors

### DIFF
--- a/cilium-cli/connectivity/check/check_test.go
+++ b/cilium-cli/connectivity/check/check_test.go
@@ -13,7 +13,8 @@ import (
 func TestAnnotationMap(t *testing.T) {
 	var a annotationsMap
 	err := a.Set(`not json`)
-	assert.IsType(t, &json.SyntaxError{}, err)
+	var wantErr *json.SyntaxError
+	assert.ErrorAs(t, err, &wantErr)
 
 	err = a.Set(`{"foo*bar":{}}`)
 	assert.ErrorContains(t, err, "wildcard only allowed at end of key")

--- a/pkg/netns/netns_test.go
+++ b/pkg/netns/netns_test.go
@@ -80,7 +80,7 @@ func TestPrivilegedNetNSClose(t *testing.T) {
 	assert.NoError(t, ns.Close())
 
 	assert.Nil(t, ns.f)
-	assert.Equal(t, ns.FD(), -1)
+	assert.Equal(t, -1, ns.FD())
 }
 
 func TestPrivilegedNetNSDo(t *testing.T) {


### PR DESCRIPTION
Fix the following errors appearing with golangci-lint 2.5.0:

    Error: cilium-cli/connectivity/check/check_test.go:16:2: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
  	assert.IsType(t, &json.SyntaxError{}, err)
    Error: pkg/netns/netns_test.go:83:2: expected-actual: need to reverse actual and expected values (testifylint)
  	assert.Equal(t, ns.FD(), -1)

This should allow https://github.com/cilium/cilium/pull/41805 to move forward.