### PR TITLE
clustermesh: add ServiceImport clusters count metric

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -1013,6 +1013,7 @@ Name                                                 Labels                     
 ``serviceexport_status_condition``   ``serviceexport``, ``namespace``, ``condition``, ``status``  Enabled    Status Condition of ServiceExport in the local cluster
 ``serviceimport_info``               ``serviceimport``, ``namespace``                             Enabled    Information about ServiceImport in the local cluster
 ``serviceimport_status_condition``   ``serviceimport``, ``namespace``, ``condition``, ``status``  Enabled    Status Condition of ServiceImport in the local cluster
+``serviceimport_status_clusters``    ``serviceimport``, ``namespace``                             Enabled    The number of clusters currently backing a ServiceImport
 ==================================== ============================================================ ========== ===========================================================
 
 Clustermesh


### PR DESCRIPTION
Allow users to get some info about the backing clusters of a ServiceImport through metrics in addition to the Kubernetes API.

Should be the last metrics (at least that I could think of today :sweat_smile:) of purely MCS metrics (note that all the others MCS metrics are not yet in stable release / will all be released together with 1.19).

```release-note
clustermesh: add ServiceImport clusters count metric
```
