### PR TITLE
encryption: skip conntrack for wireguard traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1133,8 +1133,10 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 			next_proto = ip6->nexthdr;
 			hdrlen = ipv6_hdrlen(ctx, &next_proto);
 			if (likely(hdrlen > 0) &&
-			    ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, ipcache_srcid))
+			    ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, ipcache_srcid)) {
 				trace.reason = TRACE_REASON_ENCRYPTED;
+				set_decrypt_mark(ctx, 0);
+			}
 		}
 # endif /* ENABLE_WIREGUARD */
 
@@ -1176,8 +1178,10 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 		if (!from_host) {
 			next_proto = ip4->protocol;
 			hdrlen = ipv4_hdrlen(ip4);
-			if (ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, ipcache_srcid))
+			if (ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, ipcache_srcid)) {
 				trace.reason = TRACE_REASON_ENCRYPTED;
+				set_decrypt_mark(ctx, 0);
+			}
 		}
 #endif /* ENABLE_WIREGUARD */
 

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -195,3 +195,43 @@ l2_announce6_na = (
     ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one) /
     ICMPv6NDOptDstLLAddr(lladdr=mac_two)
 )
+
+## Wireguard
+
+wireguard_port = 51871
+
+v4_wireguard = (
+    Ether(dst=mac_two, src=mac_one) /
+    IP(src=v4_node_one, dst=v4_node_two) /
+    UDP(sport=wireguard_port, dport=wireguard_port)
+)
+
+v4_wireguard_sport_mismatch = (
+    Ether(dst=mac_two, src=mac_one) /
+    IP(src=v4_node_one, dst=v4_node_two) /
+    UDP(sport=wireguard_port+1, dport=wireguard_port)
+)
+
+v4_wireguard_proto_mismatch = (
+    Ether(dst=mac_two, src=mac_one) /
+    IP(src=v4_node_one, dst=v4_node_two) /
+    TCP(sport=wireguard_port, dport=wireguard_port)
+)
+
+v6_wireguard = (
+    Ether(dst=mac_two, src=mac_one) /
+    IPv6(src=v6_node_one, dst=v6_node_two) /
+    UDP(sport=wireguard_port, dport=wireguard_port)
+)
+
+v6_wireguard_sport_mismatch = (
+    Ether(dst=mac_two, src=mac_one) /
+    IPv6(src=v6_node_one, dst=v6_node_two) /
+    UDP(sport=wireguard_port+1, dport=wireguard_port)
+)
+
+v6_wireguard_proto_mismatch = (
+    Ether(dst=mac_two, src=mac_one) /
+    IPv6(src=v6_node_one, dst=v6_node_two) /
+    TCP(sport=wireguard_port, dport=wireguard_port)
+)

--- a/bpf/tests/wireguard_from_netdev.c
+++ b/bpf/tests/wireguard_from_netdev.c
@@ -15,6 +15,7 @@
 #include "lib/bpf_host.h"
 
 #include "lib/node.h"
+#include "scapy.h"
 
 ASSIGN_CONFIG(__u16, wg_port, 51871)
 
@@ -30,20 +31,11 @@ PKTGEN("tc", "ipv4_not_decrypted_wireguard_from_netdev")
 int ipv4_not_decrypted_wireguard_from_netdev_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct udphdr *l4;
 
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv4_udp_packet(&builder,
-					  (__u8 *)mac_one,
-					       (__u8 *)mac_two,
-					       v4_node_one,
-					       v4_node_two,
-					       bpf_htons(CONFIG(wg_port)),
-					       bpf_htons(CONFIG(wg_port)));
-
-	if (!l4)
-		return TEST_ERROR;
+	BUF_DECL(V4_WIREGUARD, v4_wireguard);
+	BUILDER_PUSH_BUF(builder, V4_WIREGUARD);
 
 	pktgen__finish(&builder);
 	return 0;
