### PR TITLE
Revert "gh: renovate: remove reference to old ipsec config file"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,7 @@
     ".github/actions/ginkgo/**",
     ".github/actions/lvh-kind/**",
     ".github/actions/set-env-variables/action.yml",
+    ".github/actions/ipsec/configs.yaml",
     ".github/workflows/**",
     ".github/ISSUE_TEMPLATE/bug_report.yaml",
     "cilium-cli/**",


### PR DESCRIPTION
In commit f207c8773dd973d5e493c629d4a9885824111fa4, we erroneously removed the reference to the ".github/actions/ipsec/configs.yaml" file, given it was not used anymore in main. However, the renovate config also manages stable branches, where the file is still present (v1.16).
This reverts commit f207c8773dd973d5e493c629d4a9885824111fa4.
