### PR TITLE
fix(cilium-dbg): include pod backends in `lrp list`

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/redirectpolicy/cell.go
@@ -8,7 +8,9 @@ import (
 	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/api/v1/server/restapi/service"
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/option"
@@ -64,8 +66,14 @@ var Cell = cell.Module(
 	cell.Provide(lrpAPI),
 )
 
-func lrpAPI(enabled lrpIsEnabled, db *statedb.DB, lrps statedb.Table[*LocalRedirectPolicy]) service.GetLrpHandler {
-	return &getLrpHandler{db, lrps}
+func lrpAPI(
+	enabled lrpIsEnabled,
+	db *statedb.DB,
+	lrps statedb.Table[*LocalRedirectPolicy],
+	backends statedb.Table[*lb.Backend],
+	pods statedb.Table[daemonk8s.LocalPod],
+) service.GetLrpHandler {
+	return &getLrpHandler{db, lrps, backends, pods}
 }
 
 type lrpIsEnabled bool


### PR DESCRIPTION
The `cilium-dbg lrp list` command did not previously display the pods associated with the Local Redirect Policies (LRPs). This was unintended and led to confusion about the functionality of the CLRPs.

In the issue linked below, there are times when there was no backend shown for `cilium-dbg lrp list`.

After looking into this, it seems that this is a cosmetic issue with `ciilum-dbg lrp` rather than an issue with the functionality of CLRPs. For example, replicating the issue seen in the link below, I get this:

## Create the deployments

```
kubectl apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-app
  namespace: kube-system
spec:
  replicas: 1
  selector:
    matchLabels:
      app: my-app
  template:
    metadata:
      labels:
        app: my-app
    spec:
      nodeName: kind-worker
      containers:
      - name: simple-http-container
        image: httpd:latest
        ports:
        - containerPort: 80
        command: ["/bin/sh", "-c"]
        args: ["echo 'Pod responded' > /usr/local/apache2/htdocs/index.html && httpd -D FOREGROUND"]
EOF

kubectl apply -f - <<EOF
# Pod (The IP Target Server)
apiVersion: v1
kind: Pod
metadata:
  name: ip-target
  namespace: kube-system
  labels:
    app: ip-target # A label just for easy selection/identification
spec:
  nodeName: kind-worker
  containers:
  - name: server-container
    image: nicolaka/netshoot:latest
    ports:
    - containerPort: 80
    # Keep it running with a simple server, though it won't actually serve traffic 
    # for the CLRP test—it just provides the IP.
    command: ["/usr/bin/python3"]
    args: ["-m", "http.server", "80"]
EOF
```
From checking this deployment I get the IP of `10.244.1.152` for `ip-target` and `10.244.1.106` for `my-app-65858f446-9znpt`. Therefore, I create a CLRPs targeting the same frontend as `ip-target` (with `skipRedirectFromBackend=true`).

```
kubectl apply -f - <<EOF
apiVersion: "cilium.io/v2"
kind: CiliumLocalRedirectPolicy
metadata:
  name: x-clrp
  namespace: kube-system
spec:
  skipRedirectFromBackend: true
  redirectFrontend:
    addressMatcher:
      ip: "10.244.1.152"
      toPorts:
      - port: "80"
        protocol: TCP
  redirectBackend:
    localEndpointSelector:
      matchLabels:
        app: my-app
    toPorts:
    - port: "80"
      protocol: TCP
EOF
```

Like the issue below (though I can't replicate the exact issue they see where they do get a backend to start before recreating the pods), there is no CLRP backend registered:

```
HOST=$( k get pod -n kube-system -l app=my-app -ojsonpath='{ .items[0].spec.nodeName }' )
ANETD=$( k get pod -n kube-system \
    -l k8s-app=cilium \
    --field-selector=spec.nodeName=${HOST} \
    -ojsonpath='{.items[].metadata.name}' )
kubectl exec -it -n kube-system ${ANETD} -c cilium-agent -- cilium-dbg lrp list

LRP namespace   LRP name         FrontendType   Matching Service
kube-system     x-clrp           IP + port
                |                10.244.1.152:80/TCP -> 
```

However, under `service list`, I DO see this redirect:
`9    10.244.1.152:80/TCP     LocalRedirect   1 => 10.244.1.106:80/TCP (active)
`

This indicates that the LRP is active, although the `lrp list` command isn't registering it. Now I create a `client` pod so that I can test to see if this translation is occuring:

```
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: clrp-client
  name: clrp-client
  namespace: kube-system
spec:
  containers:
  - args:
    - infinity
    command:
    - sleep
    image: nicolaka/netshoot:latest
    name: client-container
```

When I generate traffic from this `clrp-client` pod to the address `10.244.1.152`, we expect there to be a translation from the CLRP. This is confirmed by checking the logs for the `ip-target` and seeing no traffic:
```
kubectl exec -it clrp-client -n kube-system -- curl -I -s http://10.244.1.152
HTTP/1.0 200 OK
Server: SimpleHTTP/0.6 Python/3.12.11
Date: Fri, 10 Oct 2025 04:14:30 GMT
Content-type: text/html; charset=utf-8
Content-Length: 304

kubectl exec -it -n kube-system ${ANETD} -c cilium-agent -- cilium monitor -Dv --related-to $(kubectl get cep ip-target -n kube-system -ojsonpath='{.status.id}')
Listening for events on 24 CPUs with 64x4096 of shared memory
Press Ctrl-C to quit
```

But, traffic DOES arrive at the my-app pod:
```
bigdelle@bigdelle-gke:~/dev/cilium-bigdelle$ kubectl exec -it -n kube-system ${ANETD} -c cilium-agent -- cilium monitor -Dv --related-to $(kubectl get cep my-app-65858f446-9znpt -n kube-system -ojsonpath='{.status.id}')
Listening for events on 24 CPUs with 64x4096 of shared memory
Press Ctrl-C to quit
CPU 16: MARK 0xdf31e3c3 FROM 1447 DEBUG: Inheriting identity=6848 from stack
CPU 16: MARK 0xdf31e3c3 FROM 1447 DEBUG: Conntrack lookup 1/2: src=10.244.1.211:33690 dst=10.244.1.106:80
CPU 16: MARK 0xdf31e3c3 FROM 1447 DEBUG: Conntrack lookup 2/2: nexthdr=6 flags=0 dir=1 scope=2
CPU 16: MARK 0xdf31e3c3 FROM 1447 DEBUG: CT verdict: New, revnat=0
CPU 16: MARK 0xdf31e3c3 FROM 1447 DEBUG: Attempting local delivery for container id 1447 from seclabel 7392
CPU 16: MARK 0xdf31e3c3 FROM 1447 DEBUG: Conntrack create: proxy-port=0 revnat=0 src-identity=6848 lb=0.0.0.0
time=2025-10-10T04:17:50.560528475Z level=info source=/go/src/github.com/cilium/cilium/pkg/monitor/dissect.go:78 msg="Initializing dissection cache..."
-> endpoint 1447 flow 0xdf31e3c3 , identity 6848->7392 state new ifindex lxca66c1279a1ef orig-ip 10.244.1.211: 10.244.1.211:33690 -> 10.244.1.106:80 tcp SYN
CPU 16: MARK 0x8a85e140 FROM 1447 DEBUG: Conntrack lookup 1/2: src=10.244.1.106:80 dst=10.244.1.211:33690
CPU 16: MARK 0x8a85e140 FROM 1447 DEBUG: Conntrack lookup 2/2: nexthdr=6 flags=1 dir=0 scope=2
CPU 16: MARK 0x8a85e140 FROM 1447 DEBUG: CT entry found lifetime=1388368, revnat=0
CPU 16: MARK 0x8a85e140 FROM 1447 DEBUG: CT verdict: Reply, revnat=0
CPU 16: MARK 0x8a85e140 FROM 1447 DEBUG: Successfully mapped addr=10.244.1.211 to identity=6848
-> stack flow 0x8a85e140 , identity 7392->6848 state reply ifindex 0 orig-ip 0.0.0.0: 10.244.1.106:80 -> 10.244.1.211:33690 tcp SYN, ACK
```

Therefore, the clrp is defining the backend. To confirm that the `skipRedirectFromBackend=true` works, we can send traffic from the `my-app` pod itself to that CLRP frontend. We see that we do get traffic to the actual pod `ip-target` which means the CLRP knows it should not redirect this traffic:

```
bigdelle@bigdelle-gke:~/dev/cilium-bigdelle$ kubectl exec -it my-app-65858f446-9znpt -n kube-system -- curl -I -s http://10.244.1.152
HTTP/1.0 200 OK
Server: SimpleHTTP/0.6 Python/3.12.11
Date: Fri, 10 Oct 2025 04:20:31 GMT
Content-type: text/html; charset=utf-8
Content-Length: 304

bigdelle@bigdelle-gke:~/dev/cilium-bigdelle$ kubectl exec -it -n kube-system ${ANETD} -c cilium-agent -- cilium monitor -Dv --related-to $(kubectl get cep ip-target -n kube-system -ojsonpath='{.status.id}')

Listening for events on 24 CPUs with 64x4096 of shared memory
Press Ctrl-C to quit
CPU 07: MARK 0x8c26eee7 FROM 2767 DEBUG: Inheriting identity=7392 from stack
CPU 07: MARK 0x8c26eee7 FROM 2767 DEBUG: Conntrack lookup 1/2: src=10.244.1.106:51584 dst=10.244.1.152:80
CPU 07: MARK 0x8c26eee7 FROM 2767 DEBUG: Conntrack lookup 2/2: nexthdr=6 flags=0 dir=1 scope=2
CPU 07: MARK 0x8c26eee7 FROM 2767 DEBUG: CT verdict: New, revnat=0
CPU 07: MARK 0x8c26eee7 FROM 2767 DEBUG: Attempting local delivery for container id 2767 from seclabel 37376
CPU 07: MARK 0x8c26eee7 FROM 2767 DEBUG: Conntrack create: proxy-port=0 revnat=0 src-identity=7392 lb=0.0.0.0
time=2025-10-10T04:20:31.340894987Z level=info source=/go/src/github.com/cilium/cilium/pkg/monitor/dissect.go:78 msg="Initializing dissection cache..."
-> endpoint 2767 flow 0x8c26eee7 , identity 7392->37376 state new ifindex lxc9392fcae8805 orig-ip 10.244.1.106: 10.244.1.106:51584 -> 10.244.1.152:80 tcp SYN
CPU 07: MARK 0x590525c1 FROM 2767 DEBUG: Conntrack lookup 1/2: src=10.244.1.152:80 dst=10.244.1.106:51584
CPU 07: MARK 0x590525c1 FROM 2767 DEBUG: Conntrack lookup 2/2: nexthdr=6 flags=1 dir=0 scope=2
CPU 07: MARK 0x590525c1 FROM 2767 DEBUG: CT entry found lifetime=1388529, revnat=0
CPU 07: MARK 0x590525c1 FROM 2767 DEBUG: CT verdict: Reply, revnat=0
CPU 07: MARK 0x590525c1 FROM 2767 DEBUG: Successfully mapped addr=10.244.1.106 to identity=7392
-> stack flow 0x590525c1 , identity 37376->7392 state reply ifindex 0 orig-ip 0.0.0.0: 10.244.1.152:80 -> 10.244.1.106:51584 tcp SYN, ACK
```

Therefore, the bug seems to be cosmetic ONLY. The CLRP is working as expected.


## The fix
I investigated this a bit further and saw that in `/redirectpolicy/api.go` we do create the frontend addresses, but never populate the backend addresses. This change adds the logic that does find the backend addresses. It seems that the reason some people were getting the backend resolved intermittently is because of something of dead code where the resolution doesn't occur in `api.go` which the `cilium-dbg lrp` command relies on at runtime.

### With the new code:
After building a cilium image with the code from this PR, now we can do the same `cilium-dbg lrp list` and see the correct backend service:

```
HOST=$( k get pod -n kube-system -l app=my-app -ojsonpath='{ .items[0].spec.nodeName }' )
ANETD=$( k get pod -n kube-system \
    -l k8s-app=cilium \
    --field-selector=spec.nodeName=${HOST} \
    -ojsonpath='{.items[].metadata.name}' )
kubectl exec -it -n kube-system ${ANETD} -c cilium-agent -- cilium-dbg lrp list
LRP namespace   LRP name   FrontendType   Matching Service
kube-system     x-clrp     IP + port
                |          10.244.1.152:80/TCP -> 10.244.1.41:80(kube-system/my-app-6576858d95-qlgh5),
```

```release-note
Fix the output of cilium lrp list command to show LRP selected backends.
```
