### PR TITLE
Fix BGP auto discovery not sending community info

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/default_gateway.go
+++ b/pkg/bgpv1/manager/reconcilerv2/default_gateway.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconcilerv2
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"slices"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
+	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// DefaultGatewayReconciler is a ConfigReconciler which handles auto-discovery
+// of peer addresses for DefaultGateway mode. It runs with the highest priority
+// to ensure peer addresses are populated before other reconcilers run.
+type DefaultGatewayReconciler struct {
+	logger      *slog.Logger
+	DB          *statedb.DB
+	routeTable  statedb.Table[*tables.Route]
+	deviceTable statedb.Table[*tables.Device]
+}
+
+type DefaultGatewayReconcilerOut struct {
+	cell.Out
+
+	Reconciler ConfigReconciler `group:"bgp-config-reconciler-v2"`
+}
+
+type DefaultGatewayReconcilerIn struct {
+	cell.In
+
+	Logger      *slog.Logger
+	DB          *statedb.DB
+	JobGroup    job.Group
+	Signaler    *signaler.BGPCPSignaler
+	RouteTable  statedb.Table[*tables.Route]
+	DeviceTable statedb.Table[*tables.Device]
+}
+
+var (
+	ipv4Default = netip.PrefixFrom(netip.IPv4Unspecified(), 0)
+	ipv6Default = netip.PrefixFrom(netip.IPv6Unspecified(), 0)
+)
+
+func NewDefaultGatewayReconciler(p DefaultGatewayReconcilerIn) DefaultGatewayReconcilerOut {
+	logger := p.Logger.With(types.ReconcilerLogField, "DefaultGateway")
+
+	// Add job observers for route and device change tracking
+	p.JobGroup.Add(
+		job.Observer("default-gateway-route-change-tracker",
+			routeChangeTrackerObserver(p.Signaler, logger),
+			statedb.Observable(p.DB, p.RouteTable)),
+	)
+
+	p.JobGroup.Add(
+		job.Observer("device-change-device-change-tracker",
+			deviceChangeTrackerObserver(p.Signaler, logger),
+			statedb.Observable(p.DB, p.DeviceTable)),
+	)
+
+	return DefaultGatewayReconcilerOut{
+		Reconciler: &DefaultGatewayReconciler{
+			logger:      logger,
+			DB:          p.DB,
+			routeTable:  p.RouteTable,
+			deviceTable: p.DeviceTable,
+		},
+	}
+}
+
+func (r *DefaultGatewayReconciler) Name() string {
+	return DefaultGatewayReconcilerName
+}
+
+// Priority of default gateway reconciler is lower than pod cidr reconciler.
+// This is so that pod cidr does not skip setting the policy due to peer address not being set.
+func (r *DefaultGatewayReconciler) Priority() int {
+	return DefaultGatewayReconcilerPriority
+}
+
+func (r *DefaultGatewayReconciler) Init(i *instance.BGPInstance) error {
+	if i == nil {
+		return fmt.Errorf("BUG: default gateway reconciler initialization with nil BGPInstance")
+	}
+	return nil
+}
+
+func (r *DefaultGatewayReconciler) Cleanup(i *instance.BGPInstance) {
+}
+
+func (r *DefaultGatewayReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
+	if err := p.ValidateParams(); err != nil {
+		return err
+	}
+
+	l := r.logger.With(types.InstanceLogField, p.DesiredConfig.Name)
+
+	for i, peer := range p.DesiredConfig.Peers {
+		if peer.PeerAddress != nil || peer.AutoDiscovery == nil {
+			continue
+		}
+
+		switch peer.AutoDiscovery.Mode {
+		case v2.BGPDefaultGatewayMode:
+			defaultGateway, err := r.getDefaultGateway(peer.AutoDiscovery.DefaultGateway)
+			if err != nil {
+				l.Debug("Failed to get default gateway, skipping",
+					logfields.Error, err)
+				continue
+			}
+
+			p.DesiredConfig.Peers[i].PeerAddress = &defaultGateway
+
+			l.Debug("Auto-discovered peer address",
+				types.PeerLogField, peer.Name,
+				logfields.Address, defaultGateway)
+		default:
+			l.Debug("Unsupported auto-discovery mode",
+				types.PeerLogField, peer.Name,
+				logfields.Mode, peer.AutoDiscovery.Mode)
+			continue
+		}
+	}
+
+	return nil
+}
+
+// getDefaultGateway returns the default gateway address with lower priority using route and device
+// statedb tables and the provided default gateway configuration.
+func (r *DefaultGatewayReconciler) getDefaultGateway(defaultGateway *v2.DefaultGateway) (string, error) {
+	var defaultRoute netip.Prefix
+	switch defaultGateway.AddressFamily {
+	case "ipv4":
+		defaultRoute = ipv4Default
+	case "ipv6":
+		defaultRoute = ipv6Default
+	default:
+		return "", fmt.Errorf("invalid address family %s", defaultGateway.AddressFamily)
+	}
+
+	txn := r.DB.ReadTxn()
+	// get routes from statedb route table
+	// TODO: add RoutePrefixIndex Query to lookup routes by prefix
+	routes := r.routeTable.All(txn)
+	activeDefaultRoutes := []*tables.Route{}
+
+	for route := range routes {
+		// ignore routes that are not default routes or do not have a valid gateway
+		if !route.Gw.IsValid() || route.Dst != defaultRoute {
+			continue
+		}
+		dev, _, found := r.deviceTable.Get(txn, tables.DeviceIDIndex.Query(route.LinkIndex))
+		// ignore routes if the link through which it is reachable is not up
+		if !found || dev.OperStatus != "up" {
+			continue
+		}
+		if route.Gw.IsLinkLocalUnicast() {
+			r.logger.Warn("link local address is not supported for default gateway mode of bgp auto-discovery",
+				logfields.Gateway, route.Gw,
+			)
+			continue
+		}
+		activeDefaultRoutes = append(activeDefaultRoutes, route)
+	}
+
+	if len(activeDefaultRoutes) == 0 {
+		return "", fmt.Errorf("no active default route found")
+	}
+
+	// return the gateway address with lowest priority
+	return slices.MinFunc(activeDefaultRoutes, func(r0, r1 *tables.Route) int {
+		return cmp.Compare(r0.Priority, r1.Priority)
+	}).Gw.String(), nil
+}
+
+// routeChangeTrackerObserver triggers BGP reconciliation when there is a change in IPv4 or IPv6 default route
+func routeChangeTrackerObserver(signaler *signaler.BGPCPSignaler, logger *slog.Logger) job.ObserverFunc[statedb.Change[*tables.Route]] {
+	return func(ctx context.Context, event statedb.Change[*tables.Route]) error {
+		route := event.Object
+		// check for default route change
+		if route.Dst == ipv4Default ||
+			route.Dst == ipv6Default {
+			// trigger reconciliation for default route changes
+			signaler.Event(struct{}{})
+			logger.Debug("Default route change detected, triggering BGP reconciliation")
+		}
+		return nil
+	}
+}
+
+// deviceChangeTrackerObserver triggers BGP reconciliation when there is a change in the device table
+func deviceChangeTrackerObserver(signaler *signaler.BGPCPSignaler, logger *slog.Logger) job.ObserverFunc[statedb.Change[*tables.Device]] {
+	return func(ctx context.Context, event statedb.Change[*tables.Device]) error {
+		// trigger reconciliation for device changes
+		signaler.Event(struct{}{})
+		logger.Debug("Device change detected, triggering BGP reconciliation")
+		return nil
+	}
+}

