### PR TITLE
cilium-cli: Specify TARGET for building release binaries

### DIFF
--- a/cilium-cli/Makefile
+++ b/cilium-cli/Makefile
@@ -20,12 +20,9 @@ GO_TAGS_FLAGS += $(GO_TAGS)
 
 TEST_TIMEOUT ?= 5s
 
-BUILDDIR ?= .
-EXT ?=
-
 $(TARGET):
 	$(GO_BUILD) \
-		-o $(BUILDDIR)/$(@)$(EXT) \
+		-o $(@) \
 		$(CLI_MAIN_DIR)
 
 local-release: clean
@@ -48,7 +45,7 @@ local-release: clean
 		for ARCH in $$ARCHS; do \
 			echo Building release binary for $$OS/$$ARCH...; \
 			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
-			$(MAKE) GOOS=$$OS GOARCH=$$ARCH BUILDDIR=release/$$OS/$$ARCH EXT=$$EXT; \
+			$(MAKE) GOOS=$$OS GOARCH=$$ARCH TARGET=release/$$OS/$$ARCH/$(TARGET)$$EXT; \
 			if [ $$OS = "windows" ]; \
 			then \
 				zip -j release/$(TARGET)-$$OS-$$ARCH.zip release/$$OS/$$ARCH/$(TARGET)$$EXT; \
@@ -63,7 +60,7 @@ local-release: clean
 
 install: $(TARGET)
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 0755 $(BUILDDIR)/$(TARGET)$(EXT) $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 
 clean:
 	rm -f $(TARGET)


### PR DESCRIPTION
Some downstream projects [^1] override TARGET, expecting the output file to go to the location specified by it. Although TARGET is marked phony, I think it's best to keep the previous behavior of using TARGET as the output file location to avoid impacting downstream projects.

This commit changes the local-release target to specify TARGET instead of introducing BUILDDIR and EXT that modify the location of the output file of TARGET.

[^1]: https://github.com/cilium/cilium-cli/blob/649a1df5bcfcc6c87bc30e1fe70610a7806d04a7/action.yaml#L85

Fixes: 0532a11463d5 ("cilium-cli: Use the default Make target to build release binaries")

Reported-by: Viktor Kurchenko <viktor.kurchenko@isovalent.com>