### PR TITLE
clustermesh: add version check for remote clusters

### DIFF
--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -76,7 +76,7 @@ you may perform the following steps to troubleshoot ClusterMesh issues.
         ClusterMesh:   1/1 remote clusters ready
            k8s-c2: ready, 3 nodes, 25 endpoints, 8 identities, 10 services, 0 MCS-API service exports, 0 reconnections (last: never)
            └  etcd: 1/1 connected, leases=0, lock lease-ID=7c028201b53de662, has-quorum=true: https://k8s-c2.mesh.cilium.io:2379 - 3.5.4 (Leader)
-           └  remote configuration: expected=true, retrieved=true, cluster-id=3, kvstoremesh=false, sync-canaries=true, service-exports=disabled
+           └  remote configuration: expected=true, retrieved=true, version=1.19.0-dev f45dc73c78 2025-09-28T17:43:59+02:00 go version go1.25.1 linux/amd64 (supported), cluster-id=3, kvstoremesh=false, sync-canaries=true, service-exports=disabled
            └  synchronization status: nodes=true, endpoints=true, identities=true, services=true
 
     When KVStoreMesh is enabled, additionally check its status and validate that

--- a/api/v1/kvstoremesh/models/remote_cluster_config.go
+++ b/api/v1/kvstoremesh/models/remote_cluster_config.go
@@ -39,6 +39,9 @@ type RemoteClusterConfig struct {
 
 	// Whether the remote cluster supports per-prefix "synced" canaries
 	SyncCanaries bool `json:"sync-canaries,omitempty"`
+
+	// The Cilium version advertised by the remote cluster
+	Version string `json:"version,omitempty"`
 }
 
 // Validate validates this remote cluster config

--- a/api/v1/kvstoremesh/server/embedded_spec.go
+++ b/api/v1/kvstoremesh/server/embedded_spec.go
@@ -166,6 +166,10 @@ func init() {
             },
             "synced": {
               "$ref": "#/definitions/remoteClusterSynced"
+            },
+            "version-compatibility": {
+              "description": "Version compatibility with the remote cluster",
+              "type": "string"
             }
           }
         }
@@ -205,6 +209,10 @@ func init() {
         "sync-canaries": {
           "description": "Whether the remote cluster supports per-prefix \"synced\" canaries",
           "type": "boolean"
+        },
+        "version": {
+          "description": "The Cilium version advertised by the remote cluster",
+          "type": "string"
         }
       }
     },

--- a/api/v1/models/remote_cluster.go
+++ b/api/v1/models/remote_cluster.go
@@ -63,6 +63,9 @@ type RemoteCluster struct {
 
 	// Synchronization status about each resource type
 	Synced *RemoteClusterSynced `json:"synced,omitempty"`
+
+	// Version compatibility with the remote cluster
+	VersionCompatibility string `json:"version-compatibility,omitempty"`
 }
 
 // Validate validates this remote cluster

--- a/api/v1/models/remote_cluster_config.go
+++ b/api/v1/models/remote_cluster_config.go
@@ -39,6 +39,9 @@ type RemoteClusterConfig struct {
 
 	// Whether the remote cluster supports per-prefix "synced" canaries
 	SyncCanaries bool `json:"sync-canaries,omitempty"`
+
+	// The Cilium version advertised by the remote cluster
+	Version string `json:"version,omitempty"`
 }
 
 // Validate validates this remote cluster config

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2351,6 +2351,9 @@ definitions:
       ready:
         description: Indicates readiness of the remote cluster
         type: boolean
+      version-compatibility:
+        description: Version compatibility with the remote cluster
+        type: string
       connected:
         description: Indicates whether the connection to the remote kvstore is established
         type: boolean
@@ -2425,6 +2428,9 @@ definitions:
       cluster-id:
         description: The Cluster ID advertised by the remote cluster
         type: integer
+      version:
+        description: The Cilium version advertised by the remote cluster
+        type: string
       kvstoremesh:
         description: Whether the remote cluster information is locally cached by kvstoremesh
         type: boolean

