### PR TITLE
metrics: remove endpoint_max_ifindex

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -467,19 +467,10 @@ Endpoint
 Name                                         Labels                                             Default    Description
 ============================================ ================================================== ========== ========================================================
 ``endpoint``                                                                                    Enabled    Number of endpoints managed by this agent
-``endpoint_max_ifindex``                                                                        Disabled   Maximum interface index observed for existing endpoints
 ``endpoint_regenerations_total``             ``outcome``                                        Enabled    Count of all endpoint regenerations that have completed
 ``endpoint_regeneration_time_stats_seconds`` ``scope``                                          Enabled    Endpoint regeneration time stats
 ``endpoint_state``                           ``state``                                          Enabled    Count of all endpoints
 ============================================ ================================================== ========== ========================================================
-
-The default enabled status of ``endpoint_max_ifindex`` is dynamic. On earlier
-kernels (typically with version lower than 5.10), Cilium must store the
-interface index for each endpoint in the conntrack map, which reserves 16 bits
-for this field. If Cilium is running on such a kernel, this metric will be
-enabled by default. It can be used to implement an alert if the ifindex is
-approaching the limit of 65535. This may be the case in instances of
-significant Endpoint churn.
 
 Services
 ~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -368,6 +368,7 @@ Removed Metrics
 ~~~~~~~~~~~~~~~
 
 * ``k8s_internal_traffic_policy_enabled`` has been removed, because the corresponding feature is enabled by default.
+* ``endpoint_max_ifindex`` has been removed, because the corresponding datapath limitation no longer applies.
 
 Changed Metrics
 ~~~~~~~~~~~~~~~

--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
@@ -222,15 +221,6 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 			s.params.IPCache.RemoveMetadata(p, daemonResourceID, labels.LabelHost)
 		}
 	}
-
-	// we have a reference to all ifindex values, so we update the related metric
-	maxIfindex := uint32(0)
-	for _, endpoint := range existingEndpoints {
-		if endpoint.IfIndex > maxIfindex {
-			maxIfindex = endpoint.IfIndex
-		}
-	}
-	metrics.EndpointMaxIfindex.Set(float64(maxIfindex))
 
 	return nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -285,9 +285,6 @@ var (
 	// It must be thread-safe.
 	Endpoint metric.GaugeFunc
 
-	// EndpointMaxIfindex is the maximum observed interface index for existing endpoints
-	EndpointMaxIfindex = NoOpGauge
-
 	// EndpointRegenerationTotal is a count of the number of times any endpoint
 	// has been regenerated and success/fail outcome
 	EndpointRegenerationTotal = NoOpCounterVec
@@ -625,7 +622,6 @@ type LegacyMetrics struct {
 	NodeHealthConnectivityStatus     metric.Vec[metric.Gauge]
 	NodeHealthConnectivityLatency    metric.Vec[metric.Observer]
 	Endpoint                         metric.GaugeFunc
-	EndpointMaxIfindex               metric.Gauge
 	EndpointRegenerationTotal        metric.Vec[metric.Counter]
 	EndpointStateCount               metric.Vec[metric.Gauge]
 	EndpointRegenerationTimeStats    metric.Vec[metric.Observer]
@@ -1267,15 +1263,6 @@ func NewLegacyMetrics() *LegacyMetrics {
 		WorkQueueRetries:                 WorkQueueRetries,
 	}
 
-	ifindexOpts := metric.GaugeOpts{
-		ConfigName: Namespace + "_endpoint_max_ifindex",
-		Disabled:   true,
-		Namespace:  Namespace,
-		Name:       "endpoint_max_ifindex",
-		Help:       "Maximum interface index observed for existing endpoints",
-	}
-	lm.EndpointMaxIfindex = metric.NewGauge(ifindexOpts)
-
 	v := version.GetCiliumVersion()
 	lm.VersionMetric.WithLabelValues(v.Version, v.Revision, v.Arch)
 	lm.BPFMapCapacity.WithLabelValues("default").Set(DefaultMapCapacity)
@@ -1285,7 +1272,6 @@ func NewLegacyMetrics() *LegacyMetrics {
 	NodeHealthConnectivityStatus = lm.NodeHealthConnectivityStatus
 	NodeHealthConnectivityLatency = lm.NodeHealthConnectivityLatency
 	Endpoint = lm.Endpoint
-	EndpointMaxIfindex = lm.EndpointMaxIfindex
 	EndpointRegenerationTotal = lm.EndpointRegenerationTotal
 	EndpointStateCount = lm.EndpointStateCount
 	EndpointRegenerationTimeStats = lm.EndpointRegenerationTimeStats


### PR DESCRIPTION
The u16 ifindex limitation in the datapath was lifted in v1.18 with 105cd80bf473 ("datapath: require HAVE_FIB_IFINDEX").

Therefore this metric is no longer needed, remove it.

```release-note
The `endpoint_max_ifindex` metric is no longer useful and has been removed.
```
