### PR TITLE
maps/multicast: set GroupV4OuterMap.logger in OpenGroupV4OuterMap

### DIFF
--- a/pkg/maps/multicast/subscribermap.go
+++ b/pkg/maps/multicast/subscribermap.go
@@ -280,6 +280,7 @@ func OpenGroupV4OuterMap(logger *slog.Logger, name string) (*GroupV4OuterMap, er
 	return &GroupV4OuterMap{
 		Map:                  m,
 		batchLookupSupported: haveBatchLookupSupport[GroupV4Key, GroupV4Val](m),
+		logger:               logger,
 	}, nil
 }
 


### PR DESCRIPTION
Otherwise multicast map access from cilium-dbg will cause a panic due to nil-pointer dereference:

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8a8018]

goroutine 1 [running]:
log/slog.(*Logger).Handler(...)
	/usr/local/go/src/log/slog/logger.go:121
log/slog.(*Logger).Enabled(0x49fce0?, {0x3cb4410?, 0x6454960?}, 0x735f747361636d5f?)
	/usr/local/go/src/log/slog/logger.go:168 +0x18
log/slog.(*Logger).log(0x0, {0x3cb4410?, 0x6454960?}, 0xfffffffffffffffc, {0x3792070, 0x12}, {0xc0008eb918, 0x2, 0x2})
	/usr/local/go/src/log/slog/logger.go:244 +0x99
log/slog.(*Logger).Debug(...)
	/usr/local/go/src/log/slog/logger.go:199
github.com/cilium/cilium/pkg/ebpf.registerMap(0xc000823700)
	/go/src/github.com/cilium/cilium/pkg/ebpf/map_register.go:22 +0x114
github.com/cilium/cilium/pkg/ebpf.(*Map).OpenOrCreate(0xc000823700)
	/go/src/github.com/cilium/cilium/pkg/ebpf/map.go:187 +0x68a
github.com/cilium/cilium/pkg/maps/multicast.newSubscriberV4InnerMap(0x0)
	/go/src/github.com/cilium/cilium/pkg/maps/multicast/subscribermap.go:320 +0xb2
github.com/cilium/cilium/pkg/maps/multicast.GroupV4OuterMap.Insert({0xc0008236c0?, 0x22?, 0x0?}, {{0x0?, 0x0?}, {0xc00000f680?}})
	/go/src/github.com/cilium/cilium/pkg/maps/multicast/subscribermap.go:138 +0x65
github.com/cilium/cilium/cilium-dbg/cmd.init.func74(0xc000cded00?, {0xc000d95ca0, 0x1, 0x1})
	/go/src/github.com/cilium/cilium/cilium-dbg/cmd/bpf_multicast_groups.go:97 +0x10c
github.com/spf13/cobra.(*Command).execute(0x5ed4120, {0xc000d95c60, 0x1, 0x1})
	/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:1019 +0xae7
github.com/spf13/cobra.(*Command).ExecuteC(0x5ed91a0)
	/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:1071
github.com/cilium/cilium/cilium-dbg/cmd.Execute()
	/go/src/github.com/cilium/cilium/cilium-dbg/cmd/root.go:45 +0x1a
main.main()
	/go/src/github.com/cilium/cilium/cilium-dbg/main.go:9 +0xf
```

Fixes: 4ce357a9573d ("pkg/maps: migrate to slog")
Fixes #42079

```release-note
Fix a fatal error when accessing multicast map using cilium-dbg bpf multicast
```