### PR TITLE
[v1.16] bpf:tests:egressgw: fix metrics count (part 2)

### DIFF
--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -161,7 +161,10 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 	entry = map_lookup_elem(&METRICS_MAP, &key);
 	if (!entry)
 		test_fatal("metrics entry not found");
-	assert(entry->count == 1);
+
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 
 	policy_delete_egress_entry();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);


### PR DESCRIPTION
Fix up a v1.16-only ocurrence of what 0ffff5f2925f ("bpf:tests:egressgw: fix metrics count") addressed. I missed this in the initial backport (https://github.com/cilium/cilium/pull/41824).