### PR TITLE
bpf: hostfw: share code for CT entry creation in egress policy path

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -574,7 +574,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		 * within the cluster, it must match policy or be dropped. If it's
 		 * bound for the host/outside, perform the CIDR policy check.
 		 */
-		verdict = policy_can_egress6(ctx, &cilium_policy_v2, tuple, l4_off, SECLABEL_IPV6,
+		verdict = policy_can_egress6(ctx, tuple, l4_off, SECLABEL_IPV6,
 					     *dst_sec_identity, &policy_match_type, &audited,
 					     ext_err, &proxy_port);
 
@@ -1018,7 +1018,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		 * within the cluster, it must match policy or be dropped. If it's
 		 * bound for the host/outside, perform the CIDR policy check.
 		 */
-		verdict = policy_can_egress4(ctx, &cilium_policy_v2, tuple, l4_off, SECLABEL_IPV4,
+		verdict = policy_can_egress4(ctx, tuple, l4_off, SECLABEL_IPV4,
 					     *dst_sec_identity, &policy_match_type, &audited,
 					     ext_err, &proxy_port);
 
@@ -1688,7 +1688,7 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 			break;
 #endif /* ENABLE_PER_PACKET_LB */
 
-		verdict = policy_can_ingress6(ctx, &cilium_policy_v2, tuple, l4_off,
+		verdict = policy_can_ingress6(ctx, tuple, l4_off,
 					      is_untracked_fragment, src_label, SECLABEL_IPV6,
 					      &policy_match_type, &audited, ext_err, proxy_port);
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
@@ -2028,7 +2028,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 			break;
 #endif /* ENABLE_PER_PACKET_LB */
 
-		verdict = policy_can_ingress4(ctx, &cilium_policy_v2, tuple, l4_off,
+		verdict = policy_can_ingress4(ctx, tuple, l4_off,
 					      is_untracked_fragment, src_label, SECLABEL_IPV4,
 					      &policy_match_type, &audited, ext_err, proxy_port);
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -94,7 +94,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		return CTX_ACT_OK;
 
 	/* Perform policy lookup. */
-	verdict = policy_can_egress6(ctx, &cilium_policy_v2, tuple, ct_buffer->l4_off, HOST_ID,
+	verdict = policy_can_egress6(ctx, tuple, ct_buffer->l4_off, HOST_ID,
 				     dst_sec_identity, &policy_match_type, &audited, ext_err,
 				     &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
@@ -235,7 +235,7 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 #  endif
 
 	/* Perform policy lookup */
-	verdict = policy_can_ingress6(ctx, &cilium_policy_v2, tuple, ct_buffer->l4_off,
+	verdict = policy_can_ingress6(ctx, tuple, ct_buffer->l4_off,
 				      is_untracked_fragment, *src_sec_identity, HOST_ID,
 				      &policy_match_type, &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
@@ -379,7 +379,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		return CTX_ACT_OK;
 
 	/* Perform policy lookup. */
-	verdict = policy_can_egress4(ctx, &cilium_policy_v2, tuple, ct_buffer->l4_off, HOST_ID,
+	verdict = policy_can_egress4(ctx, tuple, ct_buffer->l4_off, HOST_ID,
 				     dst_sec_identity, &policy_match_type,
 				     &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
@@ -512,7 +512,7 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 #  endif
 
 	/* Perform policy lookup */
-	verdict = policy_can_ingress4(ctx, &cilium_policy_v2, tuple, ct_buffer->l4_off,
+	verdict = policy_can_ingress4(ctx, tuple, ct_buffer->l4_off,
 				      is_untracked_fragment, *src_sec_identity, HOST_ID,
 				      &policy_match_type, &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -56,13 +56,11 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 			  struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
-	__u32 tunnel_endpoint = 0;
 	int ret = ct_buffer->ret;
-	int verdict;
+	int verdict = CTX_ACT_OK;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 	__u8 audited = 0;
 	__u8 auth_type = 0;
-	struct remote_endpoint_info *info;
 	__u32 dst_sec_identity = 0;
 	__u16 proxy_port = 0;
 
@@ -73,40 +71,35 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	if (ret == CT_REPLY || ret == CT_RELATED)
 		return CTX_ACT_OK;
 
-	if (!is_host_id) {
-		if (ret == CT_NEW) {
-			ret = ct_create6(get_ct_map6(tuple), &cilium_ct_any6_global,
-					 tuple, ctx, CT_EGRESS, NULL, ext_err);
-			if (unlikely(ret < 0))
-				return ret;
+	if (is_host_id) {
+		struct remote_endpoint_info *info;
+		__u32 tunnel_endpoint = 0;
+
+		/* Retrieve destination identity. */
+		info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
+		if (info) {
+			dst_sec_identity = info->sec_identity;
+			tunnel_endpoint = info->tunnel_endpoint.ip4;
 		}
+		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
+			   ip6->daddr.s6_addr32[3], dst_sec_identity);
 
-		return CTX_ACT_OK;
-	}
-
-	/* Retrieve destination identity. */
-	info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
-	if (info) {
-		dst_sec_identity = info->sec_identity;
-		tunnel_endpoint = info->tunnel_endpoint.ip4;
-	}
-	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
-		   ip6->daddr.s6_addr32[3], dst_sec_identity);
-
-	/* Perform policy lookup. */
-	verdict = policy_can_egress6(ctx, tuple, ct_buffer->l4_off, HOST_ID,
-				     dst_sec_identity, &policy_match_type, &audited, ext_err,
-				     &proxy_port);
-	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
-		auth_type = (__u8)*ext_err;
-		verdict = auth_lookup(ctx, HOST_ID, dst_sec_identity, tunnel_endpoint, auth_type);
+		/* Perform policy lookup. */
+		verdict = policy_can_egress6(ctx, tuple, ct_buffer->l4_off, HOST_ID,
+					     dst_sec_identity, &policy_match_type,
+					     &audited, ext_err, &proxy_port);
+		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
+			auth_type = (__u8)*ext_err;
+			verdict = auth_lookup(ctx, HOST_ID, dst_sec_identity,
+					      tunnel_endpoint, auth_type);
+		}
 	}
 
 	/* Only create CT entry for accepted connections */
 	if (ret == CT_NEW && verdict == CTX_ACT_OK) {
 		struct ct_state ct_state_new = {};
 
-		ct_state_new.src_sec_id = HOST_ID;
+		ct_state_new.src_sec_id = is_host_id ? HOST_ID : 0;
 		ct_state_new.proxy_redirect = proxy_port > 0;
 
 		/* ext_err may contain a value from __policy_can_access, and
@@ -121,19 +114,21 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 			return ret;
 	}
 
-	/* Emit verdict if drop or if allow for CT_NEW. */
-	if (verdict != CTX_ACT_OK || ret != CT_ESTABLISHED)
-		send_policy_verdict_notify(ctx, dst_sec_identity, tuple->dport,
-					   tuple->nexthdr, POLICY_EGRESS, 1,
-					   verdict, proxy_port, policy_match_type, audited,
-					   auth_type);
+	if (is_host_id) {
+		/* Emit verdict if drop or if allow for CT_NEW. */
+		if (verdict != CTX_ACT_OK || ret != CT_ESTABLISHED)
+			send_policy_verdict_notify(ctx, dst_sec_identity, tuple->dport,
+						   tuple->nexthdr, POLICY_EGRESS, 1,
+						   verdict, proxy_port, policy_match_type, audited,
+						   auth_type);
 
-	if (proxy_port > 0 && (ret == CT_NEW || ret == CT_ESTABLISHED)) {
-		/* Trace the packet before it is forwarded to proxy */
-		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL_IPV6, UNKNOWN_ID,
-				  bpf_ntohs(proxy_port), TRACE_IFINDEX_UNKNOWN,
-				  trace->reason, trace->monitor, bpf_htons(ETH_P_IPV6));
-		return ctx_redirect_to_proxy_host_egress(ctx, proxy_port);
+		if (proxy_port > 0 && (ret == CT_NEW || ret == CT_ESTABLISHED)) {
+			/* Trace the packet before it is forwarded to proxy */
+			send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL_IPV6, UNKNOWN_ID,
+					  bpf_ntohs(proxy_port), TRACE_IFINDEX_UNKNOWN,
+					  trace->reason, trace->monitor, bpf_htons(ETH_P_IPV6));
+			return ctx_redirect_to_proxy_host_egress(ctx, proxy_port);
+		}
 	}
 
 	return verdict;
@@ -330,13 +325,11 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 			  struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ipv4_ct_tuple *tuple = &ct_buffer->tuple;
-	__u32 tunnel_endpoint = 0;
 	int ret = ct_buffer->ret;
-	int verdict;
+	int verdict = CTX_ACT_OK;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 	__u8 audited = 0;
 	__u8 auth_type = 0;
-	struct remote_endpoint_info *info;
 	__u32 dst_sec_identity = 0;
 	__u16 proxy_port = 0;
 
@@ -351,50 +344,47 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	 * (eg. non-transparent proxy connection, or when using iptables masquerading).
 	 * The response packet will therefore have a host IP as the destination IP.
 	 *
-	 * To avoid enforcing host policies for response packets to pods, we
+	 * We don't want to apply egress policy for such packets. But
+	 * to avoid enforcing host policies for response packets to pods, we
 	 * need to create a CT entry for the forward, SNATed packet from the
 	 * pod. Response packets will thus match this CT entry and bypass host
 	 * policies.
 	 * We know the packet is a SNATed packet if the srcid from ipcache is
 	 * HOST_ID, but the actual srcid (derived from the packet mark) isn't.
 	 */
-	if (!is_host_id) {
-		if (ret == CT_NEW) {
-			ret = ct_create4(get_ct_map4(tuple), &cilium_ct_any4_global,
-					 tuple, ctx, CT_EGRESS, NULL, ext_err);
-			if (unlikely(ret < 0))
-				return ret;
+
+	if (is_host_id) {
+		struct remote_endpoint_info *info;
+		__u32 tunnel_endpoint = 0;
+
+		/* Retrieve destination identity. */
+		info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
+		if (info) {
+			dst_sec_identity = info->sec_identity;
+			tunnel_endpoint = info->tunnel_endpoint.ip4;
 		}
+		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
+			   ip4->daddr, dst_sec_identity);
 
-		return CTX_ACT_OK;
-	}
-
-	/* Retrieve destination identity. */
-	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-	if (info) {
-		dst_sec_identity = info->sec_identity;
-		tunnel_endpoint = info->tunnel_endpoint.ip4;
-	}
-	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
-		   ip4->daddr, dst_sec_identity);
-
-	/* Perform policy lookup. */
-	verdict = policy_can_egress4(ctx, tuple, ct_buffer->l4_off, HOST_ID,
-				     dst_sec_identity, &policy_match_type,
-				     &audited, ext_err, &proxy_port);
-	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
-		auth_type = (__u8)*ext_err;
-		verdict = auth_lookup(ctx, HOST_ID, dst_sec_identity, tunnel_endpoint, auth_type);
+		/* Perform policy lookup. */
+		verdict = policy_can_egress4(ctx, tuple, ct_buffer->l4_off, HOST_ID,
+					     dst_sec_identity, &policy_match_type,
+					     &audited, ext_err, &proxy_port);
+		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
+			auth_type = (__u8)*ext_err;
+			verdict = auth_lookup(ctx, HOST_ID, dst_sec_identity,
+					      tunnel_endpoint, auth_type);
+		}
 	}
 
 	/* Only create CT entry for accepted connections */
 	if (ret == CT_NEW && verdict == CTX_ACT_OK) {
 		struct ct_state ct_state_new = {};
 
-		ct_state_new.src_sec_id = HOST_ID;
+		ct_state_new.src_sec_id = is_host_id ? HOST_ID : 0;
 		ct_state_new.proxy_redirect = proxy_port > 0;
 
-		/* ext_err may contain a value from __eolicy_can_access, and
+		/* ext_err may contain a value from __policy_can_access, and
 		 * ct_create4 overwrites it only if it returns an error itself.
 		 * As the error from __policy_can_access is dropped in that
 		 * case, it's OK to return ext_err from ct_create4 along with
@@ -406,19 +396,21 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 			return ret;
 	}
 
-	/* Emit verdict if drop or if allow for CT_NEW. */
-	if (verdict != CTX_ACT_OK || ret != CT_ESTABLISHED)
-		send_policy_verdict_notify(ctx, dst_sec_identity, tuple->dport,
-					   tuple->nexthdr, POLICY_EGRESS, 0,
-					   verdict, proxy_port, policy_match_type, audited,
-					   auth_type);
+	if (is_host_id) {
+		/* Emit verdict if drop or if allow for CT_NEW. */
+		if (verdict != CTX_ACT_OK || ret != CT_ESTABLISHED)
+			send_policy_verdict_notify(ctx, dst_sec_identity, tuple->dport,
+						   tuple->nexthdr, POLICY_EGRESS, 0,
+						   verdict, proxy_port, policy_match_type, audited,
+						   auth_type);
 
-	if (proxy_port > 0 && (ret == CT_NEW || ret == CT_ESTABLISHED)) {
-		/* Trace the packet before it is forwarded to proxy */
-		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL_IPV4, UNKNOWN_ID,
-				  bpf_ntohs(proxy_port), TRACE_IFINDEX_UNKNOWN,
-				  trace->reason, trace->monitor, bpf_htons(ETH_P_IP));
-		return ctx_redirect_to_proxy_host_egress(ctx, proxy_port);
+		if (proxy_port > 0 && (ret == CT_NEW || ret == CT_ESTABLISHED)) {
+			/* Trace the packet before it is forwarded to proxy */
+			send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL_IPV4, UNKNOWN_ID,
+					  bpf_ntohs(proxy_port), TRACE_IFINDEX_UNKNOWN,
+					  trace->reason, trace->monitor, bpf_htons(ETH_P_IP));
+			return ctx_redirect_to_proxy_host_egress(ctx, proxy_port);
+		}
 	}
 
 	return verdict;

--- a/bpf/tests/network_policy.c
+++ b/bpf/tests/network_policy.c
@@ -20,8 +20,7 @@ check_egress_policy(struct __ctx_buff *ctx, __u32 dst_id, __u8 proto, __be16 dpo
 	__s8 ext_err;
 	__u16 proxy_port;
 
-	return policy_can_egress(ctx, &cilium_policy_v2,
-				 0 /* ignored */, dst_id,
+	return policy_can_egress(ctx, 0 /* ignored */, dst_id,
 				 0 /* ICMP only */,
 				 dport, proto, 0 /* ICMP only */,
 				 &match_type, &audited, &ext_err, &proxy_port);


### PR DESCRIPTION
As follow-up to https://github.com/cilium/cilium/pull/41915, de-dup the HostFW code that creates the CT entry for outbound connections.