### PR TITLE
operator: prometheus support TLS/mTLS using existing secret

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -129,6 +129,41 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.sha.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
+      - name: Generate CA, Server and Client certs for Operator Prometheus
+        id: gen_certs
+        run: |
+          CA_CERT=ca.crt
+          CLIENT_CERT=client.crt
+          CLIENT_KEY=client.key
+          SERVER_NAME=server.operator.prometheus
+
+          openssl genrsa -out ca.key 4096
+          openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 \
+            -subj "/CN=operator.prometheus" -out ${CA_CERT}
+
+          openssl genrsa -out tls.key 2048
+          openssl req -new -key tls.key -subj "/CN=${SERVER_NAME}" -out server.csr
+
+          openssl x509 -req -in server.csr -CA ${CA_CERT} -CAkey ca.key -CAcreateserial \
+            -out tls.crt -days 365 -sha256
+
+          openssl genrsa -out ${CLIENT_KEY} 2048
+          openssl req -new -key ${CLIENT_KEY} -subj "/CN=client.operator.prometheus" -out client.csr
+
+          openssl x509 -req -in client.csr -CA ${CA_CERT} -CAkey ca.key -CAcreateserial \
+            -out ${CLIENT_CERT} -days 365 -sha256
+
+          OPERATOR_PROMETHEUS_TLS_SECRET_NAME=operator-prometheus-tls-secret
+          kubectl -n kube-system create secret generic ${OPERATOR_PROMETHEUS_TLS_SECRET_NAME} \
+            --from-file=ca.crt=${CA_CERT} \
+            --from-file=tls.crt=tls.crt \
+            --from-file=tls.key=tls.key \
+            --from-file=${CLIENT_CERT}=${CLIENT_CERT} \
+            --from-file=${CLIENT_KEY}=${CLIENT_KEY}
+
+          echo operator_prometheus_tls_secret_name=${OPERATOR_PROMETHEUS_TLS_SECRET_NAME} >> $GITHUB_OUTPUT
+          echo server_name=${SERVER_NAME} >> $GITHUB_OUTPUT
+
       - name: Set up install variables
         id: vars
         run: |
@@ -139,6 +174,9 @@ jobs:
              --helm-set hubble.relay.enabled=true \
              --helm-set prometheus.enabled=true \
              --helm-set operator.prometheus.enabled=true \
+             --helm-set operator.prometheus.tls.enabled=true \
+             --helm-set operator.prometheus.tls.server.existingSecret=${{ steps.gen_certs.outputs.operator_prometheus_tls_secret_name }} \
+             --helm-set operator.prometheus.tls.server.mtls.enabled=true \
              --helm-set hubble.enabled=true \
              --helm-set=hubble.metrics.enabled=\"{dns,drop,tcp,flow,port-distribution,icmp,http}\" \
              --helm-set ingressController.enabled=true"
@@ -176,8 +214,28 @@ jobs:
           cilium_pod_ip=$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].status.podIP}' )
           curl http://${cilium_pod_ip}:9962/metrics > metrics-agent.prom
 
+          kubectl get secret ${{ steps.gen_certs.outputs.operator_prometheus_tls_secret_name }} \
+            -n kube-system \
+            -o jsonpath='{.data.client\.crt}' \
+            | base64 -d > client.crt
+
+          kubectl get secret ${{ steps.gen_certs.outputs.operator_prometheus_tls_secret_name }} \
+            -n kube-system \
+            -o jsonpath='{.data.client\.key}' \
+            | base64 -d > client.key
+
+          kubectl get secret ${{ steps.gen_certs.outputs.operator_prometheus_tls_secret_name }} \
+            -n kube-system \
+            -o jsonpath='{.data.ca\.crt}' \
+            | base64 -d > ca.crt
+
           operator_ip=$(kubectl get pods -n kube-system -l io.cilium/app=operator -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}')
