### PR TITLE
gatewayAPI: fix reference to cluster-scoped CGCC resource

### DIFF
--- a/operator/pkg/gateway-api/gatewayclass_reconcile.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile.go
@@ -61,20 +61,9 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return controllerruntime.Fail(nil)
 		}
 
-		if ref.Namespace == nil || ref.Name == "" {
-			scopedLog.ErrorContext(ctx, "ParametersRef must specify namespace and name")
-			setGatewayClassAccepted(gwc, false)
-			if err := r.ensureStatus(ctx, gwc, original); err != nil {
-				scopedLog.ErrorContext(ctx, "Failed to update GatewayClass status", logfields.Error, err)
-				return controllerruntime.Fail(err)
-			}
-			return controllerruntime.Fail(nil)
-		}
-
 		cgcc := &v2alpha1.CiliumGatewayClassConfig{}
 		key := client.ObjectKey{
-			Namespace: string(*ref.Namespace),
-			Name:      ref.Name,
+			Name: ref.Name,
 		}
 		if err := r.Client.Get(ctx, key, cgcc); err != nil {
 			setGatewayClassAccepted(gwc, false)

--- a/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
@@ -27,8 +27,7 @@ var (
 	cgwccFixture = []client.Object{
 		&v2alpha1.CiliumGatewayClassConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dummy-gateway-class-config",
-				Namespace: "default",
+				Name: "dummy-gateway-class-config",
 			},
 			Spec: v2alpha1.CiliumGatewayClassConfigSpec{},
 		},
@@ -63,10 +62,9 @@ var (
 			Spec: gatewayv1.GatewayClassSpec{
 				ControllerName: "io.cilium/gateway-controller",
 				ParametersRef: &gatewayv1.ParametersReference{
-					Group:     "cilium.io",
-					Kind:      "CiliumGatewayClassConfig",
-					Name:      "dummy-gateway-class-config",
-					Namespace: ptr.To(gatewayv1.Namespace("default")),
+					Group: "cilium.io",
+					Kind:  "CiliumGatewayClassConfig",
+					Name:  "dummy-gateway-class-config",
 				},
 			},
 		},


### PR DESCRIPTION
`CiliumGatewayClassConfig` has genclient tag as being a `nonNamespaced` (i.e. cluster-scoped) resource, this means it is expected that  namespace part of a `types.NamespacedName` is empty. 

This was mistakenly thought as being a namespaced resource and users have gotten a wrong status update:
```
  Conditions:
    Last Transition Time:  2025-10-10T12:23:51Z
    Message:               Invalid GatewayClass
    Observed Generation:   6
    Reason:                InvalidParameters
    Status:                False
    Type:                  Accepted
```
when they specified e.g.:
```
  parametersRef:
    group: cilium.io
    kind: CiliumGatewayClassConfig
    name: polonium-gatewayclass-config
``` 
with no `namespace` part.   

Relevant slack thread https://cilium.slack.com/archives/C1MATJ5U5/p1760109460023059

```release-note
gatewayAPI: correctly handle reference to CGCC as cluster-scoped resource instead of namespaced one
```
