### PR TITLE
envoy: Preserve leading slash in root path prefix rewrites

### DIFF
--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -286,6 +286,13 @@ func pathPrefixMutation(rewrite *model.HTTPURLRewriteFilter, httpRoute *model.HT
 				// hold `/` in case the entire path is removed
 				Substitution: `/\2`,
 			}
+		} else if httpRoute.PathMatch.Prefix == "/" {
+			route.Route.RegexRewrite = &envoy_type_matcher_v3.RegexMatchAndSubstitute{
+				Pattern: &envoy_type_matcher_v3.RegexMatcher{
+					Regex: `^/(.*)`,
+				},
+				Substitution: strings.TrimSuffix(rewrite.Path.Prefix, "/") + `/\1`,
+			}
 		} else {
 			route.Route.PrefixRewrite = rewrite.Path.Prefix
 		}


### PR DESCRIPTION
## Description

- Fixed path rewriting behavior when [httpRoute.PathMatch.Prefix](https://gateway-api.sigs.k8s.io/reference/spec/#httppathmatch) is set to `/` to preserve the slash and properly append the path specified in [replacePrefixMatch](https://gateway-api.sigs.k8s.io/reference/spec/#httppathmodifier)

  - When replacePrefixMatch is /consumer and `httpRoute.PathMatch.Prefix` is `/`:
    - Before: `/some-path` -> `/consumersome-path`
    - After:  `/some-path` -> `/consumer/some-path`

## Resolution

- When `httpRoute.PathMatch.Prefix` is `/`, extract the subsequent path and explicitly prepend `/` before concatenating with the extracted path

## Testing

The following configuration was used for testing:

### Configuration

<details><summary>Manifest</summary>
<p>

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: api
  namespace: production
  labels:
    app: api
spec:
  containers:
  - name: nginx
    image: nginx:alpine
    ports:
    - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: api
  namespace: production
spec:
  selector:
    app: api
  ports:
  - port: 80
    targetPort: 80
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: gateway
  namespace: production
spec:
  gatewayClassName: cilium
  listeners:
  - name: http
    protocol: HTTP
    port: 80
    allowedRoutes:
      namespaces:
        from: Same
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: my-domain-route
  namespace: production
spec:
  parentRefs:
  - name: gateway
    namespace: production
  hostnames:
  - "my-domain.com"
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /
    filters:
    - type: URLRewrite
      urlRewrite:
        path:
          type: ReplacePrefixMatch
          replacePrefixMatch: /consumer
    backendRefs:
    - name: api
      port: 80
```

</p>
</details>

### Before Fix

- Request:
  ```bash
  ❯ curl -I -H "Host: my-domain.com" a8b05cdda826e4d3b98765405a9d2676-202797046.ap-northeast-1.elb.amazonaws.com/subpath
  HTTP/1.1 404 Not Found
  ... ...
  ```

- Application log shows request was sent to `consumersubpath`:
  ```
  2025/10/19 14:07:36 [error] 31#31: *2 open() "/usr/share/nginx/html/consumersubpath" failed (2: No such file or directory), client: 192.168.45.177, server: localhost, request: "HEAD /consumersubpath HTTP/1.1", host: "my-domain.com"
  ```

### After Fix

- Request:
  ```bash
  ❯ curl -I -H "Host: my-domain.com" a67c973f6de6147a3b098444002f5fa1-613876723.ap-northeast-1.elb.amazonaws.com/subpath
  HTTP/1.1 301 Moved Permanently
  server: envoy
  ```

- Application log confirms request was properly sent to `/consumer/subpath`:
  ```
  192.168.45.177 - - [19/Oct/2025:14:17:30 +0000] "HEAD /consumer/subpath HTTP/1.1" 301 0 "-" "curl/8.7.1" "192.168.47.177"
  ```


Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes: #41998

```release-note
envoy: Preserve leading slash in root path prefix rewrites
```


