### PR TITLE
ipam: Support for static IP allocation in Azure

### DIFF
--- a/pkg/azure/api/api_test.go
+++ b/pkg/azure/api/api_test.go
@@ -7,7 +7,11 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7"
 	"github.com/stretchr/testify/require"
+
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 )
 
 func TestAvailableIPs(t *testing.T) {
@@ -15,4 +19,92 @@ func TestAvailableIPs(t *testing.T) {
 	require.Equal(t, 16777216, availableIPs(cidr))
 	cidr = netip.MustParsePrefix("1.1.1.1/32")
 	require.Equal(t, 1, availableIPs(cidr))
+}
+
+func TestFindPublicIPPrefixByTags(t *testing.T) {
+	prefixes := []*armnetwork.PublicIPPrefix{
+		{
+			ID: to.Ptr("prefix1"),
+			Tags: map[string]*string{
+				"env":  to.Ptr("prod"),
+				"pool": to.Ptr("pool-1"),
+			},
+			Properties: &armnetwork.PublicIPPrefixPropertiesFormat{
+				ProvisioningState: to.Ptr(armnetwork.ProvisioningStateSucceeded),
+				IPPrefix:          to.Ptr("10.0.0.0/28"),
+				PublicIPAddresses: []*armnetwork.ReferencedPublicIPAddress{
+					{ID: to.Ptr("ip1")},
+				},
+			},
+		},
+		{
+			ID: to.Ptr("prefix2"),
+			Tags: map[string]*string{
+				"env": to.Ptr("dev"),
+			},
+			Properties: &armnetwork.PublicIPPrefixPropertiesFormat{
+				ProvisioningState: to.Ptr(armnetwork.ProvisioningStateSucceeded),
+				IPPrefix:          to.Ptr("10.1.0.0/28"),
+			},
+		},
+		{
+			// Not provisioned
+			ID: to.Ptr("prefix3"),
+			Tags: map[string]*string{
+				"env": to.Ptr("staging"),
+			},
+			Properties: &armnetwork.PublicIPPrefixPropertiesFormat{
+				ProvisioningState: to.Ptr(armnetwork.ProvisioningStateFailed),
+				IPPrefix:          to.Ptr("10.2.0.0/28"),
+			},
+		},
+		{
+			// Full
+			ID: to.Ptr("prefix4"),
+			Tags: map[string]*string{
+				"env": to.Ptr("test"),
+			},
+			Properties: &armnetwork.PublicIPPrefixPropertiesFormat{
+				ProvisioningState: to.Ptr(armnetwork.ProvisioningStateSucceeded),
+				IPPrefix:          to.Ptr("10.3.0.0/31"), // 2 IPs
+				PublicIPAddresses: []*armnetwork.ReferencedPublicIPAddress{
+					{ID: to.Ptr("ip1")},
+					{ID: to.Ptr("ip2")},
+				},
+			},
+		},
+	}
+
+	// Test exact tag match
+	prefixID, found := findPublicIPPrefixByTags(prefixes, ipamTypes.Tags{
+		"env":  "prod",
+		"pool": "pool-1",
+	})
+	require.True(t, found)
+	require.Equal(t, "prefix1", prefixID)
+
+	// Test subset tag match
+	prefixID, found = findPublicIPPrefixByTags(prefixes, ipamTypes.Tags{
+		"env": "dev",
+	})
+	require.True(t, found)
+	require.Equal(t, "prefix2", prefixID)
+
+	// Test no match for non-existent tags
+	_, found = findPublicIPPrefixByTags(prefixes, ipamTypes.Tags{
+		"env": "nonexistent",
+	})
+	require.False(t, found)
+
+	// Test skipping non-provisioned prefix
+	_, found = findPublicIPPrefixByTags(prefixes, ipamTypes.Tags{
+		"env": "staging",
+	})
+	require.False(t, found)
+
+	// Test skipping full prefix
+	_, found = findPublicIPPrefixByTags(prefixes, ipamTypes.Tags{
+		"env": "test",
+	})
+	require.False(t, found)
 }

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -252,3 +252,13 @@ func (a *API) AssignPrivateIpAddressesVMSS(ctx context.Context, vmName, vmssName
 
 	return nil
 }
+
+func (a *API) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vmssName string, publicIpTags ipamTypes.Tags) (string, error) {
+	a.rateLimit()
+	return "mock-public-ip-prefix-id", nil
+}
+
+func (a *API) AssignPublicIPAddressesVM(ctx context.Context, instanceID string, publicIpTags ipamTypes.Tags) (string, error) {
+	a.rateLimit()
+	return "mock-public-ip-prefix-id", nil
+}

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -22,6 +22,8 @@ type AzureAPI interface {
 	GetVpcsAndSubnets(ctx context.Context) (ipamTypes.VirtualNetworkMap, ipamTypes.SubnetMap, error)
 	AssignPrivateIpAddressesVM(ctx context.Context, subnetID, interfaceName string, addresses int) error
 	AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, vmssName, subnetID, interfaceName string, addresses int) error
+	AssignPublicIPAddressesVM(ctx context.Context, instanceID string, publicIpTags ipamTypes.Tags) (string, error)
+	AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vmssName string, publicIpTags ipamTypes.Tags) (string, error)
 }
 
 // InstancesManager maintains the list of instances. It must be kept up to date


### PR DESCRIPTION
# Description
This PR implements Public IP assignments functionality for Azure, it's exactly the same idea as https://github.com/cilium/cilium/pull/34622 for AWS.

This implementation relies on tagged Azure [Public IP Prefixes](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-address-prefix). Users can specify Public IP Prefix tags in their CNI config and the Operator will automatically assign to the node a Public IP from a Prefix which matches.

The implementation works for both VMSS instances and standalone VM instances.

# Testing
Backported to our 1.18.2 fork. Then created an Azure VMSS node in a public subnet (no NAT gateway).  Set `static-ip-tags` in the CNI config for this node:
```json
    "ipam": {
        "pre-allocate": 1,
        "min-allocate": 5,
        "static-ip-tags": {
          "pool-name": "anton-test"
        }
```
Afterwards, created an Azure Public IP Prefix with tags `pool-name=anton-test`. Then confirmed:
- [x] Cilium Operator created an IP in the pool I tagged:
<img width="214" height="75" alt="image" src="https://github.com/user-attachments/assets/a6a3cf1d-7885-4900-a3b4-a95653882967" />

- [x] The IP was successfully attached to the instance:
<img width="327" height="72" alt="Screenshot 2025-10-16 at 18 19 43" src="https://github.com/user-attachments/assets/98fccf0c-d845-4ae6-b981-fc755f884e7d" />

- [x] When masquerading was enabled (thanks to https://github.com/cilium/cilium/pull/42196), the pod was able to use that Public IP:
   ```
    anton-test-6d954ccf46-v2dg5:/# curl ifconfig.me
    20.XX.XX.XX 
    ```

- [x] When the instance was deleted, the IP was released


<br/>
<br/>

```release-note
ipam: Support for public IP allocation in Azure
```