### PR TITLE
gha: Reduce stress testing scope for EGW scale workflow

### DIFF
--- a/.github/actions/cl2-modules/egw/modules/stress-test.yaml
+++ b/.github/actions/cl2-modules/egw/modules/stress-test.yaml
@@ -4,9 +4,9 @@
 
 # One repetition towards the given IP/port combination
 # Another repetition towards the same IP/port combination (same node)
-# Another repetition towards the same IP/port combination (different node)
-# Another repetition towards the same IP, but different port (same node)
-{{$tests := "base,same-port-node,diff-node,diff-port" }}
+#{{$tests := "base,same-port-node,diff-node,diff-port" }}
+# https://github.com/cilium/cilium/pull/41781
+{{$tests := "base,same-port-node" }}
 
 steps:
 - module:


### PR DESCRIPTION
The stress tests are causing the workflow to time out, and the workflow was failing consistently - https://github.com/cilium/cilium/actions/workflows/scale-test-egw.yaml?query=branch%3Amain. Reduce the scope of the stress tests that spawn parallel connections until the root cause for timeouts is known.

Signed-off-by: Aditi Ghag <aditi@cilium.io>
