### PR TITLE
docs: remove stale kernel requirements

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -307,12 +307,6 @@ enabled by upgrading to more recent kernel versions as detailed below.
 ====================================================== ===============================
 Cilium Feature                                         Minimum Kernel Version
 ====================================================== ===============================
-:ref:`encryption_wg`                                   >= 5.6
-Full support for :ref:`session-affinity`               >= 5.7
-BPF-based proxy redirection                            >= 5.7
-Socket-level LB bypass in pod netns                    >= 5.7
-L3 devices                                             >= 5.8
-BPF-based host routing                                 >= 5.10
 :ref:`enable_multicast` (AMD64)                        >= 5.10
 IPv6 BIG TCP support                                   >= 5.19
 :ref:`enable_multicast` (AArch64)                      >= 6.0


### PR DESCRIPTION
With v1.18 we bumped the minimum kernel version to 5.10, but the docs still contain references to some older versions. Clean it up.