### PR TITLE
bpf: wireguard: set SKIP_SRV6_HANDLING and SKIP_ICMPV6_NS_HANDLING

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -18,7 +18,7 @@
 #define SECLABEL_IPV6 WORLD_IPV6_ID
 
 /* Controls the inclusion of the CILIUM_CALL_HANDLE_ICMP6_NS section in the
- * bpf_lxc object file.
+ * object file.
  */
 #define SKIP_ICMPV6_NS_HANDLING
 

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -17,6 +17,10 @@
 #define SECLABEL_IPV4 WORLD_IPV4_ID
 #define SECLABEL_IPV6 WORLD_IPV6_ID
 
+/* Controls the inclusion of the CILIUM_CALL_SRV6 section in the object file.
+ */
+#define SKIP_SRV6_HANDLING
+
 #include "lib/tailcall.h"
 #include "lib/common.h"
 #include "lib/ipv6.h"

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -17,6 +17,11 @@
 #define SECLABEL_IPV4 WORLD_IPV4_ID
 #define SECLABEL_IPV6 WORLD_IPV6_ID
 
+/* Controls the inclusion of the CILIUM_CALL_HANDLE_ICMP6_NS section in the
+ * object file.
+ */
+#define SKIP_ICMPV6_NS_HANDLING
+
 /* Controls the inclusion of the CILIUM_CALL_SRV6 section in the object file.
  */
 #define SKIP_SRV6_HANDLING

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -18,7 +18,7 @@
 #define SECLABEL_IPV6 WORLD_IPV6_ID
 
 /* Controls the inclusion of the CILIUM_CALL_HANDLE_ICMP6_NS section in the
- * bpf_lxc object file.
+ * object file.
  */
 #define SKIP_ICMPV6_NS_HANDLING
 


### PR DESCRIPTION
Have `bpf_wireguard` set the usual `SKIP_*` defines to avoid including unneeded tailcalls.