### PR TITLE
bpf: host/wireguard: clarify security identities for proxy traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1364,6 +1364,8 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 
 	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY || ctx_mark_is_encrypted(ctx))
 		src_sec_identity = HOST_ID;
+	else if (magic == MARK_MAGIC_PROXY_EGRESS)
+		src_sec_identity = get_identity(ctx);
 #ifdef ENABLE_IDENTITY_MARK
 	else if (magic == MARK_MAGIC_IDENTITY)
 		src_sec_identity = get_identity(ctx);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -556,19 +556,20 @@ enum metric_dir {
  *  - the key index to use for encryption when multiple keys are in-flight.
  *    In the IPsec case this becomes the SPI on the wire.
  */
+/*						Packet mark content: */
 #define MARK_MAGIC_HOST_MASK		0x0F00
 #define MARK_MAGIC_SKIP_TPROXY		0x0800
-#define MARK_MAGIC_PROXY_EGRESS_EPID	0x0900 /* mark carries source endpoint ID */
-#define MARK_MAGIC_PROXY_INGRESS	0x0A00
-#define MARK_MAGIC_PROXY_EGRESS		0x0B00
+#define MARK_MAGIC_PROXY_EGRESS_EPID	0x0900 /* source endpoint ID */
+#define MARK_MAGIC_PROXY_INGRESS	0x0A00 /* source identity (upstream traffic only) */
+#define MARK_MAGIC_PROXY_EGRESS		0x0B00 /* source identity (upstream traffic only) */
 #define MARK_MAGIC_HOST			0x0C00
 #define MARK_MAGIC_DECRYPT		0x0D00
 #define MARK_MAGIC_ENCRYPT		0x0E00
-#define MARK_MAGIC_IDENTITY		0x0F00 /* mark carries identity */
+#define MARK_MAGIC_IDENTITY		0x0F00 /* source identity */
 #define MARK_MAGIC_TO_PROXY		0x0200
 #define MARK_MAGIC_SNAT_DONE		0x0300
-#define MARK_MAGIC_OVERLAY		0x0400 /* mark carries identity */
-#define MARK_MAGIC_EGW_DONE		0x0500 /* mark carries identity */
+#define MARK_MAGIC_OVERLAY		0x0400 /* source identity */
+#define MARK_MAGIC_EGW_DONE		0x0500 /* source identity */
 
 #define MARK_MAGIC_KEY_MASK		0xFF00
 

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -135,15 +135,14 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	}
 
 #ifndef ENABLE_NODE_ENCRYPTION
-	/* A pkt coming from L7 proxy (i.e., Envoy or the DNS proxy on behalf of
-	 * a client pod) has src IP addr of a host, but not of the client pod
-	 * (if
-	 * --dnsproxy-enable-transparent-mode=false). Such a pkt must be
-	 *  encrypted.
+	/* We want to encrypt all proxy traffic. Looking at the packet mark is
+	 * needed for non-transparent connections.
+	 *
+	 * For connections by the egress proxy (MARK_MAGIC_PROXY_EGRESS) we
+	 * can rely on the provided source identity.
 	 */
 	magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 	if (magic == MARK_MAGIC_PROXY_INGRESS ||
-	    magic == MARK_MAGIC_PROXY_EGRESS ||
 	    magic == MARK_MAGIC_SKIP_TPROXY)
 		goto maybe_encrypt;
 #if defined(TUNNEL_MODE)


### PR DESCRIPTION
Fine-tune the datapath's understanding of which proxy traffic provides the original source identity, and make first use of it to simplify the wireguard encryption logic.

Towards https://github.com/cilium/cilium/issues/33195.