--- a/api/v1/operator/models/remote_cluster_config.go
+++ b/api/v1/operator/models/remote_cluster_config.go
@@ -39,6 +39,9 @@ type RemoteClusterConfig struct {
 
 	// Whether the remote cluster supports per-prefix "synced" canaries
 	SyncCanaries bool `json:"sync-canaries,omitempty"`
+
+	// The Cilium version advertised by the remote cluster
+	Version string `json:"version,omitempty"`
 }
 
 // Validate validates this remote cluster config

--- a/api/v1/operator/server/embedded_spec.go
+++ b/api/v1/operator/server/embedded_spec.go
@@ -280,6 +280,10 @@ func init() {
             },
             "synced": {
               "$ref": "#/definitions/remoteClusterSynced"
+            },
+            "version-compatibility": {
+              "description": "Version compatibility with the remote cluster",
+              "type": "string"
             }
           }
         }
@@ -340,6 +344,10 @@ func init() {
         "sync-canaries": {
           "description": "Whether the remote cluster supports per-prefix \"synced\" canaries",
           "type": "boolean"
+        },
+        "version": {
+          "description": "The Cilium version advertised by the remote cluster",
+          "type": "string"
         }
       }
     },

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -4403,6 +4403,10 @@ func init() {
         "synced": {
           "description": "Synchronization status about each resource type",
           "$ref": "#/definitions/RemoteClusterSynced"
+        },
+        "version-compatibility": {
+          "description": "Version compatibility with the remote cluster",
+          "type": "string"
         }
       }
     },
@@ -4433,6 +4437,10 @@ func init() {
         "sync-canaries": {
           "description": "Whether the remote cluster supports per-prefix \"synced\" canaries",
           "type": "boolean"
+        },
+        "version": {
+          "description": "The Cilium version advertised by the remote cluster",
+          "type": "string"
         }
       }
     },
@@ -10212,6 +10220,10 @@ func init() {
         "synced": {
           "description": "Synchronization status about each resource type",
           "$ref": "#/definitions/RemoteClusterSynced"
+        },
+        "version-compatibility": {
+          "description": "Version compatibility with the remote cluster",
+          "type": "string"
         }
       }
     },
@@ -10242,6 +10254,10 @@ func init() {
         "sync-canaries": {
           "description": "Whether the remote cluster supports per-prefix \"synced\" canaries",
           "type": "boolean"
+        },
+        "version": {
+          "description": "The Cilium version advertised by the remote cluster",
+          "type": "string"
         }
       }
     },

