### PR TITLE
ci: add wildcard ton runtime image file

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Copy runtime image tag from untrusted branch
         run: |
-          cp -r .github/actions/set-runtime-image/runtime-image.txt ../cilium-base-branch/set-runtime-image/
+          cp -r .github/actions/set-runtime-image/runtime-image*.txt ../cilium-base-branch/set-runtime-image/
 
       - name: Set runtime image environment variable
         uses: ./../cilium-base-branch/set-runtime-image

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Copy runtime image tag from stable branch
         run: |
-          cp -r .github/actions/set-runtime-image/runtime-image.txt ../cilium-base-branch/set-runtime-image/
+          cp -r .github/actions/set-runtime-image/runtime-image*.txt ../cilium-base-branch/set-runtime-image/
 
       - name: Set runtime image environment variable
         uses: ./../cilium-base-branch/set-runtime-image

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Copy runtime image tag from stable branch
         run: |
-          cp -r .github/actions/set-runtime-image/runtime-image.txt ../cilium-base-branch/set-runtime-image/
+          cp -r .github/actions/set-runtime-image/runtime-image*.txt ../cilium-base-branch/set-runtime-image/
 
       - name: Set runtime image environment variable
         uses: ./../cilium-base-branch/set-runtime-image


### PR DESCRIPTION
Allow passing multiple files to help fork test different runtime images.