### PR TITLE
bpf:nat: Fix DSR support for remote NodePort services

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1861,10 +1861,12 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 		}
 
 		/* Reverse NAT applies to return traffic only. */
-		if (unlikely(ct_state->rev_nat_index)) {
+		if (unlikely(ct_state->rev_nat_index || ct_state->nat_port)) {
 			int ret2;
 
-			ret2 = lb6_rev_nat(ctx, l4_off, ct_state->rev_nat_index,
+			ret2 = lb6_rev_nat(ctx, l4_off,
+					   ct_state->rev_nat_index,
+					   &ct_state->nat_addr, ct_state->nat_port,
 					   ct_state->loopback,
 					   tuple,
 					   ipfrag_has_l4_header(fraginfo), CT_INGRESS);
@@ -2164,13 +2166,14 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 		}
 
 		/* Reverse NAT applies to return traffic only. */
-		if (unlikely(ct_state->rev_nat_index)) {
+		if (unlikely(ct_state->rev_nat_index || ct_state->nat_port)) {
 			int ret2;
 
 			ret2 = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
 					   ct_state->rev_nat_index,
-					   ct_state->loopback,
-					   tuple, ipfrag_has_l4_header(fraginfo));
+					   ct_state->nat_addr.p4, ct_state->nat_port,
+					   ct_state->loopback, tuple,
+					   ipfrag_has_l4_header(fraginfo));
 			if (IS_ERR(ret2))
 				return ret2;
 		}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -239,7 +239,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 #endif
 
 		ret = lb4_dnat_request(ctx, backend, ETH_HLEN, fraginfo,
-				       l4_off, &key, &tuple, ct_state_new.loopback);
+				       l4_off, &tuple, ct_state_new.loopback);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -370,7 +370,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 		}
 
 		ret = lb6_dnat_request(ctx, backend, ETH_HLEN, fraginfo,
-				       l4_off, &key, &tuple, ct_state_new.loopback);
+				       l4_off, &tuple, ct_state_new.loopback);
 		if (IS_ERR(ret))
 			return ret;
 	}

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -280,6 +280,8 @@ ct_lookup_fill_state(struct ct_state *state, const struct ct_entry *entry,
 		state->proxy_redirect = entry->proxy_redirect;
 		state->from_l7lb = entry->from_l7lb;
 		state->from_tunnel = entry->from_tunnel;
+		ipv6_addr_copy(&state->nat_addr, &entry->nat_addr);
+		state->nat_port = entry->nat_port;
 	}
 }
 

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1212,6 +1212,32 @@ ct_has_loopback_egress_entry6(const void *map, struct ipv6_ct_tuple *tuple)
 #endif
 
 static __always_inline bool
+ct_has_egress_entry4(const void *map, struct ipv4_ct_tuple *tuple)
+{
+	__u8 flags = tuple->flags;
+	const struct ct_entry *entry;
+
+	tuple->flags = TUPLE_F_OUT;
+	entry = map_lookup_elem(map, tuple);
+	tuple->flags = flags;
+
+	return entry;
+}
+
+static __always_inline bool
+ct_has_egress_entry6(const void *map, struct ipv6_ct_tuple *tuple)
+{
+	__u8 flags = tuple->flags;
+	const struct ct_entry *entry;
+
+	tuple->flags = TUPLE_F_OUT;
+	entry = map_lookup_elem(map, tuple);
+	tuple->flags = flags;
+
+	return entry;
+}
+
+static __always_inline bool
 __ct_has_nodeport_egress_entry(const struct ct_entry *entry,
 			       __u16 *rev_nat_index, bool check_dsr)
 {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1442,7 +1442,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 
 	if (!nodeport_skip_xlate6(svc)) {
 		ret = lb6_dnat_request(ctx, backend, l3_off, fraginfo,
-				       l4_off, key, tuple, false);
+				       l4_off, tuple, false);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -2843,7 +2843,7 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 
 		if (!nodeport_skip_xlate4(svc))
 			ret = lb4_dnat_request(ctx, backend, l3_off, fraginfo,
-					       l4_off, key, tuple, false);
+					       l4_off, tuple, false);
 	}
 
 	if (IS_ERR(ret))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1007,8 +1007,9 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, enum ct_dir dir,
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
 
-		ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index, false,
-				  &tuple, ipfrag_has_l4_header(fraginfo),
+		ret = lb6_rev_nat(ctx, l4_off,
+				  ct_state.rev_nat_index, NULL, 0,
+				  false, &tuple, ipfrag_has_l4_header(fraginfo),
 				  dir);
 		if (IS_ERR(ret))
 			return ret;
@@ -2371,8 +2372,9 @@ nodeport_rev_dnat_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		trace->monitor = monitor;
-		ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index, false,
-				  &tuple, ipfrag_has_l4_header(fraginfo));
+		ret = lb4_rev_nat(ctx, l3_off, l4_off,
+				  ct_state.rev_nat_index, 0, 0,
+				  false, &tuple, ipfrag_has_l4_header(fraginfo));
 		if (IS_ERR(ret))
 			return ret;
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))

