### PR TITLE
loader: dump datapath config object to disk

### DIFF
--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -192,7 +192,7 @@ func LoadCollection(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *Collec
 
 	logger.Debug("Loading Collection into kernel",
 		logfields.MapRenames, opts.MapRenames,
-		logfields.Constants, fmt.Sprintf("%#v", opts.Constants),
+		logfields.Constants, printConstants(opts.Constants),
 	)
 
 	// Copy spec so the modifications below don't affect the input parameter,

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf/analyze"
 	"github.com/cilium/cilium/pkg/container/set"
-	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -280,38 +279,6 @@ func renameMaps(coll *ebpf.CollectionSpec, renames map[string]string) error {
 		}
 
 		mapSpec.Name = rename
-	}
-
-	return nil
-}
-
-// applyConstants sets the values of BPF C runtime configurables defined using
-// the DECLARE_CONFIG macro.
-func applyConstants(spec *ebpf.CollectionSpec, obj any) error {
-	if obj == nil {
-		return nil
-	}
-
-	constants, err := config.Map(obj)
-	if err != nil {
-		return fmt.Errorf("converting struct to map: %w", err)
-	}
-
-	for name, value := range constants {
-		constName := config.ConstantPrefix + name
-
-		v, ok := spec.Variables[constName]
-		if !ok {
-			return fmt.Errorf("can't set non-existent Variable %s", name)
-		}
-
-		if v.SectionName != config.Section {
-			return fmt.Errorf("can only set Cilium config variables in section %s (got %s:%s), ", config.Section, v.SectionName, name)
-		}
-
-		if err := v.Set(value); err != nil {
-			return fmt.Errorf("setting Variable %s: %w", name, err)
-		}
 	}
 
 	return nil

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -149,6 +149,10 @@ type CollectionOptions struct {
 
 	// Set of objects to keep during reachability pruning.
 	Keep *set.Set[string]
+
+	// ConfigDumpPath is the path to write a file to containing the constants used
+	// during loading, typically to be included in sysdumps.
+	ConfigDumpPath string
 }
 
 func (co *CollectionOptions) populateMapReplacements() {
@@ -223,6 +227,10 @@ func LoadCollection(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *Collec
 	fixed := fixedResources(spec, opts.Keep)
 	if err := removeUnusedMaps(spec, fixed, reach, logger); err != nil {
 		return nil, nil, fmt.Errorf("pruning unused maps: %w", err)
+	}
+
+	if err := dumpConstants(spec, opts); err != nil {
+		return nil, nil, fmt.Errorf("writing constants: %w", err)
 	}
 
 	// Find and strip all CILIUM_PIN_REPLACE pinning flags before creating the

--- a/pkg/bpf/constants.go
+++ b/pkg/bpf/constants.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bpf
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/cilium/cilium/pkg/datapath/config"
+)
+
+// applyConstants sets the values of BPF C runtime configurables defined using
+// the DECLARE_CONFIG macro.
+func applyConstants(spec *ebpf.CollectionSpec, obj any) error {
+	if obj == nil {
+		return nil
+	}
+
+	constants, err := config.Map(obj)
+	if err != nil {
+		return fmt.Errorf("converting struct to map: %w", err)
+	}
+
+	for name, value := range constants {
+		constName := config.ConstantPrefix + name
+
+		v, ok := spec.Variables[constName]
+		if !ok {
+			return fmt.Errorf("can't set non-existent Variable %s", name)
+		}
+
+		if v.SectionName != config.Section {
+			return fmt.Errorf("can only set Cilium config variables in section %s (got %s:%s), ", config.Section, v.SectionName, name)
+		}
+
+		if err := v.Set(value); err != nil {
+			return fmt.Errorf("setting Variable %s: %w", name, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/bpf/constants_test.go
+++ b/pkg/bpf/constants_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bpf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintConstants(t *testing.T) {
+	consts := []any{
+		struct{ Foo int }{Foo: 42},
+		map[string]any{"baz": true},
+		uint32(123),
+	}
+	assert.Equal(t, "[]", printConstants(nil))
+	assert.Equal(t, `["foo"]`, printConstants([]any{nil, "foo"}))
+	assert.Equal(t, "[]", printConstants([]int{}))
+	assert.Equal(t, "[]", printConstants([]any{}))
+	assert.Equal(t, "[]", printConstants([]any{nil, nil}))
+	assert.Equal(t, `[42]`, printConstants(42))
+	assert.Equal(t, `[42, "foo"]`, printConstants([]any{42, "foo"}))
+
+	assert.Equal(t, `[struct { Foo int }{Foo:42}, map[string]interface {}{"baz":true}, 0x7b]`, printConstants(consts))
+}

--- a/pkg/bpf/constants_test.go
+++ b/pkg/bpf/constants_test.go
@@ -4,9 +4,16 @@
 package bpf
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/datapath/config"
 )
 
 func TestPrintConstants(t *testing.T) {
@@ -24,4 +31,70 @@ func TestPrintConstants(t *testing.T) {
 	assert.Equal(t, `[42, "foo"]`, printConstants([]any{42, "foo"}))
 
 	assert.Equal(t, `[struct { Foo int }{Foo:42}, map[string]interface {}{"baz":true}, 0x7b]`, printConstants(consts))
+}
+
+func TestDumpConstants(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+
+	spec := &ebpf.CollectionSpec{
+		Variables: map[string]*ebpf.VariableSpec{
+			"__config_device_mtu": {
+				Name:        "__config_device_mtu",
+				SectionName: config.Section,
+				Value:       []byte{0xdc, 0x05}, // 1500
+			},
+			"__config_enable_foo": {
+				Name:        "__config_enable_foo",
+				SectionName: config.Section,
+				Value:       []byte{0x01}, // true
+			},
+			// Variable in a different section should be excluded.
+			"other_var": {
+				Name:        "other_var",
+				SectionName: ".rodata",
+				Value:       []byte{0xff},
+			},
+		},
+	}
+
+	type testObj struct {
+		DeviceMTU uint16 `config:"device_mtu"`
+		EnableFoo bool   `config:"enable_foo"`
+	}
+	constants := &testObj{
+		DeviceMTU: 1500,
+		EnableFoo: true,
+	}
+
+	opts := &CollectionOptions{
+		ConfigDumpPath: configPath,
+		Constants:      constants,
+	}
+
+	err := dumpConstants(spec, opts)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var result configDumpLayout
+	err = json.Unmarshal(data, &result)
+	require.NoError(t, err)
+
+	// Verify the objects section. This is mainly for human consumption, but we
+	// check that it at least contains the expected values.
+	assert.Len(t, result.Objects, 1)
+	obj := result.Objects[0]
+	assert.Contains(t, obj.Name, "bpf.testObj")
+
+	v := obj.Values.(map[string]any)
+	assert.Equal(t, float64(1500), v["DeviceMTU"])
+	assert.Equal(t, true, v["EnableFoo"])
+
+	// Verify the variables section contains only config section variables.
+	assert.Len(t, result.Variables, 2)
+	assert.Equal(t, []byte{0xdc, 0x05}, result.Variables["__config_device_mtu"])
+	assert.Equal(t, []byte{0x01}, result.Variables["__config_enable_foo"])
+	assert.NotContains(t, result.Variables, "other_var")
 }

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -38,26 +38,32 @@ const (
 	endpointPrefix = "bpf_lxc"
 	endpointProg   = endpointPrefix + "." + string(outputSource)
 	endpointObj    = endpointPrefix + ".o"
+	endpointConfig = endpointPrefix + ".json"
 
 	hostEndpointPrefix = "bpf_host"
 	hostEndpointProg   = hostEndpointPrefix + "." + string(outputSource)
 	hostEndpointObj    = hostEndpointPrefix + ".o"
+	hostEndpointConfig = hostEndpointPrefix + ".json"
 
 	networkPrefix = "bpf_network"
 	networkProg   = networkPrefix + "." + string(outputSource)
 	networkObj    = networkPrefix + ".o"
+	networkConfig = networkPrefix + ".json"
 
 	xdpPrefix = "bpf_xdp"
 	xdpProg   = xdpPrefix + "." + string(outputSource)
 	xdpObj    = xdpPrefix + ".o"
+	xdpConfig = xdpPrefix + ".json"
 
 	overlayPrefix = "bpf_overlay"
 	overlayProg   = overlayPrefix + "." + string(outputSource)
 	overlayObj    = overlayPrefix + ".o"
+	overlayConfig = overlayPrefix + ".json"
 
 	wireguardPrefix = "bpf_wireguard"
 	wireguardProg   = wireguardPrefix + "." + string(outputSource)
 	wireguardObj    = wireguardPrefix + ".o"
+	wireguardConfig = wireguardPrefix + ".json"
 )
 
 var (

--- a/pkg/datapath/loader/encryption.go
+++ b/pkg/datapath/loader/encryption.go
@@ -52,6 +52,9 @@ func replaceEncryptionDatapath(ctx context.Context, logger *slog.Logger, lnc *da
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
 		Constants: encryptionConfiguration(lnc),
+		// A single bpf_network.o Collection is attached to multiple devices, only
+		// store a single config at the root of the bpf statedir.
+		ConfigDumpPath: bpfStateDeviceDir(networkConfig),
 	})
 	if err != nil {
 		return err

--- a/pkg/datapath/loader/endpoint.go
+++ b/pkg/datapath/loader/endpoint.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/netip"
+	"path/filepath"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/hive/cell"
@@ -186,8 +187,9 @@ func reloadEndpoint(logger *slog.Logger, db *statedb.DB,
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
-		Constants:  endpointConfiguration(ep, lnc),
-		MapRenames: endpointMapRenames(ep),
+		Constants:      endpointConfiguration(ep, lnc),
+		MapRenames:     endpointMapRenames(ep),
+		ConfigDumpPath: filepath.Join(ep.StateDir(), endpointConfig),
 	})
 	if err != nil {
 		return err

--- a/pkg/datapath/loader/host.go
+++ b/pkg/datapath/loader/host.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"path/filepath"
 
 	"github.com/cilium/ebpf"
 	"github.com/vishvananda/netlink"
@@ -89,8 +90,9 @@ func attachCiliumHost(logger *slog.Logger, ep datapath.Endpoint, lnc *datapath.L
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
-		Constants:  ciliumHostConfiguration(ep, lnc),
-		MapRenames: ciliumHostMapRenames(ep),
+		Constants:      ciliumHostConfiguration(ep, lnc),
+		MapRenames:     ciliumHostMapRenames(ep),
+		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(ep.InterfaceName()), hostEndpointConfig),
 	})
 	if err != nil {
 		return err
@@ -154,8 +156,9 @@ func attachCiliumNet(logger *slog.Logger, ep datapath.Endpoint, lnc *datapath.Lo
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
-		Constants:  ciliumNetConfiguration(ep, lnc, net),
-		MapRenames: ciliumNetMapRenames(ep, net),
+		Constants:      ciliumNetConfiguration(ep, lnc, net),
+		MapRenames:     ciliumNetMapRenames(ep, net),
+		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(defaults.SecondHostDevice), hostEndpointConfig),
 	})
 	if err != nil {
 		return err
@@ -238,8 +241,9 @@ func attachNetworkDevices(logger *slog.Logger, ep datapath.Endpoint, lnc *datapa
 			CollectionOptions: ebpf.CollectionOptions{
 				Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 			},
-			Constants:  netdevConfiguration(ep, lnc, iface, masq4, masq6),
-			MapRenames: netdevMapRenames(ep, iface),
+			Constants:      netdevConfiguration(ep, lnc, iface, masq4, masq6),
+			MapRenames:     netdevMapRenames(ep, iface),
+			ConfigDumpPath: filepath.Join(bpfStateDeviceDir(iface.Attrs().Name), hostEndpointConfig),
 		})
 		if err != nil {
 			return err

--- a/pkg/datapath/loader/netdev.go
+++ b/pkg/datapath/loader/netdev.go
@@ -113,7 +113,7 @@ func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string) error {
 		if err := bpf.Remove(bpffsPath); err != nil {
 			logger.Error("Failed to remove bpffs entry",
 				logfields.Error, err,
-				logfields.BPFSPath, bpffsPath,
+				logfields.BPFFSPath, bpffsPath,
 			)
 		}
 

--- a/pkg/datapath/loader/netdev.go
+++ b/pkg/datapath/loader/netdev.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"os"
 	"slices"
 	"strings"
 
@@ -114,6 +115,15 @@ func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string) error {
 			logger.Error("Failed to remove bpffs entry",
 				logfields.Error, err,
 				logfields.BPFFSPath, bpffsPath,
+			)
+		}
+
+		// Remove the per-device state directory.
+		statePath := bpfStateDeviceDir(l.Attrs().Name)
+		if err := os.RemoveAll(statePath); err != nil {
+			logger.Error("Failed to remove device state directory",
+				logfields.Error, err,
+				logfields.Path, statePath,
 			)
 		}
 

--- a/pkg/datapath/loader/overlay.go
+++ b/pkg/datapath/loader/overlay.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 
 	"github.com/cilium/ebpf"
 	"github.com/vishvananda/netlink"
@@ -59,6 +60,7 @@ func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, lnc *datap
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
+		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(link.Attrs().Name), overlayConfig),
 	})
 	if err != nil {
 		return err

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // bpffsDevicesDir returns the path to the 'devices' directory on bpffs, usually
@@ -72,4 +73,14 @@ func bpffsEndpointDir(base string, ep datapath.Endpoint) string {
 // during tests.
 func bpffsEndpointLinksDir(base string, ep datapath.Endpoint) string {
 	return filepath.Join(bpffsEndpointDir(base, ep), "links")
+}
+
+// bpfStateDeviceDir returns the path to the per-device directory in the Cilium
+// state directory, usually /var/run/cilium/bpf/<device>. It does not ensure the
+// directory exists.
+func bpfStateDeviceDir(device string) string {
+	if device == "" {
+		return ""
+	}
+	return filepath.Join(option.Config.StateDir, "bpf", device)
 }

--- a/pkg/datapath/loader/wireguard.go
+++ b/pkg/datapath/loader/wireguard.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 
 	"github.com/cilium/ebpf"
 	"github.com/vishvananda/netlink"
@@ -59,6 +60,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, lnc *dat
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
+		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(device.Attrs().Name), wireguardConfig),
 	})
 	if err != nil {
 		return err

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -182,6 +182,7 @@ func loadAssignAttach(logger *slog.Logger, xdpMode xdp.Mode, iface netlink.Link,
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
+		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(iface.Attrs().Name), xdpConfig),
 	})
 	if err != nil {
 		return err

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1583,7 +1583,7 @@ const (
 
 	RssBytes = "rssBytes"
 
-	BPFSPath = "bpffsPath"
+	BPFFSPath = "bpffsPath"
 
 	ProgName = "progName"
 


### PR DESCRIPTION
For better debugging information, this commit ensures that the configuration objects with load-time config values will be written out to the state directory. With this change, sysdumps should automatically include these configuration objects that define how the datapath was configured.

Fixes: #41746
