### PR TITLE
[v1.18] ipsec: add support for using remote PodCIDR entries

### DIFF
--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -189,12 +189,9 @@ do_decrypt(struct __ctx_buff *ctx, __u16 proto)
  * 1. Host-to-Host or Pod-to-Host traffic
  * 2. Traffic leaving the cluster
  * 3. Remote nodes including Kube API server
- * 4. Traffic is already ESP encrypted
  */
 static __always_inline int
-ipsec_redirect_sec_id_ok(__u32 src_sec_id, __u32 dst_sec_id, int ip_proto) {
-	if (ip_proto == IPPROTO_ESP)
-		return 0;
+ipsec_redirect_sec_id_ok(__u32 src_sec_id, __u32 dst_sec_id) {
 	if (src_sec_id == HOST_ID)
 		return 0;
 	if (dst_sec_id == HOST_ID)
@@ -219,7 +216,6 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	void *data __maybe_unused, *data_end __maybe_unused;
 	struct iphdr __maybe_unused *ip4;
 	struct ipv6hdr __maybe_unused *ip6;
-	int ip_proto = 0;
 	int ret = 0;
 	union macaddr dst_mac = CILIUM_NET_MAC;
 
@@ -276,8 +272,6 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 		}
 #  endif /* TUNNEL_MODE */
 
-		ip_proto = ip4->protocol;
-
 		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 
 		if (src_sec_identity == UNKNOWN_ID) {
@@ -320,8 +314,6 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 		}
 #  endif /* TUNNEL_MODE */
 
-		ip_proto = ip6->nexthdr;
-
 		dst = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
 
 		if (src_sec_identity == UNKNOWN_ID) {
@@ -340,8 +332,7 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	if (!dst || !dst->flag_has_tunnel_ep)
 		return CTX_ACT_OK;
 
-	if (!ipsec_redirect_sec_id_ok(src_sec_identity, dst->sec_identity,
-				      ip_proto))
+	if (!ipsec_redirect_sec_id_ok(src_sec_identity, dst->sec_identity))
 		return CTX_ACT_OK;
 
 	/* mark packet for encryption

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -184,23 +184,13 @@ do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 #endif /* ENABLE_ENDPOINT_ROUTES */
 }
 
-/* checks whether a IPsec redirect should be performed for the security id
- * we do not IPsec encrypt:
- * 1. Host-to-Host or Pod-to-Host traffic
- * 2. Traffic leaving the cluster
- * 3. Remote nodes including Kube API server
+/* checks whether a IPsec redirect should be performed for the source
  */
 static __always_inline int
-ipsec_redirect_sec_id_ok(__u32 src_sec_id, __u32 dst_sec_id) {
+ipsec_redirect_sec_id_ok(__u32 src_sec_id) {
 	if (src_sec_id == HOST_ID)
 		return 0;
-	if (dst_sec_id == HOST_ID)
-		return 0;
-	if (!identity_is_cluster(dst_sec_id))
-		return 0;
 	if (!identity_is_cluster(src_sec_id))
-		return 0;
-	if (identity_is_remote_node(dst_sec_id))
 		return 0;
 	if (identity_is_remote_node(src_sec_id))
 		return 0;
@@ -329,10 +319,10 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 		return CTX_ACT_OK;
 	}
 
-	if (!dst || !dst->flag_has_tunnel_ep)
+	if (!dst || !dst->flag_has_tunnel_ep || !dst->key)
 		return CTX_ACT_OK;
 
-	if (!ipsec_redirect_sec_id_ok(src_sec_identity, dst->sec_identity))
+	if (!ipsec_redirect_sec_id_ok(src_sec_identity))
 		return CTX_ACT_OK;
 
 	/* mark packet for encryption

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -219,7 +219,6 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	void *data __maybe_unused, *data_end __maybe_unused;
 	struct iphdr __maybe_unused *ip4;
 	struct ipv6hdr __maybe_unused *ip6;
-	__u32 magic __maybe_unused = 0;
 	int ip_proto = 0;
 	int ret = 0;
 	union macaddr dst_mac = CILIUM_NET_MAC;

--- a/bpf/tests/encrypt_host.h
+++ b/bpf/tests/encrypt_host.h
@@ -1,0 +1,243 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+ * Copyright Authors of Cilium
+ */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4			1
+
+#define SRC_POD_V4			v4_pod_one
+#define DST_POD_V4			v4_pod_one_on_node_two
+#define DST_POD_CIDR_V4			v4_pod_cidr_on_node_two
+
+#define SRC_POD_SEC_IDENTITY		(CIDR_IDENTITY_RANGE_START - 2)
+#define DST_POD_SEC_IDENTITY		(CIDR_IDENTITY_RANGE_START - 3)
+
+#define SRC_NODE_V4			v4_node_one
+#define DST_NODE_V4			v4_node_two
+
+#define ENCRYPT_KEY			0xFF
+
+#include "bpf_host.c"
+
+#include "lib/ipcache.h"
+#include "lib/node.h"
+
+#define TO_NETDEV	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+static __always_inline
+int v4_build_packet(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct iphdr *l3;
+
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv4_packet(&builder, (__u8 *)mac_one, (__u8 *)mac_two,
+				      SRC_POD_V4, DST_POD_V4);
+	if (!l3)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+/* Validate that if the destination endpoint is being torn down (and
+ * its ipcache entry is missing), then the corresponding PodCIDR entry
+ * is still sufficient to apply encryption for a pod-to-pod packet.
+ */
+PKTGEN("tc", "encrypt_v4_1_missing_dst")
+int encrypt_v4_1_missing_dst_pktgen(struct __ctx_buff *ctx)
+{
+	return v4_build_packet(ctx);
+}
+
+SETUP("tc", "encrypt_v4_1_missing_dst")
+int encrypt_v4_1_missing_dst_setup(struct __ctx_buff *ctx)
+{
+	ipcache_v4_add_entry_with_mask_size(DST_POD_CIDR_V4, 0, WORLD_ID,
+					    DST_NODE_V4, ENCRYPT_KEY,
+					    v4_pod_cidr_size);
+
+#ifdef ENABLE_IPSEC
+	__u32 encrypt_key = 0;
+	struct encrypt_config cfg = {
+		.encrypt_key = ENCRYPT_KEY,
+	};
+
+	map_update_elem(&cilium_encrypt_state, &encrypt_key, &cfg, BPF_ANY);
+
+	node_v4_add_entry(DST_NODE_V4, 123, ENCRYPT_KEY);
+#endif
+
+	set_identity_mark(ctx, SRC_POD_SEC_IDENTITY, MARK_MAGIC_IDENTITY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "encrypt_v4_1_missing_dst")
+int encrypt_v4_1_missing_dst_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	test_finish();
+}
+
+/* Validate the behavior for a terminating source endpoint.
+ *
+ * First we test *with* the sec identity in the mark. This should be
+ * sufficient to trigger encryption, even if the endpoint's ipcache entry
+ * is not available.
+ */
+PKTGEN("tc", "encrypt_v4_2_src_mark")
+int encrypt_v4_2_src_mark_pktgen(struct __ctx_buff *ctx)
+{
+	return v4_build_packet(ctx);
+}
+
+SETUP("tc", "encrypt_v4_2_src_mark")
+int encrypt_v4_2_src_mark_setup(struct __ctx_buff *ctx)
+{
+	ipcache_v4_add_entry(DST_POD_V4, 0, DST_POD_SEC_IDENTITY,
+			     DST_NODE_V4, ENCRYPT_KEY);
+
+	set_identity_mark(ctx, SRC_POD_SEC_IDENTITY, MARK_MAGIC_IDENTITY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "encrypt_v4_2_src_mark")
+int encrypt_v4_2_src_mark_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	test_finish();
+}
+
+/* Now test *without* the identity in the mark. This should *not* trigger
+ * encryption:
+ */
+PKTGEN("tc", "encrypt_v4_3_no_src_mark")
+int encrypt_v4_3_no_src_mark_pktgen(struct __ctx_buff *ctx)
+{
+	return v4_build_packet(ctx);
+}
+
+SETUP("tc", "encrypt_v4_3_no_src_mark")
+int encrypt_v4_3_no_src_mark_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "encrypt_v4_3_no_src_mark")
+int encrypt_v4_3_no_src_mark_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}
+
+/* Finally test without the mark, but with the endpoint's ipcache entry: */
+PKTGEN("tc", "encrypt_v4_4_no_src_mark_with_src_entry")
+int encrypt_v4_4_no_src_mark_with_src_entry_pktgen(struct __ctx_buff *ctx)
+{
+	return v4_build_packet(ctx);
+}
+
+SETUP("tc", "encrypt_v4_4_no_src_mark_with_src_entry")
+int encrypt_v4_4_no_src_mark_with_src_entry_setup(struct __ctx_buff *ctx)
+{
+	ipcache_v4_add_entry(SRC_POD_V4, 0, SRC_POD_SEC_IDENTITY,
+			     0, ENCRYPT_KEY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "encrypt_v4_4_no_src_mark_with_src_entry")
+int encrypt_v4_4_no_src_mark_with_src_entry_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	test_finish();
+}

--- a/bpf/tests/encrypt_host_ipsec.c
+++ b/bpf/tests/encrypt_host_ipsec.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_IPSEC		1
+
+#include "encrypt_host.h"

--- a/bpf/tests/encrypt_host_wireguard.c
+++ b/bpf/tests/encrypt_host_wireguard.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_WIREGUARD	1
+
+#include "encrypt_host.h"

--- a/bpf/tests/ipsec_redirect_native.c
+++ b/bpf/tests/ipsec_redirect_native.c
@@ -45,24 +45,24 @@ void set_src_identity(bool ipv4_inner, bool ipv4_outer, __u32 identity)
 }
 
 static __always_inline