--- a/bpf/tests/tc_lxc_lb4_dsr_nodeport.c
+++ b/bpf/tests/tc_lxc_lb4_dsr_nodeport.c
@@ -1,0 +1,687 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define ENCAP_IFINDEX		42
+
+#define CLIENT_IP		v4_pod_one
+#define CLIENT_PORT		__bpf_htons(12345)
+
+#define REMOTE_NODE_IP		v4_node_two
+#define LOCAL_NODE_IP		v4_node_one
+#define NODEPORT_PORT		__bpf_htons(30080)
+#define NODEPORT_PORT_HAIRPIN	__bpf_htons(30081)
+#define NODEPORT_PORT_UDP	__bpf_htons(30082)
+
+#define BACKEND_IP_LOCAL	v4_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define BACKEND_IFACE		25
+#define BACKEND_EP_ID		127
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *node_mac = mac_three;
+static volatile const __u8 *backend_mac = mac_four;
+
+__section_entry
+int mock_handle_policy(struct __ctx_buff *ctx __maybe_unused)
+{
+	return CTX_ACT_OK;
+}
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 256);
+	__array(values, int());
+} mock_policy_call_map __section(".maps") = {
+	.values = {
+		[BACKEND_EP_ID] = &mock_handle_policy,
+	},
+};
+
+#define tail_call_dynamic mock_tail_call_dynamic
+static __always_inline __maybe_unused void
+mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
+		       const void *map __maybe_unused, __u32 slot __maybe_unused)
+{
+	tail_call(ctx, &mock_policy_call_map, slot);
+}
+
+#include "lib/bpf_lxc.h"
+
+/* Set the LXC source address to be the address of the client pod */
+ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = CLIENT_IP })
+ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/policy.h"
+#include "nodeport_defaults.h"
+
+/*
+ * Test: Pod -> Remote NodePort -> Local backend
+ * - Client pod sends packet to remote node's NodePort
+ * - LB selects a backend on the local node (same node as client)
+ * - Packet should be DNATed to local backend IP and port
+ * - Connection tracking entry should be created with
+ * - nat_addr = REMOTE_NODE_IP and nat_port = NODEPORT_PORT
+ */
+PKTGEN("tc", "tc_lxc_dsr_remote_nodeport_local_backend")
+int lxc_dsr_remote_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  CLIENT_IP, REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr_remote_nodeport_local_backend")
+int lxc_dsr_remote_nodeport_local_backend_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
+
+	lb_v4_add_service(0, NODEPORT_PORT, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(0, NODEPORT_PORT, 1, 125,
+			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112234, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr_remote_nodeport_local_backend")
+int lxc_dsr_remote_nodeport_local_backend_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed unexpectedly");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (l3->daddr != BACKEND_IP_LOCAL)
+		test_fatal("dst IP hasn't been DNATed to local backend IP");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been DNATed to backend port");
+
+	struct ipv4_ct_tuple tuple = {
+		.saddr = BACKEND_IP_LOCAL,
+		.daddr = CLIENT_IP,
+		.sport = CLIENT_PORT,
+		.dport = BACKEND_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	if (ct_entry->nat_addr.p4 != REMOTE_NODE_IP)
+		test_fatal("CT entry has incorrect nat_addr");
+
+	if (ct_entry->nat_port != NODEPORT_PORT)
+		test_fatal("CT entry has incorrect nat_port");
+
+	test_finish();
+}
+
+/*
+ * Test: Reply from local backend -> Client pod
+ * - Backend sends reply packet to client
+ * - Client pod's cil_to_container receives it
+ * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT
+ */
+PKTGEN("tc", "tc_lxc_dsr_remote_nodeport_local_backend_reply")
+int lxc_dsr_remote_nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)backend_mac, (__u8 *)client_mac,
+					  BACKEND_IP_LOCAL, CLIENT_IP,
+					  BACKEND_PORT, CLIENT_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr_remote_nodeport_local_backend_reply")
+int lxc_dsr_remote_nodeport_local_backend_reply_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(CLIENT_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)client_mac, (__u8 *)node_mac);
+
+	return pod_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr_remote_nodeport_local_backend_reply")
+int lxc_dsr_remote_nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l3->saddr != REMOTE_NODE_IP)
+		test_fatal("src IP hasn't been RevNATed to remote node IP");
+
+	if (l4->source != NODEPORT_PORT)
+		test_fatal("src port hasn't been RevNATed to nodeport");
+
+	if (l3->daddr != CLIENT_IP)
+		test_fatal("dst IP has changed unexpectedly");
+
+	if (l4->dest != CLIENT_PORT)
+		test_fatal("dst port has changed unexpectedly");
+
+	test_finish();
+}
+
+/*
+ * Test: Pod -> Remote NodePort -> Self (hairpin)
+ * - Client pod sends packet to remote node's NodePort
+ * - LB selects the client pod itself as the backend (loopback)
+ * - Packet should be DNATed to CLIENT_IP:BACKEND_PORT
+ * - Source should be SNATed to loopback IP to avoid routing issues
+ */
+PKTGEN("tc", "tc_lxc_dsr_remote_nodeport_hairpin")
+int lxc_dsr_remote_nodeport_hairpin_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  CLIENT_IP, REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_HAIRPIN);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr_remote_nodeport_hairpin")
+int lxc_dsr_remote_nodeport_hairpin_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 3;
+
+	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
+
+	lb_v4_add_service(0, NODEPORT_PORT_HAIRPIN, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(0, NODEPORT_PORT_HAIRPIN, 1, 126,
+			  CLIENT_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v4_add_entry(CLIENT_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)client_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(CLIENT_IP, 0, 112233, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr_remote_nodeport_hairpin")
+int lxc_dsr_remote_nodeport_hairpin_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l3->daddr != CLIENT_IP)
+		test_fatal("dst IP hasn't been DNATed to client IP (hairpin)");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been DNATed to backend port");
+
+	if (l3->saddr != v4_svc_loopback)
+		test_fatal("src IP hasn't been SNATed to loopback IP for hairpin");
+
+	struct ipv4_ct_tuple tuple = {
+		.saddr = CLIENT_IP,
+		.daddr = v4_svc_loopback,
+		.sport = CLIENT_PORT,
+		.dport = BACKEND_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	if (ct_entry->nat_addr.p4 != REMOTE_NODE_IP)
+		test_fatal("CT entry has incorrect nat_addr");
+
+	if (ct_entry->nat_port != NODEPORT_PORT_HAIRPIN)
+		test_fatal("CT entry has incorrect nat_port");
+
+	test_finish();
+}
+
+/*
+ * Test: Hairpin reply - Backend (self) -> Client pod
+ * - After hairpin, the pod replies to loopback IP
+ * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT_HAIRPIN
+ */
+PKTGEN("tc", "tc_lxc_dsr_remote_nodeport_hairpin_reply")
+int lxc_dsr_remote_nodeport_hairpin_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	/* Reply from backend (self) to loopback IP */
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  CLIENT_IP, v4_svc_loopback,
+					  BACKEND_PORT, CLIENT_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr_remote_nodeport_hairpin_reply")
+int lxc_dsr_remote_nodeport_hairpin_reply_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(CLIENT_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)client_mac, (__u8 *)node_mac);
+
+	return pod_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr_remote_nodeport_hairpin_reply")
+int lxc_dsr_remote_nodeport_hairpin_reply_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l3->saddr != REMOTE_NODE_IP)
+		test_fatal("src IP hasn't been RevNATed to remote node IP");
+
+	if (l4->source != NODEPORT_PORT_HAIRPIN)
+		test_fatal("src port hasn't been RevNATed to nodeport");
+
+	if (l3->daddr != CLIENT_IP)
+		test_fatal("dst IP has changed unexpectedly");
+
+	if (l4->dest != CLIENT_PORT)
+		test_fatal("dst port has changed unexpectedly");
+
+	test_finish();
+}
+
+/*
+ * Test: Existing connection - first UDP packet (without NodePort service)
+ * - Client pod sends UDP packet to remote node's NodePort
+ * - No NodePort service exists yet
+ * - Packet should NOT be DNATed (goes to remote node directly)
+ * - CT entry is created for this connection
+ */
+PKTGEN("tc", "tc_lxc_dsr_existing_conn_udp_first")
+int lxc_dsr_existing_conn_udp_first_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  CLIENT_IP, REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_UDP);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr_existing_conn_udp_first")
+int lxc_dsr_existing_conn_udp_first_setup(struct __ctx_buff *ctx)
+{
+	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr_existing_conn_udp_first")
+int lxc_dsr_existing_conn_udp_first_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct udphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct udphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Packet should NOT be DNATed - destination should still be remote node */
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed unexpectedly");
+
+	if (l3->daddr != REMOTE_NODE_IP)
+		test_fatal("dst IP should still be remote node IP (no DNAT)");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (l4->dest != NODEPORT_PORT_UDP)
+		test_fatal("dst port should still be nodeport (no DNAT)");
+
+	struct ipv4_ct_tuple tuple = {
+		.saddr = REMOTE_NODE_IP,
+		.daddr = CLIENT_IP,
+		.sport = CLIENT_PORT,
+		.dport = NODEPORT_PORT_UDP,
+		.nexthdr = IPPROTO_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found - CT entry should be created");
+
+	test_finish();
+}
+
+/*
+ * Test: Existing connection - second UDP packet (with NodePort service added)
+ * - Same UDP connection as previous test
+ * - NodePort service is NOW added
+ * - Packet should still NOT be DNATed because CT entry already exists
+ * - This verifies the CT check prevents wildcard lookup for existing connections
+ */
+PKTGEN("tc", "tc_lxc_dsr_existing_conn_udp_second")
+int lxc_dsr_existing_conn_udp_second_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	/* Same packet as first test */
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  CLIENT_IP, REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_UDP);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr_existing_conn_udp_second")
+int lxc_dsr_existing_conn_udp_second_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 10;
+
+	lb_v4_add_service(0, NODEPORT_PORT_UDP, IPPROTO_UDP, 1, revnat_id);
+	lb_v4_add_backend(0, NODEPORT_PORT_UDP, 1, 130,
+			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
+
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr_existing_conn_udp_second")
+int lxc_dsr_existing_conn_udp_second_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct udphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct udphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Even though NodePort service exists now, packet should NOT be DNATed
+	 * because CT entry already exists from the first packet.
+	 * The CT check should skip wildcard lookup for existing connections.
+	 */
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed unexpectedly");
+
+	if (l3->daddr != REMOTE_NODE_IP)
+		test_fatal("dst IP should still be remote node IP (CT check should skip wildcard)");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (l4->dest != NODEPORT_PORT_UDP)
+		test_fatal("dst port should still be nodeport (CT check should skip wildcard)");
+
+	test_finish();
+}

