### PR TITLE
Introduce tuned buffer margin logic for netkit

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -121,6 +121,7 @@ Stormtroopers
 Suchakra
 Suricata
 Synchronizer
+Tailroom
 Talos
 Telco
 Terraform
@@ -548,8 +549,8 @@ matchLabels
 matchPattern
 maxUnavailable
 mc
-mediabot
 mcsapi
+mediabot
 memcache
 memcached
 memcd

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -44,8 +44,14 @@ type DaemonConfigurationStatus struct {
 	// datapath mode
 	DatapathMode DatapathMode `json:"datapathMode,omitempty"`
 
+	// Headroom buffer margin on workload facing devices
+	DeviceHeadroom int64 `json:"deviceHeadroom,omitempty"`
+
 	// MTU on workload facing devices
 	DeviceMTU int64 `json:"deviceMTU,omitempty"`
+
+	// Tailroom buffer margin on workload facing devices
+	DeviceTailroom int64 `json:"deviceTailroom,omitempty"`
 
 	// Configured compatibility mode for --egress-multi-home-ip-rule-compat
 	EgressMultiHomeIPRuleCompat bool `json:"egress-multi-home-ip-rule-compat,omitempty"`

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2566,6 +2566,12 @@ definitions:
       GROIPv4MaxSize:
         description: Maximum IPv4 GRO size on workload facing devices
         type: integer
+      deviceHeadroom:
+        description: Headroom buffer margin on workload facing devices
+        type: integer
+      deviceTailroom:
+        description: Tailroom buffer margin on workload facing devices
+        type: integer
       ipLocalReservedPorts:
         description: Comma-separated list of IP ports should be reserved in the workload network namespace
         type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2450,8 +2450,16 @@ func init() {
         "datapathMode": {
           "$ref": "#/definitions/DatapathMode"
         },
+        "deviceHeadroom": {
+          "description": "Headroom buffer margin on workload facing devices",
+          "type": "integer"
+        },
         "deviceMTU": {
           "description": "MTU on workload facing devices",
+          "type": "integer"
+        },
+        "deviceTailroom": {
+          "description": "Tailroom buffer margin on workload facing devices",
           "type": "integer"
         },
         "egress-multi-home-ip-rule-compat": {
@@ -7867,8 +7875,16 @@ func init() {
         "datapathMode": {
           "$ref": "#/definitions/DatapathMode"
         },
+        "deviceHeadroom": {
+          "description": "Headroom buffer margin on workload facing devices",
+          "type": "integer"
+        },
         "deviceMTU": {
           "description": "MTU on workload facing devices",
+          "type": "integer"
+        },
+        "deviceTailroom": {
+          "description": "Tailroom buffer margin on workload facing devices",
           "type": "integer"
         },
         "egress-multi-home-ip-rule-compat": {

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -103,6 +103,7 @@ func newConfigModifyApiHandler(params configModifyApiHandlerParams) configModify
 			tunnelConfig:    params.TunnelConfig,
 			bandwidthConfig: params.BandwidthConfig,
 			wgConfig:        params.WgConfig,
+			connectorConfig: params.ConnectorConfig,
 		},
 		PatchConfigHandler: &patchConfigHandler{
 			logger:       params.Logger,
@@ -348,6 +349,7 @@ type getConfigHandler struct {
 	tunnelConfig    tunnel.Config
 	bandwidthConfig datapath.BandwidthConfig
 	wgConfig        wgTypes.WireguardConfig
+	connectorConfig types.ConnectorConfig
 }
 
 func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.Responder {
@@ -408,6 +410,8 @@ func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.R
 		GSOIPV4MaxSize:                      int64(h.bigTCPConfig.GetGSOIPv4MaxSize()),
 		IPLocalReservedPorts:                h.getIPLocalReservedPorts(),
 		EnableBBRHostNamespaceOnly:          h.bandwidthConfig.EnableBBRHostnsOnly,
+		DeviceHeadroom:                      int64(h.connectorConfig.GetPodDeviceHeadroom()),
+		DeviceTailroom:                      int64(h.connectorConfig.GetPodDeviceTailroom()),
 	}
 
 	cfg := &models.DaemonConfiguration{

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/datapath/types"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -76,6 +77,7 @@ type configModifyApiHandlerParams struct {
 	TunnelConfig    tunnel.Config
 	BandwidthConfig datapath.BandwidthConfig
 	WgConfig        wgTypes.WireguardConfig
+	ConnectorConfig types.ConnectorConfig
 
 	EventHandler *ConfigModifyEventHandler
 }

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/act"
 	"github.com/cilium/cilium/pkg/datapath/agentliveness"
+	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/gneigh"
 	"github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
@@ -109,6 +110,9 @@ var Cell = cell.Module(
 
 	// MTU provides the MTU configuration of the node.
 	mtu.Cell,
+
+	// Connector provides pod-specific interface configuration
+	connector.Cell,
 
 	orchestrator.Cell,
 

--- a/pkg/datapath/connector/cell.go
+++ b/pkg/datapath/connector/cell.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package connector
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/datapath/types"
+)
+
+var Cell = cell.Module(
+	"connector",
+	"Datapath connector configuration mutator",
+
+	cell.Provide(newConnectorConfig),
+)
+
+func newConnectorConfig(p connectorParams) types.ConnectorConfig {
+	return newConfig(p)
+}

--- a/pkg/datapath/connector/config.go
+++ b/pkg/datapath/connector/config.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package connector
+
+import (
+	"log/slog"
+	"math"
+
+	"github.com/cilium/hive/cell"
+
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
+)
+
+// Connector configuration. As per BIGTCP, the values here will not be calculated
+// until the Hive has started. This is necessary to allow other dependencies to
+// setup their interfaces etc.
+type ConnectorConfig struct {
+	// podDeviceHeadroom tracks the desired headroom buffer margin for the
+	// network device pair facing a workload.
+	podDeviceHeadroom uint16
+
+	// podDeviceTailroom tracks the desired tailroom buffer margin for the
+	// network device pairs facing a workload.
+	podDeviceTailroom uint16
+}
+
+func (cc *ConnectorConfig) GetPodDeviceHeadroom() uint16 {
+	return cc.podDeviceHeadroom
+}
+
+func (cc *ConnectorConfig) GetPodDeviceTailroom() uint16 {
+	return cc.podDeviceTailroom
+}
+
+type connectorParams struct {
+	cell.In
+
+	Lifecycle    cell.Lifecycle
+	Log          *slog.Logger
+	DaemonConfig *option.DaemonConfig
+	Orchestrator types.Orchestrator
+	WgAgent      wgTypes.WireguardAgent
+	TunnelConfig tunnel.Config
+}
+
+// Returns true if we should actively try and align the connector's netdev buffer
+// margins with that of the host's egress interfaces (e.g. tunnel, wireguard).
+func useTunedBufferMargins(datapathMode string) bool {
+	switch datapathMode {
+	case datapathOption.DatapathModeNetkit, datapathOption.DatapathModeNetkitL2:
+		return true
+	}
+	return false
+}
+
+// newConnectorConfig initialises a new ConnectorConfig object with default parameters.
+func newConfig(p connectorParams) *ConnectorConfig {
+	cc := &ConnectorConfig{}
+
+	if useTunedBufferMargins(p.DaemonConfig.DatapathMode) {
+		// TODO: We need a way of validating that we can rely on the kernel
+		// to report buffer margins via netlink generic attributes. If we can't
+		// rely on the kernel here, we should probably error out in future.
+		//
+		// In an ideal world we'd have something like nk.SupportsScrub() in
+		// the upstream netlink library, but that would need to be done at
+		// a generic level and probably isn't acceptable to the maintainer.
+		//
+		// A better approach might be to just try create a dummy netkit
+		// interface with some magic headroom value, and check we can read
+		// it back.
+		p.Lifecycle.Append(cell.Hook{
+			OnStart: func(cell.HookContext) error {
+				return generateConfig(p, cc)
+			},
+		})
+	}
+
+	return cc
+}
+
+// generateConfig aims to calculate necessary tuning parameters for pod/workload-facing
+// network device pairs.
+func generateConfig(p connectorParams, cc *ConnectorConfig) error {
+	if !useTunedBufferMargins(p.DaemonConfig.DatapathMode) {
+		return nil
+	}
+
+	// We must wait for the Orchestrator to signal that the datapath is initialised,
+	// so that it has chance to create any tunneling devices. Otherwise, we'll fail
+	// to query a device below and error out by accident.
+	<-p.Orchestrator.DatapathInitialized()
+
+	wgHeadroom, wgTailroom, err := p.WgAgent.IfaceBufferMargins()
+	if err != nil {
+		return err
+	}
+
+	tunnelHeadroom, tunnelTailroom, err := p.TunnelConfig.DeviceBufferMargins()
+	if err != nil {
+		return err
+	}
+
+	// There's nothing technically stopping these discovered values from being
+	// to be on the high end of the underlying storage type. When combined, they
+	// may overflow a U16.
+	var totalHeadroom = uint32(wgHeadroom) + uint32(tunnelHeadroom)
+	if totalHeadroom > math.MaxUint16 {
+		p.Log.Warn("Total calculated headroom would exceed maximum value, using default",
+			logfields.DeviceHeadroom, totalHeadroom)
+	} else {
+		cc.podDeviceHeadroom = uint16(totalHeadroom)
+	}
+	var totalTailroom = uint32(wgTailroom) + uint32(tunnelTailroom)
+	if totalTailroom > math.MaxUint16 {
+		p.Log.Warn("Total calculated tailroom would exceed maximum value, using default",
+			logfields.DeviceTailroom, totalTailroom)
+	} else {
+		cc.podDeviceTailroom = uint16(totalTailroom)
+	}
+	return nil
+}

--- a/pkg/datapath/connector/config_test.go
+++ b/pkg/datapath/connector/config_test.go
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package connector
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/datapath/link"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
+)
+
+var (
+	// Fake links
+	fakeLinkWireguard = &netlink.Wireguard{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: wgTypes.IfaceName,
+		},
+	}
+	fakeLinkGeneve = &netlink.Geneve{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: defaults.GeneveDevice,
+		},
+	}
+	fakeLinkVxlan = &netlink.Wireguard{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: defaults.VxlanDevice,
+		},
+	}
+
+	// DaemonConfigs
+	daemonConfigVeth = option.DaemonConfig{
+		DatapathMode: datapathOption.DatapathModeVeth,
+		EnableIPv4:   true,
+		EnableIPv6:   true,
+	}
+	daemonConfigNetkit = option.DaemonConfig{
+		DatapathMode: datapathOption.DatapathModeNetkit,
+		EnableIPv4:   true,
+		EnableIPv6:   true,
+	}
+	daemonConfigNetkitL2 = option.DaemonConfig{
+		DatapathMode: datapathOption.DatapathModeNetkitL2,
+		EnableIPv4:   true,
+		EnableIPv6:   true,
+	}
+
+	// WireguardConfigs
+	wgConfigEnabled  = fakeTypes.WireguardConfig{EnableWireguard: true}
+	wgConfigDisabled = fakeTypes.WireguardConfig{EnableWireguard: false}
+
+	// TunnelConfigs
+	tunnelConfigNative = tunnel.NewTestConfig(tunnel.Disabled)
+	tunnelConfigVxlan  = tunnel.NewTestConfig(tunnel.VXLAN)
+	tunnelConfigGeneve = tunnel.NewTestConfig(tunnel.Geneve)
+
+	// ConnectorConfigs
+	ccTuningZero = ConnectorConfig{}
+)
+
+type fakeLinkAttributes struct {
+	Name       string
+	Headroom   uint16
+	Tailroom   uint16
+	WasCreated bool
+}
+
+// Reuseable logic to create a test device link via netlink
+func createFakeLink(ifLink netlink.Link) (*fakeLinkAttributes, error) {
+	fakeAttr := &fakeLinkAttributes{Name: ifLink.Attrs().Name}
+
+	// Attempt to create the device that allows our tests to run. It's
+	// possible we're running in parallel with another test, so this could
+	// already exist. Allow EEXIST errors to flow through.
+	err := netlink.LinkAdd(ifLink)
+	if err != nil {
+		if !errors.Is(err, unix.EEXIST) {
+			return nil, err
+		}
+	} else {
+		fakeAttr.WasCreated = true
+	}
+
+	// Re-query the kernel for the device attributes so we know what we
+	// expect the connector config logic to produce.
+	//
+	// This is necessary because we might be on a kernel that doesn't
+	// report the IFLA_HEADROOM and IFLA_TAILROOM. Or, perhaps a driver
+	// changes its internal headroom/tailroom reservations at some
+	// point in the future.
+	fakeLink, err := safenetlink.LinkByName(fakeAttr.Name)
+	if err != nil {
+		destroyFakeLink(fakeAttr)
+		return nil, err
+	}
+
+	fakeAttr.Headroom = fakeLink.Attrs().Headroom
+	fakeAttr.Tailroom = fakeLink.Attrs().Tailroom
+	return fakeAttr, nil
+}
+
+func destroyFakeLink(fakeAttr *fakeLinkAttributes) error {
+	if fakeAttr.WasCreated {
+		return link.DeleteByName(fakeAttr.Name)
+	}
+	return nil
+}
+
+func TestUseTunedBufferMargins(t *testing.T) {
+	tests := []struct {
+		name           string
+		datapathMode   string
+		expectedResult bool
+	}{
+		{
+			name:           "datapath-veth",
+			datapathMode:   datapathOption.DatapathModeVeth,
+			expectedResult: false,
+		},
+		{
+			name:           "datapath-netkit",
+			datapathMode:   datapathOption.DatapathModeNetkit,
+			expectedResult: true,
+		},
+		{
+			name:           "datapath-netkit-l2",
+			datapathMode:   datapathOption.DatapathModeNetkitL2,
+			expectedResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := useTunedBufferMargins(tt.datapathMode)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	tests := []struct {
+		name           string
+		daemonConfig   *option.DaemonConfig
+		wgAgent        *fakeTypes.WireguardAgent
+		tunnelConfig   tunnel.Config
+		expectedConfig *ConnectorConfig
+	}{
+		{
+			name:           "datapath-veth",
+			daemonConfig:   &daemonConfigVeth,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &ccTuningZero,
+		},
+		{
+			name:           "datapath-netkit",
+			daemonConfig:   &daemonConfigNetkit,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &ccTuningZero,
+		},
+		{
+			name:           "datapath-netkit-l2",
+			daemonConfig:   &daemonConfigNetkitL2,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &ccTuningZero,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := connectorParams{
+				Lifecycle:    &cell.DefaultLifecycle{},
+				Log:          logger,
+				Orchestrator: &fakeTypes.FakeOrchestrator{},
+				DaemonConfig: tt.daemonConfig,
+				WgAgent:      tt.wgAgent,
+				TunnelConfig: tt.tunnelConfig,
+			}
+			connector := newConfig(p)
+
+			assert.NotNil(t, connector)
+			assert.Equal(t, tt.expectedConfig, connector)
+		})
+	}
+}
+
+func TestPrivilegedGenerateConfig(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	logger := hivetest.Logger(t)
+
+	// Setup fake devices so we know the underlying magins of each driver
+	// on the system we're running on.
+	wgAttr, err := createFakeLink(fakeLinkWireguard)
+	if err != nil {
+		t.Fatalf("failed to create fake device %+v: %s", fakeLinkWireguard, err)
+	}
+	defer destroyFakeLink(wgAttr)
+	geneveAttr, err := createFakeLink(fakeLinkGeneve)
+	if err != nil {
+		t.Fatalf("failed to create fake device %+v: %s", fakeLinkGeneve, err)
+	}
+	defer destroyFakeLink(geneveAttr)
+	vxlanAttr, err := createFakeLink(fakeLinkVxlan)
+	if err != nil {
+		t.Fatalf("failed to create fake device %+v: %s", fakeLinkVxlan, err)
+	}
+	defer destroyFakeLink(vxlanAttr)
+
+	// Verify nothing overflows before we test
+	assert.NotNil(t, wgAttr)
+	assert.NotNil(t, geneveAttr)
+	assert.NotNil(t, vxlanAttr)
+	assert.Less(t,
+		uint32(wgAttr.Headroom+geneveAttr.Headroom+vxlanAttr.Headroom),
+		uint32(math.MaxUint16))
+	assert.Less(t,
+		uint32(wgAttr.Tailroom+geneveAttr.Tailroom+vxlanAttr.Tailroom),
+		uint32(math.MaxUint16))
+
+	tests := []struct {
+		name             string
+		daemonConfig     *option.DaemonConfig
+		wgAgent          *fakeTypes.WireguardAgent
+		tunnelConfig     tunnel.Config
+		shouldError      bool
+		expectedHeadroom uint16
+		expectedTailroom uint16
+	}{
+		// veth
+		{
+			name:             "veth+native-routing",
+			daemonConfig:     &daemonConfigVeth,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:     tunnelConfigNative,
+			shouldError:      false,
+			expectedHeadroom: 0,
+			expectedTailroom: 0,
+		},
+		{
+			name:             "veth+native-routing+wireguard",
+			daemonConfig:     &daemonConfigVeth,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigEnabled),
+			tunnelConfig:     tunnelConfigNative,
+			shouldError:      false,
+			expectedHeadroom: 0,
+			expectedTailroom: 0,
+		},
+		{
+			name:             "veth+geneve-routing",
+			daemonConfig:     &daemonConfigVeth,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:     tunnelConfigGeneve,
+			shouldError:      false,
+			expectedHeadroom: 0,
+			expectedTailroom: 0,
+		},
+		{
+			name:             "veth+geneve-routing+wireguard",
+			daemonConfig:     &daemonConfigVeth,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigEnabled),
+			tunnelConfig:     tunnelConfigGeneve,
+			shouldError:      false,
+			expectedHeadroom: 0,
+			expectedTailroom: 0,
+		},
+		{
+			name:             "veth+vxlan-routing",
+			daemonConfig:     &daemonConfigVeth,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:     tunnelConfigVxlan,
+			shouldError:      false,
+			expectedHeadroom: 0,
+			expectedTailroom: 0,
+		},
+		{
+			name:             "veth+vxlan-routing+wireguard",
+			daemonConfig:     &daemonConfigVeth,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigEnabled),
+			tunnelConfig:     tunnelConfigVxlan,
+			shouldError:      false,
+			expectedHeadroom: 0,
+			expectedTailroom: 0,
+		},
+
+		// netkit
+		{
+			name:             "netkit+native-routing",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:     tunnelConfigNative,
+			shouldError:      false,
+			expectedHeadroom: 0,
+			expectedTailroom: 0,
+		},
+		{
+			name:             "netkit+native-routing+wireguard",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigEnabled),
+			tunnelConfig:     tunnelConfigNative,
+			shouldError:      false,
+			expectedHeadroom: wgAttr.Headroom,
+			expectedTailroom: wgAttr.Tailroom,
+		},
+		{
+			name:             "netkit+geneve-routing",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:     tunnelConfigGeneve,
+			shouldError:      false,
+			expectedHeadroom: geneveAttr.Headroom,
+			expectedTailroom: geneveAttr.Tailroom,
+		},
+		{
+			name:             "netkit+geneve-routing+wireguard",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigEnabled),
+			tunnelConfig:     tunnelConfigGeneve,
+			shouldError:      false,
+			expectedHeadroom: geneveAttr.Headroom + wgAttr.Headroom,
+			expectedTailroom: geneveAttr.Tailroom + wgAttr.Tailroom,
+		},
+		{
+			name:             "netkit+vxlan-routing",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:     tunnelConfigVxlan,
+			shouldError:      false,
+			expectedHeadroom: vxlanAttr.Headroom,
+			expectedTailroom: vxlanAttr.Tailroom,
+		},
+		{
+			name:             "netkit+vxlan-routing+wireguard",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigEnabled),
+			tunnelConfig:     tunnelConfigVxlan,
+			shouldError:      false,
+			expectedHeadroom: vxlanAttr.Headroom + wgAttr.Headroom,
+			expectedTailroom: vxlanAttr.Tailroom + wgAttr.Tailroom,
+		},
+
+		// netkit-l2
+		{
+			name:             "netkit+native-routing",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:     tunnelConfigNative,
+			shouldError:      false,
+			expectedHeadroom: 0,
+			expectedTailroom: 0,
+		},
+		{
+			name:             "netkit+native-routing+wireguard",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigEnabled),
+			tunnelConfig:     tunnelConfigNative,
+			shouldError:      false,
+			expectedHeadroom: wgAttr.Headroom,
+			expectedTailroom: wgAttr.Tailroom,
+		},
+		{
+			name:             "netkit+geneve-routing",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:     tunnelConfigGeneve,
+			shouldError:      false,
+			expectedHeadroom: geneveAttr.Headroom,
+			expectedTailroom: geneveAttr.Tailroom,
+		},
+		{
+			name:             "netkit+geneve-routing+wireguard",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigEnabled),
+			tunnelConfig:     tunnelConfigGeneve,
+			shouldError:      false,
+			expectedHeadroom: geneveAttr.Headroom + wgAttr.Headroom,
+			expectedTailroom: geneveAttr.Tailroom + wgAttr.Tailroom,
+		},
+		{
+			name:             "netkit+vxlan-routing",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:     tunnelConfigVxlan,
+			shouldError:      false,
+			expectedHeadroom: vxlanAttr.Headroom,
+			expectedTailroom: vxlanAttr.Tailroom,
+		},
+		{
+			name:             "netkit+vxlan-routing+wireguard",
+			daemonConfig:     &daemonConfigNetkit,
+			wgAgent:          fakeTypes.NewTestAgent(wgConfigEnabled),
+			tunnelConfig:     tunnelConfigVxlan,
+			shouldError:      false,
+			expectedHeadroom: vxlanAttr.Headroom + wgAttr.Headroom,
+			expectedTailroom: vxlanAttr.Tailroom + wgAttr.Tailroom,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := connectorParams{
+				Lifecycle:    &cell.DefaultLifecycle{},
+				Log:          logger,
+				Orchestrator: &fakeTypes.FakeOrchestrator{},
+				DaemonConfig: tt.daemonConfig,
+				WgAgent:      tt.wgAgent,
+				TunnelConfig: tt.tunnelConfig,
+			}
+			uninitialisedConnector := &ConnectorConfig{}
+			connector := &ConnectorConfig{}
+
+			err := generateConfig(p, connector)
+
+			switch tt.shouldError {
+			case true:
+				assert.Error(t, err)
+				assert.Equal(t, uninitialisedConnector, connector)
+
+			case false:
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedHeadroom, connector.podDeviceHeadroom)
+				assert.Equal(t, tt.expectedTailroom, connector.podDeviceTailroom)
+			}
+		})
+	}
+}

