### PR TITLE
gneigh: add InterfaceFromNetInterface

### DIFF
--- a/pkg/datapath/gneigh/gneigh.go
+++ b/pkg/datapath/gneigh/gneigh.go
@@ -62,6 +62,11 @@ type Interface struct {
 	iface *net.Interface
 }
 
+// InterfaceFromNetInterface constructs an Interface from the given *net.Interface.
+func InterfaceFromNetInterface(iface *net.Interface) Interface {
+	return Interface{iface: iface}
+}
+
 type sender struct{}
 
 // arpDropAllFilter filters out all packets, as we are only interested in
@@ -216,13 +221,13 @@ func (s *sender) InterfaceByIndex(idx int) (Interface, error) {
 		return Interface{}, err
 	}
 
-	return Interface{
-		iface: &net.Interface{
+	return InterfaceFromNetInterface(
+		&net.Interface{
 			Index:        link.Attrs().Index,
 			MTU:          link.Attrs().MTU,
 			Name:         link.Attrs().Name,
 			Flags:        link.Attrs().Flags,
 			HardwareAddr: link.Attrs().HardwareAddr,
 		},
-	}, nil
+	), nil
 }

--- a/pkg/datapath/gneigh/processor_test.go
+++ b/pkg/datapath/gneigh/processor_test.go
@@ -57,12 +57,12 @@ func (fs *fakeSender) InterfaceByIndex(idx int) (Interface, error) {
 		return Interface{}, fmt.Errorf("Device does not exit: %d", idx)
 	}
 
-	return Interface{
-		iface: &net.Interface{
+	return InterfaceFromNetInterface(
+		&net.Interface{
 			Index: def.Index,
 			Name:  def.Name,
 		},
-	}, nil
+	), nil
 }
 
 var fakeDevices = map[int]*tables.Device{


### PR DESCRIPTION
Add the `InterfaceFromNetInterface` helper method to construct a `gneigh.Interface` from a given `*net.Interface`. This will be useful to construct `gneigh.Interface` instances e.g. in tests in other packages.