### PR TITLE
Add L7 policy traffic disruption tests

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -28,6 +28,10 @@ inputs:
     required: false
     default: 'false'
     description: 'Skip NS traffic disruption test (--include-conn-disrupt-test-ns-traffic). Can be removed after Cilium v1.20 release'
+  include-conn-disrupt-test-l7-traffic:
+    required: false
+    default: 'false'
+    description: 'Include L7 traffic disruption test (--include-conn-disrupt-test-l7-traffic)'
 runs:
   using: composite
   steps:
@@ -50,6 +54,11 @@ runs:
             EXTRA_ARG="${EXTRA_ARG} --include-conn-disrupt-test-ns-traffic"
           fi
         fi
+
+        if [[ "${{ inputs.include-conn-disrupt-test-l7-traffic }}" == "true" ]]; then
+          EXTRA_ARG="${EXTRA_ARG} --include-conn-disrupt-test-l7-traffic"
+        fi
+
         ${{ inputs.cilium-cli }} connectivity test --include-unsafe-tests \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
           --conn-disrupt-test-xfrm-errors-path "./cilium-conn-disrupt-xfrm-errors" \

--- a/.github/actions/conn-disrupt-test-setup/action.yaml
+++ b/.github/actions/conn-disrupt-test-setup/action.yaml
@@ -6,6 +6,10 @@ inputs:
     required: false
     default: "/usr/local/bin/cilium"
     description: 'Path to the Cilium CLI binary'
+  include-conn-disrupt-test-l7-traffic:
+    required: false
+    default: 'false'
+    description: 'Include L7 traffic disruption test setup (--include-conn-disrupt-test-l7-traffic)'
 
 runs:
   using: composite
@@ -13,6 +17,10 @@ runs:
     - name: Setup Conn Disrupt Test
       shell: bash
       run: |
+        if [[ "${{ inputs.include-conn-disrupt-test-l7-traffic }}" == "true" ]]; then
+          EXTRA_ARG="--include-conn-disrupt-test-l7-traffic"
+        fi
+
         # Create pods which establish long lived connections. It will be used by
         # subsequent connectivity tests with --include-conn-disrupt-test to catch any
         # interruption in such flows.
@@ -24,4 +32,5 @@ runs:
           --conn-disrupt-dispatch-interval 0ms \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
           --conn-disrupt-test-xfrm-errors-path "./cilium-conn-disrupt-xfrm-errors" \
-          --expected-xfrm-errors "+inbound_no_state"
+          --expected-xfrm-errors "+inbound_no_state" \
+          ${EXTRA_ARG}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -463,6 +463,40 @@ jobs:
         if: ${{ matrix.encryption != '' }}
         uses: ./.github/actions/bpftrace/check
 
+      - name: Features tested before cilium-agent restart
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested before cilium-agent restart"
+          json-filename: "${{ env.job_name }} (${{ matrix.name }}) - before agent restart"
+
+      - name: Setup conn-disrupt-test before restarting
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        uses: ./.github/actions/conn-disrupt-test-setup
+        with:
+          # cilium-agent only restart should not result in L7 traffic failures.
+          include-conn-disrupt-test-l7-traffic: true
+
+      - name: Restart Cilium Agent
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        shell: bash
+        run: |
+          kubectl -n kube-system rollout restart daemonset cilium
+          kubectl -n kube-system rollout status daemonset cilium
+
+          cilium status --wait --interactive=false --wait-duration=10m
+          kubectl get pods --all-namespaces -o wide
+          kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
+
+      - name: Test Cilium ${{ matrix.skip-upgrade != 'true' && 'after agent restart' }}
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        uses: ./.github/actions/conn-disrupt-test-check
+        with:
+          job-name: cilium-restart-${{ matrix.name }}-precheck
+          extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
+          include-conn-disrupt-test-l7-traffic: true
+
       - name: Features tested before downgrade
         uses: ./.github/actions/feature-status
         with:
@@ -480,7 +514,6 @@ jobs:
           # disable the check for proxy traffic.
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
           args: ${{ steps.bpftrace-params.outputs.params }} "false" "${{ matrix.encryption }}"
-
 
       - name: Downgrade to Cilium ${{ steps.vars.outputs.downgrade_version }}
         if: ${{ matrix.skip-upgrade != 'true' }}

