### PR TITLE
mac: add `MustParseMAC` test helper and remove unused functions

### DIFF
--- a/pkg/datapath/linux/routing/info_test.go
+++ b/pkg/datapath/linux/routing/info_test.go
@@ -20,8 +20,7 @@ func TestPrivilegedParse(t *testing.T) {
 	_, fakeCIDR, err := net.ParseCIDR("192.168.0.0/16")
 	require.NoError(t, err)
 
-	fakeMAC, err := mac.ParseMAC("11:22:33:44:55:66")
-	require.NoError(t, err)
+	fakeMAC := mac.MustParseMAC("11:22:33:44:55:66")
 
 	validCIDRs := []net.IPNet{*fakeCIDR}
 

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -257,9 +257,7 @@ func getFakes(t *testing.T, withCIDR bool, withZeroCIDR bool) (netip.Addr, Routi
 	fakeGateway := netip.MustParseAddr("192.168.2.1")
 	fakeSubnet1CIDR := netip.MustParsePrefix("192.168.0.0/16")
 	fakeSubnet2CIDR := netip.MustParsePrefix("192.170.0.0/16")
-	fakeMAC, err := mac.ParseMAC("00:11:22:33:44:55")
-	require.NoError(t, err)
-	require.NotNil(t, fakeMAC)
+	fakeMAC := mac.MustParseMAC("00:11:22:33:44:55")
 	logger := hivetest.Logger(t)
 
 	var fakeRoutingInfo *RoutingInfo

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -29,6 +29,7 @@ import (
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
@@ -227,9 +228,8 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 
 	for i := range numFlows {
 		tn := monitor.TraceNotify{Type: byte(monitorAPI.MessageTypeTrace)}
-		macOnly := func(mac string) net.HardwareAddr {
-			m, _ := net.ParseMAC(mac)
-			return m
+		macOnly := func(s string) net.HardwareAddr {
+			return net.HardwareAddr(mac.MustParseMAC(s))
 		}
 		data := testutils.MustCreateL3L4Payload(tn, &layers.Ethernet{
 			SrcMAC: macOnly(fake.MAC()),

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/server"
 	"github.com/cilium/cilium/pkg/hubble/server/serveroption"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -107,12 +108,10 @@ func newHubbleObserver(t testing.TB, nodeName string, numFlows int) *observer.Lo
 		tn := monitor.TraceNotify{Type: byte(monitorAPI.MessageTypeTrace)}
 		src := getRandomEndpoint()
 		dst := getRandomEndpoint()
-		srcMAC, _ := net.ParseMAC(fake.MAC())
-		dstMAC, _ := net.ParseMAC(fake.MAC())
 		data := testutils.MustCreateL3L4Payload(tn,
 			&layers.Ethernet{
-				SrcMAC:       srcMAC,
-				DstMAC:       dstMAC,
+				SrcMAC:       net.HardwareAddr(mac.MustParseMAC(fake.MAC())),
+				DstMAC:       net.HardwareAddr(mac.MustParseMAC(fake.MAC())),
 				EthernetType: layers.EthernetTypeIPv4,
 			},
 			&layers.IPv4{

--- a/pkg/mac/mac.go
+++ b/pkg/mac/mac.go
@@ -124,16 +124,6 @@ func GenerateRandMAC() (MAC, error) {
 	return buf, nil
 }
 
-// HaveMACAddrs returns true if all given network interfaces have L2 addr.
-func HaveMACAddrs(ifaces []string) bool {
-	for _, iface := range ifaces {
-		if !HasMacAddr(iface) {
-			return false
-		}
-	}
-	return true
-}
-
 // CArrayString returns a string which can be used for assigning the given
 // MAC addr to "union macaddr" in C.
 func CArrayString(m net.HardwareAddr) string {

--- a/pkg/mac/mac.go
+++ b/pkg/mac/mac.go
@@ -58,6 +58,16 @@ func ParseMAC(s string) (MAC, error) {
 	return MAC(ha), nil
 }
 
+// MustParseMAC calls [ParseMAC] and panics on error. It is intended for use in tests with
+// hard-coded strings.
+func MustParseMAC(s string) MAC {
+	mac, err := ParseMAC(s)
+	if err != nil {
+		panic(err)
+	}
+	return mac
+}
+
 // Uint64 returns the MAC in uint64 format. The MAC is represented as little-endian in
 // the returned value.
 // Example:

--- a/pkg/mac/mac_linux.go
+++ b/pkg/mac/mac_linux.go
@@ -12,20 +12,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 )
 
-// HasMacAddr returns true if the given network interface has L2 addr.
-func HasMacAddr(iface string) bool {
-	link, err := safenetlink.LinkByName(iface)
-	if err != nil {
-		return false
-	}
-	return LinkHasMacAddr(link)
-}
-
-// LinkHasMacAddr returns true if the given network interface has L2 addr.
-func LinkHasMacAddr(link netlink.Link) bool {
-	return len(link.Attrs().HardwareAddr) != 0
-}
-
 // ReplaceMacAddressWithLinkName replaces the MAC address of the given link
 func ReplaceMacAddressWithLinkName(ifName, macAddress string) error {
 	l, err := safenetlink.LinkByName(ifName)

--- a/pkg/mac/mac_unspecified.go
+++ b/pkg/mac/mac_unspecified.go
@@ -7,12 +7,6 @@ package mac
 
 import "fmt"
 
-// HasMacAddr returns true if the given network interface has L2 addr.
-// This is not supported for non-linux environment
-func HasMacAddr(iface string) bool {
-	return false
-}
-
 func ReplaceMacAddressWithLinkName(ifName, macAddress string) error {
 	return fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
See commit messages for details.