--- a/pkg/bgpv1/manager/reconcilerv2/default_gateway_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/default_gateway_test.go
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconcilerv2
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
+	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+func TestDefaultGatewayReconciler_Basic(t *testing.T) {
+	// Test basic functionality
+	reconciler := &DefaultGatewayReconciler{
+		logger: hivetest.Logger(t),
+	}
+
+	// Test Name and Priority
+	assert.Equal(t, "DefaultGateway", reconciler.Name())
+	assert.Equal(t, 10, reconciler.Priority())
+
+	// Test Init and Cleanup
+	bgpInstance := &instance.BGPInstance{Name: "test-instance"}
+	err := reconciler.Init(bgpInstance)
+	assert.NoError(t, err)
+	reconciler.Cleanup(bgpInstance)
+}
+
+func TestDefaultGatewayReconciler_Reconcile(t *testing.T) {
+	req := require.New(t)
+
+	// Test data
+	defaultRouteTable := []*tables.Route{
+		{
+			Dst:       netip.MustParsePrefix("0.0.0.0/0"),
+			Gw:        netip.MustParseAddr("192.168.0.3"),
+			LinkIndex: 123,
+			Priority:  100,
+		},
+		{
+			Dst:       netip.MustParsePrefix("0.0.0.0/0"),
+			Gw:        netip.MustParseAddr("192.168.0.4"),
+			LinkIndex: 124,
+			Priority:  200,
+		},
+		{
+			Dst:       netip.MustParsePrefix("::/0"),
+			Gw:        netip.MustParseAddr("fd00:10:0:1::1"),
+			LinkIndex: 124,
+			Priority:  200,
+		},
+	}
+
+	table := []struct {
+		name             string
+		routes           []*tables.Route
+		newRoutes        []*tables.Route
+		peers            []v2.CiliumBGPNodePeer
+		expectedPeers    []v2.CiliumBGPNodePeer
+		newPeers         []v2.CiliumBGPNodePeer
+		expectedNewPeers []v2.CiliumBGPNodePeer
+		err              error
+	}{
+		{
+			name:   "default gateway no change",
+			routes: defaultRouteTable,
+			peers: []v2.CiliumBGPNodePeer{
+				{
+					Name: "peer-3",
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			expectedPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-3",
+					PeerAddress: ptr.To[string]("192.168.0.3"),
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			newPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name: "peer-3",
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			expectedNewPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-3",
+					PeerAddress: ptr.To[string]("192.168.0.3"),
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			err: nil,
+		},
+		{
+			name:   "add ipv4 default gateway peer",
+			routes: defaultRouteTable,
+			peers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-1",
+					PeerAddress: ptr.To[string]("192.168.0.1"),
+					PeerASN:     ptr.To[int64](64124),
+				},
+			},
+			expectedPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-1",
+					PeerAddress: ptr.To[string]("192.168.0.1"),
+					PeerASN:     ptr.To[int64](64124),
+				},
+			},
+			newPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name: "peer-3",
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			expectedNewPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-3",
+					PeerAddress: ptr.To[string]("192.168.0.3"),
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			err: nil,
+		},
+		{
+			name:   "add ipv6 default gateway peer",
+			routes: defaultRouteTable,
+			peers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-2",
+					PeerAddress: ptr.To[string]("192.168.0.2"),
+					PeerASN:     ptr.To[int64](64124),
+				},
+			},
+			expectedPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-2",
+					PeerAddress: ptr.To[string]("192.168.0.2"),
+					PeerASN:     ptr.To[int64](64124),
+				},
+			},
+			newPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name: "peer-4",
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv6",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			expectedNewPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-4",
+					PeerAddress: ptr.To[string]("fd00:10:0:1::1"),
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv6",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			err: nil,
+		},
+		{
+			name:   "update priority of default route",
+			routes: defaultRouteTable,
+			peers: []v2.CiliumBGPNodePeer{
+				{
+					Name: "peer-3",
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			expectedPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-3",
+					PeerAddress: ptr.To[string]("192.168.0.3"),
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			newRoutes: []*tables.Route{
+				{
+					Dst:       netip.MustParsePrefix("0.0.0.0/0"),
+					Gw:        netip.MustParseAddr("192.168.0.3"),
+					LinkIndex: 123,
+					Priority:  200,
+				},
+				{
+					Dst:       netip.MustParsePrefix("0.0.0.0/0"),
+					Gw:        netip.MustParseAddr("192.168.0.4"),
+					LinkIndex: 124,
+					Priority:  100,
+				},
+			},
+			newPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name: "peer-3",
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			expectedNewPeers: []v2.CiliumBGPNodePeer{
+				{
+					Name:        "peer-3",
+					PeerAddress: ptr.To[string]("192.168.0.4"),
+					AutoDiscovery: &v2.BGPAutoDiscovery{
+						Mode: v2.BGPDefaultGatewayMode,
+						DefaultGateway: &v2.DefaultGateway{
+							AddressFamily: "ipv4",
+						},
+					},
+					PeerASN: ptr.To[int64](64124),
+				},
+			},
+			err: nil,
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup BGP instance
+			testInstance, err := setupBGPInstance(hivetest.Logger(t))
+			req.NoError(err)
+
+			t.Cleanup(func() {
+				testInstance.Router.Stop(context.Background(), types.StopRequest{FullDestroy: true})
+			})
+
+			// Setup state database
+			db, err := setupStateDB(tt.routes)
+			req.NoError(err)
+
+			txn := db.ReadTxn()
+			routeTable := db.GetTable(txn, "routes").(statedb.Table[*tables.Route])
+			deviceTable := db.GetTable(txn, "devices").(statedb.Table[*tables.Device])
+
+			// Create reconciler
+			reconciler := &DefaultGatewayReconciler{
+				logger:      hivetest.Logger(t),
+				DB:          db,
+				routeTable:  routeTable,
+				deviceTable: deviceTable,
+			}
+
+			// Test initial reconciliation
+			desiredConfig := &v2.CiliumBGPNodeInstance{
+				Name:  "test-instance",
+				Peers: tt.peers,
+			}
+
+			reconcileParams := ReconcileParams{
+				BGPInstance:   testInstance,
+				DesiredConfig: desiredConfig,
+				CiliumNode: &v2.CiliumNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-node",
+					},
+				},
+			}
+
+			err = reconciler.Init(testInstance)
+			req.NoError(err)
+			defer reconciler.Cleanup(testInstance)
+
+			err = reconciler.Reconcile(context.Background(), reconcileParams)
+			req.NoError(err)
+
+			// Validate initial peers
+			validatePeers(req, tt.expectedPeers, desiredConfig.Peers)
+
+			// Test updated reconciliation
+			routes := tt.routes
+			if tt.newRoutes != nil {
+				routes = tt.newRoutes
+			}
+
+			db, err = setupStateDB(routes)
+			req.NoError(err)
+
+			txn = db.ReadTxn()
+			routeTable = db.GetTable(txn, "routes").(statedb.Table[*tables.Route])
+			deviceTable = db.GetTable(txn, "devices").(statedb.Table[*tables.Device])
+
+			reconciler.DB = db
+			reconciler.routeTable = routeTable
+			reconciler.deviceTable = deviceTable
+
+			desiredConfig = &v2.CiliumBGPNodeInstance{
+				Name:  "test-instance",
+				Peers: tt.newPeers,
+			}
+
+			reconcileParams = ReconcileParams{
+				BGPInstance:   testInstance,
+				DesiredConfig: desiredConfig,
+				CiliumNode: &v2.CiliumNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-node",
+					},
+				},
+			}
+
+			err = reconciler.Reconcile(context.Background(), reconcileParams)
+			req.NoError(err)
+
+			// Validate updated peers
+			validatePeers(req, tt.expectedNewPeers, desiredConfig.Peers)
+		})
+	}
+}
+
+func TestDefaultGatewayTrackerObserver(t *testing.T) {
+	table := []struct {
+		name      string
+		route     *tables.Route
+		isDefault bool
+		err       error
+	}{
+		{
+			name: "IPv4 default route",
+			route: &tables.Route{
+				Table:     tables.RT_TABLE_MAIN,
+				LinkIndex: 1,
+				Dst:       ipv4Default,
+				Gw:        netip.MustParseAddr("192.168.1.1"),
+				Priority:  100,
+			},
+			isDefault: true,
+		},
+		{
+			name: "IPv6 default route",
+			route: &tables.Route{
+				Table:     tables.RT_TABLE_MAIN,
+				LinkIndex: 1,
+				Dst:       ipv6Default,
+				Gw:        netip.MustParseAddr("2001:db8::1"),
+				Priority:  100,
+			},
+			isDefault: true,
+		},
+		{
+			name: "Non-default IPv4 route",
+			route: &tables.Route{
+				Table:     tables.RT_TABLE_MAIN,
+				LinkIndex: 1,
+				Dst:       netip.MustParsePrefix("10.0.0.0/24"),
+				Gw:        netip.MustParseAddr("192.168.1.1"),
+				Priority:  100,
+			},
+			isDefault: false,
+		},
+		{
+			name: "Non-default IPv6 route",
+			route: &tables.Route{
+				Table:     tables.RT_TABLE_MAIN,
+				LinkIndex: 1,
+				Dst:       netip.MustParsePrefix("fd00:10:0:1::/64"),
+				Gw:        netip.MustParseAddr("fd00:10:0:1::1"),
+				Priority:  100,
+			},
+			isDefault: false,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			signaler := signaler.NewBGPCPSignaler()
+			logger := hivetest.Logger(t)
+
+			// Get the observer function
+			observerFunc := routeChangeTrackerObserver(signaler, logger)
+
+			// Call the observer function with the test route
+			err := observerFunc(context.Background(), statedb.Change[*tables.Route]{
+				Object:   tt.route,
+				Revision: 1,
+				Deleted:  false,
+			})
+			require.NoError(t, err)
+
+			// Check if an event was triggered by checking if there's a signal in the channel
+			select {
+			case <-signaler.Sig:
+				if !tt.isDefault {
+					t.Fatal("Unexpected signal received for non-default route")
+				}
+				// Success - we received a signal and its a default route
+			default:
+				if tt.isDefault {
+					t.Fatal("Expected signal was not received")
+				}
+				// Success - we didn't receive a signal and its not a default route
+			}
+		})
+	}
+}
+
+func TestDeviceChangeTrackerObserver(t *testing.T) {
+	table := []struct {
+		name   string
+		device *tables.Device
+	}{
+		{
+			name: "Device change",
+			device: &tables.Device{
+				Name:       "net0",
+				Index:      1,
+				OperStatus: "up",
+			},
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			signaler := signaler.NewBGPCPSignaler()
+			logger := hivetest.Logger(t)
+
+			// Get the observer function
+			observerFunc := deviceChangeTrackerObserver(signaler, logger)
+
+			// Call the observer function with the test device
+			err := observerFunc(context.Background(), statedb.Change[*tables.Device]{
+				Object:   tt.device,
+				Revision: 1,
+				Deleted:  false,
+			})
+			require.NoError(t, err)
+
+			// Check if an event was triggered by checking if there's a signal in the channel
+			select {
+			case <-signaler.Sig:
+				// Success - we received a signal and its a device change
+			default:
+				t.Fatal("Expected signal was not received")
+			}
+		})
+	}
+}
+
+func setupBGPInstance(logger *slog.Logger) (*instance.BGPInstance, error) {
+	// our test BgpServer with our original router ID and local port
+	srvParams := types.ServerParameters{
+		Global: types.BGPGlobal{
+			ASN:        64125,
+			RouterID:   "127.0.0.1",
+			ListenPort: -1,
+		},
+	}
+
+	testInstance, err := instance.NewBGPInstance(context.Background(), logger, "test-instance", srvParams)
+	return testInstance, err
+}
+
+func setupStateDB(routes []*tables.Route) (*statedb.DB, error) {
+	// create a test statedb
+	db := statedb.New()
+
+	if len(routes) == 0 {
+		return db, nil
+	}
+	routeTable, err := tables.NewRouteTable(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create default gateway table: %w", err)
+	}
+	deviceTable, err := tables.NewDeviceTable(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create device table: %w", err)
+	}
+	txn := db.WriteTxn(routeTable, deviceTable)
+	for _, r := range routes {
+		routeTable.Insert(txn, r)
+	}
+
+	deviceTable.Insert(txn, &tables.Device{
+		Name:       "eth0",
+		Index:      123,
+		OperStatus: "up",
+	})
+	deviceTable.Insert(txn, &tables.Device{
+		Name:       "eth1",
+		Index:      124,
+		OperStatus: "up",
+	})
+	txn.Commit()
+
+	return db, nil
+}
+
+func validatePeers(req *require.Assertions, expected, actual []v2.CiliumBGPNodePeer) {
+	req.Len(actual, len(expected))
+
+	for _, expPeer := range expected {
+		found := false
+		for _, actPeer := range actual {
+			if expPeer.Name == actPeer.Name {
+				found = true
+				if expPeer.PeerAddress != nil {
+					req.NotNil(actPeer.PeerAddress)
+					req.Equal(*expPeer.PeerAddress, *actPeer.PeerAddress)
+				}
+				if expPeer.PeerASN != nil {
+					req.NotNil(actPeer.PeerASN)
+					req.Equal(*expPeer.PeerASN, *actPeer.PeerASN)
+				}
+				break
+			}
+		}
+		req.True(found, "Expected peer %s not found", expPeer.Name)
+	}
+}

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor.go
@@ -4,27 +4,19 @@
 package reconcilerv2
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/netip"
-	"slices"
 
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/hive/job"
-	"github.com/cilium/statedb"
 
