### PR TITLE
Add initializer for per-endpoint routes in endpoint restorer

### DIFF
--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -4,17 +4,28 @@
 package loader
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net"
 	"path/filepath"
 	"testing"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	"github.com/spf13/afero"
 
 	"github.com/cilium/cilium/pkg/cidr"
+	routeReconciler "github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
 )
 
 var (
@@ -32,7 +43,7 @@ var (
 func setupCompilationDirectories(tb testing.TB) {
 	option.Config.DryMode = true
 	option.Config.BpfDir = bpfDir
-	option.Config.StateDir = bpfDir
+	option.Config.StateDir = tb.TempDir()
 	testIncludes = []string{
 		// Unit tests rely on using bpf/ep_config.h instead of
 		// the real per endpoint config. Otherwise you get compilation
@@ -51,13 +62,48 @@ func setupCompilationDirectories(tb testing.TB) {
 
 func newTestLoader(tb testing.TB) *loader {
 	setupCompilationDirectories(tb)
-	logger := hivetest.Logger(tb)
 
-	l := newLoader(Params{
-		Logger: logger,
-		Sysctl: sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
-	})
-	cw := configWriterForTest(tb)
-	l.templateCache = newObjectCache(logger, cw, tb.TempDir())
+	var l *loader
+	err := hive.New(
+		cell.Invoke(func(ld datapath.Loader) {
+			l = ld.(*loader)
+		}),
+		Cell,
+
+		routeReconciler.TableCell,
+		cell.Provide(tables.NewDeviceTable), cell.Provide(statedb.RWTable[*tables.Device].ToTable),
+		cell.Provide(func() (
+			sysctl.Sysctl,
+			datapath.ConfigWriter,
+			*manager.NodeConfigNotifier,
+			promise.Promise[endpointstate.Restorer],
+			datapath.PreFilter,
+		) {
+			resolver, promise := promise.New[endpointstate.Restorer]()
+			resolver.Resolve(&FakeRestorer{})
+			return sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
+				configWriterForTest(tb),
+				&manager.NodeConfigNotifier{},
+				promise,
+				&FakePreFilter{}
+		}),
+	).Populate(hivetest.Logger(tb))
+	if err != nil {
+		tb.Fatal(err)
+	}
+
 	return l
 }
+
+type FakeRestorer struct{}
+
+func (fr *FakeRestorer) WaitForEndpointRestore(ctx context.Context) error { return nil }
+func (fr *FakeRestorer) WaitForInitialPolicy(ctx context.Context) error   { return nil }
+
+type FakePreFilter struct{}
+
+func (fpf *FakePreFilter) Enabled() bool                                  { return true }
+func (fpf *FakePreFilter) WriteConfig(fw io.Writer)                       {}
+func (fpf *FakePreFilter) Dump(to []string) ([]string, int64)             { return nil, 0 }
+func (fpf *FakePreFilter) Insert(revision int64, cidrs []net.IPNet) error { return nil }
+func (fpf *FakePreFilter) Delete(revision int64, cidrs []net.IPNet) error { return nil }


### PR DESCRIPTION
PR #41528 added route reconciliation, and converted the loader to use it for per-endpoint routes. However, the PR forgot to add an initializer. Without which we drop packets during the brief window between pruning and endpoint re-initialization.

An initializer ensures the route reconciler does not start removing routes from the kernel before we had a chance to initially populate the desired routes. Preventing the temporary loss of connectivity.

This PR adds logic that registers the initializer during loader construction and adds a one-shot job to the loader which waits for the endpoint restorer to signal it is done restoring endpoints, and then finalizes the route reconciler initializer.