### PR TITLE
renovate: Allow cilium-proxy 1.34.x for all stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -690,21 +690,11 @@
         "quay.io/cilium/cilium-envoy"
       ],
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
-      "allowedVersions": "/^v1\\.33\\.([0-9]+)-([0-9]+)-.*$/",
+      "allowedVersions": "/^v1\\.34\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "v1.18",
         "v1.17",
         "v1.16"
-      ]
-    },
-    {
-      "matchDepNames": [
-        "quay.io/cilium/cilium-envoy"
-      ],
-      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
-      "allowedVersions": "/^v1\\.34\\.([0-9]+)-([0-9]+)-.*$/",
-      "matchBaseBranches": [
-        "v1.18",
       ]
     },
     {


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/42096
Relates: https://github.com/cilium/cilium/pull/42095