--- a/pkg/datapath/connector/netkit.go
+++ b/pkg/datapath/connector/netkit.go
@@ -28,8 +28,8 @@ func SetupNetkit(defaultLogger *slog.Logger, id string, cfg LinkConfig, l2Mode b
 	lxcIfName := Endpoint2IfName(id)
 	tmpIfName := Endpoint2TempIfName(id)
 
-	netkit, link, err := SetupNetkitWithNames(defaultLogger, lxcIfName, tmpIfName, cfg, l2Mode, sysctl)
-	return netkit, link, tmpIfName, err
+	netkit, peer, err := SetupNetkitWithNames(defaultLogger, lxcIfName, tmpIfName, cfg, l2Mode, sysctl)
+	return netkit, peer, tmpIfName, err
 }
 
 // SetupNetkitWithNames sets up the net interface, the peer interface and fills up some
@@ -55,11 +55,11 @@ func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName stri
 		// from changing the addrs.
 		epHostMAC, err = mac.GenerateRandMAC()
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to generate rnd mac addr: %w", err)
+			return nil, nil, fmt.Errorf("unable to generate host mac addr: %w", err)
 		}
 		epLXCMAC, err = mac.GenerateRandMAC()
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to generate rnd mac addr: %w", err)
+			return nil, nil, fmt.Errorf("unable to generate peer mac addr: %w", err)
 		}
 	}
 	netkit := &netlink.Netkit{

--- a/pkg/datapath/connector/netkit.go
+++ b/pkg/datapath/connector/netkit.go
@@ -77,6 +77,11 @@ func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName stri
 		// Ensure that packets leaving the pod's networking namespace are
 		// scrubbed.
 		PeerScrub: netlink.NETKIT_SCRUB_DEFAULT,
+		// Configure the headroom and tailroom, which should be calculated to
+		// appropriate values by the agent, taking into account things like
+		// tunneling and encryption.
+		DesiredHeadroom: uint16(cfg.DeviceHeadroom),
+		DesiredTailroom: uint16(cfg.DeviceTailroom),
 	}
 	peerAttr := &netlink.LinkAttrs{
 		Name:         peerIfName,
@@ -101,6 +106,8 @@ func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName stri
 
 	logger.Debug("Created netkit pair",
 		logfields.NetkitPair, []string{peerIfName, lxcIfName},
+		logfields.DeviceHeadroom, netkit.DesiredHeadroom,
+		logfields.DeviceTailroom, netkit.DesiredTailroom,
 	)
 
 	// Disable reverse path filter on the host side netkit peer to allow
@@ -111,19 +118,9 @@ func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName stri
 		return nil, nil, err
 	}
 
