### PR TITLE
daemon: remove unused close method

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -736,11 +736,3 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	return &d, restoredEndpoints, nil
 }
-
-// Close shuts down a daemon
-func (d *Daemon) Close() {
-	d.idmgr.RemoveAll()
-
-	// Ensures all controllers are stopped!
-	d.controllers.RemoveAllAndWait()
-}

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -197,8 +197,6 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 
 		err := ds.hive.Stop(ds.log, ctx)
 		require.NoError(tb, err)
-
-		ds.d.Close()
 	})
 
 	return ds

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -61,10 +61,6 @@ func (h *agentHandle) tearDown() {
 			h.t.Fatalf("Failed to stop the agent: %s", err)
 		}
 	}
-
-	if h.d != nil {
-		h.d.Close()
-	}
 }
 
 func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraCell cell.Cell) {
@@ -137,7 +133,6 @@ func (h *agentHandle) populateCiliumAgentOptions(testDir string, modConfig func(
 	// (i.e. the ones defined through cell.Config(...)) must be set to the *viper.Viper
 	// object bound to the test hive.
 	h.hive.Viper().Set(option.EndpointGCInterval, 0)
-
 }
 
 func (h *agentHandle) startCiliumAgent() (*cmd.Daemon, error) {


### PR DESCRIPTION
This commit removes the unused method `Close` on the `Daemon`. It's only used in tests (but it seems no longer in prod code).

Note: The goal is to remove `Daemon.controllers` anyway (once it's no longer used - see https://github.com/cilium/cilium/pull/41905 & https://github.com/cilium/cilium/pull/41907).  Not sure whether we need to remove all identities from the identitymanager in the identitymanager hive cell via stop hook. But it seems nobody missed this cleanup anyway)