### PR TITLE
bpf: nodeport: punt eTP=local requests from XDP to TC

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -437,6 +437,16 @@ bool lb6_svc_is_itp_local(const struct lb6_service *svc)
 	return svc->flags2 & SVC_FLAG_INT_LOCAL_SCOPE;
 }
 
+static __always_inline
+bool lb_punt_etp_local(void)
+{
+#if __ctx_is == __ctx_xdp
+	return true;
+#else
+	return false;
+#endif
+}
+
 static __always_inline int reverse_map_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 					       __be16 old_port, __be16 port, int l4_off,
 					       struct csum_offset *csum_off)

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1489,12 +1489,10 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 		/* Check if the identified service is a wildcard entry. This
 		 * means we have no protocol-level service entry, meaning we
 		 * should drop the traffic to avoid it being punted back to
-		 * the network and re-delivered to is in a loop.
+		 * the network and re-delivered to us in a loop.
 		 */
-		if (lb6_key_is_wildcard(&key)) {
-			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
+		if (lb6_key_is_wildcard(&key))
 			return DROP_NO_SERVICE;
-		}
 
 		return nodeport_svc_lb6(ctx, &tuple, svc, &key, ip6, l3_off,
 					fraginfo, l4_off, src_sec_identity,
@@ -2868,12 +2866,10 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		/* Check if the identified service is a wildcard entry. This
 		 * means we have no protocol-level service entry, meaning we
 		 * should drop the traffic to avoid it being punted back to
-		 * the network and re-delivered to is in a loop.
+		 * the network and re-delivered to us in a loop.
 		 */
-		if (lb4_key_is_wildcard(&key)) {
-			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
+		if (lb4_key_is_wildcard(&key))
 			return DROP_NO_SERVICE;
-		}
 
 		return nodeport_svc_lb4(ctx, &tuple, svc, &key, ip4, l3_off,
 					fraginfo, l4_off, src_sec_identity,

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -18,6 +18,7 @@
 
 #define FRONTEND_IP_LOCAL	v4_svc_one
 #define FRONTEND_IP_REMOTE	v4_svc_two
+#define FRONTEND_IP_ETP_LOCAL	v4_svc_three
 #define FRONTEND_PORT		tcp_svc_one
 
 #define LB_IP			v4_node_one
@@ -192,6 +193,107 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 
 	if (l4->check != bpf_htons(0xd7d0))
 		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+
+	test_finish();
+}
+
+/* Test that a eTP=local SVC request
+ * - gets passed up from XDP to TC without DNAT,
+ * - doesn't have the XFER_PKT_NO_SVC flag set, so that the TC layer applies
+ *   another round of SVC processing
+ */
+PKTGEN("xdp", "xdp_nodeport_etp_local")
+int nodeport_etp_local_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP_ETP_LOCAL,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("xdp", "xdp_nodeport_etp_local")
+int nodeport_etp_local_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	lb_v4_add_service_with_flags(FRONTEND_IP_ETP_LOCAL, FRONTEND_PORT,
+				     IPPROTO_TCP, 1, revnat_id,
+				     SVC_FLAG_ROUTABLE | SVC_FLAG_EXT_LOCAL_SCOPE,
+				     0);
+	lb_v4_add_backend(FRONTEND_IP_ETP_LOCAL, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	return xdp_receive_packet(ctx);
+}
+
+CHECK("xdp", "xdp_nodeport_etp_local")
+int nodeport_etp_local_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	status_code = data;
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	/* No meta information transferred. */
+
+	l2 = (void *)status_code + sizeof(__u32);
+	if ((void *)status_code + sizeof(__u32) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	assert(*status_code == CTX_ACT_OK);
+
+	if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the client MAC")
+	if (memcmp(l2->h_dest, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the LB MAC")
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != FRONTEND_IP_ETP_LOCAL)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != FRONTEND_PORT)
+		test_fatal("dst port has changed");
 
 	test_finish();
 }


### PR DESCRIPTION
```
For eTP=local service traffic we **know** that it stays on the node. By
defering the SVC processing to the TC layer we benefit from processing
GRO'd super-sized packets, instead of MTU-sized frames.
```

While at it also apply a minor drive-by cleanup for the wildcard-entry code that was introduced by https://github.com/cilium/cilium/pull/40684.