### PR TITLE
bpf: don't look up trace ID if packet tracing via IP options is disabled

### DIFF
--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -247,7 +247,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.reason		= reason,
 		.flags		= flags,
 		.ifindex	= ifindex,
-		.ip_trace_id = ip_trace_id,
+		.ip_trace_id	= ip_trace_id,
 	};
 	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
 
@@ -299,7 +299,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.ifindex	= ifindex,
 		.flags		= flags,
 		.orig_ip4	= orig_addr,
-		.ip_trace_id = ip_trace_id,
+		.ip_trace_id	= ip_trace_id,
 	};
 
 	ctx_event_output(ctx, &cilium_events,
@@ -349,7 +349,7 @@ _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.reason		= reason,
 		.ifindex	= ifindex,
 		.flags		= flags,
-		.ip_trace_id = ip_trace_id,
+		.ip_trace_id	= ip_trace_id,
 	};
 
 	ipv6_addr_copy(&msg.orig_ip6, orig_addr);

--- a/bpf/lib/trace_helpers.h
+++ b/bpf/lib/trace_helpers.h
@@ -45,10 +45,8 @@ check_and_store_ip_trace_id(struct __ctx_buff *ctx)
 	__s64 trace_id = 0;
 	int ret;
 
-	if (CONFIG(tracing_ip_option_type) == 0) {
-		bpf_trace_id_set(0);
+	if (CONFIG(tracing_ip_option_type) == 0)
 		return;
-	}
 
 	ret = trace_id_from_ctx(ctx, &trace_id, CONFIG(tracing_ip_option_type));
 	if (IS_ERR(ret))
@@ -59,5 +57,7 @@ check_and_store_ip_trace_id(struct __ctx_buff *ctx)
 
 static __always_inline __u64 load_ip_trace_id(void)
 {
+	if (CONFIG(tracing_ip_option_type) == 0)
+		return 0;
 	return bpf_trace_id_get();
 }


### PR DESCRIPTION
Currently, `check_and_store_ip_trace_id` incurs a map lookup on every call, even if packet tracing via IP options is disabled (`--ip-tracing-option-type=0`). Avoid this unnecessary lookup in case the feature is disabled.

Fixes: a860170c107d ("feat: add IPv4 packet tracing via IP options")

/cc @Bigdelle