### PR TITLE
v1.16 Backports 2025-10-02

### DIFF
--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -389,7 +389,7 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 	}
 }
 
-// 'ackVersion' is the last version that was acked. 'nackVersion', if greater than 'nackVersion', is the last version that was NACKed.
+// 'ackVersion' is the last version that was acked. 'nackVersion', if greater than 'ackVersion', is the last version that was NACKed.
 func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, nodeIP string, resourceNames []string, typeURL string, detail string) {
 	ackLog := log.WithFields(logrus.Fields{
 		logfields.XDSAckedVersion: ackVersion,
@@ -409,7 +409,7 @@ func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint6
 		m.ackedVersions[nodeIP] = ackVersion
 
 		// Signal reception of an ACK (exluding the version 0, or any NACKs).
-		if exists && previouslyAckedVersion < ackVersion {
+		if previouslyAckedVersion < ackVersion {
 			ch, exists := m.ackedNodes[nodeIP]
 			if !exists || ch != nil {
 				log.WithFields(logrus.Fields{

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -267,6 +267,9 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 	// Indicates if client received the first response,
 	// but it doesn't necessarily mean that it was ACKed.
 	clientReceivedFirstResponse := false
+	// responseAcked indicates if we already
+	// had some request on this stream that was ACKed by a client.
+	responseAcked := false
 
 	for {
 		// Process either a new request from the xDS stream or a response
@@ -364,6 +367,12 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				clientReceivedFirstResponse = true
 			}
 
+			if clientReceivedFirstResponse && versionInfo == nonce {
+				// Once we get the first ACK,
+				// we can start using versionInfo for ACKing observers.
+				responseAcked = true
+			}
+
 			if versionInfo > 0 && firstRequest {
 				requestLog.Infof("xDS was restarted, previous versionInfo: %d", versionInfo)
 			}
@@ -378,7 +387,15 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				ackObserver := s.ackObservers[typeURL]
 				if ackObserver != nil {
 					requestLog.Debug("notifying observers of ACKs")
-					ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
+					if !responseAcked {
+						// If we haven't received any ACK, it means that versionInfo
+						// is stale and we can't ACK anything.
+						// Also we can't send versionInfo as it would incorrectly be cached
+						// as last acked version.
+						ackObserver.HandleResourceVersionAck(0, nonce, nodeIP, state.resourceNames, typeURL, detail)
+					} else {
+						ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
+					}
 				} else {
 					requestLog.Info("ACK received but no observers are waiting for ACKs")
 				}

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -317,19 +317,19 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			// In case of xDS server restart (cilium-agent),
 			// Envoy will send a request with VersionInfo set to the last ACKed version
 			// it received. Additionally, nonce will be empty.
-			var versionInfo uint64
+			var lastAppliedVersion uint64
 			if req.GetVersionInfo() != "" {
 				var err error
-				versionInfo, err = strconv.ParseUint(req.VersionInfo, 10, 64)
+				lastAppliedVersion, err = strconv.ParseUint(req.VersionInfo, 10, 64)
 				if err != nil {
 					requestLog.Errorf("invalid version info in xDS request, not a uint64")
 					return ErrInvalidVersionInfo
 				}
 			}
-			var nonce uint64
+			var lastReceivedVersion uint64
 			if req.GetResponseNonce() != "" {
 				var err error
-				nonce, err = strconv.ParseUint(req.ResponseNonce, 10, 64)
+				lastReceivedVersion, err = strconv.ParseUint(req.ResponseNonce, 10, 64)
 				if err != nil {
 					requestLog.Error("invalid response nonce info in xDS request, not a uint64")
 					return ErrInvalidResponseNonce
@@ -361,23 +361,23 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state := &typeStates[index]
 			watcher := s.watchers[typeURL]
 
-			if nonce > 0 {
-				// Non-zero nonce indicates that we have already sent
+			if lastReceivedVersion > 0 {
+				// Non-zero lastReceivedVersion indicates that we have already sent
 				// a response to the client and client saw response.
 				clientReceivedFirstResponse = true
 			}
 
-			if clientReceivedFirstResponse && versionInfo == nonce {
+			if clientReceivedFirstResponse && lastAppliedVersion == lastReceivedVersion {
 				// Once we get the first ACK,
 				// we can start using versionInfo for ACKing observers.
 				responseAcked = true
 			}
 
-			if versionInfo > 0 && firstRequest {
-				requestLog.Infof("xDS was restarted, previous versionInfo: %d", versionInfo)
+			if lastAppliedVersion > 0 && firstRequest {
+				requestLog.Infof("xDS was restarted, previous versionInfo: %d", lastAppliedVersion)
 			}
 
-			if versionInfo > nonce && clientReceivedFirstResponse {
+			if lastAppliedVersion > lastReceivedVersion && clientReceivedFirstResponse {
 				requestLog.Warning("received invalid nonce in xDS request")
 				return ErrInvalidResponseNonce
 			}
@@ -388,21 +388,21 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				if ackObserver != nil {
 					requestLog.Debug("notifying observers of ACKs")
 					if !responseAcked {
-						// If we haven't received any ACK, it means that versionInfo
+						// If we haven't received any ACK, it means that lastAppliedVersion
 						// is stale and we can't ACK anything.
-						// Also we can't send versionInfo as it would incorrectly be cached
+						// Also we can't send lastAppliedVersion as it would incorrectly be cached
 						// as last acked version.
-						ackObserver.HandleResourceVersionAck(0, nonce, nodeIP, state.resourceNames, typeURL, detail)
+						ackObserver.HandleResourceVersionAck(0, lastReceivedVersion, nodeIP, state.resourceNames, typeURL, detail)
 					} else {
-						ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
+						ackObserver.HandleResourceVersionAck(lastAppliedVersion, lastReceivedVersion, nodeIP, state.resourceNames, typeURL, detail)
 					}
 				} else {
 					requestLog.Info("ACK received but no observers are waiting for ACKs")
 				}
 			}
 
-			if versionInfo < nonce && clientReceivedFirstResponse {
-				// versions after VersionInfo, upto and including ResponseNonce are NACKed
+			if lastAppliedVersion < lastReceivedVersion && clientReceivedFirstResponse {
+				// versions after lastAppliedVersion, upto and including lastReceivedVersion are NACKed
 				requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
 			}
 
@@ -420,7 +420,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state.pendingWatchCancel = cancel
 
 			requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
-			go watcher.WatchResources(ctx, typeURL, nonce, versionInfo, nodeIP, req.GetResourceNames(), respCh)
+			go watcher.WatchResources(ctx, typeURL, lastReceivedVersion, lastAppliedVersion, nodeIP, req.GetResourceNames(), respCh)
 
 			firstRequest = false
 

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -195,11 +195,6 @@ type perTypeStreamState struct {
 	// If nil, no watch is pending.
 	pendingWatchCancel context.CancelFunc
 
-	// version is the last version sent. This is needed so that we'll know
-	// if a new request is an ACK (VersionInfo matches current version), or a NACK
-	// (VersionInfo matches an earlier version).
-	version uint64
-
 	// resourceNames is the list of names of resources sent in the last
 	// response to a request for this resource type.
 	resourceNames []string
@@ -309,9 +304,13 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 
 			requestLog := streamLog.WithFields(getXDSRequestFields(req))
 
-			// Ensure that the version info is a string that was sent by this
-			// server or the empty string (the first request in a stream should
-			// always have an empty version info).
+			// VersionInfo is property of resources,
+			// while nonce is property of the stream.
+			// VersionInfo is only empty for a new client instance that did not
+			// receive any ACKed version of resources previously.
+			// In case of xDS server restart (cilium-agent),
+			// Envoy will send a request with VersionInfo set to the last ACKed version
+			// it received. Additionally, nonce will be empty.
 			var versionInfo uint64
 			if req.GetVersionInfo() != "" {
 				var err error
@@ -380,7 +379,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 					// Watcher will behave as if the sent version was acked.
 					// Otherwise we will just be sending the same failing
 					// version over and over filling logs.
-					versionInfo = state.version
+					versionInfo = nonce
 				}
 
 				if state.pendingWatchCancel != nil {
@@ -455,7 +454,6 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				return err
 			}
 
-			state.version = resp.Version
 			state.resourceNames = resp.ResourceNames
 		}
 	}

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -420,7 +420,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state.pendingWatchCancel = cancel
 
 			requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
-			go watcher.WatchResources(ctx, typeURL, nonce, nodeIP, req.GetResourceNames(), respCh)
+			go watcher.WatchResources(ctx, typeURL, nonce, versionInfo, nodeIP, req.GetResourceNames(), respCh)
 
 			firstRequest = false
 

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -386,10 +386,6 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			if versionInfo < nonce {
 				// versions after VersionInfo, upto and including ResponseNonce are NACKed
 				requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
-				// Watcher will behave as if the sent version was acked.
-				// Otherwise we will just be sending the same failing
-				// version over and over filling logs.
-				versionInfo = nonce
 			}
 
 			if state.pendingWatchCancel != nil {
@@ -406,7 +402,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state.pendingWatchCancel = cancel
 
 			requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
-			go watcher.WatchResources(ctx, typeURL, versionInfo, nodeIP, req.GetResourceNames(), respCh)
+			go watcher.WatchResources(ctx, typeURL, nonce, nodeIP, req.GetResourceNames(), respCh)
 
 			firstRequest = false
 

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -264,6 +264,9 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 
 	nodeIP := ""
 	firstRequest := true
+	// Indicates if client received the first response,
+	// but it doesn't necessarily mean that it was ACKed.
+	clientReceivedFirstResponse := false
 
 	for {
 		// Process either a new request from the xDS stream or a response
@@ -355,6 +358,11 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			state := &typeStates[index]
 			watcher := s.watchers[typeURL]
 
+			if nonce > 0 {
+				// Non-zero nonce indicates that we have already sent
+				// a response to the client and client saw response.
+				clientReceivedFirstResponse = true
+			}
 			if nonce == 0 && versionInfo > 0 {
 				requestLog.Infof("xDS was restarted, setting nonce to %d", versionInfo)
 				nonce = versionInfo
@@ -365,17 +373,15 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				return ErrInvalidResponseNonce
 			}
 
-			// Response nonce is always the same as the response version.
-			// Request version indicates the last acked version. If the
-			// response nonce in the request is different(bigger) than
-			// request version, all versions upto that version are acked, but
-			// the versions from that to and including the nonce are nacked.
-			ackObserver := s.ackObservers[typeURL]
-			if ackObserver != nil {
-				requestLog.Debug("notifying observers of ACKs")
-				ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
-			} else if firstRequest {
-				requestLog.Info("ACK received but no observers are waiting for ACKs")
+			// We want to trigger HandleResourceVersionAck even for NACKs
+			if clientReceivedFirstResponse {
+				ackObserver := s.ackObservers[typeURL]
+				if ackObserver != nil {
+					requestLog.Debug("notifying observers of ACKs")
+					ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
+				} else {
+					requestLog.Info("ACK received but no observers are waiting for ACKs")
+				}
 			}
 			if versionInfo < nonce {
 				// versions after VersionInfo, upto and including ResponseNonce are NACKed

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -360,47 +360,48 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				nonce = versionInfo
 			}
 
-			// Response nonce is always the same as the response version.
-			// Request version indicates the last acked version. If the
-			// response nonce in the request is different (smaller) than
-			// the version, all versions upto that version are acked, but
-			// the versions from that to and including the nonce are nacked.
-			if versionInfo <= nonce {
-				ackObserver := s.ackObservers[typeURL]
-				if ackObserver != nil {
-					requestLog.Debug("notifying observers of ACKs")
-					ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
-				} else if firstRequest {
-					requestLog.Info("ACK received but no observers are waiting for ACKs")
-				}
-				if versionInfo < nonce {
-					// versions after VersionInfo, upto and including ResponseNonce are NACKed
-					requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
-					// Watcher will behave as if the sent version was acked.
-					// Otherwise we will just be sending the same failing
-					// version over and over filling logs.
-					versionInfo = nonce
-				}
-
-				if state.pendingWatchCancel != nil {
-					// A pending watch exists for this type URL. Cancel it to
-					// start a new watch.
-					requestLog.Debug("canceling pending watch")
-					state.pendingWatchCancel()
-				}
-
-				respCh := make(chan *VersionedResources, 1)
-				selectCases[index].Chan = reflect.ValueOf(respCh)
-
-				ctx, cancel := context.WithCancel(ctx)
-				state.pendingWatchCancel = cancel
-
-				requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
-				go watcher.WatchResources(ctx, typeURL, versionInfo, nodeIP, req.GetResourceNames(), respCh)
-			} else {
+			if versionInfo > nonce {
 				requestLog.Warning("received invalid nonce in xDS request")
 				return ErrInvalidResponseNonce
 			}
+
+			// Response nonce is always the same as the response version.
+			// Request version indicates the last acked version. If the
+			// response nonce in the request is different(bigger) than
+			// request version, all versions upto that version are acked, but
+			// the versions from that to and including the nonce are nacked.
+			ackObserver := s.ackObservers[typeURL]
+			if ackObserver != nil {
+				requestLog.Debug("notifying observers of ACKs")
+				ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
+			} else if firstRequest {
+				requestLog.Info("ACK received but no observers are waiting for ACKs")
+			}
+			if versionInfo < nonce {
+				// versions after VersionInfo, upto and including ResponseNonce are NACKed
+				requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
+				// Watcher will behave as if the sent version was acked.
+				// Otherwise we will just be sending the same failing
+				// version over and over filling logs.
+				versionInfo = nonce
+			}
+
+			if state.pendingWatchCancel != nil {
+				// A pending watch exists for this type URL. Cancel it to
+				// start a new watch.
+				requestLog.Debug("canceling pending watch")
+				state.pendingWatchCancel()
+			}
+
+			respCh := make(chan *VersionedResources, 1)
+			selectCases[index].Chan = reflect.ValueOf(respCh)
+
+			ctx, cancel := context.WithCancel(ctx)
+			state.pendingWatchCancel = cancel
+
+			requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
+			go watcher.WatchResources(ctx, typeURL, versionInfo, nodeIP, req.GetResourceNames(), respCh)
+
 			firstRequest = false
 
 		default: // Pending watch response.

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -363,12 +363,12 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				// a response to the client and client saw response.
 				clientReceivedFirstResponse = true
 			}
-			if nonce == 0 && versionInfo > 0 {
-				requestLog.Infof("xDS was restarted, setting nonce to %d", versionInfo)
-				nonce = versionInfo
+
+			if versionInfo > 0 && firstRequest {
+				requestLog.Infof("xDS was restarted, previous versionInfo: %d", versionInfo)
 			}
 
-			if versionInfo > nonce {
+			if versionInfo > nonce && clientReceivedFirstResponse {
 				requestLog.Warning("received invalid nonce in xDS request")
 				return ErrInvalidResponseNonce
 			}
@@ -383,7 +383,8 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 					requestLog.Info("ACK received but no observers are waiting for ACKs")
 				}
 			}
-			if versionInfo < nonce {
+
+			if versionInfo < nonce && clientReceivedFirstResponse {
 				// versions after VersionInfo, upto and including ResponseNonce are NACKed
 				requestLog.WithField(logfields.XDSDetail, detail).Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
 			}

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -666,21 +666,19 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.Equal(t, uint64(3), v)
 	require.Equal(t, true, mod)
 
-	// Request the next version of resources, with a stale nonce.
+	// Request the next version of resources, with a stale nonce and version.
 	req = &envoy_service_discovery.DiscoveryRequest{
 		TypeUrl:       typeURL,
-		VersionInfo:   resp.VersionInfo, // ACK the received version.
+		VersionInfo:   "1",
 		Node:          nodes[node0],
 		ResourceNames: nil,
-		ResponseNonce: "0",
+		ResponseNonce: "1",
 	}
 	// Do not update the nonce.
 	err = stream.SendRequest(req)
 	require.NoError(t, err)
 
-	// Server correctly detects 0 nonce and resets it to the correct value.
-
-	// Expecting a response with both resources.
+	// Server correctly detects stale Nonce and sends response.
 	resp, err = stream.RecvResponse()
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -1034,6 +1034,94 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	}
 }
 
+func TestTheSameVersionOnRestart(t *testing.T) {
+	// This is a special case similar to the TestRequestHighVersionFromTheStart.
+	// We check that if new stream is established with accidentally the
+	// same version as previously, we still receive response.
+	// It can happen especially with Listeners as we have fixed number
+	// of listeners and we can hit this edge case.
+	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+
+	var err error
+	var req *envoy_service_discovery.DiscoveryRequest
+	var resp *envoy_service_discovery.DiscoveryResponse
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+	wg := completion.NewWaitGroup(ctx)
+
+	cache := NewCache()
+	mutator := NewAckingResourceMutatorWrapper(cache)
+
+	streamCtx, closeStream := context.WithCancel(ctx)
+	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
+
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+
+	streamDone := make(chan struct{})
+
+	// Run the server's stream handler concurrently.
+	go func() {
+		defer close(streamDone)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
+		require.NoError(t, err)
+	}()
+
+	// Create version 2 with resource 0.
+	callback1, comp1 := newCompCallback()
+	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
+	require.Condition(t, isNotCompletedComparison(comp1))
+
+	// Close previous stream and create a new one.
+	closeStream()
+	streamCtx, closeStream = context.WithCancel(ctx)
+	stream = NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer stream.Close()
+
+	select {
+	case <-ctx.Done():
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+	case <-streamDone:
+	}
+
+	streamDone = make(chan struct{})
+	// Start processing new stream
+	go func() {
+		defer close(streamDone)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
+		require.NoError(t, err)
+	}()
+
+	// Request all resources, with a version equal to the version currently
+	// in Cilium's cache. This happens after the server restarts but the
+	// xDS client survives and continues to request the same version.
+	// Nonce is empty though as it's a new stream.
+	req = &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   "2",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "",
+	}
+	err = stream.SendRequest(req)
+	require.NoError(t, err)
+
+	// Expecting a response with that resource, and an updated version.
+	resp, err = stream.RecvResponse()
+	require.NoError(t, err)
+	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0]}, false, typeURL))
+	require.NotEmpty(t, resp.Nonce)
+
+	// Close the stream.
+	closeStream()
+
+	select {
+	case <-ctx.Done():
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+	case <-streamDone:
+	}
+}
+
 func toAny(pb proto.Message) *anypb.Any {
 	a, err := anypb.New(pb)
 	if err != nil {

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -1011,7 +1011,7 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 		VersionInfo:   "64",
 		Node:          nodes[node0],
 		ResourceNames: nil,
-		ResponseNonce: "64",
+		ResponseNonce: "",
 	}
 	err = stream.SendRequest(req)
 	require.NoError(t, err)

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -1120,6 +1120,96 @@ func TestTheSameVersionOnRestart(t *testing.T) {
 	}
 }
 
+func TestNotAckedAfterRestart(t *testing.T) {
+	// Similar to test case TestNAckFromTheStart
+	// But here we are making sure that we don't issue incorrect ACKs
+	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+
+	var err error
+	var req *envoy_service_discovery.DiscoveryRequest
+	var resp *envoy_service_discovery.DiscoveryResponse
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+	wg := completion.NewWaitGroup(ctx)
+
+	cache := NewCache()
+	mutator := NewAckingResourceMutatorWrapper(cache)
+
+	streamCtx, closeStream := context.WithCancel(ctx)
+	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	defer stream.Close()
+
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+
+	streamDone := make(chan struct{})
+
+	// Run the server's stream handler concurrently.
+	go func() {
+		defer close(streamDone)
+		err := server.HandleRequestStream(ctx, stream, AnyTypeURL, "")
+		require.NoError(t, err)
+	}()
+
+	// Create version 2 with resource 0.
+	callback1, comp1 := newCompCallback()
+	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
+	require.Condition(t, isNotCompletedComparison(comp1))
+
+	// Request all resources, with a version higher than the version currently
+	// in Cilium's cache. This happens after the server restarts but the
+	// xDS client survives and continues to request the same version.
+	req = &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   "64",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "",
+	}
+	err = stream.SendRequest(req)
+	require.NoError(t, err)
+
+	// Expecting a response with that resource.
+	resp, err = stream.RecvResponse()
+	require.NoError(t, err)
+	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Condition(t, responseCheck(resp, "65", []proto.Message{resources[0]}, false, typeURL))
+
+	// Version 2 was not ACKED by the last request, so it must NOT be completedInTime successfully.
+	require.Condition(t, isNotCompletedComparison(comp1))
+	// Check that the completion was not NACKed
+	require.NoError(t, comp1.Err())
+	// Simulate that first request on a new stream was NACKed.
+	req = &envoy_service_discovery.DiscoveryRequest{
+		TypeUrl:       typeURL,
+		VersionInfo:   "64",
+		Node:          nodes[node0],
+		ResourceNames: nil,
+		ResponseNonce: "65",
+	}
+	err = stream.SendRequest(req)
+	require.NoError(t, err)
+
+	// Since we don't update resources, we expect that we will not receive
+	// any response. However, we want to make sure that previously
+	// pending completions are still not ACKed, but they are NACKed.
+	resp, err = stream.RecvResponse()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	// IsCompleted is true only for completions without error
+	require.Condition(t, isNotCompletedComparison(comp1))
+	// Check that the completion was NACKed
+	require.Error(t, comp1.Err())
+
+	// Close the stream.
+	closeStream()
+
+	select {
+	case <-ctx.Done():
+		t.Errorf("HandleRequestStream(%v, %v, %v) took too long to return after stream was closed", "ctx", "stream", AnyTypeURL)
+	case <-streamDone:
+	}
+}
+
 func toAny(pb proto.Message) *anypb.Any {
 	a, err := anypb.New(pb)
 	if err != nil {


### PR DESCRIPTION
 * [x] #38654 (@marseel)

This backport should fix recurring CI failures on v1.17 downgrade tests (downgrading to v1.16), where errors like this were observed:
```
❌ Error finalizing 'seq-egress-gateway-with-l7-policy': timed out waiting for policy updates to be processed on Cilium agents: command failed (pod=kube-system/cilium-mmjks, container=cilium-agent): command terminated with exit code 1: "Error: \n1 endpoints still not ready after 30.186697433s (0 failed)\n\n"
```
This was caused by the backport https://github.com/cilium/cilium/pull/41607 adding a wait for the Clusters from Envoy, but that ACK never appearing due to a failure to send the Clusters after restart when version numbers happened to match. This bug is fixed by this backport of #38654, which should fix this error condition seen in downgrade tests to v1.16.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 38654
```
