### PR TITLE
tools: add a plain input mode to testowners

### DIFF
--- a/tools/testowners/main.go
+++ b/tools/testowners/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cilium/cilium/tools/testowners/codeowners"
 )
 
-func fatal(fmt string, msg ...any) {
-	slog.Error(fmt, msg...)
+func fatal(msg string, args ...any) {
+	slog.Error(msg, args...)
 	os.Exit(1)
 }
 
@@ -133,7 +133,7 @@ func main() {
 
 	owners, err := codeowners.Load(CodeOwners)
 	if err != nil {
-		fatal("❗ Failed to load code owners: %s\n", err)
+		fatal("❗ Failed to load code owners", "error", err)
 	}
 
 	switch Format {


### PR DESCRIPTION
Add a "plain" input mode to the testowners tool, which does not parse the input. 

Rather, it expects one filepath per line, relative to the root of the Cilium repo.

An example interactive invocation:

```
$ go run tools/testowners/main.go --format=plain
USERS.md
⛑️ The following owners are responsible for USERS.md:
 - @cilium/community
.github/workflows/cilium-cli.yaml
⛑️ The following owners are responsible for .github/workflows/cilium-cli.yaml:
 - @cilium/cli
 - @cilium/github-sec
 - @cilium/ci-structure
images/cilium/Dockerfile
⛑️ The following owners are responsible for images/cilium/Dockerfile:
 - @cilium/build
bpf/Makefile
⛑️ The following owners are responsible for bpf/Makefile:
 - @cilium/loader
install/kubernetes/cilium/README.md
⛑️ The following owners are responsible for install/kubernetes/cilium/README.md:
 - @cilium/sig-k8s
 - @cilium/helm
pkg/option/config.go
⛑️ The following owners are responsible for pkg/option/config.go:
 - @cilium/sig-agent
 - @cilium/cli
```
