### PR TITLE
ginkgo: add test ownership for ginkgo tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -663,10 +663,12 @@ Makefile* @cilium/build
 /test/Makefile* @cilium/ci-structure @cilium/build
 # Service handling tests
 /test/k8s/services.go @cilium/sig-lb @cilium/ci-structure
+/test/k8s/lrp.go @cilium/sig-lb
 # Datapath tests
 /test/k8s/bandwidth.go @cilium/sig-datapath @cilium/ci-structure
 /test/k8s/datapath_configuration.go @cilium/sig-datapath @cilium/ci-structure
 # Policy tests
+/test/k8s/chaos.go @cilium/sig-policy
 /test/k8s/net_policies.go @cilium/sig-policy @cilium/ci-structure
 /test/runtime/net_policies.go @cilium/sig-policy @cilium/ci-structure
 # Hubble/monitoring tests
@@ -679,6 +681,8 @@ Makefile* @cilium/build
 # BIG TCP tests
 /test/bigtcp @cilium/sig-datapath @cilium/ci-structure
 # Misc. tests
+/test/k8s/config.go @cilium/sig-k8s
+/test/k8s/pod_mac_address.go @cilium/sig-k8s
 /tools/dpgen @cilium/loader
 /tools/metricslint @cilium/metrics
 /tools/ @cilium/contributing

--- a/test/ginkgo-ext/junit_reporter.go
+++ b/test/ginkgo-ext/junit_reporter.go
@@ -20,27 +20,44 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/types"
+
+	"github.com/cilium/cilium/tools/testowners/codeowners"
 )
+
+// JUnitProperty represents a property in the JUnit XML
+type JUnitProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// JUnitProperties represents the properties section in JUnit XML
+type JUnitProperties struct {
+	XMLName    xml.Name        `xml:"properties"`
+	Properties []JUnitProperty `xml:"property"`
+}
 
 // JUnitTestSuite main struct to report all test in Junit Format
 type JUnitTestSuite struct {
-	XMLName   xml.Name        `xml:"testsuite"`
-	TestCases []JUnitTestCase `xml:"testcase"`
-	Name      string          `xml:"name,attr"`
-	Tests     int             `xml:"tests,attr"`
-	Failures  int             `xml:"failures,attr"`
-	Errors    int             `xml:"errors,attr"`
-	Time      float64         `xml:"time,attr"`
+	XMLName    xml.Name         `xml:"testsuite"`
+	Properties *JUnitProperties `xml:"properties,omitempty"`
+	TestCases  []JUnitTestCase  `xml:"testcase"`
+	Name       string           `xml:"name,attr"`
+	Tests      int              `xml:"tests,attr"`
+	Failures   int              `xml:"failures,attr"`
+	Errors     int              `xml:"errors,attr"`
+	Time       float64          `xml:"time,attr"`
 }
 
 // JUnitTestCase test case struct to report in Junit Format.
 type JUnitTestCase struct {
 	Name           string               `xml:"name,attr"`
 	ClassName      string               `xml:"classname,attr"`
+	Properties     *JUnitProperties     `xml:"properties,omitempty"`
 	FailureMessage *JUnitFailureMessage `xml:"failure,omitempty"`
 	Skipped        *JUnitSkipped        `xml:"skipped,omitempty"`
 	Time           float64              `xml:"time,attr"`
@@ -79,7 +96,37 @@ func (reporter *JUnitReporter) SpecSuiteWillBegin(config config.GinkgoConfigType
 		Name:      summary.SuiteDescription,
 		TestCases: []JUnitTestCase{},
 	}
-	reporter.testSuiteName = summary.SuiteDescription
+}
+
+// extractTestOwnerPrefix extracts the test owner from the test name pattern
+func (reporter *JUnitReporter) extractTestOwnerPrefix(testName string) string {
+	if testName == "" {
+		return ""
+	}
+
+	testName = strings.TrimPrefix(testName, "[Top Level] ")
+
+	// Look for test class patterns like "K8sAgentPolicyTest", "K8sDatapathServicesTest", etc.
+	// These typically end with "Test" and are at the beginning of the test name
+	parts := strings.Fields(testName)
+	if len(parts) > 0 {
+		firstPart := parts[0]
+		// Check if it looks like a test class name (ends with "Test")
+		if strings.HasSuffix(firstPart, "Test") ||
+			strings.HasSuffix(firstPart, "DatapathConfig") ||
+			strings.HasPrefix(firstPart, "RuntimeAgent") {
+			return firstPart
+		}
+	}
+
+	// Fallback: look for any word ending with "Test" in the test name
+	re := regexp.MustCompile(`\b\w+Test(s)?(Extended)?\b`)
+	matches := re.FindAllString(testName, -1)
+	if len(matches) > 0 {
+		return matches[0]
+	}
+
+	return ""
 }
 
 // SpecWillRun needed by ginkgo. Not used.
