### PR TITLE
bpf: test: improve network policy testing

### DIFF
--- a/bpf/tests/hostfw_extended_protocols.c
+++ b/bpf/tests/hostfw_extended_protocols.c
@@ -99,7 +99,7 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 1);
 
-	policy_delete_egress_entry();
+	policy_delete_egress_all_entry();
 
 	test_finish();
 }
@@ -244,7 +244,7 @@ int hostfw_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
-	policy_delete_egress_entry();
+	policy_delete_egress_all_entry();
 	test_finish();
 }
 

--- a/bpf/tests/hostfw_host_iptables.c
+++ b/bpf/tests/hostfw_host_iptables.c
@@ -364,7 +364,7 @@ int hostfw_iptables_host_ipv4_05_host_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 2);
 
-	policy_delete_egress_entry();
+	policy_delete_egress_all_entry();
 
 	test_finish();
 }

--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -1,11 +1,51 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-static __always_inline void
-policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool deny,
-		 __u8 prefix_length)
+static __always_inline __u8
+policy_calc_wildcard_bits(__u8 protocol, __u16 dport)
 {
+	__u8 wildcard_bits = 0;
+
+	/* Wildcard the port: */
+	if (!dport) {
+		wildcard_bits += 16;
+
+		/* Only wildcard protocol if port is also wildcarded: */
+		if (!protocol)
+			wildcard_bits += 8;
+	}
+
+	return wildcard_bits;
+}
+
+static __always_inline void
+policy_delete_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport)
+{
+	__u8 wildcard_bits = policy_calc_wildcard_bits(protocol, dport);
+	/* Start with an exact L3/L4 policy, and wildcard it as determined above: */
+	__u32 key_prefix_len = POLICY_FULL_PREFIX - wildcard_bits;
+
 	struct policy_key key = {
+		.lpm_key = { key_prefix_len, {} },
+		.sec_label = sec_label,
+		.egress = egress,
+		.protocol = protocol,
+		.dport = dport,
+	};
+
+	map_delete_elem(&cilium_policy_v2, &key);
+}
+
+static __always_inline void
+policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool deny)
+{
+	__u8 wildcard_bits = policy_calc_wildcard_bits(protocol, dport);
+	/* Start with an exact L3/L4 policy, and wildcard it as determined above: */
+	__u32 key_prefix_len = POLICY_FULL_PREFIX - wildcard_bits;
+	__u8 value_prefix_len = LPM_FULL_PREFIX_BITS - wildcard_bits;
+
+	struct policy_key key = {
+		.lpm_key = { key_prefix_len, {} },
 		.sec_label = sec_label,
 		.egress = egress,
 		.protocol = protocol,
@@ -13,7 +53,7 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool 
 	};
 	struct policy_entry value = {
 		.deny = deny,
-		.lpm_prefix_length = prefix_length,
+		.lpm_prefix_length = value_prefix_len,
 	};
 
 	map_update_elem(&cilium_policy_v2, &key, &value, BPF_ANY);
@@ -22,42 +62,44 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool 
 static __always_inline void
 policy_add_ingress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	policy_add_entry(false, sec_label, protocol, dport, false, 0);
+	policy_add_entry(false, sec_label, protocol, dport, false);
 }
 
 static __always_inline void
 policy_add_l4_ingress_deny_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	policy_add_entry(false, sec_label, protocol, dport, true, LPM_PROTO_PREFIX_BITS);
+	policy_add_entry(false, sec_label, protocol, dport, true);
 }
 
 static __always_inline void
 policy_add_ingress_deny_all_entry(void)
 {
-	policy_add_entry(false, 0, 0, 0, true, 0);
+	policy_add_entry(false, 0, 0, 0, true);
 }
 
 static __always_inline void
 policy_add_egress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	policy_add_entry(true, sec_label, protocol, dport, false, 0);
+	policy_add_entry(true, sec_label, protocol, dport, false);
 }
 
 static __always_inline void policy_add_egress_allow_all_entry(void)
 {
-	policy_add_entry(true, 0, 0, 0, false, 0);
+	policy_add_entry(true, 0, 0, 0, false);
 }
 
 static __always_inline void policy_add_egress_deny_all_entry(void)
 {
-	policy_add_entry(true, 0, 0, 0, true, 0);
+	policy_add_entry(true, 0, 0, 0, true);
 }
 
-static __always_inline void policy_delete_egress_entry(void)
+static __always_inline void
+policy_delete_egress_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	struct policy_key key = {
-		.egress = 1,
-	};
+	policy_delete_entry(true, sec_label, protocol, dport);
+}
 
-	map_delete_elem(&cilium_policy_v2, &key);
+static __always_inline void policy_delete_egress_all_entry(void)
+{
+	policy_delete_egress_entry(0, 0, 0);
 }

--- a/bpf/tests/network_policy.c
+++ b/bpf/tests/network_policy.c
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+#include <node_config.h>
+
+#include <lib/policy.h>
+
+#include "lib/policy.h"
+
+#define REMOTE_IDENTITY		112233
+
+static __always_inline int
+check_egress_policy(struct __ctx_buff *ctx, __u32 dst_id, __u8 proto, __be16 dport)
+{
+	__u8 match_type;
+	__u8 audited;
+	__s8 ext_err;
+	__u16 proxy_port;
+
+	return policy_can_egress(ctx, &cilium_policy_v2,
+				 0 /* ignored */, dst_id,
+				 0 /* ICMP only */,
+				 dport, proto, 0 /* ICMP only */,
+				 &match_type, &audited, &ext_err, &proxy_port);
+}
+
+CHECK("tc", "network_policy_egress_allow")
+int network_policy_egress_allow_check(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	TEST("deny by default", {
+		int ret;
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+	});
+
+	TEST("L3+L4 policy", {
+		int ret;
+
+		policy_add_egress_allow_entry(REMOTE_IDENTITY, IPPROTO_UDP,
+					      __bpf_htons(80));
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(81));
+		assert(ret == DROP_POLICY);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		policy_delete_egress_entry(REMOTE_IDENTITY, IPPROTO_UDP,
+					   __bpf_htons(80));
+	});
+
+	TEST("wildcarded L4", {
+		int ret;
+
+		policy_add_egress_allow_entry(REMOTE_IDENTITY, IPPROTO_UDP, 0);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		policy_delete_egress_entry(REMOTE_IDENTITY, IPPROTO_UDP, 0);
+	});
+
+	TEST("wildcarded L3+L4", {
+		int ret;
+
+		policy_add_egress_allow_entry(REMOTE_IDENTITY, 0, 0);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		policy_delete_egress_entry(REMOTE_IDENTITY, 0, 0);
+	});
+
+	TEST("L3+L4 policy, any identity", {
+		int ret;
+
+		policy_add_egress_allow_entry(0, IPPROTO_UDP,
+					      __bpf_htons(80));
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(81));
+		assert(ret == DROP_POLICY);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		policy_delete_egress_entry(0, IPPROTO_UDP,
+					   __bpf_htons(80));
+	});
+
+	TEST("wildcarded L4, any-identity", {
+		int ret;
+
+		policy_add_egress_allow_entry(0, IPPROTO_UDP, 0);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		policy_delete_egress_entry(0, IPPROTO_UDP, 0);
+	});
+
+	TEST("wildcarded L3+L4, any identity [allow-all]", {
+		int ret;
+
+		policy_add_egress_allow_entry(0, 0, 0);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		policy_delete_egress_entry(0, 0, 0);
+	});
+
+	test_finish();
+}


### PR DESCRIPTION
Implement all the LPM-related parts for the policy key & value. And start adding unit tests for the BPF policy engine.