### PR TITLE
eni: Lower severity of IMDS failure

### DIFF
--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -214,8 +214,10 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 	var currentVpcID string
 	metadataInfo, err := m.metadataapi.GetInstanceMetadata()
 	if err != nil {
-		m.logger.Warn("Unable to retrieve AWS instance metadata and will use cached VPC ID", logfields.Error, err)
 		// when we can't retrieve the VPC ID from AWS metadata, we use the cached VPC ID
+		m.logger.Info("Unable to retrieve AWS instance metadata and will use cached VPC ID",
+			logfields.VPCID, m.vpcID,
+			logfields.Error, err)
 		currentVpcID = m.vpcID
 	} else {
 		currentVpcID = metadataInfo.VPCID


### PR DESCRIPTION
When fetching the instance metadata in the operator, it seems like this can sometimes fail. Since this causes CI flakes and there is nothing the user can do about it, lower the severity of the log message. The operator will either use the last observed VPCID or none if this happens the first time. In either case, the operator can continue its operations.

Additionally, also log the cached VPC ID as it will help in troubleshooting.

Fixes: 0821c15c2cc2 ("pkg/aws: filter aws resources through vpc id")
Fixes: #42065