--- a/bpf/tests/tc_lxc_lb4_hybrid_dsr_nodeport.c
+++ b/bpf/tests/tc_lxc_lb4_hybrid_dsr_nodeport.c
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define ENABLE_DSR_BYUSER	1
+#define ENCAP_IFINDEX		42
+
+#define CLIENT_IP		v4_pod_one
+#define CLIENT_PORT		__bpf_htons(12345)
+
+#define REMOTE_NODE_IP		v4_node_two
+#define LOCAL_NODE_IP		v4_node_one
+#define NODEPORT_PORT_DSR	__bpf_htons(30080)
+#define NODEPORT_PORT_SNAT	__bpf_htons(30081)
+
+#define BACKEND_IP_LOCAL	v4_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define BACKEND_IFACE		25
+#define BACKEND_EP_ID		127
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *node_mac = mac_three;
+static volatile const __u8 *backend_mac = mac_four;
+
+__section_entry
+int mock_handle_policy(struct __ctx_buff *ctx __maybe_unused)
+{
+	return CTX_ACT_OK;
+}
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 256);
+	__array(values, int());
+} mock_policy_call_map __section(".maps") = {
+	.values = {
+		[BACKEND_EP_ID] = &mock_handle_policy,
+	},
+};
+
+#define tail_call_dynamic mock_tail_call_dynamic
+static __always_inline __maybe_unused void
+mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
+		       const void *map __maybe_unused, __u32 slot __maybe_unused)
+{
+	tail_call(ctx, &mock_policy_call_map, slot);
+}
+
+#include "lib/bpf_lxc.h"
+
+/* Set the LXC source address to be the address of the client pod */
+ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = CLIENT_IP })
+ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/policy.h"
+#include "nodeport_defaults.h"
+
+/*
+ * Test: DSR service - Pod -> Remote NodePort -> Local backend
+ * - NodePort service is configured with SVC_FLAG_FWD_MODE_DSR
+ * - Client pod sends packet to remote node's NodePort
+ * - Wildcard lookup should match and DNAT to local backend
+ */
+PKTGEN("tc", "tc_lxc_hybrid_dsr_service_dnat")
+int lxc_hybrid_dsr_service_dnat_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  CLIENT_IP, REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_DSR);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_hybrid_dsr_service_dnat")
+int lxc_hybrid_dsr_service_dnat_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
+
+	/* Add DSR service with SVC_FLAG_FWD_MODE_DSR */
+	lb_v4_add_service_with_flags(0, NODEPORT_PORT_DSR, IPPROTO_TCP, 1, revnat_id,
+				     SVC_FLAG_ROUTABLE, SVC_FLAG_FWD_MODE_DSR);
+	lb_v4_add_backend(0, NODEPORT_PORT_DSR, 1, 125,
+			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112234, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_hybrid_dsr_service_dnat")
+int lxc_hybrid_dsr_service_dnat_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* DSR service: packet SHOULD be DNATed to local backend */
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed unexpectedly");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (l3->daddr != BACKEND_IP_LOCAL)
+		test_fatal("dst IP hasn't been DNATed to local backend IP");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been DNATed to backend port");
+
+	struct ipv4_ct_tuple tuple = {
+		.saddr = BACKEND_IP_LOCAL,
+		.daddr = CLIENT_IP,
+		.sport = CLIENT_PORT,
+		.dport = BACKEND_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	if (ct_entry->nat_addr.p4 != REMOTE_NODE_IP)
+		test_fatal("CT entry has incorrect nat_addr");
+
+	if (ct_entry->nat_port != NODEPORT_PORT_DSR)
+		test_fatal("CT entry has incorrect nat_port");
+
+	test_finish();
+}
+
+/*
+ * Test: non-DSR (SNAT) service - Pod -> Remote NodePort -> No DNAT
+ * - NodePort service is configured WITHOUT SVC_FLAG_FWD_MODE_DSR
+ * - Client pod sends packet to remote node's NodePort
+ * - Wildcard lookup should be SKIPPED (nodeport_uses_dsr4 returns false)
+ * - Packet should go to original destination (remote node) without DNAT
+ */
+PKTGEN("tc", "tc_lxc_hybrid_snat_service_no_dnat")
+int lxc_hybrid_snat_service_no_dnat_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  CLIENT_IP, REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_SNAT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_hybrid_snat_service_no_dnat")
+int lxc_hybrid_snat_service_no_dnat_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
+
+	/* Add non-DSR (SNAT) service WITHOUT SVC_FLAG_FWD_MODE_DSR */
+	lb_v4_add_service_with_flags(0, NODEPORT_PORT_SNAT, IPPROTO_TCP, 1, revnat_id,
+				     SVC_FLAG_ROUTABLE, 0);
+	lb_v4_add_backend(0, NODEPORT_PORT_SNAT, 1, 126,
+			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112234, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_hybrid_snat_service_no_dnat")
+int lxc_hybrid_snat_service_no_dnat_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* non-DSR service: packet should NOT be DNATed
+	 * nodeport_uses_dsr4() returns false, so wildcard lookup is skipped
+	 */
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed unexpectedly");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (l3->daddr != REMOTE_NODE_IP)
+		test_fatal("dst IP should still be remote node (non-DSR skips wildcard)");
+
+	if (l4->dest != NODEPORT_PORT_SNAT)
+		test_fatal("dst port should still be nodeport (non-DSR skips wildcard)");
+
+	test_finish();
+}

--- a/bpf/tests/tc_lxc_lb6_dsr_nodeport.c
+++ b/bpf/tests/tc_lxc_lb6_dsr_nodeport.c
@@ -1,0 +1,747 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define ENCAP_IFINDEX		42
+
+#define CLIENT_IP		v6_pod_one
+#define CLIENT_PORT		__bpf_htons(12345)
+
+#define REMOTE_NODE_IP		v6_node_two
+#define LOCAL_NODE_IP		v6_node_one
+#define NODEPORT_PORT		__bpf_htons(30080)
+#define NODEPORT_PORT_HAIRPIN	__bpf_htons(30081)
+#define NODEPORT_PORT_UDP	__bpf_htons(30082)
+
+#define BACKEND_IP_LOCAL	v6_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define BACKEND_IFACE		25
+#define BACKEND_EP_ID		127
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *node_mac = mac_three;
+static volatile const __u8 *backend_mac = mac_four;
+
+__section_entry
+int mock_handle_policy(struct __ctx_buff *ctx __maybe_unused)
+{
+	return CTX_ACT_OK;
+}
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 256);
+	__array(values, int());
+} mock_policy_call_map __section(".maps") = {
+	.values = {
+		[BACKEND_EP_ID] = &mock_handle_policy,
+	},
+};
+
+#define tail_call_dynamic mock_tail_call_dynamic
+static __always_inline __maybe_unused void
+mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
+		       const void *map __maybe_unused, __u32 slot __maybe_unused)
+{
+	tail_call(ctx, &mock_policy_call_map, slot);
+}
+
+#include "lib/bpf_lxc.h"
+
+/* Set the LXC source address to be the address of the client pod */
+ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_one_addr })
+ASSIGN_CONFIG(union v6addr, service_loopback_ipv6, { .addr = v6_svc_loopback })
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/policy.h"
+#include "nodeport_defaults.h"
+
+/*
+ * Test: Pod -> Remote NodePort -> Local backend
+ * - Client pod sends packet to remote node's NodePort
+ * - LB selects a backend on the local node (same node as client)
+ * - Packet should be DNATed to local backend IP and port
+ * - Connection tracking entry should be created with
+ * - nat_addr = REMOTE_NODE_IP and nat_port = NODEPORT_PORT
+ */
+PKTGEN("tc", "tc_lxc_dsr6_remote_nodeport_local_backend")
+int lxc_dsr6_remote_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  (__u8 *)CLIENT_IP, (__u8 *)REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr6_remote_nodeport_local_backend")
+int lxc_dsr6_remote_nodeport_local_backend_setup(struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr backend_ip = {};
+	union v6addr zero_addr = {};
+	__u16 revnat_id = 2;
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&backend_ip, (const union v6addr *)BACKEND_IP_LOCAL);
+
+	ipcache_v6_add_entry(&remote_node_ip, 0, REMOTE_NODE_ID, 0, 0);
+
+	lb_v6_add_service(&zero_addr, NODEPORT_PORT, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_backend(&zero_addr, NODEPORT_PORT, 1, 125,
+			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v6_add_entry(&backend_ip, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+	ipcache_v6_add_entry(&backend_ip, 0, 112234, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr6_remote_nodeport_local_backend")
+int lxc_dsr6_remote_nodeport_local_backend_check(const struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr backend_ip = {};
+	union v6addr client_ip = {};
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	test_init();
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&backend_ip, (const union v6addr *)BACKEND_IP_LOCAL);
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &client_ip))
+		test_fatal("src IP has changed unexpectedly");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &backend_ip))
+		test_fatal("dst IP hasn't been DNATed to local backend IP");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been DNATed to backend port");
+
+	struct ipv6_ct_tuple tuple __align_stack_8 = {
+		.nexthdr = IPPROTO_TCP,
+		.sport = CLIENT_PORT,
+		.dport = BACKEND_PORT,
+		.flags = TUPLE_F_OUT,
+	};
+	ipv6_addr_copy(&tuple.saddr, &backend_ip);
+	ipv6_addr_copy(&tuple.daddr, &client_ip);
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	if (!ipv6_addr_equals(&ct_entry->nat_addr, &remote_node_ip))
+		test_fatal("CT entry has incorrect nat_addr");
+
+	if (ct_entry->nat_port != NODEPORT_PORT)
+		test_fatal("CT entry has incorrect nat_port");
+
+	test_finish();
+}
+
+/*
+ * Test: Reply from local backend -> Client pod
+ * - Backend sends reply packet to client
+ * - Client pod's cil_to_container receives it
+ * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT
+ */
+PKTGEN("tc", "tc_lxc_dsr6_remote_nodeport_local_backend_reply")
+int lxc_dsr6_remote_nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)backend_mac, (__u8 *)client_mac,
+					  (__u8 *)BACKEND_IP_LOCAL, (__u8 *)CLIENT_IP,
+					  BACKEND_PORT, CLIENT_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr6_remote_nodeport_local_backend_reply")
+int lxc_dsr6_remote_nodeport_local_backend_reply_setup(struct __ctx_buff *ctx)
+{
+	union v6addr client_ip = {};
+
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	endpoint_v6_add_entry(&client_ip, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+			      (__u8 *)client_mac, (__u8 *)node_mac);
+
+	return pod_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr6_remote_nodeport_local_backend_reply")
+int lxc_dsr6_remote_nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr client_ip = {};
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	test_init();
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &remote_node_ip))
+		test_fatal("src IP hasn't been RevNATed to remote node IP");
+
+	if (l4->source != NODEPORT_PORT)
+		test_fatal("src port hasn't been RevNATed to nodeport");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &client_ip))
+		test_fatal("dst IP has changed unexpectedly");
+
+	if (l4->dest != CLIENT_PORT)
+		test_fatal("dst port has changed unexpectedly");
+
+	test_finish();
+}
+
+/*
+ * Test: Pod -> Remote NodePort -> Self (hairpin)
+ * - Client pod sends packet to remote node's NodePort
+ * - LB selects the client pod itself as the backend (loopback)
+ * - Packet should be DNATed to CLIENT_IP:BACKEND_PORT
+ * - Source should be SNATed to loopback IP to avoid routing issues
+ */
+PKTGEN("tc", "tc_lxc_dsr6_remote_nodeport_hairpin")
+int lxc_dsr6_remote_nodeport_hairpin_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  (__u8 *)CLIENT_IP, (__u8 *)REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_HAIRPIN);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr6_remote_nodeport_hairpin")
+int lxc_dsr6_remote_nodeport_hairpin_setup(struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr client_ip = {};
+	union v6addr zero_addr = {};
+	__u16 revnat_id = 3;
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	ipcache_v6_add_entry(&remote_node_ip, 0, REMOTE_NODE_ID, 0, 0);
+
+	lb_v6_add_service(&zero_addr, NODEPORT_PORT_HAIRPIN, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_backend(&zero_addr, NODEPORT_PORT_HAIRPIN, 1, 126,
+			  &client_ip, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v6_add_entry(&client_ip, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+			      (__u8 *)client_mac, (__u8 *)node_mac);
+	ipcache_v6_add_entry(&client_ip, 0, 112233, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr6_remote_nodeport_hairpin")
+int lxc_dsr6_remote_nodeport_hairpin_check(const struct __ctx_buff *ctx)
+{
+	union v6addr client_ip = {};
+	union v6addr svc_loopback = { .addr = v6_svc_loopback };
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	test_init();
+
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &client_ip))
+		test_fatal("dst IP hasn't been DNATed to client IP (hairpin)");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been DNATed to backend port");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &svc_loopback))
+		test_fatal("src IP hasn't been SNATed to loopback IP for hairpin");
+
+	union v6addr remote_node_ip = {};
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+
+	struct ipv6_ct_tuple tuple __align_stack_8 = {
+		.nexthdr = IPPROTO_TCP,
+		.sport = CLIENT_PORT,
+		.dport = BACKEND_PORT,
+		.flags = TUPLE_F_OUT,
+	};
+	ipv6_addr_copy(&tuple.saddr, &client_ip);
+	ipv6_addr_copy(&tuple.daddr, &svc_loopback);
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	if (!ipv6_addr_equals(&ct_entry->nat_addr, &remote_node_ip))
+		test_fatal("CT entry has incorrect nat_addr");
+
+	if (ct_entry->nat_port != NODEPORT_PORT_HAIRPIN)
+		test_fatal("CT entry has incorrect nat_port");
+
+	test_finish();
+}
+
+/*
+ * Test: Hairpin reply - Backend (self) -> Client pod
+ * - After hairpin, the pod replies to loopback IP
+ * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT_HAIRPIN
+ */
+PKTGEN("tc", "tc_lxc_dsr6_remote_nodeport_hairpin_reply")
+int lxc_dsr6_remote_nodeport_hairpin_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+	static volatile const __u8 svc_loopback[] = v6_svc_loopback;
+
+	pktgen__init(&builder, ctx);
+
+	/* Reply from backend (self) to loopback IP */
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  (__u8 *)CLIENT_IP, (__u8 *)svc_loopback,
+					  BACKEND_PORT, CLIENT_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr6_remote_nodeport_hairpin_reply")
+int lxc_dsr6_remote_nodeport_hairpin_reply_setup(struct __ctx_buff *ctx)
+{
+	union v6addr client_ip = {};
+
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	endpoint_v6_add_entry(&client_ip, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+			      (__u8 *)client_mac, (__u8 *)node_mac);
+
+	return pod_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr6_remote_nodeport_hairpin_reply")
+int lxc_dsr6_remote_nodeport_hairpin_reply_check(const struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr client_ip = {};
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	test_init();
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &remote_node_ip))
+		test_fatal("src IP hasn't been RevNATed to remote node IP");
+
+	if (l4->source != NODEPORT_PORT_HAIRPIN)
+		test_fatal("src port hasn't been RevNATed to nodeport");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &client_ip))
+		test_fatal("dst IP has changed unexpectedly");
+
+	if (l4->dest != CLIENT_PORT)
+		test_fatal("dst port has changed unexpectedly");
+
+	test_finish();
+}
+
+/*
+ * Test: Existing connection - first UDP packet (without NodePort service)
+ * - Client pod sends UDP packet to remote node's NodePort
+ * - No NodePort service exists yet
+ * - Packet should NOT be DNATed (goes to remote node directly)
+ * - CT entry is created for this connection
+ */
+PKTGEN("tc", "tc_lxc_dsr6_existing_conn_udp_first")
+int lxc_dsr6_existing_conn_udp_first_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_udp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  (__u8 *)CLIENT_IP, (__u8 *)REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_UDP);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr6_existing_conn_udp_first")
+int lxc_dsr6_existing_conn_udp_first_setup(struct __ctx_buff *ctx)
+{
+	/* Add ipcache entry for remote node, but NO NodePort service */
+	ipcache_v6_add_entry((union v6addr *)REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr6_existing_conn_udp_first")
+int lxc_dsr6_existing_conn_udp_first_check(const struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr client_ip = {};
+	void *data, *data_end;
+	__u32 *status_code;
+	struct udphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	test_init();
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct udphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Packet should NOT be DNATed - destination should still be remote node */
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &client_ip))
+		test_fatal("src IP has changed unexpectedly");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &remote_node_ip))
+		test_fatal("dst IP should still be remote node IP (no DNAT)");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (l4->dest != NODEPORT_PORT_UDP)
+		test_fatal("dst port should still be nodeport (no DNAT)");
+
+	/* Verify CT entry was created */
+	struct ipv6_ct_tuple tuple __align_stack_8 = {
+		.nexthdr = IPPROTO_UDP,
+		.sport = CLIENT_PORT,
+		.dport = NODEPORT_PORT_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+	ipv6_addr_copy(&tuple.saddr, &remote_node_ip);
+	ipv6_addr_copy(&tuple.daddr, &client_ip);
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found - CT entry should be created");
+
+	test_finish();
+}
+
+/*
+ * Test: Existing connection - second UDP packet (with NodePort service added)
+ * - Same UDP connection as previous test
+ * - NodePort service is NOW added
+ * - Packet should still NOT be DNATed because CT entry already exists
+ * - This verifies the CT check prevents wildcard lookup for existing connections
+ */
+PKTGEN("tc", "tc_lxc_dsr6_existing_conn_udp_second")
+int lxc_dsr6_existing_conn_udp_second_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	/* Same packet as first test */
+	l4 = pktgen__push_ipv6_udp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  (__u8 *)CLIENT_IP, (__u8 *)REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_UDP);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_dsr6_existing_conn_udp_second")
+int lxc_dsr6_existing_conn_udp_second_setup(struct __ctx_buff *ctx)
+{
+	union v6addr zero_addr = {};
+	__u16 revnat_id = 10;
+
+	/* NOW add the wildcard NodePort service with local backend */
+	lb_v6_add_service(&zero_addr, NODEPORT_PORT_UDP, IPPROTO_UDP, 1, revnat_id);
+	lb_v6_add_backend(&zero_addr, NODEPORT_PORT_UDP, 1, 130,
+			  (union v6addr *)BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
+
+	endpoint_v6_add_entry((union v6addr *)BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID,
+			      0, 0, (__u8 *)backend_mac, (__u8 *)node_mac);
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_dsr6_existing_conn_udp_second")
+int lxc_dsr6_existing_conn_udp_second_check(const struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr client_ip = {};
+	void *data, *data_end;
+	__u32 *status_code;
+	struct udphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	test_init();
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct udphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Even though NodePort service exists now, packet should NOT be DNATed
+	 * because CT entry already exists from the first packet.
+	 * The CT check should skip wildcard lookup for existing connections.
+	 */
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &client_ip))
+		test_fatal("src IP has changed unexpectedly");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &remote_node_ip))
+		test_fatal("dst IP should still be remote node IP (CT check should skip wildcard)");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (l4->dest != NODEPORT_PORT_UDP)
+		test_fatal("dst port should still be nodeport (CT check should skip wildcard)");
+
+	test_finish();
+}

