### PR TITLE
bpf: conntrack: let callers of ct_lookup6() provide fraginfo

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -374,6 +374,7 @@ int NAME(struct __ctx_buff *ctx)						\
 	struct ct_state *ct_state;						\
 	void *data, *data_end;							\
 	struct ipv6hdr *ip6;							\
+	fraginfo_t fraginfo;							\
 	__s8 ext_err = 0;							\
 	__u32 zero = 0;								\
 										\
@@ -387,7 +388,7 @@ int NAME(struct __ctx_buff *ctx)						\
 	ipv6_addr_copy(&tuple->daddr, (union v6addr *)&ip6->daddr);		\
 	ipv6_addr_copy(&tuple->saddr, (union v6addr *)&ip6->saddr);		\
 										\
-	hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);				\
+	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple->nexthdr, &fraginfo);	\
 	if (hdrlen < 0)								\
 		return drop_for_direction(ctx, DIR, hdrlen, ext_err);		\
 										\
@@ -408,7 +409,7 @@ int NAME(struct __ctx_buff *ctx)						\
 	}									\
 										\
 	ct_buffer.ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, ip6,		\
-				   ct_buffer.l4_off, DIR, scope,		\
+				   fraginfo, ct_buffer.l4_off, DIR, scope,	\
 				   ct_state, &ct_buffer.monitor);		\
 	if (ct_buffer.ret < 0)							\
 		return drop_for_direction(ctx, DIR, ct_buffer.ret, ext_err);	\

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -661,16 +661,12 @@ ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff 
 static __always_inline int ct_lookup6(const void *map,
 				      struct ipv6_ct_tuple *tuple,
 				      struct __ctx_buff *ctx, struct ipv6hdr *ip6,
-				      int l4_off, enum ct_dir dir, enum ct_scope scope,
+				      fraginfo_t fraginfo, int l4_off,
+				      enum ct_dir dir, enum ct_scope scope,
 				      struct ct_state *ct_state,
 				      __u32 *monitor)
 {
-	fraginfo_t fraginfo;
 	int ret;
-
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
 
 	tuple->flags = ct_lookup_select_tuple_type(dir, scope);
 


### PR DESCRIPTION
All callers already walk the IPv6 extension headers as part of ipv6_hdrlen(). So we might as well also get the fraginfo at that moment, and not walk the extension headers a second time inside ct_lookup6().