### PR TITLE
Enable PLPMTUD on endpoint netns

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -167,6 +167,7 @@ cilium-agent [flags]
       --enable-nat46x64-gateway                                   Enable NAT46 and NAT64 gateway
       --enable-no-service-endpoints-routable                      Enable routes when service has 0 endpoints (default true)
       --enable-node-selector-labels                               Enable use of node label based identity
+      --enable-packetization-layer-pmtud                          Enables kernel packetization layer path mtu discovery on Pod netns (default true)
       --enable-pmtu-discovery                                     Enable path MTU discovery to send ICMP fragmentation-needed replies to the client
       --enable-policy string                                      Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -82,6 +82,7 @@ cilium-agent hive [flags]
       --enable-l2-pod-announcements                               Enable announcing Pod IPs with Gratuitous ARP and NDP
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-no-service-endpoints-routable                      Enable routes when service has 0 endpoints (default true)
+      --enable-packetization-layer-pmtud                          Enables kernel packetization layer path mtu discovery on Pod netns (default true)
       --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -88,6 +88,7 @@ cilium-agent hive dot-graph [flags]
       --enable-l2-pod-announcements                               Enable announcing Pod IPs with Gratuitous ARP and NDP
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-no-service-endpoints-routable                      Enable routes when service has 0 endpoints (default true)
+      --enable-packetization-layer-pmtud                          Enables kernel packetization layer path mtu discovery on Pod netns (default true)
       --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3248,6 +3248,10 @@
      - Enable path MTU discovery to send ICMP fragmentation-needed replies to the client.
      - bool
      - ``false``
+   * - :spelling:ignore:`pmtuDiscovery.packetizationLayerPMTUD`
+     - Enable kernel probing path MTU discovery for Pods which uses different message sizes to search for correct MTU value.
+     - object
+     - ``{"enabled":true}``
    * - :spelling:ignore:`podAnnotations`
      - Annotations to be added to agent pods
      - object

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -603,6 +603,22 @@ jumbo frames, Cilium will automatically make use of it.
 To benefit from this, make sure that your system is configured to use jumbo
 frames if your network allows for it.
 
+Disable Packet Layer PMTUD
+--------------------------
+
+Cilium enables Linux's TCP Packetization Layer Path MTU Discovery by default for Pod endpoints.
+This is a kernel feature that implements `RFC4821 <https://datatracker.ietf.org/doc/html/rfc4821>`__ which provides a way of
+dynamically discovering the correct path MTU size for connections that is resilient against lost packets
+and firewalls blocking regular ICMP based PMTUD messages.
+In particular, this provides a robust MTU discovery mechanism against network black holes arising 
+from incorrect MTU sizes and firewalls dropping PMTUD error messages.
+
+Although this provides a more robust way of discovery path MTU, it comes at the possible cost of connections
+initially using sub-optimal MSS resulting in lower network performance.
+In the case where the correct MTU is known, disabling this feature may provide some improved network throughput on TCP connections.
+
+This feature can be disabled via the helm value: ``pmtuDiscovery.packetizationLayerPMTUD.enabled=false``.
+
 Bandwidth Manager
 =================
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -337,6 +337,7 @@ communicating via the proxy must reconnect to re-establish connections.
 * Testing for RHEL8 compatibility now uses a RHEL8.10-compatible kernel
   (previously this was a RHEL8.6-compatible kernel).
 * The previously deprecated ``FromRequires`` and ``ToRequires`` fields of the `CiliumNetworkPolicy` and `CiliumClusterwideNetworkPolicy` CRDs have been removed.
+* This release introduces enabling packet layer path MTU discovery by default on CNI Pod endpoints, this is controlled via the ``enable-endpoint-packet-layer-pmtud`` flag.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -98,6 +98,7 @@ NewProto
 Nic
 O'Reilly
 PaaS
