### PR TITLE
bpf: tests: add helpers to call entrypoints

### DIFF
--- a/bpf/tests/bpf_nat_icmp6.h
+++ b/bpf/tests/bpf_nat_icmp6.h
@@ -1,13 +1,17 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
 #define ENABLE_SCTP
 #define ENABLE_IPV4
 #define ENABLE_IPV6
 #define ENABLE_NODEPORT
 #define ENABLE_MASQUERADE_IPV6
 
-#include "bpf_host.c"
+#include "lib/bpf_host.h"
 
 #include <bpf/config/node.h>
 
@@ -19,10 +23,7 @@
 #include <lib/time.h>
 
 #include <bpf/helpers.h>
-#include <bpf/ctx/skb.h>
 #include <bpf/api.h>
-#include "common.h"
-#include "pktgen.h"
 
 #include <bpf/ctx/skb.h>
 #include <bpf/api.h>
@@ -40,21 +41,6 @@
 #define NODE_ONE { .addr = v6_node_one_addr }
 #define EXT_IP { .addr = v6_ext_node_one_addr }
 #define POD_IP { .addr = v6_pod_one_addr }
-
-#define FROM_NETDEV	0
-#define TO_NETDEV	1
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 2);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[FROM_NETDEV] = &cil_from_netdev,
-		[TO_NETDEV] = &cil_to_netdev,
-	},
-};
 
 /*
  * Input packet represents a device sending a PKT_TOO_BIG response ICMPv6
@@ -240,8 +226,8 @@ int snat_v6_pmtu_setup(struct __ctx_buff *ctx)
 	ret = snat_v6_insert_ct_nat(IPPROTO_TCP);
 	if (ret < 0)
 		return TEST_FAIL;
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-	return TEST_PASS;
+
+	return netdev_receive_packet(ctx);
 }
 
 CHECK("tc", "snat_v6_tcp_pmtu")
@@ -273,8 +259,8 @@ int snat_v6_pmtu_udp_setup(struct __ctx_buff *ctx)
 	ret = snat_v6_insert_ct_nat(IPPROTO_UDP);
 	if (ret < 0)
 		return TEST_FAIL;
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-	return TEST_PASS;
+
+	return netdev_receive_packet(ctx);
 }
 
 CHECK("tc", "snat_v6_udp_pmtu")

--- a/bpf/tests/lib/bpf_host.h
+++ b/bpf/tests/lib/bpf_host.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf_host.c>
+
+#define FROM_NETDEV		0
+#define TO_NETDEV		1
+#define FROM_HOST		2
+#define TO_HOST			3
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 4);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+		[TO_NETDEV] = &cil_to_netdev,
+		[FROM_HOST] = &cil_from_host,
+		[TO_HOST] = &cil_to_host,
+	},
+};
+
+static __always_inline int
+netdev_receive_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	return TEST_ERROR;
+}
+
+static __always_inline int
+netdev_send_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	return TEST_ERROR;
+}
+
+static __always_inline int
+host_receive_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, TO_HOST);
+	return TEST_ERROR;
+}
+
+static __always_inline int
+host_send_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, FROM_HOST);
+	return TEST_ERROR;
+}

--- a/bpf/tests/lib/bpf_lxc.h
+++ b/bpf/tests/lib/bpf_lxc.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf_lxc.c>
+
+#define FROM_CONTAINER		0
+#define TO_CONTAINER		1
+#define TO_CONTAINER_TAILCALL	2
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 3);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+		[TO_CONTAINER] = &cil_to_container,
+		[TO_CONTAINER_TAILCALL] = &cil_lxc_policy,
+	},
+};
+
+static __always_inline int
+pod_send_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	return TEST_ERROR;
+}
+
+static __always_inline int
+pod_receive_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, TO_CONTAINER);
+	return TEST_ERROR;
+}
+
+static __always_inline int
+pod_receive_packet_by_tailcall(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, TO_CONTAINER_TAILCALL);
+	return TEST_ERROR;
+}

--- a/bpf/tests/lib/bpf_network.h
+++ b/bpf/tests/lib/bpf_network.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf_network.c>
+
+#define FROM_NETWORK		0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETWORK] = &cil_from_network,
+	},
+};
+
+static __always_inline int
+network_receive_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, FROM_NETWORK);
+	return TEST_ERROR;
+}

--- a/bpf/tests/lib/bpf_overlay.h
+++ b/bpf/tests/lib/bpf_overlay.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf_overlay.c>
+
+#define FROM_OVERLAY		0
+#define TO_OVERLAY		1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_OVERLAY] = &cil_from_overlay,
+		[TO_OVERLAY] = &cil_to_overlay,
+	},
+};
+
+static __always_inline int
+overlay_receive_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
+	return TEST_ERROR;
+}
+
+static __always_inline int
+overlay_send_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, TO_OVERLAY);
+	return TEST_ERROR;
+}
+

--- a/bpf/tests/lib/bpf_xdp.h
+++ b/bpf/tests/lib/bpf_xdp.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf_xdp.c>
+
+#define FROM_XDP		0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_XDP] = &cil_xdp_entry,
+	},
+};
+
+static __always_inline int
+xdp_receive_packet(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, entry_call_map, FROM_XDP);
+	return TEST_ERROR;
+}

--- a/bpf/tests/session_affinity_maglev_test.c
+++ b/bpf/tests/session_affinity_maglev_test.c
@@ -121,19 +121,8 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 	return 0;
 }
 
-#include "bpf_xdp.c"
+#include "lib/bpf_xdp.h"
 #include "lib/lb.h"
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 1);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-.values = {
-  [0] = &cil_xdp_entry,
-},
-};
 
 static __always_inline int
 generate_packet(struct __ctx_buff *ctx, int client_id, __u16 src_port)
@@ -281,10 +270,8 @@ SETUP("xdp", "session_affinity_maglev_client_1_port_1")
 int setup_1_1(struct __ctx_buff *ctx)
 {
 	setup_test();
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, 0);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+
+	return xdp_receive_packet(ctx);
 }
 
 CHECK("xdp", "session_affinity_maglev_client_1_port_1")
@@ -306,10 +293,8 @@ SETUP("xdp", "session_affinity_maglev_client_1_port_2")
 int setup_1_2(struct __ctx_buff *ctx)
 {
 	setup_test();
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, 0);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+
+	return xdp_receive_packet(ctx);
 }
 
 CHECK("xdp", "session_affinity_maglev_client_1_port_2")
@@ -331,10 +316,8 @@ SETUP("xdp", "session_affinity_maglev_client_1_port_3")
 int setup_1_3(struct __ctx_buff *ctx)
 {
 	setup_test();
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, 0);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+
+	return xdp_receive_packet(ctx);
 }
 
 CHECK("xdp", "session_affinity_maglev_client_1_port_3")
@@ -356,10 +339,8 @@ SETUP("xdp", "session_affinity_maglev_client_2_port_1")
 int setup_2_1(struct __ctx_buff *ctx)
 {
 	setup_test();
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, 0);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+
+	return xdp_receive_packet(ctx);
 }
 
 CHECK("xdp", "session_affinity_maglev_client_2_port_1")
@@ -381,10 +362,8 @@ SETUP("xdp", "session_affinity_maglev_client_2_port_2")
 int setup_2_2(struct __ctx_buff *ctx)
 {
 	setup_test();
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, 0);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+
+	return xdp_receive_packet(ctx);
 }
 
 CHECK("xdp", "session_affinity_maglev_client_2_port_2")
@@ -406,10 +385,8 @@ SETUP("xdp", "session_affinity_maglev_client_2_port_3")
 int setup_2_3(struct __ctx_buff *ctx)
 {
 	setup_test();
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, 0);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+
+	return xdp_receive_packet(ctx);
 }
 
 CHECK("xdp", "session_affinity_maglev_client_2_port_3")

--- a/bpf/tests/skip_tunnel_nodeport_nat.c
+++ b/bpf/tests/skip_tunnel_nodeport_nat.c
@@ -67,7 +67,7 @@ long mock_fib_lookup(const __maybe_unused void *ctx, const struct bpf_fib_lookup
 /*
  * Include entrypoint into host stack
  */
