### PR TITLE
pkg/hubble/filters: replace reflect.DeepEqual with assert.Equal in tests

### DIFF
--- a/pkg/hubble/filters/labelparser_test.go
+++ b/pkg/hubble/filters/labelparser_test.go
@@ -4,8 +4,9 @@
 package filters
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_translateSelector(t *testing.T) {
@@ -93,8 +94,8 @@ func Test_translateSelector(t *testing.T) {
 				t.Errorf("parseSelector() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseSelector() = %q, want %q", got, tt.want)
+			if !tt.wantErr {
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}

--- a/pkg/hubble/filters/labels_test.go
+++ b/pkg/hubble/filters/labels_test.go
@@ -4,8 +4,9 @@
 package filters
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
@@ -647,8 +648,8 @@ func Test_parseSelector(t *testing.T) {
 				t.Errorf("parseSelector() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !tt.wantErr && !reflect.DeepEqual(got.String(), tt.want) {
-				t.Errorf("parseSelector() = %q, want %q", got, tt.want)
+			if !tt.wantErr {
+				assert.Equal(t, tt.want, got.String())
 			}
 		})
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope following #42185. It replaces all usages of `reflect.DeepEqual` in the `pkg/hubble/filters/` package:

- `pkg/hubble/filters/labelparser_test.go`
- `pkg/hubble/filters/labels_test.go`

## Testing

All existing tests in `pkg/hubble/filters/` continue to pass:
```bash
$ go test ./pkg/hubble/filters/... -v
PASS
ok      github.com/cilium/cilium/pkg/hubble/filters       0.032s
```

## Follow-up

This is an incremental change affecting a single package. Once merged, similar changes can be made to other packages across the codebase.

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/hubble/filters tests for better error messages
```

