### PR TITLE
.github/workflows: Let verifier complexity test merge and diff

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -15,7 +15,7 @@ on:
         required: true
       base-SHA:
         description: "SHA of the base branch (target branch of the PR)."
-        required: false
+        required: true
       extra-args:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
@@ -86,23 +86,32 @@ jobs:
       matrix:
         include:
           - kernel: '5.10'
+            kernel-name: '510'
             ci-kernel: '510'
           - kernel: '5.15'
+            kernel-name: '515'
             ci-kernel: '510'
           - kernel: '6.1'
+            kernel-name: '61'
             ci-kernel: '61'
           - kernel: '6.6'
+            kernel-name: '66'
             ci-kernel: '61'
           - kernel: '6.12'
+            kernel-name: '612'
             ci-kernel: '61'
           - kernel: 'bpf-next'
+            kernel-name: 'bpf-next'
             ci-kernel: 'netnext'
     timeout-minutes: 60
     steps:
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
+      - name: Checkout merge branch
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
-          comment_on_pr: false
+          ref: ${{ inputs.base-SHA }}
+          persist-credentials: false
+          path: ./merge
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
@@ -111,6 +120,7 @@ jobs:
         with:
           ref: ${{ inputs.SHA || github.sha }}
           persist-credentials: false
+          path: ./pull
 
       - name: Resolve full kernel version
         id: kernel-version
@@ -148,7 +158,8 @@ jobs:
           cmd: |
             for i in {1..5}; do curl "https://golang.org" > /dev/null 2>&1 && break || sleep 5; echo "Waiting for systemd-resolved to be ready..."; done
 
-            git config --global --add safe.directory /host
+            git config --global --add safe.directory /host/pull
+            git config --global --add safe.directory /host/merge
             uname -a
 
             # The LVH image might ship with an arbitrary Go toolchain version,
@@ -158,19 +169,32 @@ jobs:
 
             # The LVH image ships with LLVM taken from a release Cilium version.
             # Replace it with the one extracted from the cilium-builder image.
-            /host/contrib/scripts/extract-llvm.sh /tmp/llvm
+            /host/merge/contrib/scripts/extract-llvm.sh /tmp/llvm
             mv /tmp/llvm/usr/local/bin/{clang,llc} /bin/
             rm -r /tmp/llvm
 
-      - name: Run verifier tests
+      - name: Run verifier tests (on base branch)
+        uses: cilium/little-vm-helper@ad43ff511dd5365a0011ae9f864ec959c36daebf # v0.0.28
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          provision: 'false'
+          cmd: |
+            # cd into the PR branch so we run the go test from the PR, but on the BPF code of the base branch.
+            cd /host/pull
+            mkdir -p /host/datapath-verifier
+            # Run with cgo disabled, LVH images don't ship with gcc.
+            CGO_ENABLED=0 PRIVILEGED_TESTS=true go${{ env.go-version }} test -v -timeout=20m ./pkg/datapath/loader -run "TestPrivilegedVerifier" --cilium-base-path /host/merge --kernel-version ${{ matrix.ci-kernel }} --kernel-name ${{ matrix.kernel-name }} --result-dir /host/datapath-verifier
+            mv /host/datapath-verifier/verifier-complexity.json /host/datapath-verifier/verifier-complexity-merge.json
+
+      - name: Run verifier tests (on PR branch)
         uses: cilium/little-vm-helper@ad43ff511dd5365a0011ae9f864ec959c36daebf # v0.0.28
         with:
           provision: 'false'
           cmd: |
-            cd /host/
-            mkdir /host/datapath-verifier
+            cd /host/pull
+            mkdir -p /host/datapath-verifier
             # Run with cgo disabled, LVH images don't ship with gcc.
-            CGO_ENABLED=0 PRIVILEGED_TESTS=true go${{ env.go-version }} test -v -timeout=20m ./pkg/datapath/loader -run "TestPrivilegedVerifier" --cilium-base-path /host --kernel-version ${{ matrix.ci-kernel }} --result-dir /host/datapath-verifier
+            CGO_ENABLED=0 PRIVILEGED_TESTS=true go${{ env.go-version }} test -v -timeout=20m ./pkg/datapath/loader -run "TestPrivilegedVerifier" --cilium-base-path /host/pull --kernel-version ${{ matrix.ci-kernel }} --kernel-name ${{ matrix.kernel-name }} --result-dir /host/datapath-verifier
 
       - name: Upload artifacts
         if: ${{ always() }}
