### PR TITLE
fix(bpf) Initialize cilium_percpu_trace_id map via Hive Start hook

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
 	ipmasqmaps "github.com/cilium/cilium/pkg/maps/ipmasq"
+	"github.com/cilium/cilium/pkg/maps/iptrace"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	natStats "github.com/cilium/cilium/pkg/maps/nat/stats"
 	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
@@ -131,6 +132,9 @@ var (
 
 		// Provides cilium_datapath_drop/forward Prometheus metrics.
 		metricsmap.Cell,
+
+		// Provides the IP trace map.
+		iptrace.Cell,
 
 		// Provides cilium_bpf_ratelimit_dropped_total Prometheus metric.
 		ratelimitmap.Cell,

--- a/pkg/maps/iptrace/cell.go
+++ b/pkg/maps/iptrace/cell.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptrace
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+// Cell provides the PerCPUTraceMap, which is an eBPF map used for IP tracing.
+// This map is designed to store trace IDs on a per-CPU basis, allowing for
+// efficient and concurrent tracing of IP packets. The map has a maximum of
+// one entry, which is used to store the trace ID for the current CPU.
+var Cell = cell.Module(
+	"iptrace-map",
+	"eBPF map for IP tracing",
+
+	cell.Provide(
+		func(lc cell.Lifecycle) bpf.MapOut[*ipTraceMap] {
+			m := NewMap()
+			lc.Append(cell.Hook{
+				OnStart: func(startCtx cell.HookContext) error {
+					return m.OpenOrCreate()
+				},
+				OnStop: func(stopCtx cell.HookContext) error {
+					return m.Close()
+				},
+			})
+			return bpf.NewMapOut(m)
+		},
+	),
+)

--- a/pkg/maps/iptrace/iptrace_map.go
+++ b/pkg/maps/iptrace/iptrace_map.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptrace
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+const (
+	// MapName is the name of the map.
+	MapName = "cilium_percpu_trace_id"
+
+	// MaxEntries represents the maximum number of trace ID entries.
+	MaxEntries = 1
+)
+
+// Key is the key for the IP trace map.
+type Key uint32
+
+// TraceId is the value for the IP trace map.
+type TraceId uint64
+
+// String returns the string representation of the key.
+func (k *Key) String() string { return fmt.Sprintf("%d", uint32(*k)) }
+
+// New creates a new key.
+func (k *Key) New() bpf.MapKey { return new(Key) }
+
+// String returns the string representation of the value.
+func (v *TraceId) String() string { return fmt.Sprintf("%d", uint64(*v)) }
+
+// New creates a new value.
+func (v *TraceId) New() bpf.MapValue { return new(TraceId) }
+
+// ipTraceMap is the trace map.
+type ipTraceMap struct {
+	*bpf.Map
+}
+
+// NewMap returns a new trace map.
+func NewMap() *ipTraceMap {
+	var ipopt Key
+	var traceid TraceId
+
+	return &ipTraceMap{
+		Map: bpf.NewMap(
+			MapName,
+			ebpf.PerCPUArray,
+			&ipopt,
+			&traceid,
+			MaxEntries,
+			0,
+		),
+	}
+}

--- a/pkg/maps/iptrace/iptrace_map_test.go
+++ b/pkg/maps/iptrace/iptrace_map_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptrace
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func setup(tb testing.TB) {
+	testutils.PrivilegedTest(tb)
+	logger := hivetest.Logger(tb)
+
+	bpf.CheckOrMountFS(logger, "")
+	require.NoError(tb, rlimit.RemoveMemlock(), "Failed to set memlock rlimit")
+}
+
+func TestKey(t *testing.T) {
+	k := Key(123)
+	require.Equal(t, "123", k.String())
+
+	nk := k.New()
+	require.IsType(t, new(Key), nk)
+	require.NotEqual(t, k, nk)
+}
+
+func TestTraceId(t *testing.T) {
+	v := TraceId(456)
+	require.Equal(t, "456", v.String())
+
+	nv := v.New()
+	require.IsType(t, new(TraceId), nv)
+	require.NotEqual(t, v, nv)
+}
+
+func TestNewMap(t *testing.T) {
+	m := NewMap()
+	require.NotNil(t, m)
+	require.Equal(t, MapName, m.Name())
+	require.Equal(t, ebpf.PerCPUArray, m.Type())
+	require.Equal(t, uint32(MaxEntries), m.MaxEntries())
+	require.Equal(t, uint32(0), m.Flags())
+	require.Equal(t, uint32(4), m.KeySize())
+	require.Equal(t, uint32(8), m.ValueSize())
+}
+
+func TestPrivilegedIPTraceMap(t *testing.T) {
+	setup(t)
+	logger := hivetest.Logger(t)
+
+	m := NewMap()
+	require.NotNil(t, m, "Failed to initialize map")
+
+	// Pinning a map requires it to be opened first.
+	require.NoError(t, m.OpenOrCreate(), "Failed to create maps")
+	t.Cleanup(func() {
+		require.NoError(t, m.Close())
+	})
+
+	require.FileExists(t, bpf.MapPath(logger, m.Name()), "Failed to create map")
+
+	// Re-opening an existing map should not cause an error.
+	m2 := NewMap()
+	require.NotNil(t, m2, "Failed to initialize map")
+	require.NoError(t, m2.OpenOrCreate(), "Failed to re-open map")
+	require.NoError(t, m2.Close())
+}


### PR DESCRIPTION
## Description
This PR resolves a race condition during agent startup that caused CI flakes when loading the cilium_percpu_trace_id BPF map.

As noted by this https://github.com/cilium/cilium/pull/41306#issuecomment-3328224636, the original error seen in logs was:
`error="loading eBPF collection into the kernel: map cilium_percpu_trace_id: pin map to /sys/fs/bpf/tc/globals/cilium_percpu_trace_id: file exists"`

## Cause
The cilium_percpu_trace_id map is defined with the LIBBPF_PIN_BY_NAME flag, making it a globally shared, pinned map, so because multiple datapath components start and load BPF programs concurrently during agent initialization, multiple goroutines were attempting to create/pin this BPF map simultaneously. The first attempt works, but all other attempts fail with the message linked above.

## Fix
The map's initializeion is now done via Hive injection: A dedicated iptrace.Cell is registered in daemon/cmd/cells.go. This uses the OnStart hook to call `OpenOrCreate()` for the cilium_percpu_trace_id map.

Fixes: https://github.com/cilium/cilium/issues/42125