--- a/clustermesh-apiserver/clustermesh/testdata/clusterconfig-serviceexport.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/clusterconfig-serviceexport.txtar
@@ -12,6 +12,13 @@ kvstore/list -o json cilium/cluster-config config.actual
 # cilium/cluster-config/cluster5
 {
   "id": 5,
+  "version": {
+    "Version": "",
+    "Revision": "",
+    "GoRuntimeVersion": "",
+    "Arch": "",
+    "AuthorDate": ""
+  },
   "capabilities": {
     "syncedCanaries": true,
     "maxConnectedClusters": 255,

--- a/clustermesh-apiserver/clustermesh/testdata/clusterconfig.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/clusterconfig.txtar
@@ -28,6 +28,13 @@ kvstore/list -o json cilium/cluster-config config.actual
 # cilium/cluster-config/cluster3
 {
   "id": 3,
+  "version": {
+    "Version": "",
+    "Revision": "",
+    "GoRuntimeVersion": "",
+    "Arch": "",
+    "AuthorDate": ""
+  },
   "capabilities": {
     "syncedCanaries": true,
     "maxConnectedClusters": 255,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,7 +22,9 @@ import (
 
 	clientapi "github.com/cilium/cilium/api/v1/client"
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/version"
 )
 
 type Client struct {
@@ -858,8 +860,10 @@ func FormatStatusResponseRemoteClusters(w io.Writer, clusters []*models.RemoteCl
 					}
 				}
 				if cluster.Config.Retrieved {
-					fmt.Fprintf(w, ", cluster-id=%d, kvstoremesh=%t, sync-canaries=%t, service-exports=%s",
-						cluster.Config.ClusterID, cluster.Config.Kvstoremesh, cluster.Config.SyncCanaries, serviceExportsConfig)
+					ver := cluster.Config.Version
+					versionCheckResult, _ := types.CheckVersionCompatibility(version.FromString(cluster.Config.Version))
+					fmt.Fprintf(w, ", version=%s (%s), cluster-id=%d, kvstoremesh=%t, sync-canaries=%t, service-exports=%s",
+						ver, versionCheckResult, cluster.Config.ClusterID, cluster.Config.Kvstoremesh, cluster.Config.SyncCanaries, serviceExportsConfig)
 				}
 			} else {
 				fmt.Fprint(w, "expected=unknown, retrieved=unknown")

--- a/pkg/clustermesh/clustercfg/cell/cell.go
+++ b/pkg/clustermesh/clustercfg/cell/cell.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/clustercfg"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/version"
 )
 
 // Cell takes care of writing the cluster configuration to the kvstore, and
@@ -20,7 +21,8 @@ var Cell = cell.Module(
 	cell.Provide(
 		func(cinfo cmtypes.ClusterInfo, mcsAPICfg operator.MCSAPIConfig, sc syncedCanaries) cmtypes.CiliumClusterConfig {
 			return cmtypes.CiliumClusterConfig{
-				ID: cinfo.ID,
+				ID:      cinfo.ID,
+				Version: version.GetCiliumVersion(),
 				Capabilities: cmtypes.CiliumClusterConfigCapabilities{
 					SyncedCanaries:        bool(sc),
 					MaxConnectedClusters:  cinfo.MaxConnectedClusters,

--- a/pkg/clustermesh/common/clustermesh_test.go
+++ b/pkg/clustermesh/common/clustermesh_test.go
@@ -79,7 +79,7 @@ func TestClusterMesh(t *testing.T) {
 		require.Zero(t, status.NumFailures, "The status for %s should not report failures", name)
 		require.Zero(t, status.LastFailure, "The status for %s should not report a last failure", name)
 
-		cfg := models.RemoteClusterConfig{ClusterID: int64(id), Kvstoremesh: true, Required: true, Retrieved: true, SyncCanaries: false}
+		cfg := models.RemoteClusterConfig{ClusterID: int64(id), Version: string(types.VersionCompatibilityUnknown), Kvstoremesh: true, Required: true, Retrieved: true, SyncCanaries: false}
 		require.Equal(t, &cfg, status.Config, "The status for %s should propagate the cluster configuration", name)
 	}
 

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -76,7 +76,8 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 	}
 
 	dstcfg := types.CiliumClusterConfig{
-		ID: srccfg.ID,
+		ID:      srccfg.ID,
+		Version: srccfg.Version,
 		Capabilities: types.CiliumClusterConfigCapabilities{
 			SyncedCanaries:        true,
 			Cached:                true,

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -106,6 +106,14 @@ func (c ClusterInfo) ValidateRemoteConfig(config CiliumClusterConfig) error {
 		return err
 	}
 
+	versionCheckResult, err := CheckVersionCompatibility(config.Version)
+	if err != nil {
+		return err
+	}
+	if versionCheckResult == VersionCompatibilityIncompatible {
+		return fmt.Errorf("remote cluster is running unsupported Cilium version %q", config.Version)
+	}
+
 	if c.ExtendedClusterMeshEnabled() && (c.MaxConnectedClusters != config.Capabilities.MaxConnectedClusters) {
 		return fmt.Errorf("mismatched MaxConnectedClusters; local=%d, remote=%d", c.MaxConnectedClusters, config.Capabilities.MaxConnectedClusters)
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -31,6 +31,13 @@ type CiliumVersion struct {
 	AuthorDate string
 }
 
+func (c CiliumVersion) String() string {
+	if c.Version == "" {
+		return "unknown"
+	}
+	return fmt.Sprintf("%s %s %s go version %s %s", c.Version, c.Revision, c.AuthorDate, c.GoRuntimeVersion, c.Arch)
+}
+
 // ciliumVersion is set to Cilium's version, revision and git author time reference during build.
 var ciliumVersion string
 


### PR DESCRIPTION
This add version reporting in the dbg commands.

Thanks to that we can add a version check which makes more obvious that we only test for one version skew. We report this check to users in the CLI with the `cilium clustermesh status` command.

It also add some code path for "incompatible" versions that we could leverage if we introduce a breaking change in the future. Currently there is no incompatible version though.

```release-note
clustermesh: add version reporting and version compaitiblity check
```
