### PR TITLE
add one-off CES GC

### DIFF
--- a/Documentation/network/kubernetes/ciliumendpointslice.rst
+++ b/Documentation/network/kubernetes/ciliumendpointslice.rst
@@ -91,6 +91,11 @@ let it create all CES objects, and then upgrade the Agents afterwards.
 #. Once the metrics have stabilized (in other words, when the Operator has created CES objects for all existing CEPs), upgrade the
    Cilium Agents on all nodes by setting the ``--enable-cilium-endpoint-slice`` flag to ``true`` and re-deploying them.
 
+Downgrade Procedure
+~~~~~~~~~~~~~~~~~~~
+In order to avoid connectivity disruptions, if you need to disable CES and go back to using CEPs, you will need to first disable CES in the Cilium Agents, so the agents will return to watching on CEPs.
+This can be done by setting the ``--enable-cilium-endpoint-slice`` flag to ``false`` and re-deploying the agents.
+Then, once all agents have been updated, you can disable CES in the operator, which will stop creating new CES objects and delete existing ones.
 
 Configuration Options
 =====================

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -414,3 +414,9 @@ rules:
   - delete
 {{- end }}
 {{- end }}
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpointslices
+  verbs:
+  - deletecollection

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/operator/auth"
 	"github.com/cilium/cilium/operator/doublewrite"
 	"github.com/cilium/cilium/operator/endpointgc"
+	"github.com/cilium/cilium/operator/endpointslicegc"
 	"github.com/cilium/cilium/operator/identitygc"
 	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	operatorMetrics "github.com/cilium/cilium/operator/metrics"