-	peer, err := safenetlink.LinkByName(peerIfName)
+	peer, err := validateNetkitPair(logger, lxcIfName, peerIfName, cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to lookup netkit peer just created: %w", err)
-	}
-
-	if nk, ok := peer.(*netlink.Netkit); !ok {
-		logger.Debug("peer does not appear to be a Netkit device",
-			logfields.NetkitPair, []string{peerIfName, lxcIfName},
-		)
-	} else if !nk.SupportsScrub() {
-		logger.Warn("kernel does not support IFLA_NETKIT_SCRUB, some features may not work with netkit",
-			logfields.Netkit, netkit.Name,
-		)
+		return nil, nil, fmt.Errorf("netkit validation failed: %w", err)
 	}
 
 	err = configurePair(netkit, peer, cfg)
@@ -132,4 +129,54 @@ func SetupNetkitWithNames(defaultLogger *slog.Logger, lxcIfName, peerIfName stri
 	}
 
 	return netkit, peer, nil
+}
+
+// validateNetkitPair queries the kernel for a copy of the underlying device attributes
+// for both the lxc host interface and the peer interface.
+func validateNetkitPair(logger *slog.Logger, lxcIfName string, peerIfName string, cfg LinkConfig) (netlink.Link, error) {
+	// Query the kernel for the host link attributes, so we can verify the kernel
+	// has applied the configuration we expected.
+	hostLink, err := safenetlink.LinkByName(lxcIfName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup netkit host link: %w", err)
+	}
+
+	hostDevice, ok := hostLink.(*netlink.Netkit)
+	if !ok {
+		return nil, fmt.Errorf("host link does not appear to be a Netkit device")
+	}
+
+	peerLink, err := safenetlink.LinkByName(peerIfName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup netkit peer link: %w", err)
+	}
+
+	peerDevice, ok := peerLink.(*netlink.Netkit)
+	if !ok {
+		return nil, fmt.Errorf("peer link does not appear to be a Netkit device")
+	}
+
+	// Validate the kernel supports Scrub functionality.
+	if !hostDevice.SupportsScrub() || !peerDevice.SupportsScrub() {
+		logger.Warn("kernel does not support IFLA_NETKIT_SCRUB, some features may not work with netkit",
+			logfields.NetkitPair, []string{hostDevice.Name, peerDevice.Name})
+	}
+
+	// Verify we have the correct buffer margins configured. We accept a margin that
+	// is greater than what we requested, just in case it's ever rounded or aligned
+	// within the kernel.
+	if hostDevice.Headroom < cfg.DeviceHeadroom || hostDevice.Tailroom < cfg.DeviceTailroom {
+		logger.Warn("unexpected buffer margins on host link",
+			logfields.Device, lxcIfName,
+			logfields.DeviceHeadroom, hostDevice.Headroom,
+			logfields.DeviceTailroom, hostDevice.Tailroom)
+	}
+	if peerDevice.Headroom != hostDevice.Headroom || peerDevice.Tailroom != hostDevice.Tailroom {
+		return nil, fmt.Errorf("mismatched buffer margins on peer link %s (%s:%d %s:%d)",
+			peerIfName,
+			logfields.DeviceHeadroom, peerDevice.Headroom,
+			logfields.DeviceTailroom, peerDevice.Tailroom)
+	}
+
+	return peerLink, nil
 }

