### PR TITLE
ipsec:mtu: runtime adjustment of mtu when rotating key with different auth size

### DIFF
--- a/.github/actions/e2e/ipsec.yaml
+++ b/.github/actions/e2e/ipsec.yaml
@@ -6,7 +6,7 @@
   tunnel: 'vxlan'
   encryption: 'ipsec'
   key-one: 'rfc4106-gcm-aes'
-  key-two: 'rfc4106-gcm-aes'
+  key-two: 'cbc-aes-sha512'
 - name: 'ipsec-2'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.10-20251008.075427'
@@ -15,7 +15,7 @@
   tunnel: 'disabled'
   encryption: 'ipsec'
   key-one: 'cbc-aes-sha256'
-  key-two: 'cbc-aes-sha256'
+  key-two: 'rfc4106-gcm-aes'
 - name: 'ipsec-3'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.10-20251008.075427'

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -221,12 +221,6 @@ Key Rotation
    is, all nodes in the cluster (or clustermesh) should be on the same Cilium
    version before rotating keys.
 
-.. attention::
-
-   It is not recommended to change algorithms that involve different authentication
-   key lengths during key rotations. If this is attempted, Cilium will delay the
-   application of the new key until the agent restarts and will continue using the
-   previous key. This is designed to maintain uninterrupted IPv6 pod-to-pod connectivity.
 
 To replace cilium-ipsec-keys secret with a new key:
 

--- a/pkg/datapath/fake/types/ipsec.go
+++ b/pkg/datapath/fake/types/ipsec.go
@@ -15,11 +15,12 @@ var (
 )
 
 type IPsecAgent struct {
-	EnableIPsec bool
+	EnableIPsec      bool
+	AuthKeySizeValue int
 }
 
