### PR TITLE
bpf: don't use bpf_redirect_neigh() from overlay programs

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -7,7 +7,6 @@
 #include <bpf/config/node.h>
 #include <bpf/config/global.h>
 #include <netdev_config.h>
-#include "lib/mcast.h"
 
 #define IS_BPF_OVERLAY 1
 
@@ -26,7 +25,6 @@
  */
 #define SKIP_SRV6_HANDLING
 
-#include "lib/tailcall.h"
 #include "lib/common.h"
 #include "lib/edt.h"
 #include "lib/eps.h"
@@ -38,10 +36,12 @@
 #include "lib/local_delivery.h"
 #include "lib/drop.h"
 #include "lib/identity.h"
+#include "lib/mcast.h"
 #include "lib/nodeport.h"
 #include "lib/nodeport_egress.h"
 #include "lib/clustermesh.h"
 #include "lib/egress_gateway.h"
+#include "lib/tailcall.h"
 
 #ifdef ENABLE_VTEP
 #include "lib/vtep.h"

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -60,14 +60,22 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 	__u32 oif;
 	int ret;
 
-	if (egress_ifindex)
+	/* Immediate redirect to egress_ifindex requires L2 resolution.
+	 * Fall back to FIB lookup on older kernels.
+	 */
+	if (egress_ifindex && neigh_resolver_available())
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr, 0);
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
+		break;
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
+		/* Don't redirect if we can't update the L2 DMAC: */
+		if (!neigh_resolver_available())
+			return CTX_ACT_OK;
+
 		break;
 	default:
 		*ext_err = (__s8)ret;
@@ -369,7 +377,7 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 	__u32 oif;
 	int ret;
 
-	if (egress_ifindex)
+	if (egress_ifindex && neigh_resolver_available())
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	ret = (__s8)fib_lookup_v6(ctx, &fib_params,
@@ -378,7 +386,10 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
+		break;
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
+		if (!neigh_resolver_available())
+			return CTX_ACT_OK;
 		break;
 	default:
 		*ext_err = (__s8)ret;

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -153,6 +153,12 @@ redirect_self(const struct __sk_buff *ctx)
 static __always_inline __maybe_unused bool
 neigh_resolver_available(void)
 {
+	/* Work around for
+	 * https://lore.kernel.org/netdev/20251003073418.291171-1-daniel@iogearbox.net
+	 */
+	if (is_defined(IS_BPF_OVERLAY))
+		return false;
+
 	return true;
 }
 

--- a/bpf/tests/overlay.c
+++ b/bpf/tests/overlay.c
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+
+#include "bpf_overlay.c"
+
+CHECK("tc", "overlay_neigh_resolver")
+int overlay_neigh_resolver(__maybe_unused struct __sk_buff *ctx)
+{
+	test_init();
+
+	/* Due to https://lore.kernel.org/netdev/20251003073418.291171-1-daniel@iogearbox.net
+	 * we shouldn't use bpf_redirect_neigh() from overlay programs.
+	 */
+	TEST("no_neigh_resolver_on_overlay", {
+		assert(!neigh_resolver_available());
+	});
+
+	test_finish();
+}

--- a/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
@@ -53,8 +53,8 @@ static __always_inline __maybe_unused long
 mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused)
 {
-	/* Should not need a FIB lookup, we provide the EGRESS_IFINDEX */
-	return -1;
+	params->ifindex = IFACE_IFINDEX;
+	return 0;
 }
 
 /* Test that a packet matching an egress gateway policy on the from-overlay program


### PR DESCRIPTION
Yusuke chased down a kernel bug [0] that causes memory leaks when bpf_redirect_neigh() is called from bpf_overlay.

As work-around we can opt-out from using the helper, and going down the fallback path in the callers (eg treating it like a call from XDP context).

[0]: https://lore.kernel.org/netdev/20251003073418.291171-1-daniel@iogearbox.net/T/#u

```release-note
Work-around a memory leak in the kernel networking stack, which occurs when redirecting packets inside a node that previously arrived via Cilium's overlay interface.
```