--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -49,6 +49,7 @@ cilium connectivity test [flags]
       --hubble-server string                                  Address of the Hubble endpoint for flow validation (default "localhost:4245")
       --include-conn-disrupt-test                             Include conn disrupt test
       --include-conn-disrupt-test-egw                         Include conn disrupt test for Egress Gateway
+      --include-conn-disrupt-test-l7-traffic                  Include conn disrupt test for L7 traffic
       --include-conn-disrupt-test-ns-traffic                  Include conn disrupt test for NS traffic
       --ip-families strings                                   Restrict test actions to specific IP families (default [ipv4,ipv6])
       --json-mock-image string                                Image path to use for json mock (default "quay.io/cilium/json-mock:v1.3.9@sha256:c98b26177a5a60020e5aa404896d55f0ab573d506f42acfb4aa4f5705a5c6f56")
@@ -112,7 +113,7 @@ cilium connectivity test [flags]
                                                               NOTE: There is a lower bound requirement on the number of workers for the sysdump operation to be effective. Therefore, for low values, the actual number of workers may be adjusted upwards. Defaults to the number of available CPUs. (default 20)
       --test strings                                          Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'
       --test-concurrency int                                  Count of namespaces to perform the connectivity tests in parallel (value <= 0 will be treated as 1) (default 1)
-      --test-conn-disrupt-image string                        Image path to use for connection disruption tests (default "quay.io/cilium/test-connection-disruption:v0.0.16@sha256:e8e3257b2c89543dc49a2d820f2d2d69c1fe60eaf1036fc1f1f7375bad8e6232")
+      --test-conn-disrupt-image string                        Image path to use for connection disruption tests (default "quay.io/cilium/test-connection-disruption:v0.0.17@sha256:62374cfd0e87e6541244331ccf477a21c527c3eefa9d841b97af79996939be0c")
       --test-namespace string                                 Namespace to perform the connectivity in (always suffixed with a sequence number to be compliant with test-concurrency param, e.g.: cilium-test-1) (default "cilium-test")
       --timeout duration                                      Maximum time to allow the connectivity test suite to take
   -t, --timestamp                                             Show timestamp in messages

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -198,6 +198,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.IncludeConnDisruptTest, "include-conn-disrupt-test", false, "Include conn disrupt test")
 	cmd.Flags().BoolVar(&params.IncludeConnDisruptTestNSTraffic, "include-conn-disrupt-test-ns-traffic", false, "Include conn disrupt test for NS traffic")
 	cmd.Flags().BoolVar(&params.IncludeConnDisruptTestEgressGateway, "include-conn-disrupt-test-egw", false, "Include conn disrupt test for Egress Gateway")
