### PR TITLE
proxy: fix panic in standalone cilium-agent with `--enable-l7-proxy=false`

### DIFF
--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -113,10 +113,6 @@ type envoyProxyIntegrationParams struct {
 }
 
 func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyIntegration {
-	if !option.Config.EnableL7Proxy {
-		return nil
-	}
-
 	return &envoyProxyIntegration{
 		xdsServer:       params.XdsServer,
 		iptablesManager: params.IptablesManager,
@@ -125,10 +121,6 @@ func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyInt
 }
 
 func newDNSProxyIntegration(dnsProxy fqdnproxy.DNSProxier, sdpPolicyUpdater *service.FQDNDataServer) *dnsProxyIntegration {
-	if !option.Config.EnableL7Proxy {
-		return nil
-	}
-
 	return &dnsProxyIntegration{
 		dnsProxy:         dnsProxy,
 		sdpPolicyUpdater: sdpPolicyUpdater,


### PR DESCRIPTION
After the recent route reconciliation changes in the referenced commit, starting standalone cilium-agent container will panic:

    docker create \
      --name gateway0 \
      --network=name=kind,driver-opt=com.docker.network.endpoint.ifname=eth0 \
      --privileged=true \
      <image> \
          cilium-agent \
	  [...]
          --enable-l7-proxy=false \
          [...]
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x317243c]

    goroutine 77 [running]:
    github.com/cilium/cilium/pkg/proxy.(*envoyProxyIntegration).UpdateNetworkPolicy(...)
    	/go/src/github.com/cilium/cilium/pkg/proxy/envoyproxy.go:69
    github.com/cilium/cilium/pkg/proxy.(*Proxy).UpdateNetworkPolicy(0xc001e986b0?, {0x58e1f40?, 0xc000a45908?}, 0xfffffffffffffffc?, 0x9a?, 0xb5?, 0x27?)
    	/go/src/github.com/cilium/cilium/pkg/proxy/proxy.go:332 +0x1c
    github.com/cilium/cilium/pkg/endpoint.(*Endpoint).ComputeInitialPolicy(0xc000a45908, 0xc001e98488)
    	/go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:921 +0x4d3
    github.com/cilium/cilium/pkg/endpoint.(*EndpointRegenerationEvent).Handle(0xc0040028e0, 0xc0005405b0)
    	/go/src/github.com/cilium/cilium/pkg/endpoint/events.go:36 +0x71
    github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run.func1()
    	/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:243 +0x11e
    sync.(*Once).doSlow(0x0?, 0x0?)
    	/usr/local/go/src/sync/once.go:78 +0xac
    sync.(*Once).Do(...)
    	/usr/local/go/src/sync/once.go:69
    github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run(0xc002f4f650?)
    	/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:231 +0x36
    created by github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run in goroutine 428
    	/go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:227 +0x6a

Fix this by unconditionally creating `*envoyProxyIntegration` (and `*dnsProxyIntegration` while at it) because `createProxy` now always creates a non-nil `*Proxy` regardless of whether `--enable-l7-proxy=false` is set.

Fixes: fdc0786bf559 ("pkg/proxy: Reconcile routes")