### PR TITLE
Policy: Only compare exported fields in unit tests

### DIFF
--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -448,7 +448,7 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 
 	var realizedL4Policy *policy.L4Policy
 	if e.realizedPolicy != nil {
-		realizedL4Policy = &e.realizedPolicy.L4Policy
+		realizedL4Policy = &e.realizedPolicy.SelectorPolicy.L4Policy
 	}
 
 	mdl := &models.EndpointPolicy{
@@ -466,7 +466,7 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 
 	var desiredL4Policy *policy.L4Policy
 	if e.desiredPolicy != nil {
-		desiredL4Policy = &e.desiredPolicy.L4Policy
+		desiredL4Policy = &e.desiredPolicy.SelectorPolicy.L4Policy
 	}
 
 	desiredMdl := &models.EndpointPolicy{
@@ -497,11 +497,11 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 func (e *Endpoint) policyStatus() models.EndpointPolicyEnabled {
 	policyEnabled := models.EndpointPolicyEnabledNone
 	switch {
-	case e.realizedPolicy.IngressPolicyEnabled && e.realizedPolicy.EgressPolicyEnabled:
+	case e.realizedPolicy.SelectorPolicy.IngressPolicyEnabled && e.realizedPolicy.SelectorPolicy.EgressPolicyEnabled:
 		policyEnabled = models.EndpointPolicyEnabledBoth
-	case e.realizedPolicy.IngressPolicyEnabled:
+	case e.realizedPolicy.SelectorPolicy.IngressPolicyEnabled:
 		policyEnabled = models.EndpointPolicyEnabledIngress
-	case e.realizedPolicy.EgressPolicyEnabled:
+	case e.realizedPolicy.SelectorPolicy.EgressPolicyEnabled:
 		policyEnabled = models.EndpointPolicyEnabledEgress
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1150,7 +1150,7 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 		return ErrComingOutOfLockdown
 	}
 
-	hasEnvoyRedirect := e.desiredPolicy.L4Policy.HasEnvoyRedirect()
+	hasEnvoyRedirect := e.desiredPolicy.SelectorPolicy.L4Policy.HasEnvoyRedirect()
 	if !changes.Empty() {
 		// updateEnvoy if there were any mapChanges, but only if the endpoint has Envoy
 		// redirects, or is an Ingress endpoint, which needs to enforce also the full L3/4
@@ -1199,7 +1199,7 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 			)
 			stats.proxyPolicyCalculation.Start()
 			var rf revert.RevertFunc
-			err, rf = e.proxy.UpdateNetworkPolicy(e, &e.desiredPolicy.L4Policy, e.desiredPolicy.IngressPolicyEnabled, e.desiredPolicy.EgressPolicyEnabled, proxyWaitGroup)
+			err, rf = e.proxy.UpdateNetworkPolicy(e, &e.desiredPolicy.SelectorPolicy.L4Policy, e.desiredPolicy.SelectorPolicy.IngressPolicyEnabled, e.desiredPolicy.SelectorPolicy.EgressPolicyEnabled, proxyWaitGroup)
 			stats.proxyPolicyCalculation.End(err == nil)
 			if err == nil {
 				datapathRegenCtxt.revertStack.Push(rf)
@@ -1210,7 +1210,7 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 				"applyPolicyMapChanges: Using current Networkpolicy",
 				logfields.SelectorCacheVersion, e.desiredPolicy.VersionHandle,
 			)
-			e.proxy.UseCurrentNetworkPolicy(e, &e.desiredPolicy.L4Policy, proxyWaitGroup)
+			e.proxy.UseCurrentNetworkPolicy(e, &e.desiredPolicy.SelectorPolicy.L4Policy, proxyWaitGroup)
 		}
 	}
 
@@ -1624,10 +1624,10 @@ func (e *Endpoint) RequireEndpointRoute() bool {
 // consistent with how it is used in policy_verdict_filter_allow() in bpf/lib/policy_log.h
 func (e *Endpoint) GetPolicyVerdictLogFilter() uint32 {
 	var filter uint32 = 0
-	if e.desiredPolicy.IngressPolicyEnabled {
+	if e.desiredPolicy.SelectorPolicy.IngressPolicyEnabled {
 		filter = (filter | 0x1)
 	}
-	if e.desiredPolicy.EgressPolicyEnabled {
+	if e.desiredPolicy.SelectorPolicy.EgressPolicyEnabled {
 		filter = (filter | 0x2)
 	}
 	return filter

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2673,8 +2673,8 @@ func (e *Endpoint) SetDefaultConfiguration() {
 func (e *Endpoint) setDefaultPolicyConfig() {
 	e.SetDefaultOpts(option.Config.Opts)
 	alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
-	e.desiredPolicy.IngressPolicyEnabled = alwaysEnforce
-	e.desiredPolicy.EgressPolicyEnabled = alwaysEnforce
+	e.desiredPolicy.SelectorPolicy.IngressPolicyEnabled = alwaysEnforce
+	e.desiredPolicy.SelectorPolicy.EgressPolicyEnabled = alwaysEnforce
 }
 
 // GetCreatedAt returns the endpoint creation time.

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -918,7 +918,7 @@ func (e *Endpoint) ComputeInitialPolicy(regenContext *regenerationContext) (erro
 
 		stats.proxyPolicyCalculation.Start()
 		// Initial NetworkPolicy is not reverted
-		err, _ = e.proxy.UpdateNetworkPolicy(e, &e.desiredPolicy.L4Policy, e.desiredPolicy.IngressPolicyEnabled, e.desiredPolicy.EgressPolicyEnabled, nil)
+		err, _ = e.proxy.UpdateNetworkPolicy(e, &e.desiredPolicy.SelectorPolicy.L4Policy, e.desiredPolicy.SelectorPolicy.IngressPolicyEnabled, e.desiredPolicy.SelectorPolicy.EgressPolicyEnabled, nil)
 		stats.proxyPolicyCalculation.End(err == nil)
 		if err != nil {
 			e.getLogger().Warn(

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1367,9 +1367,9 @@ func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, versio
 		if len(l7Rules.HTTP) > 0 {
 			// Use L7 rules computed earlier?
 			var httpRules *cilium.HttpNetworkPolicyRules
-			if l7Rules.EnvoyHTTPRules != nil {
-				httpRules = l7Rules.EnvoyHTTPRules
-				canShortCircuit = l7Rules.CanShortCircuit
+			if l7Rules.EnvoyHTTPRules() != nil {
+				httpRules = l7Rules.EnvoyHTTPRules()
+				canShortCircuit = l7Rules.CanShortCircuit()
 			} else {
 				httpRules, canShortCircuit = s.l7RulesTranslator.GetEnvoyHTTPRules(&l7Rules.L7Rules, "")
 			}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -235,6 +235,9 @@ const (
 	// Port is a L4 port
 	Port = "port"
 
+	// EndPort is the last L4 port in a range of ports
+	EndPort = "endPort"
+
 	// Ports is a list of L4 ports
 	Ports = "ports"
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -660,8 +660,6 @@ func (l4 *L4Filter) makeMapStateEntry(logger *slog.Logger, p *EndpointPolicy, po
 // 'p.PolicyMapState' using insertWithChanges().
 // Keys and old values of any added or deleted entries are added to 'changes'.
 // 'redirects' is the map of currently realized redirects, it is used to find the proxy port for any redirects.
-// p.SelectorCache is used as Identities interface during this call, which only has GetPrefix() that
-// needs no lock.
 func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features policyFeatures, changes ChangeState) {
 	port := l4.Port
 	proto := l4.U8Proto
@@ -675,6 +673,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 	if option.Config.Debug {
 		scopedLog = logger.With(
 			logfields.Port, port,
+			logfields.EndPort, l4.EndPort,
 			logfields.PortName, l4.PortName,
 			logfields.Protocol, proto,
 			logfields.TrafficDirection, direction,

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -527,7 +527,7 @@ func BenchmarkEvaluateL4PolicyMapState(b *testing.B) {
 
 	newEmptyEndpointPolicy := func() *EndpointPolicy {
 		return &EndpointPolicy{
-			selectorPolicy:   &selectorPolicy{},
+			SelectorPolicy:   &selectorPolicy{},
 			PolicyOwner:      owner,
 			policyMapState:   emptyMapState(logger),
 			policyMapChanges: MapChanges{logger: logger},

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1168,7 +1168,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 	}
 
 	epPolicy := &EndpointPolicy{
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			SelectorCache: selectorCache,
 		},
 		PolicyOwner: DummyOwner{logger: hivetest.Logger(t)},
@@ -1655,7 +1655,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 	}
 
 	epPolicy := &EndpointPolicy{
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			SelectorCache: selectorCache,
 		},
 		PolicyOwner: DummyOwner{logger: hivetest.Logger(t)},

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -195,7 +195,7 @@ func (p *selectorPolicy) Attach(ctx PolicyContext) {
 type EndpointPolicy struct {
 	// Note that all Endpoints sharing the same identity will be
 	// referring to a shared selectorPolicy!
-	*selectorPolicy
+	SelectorPolicy *selectorPolicy
 
 	// VersionHandle represents the version of the SelectorCache 'policyMapState' was generated
 	// from.
@@ -321,7 +321,7 @@ func (p *selectorPolicy) DistillPolicy(logger *slog.Logger, policyOwner PolicyOw
 	//   ConsumeMapChanges().
 	p.SelectorCache.GetVersionHandleFunc(func(version *versioned.VersionHandle) {
 		calculatedPolicy = &EndpointPolicy{
-			selectorPolicy: p,
+			SelectorPolicy: p,
 			VersionHandle:  version,
 			policyMapState: newMapState(logger, policyOwner.MapStateSize()),
 			policyMapChanges: MapChanges{
@@ -365,7 +365,7 @@ func (p *EndpointPolicy) Ready() (err error) {
 // to allow the EndpointPolicy to be GC'd.
 // PolicyOwner (aka Endpoint) is also locked during this call.
 func (p *EndpointPolicy) Detach(logger *slog.Logger) {
-	p.selectorPolicy.removeUser(p)
+	p.SelectorPolicy.removeUser(p)
 	// in case the call was missed previouly
 	if p.Ready() == nil {
 		// succeeded, so it was missed previously
@@ -500,8 +500,8 @@ func (p *EndpointPolicy) RevertChanges(changes ChangeState) {
 // PolicyOwner (aka Endpoint) is also unlocked during this call,
 // but the Endpoint's build mutex is held.
 func (p *EndpointPolicy) toMapState(logger *slog.Logger) {
-	p.L4Policy.Ingress.toMapState(logger, p)
-	p.L4Policy.Egress.toMapState(logger, p)
+	p.SelectorPolicy.L4Policy.Ingress.toMapState(logger, p)
+	p.SelectorPolicy.L4Policy.Egress.toMapState(logger, p)
 }
 
 // toMapState transforms the L4DirectionPolicy into
@@ -548,7 +548,7 @@ func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, Pe
 // Caller is responsible for calling the returned 'closer' to release resources held for the new version!
 // 'closer' may not be called while selector cache is locked!
 func (p *EndpointPolicy) ConsumeMapChanges() (closer func(), changes ChangeState) {
-	features := p.selectorPolicy.L4Policy.Ingress.features | p.selectorPolicy.L4Policy.Egress.features
+	features := p.SelectorPolicy.L4Policy.Ingress.features | p.SelectorPolicy.L4Policy.Egress.features
 	version, changes := p.policyMapChanges.consumeMapChanges(p, features)
 
 	closer = func() {}
@@ -580,7 +580,7 @@ func (p *EndpointPolicy) ConsumeMapChanges() (closer func(), changes ChangeState
 // NewEndpointPolicy returns an empty EndpointPolicy stub.
 func NewEndpointPolicy(logger *slog.Logger, repo PolicyRepository) *EndpointPolicy {
 	return &EndpointPolicy{
-		selectorPolicy: newSelectorPolicy(repo.GetSelectorCache()),
+		SelectorPolicy: newSelectorPolicy(repo.GetSelectorCache()),
 		policyMapState: emptyMapState(logger),
 	}
 }

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -250,7 +250,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	policy.Ready()
 
 	expectedEndpointPolicy := EndpointPolicy{
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
@@ -267,9 +267,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 						},
 						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 					},
-				}),
-					features: denyRules,
-				},
+				})},
 				Egress: newL4DirectionPolicy(),
 			},
 			IngressPolicyEnabled: true,
@@ -282,18 +280,12 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach(true, 0)
+	policy.SelectorPolicy.detach(true, 0)
 
-	// Assign an empty mutex so that checker.Equal does not complain about the
-	// difference of the internal time.Time from the lock_debug.go.
-	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	policy.policyMapChanges.mutex = lock.Mutex{}
-	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
-	policy.policyMapState = mapState{}
-	expectedEndpointPolicy.policyMapState = mapState{}
-	require.Equal(t, &expectedEndpointPolicy, policy)
+
+	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
 }
 
 func TestL3WithLocalHostWildcardd(t *testing.T) {
@@ -347,7 +339,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	require.NotNil(t, cachedSelectorHost)
 
 	expectedEndpointPolicy := EndpointPolicy{
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
@@ -379,18 +371,18 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach(true, 0)
+	policy.SelectorPolicy.detach(true, 0)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
-	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
+	policy.SelectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = mapState{}
 	expectedEndpointPolicy.policyMapState = mapState{}
-	require.Equal(t, &expectedEndpointPolicy, policy)
+	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
 }
 
 func TestMapStateWithIngressDenyWildcard(t *testing.T) {
@@ -443,7 +435,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	allowEgressMapStateEntry := newAllowEntryWithLabels(ruleLabelAllowAnyEgress)
 
 	expectedEndpointPolicy := EndpointPolicy{
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
@@ -489,11 +481,11 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	require.Empty(t, policy.policyMapChanges.synced)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach(true, 0)
+	policy.SelectorPolicy.detach(true, 0)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
-	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
+	policy.SelectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
@@ -601,7 +593,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	allowEgressMapStateEntry := newAllowEntryWithLabels(ruleLabelAllowAnyEgress)
 
 	expectedEndpointPolicy := EndpointPolicy{
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
@@ -657,7 +649,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	require.Equal(t, Keys{}, changes.Deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
-	policy.selectorPolicy.detach(true, 0)
+	policy.SelectorPolicy.detach(true, 0)
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
@@ -665,7 +657,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
-	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
+	policy.SelectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
@@ -284,7 +283,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 
 	expectedEndpointPolicy := EndpointPolicy{
 		Redirects: testRedirects,
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
@@ -294,7 +293,6 @@ func TestL7WithIngressWildcard(t *testing.T) {
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
-						wildcard: td.wildcardCachedSelector,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{
@@ -303,42 +301,20 @@ func TestL7WithIngressWildcard(t *testing.T) {
 								L7Rules: api.L7Rules{
 									HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/good"}},
 								},
-								CanShortCircuit: true,
 							},
 						},
 						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 					},
-				}),
-					features: redirectRules,
-				},
-				Egress:        newL4DirectionPolicy(),
-				redirectTypes: redirectTypeEnvoy,
+				})},
+				Egress: newL4DirectionPolicy(),
 			},
 			IngressPolicyEnabled: true,
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{logger: logger},
-		// inherit this from the result as it is outside of the scope
-		// of this test
-		policyMapState:   policy.policyMapState,
-		policyMapChanges: MapChanges{logger: logger},
 	}
 
-	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach(true, 0)
-
-	// Assign an empty mutex so that checker.Equal does not complain about the
-	// difference of the internal time.Time from the lock_debug.go.
-	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	policy.policyMapChanges.mutex = lock.Mutex{}
-	policy.policyMapChanges.firstVersion = 0
-	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
-	policy.policyMapState = mapState{}
-	expectedEndpointPolicy.policyMapState = mapState{}
-	// reset cached envoy http rules to avoid unnecessary diff
-	resetCachedEnvoyHTTPRules(policy)
-	require.Equal(t, &expectedEndpointPolicy, policy)
+	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
 }
 
 func TestL7WithLocalHostWildcard(t *testing.T) {
@@ -400,7 +376,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 
 	expectedEndpointPolicy := EndpointPolicy{
 		Redirects: testRedirects,
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
@@ -410,66 +386,29 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
-						wildcard: td.wildcardCachedSelector,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
+							cachedSelectorHost: nil,
 							td.wildcardCachedSelector: &PerSelectorPolicy{
 								L7Parser: ParserTypeHTTP,
 								Priority: ListenerPriorityHTTP,
 								L7Rules: api.L7Rules{
 									HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/good"}},
 								},
-								CanShortCircuit: true,
 							},
-							cachedSelectorHost: nil,
 						},
 						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 					},
-				}),
-					features: redirectRules,
-				},
-				Egress:        newL4DirectionPolicy(),
-				redirectTypes: redirectTypeEnvoy,
+				})},
+				Egress: newL4DirectionPolicy(),
 			},
 			IngressPolicyEnabled: true,
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{logger: logger},
-		// inherit this from the result as it is outside of the scope
-		// of this test
-		policyMapState:   policy.policyMapState,
-		policyMapChanges: MapChanges{logger: logger},
 	}
 
-	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach(true, 0)
-
-	// Assign an empty mutex so that checker.Equal does not complain about the
-	// difference of the internal time.Time from the lock_debug.go.
-	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	policy.policyMapChanges.mutex = lock.Mutex{}
-	policy.policyMapChanges.firstVersion = 0
-	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
-	policy.policyMapState = mapState{}
-	expectedEndpointPolicy.policyMapState = mapState{}
-	// reset cached envoy http rules to avoid unnecessary diff
-	resetCachedEnvoyHTTPRules(policy)
-	require.Equal(t, &expectedEndpointPolicy, policy)
-}
-
-func resetCachedEnvoyHTTPRules(policy *EndpointPolicy) {
-	resetEnvoyHTTPRules := func(l4 *L4Filter) bool {
-		for _, pol := range l4.PerSelectorPolicies {
-			if pol != nil {
-				pol.EnvoyHTTPRules = nil
-			}
-		}
-		return true
-	}
-
-	policy.L4Policy.Ingress.PortRules.ForEach(resetEnvoyHTTPRules)
-	policy.L4Policy.Egress.PortRules.ForEach(resetEnvoyHTTPRules)
+	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
 }
 
 func TestMapStateWithIngressWildcard(t *testing.T) {
@@ -525,7 +464,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 
 	expectedEndpointPolicy := EndpointPolicy{
 		Redirects: testRedirects,
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
@@ -535,7 +474,6 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
-						wildcard: td.wildcardCachedSelector,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: nil,
@@ -553,7 +491,6 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 			EgressKey():                  allowEgressMapStateEntry,
 			IngressKey().WithTCPPort(80): rule1MapStateEntry,
 		}),
-		policyMapChanges: MapChanges{logger: logger},
 	}
 
 	// Add new identity to test accumulation of MapChanges
@@ -563,21 +500,12 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	td.sc.UpdateIdentities(added1, nil, wg)
 	wg.Wait()
-	require.Empty(t, policy.policyMapChanges.synced) // XXX why 0?
+	require.Empty(t, policy.policyMapChanges.synced)
 
-	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach(true, 0)
-
-	// Assign an empty mutex so that checker.Equal does not complain about the
-	// difference of the internal time.Time from the lock_debug.go.
-	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	policy.policyMapChanges.mutex = lock.Mutex{}
-	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
-	policy.policyMapState = mapState{}
-	expectedEndpointPolicy.policyMapState = mapState{}
-	require.Equal(t, &expectedEndpointPolicy, policy)
+
+	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
 }
 
 func TestMapStateWithIngress(t *testing.T) {
@@ -685,7 +613,7 @@ func TestMapStateWithIngress(t *testing.T) {
 
 	expectedEndpointPolicy := EndpointPolicy{
 		Redirects: testRedirects,
-		selectorPolicy: &selectorPolicy{
+		SelectorPolicy: &selectorPolicy{
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: L4Policy{
@@ -704,7 +632,6 @@ func TestMapStateWithIngress(t *testing.T) {
 								Authentication: &api.Authentication{
 									Mode: api.AuthenticationModeDisabled,
 								},
-								CanShortCircuit: true,
 							},
 						},
 						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
@@ -714,9 +641,7 @@ func TestMapStateWithIngress(t *testing.T) {
 							cachedSelectorTest:    {ruleLabel},
 						}),
 					},
-				}),
-					features: authRules,
-				},
+				})},
 				Egress: newL4DirectionPolicy(),
 			},
 			IngressPolicyEnabled: true,
@@ -731,11 +656,11 @@ func TestMapStateWithIngress(t *testing.T) {
 			IngressKey().WithIdentity(192).WithTCPPort(80):                                rule1MapStateEntry.withExplicitAuth(AuthTypeDisabled),
 			IngressKey().WithIdentity(194).WithTCPPort(80):                                rule1MapStateEntry.withExplicitAuth(AuthTypeDisabled),
 		}),
-		policyMapChanges: MapChanges{logger: logger},
 	}
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
-	policy.selectorPolicy.detach(true, 0)
+	policy.SelectorPolicy.detach(true, 0)
+
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
@@ -753,13 +678,9 @@ func TestMapStateWithIngress(t *testing.T) {
 	}, changes.Adds)
 	require.Equal(t, Keys{}, changes.Deletes)
 
