### PR TITLE
vendor: Bump to StateDB v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v0.0.0-20250731144630-28e7a35ed227
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.5.0
+	github.com/cilium/statedb v0.5.1
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.5.0 h1:GZtOa1QynwoIpf4j46+gF+CtOJzJAt8d94o92kOMK8M=
-github.com/cilium/statedb v0.5.0/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
+github.com/cilium/statedb v0.5.1 h1:hVmVUk7Kfrl9nntxh/+O5f9TKz3Bzqc6LOXvXWc2xAQ=
+github.com/cilium/statedb v0.5.1/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/pkg/datapath/linux/route/reconciler/reconciler.go
+++ b/pkg/datapath/linux/route/reconciler/reconciler.go
@@ -31,13 +31,14 @@ type RouteReconcilerMetrics *reconciler.ExpVarMetrics
 
 func registerReconciler(
 	params reconciler.Params,
+	lc cell.Lifecycle,
 	tbl statedb.RWTable[*DesiredRoute],
 	devices statedb.Table[*tables.Device],
 	log *slog.Logger,
 	config *option.DaemonConfig,
 ) (reconciler.Reconciler[*DesiredRoute], RouteReconcilerMetrics, error) {
 	metrics := reconciler.NewUnpublishedExpVarMetrics()
-	ops := newOps(params.Lifecycle, params.DB, tbl, devices, log, config)
+	ops := newOps(lc, params.DB, tbl, devices, log, config)
 	rec, err := reconciler.Register(
 		params,
 		tbl,

--- a/vendor/github.com/cilium/statedb/part/node.go
+++ b/vendor/github.com/cilium/statedb/part/node.go
@@ -332,13 +332,16 @@ func (n *header[T]) find(key byte) *header[T] {
 		return nil
 	case nodeKind4:
 		n4 := n.node4()
-		size := n4.size()
-		for i := 0; i < int(size); i++ {
-			if n4.keys[i] == key {
-				return n4.children[i]
-			} else if n4.keys[i] > key {
-				return nil
-			}
+		keys := n4.keys
+		switch key {
+		case keys[0]:
+			return n4.children[0]
+		case keys[1]:
+			return n4.children[1]
+		case keys[2]:
+			return n4.children[2]
+		case keys[3]:
+			return n4.children[3]
 		}
 		return nil
 	case nodeKind16:

--- a/vendor/github.com/cilium/statedb/reconciler/builder.go
+++ b/vendor/github.com/cilium/statedb/reconciler/builder.go
@@ -12,7 +12,8 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// Register creates a new reconciler and registers it to the application lifecycle.
+// Register creates a new reconciler and adds the reconcilation jobs to the provided
+// job group.
 //
 // The setStatus etc. functions are passed in as arguments rather than requiring
 // the object to implement them via interface as this allows constructing multiple
@@ -79,11 +80,9 @@ func Register[Obj comparable](
 		primaryIndexer:       idx,
 	}
 
-	g := params.Jobs.NewGroup(params.Health, params.Lifecycle)
-
-	g.Add(job.OneShot("reconcile", r.reconcileLoop))
+	params.JobGroup.Add(job.OneShot("reconcile", r.reconcileLoop))
 	if r.config.RefreshInterval > 0 {
-		g.Add(job.OneShot("refresh", r.refreshLoop))
+		params.JobGroup.Add(job.OneShot("refresh", r.refreshLoop))
 	}
 	return r, nil
 }

--- a/vendor/github.com/cilium/statedb/reconciler/types.go
+++ b/vendor/github.com/cilium/statedb/reconciler/types.go
@@ -41,12 +41,10 @@ type Reconciler[Obj any] interface {
 type Params struct {
 	cell.In
 
-	Lifecycle      cell.Lifecycle
 	Log            *slog.Logger
 	DB             *statedb.DB
-	Jobs           job.Registry
+	JobGroup       job.Group
 	ModuleID       cell.FullModuleID
-	Health         cell.Health
 	DefaultMetrics Metrics `optional:"true"`
 }
 

--- a/vendor/github.com/cilium/statedb/script.go
+++ b/vendor/github.com/cilium/statedb/script.go
@@ -5,6 +5,7 @@ package statedb
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -78,6 +79,7 @@ func DBCmd(db *DB) script.Cmd {
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
 			txn := db.ReadTxn()
 			tbls := db.GetTables(txn)
+			slices.SortFunc(tbls, func(a, b TableMeta) int { return cmp.Compare(a.Name(), b.Name()) })
 			w := newTabWriter(s.LogWriter())
 			fmt.Fprintf(w, "Name\tObject count\tZombie objects\tIndexes\tInitializers\tGo type\tLast WriteTxn\n")
 			for _, tbl := range tbls {
@@ -351,7 +353,7 @@ func CompareCmd(db *DB) script.Cmd {
 			if err != nil {
 				return nil, fmt.Errorf("ReadFile(%s): %w", args[1], err)
 			}
-			lines := strings.Split(string(data), "\n")
+			lines := strings.Split(s.ExpandEnv(string(data), false), "\n")
 			lines = slices.DeleteFunc(lines, func(line string) bool {
 				return strings.TrimSpace(line) == ""
 			})
@@ -364,6 +366,7 @@ func CompareCmd(db *DB) script.Cmd {
 			if err != nil {
 				return nil, err
 			}
+			padByTabs := strings.ContainsRune(lines[0], '\t')
 			lines = lines[1:]
 			origLines := lines
 			timeoutChan := time.After(timeout)
@@ -375,12 +378,12 @@ func CompareCmd(db *DB) script.Cmd {
 				equal := true
 				var diff bytes.Buffer
 				w := newTabWriter(&diff)
-				fmt.Fprintf(w, "  %s\n", joinByPositions(columnNames, columnPositions))
+				fmt.Fprintf(w, "  %s\n", joinByPositions(columnNames, columnPositions, false))
 
 				objs, watch := tbl.AllWatch(db.ReadTxn())
 				for obj := range objs {
 					rowRaw := takeColumns(obj.(TableWritable).TableRow(), columnIndexes)
-					row := joinByPositions(rowRaw, columnPositions)
+					row := joinByPositions(rowRaw, columnPositions, padByTabs)
 					if grepRe != nil && !grepRe.Match([]byte(row)) {
 						continue
 					}
@@ -391,7 +394,7 @@ func CompareCmd(db *DB) script.Cmd {
 						continue
 					}
 					line := lines[0]
-					splitLine := splitByPositions(line, columnPositions)
+					splitLine := splitByPositions(line, columnPositions, padByTabs)
 
 					if slices.Equal(rowRaw, splitLine) {
 						fmt.Fprintf(w, "  %s\n", row)
@@ -934,19 +937,29 @@ func splitHeaderLine(line string) (names []string, pos []int) {
 // The whitespace on the right of the start position (e.g. "1  \t") is trimmed.
 // This of course requires that the table is properly formatted in a way that the
 // header columns are indented to fit the data exactly.
-func splitByPositions(line string, positions []int) []string {
+func splitByPositions(line string, positions []int, splitByTabs bool) []string {
 	out := make([]string, 0, len(positions))
 	start := 0
-	for _, pos := range positions[1:] {
+	for i, pos := range positions[1:] {
 		if start >= len(line) {
 			out = append(out, "")
 			start = len(line)
 			continue
 		}
-		out = append(out, strings.TrimRight(line[start:min(pos, len(line))], " \t"))
-		start = pos
+		if splitByTabs {
+			s := strings.Split(line[start:min(pos, len(line))], "\t")[i]
+			out = append(out, s)
+			start += len(s) + i
+		} else {
+			out = append(out, strings.TrimRight(line[start:min(pos, len(line))], " \t"))
+			start = pos
+		}
 	}
-	out = append(out, strings.TrimRight(line[min(start, len(line)):], " \t"))
+	if splitByTabs {
+		out = append(out, strings.Split(line[min(start, len(line)):], "\t")...)
+	} else {
+		out = append(out, strings.TrimRight(line[min(start, len(line)):], " \t"))
+	}
 	return out
 }
 
@@ -955,12 +968,17 @@ func splitByPositions(line string, positions []int) []string {
 // e.g. [1,a,b] and positions [0,5,9] expands to "1    a   b".
 // NOTE: This does not deal well with mixing tabs and spaces. The test input
 // data should preferably just use spaces.
-func joinByPositions(row []string, positions []int) string {
+func joinByPositions(row []string, positions []int, padByTabs bool) string {
 	var w strings.Builder
 	prev := 0
 	for i, pos := range positions {
-		for pad := pos - prev; pad > 0; pad-- {
-			w.WriteByte(' ')
+		pad := pos - prev
+		if pad > 0 && padByTabs {
+			w.WriteByte('\t')
+		} else {
+			for ; pad > 0; pad-- {
+				w.WriteByte(' ')
+			}
 		}
 		w.WriteString(row[i])
 		prev = pos + len(row[i])

--- a/vendor/github.com/cilium/statedb/types.go
+++ b/vendor/github.com/cilium/statedb/types.go
@@ -310,7 +310,8 @@ type Index[Obj any, Key any] struct {
 	Name string
 
 	// FromObject extracts key(s) from the object. The key set
-	// can contain 0, 1 or more keys.
+	// can contain 0, 1 or more keys. Must contain exactly one
+	// key for primary indices.
 	FromObject func(obj Obj) index.KeySet
 
 	// FromKey converts the index key into a raw key.
@@ -379,6 +380,16 @@ func (i Index[Obj, Key]) QueryFromObject(obj Obj) Query[Obj] {
 	return Query[Obj]{
 		index: i.Name,
 		key:   i.encodeKey(i.FromObject(obj).First()),
+	}
+}
+
+// QueryFromKey constructs a query against the index using the given
+// user-supplied key. Be careful when using this and prefer [Index.Query]
+// over this if possible.
+func (i Index[Obj, Key]) QueryFromKey(key index.Key) Query[Obj] {
+	return Query[Obj]{
+		index: i.Name,
+		key:   key,
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -324,7 +324,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.5.0
+# github.com/cilium/statedb v0.5.1
 ## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
Changes: https://github.com/cilium/statedb/releases/tag/v0.5.1

The reconciler now takes a JobGroup instead of a Lifecycle so reconcilers can now also be registered after starting. Adapt route and LB reconcilers to work with this.