+	cmd.Flags().BoolVar(&params.IncludeConnDisruptTestL7Traffic, "include-conn-disrupt-test-l7-traffic", false, "Include conn disrupt test for L7 traffic")
 	cmd.Flags().BoolVar(&params.ConnDisruptTestSetup, "conn-disrupt-test-setup", false, "Set up conn disrupt test dependencies")
 	cmd.Flags().StringVar(&params.ConnDisruptTestRestartsPath, "conn-disrupt-test-restarts-path", "/tmp/cilium-conn-disrupt-restarts", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -116,6 +116,7 @@ type Parameters struct {
 	IncludeConnDisruptTest              bool
 	IncludeConnDisruptTestNSTraffic     bool
 	IncludeConnDisruptTestEgressGateway bool
+	IncludeConnDisruptTestL7Traffic     bool
 	ConnDisruptTestSetup                bool
 	ConnDisruptTestRestartsPath         string
 	ConnDisruptTestXfrmErrorsPath       string

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -106,6 +106,7 @@ type ConnectivityTest struct {
 	ciliumNodes        map[NodeIdentity]*ciliumv2.CiliumNode
 
 	testConnDisruptClientNSTrafficDeploymentNames []string
+	testConnDisruptClientL7TrafficDeploymentNames []string
 }
 
 // NodeIdentity uniquely identifies a Node by Cluster and Name.
@@ -1345,6 +1346,13 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 		ct.Features[features.NodeWithoutCilium].Enabled &&
 		(ct.Params().MultiCluster == "" || ct.Features[features.KPR].Enabled) &&
 		!ct.Features[features.KPRNodePortAcceleration].Enabled
+}
+
+func (ct *ConnectivityTest) ShouldRunConnDisruptL7Traffic() bool {
+	return ct.params.IncludeConnDisruptTestL7Traffic &&
+		ct.Features[features.CNP].Enabled &&
+		ct.Features[features.L7Proxy].Enabled &&
+		ct.Features[features.ExternalEnvoyProxy].Enabled
 }
 
 func (ct *ConnectivityTest) ShouldRunConnDisruptEgressGateway() bool {

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -91,24 +91,31 @@ const (
 
 	testConnDisruptClientDeploymentName                              = "test-conn-disrupt-client"
 	testConnDisruptClientNSTrafficDeploymentName                     = "test-conn-disrupt-client"
+	testConnDisruptClientL7TrafficDeploymentName                     = "test-conn-disrupt-client-l7"
 	testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName    = "test-conn-disrupt-client-egw-gw-node"
 	testConnDisruptClientEgressGatewayOnNonGatewayNodeDeploymentName = "test-conn-disrupt-client-egw-non-gw-node"
 	testConnDisruptServerDeploymentName                              = "test-conn-disrupt-server"
 	testConnDisruptServerNSTrafficDeploymentName                     = "test-conn-disrupt-server-ns-traffic"
+	testConnDisruptServerL7TrafficDeploymentName                     = "test-conn-disrupt-server-l7-traffic"
 	testConnDisruptServerEgressGatewayDeploymentName                 = "test-conn-disrupt-server-egw"
 	testConnDisruptServiceName                                       = "test-conn-disrupt"
 	testConnDisruptNSTrafficServiceName                              = "test-conn-disrupt-ns-traffic"
+	testConnDisruptL7TrafficServiceName                              = "test-conn-disrupt-l7-traffic"
 	testConnDisruptEgressGatewayServiceName                          = "test-conn-disrupt-egw"
 	testConnDisruptCNPName                                           = "test-conn-disrupt"
 	testConnDisruptNSTrafficCNPName                                  = "test-conn-disrupt-ns-traffic"
+	testConnDisruptL7TrafficCNPName                                  = "test-conn-disrupt-l7-traffic"
 	testConnDisruptEgressGatewayCNPName                              = "test-conn-disrupt-egw"
 	testConnDisruptCEGPName                                          = "test-conn-disrupt"
 	testConnDisruptServerNSTrafficAppLabel                           = "test-conn-disrupt-server-ns-traffic"
+	testConnDisruptServerL7TrafficAppLabel                           = "test-conn-disrupt-server-l7-traffic"
+	testConnDisruptClientL7TrafficAppLabel                           = "test-conn-disrupt-client-l7-traffic"
 	testConnDisruptServerEgressGatewayAppLabel                       = "test-conn-disrupt-server-egw"
 	testConnDisruptClientEgressGatewayOnGatewayNodeAppLabel          = "test-conn-disrupt-client-egw-gw-node"
 	testConnDisruptClientEgressGatewayOnNonGatewayNodeAppLabel       = "test-conn-disrupt-client-egw-non-gw-node"
 	KindTestConnDisrupt                                              = "test-conn-disrupt"
 	KindTestConnDisruptNSTraffic                                     = "test-conn-disrupt-ns-traffic"
+	KindTestConnDisruptL7Traffic                                     = "test-conn-disrupt-l7-traffic"
 	KindTestConnDisruptEgressGateway                                 = "test-conn-disrupt-egw"
 
 	bwPrioAnnotationString = "bandwidth.cilium.io/priority"
@@ -538,6 +545,46 @@ func newConnDisruptCNPForNSTraffic(ns string) *ciliumv2.CiliumNetworkPolicy {
 	}
 }
 
+func newConnDisruptCNPForL7Traffic(ns string) *ciliumv2.CiliumNetworkPolicy {
+	selector := policyapi.EndpointSelector{
+		LabelSelector: &slimmetav1.LabelSelector{
+			MatchLabels: map[string]string{"kind": KindTestConnDisruptL7Traffic},
+		},
+	}
+
+	ports := []policyapi.PortRule{{
+		Ports: []policyapi.PortProtocol{{
+			Protocol: policyapi.ProtoTCP,
+			Port:     "8000",
+		}},
+		Rules: &policyapi.L7Rules{
+			HTTP: []policyapi.PortRuleHTTP{{
+				Path:   "/echo",
+				Method: "GET",
+			}},
+		},
+	}}
+
+	return &ciliumv2.CiliumNetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.CNPKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: testConnDisruptL7TrafficCNPName, Namespace: ns},
+		Spec: &policyapi.Rule{
+			EndpointSelector: selector,
+			Ingress: []policyapi.IngressRule{{
+				IngressCommonRule: policyapi.IngressCommonRule{
+					FromEntities: policyapi.EntitySlice{
+						policyapi.EntityCluster,
+					},
+				},
+				ToPorts: ports,
+			}},
+		},
+	}
+}
+
 func newConnDisruptCNPForEgressGateway(ns string) *ciliumv2.CiliumNetworkPolicy {
 	selector := policyapi.EndpointSelector{
 		LabelSelector: &slimmetav1.LabelSelector{
@@ -755,19 +802,19 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	// test namespace in case of tests concurrent run)
 	if ct.params.ConnDisruptTestSetup && ct.params.TestNamespaceIndex == 0 {
 		if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerDeploymentName, KindTestConnDisrupt, 3,
-			testConnDisruptServiceName, "test-conn-disrupt-server", false, newConnDisruptCNP); err != nil {
+			testConnDisruptServiceName, "test-conn-disrupt-server", false, newConnDisruptCNP, ""); err != nil {
 			return err
 		}
 
 		if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientDeploymentName, KindTestConnDisrupt,
 			"test-conn-disrupt-client", fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
-			5, false, nil); err != nil {
+			5, false, nil, ""); err != nil {
 			return err
 		}
 
 		if ct.ShouldRunConnDisruptNSTraffic() {
 			if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerNSTrafficDeploymentName, KindTestConnDisruptNSTraffic, 1,
-				testConnDisruptNSTrafficServiceName, testConnDisruptServerNSTrafficAppLabel, false, newConnDisruptCNPForNSTraffic); err != nil {
+				testConnDisruptNSTrafficServiceName, testConnDisruptServerNSTrafficAppLabel, false, newConnDisruptCNPForNSTraffic, ""); err != nil {
 				return err
 			}
 
@@ -776,6 +823,49 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			}
 		} else {
 			ct.Info("Skipping conn-disrupt-test for NS traffic")
+		}
+
+		if ct.ShouldRunConnDisruptL7Traffic() {
+			if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerL7TrafficDeploymentName, KindTestConnDisruptL7Traffic, 1,
+				testConnDisruptL7TrafficServiceName, testConnDisruptServerL7TrafficAppLabel, false, newConnDisruptCNPForL7Traffic, "http"); err != nil {
+				return err
+			}
+
+			allTargets := map[string]string{
+				"svc": fmt.Sprintf("%s.%s.svc.cluster.local.", testConnDisruptL7TrafficServiceName, ct.params.TestNamespace),
+			}
+			serverPods, err := ct.clients.src.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", testConnDisruptServerL7TrafficAppLabel)})
+			if err != nil {
+				return err
+			}
+			for _, serverPod := range serverPods.Items {
+				for _, podIPAddr := range serverPod.Status.PodIPs {
+					podIP := net.ParseIP(podIPAddr.IP)
+					if podIP == nil {
+						continue
+					}
+
+					if podIP.To4() != nil {
+						allTargets["ep-v4"] = podIPAddr.IP
+					} else {
+						allTargets["ep-v6"] = podIPAddr.IP
+					}
+				}
+			}
+
+			for targetName, target := range allTargets {
+				clientDeploymentName := fmt.Sprintf("%s-%s", testConnDisruptClientL7TrafficDeploymentName, targetName)
+				targetAddress := fmt.Sprintf("http://%s:8000/echo", target)
+
+				if err := ct.createTestConnDisruptClientDeployment(ctx, clientDeploymentName, KindTestConnDisruptL7Traffic,
+					testConnDisruptClientL7TrafficAppLabel, targetAddress, 1, false, nil, "http"); err != nil {
+					return err
+				}
+
+				ct.testConnDisruptClientL7TrafficDeploymentNames = append(ct.testConnDisruptClientL7TrafficDeploymentNames, clientDeploymentName)
+			}
+		} else {
+			ct.Info("Skipping conn-disrupt-test for L7 traffic")
 		}
 
 		if ct.ShouldRunConnDisruptEgressGateway() {
@@ -791,18 +881,18 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			}
 
 			if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerEgressGatewayDeploymentName, KindTestConnDisruptEgressGateway, 1,