@@ -179,6 +203,44 @@ jobs:
           name: datapath-verifier_${{ matrix.kernel }}
           path: datapath-verifier
           retention-days: 5
+
+  merge-and-diff:
+    name: Merge & Diff
+    needs: setup-and-test
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout pull request branch (NOT TRUSTED)
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        ref: ${{ inputs.SHA || github.sha }}
+        persist-credentials: false
+
+    - name: Download per-kernel results
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+      with:
+        path: ./artifacts
+        pattern: datapath-verifier_*
+
+    - name: Merge verifier-complexity.json
+      run: |
+        cat ./artifacts/*/verifier-complexity.json | jq -s 'add' > ./artifacts/verifier-complexity.json
+
+    - name: Merge verifier-complexity-merge.json
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        cat ./artifacts/*/verifier-complexity-merge.json | jq -s 'add' > ./artifacts/verifier-complexity-merge.json
+        go run ./tools/complexity-diff ./artifacts/verifier-complexity-merge.json ./artifacts/verifier-complexity.json ./artifacts/complexity-diff.json >> $GITHUB_STEP_SUMMARY
+
+    - name: Remove per-kernel results from workspace
+      run: |
+        rm -Rf ./artifacts/datapath-verifier*
+
+    - name: Upload merged
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: verifier-complexity
+        path: ./artifacts
+        retention-days: 5
 
   commit-status-final:
     if: ${{ always() }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -692,6 +692,7 @@ Makefile* @cilium/build
 # Misc. tests
 /test/k8s/config.go @cilium/sig-k8s
 /test/k8s/pod_mac_address.go @cilium/sig-k8s
+/tools/complexity-diff @cilium/loader
 /tools/dpgen @cilium/loader
 /tools/metricslint @cilium/metrics
 /tools/ @cilium/contributing

--- a/contrib/scripts/check-fipsonly.sh
+++ b/contrib/scripts/check-fipsonly.sh
@@ -15,6 +15,7 @@ EXCLUDED_DIRS=(
     "pkg/loadbalancer/repl"
     "tools/alignchecker"
     "tools/api-flaggen"
+    "tools/complexity-diff"
     "tools/crdcheck"
     "tools/crdlistgen"
     "tools/dev-doctor"

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -32,7 +32,8 @@ import (
 
 var (
 	flagCiliumBasePath = flag.String("cilium-base-path", "", "Cilium checkout base path")
-	flagKernelVersion  = flag.String("kernel-version", kernelVersionNetNext.String(), "Kernel version to assume for verifier tests")
+	flagKernelName     = flag.String("kernel-name", "netnext", "Name of the kernel under test")
+	flagKernelVersion  = flag.String("kernel-version", kernelVersionNetNext.String(), "Kernel version to assume for verifier tests for the purposes of selecting build permutations.")
 	flagResultDir      = flag.String("result-dir", "", "Directory to write verifier complexity results and verifier logs to (temp directory if empty)")
 	flagFullLog        = flag.Bool("full-log", false, "Write full verifier log to file (default: false)")
 )
@@ -321,6 +322,7 @@ func loadAndRecordComplexity(
 			lastOff := lastLineIndex + 1
 
 			r := verifierComplexityRecord{
+				Kernel:     *flagKernelName,
 				Collection: collection,
 				Build:      strconv.Itoa(build),
 				Load:       strconv.Itoa(load),
@@ -350,6 +352,7 @@ func loadAndRecordComplexity(
 }
 
 type verifierComplexityRecord struct {
+	Kernel     string `json:"kernel"`
 	Collection string `json:"collection"`
 	Build      string `json:"build"`
 	Load       string `json:"load"`

--- a/tools/complexity-diff/main.go
+++ b/tools/complexity-diff/main.go
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"sort"
+)
+
+type verifierComplexityRecord struct {
+	Kernel     string `json:"kernel"`
+	Collection string `json:"collection"`
+	Build      string `json:"build"`
+	Load       string `json:"load"`
+	Program    string `json:"program"`
+
+	InsnsProcessed   int `json:"insns_processed"`
+	InsnsLimit       int `json:"insns_limit"`
+	MaxStatesPerInsn int `json:"max_states_per_insn"`
+	TotalStates      int `json:"total_states"`
+	PeakStates       int `json:"peak_states"`
+	MarkRead         int `json:"mark_read"`
+
+	VerificationTimeMicroseconds int `json:"verification_time_microseconds"`
+	StackDepth                   int `json:"stack_depth"`
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		panic("usage: complexity-diff <old> <new> <diff>")
+	}
+
+	oldFile := os.Args[1]
+	newFile := os.Args[2]
+	diffFile := os.Args[3]
+
+	oldRecords, err := loadRecords(oldFile)
+	if err != nil {
+		panic(err)
+	}
+	newRecords, err := loadRecords(newFile)
+	if err != nil {
+		panic(err)
+	}
+
+	diffRecords := calcDiffRecords(oldRecords, newRecords, true)
+
+	minMaxInsnsProcessed := calcMinMax(diffRecords, func(r verifierComplexityRecord) int {
+		return r.InsnsProcessed
+	})
+	printTop15MinMax("largest differences by instructions processed", minMaxInsnsProcessed, percentInsnsProcessed, colorRelativeChange)
+
+	minMaxStackDepth := calcMinMax(diffRecords, func(r verifierComplexityRecord) int {
+		return r.StackDepth
+	})
+	printTop15MinMax("largest differences by stack depth", minMaxStackDepth, percentStackDepth, colorRelativeChange)
+
+	var sortedNewRecords []verifierComplexityRecord
+	for _, key := range slices.Sorted(maps.Keys(newRecords)) {
+		sortedNewRecords = append(sortedNewRecords, newRecords[key])
+	}
+
+	minMaxInsnsProcessed = calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
+		return r.InsnsProcessed
+	})
+	printTop15MinMax("largest instructions processed", minMaxInsnsProcessed, percentInsnsProcessed, colorAbsoluteValue)
+
+	minMaxStackDepth = calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
+		return r.StackDepth
+	})
+	printTop15MinMax("largest stack depth", minMaxStackDepth, percentStackDepth, colorAbsoluteValue)
+
+	diffRecords = calcDiffRecords(oldRecords, newRecords, false)
+
+	// Sort diff records to be more logically grouped for human consumption, even though its JSON.
+	sort.Slice(diffRecords, func(i, j int) bool {
+		if diffRecords[i].Kernel != diffRecords[j].Kernel {
+			return diffRecords[i].Kernel < diffRecords[j].Kernel
+		}
+		if diffRecords[i].Collection != diffRecords[j].Collection {
+			return diffRecords[i].Collection < diffRecords[j].Collection
+		}
+		if diffRecords[i].Program != diffRecords[j].Program {
+			return diffRecords[i].Program < diffRecords[j].Program
+		}
+		if diffRecords[i].Build != diffRecords[j].Build {
+			return diffRecords[i].Build < diffRecords[j].Build
+		}
+		return diffRecords[i].Load < diffRecords[j].Load
+	})
+
+	file, err := os.Create(diffFile)
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	bufWriter := bufio.NewWriter(file)
+	defer bufWriter.Flush()
+
+	encoder := json.NewEncoder(bufWriter)
+	encoder.SetIndent("", "  ")
+	err = encoder.Encode(diffRecords)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func printTop15MinMax(title string, minMaxes map[string]minMax, percentFn func(i int) float64, fmtFn func(s string, i int, p float64) string) {
+	fmt.Printf("## Top 15 %s\n", title)
+	fmt.Println("Collection/Program | Min | Max")
+	fmt.Println("-------------------|-----|----")
+	for i, key := range minMaxKeysSortAbs(minMaxes) {
+		if i >= 15 {
+			break
+		}
+
+		mm := minMaxes[key]
+		minPercent := percentFn(mm.min)
+		min := fmtFn(mm.minKey, mm.min, minPercent)
+
+		maxPercent := percentFn(mm.max)
+		max := fmtFn(mm.maxKey, mm.max, maxPercent)
+
+		fmt.Printf("%s | %s | %s\n", key, min, max)
+	}
+	fmt.Println()
+}
+
+func percentInsnsProcessed(i int) float64 {
+	return float64(i) / float64(1_000_000) * 100
+}
+
+func percentStackDepth(i int) float64 {
+	return float64(i) / float64(512) * 100
+}
+
+func colorRelativeChange(program string, i int, p float64) string {
+	s := fmt.Sprintf("%s %+d (%.2f\\\\%%)", program, i, p)
+	if p == 0 {
+		return texNoColor(s)
+	}
+
+	if p < 0 {
+		return texGreen(s)
+	}
+
+	return texRed(s)
+}
+
+func colorAbsoluteValue(program string, i int, p float64) string {
+	s := fmt.Sprintf("%s %d (%.2f\\\\%%)", program, i, p)
+	if p > 80 {
+		return texRed(s)
+	}
+
+	return texGreen(s)
+}
+
+func texNoColor(s string) string {
+	return "$\\textsf{" + s + "}$"
+}
+
+func texGreen(s string) string {
+	return "$\\color{green}{\\textsf{" + s + "}}$"
+}
+
+func texRed(s string) string {
+	return "$\\color{red}{\\textsf{" + s + "}}$"
+}
+
+type minMax struct {
+	minKey string
+	min    int
+	maxKey string
+	max    int
+}
+
+func calcMinMax(records []verifierComplexityRecord, metric func(r verifierComplexityRecord) int) map[string]minMax {
+	minMaxRecords := map[string]minMax{}
+	for _, r := range records {
+		mm, ok := minMaxRecords[collectionProgramKey(r)]
+		if !ok {
+			mm = minMax{
+				min:    metric(r),
+				minKey: kernelBuildLoadKey(r),
+				max:    metric(r),
+				maxKey: kernelBuildLoadKey(r),
+			}
+		}
+		if metric(r) < mm.min {
+			mm.minKey = kernelBuildLoadKey(r)
+			mm.min = metric(r)
+		}
+		if metric(r) > mm.max {
+			mm.maxKey = kernelBuildLoadKey(r)
+			mm.max = metric(r)
+		}
+		minMaxRecords[collectionProgramKey(r)] = mm
+	}
+
+	return minMaxRecords
+}
+
+func minMaxKeysSortAbs(minMaxes map[string]minMax) []string {
+	keys := slices.Sorted(maps.Keys(minMaxes))
+	slices.SortStableFunc(keys, func(a, b string) int {
+		absMinA := minMaxes[a].min
+		if absMinA < 0 {
+			absMinA = -absMinA
+		}
+		absMaxA := minMaxes[a].max
+		if absMaxA < 0 {
+			absMaxA = -absMaxA
+		}
+		absA := absMinA + absMaxA
+
+		absMinB := minMaxes[b].min
+		if absMinB < 0 {
+			absMinB = -absMinB
+		}
+		absMaxB := minMaxes[b].max
+		if absMaxB < 0 {
+			absMaxB = -absMaxB
+		}
+		absB := absMinB + absMaxB
+
+		return absB - absA
+	})
+	return keys
+}
+
+func calcDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord, onlyChange bool) []verifierComplexityRecord {
+	diffRecords := make([]verifierComplexityRecord, 0)
+	for _, key := range slices.Sorted(maps.Keys(newRecords)) {
+		newRecord := newRecords[key]
+		oldRecord, ok := oldRecords[key]
+		if !ok {
+			if onlyChange {
+				continue
+			}
+
+			diffRecords = append(diffRecords, newRecord)
+			continue
+		}
+
+		diffRecords = append(diffRecords, verifierComplexityRecord{
+			Kernel:     newRecord.Kernel,
+			Collection: newRecord.Collection,
+			Build:      newRecord.Build,
+			Load:       newRecord.Load,
+			Program:    newRecord.Program,
+
+			InsnsProcessed:   newRecord.InsnsProcessed - oldRecord.InsnsProcessed,
+			InsnsLimit:       newRecord.InsnsLimit - oldRecord.InsnsLimit,
+			MaxStatesPerInsn: newRecord.MaxStatesPerInsn - oldRecord.MaxStatesPerInsn,
+			TotalStates:      newRecord.TotalStates - oldRecord.TotalStates,
+			PeakStates:       newRecord.PeakStates - oldRecord.PeakStates,
+			MarkRead:         newRecord.MarkRead - oldRecord.MarkRead,
+
+			VerificationTimeMicroseconds: newRecord.VerificationTimeMicroseconds - oldRecord.VerificationTimeMicroseconds,
+			StackDepth:                   newRecord.StackDepth - oldRecord.StackDepth,
+		})
+	}
+
+	if !onlyChange {
+		for key, oldRecord := range oldRecords {
+			_, ok := newRecords[key]
+			if !ok {
+				diffRecords = append(diffRecords, verifierComplexityRecord{
+					Kernel:     oldRecord.Kernel,
+					Collection: oldRecord.Collection,
+					Build:      oldRecord.Build,
+					Load:       oldRecord.Load,
+					Program:    oldRecord.Program,
+
+					InsnsProcessed:   -oldRecord.InsnsProcessed,
+					InsnsLimit:       -oldRecord.InsnsLimit,
+					MaxStatesPerInsn: -oldRecord.MaxStatesPerInsn,
+					TotalStates:      -oldRecord.TotalStates,
+					PeakStates:       -oldRecord.PeakStates,
+					MarkRead:         -oldRecord.MarkRead,
+
+					VerificationTimeMicroseconds: -oldRecord.VerificationTimeMicroseconds,
+					StackDepth:                   -oldRecord.StackDepth,
+				})
+			}
+		}
+	}
+
+	return diffRecords
+}
+
+func recordKey(r verifierComplexityRecord) string {
+	return r.Kernel + "/" + r.Collection + "/" + r.Program + "/" + r.Build + "/" + r.Load
+}
+
+func collectionProgramKey(r verifierComplexityRecord) string {
+	return r.Collection + "/" + r.Program
+}
+
+func kernelBuildLoadKey(r verifierComplexityRecord) string {
+	if r.Kernel == "" {
+		return r.Build + "/" + r.Load
+	}
+
+	return r.Kernel + "/" + r.Build + "/" + r.Load
+}
+
+func loadRecords(path string) (map[string]verifierComplexityRecord, error) {
+	var records []verifierComplexityRecord
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(bufio.NewReader(file))
+	err = decoder.Decode(&records)
+	if err != nil {
+		return nil, err
+	}
+
+	recordMap := make(map[string]verifierComplexityRecord)
+	for _, record := range records {
+		recordMap[recordKey(record)] = record
+	}
+	return recordMap, nil
+}


### PR DESCRIPTION
Since https://github.com/cilium/cilium/pull/40367 the verifier complexity test has gained the ability to output JSON files with all the results. So far these were emitted as artifacts per kernel.

This commit expends the JSON files by adding the kernel version which produced the results. This allows us to merge all results together into one big JSON file. The workflow is modified to download all separate artifacts and to merge them into one big JSON file which is then uploaded as an artifact. This will allow us to collect tests results from scheduled runs to track complexity over time.

This commit also changes the workflow to run the complexity tests twice when triggered on a PR. The first run is on the base/merge branch and then on the HEAD of the PR branch. The merged results of both are then compared by a new tool `complexity-diff` which outputs the diff in a separate JSON file as well as outputting a markdown summary.

The summary states the most significant changes in complexity and stack depth as result of the current PR. It also states the 15 largest programs in terms of complexity and stack depth.

For every "program" the summary lists the permutation with the smallest number "min" and the largest number "max". Though results for all permutations are available in the JSON files.

Summary output: https://github.com/cilium/cilium/actions/runs/19500527377/attempts/1#summary-55814969793