### PR TITLE
.github/renovate: add postUpgradeTasks for cilium/charts

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -604,6 +604,21 @@
       }
     },
     {
+      "matchPackageNames": [
+        "github.com/cilium/charts"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "make -C Documentation update-cmdref"
+        ],
+        "fileFilters": [
+          "Documentation/cmdref/cilium_install.md",
+          "Documentation/cmdref/cilium_upgrade.md"
+        ],
+        "executionMode": "update"
+      }
+    },
+    {
       enabled: false,
       matchDepPatterns: [
         // k8s dependencies will be updated manually along with tests


### PR DESCRIPTION
When updating cilium/charts, renovate also needs to run a postUpgradeTask to generate the proper documentation.
