### PR TITLE
v1.17 Backports 2025-10-13

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -1042,6 +1042,10 @@ type AllocatorEvent struct {
 
 	// Key is the key associated with the ID
 	Key AllocatorKey
+
+	// Done is a channel that is closed when this event is processed.
+	// Optional
+	Done chan<- struct{}
 }
 
 // remoteCache represents the cache content of an additional kvstore managing


### PR DESCRIPTION
 * [x] #42049 (@squeed) :warning: resolved conflicts - replaced some log line because v1.17 doesn't use slog

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 42049
```
