### PR TITLE
workflows/eks: Fix cluster name for scheduled runs

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -101,7 +101,7 @@ concurrency:
 
 env:
   test_concurrency: ${{ inputs.test-concurrency || 3 }}
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.UID }}
+  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ inputs.UID }}-${{ github.run_attempt }}
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.214.0
   # renovate: datasource=github-releases depName=kubernetes/kubernetes


### PR DESCRIPTION
Commit 726967ce73a7 changed the cluster name in case of `workflow_call` to include an additional number at the end. In case of `scheduled` runs however, the number is undefined and we end up with a dash at the end of the cluster name. Cilium then complains:

    🔮 Auto-detected Kubernetes kind: EKS
    ℹ️  Using Cilium version 1.19.0
    ℹ️  Using cluster name "cilium-cilium-18131028140-1-"
    🔮 Auto-detected kube-proxy has been installed

    Error: Unable to install Cilium: execution error at (cilium/templates/validate.yaml:159:5): The cluster name is invalid: must consist of lower case alphanumeric characters and '-', and must start and end with an alphanumeric character

This pull request fixes it by moving the number to a different place in the name.

Fixes: https://github.com/cilium/cilium/pull/41877.