### PR TITLE
identity: wait for identities to be added to SelectorCache

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -1042,6 +1042,10 @@ type AllocatorEvent struct {
 
 	// Key is the key associated with the ID
 	Key AllocatorKey
+
+	// Done is a channel that is closed when this event is processed.
+	// Optional
+	Done chan<- struct{}
 }
 
 // remoteCache represents the cache content of an additional kvstore managing

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -104,12 +104,23 @@ func (m *CachingIdentityAllocator) GetIdentities() IdentitiesModel {
 
 type identityWatcher struct {
 	owner IdentityAllocatorOwner
+
+	added, deleted identity.IdentityMap
+	toClose        []chan<- struct{}
 }
 
 // collectEvent records the 'event' as an added or deleted identity,
 // and makes sure that any identity is present in only one of the sets
 // (added or deleted).
-func collectEvent(event allocator.AllocatorEvent, added, deleted identity.IdentityMap) bool {
+func (w *identityWatcher) collectEvent(event allocator.AllocatorEvent) {
+	if event.Done != nil {
+		w.toClose = append(w.toClose, event.Done)
+	}
+
+	if event.Typ == allocator.AllocatorChangeSync {
+		return
+	}
+
 	id := identity.NumericIdentity(event.ID)
 	// Only create events have the key
 	if event.Typ == allocator.AllocatorChangeUpsert {
@@ -117,22 +128,23 @@ func collectEvent(event allocator.AllocatorEvent, added, deleted identity.Identi
 			// Un-delete the added ID if previously
 			// 'deleted' so that collected events can be
 			// processed in any order.
-			delete(deleted, id)
-			added[id] = gi.LabelArray
-			return true
+			delete(w.deleted, id)
+			w.added[id] = gi.LabelArray
+		} else {
+			log.Warn(
+				"collectEvent: Ignoring unknown identity type",
+				logfields.Type, reflect.TypeOf(event.Key),
+				logfields.Value, event.Key,
+			)
 		}
-		log.Warningf("collectEvent: Ignoring unknown identity type '%s': %+v",
-			reflect.TypeOf(event.Key), event.Key)
-		return false
+		return
 	}
 	// Reverse an add when subsequently deleted
-	delete(added, id)
+	delete(w.added, id)
 	// record the id deleted even if an add was reversed, as the
 	// id may also have previously existed, in which case the
 	// result is not no-op!
-	deleted[id] = labels.LabelArray{}
-
-	return true
+	w.deleted[id] = labels.LabelArray{}
 }
 
 // watch starts the identity watcher
@@ -140,25 +152,19 @@ func (w *identityWatcher) watch(events allocator.AllocatorEventRecvChan) {
 
 	go func() {
 		for {
-			added := identity.IdentityMap{}
-			deleted := identity.IdentityMap{}
-		First:
-			for {
-				event, ok := <-events
-				// Wait for one identity add or delete or stop
-				if !ok {
-					// 'events' was closed
-					return
-				}
-				// Collect first added and deleted labels
-				switch event.Typ {
-				case allocator.AllocatorChangeUpsert, allocator.AllocatorChangeDelete:
-					if collectEvent(event, added, deleted) {
-						// First event collected
-						break First
-					}
-				}
+			w.added = identity.IdentityMap{}
+			w.deleted = identity.IdentityMap{}
+			w.toClose = nil
+
+			// Consume first event synchronously
+			event, ok := <-events
+			// Wait for one identity add or delete or stop
+			if !ok {
+				// 'events' was closed
+				return
 			}
+
+			w.collectEvent(event)
 
 		More:
 			for {
@@ -170,17 +176,26 @@ func (w *identityWatcher) watch(events allocator.AllocatorEventRecvChan) {
 						break More
 					}
 					// Collect more added and deleted labels
-					switch event.Typ {
-					case allocator.AllocatorChangeUpsert, allocator.AllocatorChangeDelete:
-						collectEvent(event, added, deleted)
-					}
+					w.collectEvent(event)
+
 				default:
 					// No more events available without blocking
 					break More
 				}
 			}
 			// Issue collected updates
-			w.owner.UpdateIdentities(added, deleted) // disjoint sets
+			if len(w.added)+len(w.deleted) > 0 {
+				w.owner.UpdateIdentities(w.added, w.deleted) // disjoint sets
+			}
+
+			// If requested, inform producers that events have been consumed
+			//
+			// Note that this does not wait for PolicyMap updates to be distributed
+			// via the SelectorCache. This is curently safe, as it is only used during
+			// initialization, and thus there are no endpoints (and no policymaps).
+			for _, ch := range w.toClose {
+				close(ch)
+			}
 		}
 	}()
 }


### PR DESCRIPTION
[ upstream commit 33a1e2c7ecf4ffd671827e3667c7d7124cad3257 ]

This fixes a rare race condition where clusters with large numbers of identities and selectors may get a partial policy calculation. This happens because a given identity A may not be propagated to all cached selectors before an endpoint using that identity is added.

A flow goes like this:

1. UpsertIdentity(A)
2. m.Events <- IdentityUpdate(a)
3. Mark list done
4. Regenerate endpoint A1
5. A1 policy calculation calls GetSelections()
6. UpdateIdentities(A) adds A to SelectorCache

This leaves endpoint A1 with incorrect policy. The fix is to block identity allocation until the update queue has seen the Sync event generated by the kvstore / crd list-watch.

```release-note
Fixes a rare bug where endpoints may have incomplete policies in large clusters.
```
