### PR TITLE
gh: ginkgo: replace rhel8 with 5.10 kernel

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -14,7 +14,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.33.0@sha256:03032c2e474eef9d706416a077f2eeb14600653eecbdfada9fc2d81a4e0461f9"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20250812.093650"
+    kernel: "5.10-20250929.013214"
     kernel-type: "oldstable"
 
   - k8s-version: "1.32"
@@ -22,7 +22,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.32.0@sha256:22cf2864f90cfab0d442fda2decf2eae107edd03483053a902614dec637eff76"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20250812.093650"
+    kernel: "5.10-20250929.013214"
     kernel-type: "oldstable"
 
   - k8s-version: "1.31"


### PR DESCRIPTION
At a distant point in the past we replaced the "oldstable" 4.19 kernel with rhel8, this being the oldest tested kernel at the time.

But now that the minimum kernel requirement is 5.10 and we stipulate that rhel8 is feature-equivalent, let's test with a kernel that is actually still maintained.