### PR TITLE
bpf: fine-tune work-around for bpf_redirect_neigh() from overlay programs

### DIFF
--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -63,7 +63,7 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 	/* Immediate redirect to egress_ifindex requires L2 resolution.
 	 * Fall back to FIB lookup on older kernels.
 	 */
-	if (egress_ifindex && neigh_resolver_available())
+	if (egress_ifindex && neigh_resolver_without_nh_available())
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr, 0);
@@ -377,7 +377,7 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 	__u32 oif;
 	int ret;
 
-	if (egress_ifindex && neigh_resolver_available())
+	if (egress_ifindex && neigh_resolver_without_nh_available())
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	ret = (__s8)fib_lookup_v6(ctx, &fib_params,

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -70,12 +70,7 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
-		break;
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
-		/* Don't redirect if we can't update the L2 DMAC: */
-		if (!neigh_resolver_available())
-			return CTX_ACT_OK;
-
 		break;
 	default:
 		*ext_err = (__s8)ret;
@@ -386,10 +381,7 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
-		break;
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
-		if (!neigh_resolver_available())
-			return CTX_ACT_OK;
 		break;
 	default:
 		*ext_err = (__s8)ret;

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -153,12 +153,6 @@ redirect_self(const struct __sk_buff *ctx)
 static __always_inline __maybe_unused bool
 neigh_resolver_available(void)
 {
-	/* Work around for
-	 * https://lore.kernel.org/netdev/20251003073418.291171-1-daniel@iogearbox.net
-	 */
-	if (is_defined(IS_BPF_OVERLAY))
-		return false;
-
 	return true;
 }
 

--- a/bpf/tests/overlay.c
+++ b/bpf/tests/overlay.c
@@ -12,8 +12,13 @@ int overlay_neigh_resolver(__maybe_unused struct __sk_buff *ctx)
 	test_init();
 
 	/* Due to https://lore.kernel.org/netdev/20251003073418.291171-1-daniel@iogearbox.net
-	 * we shouldn't use bpf_redirect_neigh() from overlay programs.
+	 * we shouldn't use bpf_redirect_neigh() from overlay programs without providing
+	 * the next-hop.
 	 */
+	TEST("no_neigh_resolver_without_nh_on_overlay", {
+		assert(!neigh_resolver_without_nh_available());
+	});
+
 	TEST("no_neigh_resolver_on_overlay", {
 		assert(!neigh_resolver_available());
 	});

--- a/bpf/tests/overlay.c
+++ b/bpf/tests/overlay.c
@@ -19,8 +19,8 @@ int overlay_neigh_resolver(__maybe_unused struct __sk_buff *ctx)
 		assert(!neigh_resolver_without_nh_available());
 	});
 
-	TEST("no_neigh_resolver_on_overlay", {
-		assert(!neigh_resolver_available());
+	TEST("neigh_resolver_on_overlay", {
+		assert(neigh_resolver_available());
 	});
 
 	test_finish();


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/42000 limited the usage of bpf_redirect_neigh() from overlay programs, to work-around a kernel bug that causes a memory leak.

This bug only manifests when bpf_redirect_neigh() is called without next-hop information - or in Cilium terms, without a preceding FIB lookup. By annotating such specific usage of bpf_redirect_neigh() with a fine-grained capability check, we can otherwise allow the use of bpf_redirect_neigh() from overlay context.

Fixes: #42086.