-#include "bpf_host.c"
+#include "lib/bpf_host.h"
 
 /*
  * Include test helpers
@@ -85,18 +85,6 @@ long mock_fib_lookup(const __maybe_unused void *ctx, const struct bpf_fib_lookup
 #include "lib/conntrack.h"
 #include "lib/nat.h"
 #include "lib/nodeport.h"
-
-#define FROM_NETDEV 0
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 1);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[FROM_NETDEV] = &cil_from_netdev,
-	},
-};
 
 static __always_inline int
 pktgen(struct __ctx_buff *ctx, bool v4)
@@ -179,8 +167,7 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 						0, 1230, DST_TUNNEL_IP, 0, flag_skip_tunnel);
 	}
 
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-	return TEST_ERROR;
+	return netdev_receive_packet(ctx);
 }
 
 static __always_inline int

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -14,25 +14,12 @@
 #define ENABLE_MASQUERADE_IPV6
 #define ENCAP_IFINDEX 0
 
-#include "bpf_host.c"
+#include "lib/bpf_host.h"
 
 #include "lib/egressgw.h"
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/policy.h"
-
-#define TO_NETDEV 0
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 1);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[TO_NETDEV] = &cil_to_netdev,
-	},
-};
 
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program gets redirected to the gateway node.
@@ -53,10 +40,7 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
 				  EGRESS_IP);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, TO_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_send_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_redirect")
@@ -92,10 +76,7 @@ int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_EXCLUDED_CIDR,
 				  EGRESS_IP);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, TO_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_send_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect")
@@ -136,10 +117,7 @@ int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY,
 				  EGRESS_IP);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, TO_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_send_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_skip_no_gateway_redirect")
@@ -198,10 +176,7 @@ int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, GATEWAY_NODE_IP,
 				  EGRESS_GATEWAY_NO_EGRESS_IP);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, TO_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_send_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_drop_no_egress_ip")
@@ -257,10 +232,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, TO_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_send_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_redirect_v6")
@@ -303,10 +275,7 @@ int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_EXCLUDED_CIDR,
 				     &egress_ip);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, TO_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_send_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect_v6")
@@ -354,10 +323,7 @@ int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_NO_GATEWAY,
 				     &egress_ip);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, TO_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_send_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_skip_no_gateway_redirect_v6")
@@ -421,10 +387,7 @@ int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, GATEWAY_NODE_IP,
 				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, TO_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_send_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_drop_no_egress_ip_v6")

--- a/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
@@ -34,7 +34,7 @@ static int mock_skb_get_tunnel_key(__maybe_unused struct __sk_buff *skb,
 	return 0;
 }
 
-#include "bpf_overlay.c"
+#include "lib/bpf_overlay.h"
 
 #include "lib/egressgw.h"
 #include "lib/ipcache.h"
@@ -57,19 +57,6 @@ mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_
 	return -1;
 }
 
-#define FROM_OVERLAY 0
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 2);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[FROM_OVERLAY] = &cil_from_overlay,
-	},
-};
-
 /* Test that a packet matching an egress gateway policy on the from-overlay program
  * gets correctly redirected to the target netdev.
  */