@@ -117,12 +164,63 @@ func (reporter *JUnitReporter) handleSetupSummary(name string, setupSummary *typ
 	}
 }
 
+// AddProperty adds a property to a specific test case
+func (testCase *JUnitTestCase) AddProperty(name, value string) {
+	if testCase.Properties == nil {
+		testCase.Properties = &JUnitProperties{
+			Properties: []JUnitProperty{},
+		}
+	}
+	testCase.Properties.Properties = append(testCase.Properties.Properties, JUnitProperty{
+		Name:  name,
+		Value: value,
+	})
+}
+
+type scenario struct {
+	name     string
+	filePath string
+}
+
+func (s scenario) Name() string {
+	return s.name
+}
+
+func (s scenario) FilePath() string {
+	return s.filePath
+}
+
 // SpecDidComplete reports the test results in a JUTestCase struct
 func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 	testCase := JUnitTestCase{
 		Name:      strings.Join(specSummary.ComponentTexts[1:], " "),
 		ClassName: reporter.testSuiteName,
 	}
+
+	// Extract owner from the full test name for individual test cases
+	fullTestName := strings.Join(specSummary.ComponentTexts, " ")
+	testPrefixName := reporter.extractTestOwnerPrefix(fullTestName)
+	filePath := reporter.mapTestToCODEOWNER(testPrefixName)
+	if filePath == "" {
+		panic(fmt.Sprintf("filePath not found for test %s", fullTestName))
+	}
+
+	owners, err := codeowners.Load([]string{})
+	if err != nil {
+		panic(fmt.Sprintf("failed to load owners: %s", err))
+	}
+	s := scenario{
+		name:     testPrefixName,
+		filePath: filePath,
+	}
+	codeOwners, err := owners.Owners(false, &s)
+	if err != nil {
+		panic(fmt.Sprintf("failed to find owners: %s", err))
+	}
+	for _, o := range codeOwners {
+		testCase.AddProperty("owner", o)
+	}
+
 	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
 		testCase.FailureMessage = &JUnitFailureMessage{
 			Type:    reporter.failureTypeForState(specSummary.State),
@@ -200,4 +298,43 @@ func reportChecks(output string) (string, string) {
 		}
 	}
 	return stdout, checks
+}
+
+// mapTestToCODEOWNER maps the test prefix to the corresponding filename
+// where the test is defined.
+// If no mapping is found, it returns an empty string.
+func (reporter *JUnitReporter) mapTestToCODEOWNER(prefix string) string {
+	switch prefix {
+	case "K8sAgentChaosTest":
+		return "test/k8s/chaos.go"
+	case "K8sAgentFQDNTest":
+		return "test/k8s/fqdn.go"
+	case "RuntimeAgentFQDNPolicies":
+		return "test/runtime/fqdn.go"
+	case "K8sAgentHubbleTest":
+		return "test/k8s/hubble.go"
+	case "K8sAgentPolicyTest":
+		return "test/k8s/net_policies.go"
+	case "K8sAgentPerNodeConfigTest":
+		return "test/k8s/config.go"
+	case "K8sPolicyTestExtended":
+		return "test/k8s/net_policies.go"
+	case "RuntimeAgentPolicies":
+		return "test/runtime/net_policies.go"
+	case "K8sDatapathBandwidthTest":
+		return "test/k8s/bandwidth.go"
+	case "K8sDatapathConfig":
+		return "test/k8s/datapath_configuration.go"
+	case "RuntimeDatapathMonitorTest":
+		return "test/runtime/monitor.go"
+	case "K8sDatapathLRPTests":
+		return "test/k8s/lrp.go"
+	case "K8sDatapathServicesTest":
+		return "test/k8s/services.go"
+	case "K8sKafkaPolicyTest":
+		return "test/k8s/kafka_policies.go"
+	case "K8sSpecificMACAddressTests":
+		return "test/k8s/pod_mac_address.go"
+	}
+	return ""
 }


### PR DESCRIPTION
Ginkgo tests are missing some ownership, we should add them so that we can have an owner for these tests and log them accordingly on OpenSearch.