### PR TITLE
hubble: add emitter information to Hubble flow

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -9,6 +9,7 @@
     - [CiliumEventType](#flow-CiliumEventType)
     - [DNS](#flow-DNS)
     - [DebugEvent](#flow-DebugEvent)
+    - [Emitter](#flow-Emitter)
     - [Endpoint](#flow-Endpoint)
     - [EndpointRegenNotification](#flow-EndpointRegenNotification)
     - [EndpointUpdateNotification](#flow-EndpointUpdateNotification)
@@ -173,6 +174,22 @@ DNS flow. This is basically directly mapped from Cilium&#39;s [LogRecordDNS](htt
 
 
 
+<a name="flow-Emitter"></a>
+
+### Emitter
+Emitter identifies the source that emits a Hubble flow.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | name identifies the emitter. The name should be capitalized (&#34;Hubble&#34;, not &#34;hubble&#34; nor &#34;HUBBLE&#34;). |
+| version | [string](#string) |  | version identifiers the emitter version. The version should not contain a &#39;v&#39; prefix as sometimes seen (&#34;1.19.0&#34;, not &#34;v1.19.0&#34;). |
+
+
+
+
+
+
 <a name="flow-Endpoint"></a>
 
 ### Endpoint
@@ -289,6 +306,7 @@ EventTypeFilter is a filter describing a particular event type.
 | ----- | ---- | ----- | ----------- |
 | time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
 | uuid | [string](#string) |  | uuid is a universally unique identifier for this flow. |
+| emitter | [Emitter](#flow-Emitter) |  | emitter identifies the source that emitted the flow. |
 | verdict | [Verdict](#flow-Verdict) |  |  |
 | drop_reason | [uint32](#uint32) |  | **Deprecated.** only applicable to Verdict = DROPPED. deprecated in favor of drop_reason_desc. |
 | auth_type | [AuthType](#flow-AuthType) |  | auth_type is the authentication type specified for the flow in Cilium Network Policy. Only set on policy verdict events. |

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -1438,15 +1438,17 @@ func (x Tunnel_Protocol) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Tunnel_Protocol.Descriptor instead.
 func (Tunnel_Protocol) EnumDescriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{16, 0}
+	return file_flow_flow_proto_rawDescGZIP(), []int{17, 0}
 }
 
 type Flow struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Time  *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=time,proto3" json:"time,omitempty"`
 	// uuid is a universally unique identifier for this flow.
-	Uuid    string  `protobuf:"bytes,34,opt,name=uuid,proto3" json:"uuid,omitempty"`
-	Verdict Verdict `protobuf:"varint,2,opt,name=verdict,proto3,enum=flow.Verdict" json:"verdict,omitempty"`
+	Uuid string `protobuf:"bytes,34,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	// emitter identifies the source that emitted the flow.
+	Emitter *Emitter `protobuf:"bytes,41,opt,name=emitter,proto3" json:"emitter,omitempty"`
+	Verdict Verdict  `protobuf:"varint,2,opt,name=verdict,proto3,enum=flow.Verdict" json:"verdict,omitempty"`
 	// only applicable to Verdict = DROPPED.
 	// deprecated in favor of drop_reason_desc.
 	//
@@ -1594,6 +1596,13 @@ func (x *Flow) GetUuid() string {
 		return x.Uuid
 	}
 	return ""
+}
+
+func (x *Flow) GetEmitter() *Emitter {
+	if x != nil {
+		return x.Emitter
+	}
+	return nil
 }
 
 func (x *Flow) GetVerdict() Verdict {
@@ -1886,6 +1895,64 @@ func (x *Flow) GetPolicyLog() []string {
 	return nil
 }
 
+// Emitter identifies the source that emits a Hubble flow.
+type Emitter struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name identifies the emitter.
+	// The name should be capitalized ("Hubble", not "hubble" nor "HUBBLE").
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// version identifiers the emitter version.
+	// The version should not contain a 'v' prefix as sometimes seen ("1.19.0",
+	// not "v1.19.0").
+	Version       string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Emitter) Reset() {
+	*x = Emitter{}
+	mi := &file_flow_flow_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Emitter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Emitter) ProtoMessage() {}
+
+func (x *Emitter) ProtoReflect() protoreflect.Message {
+	mi := &file_flow_flow_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Emitter.ProtoReflect.Descriptor instead.
+func (*Emitter) Descriptor() ([]byte, []int) {
+	return file_flow_flow_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Emitter) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Emitter) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
 type FileInfo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -1896,7 +1963,7 @@ type FileInfo struct {
 
 func (x *FileInfo) Reset() {
 	*x = FileInfo{}
-	mi := &file_flow_flow_proto_msgTypes[1]
+	mi := &file_flow_flow_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1908,7 +1975,7 @@ func (x *FileInfo) String() string {
 func (*FileInfo) ProtoMessage() {}
 
 func (x *FileInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[1]
+	mi := &file_flow_flow_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1921,7 +1988,7 @@ func (x *FileInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileInfo.ProtoReflect.Descriptor instead.
 func (*FileInfo) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{1}
+	return file_flow_flow_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *FileInfo) GetName() string {
@@ -1954,7 +2021,7 @@ type Layer4 struct {
 
 func (x *Layer4) Reset() {
 	*x = Layer4{}
-	mi := &file_flow_flow_proto_msgTypes[2]
+	mi := &file_flow_flow_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1966,7 +2033,7 @@ func (x *Layer4) String() string {
 func (*Layer4) ProtoMessage() {}
 
 func (x *Layer4) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[2]
+	mi := &file_flow_flow_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1979,7 +2046,7 @@ func (x *Layer4) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Layer4.ProtoReflect.Descriptor instead.
 func (*Layer4) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{2}
+	return file_flow_flow_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Layer4) GetProtocol() isLayer4_Protocol {
@@ -2089,7 +2156,7 @@ type Layer7 struct {
 
 func (x *Layer7) Reset() {
 	*x = Layer7{}
-	mi := &file_flow_flow_proto_msgTypes[3]
+	mi := &file_flow_flow_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2101,7 +2168,7 @@ func (x *Layer7) String() string {
 func (*Layer7) ProtoMessage() {}
 
 func (x *Layer7) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[3]
+	mi := &file_flow_flow_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2114,7 +2181,7 @@ func (x *Layer7) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Layer7.ProtoReflect.Descriptor instead.
 func (*Layer7) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{3}
+	return file_flow_flow_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Layer7) GetType() L7FlowType {
@@ -2200,7 +2267,7 @@ type TraceContext struct {
 
 func (x *TraceContext) Reset() {
 	*x = TraceContext{}
-	mi := &file_flow_flow_proto_msgTypes[4]
+	mi := &file_flow_flow_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2212,7 +2279,7 @@ func (x *TraceContext) String() string {
 func (*TraceContext) ProtoMessage() {}
 
 func (x *TraceContext) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[4]
+	mi := &file_flow_flow_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2225,7 +2292,7 @@ func (x *TraceContext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraceContext.ProtoReflect.Descriptor instead.
 func (*TraceContext) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{4}
+	return file_flow_flow_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *TraceContext) GetParent() *TraceParent {
@@ -2247,7 +2314,7 @@ type TraceParent struct {
 
 func (x *TraceParent) Reset() {
 	*x = TraceParent{}
-	mi := &file_flow_flow_proto_msgTypes[5]
+	mi := &file_flow_flow_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2259,7 +2326,7 @@ func (x *TraceParent) String() string {
 func (*TraceParent) ProtoMessage() {}
 
 func (x *TraceParent) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[5]
+	mi := &file_flow_flow_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2272,7 +2339,7 @@ func (x *TraceParent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraceParent.ProtoReflect.Descriptor instead.
 func (*TraceParent) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{5}
+	return file_flow_flow_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *TraceParent) GetTraceId() string {
@@ -2298,7 +2365,7 @@ type Endpoint struct {
 
 func (x *Endpoint) Reset() {
 	*x = Endpoint{}
-	mi := &file_flow_flow_proto_msgTypes[6]
+	mi := &file_flow_flow_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2310,7 +2377,7 @@ func (x *Endpoint) String() string {
 func (*Endpoint) ProtoMessage() {}
 
 func (x *Endpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[6]
+	mi := &file_flow_flow_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2323,7 +2390,7 @@ func (x *Endpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Endpoint.ProtoReflect.Descriptor instead.
 func (*Endpoint) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{6}
+	return file_flow_flow_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Endpoint) GetID() uint32 {
@@ -2385,7 +2452,7 @@ type Workload struct {
 
 func (x *Workload) Reset() {
 	*x = Workload{}
-	mi := &file_flow_flow_proto_msgTypes[7]
+	mi := &file_flow_flow_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2397,7 +2464,7 @@ func (x *Workload) String() string {
 func (*Workload) ProtoMessage() {}
 
 func (x *Workload) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[7]
+	mi := &file_flow_flow_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2410,7 +2477,7 @@ func (x *Workload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Workload.ProtoReflect.Descriptor instead.
 func (*Workload) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{7}
+	return file_flow_flow_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Workload) GetName() string {
@@ -2438,7 +2505,7 @@ type TCP struct {
 
 func (x *TCP) Reset() {
 	*x = TCP{}
-	mi := &file_flow_flow_proto_msgTypes[8]
+	mi := &file_flow_flow_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2450,7 +2517,7 @@ func (x *TCP) String() string {
 func (*TCP) ProtoMessage() {}
 
 func (x *TCP) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[8]
+	mi := &file_flow_flow_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2463,7 +2530,7 @@ func (x *TCP) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TCP.ProtoReflect.Descriptor instead.
 func (*TCP) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{8}
+	return file_flow_flow_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *TCP) GetSourcePort() uint32 {
@@ -2505,7 +2572,7 @@ type IP struct {
 
 func (x *IP) Reset() {
 	*x = IP{}
-	mi := &file_flow_flow_proto_msgTypes[9]
+	mi := &file_flow_flow_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2517,7 +2584,7 @@ func (x *IP) String() string {
 func (*IP) ProtoMessage() {}
 
 func (x *IP) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[9]
+	mi := &file_flow_flow_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2530,7 +2597,7 @@ func (x *IP) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IP.ProtoReflect.Descriptor instead.
 func (*IP) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{9}
+	return file_flow_flow_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *IP) GetSource() string {
@@ -2578,7 +2645,7 @@ type Ethernet struct {
 
 func (x *Ethernet) Reset() {
 	*x = Ethernet{}
-	mi := &file_flow_flow_proto_msgTypes[10]
+	mi := &file_flow_flow_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2590,7 +2657,7 @@ func (x *Ethernet) String() string {
 func (*Ethernet) ProtoMessage() {}
 
 func (x *Ethernet) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[10]
+	mi := &file_flow_flow_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2603,7 +2670,7 @@ func (x *Ethernet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Ethernet.ProtoReflect.Descriptor instead.
 func (*Ethernet) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{10}
+	return file_flow_flow_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Ethernet) GetSource() string {
@@ -2637,7 +2704,7 @@ type TCPFlags struct {
 
 func (x *TCPFlags) Reset() {
 	*x = TCPFlags{}
-	mi := &file_flow_flow_proto_msgTypes[11]
+	mi := &file_flow_flow_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2649,7 +2716,7 @@ func (x *TCPFlags) String() string {
 func (*TCPFlags) ProtoMessage() {}
 
 func (x *TCPFlags) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[11]
+	mi := &file_flow_flow_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2662,7 +2729,7 @@ func (x *TCPFlags) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TCPFlags.ProtoReflect.Descriptor instead.
 func (*TCPFlags) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{11}
+	return file_flow_flow_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *TCPFlags) GetFIN() bool {
@@ -2738,7 +2805,7 @@ type UDP struct {
 
 func (x *UDP) Reset() {
 	*x = UDP{}
-	mi := &file_flow_flow_proto_msgTypes[12]
+	mi := &file_flow_flow_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2750,7 +2817,7 @@ func (x *UDP) String() string {
 func (*UDP) ProtoMessage() {}
 
 func (x *UDP) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[12]
+	mi := &file_flow_flow_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2763,7 +2830,7 @@ func (x *UDP) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UDP.ProtoReflect.Descriptor instead.
 func (*UDP) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{12}
+	return file_flow_flow_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *UDP) GetSourcePort() uint32 {
@@ -2790,7 +2857,7 @@ type SCTP struct {
 
 func (x *SCTP) Reset() {
 	*x = SCTP{}
-	mi := &file_flow_flow_proto_msgTypes[13]
+	mi := &file_flow_flow_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2802,7 +2869,7 @@ func (x *SCTP) String() string {
 func (*SCTP) ProtoMessage() {}
 
 func (x *SCTP) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[13]
+	mi := &file_flow_flow_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2815,7 +2882,7 @@ func (x *SCTP) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SCTP.ProtoReflect.Descriptor instead.
 func (*SCTP) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{13}
+	return file_flow_flow_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SCTP) GetSourcePort() uint32 {
@@ -2842,7 +2909,7 @@ type ICMPv4 struct {
 
 func (x *ICMPv4) Reset() {
 	*x = ICMPv4{}
-	mi := &file_flow_flow_proto_msgTypes[14]
+	mi := &file_flow_flow_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2854,7 +2921,7 @@ func (x *ICMPv4) String() string {
 func (*ICMPv4) ProtoMessage() {}
 
 func (x *ICMPv4) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[14]
+	mi := &file_flow_flow_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2867,7 +2934,7 @@ func (x *ICMPv4) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ICMPv4.ProtoReflect.Descriptor instead.
 func (*ICMPv4) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{14}
+	return file_flow_flow_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ICMPv4) GetType() uint32 {
@@ -2894,7 +2961,7 @@ type ICMPv6 struct {
 
 func (x *ICMPv6) Reset() {
 	*x = ICMPv6{}
-	mi := &file_flow_flow_proto_msgTypes[15]
+	mi := &file_flow_flow_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2906,7 +2973,7 @@ func (x *ICMPv6) String() string {
 func (*ICMPv6) ProtoMessage() {}
 
 func (x *ICMPv6) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[15]
+	mi := &file_flow_flow_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2919,7 +2986,7 @@ func (x *ICMPv6) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ICMPv6.ProtoReflect.Descriptor instead.
 func (*ICMPv6) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{15}
+	return file_flow_flow_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ICMPv6) GetType() uint32 {
@@ -2947,7 +3014,7 @@ type Tunnel struct {
 
 func (x *Tunnel) Reset() {
 	*x = Tunnel{}
-	mi := &file_flow_flow_proto_msgTypes[16]
+	mi := &file_flow_flow_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2959,7 +3026,7 @@ func (x *Tunnel) String() string {
 func (*Tunnel) ProtoMessage() {}
 
 func (x *Tunnel) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[16]
+	mi := &file_flow_flow_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2972,7 +3039,7 @@ func (x *Tunnel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Tunnel.ProtoReflect.Descriptor instead.
 func (*Tunnel) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{16}
+	return file_flow_flow_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Tunnel) GetProtocol() Tunnel_Protocol {
@@ -3009,7 +3076,7 @@ type Policy struct {
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_flow_flow_proto_msgTypes[17]
+	mi := &file_flow_flow_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3021,7 +3088,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[17]
+	mi := &file_flow_flow_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3034,7 +3101,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{17}
+	return file_flow_flow_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *Policy) GetName() string {
@@ -3090,7 +3157,7 @@ type EventTypeFilter struct {
 
 func (x *EventTypeFilter) Reset() {
 	*x = EventTypeFilter{}
-	mi := &file_flow_flow_proto_msgTypes[18]
+	mi := &file_flow_flow_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3102,7 +3169,7 @@ func (x *EventTypeFilter) String() string {
 func (*EventTypeFilter) ProtoMessage() {}
 
 func (x *EventTypeFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[18]
+	mi := &file_flow_flow_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3115,7 +3182,7 @@ func (x *EventTypeFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventTypeFilter.ProtoReflect.Descriptor instead.
 func (*EventTypeFilter) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{18}
+	return file_flow_flow_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *EventTypeFilter) GetType() int32 {
@@ -3156,7 +3223,7 @@ type CiliumEventType struct {
 
 func (x *CiliumEventType) Reset() {
 	*x = CiliumEventType{}
-	mi := &file_flow_flow_proto_msgTypes[19]
+	mi := &file_flow_flow_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3168,7 +3235,7 @@ func (x *CiliumEventType) String() string {
 func (*CiliumEventType) ProtoMessage() {}
 
 func (x *CiliumEventType) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[19]
+	mi := &file_flow_flow_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3181,7 +3248,7 @@ func (x *CiliumEventType) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CiliumEventType.ProtoReflect.Descriptor instead.
 func (*CiliumEventType) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{19}
+	return file_flow_flow_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CiliumEventType) GetType() int32 {
@@ -3306,7 +3373,7 @@ type FlowFilter struct {
 
 func (x *FlowFilter) Reset() {
 	*x = FlowFilter{}
-	mi := &file_flow_flow_proto_msgTypes[20]
+	mi := &file_flow_flow_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3318,7 +3385,7 @@ func (x *FlowFilter) String() string {
 func (*FlowFilter) ProtoMessage() {}
 
 func (x *FlowFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[20]
+	mi := &file_flow_flow_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3331,7 +3398,7 @@ func (x *FlowFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FlowFilter.ProtoReflect.Descriptor instead.
 func (*FlowFilter) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{20}
+	return file_flow_flow_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *FlowFilter) GetUuid() []string {
@@ -3646,7 +3713,7 @@ type DNS struct {
 
 func (x *DNS) Reset() {
 	*x = DNS{}
-	mi := &file_flow_flow_proto_msgTypes[21]
+	mi := &file_flow_flow_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3658,7 +3725,7 @@ func (x *DNS) String() string {
 func (*DNS) ProtoMessage() {}
 
 func (x *DNS) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[21]
+	mi := &file_flow_flow_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3671,7 +3738,7 @@ func (x *DNS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNS.ProtoReflect.Descriptor instead.
 func (*DNS) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{21}
+	return file_flow_flow_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DNS) GetQuery() string {
@@ -3740,7 +3807,7 @@ type HTTPHeader struct {
 
 func (x *HTTPHeader) Reset() {
 	*x = HTTPHeader{}
-	mi := &file_flow_flow_proto_msgTypes[22]
+	mi := &file_flow_flow_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3752,7 +3819,7 @@ func (x *HTTPHeader) String() string {
 func (*HTTPHeader) ProtoMessage() {}
 
 func (x *HTTPHeader) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[22]
+	mi := &file_flow_flow_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3765,7 +3832,7 @@ func (x *HTTPHeader) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPHeader.ProtoReflect.Descriptor instead.
 func (*HTTPHeader) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{22}
+	return file_flow_flow_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *HTTPHeader) GetKey() string {
@@ -3796,7 +3863,7 @@ type HTTP struct {
 
 func (x *HTTP) Reset() {
 	*x = HTTP{}
-	mi := &file_flow_flow_proto_msgTypes[23]
+	mi := &file_flow_flow_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3808,7 +3875,7 @@ func (x *HTTP) String() string {
 func (*HTTP) ProtoMessage() {}
 
 func (x *HTTP) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[23]
+	mi := &file_flow_flow_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3821,7 +3888,7 @@ func (x *HTTP) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTP.ProtoReflect.Descriptor instead.
 func (*HTTP) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{23}
+	return file_flow_flow_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *HTTP) GetCode() uint32 {
@@ -3873,7 +3940,7 @@ type Kafka struct {
 
 func (x *Kafka) Reset() {
 	*x = Kafka{}
-	mi := &file_flow_flow_proto_msgTypes[24]
+	mi := &file_flow_flow_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3885,7 +3952,7 @@ func (x *Kafka) String() string {
 func (*Kafka) ProtoMessage() {}
 
 func (x *Kafka) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[24]
+	mi := &file_flow_flow_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3898,7 +3965,7 @@ func (x *Kafka) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Kafka.ProtoReflect.Descriptor instead.
 func (*Kafka) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{24}
+	return file_flow_flow_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *Kafka) GetErrorCode() int32 {
@@ -3946,7 +4013,7 @@ type Service struct {
 
 func (x *Service) Reset() {
 	*x = Service{}
-	mi := &file_flow_flow_proto_msgTypes[25]
+	mi := &file_flow_flow_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3958,7 +4025,7 @@ func (x *Service) String() string {
 func (*Service) ProtoMessage() {}
 
 func (x *Service) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[25]
+	mi := &file_flow_flow_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3971,7 +4038,7 @@ func (x *Service) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Service.ProtoReflect.Descriptor instead.
 func (*Service) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{25}
+	return file_flow_flow_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *Service) GetName() string {
@@ -3998,7 +4065,7 @@ type IPTraceID struct {
 
 func (x *IPTraceID) Reset() {
 	*x = IPTraceID{}
-	mi := &file_flow_flow_proto_msgTypes[26]
+	mi := &file_flow_flow_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4010,7 +4077,7 @@ func (x *IPTraceID) String() string {
 func (*IPTraceID) ProtoMessage() {}
 
 func (x *IPTraceID) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[26]
+	mi := &file_flow_flow_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4023,7 +4090,7 @@ func (x *IPTraceID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IPTraceID.ProtoReflect.Descriptor instead.
 func (*IPTraceID) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{26}
+	return file_flow_flow_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *IPTraceID) GetTraceId() uint64 {
@@ -4061,7 +4128,7 @@ type LostEvent struct {
 
 func (x *LostEvent) Reset() {
 	*x = LostEvent{}
-	mi := &file_flow_flow_proto_msgTypes[27]
+	mi := &file_flow_flow_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4073,7 +4140,7 @@ func (x *LostEvent) String() string {
 func (*LostEvent) ProtoMessage() {}
 
 func (x *LostEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[27]
+	mi := &file_flow_flow_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4086,7 +4153,7 @@ func (x *LostEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LostEvent.ProtoReflect.Descriptor instead.
 func (*LostEvent) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{27}
+	return file_flow_flow_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LostEvent) GetSource() LostEventSource {
@@ -4144,7 +4211,7 @@ type AgentEvent struct {
 
 func (x *AgentEvent) Reset() {
 	*x = AgentEvent{}
-	mi := &file_flow_flow_proto_msgTypes[28]
+	mi := &file_flow_flow_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4156,7 +4223,7 @@ func (x *AgentEvent) String() string {
 func (*AgentEvent) ProtoMessage() {}
 
 func (x *AgentEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[28]
+	mi := &file_flow_flow_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4169,7 +4236,7 @@ func (x *AgentEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentEvent.ProtoReflect.Descriptor instead.
 func (*AgentEvent) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{28}
+	return file_flow_flow_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *AgentEvent) GetType() AgentEventType {
@@ -4328,7 +4395,7 @@ type AgentEventUnknown struct {
 
 func (x *AgentEventUnknown) Reset() {
 	*x = AgentEventUnknown{}
-	mi := &file_flow_flow_proto_msgTypes[29]
+	mi := &file_flow_flow_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4340,7 +4407,7 @@ func (x *AgentEventUnknown) String() string {
 func (*AgentEventUnknown) ProtoMessage() {}
 
 func (x *AgentEventUnknown) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[29]
+	mi := &file_flow_flow_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4353,7 +4420,7 @@ func (x *AgentEventUnknown) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentEventUnknown.ProtoReflect.Descriptor instead.
 func (*AgentEventUnknown) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{29}
+	return file_flow_flow_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *AgentEventUnknown) GetType() string {
@@ -4379,7 +4446,7 @@ type TimeNotification struct {
 
 func (x *TimeNotification) Reset() {
 	*x = TimeNotification{}
-	mi := &file_flow_flow_proto_msgTypes[30]
+	mi := &file_flow_flow_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4391,7 +4458,7 @@ func (x *TimeNotification) String() string {
 func (*TimeNotification) ProtoMessage() {}
 
 func (x *TimeNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[30]
+	mi := &file_flow_flow_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4404,7 +4471,7 @@ func (x *TimeNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeNotification.ProtoReflect.Descriptor instead.
 func (*TimeNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{30}
+	return file_flow_flow_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *TimeNotification) GetTime() *timestamppb.Timestamp {
@@ -4425,7 +4492,7 @@ type PolicyUpdateNotification struct {
 
 func (x *PolicyUpdateNotification) Reset() {
 	*x = PolicyUpdateNotification{}
-	mi := &file_flow_flow_proto_msgTypes[31]
+	mi := &file_flow_flow_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4437,7 +4504,7 @@ func (x *PolicyUpdateNotification) String() string {
 func (*PolicyUpdateNotification) ProtoMessage() {}
 
 func (x *PolicyUpdateNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[31]
+	mi := &file_flow_flow_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4450,7 +4517,7 @@ func (x *PolicyUpdateNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyUpdateNotification.ProtoReflect.Descriptor instead.
 func (*PolicyUpdateNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{31}
+	return file_flow_flow_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *PolicyUpdateNotification) GetLabels() []string {
@@ -4485,7 +4552,7 @@ type EndpointRegenNotification struct {
 
 func (x *EndpointRegenNotification) Reset() {
 	*x = EndpointRegenNotification{}
-	mi := &file_flow_flow_proto_msgTypes[32]
+	mi := &file_flow_flow_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4497,7 +4564,7 @@ func (x *EndpointRegenNotification) String() string {
 func (*EndpointRegenNotification) ProtoMessage() {}
 
 func (x *EndpointRegenNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[32]
+	mi := &file_flow_flow_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4510,7 +4577,7 @@ func (x *EndpointRegenNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointRegenNotification.ProtoReflect.Descriptor instead.
 func (*EndpointRegenNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{32}
+	return file_flow_flow_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *EndpointRegenNotification) GetId() uint64 {
@@ -4547,7 +4614,7 @@ type EndpointUpdateNotification struct {
 
 func (x *EndpointUpdateNotification) Reset() {
 	*x = EndpointUpdateNotification{}
-	mi := &file_flow_flow_proto_msgTypes[33]
+	mi := &file_flow_flow_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4559,7 +4626,7 @@ func (x *EndpointUpdateNotification) String() string {
 func (*EndpointUpdateNotification) ProtoMessage() {}
 
 func (x *EndpointUpdateNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[33]
+	mi := &file_flow_flow_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4572,7 +4639,7 @@ func (x *EndpointUpdateNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointUpdateNotification.ProtoReflect.Descriptor instead.
 func (*EndpointUpdateNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{33}
+	return file_flow_flow_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *EndpointUpdateNotification) GetId() uint64 {
@@ -4626,7 +4693,7 @@ type IPCacheNotification struct {
 
 func (x *IPCacheNotification) Reset() {
 	*x = IPCacheNotification{}
-	mi := &file_flow_flow_proto_msgTypes[34]
+	mi := &file_flow_flow_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4638,7 +4705,7 @@ func (x *IPCacheNotification) String() string {
 func (*IPCacheNotification) ProtoMessage() {}
 
 func (x *IPCacheNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[34]
+	mi := &file_flow_flow_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4651,7 +4718,7 @@ func (x *IPCacheNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IPCacheNotification.ProtoReflect.Descriptor instead.
 func (*IPCacheNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{34}
+	return file_flow_flow_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *IPCacheNotification) GetCidr() string {
@@ -4721,7 +4788,7 @@ type ServiceUpsertNotificationAddr struct {
 
 func (x *ServiceUpsertNotificationAddr) Reset() {
 	*x = ServiceUpsertNotificationAddr{}
-	mi := &file_flow_flow_proto_msgTypes[35]
+	mi := &file_flow_flow_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4733,7 +4800,7 @@ func (x *ServiceUpsertNotificationAddr) String() string {
 func (*ServiceUpsertNotificationAddr) ProtoMessage() {}
 
 func (x *ServiceUpsertNotificationAddr) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[35]
+	mi := &file_flow_flow_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4746,7 +4813,7 @@ func (x *ServiceUpsertNotificationAddr) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceUpsertNotificationAddr.ProtoReflect.Descriptor instead.
 func (*ServiceUpsertNotificationAddr) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{35}
+	return file_flow_flow_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ServiceUpsertNotificationAddr) GetIp() string {
@@ -4782,7 +4849,7 @@ type ServiceUpsertNotification struct {
 
 func (x *ServiceUpsertNotification) Reset() {
 	*x = ServiceUpsertNotification{}
-	mi := &file_flow_flow_proto_msgTypes[36]
+	mi := &file_flow_flow_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4794,7 +4861,7 @@ func (x *ServiceUpsertNotification) String() string {
 func (*ServiceUpsertNotification) ProtoMessage() {}
 
 func (x *ServiceUpsertNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[36]
+	mi := &file_flow_flow_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4807,7 +4874,7 @@ func (x *ServiceUpsertNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceUpsertNotification.ProtoReflect.Descriptor instead.
 func (*ServiceUpsertNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{36}
+	return file_flow_flow_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ServiceUpsertNotification) GetId() uint32 {
@@ -4884,7 +4951,7 @@ type ServiceDeleteNotification struct {
 
 func (x *ServiceDeleteNotification) Reset() {
 	*x = ServiceDeleteNotification{}
-	mi := &file_flow_flow_proto_msgTypes[37]
+	mi := &file_flow_flow_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4896,7 +4963,7 @@ func (x *ServiceDeleteNotification) String() string {
 func (*ServiceDeleteNotification) ProtoMessage() {}
 
 func (x *ServiceDeleteNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[37]
+	mi := &file_flow_flow_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4909,7 +4976,7 @@ func (x *ServiceDeleteNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceDeleteNotification.ProtoReflect.Descriptor instead.
 func (*ServiceDeleteNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{37}
+	return file_flow_flow_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ServiceDeleteNotification) GetId() uint32 {
@@ -4929,7 +4996,7 @@ type NetworkInterface struct {
 
 func (x *NetworkInterface) Reset() {
 	*x = NetworkInterface{}
-	mi := &file_flow_flow_proto_msgTypes[38]
+	mi := &file_flow_flow_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4941,7 +5008,7 @@ func (x *NetworkInterface) String() string {
 func (*NetworkInterface) ProtoMessage() {}
 
 func (x *NetworkInterface) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[38]
+	mi := &file_flow_flow_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4954,7 +5021,7 @@ func (x *NetworkInterface) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkInterface.ProtoReflect.Descriptor instead.
 func (*NetworkInterface) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{38}
+	return file_flow_flow_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *NetworkInterface) GetIndex() uint32 {
@@ -4987,7 +5054,7 @@ type DebugEvent struct {
 
 func (x *DebugEvent) Reset() {
 	*x = DebugEvent{}
-	mi := &file_flow_flow_proto_msgTypes[39]
+	mi := &file_flow_flow_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4999,7 +5066,7 @@ func (x *DebugEvent) String() string {
 func (*DebugEvent) ProtoMessage() {}
 
 func (x *DebugEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[39]
+	mi := &file_flow_flow_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5012,7 +5079,7 @@ func (x *DebugEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugEvent.ProtoReflect.Descriptor instead.
 func (*DebugEvent) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{39}
+	return file_flow_flow_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *DebugEvent) GetType() DebugEventType {
@@ -5091,7 +5158,7 @@ type FlowFilter_Experimental struct {
 
 func (x *FlowFilter_Experimental) Reset() {
 	*x = FlowFilter_Experimental{}
-	mi := &file_flow_flow_proto_msgTypes[40]
+	mi := &file_flow_flow_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5103,7 +5170,7 @@ func (x *FlowFilter_Experimental) String() string {
 func (*FlowFilter_Experimental) ProtoMessage() {}
 
 func (x *FlowFilter_Experimental) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[40]
+	mi := &file_flow_flow_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5116,7 +5183,7 @@ func (x *FlowFilter_Experimental) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FlowFilter_Experimental.ProtoReflect.Descriptor instead.
 func (*FlowFilter_Experimental) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{20, 0}
+	return file_flow_flow_proto_rawDescGZIP(), []int{21, 0}
 }
 
 func (x *FlowFilter_Experimental) GetCelExpression() []string {
@@ -5130,10 +5197,11 @@ var File_flow_flow_proto protoreflect.FileDescriptor
 
 const file_flow_flow_proto_rawDesc = "" +
 	"\n" +
-	"\x0fflow/flow.proto\x12\x04flow\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe5\x0f\n" +
+	"\x0fflow/flow.proto\x12\x04flow\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8e\x10\n" +
 	"\x04Flow\x12.\n" +
 	"\x04time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\x12\x12\n" +
 	"\x04uuid\x18\" \x01(\tR\x04uuid\x12'\n" +
+	"\aemitter\x18) \x01(\v2\r.flow.EmitterR\aemitter\x12'\n" +
 	"\averdict\x18\x02 \x01(\x0e2\r.flow.VerdictR\averdict\x12#\n" +
 	"\vdrop_reason\x18\x03 \x01(\rB\x02\x18\x01R\n" +
 	"dropReason\x12+\n" +
@@ -5182,7 +5250,10 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\x10egress_denied_by\x18\x8c\xa4\x01 \x03(\v2\f.flow.PolicyR\x0eegressDeniedBy\x12:\n" +
 	"\x11ingress_denied_by\x18\x8d\xa4\x01 \x03(\v2\f.flow.PolicyR\x0fingressDeniedBy\x12\x1f\n" +
 	"\n" +
-	"policy_log\x18\x8e\xa4\x01 \x03(\tR\tpolicyLogJ\x04\b\a\x10\bJ\x04\b\f\x10\rJ\x04\b\x11\x10\x12J\x04\b\x12\x10\x13\"2\n" +
+	"policy_log\x18\x8e\xa4\x01 \x03(\tR\tpolicyLogJ\x04\b\a\x10\bJ\x04\b\f\x10\rJ\x04\b\x11\x10\x12J\x04\b\x12\x10\x13\"7\n" +
+	"\aEmitter\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\"2\n" +
 	"\bFileInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04line\x18\x02 \x01(\rR\x04line\"\xc4\x01\n" +
@@ -5719,7 +5790,7 @@ func file_flow_flow_proto_rawDescGZIP() []byte {
 }
 
 var file_flow_flow_proto_enumTypes = make([]protoimpl.EnumInfo, 16)
-var file_flow_flow_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
+var file_flow_flow_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_flow_flow_proto_goTypes = []any{
 	(FlowType)(0),                         // 0: flow.FlowType
 	(AuthType)(0),                         // 1: flow.AuthType
@@ -5738,140 +5809,142 @@ var file_flow_flow_proto_goTypes = []any{
 	(DebugEventType)(0),                   // 14: flow.DebugEventType
 	(Tunnel_Protocol)(0),                  // 15: flow.Tunnel.Protocol
 	(*Flow)(nil),                          // 16: flow.Flow
-	(*FileInfo)(nil),                      // 17: flow.FileInfo
-	(*Layer4)(nil),                        // 18: flow.Layer4
-	(*Layer7)(nil),                        // 19: flow.Layer7
-	(*TraceContext)(nil),                  // 20: flow.TraceContext
-	(*TraceParent)(nil),                   // 21: flow.TraceParent
-	(*Endpoint)(nil),                      // 22: flow.Endpoint
-	(*Workload)(nil),                      // 23: flow.Workload
-	(*TCP)(nil),                           // 24: flow.TCP
-	(*IP)(nil),                            // 25: flow.IP
-	(*Ethernet)(nil),                      // 26: flow.Ethernet
-	(*TCPFlags)(nil),                      // 27: flow.TCPFlags
-	(*UDP)(nil),                           // 28: flow.UDP
-	(*SCTP)(nil),                          // 29: flow.SCTP
-	(*ICMPv4)(nil),                        // 30: flow.ICMPv4
-	(*ICMPv6)(nil),                        // 31: flow.ICMPv6
-	(*Tunnel)(nil),                        // 32: flow.Tunnel
-	(*Policy)(nil),                        // 33: flow.Policy
-	(*EventTypeFilter)(nil),               // 34: flow.EventTypeFilter
-	(*CiliumEventType)(nil),               // 35: flow.CiliumEventType
-	(*FlowFilter)(nil),                    // 36: flow.FlowFilter
-	(*DNS)(nil),                           // 37: flow.DNS
-	(*HTTPHeader)(nil),                    // 38: flow.HTTPHeader
-	(*HTTP)(nil),                          // 39: flow.HTTP
-	(*Kafka)(nil),                         // 40: flow.Kafka
-	(*Service)(nil),                       // 41: flow.Service
-	(*IPTraceID)(nil),                     // 42: flow.IPTraceID
-	(*LostEvent)(nil),                     // 43: flow.LostEvent
-	(*AgentEvent)(nil),                    // 44: flow.AgentEvent
-	(*AgentEventUnknown)(nil),             // 45: flow.AgentEventUnknown
-	(*TimeNotification)(nil),              // 46: flow.TimeNotification
-	(*PolicyUpdateNotification)(nil),      // 47: flow.PolicyUpdateNotification
-	(*EndpointRegenNotification)(nil),     // 48: flow.EndpointRegenNotification
-	(*EndpointUpdateNotification)(nil),    // 49: flow.EndpointUpdateNotification
-	(*IPCacheNotification)(nil),           // 50: flow.IPCacheNotification
-	(*ServiceUpsertNotificationAddr)(nil), // 51: flow.ServiceUpsertNotificationAddr
-	(*ServiceUpsertNotification)(nil),     // 52: flow.ServiceUpsertNotification
-	(*ServiceDeleteNotification)(nil),     // 53: flow.ServiceDeleteNotification
-	(*NetworkInterface)(nil),              // 54: flow.NetworkInterface
-	(*DebugEvent)(nil),                    // 55: flow.DebugEvent
-	(*FlowFilter_Experimental)(nil),       // 56: flow.FlowFilter.Experimental
-	(*timestamppb.Timestamp)(nil),         // 57: google.protobuf.Timestamp
-	(*wrapperspb.BoolValue)(nil),          // 58: google.protobuf.BoolValue
-	(*anypb.Any)(nil),                     // 59: google.protobuf.Any
-	(*wrapperspb.Int32Value)(nil),         // 60: google.protobuf.Int32Value
-	(*wrapperspb.UInt32Value)(nil),        // 61: google.protobuf.UInt32Value
+	(*Emitter)(nil),                       // 17: flow.Emitter
+	(*FileInfo)(nil),                      // 18: flow.FileInfo
+	(*Layer4)(nil),                        // 19: flow.Layer4
+	(*Layer7)(nil),                        // 20: flow.Layer7
+	(*TraceContext)(nil),                  // 21: flow.TraceContext
+	(*TraceParent)(nil),                   // 22: flow.TraceParent
+	(*Endpoint)(nil),                      // 23: flow.Endpoint
+	(*Workload)(nil),                      // 24: flow.Workload
+	(*TCP)(nil),                           // 25: flow.TCP
+	(*IP)(nil),                            // 26: flow.IP
+	(*Ethernet)(nil),                      // 27: flow.Ethernet
+	(*TCPFlags)(nil),                      // 28: flow.TCPFlags
+	(*UDP)(nil),                           // 29: flow.UDP
+	(*SCTP)(nil),                          // 30: flow.SCTP
+	(*ICMPv4)(nil),                        // 31: flow.ICMPv4
+	(*ICMPv6)(nil),                        // 32: flow.ICMPv6
+	(*Tunnel)(nil),                        // 33: flow.Tunnel
+	(*Policy)(nil),                        // 34: flow.Policy
+	(*EventTypeFilter)(nil),               // 35: flow.EventTypeFilter
+	(*CiliumEventType)(nil),               // 36: flow.CiliumEventType
+	(*FlowFilter)(nil),                    // 37: flow.FlowFilter
+	(*DNS)(nil),                           // 38: flow.DNS
+	(*HTTPHeader)(nil),                    // 39: flow.HTTPHeader
+	(*HTTP)(nil),                          // 40: flow.HTTP
+	(*Kafka)(nil),                         // 41: flow.Kafka
+	(*Service)(nil),                       // 42: flow.Service
+	(*IPTraceID)(nil),                     // 43: flow.IPTraceID
+	(*LostEvent)(nil),                     // 44: flow.LostEvent
+	(*AgentEvent)(nil),                    // 45: flow.AgentEvent
+	(*AgentEventUnknown)(nil),             // 46: flow.AgentEventUnknown
+	(*TimeNotification)(nil),              // 47: flow.TimeNotification
+	(*PolicyUpdateNotification)(nil),      // 48: flow.PolicyUpdateNotification
+	(*EndpointRegenNotification)(nil),     // 49: flow.EndpointRegenNotification
+	(*EndpointUpdateNotification)(nil),    // 50: flow.EndpointUpdateNotification
+	(*IPCacheNotification)(nil),           // 51: flow.IPCacheNotification
+	(*ServiceUpsertNotificationAddr)(nil), // 52: flow.ServiceUpsertNotificationAddr
+	(*ServiceUpsertNotification)(nil),     // 53: flow.ServiceUpsertNotification
+	(*ServiceDeleteNotification)(nil),     // 54: flow.ServiceDeleteNotification
+	(*NetworkInterface)(nil),              // 55: flow.NetworkInterface
+	(*DebugEvent)(nil),                    // 56: flow.DebugEvent
+	(*FlowFilter_Experimental)(nil),       // 57: flow.FlowFilter.Experimental
+	(*timestamppb.Timestamp)(nil),         // 58: google.protobuf.Timestamp
+	(*wrapperspb.BoolValue)(nil),          // 59: google.protobuf.BoolValue
+	(*anypb.Any)(nil),                     // 60: google.protobuf.Any
+	(*wrapperspb.Int32Value)(nil),         // 61: google.protobuf.Int32Value
+	(*wrapperspb.UInt32Value)(nil),        // 62: google.protobuf.UInt32Value
 }
 var file_flow_flow_proto_depIdxs = []int32{
-	57, // 0: flow.Flow.time:type_name -> google.protobuf.Timestamp
-	6,  // 1: flow.Flow.verdict:type_name -> flow.Verdict
-	1,  // 2: flow.Flow.auth_type:type_name -> flow.AuthType
-	26, // 3: flow.Flow.ethernet:type_name -> flow.Ethernet
-	25, // 4: flow.Flow.IP:type_name -> flow.IP
-	18, // 5: flow.Flow.l4:type_name -> flow.Layer4
-	32, // 6: flow.Flow.tunnel:type_name -> flow.Tunnel
-	22, // 7: flow.Flow.source:type_name -> flow.Endpoint
-	22, // 8: flow.Flow.destination:type_name -> flow.Endpoint
-	0,  // 9: flow.Flow.Type:type_name -> flow.FlowType
-	19, // 10: flow.Flow.l7:type_name -> flow.Layer7
-	35, // 11: flow.Flow.event_type:type_name -> flow.CiliumEventType
-	41, // 12: flow.Flow.source_service:type_name -> flow.Service
-	41, // 13: flow.Flow.destination_service:type_name -> flow.Service
-	8,  // 14: flow.Flow.traffic_direction:type_name -> flow.TrafficDirection
-	2,  // 15: flow.Flow.trace_observation_point:type_name -> flow.TraceObservationPoint
-	3,  // 16: flow.Flow.trace_reason:type_name -> flow.TraceReason
-	17, // 17: flow.Flow.file:type_name -> flow.FileInfo
-	42, // 18: flow.Flow.ip_trace_id:type_name -> flow.IPTraceID
-	7,  // 19: flow.Flow.drop_reason_desc:type_name -> flow.DropReason
-	58, // 20: flow.Flow.is_reply:type_name -> google.protobuf.BoolValue
-	9,  // 21: flow.Flow.debug_capture_point:type_name -> flow.DebugCapturePoint
-	54, // 22: flow.Flow.interface:type_name -> flow.NetworkInterface
-	20, // 23: flow.Flow.trace_context:type_name -> flow.TraceContext
-	13, // 24: flow.Flow.sock_xlate_point:type_name -> flow.SocketTranslationPoint
-	59, // 25: flow.Flow.extensions:type_name -> google.protobuf.Any
-	33, // 26: flow.Flow.egress_allowed_by:type_name -> flow.Policy
-	33, // 27: flow.Flow.ingress_allowed_by:type_name -> flow.Policy
-	33, // 28: flow.Flow.egress_denied_by:type_name -> flow.Policy
-	33, // 29: flow.Flow.ingress_denied_by:type_name -> flow.Policy
-	24, // 30: flow.Layer4.TCP:type_name -> flow.TCP
-	28, // 31: flow.Layer4.UDP:type_name -> flow.UDP
-	30, // 32: flow.Layer4.ICMPv4:type_name -> flow.ICMPv4
-	31, // 33: flow.Layer4.ICMPv6:type_name -> flow.ICMPv6
-	29, // 34: flow.Layer4.SCTP:type_name -> flow.SCTP
-	4,  // 35: flow.Layer7.type:type_name -> flow.L7FlowType
-	37, // 36: flow.Layer7.dns:type_name -> flow.DNS
-	39, // 37: flow.Layer7.http:type_name -> flow.HTTP
-	40, // 38: flow.Layer7.kafka:type_name -> flow.Kafka
-	21, // 39: flow.TraceContext.parent:type_name -> flow.TraceParent
-	23, // 40: flow.Endpoint.workloads:type_name -> flow.Workload
-	27, // 41: flow.TCP.flags:type_name -> flow.TCPFlags
-	5,  // 42: flow.IP.ipVersion:type_name -> flow.IPVersion
-	15, // 43: flow.Tunnel.protocol:type_name -> flow.Tunnel.Protocol
-	25, // 44: flow.Tunnel.IP:type_name -> flow.IP
-	18, // 45: flow.Tunnel.l4:type_name -> flow.Layer4
-	23, // 46: flow.FlowFilter.source_workload:type_name -> flow.Workload
-	23, // 47: flow.FlowFilter.destination_workload:type_name -> flow.Workload
-	8,  // 48: flow.FlowFilter.traffic_direction:type_name -> flow.TrafficDirection
-	6,  // 49: flow.FlowFilter.verdict:type_name -> flow.Verdict
-	7,  // 50: flow.FlowFilter.drop_reason_desc:type_name -> flow.DropReason
-	54, // 51: flow.FlowFilter.interface:type_name -> flow.NetworkInterface
-	34, // 52: flow.FlowFilter.event_type:type_name -> flow.EventTypeFilter
-	38, // 53: flow.FlowFilter.http_header:type_name -> flow.HTTPHeader
-	27, // 54: flow.FlowFilter.tcp_flags:type_name -> flow.TCPFlags
-	5,  // 55: flow.FlowFilter.ip_version:type_name -> flow.IPVersion
-	56, // 56: flow.FlowFilter.experimental:type_name -> flow.FlowFilter.Experimental
-	38, // 57: flow.HTTP.headers:type_name -> flow.HTTPHeader
-	11, // 58: flow.LostEvent.source:type_name -> flow.LostEventSource
-	60, // 59: flow.LostEvent.cpu:type_name -> google.protobuf.Int32Value
-	57, // 60: flow.LostEvent.first:type_name -> google.protobuf.Timestamp
-	57, // 61: flow.LostEvent.last:type_name -> google.protobuf.Timestamp
-	12, // 62: flow.AgentEvent.type:type_name -> flow.AgentEventType
-	45, // 63: flow.AgentEvent.unknown:type_name -> flow.AgentEventUnknown
-	46, // 64: flow.AgentEvent.agent_start:type_name -> flow.TimeNotification
-	47, // 65: flow.AgentEvent.policy_update:type_name -> flow.PolicyUpdateNotification
-	48, // 66: flow.AgentEvent.endpoint_regenerate:type_name -> flow.EndpointRegenNotification
-	49, // 67: flow.AgentEvent.endpoint_update:type_name -> flow.EndpointUpdateNotification
-	50, // 68: flow.AgentEvent.ipcache_update:type_name -> flow.IPCacheNotification
-	52, // 69: flow.AgentEvent.service_upsert:type_name -> flow.ServiceUpsertNotification
-	53, // 70: flow.AgentEvent.service_delete:type_name -> flow.ServiceDeleteNotification
-	57, // 71: flow.TimeNotification.time:type_name -> google.protobuf.Timestamp
-	61, // 72: flow.IPCacheNotification.old_identity:type_name -> google.protobuf.UInt32Value
-	51, // 73: flow.ServiceUpsertNotification.frontend_address:type_name -> flow.ServiceUpsertNotificationAddr
-	51, // 74: flow.ServiceUpsertNotification.backend_addresses:type_name -> flow.ServiceUpsertNotificationAddr
-	14, // 75: flow.DebugEvent.type:type_name -> flow.DebugEventType
-	22, // 76: flow.DebugEvent.source:type_name -> flow.Endpoint
-	61, // 77: flow.DebugEvent.hash:type_name -> google.protobuf.UInt32Value
-	61, // 78: flow.DebugEvent.arg1:type_name -> google.protobuf.UInt32Value
-	61, // 79: flow.DebugEvent.arg2:type_name -> google.protobuf.UInt32Value
-	61, // 80: flow.DebugEvent.arg3:type_name -> google.protobuf.UInt32Value
-	60, // 81: flow.DebugEvent.cpu:type_name -> google.protobuf.Int32Value
-	82, // [82:82] is the sub-list for method output_type
-	82, // [82:82] is the sub-list for method input_type
-	82, // [82:82] is the sub-list for extension type_name
-	82, // [82:82] is the sub-list for extension extendee
-	0,  // [0:82] is the sub-list for field type_name
+	58, // 0: flow.Flow.time:type_name -> google.protobuf.Timestamp
+	17, // 1: flow.Flow.emitter:type_name -> flow.Emitter
+	6,  // 2: flow.Flow.verdict:type_name -> flow.Verdict
+	1,  // 3: flow.Flow.auth_type:type_name -> flow.AuthType
+	27, // 4: flow.Flow.ethernet:type_name -> flow.Ethernet
+	26, // 5: flow.Flow.IP:type_name -> flow.IP
+	19, // 6: flow.Flow.l4:type_name -> flow.Layer4
+	33, // 7: flow.Flow.tunnel:type_name -> flow.Tunnel
+	23, // 8: flow.Flow.source:type_name -> flow.Endpoint
+	23, // 9: flow.Flow.destination:type_name -> flow.Endpoint
+	0,  // 10: flow.Flow.Type:type_name -> flow.FlowType
+	20, // 11: flow.Flow.l7:type_name -> flow.Layer7
+	36, // 12: flow.Flow.event_type:type_name -> flow.CiliumEventType
+	42, // 13: flow.Flow.source_service:type_name -> flow.Service
+	42, // 14: flow.Flow.destination_service:type_name -> flow.Service
+	8,  // 15: flow.Flow.traffic_direction:type_name -> flow.TrafficDirection
+	2,  // 16: flow.Flow.trace_observation_point:type_name -> flow.TraceObservationPoint
+	3,  // 17: flow.Flow.trace_reason:type_name -> flow.TraceReason
+	18, // 18: flow.Flow.file:type_name -> flow.FileInfo
+	43, // 19: flow.Flow.ip_trace_id:type_name -> flow.IPTraceID
+	7,  // 20: flow.Flow.drop_reason_desc:type_name -> flow.DropReason
+	59, // 21: flow.Flow.is_reply:type_name -> google.protobuf.BoolValue
+	9,  // 22: flow.Flow.debug_capture_point:type_name -> flow.DebugCapturePoint
+	55, // 23: flow.Flow.interface:type_name -> flow.NetworkInterface
+	21, // 24: flow.Flow.trace_context:type_name -> flow.TraceContext
+	13, // 25: flow.Flow.sock_xlate_point:type_name -> flow.SocketTranslationPoint
+	60, // 26: flow.Flow.extensions:type_name -> google.protobuf.Any
+	34, // 27: flow.Flow.egress_allowed_by:type_name -> flow.Policy
+	34, // 28: flow.Flow.ingress_allowed_by:type_name -> flow.Policy
+	34, // 29: flow.Flow.egress_denied_by:type_name -> flow.Policy
+	34, // 30: flow.Flow.ingress_denied_by:type_name -> flow.Policy
+	25, // 31: flow.Layer4.TCP:type_name -> flow.TCP
+	29, // 32: flow.Layer4.UDP:type_name -> flow.UDP
+	31, // 33: flow.Layer4.ICMPv4:type_name -> flow.ICMPv4
+	32, // 34: flow.Layer4.ICMPv6:type_name -> flow.ICMPv6
+	30, // 35: flow.Layer4.SCTP:type_name -> flow.SCTP
+	4,  // 36: flow.Layer7.type:type_name -> flow.L7FlowType
+	38, // 37: flow.Layer7.dns:type_name -> flow.DNS
+	40, // 38: flow.Layer7.http:type_name -> flow.HTTP
+	41, // 39: flow.Layer7.kafka:type_name -> flow.Kafka
+	22, // 40: flow.TraceContext.parent:type_name -> flow.TraceParent
+	24, // 41: flow.Endpoint.workloads:type_name -> flow.Workload
+	28, // 42: flow.TCP.flags:type_name -> flow.TCPFlags
+	5,  // 43: flow.IP.ipVersion:type_name -> flow.IPVersion
+	15, // 44: flow.Tunnel.protocol:type_name -> flow.Tunnel.Protocol
+	26, // 45: flow.Tunnel.IP:type_name -> flow.IP
+	19, // 46: flow.Tunnel.l4:type_name -> flow.Layer4
+	24, // 47: flow.FlowFilter.source_workload:type_name -> flow.Workload
+	24, // 48: flow.FlowFilter.destination_workload:type_name -> flow.Workload
+	8,  // 49: flow.FlowFilter.traffic_direction:type_name -> flow.TrafficDirection
+	6,  // 50: flow.FlowFilter.verdict:type_name -> flow.Verdict
+	7,  // 51: flow.FlowFilter.drop_reason_desc:type_name -> flow.DropReason
+	55, // 52: flow.FlowFilter.interface:type_name -> flow.NetworkInterface
+	35, // 53: flow.FlowFilter.event_type:type_name -> flow.EventTypeFilter
+	39, // 54: flow.FlowFilter.http_header:type_name -> flow.HTTPHeader
+	28, // 55: flow.FlowFilter.tcp_flags:type_name -> flow.TCPFlags
+	5,  // 56: flow.FlowFilter.ip_version:type_name -> flow.IPVersion
+	57, // 57: flow.FlowFilter.experimental:type_name -> flow.FlowFilter.Experimental
+	39, // 58: flow.HTTP.headers:type_name -> flow.HTTPHeader
+	11, // 59: flow.LostEvent.source:type_name -> flow.LostEventSource
+	61, // 60: flow.LostEvent.cpu:type_name -> google.protobuf.Int32Value
+	58, // 61: flow.LostEvent.first:type_name -> google.protobuf.Timestamp
+	58, // 62: flow.LostEvent.last:type_name -> google.protobuf.Timestamp
+	12, // 63: flow.AgentEvent.type:type_name -> flow.AgentEventType
+	46, // 64: flow.AgentEvent.unknown:type_name -> flow.AgentEventUnknown
+	47, // 65: flow.AgentEvent.agent_start:type_name -> flow.TimeNotification
+	48, // 66: flow.AgentEvent.policy_update:type_name -> flow.PolicyUpdateNotification
+	49, // 67: flow.AgentEvent.endpoint_regenerate:type_name -> flow.EndpointRegenNotification
+	50, // 68: flow.AgentEvent.endpoint_update:type_name -> flow.EndpointUpdateNotification
+	51, // 69: flow.AgentEvent.ipcache_update:type_name -> flow.IPCacheNotification
+	53, // 70: flow.AgentEvent.service_upsert:type_name -> flow.ServiceUpsertNotification
+	54, // 71: flow.AgentEvent.service_delete:type_name -> flow.ServiceDeleteNotification
+	58, // 72: flow.TimeNotification.time:type_name -> google.protobuf.Timestamp
+	62, // 73: flow.IPCacheNotification.old_identity:type_name -> google.protobuf.UInt32Value
+	52, // 74: flow.ServiceUpsertNotification.frontend_address:type_name -> flow.ServiceUpsertNotificationAddr
+	52, // 75: flow.ServiceUpsertNotification.backend_addresses:type_name -> flow.ServiceUpsertNotificationAddr
+	14, // 76: flow.DebugEvent.type:type_name -> flow.DebugEventType
+	23, // 77: flow.DebugEvent.source:type_name -> flow.Endpoint
+	62, // 78: flow.DebugEvent.hash:type_name -> google.protobuf.UInt32Value
+	62, // 79: flow.DebugEvent.arg1:type_name -> google.protobuf.UInt32Value
+	62, // 80: flow.DebugEvent.arg2:type_name -> google.protobuf.UInt32Value
+	62, // 81: flow.DebugEvent.arg3:type_name -> google.protobuf.UInt32Value
+	61, // 82: flow.DebugEvent.cpu:type_name -> google.protobuf.Int32Value
+	83, // [83:83] is the sub-list for method output_type
+	83, // [83:83] is the sub-list for method input_type
+	83, // [83:83] is the sub-list for extension type_name
+	83, // [83:83] is the sub-list for extension extendee
+	0,  // [0:83] is the sub-list for field type_name
 }
 
 func init() { file_flow_flow_proto_init() }
@@ -5879,19 +5952,19 @@ func file_flow_flow_proto_init() {
 	if File_flow_flow_proto != nil {
 		return
 	}
-	file_flow_flow_proto_msgTypes[2].OneofWrappers = []any{
+	file_flow_flow_proto_msgTypes[3].OneofWrappers = []any{
 		(*Layer4_TCP)(nil),
 		(*Layer4_UDP)(nil),
 		(*Layer4_ICMPv4)(nil),
 		(*Layer4_ICMPv6)(nil),
 		(*Layer4_SCTP)(nil),
 	}
-	file_flow_flow_proto_msgTypes[3].OneofWrappers = []any{
+	file_flow_flow_proto_msgTypes[4].OneofWrappers = []any{
 		(*Layer7_Dns)(nil),
 		(*Layer7_Http)(nil),
 		(*Layer7_Kafka)(nil),
 	}
-	file_flow_flow_proto_msgTypes[28].OneofWrappers = []any{
+	file_flow_flow_proto_msgTypes[29].OneofWrappers = []any{
 		(*AgentEvent_Unknown)(nil),
 		(*AgentEvent_AgentStart)(nil),
 		(*AgentEvent_PolicyUpdate)(nil),
@@ -5907,7 +5980,7 @@ func file_flow_flow_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_flow_flow_proto_rawDesc), len(file_flow_flow_proto_rawDesc)),
 			NumEnums:      16,
-			NumMessages:   41,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/v1/flow/flow.pb.json.go
+++ b/api/v1/flow/flow.pb.json.go
@@ -23,6 +23,18 @@ func (msg *Flow) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
+func (msg *Emitter) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseProtoNames: true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *Emitter) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
 func (msg *FileInfo) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseProtoNames: true,

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -17,6 +17,9 @@ message Flow {
     // uuid is a universally unique identifier for this flow.
     string uuid = 34;
 
+    // emitter identifies the source that emitted the flow.
+    Emitter emitter = 41;
+
     Verdict verdict = 2;
     // only applicable to Verdict = DROPPED.
     // deprecated in favor of drop_reason_desc.
@@ -148,6 +151,17 @@ message Flow {
     // this list is empty. Duplicate values are elided; each
     // entry is unique.
     repeated string policy_log = 21006;
+}
+
+// Emitter identifies the source that emits a Hubble flow.
+message Emitter {
+    // name identifies the emitter.
+    // The name should be capitalized ("Hubble", not "hubble" nor "HUBBLE").
+    string name = 1;
+    // version identifiers the emitter version.
+    // The version should not contain a 'v' prefix as sometimes seen ("1.19.0",
+    // not "v1.19.0").
+    string version = 2;
 }
 
 enum FlowType {

--- a/api/v1/observer/observer.pb.go
+++ b/api/v1/observer/observer.pb.go
@@ -359,6 +359,7 @@ var Tunnel_Protocol_name = flow.Tunnel_Protocol_name
 var Tunnel_Protocol_value = flow.Tunnel_Protocol_value
 
 type Flow = flow.Flow
+type Emitter = flow.Emitter
 type FileInfo = flow.FileInfo
 type Layer4 = flow.Layer4
 type Layer4_TCP = flow.Layer4_TCP

--- a/pkg/hubble/api/v1/flow.go
+++ b/pkg/hubble/api/v1/flow.go
@@ -5,8 +5,15 @@ package v1
 
 import (
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/build"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
+
+// FlowEmitter is an identifier for the source system that emits a flow.
+const FlowEmitter = "Hubble"
+
+// FlowEmitterVersion is the version of the component that emits flows.
+var FlowEmitterVersion = build.ServerVersion.SemVer()
 
 // FlowProtocol returns the protocol best describing the flow. If available,
 // this is the L7 protocol name, then the L4 protocol name.

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -114,7 +114,12 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 			return nil, errors.ErrEmptyData
 		}
 
-		flow := &pb.Flow{}
+		flow := &pb.Flow{
+			Emitter: &pb.Emitter{
+				Name:    v1.FlowEmitter,
+				Version: v1.FlowEmitterVersion,
+			},
+		}
 		switch payload.Data[0] {
 		case monitorAPI.MessageTypeDebug:
 			// Debug and TraceSock are both perf ring buffer events without any
@@ -145,7 +150,12 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 	case *observerTypes.AgentEvent:
 		switch payload.Type {
 		case monitorAPI.MessageTypeAccessLog:
-			flow := &pb.Flow{}
+			flow := &pb.Flow{
+				Emitter: &pb.Emitter{
+					Name:    v1.FlowEmitter,
+					Version: v1.FlowEmitterVersion,
+				},
+			}
 			logrecord, ok := payload.Message.(accesslog.LogRecord)
 			if !ok {
 				return nil, errors.ErrInvalidAgentMessageType

--- a/pkg/hubble/parser/parser_test.go
+++ b/pkg/hubble/parser/parser_test.go
@@ -69,6 +69,7 @@ func Test_ParserDispatch(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, flowpb.FlowType_L3_L4, e.GetFlow().GetType())
 	assert.Equal(t, id.String(), e.GetFlow().GetUuid())
+	assert.Equal(t, &flowpb.Emitter{Name: v1.FlowEmitter, Version: v1.FlowEmitterVersion}, e.GetFlow().GetEmitter())
 
 	// Test L7 dispatch
 	node := "k8s1"
@@ -86,6 +87,7 @@ func Test_ParserDispatch(t *testing.T) {
 	assert.Equal(t, node, e.GetFlow().GetNodeName())
 	assert.Equal(t, flowpb.FlowType_L7, e.GetFlow().GetType())
 	assert.Equal(t, id.String(), e.GetFlow().GetUuid())
+	assert.Equal(t, &flowpb.Emitter{Name: v1.FlowEmitter, Version: v1.FlowEmitterVersion}, e.GetFlow().GetEmitter())
 }
 
 func Test_EventType_RecordLost(t *testing.T) {


### PR DESCRIPTION
With Hubble being adopted by different projects as a standard way to provide enriched network flow data to observability systems (see for example [Microsoft's Retina project](https://github.com/microsoft/retina)), being able to identify the system that is at the source of a Hubble flow would be very handy in certain situations such as troubleshooting.

The implementation is loose on purpose such that systems that adopt Hubble flows are not forced to update the definition of a Hubble flow.

```release-note
hubble: add emitter information to Hubble flow to allow identifying the source that emitted it
```
