### PR TITLE
operator: Prevent panic when GCing identities

### DIFF
--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -147,8 +147,10 @@ func registerGC(p params) {
 				// CRD mode GC runs in an additional goroutine
 				gc.mgr.RemoveAllAndWait()
 			}
-			gc.rateLimiter.Stop()
+			// Close the worker pool first to ensure all goroutines complete
+			// before stopping the rate limiter they depend on
 			gc.wp.Close()
+			gc.rateLimiter.Stop()
 
 			return nil
 		},


### PR DESCRIPTION
We've observed panics in the operator identity GC component:
```
panic: limiter misuse: Allow / Wait / WaitN called concurrently after Stop
goroutine 725 [running]:
github.com/cilium/cilium/pkg/rate.(*Limiter).assertAlive(...)
/go/src/github.com/cilium/cilium/pkg/rate/limiter.go:68
github.com/cilium/cilium/pkg/rate.(*Limiter).WaitN(0x400154d4c0, {0x5666550, 0x4002052b90}, 0x1)
/go/src/github.com/cilium/cilium/pkg/rate/limiter.go:100 +0x148
github.com/cilium/cilium/pkg/rate.(*Limiter).Wait(...)
/go/src/github.com/cilium/cilium/pkg/rate/limiter.go:91
github.com/cilium/cilium/operator/identitygc.(*GC).runAuthGC(0x4000b5ea50, {0x5666550, 0x4002052b90}, 0x40015daab0)
/go/src/github.com/cilium/cilium/operator/identitygc/kvstore_gc.go:96 +0x38
github.com/cilium/cilium/operator/identitygc.(*GC).runKVStoreModeGC(0x4000b5ea50, {0x5666550, 0x4002052b90})
/go/src/github.com/cilium/cilium/operator/identitygc/kvstore_gc.go:52 +0x2bc
github.com/cilium/workerpool.(*WorkerPool).run.func1()
```

This panic is caused by a race condition in the identities GC shutdown: The [OnStop](https://github.com/cilium/cilium/blob/5315c6cb749db554b2cbd137c01bcf9e40b68918/operator/identitygc/gc.go#L143-L156) hook stops the rate limiter before closing the worker pool. This causes a race where worker goroutines running `runKVStoreModeGC` -> `runAuthGC` could still call `rateLimiter.Wait()` after the limiter is stopped, triggering the panic.

This PR swaps closing the worker pool and stopping the rate limiter in the shutdown hook to prevent that panic.