-				testConnDisruptEgressGatewayServiceName, testConnDisruptServerEgressGatewayAppLabel, true, newConnDisruptCNPForEgressGateway); err != nil {
+				testConnDisruptEgressGatewayServiceName, testConnDisruptServerEgressGatewayAppLabel, true, newConnDisruptCNPForEgressGateway, ""); err != nil {
 				return err
 			}
 
 			if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName, KindTestConnDisruptEgressGateway,
 				testConnDisruptClientEgressGatewayOnGatewayNodeAppLabel, fmt.Sprintf("test-conn-disrupt-egw.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
-				1, false, map[string]string{"kubernetes.io/hostname": gatewayNode}); err != nil {
+				1, false, map[string]string{"kubernetes.io/hostname": gatewayNode}, ""); err != nil {
 				return err
 			}
 			if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientEgressGatewayOnNonGatewayNodeDeploymentName, KindTestConnDisruptEgressGateway,
 				testConnDisruptClientEgressGatewayOnNonGatewayNodeAppLabel, fmt.Sprintf("test-conn-disrupt-egw.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
-				1, false, map[string]string{"kubernetes.io/hostname": nonGatewayNode}); err != nil {
+				1, false, map[string]string{"kubernetes.io/hostname": nonGatewayNode}, ""); err != nil {
 				return err
 			}
 			for _, clientDeploy := range []string{testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName, testConnDisruptClientEgressGatewayOnNonGatewayNodeDeploymentName} {
@@ -1516,7 +1606,12 @@ func (ct *ConnectivityTest) patchDeployment(ctx context.Context) error {
 }
 
 func (ct *ConnectivityTest) createTestConnDisruptServerDeployAndSvc(ctx context.Context, deployName, kind string, replicas int, svcName, appLabel string,
-	isExternal bool, cnpFunc func(ns string) *ciliumv2.CiliumNetworkPolicy) error {
+	isExternal bool, cnpFunc func(ns string) *ciliumv2.CiliumNetworkPolicy, protocol string) error {
+	command := []string{"tcd-server", "8000"}
+	if len(protocol) != 0 {
+		command = []string{"tcd-server", "--protocol", protocol, "8000"}
+	}
+
 	_, err := ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, deployName, metav1.GetOptions{})
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.src.ClusterName(), deployName)
@@ -1536,7 +1631,7 @@ func (ct *ConnectivityTest) createTestConnDisruptServerDeployAndSvc(ctx context.
 			Image:          ct.params.TestConnDisruptImage,
 			Replicas:       replicas,
 			Labels:         map[string]string{"app": appLabel},
-			Command:        []string{"tcd-server", "8000"},
+			Command:        command,
 			Port:           8000,
 			ReadinessProbe: readinessProbe,
 			Resources: corev1.ResourceRequirements{
@@ -1600,7 +1695,15 @@ func (ct *ConnectivityTest) createTestConnDisruptServerDeployAndSvc(ctx context.
 	return err
 }
 
-func (ct *ConnectivityTest) createTestConnDisruptClientDeployment(ctx context.Context, deployName, kind, appLabel, address string, replicas int, isExternal bool, nodeSelector map[string]string) error {
+func (ct *ConnectivityTest) createTestConnDisruptClientDeployment(ctx context.Context, deployName, kind, appLabel, address string, replicas int, isExternal bool, nodeSelector map[string]string, protocol string) error {
+	command := []string{
+		"tcd-client",
+		"--dispatch-interval", ct.params.ConnDisruptDispatchInterval.String(),
+	}
+	if len(protocol) != 0 {
+		command = append(command, "--protocol", protocol)
+	}
+
 	_, err := ct.clients.dst.GetDeployment(ctx, ct.params.TestNamespace, deployName, metav1.GetOptions{})
 	if err != nil {
 		ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.dst.ClusterName(), deployName)
@@ -1621,11 +1724,8 @@ func (ct *ConnectivityTest) createTestConnDisruptClientDeployment(ctx context.Co
 			Image:    ct.params.TestConnDisruptImage,
 			Replicas: replicas,
 			Labels:   map[string]string{"app": appLabel},
-			Command: []string{
-				"tcd-client",
-				"--dispatch-interval", ct.params.ConnDisruptDispatchInterval.String(),
-				address,
-			},
+			Command:  append(command, address),
+
 			ReadinessProbe: readinessProbe,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{corev1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI)},
@@ -1692,7 +1792,7 @@ func (ct *ConnectivityTest) createTestConnDisruptClientDeploymentForNSTraffic(ct
 						KindTestConnDisruptNSTraffic,
 						fmt.Sprintf("test-conn-disrupt-client-%s-%s-%s", n.nodeType, family, strings.ToLower(string(addr.Type))),
 						netip.AddrPortFrom(netip.MustParseAddr(addr.Address), np).String(),
-						1, true, nil); err != nil {
+						1, true, nil, ""); err != nil {
 						errs = errors.Join(errs, err)
 					}
 					ct.testConnDisruptClientNSTrafficDeploymentNames = append(ct.testConnDisruptClientNSTrafficDeploymentNames, deployName)
@@ -2175,6 +2275,10 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 			srcList = append(srcList, testConnDisruptServerNSTrafficDeploymentName)
 			dstList = append(dstList, ct.testConnDisruptClientNSTrafficDeploymentNames...)
 		}
+		if ct.ShouldRunConnDisruptL7Traffic() {
+			srcList = append(srcList, testConnDisruptServerL7TrafficDeploymentName)
+			dstList = append(dstList, ct.testConnDisruptClientL7TrafficDeploymentNames...)
+		}
 		if ct.ShouldRunConnDisruptEgressGateway() {
 			srcList = append(srcList, testConnDisruptServerEgressGatewayDeploymentName)
 			dstList = append(dstList, testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName,
@@ -2241,6 +2345,7 @@ func (ct *ConnectivityTest) DeleteConnDisruptTestDeployment(ctx context.Context,
 	ct.Debugf("🔥 [%s] Deleting test-conn-disrupt deployments...", client.ClusterName())
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptClientDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.DeleteOptions{})
+
 	deployList, err := client.ListDeployment(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + KindTestConnDisruptNSTraffic})
 	if err != nil {
 		ct.Warnf("failed to list deployments: %s %v", KindTestConnDisruptNSTraffic, err)
@@ -2249,21 +2354,35 @@ func (ct *ConnectivityTest) DeleteConnDisruptTestDeployment(ctx context.Context,
 		_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, deploy.Name, metav1.DeleteOptions{})
 		_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, deploy.Name, metav1.DeleteOptions{})
 	}
+
+	deployList, err = client.ListDeployment(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + KindTestConnDisruptL7Traffic})
+	if err != nil {
+		ct.Warnf("failed to list deployments: %s %v", KindTestConnDisruptNSTraffic, err)
+	}
+	for _, deploy := range deployList.Items {
+		_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, deploy.Name, metav1.DeleteOptions{})
+		_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, deploy.Name, metav1.DeleteOptions{})
+	}
+
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerNSTrafficDeploymentName, metav1.DeleteOptions{})
+	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerL7TrafficDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptClientEgressGatewayOnNonGatewayNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerEgressGatewayDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptClientDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptServerNSTrafficDeploymentName, metav1.DeleteOptions{})
+	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptServerL7TrafficDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptServerEgressGatewayDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptClientEgressGatewayOnGatewayNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptClientEgressGatewayOnNonGatewayNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteService(ctx, ct.params.TestNamespace, testConnDisruptServiceName, metav1.DeleteOptions{})
 	_ = client.DeleteService(ctx, ct.params.TestNamespace, testConnDisruptNSTrafficServiceName, metav1.DeleteOptions{})
