### PR TITLE
workflows/ipsec: Improve LTS kernels coverage

### DIFF
--- a/.github/actions/e2e/ipsec_configs.yaml
+++ b/.github/actions/e2e/ipsec_configs.yaml
@@ -29,7 +29,7 @@
   kvstore: 'true'
 - name: 'ipsec-4'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: '6.12-20250923.075842'
+  kernel: '6.1-20250923.075842'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'geneve'
@@ -40,7 +40,7 @@
   kvstore: 'true'
 - name: 'ipsec-5'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: '5.10-20250923.075842'
+  kernel: '6.6-20250923.075842'
   kube-proxy: 'none'
   kpr: 'true'
   devices: '{eth0,eth1}'
@@ -51,7 +51,7 @@
   key-two: 'cbc-aes-sha256'
 - name: 'ipsec-6'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: '5.10-20250923.075842'
+  kernel: '6.1-20250923.075842'
   kube-proxy: 'none'
   kpr: 'true'
   devices: '{eth0,eth1}'


### PR DESCRIPTION
The IPsec workflow currently covers only a small subset of all LTS kernels, with v5.10 and v6.12 being more covered than others. Let's rebalance this to also cover v6.1 and v6.6.