### PR TITLE
certloader: Log initial TLS config load errors in FutureWatcher

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/sysdump"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
+	"github.com/cilium/cilium/pkg/crypto/certloader"
 )
 
 type logMatcher interface {
@@ -70,7 +71,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI,
 		envoyExternalTargetTLSWarning, envoyExternalOtherTargetTLSWarning, ciliumNodeConfigDeprecation,
 		hubbleUIEnvVarFallback, k8sClientNetworkStatusError, bgpAlphaResourceDeprecation, ccgAlphaResourceDeprecation,
-		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn}
+		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn, certloaderInitialLoadWarn}
 
 	if ciliumVersion.LT(semver.MustParse("1.18.0")) {
 		errorLogExceptions = append(errorLogExceptions, linkNotFound)
@@ -405,7 +406,12 @@ func (n *noErrorsInLogs) checkErrorsInLogs(id string, logs []byte, a *check.Acti
 }
 
 const (
-	// Logs messages that should not be in the cilium logs
+	// Logs messages that should not be in the cilium logs.
+	//
+	// Note: when adding a new exception, please also add a comment indicating
+	// the reason why this exception is needed.
+
+	// errors
 	panicMessage                         = "panic:"
 	deadLockHeader                       = "POTENTIAL DEADLOCK:"                                  // from github.com/sasha-s/go-deadlock/deadlock.go:header
 	RunInitFailed                        = "JoinEP: "                                             // from https://github.com/cilium/cilium/pull/5052
@@ -426,6 +432,7 @@ const (
 	klogLeaderElectionFail stringMatcher = "error retrieving resource lock kube-system/cilium-operator-resource-lock:" // from: https://github.com/cilium/cilium/issues/31050
 	nilDetailsForService   stringMatcher = "retrieved nil details for Service"                                         // from: https://github.com/cilium/cilium/issues/35595
 
+	// warnings
 	cantEnableJIT               stringMatcher = "bpf_jit_enable: no such file or directory"                              // Because we run tests in Kind.
 	delMissingService           stringMatcher = "Deleting no longer present service"                                     // cf. https://github.com/cilium/cilium/issues/29679
 	podCIDRUnavailable          stringMatcher = " PodCIDR not available"                                                 // cf. https://github.com/cilium/cilium/issues/29680
@@ -464,6 +471,8 @@ const (
 
 	k8sEndpointDeprecatedWarn stringMatcher = "v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice" // cf. https://github.com/cilium/cilium/issues/39105
 	proxylibDeprecatedWarn    stringMatcher = "The support for Envoy Go Extensions (proxylib) has been deprecated"          // cf. https://github.com/cilium/cilium/issues/38224
+
+	certloaderInitialLoadWarn stringMatcher = certloader.InitialLoadWarn // Expected when certificates are not yet mounted.
 
 	// Logs messages that should not be in the cilium-envoy DS logs
 	envoyErrorMessage    = "[error]"

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1828,4 +1828,8 @@ const (
 
 	// CompiledPools is a map of pools that use podSelectors
 	CompiledPools = "compiledPools"
+
+	ReloadKeypairError = "reloadKeypairError"
+
+	ReloadCAError = "reloadCAError"
 )


### PR DESCRIPTION
When FutureWatcher sets up file watching for certificates, it performs an initial load before starting the watcher. This initial load could fail with a certificate validation error, but we are not logging errors and instead continue with setting up the watcher, waiting for subsequent updates, which might never come if the certificate is never updated.

Add warning log statements and include the errors returned from loading the certificate keypair and CA. This should help investigating certificate loading issues when the certificates already exists when FutureWatcher is called. When the certificates do not exists yet, the watcher is started and proper logging is performed upon errors already.

To put this PR into context, the latest Go release (1.24.8/1.25.2) broke certificate validation for FQDNs with trailing dot: https://github.com/golang/go/issues/75828. Downstream, we use certloader to template and install certificates that contain a trailing dot, and no logging here meant we were faced with only the log: `waiting on fswatcher update to be ready`, which was not very helpful.

Please label the PR for backports to all branches, thank you!