-	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
-	"github.com/cilium/cilium/pkg/datapath/tables"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -32,9 +24,6 @@ import (
 // provided BGP server with the provided CiliumBGPVirtualRouter.
 type NeighborReconciler struct {
 	logger       *slog.Logger
-	DB           *statedb.DB
-	routeTable   statedb.Table[*tables.Route]
-	deviceTable  statedb.Table[*tables.Device]
 	SecretStore  store.BGPCPResourceStore[*slim_corev1.Secret]
 	PeerConfig   store.BGPCPResourceStore[*v2.CiliumBGPPeerConfig]
 	DaemonConfig *option.DaemonConfig
@@ -53,70 +42,19 @@ type NeighborReconcilerIn struct {
 	SecretStore  store.BGPCPResourceStore[*slim_corev1.Secret]
 	PeerConfig   store.BGPCPResourceStore[*v2.CiliumBGPPeerConfig]
 	DaemonConfig *option.DaemonConfig
-
-	DB          *statedb.DB
-	JobGroup    job.Group
-	Signaler    *signaler.BGPCPSignaler
-	RouteTable  statedb.Table[*tables.Route]
-	DeviceTable statedb.Table[*tables.Device]
 }
-
-var (
-	ipv4Default = netip.PrefixFrom(netip.IPv4Unspecified(), 0)
-	ipv6Default = netip.PrefixFrom(netip.IPv6Unspecified(), 0)
-)
 
 func NewNeighborReconciler(params NeighborReconcilerIn) NeighborReconcilerOut {
 	logger := params.Logger.With(types.ReconcilerLogField, "Neighbor")
 
-	params.JobGroup.Add(
-		job.Observer("default-gateway-route-change-tracker",
-			routeChangeTrackerObserver(params.Signaler, params.Logger),
-			statedb.Observable(params.DB, params.RouteTable)),
-	)
-
-	params.JobGroup.Add(
-		job.Observer("device-change-device-change-tracker",
-			deviceChangeTrackerObserver(params.Signaler, params.Logger),
-			statedb.Observable(params.DB, params.DeviceTable)),
-	)
-
 	return NeighborReconcilerOut{
 		Reconciler: &NeighborReconciler{
 			logger:       logger,
-			DB:           params.DB,
-			routeTable:   params.RouteTable,
-			deviceTable:  params.DeviceTable,
 			SecretStore:  params.SecretStore,
 			PeerConfig:   params.PeerConfig,
 			DaemonConfig: params.DaemonConfig,
 			metadata:     make(map[string]NeighborReconcilerMetadata),
 		},
-	}
-}
-
-// routeChangeTrackerObserver triggers BGP reconciliation when there is a change in IPv4 or IPv6 default route
-func routeChangeTrackerObserver(signaler *signaler.BGPCPSignaler, logger *slog.Logger) job.ObserverFunc[statedb.Change[*tables.Route]] {
-	return func(ctx context.Context, event statedb.Change[*tables.Route]) error {
-		route := event.Object
-		// check for default route change
-		if route.Dst == ipv4Default ||
-			route.Dst == ipv6Default {
-			// trigger reconciliation for default route changes
-			signaler.Event(struct{}{})
-			logger.Debug("Default route change detected, triggering BGP reconciliation")
-		}
-		return nil
-	}
-}
-
-// deviceChangeTrackerObserver triggers BGP reconciliation when there is a change in the device table
-func deviceChangeTrackerObserver(signaler *signaler.BGPCPSignaler, logger *slog.Logger) job.ObserverFunc[statedb.Change[*tables.Device]] {
-	return func(ctx context.Context, event statedb.Change[*tables.Device]) error {
-		// trigger reconciliation for device changes
-		signaler.Event(struct{}{})
-		logger.Debug("Device change detected, triggering BGP reconciliation")
-		return nil
 	}
 }
 
@@ -211,21 +149,8 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		}
 
 		if n.PeerAddress == nil {
-			// future auto-discovery modes can be added here to get the peer address
-			switch n.AutoDiscovery.Mode {
-			case v2.BGPDefaultGatewayMode:
-				defaultGateway, err := r.getDefaultGateway(n.AutoDiscovery.DefaultGateway)
-				if err != nil {
-					l.Debug("failed to get default gateway, skipping",
-						logfields.Error,
-						err)
-					continue
-				}
-				newNeigh[i].PeerAddress = &defaultGateway
-			default:
-				l.Debug("Peer does not have PeerAddress configured, skipping")
-				continue
-			}
+			l.Debug("Peer does not have PeerAddress configured, skipping")
+			continue
 		}
 
 		var (
@@ -338,50 +263,6 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 
 	l.Debug("Done reconciling peers")
 	return nil
-}
-
-// getDefaultGateway returns the default gateway address with lower priority using route and device
-// statedb tables and the provided default gateway configuration.
-func (r *NeighborReconciler) getDefaultGateway(defaultGateway *v2.DefaultGateway) (string, error) {
-	var defaultRoute netip.Prefix
-	switch defaultGateway.AddressFamily {
-	case "ipv4":
-		defaultRoute = ipv4Default
-	case "ipv6":
-		defaultRoute = ipv6Default
-	default:
-		return "", fmt.Errorf("invalid address family %s", defaultGateway.AddressFamily)
-	}
-	txn := r.DB.ReadTxn()
-	// get routes from statedb route table
-	// TODO: add RoutePrefixIndex Query to lookup routes by prefix
-	routes := r.routeTable.All(txn)
-	activeDefaultRoutes := []*tables.Route{}
-	for route := range routes {
-		// ignore routes that are not default routes or do not have a valid gateway
-		if !route.Gw.IsValid() || route.Dst != defaultRoute {
-			continue
-		}
-		dev, _, found := r.deviceTable.Get(txn, tables.DeviceIDIndex.Query(route.LinkIndex))
-		// ignore routes if the link through which it is reachable is not up
-		if !found || dev.OperStatus != "up" {
-			continue
-		}
-		if route.Gw.IsLinkLocalUnicast() {
-			r.logger.Warn("link local address is not supported for default gateway mode of bgp auto-discovery",
-				logfields.Gateway, route.Gw,
-			)
-			continue
-		}
-		activeDefaultRoutes = append(activeDefaultRoutes, route)
-	}
-	if len(activeDefaultRoutes) == 0 {
-		return "", fmt.Errorf("no active default route found")
-	}
-	// return the gateway address with lowest priority
-	return slices.MinFunc(activeDefaultRoutes, func(r0, r1 *tables.Route) int {
-		return cmp.Compare(r0.Priority, r1.Priority)
-	}).Gw.String(), nil
 }
 
 // getPeerConfig returns the CiliumBGPPeerConfigSpec for the given peerConfig.

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
@@ -5,35 +5,22 @@ package reconcilerv2
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
-	"net/netip"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
-	"github.com/cilium/cilium/pkg/datapath/tables"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/option"
 )
