### PR TITLE
Fix GKE conformance: conditionally set ipv4NativeRoutingCIDR for nati…

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -395,11 +395,20 @@ jobs:
         run: |
           cilium encrypt create-key --auth-algo rfc4106-gcm-aes
 
+      - name: Set native routing CIDR option
+        id: native-cidr
+        run: |
+          NATIVE_CIDR_OPT=""
+          if [[ "${{ matrix.config.type }}" == "no-tunnel" ]]; then
+            NATIVE_CIDR_OPT="--helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }}"
+          fi
+          echo "native_cidr_opt=${NATIVE_CIDR_OPT}" >> $GITHUB_OUTPUT
+
       - name: Install Cilium
         id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} ${{ matrix.config.cilium-install-opts }} \
-          --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }}
+          ${{ steps.native-cidr.outputs.native_cidr_opt }}
 
       - name: Wait for Cilium to be ready
         run: |


### PR DESCRIPTION
…ve routing mode

The workflow was unconditionally setting ipv4NativeRoutingCIDR for all test configurations, including tunnel mode. This caused Cilium to create routes via cilium_host instead of cilium_vxlan, breaking cross-node pod connectivity.

Changes:
- Add 'Set native routing CIDR option' step before Cilium installation
- Only set ipv4NativeRoutingCIDR when matrix.config.type == 'no-tunnel'
- Use step output to pass the parameter to Install Cilium step

This ensures:
- Tunnel mode: Routes through cilium_vxlan (no native CIDR set)
- Native mode: Routes through native network (native CIDR set correctly)

Fixes: DNS resolution failures and connectivity test timeouts in tunnel mode

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
