### PR TITLE
check-encryption-leak: always report Overlay traffic post VinE

### DIFF
--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -120,6 +120,7 @@ kprobe:br_forward
 
   if ($proto == PROTO_IPV4) {
     if (
+      ($skb->encapsulation || $encap) ||
       (str($8) == "ipsec" && $ip4h->protocol != PROTO_ESP) ||
       (str($8) == "wireguard" && !($ip4h->protocol == PROTO_UDP &&
                                       (bswap($udph->dest) == PORT_WIREGUARD ||
@@ -146,6 +147,7 @@ kprobe:br_forward
             @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
 
       if (
+          ($skb->encapsulation || $encap) ||
           (!$pod_to_pod_via_proxy && ($src_is_pod && $dst_is_pod) && (!$src_is_internal && !$dst_is_internal)) ||
           ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))
         ) {
@@ -213,6 +215,7 @@ kprobe:br_forward
 
   if ($proto == PROTO_IPV6) {
     if (
+      ($skb->encapsulation || $encap) ||
       (str($8) == "ipsec" && $ip6h->nexthdr != PROTO_ESP) ||
       (str($8) == "wireguard" && !($ip6h->nexthdr == PROTO_UDP &&
                                       (bswap($udph->dest) == PORT_WIREGUARD ||
@@ -239,6 +242,7 @@ kprobe:br_forward
             @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
 
       if (
+          ($skb->encapsulation || $encap) ||
           (!$pod_to_pod_via_proxy && ($src_is_pod && $dst_is_pod) && (!$src_is_internal && !$dst_is_internal)) ||
           ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))
         ) {


### PR DESCRIPTION
**CLOSING** as motivated in the [comment below](https://github.com/cilium/cilium/pull/41884#issuecomment-3401544819)

check-encryption-leaks.bt: 
* **NativeRouting**: We always need to inspect headers to determine if a plain-text packet is a leak. Currently, we only detect:
     * pod-to-pod.
     * pod-to-pod-via-proxy
* **OverlayRouting**: Currently behaves the same as NativeRouting. However, with VinE (>= v1.18), both IPSec and WireGuard encrypt all overlay traffic. This means we could potentially flag all plain-text overlay packets as leaks, catching far more cases than just pod-to-pod or pod-to-pod-via-proxy.

The PR aims to simplify leak detection for overlay traffic, which should always be encrypted.

**TL;DR;** of ongoing discussion below https://github.com/cilium/cilium/pull/41884#discussion_r2388541995: we cannot catch XDP_TX-ed packets from our current kprobes (mainly `br_forward` and `__dev_queue_xmit`). Therefore DSR Geneve packets when using NodePort acceleration (XDP) are not observed, thus this change should be safe (i.e., all overlay traffic we match in kprobes must be encrypted).