### PR TITLE
Make zTunnel aware of remote workloads in the cluster

### DIFF
--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -92,6 +92,11 @@ func (k *K8sCiliumEndpointsWatcher) initCiliumEndpointOrSlices(ctx context.Conte
 	}
 }
 
+// GetCiliumEndpointResource returns Resource[T] slim CEP object
+func (k *K8sCiliumEndpointsWatcher) GetCiliumEndpointResource() resource.Resource[*types.CiliumEndpoint] {
+	return k.resources.CiliumSlimEndpoint
+}
+
 func (k *K8sCiliumEndpointsWatcher) ciliumEndpointsInit(ctx context.Context) {
 	var synced atomic.Bool
 

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -17,6 +17,7 @@ import (
 	hubblemetrics "github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	cilium_api_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/types"
@@ -95,6 +96,11 @@ func (k *K8sCiliumEndpointsWatcher) initCiliumEndpointOrSlices(ctx context.Conte
 // GetCiliumEndpointResource returns Resource[T] slim CEP object
 func (k *K8sCiliumEndpointsWatcher) GetCiliumEndpointResource() resource.Resource[*types.CiliumEndpoint] {
 	return k.resources.CiliumSlimEndpoint
+}
+
+// GetCiliumEndpointSliceResource returns Resource[T] slim CEP object
+func (k *K8sCiliumEndpointsWatcher) GetCiliumEndpointSliceResource() resource.Resource[*cilium_api_v2a1.CiliumEndpointSlice] {
+	return k.resources.CiliumEndpointSlice
 }
 
 func (k *K8sCiliumEndpointsWatcher) ciliumEndpointsInit(ctx context.Context) {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -312,3 +312,8 @@ func (k *K8sWatcher) K8sEventReceived(apiResourceName, scope, action string, val
 func (k *K8sWatcher) GetCachedPod(namespace, name string) (*slim_corev1.Pod, error) {
 	return k.k8sPodWatcher.GetCachedPod(namespace, name)
 }
+
+// GetK8sCiliumEndpointsWatcher returns CEP watcher
+func (k *K8sWatcher) GetK8sCiliumEndpointsWatcher() *K8sCiliumEndpointsWatcher {
+	return k.k8sCiliumEndpointsWatcher
+}

--- a/pkg/ztunnel/xds/cell.go
+++ b/pkg/ztunnel/xds/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/ztunnel/config"
 )
@@ -23,10 +24,11 @@ var Cell = cell.Module(
 type xdsServerParams struct {
 	cell.In
 
-	Lifecycle cell.Lifecycle
-	Logger    *slog.Logger
-	EPManager endpointmanager.EndpointManager
-	Config    config.Config
+	Lifecycle  cell.Lifecycle
+	Logger     *slog.Logger
+	EPManager  endpointmanager.EndpointManager
+	K8sWatcher *watchers.K8sWatcher
+	Config     config.Config
 }
 
 func NewServer(params xdsServerParams) (*Server, error) {
@@ -34,7 +36,7 @@ func NewServer(params xdsServerParams) (*Server, error) {
 		return nil, nil
 	}
 
-	server, err := newServer(params.Logger, params.EPManager)
+	server, err := newServer(params.Logger, params.EPManager, params.K8sWatcher.GetK8sCiliumEndpointsWatcher())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ztunnel gRPC server: %w", err)
 	}

--- a/pkg/ztunnel/xds/endpoint_event_test.go
+++ b/pkg/ztunnel/xds/endpoint_event_test.go
@@ -9,9 +9,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"istio.io/istio/pkg/workloadapi"
+	apimachineryTypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/endpoint"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
 )
 
 func TestEndpointEventToXDSAddress(t *testing.T) {
@@ -32,13 +36,17 @@ func TestEndpointEventToXDSAddress(t *testing.T) {
 				NodeName:           "test-node",
 				ServiceAccountName: "test-service-account",
 			},
+			Status: slim_corev1.PodStatus{
+				HostIP: netip.MustParseAddr("10.1.1.10").String(),
+			},
 		}
 		ep.SetPod(pod)
 
+		cep := endpointToCiliumEndpoint(ep)
 		// Create EndpointEvent for CREATE
 		event := &EndpointEvent{
-			Type:     CREATE,
-			Endpoint: ep,
+			Type:           CREATE,
+			CiliumEndpoint: cep,
 		}
 
 		// Transform to XDS Address
@@ -54,7 +62,10 @@ func TestEndpointEventToXDSAddress(t *testing.T) {
 		require.Equal(t, ep.K8sUID, workload.Uid, "Workload.Uid should match endpoint.K8sUID")
 		require.Equal(t, ep.K8sPodName, workload.Name, "Workload.Name should match endpoint.K8sPodName")
 		require.Equal(t, ep.K8sNamespace, workload.Namespace, "Workload.Namespace should match endpoint.K8sNamespace")
-		require.Equal(t, pod.Spec.NodeName, workload.Node, "Workload.Node should match pod.Spec.NodeName")
+		// TODO(hemanthmalla): Currently we're setting zTunnel node name to host IP due to lack of nodename in CEP.
+		// Revert to node name once we lookup with a local object that has node name.
+		require.Equal(t, pod.Status.HostIP, workload.Node, "Workload.Node should match pod.Status.HostIP")
+
 		require.Equal(t, pod.Spec.ServiceAccountName, workload.ServiceAccount, "Workload.ServiceAccount should match pod.Spec.ServiceAccountName")
 		require.Equal(t, workloadapi.TunnelProtocol_HBONE, workload.TunnelProtocol, "Workload.TunnelProtocol should be HBONE")
 
@@ -87,13 +98,16 @@ func TestEndpointEventToXDSAddress(t *testing.T) {
 				NodeName:           "remove-node",
 				ServiceAccountName: "remove-service-account",
 			},
+			Status: slim_corev1.PodStatus{
+				HostIP: netip.MustParseAddr("10.2.1.10").String(),
+			},
 		}
 		ep.SetPod(pod)
 
 		// Create EndpointEvent for REMOVE
 		event := &EndpointEvent{
-			Type:     REMOVED,
-			Endpoint: ep,
+			Type:           REMOVED,
+			CiliumEndpoint: endpointToCiliumEndpoint(ep),
 		}
 
 		// Transform to XDS Address
@@ -112,7 +126,9 @@ func TestEndpointEventToXDSAddress(t *testing.T) {
 		require.Equal(t, ep.K8sUID, workload.Uid, "Workload.Uid should match endpoint.K8sUID")
 		require.Equal(t, ep.K8sPodName, workload.Name, "Workload.Name should match endpoint.K8sPodName")
 		require.Equal(t, ep.K8sNamespace, workload.Namespace, "Workload.Namespace should match endpoint.K8sNamespace")
-		require.Equal(t, pod.Spec.NodeName, workload.Node, "Workload.Node should match pod.Spec.NodeName")
+		// TODO(hemanthmalla): Currently we're setting zTunnel node name to host IP due to lack of nodename in CEP.
+		// Revert to node name once we lookup with a local object that has node name.
+		require.Equal(t, pod.Status.HostIP, workload.Node, "Workload.Node should match pod.Status.HostIP")
 		require.Equal(t, pod.Spec.ServiceAccountName, workload.ServiceAccount, "Workload.ServiceAccount should match pod.Spec.ServiceAccountName")
 		require.Equal(t, workloadapi.TunnelProtocol_HBONE, workload.TunnelProtocol, "Workload.TunnelProtocol should be HBONE")
 
@@ -127,30 +143,40 @@ func TestEndpointEventToXDSAddress(t *testing.T) {
 		ipv6Bytes := ep.IPv6.AsSlice()
 		require.Contains(t, workload.Addresses, ipv6Bytes, "IPv6 address should be present in workload addresses")
 	})
+}
 
-	t.Run("Missing Pod Information", func(t *testing.T) {
-		// Create endpoint without pod information to test error case
-		ep := &endpoint.Endpoint{
-			ID:           1004,
-			K8sUID:       "no-pod-uid-12345678-1234-1234-1234-123456789abc",
-			K8sPodName:   "no-pod",
-			K8sNamespace: "no-pod-namespace",
-			IPv4:         netip.MustParseAddr("10.0.1.20"),
-			IPv6:         netip.MustParseAddr("fd00::1:200"),
-		}
-		// Don't call ep.SetPod() - leave pod as nil
+func endpointToCiliumEndpoint(ep *endpoint.Endpoint) *types.CiliumEndpoint {
+	hostIP := ""
+	serviceAccount := ""
+	if ep.GetPod() != nil {
+		hostIP = ep.GetPod().Status.HostIP
+		serviceAccount = ep.GetPod().Spec.ServiceAccountName
+	}
+	cep := &types.CiliumEndpoint{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      ep.K8sPodName,
+			Namespace: ep.K8sNamespace,
+			UID:       apimachineryTypes.UID(ep.K8sUID),
+		},
 
-		event := &EndpointEvent{
-			Type:     CREATE,
-			Endpoint: ep,
-		}
+		Networking: &v2.EndpointNetworking{
+			Addressing: v2.AddressPairList{},
+			NodeIP:     hostIP,
+		},
+		ServiceAccount: serviceAccount,
+	}
 
-		// Should return error for missing pod information
-		address, err := event.ToXDSAddress()
-		require.Error(t, err, "ToXDSAddress should error when pod is nil")
-		require.Nil(t, address, "Address should be nil when error occurs")
-		require.Contains(t, err.Error(), "missing Pod information", "Error should mention missing Pod information")
-	})
+	if ep.IPv4.IsValid() {
+		cep.Networking.Addressing = append(cep.Networking.Addressing, &v2.AddressPair{
+			IPV4: ep.IPv4.String(),
+		})
+	}
+	if ep.IPv6.IsValid() {
+		cep.Networking.Addressing = append(cep.Networking.Addressing, &v2.AddressPair{
+			IPV6: ep.IPv6.String(),
+		})
+	}
+	return cep
 }
 
 func TestEndpointEventCollectionToDeltaDiscoveryResponse(t *testing.T) {
@@ -176,6 +202,9 @@ func TestEndpointEventCollectionToDeltaDiscoveryResponse(t *testing.T) {
 				NodeName:           "create-node-1",
 				ServiceAccountName: "create-sa-1",
 			},
+			Status: slim_corev1.PodStatus{
+				HostIP: netip.MustParseAddr("100.1.1.10").String(),
+			},
 		}
 		createEp1.SetPod(createPod1)
 
@@ -192,6 +221,9 @@ func TestEndpointEventCollectionToDeltaDiscoveryResponse(t *testing.T) {
 			Spec: slim_corev1.PodSpec{
 				NodeName:           "remove-node",
 				ServiceAccountName: "remove-sa",
+			},
+			Status: slim_corev1.PodStatus{
+				HostIP: netip.MustParseAddr("100.1.1.10").String(),
 			},
 		}
 		removeEp.SetPod(removePod)
@@ -210,14 +242,17 @@ func TestEndpointEventCollectionToDeltaDiscoveryResponse(t *testing.T) {
 				NodeName:           "create-node-2",
 				ServiceAccountName: "create-sa-2",
 			},
+			Status: slim_corev1.PodStatus{
+				HostIP: netip.MustParseAddr("100.1.1.20").String(),
+			},
 		}
 		createEp2.SetPod(createPod2)
 
 		// Create EndpointEventCollection with CREATE, REMOVE, CREATE sequence
 		collection := EndpointEventCollection{
-			&EndpointEvent{Type: CREATE, Endpoint: createEp1},
-			&EndpointEvent{Type: REMOVED, Endpoint: removeEp},
-			&EndpointEvent{Type: CREATE, Endpoint: createEp2},
+			&EndpointEvent{Type: CREATE, CiliumEndpoint: endpointToCiliumEndpoint(createEp1)},
+			&EndpointEvent{Type: REMOVED, CiliumEndpoint: endpointToCiliumEndpoint(removeEp)},
+			&EndpointEvent{Type: CREATE, CiliumEndpoint: endpointToCiliumEndpoint(createEp2)},
 		}
 
 		// Transform to DeltaDiscoveryResponse
@@ -250,7 +285,8 @@ func TestEndpointEventCollectionToDeltaDiscoveryResponse(t *testing.T) {
 				require.Equal(t, testUIDs[0], workload.Uid)
 				require.Equal(t, "create-pod-1", workload.Name)
 				require.Equal(t, "create-namespace-1", workload.Namespace)
-				require.Equal(t, "create-node-1", workload.Node)
+				// require.Equal(t, "create-node-1", workload.Node)
+				require.Equal(t, "100.1.1.10", workload.Node)
 				require.Equal(t, "create-sa-1", workload.ServiceAccount)
 				require.Equal(t, workloadapi.TunnelProtocol_HBONE, workload.TunnelProtocol)
 				require.Len(t, workload.Addresses, 2, "Should have 2 IP addresses")
@@ -259,7 +295,8 @@ func TestEndpointEventCollectionToDeltaDiscoveryResponse(t *testing.T) {
 				require.Equal(t, testUIDs[2], workload.Uid)
 				require.Equal(t, "create-pod-2", workload.Name)
 				require.Equal(t, "create-namespace-2", workload.Namespace)
-				require.Equal(t, "create-node-2", workload.Node)
+				// require.Equal(t, "create-node-2", workload.Node)
+				require.Equal(t, "100.1.1.20", workload.Node)
 				require.Equal(t, "create-sa-2", workload.ServiceAccount)
 				require.Equal(t, workloadapi.TunnelProtocol_HBONE, workload.TunnelProtocol)
 				require.Len(t, workload.Addresses, 2, "Should have 2 IP addresses")
@@ -273,48 +310,5 @@ func TestEndpointEventCollectionToDeltaDiscoveryResponse(t *testing.T) {
 		// Validate REMOVE resources (should be 1: removeEp)
 		require.Len(t, response.RemovedResources, 1, "Should have 1 REMOVE resource")
 		require.Equal(t, testUIDs[1], response.RemovedResources[0], "REMOVE resource UID should match removeEp UID")
-	})
-
-	t.Run("Invalid Endpoint", func(t *testing.T) {
-		// Create endpoint without pod to test error handling
-		invalidEp := &endpoint.Endpoint{
-			ID:           4001,
-			K8sUID:       "invalid-uid-12345678-1234-1234-1234-123456789abc",
-			K8sPodName:   "invalid-pod",
-			K8sNamespace: "invalid-namespace",
-			IPv4:         netip.MustParseAddr("10.4.4.40"),
-		}
-		// Don't set pod - this will cause ToXDSAddress to fail
-
-		validEp := &endpoint.Endpoint{
-			ID:           4002,
-			K8sUID:       "valid-uid-87654321-4321-4321-4321-cba987654321",
-			K8sPodName:   "valid-pod",
-			K8sNamespace: "valid-namespace",
-			IPv4:         netip.MustParseAddr("10.5.5.50"),
-			IPv6:         netip.MustParseAddr("fd00::5:500"),
-		}
-		validPod := &slim_corev1.Pod{
-			Spec: slim_corev1.PodSpec{
-				NodeName:           "valid-node",
-				ServiceAccountName: "valid-sa",
-			},
-		}
-		validEp.SetPod(validPod)
-
-		// Create collection with invalid CREATE and valid CREATE
-		collection := EndpointEventCollection{
-			&EndpointEvent{Type: CREATE, Endpoint: invalidEp}, // Will fail transformation
-			&EndpointEvent{Type: CREATE, Endpoint: validEp},   // Will succeed
-		}
-
-		// Transform to DeltaDiscoveryResponse
-		response := collection.ToDeltaDiscoveryResponse()
-		require.NotNil(t, response, "DeltaDiscoveryResponse should not be nil")
-
-		// Should only contain the valid endpoint (invalid one is skipped)
-		require.Len(t, response.Resources, 1, "Should have 1 valid CREATE resource")
-		require.Equal(t, "valid-uid-87654321-4321-4321-4321-cba987654321", response.Resources[0].Name, "Should contain only the valid endpoint")
-		require.Empty(t, response.RemovedResources, "Should have no REMOVE resources")
 	})
 }

--- a/pkg/ztunnel/xds/xds_server.go
+++ b/pkg/ztunnel/xds/xds_server.go
@@ -28,6 +28,7 @@ import (
 	v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -62,11 +63,12 @@ var _ v3.AggregatedDiscoveryServiceServer = (*Server)(nil)
 // certificate authority capable of signing CSR(s)s submitted by zTunnel and a
 // control plane capable of sending workload and service events to zTunnel.
 type Server struct {
-	l         net.Listener
-	g         *grpc.Server
-	log       *slog.Logger
-	epManager endpointmanager.EndpointManager
-	caCert    *x509.Certificate
+	l                         net.Listener
+	g                         *grpc.Server
+	log                       *slog.Logger
+	epManager                 endpointmanager.EndpointManager
+	k8sCiliumEndpointsWatcher *watchers.K8sCiliumEndpointsWatcher
+	caCert                    *x509.Certificate
 	// cache the PEM encoded certificate, we return this as the trust anchor
 	// on zTunnel certificate creation requests.
 	caCertPEM string
@@ -75,10 +77,11 @@ type Server struct {
 	v3.UnimplementedAggregatedDiscoveryServiceServer
 }
 
-func newServer(log *slog.Logger, epManager endpointmanager.EndpointManager) (*Server, error) {
+func newServer(log *slog.Logger, EPManager endpointmanager.EndpointManager, k8sCiliumEndpointsWatcher *watchers.K8sCiliumEndpointsWatcher) (*Server, error) {
 	x := &Server{
-		log:       log,
-		epManager: epManager,
+		log:                       log,
+		k8sCiliumEndpointsWatcher: k8sCiliumEndpointsWatcher,
+		epManager:                 EPManager,
 	}
 	return x, nil
 }
@@ -369,11 +372,11 @@ func (x *Server) DeltaAggregatedResources(stream v3.AggregatedDiscoveryService_D
 	}
 
 	params := StreamProcessorParams{
-		Stream:            stream,
-		StreamRecv:        make(chan *v3.DeltaDiscoveryRequest, 1),
-		EndpointEventRecv: make(chan *EndpointEvent, 1024),
-		EndpointManager:   x.epManager,
-		Log:               x.log,
+		Stream:                    stream,
+		StreamRecv:                make(chan *v3.DeltaDiscoveryRequest, 1),
+		EndpointEventRecv:         make(chan *EndpointEvent, 1024),
+		K8sCiliumEndpointsWatcher: x.k8sCiliumEndpointsWatcher,
+		Log:                       x.log,
 	}
 
 	x.log.Debug("begin processing DeltaAggregatedResources stream")


### PR DESCRIPTION
Update WDS API to use data from agent's CEP watch cache. This would zTunnel aware of remote workloads allowing for cros-node tunnelling.

ToDo

- [x] Refactor stream processor test to work with informer cache mock
- [x] Add support for CES objects

```
➜  k get pods -A -owide | grep -E 'ztunnel|netshoot'
client-ns2           netshoot-client-anti-affinity-5fdcdcd549-t8l5r   1/1     Running   0               3d14h   10.244.0.192   kind-control-plane   <none>           <none>
default              netshoot-client-844d6c9fcc-2h5cs                 1/1     Running   0               3d14h   10.244.1.83    kind-worker          <none>           <none>
default              netshoot-client-844d6c9fcc-hk79s                 1/1     Running   0               3d14h   10.244.0.30    kind-control-plane   <none>           <none>
kube-system          ztunnel-cilium-ph7lc                             1/1     Running   0               13d     172.18.0.3     kind-control-plane   <none>           <none>
kube-system          ztunnel-cilium-xbs8t                             1/1     Running   0               13d     172.18.0.2     kind-worker          <none>           <none>
server-ns            netshoot-server-6b478b859-fb9mz                  1/1     Running   0               3d14h   10.244.1.243   kind-worker          <none>           <none>
```

Destination Node zTunnel
```
2025-09-29T22:21:34.946963Z     debug   proxy::inbound:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}      fetching cert   identity=default.server-ns (netshoot-server-6b478b859-fb9mz)
2025-09-29T22:21:34.946988Z     debug   state:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}       wait for workload       wl=default.server-ns (netshoot-server-6b478b859-fb9mz)
2025-09-29T22:21:34.946992Z     debug   state:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}       got sub, waiting for workload   wl=default.server-ns (netshoot-server-6b478b859-fb9mz)
2025-09-29T22:21:34.947243Z     debug   rustls::server::hs:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}  decided upon suite TLS13_AES_256_GCM_SHA384
2025-09-29T22:21:34.947407Z     debug   rustls::server::hs:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}  Chosen ALPN protocol [104, 50]
2025-09-29T22:21:34.948951Z     debug   proxy::inbound:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}      accepted TLS connection latency=2.017522ms
2025-09-29T22:21:34.948987Z     debug   proxy::inbound:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}      accepted connection     conn=10.244.0.192:49356(spiffe://cluster.local/ns/client-ns2/sa/default)->10.244.1.243:15008
2025-09-29T22:21:34.949014Z     debug   h2::codec::framed_write:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}     send    frame=Settings { flags: (0x0), max_concurrent_streams: 200, initial_window_size: 4194304, max_frame_size: 1048576, max_header_list_size: 65536 }
2025-09-29T22:21:34.949135Z     debug   h2::codec::framed_read:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}      received        frame=Settings { flags: (0x0), enable_push: 0, initial_window_size: 4194304, max_frame_size: 1048576, max_header_list_size: 16384 }
2025-09-29T22:21:34.949147Z     debug   h2::codec::framed_write:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}     send    frame=Settings { flags: (0x1: ACK) }
2025-09-29T22:21:34.949152Z     debug   h2::codec::framed_read:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}      received        frame=WindowUpdate { stream_id: StreamId(0), size_increment: 16711681 }
2025-09-29T22:21:34.949182Z     debug   h2::codec::framed_read:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}      received        frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
2025-09-29T22:21:34.949198Z     debug   h2::codec::framed_write:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}     send    frame=WindowUpdate { stream_id: StreamId(0), size_increment: 16711681 }
2025-09-29T22:21:34.949318Z     debug   proxy::inbound:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:inbound{id=49a1bab354bb5f83eeb93d2a5e62fbde peer=10.244.0.192:49356} received request        conn=10.244.0.192:49356(spiffe://cluster.local/ns/client-ns2/sa/default)->10.244.1.243:15008 req=H2Request { request: Parts { method: CONNECT, uri: 10.244.1.243:8080, version: HTTP/2.0, headers: {"baggage": "k8s.cluster.name=Kubernetes,k8s.namespace.name=client-ns2,k8s.deployment.name=,service.name=,service.version=,cloud.region=,cloud.availability_zone=", "forwarded": "for=\"10.244.0.192:55534\"", "traceparent": "00-49a1bab354bb5f83eeb93d2a5e62fbde-9f094bc45c3c479a-00"} } }
2025-09-29T22:21:34.949338Z     debug   state:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:inbound{id=49a1bab354bb5f83eeb93d2a5e62fbde peer=10.244.0.192:49356}  wait for workload       wl=default.server-ns (netshoot-server-6b478b859-fb9mz)
2025-09-29T22:21:34.949342Z     debug   state:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:inbound{id=49a1bab354bb5f83eeb93d2a5e62fbde peer=10.244.0.192:49356}  got sub, waiting for workload   wl=default.server-ns (netshoot-server-6b478b859-fb9mz)
2025-09-29T22:21:34.949355Z     debug   state:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:inbound{id=49a1bab354bb5f83eeb93d2a5e62fbde peer=10.244.0.192:49356}  fetch workload  addr=/10.244.0.192
2025-09-29T22:21:34.949372Z     debug   access  connection opened       src.addr=10.244.0.192:49356 src.workload="netshoot-client-anti-affinity-5fdcdcd549-t8l5r" src.namespace="client-ns2" src.identity="spiffe://cluster.local/ns/client-ns2/sa/default" dst.addr=10.244.1.243:15008 dst.hbone_addr=10.244.1.243:8080 dst.workload="netshoot-server-6b478b859-fb9mz" dst.namespace="server-ns" dst.identity="spiffe://cluster.local/ns/server-ns/sa/default" direction="inbound"
2025-09-29T22:21:34.949393Z     debug   state:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:inbound{id=49a1bab354bb5f83eeb93d2a5e62fbde peer=10.244.0.192:49356}  no allow policies, allow
2025-09-29T22:21:34.949680Z     debug   h2::codec::framed_read:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}      received        frame=Settings { flags: (0x1: ACK) }
2025-09-29T22:21:34.949697Z     debug   h2::proto::settings:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server} received settings ACK; applying Settings { flags: (0x0), max_concurrent_streams: 200, initial_window_size: 4194304, max_frame_size: 1048576, max_header_list_size: 65536 }
2025-09-29T22:21:34.949777Z     debug   proxy::inbound:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:inbound{id=49a1bab354bb5f83eeb93d2a5e62fbde peer=10.244.0.192:49356} connected to: 10.244.1.243:8080
2025-09-29T22:21:34.949813Z     debug   h2::codec::framed_write:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}     send    frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
2025-09-29T22:21:34.950256Z     debug   h2::codec::framed_read:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}      received        frame=Data { stream_id: StreamId(1) }
2025-09-29T22:21:34.951062Z     debug   h2::codec::framed_write:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}     send    frame=Data { stream_id: StreamId(1) }
2025-09-29T22:21:34.951207Z     debug   h2::codec::framed_write:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}     send    frame=Data { stream_id: StreamId(1) }
2025-09-29T22:21:34.951422Z     debug   h2::codec::framed_write:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}     send    frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
2025-09-29T22:21:34.952181Z     debug   h2::codec::framed_read:proxy{wl=server-ns/netshoot-server-6b478b859-fb9mz}:Connection{peer=Server}      received        frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
2025-09-29T22:21:34.952312Z     info    access  connection complete     src.addr=10.244.0.192:49356 src.workload="netshoot-client-anti-affinity-5fdcdcd549-t8l5r" src.namespace="client-ns2" src.identity="spiffe://cluster.local/ns/client-ns2/sa/default" dst.addr=10.244.1.243:15008 dst.hbone_addr=10.244.1.243:8080 dst.workload="netshoot-server-6b478b859-fb9mz" dst.namespace="server-ns" dst.identity="spiffe://cluster.local/ns/server-ns/sa/default" direction="inbound" bytes_sent=460 bytes_recv=81 duration="2ms"
```

Client Node zTunnel
```
2025-09-29T22:21:34.946312Z     debug   proxy::outbound:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}       connection started      component="outbound"
2025-09-29T22:21:34.946336Z     debug   state:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde} wait for workload       wl=default.client-ns2 (netshoot-client-anti-affinity-5fdcdcd549-t8l5r)
2025-09-29T22:21:34.946340Z     debug   state:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde} got sub, waiting for workload   wl=default.client-ns2 (netshoot-client-anti-affinity-5fdcdcd549-t8l5r)
2025-09-29T22:21:34.946347Z     debug   state:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde} fetch address   network_addr.address=10.244.1.243
2025-09-29T22:21:34.946351Z     debug   state:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde} fetch address   network_addr.address=10.244.1.243
2025-09-29T22:21:34.946358Z     debug   proxy::outbound:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}       built request to workload
2025-09-29T22:21:34.946373Z     debug   access  connection opened       src.addr=10.244.0.192:55534 src.workload="netshoot-client-anti-affinity-5fdcdcd549-t8l5r" src.namespace="client-ns2" src.identity="spiffe://cluster.local/ns/client-ns2/sa/default" dst.addr=10.244.1.243:15008 dst.hbone_addr=10.244.1.243:8080 dst.workload="netshoot-server-6b478b859-fb9mz" dst.namespace="server-ns" dst.identity="spiffe://cluster.local/ns/server-ns/sa/default" direction="outbound"
2025-09-29T22:21:34.946404Z     debug   proxy::pool:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}   checkout - found mutex for pool key ConnectionMeta { key: 3715623523030535003, id: 3 }, waiting for writelock
2025-09-29T22:21:34.946410Z     debug   proxy::pool:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}   new connection needed for 10.244.0.192(spiffe://cluster.local/ns/client-ns2/sa/default)->10.244.1.243:15008[spiffe://cluster.local/ns/server-ns/sa/default]
2025-09-29T22:21:34.946414Z     debug   proxy::pool:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}   spawning new pool conn for 10.244.0.192(spiffe://cluster.local/ns/client-ns2/sa/default)->10.244.1.243:15008[spiffe://cluster.local/ns/server-ns/sa/default]
2025-09-29T22:21:34.946416Z     debug   state:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde} wait for workload       wl=default.client-ns2 (netshoot-client-anti-affinity-5fdcdcd549-t8l5r)
2025-09-29T22:21:34.946419Z     debug   state:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde} got sub, waiting for workload   wl=default.client-ns2 (netshoot-client-anti-affinity-5fdcdcd549-t8l5r)
2025-09-29T22:21:34.946979Z     debug   rustls::client::hs:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}    No cached session for IpAddress(V4(Ipv4Addr([0, 0, 0, 0])))
2025-09-29T22:21:34.947032Z     debug   rustls::client::hs:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}    Not resuming any session
2025-09-29T22:21:34.947771Z     debug   rustls::client::hs:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}    Using ciphersuite TLS13_AES_256_GCM_SHA384
2025-09-29T22:21:34.947797Z     debug   rustls::client::tls13:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde} Not resuming
2025-09-29T22:21:34.947917Z     debug   rustls::client::tls13:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde} TLS1.3 encrypted extensions: [Protocols([ProtocolName(6832)])]
2025-09-29T22:21:34.947929Z     debug   rustls::client::hs:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}    ALPN protocol is Some(b"h2")
2025-09-29T22:21:34.947939Z     debug   rustls::client::tls13:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde} Got CertificateRequest CertificateRequestPayloadTls13 { context: , extensions: [SignatureAlgorithms([ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ECDSA_NISTP521_SHA512, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256]), AuthorityNames([DistinguishedName(301831163014060355040a0c0d636c75737465722e6c6f63616c)])] }
2025-09-29T22:21:34.947948Z     debug   rustls::client::common:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}        Attempting client auth
2025-09-29T22:21:34.948465Z     debug   h2::client:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}    binding client connection
2025-09-29T22:21:34.948549Z     debug   h2::client:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}    client connection bound
2025-09-29T22:21:34.948605Z     debug   h2::codec::framed_write:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}       send    frame=Settings { flags: (0x0), enable_push: 0, initial_window_size: 4194304, max_frame_size: 1048576, max_header_list_size: 16384 }
2025-09-29T22:21:34.948652Z     debug   proxy::pool:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}   initial attempt - found existing conn, done
2025-09-29T22:21:34.948688Z     debug   proxy::pool:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}   starting an idle timeout for connection ConnectionMeta { key: 3715623523030535003, id: 3 }
2025-09-29T22:21:34.948689Z     debug   h2::codec::framed_write:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}       send    frame=WindowUpdate { stream_id: StreamId(0), size_increment: 16711681 }
2025-09-29T22:21:34.948708Z     debug   h2::codec::framed_write:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}       send    frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
2025-09-29T22:21:34.949226Z     debug   h2::codec::framed_read:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}        received        frame=Settings { flags: (0x0), max_concurrent_streams: 200, initial_window_size: 4194304, max_frame_size: 1048576, max_header_list_size: 65536 }
2025-09-29T22:21:34.949246Z     debug   h2::codec::framed_write:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}       send    frame=Settings { flags: (0x1: ACK) }
2025-09-29T22:21:34.949375Z     debug   h2::codec::framed_read:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}        received        frame=Settings { flags: (0x1: ACK) }
2025-09-29T22:21:34.949390Z     debug   h2::proto::settings:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}   received settings ACK; applying Settings { flags: (0x0), enable_push: 0, initial_window_size: 4194304, max_frame_size: 1048576, max_header_list_size: 16384 }
2025-09-29T22:21:34.949395Z     debug   h2::codec::framed_read:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}        received        frame=WindowUpdate { stream_id: StreamId(0), size_increment: 16711681 }
2025-09-29T22:21:34.950065Z     debug   h2::codec::framed_read:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}        received        frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
2025-09-29T22:21:34.950121Z     debug   h2::codec::framed_write:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}       send    frame=Data { stream_id: StreamId(1) }
2025-09-29T22:21:34.951217Z     debug   h2::codec::framed_read:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}        received        frame=Data { stream_id: StreamId(1) }
2025-09-29T22:21:34.951408Z     debug   h2::codec::framed_read:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}        received        frame=Data { stream_id: StreamId(1) }
2025-09-29T22:21:34.952015Z     debug   h2::codec::framed_read:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}        received        frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
2025-09-29T22:21:34.952036Z     debug   h2::codec::framed_write:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}:Connection{peer=Client}       send    frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
2025-09-29T22:21:34.952236Z     info    access  connection complete     src.addr=10.244.0.192:55534 src.workload="netshoot-client-anti-affinity-5fdcdcd549-t8l5r" src.namespace="client-ns2" src.identity="spiffe://cluster.local/ns/client-ns2/sa/default" dst.addr=10.244.1.243:15008 dst.hbone_addr=10.244.1.243:8080 dst.workload="netshoot-server-6b478b859-fb9mz" dst.namespace="server-ns" dst.identity="spiffe://cluster.local/ns/server-ns/sa/default" direction="outbound" bytes_sent=81 bytes_recv=460 duration="5ms"
2025-09-29T22:21:34.952256Z     debug   proxy::outbound:proxy{wl=client-ns2/netshoot-client-anti-affinity-5fdcdcd549-t8l5r}:outbound{id=49a1bab354bb5f83eeb93d2a5e62fbde}       connection completed    component="outbound" dur=5.981275ms
```

Fixes: #41896 
