### PR TITLE
fix(ctmap/gc): fix race conditions and flakiness in TestGCEnableRatchet

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -726,7 +726,13 @@ func Exists(ipv4, ipv6 bool) bool {
 //   - expectedPrevInterval 	= Is the last computed interval, which we expected to
 //     wait *unless* a signal caused early pass. If this is set to zero then we use gc starting interval.
 func GetInterval(logger *slog.Logger, actualPrevInterval, expectedPrevInterval time.Duration, maxDeleteRatio float64) time.Duration {
-	if val := option.Config.ConntrackGCInterval; val != time.Duration(0) {
+	return GetIntervalWithConfig(logger, actualPrevInterval, expectedPrevInterval, maxDeleteRatio,
+		option.Config.ConntrackGCInterval, option.Config.ConntrackGCMaxInterval, GCIntervalRounding, MinGCInterval)
+}
+
+func GetIntervalWithConfig(logger *slog.Logger, actualPrevInterval, expectedPrevInterval time.Duration, maxDeleteRatio float64,
+	conntrackGCInterval, conntrackGCMaxInterval, gcIntervalRounding, minGCInterval time.Duration) time.Duration {
+	if val := conntrackGCInterval; val != time.Duration(0) {
 		return val
 	}
 
@@ -737,8 +743,8 @@ func GetInterval(logger *slog.Logger, actualPrevInterval, expectedPrevInterval t
 		adjustedDeleteRatio *= float64(expectedPrevInterval) / float64(actualPrevInterval)
 	}
 
-	newInterval := calculateInterval(expectedPrevInterval, adjustedDeleteRatio)
-	if val := option.Config.ConntrackGCMaxInterval; val != time.Duration(0) && newInterval > val {
+	newInterval := calculateIntervalWithConfig(expectedPrevInterval, adjustedDeleteRatio, gcIntervalRounding, minGCInterval)
+	if val := conntrackGCMaxInterval; val != time.Duration(0) && newInterval > val {
 		newInterval = val
 	}
 
@@ -764,6 +770,10 @@ var (
 )
 
 func calculateInterval(prevInterval time.Duration, maxDeleteRatio float64) (interval time.Duration) {
+	return calculateIntervalWithConfig(prevInterval, maxDeleteRatio, GCIntervalRounding, MinGCInterval)
+}
+
+func calculateIntervalWithConfig(prevInterval time.Duration, maxDeleteRatio float64, gcIntervalRounding, minGCInterval time.Duration) (interval time.Duration) {
 	interval = prevInterval
 
 	if maxDeleteRatio == 0.0 {
@@ -776,13 +786,13 @@ func calculateInterval(prevInterval time.Duration, maxDeleteRatio float64) (inte
 			maxDeleteRatio = 0.9
 		}
 		// 25%..90% => 1.3x..10x shorter
-		interval = max(time.Duration(float64(interval)*(1.0-maxDeleteRatio)).Round(GCIntervalRounding), MinGCInterval)
+		interval = max(time.Duration(float64(interval)*(1.0-maxDeleteRatio)).Round(gcIntervalRounding), minGCInterval)
 	case maxDeleteRatio < 0.05:
 		// When less than 5% of entries were deleted, increase the
 		// interval. Use a simple 1.5x multiplier to start growing slowly
 		// as a new node may not be seeing workloads yet and thus the
 		// scan will return a low deletion ratio at first.
-		interval = min(time.Duration(float64(interval)*1.5).Round(GCIntervalRounding), defaults.ConntrackGCMaxLRUInterval)
+		interval = min(time.Duration(float64(interval)*1.5).Round(gcIntervalRounding), defaults.ConntrackGCMaxLRUInterval)
 	}
 
 	return

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -157,6 +157,16 @@ func (gc *GC) enable(
 	runGC func(ipv4, ipv6, triggeredBySignal bool, filter ctmap.GCFilter) (maxDeleteRatio float64, success bool),
 	runMapPressureDaemon bool,
 ) {
+	gc.enableWithConfig(runGC, runMapPressureDaemon,
+		option.Config.ConntrackGCInterval, option.Config.ConntrackGCMaxInterval,
+		ctmap.GCIntervalRounding, ctmap.MinGCInterval)
+}
+
+func (gc *GC) enableWithConfig(
+	runGC func(ipv4, ipv6, triggeredBySignal bool, filter ctmap.GCFilter) (maxDeleteRatio float64, success bool),
+	runMapPressureDaemon bool,
+	conntrackGCInterval, conntrackGCMaxInterval, gcIntervalRounding, minGCInterval time.Duration,
+) {
 	var (
 		initialScan         = true
 		initialScanComplete = make(chan struct{})
@@ -229,7 +239,8 @@ func (gc *GC) enable(
 				maxDeleteRatio, success = runGC(ipv4, ipv6, triggeredBySignal, gcFilter)
 			}
 
-			interval := ctmap.GetInterval(gc.logger, gcInterval, cachedGCInterval, maxDeleteRatio)
+			interval := ctmap.GetIntervalWithConfig(gc.logger, gcInterval, cachedGCInterval, maxDeleteRatio,
+				conntrackGCInterval, conntrackGCMaxInterval, gcIntervalRounding, minGCInterval)
 			if success && gc.isFullGC(ipv4, ipv6) {
 				// Mark the CT GC as over in each EP DNSZombies instance, if we did a *full* GC run
 				nextGCTime := time.Now().Add(interval)


### PR DESCRIPTION
fix race conditions and flakiness in `TestGCEnableRatchet`

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #41960