@@ -88,10 +75,7 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
 				  EGRESS_IP);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return overlay_receive_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_redirect_from_overlay_with_egress_interface")
@@ -128,10 +112,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return overlay_receive_packet(ctx);
 }
 
 CHECK("tc", "tc_egressgw_redirect_from_overlay_with_egress_interface_v6")

--- a/bpf/tests/tc_geneve_dsr_v6_legacy.c
+++ b/bpf/tests/tc_geneve_dsr_v6_legacy.c
@@ -49,22 +49,9 @@ int mock_skb_get_tunnel_opt(__maybe_unused struct __sk_buff *skb,
 	return size;
 }
 
-#include "bpf_overlay.c"
+#include "lib/bpf_overlay.h"
 
 #include "lib/endpoint.h"
-
-#define FROM_OVERLAY 0
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 1);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[FROM_OVERLAY] = &cil_from_overlay,
-	},
-};
 
 PKTGEN("tc", "tc_geneve_dsr_v6_legacy")
 int tc_geneve_dsr_v6_legacy_pktgen(struct __ctx_buff *ctx)
@@ -101,10 +88,8 @@ int tc_geneve_dsr_v6_legacy_setup(struct __ctx_buff *ctx)
 	union v6addr backend_ip = BACKEND_IP;
 
 	endpoint_v6_add_entry(&backend_ip, 0, 0, 0, 0, NULL, NULL);
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+
+	return overlay_receive_packet(ctx);
 }
 
 CHECK("tc", "tc_geneve_dsr_v6_legacy")