+	_ = client.DeleteService(ctx, ct.params.TestNamespace, testConnDisruptL7TrafficServiceName, metav1.DeleteOptions{})
 	_ = client.DeleteService(ctx, ct.params.TestNamespace, testConnDisruptEgressGatewayServiceName, metav1.DeleteOptions{})
 	_ = client.DeleteCiliumNetworkPolicy(ctx, ct.params.TestNamespace, testConnDisruptCNPName, metav1.DeleteOptions{})
 	_ = client.DeleteCiliumNetworkPolicy(ctx, ct.params.TestNamespace, testConnDisruptNSTrafficCNPName, metav1.DeleteOptions{})
+	_ = client.DeleteCiliumNetworkPolicy(ctx, ct.params.TestNamespace, testConnDisruptL7TrafficCNPName, metav1.DeleteOptions{})
 	_ = client.DeleteCiliumNetworkPolicy(ctx, ct.params.TestNamespace, testConnDisruptEgressGatewayCNPName, metav1.DeleteOptions{})
 	_ = client.DeleteCiliumEgressGatewayPolicy(ctx, testConnDisruptCEGPName, metav1.DeleteOptions{})
 

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -150,6 +150,10 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 		Enabled: st.Proxy != nil,
 	}
 
+	result[features.ExternalEnvoyProxy] = features.Status{
+		Enabled: st.Proxy != nil && strings.ToLower(st.Proxy.EnvoyDeploymentMode) == "external",
+	}
+
 	// Host Firewall
 	status := false
 	if hf := st.HostFirewall; hf != nil {

--- a/cilium-cli/connectivity/tests/upgrade.go
+++ b/cilium-cli/connectivity/tests/upgrade.go
@@ -78,6 +78,22 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 			ct.Info("Skipping conn-disrupt-test for NS traffic")
 		}
 
