### PR TITLE
pkg/l2_responder: add/rem node-solicited MACs

### DIFF
--- a/pkg/multicast/multicast.go
+++ b/pkg/multicast/multicast.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/mac"
 )
 
 var (
@@ -157,6 +158,16 @@ func (a Address) SolicitedNodeMaddr() netip.Addr {
 	copy(maddr[13:], ipv6.AsSlice()[13:])
 
 	return netip.AddrFrom16([16]byte(maddr))
+}
+
+// Construct solicited-node multicast MAC: 33:33:FF:XX:XX:XX
+// where XX:XX:XX are the last 3 bytes of the target IP address
+func SolicitedNodeMACAddr(addr netip.Addr) mac.MAC {
+	if !addr.Is6() {
+		return mac.MAC([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+	}
+	bytes := addr.As16()
+	return mac.MAC([]byte{0x33, 0x33, 0xFF, bytes[13], bytes[14], bytes[15]})
 }
 
 // interfaceByName get *net.Interface by name using netlink.


### PR DESCRIPTION
Commit '22becd9e92' introduced IPv6 support for L2 announcements.

Unfortunately, this commit did not program the solicited-node L2 MCAST MAC
address in the interface for the VIPs. NICs that implement L2 filtering
were therefore dropping the multicast Neighbour Solicitation packets, as
they didn't have any MCAST MAC addr programmed that matched that (VIPs
are never assigned to the interface).

Fix this by adding the solicited-node MAC address. Note that this
disables '' partial reconciliation for IPv6 given that:

> Note that multiple IPv6 addresses may have the same Sol. Node MC MAC
> address (and IPv6 Sol. Node addr) if they share the same last 24bits.
> Therefore, and in absence of a more refined approach (see TODO), loop
> through all entries and aggregate.
>
> TODO: improve this by having a secondary index with last 3 bytes
> of the IP address (suggested by Dylan).

Fixes #41678


```release-note
L2 announce: fix mcast IPv6 neighbour solicitations filtered by some NICs #41678
```