### PR TITLE
loadbalancer: Keep unready backends in backends BPF map

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -288,16 +288,9 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 	}
 
 	for i, sub := range ep.Endpoints {
-		conditions := ParseEndpointConditionsV1(sub.Conditions)
-		if conditions == 0 {
-			// Skip backends that have no conditions set as these are not ready to
-			// serve traffic.
-			continue
-		}
-
 		// Construct the backend configuration shared by all the addresses in this slice.
 		backend := &Backend{
-			Conditions: conditions,
+			Conditions: ParseEndpointConditionsV1(sub.Conditions),
 			Ports:      ports,
 		}
 

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -893,9 +893,9 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 	}
 
 	activeCount, terminatingCount, inactiveCount := 0, 0, 0
-	backendCount := len(orderedBackends)
 
 	// Update backends that are new or changed.
+	slotID := 1
 	for i, be := range orderedBackends {
 		var beID loadbalancer.BackendID
 		if s, ok := ops.backendStates[be.Address]; ok && s.id != 0 {
@@ -927,6 +927,11 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 			ops.updateBackendRevision(beID, be.Address, be.Revision)
 		}
 
+		if be.State == loadbalancer.BackendStateMaintenance {
+			// Backends that are in maintenance are not included in the services map.
+			continue
+		}
+
 		// Update the service slot for the backend. We do this regardless
 		// if the backend entry is up-to-date since the backend slot order might've
 		// changed.
@@ -934,7 +939,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 		// the slot ids here are sequential.
 		ops.log.Debug("Update service slot",
 			logfields.ID, beID,
-			logfields.Slot, i+1,
+			logfields.Slot, slotID,
 			logfields.BackendID, beID)
 
 		svcVal.SetBackendID(beID)
@@ -983,7 +988,10 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 		default:
 			inactiveCount++
 		}
+
+		slotID++
 	}
+	backendCount := slotID - 1
 
 	if activeCount == 0 {
 		// If there are no active backends we can use the terminating backends.

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -453,9 +453,9 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					// fully removed to avoid disrupting connections.
 					state = loadbalancer.BackendStateTerminating
 				default:
-					// In all other cases we mark the backend as quarantined. Existing connections
-					// are not disrupted until the backend is actually deleted.
-					state = loadbalancer.BackendStateQuarantined
+					// In all other cases we mark the backend to be in maintenance. This avoids disruptions
+					// to existing connections when a backend readiness is flapping.
+					state = loadbalancer.BackendStateMaintenance
 				}
 				bep := loadbalancer.BackendParams{
 					Address:   l3n4Addr,

--- a/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
@@ -51,7 +51,7 @@ replace '$READY2' 'false' endpointslice.yaml
 replace '$TERM2' 'true' endpointslice.yaml
 replace '$SERVING2' 'true' endpointslice.yaml
 k8s/update endpointslice.yaml
-db/cmp frontends frontends-terminating2.table
+db/cmp frontends frontends.table
 db/cmp backends backends-terminating2.table
 
 # Check BPF maps
@@ -68,7 +68,7 @@ replace '$READY2' 'false' endpointslice.yaml
 replace '$SERVING2' 'false' endpointslice.yaml
 replace '$TERM2' 'true' endpointslice.yaml
 k8s/update endpointslice.yaml
-db/cmp frontends frontends-terminating3.table
+db/cmp frontends frontends.table
 db/cmp backends backends-terminating3.table
 
 # Check BPF maps
@@ -76,7 +76,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating3.expected lbmaps.actual
 
 # Set the first backend as not serving and second as ready+terminating .
-# First backend will be removed.
+# First backend will be kept but in maintenance and not load-balanced..
 # The second backend will be just considered ready and its terminating
 # condition is ignored ("ready" overrides everything).
 cp endpointslice.yaml.tmpl endpointslice.yaml
@@ -87,12 +87,28 @@ replace '$READY2' 'true' endpointslice.yaml
 replace '$SERVING2' 'false' endpointslice.yaml
 replace '$TERM2' 'true' endpointslice.yaml
 k8s/update endpointslice.yaml
-db/cmp frontends frontends-terminating4.table
+db/cmp frontends frontends.table
 db/cmp backends backends-terminating4.table
 
 # Check BPF maps
 lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating4.expected lbmaps.actual
+
+# Set both ready&serving. First backend will be added back to services map.
+cp endpointslice.yaml.tmpl endpointslice.yaml
+replace '$READY1' 'true' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
+replace '$TERM1' 'false' endpointslice.yaml
+replace '$READY2' 'true' endpointslice.yaml
+replace '$SERVING2' 'false' endpointslice.yaml
+replace '$TERM2' 'false' endpointslice.yaml
+k8s/update endpointslice.yaml
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-active.expected lbmaps.actual
 
 # Cleanup
 k8s/delete service.yaml endpointslice.yaml
@@ -110,18 +126,6 @@ test/graceful-term-svc   k8s      =8081      Cluster
 -- frontends.table --
 Address                 Type        ServiceName              Status  Backends                              
 10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
-
--- frontends-terminating2.table --
-Address                 Type        ServiceName              Status  Backends
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
-
--- frontends-terminating3.table --
-Address                 Type        ServiceName              Status  Backends
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
-
--- frontends-terminating4.table --
-Address                 Type        ServiceName              Status  Backends
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.113:8081/TCP
 
 -- backends.table --
 Address                 Instances                NodeName
@@ -145,6 +149,7 @@ Address                 Instances                                         NodeNa
 
 -- backends-terminating4.table --
 Address                 Instances                                         NodeName
+10.244.0.112:8081/TCP   test/graceful-term-svc [maintenance]              graceful-term-control-plane
 10.244.0.113:8081/TCP   test/graceful-term-svc                            graceful-term-control-plane
 
 -- service.yaml --
@@ -269,6 +274,7 @@ SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCO
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 -- lbmaps-terminating4.expected --
+BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=maintenance
 BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
 MAGLEV: ID=1 INNER=[2(1021)]
 REV: ID=1 ADDR=10.96.116.33:8081


### PR DESCRIPTION
To avoid disrupting connections to backends that are flapping on their readiness state, keep the backends in the backends BPF map, but not in the services map.

This in effect reverts the temporary workaround in #41234.

Fixes: #41244

```release-note
Cilium no longer disrupts existing connections to a terminating pod whose readiness check is failing.
```
