### PR TITLE
ci: use eks nodegroup action in egw scale test

### DIFF
--- a/.github/actions/setup-eks-nodegroup/action.yml
+++ b/.github/actions/setup-eks-nodegroup/action.yml
@@ -18,24 +18,30 @@ inputs:
     description: ''
     required: false
     default: 'true'
+  mode:
+    description: ''
+    required: false
+    default: ''
+  client_node_number:
+    description: 'Node number, will only be used for egw mode'
+    required: false
+    default: '4'
+  egw_default_zone:
+    description: 'Availability zone that will be used for egw nodegroups'
+    required: false
+    default: ''
+  egw_no_cilium_zone:
+    description: 'Availability zone that will be used for no-cilium egw nodegroup'
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
-    - name: Create EKS nodegroup
+    - name: Create nodegroup details (regular mode)
+      if: ${{ inputs.mode != 'egw' }}
       shell: bash
       run: |
-        cat <<EOF > eks-nodegroups.yaml
-        apiVersion: eksctl.io/v1alpha5
-        kind: ClusterConfig
-
-        metadata:
-          name: ${{ inputs.cluster_name }}
-          region: ${{ inputs.region }}
-          version: "${{ inputs.version }}"
-          tags:
-           usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
-           owner: "${{ inputs.owner }}"
-
+        cat <<EOF > nodegroup-details.yaml
         managedNodeGroups:
         - name: ng-amd64
           instanceTypes:
@@ -62,5 +68,105 @@ runs:
              value: "true"
              effect: "NoExecute"
         EOF
+
+    - name: Create nodegroup details (EGW mode)
+      if: ${{ inputs.mode == 'egw' }}
+      shell: bash
+      run: |
+        cat <<EOF > nodegroup-details.yaml
+        managedNodeGroups:
+        - name: ng-amd64-client
+          instanceTypes:
+           - m5n.xlarge
+          availabilityZones:
+           - ${{ inputs.egw_default_zone }}
+          desiredCapacity: ${{ inputs.client_node_number }}
+          spot: false
+          privateNetworking: true
+          volumeType: "gp3"
+          volumeSize: 20
+          maxPodsPerNode: 110
+          taints:
+           - key: "node.cilium.io/agent-not-ready"
+             value: "true"
+             effect: "NoExecute"
+          labels:
+             role.scaffolding/egw-client: "true"
+        - name: ng-amd64-egw-node
+          instanceTypes:
+           - m5n.xlarge
+          availabilityZones:
+           - ${{ inputs.egw_default_zone }}
+          desiredCapacity: 1
+          spot: false
+          privateNetworking: true
+          volumeType: "gp3"
+          volumeSize: 20
+          maxPodsPerNode: 110
+          taints:
+           - key: "node.cilium.io/agent-not-ready"
+             value: "true"
+             effect: "NoExecute"
+          labels:
+             role.scaffolding/egw-node: "true"
+        - name: ng-amd64-heapster
+          instanceTypes:
+           - m5n.xlarge
+          availabilityZones:
+           - ${{ inputs.egw_default_zone }}
+          desiredCapacity: 1
+          spot: false
+          privateNetworking: true
+          volumeType: "gp3"
+          volumeSize: 20
+          maxPodsPerNode: 110
+          taints:
+           - key: "node.cilium.io/agent-not-ready"
+             value: "true"
+             effect: "NoExecute"
+          labels:
+             role.scaffolding/monitoring: "true"
+        - name: ng-amd64-no-cilium
+          instanceTypes:
+           - m5n.xlarge
+          availabilityZones:
+           - ${{ inputs.egw_no_cilium_zone }}
+          desiredCapacity: 1
+          spot: false
+          privateNetworking: true
+          volumeType: "gp3"
+          volumeSize: 20
+          taints:
+           - key: "cilium.io/no-schedule"
+             value: "true"
+             effect: "NoSchedule"
+          labels:
+            cilium.io/no-schedule: "true"
+          # Manually inject a dummy CNI configuration to let the Kubelet turn
+          # ready. This is necessary as otherwise the node creation would
+          # never complete. Regardless, no pods will be scheduled here given
+          # that the node is tainted.
+          preBootstrapCommands:
+          - "echo '{ \"cniVersion\": \"0.3.1\", \"name\": \"dummy\", \"type\": \"dummy-cni\", \"log-file\": \"/var/run/dummy.log\" }' > /etc/cni/net.d/05-dummy.conf"
+        EOF
+
+    - name: Create EKS nodegroup
+      shell: bash
+      run: |
+        cat <<EOF > eks-nodegroups.yaml
+        apiVersion: eksctl.io/v1alpha5
+        kind: ClusterConfig
+
+        metadata:
+          name: ${{ inputs.cluster_name }}
+          region: ${{ inputs.region }}
+          version: "${{ inputs.version }}"
+          tags:
+           usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+           owner: "${{ inputs.owner }}"
+
+        EOF
+
+        cat ./nodegroup-details.yaml >> ./eks-nodegroups.yaml
 
         eksctl create nodegroup -f ./eks-nodegroups.yaml

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -416,98 +416,19 @@ jobs:
       # This needs to be performed in a different step, because nodeGroups are not
       # supported during cluster creation in a cluster without VPC CNI. Cilium is
       # also required to be already installed for the step to complete successfully.
