### PR TITLE
multipool: Fix allocations when deleting or shrinking pools

### DIFF
--- a/pkg/ipam/allocator/multipool/node_handler_test.go
+++ b/pkg/ipam/allocator/multipool/node_handler_test.go
@@ -65,7 +65,7 @@ type mockResult struct {
 
 func TestNodeHandler(t *testing.T) {
 	backend := NewPoolAllocator(hivetest.Logger(t))
-	err := backend.addPool("default", []string{"10.0.0.0/8"}, 24, nil, 0)
+	err := backend.UpsertPool("default", []string{"10.0.0.0/8"}, 24, nil, 0)
 	assert.NoError(t, err)
 
 	onUpdateArgs := make(chan mockArgs)

--- a/pkg/ipam/allocator/multipool/pool.go
+++ b/pkg/ipam/allocator/multipool/pool.go
@@ -92,6 +92,16 @@ func hasCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) bool {
 	return false
 }
 
+func containsCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) bool {
+	ipnet := netipx.PrefixIPNet(cidr)
+	for _, alloc := range allocators {
+		if alloc.InRange(ipnet) {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *cidrPool) allocCIDR(family ipam.Family) (netip.Prefix, error) {
 	switch family {
 	case ipam.IPv4:

--- a/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -117,27 +117,6 @@ func (p *PoolAllocator) RestoreFinished() {
 	p.mutex.Unlock()
 }
 
-func (p *PoolAllocator) addPool(poolName string, ipv4CIDRs []string, ipv4MaskSize int, ipv6CIDRs []string, ipv6MaskSize int) error {
-	v4, err := cidralloc.NewCIDRSets(false, ipv4CIDRs, ipv4MaskSize)
-	if err != nil {
-		return err
-	}
-
-	v6, err := cidralloc.NewCIDRSets(true, ipv6CIDRs, ipv6MaskSize)
-	if err != nil {
-		return err
-	}
-
-	p.pools[poolName] = cidrPool{
-		v4:         v4,
-		v6:         v6,
-		v4MaskSize: ipv4MaskSize,
-		v6MaskSize: ipv6MaskSize,
-	}
-
-	return nil
-}
-
 func (p *PoolAllocator) updateCIDRSets(isV6 bool, cidrSets []cidralloc.CIDRAllocator, newCIDRs []netip.Prefix, maskSize int) ([]cidralloc.CIDRAllocator, error) {
 	var newCIDRSets []cidralloc.CIDRAllocator
 	var alloc []string
@@ -241,14 +220,10 @@ func (p *PoolAllocator) UpsertPool(poolName string, ipv4CIDRs []string, ipv4Mask
 	defer p.mutex.Unlock()
 
 	pool, exists := p.pools[poolName]
-	if !exists {
-		return p.addPool(poolName, ipv4CIDRs, ipv4MaskSize, ipv6CIDRs, ipv6MaskSize)
-	}
-
-	if ipv4MaskSize != pool.v4MaskSize {
+	if exists && ipv4MaskSize != pool.v4MaskSize {
 		return fmt.Errorf("cannot change IPv4 mask size in existing pool %q", poolName)
 	}
-	if ipv6MaskSize != pool.v6MaskSize {
+	if exists && ipv6MaskSize != pool.v6MaskSize {
 		return fmt.Errorf("cannot change IPv6 mask size in existing pool %q", poolName)
 	}
 
@@ -261,12 +236,20 @@ func (p *PoolAllocator) UpsertPool(poolName string, ipv4CIDRs []string, ipv4Mask
 		return fmt.Errorf("invalid IPv6 CIDR: %w", err)
 	}
 
-	v4, err := p.updateCIDRSets(false, pool.v4, ipv4Prefixes, ipv4MaskSize)
+	var v4Prev []cidralloc.CIDRAllocator
+	if exists {
+		v4Prev = pool.v4
+	}
+	v4, err := p.updateCIDRSets(false, v4Prev, ipv4Prefixes, ipv4MaskSize)
 	if err != nil {
 		return err
 	}
 
-	v6, err := p.updateCIDRSets(true, pool.v6, ipv6Prefixes, ipv6MaskSize)
+	var v6Prev []cidralloc.CIDRAllocator
+	if exists {
+		v6Prev = pool.v6
+	}
+	v6, err := p.updateCIDRSets(true, v6Prev, ipv6Prefixes, ipv6MaskSize)
 	if err != nil {
 		return err
 	}

--- a/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -374,9 +374,17 @@ func (p *PoolAllocator) AllocateToNode(cn *v2.CiliumNode) error {
 				continue
 			}
 
-			occupyErr := p.occupyCIDR(cn.Name, allocatedPool.Pool, prefix)
-			if occupyErr != nil {
-				err = errors.Join(err, occupyErr)
+			if _, found := p.pools[allocatedPool.Pool]; found {
+				if occupyErr := p.occupyCIDR(cn.Name, allocatedPool.Pool, prefix); occupyErr != nil {
+					err = errors.Join(err, occupyErr)
+				}
+			} else {
+				// pool cannot be found: it must be a pool deleted before the operator restarted.
+				// Mark the CIDR as orphan to preserve node allocations.
+				p.markOrphan(cn.Name, allocatedPool.Pool, prefix)
+				err = errors.Join(err,
+					fmt.Errorf("unable to find pool %s, prefix %s is still allocated to the node but is marked as orphan",
+						allocatedPool.Pool, prefix))
 			}
 
 			allocatedSet[allocatedPool.Pool][prefix] = struct{}{}

--- a/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -199,7 +199,6 @@ func (p *PoolAllocator) updateCIDRSets(isV6 bool, cidrSets []cidralloc.CIDRAlloc
 		}
 
 		cidrSets[i] = nil
-		cidrSets = slices.Delete(cidrSets, i, i+1)
 
 		for node, pools := range p.nodes {
 			for pool, allocatedCIDRSets := range pools {
@@ -253,6 +252,7 @@ func (p *PoolAllocator) updateCIDRSets(isV6 bool, cidrSets []cidralloc.CIDRAlloc
 			}
 		}
 	}
+	cidrSets = slices.DeleteFunc(cidrSets, func(a cidralloc.CIDRAllocator) bool { return a == nil })
 	cidrSets = append(cidrSets, newCIDRSets...)
 	return cidrSets, errors.Join(errs...)
 }

--- a/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -293,16 +293,15 @@ func (p *PoolAllocator) DeletePool(poolName string) error {
 	}
 
 	for node, pools := range p.nodes {
-		for pool := range pools {
-			if pool == poolName {
-				p.logger.Warn(
-					"pool still in use by node",
-					logfields.PoolName, pool,
-					logfields.Node, node,
-				)
-				delete(p.nodes[node], poolName)
-			}
+		if _, found := pools[poolName]; !found {
+			continue
 		}
+		p.logger.Warn(
+			"pool still in use by node",
+			logfields.PoolName, poolName,
+			logfields.Node, node,
+		)
+		delete(p.nodes[node], poolName)
 	}
 
 	delete(p.pools, poolName)

--- a/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -12,6 +12,8 @@ import (
 	"slices"
 	"sort"
 
+	"go4.org/netipx"
+
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator/clusterpool/cidralloc"
 	"github.com/cilium/cilium/pkg/ipam/types"
@@ -154,47 +156,72 @@ func (p *PoolAllocator) updateCIDRSets(isV6 bool, cidrSets []cidralloc.CIDRAlloc
 		}
 	}
 
+	var errs []error
+
 	// delete CIDR set for CIDRs not present in the new CIDRs
 	for i, oldCIDR := range cidrSets {
 		if oldCIDR == nil {
 			continue
 		}
-		exists := slices.ContainsFunc(newCIDRs, oldCIDR.IsClusterCIDR)
-		if !exists {
-			cidrSets[i] = nil
-			cidrSets = slices.Delete(cidrSets, i, i+1)
+		if exists := slices.ContainsFunc(newCIDRs, oldCIDR.IsClusterCIDR); exists {
+			continue
+		}
 
-			prefix := oldCIDR.Prefix()
+		cidrSets[i] = nil
+		cidrSets = slices.Delete(cidrSets, i, i+1)
 
-			for node, pools := range p.nodes {
-				for pool, allocatedCIDRSets := range pools {
-					if isV6 {
-						if _, ok := allocatedCIDRSets.v6[prefix]; ok {
-							p.logger.Warn(
-								"CIDR from pool still in use by node",
-								logfields.CIDR, prefix,
-								logfields.PoolName, pool,
-								logfields.Node, node,
-							)
-							delete(p.nodes[node][pool].v6, prefix)
+		for node, pools := range p.nodes {
+			for pool, allocatedCIDRSets := range pools {
+				if isV6 {
+					for cidr := range allocatedCIDRSets.v6 {
+						ipnet := netipx.PrefixIPNet(cidr)
+						if !oldCIDR.InRange(ipnet) {
+							continue
 						}
-					} else {
-						if _, ok := allocatedCIDRSets.v4[prefix]; ok {
-							p.logger.Warn(
-								"CIDR from pool still in use by node",
-								logfields.CIDR, prefix,
-								logfields.PoolName, pool,
-								logfields.Node, node,
-							)
-							delete(p.nodes[node][pool].v4, prefix)
+						allocated, err := oldCIDR.IsAllocated(ipnet)
+						if err != nil {
+							errs = append(errs, err)
+							continue
 						}
+						if !allocated {
+							continue
+						}
+						p.logger.Warn(
+							"CIDR from pool still in use by node",
+							logfields.CIDR, cidr,
+							logfields.PoolName, pool,
+							logfields.Node, node,
+						)
+						delete(p.nodes[node][pool].v6, cidr)
+					}
+				} else {
+					for cidr := range allocatedCIDRSets.v4 {
+						ipnet := netipx.PrefixIPNet(cidr)
+						if !oldCIDR.InRange(ipnet) {
+							continue
+						}
+						allocated, err := oldCIDR.IsAllocated(ipnet)
+						if err != nil {
+							errs = append(errs, err)
+							continue
+						}
+						if !allocated {
+							continue
+						}
+						p.logger.Warn(
+							"CIDR from pool still in use by node",
+							logfields.CIDR, cidr,
+							logfields.PoolName, pool,
+							logfields.Node, node,
+						)
+						delete(p.nodes[node][pool].v4, cidr)
 					}
 				}
 			}
 		}
 	}
 	cidrSets = append(cidrSets, newCIDRSets...)
-	return cidrSets, nil
+	return cidrSets, errors.Join(errs...)
 }
 
 func parseCIDRStrings(cidrStrs []string) ([]netip.Prefix, error) {


### PR DESCRIPTION
When a CiliumPodIPPool is shrunk or deleted but its CIDRs are still in use by the nodes (i.e: there are some pods scheduled on those nodes with IPs from the removed CIDRs), we enter a status where the operator is not able to correctly account the allocated CIDRs anymore.
Specifically, it is possible to add again the deleted pool and end up with another node getting assigned the same CIDRs still in use by the initial node and ultimately having the same IPs assigned to multiple pods.

To avoid this scenario, beside emitting a warning when the operator detects that a CIDR still in use has been deleted, we introduce the concept of **orphan CIDRs**: CIDRs that do not have their parent pool anymore. The operator keeps track of those CIDRs specifically, in order to:

1) reconcile the internal allocation maps in case the original pool is restored
2) reject the insertion of new pools (i.e: pools with a different name) that contains the orphan CIDRs
3) release the orphan CIDRs if the node do not claim that anymore

This is done in order to allow fixing the orphan CIDRs scenario by either:

a) restore the CiliumPodIPPool that should not have been shrunk or deleted initially
b) delete all pods using an IP from a deleted pool

Please refer to the individual commit messages for more information.

Fixes: #41986

```release-note
Fix operator CIDR allocations in multi-pool IPAM mode after a CiliumPodIPPool update or re-insertion
```
