### PR TITLE
bpf: Replace `invoke_tailcall_if` with C if-else

### DIFF
--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -682,28 +682,26 @@ handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_id, __u32 src_id,
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		ret = invoke_traced_tailcall_if(__or4(__and(is_defined(ENABLE_IPV4),
-							    is_defined(ENABLE_IPV6)),
-						      __and(is_defined(ENABLE_HOST_FIREWALL),
-							    is_defined(IS_BPF_HOST)),
-						      __and(is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING),
-							    is_defined(ENABLE_INTER_CLUSTER_SNAT)),
-						      __and(is_defined(ENABLE_EGRESS_GATEWAY_COMMON),
-							    is_defined(IS_BPF_HOST))),
-						CILIUM_CALL_IPV4_NODEPORT_NAT_FWD,
-						handle_nat_fwd_ipv4, trace, ext_err);
+		if ((is_defined(ENABLE_IPV4) && is_defined(ENABLE_IPV6)) ||
+		    (is_defined(ENABLE_HOST_FIREWALL) && is_defined(IS_BPF_HOST)) ||
+		    (is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING) &&
+		     is_defined(ENABLE_INTER_CLUSTER_SNAT)) ||
+		    (is_defined(ENABLE_EGRESS_GATEWAY_COMMON) && is_defined(IS_BPF_HOST)))
+			ret = tail_call_internal(ctx, CILIUM_CALL_IPV4_NODEPORT_NAT_FWD,
+						 ext_err);
+		else
+			ret = handle_nat_fwd_ipv4(ctx, trace, ext_err);
 		break;
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		ret = invoke_traced_tailcall_if(__or3(__and(is_defined(ENABLE_IPV4),
-							    is_defined(ENABLE_IPV6)),
-						      __and(is_defined(ENABLE_HOST_FIREWALL),
-							    is_defined(IS_BPF_HOST)),
-						      __and(is_defined(ENABLE_EGRESS_GATEWAY_COMMON),
-							    is_defined(IS_BPF_HOST))),
-						CILIUM_CALL_IPV6_NODEPORT_NAT_FWD,
-						handle_nat_fwd_ipv6, trace, ext_err);
+		if ((is_defined(ENABLE_IPV4) && is_defined(ENABLE_IPV6)) ||
+		    (is_defined(ENABLE_HOST_FIREWALL) && is_defined(IS_BPF_HOST)) ||
+		    (is_defined(ENABLE_EGRESS_GATEWAY_COMMON) && is_defined(IS_BPF_HOST)))
+			ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_NODEPORT_NAT_FWD,
+						 ext_err);
+		else
+			ret = handle_nat_fwd_ipv6(ctx, trace, ext_err);
 		break;
 #endif /* ENABLE_IPV6 */
 	default:

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -135,34 +135,3 @@ tail_call_internal(struct __ctx_buff *ctx, const __u32 index, __s8 *ext_err)
 		*ext_err = (__s8)index;
 	return DROP_MISSED_TAIL_CALL;
 }
-
-/* invoke_tailcall_if() is a helper which based on COND either selects to emit
- * a tail call for the underlying function when true or emits it as inlined
- * when false. COND can be selected by one or multiple compile time flags.
- *
- * [...]
- * invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
- *                    CILIUM_CALL_FOO, foo_fn);
- * [...]
- *
- * The loader will only load tail calls if they are invoked at least once.
- */
-
-#define __invoke_tailcall_if_0(NAME, FUNC, EXT_ERR)			\
-	FUNC(ctx)
-#define __invoke_tailcall_if_1(NAME, FUNC, EXT_ERR)			\
-	({								\
-		tail_call_internal(ctx, NAME, EXT_ERR);			\
-	})
-#define invoke_tailcall_if(COND, NAME, FUNC, EXT_ERR)			\
-	__eval(__invoke_tailcall_if_, COND)(NAME, FUNC, EXT_ERR)
-
-#define __invoke_traced_tailcall_if_0(NAME, FUNC, TRACE, EXT_ERR)	\
-	FUNC(ctx, TRACE, EXT_ERR)
-#define __invoke_traced_tailcall_if_1(NAME, FUNC, TRACE, EXT_ERR)	\
-	({								\
-		tail_call_internal(ctx, NAME, EXT_ERR);			\
-	})
-#define invoke_traced_tailcall_if(COND, NAME, FUNC, TRACE, EXT_ERR)	\
-	__eval(__invoke_traced_tailcall_if_, COND)(NAME, FUNC, TRACE,	\
-						   EXT_ERR)


### PR DESCRIPTION
We currently use the `invoke_tailcall_if` macro to conditionally perform a tail call or inline the same function based on configuration. This macro will only work with compile time constants. So since we are preparing to move to load time configuration, we need to replace these macros with regular if-else statements.

At present all conditionals are still compile time constants, so the result should be the same. We simply rely on the compilers constant propagation to optimize away the dead branches. The big difference will be when conditionals are migrated to load time configuration.

We already have unused tail call pruning based on load time configuration in place, so after this we should just be able to migrate the conditionals to load time configuration one by one.