@@ -127,20 +119,11 @@ PKTGEN("tc", "ipv6_not_decrypted_wireguard_from_netdev")
 int ipv6_not_decrypted_wireguard_from_netdev_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct udphdr *l4;
 
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv6_udp_packet(&builder,
-					  (__u8 *)mac_one,
-					       (__u8 *)mac_two,
-					       (__u8 *)v6_node_one,
-					       (__u8 *)v6_node_two,
-					       bpf_htons(CONFIG(wg_port)),
-					       bpf_htons(CONFIG(wg_port)));
-
-	if (!l4)
-		return TEST_ERROR;
+	BUF_DECL(V6_WIREGUARD, v6_wireguard);
+	BUILDER_PUSH_BUF(builder, V6_WIREGUARD);
 
 	pktgen__finish(&builder);
 	return 0;
@@ -234,20 +217,11 @@ PKTGEN("tc", "ipv4_not_decrypted_wireguard_from_netdev_no_identity")
 int ipv4_not_decrypted_wireguard_from_netdev_no_identity_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct udphdr *l4;
 
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv4_udp_packet(&builder,
-					  (__u8 *)mac_one,
-					       (__u8 *)mac_two,
-					       v4_node_one,
-					       v4_node_two,
-					       bpf_htons(CONFIG(wg_port)),
-					       bpf_htons(CONFIG(wg_port)));
-
-	if (!l4)
-		return TEST_ERROR;
+	BUF_DECL(V4_WIREGUARD_NO_ID, v4_wireguard);
+	BUILDER_PUSH_BUF(builder, V4_WIREGUARD_NO_ID);
 
 	pktgen__finish(&builder);
 	return 0;
@@ -279,20 +253,11 @@ PKTGEN("tc", "ipv6_not_decrypted_wireguard_from_netdev_no_identity")
 int ipv6_not_decrypted_wireguard_from_netdev_no_identity_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct udphdr *l4;
 
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv6_udp_packet(&builder,
-					  (__u8 *)mac_one,
-					       (__u8 *)mac_two,
-					       (__u8 *)v6_node_one,
-					       (__u8 *)v6_node_two,
-					       bpf_htons(CONFIG(wg_port)),
-					       bpf_htons(CONFIG(wg_port)));
-
-	if (!l4)
-		return TEST_ERROR;
+	BUF_DECL(V6_WIREGUARD_NO_ID, v6_wireguard);
+	BUILDER_PUSH_BUF(builder, V6_WIREGUARD_NO_ID);
 
 	pktgen__finish(&builder);
 	return 0;
@@ -325,20 +290,11 @@ PKTGEN("tc", "ipv4_not_decrypted_wireguard_from_netdev_port_mismatch")
 int ipv4_not_decrypted_wireguard_from_netdev_port_mismatch_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct udphdr *l4;
 
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv4_udp_packet(&builder,
-					  (__u8 *)mac_one,
-					       (__u8 *)mac_two,
-					       v4_node_one,
-					       v4_node_two,
-					       bpf_htons(CONFIG(wg_port)),
-					       bpf_htons(CONFIG(wg_port)) + 1);
-
-	if (!l4)
-		return TEST_ERROR;
+	BUF_DECL(V4_WIREGUARD_SPORT_MISMATCH, v4_wireguard_sport_mismatch);
+	BUILDER_PUSH_BUF(builder, V4_WIREGUARD_SPORT_MISMATCH);
 
 	pktgen__finish(&builder);
 	return 0;
@@ -381,20 +337,11 @@ PKTGEN("tc", "ipv6_not_decrypted_wireguard_from_netdev_port_mismatch")
 int ipv6_not_decrypted_wireguard_from_netdev_port_mismatch_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct udphdr *l4;
 
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv6_udp_packet(&builder,
-					  (__u8 *)mac_one,
-					       (__u8 *)mac_two,
-					       (__u8 *)v6_node_one,
-					       (__u8 *)v6_node_two,
-					       bpf_htons(CONFIG(wg_port)),
-					       bpf_htons(CONFIG(wg_port)) + 1);
-
-	if (!l4)
-		return TEST_ERROR;
+	BUF_DECL(V6_WIREGUARD_SPORT_MISMATCH, v6_wireguard_sport_mismatch);
+	BUILDER_PUSH_BUF(builder, V6_WIREGUARD_SPORT_MISMATCH);
 
 	pktgen__finish(&builder);
 	return 0;
