### PR TITLE
check-encryption-leaks: log tunnel header when present

### DIFF
--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -97,6 +97,9 @@ kprobe:br_forward
   $udph = ((struct udphdr*) ($skb->head + $skb->transport_header));
   $tcph = ((struct tcphdr*) ($skb->head + $skb->transport_header));
   $icmph = ((struct icmphdr*) ($skb->head + $skb->transport_header));
+  $tunnel_ip4h = $ip4h;
+  $tunnel_ip6h = $ip6h;
+  $tunnel_udph = $udph;
 
   // $skb->encapsulation might be unset when encap headers are manually pushed,
   // despite $skb->inner references being correct.
@@ -149,7 +152,16 @@ kprobe:br_forward
         ) {
         $time = strftime("%H:%M:%S:%f", nsecs);
 
-        printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+        if ($skb->encapsulation || $encap) {
+          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, encap: %d, skb: %d)\n",
+            $time, $skb,
+            ntop($tunnel_ip4h->saddr), bswap($tunnel_udph->source),
+            ntop($tunnel_ip4h->daddr), bswap($tunnel_udph->dest),
+            $tunnel_ip4h->protocol,
+            $encap, $skb->encapsulation);
+        }
+
+        printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
           $time, $skb,
           ntop($ip4h->saddr),
           ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -157,7 +169,6 @@ kprobe:br_forward
           ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->dest) : 0,
           bswap($ip4h->tot_len),
           $ip4h->protocol,
-          $encap, $skb->encapsulation,
           $skb->dev->ifindex,
           $skb->dev->nd_net.net->ns.inum,
           $src_is_pod, $src_is_internal,
@@ -234,7 +245,16 @@ kprobe:br_forward
         ) {
         $time = strftime("%H:%M:%S:%f", nsecs);
 
-        printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, encap: %d (skb: %d), ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+        if ($skb->encapsulation || $encap) {
+          printf("[%s] [%p] %s:%d -> %s:%d (proto: %d, encap: %d, skb: %d)\n",
+            $time, $skb,
+            ntop($ip6h->saddr.in6_u.u6_addr8), bswap($tunnel_udph->source),
+            ntop($ip6h->daddr.in6_u.u6_addr8), bswap($tunnel_udph->dest),
+            $tunnel_ip6h->nexthdr,
+            $encap, $skb->encapsulation);
+        }
+
+        printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
           $time, $skb,
           ntop($ip6h->saddr.in6_u.u6_addr8),
           ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -242,7 +262,6 @@ kprobe:br_forward
           ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->dest) : 0,
           bswap($ip6h->payload_len),
           $ip6h->nexthdr,
-          $encap, $skb->encapsulation,
           $skb->dev->ifindex,
           $skb->dev->nd_net.net->ns.inum,
           $src_is_pod, $src_is_internal,

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -161,14 +161,14 @@ kprobe:br_forward
             $encap, $skb->encapsulation);
         }
 
