### PR TITLE
workflows: fix GCP OIDC authentication's project ID

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -132,13 +132,13 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_PR_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PR_SA }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
           create_credentials_file: true
           export_environment_variables: true
 
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
           version: ${{ env.gcloud_version }}
 
       - name: Filter Matrix
@@ -258,13 +258,13 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_PR_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PR_SA }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
           create_credentials_file: true
           export_environment_variables: true
 
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
           version: ${{ env.gcloud_version }}
 
       - name: Install gke-gcloud-auth-plugin


### PR DESCRIPTION
When we introduced OIDC authentication, we re-used the previous workflow steps in place where project ID was provided after authentication to the `gcloud` setup step.

This is actually an incorrect setup for OIDC, as if not provided at authentication time, the project ID is derived from the SA identifier and passed on to the rest of the workflow as-is. This worked incidentally because we were using a SA located on the same project as the target project, however the correct way is to pass the target project to the authentication step, allowing to use SAs located on different project.

We discovered this because we are currently cleaning up the OIDC pools on GCP, applying GCP's recommended best practices to centralized OIDC authentication to a dedicated management project which holds the SAs and delegates permissions to target projects.

This fix is thus a prerequisite for the cloud team to properly continue with this effort.


(cherry picked from commit 1a06925c0102a91839724f04ca60c03d0bf2e113)