### PR TITLE
helm: Switch to numeric target port for cilium-envoy svc

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
@@ -32,5 +32,5 @@ spec:
   - name: envoy-metrics
     port: {{ .Values.envoy.prometheus.port }}
     protocol: TCP
-    targetPort: envoy-metrics
+    targetPort: {{ .Values.envoy.prometheus.port }}
 {{- end }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
This change switches to using numeric port instead of named port in cilium envoy svc. Verified that change does not break metrics reporting and is backwards compatible. The reasoning behind the change is to make cilium envoy metrics still available when port is not explicitly declared in cilium-envoy pod spec (e.g. to avoid k8s scheduling conflict in more advanced rollout scenarios).
Fixes: #issue-number

```release-note
Use numeric port instead of named port in Cilium Envoy Service
```
