### PR TITLE
clustermesh: handle conflict/resolution of IPFamilies in MCS-API 

### DIFF
--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -24,8 +24,8 @@ You first need to install the required MCS-API CRDs:
 
    .. code-block:: shell-session
 
-      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/79efdd37ed2bf99b4ade250e4c0f4d62a4e970a2/config/crd/multicluster.x-k8s.io_serviceexports.yaml
-      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/79efdd37ed2bf99b4ade250e4c0f4d62a4e970a2/config/crd/multicluster.x-k8s.io_serviceimports.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/44eb577590157426d94d4ff6508f193e45b7f306/config/crd/multicluster.x-k8s.io_serviceexports.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/44eb577590157426d94d4ff6508f193e45b7f306/config/crd/multicluster.x-k8s.io_serviceimports.yaml
 
 
 To install Cilium with MCS-API support, run:

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -125,6 +125,10 @@ const (
 	// we have patched its configuration to enabled MCS-API support.
 	CoreDNSAutoPatched = ClusterMeshPrefix + "/autoPatchedAt"
 
+	// SupportedIPFamilies is an internal annotation in MCS-API to track which
+	// ip families are used and supported by the local cluster
+	SupportedIPFamilies = ClusterMeshPrefix + "/supported-ip-families"
+
 	// ServiceLoadBalancingAlgorithm indicates which backend selection algorithm
 	// for a given Service to use. This annotation will override the default
 	// value set in bpf-lb-algorithm.

--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -22,6 +22,7 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var Cell = cell.Module(
@@ -40,6 +41,7 @@ var ServiceExportSyncCell = cell.Module(
 type mcsAPIParams struct {
 	cell.In
 
+	AgentConfig *option.DaemonConfig
 	ClusterMesh operator.ClusterMesh
 	Cfg         operator.ClusterMeshConfig
 	CfgMCSAPI   operator.MCSAPIConfig
@@ -133,6 +135,7 @@ func registerMCSAPIController(params mcsAPIParams) error {
 	svcImportReconciler := newMCSAPIServiceImportReconciler(
 		params.CtrlRuntimeManager, params.Logger, params.ClusterInfo.Name,
 		params.ClusterMesh.GlobalServiceExports(), remoteClusterServiceSource,
+		params.AgentConfig.EnableIPv4, params.AgentConfig.EnableIPv6,
 	)
 
 	params.JobGroup.Add(job.OneShot("mcsapi-main", func(ctx context.Context, health cell.Health) error {

--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
@@ -235,13 +235,17 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      commonDerivedName,
 				Namespace: "default",
+				Annotations: map[string]string{
+					"clustermesh.cilium.io/supported-ip-families": "IPv4",
+				},
 				Labels: map[string]string{
 					"test-label": "copied",
 				},
 			},
 			Spec: corev1.ServiceSpec{
 				IPFamilies: []corev1.IPFamily{
-					corev1.IPv4Protocol,
+					// Make sure this is ignored if the supported families annotation is present
+					corev1.IPv6Protocol,
 				},
 				Ports: []corev1.ServicePort{{
 					Port: 80,

--- a/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
@@ -513,6 +513,7 @@ func Test_mcsServiceImport_Reconcile(t *testing.T) {
 		cluster:                    localClusterName,
 		globalServiceExports:       globalServiceExports,
 		remoteClusterServiceSource: remoteClusterServiceSource,
+		enableIPv4:                 true,
 	}
 
 	t.Run("Service import creation with local-only", func(t *testing.T) {
@@ -775,8 +776,9 @@ func Test_mcsServiceImport_Reconcile(t *testing.T) {
 			"exported-label": "",
 		}))
 		require.True(t, maps.Equal(svcImport.Annotations, map[string]string{
-			mcsapicontrollers.DerivedServiceAnnotation: "",
-			"exported-annotation":                      "",
+			"clustermesh.cilium.io/supported-ip-families": "IPv4",
+			mcsapicontrollers.DerivedServiceAnnotation:    "",
+			"exported-annotation":                         "",
 		}))
 	})
 
@@ -907,12 +909,14 @@ func Test_mcsServiceImport_Reconcile(t *testing.T) {
 			name: "conflict-annotations",
 			remoteSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
 				return maps.Equal(svcImport.Annotations, map[string]string{
+					"clustermesh.cilium.io/supported-ip-families":   "IPv4",
 					"service.cilium.io/global-sync-endpoint-slices": "true",
 					"service.cilium.io/lb-l7":                       "true",
 				})
 			},
 			localSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
 				return maps.Equal(svcImport.Annotations, map[string]string{
+					"clustermesh.cilium.io/supported-ip-families":   "IPv4",
 					"service.cilium.io/global-sync-endpoint-slices": "true",
 				})
 			},

--- a/pkg/clustermesh/mcsapi/types/ipfamilies.go
+++ b/pkg/clustermesh/mcsapi/types/ipfamilies.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/pkg/slices"
+)
+
+func IPFamiliesToString(ipfamilies []corev1.IPFamily) string {
+	return strings.Join(slices.Map(ipfamilies, func(ipf corev1.IPFamily) string { return string(ipf) }), ",")
+}
+
+func IPFamiliesFromString(s string) ([]corev1.IPFamily, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	ipfamilies := make([]corev1.IPFamily, 0, 2)
+	for _, ipfamily := range strings.Split(s, ",") {
+		ipfamily = strings.TrimSpace(ipfamily)
+		switch ipfamily {
+		case string(corev1.IPv4Protocol):
+			ipfamilies = append(ipfamilies, corev1.IPv4Protocol)
+		case string(corev1.IPv6Protocol):
+			ipfamilies = append(ipfamilies, corev1.IPv6Protocol)
+		default:
+			return nil, fmt.Errorf("invalid IP family: %s", ipfamily)
+		}
+	}
+	return ipfamilies, nil
+}


### PR DESCRIPTION
This PR leverage the newly added IPFamilies field in ServiceImport to resolve correctly exported service with mixed IPFamilies in different clusters. The approach here is to get an intersection of all IPFamilies exported, this ensure that we can connect to all backends in all the advertised IPFamilies that ends up in the ServiceImport.

If the the exported services IPFamilies would intersect to none a conflict condition is raised and if we import a service with no compatible IPFamilies wrt the local cluster we raise an error in the ServiceImport condition.

Additionally we leverage a new annotation rather than relying on the IPFamilies field of the derived service which might be hard to mutate correctly.

See each individual commit for more details

```release-note
clustermesh: handle conflict/resolution of IPFamilies in MCS-API to better support dual stack clusters 
```
