### PR TITLE
cleanup: remove unused DNSRequestHandler field

### DIFF
--- a/pkg/fqdn/messagehandler/message_handler.go
+++ b/pkg/fqdn/messagehandler/message_handler.go
@@ -76,7 +76,6 @@ type dnsMessageHandler struct {
 	logger            *slog.Logger
 	nameManager       namemanager.NameManager
 	proxyAccessLogger accesslog.ProxyAccessLogger
-	DNSRequestHandler DNSMessageHandler
 
 	bindPort uint16
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!


Remove the redundant DNSRequestHandler field from the dnsMessageHandler struct in `message_handler.go`. The field was never initialized or referenced and created an unnecessary circular/interface-in-struct confusion. No functional changes - cleanup only.