### PR TITLE
ztunnel/iptables: Add delete functions and replace exec iptables commands with go-iptables library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/containernetworking/cni v1.3.0
+	github.com/coreos/go-iptables v0.8.0
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/docker v28.4.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
+github.com/coreos/go-iptables v0.8.0 h1:MPc2P89IhuVpLI7ETL/2tx3XZ61VeICZjYqDEgNsPRc=
+github.com/coreos/go-iptables v0.8.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=

--- a/pkg/ztunnel/iptables/inpod.go
+++ b/pkg/ztunnel/iptables/inpod.go
@@ -4,16 +4,17 @@
 package iptables
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
 
+	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
-	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
-	"github.com/cilium/cilium/pkg/defaults"
 )
 
 const (
@@ -126,6 +127,8 @@ type rule struct {
 type ruleManager struct {
 	rules  []rule
 	logger *slog.Logger
+	ipt4   *iptables.IPTables
+	ipt6   *iptables.IPTables
 }
 
 func (m *ruleManager) add(table, chain string, parameters ...string) {
@@ -152,29 +155,32 @@ func replaceIPPlaceholder(args []string, ip string) []string {
 
 func (m *ruleManager) install(ipv4Enabled, ipv6Enabled bool) error {
 	for _, rule := range m.rules {
-		args := []string{"-t", rule.table, "-C", rule.chain}
-		args = append(args, rule.parameters...)
 		if ipv4Enabled {
+			ruleSpec := replaceIPPlaceholder(rule.parameters, rule.ipv4)
 			// Check if rule exists
-			_, checkErr := exec.WithTimeout(defaults.ExecTimeout, "iptables", replaceIPPlaceholder(args, rule.ipv4)...).Output(m.logger, false)
-			if checkErr != nil {
+			exists, err := m.ipt4.Exists(rule.table, rule.chain, ruleSpec...)
+			if err != nil {
+				return fmt.Errorf("failed to check iptables rule existence: %w", err)
+			}
+			if !exists {
 				// Rule doesn't exist, add it
-				args[2] = "-A" // -A for adding
-				if _, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", replaceIPPlaceholder(args, rule.ipv4)...).Output(m.logger, false); err != nil {
-					return fmt.Errorf("failed to insert iptables rule (%v): %w", args, err)
+				if err := m.ipt4.Append(rule.table, rule.chain, ruleSpec...); err != nil {
+					return fmt.Errorf("failed to insert iptables rule (%s %s %v): %w", rule.table, rule.chain, ruleSpec, err)
 				}
 			}
 		}
 
-		if ipv6Enabled {
+		if ipv6Enabled && m.ipt6 != nil {
+			ruleSpec := replaceIPPlaceholder(rule.parameters, rule.ipv6)
 			// Check if rule exists
-			_, checkErr := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", replaceIPPlaceholder(args, rule.ipv6)...).Output(m.logger, false)
-
-			if checkErr != nil {
+			exists, err := m.ipt6.Exists(rule.table, rule.chain, ruleSpec...)
+			if err != nil {
+				return fmt.Errorf("failed to check ip6tables rule existence: %w", err)
+			}
+			if !exists {
 				// Rule doesn't exist, add it
-				args[2] = "-A" // -A for adding
-				if _, err := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", replaceIPPlaceholder(args, rule.ipv6)...).Output(m.logger, false); err != nil {
-					return fmt.Errorf("failed to insert ip6tables rule (%v): %w", args, err)
+				if err := m.ipt6.Append(rule.table, rule.chain, ruleSpec...); err != nil {
+					return fmt.Errorf("failed to insert ip6tables rule (%s %s %v): %w", rule.table, rule.chain, ruleSpec, err)
 				}
 			}
 		}
@@ -187,20 +193,29 @@ func (m *ruleManager) createChains(ipv4Enabled, ipv6Enabled bool) error {
 		for _, chain := range []string{InpodPreroutingChain, InpodOutputChain} {
 			if ipv4Enabled {
 				// Check if chain exists first
-				_, checkErr := exec.WithTimeout(defaults.ExecTimeout, "iptables", "-t", table, "-L", chain, "-n").Output(m.logger, false)
-				if checkErr != nil {
+				chainExists, err := m.ipt4.ChainExists(table, chain)
+				if err != nil {
+					return fmt.Errorf("failed to check iptables chain existence: %w", err)
+				}
+
+				if !chainExists {
 					// Chain doesn't exist, create it
-					if _, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", "-t", table, "-N", chain).Output(m.logger, false); err != nil {
+					if err := m.ipt4.NewChain(table, chain); err != nil {
 						return fmt.Errorf("failed to create iptables chain %s: %w", chain, err)
 					}
 				}
 			}
-			if ipv6Enabled {
+
+			if ipv6Enabled && m.ipt6 != nil {
 				// Check if chain exists first
-				_, checkErr := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", "-t", table, "-L", chain, "-n").Output(m.logger, false)
-				if checkErr != nil {
+				chainExists, err := m.ipt6.ChainExists(table, chain)
+				if err != nil {
+					return fmt.Errorf("failed to check ip6tables chain existence: %w", err)
+				}
+
+				if !chainExists {
 					// Chain doesn't exist, create it
-					if _, err := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", "-t", table, "-N", chain).Output(m.logger, false); err != nil {
+					if err := m.ipt6.NewChain(table, chain); err != nil {
 						return fmt.Errorf("failed to create ip6tables chain %s: %w", chain, err)
 					}
 				}
@@ -211,9 +226,27 @@ func (m *ruleManager) createChains(ipv4Enabled, ipv6Enabled bool) error {
 }
 
 func addInPodRules(logger *slog.Logger, ipv4Enabled, ipv6Enabled bool) error {
+	var ipt4, ipt6 *iptables.IPTables
+	var err error
+
+	if ipv4Enabled {
+		ipt4, err = iptables.New()
+		if err != nil {
+			return fmt.Errorf("failed to initialize iptables: %w", err)
+		}
+	}
+
+	if ipv6Enabled {
+		ipt6, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return fmt.Errorf("failed to initialize ip6tables: %w", err)
+		}
+	}
 
 	rm := ruleManager{
 		logger: logger,
+		ipt4:   ipt4,
+		ipt6:   ipt6,
 	}
 
 	if err := rm.createChains(ipv4Enabled, ipv6Enabled); err != nil {
@@ -298,4 +331,150 @@ func addInPodRules(logger *slog.Logger, ipv4Enabled, ipv6Enabled bool) error {
 	)
 
 	return rm.install(ipv4Enabled, ipv6Enabled)
+}
+
+// DeleteInPodRules removes the iptables rules for ztunnels inpod mode.
+//
+// Note that this function is supposed to be called from within the pods
+// network namespace.
+func DeleteInPodRules(logger *slog.Logger, ipv4Enabled, ipv6Enabled bool) error {
+	if err := deleteInPodChains(logger, ipv4Enabled, ipv6Enabled); err != nil {
+		return err
+	}
+
+	if err := deleteInPodMarkRule(ipv6Enabled); err != nil {
+		return err
+	}
+
+	if err := deleteLoopbackRoute(ipv6Enabled); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deleteLoopbackRoute(ipv6Enabled bool) error {
+	cidrs := []string{"0.0.0.0/0"}
+	if ipv6Enabled {
+		cidrs = append(cidrs, "0::0/0")
+	}
+	for _, fullCIDR := range cidrs {
+		_, localhostDst, err := net.ParseCIDR(fullCIDR)
+		if err != nil {
+			return fmt.Errorf("parse CIDR: %w", err)
+		}
+
+		ciliumRoute := route.Route{
+			Device: "lo",
+			Prefix: *localhostDst,
+			Scope:  netlink.SCOPE_HOST,
+			Type:   unix.RTN_LOCAL,
+			Table:  RouteTableInbound,
+		}
+
+		if err := route.Delete(ciliumRoute); err != nil {
+			// Ignore ESRCH (no such process) and ENOENT (no such file or directory) errors,
+			// which indicate the route was already deleted
+			if !errors.Is(err, unix.ESRCH) && !errors.Is(err, unix.ENOENT) {
+				return fmt.Errorf("failed to delete route (%+v): %w", ciliumRoute, err)
+			}
+		}
+	}
+	return nil
+}
+
+func deleteInPodMarkRule(ipv6Enabled bool) error {
+	mask := uint32(InpodMask)
+
+	// IPv4 rule
+	ipv4Rule := route.Rule{
+		Priority: InpodRulePriority,
+		Mark:     InpodTProxyMark,
+		Mask:     mask,
+		Table:    RouteTableInbound,
+	}
+
+	if err := route.DeleteRule(unix.AF_INET, ipv4Rule); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to delete IPv4 netlink rule: %w", err)
+		}
+	}
+
+	if ipv6Enabled {
+		// IPv6 rule
+		ipv6Rule := route.Rule{
+			Priority: InpodRulePriority,
+			Mark:     InpodTProxyMark,
+			Mask:     mask,
+			Table:    RouteTableInbound,
+		}
+
+		if err := route.DeleteRule(unix.AF_INET6, ipv6Rule); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to delete IPv6 netlink rule: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func deleteInPodChains(logger *slog.Logger, ipv4Enabled, ipv6Enabled bool) error {
+	var ipt4, ipt6 *iptables.IPTables
+	var err error
+
+	if ipv4Enabled {
+		ipt4, err = iptables.New()
+		if err != nil {
+			return fmt.Errorf("failed to initialize iptables: %w", err)
+		}
+	}
+
+	if ipv6Enabled {
+		ipt6, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return fmt.Errorf("failed to initialize ip6tables: %w", err)
+		}
+	}
+
+	// First, delete the jump rules from the main chains to our custom chains
+	for _, table := range []string{"mangle", "nat"} {
+		jumpRules := map[string]string{
+			"PREROUTING": InpodPreroutingChain,
+			"OUTPUT":     InpodOutputChain,
+		}
+
+		for mainChain, customChain := range jumpRules {
+			if ipv4Enabled {
+				// Ignore errors - rule may not exist
+				_ = ipt4.Delete(table, mainChain, "-j", customChain)
+			}
+			if ipv6Enabled {
+				// Ignore errors - rule may not exist
+				_ = ipt6.Delete(table, mainChain, "-j", customChain)
+			}
+		}
+	}
+
+	// Then flush and delete the custom chains
+	for _, table := range []string{"mangle", "nat"} {
+		for _, chain := range []string{InpodPreroutingChain, InpodOutputChain} {
+			if ipv4Enabled {
+				if err := ipt4.ClearChain(table, chain); err != nil {
+					return fmt.Errorf("failed to flush iptables chain %s: %w", chain, err)
+				}
+				if err := ipt4.DeleteChain(table, chain); err != nil {
+					return fmt.Errorf("failed to delete iptables chain %s: %w", chain, err)
+				}
+			}
+			if ipv6Enabled {
+				if err := ipt6.ClearChain(table, chain); err != nil {
+					return fmt.Errorf("failed to flush ip6tables chain %s: %w", chain, err)
+				}
+				if err := ipt6.DeleteChain(table, chain); err != nil {
+					return fmt.Errorf("failed to delete ip6tables chain %s: %w", chain, err)
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/ztunnel/iptables/inpod_test.go
+++ b/pkg/ztunnel/iptables/inpod_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/coreos/go-iptables/iptables"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
@@ -111,7 +112,13 @@ func TestPrivilegedAddExistingChains(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, netlink.LinkSetUp(link))
 
-		rm := ruleManager{logger: slog.Default()}
+		ipt4, err := iptables.New()
+		require.NoError(t, err)
+
+		ipt6, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		require.NoError(t, err)
+
+		rm := ruleManager{logger: slog.Default(), ipt4: ipt4, ipt6: ipt6}
 
 		// Create chains first time
 		err = rm.createChains(true, true)
@@ -158,13 +165,13 @@ func TestPrivilegedAddExistingRoutes(t *testing.T) {
 		require.NoError(t, err, "Second call to addLoopbackRoute should succeed")
 
 		// Verify routes exist
-		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+		routes, err := safenetlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
 			Table: RouteTableInbound,
 		}, netlink.RT_FILTER_TABLE)
 		require.NoError(t, err)
 		require.NotEmpty(t, routes, "IPv4 routes should exist in table %d", RouteTableInbound)
 
-		routesV6, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{
+		routesV6, err := safenetlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{
 			Table: RouteTableInbound,
 		}, netlink.RT_FILTER_TABLE)
 		require.NoError(t, err)
@@ -194,7 +201,7 @@ func TestPrivilegedAddExistingMarkRules(t *testing.T) {
 		require.NoError(t, err, "Second call to addInPodMarkRule should succeed")
 
 		// Verify IPv4 rule exists
-		rules, err := netlink.RuleList(netlink.FAMILY_V4)
+		rules, err := safenetlink.RuleList(netlink.FAMILY_V4)
 		require.NoError(t, err)
 		foundV4 := false
 		for _, rule := range rules {
@@ -206,7 +213,7 @@ func TestPrivilegedAddExistingMarkRules(t *testing.T) {
 		require.True(t, foundV4, "IPv4 mark rule should exist")
 
 		// Verify IPv6 rule exists
-		rulesV6, err := netlink.RuleList(netlink.FAMILY_V6)
+		rulesV6, err := safenetlink.RuleList(netlink.FAMILY_V6)
 		require.NoError(t, err)
 		foundV6 := false
 		for _, rule := range rulesV6 {
@@ -232,8 +239,13 @@ func TestPrivilegedAddExistingIPTablesRules(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, netlink.LinkSetUp(link))
 
+		ipt4, err := iptables.New()
+		require.NoError(t, err)
+		ipt6, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		require.NoError(t, err)
+
 		// Create chains first
-		rm := ruleManager{logger: slog.Default()}
+		rm := ruleManager{logger: slog.Default(), ipt4: ipt4, ipt6: ipt6}
 		err = rm.createChains(true, true)
 		require.NoError(t, err)
 
@@ -256,6 +268,263 @@ func TestPrivilegedAddExistingIPTablesRules(t *testing.T) {
 			}
 		}
 		require.Equal(t, 1, jumpCount, "Jump rule should appear exactly once, not duplicated")
+
+		return nil
+	})
+}
+
+// TestPrivilegedDeleteInPodRules tests that DeleteInPodRules successfully removes
+// all iptables rules, chains, routes, and netlink rules.
+func TestPrivilegedDeleteInPodRules(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		// First create all rules
+		err = CreateInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "CreateInPodRules should succeed")
+
+		// Verify rules exist before deletion
+		natRulesV4Before := getIPTablesRules(t, "iptables", "nat")
+		requireRule(t, natRulesV4Before, "-A", "PREROUTING", "-j", InpodPreroutingChain)
+
+		// Delete all rules
+		err = DeleteInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "DeleteInPodRules should succeed")
+
+		// Verify iptables chains are deleted (IPv4)
+		for _, table := range []string{"mangle", "nat"} {
+			for _, chain := range []string{InpodPreroutingChain, InpodOutputChain} {
+				_, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", "-t", table, "-L", chain, "-n").Output(slog.Default(), false)
+				require.Error(t, err, "Chain %s should not exist in IPv4 %s table after deletion", chain, table)
+			}
+		}
+
+		// Verify iptables chains are deleted (IPv6)
+		for _, table := range []string{"mangle", "nat"} {
+			for _, chain := range []string{InpodPreroutingChain, InpodOutputChain} {
+				_, err := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", "-t", table, "-L", chain, "-n").Output(slog.Default(), false)
+				require.Error(t, err, "Chain %s should not exist in IPv6 %s table after deletion", chain, table)
+			}
+		}
+
+		// Verify netlink rules are deleted (IPv4)
+		rulesV4, err := safenetlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		for _, rule := range rulesV4 {
+			require.False(t, rule.Priority == InpodRulePriority && rule.Mark == InpodTProxyMark && rule.Table == RouteTableInbound,
+				"IPv4 mark rule should be deleted")
+		}
+
+		// Verify netlink rules are deleted (IPv6)
+		rulesV6, err := safenetlink.RuleList(netlink.FAMILY_V6)
+		require.NoError(t, err)
+		for _, rule := range rulesV6 {
+			require.False(t, rule.Priority == InpodRulePriority && rule.Mark == InpodTProxyMark && rule.Table == RouteTableInbound,
+				"IPv6 mark rule should be deleted")
+		}
+
+		// Verify routes are deleted (IPv4)
+		routesV4, err := safenetlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: RouteTableInbound,
+		}, netlink.RT_FILTER_TABLE)
+		require.NoError(t, err)
+		require.Empty(t, routesV4, "IPv4 routes should be deleted from table %d", RouteTableInbound)
+
+		// Verify routes are deleted (IPv6)
+		routesV6, err := safenetlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{
+			Table: RouteTableInbound,
+		}, netlink.RT_FILTER_TABLE)
+		require.NoError(t, err)
+		require.Empty(t, routesV6, "IPv6 routes should be deleted from table %d", RouteTableInbound)
+
+		return nil
+	})
+}
+
+// TestPrivilegedDeleteInPodRulesIdempotency tests that calling DeleteInPodRules
+// multiple times doesn't cause errors.
+func TestPrivilegedDeleteInPodRulesIdempotency(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		// Create rules
+		err = CreateInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "CreateInPodRules should succeed")
+
+		// First deletion - should succeed
+		err = DeleteInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "First call to DeleteInPodRules should succeed")
+
+		// Second deletion - should handle non-existent rules gracefully
+		err = DeleteInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "Second call to DeleteInPodRules should succeed (idempotency)")
+
+		return nil
+	})
+}
+
+// TestPrivilegedDeleteInPodMarkRule tests the deleteInPodMarkRule function directly.
+func TestPrivilegedDeleteInPodMarkRule(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		// Add mark rules first
+		err = addInPodMarkRule(true)
+		require.NoError(t, err, "addInPodMarkRule should succeed")
+
+		// Verify rules exist
+		rulesV4Before, err := safenetlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		foundV4 := false
+		for _, rule := range rulesV4Before {
+			if rule.Priority == InpodRulePriority && rule.Mark == InpodTProxyMark && rule.Table == RouteTableInbound {
+				foundV4 = true
+				break
+			}
+		}
+		require.True(t, foundV4, "IPv4 mark rule should exist before deletion")
+
+		rulesV6Before, err := safenetlink.RuleList(netlink.FAMILY_V6)
+		require.NoError(t, err)
+		foundV6 := false
+		for _, rule := range rulesV6Before {
+			if rule.Priority == InpodRulePriority && rule.Mark == InpodTProxyMark && rule.Table == RouteTableInbound {
+				foundV6 = true
+				break
+			}
+		}
+		require.True(t, foundV6, "IPv6 mark rule should exist before deletion")
+
+		// Delete mark rules
+		err = deleteInPodMarkRule(true)
+		require.NoError(t, err, "deleteInPodMarkRule should succeed")
+
+		// Verify rules are deleted
+		rulesV4After, err := safenetlink.RuleList(netlink.FAMILY_V4)
+		require.NoError(t, err)
+		for _, rule := range rulesV4After {
+			require.False(t, rule.Priority == InpodRulePriority && rule.Mark == InpodTProxyMark && rule.Table == RouteTableInbound,
+				"IPv4 mark rule should be deleted")
+		}
+
+		rulesV6After, err := safenetlink.RuleList(netlink.FAMILY_V6)
+		require.NoError(t, err)
+		for _, rule := range rulesV6After {
+			require.False(t, rule.Priority == InpodRulePriority && rule.Mark == InpodTProxyMark && rule.Table == RouteTableInbound,
+				"IPv6 mark rule should be deleted")
+		}
+
+		return nil
+	})
+}
+
+// TestPrivilegedDeleteLoopbackRoute tests the deleteLoopbackRoute function directly.
+func TestPrivilegedDeleteLoopbackRoute(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		// Add loopback routes first
+		err = addLoopbackRoute(slog.Default(), true)
+		require.NoError(t, err, "addLoopbackRoute should succeed")
+
+		// Verify routes exist
+		routesV4Before, err := safenetlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: RouteTableInbound,
+		}, netlink.RT_FILTER_TABLE)
+		require.NoError(t, err)
+		require.NotEmpty(t, routesV4Before, "IPv4 routes should exist before deletion")
+
+		routesV6Before, err := safenetlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{
+			Table: RouteTableInbound,
+		}, netlink.RT_FILTER_TABLE)
+		require.NoError(t, err)
+		require.NotEmpty(t, routesV6Before, "IPv6 routes should exist before deletion")
+
+		// Delete loopback routes
+		err = deleteLoopbackRoute(true)
+		require.NoError(t, err, "deleteLoopbackRoute should succeed")
+
+		// Verify routes are deleted
+		routesV4After, err := safenetlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: RouteTableInbound,
+		}, netlink.RT_FILTER_TABLE)
+		require.NoError(t, err)
+		require.Empty(t, routesV4After, "IPv4 routes should be deleted")
+
+		routesV6After, err := safenetlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{
+			Table: RouteTableInbound,
+		}, netlink.RT_FILTER_TABLE)
+		require.NoError(t, err)
+		require.Empty(t, routesV6After, "IPv6 routes should be deleted")
+
+		return nil
+	})
+}
+
+// TestPrivilegedDeleteInPodChains tests the deleteInPodChains function directly.
+func TestPrivilegedDeleteInPodChains(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		link, err := safenetlink.LinkByName("lo")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+
+		// Create chains and add some rules
+		err = addInPodRules(slog.Default(), true, true)
+		require.NoError(t, err, "addInPodRules should succeed")
+
+		// Verify chains exist before deletion
+		for _, table := range []string{"mangle", "nat"} {
+			for _, chain := range []string{InpodPreroutingChain, InpodOutputChain} {
+				_, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", "-t", table, "-L", chain, "-n").Output(slog.Default(), false)
+				require.NoError(t, err, "IPv4 chain %s should exist in %s table before deletion", chain, table)
+
+				_, err = exec.WithTimeout(defaults.ExecTimeout, "ip6tables", "-t", table, "-L", chain, "-n").Output(slog.Default(), false)
+				require.NoError(t, err, "IPv6 chain %s should exist in %s table before deletion", chain, table)
+			}
+		}
+
+		// Delete chains
+		err = deleteInPodChains(slog.Default(), true, true)
+		require.NoError(t, err, "deleteInPodChains should succeed")
+
+		// Verify chains are deleted (IPv4)
+		for _, table := range []string{"mangle", "nat"} {
+			for _, chain := range []string{InpodPreroutingChain, InpodOutputChain} {
+				_, err := exec.WithTimeout(defaults.ExecTimeout, "iptables", "-t", table, "-L", chain, "-n").Output(slog.Default(), false)
+				require.Error(t, err, "IPv4 chain %s should not exist in %s table after deletion", chain, table)
+			}
+		}
+
+		// Verify chains are deleted (IPv6)
+		for _, table := range []string{"mangle", "nat"} {
+			for _, chain := range []string{InpodPreroutingChain, InpodOutputChain} {
+				_, err := exec.WithTimeout(defaults.ExecTimeout, "ip6tables", "-t", table, "-L", chain, "-n").Output(slog.Default(), false)
+				require.Error(t, err, "IPv6 chain %s should not exist in %s table after deletion", chain, table)
+			}
+		}
 
 		return nil
 	})