-func (*IPsecAgent) AuthKeySize() int {
-	return 16
+func (a *IPsecAgent) AuthKeySize() int {
+	return a.AuthKeySizeValue
 }
 
 func (*IPsecAgent) SPI() uint8 {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -80,12 +80,11 @@ const (
 )
 
 type ipSecKey struct {
-	Spi    uint8
-	KeyLen int
-	ReqID  int
-	Auth   *netlink.XfrmStateAlgo
-	Crypt  *netlink.XfrmStateAlgo
-	Aead   *netlink.XfrmStateAlgo
+	Spi   uint8
+	ReqID int
+	Auth  *netlink.XfrmStateAlgo
+	Crypt *netlink.XfrmStateAlgo
+	Aead  *netlink.XfrmStateAlgo
 }
 
 type oldXfrmStateKey struct {
@@ -1152,14 +1151,10 @@ func (a *Agent) LoadIPSecKeys(r io.Reader) (int, uint8, error) {
 		}
 
 		ipSecKey.Spi = spi
-		ipSecKey.KeyLen = keyLen
 
 		if oldKey, ok := a.ipSecKeysGlobal[""]; ok {
 			if oldKey.Spi == spi {
 				return 0, 0, fmt.Errorf("invalid SPI: changing IPSec keys requires incrementing the key id")
-			}
-			if oldKey.KeyLen != keyLen {
-				return 0, 0, fmt.Errorf("invalid key rotation: key length must not change")
 			}
 			a.ipSecKeysRemovalTime[oldKey.Spi] = time.Now()
 		}

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -139,24 +139,15 @@ func testInvalidLoadKeys(t *testing.T) {
 func TestPrivilegedLoadKeys(t *testing.T) {
 	setupIPSecSuitePrivileged(t, "ipv4")
 
+	a := NewTestIPsecAgent(t)
 	testCases := [][]byte{keysDat, keysNullDat, keysAeadDat, keysAeadDat256}
 	for _, testCase := range testCases {
 		keys := bytes.NewReader(testCase)
-		a := NewTestIPsecAgent(t)
 		_, spi, err := a.LoadIPSecKeys(keys)
 		require.NoError(t, err)
 		err = a.setIPSecSPI(spi)
 		require.NoError(t, err)
 	}
-}
-
-func TestPrivilegedLoadKeysLenChange(t *testing.T) {
-	setupIPSecSuitePrivileged(t, "ipv4")
-
-	a := NewTestIPsecAgent(t)
-	keys := bytes.NewReader(append(keysDat, keysNullDat...))
-	_, _, err := a.LoadIPSecKeys(keys)
-	require.ErrorContains(t, err, "invalid key rotation: key length must not change")
 }
 
 func TestPrivilegedLoadKeysSameSPI(t *testing.T) {

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -147,7 +147,6 @@ func TestPrivilegedLoadKeys(t *testing.T) {
 		require.NoError(t, err)
 		err = a.setIPSecSPI(spi)
 		require.NoError(t, err)
-		require.Equal(t, spi, a.spi)
 	}
 }
 

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -85,7 +85,7 @@ func setupLinuxPrivilegedBaseTestSuite(tb testing.TB, addressing datapath.NodeAd
 	s.sysctl = sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
 
 	rlimit.RemoveMemlock()
-	mtuConfig := mtu.NewConfiguration(0, false, false, false, false)
+	mtuConfig := mtu.NewConfiguration(&fakeTypes.IPsecAgent{}, false, false, false)
 	s.mtuCalc = mtuConfig.Calculate(1500)
 	s.enableIPv6 = enableIPv6
 	s.enableIPv4 = enableIPv4

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -35,7 +35,7 @@ var (
 		RouteMTU:            calcMtu.RouteMTU,
 		RoutePostEncryptMTU: calcMtu.RoutePostEncryptMTU,
 	}
-	mtuConfig = mtu.NewConfiguration(0, false, false, false, false)
+	mtuConfig = mtu.NewConfiguration(&fakeTypes.IPsecAgent{}, false, false, false)
 	calcMtu   = mtuConfig.Calculate(100)
 	nh        = linuxNodeHandler{
 		nodeConfig: nodeConfig,

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -82,8 +82,7 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 			tunnelOverIPv6 := option.Config.RoutingMode == option.RoutingModeTunnel &&
 				p.TunnelConfig.UnderlayProtocol() == tunnel.IPv6
 			*c = NewConfiguration(
-				p.IPsec.AuthKeySize(),
-				p.IPsec.Enabled(),
+				p.IPsec,
 				p.TunnelConfig.ShouldAdaptMTU(),
 				p.WgConfig.Enabled(),
 				tunnelOverIPv6,

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -7,66 +7,68 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 )
 
 func TestNewConfiguration(t *testing.T) {
 	// Add routes with no encryption or tunnel
-	conf := NewConfiguration(0, false, false, false, false)
+	conf := NewConfiguration(&fakeTypes.IPsecAgent{}, false, false, false)
 	require.NotEqual(t, 0, conf.getDeviceMTU(0))
 	require.Equal(t, conf.getDeviceMTU(0), conf.getRouteMTU(0))
 
 	// Add routes with no encryption or tunnel and set MTU
-	conf = NewConfiguration(0, false, false, false, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{}, false, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400), conf.getRouteMTU(1400))
 
 	// Add routes with tunnel
-	conf = NewConfiguration(0, false, true, false, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{}, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverheadIPv4, conf.getRouteMTU(1400))
 
 	// Add routes with tunnel over IPv6
-	conf = NewConfiguration(0, false, true, false, true)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{}, true, false, true)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverheadIPv6, conf.getRouteMTU(1400))
 
 	// Add routes with tunnel and set MTU
-	conf = NewConfiguration(0, false, true, false, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{}, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverheadIPv4, conf.getRouteMTU(1400))
 
 	// Add routes with encryption and set MTU using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, false, false, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{EnableIPsec: true, AuthKeySizeValue: 16}, false, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-EncryptionIPsecOverhead, conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, true, false, false, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{EnableIPsec: true, AuthKeySizeValue: 32}, false, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(12, true, false, false, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{EnableIPsec: true, AuthKeySizeValue: 12}, false, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(EncryptionIPsecOverhead-4), conf.getRouteMTU(1400))
 
 	// Add routes with encryption and tunnels using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, true, false, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{EnableIPsec: true, AuthKeySizeValue: 16}, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+EncryptionIPsecOverhead), conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, true, true, false, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{EnableIPsec: true, AuthKeySizeValue: 32}, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, true, true, false, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{EnableIPsec: true, AuthKeySizeValue: 32}, true, false, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
 
 	// Add routes with WireGuard enabled
-	conf = NewConfiguration(32, false, false, true, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{EnableIPsec: false, AuthKeySizeValue: 32}, false, true, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-WireguardOverhead, conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, false, true, true, false)
+	conf = NewConfiguration(&fakeTypes.IPsecAgent{EnableIPsec: false, AuthKeySizeValue: 32}, true, true, false)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(WireguardOverhead+TunnelOverheadIPv4), conf.getRouteMTU(1400))
 }


### PR DESCRIPTION
This should allow us to rotate IPSec key with also an algorithm with different authN key size.
This was not possible, especially for IPv6, see https://github.com/cilium/cilium/issues/37051.

Fixes: #29480.