### PR TITLE
cilium-dbg: Fix status indentation formatting

### DIFF
--- a/cilium-dbg/cmd/status.go
+++ b/cilium-dbg/cmd/status.go
@@ -130,7 +130,7 @@ func statusDaemon() {
 			healthPkg.GetAndFormatModulesHealth(w, ss, allHealth, "\t\t")
 			fmt.Fprintln(w)
 		} else {
-			fmt.Fprint(w, "Cluster health:\t\tProbe disabled\n")
+			fmt.Fprint(w, "Cluster health:\tProbe disabled\n")
 		}
 		w.Flush()
 	}


### PR DESCRIPTION
Currently when running `cilium status` from an agent pod with health check disabled we get an output like that:
```
ClusterMesh:             2/2 remote clusters ready, 0 global-services
IPv4 BIG TCP:            Disabled
IPv6 BIG TCP:            Disabled
Routing:                 Network: Native   Host: BPF
Attach Mode:             TCX
Device Mode:             netkit
Masquerading:            Disabled
Controller Status:       27/27 healthy
Hubble:                  Ok         Current/Max Flows: 4095/4095 (100.00%), Flows/s: 26.73   Metrics: Ok
Encryption:              Disabled
Cluster health:                     Probe disabled
```

We can see that the line reporting the cluster health has one too many tab character causing the health status to not be properly aligned with the other elements from the other lines.