--- a/vendor/github.com/coreos/go-iptables/LICENSE
+++ b/vendor/github.com/coreos/go-iptables/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/go-iptables/NOTICE
+++ b/vendor/github.com/coreos/go-iptables/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2018 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/vendor/github.com/coreos/go-iptables/iptables/iptables.go
+++ b/vendor/github.com/coreos/go-iptables/iptables/iptables.go
@@ -1,0 +1,751 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// Adds the output of stderr to exec.ExitError
+type Error struct {
+	exec.ExitError
+	cmd        exec.Cmd
+	msg        string
+	exitStatus *int //for overriding
+}
+
+func (e *Error) ExitStatus() int {
+	if e.exitStatus != nil {
+		return *e.exitStatus
+	}
+	return e.Sys().(syscall.WaitStatus).ExitStatus()
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("running %v: exit status %v: %v", e.cmd.Args, e.ExitStatus(), e.msg)
+}
+
+var isNotExistPatterns = []string{
+	"Bad rule (does a matching rule exist in that chain?).\n",
+	"No chain/target/match by that name.\n",
+	"No such file or directory",
+	"does not exist",
+}
+
+// IsNotExist returns true if the error is due to the chain or rule not existing
+func (e *Error) IsNotExist() bool {
+	for _, str := range isNotExistPatterns {
+		if strings.Contains(e.msg, str) {
+			return true
+		}
+	}
+	return false
+}
+
+// Protocol to differentiate between IPv4 and IPv6
+type Protocol byte
+
+const (
+	ProtocolIPv4 Protocol = iota
+	ProtocolIPv6
+)
+
+type IPTables struct {
+	path              string
+	proto             Protocol
+	hasCheck          bool
+	hasWait           bool
+	waitSupportSecond bool
+	hasRandomFully    bool
+	v1                int
+	v2                int
+	v3                int
+	mode              string // the underlying iptables operating mode, e.g. nf_tables
+	timeout           int    // time to wait for the iptables lock, default waits forever
+}
+
+// Stat represents a structured statistic entry.
+type Stat struct {
+	Packets     uint64     `json:"pkts"`
+	Bytes       uint64     `json:"bytes"`
+	Target      string     `json:"target"`
+	Protocol    string     `json:"prot"`
+	Opt         string     `json:"opt"`
+	Input       string     `json:"in"`
+	Output      string     `json:"out"`
+	Source      *net.IPNet `json:"source"`
+	Destination *net.IPNet `json:"destination"`
+	Options     string     `json:"options"`
+}
+
+type option func(*IPTables)
+
+func IPFamily(proto Protocol) option {
+	return func(ipt *IPTables) {
+		ipt.proto = proto
+	}
+}
+
+func Timeout(timeout int) option {
+	return func(ipt *IPTables) {
+		ipt.timeout = timeout
+	}
+}
+
+func Path(path string) option {
+	return func(ipt *IPTables) {
+		ipt.path = path
+	}
+}
+
+// New creates a new IPTables configured with the options passed as parameters.
+// Supported parameters are:
+//
+//	IPFamily(Protocol)
+//	Timeout(int)
+//	Path(string)
+//
+// For backwards compatibility, by default New uses IPv4 and timeout 0.
+// i.e. you can create an IPv6 IPTables using a timeout of 5 seconds passing
+// the IPFamily and Timeout options as follow:
+//
+//	ip6t := New(IPFamily(ProtocolIPv6), Timeout(5))
+func New(opts ...option) (*IPTables, error) {
+
+	ipt := &IPTables{
+		proto:   ProtocolIPv4,
+		timeout: 0,
+		path:    "",
+	}
+
+	for _, opt := range opts {
+		opt(ipt)
+	}
+
+	// if path wasn't preset through New(Path()), autodiscover it
+	cmd := ""
+	if ipt.path == "" {
+		cmd = getIptablesCommand(ipt.proto)
+	} else {
+		cmd = ipt.path
+	}
+	path, err := exec.LookPath(cmd)
+	if err != nil {
+		return nil, err
+	}
+	ipt.path = path
+
+	vstring, err := getIptablesVersionString(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not get iptables version: %v", err)
+	}
+	v1, v2, v3, mode, err := extractIptablesVersion(vstring)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract iptables version from [%s]: %v", vstring, err)
+	}
+	ipt.v1 = v1
+	ipt.v2 = v2
+	ipt.v3 = v3
+	ipt.mode = mode
+
+	checkPresent, waitPresent, waitSupportSecond, randomFullyPresent := getIptablesCommandSupport(v1, v2, v3)
+	ipt.hasCheck = checkPresent
+	ipt.hasWait = waitPresent
+	ipt.waitSupportSecond = waitSupportSecond
+	ipt.hasRandomFully = randomFullyPresent
+
+	return ipt, nil
+}
+
+// New creates a new IPTables for the given proto.
+// The proto will determine which command is used, either "iptables" or "ip6tables".
+func NewWithProtocol(proto Protocol) (*IPTables, error) {
+	return New(IPFamily(proto), Timeout(0))
+}
+
+// Proto returns the protocol used by this IPTables.
+func (ipt *IPTables) Proto() Protocol {
+	return ipt.proto
+}
+
+// Exists checks if given rulespec in specified table/chain exists
+func (ipt *IPTables) Exists(table, chain string, rulespec ...string) (bool, error) {
+	if !ipt.hasCheck {
+		return ipt.existsForOldIptables(table, chain, rulespec)
+
+	}
+	cmd := append([]string{"-t", table, "-C", chain}, rulespec...)
+	err := ipt.run(cmd...)
+	eerr, eok := err.(*Error)
+	switch {
+	case err == nil:
+		return true, nil
+	case eok && eerr.ExitStatus() == 1:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+// Insert inserts rulespec to specified table/chain (in specified pos)
+func (ipt *IPTables) Insert(table, chain string, pos int, rulespec ...string) error {
+	cmd := append([]string{"-t", table, "-I", chain, strconv.Itoa(pos)}, rulespec...)
+	return ipt.run(cmd...)
+}
+
+// Replace replaces rulespec to specified table/chain (in specified pos)
+func (ipt *IPTables) Replace(table, chain string, pos int, rulespec ...string) error {
+	cmd := append([]string{"-t", table, "-R", chain, strconv.Itoa(pos)}, rulespec...)
+	return ipt.run(cmd...)
+}
+
+// InsertUnique acts like Insert except that it won't insert a duplicate (no matter the position in the chain)
+func (ipt *IPTables) InsertUnique(table, chain string, pos int, rulespec ...string) error {
+	exists, err := ipt.Exists(table, chain, rulespec...)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return ipt.Insert(table, chain, pos, rulespec...)
+	}
+
+	return nil
+}
+
+// Append appends rulespec to specified table/chain
+func (ipt *IPTables) Append(table, chain string, rulespec ...string) error {
+	cmd := append([]string{"-t", table, "-A", chain}, rulespec...)
+	return ipt.run(cmd...)
+}
+
+// AppendUnique acts like Append except that it won't add a duplicate
+func (ipt *IPTables) AppendUnique(table, chain string, rulespec ...string) error {
+	exists, err := ipt.Exists(table, chain, rulespec...)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return ipt.Append(table, chain, rulespec...)
+	}
+
+	return nil
+}
+
+// Delete removes rulespec in specified table/chain
+func (ipt *IPTables) Delete(table, chain string, rulespec ...string) error {
+	cmd := append([]string{"-t", table, "-D", chain}, rulespec...)
+	return ipt.run(cmd...)
+}
+
+func (ipt *IPTables) DeleteIfExists(table, chain string, rulespec ...string) error {
+	exists, err := ipt.Exists(table, chain, rulespec...)
+	if err == nil && exists {
+		err = ipt.Delete(table, chain, rulespec...)
+	}
+	return err
+}
+
+// DeleteById deletes the rule with the specified ID in the given table and chain.
+func (ipt *IPTables) DeleteById(table, chain string, id int) error {
+	cmd := []string{"-t", table, "-D", chain, strconv.Itoa(id)}
+	return ipt.run(cmd...)
+}
+
+// List rules in specified table/chain
+func (ipt *IPTables) ListById(table, chain string, id int) (string, error) {
+	args := []string{"-t", table, "-S", chain, strconv.Itoa(id)}
+	rule, err := ipt.executeList(args)
+	if err != nil {
+		return "", err
+	}
+	return rule[0], nil
+}
+
+// List rules in specified table/chain
+func (ipt *IPTables) List(table, chain string) ([]string, error) {
+	args := []string{"-t", table, "-S", chain}
+	return ipt.executeList(args)
+}
+
+// List rules (with counters) in specified table/chain
+func (ipt *IPTables) ListWithCounters(table, chain string) ([]string, error) {
+	args := []string{"-t", table, "-v", "-S", chain}
+	return ipt.executeList(args)
+}
+
+// ListChains returns a slice containing the name of each chain in the specified table.
+func (ipt *IPTables) ListChains(table string) ([]string, error) {
+	args := []string{"-t", table, "-S"}
+
+	result, err := ipt.executeList(args)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over rules to find all default (-P) and user-specified (-N) chains.
+	// Chains definition always come before rules.
+	// Format is the following:
+	// -P OUTPUT ACCEPT
+	// -N Custom
+	var chains []string
+	for _, val := range result {
+		if strings.HasPrefix(val, "-P") || strings.HasPrefix(val, "-N") {
+			chains = append(chains, strings.Fields(val)[1])
+		} else {
+			break
+		}
+	}
+	return chains, nil
+}
+
+// '-S' is fine with non existing rule index as long as the chain exists
+// therefore pass index 1 to reduce overhead for large chains
+func (ipt *IPTables) ChainExists(table, chain string) (bool, error) {
+	err := ipt.run("-t", table, "-S", chain, "1")
+	eerr, eok := err.(*Error)
+	switch {
+	case err == nil:
+		return true, nil
+	case eok && eerr.ExitStatus() == 1:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+// Stats lists rules including the byte and packet counts
+func (ipt *IPTables) Stats(table, chain string) ([][]string, error) {
+	args := []string{"-t", table, "-L", chain, "-n", "-v", "-x"}
+	lines, err := ipt.executeList(args)
+	if err != nil {
+		return nil, err
+	}
+
+	appendSubnet := func(addr string) string {
+		if strings.IndexByte(addr, byte('/')) < 0 {
+			if strings.IndexByte(addr, '.') < 0 {
+				return addr + "/128"
+			}
+			return addr + "/32"
+		}
+		return addr
+	}
+
+	ipv6 := ipt.proto == ProtocolIPv6
+
+	// Skip the warning if exist
+	if strings.HasPrefix(lines[0], "#") {
+		lines = lines[1:]
+	}
+
+	rows := [][]string{}
+	for i, line := range lines {
+		// Skip over chain name and field header
+		if i < 2 {
+			continue
+		}
+
+		// Fields:
+		// 0=pkts 1=bytes 2=target 3=prot 4=opt 5=in 6=out 7=source 8=destination 9=options
+		line = strings.TrimSpace(line)
+		fields := strings.Fields(line)
+
+		// The ip6tables verbose output cannot be naively split due to the default "opt"
+		// field containing 2 single spaces.
+		if ipv6 {
+			// Check if field 6 is "opt" or "source" address
+			dest := fields[6]
+			ip, _, _ := net.ParseCIDR(dest)
+			if ip == nil {
+				ip = net.ParseIP(dest)
+			}
+
+			// If we detected a CIDR or IP, the "opt" field is empty.. insert it.
+			if ip != nil {
+				f := []string{}
+				f = append(f, fields[:4]...)
+				f = append(f, "  ") // Empty "opt" field for ip6tables
+				f = append(f, fields[4:]...)
+				fields = f
+			}
+		}
+
+		// Adjust "source" and "destination" to include netmask, to match regular
+		// List output
+		fields[7] = appendSubnet(fields[7])
+		fields[8] = appendSubnet(fields[8])
+
+		// Combine "options" fields 9... into a single space-delimited field.
+		options := fields[9:]
+		fields = fields[:9]
+		fields = append(fields, strings.Join(options, " "))
+		rows = append(rows, fields)
+	}
+	return rows, nil
+}
+
+// ParseStat parses a single statistic row into a Stat struct. The input should
+// be a string slice that is returned from calling the Stat method.
+func (ipt *IPTables) ParseStat(stat []string) (parsed Stat, err error) {
+	// For forward-compatibility, expect at least 10 fields in the stat
+	if len(stat) < 10 {
+		return parsed, fmt.Errorf("stat contained fewer fields than expected")
+	}
+
+	// Convert the fields that are not plain strings
+	parsed.Packets, err = strconv.ParseUint(stat[0], 0, 64)
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse packets")
+	}
+	parsed.Bytes, err = strconv.ParseUint(stat[1], 0, 64)
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse bytes")
+	}
+	_, parsed.Source, err = net.ParseCIDR(stat[7])
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse source")
+	}
+	_, parsed.Destination, err = net.ParseCIDR(stat[8])
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse destination")
+	}
+
+	// Put the fields that are strings
+	parsed.Target = stat[2]
+	parsed.Protocol = stat[3]
+	parsed.Opt = stat[4]
+	parsed.Input = stat[5]
+	parsed.Output = stat[6]
+	parsed.Options = stat[9]
+
+	return parsed, nil
+}
+
+// StructuredStats returns statistics as structured data which may be further
+// parsed and marshaled.
+func (ipt *IPTables) StructuredStats(table, chain string) ([]Stat, error) {
+	rawStats, err := ipt.Stats(table, chain)
+	if err != nil {
+		return nil, err
+	}
+
+	structStats := []Stat{}
+	for _, rawStat := range rawStats {
+		stat, err := ipt.ParseStat(rawStat)
+		if err != nil {
+			return nil, err
+		}
+		structStats = append(structStats, stat)
+	}
+
+	return structStats, nil
+}
+
+func (ipt *IPTables) executeList(args []string) ([]string, error) {
+	var stdout bytes.Buffer
+	if err := ipt.runWithOutput(args, &stdout); err != nil {
+		return nil, err
+	}
+
+	rules := strings.Split(stdout.String(), "\n")
+
+	// strip trailing newline
+	if len(rules) > 0 && rules[len(rules)-1] == "" {
+		rules = rules[:len(rules)-1]
+	}
+
+	for i, rule := range rules {
+		rules[i] = filterRuleOutput(rule)
+	}
+
+	return rules, nil
+}
+
+// NewChain creates a new chain in the specified table.
+// If the chain already exists, it will result in an error.
+func (ipt *IPTables) NewChain(table, chain string) error {
+	return ipt.run("-t", table, "-N", chain)
+}
+
+const existsErr = 1
+
+// ClearChain flushed (deletes all rules) in the specified table/chain.
+// If the chain does not exist, a new one will be created
+func (ipt *IPTables) ClearChain(table, chain string) error {
+	err := ipt.NewChain(table, chain)
+
+	eerr, eok := err.(*Error)
+	switch {
+	case err == nil:
+		return nil
+	case eok && eerr.ExitStatus() == existsErr:
+		// chain already exists. Flush (clear) it.
+		return ipt.run("-t", table, "-F", chain)
+	default:
+		return err
+	}
+}
+
+// RenameChain renames the old chain to the new one.
+func (ipt *IPTables) RenameChain(table, oldChain, newChain string) error {
+	return ipt.run("-t", table, "-E", oldChain, newChain)
+}
+
+// DeleteChain deletes the chain in the specified table.
+// The chain must be empty
+func (ipt *IPTables) DeleteChain(table, chain string) error {
+	return ipt.run("-t", table, "-X", chain)
+}
+
+func (ipt *IPTables) ClearAndDeleteChain(table, chain string) error {
+	exists, err := ipt.ChainExists(table, chain)
+	if err != nil || !exists {
+		return err
+	}
+	err = ipt.run("-t", table, "-F", chain)
+	if err == nil {
+		err = ipt.run("-t", table, "-X", chain)
+	}
+	return err
+}
+
+func (ipt *IPTables) ClearAll() error {
+	return ipt.run("-F")
+}
+
+func (ipt *IPTables) DeleteAll() error {
+	return ipt.run("-X")
+}
+
+// ChangePolicy changes policy on chain to target
+func (ipt *IPTables) ChangePolicy(table, chain, target string) error {
+	return ipt.run("-t", table, "-P", chain, target)
+}
+
+// Check if the underlying iptables command supports the --random-fully flag
+func (ipt *IPTables) HasRandomFully() bool {
+	return ipt.hasRandomFully
+}
+
+// Return version components of the underlying iptables command
+func (ipt *IPTables) GetIptablesVersion() (int, int, int) {
+	return ipt.v1, ipt.v2, ipt.v3
+}
+
+// run runs an iptables command with the given arguments, ignoring
+// any stdout output
+func (ipt *IPTables) run(args ...string) error {
+	return ipt.runWithOutput(args, nil)
+}
+
+// runWithOutput runs an iptables command with the given arguments,
+// writing any stdout output to the given writer
+func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
+	args = append([]string{ipt.path}, args...)
+	if ipt.hasWait {
+		args = append(args, "--wait")
+		if ipt.timeout != 0 && ipt.waitSupportSecond {
+			args = append(args, strconv.Itoa(ipt.timeout))
+		}
+	} else {
+		fmu, err := newXtablesFileLock()
+		if err != nil {
+			return err
+		}
+		ul, err := fmu.tryLock()
+		if err != nil {
+			syscall.Close(fmu.fd)
+			return err
+		}
+		defer func() {
+			_ = ul.Unlock()
+		}()
+	}
+
+	var stderr bytes.Buffer
+	cmd := exec.Cmd{
+		Path:   ipt.path,
+		Args:   args,
+		Stdout: stdout,
+		Stderr: &stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		switch e := err.(type) {
+		case *exec.ExitError:
+			return &Error{*e, cmd, stderr.String(), nil}
+		default:
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getIptablesCommand returns the correct command for the given protocol, either "iptables" or "ip6tables".
+func getIptablesCommand(proto Protocol) string {
+	if proto == ProtocolIPv6 {
+		return "ip6tables"
+	} else {
+		return "iptables"
+	}
+}
+
+// Checks if iptables has the "-C" and "--wait" flag
+func getIptablesCommandSupport(v1 int, v2 int, v3 int) (bool, bool, bool, bool) {
+	return iptablesHasCheckCommand(v1, v2, v3), iptablesHasWaitCommand(v1, v2, v3), iptablesWaitSupportSecond(v1, v2, v3), iptablesHasRandomFully(v1, v2, v3)
+}
+
+// getIptablesVersion returns the first three components of the iptables version
+// and the operating mode (e.g. nf_tables or legacy)
+// e.g. "iptables v1.3.66" would return (1, 3, 66, legacy, nil)
+func extractIptablesVersion(str string) (int, int, int, string, error) {
+	versionMatcher := regexp.MustCompile(`v([0-9]+)\.([0-9]+)\.([0-9]+)(?:\s+\((\w+))?`)
+	result := versionMatcher.FindStringSubmatch(str)
+	if result == nil {
+		return 0, 0, 0, "", fmt.Errorf("no iptables version found in string: %s", str)
+	}
+
+	v1, err := strconv.Atoi(result[1])
+	if err != nil {
+		return 0, 0, 0, "", err
+	}
+
+	v2, err := strconv.Atoi(result[2])
+	if err != nil {
+		return 0, 0, 0, "", err
+	}
+
+	v3, err := strconv.Atoi(result[3])
+	if err != nil {
+		return 0, 0, 0, "", err
+	}
+
+	mode := "legacy"
+	if result[4] != "" {
+		mode = result[4]
+	}
+	return v1, v2, v3, mode, nil
+}
+
+// Runs "iptables --version" to get the version string
+func getIptablesVersionString(path string) (string, error) {
+	cmd := exec.Command(path, "--version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+// Checks if an iptables version is after 1.4.11, when --check was added
+func iptablesHasCheckCommand(v1 int, v2 int, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 > 4 {
+		return true
+	}
+	if v1 == 1 && v2 == 4 && v3 >= 11 {
+		return true
+	}
+	return false
+}
+
+// Checks if an iptables version is after 1.4.20, when --wait was added
+func iptablesHasWaitCommand(v1 int, v2 int, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 > 4 {
+		return true
+	}
+	if v1 == 1 && v2 == 4 && v3 >= 20 {
+		return true
+	}
+	return false
+}
+
+// Checks if an iptablse version is after 1.6.0, when --wait support second
+func iptablesWaitSupportSecond(v1 int, v2 int, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 >= 6 {
+		return true
+	}
+	return false
+}
+
+// Checks if an iptables version is after 1.6.2, when --random-fully was added
+func iptablesHasRandomFully(v1 int, v2 int, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 > 6 {
+		return true
+	}
+	if v1 == 1 && v2 == 6 && v3 >= 2 {
+		return true
+	}
+	return false
+}
+
+// Checks if a rule specification exists for a table
+func (ipt *IPTables) existsForOldIptables(table, chain string, rulespec []string) (bool, error) {
+	rs := strings.Join(append([]string{"-A", chain}, rulespec...), " ")
+	args := []string{"-t", table, "-S"}
+	var stdout bytes.Buffer
+	err := ipt.runWithOutput(args, &stdout)
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(stdout.String(), rs), nil
+}
+
+// counterRegex is the regex used to detect nftables counter format
+var counterRegex = regexp.MustCompile(`^\[([0-9]+):([0-9]+)\] `)
+
+// filterRuleOutput works around some inconsistencies in output.
+// For example, when iptables is in legacy vs. nftables mode, it produces
+// different results.
+func filterRuleOutput(rule string) string {
+	out := rule
+
+	// work around an output difference in nftables mode where counters
+	// are output in iptables-save format, rather than iptables -S format
+	// The string begins with "[0:0]"
+	//
+	// Fixes #49
+	if groups := counterRegex.FindStringSubmatch(out); groups != nil {
+		// drop the brackets
+		out = out[len(groups[0]):]
+		out = fmt.Sprintf("%s -c %s %s", out, groups[1], groups[2])
+	}
+
+	return out
+}

--- a/vendor/github.com/coreos/go-iptables/iptables/lock.go
+++ b/vendor/github.com/coreos/go-iptables/iptables/lock.go
@@ -1,0 +1,84 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"os"
+	"sync"
+	"syscall"
+)
+
+const (
+	// In earlier versions of iptables, the xtables lock was implemented
+	// via a Unix socket, but now flock is used via this lockfile:
+	// http://git.netfilter.org/iptables/commit/?id=aa562a660d1555b13cffbac1e744033e91f82707
+	// Note the LSB-conforming "/run" directory does not exist on old
+	// distributions, so assume "/var" is symlinked
+	xtablesLockFilePath = "/var/run/xtables.lock"
+
+	defaultFilePerm = 0600
+)
+
+type Unlocker interface {
+	Unlock() error
+}
+
+type nopUnlocker struct{}
+
+func (_ nopUnlocker) Unlock() error { return nil }
+
+type fileLock struct {
+	// mu is used to protect against concurrent invocations from within this process
+	mu sync.Mutex
+	fd int
+}
+
+// tryLock takes an exclusive lock on the xtables lock file without blocking.
+// This is best-effort only: if the exclusive lock would block (i.e. because
+// another process already holds it), no error is returned. Otherwise, any
+// error encountered during the locking operation is returned.
+// The returned Unlocker should be used to release the lock when the caller is
+// done invoking iptables commands.
+func (l *fileLock) tryLock() (Unlocker, error) {
+	l.mu.Lock()
+	err := syscall.Flock(l.fd, syscall.LOCK_EX|syscall.LOCK_NB)
+	switch err {
+	case syscall.EWOULDBLOCK:
+		l.mu.Unlock()
+		return nopUnlocker{}, nil
+	case nil:
+		return l, nil
+	default:
+		l.mu.Unlock()
+		return nil, err
+	}
+}
+
+// Unlock closes the underlying file, which implicitly unlocks it as well. It
+// also unlocks the associated mutex.
+func (l *fileLock) Unlock() error {
+	defer l.mu.Unlock()
+	return syscall.Close(l.fd)
+}
+
+// newXtablesFileLock opens a new lock on the xtables lockfile without
+// acquiring the lock
+func newXtablesFileLock() (*fileLock, error) {
+	fd, err := syscall.Open(xtablesLockFilePath, os.O_CREATE, defaultFilePerm)
+	if err != nil {
+		return nil, err
+	}
+	return &fileLock{fd: fd}, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -404,6 +404,9 @@ github.com/containernetworking/cni/pkg/types/create
 github.com/containernetworking/cni/pkg/types/internal
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
+# github.com/coreos/go-iptables v0.8.0
+## explicit; go 1.16
+github.com/coreos/go-iptables/iptables
 # github.com/coreos/go-semver v0.3.1
 ## explicit; go 1.8
 github.com/coreos/go-semver/semver


### PR DESCRIPTION
Replace direct exec() calls to iptables/ip6tables commands with the
`go-iptables` library (github.com/coreos/go-iptables) for better
maintainability and error handling.

Added DeleteInPodRules() function for complete cleanup of
iptables rules, chains, netlink rules, and routes

Signed-off-by: Quang Nguyen <nguyenquang@microsoft.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Replace direct exec() calls to iptables/ip6tables commands with the
go-iptables library (github.com/coreos/go-iptables) for better
maintainability and error handling.
    
Added DeleteInPodRules() function for complete cleanup of
iptables rules, chains, netlink rules, and routes
  
```
