### PR TITLE
cilium_cli: Override GO_BUILD Make variable

### DIFF
--- a/cilium-cli/Makefile
+++ b/cilium-cli/Makefile
@@ -20,9 +20,12 @@ GO_TAGS_FLAGS += $(GO_TAGS)
 
 TEST_TIMEOUT ?= 5s
 
+BUILDDIR ?= .
+EXT ?=
+
 $(TARGET):
 	$(GO_BUILD) \
-		-o $(@) \
+		-o $(BUILDDIR)/$(@)$(EXT) \
 		$(CLI_MAIN_DIR)
 
 local-release: clean
@@ -45,8 +48,7 @@ local-release: clean
 		for ARCH in $$ARCHS; do \
 			echo Building release binary for $$OS/$$ARCH...; \
 			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
-			env GOOS=$$OS GOARCH=$$ARCH $(GO_BUILD) \
-				-o release/$$OS/$$ARCH/$(TARGET)$$EXT $(CLI_MAIN_DIR); \
+			$(MAKE) GOOS=$$OS GOARCH=$$ARCH BUILDDIR=release/$$OS/$$ARCH EXT=$$EXT; \
 			if [ $$OS = "windows" ]; \
 			then \
 				zip -j release/$(TARGET)-$$OS-$$ARCH.zip release/$$OS/$$ARCH/$(TARGET)$$EXT; \
@@ -61,7 +63,7 @@ local-release: clean
 
 install: $(TARGET)
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 0755 $(BUILDDIR)/$(TARGET)$(EXT) $(DESTDIR)$(BINDIR)
 
 clean:
 	rm -f $(TARGET)


### PR DESCRIPTION
The top-level Makefile.defs sets GOARCH to the local architecture by default as a Make variable, which gets used by the GO_BUILD variable. The local-release Make target in the cilium-cli directory explicitly sets GOARCH environment variable to build binaries for amd64 and arm64, but it gets overridden by the top-level GO_BUILD variable. This results in all the release binaries having GOARCH set to the architecture of the machine where they get built.

To fix the issue, pass GOARCH (among other variables) to the default Make target to build release binaries instead of directly invoking go build. This way GO_BUILD variable gets updated with the correct GOARCH value for each release binary.

Suggested-by: Hadrien Patte <hadrien.patte@datadoghq.com>