### PR TITLE
bpf/nat: Move `ipv6_nat_entry` to map

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1373,18 +1373,26 @@ out:
 	return ret;
 }
 
+/* Store struct ipv6_nat_entry objects in map to optimize stack usage. */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct ipv6_nat_entry);
+} ipv6_nat_entry_storage __section_maps_btf;
+
 static __always_inline int
 snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			   struct ipv6_ct_tuple *tuple,
 			   fraginfo_t fraginfo,
 			   struct ipv6_nat_entry **state,
-			   struct ipv6_nat_entry *tmp,
 			   __u32 off,
 			   const struct ipv6_nat_target *target,
 			   struct trace_ctx *trace,
 			   __s8 *ext_err)
 {
 	bool needs_ct = target->needs_ct;
+	int zero = 0;
 
 	*state = snat_v6_lookup(tuple);
 
@@ -1422,17 +1430,21 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			/* Check for the reverse SNAT entry. If it is missing (e.g. due to LRU
 			 * eviction), it must be restored before returning.
 			 */
-			struct ipv6_nat_entry rstate;
+			struct ipv6_nat_entry *rstate;
 			struct ipv6_nat_entry *lookup_result;
 
 			lookup_result = snat_v6_lookup(&rtuple);
 			if (!lookup_result) {
-				memset(&rstate, 0, sizeof(rstate));
-				rstate.to_daddr = tuple->saddr;
-				rstate.to_dport = tuple->sport;
-				rstate.common.needs_ct = needs_ct;
-				rstate.common.created = bpf_mono_now();
-				ret = __snat_create(&cilium_snat_v6_external, &rtuple, &rstate,
+				rstate = map_lookup_elem(&ipv6_nat_entry_storage, &zero);
+				if (!rstate)
+					return DROP_INVALID;
+
+				memset(rstate, 0, sizeof(*rstate));
+				rstate->to_daddr = tuple->saddr;
+				rstate->to_dport = tuple->sport;
+				rstate->common.needs_ct = needs_ct;
+				rstate->common.created = bpf_mono_now();
+				ret = __snat_create(&cilium_snat_v6_external, &rtuple, rstate,
 						    false);
 				if (ret < 0) {
 					if (ext_err)
@@ -1454,8 +1466,10 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			__snat_delete(&cilium_snat_v6_external, &rtuple);
 	}
 
-	*state = tmp;
-	return snat_v6_new_mapping(ctx, tuple, tmp, target, needs_ct, ext_err);
+	*state = map_lookup_elem(&ipv6_nat_entry_storage, &zero);
+	if (!*state)
+		return DROP_INVALID;
+	return snat_v6_new_mapping(ctx, tuple, *state, target, needs_ct, ext_err);
 }
 
 static __always_inline int
@@ -1847,10 +1861,10 @@ __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, fraginfo_t fr
 	      int l4_off, bool update_tuple, const struct ipv6_nat_target *target,
 	      __u16 port_off, struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ipv6_nat_entry *state, tmp;
+	struct ipv6_nat_entry *state;
 	int ret;
 
-	ret = snat_v6_nat_handle_mapping(ctx, tuple, fraginfo, &state, &tmp,
+	ret = snat_v6_nat_handle_mapping(ctx, tuple, fraginfo, &state,
 					 l4_off, target, trace, ext_err);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
This pull request moves the `ipv6_nat_entry` local variable of `snat_v6_nat_handle_mapping()` from the stack to a per-cpu array map. This function (or rather its caller) has a very large stack because `ipv6_nat_entry` is huge and we manipulate several variables of that type.

This pull request therefore implements the strategy tried by @aditighag before and extends it to the `tmp` variable. We're moving the `rstate` and `tmp` variables of type `ipv6_nat_entry` to a map. We can use the same map for both variables because (1) they are not used at the same time and (2) they are always cleared before being used anyway.

The following two tables show the impact on the stack size of `tail_handle_snat_fwd_ipv6()` of moving the two variables to the map. Config 1 corresponds to the config generated by `make build_all`. Config 2 corresponds to the config generated by `make`.

Impact on `tail_handle_snat_fwd_ipv6()` after moving `rstate` to the map:

| Program       | Config 1 | Config 2 |
|---------------|----------|----------|
| bpf_host      |       -0 |       -0 |
| bpf_overlay   |       -0 |       -0 |
| bpf_wireguard |      -56 |       -0 |

Impact on `tail_handle_snat_fwd_ipv6()` after moving `tmp` to the map:

| Program       | Config 1 | Config 2 |
|---------------|----------|----------|
| bpf_host      |      -64 |      -48 |
| bpf_overlay   |      -40 |      -48 |
| bpf_wireguard |      -56 |      -56 |
