### PR TITLE
plugins/cilium-cni: Busy wait for a bootstrapping agent

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -38,7 +38,11 @@ func DefaultSockPath() string {
 		// If unset, fall back to default value
 		e = defaults.SockPath
 	}
-	return "unix://" + e
+	return e
+}
+
+func DefaultSockPathProtocol() string {
+	return "unix://" + DefaultSockPath()
 }
 
 func configureTransport(tr *http.Transport, proto, addr string) *http.Transport {
@@ -129,7 +133,7 @@ func WithBasePath(basePath string) func(options *runtimeOptions) {
 
 func NewTransport(host string) (*http.Transport, error) {
 	if host == "" {
-		host = DefaultSockPath()
+		host = DefaultSockPathProtocol()
 	}
 	schema, host, found := strings.Cut(host, "://")
 	if !found {
@@ -159,7 +163,7 @@ func NewRuntime(opts ...func(options *runtimeOptions)) (*runtime_client.Runtime,
 
 	host := r.host
 	if host == "" {
-		host = DefaultSockPath()
+		host = DefaultSockPathProtocol()
 	}
 
 	_, hostHeader, found := strings.Cut(host, "://")

--- a/pkg/health/health_connectivity_node.go
+++ b/pkg/health/health_connectivity_node.go
@@ -48,7 +48,7 @@ func (h *ciliumHealthManager) launchCiliumNodeHealth(spec *healthApi.Spec, initi
 	)
 
 	config := server.Config{
-		CiliumURI:     ciliumPkg.DefaultSockPath(),
+		CiliumURI:     ciliumPkg.DefaultSockPathProtocol(),
 		Debug:         option.Config.Opts.IsEnabled(option.Debug),
 		ICMPReqsCount: option.Config.HealthCheckICMPFailureThreshold,
 		ProbeDeadline: serverProbeDeadline,

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -80,7 +80,7 @@ func newLibnetworkRoute(route route.Route) api.StaticRoute {
 func NewDriver(logger *slog.Logger, ciliumSockPath, dockerHostPath string) (Driver, error) {
 
 	if ciliumSockPath == "" {
-		ciliumSockPath = client.DefaultSockPath()
+		ciliumSockPath = client.DefaultSockPathProtocol()
 	}
 
 	scopedLog := logger.With(


### PR DESCRIPTION
Before processing the deletion queue, the bootstrapping agent has to take an exclusive lock on the directory, to avoid racing with the cilium CNI handling a concurrent DEL request. In environments with high pod churn, where the agent is racing with the CNI handling multiple DEL requests, this can lead to lock starvation, since the CNI takes the lock in non-exclusive mode.  In that case, the agent might expire all the time allotted by the hive to complete the start hooks, set by default to 5 minutes, ultimately leading to an agent restart.

To avoid this, let the CNI checks if the agent is bootstrapping before taking the lock. If so, avoid taking the lock to reduce contention and try to wait 5 seconds (up to 3 times) for the agent to be ready to handle the DEL request.

To understand that the agent is bootstrapping, we check that the directory "/var/run/cilium" exists but the socket has not yet been created. This works because at the very early stages of its startup phase the agent creates the directory and removes the socket file created by previous instances. Then it proceeds executing all its start hooks, among which there is the deletion queue handling and soon after the creation of the socket file. Note that checking the directory helps detect the case when the agent has never started on the node.

The unit test exercising the fallback client has been updated to take into account the additional retries due to the busy wait logic.
