### PR TITLE
auth: Refactor/replace reflect deepequal incremental

### DIFF
--- a/pkg/auth/always_fail_authhandler_test.go
+++ b/pkg/auth/always_fail_authhandler_test.go
@@ -4,8 +4,9 @@
 package auth
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_alwaysFailAuthHandler_authenticate(t *testing.T) {
@@ -32,9 +33,7 @@ func Test_alwaysFailAuthHandler_authenticate(t *testing.T) {
 				t.Errorf("alwaysFailAuthHandler.authenticate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("alwaysFailAuthHandler.authenticate() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/auth/mutual_authhandler_test.go
+++ b/pkg/auth/mutual_authhandler_test.go
@@ -15,12 +15,12 @@ import (
 	"math/big"
 	"net"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/auth/certs"
@@ -265,9 +265,7 @@ func Test_mutualAuthHandler_verifyPeerCertificate(t *testing.T) {
 				t.Errorf("mutualAuthHandler.verifyPeerCertificate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("mutualAuthHandler.verifyPeerCertificate() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -342,9 +340,7 @@ func Test_mutualAuthHandler_GetCertificateForIncomingConnection(t *testing.T) {
 					t.Errorf("mutualAuthHandler.GetCertificateForIncomingConnection() leaf certificate has no URIs")
 				}
 				gotURI := got.Leaf.URIs[0].String()
-				if !reflect.DeepEqual(gotURI, tt.wantURI) {
-					t.Errorf("mutualAuthHandler.GetCertificateForIncomingConnection() = %v, want %v", got, tt.wantURI)
-				}
+				assert.Equal(t, tt.wantURI, gotURI)
 			}
 
 		})
@@ -432,9 +428,7 @@ func Test_mutualAuthHandler_authenticate(t *testing.T) {
 				t.Errorf("mutualAuthHandler.authenticate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("mutualAuthHandler.authenticate() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR is the first incremental change to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces all 4 usages of `reflect.DeepEqual` in the `pkg/auth/` package:

- `pkg/auth/always_fail_authhandler_test.go` (1 usage)
- `pkg/auth/mutual_authhandler_test.go` (3 usages)

## Testing

All existing tests in `pkg/auth/` continue to pass:
```bash
$ go test ./pkg/auth/... -v
PASS
ok      github.com/cilium/cilium/pkg/auth       0.035s
```

## Follow-up

This is an incremental change affecting a single package. Once merged, similar changes can be made to other packages across the codebase.

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/auth tests for better error messages
```