-	// Assign an empty mutex so that checker.Equal does not complain about the
-	// difference of the internal time.Time from the lock_debug.go.
-	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
-	policy.policyMapChanges.mutex = lock.Mutex{}
-	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
+
 	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
 }
 
@@ -769,7 +690,7 @@ func TestMapStateWithIngress(t *testing.T) {
 //
 // Returning true for either return value indicates all traffic is allowed.
 func (p *EndpointPolicy) allowsIdentity(identity identity.NumericIdentity) (ingress, egress bool) {
-	if !p.IngressPolicyEnabled {
+	if !p.SelectorPolicy.IngressPolicyEnabled {
 		ingress = true
 	} else {
 		key := IngressKey().WithIdentity(identity)
@@ -778,7 +699,7 @@ func (p *EndpointPolicy) allowsIdentity(identity identity.NumericIdentity) (ingr
 		}
 	}
 
-	if !p.EgressPolicyEnabled {
+	if !p.SelectorPolicy.EgressPolicyEnabled {
 		egress = true
 	} else {
 		key := EgressKey().WithIdentity(identity)
@@ -942,7 +863,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &EndpointPolicy{
-				selectorPolicy: tt.fields.selectorPolicy,
+				SelectorPolicy: tt.fields.selectorPolicy,
 				policyMapState: tt.fields.PolicyMapState,
 			}
 			gotIngress, gotEgress := p.allowsIdentity(tt.args.identity)


### PR DESCRIPTION
Change policy tests comparing expected to actual EndpointPolicy to only test exported fields. This solves the problem where `require.Equal` apparently goes to an infinite loop when the expected policy is not equal to the actual policy. `require.EqualExportedValues` only compares exported fields, but the type of the field need not be exported. `require.EqualExportedValues` also has maximum depth for diffing, so it avoids the seemingly infinite loop, but in some cases fails to show a meaningful diff for this reason. This is still better than never finishing the test.

Unexport internal fields and remove the hoops we had to go through to zero out fields we did not want to compare with `require.Equal`.

Export the `selectorPolicy` field by giving it the name `SelectorPolicy`. Some tests were missing data in expected policy, as they were already using `require.EqualExportedValues`, but the `selectorPolicy` was not in fact exported.