+		if ct.ShouldRunConnDisruptL7Traffic() {
+			pods, err = client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptL7Traffic})
+			if err != nil {
+				t.Fatalf("Unable to list test-conn-disrupt-l7-traffic pods: %s", err)
+			}
+			if len(pods.Items) == 0 {
+				t.Fatal("No test-conn-disrupt-{client,server} for L7 traffic pods found")
+			}
+
+			for _, pod := range pods.Items {
+				restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+			}
+		} else {
+			ct.Info("Skipping conn-disrupt-test for L7 traffic")
+		}
+
 		if ct.ShouldRunConnDisruptEgressGateway() {
 			pods, err = client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptEgressGateway})
 			if err != nil {

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -173,7 +173,7 @@ var (
 		// renovate: datasource=docker
 		"ConnectivityDNSTestServerImage": "registry.k8s.io/coredns/coredns:v1.12.4@sha256:986f04c2e15e147d00bdd51e8c51bcef3644b13ff806be7d2ff1b261d6dfbae1",
 		// renovate: datasource=docker
-		"ConnectivityTestConnDisruptImage": "quay.io/cilium/test-connection-disruption:v0.0.16@sha256:e8e3257b2c89543dc49a2d820f2d2d69c1fe60eaf1036fc1f1f7375bad8e6232",
+		"ConnectivityTestConnDisruptImage": "quay.io/cilium/test-connection-disruption:v0.0.17@sha256:62374cfd0e87e6541244331ccf477a21c527c3eefa9d841b97af79996939be0c",
 		// renovate: datasource=docker
 		"ConnectivityTestFRRImage": "quay.io/frrouting/frr:10.5.0@sha256:fc7f887ab4d8da06f481a4f8d59afded88b3c5823f03610a7e808f7eba45eeea",
 		// renovate: datasource=docker

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -120,6 +120,8 @@ const (
 	L7LoadBalancer Feature = "loadbalancer-l7"
 
 	RHEL Feature = "rhel"
+
+	ExternalEnvoyProxy Feature = "external-envoy-proxy"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)


### PR DESCRIPTION
Dependency: https://github.com/cilium/test-connection-disruption/pull/16

This PR adds a new flag to cilium-cli to run L7 traffic disruption tests as part of upgrade tests that validate connections are not interrupted. Currently it covers HTTP traffic with a L7 policy.
The check can be enabled with `--include-conn-disrupt-test-l7-traffic` flag.

Currently cilium-envoy restarts are not hitless, so this check fails for full cilium upgrade(which includes a proxy restart). This PR updates the ci-e2e-upgrade workflow to add steps for running conn-disrupt-test during cilium-agent restart. We expect L7 policy and traffic to not be impacted during just cilium-agent restart.