@@ -439,20 +386,11 @@ PKTGEN("tc", "ipv4_not_decrypted_wireguard_from_netdev_protocol_mismatch")
 int ipv4_not_decrypted_wireguard_from_netdev_protocol_mismatch_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct tcphdr *l4;
 
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv4_tcp_packet(&builder,
-					  (__u8 *)mac_one,
-					       (__u8 *)mac_two,
-					       v4_node_one,
-					       v4_node_two,
-					       bpf_htons(CONFIG(wg_port)),
-					       bpf_htons(CONFIG(wg_port)));
-
-	if (!l4)
-		return TEST_ERROR;
+	BUF_DECL(V4_WIREGUARD_PROTO_MISMATCH, v4_wireguard_proto_mismatch);
+	BUILDER_PUSH_BUF(builder, V4_WIREGUARD_PROTO_MISMATCH);
 
 	pktgen__finish(&builder);
 	return 0;
@@ -495,20 +433,11 @@ PKTGEN("tc", "ipv6_not_decrypted_wireguard_from_netdev_protocol_mismatch")
 int ipv6_not_decrypted_wireguard_from_netdev_protocol_mismatch_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
-	struct tcphdr *l4;
 
 	pktgen__init(&builder, ctx);
 
-	l4 = pktgen__push_ipv6_tcp_packet(&builder,
-					  (__u8 *)mac_one,
-					       (__u8 *)mac_two,
-					       (__u8 *)v6_node_one,
-					       (__u8 *)v6_node_two,
-					       bpf_htons(CONFIG(wg_port)),
-					       bpf_htons(CONFIG(wg_port)));
-
-	if (!l4)
-		return TEST_ERROR;
+	BUF_DECL(V6_WIREGUARD_PROTO_MISMATCH, v6_wireguard_proto_mismatch);
+	BUILDER_PUSH_BUF(builder, V6_WIREGUARD_PROTO_MISMATCH);
 
 	pktgen__finish(&builder);
 	return 0;

