### PR TITLE
helm: Support extending cilium-operator securityContext helm templates

### DIFF
--- a/install/kubernetes/cilium/templates/_extensions.tpl
+++ b/install/kubernetes/cilium/templates/_extensions.tpl
@@ -31,6 +31,15 @@ Allow packagers to add extra volumes to cilium-operator.
 {{- end }}
 
 {{/*
+Allow packagers to set securityContext for cilium-operator.
+*/}}
+{{- define "cilium.operator.securityContext" }}
+{{- with .Values.operator.securityContext }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Intentionally empty to allow downstream chart packagers to add extra
 containers to hubble-relay without having to modify the deployment manifest
 directly.

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -263,9 +263,10 @@ spec:
         resources:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
-        {{- with .Values.operator.securityContext }}
+        {{- $sc := include "cilium.operator.securityContext" . | trim }}
+        {{- if $sc }}
         securityContext:
-          {{- toYaml . | trim | nindent 10 }}
+          {{- $sc | nindent 10 }}
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: {{ .Values.operator.hostNetwork }}


### PR DESCRIPTION
We want to repackage the cilium chart and adjust the operator's securityContext programmatically based on additional helm values and templates.

Add a new extension template: cilium.operator.securityContext that is included in the cilium-operator deployment and can be overridden by downstream packagers with custom handling.
