### PR TITLE
VTEP: introduce cells for VTEP map & VTEP manager (new)

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -411,6 +411,7 @@ cilium-agent [flags]
       --vtep-endpoint strings                                     List of VTEP IP addresses
       --vtep-mac strings                                          List of VTEP MAC addresses for forwarding traffic outside the cluster
       --vtep-mask string                                          VTEP CIDR Mask for all VTEP CIDRs (default "255.255.255.0")
+      --vtep-sync-interval duration                               Interval for VTEP sync (default 1m0s)
       --wireguard-persistent-keepalive duration                   The Wireguard keepalive interval as a Go duration string
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
 ```

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -233,6 +233,10 @@ cilium-agent hive [flags]
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")
       --underlay-protocol string                                  IP family for the underlay ("ipv4" or "ipv6") (default "ipv4")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
+      --vtep-cidr strings                                         List of VTEP CIDRs that will be routed towards VTEPs for traffic cluster egress
+      --vtep-endpoint strings                                     List of VTEP IP addresses
+      --vtep-mac strings                                          List of VTEP MAC addresses for forwarding traffic outside the cluster
+      --vtep-sync-interval duration                               Interval for VTEP sync (default 1m0s)
       --wireguard-persistent-keepalive duration                   The Wireguard keepalive interval as a Go duration string
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
 ```

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -238,6 +238,10 @@ cilium-agent hive dot-graph [flags]
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")
       --underlay-protocol string                                  IP family for the underlay ("ipv4" or "ipv6") (default "ipv4")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.