--- a/pkg/datapath/connector/veth.go
+++ b/pkg/datapath/connector/veth.go
@@ -46,7 +46,7 @@ func SetupVeth(defaultLogger *slog.Logger, id string, cfg LinkConfig, sysctl sys
 	return veth, link, tmpIfName, err
 }
 
-// LinkConfig contains the GRO/GSO and MTU values to be configured on both sides of the created pair.
+// LinkConfig contains the GRO/GSO, MTU values and buffer margins to be configured on both sides of the created pair.
 type LinkConfig struct {
 	GROIPv6MaxSize int
 	GSOIPv6MaxSize int
@@ -54,7 +54,9 @@ type LinkConfig struct {
 	GROIPv4MaxSize int
 	GSOIPv4MaxSize int
 
-	DeviceMTU int
+	DeviceMTU      int
+	DeviceHeadroom uint16
+	DeviceTailroom uint16
 }
 
 // SetupVethWithNames sets up the net interface, the peer interface and fills up some endpoint

--- a/pkg/datapath/fake/types/wireguard.go
+++ b/pkg/datapath/fake/types/wireguard.go
@@ -6,6 +6,7 @@ package types
 import (
 	"github.com/cilium/cilium/api/v1/models"
 
+	"github.com/cilium/cilium/pkg/datapath/link"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
@@ -18,16 +19,33 @@ type WireguardAgent struct {
 	config WireguardConfig
 }
 
+func NewTestAgent(fwc WireguardConfig) *WireguardAgent {
+	wgAgent := &WireguardAgent{
+		config: fwc,
+	}
+	return wgAgent
+}
+
 func (fwa *WireguardAgent) Enabled() bool {
 	return fwa.config.Enabled()
 }
 
+// Fake IfaceIndex will still query the underlying system for the
+// wireguard device. This will fail if not setup by the caller.
 func (fwa *WireguardAgent) IfaceIndex() (uint32, error) {
-	return 0, nil
+	if !fwa.Enabled() {
+		return 0, nil
+	}
+	return link.GetIfIndex(wgTypes.IfaceName)
 }
 
+// Fake IfaceBufferMargins will still query the underlying system for the
+// wireguard device. This will fail if not setup by the caller.
 func (fwa *WireguardAgent) IfaceBufferMargins() (uint16, uint16, error) {
-	return 0, 0, nil
+	if !fwa.Enabled() {
+		return 0, 0, nil
+	}
+	return link.GetIfBufferMargins(wgTypes.IfaceName)
 }
 
 func (fwa *WireguardAgent) Status(withPeers bool) (*models.WireguardStatus, error) {

--- a/pkg/datapath/fake/types/wireguard.go
+++ b/pkg/datapath/fake/types/wireguard.go
@@ -26,6 +26,10 @@ func (fwa *WireguardAgent) IfaceIndex() (uint32, error) {
 	return 0, nil
 }
 
+func (fwa *WireguardAgent) IfaceBufferMargins() (uint16, uint16, error) {
+	return 0, 0, nil
+}
+
 func (fwa *WireguardAgent) Status(withPeers bool) (*models.WireguardStatus, error) {
 	return nil, nil
 }

--- a/pkg/datapath/link/link.go
+++ b/pkg/datapath/link/link.go
@@ -66,6 +66,14 @@ func GetIfIndex(ifName string) (uint32, error) {
 	return uint32(iface.Attrs().Index), nil
 }
 
+func GetIfBufferMargins(ifName string) (uint16, uint16, error) {
+	iface, err := safenetlink.LinkByName(ifName)
+	if err != nil {
+		return 0, 0, err
+	}
+	return iface.Attrs().Headroom, iface.Attrs().Tailroom, nil
+}
+
 type LinkCache struct {
 	mu          lock.RWMutex
 	indexToName map[int]string

--- a/pkg/datapath/tunnel/tunnel.go
+++ b/pkg/datapath/tunnel/tunnel.go
@@ -178,6 +178,20 @@ func (cfg Config) SrcPortHigh() uint16 { return cfg.srcPortHigh }
 // DeviceName returns the name of the tunnel device (empty if disabled).
 func (cfg Config) DeviceName() string { return cfg.deviceName }
 
+// DeviceBufferMargins returns the buffer margins of the tunnel device (zero if disabled)
+func (cfg Config) DeviceBufferMargins() (uint16, uint16, error) {
+	if cfg.EncapProtocol() == Disabled {
+		return 0, 0, nil
+	}
+
+	tunnelDev, err := safenetlink.LinkByName(cfg.DeviceName())
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return tunnelDev.Attrs().Headroom, tunnelDev.Attrs().Tailroom, nil
+}
+
 // ShouldAdaptMTU returns whether we should adapt the MTU calculation to
 // account for encapsulation.
 func (cfg Config) ShouldAdaptMTU() bool { return cfg.shouldAdaptMTU }

--- a/pkg/datapath/types/connector.go
+++ b/pkg/datapath/types/connector.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+type ConnectorConfig interface {
+	GetPodDeviceHeadroom() uint16
+	GetPodDeviceTailroom() uint16
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -488,6 +488,12 @@ const (
 	// Device is the device name
 	Device = "device"
 
+	// DeviceHeadroom is the head buffer margin of a network device
+	DeviceHeadroom = "deviceHeadroom"
+
+	// DeviceHeadroom is the tail buffer margin of a network device
+	DeviceTailroom = "deviceTailroom"
+
 	// Devices is the devices name
 	Devices = "devices"
 

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -828,6 +828,15 @@ func (a *Agent) IfaceIndex() (uint32, error) {
 	return link.GetIfIndex(types.IfaceName)
 }
 
+// IfaceBufferMargins() returns the buffer margins of the Wireguard interface.
+func (a *Agent) IfaceBufferMargins() (uint16, uint16, error) {
+	if !a.Enabled() {
+		return 0, 0, nil
+	}
+
+	return link.GetIfBufferMargins(types.IfaceName)
+}
+
 // Status returns the state of the WireGuard tunnel managed by this instance.
 // If withPeers is true, then the details about each connected peer are
 // are populated as well.

--- a/pkg/wireguard/types/types.go
+++ b/pkg/wireguard/types/types.go
@@ -4,7 +4,9 @@
 // Common WireGuard types and constants
 package types
 
-import "github.com/cilium/cilium/api/v1/models"
+import (
+	"github.com/cilium/cilium/api/v1/models"
+)
 
 const (
 	// ListenPort is the port on which the WireGuard tunnel device listens on
@@ -23,6 +25,7 @@ type WireguardAgent interface {
 	Enabled() bool
 	Status(withPeers bool) (*models.WireguardStatus, error)
 	IfaceIndex() (uint32, error)
+	IfaceBufferMargins() (uint16, uint16, error)
 }
 
 // WireguardConfig exports the Enabled method rather than the whole config.

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -644,6 +644,8 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 			GROIPv4MaxSize: int(conf.GROIPV4MaxSize),
 			GSOIPv4MaxSize: int(conf.GSOIPV4MaxSize),
 			DeviceMTU:      int(conf.DeviceMTU),
+			DeviceHeadroom: uint16(conf.DeviceHeadroom),
+			DeviceTailroom: uint16(conf.DeviceTailroom),
 		}
 		var hostLink, epLink netlink.Link
 		var tmpIfName string


### PR DESCRIPTION
Introduce data path connector Cell, which provides `Tuned Buffer Margin` logic.

When enabled in combination with netkit/netkit-l2, the component will query buffer margins for Wireguard and Tunnel devices. These values are then aggregated and passed into netkit devices on startup, such that SKB buffer margins of netkit pairs have sufficient space for the potential encapsulation overhead of packets that may be passed through a tunnel and/or wireguard interface.

`IFLA_HEADROOM` and `IFLA_TAILROOM` have added to the kernel in commit https://github.com/torvalds/linux/commit/b73b8146d7ff68e245525adb944a4c998d423d59 which has been merged into 6.18-rc1, but the logic here is dynamic and so does not fail on old kernels. The result is simply that netkit buffer margins remain at zero, which is no worse than what they would be as of now.

Headroom and Tailroom attributes are not yet visible via iproute2 but will be added upstream soon. However, it's possible to see the _desired_ head/tailroom attributes are from the new Connector cell via the Cilium status JSON API. Below example shows calculated values when using Wireguard and Geneve overlay.

```
$ cb-ac cilium-tpzj9 | jq -r '.status'
{
  "GROIPv4MaxSize": 65536,
  "GROMaxSize": 65536,
  "GSOIPv4MaxSize": 65536,
  "GSOMaxSize": 65536,
  ...
  "datapathMode": "netkit",
  "deviceHeadroom": 212,
  "deviceMTU": 1500,
  "deviceTailroom": 32,
  "ipLocalReservedPorts": "51871,6081",
  "ipam-mode": "kubernetes",
  ...
  "routeMTU": 1370
}
```

```release-note
Introduce experimental support for tuned buffer margins on netkit devices.
```
