### PR TITLE
ipam/multipool: Promote the feature to stable

### DIFF
--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -6,10 +6,8 @@
 
 .. _ipam_crd_multi_pool:
 
-Multi-Pool (Beta)
-#################
-
-.. include:: ../../../beta.rst
+Multi-Pool
+##########
 
 The Multi-Pool IPAM mode supports allocating PodCIDRs from multiple different IPAM pools, depending
 on workload annotations and node labels defined by the user.
@@ -251,8 +249,7 @@ between nodes on a L2 network.
 Limitations
 ***********
 
-Multi-Pool IPAM is a preview feature. The following limitations apply to Cilium running in
-Multi-Pool IPAM mode:
+The following limitations apply to Cilium running in Multi-Pool IPAM mode:
 
 .. warning::
    - IPAM pools with overlapping CIDRs are not supported. Each pod IP must be

--- a/Documentation/network/kubernetes/ipam-multi-pool.rst
+++ b/Documentation/network/kubernetes/ipam-multi-pool.rst
@@ -6,11 +6,9 @@
 
 .. _gsg_ipam_crd_multi_pool:
 
-*******************************************
-CRD-Backed by Cilium Multi-Pool IPAM (Beta)
-*******************************************
-
-.. include:: ../../beta.rst
+************************************
+CRD-Backed by Cilium Multi-Pool IPAM
+************************************
 
 This is a quick tutorial walking through how to enable multi-pool IPAM backed by the
 ``CiliumPodIPPool`` CRD. The purpose of this tutorial is to show how components are configured and


### PR DESCRIPTION
Given the last improvements to stabilize Multi-Pool IPAM, it's time to remove the "Beta" qualifier and promote the feature to stable.

Related:
- https://github.com/cilium/cilium/pull/40460
- https://github.com/cilium/cilium/pull/40191
- https://github.com/cilium/cilium/pull/40142
- https://github.com/cilium/cilium/pull/39638
- https://github.com/cilium/cilium/pull/39442
- https://github.com/cilium/cilium/pull/38483
- https://github.com/cilium/cilium/pull/42126

```release-note
Promote Multi-Pool IPAM feature from Beta to Stable
```
