### PR TITLE
policy: return ICMP "Destination unreachable" on ipv4 ingress policy denials

### DIFF
--- a/Documentation/security/policy/intro.rst
+++ b/Documentation/security/policy/intro.rst
@@ -121,8 +121,8 @@ This behavior can be configured with the ``--policy-deny-response`` option:
   This provides immediate feedback to applications that the connection was rejected.
 
 .. note::
-   This feature only applies to ipv4 egress pod traffic denied by network policy.
-   Ingress traffic denial behavior and ipv6 are not supported currently. Check :gh-issue:`41859` for updates
+   This feature only applies to ipv4 pod traffic denied by network policy.
+   Ipv6 is not supported currently. Check :gh-issue:`41859` for updates
 
 .. warning::
    When using ``--policy-deny-response=icmp``, ensure that ICMP ingress traffic is allowed by your network policies. 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -662,11 +662,13 @@ enum {
 #define	CB_SRV6_SID_2		CB_1		/* Alias, non-overlapping */
 #define	CB_CLUSTER_ID_EGRESS	CB_1		/* Alias, non-overlapping */
 #define	CB_TRACED		CB_1		/* Alias, non-overlapping */
+#define	CB_POLICY_DENY_DIR	CB_1		/* Alias, non-overlapping */
 	CB_2,
 #define	CB_ADDR_V6_2		CB_2		/* Alias, non-overlapping */
 #define CB_SRV6_SID_3		CB_2		/* Alias, non-overlapping */
 #define	CB_CLUSTER_ID_INGRESS	CB_2		/* Alias, non-overlapping */
 #define CB_NAT_FLAGS		CB_2		/* Alias, non-overlapping */
+#define CB_POLICY_DENY_SRC_ID	CB_2		/* Alias, non-overlapping */
 	CB_3,
 #define	CB_ADDR_V6_3		CB_3		/* Alias, non-overlapping */
 #define	CB_FROM_HOST		CB_3		/* Alias, non-overlapping */


### PR DESCRIPTION
# Description
Follow-up to https://github.com/cilium/cilium/pull/41406. See https://github.com/cilium/cilium/issues/41859 for the full list of TODOs.

This PR adds the ICMP response functionality to *ingress* policy denials.
The functionality works for local and remote endpoints with/without tunneling and with/without eBPF Host Routing.

# Testing
- Created a new unit test
- Performed integration tests: backported the PR to Cilium 1.18.2, then created a pod with an ingress policy denying all traffic. Then tried to reach this pod from multiple different places and confirmed `ping` was returning "Packet filtered":
   ```
    # ping 10.130.112.4
    PING 10.130.112.4 (10.130.112.4) 56(84) bytes of data.
    From 10.130.112.4 icmp_seq=1 Packet filtered
    From 10.130.112.4 icmp_seq=2 Packet filtered
    [...]
   ```
  - [x] Local pod from same node [legacy routing]
  - [x] Pod from a different node in the same cluster [legacy routing]
  - [x] Pod in a different cluster [legacy routing]
  - [x] Local pod from same node [eBPF host routing]
  - [x] Pod from a different node in the same cluster [eBPF host routing]
  - [x] Pod in a different cluster [eBPF host routing]
- Set up Cilium with tunneling in `kind` and ran the connectivity test suite:
   ```
    $ cilium connectivity test
    [...]
    ✅ [cilium-test-1] All 77 tests (1087 actions) successful, 46 tests skipped, 1 scenarios skipped.
   ```

<br/>

```release-note
policy: add option to return ICMP "Destination unreachable" on ipv4 ingress policy denials
```