-void set_dst_identity(bool ipv4_inner, bool ipv4_outer, __u32 identity)
+void set_dst_identity(bool ipv4_inner, bool ipv4_outer, __u32 identity, __u8 spi)
 {
 	if (ipv4_inner)
 		if (ipv4_outer)
-			ipcache_v4_add_entry(DST_IP, 0, identity, DST_NODE_IP, TARGET_SPI);
+			ipcache_v4_add_entry(DST_IP, 0, identity, DST_NODE_IP, spi);
 		else
 			ipcache_v4_add_entry_ipv6_underlay(DST_IP, 0, identity,
 							   (const union v6addr *)DST_NODE_IP_6,
-							   TARGET_SPI);
+							   spi);
 	else
 		if (ipv4_outer)
 			ipcache_v6_add_entry((const union v6addr *)DST_IP_6, 0,
-					     identity, DST_NODE_IP, TARGET_SPI);
+					     identity, DST_NODE_IP, spi);
 		else
 			ipcache_v6_add_entry_ipv6_underlay((const union v6addr *)DST_IP_6, 0,
 							   identity,
 							   (const union v6addr *)DST_NODE_IP_6,
-							   TARGET_SPI);
+							   spi);
 }
 
 static __always_inline
@@ -83,7 +83,7 @@ int ipsec_redirect_setup(struct __ctx_buff *ctx, bool ipv4_inner, bool ipv4_oute
 	map_update_elem(&cilium_encrypt_state, &encrypt_key, &cfg, BPF_ANY);
 
 	set_src_identity(ipv4_inner, ipv4_outer, SOURCE_IDENTITY);
-	set_dst_identity(ipv4_inner, ipv4_outer, DST_IDENTITY);
+	set_dst_identity(ipv4_inner, ipv4_outer, DST_IDENTITY, TARGET_SPI);
 
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	return TEST_ERROR;
@@ -143,7 +143,7 @@ int bad_identities_check(struct __ctx_buff *ctx, bool is_ipv4)
 	 * Ensure host-to-pod traffic is not encrypted.
 	 */
 	TEST("native-host-to-pod", {
-		set_dst_identity(is_ipv4, true, DST_IDENTITY);
+		set_dst_identity(is_ipv4, true, DST_IDENTITY, TARGET_SPI);
 		ret = ipsec_maybe_redirect_to_encrypt(ctx, proto, HOST_ID);
 		assert(ret == CTX_ACT_OK);
 	})
@@ -152,7 +152,7 @@ int bad_identities_check(struct __ctx_buff *ctx, bool is_ipv4)
 	 * Ensure world-to-pod traffic is not encrypted.
 	 */
 	TEST("native-world-to-pod", {
-		set_dst_identity(is_ipv4, true, DST_IDENTITY);
+		set_dst_identity(is_ipv4, true, DST_IDENTITY, TARGET_SPI);
 		ret = ipsec_maybe_redirect_to_encrypt(ctx, proto, WORLD_ID);
 		assert(ret == CTX_ACT_OK);
 	})
@@ -161,7 +161,7 @@ int bad_identities_check(struct __ctx_buff *ctx, bool is_ipv4)
 	 * Ensure remote_node-to-pod traffic is not encrypted.
 	 */
 	TEST("native-remote_node-to-pod", {
-		set_dst_identity(is_ipv4, true, DST_IDENTITY);
+		set_dst_identity(is_ipv4, true, DST_IDENTITY, TARGET_SPI);
 		ret = ipsec_maybe_redirect_to_encrypt(ctx, proto, REMOTE_NODE_ID);
 		assert(ret == CTX_ACT_OK);
 	})
@@ -170,7 +170,7 @@ int bad_identities_check(struct __ctx_buff *ctx, bool is_ipv4)
 	 * Ensure pod-to-host traffic is not encrypted.
 	 */
 	TEST("native-pod-to-host", {
-		set_dst_identity(is_ipv4, true, HOST_ID);
+		set_dst_identity(is_ipv4, true, HOST_ID, 0);
 		ret = ipsec_maybe_redirect_to_encrypt(ctx, proto, SOURCE_IDENTITY);
 		assert(ret == CTX_ACT_OK);
 	})
@@ -179,7 +179,7 @@ int bad_identities_check(struct __ctx_buff *ctx, bool is_ipv4)
 	 * Ensure pod-to-world traffic is not encrypted.
 	 */
 	TEST("native-pod-to-world", {
-		set_dst_identity(is_ipv4, true, WORLD_ID);
+		set_dst_identity(is_ipv4, true, WORLD_ID, 0);
 		ret = ipsec_maybe_redirect_to_encrypt(ctx, proto, SOURCE_IDENTITY);
 		assert(ret == CTX_ACT_OK);
 	})
@@ -188,7 +188,7 @@ int bad_identities_check(struct __ctx_buff *ctx, bool is_ipv4)
 	 * Ensure pod-to-remote_node traffic is not encrypted.
 	 */
 	TEST("native-pod-to-remote_node", {
-		set_dst_identity(is_ipv4, true, REMOTE_NODE_ID);
+		set_dst_identity(is_ipv4, true, REMOTE_NODE_ID, 0);
 		ret = ipsec_maybe_redirect_to_encrypt(ctx, proto, SOURCE_IDENTITY);
 		assert(ret == CTX_ACT_OK);
 	})

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -66,6 +66,14 @@ volatile const __u8 mac_zero[] = mac_zero_addr;
 #define v4_pod_two	IPV4(192, 168, 0, 2)
 #define v4_pod_three	IPV4(192, 168, 0, 3)
 
+/* Node-specific PodCIDR */
+#define v4_pod_one_on_node_two		IPV4(192, 168, 1, 1)
+#define v4_pod_two_on_node_two		IPV4(192, 168, 1, 2)
+#define v4_pod_three_on_node_two	IPV4(192, 168, 1, 3)
+#define v4_pod_cidr_on_node_two		IPV4(192, 168, 1, 0)
+
+#define v4_pod_cidr_size		24
+
 #define v4_svc_loopback	IPV4(10, 245, 255, 31)
 
 #define v4_all	IPV4(0, 0, 0, 0)


### PR DESCRIPTION
Author backport of
* [ ] #39660 (cherry-picked a trivial cleanup, to resolve a conflict in a subsequent patch)
* [ ] #41519 (minor adjustments in the test, due to infrastructure changes)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 41519
```