### PR TITLE
github: fix concurrency group naming in conformance workflows

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -63,22 +63,25 @@ permissions:
 concurrency:
   # Structure:
   # - Workflow name
+  #   For workflow_call events, this is the name of the *parent* workflow.
   # - Event type
   # - A unique identifier depending on event type:
   #   - schedule: SHA
-  #   - workflow_dispatch: PR number. Because in workflow_call the parent context
-  #     is used, we need to add a prefix name ('aks') for the concurrency group
-  #     so that workflows that are executed in parallel don't conflict with each
-  #     other.
+  #   - workflow_dispatch: PR number.
+  # The 'aks' suffix added to both schedule and workflow_dispatch ensures
+  # that for workflow_call events it doesn't conflict with other potential
+  # parallel workflow_call done to other workflows from the same parent
+  # workflow. As otherwise the group name would be identical.
   #
   # This structure ensures a unique concurrency group name is generated for each
   # type of testing, such that re-runs will cancel the previous run.
   group: |
     ${{ github.workflow }}
+    aks
     ${{ github.event_name }}
     ${{
-      (github.event_name == 'schedule' && format('{0}-{1}', github.sha, 'aks')) ||
-      (github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.event.inputs.PR-number, 'aks'))
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
     }}
   cancel-in-progress: true
 

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -80,23 +80,27 @@ permissions:
 concurrency:
   # Structure:
   # - Workflow name
+  #   For workflow_call events, this is the name of the *parent* workflow.
   # - Event type
   # - A unique identifier depending on event type:
   #   - schedule: SHA
-  #   - workflow_dispatch: PR number. Because in workflow_call the parent context
-  #     is used, we need to add a prefix name ('eks') for the concurrency group
-  #     so that workflows that are executed in parallel don't conflict with each
-  #     other.
+  #   - workflow_dispatch: PR number.
+  # The 'eks' suffix added to both schedule and workflow_dispatch ensures
+  # that for workflow_call events it doesn't conflict with other potential
+  # parallel workflow_call done to other workflows from the same parent
+  # workflow. As otherwise the group name would be identical.
   #
   # This structure ensures a unique concurrency group name is generated for each
   # type of testing, such that re-runs will cancel the previous run.
   group: |
     ${{ github.workflow }}
+    eks
     ${{ github.event_name }}
     ${{
-      (github.event_name == 'schedule' && format('{0}-{1}', github.sha, 'eks')) ||
-      (github.event_name == 'workflow_dispatch' && format('{0}-{1}-{2}', github.event.inputs.PR-number, 'eks', inputs.UID))
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
     }}
+    ${{ inputs.UID }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -63,22 +63,25 @@ permissions:
 concurrency:
   # Structure:
   # - Workflow name
+  #   For workflow_call events, this is the name of the *parent* workflow.
   # - Event type
   # - A unique identifier depending on event type:
   #   - schedule: SHA
-  #   - workflow_dispatch: PR number. Because in workflow_call the parent context
-  #     is used, we need to add a prefix name ('gke') for the concurrency group
-  #     so that workflows that are executed in parallel don't conflict with each
-  #     other.
+  #   - workflow_dispatch: PR number.
+  # The 'gke' suffix added to both schedule and workflow_dispatch ensures
+  # that for workflow_call events it doesn't conflict with other potential
+  # parallel workflow_call done to other workflows from the same parent
+  # workflow. As otherwise the group name would be identical.
   #
   # This structure ensures a unique concurrency group name is generated for each
   # type of testing, such that re-runs will cancel the previous run.
   group: |
     ${{ github.workflow }}
+    gke
     ${{ github.event_name }}
     ${{
-      (github.event_name == 'schedule' && format('{0}-{1}', github.sha, 'gke')) ||
-      (github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.event.inputs.PR-number, 'gke'))
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
     }}
   cancel-in-progress: true
 


### PR DESCRIPTION
Standardize the concurrency group naming in conformance workflows.

Pick up suggestion by @joestringer in https://github.com/cilium/cilium/pull/41541#pullrequestreview-3280535229