### PR TITLE
identity: Remove unused CIDRLabel field

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -34,17 +34,6 @@ type Identity struct {
 	// for faster lookup.
 	LabelArray labels.LabelArray `json:"-"`
 
-	// CIDRLabel is the primary identity label when the identity represents
-	// a CIDR. The Labels field will consist of all matching prefixes, e.g.
-	// 10.0.0.0/8
-	// 10.0.0.0/7
-	// 10.0.0.0/6
-	// [...]
-	// reserved:world
-	//
-	// The CIDRLabel field will only contain 10.0.0.0/8
-	CIDRLabel labels.Labels `json:"-"`
-
 	// ReferenceCount counts the number of references pointing to this
 	// identity. This field is used by the owning cache of the identity.
 	ReferenceCount int `json:"-"`

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -739,9 +739,6 @@ func (ipc *IPCache) resolveIdentity(prefix cmtypes.PrefixCluster, info *resource
 		)
 		return nil, false, err
 	}
-	if lbls.HasWorldLabel() {
-		id.CIDRLabel = labels.NewLabelsFromModel([]string{labels.LabelSourceCIDR + ":" + prefix.String()})
-	}
 	return id, isNew, err
 }
 


### PR DESCRIPTION
This field is no longer in use (it is only set, but never read). In addition, the code comment is also outdated, as we no longer add all parent prefixes as a label.

The last use was removed in https://github.com/cilium/cilium/pull/31311