--- a/bpf/tests/tc_lxc_lb4_no_backend.c
+++ b/bpf/tests/tc_lxc_lb4_no_backend.c
@@ -23,25 +23,12 @@ static volatile const __u8 *client_mac = mac_one;
 /* this matches the default node_config.h: */
 static volatile const __u8 lb_mac[ETH_ALEN] = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
 
-#include <bpf_lxc.c>
+#include "lib/bpf_lxc.h"
 
 ASSIGN_CONFIG(bool, enable_no_service_endpoints_routable, true)
 
 #include "lib/ipcache.h"
 #include "lib/lb.h"
-
-#define FROM_CONTAINER	0
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 2);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[FROM_CONTAINER] = &cil_from_container,
-	},
-};
 
 /* Test that a SVC without backends returns a TCP RST or ICMP error */
 PKTGEN("tc", "tc_lxc_no_backend")
@@ -80,11 +67,7 @@ int lxc_no_backend_setup(struct __ctx_buff *ctx)
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
-
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return pod_send_packet(ctx);
 }
 
 CHECK("tc", "tc_lxc_no_backend")

--- a/bpf/tests/tc_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_lb.c
@@ -49,25 +49,10 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 	return 0;
 }
 
-#include <bpf_host.c>
+#include "lib/bpf_host.h"
 
 #include "lib/ipcache.h"
 #include "lib/lb.h"
-
-#define FROM_NETDEV	0
-#define TO_NETDEV	1
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 2);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[FROM_NETDEV] = &cil_from_netdev,
-		[TO_NETDEV] = &cil_to_netdev,
-	},
-};
 
 /* Test that a SVC request that is LBed to a DSR remote backend
  * - gets DNATed,
@@ -112,10 +97,7 @@ int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_receive_packet(ctx);
 }
 
 CHECK("tc", "tc_nodeport_dsr_fwd")

--- a/bpf/tests/tc_nodeport_lb4_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_no_backend.c
@@ -24,28 +24,13 @@ static volatile const __u8 *client_mac = mac_one;
 /* this matches the default node_config.h: */
 static volatile const __u8 lb_mac[ETH_ALEN] = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
 
-#include <bpf_host.c>
+#include "lib/bpf_host.h"
 
 ASSIGN_CONFIG(union v4addr, nat_ipv4_masquerade, { .be32 = FRONTEND_IP})
 ASSIGN_CONFIG(bool, enable_no_service_endpoints_routable, true)
 
 #include "lib/ipcache.h"
 #include "lib/lb.h"