--- a/bpf/tests/tc_lxc_lb6_hybrid_dsr_nodeport.c
+++ b/bpf/tests/tc_lxc_lb6_hybrid_dsr_nodeport.c
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define ENABLE_DSR_BYUSER	1
+#define ENCAP_IFINDEX		42
+
+#define CLIENT_IP		v6_pod_one
+#define CLIENT_PORT		__bpf_htons(12345)
+
+#define REMOTE_NODE_IP		v6_node_two
+#define LOCAL_NODE_IP		v6_node_one
+#define NODEPORT_PORT_DSR	__bpf_htons(30080)
+#define NODEPORT_PORT_SNAT	__bpf_htons(30081)
+
+#define BACKEND_IP_LOCAL	v6_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define BACKEND_IFACE		25
+#define BACKEND_EP_ID		127
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *node_mac = mac_three;
+static volatile const __u8 *backend_mac = mac_four;
+
+__section_entry
+int mock_handle_policy(struct __ctx_buff *ctx __maybe_unused)
+{
+	return CTX_ACT_OK;
+}
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 256);
+	__array(values, int());
+} mock_policy_call_map __section(".maps") = {
+	.values = {
+		[BACKEND_EP_ID] = &mock_handle_policy,
+	},
+};
+
+#define tail_call_dynamic mock_tail_call_dynamic
+static __always_inline __maybe_unused void
+mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
+		       const void *map __maybe_unused, __u32 slot __maybe_unused)
+{
+	tail_call(ctx, &mock_policy_call_map, slot);
+}
+
+#include "lib/bpf_lxc.h"
+
+/* Set the LXC source address to be the address of the client pod */
+ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_one_addr })
+ASSIGN_CONFIG(union v6addr, service_loopback_ipv6, { .addr = v6_svc_loopback })
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/policy.h"
+#include "nodeport_defaults.h"
+
+/*
+ * Test: DSR service - Pod -> Remote NodePort -> Local backend
+ * - NodePort service is configured with SVC_FLAG_FWD_MODE_DSR
+ * - Client pod sends packet to remote node's NodePort
+ * - Wildcard lookup should match and DNAT to local backend
+ */
+PKTGEN("tc", "tc_lxc_hybrid6_dsr_service_dnat")
+int lxc_hybrid6_dsr_service_dnat_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  (__u8 *)CLIENT_IP, (__u8 *)REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_DSR);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_hybrid6_dsr_service_dnat")
+int lxc_hybrid6_dsr_service_dnat_setup(struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr backend_ip = {};
+	union v6addr zero_addr = {};
+	__u16 revnat_id = 1;
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&backend_ip, (const union v6addr *)BACKEND_IP_LOCAL);
+
+	ipcache_v6_add_entry(&remote_node_ip, 0, REMOTE_NODE_ID, 0, 0);
+
+	/* Add DSR service with SVC_FLAG_FWD_MODE_DSR */
+	lb_v6_add_service_with_flags(&zero_addr, NODEPORT_PORT_DSR, IPPROTO_TCP, 1, revnat_id,
+				     SVC_FLAG_ROUTABLE, SVC_FLAG_FWD_MODE_DSR);
+	lb_v6_add_backend(&zero_addr, NODEPORT_PORT_DSR, 1, 125,
+			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v6_add_entry(&backend_ip, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+	ipcache_v6_add_entry(&backend_ip, 0, 112234, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_hybrid6_dsr_service_dnat")
+int lxc_hybrid6_dsr_service_dnat_check(const struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr backend_ip = {};
+	union v6addr client_ip = {};
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	test_init();
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&backend_ip, (const union v6addr *)BACKEND_IP_LOCAL);
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* DSR service: packet SHOULD be DNATed to local backend */
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &client_ip))
+		test_fatal("src IP has changed unexpectedly");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &backend_ip))
+		test_fatal("dst IP hasn't been DNATed to local backend IP");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been DNATed to backend port");
+
+	struct ipv6_ct_tuple tuple __align_stack_8 = {
+		.nexthdr = IPPROTO_TCP,
+		.sport = CLIENT_PORT,
+		.dport = BACKEND_PORT,
+		.flags = TUPLE_F_OUT,
+	};
+	ipv6_addr_copy(&tuple.saddr, &backend_ip);
+	ipv6_addr_copy(&tuple.daddr, &client_ip);
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	if (!ipv6_addr_equals(&ct_entry->nat_addr, &remote_node_ip))
+		test_fatal("CT entry has incorrect nat_addr");
+
+	if (ct_entry->nat_port != NODEPORT_PORT_DSR)
+		test_fatal("CT entry has incorrect nat_port");
+
+	test_finish();
+}
+
+/*
+ * Test: non-DSR (SNAT) service - Pod -> Remote NodePort -> No DNAT
+ * - NodePort service is configured WITHOUT SVC_FLAG_FWD_MODE_DSR
+ * - Client pod sends packet to remote node's NodePort
+ * - Wildcard lookup should be SKIPPED (nodeport_uses_dsr6 returns false)
+ * - Packet should go to original destination (remote node) without DNAT
+ */
+PKTGEN("tc", "tc_lxc_hybrid6_snat_service_no_dnat")
+int lxc_hybrid6_snat_service_no_dnat_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)node_mac,
+					  (__u8 *)CLIENT_IP, (__u8 *)REMOTE_NODE_IP,
+					  CLIENT_PORT, NODEPORT_PORT_SNAT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lxc_hybrid6_snat_service_no_dnat")
+int lxc_hybrid6_snat_service_no_dnat_setup(struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr backend_ip = {};
+	union v6addr zero_addr = {};
+	__u16 revnat_id = 2;
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&backend_ip, (const union v6addr *)BACKEND_IP_LOCAL);
+
+	ipcache_v6_add_entry(&remote_node_ip, 0, REMOTE_NODE_ID, 0, 0);
+
+	/* Add non-DSR (SNAT) service WITHOUT SVC_FLAG_FWD_MODE_DSR */
+	lb_v6_add_service_with_flags(&zero_addr, NODEPORT_PORT_SNAT, IPPROTO_TCP, 1, revnat_id,
+				     SVC_FLAG_ROUTABLE, 0);
+	lb_v6_add_backend(&zero_addr, NODEPORT_PORT_SNAT, 1, 126,
+			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v6_add_entry(&backend_ip, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+	ipcache_v6_add_entry(&backend_ip, 0, 112234, 0, 0);
+
+	policy_add_egress_allow_all_entry();
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_lxc_hybrid6_snat_service_no_dnat")
+int lxc_hybrid6_snat_service_no_dnat_check(const struct __ctx_buff *ctx)
+{
+	union v6addr remote_node_ip = {};
+	union v6addr client_ip = {};
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	test_init();
+
+	ipv6_addr_copy(&remote_node_ip, (const union v6addr *)REMOTE_NODE_IP);
+	ipv6_addr_copy(&client_ip, (const union v6addr *)CLIENT_IP);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* non-DSR service: packet should NOT be DNATed
+	 * nodeport_uses_dsr6() returns false, so wildcard lookup is skipped
+	 */
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &client_ip))
+		test_fatal("src IP has changed unexpectedly");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed unexpectedly");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &remote_node_ip))
+		test_fatal("dst IP should still be remote node (non-DSR skips wildcard)");
+
+	if (l4->dest != NODEPORT_PORT_SNAT)
+		test_fatal("dst port should still be nodeport (non-DSR skips wildcard)");
+
+	test_finish();
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

---

<!-- Description of change -->

# Problem Statement

- When DSR and PER_PACKET_LB are enabled, connections fail if a client pod sends a request to a remote nodes's NodePort service while the server pod is located on the same node as the client. 
- This issue causes the Cilium connectivity tests to fail.
- For more details, refer to #41962 

# Root Cause

<img width="8284" height="2684" alt="image" src="https://github.com/user-attachments/assets/e28423c8-ba16-4bf6-9eb8-0733ef0fc1fd" />

- The root cause is that remote node only performs DNAT. This sets the packets's source address to client's node address, leading to a hairpin problem. Consequently, the originating node cannot perform the necessary REV NAT for the reply packets.
- The problem occurs through the following path:
  - Request
    - Client Pod -> Remote Node:nodePort
    - Local Node:sport -> Remote Node:nodePort (masquerading)
    - Local Node:sport -> Backend Pod:port (DSR DNAT)
    - Send the above packet over Geneve From Remote Node
    - Local Node route above packet to Backend Pod:port
   - Reply
     - BackendPod:port -> Local Node:sport
     - Route to loopback without REVNAT. Because of destination address is Local Node

# Solution Summary

<img width="4664" height="2604" alt="image" src="https://github.com/user-attachments/assets/0b254aa2-e33c-4d32-8521-fbadbf21a795" />

- To resolve this, remote service requests are now handled on the source node when DSR is enabled, similar to the behavior of socket-level load balancing.

# Key Consideration

- If we choose to address this by egressing to a remote node, a REV NAT stage corresponding to the native device masquerading is required. Because REV NAT executes only on the native devices's ingress path, we conclude it is better to handle this on the local node--analogous to the BPF socket load-balancer. Performing REV NAT in cil_from_container would unnecessarily increase complexity.

# Release Note
```release-note
Fix in-cluster NodePort connectivity failure in DSR mode when SocketLB
is disabled. When a pod accesses a NodePort service via a remote node's
IP (instead of the ClusterIP) and the selected backend resides on the
same node as the client, the connection fails due to missing reverse NAT
on the reply path.
```