+
       - name: Create EKS nodegroups
-        shell: bash
-        run: |
-          cat <<EOF > eks-nodegroup.yaml
-          apiVersion: eksctl.io/v1alpha5
-          kind: ClusterConfig
-
-          metadata:
-            name: ${{ steps.vars.outputs.cluster_name }}
-            region: ${{ steps.vars.outputs.eks_region }}
-            version: "${{ steps.vars.outputs.eks_version }}"
-            tags:
-              usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
-              owner: "${{ steps.vars.outputs.owner }}"
-
-          managedNodeGroups:
-          - name: ng-amd64-client
-            instanceTypes:
-            - ${{ steps.vars.outputs.node_instance_type }}
-            availabilityZones:
-            - ${{ steps.vars.outputs.eks_zone_1 }}
-            desiredCapacity: ${{ steps.vars.outputs.num_client_nodes }}
-            spot: false
-            privateNetworking: true
-            volumeType: "gp3"
-            volumeSize: 20
-            maxPodsPerNode: 110
-            taints:
-            - key: "node.cilium.io/agent-not-ready"
-              value: "true"
-              effect: "NoExecute"
-            labels:
-              role.scaffolding/egw-client: "true"
-          - name: ng-amd64-egw-node
-            instanceTypes:
-            - ${{ steps.vars.outputs.node_instance_type }}
-            availabilityZones:
-            - ${{ steps.vars.outputs.eks_zone_1 }}
-            desiredCapacity: 1
-            spot: false
-            privateNetworking: true
-            volumeType: "gp3"
-            volumeSize: 20
-            maxPodsPerNode: 110
-            taints:
-            - key: "node.cilium.io/agent-not-ready"
-              value: "true"
-              effect: "NoExecute"
-            labels:
-              role.scaffolding/egw-node: "true"
-          - name: ng-amd64-heapster
-            instanceTypes:
-            - ${{ steps.vars.outputs.node_instance_type }}
-            availabilityZones:
-            - ${{ steps.vars.outputs.eks_zone_1 }}
-            desiredCapacity: 1
-            spot: false
-            privateNetworking: true
-            volumeType: "gp3"
-            volumeSize: 20
-            maxPodsPerNode: 110
-            taints:
-            - key: "node.cilium.io/agent-not-ready"
-              value: "true"
-              effect: "NoExecute"
-            labels:
-              role.scaffolding/monitoring: "true"
-          - name: ng-amd64-no-cilium
-            instanceTypes:
-            - ${{ steps.vars.outputs.node_instance_type }}
-            availabilityZones:
-            - ${{ steps.vars.outputs.eks_zone_2 }}
-            desiredCapacity: 1
-            spot: false
-            privateNetworking: true
-            volumeType: "gp3"
-            volumeSize: 20
-            taints:
-            - key: "cilium.io/no-schedule"
-              value: "true"
-              effect: "NoSchedule"
-            labels:
-              cilium.io/no-schedule: "true"
-            # Manually inject a dummy CNI configuration to let the Kubelet turn
-            # ready. This is necessary as otherwise the node creation would
-            # never complete. Regardless, no pods will be scheduled here given
-            # that the node is tainted.
-            preBootstrapCommands:
-            - "echo '{ \"cniVersion\": \"0.3.1\", \"name\": \"dummy\", \"type\": \"dummy-cni\", \"log-file\": \"/var/run/dummy.log\" }' > /etc/cni/net.d/05-dummy.conf"
-          EOF
-
-          eksctl create nodegroup -f ./eks-nodegroup.yaml --timeout=10m
+        uses: ./.github/actions/setup-eks-nodegroup
+        with:
+          cluster_name: ${{ steps.vars.outputs.cluster_name }}
+          region: ${{ steps.vars.outputs.eks_region }}
+          owner: "${{ steps.vars.outputs.owner }}"
+          version: ${{ steps.vars.outputs.eks_version }}
+          spot: false
+          mode: "egw"
+          client_node_number: ${{ steps.vars.outputs.num_client_nodes }}
+          egw_default_zone: ${{ steps.vars.outputs.eks_zone_1 }}
+          egw_no_cilium_zone: ${{ steps.vars.outputs.eks_zone_2 }}
 
       - name: Wait for Cilium status to be ready
         run: |


### PR DESCRIPTION
This commit refactors eks nodegroup action to add egw specific setup. Avoid shell script duplication and improves readability of the workflow.