### PR TITLE
ztunnel/iptables: Make in-pod rules idempotent and add tests

### DIFF
--- a/pkg/ztunnel/iptables/inpod.go
+++ b/pkg/ztunnel/iptables/inpod.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/command/exec"
-	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/defaults"
 )
 
@@ -41,7 +41,7 @@ const (
 // Note that this function is supposed to be called from within the pods
 // network namespace.
 func CreateInPodRules(logger *slog.Logger, ipv4Enabled, ipv6Enabled bool) error {
-	if err := addLoopbackRoute(ipv6Enabled); err != nil {
+	if err := addLoopbackRoute(logger, ipv6Enabled); err != nil {
 		return err
 	}
 
@@ -56,12 +56,7 @@ func CreateInPodRules(logger *slog.Logger, ipv4Enabled, ipv6Enabled bool) error 
 	return nil
 }
 
-func addLoopbackRoute(ipv6Enabled bool) error {
-	loopbackLink, err := safenetlink.LinkByName("lo")
-	if err != nil {
-		return fmt.Errorf("failed to find 'lo' link: %w", err)
-	}
-
+func addLoopbackRoute(logger *slog.Logger, ipv6Enabled bool) error {
 	// Set up netlink routes for localhost
 	cidrs := []string{"0.0.0.0/0"}
 	if ipv6Enabled {
@@ -74,46 +69,47 @@ func addLoopbackRoute(ipv6Enabled bool) error {
 		}
 
 		// Equiv: "ip route add local 0.0.0.0/0 dev lo table 100"
-		netlinkRoute := &netlink.Route{
-			Dst:       localhostDst,
-			Scope:     netlink.SCOPE_HOST,
-			Type:      unix.RTN_LOCAL,
-			Table:     RouteTableInbound,
-			LinkIndex: loopbackLink.Attrs().Index,
+		ciliumRoute := route.Route{
+			Device: "lo",
+			Prefix: *localhostDst,
+			Scope:  netlink.SCOPE_HOST,
+			Type:   unix.RTN_LOCAL,
+			Table:  RouteTableInbound,
 		}
 
-		if err := netlink.RouteAdd(netlinkRoute); err != nil {
-			return fmt.Errorf("failed to add route (%+v): %w", netlinkRoute, err)
+		if err := route.Upsert(logger, ciliumRoute); err != nil {
+			return fmt.Errorf("failed to add route (%+v): %w", ciliumRoute, err)
 		}
 	}
 	return nil
 }
 
 func addInPodMarkRule(ipv6Enabled bool) error {
-	var rules []*netlink.Rule
 	mask := uint32(InpodMask)
 
-	inpodMarkRule := netlink.NewRule()
-	inpodMarkRule.Family = unix.AF_INET
-	inpodMarkRule.Table = RouteTableInbound
-	inpodMarkRule.Mark = InpodTProxyMark
-	inpodMarkRule.Mask = &mask
-	inpodMarkRule.Priority = InpodRulePriority
-	rules = append(rules, inpodMarkRule)
-
-	if ipv6Enabled {
-		inpodMarkRule6 := netlink.NewRule()
-		inpodMarkRule6.Family = unix.AF_INET6
-		inpodMarkRule6.Table = RouteTableInbound
-		inpodMarkRule6.Mark = InpodTProxyMark
-		inpodMarkRule6.Mask = &mask
-		inpodMarkRule6.Priority = InpodRulePriority
-		rules = append(rules, inpodMarkRule6)
+	// IPv4 rule
+	ipv4Rule := route.Rule{
+		Priority: InpodRulePriority,
+		Mark:     InpodTProxyMark,
+		Mask:     mask,
+		Table:    RouteTableInbound,
 	}
 
-	for _, rule := range rules {
-		if err := netlink.RuleAdd(rule); err != nil {
-			return fmt.Errorf("failed to configure netlink rule: %w", err)
+	if err := route.ReplaceRule(ipv4Rule); err != nil {
+		return fmt.Errorf("failed to configure IPv4 netlink rule: %w", err)
+	}
+
+	if ipv6Enabled {
+		// IPv6 rule
+		ipv6Rule := route.Rule{
+			Priority: InpodRulePriority,
+			Mark:     InpodTProxyMark,
+			Mask:     mask,
+			Table:    RouteTableInbound,
+		}
+
+		if err := route.ReplaceRuleIPv6(ipv6Rule); err != nil {
+			return fmt.Errorf("failed to configure IPv6 netlink rule: %w", err)
 		}
 	}
 	return nil
@@ -156,17 +152,30 @@ func replaceIPPlaceholder(args []string, ip string) []string {
 
 func (m *ruleManager) install(ipv4Enabled, ipv6Enabled bool) error {
 	for _, rule := range m.rules {
-		args := []string{"-t", rule.table, "-A", rule.chain}
+		args := []string{"-t", rule.table, "-C", rule.chain}
 		args = append(args, rule.parameters...)
 		if ipv4Enabled {
-			if _, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", replaceIPPlaceholder(args, rule.ipv4)...).Output(m.logger, false); err != nil {
-				return fmt.Errorf("failed to insert iptables rule (%v): %w", args, err)
+			// Check if rule exists
+			_, checkErr := exec.WithTimeout(defaults.ExecTimeout, "iptables", replaceIPPlaceholder(args, rule.ipv4)...).Output(m.logger, false)
+			if checkErr != nil {
+				// Rule doesn't exist, add it
+				args[2] = "-A" // -A for adding
+				if _, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", replaceIPPlaceholder(args, rule.ipv4)...).Output(m.logger, false); err != nil {
+					return fmt.Errorf("failed to insert iptables rule (%v): %w", args, err)
+				}
 			}
 		}
 
 		if ipv6Enabled {
-			if _, err := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", replaceIPPlaceholder(args, rule.ipv6)...).Output(m.logger, false); err != nil {
-				return fmt.Errorf("failed to insert ip6tables rule (%v): %w", args, err)
+			// Check if rule exists
+			_, checkErr := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", replaceIPPlaceholder(args, rule.ipv6)...).Output(m.logger, false)
+
+			if checkErr != nil {
+				// Rule doesn't exist, add it
+				args[2] = "-A" // -A for adding
+				if _, err := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", replaceIPPlaceholder(args, rule.ipv6)...).Output(m.logger, false); err != nil {
+					return fmt.Errorf("failed to insert ip6tables rule (%v): %w", args, err)
+				}
 			}
 		}
 	}
@@ -177,13 +186,23 @@ func (m *ruleManager) createChains(ipv4Enabled, ipv6Enabled bool) error {
 	for _, table := range []string{"mangle", "nat"} {
 		for _, chain := range []string{InpodPreroutingChain, InpodOutputChain} {
 			if ipv4Enabled {
-				if _, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", "-t", table, "-N", chain).Output(m.logger, false); err != nil {
-					return fmt.Errorf("failed to create iptables chain %s: %w", chain, err)
+				// Check if chain exists first
+				_, checkErr := exec.WithTimeout(defaults.ExecTimeout, "iptables", "-t", table, "-L", chain, "-n").Output(m.logger, false)
+				if checkErr != nil {
+					// Chain doesn't exist, create it
+					if _, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", "-t", table, "-N", chain).Output(m.logger, false); err != nil {
+						return fmt.Errorf("failed to create iptables chain %s: %w", chain, err)
+					}
 				}
 			}
 			if ipv6Enabled {
-				if _, err := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", "-t", table, "-N", chain).Output(m.logger, false); err != nil {
-					return fmt.Errorf("failed to create ip6tables chain %s: %w", chain, err)
+				// Check if chain exists first
+				_, checkErr := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", "-t", table, "-L", chain, "-n").Output(m.logger, false)
+				if checkErr != nil {
+					// Chain doesn't exist, create it
+					if _, err := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", "-t", table, "-N", chain).Output(m.logger, false); err != nil {
+						return fmt.Errorf("failed to create ip6tables chain %s: %w", chain, err)
+					}
 				}
 			}
 		}

--- a/pkg/ztunnel/iptables/inpod_test.go
+++ b/pkg/ztunnel/iptables/inpod_test.go
@@ -73,6 +73,194 @@ func TestPrivilegedCreateInPodRules(t *testing.T) {
 	})
 }
 
+// TestPrivilegedCreateInPodRulesIdempotency tests that calling CreateInPodRules
+// multiple times with existing rules, routes, and chains doesn't cause errors.
+func TestPrivilegedCreateInPodRulesIdempotency(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		// First call - creates all rules, routes, and chains
+		err = CreateInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "First call to CreateInPodRules should succeed")
+
+		// Second call - should handle existing rules/routes/chains without error
+		err = CreateInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "Second call to CreateInPodRules should succeed (idempotency)")
+
+		// Third call - verify it's truly idempotent
+		err = CreateInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "Third call to CreateInPodRules should succeed (idempotency)")
+
+		return nil
+	})
+}
+
+// TestPrivilegedAddExistingChains tests that creating chains that already exist
+// doesn't cause errors.
+func TestPrivilegedAddExistingChains(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		rm := ruleManager{logger: slog.Default()}
+
+		// Create chains first time
+		err = rm.createChains(true, true)
+		require.NoError(t, err, "First call to createChains should succeed")
+
+		// Create chains second time - should not error
+		err = rm.createChains(true, true)
+		require.NoError(t, err, "Second call to createChains should succeed")
+
+		// Verify chains exist
+		for _, table := range []string{"mangle", "nat"} {
+			for _, chain := range []string{InpodPreroutingChain, InpodOutputChain} {
+				// IPv4
+				_, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", "-t", table, "-L", chain, "-n").Output(slog.Default(), false)
+				require.NoError(t, err, "Chain %s should exist in IPv4 %s table", chain, table)
+
+				// IPv6
+				_, err = exec.WithTimeout(defaults.ExecTimeout, "ip6tables", "-t", table, "-L", chain, "-n").Output(slog.Default(), false)
+				require.NoError(t, err, "Chain %s should exist in IPv6 %s table", chain, table)
+			}
+		}
+
+		return nil
+	})
+}
+
+// TestPrivilegedAddExistingRoutes tests that adding routes that already exist
+// doesn't cause errors due to RouteReplace behavior.
+func TestPrivilegedAddExistingRoutes(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		// Add routes first time
+		err = addLoopbackRoute(slog.Default(), true)
+		require.NoError(t, err, "First call to addLoopbackRoute should succeed")
+
+		// Add routes second time - should not error due to RouteReplace
+		err = addLoopbackRoute(slog.Default(), true)
+		require.NoError(t, err, "Second call to addLoopbackRoute should succeed")
+
+		// Verify routes exist
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: RouteTableInbound,
+		}, netlink.RT_FILTER_TABLE)
+		require.NoError(t, err)
+		require.NotEmpty(t, routes, "IPv4 routes should exist in table %d", RouteTableInbound)
+
+		routesV6, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{
+			Table: RouteTableInbound,
+		}, netlink.RT_FILTER_TABLE)
+		require.NoError(t, err)
+		require.NotEmpty(t, routesV6, "IPv6 routes should exist in table %d", RouteTableInbound)
+
+		return nil
+	})
+}
+
+// TestPrivilegedAddExistingMarkRules tests that adding netlink mark rules that
+// already exist doesn't cause errors due to ReplaceRule behavior.
+func TestPrivilegedAddExistingMarkRules(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		// Add mark rules first time
+		err = addInPodMarkRule(true)
+		require.NoError(t, err, "First call to addInPodMarkRule should succeed")
+
+		// Add mark rules second time - should not error due to ReplaceRule
+		err = addInPodMarkRule(true)
+		require.NoError(t, err, "Second call to addInPodMarkRule should succeed")
+
+		// Verify IPv4 rule exists
+		rules, err := netlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		foundV4 := false
+		for _, rule := range rules {
+			if rule.Priority == InpodRulePriority && rule.Mark == InpodTProxyMark && rule.Table == RouteTableInbound {
+				foundV4 = true
+				break
+			}
+		}
+		require.True(t, foundV4, "IPv4 mark rule should exist")
+
+		// Verify IPv6 rule exists
+		rulesV6, err := netlink.RuleList(netlink.FAMILY_V6)
+		require.NoError(t, err)
+		foundV6 := false
+		for _, rule := range rulesV6 {
+			if rule.Priority == InpodRulePriority && rule.Mark == InpodTProxyMark && rule.Table == RouteTableInbound {
+				foundV6 = true
+				break
+			}
+		}
+		require.True(t, foundV6, "IPv6 mark rule should exist")
+
+		return nil
+	})
+}
+
+// TestPrivilegedAddExistingIPTablesRules tests that adding iptables rules that
+// already exist doesn't cause errors.
+func TestPrivilegedAddExistingIPTablesRules(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		// Create chains first
+		rm := ruleManager{logger: slog.Default()}
+		err = rm.createChains(true, true)
+		require.NoError(t, err)
+
+		// Install rules first time
+		err = addInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "First call to addInPodRules should succeed")
+
+		// Install rules second time - should not error (rules already exist)
+		err = addInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "Second call to addInPodRules should succeed")
+
+		// Verify that rules weren't duplicated
+		natRulesV4 := getIPTablesRules(t, "iptables", "nat")
+
+		// Count occurrences of a specific rule to ensure no duplication
+		jumpCount := 0
+		for _, rule := range natRulesV4 {
+			if strings.Contains(rule, "-A PREROUTING -j "+InpodPreroutingChain) {
+				jumpCount++
+			}
+		}
+		require.Equal(t, 1, jumpCount, "Jump rule should appear exactly once, not duplicated")
+
+		return nil
+	})
+}
+
 func getIPTablesRules(t *testing.T, cmd, table string) []string {
 	out, err := exec.WithTimeout(defaults.ExecTimeout, cmd, "-t", table, "-S").Output(slog.Default(), false)
 	require.NoError(t, err, "Failed to get iptables rules for table %s", table)


### PR DESCRIPTION
Make CreateInPodRules idempotent by checking for existing chains and
rules before creation/insertion. Replace direct netlink usage with
Cilium's route package (route.Upsert and route.ReplaceRule). Add
comprehensive privileged unit tests to verify idempotency of chains,
routes, rules, and iptables configuration.

Signed-off-by: Quang Nguyen <nguyenquang@microsoft.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Make CreateInPodRules idempotent by checking for existing chains and
rules before creation/insertion. Replace direct netlink usage with
Cilium's route package (route.Upsert and route.ReplaceRule). Add
comprehensive privileged unit tests to verify idempotency of chains,
routes, rules, and iptables configuration.
```
