### PR TITLE
actions/eks: remove leftover ipsec:true entry

### DIFF
--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -5,7 +5,6 @@ include:
     region: us-west-1
   - version: "1.31"
     region: us-east-2
-    ipsec: true
   - version: "1.32"
     region: ca-central-1
     default: true


### PR DESCRIPTION
This entry should have been removed as part of commit a34335b0614c.

Fixes: a34335b0614c ("workflows/conformance-ipsec: introduce ipsec cloud conformance")
Reported-by: Paul Chaignon <paul.chaignon@gmail.com>