-        printf("[%s] [%p]  ↳ %s:%d -> %s:%d (len: %d, proto: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+        printf("[%s] [%p]  ↳ %s:%d -> %s:%d (proto: %d, len: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
           $time, $skb,
           ntop($ip4h->saddr),
           ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
           ntop($ip4h->daddr),
           ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->dest) : 0,
-          bswap($ip4h->tot_len),
           $ip4h->protocol,
+          bswap($ip4h->tot_len),
           $skb->dev->ifindex,
           $skb->dev->nd_net.net->ns.inum,
           $src_is_pod, $src_is_internal,
@@ -177,7 +177,7 @@ kprobe:br_forward
           $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
 
         if ($ip4h->protocol == PROTO_TCP) {
-          printf("[%s] [%p]   ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
+          printf("[%s] [%p]   ↳ TCP (TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u)\n",
             $time, $skb,
             $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
             $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
@@ -189,7 +189,7 @@ kprobe:br_forward
         if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
           $dns = (struct dnshdr*)($udph + 1);
           $query = (uint8 *)($dns + 1);
-          printf("[%s] [%p]   ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+          printf("[%s] [%p]   ↳ DNS (ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s)\n",
             $time, $skb,
             bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
             bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
@@ -199,12 +199,12 @@ kprobe:br_forward
         if ($ip4h->protocol == PROTO_ICMP_IPV4) {
           $frag_off = bswap($ip4h->frag_off);
 
-          printf("[%s] [%p]   ↳ Detected ICMP message, IPFlags: .%c%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
+          printf("[%s] [%p]   ↳ ICMP (Type: %u, Code: %u, IPFlags: .%c%c, FragOff: %d, FragID: %d)\n",
             $time, $skb,
-            ($frag_off & 0x4000) >> 14 ? CH_D : CH_DOT,
-            ($frag_off & 0x2000) >> 13 ? CH_M : CH_DOT,
             $icmph->type,
             $icmph->code,
+            ($frag_off & 0x4000) >> 14 ? CH_D : CH_DOT,
+            ($frag_off & 0x2000) >> 13 ? CH_M : CH_DOT,
             $frag_off & 0x1FFF,
             bswap($ip4h->id));
         }
@@ -254,14 +254,14 @@ kprobe:br_forward
             $encap, $skb->encapsulation);
         }
 
-        printf("[%s] [%p]  ↳ %s:%d -> %s:%d (len: %d, proto: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+        printf("[%s] [%p]  ↳ %s:%d -> %s:%d (proto: %d, len: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
           $time, $skb,
           ntop($ip6h->saddr.in6_u.u6_addr8),
           ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
           ntop($ip6h->daddr.in6_u.u6_addr8),
           ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->dest) : 0,
-          bswap($ip6h->payload_len),
           $ip6h->nexthdr,
+          bswap($ip6h->payload_len),
           $skb->dev->ifindex,
           $skb->dev->nd_net.net->ns.inum,
           $src_is_pod, $src_is_internal,
@@ -270,7 +270,7 @@ kprobe:br_forward
           $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
 
         if ($ip6h->nexthdr == PROTO_TCP) {
-          printf("[%s] [%p]   ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
+          printf("[%s] [%p]   ↳ TCP (TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u)\n",
             $time, $skb,
             $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
             $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
@@ -282,7 +282,7 @@ kprobe:br_forward
         if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
           $dns = (struct dnshdr*)($udph + 1);
           $query = (uint8 *)($dns + 1);
-          printf("[%s] [%p]   ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+          printf("[%s] [%p]   ↳ DNS (ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s)\n",
             $time, $skb,
             bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
             bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
@@ -299,11 +299,11 @@ kprobe:br_forward
             $frag_off_res_m = bswap($frag_hdr->frag_off);
           }
 
-          printf("[%s] [%p]   ↳ Detected ICMP message, IPFlags: ..%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
+          printf("[%s] [%p]   ↳ ICMP (Type: %u, Code: %u, IPFlags: ..%c, FragOff: %d, FragID: %d)\n",
             $time, $skb,
-            $frag_off_res_m & 0x0001 ? CH_M : CH_DOT,
             $icmph->type,
             $icmph->code,
+            $frag_off_res_m & 0x0001 ? CH_M : CH_DOT,
             $frag_off_res_m >> 3,
             $frag_id);
         }

--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -161,7 +161,7 @@ kprobe:br_forward
             $encap, $skb->encapsulation);
         }
 
-        printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+        printf("[%s] [%p]  ↳ %s:%d -> %s:%d (len: %d, proto: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
           $time, $skb,
           ntop($ip4h->saddr),
           ($ip4h->protocol == PROTO_UDP || $ip4h->protocol == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -177,7 +177,7 @@ kprobe:br_forward
           $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
 
         if ($ip4h->protocol == PROTO_TCP) {
-          printf("[%s] [%p] ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
+          printf("[%s] [%p]   ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
             $time, $skb,
             $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
             $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
@@ -189,7 +189,7 @@ kprobe:br_forward
         if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
           $dns = (struct dnshdr*)($udph + 1);
           $query = (uint8 *)($dns + 1);
-          printf("[%s] [%p] ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+          printf("[%s] [%p]   ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
             $time, $skb,
             bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
             bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
@@ -199,7 +199,7 @@ kprobe:br_forward
         if ($ip4h->protocol == PROTO_ICMP_IPV4) {
           $frag_off = bswap($ip4h->frag_off);
 
-          printf("[%s] [%p] ↳ Detected ICMP message, IPFlags: .%c%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
+          printf("[%s] [%p]   ↳ Detected ICMP message, IPFlags: .%c%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
             $time, $skb,
             ($frag_off & 0x4000) >> 14 ? CH_D : CH_DOT,
             ($frag_off & 0x2000) >> 13 ? CH_M : CH_DOT,
@@ -254,7 +254,7 @@ kprobe:br_forward
             $encap, $skb->encapsulation);
         }
 
-        printf("[%s] [%p] %s:%d -> %s:%d (len: %d, proto: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
+        printf("[%s] [%p]  ↳ %s:%d -> %s:%d (len: %d, proto: %d, ifindex: %d, netns: %x, srcPod: %d (internal: %d), dstPod: %d (internal: %d), proxy: %d (masqueraded: %d))\n",
           $time, $skb,
           ntop($ip6h->saddr.in6_u.u6_addr8),
           ($ip6h->nexthdr == PROTO_UDP || $ip6h->nexthdr == PROTO_TCP) ? bswap($udph->source) : 0,
@@ -270,7 +270,7 @@ kprobe:br_forward
           $pod_to_pod_via_proxy == PROXY_TRACED_AND_MASQUERADED);
 
         if ($ip6h->nexthdr == PROTO_TCP) {
-          printf("[%s] [%p] ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
+          printf("[%s] [%p]   ↳ Detected TCP message, TCPFlags: %c%c%c%c%c%c%c%c, Seq: %u, Ack: %u\n",
             $time, $skb,
             $tcph->cwr ? CH_C : CH_DOT, $tcph->ece ? CH_E : CH_DOT,
             $tcph->urg ? CH_U : CH_DOT, $tcph->ack ? CH_A : CH_DOT,
@@ -282,7 +282,7 @@ kprobe:br_forward
         if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
           $dns = (struct dnshdr*)($udph + 1);
           $query = (uint8 *)($dns + 1);
-          printf("[%s] [%p] ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+          printf("[%s] [%p]   ↳ Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
             $time, $skb,
             bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
             bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
@@ -299,7 +299,7 @@ kprobe:br_forward
             $frag_off_res_m = bswap($frag_hdr->frag_off);
           }
 
-          printf("[%s] [%p] ↳ Detected ICMP message, IPFlags: ..%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
+          printf("[%s] [%p]   ↳ Detected ICMP message, IPFlags: ..%c, Type: %u, Code: %u, FragOff: %d, FragID: %d\n",
             $time, $skb,
             $frag_off_res_m & 0x0001 ? CH_M : CH_DOT,
             $icmph->type,


### PR DESCRIPTION
Let's print tunnel header, if present, when reporting the leak in `check-encryption-leaks.bt`.
No functional changes to current leak detection logic, just new print (if overlay).