### PR TITLE
ipam: Wait for ENI netlink interface before configuring routes

### DIFF
--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -48,7 +48,7 @@ type EC2API interface {
 }
 
 type MetadataAPI interface {
-	GetInstanceMetadata() (metadata.MetaDataInfo, error)
+	GetInstanceMetadata(ctx context.Context) (metadata.MetaDataInfo, error)
 }
 
 // InstancesManager maintains the list of instances. It must be kept up to date
@@ -212,7 +212,7 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 	resyncStart := time.Now()
 
 	var currentVpcID string
-	metadataInfo, err := m.metadataapi.GetInstanceMetadata()
+	metadataInfo, err := m.metadataapi.GetInstanceMetadata(ctx)
 	if err != nil {
 		// when we can't retrieve the VPC ID from AWS metadata, we use the cached VPC ID
 		m.logger.Info("Unable to retrieve AWS instance metadata and will use cached VPC ID",

--- a/pkg/aws/metadata/metadata.go
+++ b/pkg/aws/metadata/metadata.go
@@ -25,16 +25,16 @@ type MetaDataInfo struct {
 	SubnetID         string
 }
 
-func NewClient() (*metadataClient, error) {
-	client, err := newClient()
+func NewClient(ctx context.Context) (*metadataClient, error) {
+	client, err := newClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &metadataClient{client: client}, nil
 }
 
-func newClient() (*imds.Client, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+func newClient(ctx context.Context) (*imds.Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +42,8 @@ func newClient() (*imds.Client, error) {
 	return imds.NewFromConfig(cfg), nil
 }
 
-func getMetadata(client *imds.Client, path string) (string, error) {
-	res, err := client.GetMetadata(context.TODO(), &imds.GetMetadataInput{
+func getMetadata(ctx context.Context, client *imds.Client, path string) (string, error) {
+	res, err := client.GetMetadata(ctx, &imds.GetMetadataInput{
 		Path: path,
 	})
 	if err != nil {
@@ -60,35 +60,35 @@ func getMetadata(client *imds.Client, path string) (string, error) {
 }
 
 // GetInstanceMetadata returns required AWS metadatas
-func (m *metadataClient) GetInstanceMetadata() (MetaDataInfo, error) {
+func (m *metadataClient) GetInstanceMetadata(ctx context.Context) (MetaDataInfo, error) {
 
-	instanceID, err := getMetadata(m.client, "instance-id")
+	instanceID, err := getMetadata(ctx, m.client, "instance-id")
 	if err != nil {
 		return MetaDataInfo{}, err
 	}
 
-	instanceType, err := getMetadata(m.client, "instance-type")
+	instanceType, err := getMetadata(ctx, m.client, "instance-type")
 	if err != nil {
 		return MetaDataInfo{}, err
 	}
 
-	eth0MAC, err := getMetadata(m.client, "mac")
+	eth0MAC, err := getMetadata(ctx, m.client, "mac")
 	if err != nil {
 		return MetaDataInfo{}, err
 	}
 	vpcIDPath := fmt.Sprintf("network/interfaces/macs/%s/vpc-id", eth0MAC)
-	vpcID, err := getMetadata(m.client, vpcIDPath)
+	vpcID, err := getMetadata(ctx, m.client, vpcIDPath)
 	if err != nil {
 		return MetaDataInfo{}, err
 	}
 
 	subnetIDPath := fmt.Sprintf("network/interfaces/macs/%s/subnet-id", eth0MAC)
-	subnetID, err := getMetadata(m.client, subnetIDPath)
+	subnetID, err := getMetadata(ctx, m.client, subnetIDPath)
 	if err != nil {
 		return MetaDataInfo{}, err
 	}
 
-	availabilityZone, err := getMetadata(m.client, "placement/availability-zone")
+	availabilityZone, err := getMetadata(ctx, m.client, "placement/availability-zone")
 	if err != nil {
 		return MetaDataInfo{}, err
 	}

--- a/pkg/aws/metadata/mock/metadata_mock.go
+++ b/pkg/aws/metadata/mock/metadata_mock.go
@@ -3,7 +3,11 @@
 
 package mock
 
-import "github.com/cilium/cilium/pkg/aws/metadata"
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/aws/metadata"
+)
 
 type metadataMock struct {
 }
@@ -13,6 +17,6 @@ func NewMetadataMock() (*metadataMock, error) {
 }
 
 // GetInstanceMetadata returns required AWS metadatas
-func (m *metadataMock) GetInstanceMetadata() (metadata.MetaDataInfo, error) {
+func (m *metadataMock) GetInstanceMetadata(ctx context.Context) (metadata.MetaDataInfo, error) {
 	return metadata.MetaDataInfo{}, nil
 }

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -129,7 +129,7 @@ func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 	} else {
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
-	imds, err := metadata.NewClient()
+	imds, err := metadata.NewClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize metadata client: %w", err)
 	}

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -381,11 +381,11 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 	case ipamOption.IPAMENI:
 		// set ENI field in the node only when the ENI ipam is specified
 		nodeResource.Spec.ENI = eniTypes.ENISpec{}
-		imds, err := metadata.NewClient()
+		imds, err := metadata.NewClient(ctx)
 		if err != nil {
 			logging.Fatal(n.logger, "Unable to create metadata client", logfields.Error, err)
 		}
-		info, err := imds.GetInstanceMetadata()
+		info, err := imds.GetInstanceMetadata(ctx)
 		if err != nil {
 			logging.Fatal(n.logger, "Unable to retrieve InstanceID of own EC2 instance", logfields.Error, err)
 		}


### PR DESCRIPTION
In ENI IPAM mode, the ENIs are created by the operator. At the same
time, on each node, the agents configure the v4 and v6 rules and routes
for the Cilium router, after retrieving its IPs from either k8s or the
filesystem. In order to do so, each agent query netlink to get the
ifindex of the interface with the router IP, given its MAC address.
Unfortunately this behavior is racy, since the agent might query netlink
too soon, when the ENI is not yet up and running. This leads to the
following error from netlink:

"daemon creation failed: failed to configure router IP rules and routes:
unable to find ifindex for interface MAC: interface with MAC ... not
found"

that ultimately stops the daemon startup.

To address this, let's poll netlink and wait for the ENI netlink
interface to show up before going ahead with routes and rules
configuration.

Fixes: #37948

~Depends on https://github.com/cilium/cilium/pull/41783~