+      --vtep-cidr strings                                         List of VTEP CIDRs that will be routed towards VTEPs for traffic cluster egress
+      --vtep-endpoint strings                                     List of VTEP IP addresses
+      --vtep-mac strings                                          List of VTEP MAC addresses for forwarding traffic outside the cluster
+      --vtep-sync-interval duration                               Interval for VTEP sync (default 1m0s)
       --wireguard-persistent-keepalive duration                   The Wireguard keepalive interval as a Go duration string
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
 ```

--- a/cilium-dbg/cmd/bpf_vtep_delete.go
+++ b/cilium-dbg/cmd/bpf_vtep_delete.go
@@ -28,9 +28,7 @@ var bpfVtepDeleteCmd = &cobra.Command{
 			Fatalf("error parsing cidr %s: %s", args[0], err)
 		}
 
-		key := vtep.NewKey(vcidr.IP)
-
-		if err := vtep.VtepMap(nil).Delete(&key); err != nil {
+		if err := vtep.LoadVTEPMap(log).Delete(vcidr.IP); err != nil {
 			Fatalf("error deleting contents of map: %s\n", err)
 		}
 	},

--- a/cilium-dbg/cmd/bpf_vtep_list.go
+++ b/cilium-dbg/cmd/bpf_vtep_list.go
@@ -19,9 +19,7 @@ const (
 	vtepTitle     = "VTEP"
 )
 
-var (
-	vtepListUsage = "List VTEP CIDR and their corresponding VTEP MAC/IP.\n"
-)
+var vtepListUsage = "List VTEP CIDR and their corresponding VTEP MAC/IP.\n"
 
 var bpfVtepListCmd = &cobra.Command{
 	Use:     "list",
@@ -32,7 +30,7 @@ var bpfVtepListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf vtep list")
 
 		bpfVtepList := make(map[string][]string)
-		if err := vtep.VtepMap(nil).Dump(bpfVtepList); err != nil {
+		if err := vtep.LoadVTEPMap(log).Dump(bpfVtepList); err != nil {
 			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)
 			os.Exit(1)
 		}

--- a/cilium-dbg/cmd/bpf_vtep_update.go
+++ b/cilium-dbg/cmd/bpf_vtep_update.go
@@ -44,7 +44,7 @@ var bpfVtepUpdateCmd = &cobra.Command{
 			Fatalf("Unable to parse vtep mac '%s'", args[2])
 		}
 
-		if err := vtep.UpdateVTEPMapping(log, nil, vcidr, vip, vmac); err != nil {
+		if err := vtep.LoadVTEPMap(log).Update(vcidr, vip, vmac); err != nil {
 			fmt.Fprintf(os.Stderr, "error updating contents of map: %s\n", err)
 			os.Exit(1)
 		}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/datapath/vtep"
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -136,6 +137,8 @@ type Daemon struct {
 	healthConfig healthconfig.CiliumHealthConfig
 
 	ipsecAgent datapath.IPsecAgent
+
+	vtepManager *vtep.VTEPManager
 }
 
 func (d *Daemon) init() error {
@@ -334,6 +337,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		ciliumHealth:      params.CiliumHealth,
 		endpointAPIFence:  params.EndpointAPIFence,
 		healthConfig:      params.HealthConfig,
+		vtepManager:       params.VTEPManager,
 	}
 
 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems
@@ -708,7 +712,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			syncVTEPControllerGroup.Name,
 			controller.ControllerParams{
 				Group:       syncVTEPControllerGroup,
-				DoFunc:      syncVTEP(d.logger, d.metricsRegistry),
+				DoFunc:      syncVTEP(d.vtepManager),
 				RunInterval: time.Minute,
 				Context:     d.ctx,
 			})

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -41,6 +41,7 @@ import (
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/datapath/vtep"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
@@ -895,7 +896,7 @@ func restoreExecPermissions(searchDir string, patterns ...string) error {
 		// Changing files permissions to -rwx:r--:---, we are only
 		// adding executable permission to the owner and keeping the
 		// same permissions stored by go-bindata.
-		if err := os.Chmod(fileToChange, os.FileMode(0740)); err != nil {
+		if err := os.Chmod(fileToChange, os.FileMode(0o740)); err != nil {
 			return err
 		}
 	}
@@ -1313,6 +1314,7 @@ type daemonParams struct {
 	EndpointAPIFence    endpointapi.Fence
 	IPSecConfig         datapath.IPsecConfig
 	HealthConfig        healthconfig.CiliumHealthConfig
+	VTEPManager         *vtep.VTEPManager
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], legacy.DaemonInitialization) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -41,7 +41,6 @@ import (
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/datapath/vtep"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
@@ -1314,7 +1313,6 @@ type daemonParams struct {
 	EndpointAPIFence    endpointapi.Fence
 	IPSecConfig         datapath.IPsecConfig
 	HealthConfig        healthconfig.CiliumHealthConfig
-	VTEPManager         *vtep.VTEPManager
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], legacy.DaemonInitialization) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -794,17 +794,8 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableVTEP, defaults.EnableVTEP, "Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)")
 	option.BindEnv(vp, option.EnableVTEP)
 
-	flags.StringSlice(option.VtepEndpoint, []string{}, "List of VTEP IP addresses")
-	option.BindEnv(vp, option.VtepEndpoint)
-
-	flags.StringSlice(option.VtepCIDR, []string{}, "List of VTEP CIDRs that will be routed towards VTEPs for traffic cluster egress")
-	option.BindEnv(vp, option.VtepCIDR)
-
 	flags.String(option.VtepMask, "255.255.255.0", "VTEP CIDR Mask for all VTEP CIDRs")
 	option.BindEnv(vp, option.VtepMask)
-
-	flags.StringSlice(option.VtepMAC, []string{}, "List of VTEP MAC addresses for forwarding traffic outside the cluster")
-	option.BindEnv(vp, option.VtepMAC)
 
 	flags.Int(option.TCFilterPriority, 1, "Priority of TC BPF filter")
 	flags.MarkHidden(option.TCFilterPriority)

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -15,7 +14,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
-	"github.com/cilium/cilium/pkg/datapath/vtep"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -229,20 +227,4 @@ func (d *Daemon) initMaps() error {
 	}
 
 	return nil
-}
-
-func syncVTEP(vtepManager *vtep.VTEPManager) func(context.Context) error {
-	return func(context.Context) error {
-		if option.Config.EnableVTEP {
-			err := vtepManager.SetupVTEPMapping()
-			if err != nil {
-				return err
-			}
-			err = vtepManager.SetupRouteToVtepCidr()
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	}
 }

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/datapath/vtep"
 	"github.com/cilium/cilium/pkg/datapath/xdp"
 	"github.com/cilium/cilium/pkg/maps"
 	"github.com/cilium/cilium/pkg/maps/eventsmap"
@@ -127,6 +128,8 @@ var Cell = cell.Module(
 
 	// XDP cell provides modularized XDP enablement.
 	xdp.Cell,
+
+	vtep.Cell,
 
 	// Provides node handler, which handles node events.
 	cell.Provide(linuxdatapath.NewNodeHandler),

--- a/pkg/datapath/vtep/cell.go
+++ b/pkg/datapath/vtep/cell.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package vtep
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+var Cell = cell.Module(
+	"datapath-vtep",
+	"VTEP Manager",
+
+	cell.Provide(newVTEPManager),
+)

--- a/pkg/datapath/vtep/cell.go
+++ b/pkg/datapath/vtep/cell.go
@@ -4,12 +4,129 @@
 package vtep
 
 import (
+	"fmt"
+	"log/slog"
+	"net"
+
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/maps/vtep"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var Cell = cell.Module(
-	"vtep",
-	"VTEP",
+	"vtep-integration",
+	"VXLAN Tunnel Endpoint Integration",
 
+	cell.Config(config{
+		VTEPSyncInterval: 1 * time.Minute,
+		VTEPEndpoint:     []string{},
+		VTEPCIDR:         []string{},
+		VTEPMAC:          []string{},
+	}),
 	cell.Invoke(newVTEPManager),
 )
+
+type vtepManagerParams struct {
+	cell.In
+
+	Logger    *slog.Logger
+	Lifecycle cell.Lifecycle
+	JobGroup  job.Group
+
+	VTEPMap vtep.Map
+	Config  config
+}
+
+func newVTEPManager(params vtepManagerParams) error {
+	if !option.Config.EnableVTEP {
+		return nil
+	}
+
+	validatedConfig, err := params.Config.validatedConfig()
+	if err != nil {
+		return fmt.Errorf("invalid vtep config: %w", err)
+	}
+
+	mgr := &vtepManager{
+		logger:  params.Logger,
+		vtepMap: params.VTEPMap,
+		config:  *validatedConfig,
+	}
+
+	// Start job to setup and periodically verify VTEP endpoints and routes.
+
+	// use trigger to enforce first execution immediately when the timer job starts
+	tr := job.NewTrigger()
+	tr.Trigger()
+	params.JobGroup.Add(job.Timer("sync-vtep", mgr.syncVTEP, 1*time.Minute, job.WithTrigger(tr)))
+
+	return nil
+}
+
+type config struct {
+	VTEPSyncInterval time.Duration
+	VTEPEndpoint     []string
+	VTEPCIDR         []string
+	VTEPMAC          []string
+}
+
+func (r config) Flags(flags *pflag.FlagSet) {
+	flags.Duration("vtep-sync-interval", r.VTEPSyncInterval, "Interval for VTEP sync")
+	flags.StringSlice("vtep-endpoint", r.VTEPEndpoint, "List of VTEP IP addresses")
+	flags.StringSlice("vtep-cidr", r.VTEPCIDR, "List of VTEP CIDRs that will be routed towards VTEPs for traffic cluster egress")
+	flags.StringSlice("vtep-mac", r.VTEPMAC, "List of VTEP MAC addresses for forwarding traffic outside the cluster")
+}
+
+func (r config) validatedConfig() (*vtepManagerConfig, error) {
+	config := vtepManagerConfig{}
+
+	if len(r.VTEPEndpoint) < 1 {
+		return nil, fmt.Errorf("If VTEP is enabled, at least one VTEP device must be configured")
+	}
+
+	if len(r.VTEPEndpoint) > defaults.MaxVTEPDevices {
+		return nil, fmt.Errorf("VTEP must not exceed %d VTEP devices (Found %d VTEPs)", defaults.MaxVTEPDevices, len(r.VTEPEndpoint))
+	}
+
+	if len(r.VTEPEndpoint) != len(r.VTEPCIDR) ||
+		len(r.VTEPEndpoint) != len(r.VTEPMAC) {
+		return nil, fmt.Errorf("VTEP configuration must have the same number of Endpoint, VTEP and MAC configurations (Found %d endpoints, %d MACs, %d CIDR ranges)", len(r.VTEPEndpoint), len(r.VTEPMAC), len(r.VTEPCIDR))
+	}
+
+	for _, ep := range r.VTEPEndpoint {
+		endpoint := net.ParseIP(ep)
+		if endpoint == nil {
+			return nil, fmt.Errorf("Invalid VTEP IP: %v", ep)
+		}
+		ip4 := endpoint.To4()
+		if ip4 == nil {
+			return nil, fmt.Errorf("Invalid VTEP IPv4 address %v", ip4)
+		}
+		config.vtepEndpoints = append(config.vtepEndpoints, endpoint)
+	}
+
+	for _, v := range r.VTEPCIDR {
+		externalCIDR, err := cidr.ParseCIDR(v)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid VTEP CIDR: %v", v)
+		}
+		config.vtepCIDRs = append(config.vtepCIDRs, externalCIDR)
+	}
+
+	for _, m := range r.VTEPMAC {
+		externalMAC, err := mac.ParseMAC(m)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid VTEP MAC: %v", m)
+		}
+		config.vtepMACs = append(config.vtepMACs, externalMAC)
+	}
+
+	return &config, nil
+}

--- a/pkg/datapath/vtep/cell.go
+++ b/pkg/datapath/vtep/cell.go
@@ -8,8 +8,8 @@ import (
 )
 
 var Cell = cell.Module(
-	"datapath-vtep",
-	"VTEP Manager",
+	"vtep",
+	"VTEP",
 
-	cell.Provide(newVTEPManager),
+	cell.Invoke(newVTEPManager),
 )

--- a/pkg/datapath/vtep/vtep_manager.go
+++ b/pkg/datapath/vtep/vtep_manager.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package vtep
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/vtep"
+	"github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type VTEPManager struct {
+	logger  *slog.Logger
+	vtepMap vtep.Map
+}
+
+func newVTEPManager(logger *slog.Logger, vtepMap vtep.Map) *VTEPManager {
+	return &VTEPManager{
+		logger:  logger,
+		vtepMap: vtepMap,
+	}
+}
+
+func (r *VTEPManager) SetupVTEPMapping() error {
+	for i, ep := range option.Config.VtepEndpoints {
+		r.logger.Debug(
+			"Updating vtep map entry for VTEP",
+			logfields.IPAddr, ep,
+		)
+
+		err := r.vtepMap.Update(option.Config.VtepCIDRs[i], ep, option.Config.VtepMACs[i])
+		if err != nil {
+			return fmt.Errorf("Unable to set up VTEP ipcache mappings: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *VTEPManager) SetupRouteToVtepCidr() error {
+	routeCidrs := []*cidr.CIDR{}
+
+	filter := &netlink.Route{
+		Table: linux_defaults.RouteTableVtep,
+	}
+
+	routes, err := safenetlink.RouteListFiltered(netlink.FAMILY_V4, filter, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return fmt.Errorf("failed to list routes: %w", err)
+	}
+	for _, rt := range routes {
+		rtCIDR, err := cidr.ParseCIDR(rt.Dst.String())
+		if err != nil {
+			return fmt.Errorf("Invalid VTEP Route CIDR: %w", err)
+		}
+		routeCidrs = append(routeCidrs, rtCIDR)
+	}
+
+	addedVtepRoutes, removedVtepRoutes := cidr.DiffCIDRLists(routeCidrs, option.Config.VtepCIDRs)
+	vtepMTU := mtu.EthernetMTU - mtu.TunnelOverheadIPv4
+
+	if option.Config.EnableL7Proxy {
+		for _, prefix := range addedVtepRoutes {
+			ip4 := prefix.IP.To4()
+			if ip4 == nil {
+				return fmt.Errorf("Invalid VTEP CIDR IPv4 address: %v", ip4)
+			}
+			rt := route.Route{
+				Device: defaults.HostDevice,
+				Prefix: *prefix.IPNet,
+				Scope:  netlink.SCOPE_LINK,
+				MTU:    vtepMTU,
+				Table:  linux_defaults.RouteTableVtep,
+			}
+			if err := route.Upsert(r.logger, rt); err != nil {
+				return fmt.Errorf("Update VTEP CIDR route error: %w", err)
+			}
+			r.logger.Info(
+				"VTEP route added",
+				logfields.IPAddr, rt.Prefix,
+			)
+
+			rule := route.Rule{
+				Priority: linux_defaults.RulePriorityVtep,
+				To:       prefix.IPNet,
+				Table:    linux_defaults.RouteTableVtep,
+			}
+			if err := route.ReplaceRule(rule); err != nil {
+				return fmt.Errorf("Update VTEP CIDR rule error: %w", err)
+			}
+		}
+	} else {
+		removedVtepRoutes = routeCidrs
+	}
+
+	for _, prefix := range removedVtepRoutes {
+		ip4 := prefix.IP.To4()
+		if ip4 == nil {
+			return fmt.Errorf("Invalid VTEP CIDR IPv4 address: %v", ip4)
+		}
+		rt := route.Route{
+			Device: defaults.HostDevice,
+			Prefix: *prefix.IPNet,
+			Scope:  netlink.SCOPE_LINK,
+			MTU:    vtepMTU,
+			Table:  linux_defaults.RouteTableVtep,
+		}
+		if err := route.Delete(rt); err != nil {
+			return fmt.Errorf("Delete VTEP CIDR route error: %w", err)
+		}
+		r.logger.Info(
+			"VTEP route removed",
+			logfields.IPAddr, rt.Prefix,
+		)
+
+		rule := route.Rule{
+			Priority: linux_defaults.RulePriorityVtep,
+			To:       prefix.IPNet,
+			Table:    linux_defaults.RouteTableVtep,
+		}
+		if err := route.DeleteRule(netlink.FAMILY_V4, rule); err != nil {
+			return fmt.Errorf("Delete VTEP CIDR rule error: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
 	"github.com/cilium/cilium/pkg/maps/srv6map"
+	"github.com/cilium/cilium/pkg/maps/vtep"
 )
 
 // Cell contains all cells which are providing BPF Maps.
@@ -77,6 +78,9 @@ var Cell = cell.Module(
 
 	// Provides access to the encryption map.
 	encrypt.Cell,
+
+	// Provides access to the vtep map.
+	vtep.Cell,
 )
 
 type mapApiHandlerOut struct {

--- a/pkg/maps/vtep/cell.go
+++ b/pkg/maps/vtep/cell.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package vtep
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides the VTEP map that contains the VTEP device information.
+var Cell = cell.Module(
+	"vtep-map",
+	"eBPF map which contains the VTEP device information",
+
+	cell.Provide(newVTEPMap),
+)
+
+func newVTEPMap(lifecycle cell.Lifecycle, logger *slog.Logger, registry *metrics.Registry) bpf.MapOut[Map] {
+	if !option.Config.EnableVTEP {
+		return bpf.MapOut[Map]{}
+	}
+
+	vtepMap := newMap(logger, registry)
+
+	lifecycle.Append(cell.Hook{
+		OnStart: func(context cell.HookContext) error {
+			return vtepMap.init()
+		},
+		OnStop: func(context cell.HookContext) error {
+			return vtepMap.close()
+		},
+	})
+
+	return bpf.NewMapOut(Map(vtepMap))
+}


### PR DESCRIPTION
```
vtep: modularized vtep map & manager

This commto modularizes the VTEP map and introduces a `VTEPManager` in
`pkg/datapath/vtep` that contains the logic that is necessary to periodically
sync the VTEP information to the VTEP map.

Both components are provided as Hive cells. This way following commits
can get rid of the VTEP sync code in the `Daemon`.
```

```
vtep: replace controller with hive job

This commit removes the VTEP sync code from the `Daemon` into the
new `VTEPManager`. In addition the controller gets refactored into
a Hive timer job.
```

```
vtep: introduce hive config

This commit introduces a Hive config for the `VTEPManager` that contains
the VTEP related configuration that is only used by this cell.

* vtep-endpoint (existing)
* vtep-cidr (existing)
* vtep-mac (existing)
* vtep-sync-interval (new)

Note: "global" vtep configuration properties (used by map & datapath init) are
kept in the global config file for the time being.
```