### PR TITLE
bpf: pass IPv6 header to ipv6_dec_hoplimit()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -361,10 +361,14 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			if (l2_hdr_required) {
 				/* l2 header is added */
 				l3_off += __ETH_HLEN;
+				if (!____revalidate_data_pull(ctx, &data, &data_end,
+							      (void **)&ip6, sizeof(*ip6),
+							      false, l3_off))
+					return DROP_INVALID;
 			}
 		}
 #endif
-		return ipv6_local_delivery(ctx, l3_off, secctx, magic, ep,
+		return ipv6_local_delivery(ctx, l3_off, secctx, magic, ip6, ep,
 					   METRIC_INGRESS, from_host, false);
 	}
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -131,7 +131,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 			if (ipv6_addr_equals(&snat_addr, &EGRESS_GATEWAY_NO_EGRESS_IP_V6))
 				return DROP_NO_EGRESS_IP;
 
-			ret = ipv6_l3(ctx, ETH_HLEN, NULL, NULL, METRIC_INGRESS);
+			ret = ipv6_l3(ctx, ETH_HLEN, NULL, NULL, ip6, METRIC_INGRESS);
 			if (unlikely(ret != CTX_ACT_OK))
 				return ret;
 
@@ -162,7 +162,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	ep = lookup_ip6_endpoint(ip6);
 	if (ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
 		return ipv6_local_delivery(ctx, l3_off, *identity, MARK_MAGIC_IDENTITY,
-					   ep, METRIC_INGRESS, false, true);
+					   ip6, ep, METRIC_INGRESS, false, true);
 
 	/* A packet entering the node from the tunnel and not going to a local
 	 * endpoint has to be going to the local host.
@@ -172,7 +172,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		union macaddr router_mac = THIS_INTERFACE_MAC;
 
 		ret = ipv6_l3(ctx, ETH_HLEN, (__u8 *)&router_mac.addr,
-			      (__u8 *)&host_mac.addr, METRIC_INGRESS);
+			      (__u8 *)&host_mac.addr, ip6, METRIC_INGRESS);
 		if (ret != CTX_ACT_OK)
 			return ret;
 

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -113,12 +113,17 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 identity, __s8 *ext_err __maybe_unused
 		ret = maybe_add_l2_hdr(ctx, ep->ifindex, &l2_hdr_required);
 		if (ret != 0)
 			return ret;
-		if (l2_hdr_required)
+		if (l2_hdr_required) {
 			l3_off += __ETH_HLEN;
+			if (!____revalidate_data_pull(ctx, &data, &data_end,
+						      (void **)&ip6, sizeof(*ip6),
+						      false, l3_off))
+				return DROP_INVALID;
+		}
 #endif
 
-		return ipv6_local_delivery(ctx, l3_off, identity, MARK_MAGIC_IDENTITY, ep,
-					   METRIC_INGRESS, false, false);
+		return ipv6_local_delivery(ctx, l3_off, identity, MARK_MAGIC_IDENTITY,
+					   ip6, ep, METRIC_INGRESS, false, false);
 	}
 
 	return TC_ACT_OK;

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -23,8 +23,7 @@
 #define SKIP_ICMPV6_NS_HANDLING
 
 /* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED section
- * in the bpf_lxc object file. This is needed for all callers of
- * ipv6_local_delivery, which calls into the IPv6 L3 handling.
+ * in the object file.
  */
 #define SKIP_ICMPV6_HOPLIMIT_HANDLING
 

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -227,7 +227,7 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 	int ret;
 
 	if (is_defined(ENABLE_SKIP_FIB) && neigh_resolver_without_nh_available()) {
-		ret = ipv6_l3(ctx, l3_off, NULL, NULL, METRIC_EGRESS);
+		ret = ipv6_l3(ctx, l3_off, NULL, NULL, ip6, METRIC_EGRESS);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
 
@@ -253,7 +253,7 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 
 		*oif = fib_params.l.ifindex;
 
-		ret = ipv6_l3(ctx, l3_off, NULL, NULL, METRIC_EGRESS);
+		ret = ipv6_l3(ctx, l3_off, NULL, NULL, ip6, METRIC_EGRESS);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
 

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -250,13 +250,10 @@ static __always_inline void ipv6_addr_clear_suffix(union v6addr *addr,
 	addr->p4 &= GET_PREFIX(prefix);
 }
 
-static __always_inline int ipv6_dec_hoplimit(struct __ctx_buff *ctx, int off)
+static __always_inline int ipv6_dec_hoplimit(struct __ctx_buff *ctx, int off,
+					     const struct ipv6hdr *ip6)
 {
-	__u8 hl;
-
-	if (ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, hop_limit),
-			   &hl, sizeof(hl)) < 0)
-		return DROP_INVALID;
+	__u8 hl = ip6->hop_limit;
 
 	if (hl <= 1)
 		return DROP_TTL_EXCEEDED;

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -12,11 +12,12 @@
 #ifdef ENABLE_IPV6
 static __always_inline int ipv6_l3(struct __ctx_buff *ctx, int l3_off,
 				   const __u8 *smac, const __u8 *dmac,
+				   struct ipv6hdr *ip6,
 				   __u8 __maybe_unused direction)
 {
 	int ret;
 
-	ret = ipv6_dec_hoplimit(ctx, l3_off);
+	ret = ipv6_dec_hoplimit(ctx, l3_off, ip6);
 	if (IS_ERR(ret)) {
 #ifndef SKIP_ICMPV6_HOPLIMIT_HANDLING
 		if (ret == DROP_TTL_EXCEEDED)

--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -173,6 +173,7 @@ local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
  */
 static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel, __u32 magic,
+					       struct ipv6hdr *ip6,
 					       const struct endpoint_info *ep,
 					       __u8 direction, bool from_host,
 					       bool from_tunnel)
@@ -183,7 +184,8 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 
 	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, ep->lxc_id, seclabel);
 
