### PR TITLE
lbipam: fix incorrect conflicting pools metric

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1903,6 +1903,20 @@ func (ipam *LBIPAM) settleConflicts(ctx context.Context) error {
 		}
 	}
 
+	// Count the number of conflicting pools and update the metric.
+	var conflictingPools float64
+	for _, pool := range ipam.pools {
+		lbRanges, _ := ipam.rangesStore.GetRangesForPool(pool.GetName())
+		// When a pool is marked as conflicting, all of its lbRanges are
+		// internally disabled. Therefore, checking a single lbRange
+		// is sufficient to conclude that the pool is conflicting.
+		if len(lbRanges) > 0 && lbRanges[0].internallyDisabled {
+			conflictingPools++
+		}
+	}
+
+	ipam.metrics.ConflictingPools.Set(conflictingPools)
+
 	return nil
 }
 
@@ -1916,8 +1930,6 @@ func (ipam *LBIPAM) markPoolConflicting(
 	if isPoolConflicting(targetPool) {
 		return nil
 	}
-
-	ipam.metrics.ConflictingPools.Inc()
 
 	ipam.logger.WarnContext(ctx,
 		fmt.Sprintf("Pool '%s' conflicts since range '%s' overlaps range '%s' from IP Pool '%s'",
@@ -1961,8 +1973,6 @@ func (ipam *LBIPAM) unmarkPool(ctx context.Context, targetPool *cilium_api_v2.Ci
 	for _, poolRange := range targetPoolRanges {
 		poolRange.internallyDisabled = false
 	}
-
-	ipam.metrics.ConflictingPools.Dec()
 
 	if ipam.setPoolCondition(targetPool, ciliumPoolConflict, meta_v1.ConditionFalse, "resolved", "") {
 		err := ipam.patchPoolStatus(ctx, targetPool)

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -59,6 +59,10 @@ func TestConflictResolution(t *testing.T) {
 		}
 	}
 
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 1 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 1 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
+	}
+
 	// Phase 2, resolving the conflict
 
 	// Remove the conflicting range
@@ -72,6 +76,10 @@ func TestConflictResolution(t *testing.T) {
 	poolB = fixture.GetPool("pool-b")
 	if isPoolConflicting(poolB) {
 		t.Fatal("Pool B should no longer be conflicting")
+	}
+
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 0 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 0 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
 	}
 }
 
@@ -88,6 +96,10 @@ func TestPoolInternalConflict(t *testing.T) {
 		t.Fatal("Pool A should be conflicting")
 	}
 
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 1 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 1 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
+	}
+
 	poolA.Spec.Blocks = []cilium_api_v2.CiliumLoadBalancerIPPoolIPBlock{
 		{
 			Cidr: "10.0.10.0/24",
@@ -98,6 +110,10 @@ func TestPoolInternalConflict(t *testing.T) {
 
 	if isPoolConflicting(poolA) {
 		t.Fatal("Expected pool to be un-marked conflicting")
+	}
+
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 0 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 0 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
 	}
 }
 


### PR DESCRIPTION
The `cilium_operator_lbipam_conflicting_pools` metric was reporting incorrect values, including negative counts, due to asymmetric usage of `Inc()` and `Dec()` when updating the gauge. In particular, `Dec()` was called whenever a new pool was created, causing the gauge to start from a negative value.

This change removes incremental updates to the gauge. The value is now recomputed whenever the pools are checked for conflicts and updated using Set().

With this change, the metric reliably reports 0 when no conflicts exist, and the correct count when conflicts are present.

Fixes: #41981

### Before 
There is an example in the issue description: #41981

### After
Running the same procedures as the issue shows that the metric now reports correct values.

When there are no conflicts.
```console
$ kubectl get ciliumloadbalancerippools.cilium.io
NAME           DISABLED   CONFLICTING   IPS AVAILABLE          AGE
ip-pool-blue   false      False         18446744073709551870   54s
ip-pool-red    false      False         18446744073709551870   54s
```
```console
$ curl -s http://10.0.2.2:9963/metrics | grep lbipam_conflicting_pools
# HELP cilium_operator_lbipam_conflicting_pools The number of conflicting pools
# TYPE cilium_operator_lbipam_conflicting_pools gauge
cilium_operator_lbipam_conflicting_pools 0
```

When there is a conflict.
```console
$ kubectl get ciliumloadbalancerippools.cilium.io
NAME                DISABLED   CONFLICTING   IPS AVAILABLE          AGE
ip-pool-blue        false      False         18446744073709551870   2m38s
ip-pool-blue-conf   false      True          18446744073709551872   4s
ip-pool-red         false      False         18446744073709551870   2m38s
```
```console
$ curl -s http://10.0.2.2:9963/metrics | grep lbipam_conflicting_pools
# HELP cilium_operator_lbipam_conflicting_pools The number of conflicting pools
# TYPE cilium_operator_lbipam_conflicting_pools gauge
cilium_operator_lbipam_conflicting_pools 1
```

```release-note
Fix cilium_operator_lbipam_conflicting_pools metric to report correct value.
```
