### PR TITLE
cli, ipsec: Fix bidirectional IPsec tunnel check

### DIFF
--- a/cilium-cli/connectivity/tests/ipsec_key_derivation.go
+++ b/cilium-cli/connectivity/tests/ipsec_key_derivation.go
@@ -161,6 +161,14 @@ func (t *ipsecKeyDerivationTest) validateNodeBidirectionalTunnels(test *check.Te
 
 	// Check that each tunnel has its reverse
 	for _, state := range states {
+		// Each Encrypt state has two Decrypt states (to support both
+		// CiliumInternalIP and NodeInternalIP at the same time). Thus, we
+		// should check that each Encrypt state has a reverse state, as the
+		// other way around isn't true.
+		if !state.Encrypt {
+			continue
+		}
+
 		forward := fmt.Sprintf("%s->%s", state.Src, state.Dst)
 		reverse := fmt.Sprintf("%s->%s", state.Dst, state.Src)
 

--- a/cilium-dbg/cmd/encrypt_status.go
+++ b/cilium-dbg/cmd/encrypt_status.go
@@ -284,10 +284,11 @@ func dumpXfrmStates() ([]types.XfrmStateInfo, error) {
 		// Only include Cilium-managed states (ReqID == 1)
 		if state.Reqid == 1 {
 			stateInfo := types.XfrmStateInfo{
-				Src:   state.Src.String(),
-				Dst:   state.Dst.String(),
-				SPI:   uint32(state.Spi),
-				ReqID: uint32(state.Reqid),
+				Encrypt: ipsec.IsDecryptState(state),
+				Src:     state.Src.String(),
+				Dst:     state.Dst.String(),
+				SPI:     uint32(state.Spi),
+				ReqID:   uint32(state.Reqid),
 			}
 
 			// Extract algorithm and key information

--- a/pkg/common/ipsec/utils.go
+++ b/pkg/common/ipsec/utils.go
@@ -40,6 +40,13 @@ func CountUniqueIPsecKeys(states []netlink.XfrmState) (int, error) {
 	return len(keys), nil
 }
 
+func IsDecryptState(state netlink.XfrmState) bool {
+	if state.Mark == nil {
+		return false
+	}
+	return state.Mark.Value&maskStateDir == markStateOut
+}
+
 func CountXfrmStatesByDir(states []netlink.XfrmState) (int, int) {
 	nbXfrmIn := 0
 	nbXfrmOut := 0

--- a/pkg/types/xfrm.go
+++ b/pkg/types/xfrm.go
@@ -7,6 +7,7 @@ package types
 // This struct is used for JSON serialization of XFRM state information
 // and is shared between cilium-dbg and cilium-cli for consistency
 type XfrmStateInfo struct {
+	Encrypt  bool   `json:"encrypt"`
 	Src      string `json:"src"`
 	Dst      string `json:"dst"`
 	SPI      uint32 `json:"spi"`


### PR DESCRIPTION
The new `ipsec-key-derivation-validation` connectivity test is currently often failing with the following error:

    [=] [cilium-test-1] Test [ipsec-key-derivation-validation] [54/54]
    [-] Scenario [ipsec-key-derivation-validation/ipsec-key-derivation-validation]
    🟥 Bidirectional tunnel validation failed on node cilium-tpkrb: found 192.168.181.199->192.168.166.169 but missing 192.168.166.169->192.168.181.199

This test aims to check that for each IPsec tunnel we have XFRM states for both directions.

In practice, we usually have two Decrypt states for each Encrypt state because we support both CiliumInternalIP and NodeInternalIP addresses on ingress, but only emit packets encrypted with a single type of addresses. Because of that the test currently fails.

This pull request fixes it by always checking that Encrypt states have a corresponding Decrypt state and not the other way around.

cc @pillai-ashwin 

Fixes: https://github.com/cilium/cilium/pull/40808.