### PR TITLE
loadbalancer: Add LookupFrontendByTuple and use from Hubble parser

### DIFF
--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -162,11 +162,10 @@ func (h *payloadGetters) GetServiceByAddr(ip netip.Addr, port uint16) *flowpb.Se
 		return nil
 	}
 	addrCluster := cmtypes.AddrClusterFrom(ip, 0)
-	addr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster, port, loadbalancer.ScopeExternal)
-	fe, _, found := h.frontends.Get(h.db.ReadTxn(), loadbalancer.FrontendByAddress(addr))
+	txn := h.db.ReadTxn()
+	fe, found := loadbalancer.LookupFrontendByTuple(txn, h.frontends, addrCluster, loadbalancer.TCP, port, loadbalancer.ScopeExternal)
 	if !found {
-		addr := loadbalancer.NewL3n4Addr(loadbalancer.UDP, addrCluster, port, loadbalancer.ScopeExternal)
-		fe, _, found = h.frontends.Get(h.db.ReadTxn(), loadbalancer.FrontendByAddress(addr))
+		fe, found = loadbalancer.LookupFrontendByTuple(txn, h.frontends, addrCluster, loadbalancer.UDP, port, loadbalancer.ScopeExternal)
 	}
 	if !found {
 		return nil

--- a/pkg/hubble/parser/cell/cell_test.go
+++ b/pkg/hubble/parser/cell/cell_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"math/rand/v2"
+	"net/netip"
+	"runtime"
+	"testing"
+
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+func TestPayloadGetters_GetServiceByAddr(t *testing.T) {
+	db := statedb.New()
+	fes, err := loadbalancer.NewFrontendsTable(loadbalancer.DefaultConfig, db)
+	require.NoError(t, err)
+
+	var addrTCP, addrUDP loadbalancer.L3n4Addr
+	require.NoError(t, addrTCP.ParseFromString("10.0.0.1:80/TCP"))
+	require.NoError(t, addrUDP.ParseFromString("20.0.0.2:80/UDP"))
+	wtxn := db.WriteTxn(fes)
+	svcNameTCP := loadbalancer.NewServiceName("nstcp", "tcp")
+	svcNameUDP := loadbalancer.NewServiceName("nsudp", "udp")
+	fes.Insert(wtxn, &loadbalancer.Frontend{FrontendParams: loadbalancer.FrontendParams{Address: addrTCP, ServiceName: svcNameTCP}})
+	fes.Insert(wtxn, &loadbalancer.Frontend{FrontendParams: loadbalancer.FrontendParams{Address: addrUDP, ServiceName: svcNameUDP}})
+	wtxn.Commit()
+
+	pg := payloadGetters{db: db, frontends: fes}
+
+	svc := pg.GetServiceByAddr(addrTCP.Addr(), 80)
+	require.NotNil(t, svc)
+	require.Equal(t, svcNameTCP.Namespace(), svc.Namespace)
+	require.Equal(t, svcNameTCP.Name(), svc.Name)
+
+	svc = pg.GetServiceByAddr(addrUDP.Addr(), 80)
+	require.NotNil(t, svc)
+	require.Equal(t, svcNameUDP.Namespace(), svc.Namespace)
+	require.Equal(t, svcNameUDP.Name(), svc.Name)
+
+	svc = pg.GetServiceByAddr(addrUDP.Addr(), 81)
+	require.Nil(t, svc)
+}
+
+func BenchmarkGetServiceByAddr(b *testing.B) {
+	db := statedb.New()
+	fes, err := loadbalancer.NewFrontendsTable(loadbalancer.DefaultConfig, db)
+	require.NoError(b, err)
+	pg := payloadGetters{db: db, frontends: fes}
+
+	b.ResetTimer()
+	for b.Loop() {
+		addr, port := randomAddrPort()
+		svc := pg.GetServiceByAddr(addr, port)
+		if svc != nil {
+			b.Fatal("non-nil svc")
+		}
+	}
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	b.ReportMetric(float64(mem.HeapSys+mem.HeapReleased)/1024/1024, "HeapSys+Released/MB")
+}
+
+func randomAddrPort() (netip.Addr, uint16) {
+	addr := [4]byte{byte(rand.Int()), byte(rand.Int()), byte(rand.Int()), byte(rand.Int())}
+	return netip.AddrFrom4(addr), uint16(rand.Int())
+}

--- a/pkg/loadbalancer/frontend_test.go
+++ b/pkg/loadbalancer/frontend_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loadbalancer
+
+import (
+	"testing"
+
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupFrontendByTuple(t *testing.T) {
+	db := statedb.New()
+	fes, err := NewFrontendsTable(DefaultConfig, db)
+	require.NoError(t, err, "NewFrontendsTable")
+
+	var addr L3n4Addr
+	addr.ParseFromString("10.0.0.1:80/TCP")
+
+	wtxn := db.WriteTxn(fes)
+	fe := &Frontend{
+		FrontendParams: FrontendParams{Address: addr},
+	}
+	fes.Insert(wtxn, fe)
+	txn := wtxn.Commit()
+
+	fe2, found := LookupFrontendByTuple(txn, fes, addr.AddrCluster(), addr.Protocol(), addr.Port(), addr.Scope())
+	require.True(t, found)
+	require.NotNil(t, fe2)
+	require.Equal(t, fe, fe2)
+
+	var addr2 L3n4Addr
+	addr2.ParseFromString("10.0.0.2:80/TCP")
+	fe2, found = LookupFrontendByTuple(txn, fes, addr2.AddrCluster(), addr2.Protocol(), addr2.Port(), addr2.Scope())
+	require.False(t, found)
+	require.Nil(t, fe2)
+}


### PR DESCRIPTION
676d346a1ead ("loadbalancer: Use unique for L3n4Addr") changed L3n4Addr to be backed by a `unique.Handle` to reduce memory usage and make hashing and comparisons fast. This significantly sped up the load-balancer control-plane as it was using `L3n4Addr` as a map key a lot. Unfortunately Go v1.24's unique package implementation wasn't tuned for very high rate of allocations and if `GOMAXPROCS` was low enough and allocation rate high enough this caused a huge backlog of `unique.Handle`s waiting to be cleaned up and memory usage kept ticking upwards. This was due to Go v1.24's unique implementing a cleanup with a background goroutine that iterated over the whole unique map to find `nil`d weak references. In Go v1.25 this issue doesn't exist as it uses `runtime.AddCleanup` to remove the references.

To fix the issue in v1.18 that uses Go v1.24 for some time now this introduces the `loadbalancer.LookupFrontendByTuple` that avoids creating a unique `L3n4Addr` value.

Benchmark results (GOMAXPROCS=4 benchtime=5s):
```
Go v1.24.0 no fix:
    BenchmarkGetServiceByAddr-4  3206036    2062·ns/op    1269·HeapSys+Released/MB    503·B/op    10·allocs/op⏎

Go v1.25.0 no fix:
    BenchmarkGetServiceByAddr-4  2083958    3425·ns/op    73.45·HeapSys+Released/MB    549·B/op    16·allocs/op⏎

Go v1.24.0 with LookupFrontendByTuple:
    BenchmarkGetServiceByAddr-4   18820899   315.4 ns/op    27.78 HeapSys+Released/MB      176 B/op     4 allocs/op

Go v1.25.0 with LookupFrontendByTuple:
    BenchmarkGetServiceByAddr-4   18694239   317.0 ns/op    28.14 HeapSys+Released/MB      176 B/op     4 allocs/op
```

In addition to fixing the leak this also sped up the best-case lookup times by 10x on both v1.24 and v1.25 due to avoiding the lookups into the unique map and allocations.

Fixes: #41623

```release-note
Fix increase in memory usage when service names are looked up at high rate during Hubble flow creation
```