-
-type checks struct {
-	holdTimer         bool
-	connectRetryTimer bool
-	keepaliveTimer    bool
-	grRestartTime     bool
-}
 
 var (
 	peer1 = PeerData{
@@ -149,130 +136,6 @@ var (
 
 		return peer2Copy
 	}()
-
-	peer3 = PeerData{
-		Peer: &v2.CiliumBGPNodePeer{
-			Name: "peer-3",
-			AutoDiscovery: &v2.BGPAutoDiscovery{
-				Mode: "DefaultGateway",
-				DefaultGateway: &v2.DefaultGateway{
-					AddressFamily: "ipv4",
-				},
-			},
-			PeerASN: ptr.To[int64](64124),
-			PeerConfigRef: &v2.PeerConfigReference{
-				Name: "peer-config",
-			},
-		},
-		Config: &v2.CiliumBGPPeerConfigSpec{
-			Transport: &v2.CiliumBGPTransport{
-				PeerPort: ptr.To[int32](v2.DefaultBGPPeerPort),
-			},
-		},
-	}
-
-	expectedPeer3 = PeerData{
-		Peer: &v2.CiliumBGPNodePeer{
-			Name:        "peer-3",
-			PeerAddress: ptr.To[string]("192.168.0.3"),
-			AutoDiscovery: &v2.BGPAutoDiscovery{
-				Mode: "DefaultGateway",
-				DefaultGateway: &v2.DefaultGateway{
-					AddressFamily: "ipv4",
-				},
-			},
-			PeerASN: ptr.To[int64](64124),
-			PeerConfigRef: &v2.PeerConfigReference{
-				Name: "peer-config",
-			},
-		},
-		Config: &v2.CiliumBGPPeerConfigSpec{
-			Transport: &v2.CiliumBGPTransport{
-				PeerPort: ptr.To[int32](v2.DefaultBGPPeerPort),
-			},
-		},
-	}
-
-	expectedPeer3PriorityUpdated = PeerData{
-		Peer: &v2.CiliumBGPNodePeer{
-			Name:        "peer-4",
-			PeerAddress: ptr.To[string]("192.168.0.4"),
-			AutoDiscovery: &v2.BGPAutoDiscovery{
-				Mode: "DefaultGateway",
-				DefaultGateway: &v2.DefaultGateway{
-					AddressFamily: "ipv4",
-				},
-			},
-			PeerASN: ptr.To[int64](64124),
-			PeerConfigRef: &v2.PeerConfigReference{
-				Name: "peer-config",
-			},
-		},
-		Config: &v2.CiliumBGPPeerConfigSpec{
-			Transport: &v2.CiliumBGPTransport{
-				PeerPort: ptr.To[int32](v2.DefaultBGPPeerPort),
-			},
-		},
-	}
-
-	peer3UpdatedPeerAddress = PeerData{
-		Peer: &v2.CiliumBGPNodePeer{
-			Name:        "peer-3",
-			PeerAddress: ptr.To[string]("192.168.0.3"),
-			PeerASN:     ptr.To[int64](64124),
-			PeerConfigRef: &v2.PeerConfigReference{
-				Name: "peer-config",
-			},
-		},
-		Config: &v2.CiliumBGPPeerConfigSpec{
-			Transport: &v2.CiliumBGPTransport{
-				PeerPort: ptr.To[int32](v2.DefaultBGPPeerPort),
-			},
-		},
-	}
-
-	peer4 = PeerData{
-		Peer: &v2.CiliumBGPNodePeer{
-			Name: "peer-4",
-			AutoDiscovery: &v2.BGPAutoDiscovery{
-				Mode: "DefaultGateway",
-				DefaultGateway: &v2.DefaultGateway{
-					AddressFamily: "ipv6",
-				},
-			},
-			PeerASN: ptr.To[int64](64124),
-			PeerConfigRef: &v2.PeerConfigReference{
-				Name: "peer-config",
-			},
-		},
-		Config: &v2.CiliumBGPPeerConfigSpec{
-			Transport: &v2.CiliumBGPTransport{
-				PeerPort: ptr.To[int32](v2.DefaultBGPPeerPort),
-			},
-		},
-	}
-
-	expectedPeer4 = PeerData{
-		Peer: &v2.CiliumBGPNodePeer{
-			Name:        "peer-4",
-			PeerAddress: ptr.To[string]("fd00:10:0:1::1"),
-			AutoDiscovery: &v2.BGPAutoDiscovery{
-				Mode: "DefaultGateway",
-				DefaultGateway: &v2.DefaultGateway{
-					AddressFamily: "ipv6",
-				},
-			},
-			PeerASN: ptr.To[int64](64124),
-			PeerConfigRef: &v2.PeerConfigReference{
-				Name: "peer-config",
-			},
-		},
-		Config: &v2.CiliumBGPPeerConfigSpec{
-			Transport: &v2.CiliumBGPTransport{
-				PeerPort: ptr.To[int32](v2.DefaultBGPPeerPort),
-			},
-		},
-	}
 )
 
 // TestNeighborReconciler_StaticPeer confirms the `neighborReconciler` function configures
@@ -285,7 +148,6 @@ func TestNeighborReconciler_StaticPeer(t *testing.T) {
 		neighbors    []PeerData
 		newNeighbors []PeerData
 		secretStore  resource.Store[*slim_corev1.Secret]
-		checks       checks
 		err          error
 	}{
 		{
@@ -364,7 +226,6 @@ func TestNeighborReconciler_StaticPeer(t *testing.T) {
 			neighborReconciler := NeighborReconcilerOut{
 				Reconciler: &NeighborReconciler{
 					logger:       params.Logger,
-					DB:           params.DB,
 					SecretStore:  params.SecretStore,
 					PeerConfig:   params.PeerConfig,
 					DaemonConfig: params.DaemonConfig,
@@ -386,7 +247,7 @@ func TestNeighborReconciler_StaticPeer(t *testing.T) {
 			req.NoError(err)
 
 			// validate neighbors
-			validatePeers(req, tt.neighbors, getRunningPeers(req, testInstance), tt.checks)
+			validatePeerData(req, tt.neighbors, getRunningPeers(req, testInstance))
 
 			// update neighbors
 
@@ -406,335 +267,9 @@ func TestNeighborReconciler_StaticPeer(t *testing.T) {
 			req.NoError(err)
 
 			// validate neighbors
-			validatePeers(req, tt.newNeighbors, getRunningPeers(req, testInstance), tt.checks)
+			validatePeerData(req, tt.newNeighbors, getRunningPeers(req, testInstance))
 		})
 	}
-}
-
-func TestNeighborReconciler_DefaultGateway(t *testing.T) {
-	req := require.New(t)
-	defaultRouteTable := []*tables.Route{
-		{
-			Dst:       netip.MustParsePrefix("0.0.0.0/0"),
-			Gw:        netip.MustParseAddr("192.168.0.3"),
-			LinkIndex: 123,
-			Priority:  100,
-		},
-		{
-			Dst:       netip.MustParsePrefix("0.0.0.0/0"),
-			Gw:        netip.MustParseAddr("192.168.0.4"),
-			LinkIndex: 124,
-			Priority:  200,
-		},
-		{
-			Dst:       netip.MustParsePrefix("::/0"),
-			Gw:        netip.MustParseAddr("fd00:10:0:1::1"),
-			LinkIndex: 124,
-			Priority:  200,
-		},
-	}
-	table := []struct {
-		name                 string
-		routes               []*tables.Route
-		newRoutes            []*tables.Route
-		neighbors            []PeerData
-		expectedNeighbors    []PeerData
-		newNeighbors         []PeerData
-		expectedNewNeighbors []PeerData
-		checks               checks
-		err                  error
-	}{
-		{
-			name:                 "default gateway no change",
-			routes:               defaultRouteTable,
-			neighbors:            []PeerData{peer3},
-			expectedNeighbors:    []PeerData{expectedPeer3},
-			newNeighbors:         []PeerData{peer3},
-			expectedNewNeighbors: []PeerData{expectedPeer3},
-			err:                  nil,
-		},
-		{
-			name:                 "add ipv4 default gateway peer",
-			routes:               defaultRouteTable,
-			neighbors:            []PeerData{peer1},
-			expectedNeighbors:    []PeerData{peer1},
-			newNeighbors:         []PeerData{peer3},
-			expectedNewNeighbors: []PeerData{expectedPeer3},
-			err:                  nil,
-		},
-		{
-			name:                 "add ipv6 default gateway peer",
-			routes:               defaultRouteTable,
-			neighbors:            []PeerData{peer2},
-			expectedNeighbors:    []PeerData{peer2},
-			newNeighbors:         []PeerData{peer4},
-			expectedNewNeighbors: []PeerData{expectedPeer4},
-			err:                  nil,
-		},
-		{
-			name:              "remove default gateway peer",
-			routes:            defaultRouteTable,
-			neighbors:         []PeerData{peer3, peer2},
-			expectedNeighbors: []PeerData{expectedPeer3, peer2},
-
-			newNeighbors:         []PeerData{peer2},
-			expectedNewNeighbors: []PeerData{peer2},
-			err:                  nil,
-		},
-		{
-			name:                 "update default gateway to static peer",
-			routes:               defaultRouteTable,
-			neighbors:            []PeerData{peer3},
-			expectedNeighbors:    []PeerData{expectedPeer3},
-			newNeighbors:         []PeerData{peer3UpdatedPeerAddress},
-			expectedNewNeighbors: []PeerData{peer3UpdatedPeerAddress},
-			err:                  nil,
-		},
-		{
-			name:              "update priority of default route",
-			routes:            defaultRouteTable,
-			neighbors:         []PeerData{peer3},
-			expectedNeighbors: []PeerData{expectedPeer3},
-			newRoutes: []*tables.Route{
-				{
-					Dst:       netip.MustParsePrefix("0.0.0.0/0"),
-					Gw:        netip.MustParseAddr("192.168.0.3"),
-					LinkIndex: 123,
-					Priority:  200,
-				},
-				{
-					Dst:       netip.MustParsePrefix("0.0.0.0/0"),
-					Gw:        netip.MustParseAddr("192.168.0.4"),
-					LinkIndex: 124,
-					Priority:  100,
-				},
-			},
-			newNeighbors:         []PeerData{peer3},
-			expectedNewNeighbors: []PeerData{expectedPeer3PriorityUpdated},
-			err:                  nil,
-		},
-	}
-	for _, tt := range table {
-		t.Run(tt.name, func(t *testing.T) {
-
-			testInstance, err := setupBGPInstance(hivetest.Logger(t))
-			req.NoError(err)
-
-			t.Cleanup(func() {
-				testInstance.Router.Stop(context.Background(), types.StopRequest{FullDestroy: true})
-			})
-
-			params, nodeConfig := setupNeighbors(t, tt.neighbors)
-
-			db, err := setupStateDB(tt.routes)
-			req.NoError(err)
-			params.DB = db
-			txn := db.ReadTxn()
-			params.RouteTable = db.GetTable(txn, "routes").(statedb.Table[*tables.Route])
-			params.DeviceTable = db.GetTable(txn, "devices").(statedb.Table[*tables.Device])
-
-			// setup initial neighbors
-			neighborReconciler := NeighborReconcilerOut{
-				Reconciler: &NeighborReconciler{
-					logger:       params.Logger,
-					DB:           params.DB,
-					routeTable:   params.RouteTable,
-					deviceTable:  params.DeviceTable,
-					SecretStore:  params.SecretStore,
-					PeerConfig:   params.PeerConfig,
-					DaemonConfig: params.DaemonConfig,
-					metadata:     make(map[string]NeighborReconcilerMetadata),
-				},
-			}.Reconciler
-			neighborReconciler.Init(testInstance)
-			defer neighborReconciler.Cleanup(testInstance)
-			reconcileParams := ReconcileParams{
-				BGPInstance:   testInstance,
-				DesiredConfig: nodeConfig,
-				CiliumNode: &v2.CiliumNode{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-node",
-					},
-				},
-			}
-			err = neighborReconciler.Reconcile(context.Background(), reconcileParams)
-			req.NoError(err)
-
-			// validate neighbors
-			validatePeers(req, tt.expectedNeighbors, getRunningPeers(req, testInstance), tt.checks)
-
-			routes := tt.routes
-			if tt.newRoutes != nil {
-				routes = tt.newRoutes
-			}
-			// update neighbors
-			params, nodeConfig = setupNeighbors(t, tt.newNeighbors)
-			db, err = setupStateDB(routes)
-			req.NoError(err)
-			params.DB = db
-			txn = db.ReadTxn()
-			params.RouteTable = db.GetTable(txn, "routes").(statedb.Table[*tables.Route])
-			params.DeviceTable = db.GetTable(txn, "devices").(statedb.Table[*tables.Device])
-			neighborReconciler.(*NeighborReconciler).PeerConfig = params.PeerConfig
-			neighborReconciler.(*NeighborReconciler).DB = params.DB
-			neighborReconciler.(*NeighborReconciler).routeTable = params.RouteTable
-			neighborReconciler.(*NeighborReconciler).deviceTable = params.DeviceTable
-			reconcileParams = ReconcileParams{
-				BGPInstance:   testInstance,
-				DesiredConfig: nodeConfig,
-				CiliumNode: &v2.CiliumNode{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "bgp-node",
-					},
-				},
-			}
-			err = neighborReconciler.Reconcile(context.Background(), reconcileParams)
-			req.NoError(err)
-
-			// validate neighbors
-			validatePeers(req, tt.expectedNewNeighbors, getRunningPeers(req, testInstance), tt.checks)
-		})
-	}
-}
-
-func TestDefaultGatewayTrackerObserver(t *testing.T) {
-	table := []struct {
-		name      string
-		route     *tables.Route
-		isDefault bool
-		err       error
-	}{
-		{
-			name: "IPv4 default route",
-			route: &tables.Route{
-				Table:     tables.RT_TABLE_MAIN,
-				LinkIndex: 1,
-				Dst:       ipv4Default,
-				Gw:        netip.MustParseAddr("192.168.1.1"),
-				Priority:  100,
-			},
-			isDefault: true,
-		},
-		{
-			name: "IPv6 default route",
-			route: &tables.Route{
-				Table:     tables.RT_TABLE_MAIN,
-				LinkIndex: 1,
-				Dst:       ipv6Default,
-				Gw:        netip.MustParseAddr("2001:db8::1"),
-				Priority:  100,
-			},
-			isDefault: true,
-		},
-		{
-			name: "Non-default IPv4 route",
-			route: &tables.Route{
-				Table:     tables.RT_TABLE_MAIN,
-				LinkIndex: 1,
-				Dst:       netip.MustParsePrefix("10.0.0.0/24"),
-				Gw:        netip.MustParseAddr("192.168.1.1"),
-				Priority:  100,
-			},
-			isDefault: false,
-		},
-		{
-			name: "Non-default IPv6 route",
-			route: &tables.Route{
-				Table:     tables.RT_TABLE_MAIN,
-				LinkIndex: 1,
-				Dst:       netip.MustParsePrefix("fd00:10:0:1::/64"),
-				Gw:        netip.MustParseAddr("fd00:10:0:1::1"),
-				Priority:  100,
-			},
-			isDefault: false,
-		},
-	}
-	for _, tt := range table {
-		t.Run(tt.name, func(t *testing.T) {
-			signaler := signaler.NewBGPCPSignaler()
-			logger := hivetest.Logger(t)
-
-			// Get the observer function
-			observerFunc := routeChangeTrackerObserver(signaler, logger)
-
-			// Call the observer function with the test route
-			err := observerFunc(context.Background(), statedb.Change[*tables.Route]{
-				Object:   tt.route,
-				Revision: 1,
-				Deleted:  false,
-			})
-			require.NoError(t, err)
-
-			// Check if an event was triggered by checking if there's a signal in the channel
-			select {
-			case <-signaler.Sig:
-				if !tt.isDefault {
-					t.Fatal("Unexpected signal received for non-default route")
-				}
-				// Success - we received a signal and its a default route
-			default:
-				if tt.isDefault {
-					t.Fatal("Expected signal was not received")
-				}
-				// Success - we didn't receive a signal and its not a default route
-			}
-		})
-	}
-}
-
-func TestDeviceChangeTrackerObserver(t *testing.T) {
-	table := []struct {
-		name   string
-		device *tables.Device
-	}{
-		{
-			name: "Device change",
-			device: &tables.Device{
-				Name:       "net0",
-				Index:      1,
-				OperStatus: "up",
-			},
-		},
-	}
-	for _, tt := range table {
-		t.Run(tt.name, func(t *testing.T) {
-			signaler := signaler.NewBGPCPSignaler()
-			logger := hivetest.Logger(t)
-
-			// Get the observer function
-			observerFunc := deviceChangeTrackerObserver(signaler, logger)
-
-			// Call the observer function with the test device
-			err := observerFunc(context.Background(), statedb.Change[*tables.Device]{
-				Object:   tt.device,
-				Revision: 1,
-				Deleted:  false,
-			})
-			require.NoError(t, err)
-
-			// Check if an event was triggered by checking if there's a signal in the channel
-			select {
-			case <-signaler.Sig:
-				// Success - we received a signal and its a device change
-			default:
-				t.Fatal("Expected signal was not received")
-			}
-		})
-	}
-}
-
-func setupBGPInstance(logger *slog.Logger) (*instance.BGPInstance, error) {
-	// our test BgpServer with our original router ID and local port
-	srvParams := types.ServerParameters{
-		Global: types.BGPGlobal{
-			ASN:        64125,
-			RouterID:   "127.0.0.1",
-			ListenPort: -1,
-		},
-	}
-
-	testInstance, err := instance.NewBGPInstance(context.Background(), logger, "test-instance", srvParams)
-	return testInstance, err
 }
 
 func setupNeighbors(t *testing.T, peers []PeerData) (NeighborReconcilerIn, *v2.CiliumBGPNodeInstance) {
@@ -784,81 +319,6 @@ func setupNeighbors(t *testing.T, peers []PeerData) (NeighborReconcilerIn, *v2.C
 	}, nodeConfig
 }
 
-func setupStateDB(routes []*tables.Route) (*statedb.DB, error) {
-	// create a test statedb
-	db := statedb.New()
-
-	if len(routes) == 0 {
-		return db, nil
-	}
-	routeTable, err := tables.NewRouteTable(db)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create default gateway table: %w", err)
-	}
-	deviceTable, err := tables.NewDeviceTable(db)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create device table: %w", err)
-	}
-	txn := db.WriteTxn(routeTable, deviceTable)
-	for _, r := range routes {
-		routeTable.Insert(txn, r)
-	}
-
-	deviceTable.Insert(txn, &tables.Device{
-		Name:       "eth0",
-		Index:      123,
-		OperStatus: "up",
-	})
-	deviceTable.Insert(txn, &tables.Device{
-		Name:       "eth1",
-		Index:      124,
-		OperStatus: "up",
-	})
-	txn.Commit()
-
-	return db, nil
-}
-
-func validatePeers(req *require.Assertions, expected, running []PeerData, checks checks) {
-	req.Len(running, len(expected))
-
-	for _, expPeer := range expected {
-		found := false
-		for _, runPeer := range running {
-			req.NotNil(runPeer.Peer.PeerAddress)
-			req.NotNil(runPeer.Peer.PeerASN)
-
-			if *expPeer.Peer.PeerAddress == *runPeer.Peer.PeerAddress && *expPeer.Peer.PeerASN == *runPeer.Peer.PeerASN {
-				found = true
-
-				if checks.holdTimer {
-					req.Equal(*expPeer.Config.Timers.HoldTimeSeconds, *runPeer.Config.Timers.HoldTimeSeconds)
-				}
-
-				if checks.connectRetryTimer {
-					req.Equal(*expPeer.Config.Timers.ConnectRetryTimeSeconds, *runPeer.Config.Timers.ConnectRetryTimeSeconds)
-				}
-
-				if checks.keepaliveTimer {
-					req.Equal(*expPeer.Config.Timers.KeepAliveTimeSeconds, *runPeer.Config.Timers.KeepAliveTimeSeconds)
-				}
-
-				if checks.grRestartTime {
-					req.Equal(expPeer.Config.GracefulRestart.Enabled, runPeer.Config.GracefulRestart.Enabled)
-					req.Equal(*expPeer.Config.GracefulRestart.RestartTimeSeconds, *runPeer.Config.GracefulRestart.RestartTimeSeconds)
-				}
-
-				if expPeer.Password != "" {
-					req.NotEmpty(runPeer.Password)
-				}
-
-				break
-			}
-		}
-		req.True(found)
-	}
-}
-
 func getRunningPeers(req *require.Assertions, instance *instance.BGPInstance) []PeerData {
 	getPeerResp, err := instance.Router.GetPeerState(context.Background())
 	req.NoError(err)
@@ -898,4 +358,22 @@ func getRunningPeers(req *require.Assertions, instance *instance.BGPInstance) []
 		})
 	}
 	return runningPeers
