### PR TITLE
bpf: ipv6: optimize fraginfo handling

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -53,6 +53,7 @@ struct ct_buffer6 {
 	__u32 monitor;
 	int ret;
 	int l4_off;
+	fraginfo_t fraginfo;
 };
 
 static __always_inline enum ct_action ct_tcp_select_action(union tcp_flags flags)

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -26,7 +26,6 @@ ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 {
 	struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
 	int l3_off = ETH_HLEN, hdrlen;
-	fraginfo_t fraginfo;
 
 	/* Further action is needed in two cases:
 	 * 1. Packets from host IPs: need to enforce host policies.
@@ -40,14 +39,16 @@ ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	tuple->nexthdr = ip6->nexthdr;
 	ipv6_addr_copy(&tuple->saddr, (union v6addr *)&ip6->saddr);
 	ipv6_addr_copy(&tuple->daddr, (union v6addr *)&ip6->daddr);
-	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple->nexthdr, &fraginfo);
+	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple->nexthdr,
+					   &ct_buffer->fraginfo);
 	if (hdrlen < 0) {
 		ct_buffer->ret = hdrlen;
 		return true;
 	}
 	ct_buffer->l4_off = l3_off + hdrlen;
-	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, ip6, fraginfo,
-				    ct_buffer->l4_off, CT_EGRESS, SCOPE_BIDIR, NULL,
+	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, ip6,
+				    ct_buffer->fraginfo, ct_buffer->l4_off,
+				    CT_EGRESS, SCOPE_BIDIR, NULL,
 				    &ct_buffer->monitor);
 	return true;
 }
@@ -160,7 +161,6 @@ ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	__u32 dst_sec_identity = WORLD_IPV6_ID;
 	struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
-	fraginfo_t fraginfo;
 	int hdrlen;
 
 	/* Retrieve destination identity. */
@@ -178,14 +178,16 @@ ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	/* Lookup connection in conntrack map. */
 	tuple->nexthdr = ip6->nexthdr;
 	ipv6_addr_copy(&tuple->saddr, (union v6addr *)&ip6->saddr);
-	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple->nexthdr, &fraginfo);
+	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple->nexthdr,
+					   &ct_buffer->fraginfo);
 	if (hdrlen < 0) {
 		ct_buffer->ret = hdrlen;
 		return true;
 	}
 	ct_buffer->l4_off = ETH_HLEN + hdrlen;
-	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, ip6, fraginfo,
-				    ct_buffer->l4_off, CT_INGRESS, SCOPE_BIDIR, NULL,
+	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, ip6,
+				    ct_buffer->fraginfo, ct_buffer->l4_off,
+				    CT_INGRESS, SCOPE_BIDIR, NULL,
 				    &ct_buffer->monitor);
 
 	return true;
@@ -204,7 +206,6 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	__u8 audited = 0;
 	__u8 auth_type = 0;
 	struct remote_endpoint_info *info;
-	fraginfo_t fraginfo __maybe_unused;
 	bool is_untracked_fragment = false;
 	__u16 proxy_port = 0;
 	__u32 cookie = 0;
@@ -229,10 +230,7 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	/* Indicate that this is a datagram fragment for which we cannot
 	 * retrieve L4 ports. Do not set flag if we support fragmentation.
 	 */
-	fraginfo = ipv6_get_fraginfo(ctx, ip6);
-	if (fraginfo < 0)
-		return (int)fraginfo;
-	is_untracked_fragment = ipfrag_is_fragment(fraginfo);
+	is_untracked_fragment = ipfrag_is_fragment(ct_buffer->fraginfo);
 #  endif
 
 	/* Perform policy lookup */

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -125,7 +125,8 @@ static __always_inline int ipv6_hdrlen_offset(struct __ctx_buff *ctx, int l3_off
 	 * - protocol = 0 (unused when !is_fragment)
 	 * This is the default in case no NEXTHDR_FRAGMENT is found.
 	 */
-	*fraginfo = 0;
+	if (fraginfo)
+		*fraginfo = 0;
 
 #pragma unroll
 	for (i = 0; i < IPV6_MAX_HEADERS; i++) {
@@ -140,7 +141,7 @@ static __always_inline int ipv6_hdrlen_offset(struct __ctx_buff *ctx, int l3_off
 			return len;
 		}
 
-		if (nh == NEXTHDR_FRAGMENT) {
+		if (fraginfo && nh == NEXTHDR_FRAGMENT) {
 			struct ipv6_frag_hdr frag = { 0 };
 
 			if (ctx_load_bytes(ctx, l3_off + len, &frag, sizeof(frag)) < 0)
@@ -166,9 +167,7 @@ static __always_inline int ipv6_hdrlen_with_fraginfo(struct __ctx_buff *ctx,
 
 static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
 {
-	fraginfo_t fraginfo;
-
-	return ipv6_hdrlen_offset(ctx, ETH_HLEN, nexthdr, &fraginfo);
+	return ipv6_hdrlen_offset(ctx, ETH_HLEN, nexthdr, NULL);
 }
 
 static __always_inline void ipv6_addr_copy(union v6addr *dst,

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1783,7 +1783,6 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	__u32 inner_l3_off = (__u32)(off + sizeof(struct icmp6hdr));
 	struct ipv6_ct_tuple tuple = {};
 	struct ipv6hdr ip6;
-	fraginfo_t fraginfo;
 	__u16 port_off;
 	__u32 icmpoff;
 	int hdrlen;
@@ -1805,7 +1804,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *)&ip6.saddr);
 	tuple.flags = NAT_DIR_EGRESS;
 
-	hdrlen = ipv6_hdrlen_offset(ctx, inner_l3_off, &tuple.nexthdr, &fraginfo);
+	hdrlen = ipv6_hdrlen_offset(ctx, inner_l3_off, &tuple.nexthdr, NULL);
 	if (hdrlen < 0)
 		return hdrlen;
 
@@ -1995,7 +1994,6 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 {
 	struct ipv6_ct_tuple tuple = {};
 	struct ipv6hdr iphdr;
-	fraginfo_t fraginfo;
 	__u16 port_off;
 	__u32 icmpoff;
 	__u8 type;
@@ -2026,7 +2024,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 	 */
 	asm volatile ("" ::"r"(&tuple));
 
-	hdrlen = ipv6_hdrlen_offset(ctx, inner_l3_off, &tuple.nexthdr, &fraginfo);
+	hdrlen = ipv6_hdrlen_offset(ctx, inner_l3_off, &tuple.nexthdr, NULL);
 	if (hdrlen < 0)
 		return hdrlen;
 


### PR DESCRIPTION
Fine-tune how we handle the IPv6 fraginfo in a few spots, so that we can avoid walking the extension headers (or perform less work when doing so).