--- a/bpf/tests/wireguard_from_netdev.c
+++ b/bpf/tests/wireguard_from_netdev.c
@@ -1,0 +1,550 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define NODE_ID 7
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_WIREGUARD
+#define CLUSTER_IDENTITY 0x5555
+#define ENABLE_NODE_ENCRYPTION
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#include "lib/bpf_host.h"
+
+#include "lib/node.h"
+
+ASSIGN_CONFIG(__u16, wg_port, 51871)
+
+/* these tests validate that a real wireguard packet is handled properly
+ * we expect the packet to not be modified, and to be passed up the stack with
+ * the MARK_MAGIC_DECRYPT mark in skb->mark.
+ * conditions:
+ *  - udp packet
+ *  - source and dest ports == $wg_port
+ *  - source node with a valid identity in the cluster
+ */
+PKTGEN("tc", "ipv4_not_decrypted_wireguard_from_netdev")
+int ipv4_not_decrypted_wireguard_from_netdev_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)mac_one,
+					       (__u8 *)mac_two,
+					       v4_node_one,
+					       v4_node_two,
+					       bpf_htons(CONFIG(wg_port)),
+					       bpf_htons(CONFIG(wg_port)));
+
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv4_not_decrypted_wireguard_from_netdev")
+int ipv4_not_decrypted_wireguard_from_netdev_setup(struct __ctx_buff *ctx)
+{
+	/* We need to populate the node ID map because we'll lookup into it on
+	 * ingress to validate the source
+	 */
+	node_v4_add_entry(v4_node_one, NODE_ID, 1);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "ipv4_not_decrypted_wireguard_from_netdev")
+int ipv4_not_decrypted_wireguard_from_netdev_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct udphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	/* packet goes up the stack for decryption */
+	assert(*status_code == CTX_ACT_OK);
+
+	/* we use this mark to skip conntrack for encrypted flows */
+	assert((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("not_decrypted: src mac hasn't been set to source node's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest node's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != v4_node_one)
+		test_fatal("src IP was changed");
+
+	if (l3->daddr != v4_node_two)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct udphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != bpf_htons(CONFIG(wg_port)) || l4->dest != bpf_htons(CONFIG(wg_port)))
+		test_fatal("wrong port. expected src:%u dst:%u, got src:%u dst:%u",
+			   bpf_htons(CONFIG(wg_port)), bpf_htons(CONFIG(wg_port)),
+			  l4->source, l4->dest);
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_not_decrypted_wireguard_from_netdev")
+int ipv6_not_decrypted_wireguard_from_netdev_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_udp_packet(&builder,
+					  (__u8 *)mac_one,
+					       (__u8 *)mac_two,
+					       (__u8 *)v6_node_one,
+					       (__u8 *)v6_node_two,
+					       bpf_htons(CONFIG(wg_port)),
+					       bpf_htons(CONFIG(wg_port)));
+
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv6_not_decrypted_wireguard_from_netdev")
+int ipv6_not_decrypted_wireguard_from_netdev_setup(struct __ctx_buff *ctx)
+{
+	/* We need to populate the node ID map because we'll lookup into it on
+	 * ingress to validate the source
+	 */
+	node_v6_add_entry((union v6addr *)v6_node_one, NODE_ID, 1);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "ipv6_not_decrypted_wireguard_from_netdev")
+int ipv6_not_decrypted_wireguard_from_netdev_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct udphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* packet goes up the stack for decryption */
+	assert(*status_code == CTX_ACT_OK);
+
+	/* we use this mark to skip conntrack for encrypted flows */
+	assert((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("not_decrypted: src mac hasn't been set to source node's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest node's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)v6_node_one, 16) != 0)
+		test_fatal("src IP was changed");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_node_two, 16) != 0)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct udphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != bpf_htons(CONFIG(wg_port)) || l4->dest != bpf_htons(CONFIG(wg_port)))
+		test_fatal("wrong port. expected src:%u dst:%u, got src:%u dst:%u",
+			   bpf_htons(CONFIG(wg_port)), bpf_htons(CONFIG(wg_port)),
+			  l4->source, l4->dest);
+
+	test_finish();
+}
+
+/* end */
+
+/* these tests below should not match wireguard traffic
+ * anything that violates any of the conditions in the
+ * block that tests with the real wireguard packets
+ * we expect to see mark value not set to MARK_MAGIC_DECRYPT
+ */
+
+/* no identity */
+PKTGEN("tc", "ipv4_not_decrypted_wireguard_from_netdev_no_identity")
+int ipv4_not_decrypted_wireguard_from_netdev_no_identity_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)mac_one,
+					       (__u8 *)mac_two,
+					       v4_node_one,
+					       v4_node_two,
+					       bpf_htons(CONFIG(wg_port)),
+					       bpf_htons(CONFIG(wg_port)));
+
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+CHECK("tc", "ipv4_not_decrypted_wireguard_from_netdev_no_identity")
+int ipv4_not_decrypted_wireguard_from_netdev_no_identity_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_DECRYPT);
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_not_decrypted_wireguard_from_netdev_no_identity")
+int ipv6_not_decrypted_wireguard_from_netdev_no_identity_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_udp_packet(&builder,
+					  (__u8 *)mac_one,
+					       (__u8 *)mac_two,
+					       (__u8 *)v6_node_one,
+					       (__u8 *)v6_node_two,
+					       bpf_htons(CONFIG(wg_port)),
+					       bpf_htons(CONFIG(wg_port)));
+
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+CHECK("tc", "ipv6_not_decrypted_wireguard_from_netdev_no_identity")
+int ipv6_not_decrypted_wireguard_from_netdev_no_identity_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_DECRYPT);
+
+	test_finish();
+}
+
+/* port mismatch */
+PKTGEN("tc", "ipv4_not_decrypted_wireguard_from_netdev_port_mismatch")
+int ipv4_not_decrypted_wireguard_from_netdev_port_mismatch_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)mac_one,
+					       (__u8 *)mac_two,
+					       v4_node_one,
+					       v4_node_two,
+					       bpf_htons(CONFIG(wg_port)),
+					       bpf_htons(CONFIG(wg_port)) + 1);
+
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv4_not_decrypted_wireguard_from_netdev_port_mismatch")
+int ipv4_not_decrypted_wireguard_from_netdev_port_mismatch_setup(struct __ctx_buff *ctx)
+{
+	/* We need to populate the node ID map because we'll lookup into it on
+	 * ingress to validate the source
+	 */
+	node_v4_add_entry(v4_node_one, NODE_ID, 1);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "ipv4_not_decrypted_wireguard_from_netdev_port_mismatch")
+int ipv4_not_decrypted_wireguard_from_netdev_port_mismatch_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_DECRYPT);
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_not_decrypted_wireguard_from_netdev_port_mismatch")
+int ipv6_not_decrypted_wireguard_from_netdev_port_mismatch_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_udp_packet(&builder,
+					  (__u8 *)mac_one,
+					       (__u8 *)mac_two,
+					       (__u8 *)v6_node_one,
+					       (__u8 *)v6_node_two,
+					       bpf_htons(CONFIG(wg_port)),
+					       bpf_htons(CONFIG(wg_port)) + 1);
+
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv6_not_decrypted_wireguard_from_netdev_port_mismatch")
+int ipv6_not_decrypted_wireguard_from_netdev_port_mismatch_setup(struct __ctx_buff *ctx)
+{
+	/* We need to populate the node ID map because we'll lookup into it on
+	 * ingress to validate the source
+	 */
+	node_v6_add_entry((union v6addr *)v6_node_one, NODE_ID, 1);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "ipv6_not_decrypted_wireguard_from_netdev_port_mismatch")
+int ipv6_not_decrypted_wireguard_from_netdev_port_mismatch_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_DECRYPT);
+
+	test_finish();
+}
+
+/* protocol mismatch */
+
+PKTGEN("tc", "ipv4_not_decrypted_wireguard_from_netdev_protocol_mismatch")
+int ipv4_not_decrypted_wireguard_from_netdev_protocol_mismatch_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one,
+					       (__u8 *)mac_two,
+					       v4_node_one,
+					       v4_node_two,
+					       bpf_htons(CONFIG(wg_port)),
+					       bpf_htons(CONFIG(wg_port)));
+
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv4_not_decrypted_wireguard_from_netdev_protocol_mismatch")
+int ipv4_not_decrypted_wireguard_from_netdev_protocol_mismatch_setup(struct __ctx_buff *ctx)
+{
+	/* We need to populate the node ID map because we'll lookup into it on
+	 * ingress to validate the source
+	 */
+	node_v4_add_entry(v4_node_one, NODE_ID, 1);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "ipv4_not_decrypted_wireguard_from_netdev_protocol_mismatch")
+int ipv4_not_decrypted_wireguard_from_netdev_protocol_mismatch_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_DECRYPT);
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_not_decrypted_wireguard_from_netdev_protocol_mismatch")
+int ipv6_not_decrypted_wireguard_from_netdev_protocol_mismatch_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)mac_one,
+					       (__u8 *)mac_two,
+					       (__u8 *)v6_node_one,
+					       (__u8 *)v6_node_two,
+					       bpf_htons(CONFIG(wg_port)),
+					       bpf_htons(CONFIG(wg_port)));
+
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv6_not_decrypted_wireguard_from_netdev_protocol_mismatch")
+int ipv6_not_decrypted_wireguard_from_netdev_protocol_mismatch_setup(struct __ctx_buff *ctx)
+{
+	/* We need to populate the node ID map because we'll lookup into it on
+	 * ingress to validate the source
+	 */
+	node_v6_add_entry((union v6addr *)v6_node_one, NODE_ID, 1);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "ipv6_not_decrypted_wireguard_from_netdev_protocol_mismatch")
+int ipv6_not_decrypted_wireguard_from_netdev_protocol_mismatch_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_DECRYPT);
+
+	test_finish();
+}
+
+/* end */

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -12,6 +12,7 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 var Cell = cell.Module(
@@ -28,6 +29,7 @@ var Cell = cell.Module(
 		cfg *option.DaemonConfig,
 		tunnelCfg tunnel.Config,
 		ipsecCfg datapath.IPsecConfig,
+		wgConfig wgTypes.WireguardConfig,
 	) SharedConfig {
 		return SharedConfig{
 			TunnelingEnabled:                cfg.TunnelingEnabled(),
@@ -47,6 +49,7 @@ var Cell = cell.Module(
 			EnableMasqueradeRouteSource: cfg.EnableMasqueradeRouteSource,
 			EnableL7Proxy:               cfg.EnableL7Proxy,
 			InstallIptRules:             cfg.InstallIptRules,
+			EnableWireguard:             wgConfig.Enabled(),
 		}
 	}),
 	cell.Provide(newIptablesManager),
@@ -108,4 +111,5 @@ type SharedConfig struct {
 	EnableMasqueradeRouteSource bool
 	EnableL7Proxy               bool
 	InstallIptRules             bool
+	EnableWireguard             bool
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -61,7 +61,7 @@ const (
 	ciliumPreRawChain     = "CILIUM_PRE_raw"
 	ciliumForwardChain    = "CILIUM_FORWARD"
 	feederDescription     = "cilium-feeder:"
-	xfrmDescription       = "cilium-xfrm-notrack:"
+	encryptionDescription = "cilium-encryption-notrack:"
 )
 
 // Minimum iptables versions supporting the -w and -w<seconds> flags
@@ -1692,8 +1692,8 @@ func (m *Manager) installRules(state desiredState) error {
 		return fmt.Errorf("cannot install static proxy rules: %w", err)
 	}
 
-	if err := m.addCiliumAcceptXfrmRules(); err != nil {
-		return fmt.Errorf("cannot install xfrm rules: %w", err)
+	if err := m.addCiliumAcceptEncryptionRules(); err != nil {
+		return fmt.Errorf("cannot install encryption rules: %w", err)
 	}
 
 	localDeliveryInterface := m.getDeliveryInterface(defaults.HostDevice)
@@ -1744,9 +1744,9 @@ func (m *Manager) installRules(state desiredState) error {
 		}
 	}
 
-	if m.sharedCfg.EnableIPSec {
-		if err := m.addCiliumNoTrackXfrmRules(); err != nil {
-			return fmt.Errorf("cannot install xfrm rules: %w", err)
+	if m.sharedCfg.EnableIPSec || m.sharedCfg.EnableWireguard {
+		if err := m.addCiliumNoTrackEncryptionRules(); err != nil {
+			return fmt.Errorf("cannot install encryption rules: %w", err)
 		}
 	}
 
@@ -1800,15 +1800,25 @@ func (m *Manager) remoteSNATDstAddrExclusionCIDR(nativeRoutingCIDR, allocCIDR st
 	return allocCIDR
 }
 
-func (m *Manager) ciliumNoTrackXfrmRules(prog iptablesInterface, input string) error {
-	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
-	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+func (m *Manager) ciliumNoTrackEncryptionRules(prog iptablesInterface, input string) error {
+	matchDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
+	matchEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
 
-	for _, match := range []string{matchFromIPSecDecrypt, matchFromIPSecEncrypt} {
+	for _, match := range []string{matchDecrypt, matchEncrypt} {
 		if err := prog.runProg([]string{
 			"-t", "raw", input, ciliumPreRawChain,
 			"-m", "mark", "--mark", match,
-			"-m", "comment", "--comment", xfrmDescription,
+			"-m", "comment", "--comment", encryptionDescription,
+			"-j", "CT", "--notrack"}); err != nil {
+			return err
+		}
+	}
+
+	for _, match := range []string{matchDecrypt, matchEncrypt} {
+		if err := prog.runProg([]string{
+			"-t", "raw", input, ciliumOutputRawChain,
+			"-m", "mark", "--mark", match,
+			"-m", "comment", "--comment", encryptionDescription,
 			"-j", "CT", "--notrack"}); err != nil {
 			return err
 		}
@@ -1820,21 +1830,21 @@ func (m *Manager) ciliumNoTrackXfrmRules(prog iptablesInterface, input string) e
 // This avoids encryption bits and keyID, 0x*d00 for decryption
 // and 0x*e00 for encryption, colliding with existing rules. Needed
 // for kube-proxy for example.
-func (m *Manager) addCiliumAcceptXfrmRules() error {
-	if !m.sharedCfg.EnableIPSec {
+func (m *Manager) addCiliumAcceptEncryptionRules() error {
+	if !m.sharedCfg.EnableIPSec && !m.sharedCfg.EnableWireguard {
 		return nil
 	}
 
-	insertAcceptXfrm := func(ipt iptablesInterface, table, chain string) error {
-		matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
-		matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+	insertAcceptEncrypt := func(ipt iptablesInterface, table, chain string) error {
+		matchDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
+		matchEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
 
-		comment := "exclude xfrm marks from " + table + " " + chain + " chain"
+		comment := "exclude encrypt/decrypt marks from " + table + " " + chain + " chain"
 
 		if err := ipt.runProg([]string{
 			"-t", table,
 			"-A", chain,
-			"-m", "mark", "--mark", matchFromIPSecEncrypt,
+			"-m", "mark", "--mark", matchEncrypt,
 			"-m", "comment", "--comment", comment,
 			"-j", "ACCEPT"}); err != nil {
 			return err
@@ -1843,7 +1853,7 @@ func (m *Manager) addCiliumAcceptXfrmRules() error {
 		return ipt.runProg([]string{
 			"-t", table,
 			"-A", chain,
-			"-m", "mark", "--mark", matchFromIPSecDecrypt,
+			"-m", "mark", "--mark", matchDecrypt,
 			"-m", "comment", "--comment", comment,
 			"-j", "ACCEPT"})
 	}
@@ -1852,13 +1862,13 @@ func (m *Manager) addCiliumAcceptXfrmRules() error {
 		switch chain.table {
 		case "filter", "nat":
 			if m.sharedCfg.EnableIPv4 {
-				if err := insertAcceptXfrm(m.ip4tables, chain.table, chain.name); err != nil {
+				if err := insertAcceptEncrypt(m.ip4tables, chain.table, chain.name); err != nil {
 					return err
 				}
 			}
 			// ip6tables chain exists only if chain.ipv6 is true
 			if m.sharedCfg.EnableIPv6 && chain.ipv6 {
-				if err := insertAcceptXfrm(m.ip6tables, chain.table, chain.name); err != nil {
+				if err := insertAcceptEncrypt(m.ip6tables, chain.table, chain.name); err != nil {
 					return err
 				}
 			}
@@ -1867,14 +1877,14 @@ func (m *Manager) addCiliumAcceptXfrmRules() error {
 	return nil
 }
 
-func (m *Manager) addCiliumNoTrackXfrmRules() (err error) {
+func (m *Manager) addCiliumNoTrackEncryptionRules() (err error) {
 	if m.sharedCfg.EnableIPv4 {
-		if err = m.ciliumNoTrackXfrmRules(m.ip4tables, "-I"); err != nil {
+		if err = m.ciliumNoTrackEncryptionRules(m.ip4tables, "-I"); err != nil {
 			return
 		}
 	}
 	if m.sharedCfg.EnableIPv6 {
-		return m.ciliumNoTrackXfrmRules(m.ip6tables, "-I")
+		return m.ciliumNoTrackEncryptionRules(m.ip6tables, "-I")
 	}
 	return nil
 }


### PR DESCRIPTION
in addition to ipsec packets, also match on wireguard packets in the inbound path (from netdev) and mark them with the MARK_MAGIC_DECRYPT mark.

in iptables, we check if wireguard is enabled and add the same set of rules that would be added if ipsec encryption is enabled (match mark and add dont track connections):

```
root@kind-control-plane:/# iptables -L -v -n -t raw | grep  -E "Chain|encr"
Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
Chain CILIUM_OUTPUT_raw (1 references)
    0     0 CT         0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xd00/0xf00 /* cilium-encryption-notrack: */ CT notrack
  695  126K CT         0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xe00/0xf00 /* cilium-encryption-notrack: */ CT notrack
Chain CILIUM_PRE_raw (1 references)
  726  129K CT         0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xd00/0xf00 /* cilium-encryption-notrack: */ CT notrack
    0     0 CT         0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xe00/0xf00 /* cilium-encryption-notrack: */ CT notrack
root@kind-control-plane:/# iptables -L -v -n -t filter | grep  -E "Chain|encr"
Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
Chain CILIUM_FORWARD (1 references)
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xd00/0xf00 /* exclude encrypt/decrypt marks from filter CILIUM_FORWARD chain */
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xe00/0xf00 /* exclude encrypt/decrypt marks from filter CILIUM_FORWARD chain */
Chain CILIUM_INPUT (1 references)
    6  1080 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xd00/0xf00 /* exclude encrypt/decrypt marks from filter CILIUM_INPUT chain */
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xe00/0xf00 /* exclude encrypt/decrypt marks from filter CILIUM_INPUT chain */
Chain CILIUM_OUTPUT (1 references)
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xd00/0xf00 /* exclude encrypt/decrypt marks from filter CILIUM_OUTPUT chain */
    6  1080 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xe00/0xf00 /* exclude encrypt/decrypt marks from filter CILIUM_OUTPUT chain */
root@kind-control-plane:/# iptables -L -v -n -t nat | grep  -E "Chain|encr"
Chain PREROUTING (policy ACCEPT 643 packets, 37750 bytes)
Chain INPUT (policy ACCEPT 631 packets, 36968 bytes)
Chain OUTPUT (policy ACCEPT 119K packets, 7142K bytes)
Chain POSTROUTING (policy ACCEPT 119K packets, 7142K bytes)
Chain CILIUM_OUTPUT_nat (1 references)
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xd00/0xf00 /* exclude encrypt/decrypt marks from nat CILIUM_OUTPUT_nat chain */
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xe00/0xf00 /* exclude encrypt/decrypt marks from nat CILIUM_OUTPUT_nat chain */
Chain CILIUM_POST_nat (1 references)
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xd00/0xf00 /* exclude encrypt/decrypt marks from nat CILIUM_POST_nat chain */
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xe00/0xf00 /* exclude encrypt/decrypt marks from nat CILIUM_POST_nat chain */
Chain CILIUM_PRE_nat (1 references)
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xd00/0xf00 /* exclude encrypt/decrypt marks from nat CILIUM_PRE_nat chain */
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xe00/0xf00 /* exclude encrypt/decrypt marks from nat CILIUM_PRE_nat chain */
```

Fixes: https://github.com/cilium/cilium/issues/41809

```release-note
Avoid conntrack for wireguard packets
```