+}
+
+func validatePeerData(req *require.Assertions, expected, running []PeerData) {
+	req.Len(running, len(expected))
+
+	for _, expPeer := range expected {
+		found := false
+		for _, runPeer := range running {
+			req.NotNil(runPeer.Peer.PeerAddress)
+			req.NotNil(runPeer.Peer.PeerASN)
+
+			if *expPeer.Peer.PeerAddress == *runPeer.Peer.PeerAddress && *expPeer.Peer.PeerASN == *runPeer.Peer.PeerASN {
+				found = true
+				break
+			}
+		}
+		req.True(found)
+	}
 }

--- a/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
+++ b/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
@@ -17,20 +17,22 @@ import (
 )
 
 const (
-	NeighborReconcilerName  = "Neighbor"
-	PodIPPoolReconcilerName = "PodIPPool"
-	ServiceReconcilerName   = "Service"
-	PodCIDRReconcilerName   = "PodCIDR"
+	DefaultGatewayReconcilerName = "DefaultGateway"
+	NeighborReconcilerName       = "Neighbor"
+	PodIPPoolReconcilerName      = "PodIPPool"
+	ServiceReconcilerName        = "Service"
+	PodCIDRReconcilerName        = "PodCIDR"
 )
 
 // Reconciler Priorities, lower number means higher priority. It is used to determine the
 // order in which reconcilers are called. Reconcilers are called from lowest to highest on
 // each Reconcile event.
 const (
-	NeighborReconcilerPriority  = 60
-	PodIPPoolReconcilerPriority = 50
-	ServiceReconcilerPriority   = 40
-	PodCIDRReconcilerPriority   = 30
+	NeighborReconcilerPriority       = 60
+	PodIPPoolReconcilerPriority      = 50
+	ServiceReconcilerPriority        = 40
+	PodCIDRReconcilerPriority        = 30
+	DefaultGatewayReconcilerPriority = 10
 )
 
 var (
@@ -63,6 +65,7 @@ type ConfigReconciler interface {
 
 var ConfigReconcilers = cell.Provide(
 	NewNeighborReconciler,
+	NewDefaultGatewayReconciler,
 	NewPodCIDRReconciler,
 	NewPodIPPoolReconciler,
 	NewServiceReconciler,


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

This commit fixes an issue with bgp gateway auto discovery.
Previously there was an issue with the priority of the reconcilers
where the gateway ip set by the neighbor reconciler auto discovery
is not picked up by the pod cidr reconciler when setting the 
policy.
This fix refactors the auto discovery logic to a new reconciler that
runs first.

Fixes: #41904

```release-note
Fix BGP auto discovery not sending community info
```
