### PR TITLE
docs: Update style guide for displaying file creation

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -518,6 +518,7 @@ linux
 linuxconf
 listenAddress
 listers
+literalinclude
 liveblog
 liveness
 llc


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Add new "Displaying file creation" section to the documentation style guide that prescribes best practices for showing file contents in documentation.

**Key changes:**
- Avoid HEREDOC syntax (`cat > file <<EOF`) which can be jarring to readers and doesn't represent typical user workflows
- Use `literalinclude` directive for files in the repository to prevent documentation drift
- Recommend 4-step pattern: describe task, show contents, explain key settings, provide copy-paste command
- Use inline code blocks with proper syntax highlighting for simple or documentation-specific content

**Benefits:**
This guidance improves readability, maintainability, and user experience by providing clear separation between file contents and shell commands, proper syntax highlighting, and better pedagogical explanations of configuration options.

**Context:**
Based on discussion and consensus from issue participants (@joestringer and @pmatulis) who identified that HEREDOC syntax is jarring to readers and recommended using `literalinclude` to prevent documentation drift while following a consistent 4-step pattern for examples.

### Examples of Current HEREDOC Usage

The following documentation files currently use the HEREDOC pattern and could be updated following this new guidance in future PRs:
- `Documentation/network/kubernetes/configuration.rst`
- `Documentation/network/kubernetes/ipam-multi-pool.rst`
- `Documentation/network/concepts/ipam/eni.rst`
- `Documentation/network/clustermesh/eks-clustermesh-prep.rst`
- `Documentation/installation/k8s-install-migration.rst`
- `Documentation/gettingstarted/k8s-install-default.rst`
- `Documentation/configuration/per-node-config.rst`

Fixes: #37263

```release-note
docs: Add guidance for displaying file creation in documentation style guide
```
