### PR TITLE
bpf: Clear `tc_classid` on all ingress code paths

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1076,8 +1076,6 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 	__s8 __maybe_unused ext_err = 0;
 	int ret;
 
-	bpf_clear_meta(ctx);
-
 	switch (proto) {
 # if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER || \
      defined ENABLE_L2_ANNOUNCEMENTS
@@ -1219,6 +1217,8 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 	__u32 src_id = UNKNOWN_ID;
 	__be16 proto = 0;
 
+	bpf_clear_meta(ctx);
+
 	check_and_store_ip_trace_id(ctx);
 
 #ifdef ENABLE_NODEPORT_ACCELERATION
@@ -1299,6 +1299,8 @@ int cil_from_host(struct __ctx_buff *ctx)
 	int ret __maybe_unused;
 	__be16 proto = 0;
 	__u32 magic;
+
+	bpf_clear_meta(ctx);
 
 	check_and_store_ip_trace_id(ctx);
 


### PR DESCRIPTION
This pull request fixes a bug that causes replies to skip the L7 proxy, possibly causing packet drops as follows. The bug happens when IPsec, native routing, BPF Host Routing, and TCX are enabled.

     1: client-64d966fcbd-kpxsr:49465 (ID:5164) <> coredns-66bc5c9577-c7frg:53 (ID:32763) from-endpoint FORWARDED (UDP)
     2: client-64d966fcbd-kpxsr:49465 (ID:5164) -> coredns-66bc5c9577-c7frg:53 (ID:32763) to-proxy FORWARDED (UDP)
     3: client-64d966fcbd-kpxsr:49465 (ID:5164) -> coredns-66bc5c9577-c7frg:53 (ID:32763) dns-request proxy FORWARDED (DNS Query x.service.cilium. A)
     4: client-64d966fcbd-kpxsr:49465 (ID:5164) <> coredns-66bc5c9577-c7frg:53 (ID:32763) from-proxy FORWARDED (UDP)
     5: client-64d966fcbd-kpxsr:49465 (ID:5164) <> coredns-66bc5c9577-c7frg:53 (ID:32763) to-stack FORWARDED (UDP)
     6: client-64d966fcbd-kpxsr:49465 (ID:5164) <> coredns-66bc5c9577-c7frg:53 (ID:32763) to-network FORWARDED (UDP)
     7: 10.244.3.30 (host) -> 10.244.1.181 (remote-node) from-stack FORWARDED (IPv4)
     8: 10.244.3.30 (host) <> 10.244.1.181 (remote-node) to-network FORWARDED (IPv4)
     9: coredns-66bc5c9577-c7frg:53 (ID:32763) <> client-64d966fcbd-kpxsr:49465 (ID:5164) from-network FORWARDED (UDP)
    10: client-64d966fcbd-kpxsr:49465 (ID:5164) <- coredns-66bc5c9577-c7frg:53 (ID:32763) to-endpoint FORWARDED (UDP)
    11: client-64d966fcbd-kpxsr:32914 (ID:5164) <> 172.20.1.100:443 (world-ipv4) from-endpoint FORWARDED (TCP Flags: SYN)
    12: client-64d966fcbd-kpxsr:32914 (ID:5164) <> 172.20.1.100:443 (world-ipv4) policy-verdict:none EGRESS DENIED (TCP Flags: SYN)
    13: client-64d966fcbd-kpxsr:32914 (ID:5164) <> 172.20.1.100:443 (world-ipv4) Policy denied DROPPED (TCP Flags: SYN)

In the above Hubble trace, a L7 policy is enforced on the `x.service.cilium` domain. We can see the DNS request from the pod intercepted by the proxy on lines 1–3. The DNS answer arrives encrypted from the network (lines 7–8) and is sent to the pod (lines 9–10) without going through the proxy. The pod then connects over TCP to the service, but, without the proper rules installed by the proxy, the request is dropped as a policy denied (lines 11–13).

The logic to decide if we should redirect a reply packet to the proxy is the following:

    /* Check it this is return traffic to an egress proxy.
     * Do not redirect again if the packet is coming from the egress proxy.
     * Always redirect connections that originated from L7 LB. */ if (ct_state_is_from_l7lb(ct_state) || (ct_state->proxy_redirect && !tc_index_from_egress_proxy(ctx))) { /* This is a reply, the proxy port does not need to be embedded
         * into ctx->mark and *proxy_port can be left unset. */ *proxy_port = 0; goto redirect_to_proxy; }

In our conntrack table, the DNS communication is correctly marked as requiring proxy redirection:

    UDP OUT 10.244.3.202:49465 -> 10.244.1.253:53 expires=316 (remaining: -27 sec(s)) Packets=0 Bytes=0 RxFlagsSeen=0x00 LastRxReport=256 TxFlagsSeen=0x00 LastTxReport=256 Flags=0x0040 [ ProxyRedirect ] RevNAT=0 SourceSecurityID=5164 BackendID=0

Thus, `ct_state->proxy_redirect` should be true and
`tc_index_from_egress_proxy()` has to be true as well if we skipped the proxy.

`tc_index_from_egress_proxy()` checks the `TC_INDEX_F_FROM_EGRESS_PROXY` bit on the `ctx->tc_index` field. On ingress from the network, we'd expect that field to be zero.

With a pwru trace capturing the skb contents, we can see the `tc_index` value is actually set to 0xffff (65535) right after the tc-bpf program exits. In the trace below, `tc_index` is displayed at each function only if non-zero. `run_filter` shows the start of the tc-bpf execution and `skb_ensure_writable` is typical of BPF packet accesses via helper calls.

    NETNS       MARK/x    IFACE   TUPLE                            FUNC
    4026532350  0         eth0:3  10.244.0.105:0->10.244.3.93:0()  run_filter
    4026532350  0         eth0:3  10.244.0.105:0->10.244.3.93:0()  tpacket_get_timestamp
    4026532350  0         eth0:3  10.244.0.105:0->10.244.3.93:0()  sk_skb_reason_drop(SKB_CONSUMED)
    4026532350  0         eth0:3  10.244.0.105:0->10.244.3.93:0()  skb_ensure_writable
    4026532350  e6e20d00  eth0:3  10.244.0.105:0->10.244.3.93:0()  ip_rcv
       .tc_index = (__u16)65535,
       .tc_index = (__u16)65535,

This is where TCX comes into play. When TCX is enabled, the `tc_classid` field [is written](https://elixir.bootlin.com/linux/v6.12.4/source/include/net/tcx.h#L151) to `tc_index` on TCX_PASS (CTX_ACT_OK). Thus, when we first reach `bpf_host@eth0` with the encrypted packet, we return CTX_ACT_OK and `tc_classid` (0xffff in our case) is written to `ctx->tc_index`. When the decrypted packet recirculates to `bpf_host@eth0`, `tc_index` is set and `tc_index_from_egress_proxy()` thus returns true.

The need to clear `tc_classid` is already known and was handled in commit 77769eae1df7 ("bpf, tcx: Clear tc_classid field"), in function `bpf_clear_meta()`. On ingress from eth0, that function is called in `do_netdev()`. When IPsec is enabled however, we never reach `do_netdev()` on the first packet traversal: we pass the packet to the stack with CTX_ACT_OK before we've had a chance to clear `tc_classid`.

This pull request fixes it by moving the call to `bpf_clear_meta()` from `do_netdev()` to the very beginning of the BPF programs (`from-netdev` and `from-host`).

Note this fix isn't a `release-note/bug` as IPsec + BPF Host Routing isn't supported yet today.