### PR TITLE
gneigh: add interface name and hardware address accessor methods

### DIFF
--- a/pkg/datapath/gneigh/gneigh.go
+++ b/pkg/datapath/gneigh/gneigh.go
@@ -62,6 +62,16 @@ type Interface struct {
 	iface *net.Interface
 }
 
+// Name returns the interface name.
+func (i Interface) Name() string {
+	return i.iface.Name
+}
+
+// HardwareAddr returns the interface hardware address.
+func (i Interface) HardwareAddr() net.HardwareAddr {
+	return i.iface.HardwareAddr
+}
+
 // InterfaceFromNetInterface constructs an Interface from the given *net.Interface.
 func InterfaceFromNetInterface(iface *net.Interface) Interface {
 	return Interface{iface: iface}
@@ -90,7 +100,7 @@ func (s *sender) NewArpSender(iface Interface) (ArpSender, error) {
 
 	return &arpSender{
 		cl:    cl,
-		srcHW: iface.iface.HardwareAddr,
+		srcHW: iface.HardwareAddr(),
 	}, nil
 }
 
@@ -123,7 +133,7 @@ func (s *sender) NewNdSender(iface Interface) (NdSender, error) {
 
 	return &ndSender{
 		cl:    cl,
-		srcHW: iface.iface.HardwareAddr,
+		srcHW: iface.HardwareAddr(),
 	}, nil
 }
 

--- a/pkg/datapath/gneigh/processor_test.go
+++ b/pkg/datapath/gneigh/processor_test.go
@@ -194,7 +194,7 @@ func TestProcessorSingleInterface(t *testing.T) {
 	garps := collect(garpSent)
 	require.Len(t, garps, 1)
 	require.Equal(t, garps[0].addr.String(), ep1.IPv4.String())
-	require.Equal(t, garps[0].iface.iface.Name, cfg.L2PodAnnouncementsInterface)
+	require.Equal(t, garps[0].iface.Name(), cfg.L2PodAnnouncementsInterface)
 
 	// On second event we expect no GARP to be sent.
 	proc.EndpointCreated(ep1)
@@ -205,7 +205,7 @@ func TestProcessorSingleInterface(t *testing.T) {
 	garps = collect(garpSent)
 	require.Len(t, garps, 1)
 	require.Equal(t, garps[0].addr.String(), ep2.IPv4.String())
-	require.Equal(t, garps[0].iface.iface.Name, cfg.L2PodAnnouncementsInterface)
+	require.Equal(t, garps[0].iface.Name(), cfg.L2PodAnnouncementsInterface)
 
 	// Second event for second endpoint should not trigger a GARP.
 	proc.EndpointCreated(ep2)
@@ -220,7 +220,7 @@ func TestProcessorSingleInterface(t *testing.T) {
 	garps = collect(garpSent)
 	require.Len(t, garps, 1)
 	require.Equal(t, garps[0].addr.String(), ep1.IPv4.String())
-	require.Equal(t, garps[0].iface.iface.Name, cfg.L2PodAnnouncementsInterface)
+	require.Equal(t, garps[0].iface.Name(), cfg.L2PodAnnouncementsInterface)
 
 	// But GARP should still not be set for recreated ep2.
 	proc.EndpointCreated(ep2)
@@ -241,8 +241,8 @@ func TestProcessorHappyPathMultipleInterface(t *testing.T) {
 	garps := collect(garpSent)
 	require.Len(t, garps, 2)
 	require.Equal(t, garps[0].addr.String(), ep1.IPv4.String())
-	gotEth0 := garps[0].iface.iface.Name == "eth0" || garps[1].iface.iface.Name == "eth0"
-	gotEns1 := garps[0].iface.iface.Name == "ens1" || garps[1].iface.iface.Name == "ens1"
+	gotEth0 := garps[0].iface.Name() == "eth0" || garps[1].iface.Name() == "eth0"
+	gotEns1 := garps[0].iface.Name() == "ens1" || garps[1].iface.Name() == "ens1"
 	if !(gotEth0 && gotEns1) {
 		t.Fatalf("Expected GARP to be sent on both eth0 and ens1, got: %v", garps)
 	}
@@ -261,7 +261,7 @@ func TestProcessorOnlySelected(t *testing.T) {
 	garps := collect(garpSent)
 	for _, d := range fakeDevices {
 		contains := slices.ContainsFunc(garps, func(g fakeGarp) bool {
-			return g.iface.iface.Name == d.Name
+			return g.iface.Name() == d.Name
 		})
 		if d.Selected && !contains {
 			t.Fatalf("Expected GARP to be sent on selected interface %s", d.Name)


### PR DESCRIPTION
Add the `Interface.Name` and `Interface.HardwareAddr` to simplify access to the respective fields of the underlying `*net.Interface`. This reduces stutter in the access to these attributes in existing code and also allows users outside the package to access them.