-          curl http://${operator_ip}:9963/metrics > metrics-operator.prom
+          curl --retry 5 \
+            --cert client.crt \
+            --key client.key \
+            --cacert ca.crt \
+            --resolve ${{ steps.gen_certs.outputs.server_name }}:9963:${operator_ip} \
+            https://${{ steps.gen_certs.outputs.server_name }}:9963/metrics > metrics-operator.prom
           # Install promtool binary release. `go install` doesn't work due to
           # https://github.com/prometheus/prometheus/issues/8852 and related issues.
           curl -sSL --remote-name-all https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/{prometheus-${PROM_VERSION}.linux-amd64.tar.gz,sha256sums.txt}

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -122,7 +122,11 @@ cilium-operator-alibabacloud [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -91,7 +91,11 @@ cilium-operator-alibabacloud hive [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -96,7 +96,11 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -130,7 +130,11 @@ cilium-operator-aws [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -91,7 +91,11 @@ cilium-operator-aws hive [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -96,7 +96,11 @@ cilium-operator-aws hive dot-graph [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -125,7 +125,11 @@ cilium-operator-azure [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -91,7 +91,11 @@ cilium-operator-azure hive [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -96,7 +96,11 @@ cilium-operator-azure hive dot-graph [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -121,7 +121,11 @@ cilium-operator-generic [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -91,7 +91,11 @@ cilium-operator-generic hive [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -96,7 +96,11 @@ cilium-operator-generic hive dot-graph [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -135,7 +135,11 @@ cilium-operator [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -91,7 +91,11 @@ cilium-operator hive [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -96,7 +96,11 @@ cilium-operator hive dot-graph [flags]
       --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
       --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
       --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3123,7 +3123,7 @@
    * - :spelling:ignore:`operator.prometheus`
      - Enable prometheus metrics for cilium-operator on the configured port at /metrics
      - object
-     - ``{"enabled":true,"metricsService":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":null,"scrapeTimeout":null}}``
+     - ``{"enabled":true,"metricsService":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":null,"scrapeTimeout":null},"tls":{"enabled":false,"server":{"existingSecret":"","mtls":{"enabled":false}}}}``
    * - :spelling:ignore:`operator.prometheus.serviceMonitor.annotations`
      - Annotations to add to ServiceMonitor cilium-operator
      - object
@@ -3156,6 +3156,14 @@
      - Timeout after which scrape is considered to be failed.
      - string
      - ``nil``
+   * - :spelling:ignore:`operator.prometheus.tls`
+     - TLS configuration for Prometheus
+     - object
+     - ``{"enabled":false,"server":{"existingSecret":"","mtls":{"enabled":false}}}``
+   * - :spelling:ignore:`operator.prometheus.tls.server.existingSecret`
+     - Name of the Secret containing the certificate, key and CA files for the Prometheus server.
+     - string
+     - ``""``
    * - :spelling:ignore:`operator.removeNodeTaints`
      - Remove Cilium node taint from Kubernetes nodes that have a healthy Cilium pod running.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -830,7 +830,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.pprof.mutexProfileFraction | int | `0` | Enable mutex contention profiling for cilium-operator and set the fraction of sampled events (set to 1 to sample all events) |
 | operator.pprof.port | int | `6061` | Configure pprof listen port for cilium-operator |
 | operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
-| operator.prometheus | object | `{"enabled":true,"metricsService":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":null,"scrapeTimeout":null}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
+| operator.prometheus | object | `{"enabled":true,"metricsService":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":null,"scrapeTimeout":null},"tls":{"enabled":false,"server":{"existingSecret":"","mtls":{"enabled":false}}}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
 | operator.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-operator |
 | operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | operator.prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
@@ -839,6 +839,8 @@ contributors across the globe, there is almost always someone available to help.
 | operator.prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor cilium-operator |
 | operator.prometheus.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor cilium-operator |
 | operator.prometheus.serviceMonitor.scrapeTimeout | string | `nil` | Timeout after which scrape is considered to be failed. |
+| operator.prometheus.tls | object | `{"enabled":false,"server":{"existingSecret":"","mtls":{"enabled":false}}}` | TLS configuration for Prometheus |
+| operator.prometheus.tls.server.existingSecret | string | `""` | Name of the Secret containing the certificate, key and CA files for the Prometheus server. |
 | operator.removeNodeTaints | bool | `true` | Remove Cilium node taint from Kubernetes nodes that have a healthy Cilium pod running. |
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |
 | operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -255,6 +255,14 @@ data:
   operator-prometheus-serve-addr: ":{{ .Values.operator.prometheus.port }}"
   enable-metrics: "true"
 {{- end }}
+{{- if and .Values.operator.prometheus.enabled .Values.operator.prometheus.tls.enabled }}
+  operator-prometheus-enable-tls: "true"
+  operator-prometheus-tls-cert-file: /var/lib/cilium/tls/prometheus/server.crt
+  operator-prometheus-tls-key-file: /var/lib/cilium/tls/prometheus/server.key
+  {{- if .Values.operator.prometheus.tls.server.mtls.enabled }}
+  operator-prometheus-tls-client-ca-files: /var/lib/cilium/tls/prometheus/client-ca.crt
+  {{- end }}
+{{- end }}
 
 {{- if .Values.operator.skipCRDCreation }}
   skip-crd-creation: "true"

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -247,6 +247,11 @@ spec:
           mountPath: {{ dir .Values.authentication.mutual.spire.agentSocketPath }}
           readOnly: true
         {{- end }}
+        {{- if and .Values.operator.prometheus.enabled .Values.operator.prometheus.tls.enabled }}
+        - name: prometheus-tls
+          mountPath: /var/lib/cilium/tls/prometheus
+          readOnly: true
+        {{- end }}
         {{- range .Values.operator.extraHostPathMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
@@ -422,6 +427,26 @@ spec:
               - key: {{ .Values.tls.caBundle.key }}
                 path: local-etcd-client-ca.crt
           {{- end }}
+      {{- end }}
+      {{- if and .Values.operator.prometheus.enabled .Values.operator.prometheus.tls.enabled }}
+      # To read the prometheus configuration
+      - name: prometheus-tls
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: {{ .Values.operator.prometheus.tls.server.existingSecret }}
+              optional: true
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.key
+                  path: server.key
+                {{- if .Values.operator.prometheus.tls.server.mtls.enabled }}
+                - key: ca.crt
+                  path: client-ca.crt
+                {{- end }}
       {{- end }}
       {{- include "cilium-operator.volumes.extra" . | nindent 6 }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4847,6 +4847,30 @@
                 }
               },
               "type": "object"
+            },
+            "tls": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "server": {
+                  "properties": {
+                    "existingSecret": {
+                      "type": "string"
+                    },
+                    "mtls": {
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3050,6 +3050,17 @@ operator:
       # @schema
       # -- Metrics relabeling configs for the ServiceMonitor cilium-operator
       metricRelabelings: ~
+    # -- TLS configuration for Prometheus
+    tls:
+      enabled: false
+      server:
+        # -- Name of the Secret containing the certificate, key and CA files for the Prometheus server.
+        existingSecret: ""
+        mtls:
+          # When set to true enforces mutual TLS between Operator Prometheus server and its clients.
+          # False allow non-mutual TLS connections.
+          # This option has no effect when TLS is disabled.
+          enabled: false
   # -- Grafana dashboards for cilium-operator
   # grafana can import dashboards based on the label and value
   # ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3074,6 +3074,17 @@ operator:
       # @schema
       # -- Metrics relabeling configs for the ServiceMonitor cilium-operator
       metricRelabelings: ~
+    # -- TLS configuration for Prometheus
+    tls:
+      enabled: false
+      server:
+        # -- Name of the Secret containing the certificate, key and CA files for the Prometheus server.
+        existingSecret: ""
+        mtls:
+          # When set to true enforces mutual TLS between Operator Prometheus server and its clients.
+          # False allow non-mutual TLS connections.
+          # This option has no effect when TLS is disabled.
+          enabled: false
   # -- Grafana dashboards for cilium-operator
   # grafana can import dashboards based on the label and value
   # ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards

--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -4,16 +4,25 @@
 package api
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/go-openapi/runtime"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/operator/models"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/metrics"
@@ -25,6 +34,13 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/safeio"
 	"github.com/cilium/cilium/pkg/testutils"
+)
+
+const (
+	certDir        = "tls/"
+	caCertPath     = certDir + "ca.crt"
+	serverCertPath = certDir + "server.crt"
+	serverKeyPath  = certDir + "server.key"
 )
 
 func TestMetricsHandlerWithoutMetrics(t *testing.T) {
@@ -183,6 +199,108 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 	}
 }
 
+func TestMetricsHandlermTLS(t *testing.T) {
+	defer testutils.GoleakVerifyNone(
+		t,
+		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
+		testutils.GoleakIgnoreTopFunction("time.Sleep"),
+	)
+
+	rr := httptest.NewRecorder()
+
+	err := os.Mkdir(certDir, 0755)
+	require.NoError(t, err)
+	caCert, caKey := newCA(t)
+	writeNewCertAndKey(t, caCert, caKey, serverCertPath, serverKeyPath)
+
+	hive := hive.New(
+		operatorMetrics.Cell,
+		cell.Provide(func() operatorMetrics.SharedConfig {
+			return operatorMetrics.SharedConfig{
+				EnableMetrics: true,
+			}
+		}),
+		cell.Provide(func() *option.DaemonConfig {
+			return option.Config
+		}),
+
+		cellMetric.Metric(newTestMetrics),
+
+		MetricsHandlerCell,
+
+		// transform GetMetricsHandler in a http.HandlerFunc to use
+		// the http package testing facilities
+		cell.Provide(func(h metrics.GetMetricsHandler) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				res := h.Handle(metrics.GetMetricsParams{})
+				res.WriteResponse(w, runtime.TextProducer())
+			}
+		}),
+
+		cell.Invoke(func(lc cell.Lifecycle, metrics *testMetrics, hf http.HandlerFunc) {
+			lc.Append(cell.Hook{
+				OnStart: func(cell.HookContext) error {
+					// set values for some metrics
+					metrics.MetricA.
+						WithLabelValues("success").
+						Inc()
+
+					req := httptest.NewRequest(http.MethodGet, "http://localhost/metrics", nil)
+					hf.ServeHTTP(rr, req)
+
+					return nil
+				},
+			})
+		}),
+	)
+
+	// Enabling the metrics for the operator will also start the prometheus server.
+	// To avoid port clashing while testing, let the kernel pick an available port.
+	hive.Viper().Set(operatorMetrics.OperatorPrometheusServeAddr, "localhost:0")
+	hive.Viper().Set(operatorMetrics.OperatorPrometheusEnableTLS, true)
+	hive.Viper().Set(operatorMetrics.OperatorPrometheusTLSCertFile, serverCertPath)
+	hive.Viper().Set(operatorMetrics.OperatorPrometheusTLSKeyFile, serverKeyPath)
+	hive.Viper().Set(operatorMetrics.OperatorPrometheusTLSClientCAFiles, caCertPath)
+
+	tlog := hivetest.Logger(t)
+	if err := hive.Start(tlog, t.Context()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected http status code %d, got %d", http.StatusOK, rr.Result().StatusCode)
+	}
+
+	body, err := safeio.ReadAllLimit(rr.Result().Body, safeio.MB)
+	if err != nil {
+		t.Fatalf("error while reading response body: %s", err)
+	}
+	rr.Result().Body.Close()
+
+	var metrics []models.Metric
+	if err := json.Unmarshal(body, &metrics); err != nil {
+		t.Fatalf("error while unmarshaling response body: %s", err)
+	}
+
+	if err := testMetric(
+		metrics,
+		"operator_api_metrics_test_metric_a",
+		float64(1),
+		map[string]string{
+			"outcome": "success",
+		},
+	); err != nil {
+		t.Fatalf("error while inspecting metric: %s", err)
+	}
+
+	if err := hive.Stop(tlog, t.Context()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+
+	err = os.RemoveAll(certDir)
+	require.NoError(t, err)
+}
+
 func testMetric(metrics []models.Metric, name string, value float64, labels map[string]string,
 ) error {
 	for _, metric := range metrics {
@@ -210,4 +328,70 @@ func newTestMetrics() *testMetrics {
 			Name:      "metric_a",
 		}, []string{"outcome"}),
 	}
+}
+
+func newCA(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
+	t.Helper()
+
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		IsCA:         true,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+	caKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+
+	certRaw, err := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certFile, err := os.Create(caCertPath)
+	require.NoError(t, err)
+	err = pem.Encode(certFile, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certRaw,
+	})
+	require.NoError(t, err)
+	certFile.Close()
+
+	return ca, caKey
+}
+
+// writeNewCertAndKey create new cert and key file
+func writeNewCertAndKey(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey, certPath, keyPath string) {
+	t.Helper()
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "*.test.cilium.io",
+		},
+		DNSNames:    []string{"*.test.cilium.io"},
+		NotAfter:    time.Now().AddDate(10, 0, 0),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+	certRaw, err := x509.CreateCertificate(rand.Reader, cert, caCert, &key.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certFile, err := os.Create(certPath)
+	require.NoError(t, err)
+	err = pem.Encode(certFile, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certRaw,
+	})
+	require.NoError(t, err)
+	certFile.Close()
+
+	keyFile, err := os.Create(keyPath)
+	require.NoError(t, err)
+	err = pem.Encode(keyFile, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	require.NoError(t, err)
+	keyFile.Close()
 }

--- a/operator/metrics/cell.go
+++ b/operator/metrics/cell.go
@@ -22,6 +22,7 @@ var Cell = cell.Module(
 	"operator-metrics",
 	"Operator Metrics",
 
+	certloaderGroup,
 	cell.Config(defaultConfig),
 	// RegistryConfig implements the config type for the agent Cell,
 	// however the operator has a different flag name for this the

--- a/operator/metrics/certloader.go
+++ b/operator/metrics/certloader.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"crypto/tls"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/crypto/certloader"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+const (
+	// OperatorPrometheusEnableTLS enable TLS for prometheus server
+	OperatorPrometheusEnableTLS = "operator-prometheus-enable-tls"
+
+	// OperatorPrometheusTLSCertFile specifies path to TLS certificate file
+	// for prometheus server. The file must contain PEM encoded data.
+	OperatorPrometheusTLSCertFile = "operator-prometheus-tls-cert-file"
+
+	// OperatorPrometheusTLSKeyFile specifies path to TLS private key file
+	// for prometheus server. The file must contain PEM encoded data.
+	OperatorPrometheusTLSKeyFile = "operator-prometheus-tls-key-file"
+
+	// OperatorPrometheusTLSClientCAFiles specifies path to one or more TLS client CA certificates files
+	// to use for TLS with mutual authentication (mTLS) for prometheus server.
+	// The files must contain PEM encoded data.
+	// When provided, this option effectively enables mTLS.
+	OperatorPrometheusTLSClientCAFiles = "operator-prometheus-tls-client-ca-files"
+)
+
+type prometheusTLSConfigPromise promise.Promise[*certloader.WatchedServerConfig]
+
+// CertloaderGroup provides a promise that can be used to obtain a TLS config
+// capable of automatically sourcing/reloading certificates from disk.
+//
+// We wrap the promise in our own type to avoid conflicts/replacements with other
+// certloader promises. We use a group instead of a module to be able to use
+// cell.ProvidePrivate and avoid providing the promise to the rest of the hive.
+var certloaderGroup = cell.Group(
+	cell.ProvidePrivate(func(lc cell.Lifecycle, jobGroup job.Group, log *slog.Logger, cfg certloaderConfig) (prometheusTLSConfigPromise, error) {
+		return certloader.NewWatchedServerConfigPromise(lc, jobGroup, log, certloader.Config(cfg))
+	}),
+	cell.ProvidePrivate(configTls),
+	cell.Config(defaultCertloaderConfig),
+)
+
+type certloaderConfig struct {
+	TLS              bool     `mapstructure:"operator-prometheus-enable-tls"`
+	TLSCertFile      string   `mapstructure:"operator-prometheus-tls-cert-file"`
+	TLSKeyFile       string   `mapstructure:"operator-prometheus-tls-key-file"`
+	TLSClientCAFiles []string `mapstructure:"operator-prometheus-tls-client-ca-files"`
+}
+
+var defaultCertloaderConfig = certloaderConfig{
+	TLS:              false,
+	TLSCertFile:      "",
+	TLSKeyFile:       "",
+	TLSClientCAFiles: []string{},
+}
+
+func (def certloaderConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool(OperatorPrometheusEnableTLS, def.TLS, "Enable TLS for prometheus server")
+	flags.String(OperatorPrometheusTLSCertFile, def.TLSCertFile, "Path to TLS certificate file for prometheus server. The file must contain PEM encoded data")
+	flags.String(OperatorPrometheusTLSKeyFile, def.TLSKeyFile, "Path to TLS private key file for prometheus server. The file must contain PEM encoded data.")
+	flags.StringSlice(OperatorPrometheusTLSClientCAFiles, def.TLSClientCAFiles, "Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.")
+}
+
+func configTls(logger *slog.Logger, cfg certloaderConfig, prometheusTlsConfigPromise prometheusTLSConfigPromise) metrics.TLSConfigPromise {
+	if !cfg.TLS {
+		logger.Debug("Operator prometheus TLS disabled")
+		return nil
+	}
+
+	return promise.Map(prometheusTlsConfigPromise, func(certLoaderWatchedServerConfig *certloader.WatchedServerConfig) *tls.Config {
+		return certLoaderWatchedServerConfig.ServerConfig(&tls.Config{
+			MinVersion: tls.VersionTLS13,
+		})
+	})
+}

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -32,7 +32,8 @@ type params struct {
 
 	Metrics []metric.WithMetadata `group:"hive-metrics"`
 
-	Registry *metrics.Registry
+	Registry         *metrics.Registry
+	TLSConfigPromise metrics.TLSConfigPromise
 }
 
 // Note: metrics are always initialized so we have access to sampler ring buffer data
@@ -79,5 +80,5 @@ func initializeMetrics(p params) {
 	p.Registry.MustRegister(metrics.ErrorsWarnings)
 	metrics.FlushLoggingMetrics()
 
-	p.Registry.AddServerRuntimeHooks()
+	p.Registry.AddServerRuntimeHooks("operator-prometheus-server", p.TLSConfigPromise)
 }


### PR DESCRIPTION
Operator prometheus support TLS/mTLS using existing secret

Other changes:
- Update smoke test Operator Prometheus to use mTLS

Relates #32266, #38990

```release-note
Add TLS/mTLS support for Prometheus metrics exposed by the Cilium Operator
```
