### PR TITLE
daemon: remove struct `Daemon` and `Promise[Daemon]`

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1211,14 +1211,13 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 }
 
 // daemonCell wraps the existing implementation of the cilium-agent that has
-// not yet been converted into a cell. Provides *Daemon as a Promise that is
-// resolved once daemon has been started to facilitate conversion into modules.
+// not yet been converted into a cell.
 var daemonCell = cell.Module(
 	"daemon",
 	"Legacy Daemon",
 
 	cell.Provide(
-		newDaemonPromise,
+		daemonLegacyInitialization,
 		promise.New[endpointstate.Restorer],
 		promise.New[*option.DaemonConfig],
 		newSyncHostIPs,
@@ -1226,7 +1225,7 @@ var daemonCell = cell.Module(
 		newInfraIPAllocator,
 	),
 	cell.Invoke(registerEndpointStateResolver),
-	cell.Invoke(func(promise.Promise[legacy.DaemonInitialization]) {}), // Force instantiation.
+	cell.Invoke(func(_ legacy.DaemonInitialization) {}), // Force instantiation.
 )
 
 type daemonParams struct {
@@ -1291,9 +1290,7 @@ type daemonParams struct {
 	InfraIPAllocator  *infraIPAllocator
 }
 
-func newDaemonPromise(params daemonParams) (promise.Promise[legacy.DaemonInitialization], legacy.DaemonInitialization) {
-	legacyDaemonInitResolver, legacyDaemonInitPromise := promise.New[legacy.DaemonInitialization]()
-
+func daemonLegacyInitialization(params daemonParams) legacy.DaemonInitialization {
 	// daemonCtx is the daemon-wide context cancelled when stopping.
 	daemonCtx, cancelDaemonCtx := context.WithCancel(context.Background())
 	cleaner := NewDaemonCleanup()
@@ -1301,18 +1298,11 @@ func newDaemonPromise(params daemonParams) (promise.Promise[legacy.DaemonInitial
 	var wg sync.WaitGroup
 
 	params.Lifecycle.Append(cell.Hook{
-		OnStart: func(cell.HookContext) (err error) {
-			defer func() {
-				// Reject promises on error
-				if err != nil {
-					params.CfgResolver.Reject(err)
-					legacyDaemonInitResolver.Reject(err)
-				}
-			}()
-
+		OnStart: func(cell.HookContext) error {
 			if err := configureDaemon(daemonCtx, cleaner, params); err != nil {
 				cancelDaemonCtx()
 				cleaner.Clean()
+				params.CfgResolver.Reject(err)
 				return fmt.Errorf("daemon configuration failed: %w", err)
 			}
 
@@ -1323,18 +1313,21 @@ func newDaemonPromise(params daemonParams) (promise.Promise[legacy.DaemonInitial
 				// datapath.NodeAddressing is used consistently across the code base.
 				params.Logger.Info("Validating configured node address ranges")
 				if err := node.ValidatePostInit(params.Logger); err != nil {
+					params.CfgResolver.Reject(err)
 					return fmt.Errorf("postinit failed: %w", err)
 				}
 
 				// Store config in file before resolving the DaemonConfig promise.
-				err = option.Config.StoreInFile(params.Logger, option.Config.StateDir)
-				if err != nil {
+				if err := option.Config.StoreInFile(params.Logger, option.Config.StateDir); err != nil {
 					params.Logger.Error("Unable to store Cilium's configuration", logfields.Error, err)
+					params.CfgResolver.Reject(err)
+					return err
 				}
 
-				err = option.StoreViperInFile(params.Logger, option.Config.StateDir)
-				if err != nil {
+				if err := option.StoreViperInFile(params.Logger, option.Config.StateDir); err != nil {
 					params.Logger.Error("Unable to store Viper's configuration", logfields.Error, err)
+					params.CfgResolver.Reject(err)
+					return err
 				}
 			}
 
@@ -1343,16 +1336,13 @@ func newDaemonPromise(params daemonParams) (promise.Promise[legacy.DaemonInitial
 			params.CfgResolver.Resolve(option.Config)
 
 			if option.Config.DryMode {
-				legacyDaemonInitResolver.Resolve(legacy.DaemonInitialization{})
-				return err
+				return nil
 			}
 
 			wg.Go(func() {
 				if err := startDaemon(daemonCtx, cleaner, params); err != nil {
 					params.Logger.Error("Daemon start failed", logfields.Error, err)
-					legacyDaemonInitResolver.Reject(err)
-				} else {
-					legacyDaemonInitResolver.Resolve(legacy.DaemonInitialization{})
+					params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
 				}
 			})
 
@@ -1365,7 +1355,7 @@ func newDaemonPromise(params daemonParams) (promise.Promise[legacy.DaemonInitial
 			return nil
 		},
 	})
-	return legacyDaemonInitPromise, legacy.DaemonInitialization{}
+	return legacy.DaemonInitialization{}
 }
 
 // startDaemon starts the old unmodular part of the cilium-agent.
@@ -1518,25 +1508,10 @@ func registerDaemonConfigValidationJob(params daemonParams) {
 	))
 }
 
-func registerEndpointStateResolver(lc cell.Lifecycle, legacyDaemonInitPromise promise.Promise[legacy.DaemonInitialization], endpointRestorer *endpointRestorer, resolver promise.Resolver[endpointstate.Restorer]) {
-	var wg sync.WaitGroup
-
-	lc.Append(cell.Hook{
-		OnStart: func(ctx cell.HookContext) error {
-			wg.Go(func() {
-				if _, err := legacyDaemonInitPromise.Await(context.Background()); err != nil {
-					resolver.Reject(err)
-				} else {
-					resolver.Resolve(endpointRestorer)
-				}
-			})
-			return nil
-		},
-		OnStop: func(ctx cell.HookContext) error {
-			wg.Wait()
-			return nil
-		},
-	})
+func registerEndpointStateResolver(endpointRestorer *endpointRestorer, resolver promise.Resolver[endpointstate.Restorer]) {
+	// Restorer promise is still required to avoid circular dependencies -
+	// but we can immediately resolve it.
+	resolver.Resolve(endpointRestorer)
 }
 
 func initClockSourceOption(logger *slog.Logger) {

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/api/v1/server"
 	cnicell "github.com/cilium/cilium/daemon/cmd/cni"
 	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
+	"github.com/cilium/cilium/daemon/cmd/legacy"
 	"github.com/cilium/cilium/pkg/controller"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
@@ -27,8 +28,12 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/dial"
 	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
+	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/hive"
+	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
+	"github.com/cilium/cilium/pkg/ipam"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sFakeClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
@@ -55,15 +60,18 @@ type DaemonSuite struct {
 	hive *hive.Hive
 	log  *slog.Logger
 
-	d *Daemon
-
 	// oldPolicyEnabled is the policy enforcement mode that was set before the test,
 	// as returned by policy.GetPolicyEnabled().
 	oldPolicyEnabled string
 
+	identityAllocator  identitycell.CachingIdentityAllocator
+	policyRepository   policy.PolicyRepository
 	PolicyImporter     policycell.PolicyImporter
 	envoyXdsServer     envoy.XDSServer
+	endpointManager    endpointmanager.EndpointManager
 	endpointAPIManager endpointapi.EndpointAPIManager
+	endpointCreator    endpointcreator.EndpointCreator
+	ipamManager        *ipam.IPAM
 }
 
 func setupTestDirectories() string {
@@ -111,7 +119,7 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
 
-	var daemonPromise promise.Promise[*Daemon]
+	var legacyDaemonInitPromise promise.Promise[legacy.DaemonInitialization]
 	ds.hive = hive.New(
 		cell.Provide(
 			func(log *slog.Logger) k8sClient.Clientset {
@@ -141,8 +149,8 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 		ControlPlane,
 		metrics.Cell,
 		store.Cell,
-		cell.Invoke(func(p promise.Promise[*Daemon]) {
-			daemonPromise = p
+		cell.Invoke(func(p promise.Promise[legacy.DaemonInitialization]) {
+			legacyDaemonInitPromise = p
 		}),
 		cell.Invoke(func(pi policycell.PolicyImporter) {
 			ds.PolicyImporter = pi
@@ -152,6 +160,21 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 		}),
 		cell.Invoke(func(endpointAPIManager endpointapi.EndpointAPIManager) {
 			ds.endpointAPIManager = endpointAPIManager
+		}),
+		cell.Invoke(func(identityAllocator identitycell.CachingIdentityAllocator) {
+			ds.identityAllocator = identityAllocator
+		}),
+		cell.Invoke(func(policyRepository policy.PolicyRepository) {
+			ds.policyRepository = policyRepository
+		}),
+		cell.Invoke(func(endpointCreator endpointcreator.EndpointCreator) {
+			ds.endpointCreator = endpointCreator
+		}),
+		cell.Invoke(func(ipamManager *ipam.IPAM) {
+			ds.ipamManager = ipamManager
+		}),
+		cell.Invoke(func(endpointManager endpointmanager.EndpointManager) {
+			ds.endpointManager = endpointManager
 		}),
 	)
 
@@ -166,16 +189,16 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 	err := ds.hive.Start(ds.log, ctx)
 	require.NoError(tb, err)
 
-	ds.d, err = daemonPromise.Await(ctx)
+	_, err = legacyDaemonInitPromise.Await(ctx)
 	require.NoError(tb, err)
 
-	ds.d.params.Policy.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
+	ds.policyRepository.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 
 	// Ensure that the identity allocator is synchronized before starting the
 	// actual tests, to prevent flakes caused by the goroutine started by
 	// [(*CachingIdentityAllocator).InitIdentityAllocator] still lingering
 	// around when the Hive gets stopped.
-	ds.d.params.IdentityAllocator.WaitForInitialGlobalIdentities(tb.Context())
+	ds.identityAllocator.WaitForInitialGlobalIdentities(tb.Context())
 
 	// Reset the most common endpoint states before each test.
 	for _, s := range []string{

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func getEPTemplate(t *testing.T, d *Daemon) *models.EndpointChangeRequest {
-	ip4, ip6, err := d.params.IPAM.AllocateNext("", "test", ipam.PoolDefault())
+func getEPTemplate(t *testing.T, ipamManager *ipam.IPAM) *models.EndpointChangeRequest {
+	ip4, ip6, err := ipamManager.AllocateNext("", "test", ipam.PoolDefault())
 	require.NoError(t, err)
 	require.NotNil(t, ip4)
 	require.NotNil(t, ip6)
@@ -51,7 +51,7 @@ func TestEndpointAddReservedLabelEtcd(t *testing.T) {
 func (ds *DaemonSuite) testEndpointAddReservedLabel(t *testing.T) {
 	assertOnMetric(t, string(models.EndpointStateWaitingDashForDashIdentity), 0)
 
-	epTemplate := getEPTemplate(t, ds.d)
+	epTemplate := getEPTemplate(t, ds.ipamManager)
 	epTemplate.Labels = []string{"reserved:world"}
 	_, code, err := ds.endpointAPIManager.CreateEndpoint(context.TODO(), epTemplate)
 	require.Error(t, err)
@@ -83,7 +83,7 @@ func TestEndpointAddInvalidLabelEtcd(t *testing.T) {
 func (ds *DaemonSuite) testEndpointAddInvalidLabel(t *testing.T) {
 	assertOnMetric(t, string(models.EndpointStateWaitingDashForDashIdentity), 0)
 
-	epTemplate := getEPTemplate(t, ds.d)
+	epTemplate := getEPTemplate(t, ds.ipamManager)
 	epTemplate.Labels = []string{"reserved:foo"}
 	_, code, err := ds.endpointAPIManager.CreateEndpoint(context.TODO(), epTemplate)
 	require.Error(t, err)
@@ -104,7 +104,7 @@ func (ds *DaemonSuite) testEndpointAddNoLabels(t *testing.T) {
 	assertOnMetric(t, string(models.EndpointStateWaitingDashForDashIdentity), 0)
 
 	// Create the endpoint without any labels.
-	epTemplate := getEPTemplate(t, ds.d)
+	epTemplate := getEPTemplate(t, ds.ipamManager)
 	_, _, err := ds.endpointAPIManager.CreateEndpoint(context.TODO(), epTemplate)
 	require.NoError(t, err)
 
@@ -113,7 +113,7 @@ func (ds *DaemonSuite) testEndpointAddNoLabels(t *testing.T) {
 	// Check that the endpoint has the reserved:init label.
 	v4ip, err := netip.ParseAddr(epTemplate.Addressing.IPV4)
 	require.NoError(t, err)
-	ep, err := ds.d.params.EndpointManager.Lookup(endpointid.NewIPPrefixID(v4ip))
+	ep, err := ds.endpointManager.Lookup(endpointid.NewIPPrefixID(v4ip))
 	require.NoError(t, err)
 	require.Equal(t, expectedLabels, ep.GetOpLabels())
 
@@ -145,7 +145,7 @@ func (ds *DaemonSuite) testUpdateLabelsFailed(t *testing.T) {
 	cancelFunc() // Cancel immediately to trigger the codepath to test.
 
 	// Create the endpoint without any labels.
-	epTemplate := getEPTemplate(t, ds.d)
+	epTemplate := getEPTemplate(t, ds.ipamManager)
 	_, _, err := ds.endpointAPIManager.CreateEndpoint(cancelledContext, epTemplate)
 	require.ErrorContains(t, err, "request cancelled while resolving identity")
 

--- a/daemon/cmd/ipam_init.go
+++ b/daemon/cmd/ipam_init.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-func (d *Daemon) configureAndStartIPAM(ctx context.Context) {
+func configureAndStartIPAM(ctx context.Context, params daemonParams) {
 	// If the device has been specified, the IPv4AllocPrefix and the
 	// IPv6AllocPrefix were already allocated before the k8s.Init().
 	//
@@ -30,7 +30,7 @@ func (d *Daemon) configureAndStartIPAM(ctx context.Context) {
 		allocCIDR, err := cidr.ParseCIDR(option.Config.IPv4Range)
 		if err != nil {
 			logging.Fatal(
-				d.params.Logger,
+				params.Logger,
 				"Invalid IPv4 allocation prefix",
 				logfields.Error, err,
 				logfields.V4Prefix, option.Config.IPv4Range,
@@ -43,7 +43,7 @@ func (d *Daemon) configureAndStartIPAM(ctx context.Context) {
 		allocCIDR, err := cidr.ParseCIDR(option.Config.IPv6Range)
 		if err != nil {
 			logging.Fatal(
-				d.params.Logger,
+				params.Logger,
 				"Invalid IPv6 allocation prefix",
 				logfields.Error, err,
 				logfields.V6Prefix, option.Config.IPv6Range,
@@ -54,18 +54,18 @@ func (d *Daemon) configureAndStartIPAM(ctx context.Context) {
 	}
 
 	device := ""
-	drd, _ := d.params.DirectRoutingDevice.Get(ctx, d.params.DB.ReadTxn())
+	drd, _ := params.DirectRoutingDevice.Get(ctx, params.DB.ReadTxn())
 	if drd != nil {
 		device = drd.Name
 	}
-	if err := node.AutoComplete(d.params.Logger, device); err != nil {
-		logging.Fatal(d.params.Logger, "Cannot autocomplete node addresses", logfields.Error, err)
+	if err := node.AutoComplete(params.Logger, device); err != nil {
+		logging.Fatal(params.Logger, "Cannot autocomplete node addresses", logfields.Error, err)
 	}
 
 	// start
 	bootstrapStats.ipam.Start()
-	d.params.Logger.Info("Initializing node addressing")
+	params.Logger.Info("Initializing node addressing")
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	d.params.IPAM.ConfigureAllocator()
+	params.IPAM.ConfigureAllocator()
 	bootstrapStats.ipam.End(true)
 }

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -208,7 +208,7 @@ func (ds *DaemonSuite) prepareEndpoint(t *testing.T, identity *identity.Identity
 		ID:    int64(testEndpointID),
 		State: ptr.To(models.EndpointState(endpoint.StateWaitingForIdentity)),
 	}
-	e, err := ds.d.params.EndpointCreator.NewEndpointFromChangeModel(t.Context(), model)
+	e, err := ds.endpointCreator.NewEndpointFromChangeModel(t.Context(), model)
 	require.NoError(t, err)
 
 	e.Start(testEndpointID)
@@ -308,25 +308,25 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
+	qaBarSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	prodBarLbls := labels.Labels{lblBar.Key: lblBar, lblProd.Key: lblProd}
-	prodBarSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), prodBarLbls, true, identity.InvalidIdentity)
+	prodBarSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), prodBarLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), prodBarSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), prodBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
+	qaFooSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 	prodFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd}
-	prodFooSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), prodFooLbls, true, identity.InvalidIdentity)
+	prodFooSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), prodFooLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), prodFooSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), prodFooSecLblsCtx, false)
 	prodFooJoeLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd, lblJoe.Key: lblJoe}
-	prodFooJoeSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), prodFooJoeLbls, true, identity.InvalidIdentity)
+	prodFooJoeSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), prodFooJoeLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), prodFooJoeSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), prodFooJoeSecLblsCtx, false)
 
 	// Prepare endpoints
 	cleanup, err2 := prepareEndpointDirs()
@@ -446,13 +446,13 @@ func TestPrivilegedL4L7ShadowingEtcd(t *testing.T) {
 func (ds *DaemonSuite) testL4L7Shadowing(t *testing.T) {
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
+	qaBarSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
+	qaFooSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -537,13 +537,13 @@ func TestPrivilegedL4L7ShadowingShortCircuitEtcd(t *testing.T) {
 func (ds *DaemonSuite) testL4L7ShadowingShortCircuit(t *testing.T) {
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
+	qaBarSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
+	qaFooSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -619,17 +619,17 @@ func TestPrivilegedL3DependentL7Etcd(t *testing.T) {
 func (ds *DaemonSuite) testL3DependentL7(t *testing.T) {
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
+	qaBarSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
+	qaFooSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaFooSecLblsCtx, false)
 	qaJoeLbls := labels.Labels{lblJoe.Key: lblJoe, lblQA.Key: lblQA}
-	qaJoeSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaJoeLbls, true, identity.InvalidIdentity)
+	qaJoeSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaJoeLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaJoeSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaJoeSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -750,7 +750,7 @@ func (ds *DaemonSuite) testReplacePolicy(t *testing.T) {
 	}
 
 	ds.policyImport(rules)
-	foundRules, _ := ds.d.params.Policy.Search(lbls)
+	foundRules, _ := ds.policyRepository.Search(lbls)
 	require.Len(t, foundRules, 2)
 	rules[0].Egress = []api.EgressRule{
 		{
@@ -767,7 +767,7 @@ func (ds *DaemonSuite) testReplacePolicy(t *testing.T) {
 		ReplaceByLabels: true,
 	})
 
-	foundRules, _ = ds.d.params.Policy.Search(lbls)
+	foundRules, _ = ds.policyRepository.Search(lbls)
 	require.Len(t, foundRules, 2)
 }
 
@@ -779,9 +779,9 @@ func TestPrivilegedRemovePolicyEtcd(t *testing.T) {
 
 func (ds *DaemonSuite) testRemovePolicy(t *testing.T) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
+	qaBarSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -872,9 +872,9 @@ func TestPrivilegedIncrementalPolicyEtcd(t *testing.T) {
 
 func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
+	qaBarSecLblsCtx, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
+	defer ds.identityAllocator.Release(context.Background(), qaBarSecLblsCtx, false)
 
 	rules := api.Rules{
 		{
@@ -954,9 +954,9 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 
 	// Allocate identities needed for this test
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooID, _, err := ds.d.params.IdentityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
+	qaFooID, _, err := ds.identityAllocator.AllocateIdentity(context.Background(), qaFooLbls, true, identity.InvalidIdentity)
 	require.NoError(t, err)
-	defer ds.d.params.IdentityAllocator.Release(context.Background(), qaFooID, false)
+	defer ds.identityAllocator.Release(context.Background(), qaFooID, false)
 
 	// Regenerate endpoint
 	ds.regenerateEndpoint(t, eQABar)

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -4,6 +4,7 @@
 package suite
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -134,7 +135,7 @@ func (cpt *ControlPlaneTest) StartAgent(modConfig func(*agentOption.DaemonConfig
 
 	cpt.agentHandle.populateCiliumAgentOptions(cpt.tempDir, modConfig)
 
-	if err := cpt.agentHandle.startCiliumAgent(); err != nil {
+	if err := cpt.agentHandle.hive.Start(cpt.agentHandle.log, context.TODO()); err != nil {
 		cpt.t.Fatalf("Failed to start cilium agent: %s", err)
 	}
 	cpt.FakeNodeHandler = cpt.agentHandle.fnh

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -134,11 +134,9 @@ func (cpt *ControlPlaneTest) StartAgent(modConfig func(*agentOption.DaemonConfig
 
 	cpt.agentHandle.populateCiliumAgentOptions(cpt.tempDir, modConfig)
 
-	daemon, err := cpt.agentHandle.startCiliumAgent()
-	if err != nil {
+	if err := cpt.agentHandle.startCiliumAgent(); err != nil {
 		cpt.t.Fatalf("Failed to start cilium agent: %s", err)
 	}
-	cpt.agentHandle.d = daemon
 	cpt.FakeNodeHandler = cpt.agentHandle.fnh
 
 	return cpt
@@ -326,7 +324,7 @@ func gvrAndName(obj k8sRuntime.Object) (gvr schema.GroupVersionResource, ns stri
 	}
 	ns = objMeta.GetNamespace()
 	name = objMeta.GetName()
-	return
+	return gvr, ns, name
 }
 
 func matchFieldSelector(obj k8sRuntime.Object, selector fields.Selector) bool {
@@ -491,7 +489,7 @@ func augmentTracker[T fakeWithTracker](f T, t *testing.T, watchers *lock.Map[str
 		case k8sTesting.ListActionImpl:
 			filterList(ret, action.GetListRestrictions())
 		}
-		return
+		return handled, ret, err
 	})
 
 	f.PrependWatchReactor(


### PR DESCRIPTION
This PR removes the `Daemon` struct and `Promise[Daemon]`. 

```
daemon: remove Daemon struct

Now that the legacy daemon initialisation logic no
longer relies on "state" being stored in the `Daemon` struct,
this commit removes the `Daemon` struct.

Usages (daemon test) of the `Promise[Daemon]` (to await the full legacy daemon start),
are refactored to use a (temporary) `Promies[legacy.DaemonInitialization]`.
```

```
daemon: remove temporary LegacyDaemon promise

This commit removes the temporary LegacyDaemonInitialization promise
and cleans up all related code.

The only usages (tests) of the promise are using DryRun - therefore
they are never awaiting the full start of the daemon. Hence there
dependency can be changed to `legacy.LegacyDaemonInitializaation` that
awaits the config of the legacy "daemon").
```