### PR TITLE
daemon: remove ctx & controller manager from `Daemon` struct

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -14,7 +14,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
-	"github.com/cilium/cilium/pkg/controller"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
@@ -50,8 +49,6 @@ const (
 // monitoring when a LXC starts.
 type Daemon struct {
 	params daemonParams
-
-	controllers *controller.Manager
 
 	endpointRestoreComplete       chan struct{}
 	endpointInitialPolicyComplete chan struct{}
@@ -218,8 +215,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 	})
 
 	d := Daemon{
-		params:      params,
-		controllers: controller.NewManager(),
+		params: params,
 	}
 
 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -51,7 +51,6 @@ const (
 type Daemon struct {
 	params daemonParams
 
-	ctx         context.Context
 	controllers *controller.Manager
 
 	endpointRestoreComplete       chan struct{}
@@ -220,7 +219,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 
 	d := Daemon{
 		params:      params,
-		ctx:         ctx,
 		controllers: controller.NewManager(),
 	}
 
@@ -360,7 +358,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 
 	bootstrapStats.restore.Start()
 	// fetch old endpoints before k8s is configured.
-	restoredEndpoints, err := d.fetchOldEndpoints(option.Config.StateDir)
+	restoredEndpoints, err := d.fetchOldEndpoints(ctx, option.Config.StateDir)
 	if err != nil {
 		params.Logger.Error("Unable to read existing endpoints", logfields.Error, err)
 	}
@@ -505,7 +503,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 	restoredRouterIPs.IPv4FromFS, restoredRouterIPs.IPv6FromFS = node.ExtractCiliumHostIPFromFS(params.Logger)
 
 	// Configure IPAM without using the configuration yet.
-	d.configureIPAM()
+	d.configureIPAM(ctx)
 
 	// Start IPAM
 	d.startIPAM()

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -535,7 +535,7 @@ func (d *Daemon) allocateIPs(ctx context.Context, router restoredIPs) error {
 	return d.allocateHealthIPs()
 }
 
-func (d *Daemon) configureIPAM() {
+func (d *Daemon) configureIPAM(ctx context.Context) {
 	// If the device has been specified, the IPv4AllocPrefix and the
 	// IPv6AllocPrefix were already allocated before the k8s.Init().
 	//
@@ -576,7 +576,7 @@ func (d *Daemon) configureIPAM() {
 	}
 
 	device := ""
-	drd, _ := d.params.DirectRoutingDevice.Get(d.ctx, d.params.DB.ReadTxn())
+	drd, _ := d.params.DirectRoutingDevice.Get(ctx, d.params.DB.ReadTxn())
 	if drd != nil {
 		device = drd.Name
 	}

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -157,7 +157,7 @@ func (d *Daemon) getPodForEndpoint(ep *endpoint.Endpoint) error {
 //
 // 3. regenerateRestoredEndpoints(): Regenerate the restored endpoints
 //   - recreate endpoint's policy, as well as bpf programs and maps
-func (d *Daemon) fetchOldEndpoints(dir string) (*endpointRestoreState, error) {
+func (d *Daemon) fetchOldEndpoints(ctx context.Context, dir string) (*endpointRestoreState, error) {
 	state := &endpointRestoreState{
 		possible: nil,
 		restored: []*endpoint.Endpoint{},
@@ -177,7 +177,7 @@ func (d *Daemon) fetchOldEndpoints(dir string) (*endpointRestoreState, error) {
 	}
 	eptsID := endpoint.FilterEPDir(dirFiles)
 
-	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, d.params.Logger, d.params.EndpointCreator, dir, eptsID)
+	state.possible = endpoint.ReadEPsFromDirNames(ctx, d.params.Logger, d.params.EndpointCreator, dir, eptsID)
 
 	if len(state.possible) == 0 {
 		d.params.Logger.Info("No old endpoints found.")


### PR DESCRIPTION
```
daemon: remove controller manager from Daemon

The PRs https://github.com/cilium/cilium/pull/41905 & https://github.com/cilium/cilium/pull/41907 refactored the last two usages of the daemon
controller manager with Hive Jobs.

Therefore, we can remove the controller manager field from the `Daemon`
struct.
```

Related PRs:
* https://github.com/cilium/cilium/pull/41905
* https://github.com/cilium/cilium/pull/41907

```
daemon: remove ctx from Daemon

It's not recommended to keep `context.Context` in structs (https://go.dev/blog/context-and-structs)
and we want to eventually get rid of the `Daemon` struct anyway.

Therefore, this commit removes the field `ctx` from the `Daemon` and passes
the daemon context that is managed by the Hive Cell lifecycle hook into
the functions that require it.
```