### PR TITLE
Azure: add support for masquerading

### DIFF
--- a/Documentation/network/concepts/ipam/azure.rst
+++ b/Documentation/network/concepts/ipam/azure.rst
@@ -203,6 +203,11 @@ When a node or instance terminates, the Kubernetes apiserver will send a node
 deletion event. This event will be picked up by the operator and the operator
 will delete the corresponding ``ciliumnodes.cilium.io`` custom resource.
 
+Masquerading
+============
+
+Masquerading is supported via the eBPF :ref:`ip-masq-agent <concepts_masquerading>` or by setting ``--ipv4-native-routing-cidr``.
+
 .. _ipam_azure_required_privileges:
 
 *******************

--- a/daemon/cmd/ipam_infra_ip_allocation.go
+++ b/daemon/cmd/ipam_infra_ip_allocation.go
@@ -255,7 +255,7 @@ func (r *infraIPAllocator) allocateDatapathIPs(ctx context.Context, family types
 
 	// Coalescing multiple CIDRs. GH #18868
 	if masq &&
-		option.Config.IPAM == ipamOption.IPAMENI &&
+		(option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) &&
 		result != nil &&
 		len(result.CIDRs) > 0 {
 		result.CIDRs, err = r.coalesceCIDRs(result.CIDRs)
@@ -363,7 +363,7 @@ func (r *infraIPAllocator) allocateHealthIPs() error {
 
 		// Coalescing multiple CIDRs. GH #18868
 		if option.Config.EnableIPv4Masquerade &&
-			option.Config.IPAM == ipamOption.IPAMENI &&
+			(option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) &&
 			result != nil &&
 			len(result.CIDRs) > 0 {
 			result.CIDRs, err = r.coalesceCIDRs(result.CIDRs)
@@ -446,7 +446,7 @@ func (r *infraIPAllocator) allocateIngressIPs() error {
 
 			// Coalescing multiple CIDRs. GH #18868
 			if option.Config.EnableIPv4Masquerade &&
-				option.Config.IPAM == ipamOption.IPAMENI &&
+				(option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) &&
 				result != nil &&
 				len(result.CIDRs) > 0 {
 				result.CIDRs, err = r.coalesceCIDRs(result.CIDRs)

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -54,8 +54,6 @@ func (info *RoutingInfo) GetCIDRs() []net.IPNet {
 // NewRoutingInfo creates a new RoutingInfo struct, from data that will be
 // parsed and validated. Note, this code assumes IPv4 values because IPv4
 // (on either ENI or Azure interface) is the only supported path currently.
-// Azure does not support masquerade yet (subnets CIDRs aren't provided):
-// until it does, we forward a masquerade bool to opt out ipam.Cidrs use.
 func NewRoutingInfo(logger *slog.Logger, gateway string, cidrs []string, mac, ifaceNum, ipamMode string, masquerade bool) (*RoutingInfo, error) {
 	return parse(logger, gateway, cidrs, mac, ifaceNum, ipamMode, masquerade)
 }

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -98,7 +98,7 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 	tableID = computeTableIDFromIfaceNumber(compat, ifaceNum)
 
 	// The condition here should mirror the condition in Delete.
-	if info.Masquerade && info.IpamMode == ipamOption.IPAMENI {
+	if info.Masquerade && (info.IpamMode == ipamOption.IPAMENI || info.IpamMode == ipamOption.IPAMAzure) {
 		// Lookup a VPC specific table for all traffic from an endpoint to the
 		// CIDR configured for the VPC on which the endpoint has the IP on.
 		// ReplaceRule function doesn't handle all zeros cidr and return `file exists` error,
@@ -313,7 +313,7 @@ func Delete(logger *slog.Logger, ip netip.Addr, compat bool) error {
 
 	// The condition here should mirror the conditions in Configure.
 	info := node.GetRouterInfo()
-	if info != nil && option.Config.EnableIPv4Masquerade && option.Config.IPAM == ipamOption.IPAMENI {
+	if info != nil && option.Config.EnableIPv4Masquerade && (option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) {
 		ipCIDRs := info.GetCIDRs()
 		cidrs := make([]*net.IPNet, 0, len(ipCIDRs))
 		for i := range ipCIDRs {


### PR DESCRIPTION
# Description

This PR adds support for Masquerading when using the [Azure IPAM](https://docs.cilium.io/en/latest/network/concepts/ipam/azure/) mode.

Users can configure masquerading by using the eBPF `ip-masq-agent` or by setting `--ipv4-native-routing-cidr`. I think this should be enough to cover most use-cases to start with. 

We could also implement automatic Azure VNET CIDR detection and propagation to the masquerading config (similar to what AWS has for VPC CIDRs [here](https://github.com/cilium/cilium/blob/ebc32309be74b59186fd9119b1d8275e8bbab00e/pkg/ipam/crd.go#L784)) but it's something that can be implemented as a second step.

# Testing
Backported the PR to our 1.18.2 fork. Then deployed the Agent on Azure with the following flags:
```
        - --enable-ipv4-masquerade=true
        - --enable-bpf-masquerade=true
        - --enable-ip-masq-agent=true
        - --ip-masq-agent-config-path=/etc/cilium-agent-ip-masq-config/config.yaml
```
The config file looks like this:
```
# cat /etc/cilium-agent-ip-masq-config/config.yaml
nonMasqueradeCIDRs:
- 10.0.0.0/8
- 172.16.0.0/12
- 100.64.0.0/10
- 192.168.0.0/16
masqLinkLocal: false
```

Then deployed a pod on an Azure node, the pod's IP is `10.194.0.56`. Verified that the `ip rule`s were properly set up with proper CIDR exclusions:
```
# ip rule | grep 10.194.0.56
20:	from all to 10.194.0.56 lookup main
110:	from 10.194.0.56 to 10.0.0.0/8 lookup 3
110:	from 10.194.0.56 to 100.64.0.0/10 lookup 3
110:	from 10.194.0.56 to 169.254.0.0/16 lookup 3
110:	from 10.194.0.56 to 172.16.0.0/12 lookup 3
110:	from 10.194.0.56 to 192.168.0.0/16 lookup 3
```

Also attached a Public IP to the primary instance interface and verified that the pod's traffic was actually masqueraded with that Public IP:
```
anton-test-6d954ccf46-kpsv6:/# curl ifconfig.me
20.XX.XX.XX
```

```release-note
Azure: add support for masquerading
```