### PR TITLE
daemon: extract endpoint restoration logic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -370,7 +370,6 @@ Makefile* @cilium/build
 /daemon/cmd/endpoint* @cilium/endpoint
 /daemon/cmd/bootstrap_statistics.go @cilium/metrics
 /daemon/cmd/policy* @cilium/sig-policy
-/daemon/cmd/state.go @cilium/endpoint
 /daemon/cmd/cells*.go @cilium/sig-foundations
 /Documentation/ @cilium/docs-structure
 /Documentation/_static/ @cilium/docs-structure

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -141,37 +141,37 @@ func (d *Daemon) removeOldCiliumHostIPs(ctx context.Context, restoredRouterIPv4,
 }
 
 // newDaemon creates and returns a new Daemon with the parameters set in c.
-func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams) (*Daemon, *endpointRestoreState, error) {
+func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams) (*Daemon, error) {
 	var err error
 
 	bootstrapStats.daemonInit.Start()
 
 	// WireGuard and IPSec are mutually exclusive.
 	if params.IPsecAgent.Enabled() && params.WGAgent.Enabled() {
-		return nil, nil, fmt.Errorf("WireGuard (--%s) cannot be used with IPsec (--%s)", wgTypes.EnableWireguard, datapath.EnableIPSec)
+		return nil, fmt.Errorf("WireGuard (--%s) cannot be used with IPsec (--%s)", wgTypes.EnableWireguard, datapath.EnableIPSec)
 	}
 
 	if !params.IPSecConfig.DNSProxyInsecureSkipTransparentModeCheckEnabled() {
 		if params.IPsecAgent.Enabled() && option.Config.EnableL7Proxy && !option.Config.DNSProxyEnableTransparentMode {
-			return nil, nil, fmt.Errorf("IPSec requires DNS proxy transparent mode to be enabled (--dnsproxy-enable-transparent-mode=\"true\")")
+			return nil, fmt.Errorf("IPSec requires DNS proxy transparent mode to be enabled (--dnsproxy-enable-transparent-mode=\"true\")")
 		}
 	}
 
 	if params.IPsecAgent.Enabled() && option.Config.TunnelingEnabled() {
 		if err := ipsec.ProbeXfrmStateOutputMask(); err != nil {
-			return nil, nil, fmt.Errorf("IPSec with tunneling requires support for xfrm state output masks (Linux 4.19 or later): %w", err)
+			return nil, fmt.Errorf("IPSec with tunneling requires support for xfrm state output masks (Linux 4.19 or later): %w", err)
 		}
 	}
 
 	if option.Config.EnableHostFirewall {
 		if params.IPsecAgent.Enabled() {
-			return nil, nil, fmt.Errorf("IPSec cannot be used with the host firewall.")
+			return nil, fmt.Errorf("IPSec cannot be used with the host firewall.")
 		}
 	}
 
 	if option.Config.LocalRouterIPv4 != "" || option.Config.LocalRouterIPv6 != "" {
 		if params.IPsecAgent.Enabled() {
-			return nil, nil, fmt.Errorf("Cannot specify %s or %s with %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, datapath.EnableIPSec)
+			return nil, fmt.Errorf("Cannot specify %s or %s with %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, datapath.EnableIPSec)
 		}
 	}
 
@@ -187,8 +187,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 		option.Config.IPAM != ipamOption.IPAMENI {
 		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute(params.Logger)
 		if err != nil {
-			return nil, nil,
-				fmt.Errorf("Ipsec default interface lookup failed, consider \"encrypt-interface\" to manually configure interface. Err: %w", err)
+			return nil, fmt.Errorf("Ipsec default interface lookup failed, consider \"encrypt-interface\" to manually configure interface. Err: %w", err)
 		}
 		option.Config.EncryptInterface = append(option.Config.EncryptInterface, link)
 	}
@@ -201,7 +200,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 	// created.
 	if err := params.KPRInitializer.InitKubeProxyReplacementOptions(); err != nil {
 		params.Logger.Error("unable to initialize kube-proxy replacement options", logfields.Error, err)
-		return nil, nil, fmt.Errorf("unable to initialize kube-proxy replacement options: %w", err)
+		return nil, fmt.Errorf("unable to initialize kube-proxy replacement options: %w", err)
 	}
 
 	ctmap.InitMapInfo(params.MetricsRegistry, option.Config.EnableIPv4, option.Config.EnableIPv6, params.KPRConfig.KubeProxyReplacement || option.Config.EnableBPFMasquerade)
@@ -253,7 +252,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 	bootstrapStats.mapsInit.EndError(err)
 	if err != nil {
 		params.Logger.Error("error while opening/creating BPF maps", logfields.Error, err)
-		return nil, nil, fmt.Errorf("error while opening/creating BPF maps: %w", err)
+		return nil, fmt.Errorf("error while opening/creating BPF maps: %w", err)
 	}
 
 	debug.RegisterStatusObject("ipam", params.IPAM)
@@ -343,16 +342,15 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 
 	bootstrapStats.restore.Start()
 	// fetch old endpoints before k8s is configured.
-	restoredEndpoints, err := d.params.EndpointRestorer.FetchOldEndpoints(ctx, option.Config.StateDir)
-	if err != nil {
+	if err := d.params.EndpointRestorer.FetchOldEndpoints(ctx, option.Config.StateDir); err != nil {
 		params.Logger.Error("Unable to read existing endpoints", logfields.Error, err)
 	}
 	bootstrapStats.restore.End(true)
 
 	// Load cached information from restored endpoints in to FQDN NameManager and DNS proxies
 	bootstrapStats.fqdn.Start()
-	params.DNSNameManager.RestoreCache(restoredEndpoints.possible)
-	params.DNSProxy.BootstrapFQDN(restoredEndpoints.possible)
+	params.DNSNameManager.RestoreCache(d.params.EndpointRestorer.GetState().possible)
+	params.DNSProxy.BootstrapFQDN(d.params.EndpointRestorer.GetState().possible)
 	bootstrapStats.fqdn.End(true)
 
 	if params.Clientset.IsEnabled() {
@@ -363,7 +361,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 		if !option.Config.DryMode {
 			_, err := params.CRDSyncPromise.Await(ctx)
 			if err != nil {
-				return nil, restoredEndpoints, err
+				return nil, err
 			}
 		}
 
@@ -376,7 +374,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 
 		if err := agentK8s.WaitForNodeInformation(ctx, params.Logger, params.Resources.LocalNode, params.Resources.LocalCiliumNode); err != nil {
 			params.Logger.Error("unable to connect to get node spec from apiserver", logfields.Error, err)
-			return nil, nil, fmt.Errorf("unable to connect to get node spec from apiserver: %w", err)
+			return nil, fmt.Errorf("unable to connect to get node spec from apiserver: %w", err)
 		}
 
 		// Kubernetes demands that the localhost can always reach local
@@ -401,8 +399,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 	if directRoutingDevice == nil {
 		if option.Config.AreDevicesRequired(params.KPRConfig, params.WGAgent.Enabled(), params.IPsecAgent.Enabled()) {
 			// Fail hard if devices are required to function.
-			return nil, nil, fmt.Errorf("unable to determine direct routing device. Use --%s to specify it",
-				option.DirectRoutingDevice)
+			return nil, fmt.Errorf("unable to determine direct routing device. Use --%s to specify it", option.DirectRoutingDevice)
 		}
 	} else {
 		drdName = directRoutingDevice.Name
@@ -415,7 +412,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 	nativeDevices, _ := datapathTables.SelectedDevices(params.Devices, rxn)
 	if err := params.KPRInitializer.FinishKubeProxyReplacementInit(nativeDevices, drdName); err != nil {
 		params.Logger.Error("failed to finalise LB initialization", logfields.Error, err)
-		return nil, nil, fmt.Errorf("failed to finalise LB initialization: %w", err)
+		return nil, fmt.Errorf("failed to finalise LB initialization: %w", err)
 	}
 
 	// BPF masquerade depends on BPF NodePort, so the following checks should
@@ -430,21 +427,21 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 		}
 		if err != nil {
 			params.Logger.Error("unable to initialize BPF masquerade support", logfields.Error, err)
-			return nil, nil, fmt.Errorf("unable to initialize BPF masquerade support: %w", err)
+			return nil, fmt.Errorf("unable to initialize BPF masquerade support: %w", err)
 		}
 		if option.Config.EnableMasqueradeRouteSource {
 			params.Logger.Error("BPF masquerading does not yet support masquerading to source IP from routing layer")
-			return nil, nil, fmt.Errorf("BPF masquerading to route source (--%s=\"true\") currently not supported with BPF-based masquerading (--%s=\"true\")", option.EnableMasqueradeRouteSource, option.EnableBPFMasquerade)
+			return nil, fmt.Errorf("BPF masquerading to route source (--%s=\"true\") currently not supported with BPF-based masquerading (--%s=\"true\")", option.EnableMasqueradeRouteSource, option.EnableBPFMasquerade)
 		}
 	} else if option.Config.EnableIPMasqAgent {
 		params.Logger.Error(
 			fmt.Sprintf("BPF ip-masq-agent requires (--%s=\"true\" or --%s=\"true\") and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade, option.EnableBPFMasquerade),
 			logfields.Error, err,
 		)
-		return nil, nil, fmt.Errorf("BPF ip-masq-agent requires (--%s=\"true\" or --%s=\"true\") and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade, option.EnableBPFMasquerade)
+		return nil, fmt.Errorf("BPF ip-masq-agent requires (--%s=\"true\" or --%s=\"true\") and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade, option.EnableBPFMasquerade)
 	} else if !option.Config.MasqueradingEnabled() && option.Config.EnableBPFMasquerade {
 		params.Logger.Error("IPv4 and IPv6 masquerading are both disabled, BPF masquerading requires at least one to be enabled")
-		return nil, nil, fmt.Errorf("BPF masquerade requires (--%s=\"true\" or --%s=\"true\")", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade)
+		return nil, fmt.Errorf("BPF masquerade requires (--%s=\"true\" or --%s=\"true\")", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade)
 	}
 	if len(nativeDevices) == 0 {
 		if option.Config.EnableHostFirewall {
@@ -453,7 +450,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 				fmt.Sprintf(msg, option.Devices),
 				logfields.Error, err,
 			)
-			return nil, nil, fmt.Errorf(msg, option.Devices)
+			return nil, fmt.Errorf(msg, option.Devices)
 		}
 	}
 
@@ -497,13 +494,13 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the
 	// endpoint not being able to be restored.
-	d.params.EndpointRestorer.RestoreOldEndpoints(restoredEndpoints)
+	d.params.EndpointRestorer.RestoreOldEndpoints()
 	bootstrapStats.restore.End(true)
 
 	// We must do this after IPAM because we must wait until the
 	// K8s resources have been synced.
 	if err := d.allocateIPs(ctx, restoredRouterIPs); err != nil { // will log errors/fatal internally
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Must occur after d.allocateIPs(), see GH-14245 and its fix.
@@ -571,13 +568,13 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 	err = d.init()
 	bootstrapStats.bpfBase.EndError(err)
 	if err != nil {
-		return nil, restoredEndpoints, fmt.Errorf("error while initializing daemon: %w", err)
+		return nil, fmt.Errorf("error while initializing daemon: %w", err)
 	}
 
 	// Start the host IP synchronization. Blocks until the initial synchronization
 	// has finished.
 	if err := params.SyncHostIPs.StartAndWaitFirst(ctx); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Start watcher for endpoint IP --> identity mappings in key-value store.
@@ -594,5 +591,5 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonParams)
 		params.Logger.Error("Unable to start IPsec key watcher", logfields.Error, err)
 	}
 
-	return &d, restoredEndpoints, nil
+	return &d, nil
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -39,7 +39,6 @@ import (
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/endpoint"
 	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
@@ -1279,26 +1278,25 @@ type daemonParams struct {
 	// Grab the GC object so that we can start the CT/NAT map garbage collection.
 	// This is currently necessary because these maps have not yet been modularized,
 	// and because it depends on parameters which are not provided through hive.
-	CTNATMapGC          ctmap.GCRunner
-	IPIdentityWatcher   *ipcache.LocalIPIdentityWatcher
-	EndpointRegenerator *endpoint.Regenerator
-	ClusterInfo         cmtypes.ClusterInfo
-	BandwidthManager    datapath.BandwidthManager
-	IPsecAgent          datapath.IPsecAgent
-	MTU                 mtu.MTU
-	SyncHostIPs         *syncHostIPs
-	NodeDiscovery       *nodediscovery.NodeDiscovery
-	IPAM                *ipam.IPAM
-	CRDSyncPromise      promise.Promise[k8sSynced.CRDSync]
-	IdentityManager     identitymanager.IDManager
-	MaglevConfig        maglev.Config
-	LBConfig            loadbalancer.Config
-	DNSProxy            bootstrap.FQDNProxyBootstrapper
-	DNSNameManager      namemanager.NameManager
-	KPRConfig           kpr.KPRConfig
-	KPRInitializer      kprinitializer.KPRInitializer
-	IPSecConfig         datapath.IPsecConfig
-	HealthConfig        healthconfig.CiliumHealthConfig
+	CTNATMapGC        ctmap.GCRunner
+	IPIdentityWatcher *ipcache.LocalIPIdentityWatcher
+	ClusterInfo       cmtypes.ClusterInfo
+	BandwidthManager  datapath.BandwidthManager
+	IPsecAgent        datapath.IPsecAgent
+	MTU               mtu.MTU
+	SyncHostIPs       *syncHostIPs
+	NodeDiscovery     *nodediscovery.NodeDiscovery
+	IPAM              *ipam.IPAM
+	CRDSyncPromise    promise.Promise[k8sSynced.CRDSync]
+	IdentityManager   identitymanager.IDManager
+	MaglevConfig      maglev.Config
+	LBConfig          loadbalancer.Config
+	DNSProxy          bootstrap.FQDNProxyBootstrapper
+	DNSNameManager    namemanager.NameManager
+	KPRConfig         kpr.KPRConfig
+	KPRInitializer    kprinitializer.KPRInitializer
+	IPSecConfig       datapath.IPsecConfig
+	HealthConfig      healthconfig.CiliumHealthConfig
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], legacy.DaemonInitialization) {
@@ -1408,7 +1406,7 @@ func startDaemon(ctx context.Context, d *Daemon, cleaner *daemonCleanup, params 
 		params.Logger.Error("Failed to wait for initial IPCache revision", logfields.Error, err)
 	}
 
-	d.params.EndpointRestorer.InitRestore(params.EndpointRegenerator)
+	d.params.EndpointRestorer.InitRestore()
 
 	bootstrapStats.enableConntrack.Start()
 	params.Logger.Info("Starting connection tracking garbage collector")

--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -7,17 +7,26 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"slices"
 	"sync"
 
+	"github.com/cilium/hive/cell"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
+	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
+	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
+	endpointmetadata "github.com/cilium/cilium/pkg/endpoint/metadata"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/ipam"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -28,7 +37,53 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-func (d *Daemon) WaitForEndpointRestore(ctx context.Context) error {
+type endpointRestorerParams struct {
+	cell.In
+
+	Logger           *slog.Logger
+	K8sWatcher       *watchers.K8sWatcher
+	Clientset        k8sClient.Clientset
+	EndpointCreator  endpointcreator.EndpointCreator
+	EndpointManager  endpointmanager.EndpointManager
+	EndpointMetadata endpointmetadata.EndpointMetadataFetcher
+	EndpointAPIFence endpointapi.Fence
+	IPSecAgent       datapath.IPsecAgent
+	IPAMManager      *ipam.IPAM
+}
+
+type endpointRestorer struct {
+	logger           *slog.Logger
+	k8sWatcher       *watchers.K8sWatcher
+	clientset        k8sClient.Clientset
+	endpointCreator  endpointcreator.EndpointCreator
+	endpointManager  endpointmanager.EndpointManager
+	endpointMetadata endpointmetadata.EndpointMetadataFetcher
+	endpointAPIFence endpointapi.Fence
+	ipSecAgent       datapath.IPsecAgent
+	ipamManager      *ipam.IPAM
+
+	endpointRestoreComplete       chan struct{}
+	endpointInitialPolicyComplete chan struct{}
+}
+
+func newEndpointRestorer(params endpointRestorerParams) *endpointRestorer {
+	return &endpointRestorer{
+		logger:           params.Logger,
+		k8sWatcher:       params.K8sWatcher,
+		clientset:        params.Clientset,
+		endpointCreator:  params.EndpointCreator,
+		endpointManager:  params.EndpointManager,
+		endpointMetadata: params.EndpointMetadata,
+		endpointAPIFence: params.EndpointAPIFence,
+		ipSecAgent:       params.IPSecAgent,
+		ipamManager:      params.IPAMManager,
+
+		endpointRestoreComplete:       make(chan struct{}),
+		endpointInitialPolicyComplete: make(chan struct{}),
+	}
+}
+
+func (r *endpointRestorer) WaitForEndpointRestore(ctx context.Context) error {
 	if !option.Config.RestoreState {
 		return nil
 	}
@@ -36,12 +91,12 @@ func (d *Daemon) WaitForEndpointRestore(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-d.endpointRestoreComplete:
+	case <-r.endpointRestoreComplete:
 	}
 	return nil
 }
 
-func (d *Daemon) WaitForInitialPolicy(ctx context.Context) error {
+func (r *endpointRestorer) WaitForInitialPolicy(ctx context.Context) error {
 	if !option.Config.RestoreState {
 		return nil
 	}
@@ -49,8 +104,8 @@ func (d *Daemon) WaitForInitialPolicy(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-d.endpointRestoreComplete:
-	case <-d.endpointInitialPolicyComplete:
+	case <-r.endpointRestoreComplete:
+	case <-r.endpointInitialPolicyComplete:
 	}
 	return nil
 }
@@ -62,7 +117,7 @@ type endpointRestoreState struct {
 }
 
 // checkLink returns an error if a link with linkName does not exist.
-func checkLink(linkName string) error {
+func (r *endpointRestorer) checkLink(linkName string) error {
 	_, err := safenetlink.LinkByName(linkName)
 	return err
 }
@@ -73,7 +128,7 @@ func checkLink(linkName string) error {
 //
 // Returns true to indicate that the endpoint is valid to restore, and an
 // optional error.
-func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error) {
+func (r *endpointRestorer) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error) {
 	if ep.IsProperty(endpoint.PropertyFakeEndpoint) {
 		return true, nil
 	}
@@ -85,12 +140,12 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 		// it as not restored. But we need to clean up the old
 		// state files, so do this now.
 		healthStateDir := ep.StateDirectoryPath()
-		d.params.Logger.Debug("Removing old health endpoint state directory",
+		r.logger.Debug("Removing old health endpoint state directory",
 			logfields.EndpointID, ep.ID,
 			logfields.Path, healthStateDir,
 		)
 		if err := os.RemoveAll(healthStateDir); err != nil {
-			d.params.Logger.Warn("Cannot clean up old health state directory",
+			r.logger.Warn("Cannot clean up old health state directory",
 				logfields.EndpointID, ep.ID,
 				logfields.Path, healthStateDir,
 			)
@@ -98,8 +153,8 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 		return false, nil
 	}
 
-	if ep.K8sPodName != "" && ep.K8sNamespace != "" && d.params.Clientset.IsEnabled() {
-		if err := d.getPodForEndpoint(ep); err != nil {
+	if ep.K8sPodName != "" && ep.K8sNamespace != "" && r.clientset.IsEnabled() {
+		if err := r.getPodForEndpoint(ep); err != nil {
 			return false, err
 		}
 
@@ -109,15 +164,15 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 		// which the endpoint manager will begin processing the events off the
 		// queue.
 		ep.InitEventQueue()
-		ep.RunRestoredMetadataResolver(d.params.EndpointMetadata.FetchK8sMetadataForEndpoint)
+		ep.RunRestoredMetadataResolver(r.endpointMetadata.FetchK8sMetadataForEndpoint)
 	}
 
-	if err := ep.ValidateConnectorPlumbing(checkLink); err != nil {
+	if err := ep.ValidateConnectorPlumbing(r.checkLink); err != nil {
 		return false, err
 	}
 
 	if !ep.DatapathConfiguration.ExternalIpam {
-		if err := d.allocateIPsLocked(ep); err != nil {
+		if err := r.allocateIPsLocked(ep); err != nil {
 			return false, fmt.Errorf("Failed to re-allocate IP of endpoint: %w", err)
 		}
 	}
@@ -125,13 +180,13 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 	return true, nil
 }
 
-func (d *Daemon) getPodForEndpoint(ep *endpoint.Endpoint) error {
+func (r *endpointRestorer) getPodForEndpoint(ep *endpoint.Endpoint) error {
 	var (
 		pod *slim_corev1.Pod
 		err error
 	)
-	d.params.K8sWatcher.WaitForCacheSync(resources.K8sAPIGroupPodV1Core)
-	pod, err = d.params.K8sWatcher.GetCachedPod(ep.K8sNamespace, ep.K8sPodName)
+	r.k8sWatcher.WaitForCacheSync(resources.K8sAPIGroupPodV1Core)
+	pod, err = r.k8sWatcher.GetCachedPod(ep.K8sNamespace, ep.K8sPodName)
 	if err != nil && k8serrors.IsNotFound(err) {
 		return fmt.Errorf("Kubernetes pod %s/%s does not exist", ep.K8sNamespace, ep.K8sPodName)
 	} else if err == nil && pod.Spec.NodeName != nodeTypes.GetName() {
@@ -153,11 +208,11 @@ func (d *Daemon) getPodForEndpoint(ep *endpoint.Endpoint) error {
 //
 // 2. restoreOldEndpoints(): validate endpoint data after k8s has been configured
 //   - IP allocation
-//   - some endpoints may be rejected and not regnerated in the 3rd step
+//   - some endpoints may be rejected and not regenerated in the 3rd step
 //
 // 3. regenerateRestoredEndpoints(): Regenerate the restored endpoints
 //   - recreate endpoint's policy, as well as bpf programs and maps
-func (d *Daemon) fetchOldEndpoints(ctx context.Context, dir string) (*endpointRestoreState, error) {
+func (r *endpointRestorer) FetchOldEndpoints(ctx context.Context, dir string) (*endpointRestoreState, error) {
 	state := &endpointRestoreState{
 		possible: nil,
 		restored: []*endpoint.Endpoint{},
@@ -165,11 +220,11 @@ func (d *Daemon) fetchOldEndpoints(ctx context.Context, dir string) (*endpointRe
 	}
 
 	if !option.Config.RestoreState {
-		d.params.Logger.Info("Endpoint restore is disabled, skipping restore step")
+		r.logger.Info("Endpoint restore is disabled, skipping restore step")
 		return state, nil
 	}
 
-	d.params.Logger.Info("Reading old endpoints...")
+	r.logger.Info("Reading old endpoints...")
 
 	dirFiles, err := os.ReadDir(dir)
 	if err != nil {
@@ -177,10 +232,10 @@ func (d *Daemon) fetchOldEndpoints(ctx context.Context, dir string) (*endpointRe
 	}
 	eptsID := endpoint.FilterEPDir(dirFiles)
 
-	state.possible = endpoint.ReadEPsFromDirNames(ctx, d.params.Logger, d.params.EndpointCreator, dir, eptsID)
+	state.possible = endpoint.ReadEPsFromDirNames(ctx, r.logger, r.endpointCreator, dir, eptsID)
 
 	if len(state.possible) == 0 {
-		d.params.Logger.Info("No old endpoints found.")
+		r.logger.Info("No old endpoints found.")
 	}
 	return state, nil
 }
@@ -190,18 +245,18 @@ func (d *Daemon) fetchOldEndpoints(ctx context.Context, dir string) (*endpointRe
 // endpoints into the endpoints list. It needs to be followed by a call to
 // regenerateRestoredEndpoints() once the endpoint builder is ready.
 // Endpoints which cannot be associated with a container workload are deleted.
-func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState) {
+func (r *endpointRestorer) RestoreOldEndpoints(state *endpointRestoreState) {
 	failed := 0
 	defer func() {
 		state.possible = nil
 	}()
 
 	if !option.Config.RestoreState {
-		d.params.Logger.Info("Endpoint restore is disabled, skipping restore step")
+		r.logger.Info("Endpoint restore is disabled, skipping restore step")
 		return
 	}
 
-	d.params.Logger.Info("Restoring endpoints...")
+	r.logger.Info("Restoring endpoints...")
 
 	var (
 		existingEndpoints map[string]lxcmap.EndpointInfo
@@ -211,21 +266,21 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState) {
 	if !option.Config.DryMode {
 		existingEndpoints, err = lxcmap.DumpToMap()
 		if err != nil {
-			d.params.Logger.Warn("Unable to open endpoint map while restoring. Skipping cleanup of endpoint map on startup", logfields.Error, err)
+			r.logger.Warn("Unable to open endpoint map while restoring. Skipping cleanup of endpoint map on startup", logfields.Error, err)
 		}
 	}
 
 	for _, ep := range state.possible {
-		scopedLog := d.params.Logger.With(logfields.EndpointID, ep.ID)
-		if d.params.Clientset.IsEnabled() {
+		scopedLog := r.logger.With(logfields.EndpointID, ep.ID)
+		if r.clientset.IsEnabled() {
 			scopedLog = scopedLog.With(logfields.CEPName, ep.GetK8sNamespaceAndCEPName())
 		}
 
-		restore, err := d.validateEndpoint(ep)
+		restore, err := r.validateEndpoint(ep)
 		if err != nil {
 			// Disconnected EPs are not failures, clean them silently below
 			if !ep.IsDisconnecting() {
-				d.params.EndpointManager.DeleteK8sCiliumEndpointSync(ep)
+				r.endpointManager.DeleteK8sCiliumEndpointSync(ep)
 				scopedLog.Warn("Unable to restore endpoint, ignoring", logfields.Error, err)
 				failed++
 			}
@@ -249,7 +304,7 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState) {
 		}
 	}
 
-	d.params.Logger.Info(
+	r.logger.Info(
 		"Endpoints restored",
 		logfields.Restored, len(state.restored),
 		logfields.Failed, failed,
@@ -258,9 +313,9 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState) {
 	for epIP, info := range existingEndpoints {
 		if ip := net.ParseIP(epIP); !info.IsHost() && ip != nil {
 			if err := lxcmap.DeleteEntry(ip); err != nil {
-				d.params.Logger.Warn("Unable to delete obsolete endpoint from BPF map", logfields.Error, err)
+				r.logger.Warn("Unable to delete obsolete endpoint from BPF map", logfields.Error, err)
 			} else {
-				d.params.Logger.Debug(
+				r.logger.Debug(
 					"Removed outdated endpoint from endpoint map",
 					logfields.EndpointLXCID, uint64(info.LxcID),
 				)
@@ -269,8 +324,8 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState) {
 	}
 }
 
-func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpointsRegenerator *endpoint.Regenerator) {
-	d.params.Logger.Info(
+func (r *endpointRestorer) regenerateRestoredEndpoints(state *endpointRestoreState, endpointsRegenerator *endpoint.Regenerator) {
+	r.logger.Info(
 		"Regenerating restored endpoints",
 		logfields.Restored, len(state.restored),
 	)
@@ -294,8 +349,8 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 		// not in a goroutine) because regenerateRestoredEndpoints must guarantee
 		// upon returning that endpoints are exposed to other subsystems via
 		// endpointmanager.
-		if err := d.params.EndpointManager.RestoreEndpoint(ep); err != nil {
-			d.params.Logger.Warn("Unable to restore endpoint", logfields.Error, err)
+		if err := r.endpointManager.RestoreEndpoint(ep); err != nil {
+			r.logger.Warn("Unable to restore endpoint", logfields.Error, err)
 			// remove endpoint from slice of endpoints to restore
 			state.restored = slices.Delete(state.restored, i, i+1)
 		}
@@ -303,7 +358,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 
 	endpointsToRegenerate := make([]*endpoint.Endpoint, 0, len(state.restored))
 	for _, ep := range state.restored {
-		if ep.IsHost() && d.params.IPsecAgent.Enabled() {
+		if ep.IsHost() && r.ipSecAgent.Enabled() {
 			// To support v1.18 VinE upgrades, we need to restore the host
 			// endpoint before any other endpoint, to ensure a drop-less upgrade.
 			// This is because in v1.18 'bpf_lxc' programs stop issuing IPsec hooks
@@ -315,9 +370,9 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 			// ensuring no IPsec leaks occur.
 			//
 			// This can be removed in v1.19.
-			d.params.Logger.Info("Successfully restored Host endpoint. Scheduling regeneration", logfields.EndpointID, ep.ID)
-			if err := ep.RegenerateAfterRestore(endpointsRegenerator, d.params.EndpointMetadata.FetchK8sMetadataForEndpoint); err != nil {
-				d.params.Logger.Debug(
+			r.logger.Info("Successfully restored Host endpoint. Scheduling regeneration", logfields.EndpointID, ep.ID)
+			if err := ep.RegenerateAfterRestore(endpointsRegenerator, r.endpointMetadata.FetchK8sMetadataForEndpoint); err != nil {
+				r.logger.Debug(
 					"Error regenerating Host endpoint during restore",
 					logfields.Error, err,
 					logfields.EndpointID, ep.ID,
@@ -338,7 +393,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 			// release it easily as it will require to block on kvstore
 			// connectivity which we can't do at this point. Let the lease
 			// expire to release the identity.
-			d.params.EndpointManager.RemoveEndpoint(ep, endpoint.DeleteConfig{
+			r.endpointManager.RemoveEndpoint(ep, endpoint.DeleteConfig{
 				NoIdentityRelease: true,
 				NoIPRelease:       true,
 			})
@@ -348,13 +403,13 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 	endpointCleanupCompleted.Wait()
 
 	// Trigger regeneration for relevant restored endopints in a separate goroutine.
-	go d.handleRestoredEndpointsRegeneration(endpointsToRegenerate, endpointsRegenerator)
+	go r.handleRestoredEndpointsRegeneration(endpointsToRegenerate, endpointsRegenerator)
 
 	go func() {
 		for _, ep := range state.restored {
 			ep.WaitForInitialPolicy()
 		}
-		close(d.endpointInitialPolicyComplete)
+		close(r.endpointInitialPolicyComplete)
 	}()
 }
 
@@ -365,13 +420,13 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 // before regenerating all remaining live endpoints.
 //
 // Once complete, this method closes the daemon 'endpointRestoreComplete' channel.
-func (d *Daemon) handleRestoredEndpointsRegeneration(endpoints []*endpoint.Endpoint, endpointsRegenerator *endpoint.Regenerator) {
+func (r *endpointRestorer) handleRestoredEndpointsRegeneration(endpoints []*endpoint.Endpoint, endpointsRegenerator *endpoint.Regenerator) {
 	startTime := time.Now()
 	// Wait for Endpoint DeletionQueue to be processed first so we can avoid
 	// expensive regeneration for already deleted endpoints.
-	_ = d.params.EndpointAPIFence.Wait(context.Background())
+	_ = r.endpointAPIFence.Wait(context.Background())
 
-	d.params.Logger.Debug(
+	r.logger.Debug(
 		"Endpoint API fence unblocked, attempting regeneration for alive endpoints",
 		logfields.Duration, time.Since(startTime),
 	)
@@ -381,23 +436,23 @@ func (d *Daemon) handleRestoredEndpointsRegeneration(endpoints []*endpoint.Endpo
 
 	for _, ep := range endpoints {
 		// Check if the endpoint still exists in EndpointManager.
-		epFromLookup := d.params.EndpointManager.LookupCiliumID(ep.ID)
+		epFromLookup := r.endpointManager.LookupCiliumID(ep.ID)
 		if epFromLookup == nil {
-			d.params.Logger.Debug(
+			r.logger.Debug(
 				"Endpoint missing in EndpointManager, assuming already deleted",
 				logfields.EndpointID, ep.ID,
 			)
 			continue
 		}
 
-		d.params.Logger.Info("Scheduling restored endpoint regeneration", logfields.EndpointID, ep.ID)
+		r.logger.Info("Scheduling restored endpoint regeneration", logfields.EndpointID, ep.ID)
 
 		regenWg.Add(1)
 		go func(ep *endpoint.Endpoint, wg *sync.WaitGroup, endpointsRegenerated chan<- bool) {
 			defer wg.Done()
 
-			if err := ep.RegenerateAfterRestore(endpointsRegenerator, d.params.EndpointMetadata.FetchK8sMetadataForEndpoint); err != nil {
-				d.params.Logger.Debug(
+			if err := ep.RegenerateAfterRestore(endpointsRegenerator, r.endpointMetadata.FetchK8sMetadataForEndpoint); err != nil {
+				r.logger.Debug(
 					"Error regenerating endpoint during restore",
 					logfields.Error, err,
 					logfields.EndpointID, ep.ID,
@@ -422,33 +477,33 @@ func (d *Daemon) handleRestoredEndpointsRegeneration(endpoints []*endpoint.Endpo
 		}
 	}
 
-	d.params.Logger.Info(
+	r.logger.Info(
 		"Finished regenerating restored endpoints",
 		logfields.Regenerated, regenerated,
 		logfields.Failed, failed,
 		logfields.Total, total,
 	)
-	close(d.endpointRestoreComplete)
+	close(r.endpointRestoreComplete)
 }
 
-func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
+func (r *endpointRestorer) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 	if option.Config.EnableIPv6 && ep.IPv6.IsValid() {
 		ipv6Pool := ipam.PoolOrDefault(ep.IPv6IPAMPool)
-		_, err = d.params.IPAM.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanString()+" [restored]", ipv6Pool)
+		_, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanString()+" [restored]", ipv6Pool)
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6, err)
 		}
 
 		defer func() {
 			if err != nil {
-				d.params.IPAM.ReleaseIP(ep.IPv6.AsSlice(), ipv6Pool)
+				r.ipamManager.ReleaseIP(ep.IPv6.AsSlice(), ipv6Pool)
 			}
 		}()
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4.IsValid() {
 		ipv4Pool := ipam.PoolOrDefault(ep.IPv4IPAMPool)
-		_, err = d.params.IPAM.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanString()+" [restored]", ipv4Pool)
+		_, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanString()+" [restored]", ipv4Pool)
 		switch {
 		// We only check for BypassIPAllocUponRestore for IPv4 because we
 		// assume that this flag is only turned on for IPv4-only IPAM modes
@@ -460,7 +515,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 		case err != nil &&
 			errors.Is(err, ipam.NewIPNotAvailableInPoolError(ep.IPv4.AsSlice())) &&
 			option.Config.BypassIPAvailabilityUponRestore:
-			d.params.Logger.Warn(
+			r.logger.Warn(
 				"Bypassing IP not available error on endpoint restore. This is "+
 					"to prevent errors upon Cilium upgrade and should not be "+
 					"relied upon. Consider restarting this pod in order to get "+
@@ -478,15 +533,17 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 	return nil
 }
 
-func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState, endpointsRegenerator *endpoint.Regenerator) {
-	bootstrapStats.restore.Start()
-	if option.Config.RestoreState {
-		// When we regenerate restored endpoints, it is guaranteed that we have
-		// received the full list of policies present at the time the daemon
-		// is bootstrapped.
-		d.regenerateRestoredEndpoints(restoredEndpoints, endpointsRegenerator)
-	} else {
-		d.params.Logger.Info("State restore is disabled. Existing endpoints on node are ignored")
+func (r *endpointRestorer) InitRestore(restoredEndpoints *endpointRestoreState, endpointsRegenerator *endpoint.Regenerator) {
+	if !option.Config.RestoreState {
+		r.logger.Info("State restore is disabled. Existing endpoints on node are ignored")
+		return
 	}
-	bootstrapStats.restore.End(true)
+
+	bootstrapStats.restore.Start()
+	defer bootstrapStats.restore.End(true)
+
+	// When we regenerate restored endpoints, it is guaranteed that we have
+	// received the full list of policies present at the time the daemon
+	// is bootstrapped.
+	r.regenerateRestoredEndpoints(restoredEndpoints, endpointsRegenerator)
 }


### PR DESCRIPTION
Please review the individual commits

Note: This PR is a subset of a previous PR (https://github.com/cilium/cilium/pull/39433) that tried to handle a lot of stuff in one PR. This PR only addresses the extraction of the endpoint restoration logic from the `Daemon` struct into its own component - but its still located in package `daemon/cmd` and the restorer promise still exists. The other aspects will be be addressed in follow up PRs.