+Packetization
 Palantir
 Pepelnjak
 Perfdash

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -60,6 +60,9 @@ type DaemonConfigurationStatus struct {
 	// True if BBR is enabled only in the host network namespace
 	EnableBBRHostNamespaceOnly bool `json:"enableBBRHostNamespaceOnly,omitempty"`
 
+	// Enable PLPMTUD probing on the pod netns
+	EnablePacketizationLayerPMTUD bool `json:"enablePacketizationLayerPMTUD,omitempty"`
+
 	// Enable route MTU for pod netns when CNI chaining is used
 	EnableRouteMTUForCNIChaining bool `json:"enableRouteMTUForCNIChaining,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2525,6 +2525,9 @@ definitions:
       enableRouteMTUForCNIChaining:
         description: Enable route MTU for pod netns when CNI chaining is used
         type: boolean
+      enablePacketizationLayerPMTUD:
+        description: Enable PLPMTUD probing on the pod netns
+        type: boolean
       datapathMode:
         "$ref": "#/definitions/DatapathMode"
       ipam-mode:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2470,6 +2470,10 @@ func init() {
           "description": "True if BBR is enabled only in the host network namespace",
           "type": "boolean"
         },
+        "enablePacketizationLayerPMTUD": {
+          "description": "Enable PLPMTUD probing on the pod netns",
+          "type": "boolean"
+        },
         "enableRouteMTUForCNIChaining": {
           "description": "Enable route MTU for pod netns when CNI chaining is used",
           "type": "boolean"
@@ -7893,6 +7897,10 @@ func init() {
         },
         "enableBBRHostNamespaceOnly": {
           "description": "True if BBR is enabled only in the host network namespace",
+          "type": "boolean"
+        },
+        "enablePacketizationLayerPMTUD": {
+          "description": "Enable PLPMTUD probing on the pod netns",
           "type": "boolean"
         },
         "enableRouteMTUForCNIChaining": {

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -412,6 +412,7 @@ func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.R
 		EnableBBRHostNamespaceOnly:          h.bandwidthConfig.EnableBBRHostnsOnly,
 		DeviceHeadroom:                      int64(h.connectorConfig.GetPodDeviceHeadroom()),
 		DeviceTailroom:                      int64(h.connectorConfig.GetPodDeviceTailroom()),
+		EnablePacketizationLayerPMTUD:       h.mtuConfig.IsEnablePacketizationLayerPMTUD(),
 	}
 
 	cfg := &models.DaemonConfiguration{

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -862,6 +862,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.unmanagedPodWatcher.selector | string | `nil` | Selector for pods that should be restarted when not managed by Cilium. If not set, defaults to built-in selector "k8s-app=kube-dns". Set to empty string to select all pods. @schema type: [null, string] @schema |
 | operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"50%"},"type":"RollingUpdate"}` | cilium-operator update strategy |
 | pmtuDiscovery.enabled | bool | `false` | Enable path MTU discovery to send ICMP fragmentation-needed replies to the client. |
+| pmtuDiscovery.packetizationLayerPMTUD | object | `{"enabled":true}` | Enable kernel probing path MTU discovery for Pods which uses different message sizes to search for correct MTU value. |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |
 | podSecurityContext | object | `{"appArmorProfile":{"type":"Unconfined"},"seccompProfile":{"type":"Unconfined"}}` | Security Context for cilium-agent pods. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1226,6 +1226,10 @@ data:
   enable-pmtu-discovery: "true"
 {{- end }}
 
+{{- if not .Values.pmtuDiscovery.packetizationLayerPMTUD.enabled }}
+  enable-packetization-layer-pmtud: "false"
+{{- end }}
+
 {{- if not .Values.securityContext.privileged }}
   procfs: "/host/proc"
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5056,6 +5056,14 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "packetizationLayerPMTUD": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -511,6 +511,10 @@ pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
   # the client.
   enabled: false
+  # -- Enable kernel probing path MTU discovery for Pods which uses different message
+  # sizes to search for correct MTU value.
+  packetizationLayerPMTUD:
+    enabled: true
 bpf:
   autoMount:
     # -- Enable automatic mount of BPF filesystem

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -514,6 +514,10 @@ pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
   # the client.
   enabled: false
+  # -- Enable kernel probing path MTU discovery for Pods which uses different message
+  # sizes to search for correct MTU value.
+  packetizationLayerPMTUD:
+    enabled: true
 bpf:
   autoMount:
     # -- Enable automatic mount of BPF filesystem

--- a/pkg/datapath/fake/types/mtu.go
+++ b/pkg/datapath/fake/types/mtu.go
@@ -23,3 +23,7 @@ func (*MTU) GetRoutePostEncryptMTU() int {
 func (*MTU) IsEnableRouteMTUForCNIChaining() bool {
 	return false
 }
+
+func (*MTU) IsEnablePacketizationLayerPMTUD() bool {
+	return false
+}

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -39,6 +39,7 @@ type MTU interface {
 	GetRouteMTU() int
 	GetRoutePostEncryptMTU() int
 	IsEnableRouteMTUForCNIChaining() bool
+	IsEnablePacketizationLayerPMTUD() bool
 }
 
 type mtuParams struct {
@@ -65,16 +66,20 @@ type Config struct {
 	// Enable route MTU for pod netns when CNI chaining is used
 	EnableRouteMTUForCNIChaining bool
 	MTU                          int
+	// EnablePacketizationLayerPMTUD configures kernel packetization layer path mtu discovery on Pod netns.
+	EnablePacketizationLayerPMTUD bool
 }
 
 var defaultConfig = Config{
-	EnableRouteMTUForCNIChaining: false,
-	MTU:                          0,
+	EnableRouteMTUForCNIChaining:  false,
+	MTU:                           0,
+	EnablePacketizationLayerPMTUD: true,
 }
 
 func (c Config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-route-mtu-for-cni-chaining", c.EnableRouteMTUForCNIChaining, "Enable route MTU for pod netns when CNI chaining is used")
 	flags.Int("mtu", c.MTU, "Overwrite auto-detected MTU of underlying network")
+	flags.Bool("enable-packetization-layer-pmtud", c.EnablePacketizationLayerPMTUD, "Enables kernel packetization layer path mtu discovery on Pod netns")
 }
 
 func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
@@ -137,18 +142,20 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 	})
 
 	return &LatestMTUGetter{
-		tbl:                            p.MTUTable,
-		db:                             p.DB,
-		isEnableRouteMTUForCNIChaining: cc.EnableRouteMTUForCNIChaining,
+		tbl:                             p.MTUTable,
+		db:                              p.DB,
+		isEnableRouteMTUForCNIChaining:  cc.EnableRouteMTUForCNIChaining,
+		isEnablePacketizationLayerPMTUD: cc.EnablePacketizationLayerPMTUD,
 	}, nil
 }
 
 var _ MTU = (*LatestMTUGetter)(nil)
 
 type LatestMTUGetter struct {
-	tbl                            statedb.Table[RouteMTU]
-	db                             *statedb.DB
-	isEnableRouteMTUForCNIChaining bool
+	tbl                             statedb.Table[RouteMTU]
+	db                              *statedb.DB
+	isEnableRouteMTUForCNIChaining  bool
+	isEnablePacketizationLayerPMTUD bool
 }
 
 func (m *LatestMTUGetter) GetDeviceMTU() int {
@@ -171,4 +178,8 @@ func (m *LatestMTUGetter) GetRoutePostEncryptMTU() int {
 
 func (m *LatestMTUGetter) IsEnableRouteMTUForCNIChaining() bool {
 	return m.isEnableRouteMTUForCNIChaining
+}
+
+func (m *LatestMTUGetter) IsEnablePacketizationLayerPMTUD() bool {
+	return m.isEnablePacketizationLayerPMTUD
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1002,6 +1002,9 @@ const (
 
 	// EnableCiliumNodeCRD is the name of the option to enable use of the CiliumNode CRD
 	EnableCiliumNodeCRDName = "enable-ciliumnode-crd"
+
+	// EnablePacketizationLayerPMTUD enables kernel plpmtud discovery on Pod netns.
+	EnablePacketizationLayerPMTUD = "enable-packetization-layer-pmtud"
 )
 
 // Default string arguments
@@ -1905,6 +1908,9 @@ type DaemonConfig struct {
 
 	// EnableCiliumNodeCRD enables the use of CiliumNode CRD
 	EnableCiliumNodeCRD bool
+
+	// EnablePacketizationLayerPMTUD enables kernel packetization layer path mtu discovery on Pod netns.
+	EnablePacketizationLayerPMTUD bool
 }
 
 var (
@@ -2599,7 +2605,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.BootIDFile = vp.GetString(BootIDFilename)
 	c.EnableExtendedIPProtocols = vp.GetBool(EnableExtendedIPProtocols)
 	c.IPTracingOptionType = vp.GetUint(IPTracingOptionType)
-
+	c.EnablePacketizationLayerPMTUD = vp.GetBool(EnablePacketizationLayerPMTUD)
 	c.ServiceNoBackendResponse = vp.GetString(ServiceNoBackendResponse)
 	switch c.ServiceNoBackendResponse {
 	case ServiceNoBackendResponseReject, ServiceNoBackendResponseDrop:


### PR DESCRIPTION
This adds option for enabling Linux TCP PMPMTU probing by default for Cilium managed endpoints via enabling the tcp_mtu_probing sysctl option on Pod netns. By default, all endpoints will now have this option enabled. When on, this will configure the endpoint with reasonable config values for base mss, as well as setting the mtu probing value to be '2'; which means it will always attempt using mtu probing.

The idea of this change is that we will allow for more robust MTU handling at a very small cost of sub-optional initial MTU
windows.

In the future, we may want to also be more smart with regards to how we set the base MSS in conjuction with vxlan/geneve tunneling.