### PR TITLE
[GH-41867][Part-1][eBPF] Add support for hybrid routing in datapath

### DIFF
--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -33,3 +33,5 @@ NODE_CONFIG(bool, supports_fib_lookup_skip_neigh,
 NODE_CONFIG(__u8, tracing_ip_option_type, "The IP option type to use for packet tracing")
 
 NODE_CONFIG(bool, policy_deny_response_enabled, "Enable ICMP responses for policy-denied traffic")
+
+NODE_CONFIG(bool, hybrid_routing_enabled, "Enable hybrid mode routing based on subnet IDs")

--- a/bpf/lib/subnet.h
+++ b/bpf/lib/subnet.h
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include "common.h"
+
+#include <linux/ip.h>
+#include "ipv6.h"
+
+#define SUBNET_MAP_SIZE 1024
+
+struct subnet_key {
+	struct bpf_lpm_trie_key lpm_key;
+	__u16 pad0;
+	__u8 pad1;
+	__u8 family;
+	union {
+		struct {
+			__u32		ip4;
+			__u32		pad2;
+			__u32		pad3;
+			__u32		pad4;
+		};
+		union v6addr	ip6;
+	};
+} __packed;
+
+struct subnet_value {
+    __u32 identity;
+};
+
+/* CIDR -> Subnet Identity map */
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__type(key, struct subnet_key);
+	__type(value, struct subnet_value);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, SUBNET_MAP_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cilium_subnet_map __section_maps_btf;
+
+/* SUBNET_STATIC_PREFIX gets sizeof non-IP, non-prefix part of subnet_key */
+#define SUBNET_STATIC_PREFIX							\
+	(8 * (sizeof(struct subnet_key) - sizeof(struct bpf_lpm_trie_key)	\
+	      - sizeof(union v6addr)))
+#define SUBNET_PREFIX_LEN(PREFIX) (SUBNET_STATIC_PREFIX + (PREFIX))
+
+#define V6_SUBNET_KEY_LEN (sizeof(union v6addr) * 8)
+
+static __always_inline __maybe_unused __u32
+subnet_lookup6(const void *map, const union v6addr *addr)
+{
+	__u32 prefix = V6_SUBNET_KEY_LEN;
+    struct subnet_value *value;
+	struct subnet_key key = {
+		.lpm_key = { SUBNET_PREFIX_LEN(prefix), {} },
+		.family = ENDPOINT_KEY_IPV6,
+		.ip6 = *addr,
+	};
+
+	/* Normalize the key before lookup.
+	 * Clear the lower bits of the IPv6 address according to the prefix length.
+	 * Note: Given that prefix length is always 128 here, this operation is effectively a no-op.
+	 * However, it is included for completeness and future-proofing.
+	 */
+	ipv6_addr_clear_suffix(&key.ip6, prefix);
+	value = (struct subnet_value *)map_lookup_elem(map, &key);
+	if (!value)
+		return 0;
+
+    return value->identity;
+}
+
+#define V4_SUBNET_KEY_LEN (sizeof(__u32) * 8)
+
+static __always_inline __maybe_unused __u32
+subnet_lookup4(const void *map, __be32 addr)
+{
+	__u32 prefix = V4_SUBNET_KEY_LEN;
+    struct subnet_value *value;
+	struct subnet_key key = {
+		.lpm_key = { SUBNET_PREFIX_LEN(prefix), {} },
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = addr,
+	};
+
+	/* Normalize the key before lookup.
+	 * Clear the lower bits of the IPv4 address according to the prefix length.
+	 */
+	key.ip4 &= GET_PREFIX(prefix);
+	value = (struct subnet_value *)map_lookup_elem(map, &key);
+	if (!value)
+		return 0;
+
+	return value->identity;
+}
+
+#define lookup_ip6_subnet_id(addr) \
+	subnet_lookup6(&cilium_subnet_map, addr)
+#define lookup_ip4_subnet_id(addr) \
+	subnet_lookup4(&cilium_subnet_map, addr)

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -11,6 +11,8 @@ package config
 type Node struct {
 	// Index of the interface used to connect nodes in the cluster.
 	DirectRoutingDevIfindex uint32 `config:"direct_routing_dev_ifindex"`
+	// Enable hybrid mode routing based on subnet IDs.
+	HybridRoutingEnabled bool `config:"hybrid_routing_enabled"`
 	// Enable ICMP responses for policy-denied traffic.
 	PolicyDenyResponseEnabled bool `config:"policy_deny_response_enabled"`
 	// Internal IPv6 router address assigned to the cilium_host interface.
@@ -30,7 +32,7 @@ type Node struct {
 }
 
 func NewNode() *Node {
-	return &Node{0x0, false,
+	return &Node{0x0, false, false,
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0},
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},


### PR DESCRIPTION
# Description

The motivation behind adding a new routing mode is discussed in this [CFP](https://github.com/cilium/design-cfps/blob/main/cilium/CFP-32810-hybrid-routing-mode.md) . 

This is Part 1 of feature:
- adds the subnet map in datapath
- add lookup functions for getting subnet id
- skip tunneling if IPs belong to same subnet ID
- won't interfere with how datapath works today (allows checking this PR in as a standalone change)

For reference, here's a draft PR with the entire feature implemented - https://github.com/cilium/cilium/pull/41405 .

## Overview

This feature would allow user to configure Cilium cluster(s) with multiple subnets, and benefit from both tunnel and native routing mode for maximum efficiency (no overhead of tunneling when not needed).

## Motivation

1. Given that tunneling can always route a packet as long as nodes have connectivity, the entire change is designed to use tunnel as default, with exceptions built in to skip tunneling when IPs belong to same subnet.
2. I have tried to adhere to existing patterns that I could identify - the eBPF map and lookup function closely resembles the IPCache library.

# Changes Overview

## Datapath

This covers all the C code changes. Files edited/added:

1. `bpf/lib/subnet.h` - This has the LPM trie based subnet map, similar to the IPCache map. Has functions for lookup.
2. `bpf_lxc.c` - Added an extra check to `skip_tunnel`. Now, skip tunneling if IPs belong to same subnet.
4. `bpf_host.c` - Added an extra check to `skip_tunnel`. Now, skip tunneling if IPs belong to same subnet.
5. Added two debug keys - `DBG_SUBNET_CHECK` and `DBG_TUNNEL_TRACE` for debugging purposes. Will remove these before merging.

# Testing Done

The full feature is tested using the change [draft PR](https://github.com/cilium/cilium/pull/41405).
I tested this change against a cluster and verified:
- the subnet map doesn't exist
- all IPs return ID=0
- No packet skips tunneling

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #41867 

```release-note
Add support for hybrid routing in datapath
```