@@ -268,6 +269,10 @@ var (
 			// Endpoints. Either once or periodically it validates all the present
 			// Cilium Endpoints and delete the ones that should be deleted.
 			endpointgc.Cell,
+
+			// Cilium Endpoint Slice Garbage Collector. One-off GC that deletes all CES
+			// present in a cluster when CES feature is disabled.
+			endpointslicegc.Cell,
 
 			// Integrates the controller-runtime library and provides its components via Hive.
 			controllerruntime.Cell,

--- a/operator/endpointslicegc/cell.go
+++ b/operator/endpointslicegc/cell.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointslicegc
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+// Cell is a cell that implements a one-off CiliumEndpointSlice
+// garbage collector.
+// The GC loops through all the CiliumEndpointSlices in the cluster and deletes
+// all of them, if the CES feature has been disabled.
+var Cell = cell.Module(
+	"k8s-endpointslice-gc",
+	"CiliumEndpointSlice garbage collector",
+
+	// Invoke forces the instantiation of the endpoint gc
+	cell.Invoke(registerGC),
+)

--- a/operator/endpointslicegc/gc.go
+++ b/operator/endpointslicegc/gc.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointslicegc
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ces "github.com/cilium/cilium/operator/pkg/ciliumendpointslice"
+	cilium_api_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// params contains all the dependencies for the endpoint-slice-gc.
+// They will be provided through dependency injection.
+type params struct {
+	cell.In
+
+	Logger   *slog.Logger
+	JobGroup job.Group
+
+	Clientset k8sClient.Clientset
+
+	SharedCfg ces.SharedConfig
+}
+
+// GC represents the Cilium Endpoint Slice one-off GC.
+type GC struct {
+	logger *slog.Logger
+
+	clientset k8sClient.Clientset
+}
+
+func registerGC(p params) {
+	if !p.Clientset.IsEnabled() {
+		return
+	}
+
+	if p.SharedCfg.EnableCiliumEndpointSlice {
+		return
+	}
+
+	gc := &GC{
+		logger:    p.Logger,
+		clientset: p.Clientset,
+	}
+
+	p.JobGroup.Add(
+		job.OneShot(
+			"to-k8s-ciliumendpointslice-gc",
+			gc.doGC,
+			job.WithRetry(3, &job.ExponentialBackoff{
+				Min: 1 * time.Minute,
+				Max: 5 * time.Minute,
+			}),
+		),
+	)
+}
+
+// Return whether the CiliumEndpointSlice CRD exists and the error encountered in
+// checking for its existence, if any.
+func (g *GC) checkForCiliumEndpointSliceCRD(ctx context.Context) (bool, error) {
+	_, err := g.clientset.ApiextensionsV1().CustomResourceDefinitions().Get(
+		ctx, cilium_api_v2a1.CESName, metav1.GetOptions{ResourceVersion: "0"},
+	)
+	if err == nil {
+		return true, nil
+	} else if k8serrors.IsNotFound(err) {
+		g.logger.InfoContext(ctx, "CiliumEndpointSlice CRD cannot be found, skipping garbage collection", logfields.Error, err)
+		return false, nil
+	} else {
+		// Some APIServer error occurred, return error so we can retry
+		g.logger.ErrorContext(ctx, "Unable to determine if CiliumEndpointSlice CRD is installed, cannot start garbage collector",
+			logfields.Error, err)
+		return false, err
+	}
+}
+
+func (g *GC) doGC(ctx context.Context, _ cell.Health) error {
+	if ok, err := g.checkForCiliumEndpointSliceCRD(ctx); !ok {
+		// CES CRD is not present, NOT starting GC
+		return err
+	}
+
+	// CES have no dependent resources; when CES are disabled and being GCed,
+	// they should not be treated as an owner.
+	propagationPolicy := metav1.DeletePropagationOrphan
+	err := g.clientset.CiliumV2alpha1().CiliumEndpointSlices().DeleteCollection(
+		ctx,
+		metav1.DeleteOptions{
+			PropagationPolicy: &propagationPolicy,
+		},
+		metav1.ListOptions{},
+	)
+	return err
+}

--- a/operator/endpointslicegc/gc_test.go
+++ b/operator/endpointslicegc/gc_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointslicegc
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sTesting "k8s.io/client-go/testing"
+
+	ces "github.com/cilium/cilium/operator/pkg/ciliumendpointslice"
+	"github.com/cilium/cilium/pkg/hive"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+)
+
+func TestRegisterControllerOnce(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		requestSent := false
+		hive := hive.New(
+			k8sClient.FakeClientCell(),
+			cell.Provide(func() ces.SharedConfig {
+				return ces.SharedConfig{
+					EnableCiliumEndpointSlice: false,
+				}
+			}),
+			cell.Invoke(prepareCiliumEndpointSliceCRD),
+			cell.Invoke(func(c *k8sClient.FakeClientset) error {
+				c.CiliumFakeClientset.PrependReactor(
+					"delete-collection",
+					"ciliumendpointslices",
+					func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+						requestSent = true
+						return true, nil, nil
+					},
+				)
+				return nil
+			}),
+			cell.Invoke(func(p params) {
+				registerGC(p)
+			}),
+		)
+
+		tlog := hivetest.Logger(t)
+		if err := hive.Start(tlog, t.Context()); err != nil {
+			t.Fatalf("failed to start: %s", err)
+		}
+
+		synctest.Wait()
+		assert.True(t, requestSent)
+
+		if err := hive.Stop(tlog, t.Context()); err != nil {
+			t.Fatalf("failed to stop: %s", err)
+		}
+	})
+}
+
+func TestRegisterControllerWithCESEnabled(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		noRequest := true
+		hive := hive.New(
+			k8sClient.FakeClientCell(),
+			cell.Provide(func() ces.SharedConfig {
+				return ces.SharedConfig{
+					EnableCiliumEndpointSlice: true,
+				}
+			}),
+			cell.Invoke(prepareCiliumEndpointSliceCRD),
+			cell.Invoke(func(c *k8sClient.FakeClientset) error {
+				// There should be no requests from the GC when CES is enabled.
+				c.CiliumFakeClientset.PrependReactor(
+					"*",
+					"*",
+					func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+						noRequest = false
+						return true, nil, nil
+					},
+				)
+				return nil
+			}),
+			cell.Invoke(func(p params) error {
+				registerGC(p)
+				return nil
+			}),
+		)
+
+		tlog := hivetest.Logger(t)
+		if err := hive.Start(tlog, t.Context()); err != nil {
+			t.Fatalf("failed to start: %s", err)
+		}
+
+		synctest.Wait()
+		assert.True(t, noRequest)
+
+		if err := hive.Stop(tlog, t.Context()); err != nil {
+			t.Fatalf("failed to stop: %s", err)
+		}
+	})
+}
+
+func prepareCiliumEndpointSliceCRD(c *k8sClient.FakeClientset) error {
+	c.APIExtFakeClientset.PrependReactor("get", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, nil
+	})
+	return nil
+}


### PR DESCRIPTION
Add a one-off garbage collector for CES resources that runs when CES is disabled. This will facilitate the config change from enable-cilium-endpoint-slice=true to false, by removing unused resources.

```release-note
add one-off CiliumEndpointSlice GC when CES is disabled
```
