### PR TITLE
datapath, endpoint: allow to get endpoint properties on cached endpoints

### DIFF
--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -109,6 +109,10 @@ func (t *templateCfg) GetPolicyVerdictLogFilter() uint32 {
 	return templatePolicyVerdictFilter
 }
 
+func (*templateCfg) GetPropertyValue(key string) any {
+	return nil
+}
+
 // wrap takes an endpoint configuration and optional stats tracker and wraps
 // it inside a templateCfg which hides static data from callers that wish to
 // generate header files based on the configuration, substituting it for

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -40,6 +40,9 @@ type LoadTimeConfiguration interface {
 
 	// GetPolicyVerdictLogFilter returns the PolicyVerdictLogFilter for the endpoint
 	GetPolicyVerdictLogFilter() uint32
+
+	// GetPropertyValue returns the endpoint property value for this key.
+	GetPropertyValue(key string) any
 }
 
 // CompileTimeConfiguration provides datapath implementations a clean interface

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -5,6 +5,7 @@ package endpoint
 
 import (
 	"log/slog"
+	"maps"
 	"net/netip"
 	"strconv"
 
@@ -43,6 +44,7 @@ type epInfoCache struct {
 	ifIndex                int
 	parentIfIndex          int
 	netNsCookie            uint64
+	properties             map[string]any
 
 	// endpoint is used to get the endpoint's logger.
 	//
@@ -59,13 +61,14 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		return &epInfoCache{
 			revision: e.nextPolicyRevision,
 
-			id:       e.GetID(),
-			identity: e.getIdentity(),
-			ifIndex:  e.GetIfIndex(),
-			mac:      e.GetNodeMAC(),
-			ipv4:     e.IPv4Address(),
-			ipv6:     e.IPv6Address(),
-			atHostNS: true,
+			id:         e.GetID(),
+			identity:   e.getIdentity(),
+			ifIndex:    e.GetIfIndex(),
+			mac:        e.GetNodeMAC(),
+			ipv4:       e.IPv4Address(),
+			ipv6:       e.IPv6Address(),
+			atHostNS:   true,
+			properties: maps.Clone(e.properties),
 
 			endpoint: e,
 		}
@@ -90,6 +93,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		ifIndex:                e.ifIndex,
 		parentIfIndex:          e.parentIfIndex,
 		netNsCookie:            e.NetNsCookie,
+		properties:             maps.Clone(e.properties),
 
 		endpoint: e,
 	}
@@ -189,4 +193,8 @@ func (ep *epInfoCache) IsHost() bool {
 
 func (ep *epInfoCache) IsAtHostNS() bool {
 	return ep.atHostNS
+}
+
+func (ep *epInfoCache) GetPropertyValue(key string) any {
+	return ep.properties[key]
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2682,14 +2682,14 @@ func (e *Endpoint) GetCreatedAt() time.Time {
 	return e.createdAt
 }
 
-// GetPropertyValue returns the metadata value for this key.
+// GetPropertyValue returns the endpoint property value for this key.
 func (e *Endpoint) GetPropertyValue(key string) any {
 	e.mutex.RWMutex.RLock()
 	defer e.mutex.RWMutex.RUnlock()
 	return e.properties[key]
 }
 
-// SetPropertyValue sets the metadata value for this key.
+// SetPropertyValue sets the endpoint property value for this key.
 func (e *Endpoint) SetPropertyValue(key string, value any) any {
 	e.mutex.RWMutex.Lock()
 	defer e.mutex.RWMutex.Unlock()

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -91,6 +91,8 @@ func (e *TestEndpoint) GetOptions() *option.IntOptions { return e.Opts }
 
 func (e *TestEndpoint) IsHost() bool { return e.isHost }
 
+func (e *TestEndpoint) GetPropertyValue(key string) any { return nil }
+
 func (e *TestEndpoint) IPv4Address() netip.Addr {
 	return netip.MustParseAddr("192.0.2.3")
 }


### PR DESCRIPTION
Commit d735c5017bd1 ("introduce 'properties' for endpoints") introduced (*Endpoint).GetPropertyValue - called GetMetadataValue at that time, renamed in commit badd0920ef9d ("endpoint: rename GetMetadataValue to GetPropertyValue") - but is was only usable on *Endpoint but not other types implementing `LoadTimeConfiguration`, namely `*epInfoCache`.

This change now adds `GetPropertyValue` to the `LoadTimeConfiguration` interface and lets `*epInfoCache` implement it so it can be used by consumers of that interface to also obtain a cached endpoint's custom property values.