-	ret = ipv6_l3(ctx, l3_off, (__u8 *)&router_mac, (__u8 *)&lxc_mac, direction);
+	ret = ipv6_l3(ctx, l3_off, (__u8 *)&router_mac, (__u8 *)&lxc_mac, ip6,
+		      direction);
 	if (ret != CTX_ACT_OK)
 		return ret;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -952,7 +952,7 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, enum ct_dir dir,
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		trace->monitor = monitor;
-		ret = ipv6_l3(ctx, ETH_HLEN, NULL, NULL, METRIC_EGRESS);
+		ret = ipv6_l3(ctx, ETH_HLEN, NULL, NULL, ip6, METRIC_EGRESS);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
 
@@ -1231,7 +1231,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	ipv6_ct_tuple_swap_ports(&tuple);
 	tuple.flags = TUPLE_F_OUT;
 
-	ret = ipv6_l3(ctx, ETH_HLEN, NULL, NULL, METRIC_EGRESS);
+	ret = ipv6_l3(ctx, ETH_HLEN, NULL, NULL, ip6, METRIC_EGRESS);
 	if (unlikely(ret != CTX_ACT_OK))
 		goto drop_err;
 
@@ -1340,7 +1340,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 				  bpf_htons(ETH_P_IPV6));
 
 #  if defined(ENABLE_TPROXY)
-		return ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
+		return ctx_redirect_to_proxy_hairpin_ipv6(ctx, ip6, proxy_port);
 #  else
 		cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port);
 		ctx->mark = MARK_MAGIC_TO_PROXY | (proxy_port << 16);

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -17,37 +17,11 @@
  *  interface.
  *
  * @arg ctx		Packet
- * @arg ip4		Pointer to IPv4 header. NULL for IPv6 packet.
  * @arg proxy_port	Proxy port
  */
 static __always_inline int
-ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, struct iphdr *ip4,
-			      __be16 proxy_port)
+ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port)
 {
-#if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
-	union macaddr host_mac = CILIUM_HOST_MAC;
-	union macaddr router_mac = THIS_INTERFACE_MAC;
-#endif
-	int ret = 0;
-
-	ctx_store_meta(ctx, CB_PROXY_MAGIC,
-		       MARK_MAGIC_TO_PROXY | (proxy_port << 16));
-	bpf_barrier(); /* verifier workaround */
-
-	if (!ip4) {
-#ifdef ENABLE_IPV6
-		ret = ipv6_l3(ctx, ETH_HLEN, (__u8 *)&router_mac, (__u8 *)&host_mac,
-			      METRIC_EGRESS);
-#endif
-	} else {
-#ifdef ENABLE_IPV4
-		ret = ipv4_l3(ctx, ETH_HLEN, (__u8 *)&router_mac, (__u8 *)&host_mac,
-			      ip4);
-#endif
-	}
-	if (IS_ERR(ret))
-		return ret;
-
 	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port);
 
 	/* Note that the actual __ctx_buff preparation for submitting the
@@ -63,14 +37,38 @@ static __always_inline int
 ctx_redirect_to_proxy_hairpin_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4,
 				   __be16 proxy_port)
 {
-	return ctx_redirect_to_proxy_hairpin(ctx, ip4, proxy_port);
+	union macaddr host_mac = CILIUM_HOST_MAC;
+	union macaddr router_mac = THIS_INTERFACE_MAC;
+	int ret = 0;
+
+	ctx_store_meta(ctx, CB_PROXY_MAGIC,
+		       MARK_MAGIC_TO_PROXY | (proxy_port << 16));
+
+	ret = ipv4_l3(ctx, ETH_HLEN, (__u8 *)&router_mac, (__u8 *)&host_mac, ip4);
+	if (IS_ERR(ret))
+		return ret;
+
+	return ctx_redirect_to_proxy_hairpin(ctx, proxy_port);
 }
 #endif
 
 #ifdef ENABLE_IPV6
 static __always_inline int
-ctx_redirect_to_proxy_hairpin_ipv6(struct __ctx_buff *ctx, __be16 proxy_port)
+ctx_redirect_to_proxy_hairpin_ipv6(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
+				   __be16 proxy_port)
 {
-	return ctx_redirect_to_proxy_hairpin(ctx, NULL, proxy_port);
+	union macaddr host_mac = CILIUM_HOST_MAC;
+	union macaddr router_mac = THIS_INTERFACE_MAC;
+	int ret = 0;
+
+	ctx_store_meta(ctx, CB_PROXY_MAGIC,
+		       MARK_MAGIC_TO_PROXY | (proxy_port << 16));
+
+	ret = ipv6_l3(ctx, ETH_HLEN, (__u8 *)&router_mac, (__u8 *)&host_mac, ip6,
+		      METRIC_EGRESS);
+	if (IS_ERR(ret))
+		return ret;
+
+	return ctx_redirect_to_proxy_hairpin(ctx, proxy_port);
 }
 #endif


### PR DESCRIPTION
Let the caller pass the IPv6 header down to ipv6_dec_hoplimit(), so that it doesn't have to load the `hop_limit` from the ctx.

This matches the IPv4 path.