-
-#define FROM_NETDEV	0
-#define TO_NETDEV	1
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 2);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[FROM_NETDEV] = &cil_from_netdev,
-		[TO_NETDEV] = &cil_to_netdev,
-	},
-};
 
 /* Test that a SVC without backends returns a TCP RST or ICMP error */
 PKTGEN("tc", "tc_nodeport_no_backend")
@@ -84,11 +69,7 @@ int nodeport_no_backend_setup(struct __ctx_buff *ctx)
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_receive_packet(ctx);
 }
 
 static __always_inline int
@@ -173,11 +154,7 @@ int nodeport_no_backend2_reply_setup(struct __ctx_buff *ctx)
 	if (__tail_no_service_ipv4(ctx))
 		return TEST_ERROR;
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, TO_NETDEV);
-
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return netdev_send_packet(ctx);
 }
 
 CHECK("tc", "tc_nodeport_no_backend2_reply")

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -547,53 +547,54 @@ int tc_drop_no_backend_check(const struct __ctx_buff *ctx)
 
 static __always_inline int build_packet_v6(struct __ctx_buff *ctx, __be16 sport)
 {
-    struct pktgen builder;
-    volatile const __u8 *src = mac_one;
-    volatile const __u8 *dst = mac_two;
-    struct tcphdr *l4;
-    void *data;
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
+	struct tcphdr *l4;
+	void *data;
 
-    pktgen__init(&builder, ctx);
+	pktgen__init(&builder, ctx);
 
-    l4 = pktgen__push_ipv6_tcp_packet(&builder,
-				      (__u8 *)src, (__u8 *)dst,
-				      (__u8 *)POD_IPV6, (__u8 *)SERVICE_IPV6,
-				      sport, tcp_svc_one);
-    if (!l4)
-	return TEST_ERROR;
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)src, (__u8 *)dst,
+					  (__u8 *)POD_IPV6, (__u8 *)SERVICE_IPV6,
+					  sport, tcp_svc_one);
+	if (!l4)
+		return TEST_ERROR;
 
-    data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-    if (!data)
-	return TEST_ERROR;
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
 
-    pktgen__finish(&builder);
-    return 0;
+	pktgen__finish(&builder);
+	return 0;
 }
 
 PKTGEN("tc", "hairpin_flow_1_forward_v6")
 int hairpin_flow_forward_pktgen_v6(struct __ctx_buff *ctx)
 {
-    return build_packet_v6(ctx, tcp_src_one);
+	return build_packet_v6(ctx, tcp_src_one);
 }
 
 SETUP("tc", "hairpin_flow_1_forward_v6")
 int hairpin_flow_forward_setup_v6(struct __ctx_buff *ctx)
 {
-    __u16 revnat_id = 1;
+	__u16 revnat_id = 1;
 
-    lb_v6_add_service((const union v6addr *)SERVICE_IPV6, tcp_svc_one, IPPROTO_TCP, 1, revnat_id);
-    lb_v6_add_backend((const union v6addr *)SERVICE_IPV6, tcp_svc_one, 1, 124,
-		      (const union v6addr *)POD_IPV6, tcp_dst_one, IPPROTO_TCP, 0);
+	lb_v6_add_service((const union v6addr *)SERVICE_IPV6, tcp_svc_one, IPPROTO_TCP,
+			  1, revnat_id);
+	lb_v6_add_backend((const union v6addr *)SERVICE_IPV6, tcp_svc_one, 1, 124,
+			  (const union v6addr *)POD_IPV6, tcp_dst_one, IPPROTO_TCP, 0);
 
-    ipcache_v6_add_entry((union v6addr *)POD_IPV6, 0, 112233, 0, 0);
+	ipcache_v6_add_entry((union v6addr *)POD_IPV6, 0, 112233, 0, 0);
 
-    endpoint_v6_add_entry((const union v6addr *)POD_IPV6, 0, 0, 0, 0, NULL, NULL);
+	endpoint_v6_add_entry((const union v6addr *)POD_IPV6, 0, 0, 0, 0, NULL, NULL);
 
-    policy_add_egress_deny_all_entry();
-    policy_add_ingress_deny_all_entry();
+	policy_add_egress_deny_all_entry();
+	policy_add_ingress_deny_all_entry();
 
-    tail_call_static(ctx, entry_call_map, 0);
-    return TEST_ERROR;
+	tail_call_static(ctx, entry_call_map, 0);
+	return TEST_ERROR;
 }
 
 CHECK("tc", "hairpin_flow_1_forward_v6")

