### PR TITLE
operator: improve AWS API pagination with automatic fallback

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -13,7 +13,7 @@ cilium-operator-aws [flags]
 ```
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
       --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-pagination-enabled                               Enable pagination for AWS EC2 API requests. The default page size is 1000 items. (default true)
+      --aws-max-results-per-call int32                       Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
       --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -14,7 +14,7 @@ cilium-operator [flags]
       --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
       --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-pagination-enabled                               Enable pagination for AWS EC2 API requests. The default page size is 1000 items. (default true)
+      --aws-max-results-per-call int32                       Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
       --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
       --azure-resource-group string                          Resource group to use for Azure IPAM

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -374,6 +374,13 @@ Deprecated Options
 * The ``--enable-ipsec-encrypted-overlay`` flag has no effect and will be removed in Cilium 1.20. Starting from
   Cilium 1.18 the IPsec encryption is always applied after overlay encapsulation, and therefore this special opt-in
   flag is no longer needed.
+* The ``--aws-pagination-enabled`` flag for cilium-operator is now deprecated in favor of the more flexible
+  ``--aws-max-results-per-call`` flag. The new flag defaults to ``0`` (unpaginated, letting AWS determine optimal
+  page size), which provides better performance in most environments. If AWS returns an ``OperationNotPermitted``
+  error indicating too many results, the operator will automatically switch to paginated requests
+  (``MaxResults=1000``) for all future API calls. Users with very large AWS accounts can set
+  ``--aws-max-results-per-call=1000`` upfront to force pagination from the start. The deprecated flag still works
+  during the deprecation period (``true`` maps to ``1000``, ``false`` maps to ``0``) and will be removed in Cilium 1.20.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -839,6 +839,7 @@ unlabel
 unmanaged
 unmarshalled
 unmigrated
+unpaginated
 unselect
 unsettable
 untriaged

--- a/operator/cmd/provider_aws_flags.go
+++ b/operator/cmd/provider_aws_flags.go
@@ -50,7 +50,13 @@ func (hook *awsFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.Vi
 	flags.String(operatorOption.EC2APIEndpoint, "", "AWS API endpoint for the EC2 service")
 	option.BindEnv(vp, operatorOption.EC2APIEndpoint)
 
-	flags.Bool(operatorOption.AWSPaginationEnabled, true, "Enable pagination for AWS EC2 API requests. The default page size is 1000 items.")
+	flags.Int32(operatorOption.AWSMaxResultsPerCall, 0, "Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests")
+	option.BindEnv(vp, operatorOption.AWSMaxResultsPerCall)
+
+	// Deprecated: aws-pagination-enabled is deprecated in v1.19 and will be removed in v1.20.
+	// Use --aws-max-results-per-call instead (true maps to 1000, false maps to 0).
+	flags.Bool(operatorOption.AWSPaginationEnabled, true, "Deprecated: Use --aws-max-results-per-call instead")
+	flags.MarkHidden(operatorOption.AWSPaginationEnabled)
 	option.BindEnv(vp, operatorOption.AWSPaginationEnabled)
 
 	vp.BindPFlags(flags)

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -111,7 +111,7 @@ func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger, reg *metri
 
 	a.client = ec2shim.NewClient(a.rootLogger, ec2.NewFromConfig(cfg, optionsFunc), aMetrics, operatorOption.Config.IPAMAPIQPSLimit,
 		operatorOption.Config.IPAMAPIBurst, subnetsFilters, instancesFilters, eniCreationTags,
-		operatorOption.Config.AWSUsePrimaryAddress)
+		operatorOption.Config.AWSUsePrimaryAddress, operatorOption.Config.AWSMaxResultsPerCall)
 
 	return nil
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1288,6 +1288,8 @@ const (
 
 	PrefixCount = "prefixCount"
 
+	MaxResults = "maxResults"
+
 	LenEIPS = "lenEIPS"
 
 	EIP = "eip"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Deprecates the `--aws-pagination-enabled` flag and improves aws api pagination handling. Will remove `MaxResults=1000` parameter and let aws decide optimal page sizes for better performance.

## Background

The `--aws-pagination-enabled` flag (#39543) controls whether we set `MaxResults=1000` on aws api calls. When enabled (default), every call is limited to 1000 results - if you have 3K+ ENIs, that's 3+ separate api calls. When disabled, aws picks the page size, potentially using fewer calls.

The problem: most users don't understand when to use this flag. The default is conservative (pagination enabled), so everyone pays the performance cost even in small environments.

## Current implementation (needs revision)

The current pushed code implements a retry mechanism based on the suggestion from [#40443](https://github.com/cilium/cilium/issues/40443): try an unpaginated request first, and if it fails, retry with `MaxResults=1000`. The idea was to get the performance benefit of fewer api calls in the happy case while falling back to pagination on errors.

issues with this approach:
- unconditional retry on any error is anti-pattern (rate limiting, unnecessary retries)
- adds complexity without clear benefit

## Revised approach

Based on review feedback, will simplify to just remove the retry logic and omit `MaxResults` entirely.

Remove `MaxResults` parameter from 4 functions controlled by the flag (from commits [8b24557f36](https://github.com/cilium/cilium/commit/8b24557f36) and [479bdf55ae](https://github.com/cilium/cilium/commit/479bdf55ae)):
- `GetDetachedNetworkInterfaces`
- `describeNetworkInterfaces` 
- `describeNetworkInterfacesFromInstances`
- `describeSecurityGroups`

The sdk paginator still handles pagination and we're just not capping pages to 1000.

Deprecate the `--aws-pagination-enabled` flag (hidden, no-op) in v1.19, remove in v1.20.

## Safety

aws docs say `DescribeNetworkInterfaces` can fail with `OperationNotPermitted` if you request too many results without filters. We use `subnet-id` filters in all calls, which satisfies aws's requirement. Same for `DescribeSecurityGroups` - we pass vpc-id from instance metadata.

The original timeout issues ([479bdf55ae](https://github.com/cilium/cilium/commit/479bdf55ae)) happened because `DescribeSecurityGroups` was called with no filters and no `MaxResults`. Now we have filters, so result sets are already bounded.

## Expected improvement

Current: 3K+ ENIs = 3+ api calls with `MaxResults=1000`  
Expected: Same data in fewer calls if aws uses larger page sizes

Not sure what the default page size is when `MaxResults` isn't set but it should be at least more than 1000 to see perf improvements.

## Backwards compatibility

Flag is ignored but still accepted for v1.19, so existing deployments won't break. Users should remove it before v1.20.

## Testing

Existing tests pass

Fixes #40443

```release-note
operator: Improve AWS API pagination with adaptive fallback
```