--- a/bpf/tests/tc_srv6_decap.c
+++ b/bpf/tests/tc_srv6_decap.c
@@ -18,23 +18,10 @@
 /* Test SRH encap. Reduced encap code path is a subset of SRH encap */
 #define ENABLE_SRV6_SRH_ENCAP
 
-#include "bpf_host.c"
+#include "lib/bpf_host.h"
 #include "lib/ipcache.h"
 #include "lib/endpoint.h"
 #include "lib/lb.h"
-
-#define FROM_NETDEV 0
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 1);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[FROM_NETDEV] = &cil_from_netdev,
-	},
-};
 
 #define POD_IPV4 v4_pod_one
 #define POD_IPV6 v6_pod_one
@@ -126,9 +113,7 @@ int srv6_decap_to_pod_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 	endpoint_v4_add_entry(POD_IPV4, 12345, 100, 0, 0, 0,
 			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
 
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-
-	return TEST_FAIL;
+	return netdev_receive_packet(ctx);
 }
 
 CHECK("tc", "tc_srv6_decap_to_pod_ipv4")
@@ -264,9 +249,7 @@ int srv6_decap_to_pod_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
 	endpoint_v6_add_entry((const union v6addr *)POD_IPV6, 12345, 100, 0, 0,
 			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
 
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-
-	return TEST_FAIL;
+	return netdev_receive_packet(ctx);
 }
 
 CHECK("tc", "tc_srv6_decap_to_pod_ipv6")
@@ -407,9 +390,7 @@ int srv6_decap_to_service_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 	endpoint_v4_add_entry(POD_IPV4, 12345, 100, 0, 0, 0,
 			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
 
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-
-	return TEST_FAIL;
+	return netdev_receive_packet(ctx);
 }
 
 CHECK("tc", "tc_srv6_decap_to_service_ipv4")
@@ -550,9 +531,7 @@ int srv6_decap_to_service_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
 	endpoint_v6_add_entry((const union v6addr *)POD_IPV6, 12345, 100, 0, 0,
 			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
 
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-
-	return TEST_FAIL;
+	return netdev_receive_packet(ctx);
 }
 
 CHECK("tc", "tc_srv6_decap_to_service_ipv6")

--- a/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
@@ -49,23 +49,10 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 	return BPF_FIB_LKUP_RET_SUCCESS;
 }
 
-#include <bpf_xdp.c>
+#include "lib/bpf_xdp.h"
 
 #include "lib/ipcache.h"
 #include "lib/lb.h"
-
-#define FROM_NETDEV	0
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(key_size, sizeof(__u32));
-	__uint(max_entries, 1);
-	__array(values, int());
-} entry_call_map __section(".maps") = {
-	.values = {
-		[FROM_NETDEV] = &cil_xdp_entry,
-	},
-};
 
 /* Test that a SVC request that is LBed to a DSR remote backend
  * - gets DNATed,
@@ -114,10 +101,7 @@ int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
 
 	ipcache_v6_add_entry(&backend_ip, 0, 112233, 0, 0);
 
-	/* Jump into the entrypoint */
-	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
-	/* Fail if we didn't jump */
-	return TEST_ERROR;
+	return xdp_receive_packet(ctx);
 }
 
 CHECK("xdp", "xdp_nodeport_dsr_fwd")


### PR DESCRIPTION
Add a bit of helper glue so that individual tests don't need to manage the entrypoints of their program-under-test.
