### PR TITLE
egressgw: minor fine-tuning

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -331,6 +331,8 @@ Removed Options
 * The previously deprecated ``--enable-node-port``, ``--enable-host-port``, and ``--enable-external-ips``
   flags have been removed. To enable the corresponding features, users must set ``--kube-proxy-replacement=true``.
 * The previously deprecated custom calls feature (``--enable-custom-calls``) has been removed.
+* The previously deprecated ``--enable-ipv4-egress-gateway`` flag has been removed. To enable the
+  corresponding features, users must set ``--enable-egress-gateway=true``.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -494,18 +494,15 @@ int egress_gw_handle_request(struct __ctx_buff *ctx, __be16 proto,
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
 
-		fraginfo = ipv6_get_fraginfo(ctx, ip6);
-		if (fraginfo < 0)
-			return (int)fraginfo;
-
 		tuple6.nexthdr = ip6->nexthdr;
 		ipv6_addr_copy(&tuple6.daddr, (union v6addr *)&ip6->daddr);
 		ipv6_addr_copy(&tuple6.saddr, (union v6addr *)&ip6->saddr);
 
-		l4_off = ETH_HLEN + ipv6_hdrlen(ctx, &tuple6.nexthdr);
-		if (l4_off < 0)
-			return l4_off;
+		ret = ipv6_hdrlen_with_fraginfo(ctx, &tuple6.nexthdr, &fraginfo);
+		if (ret < 0)
+			return ret;
 
+		l4_off = ETH_HLEN + ret;
 		ret = ct_extract_ports6(ctx, ip6, fraginfo, l4_off,
 					CT_EGRESS, &tuple6);
 		if (IS_ERR(ret)) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -530,10 +530,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableMasqueradeRouteSource, false, "Masquerade packets to the source IP provided from the routing layer rather than interface address")
 	option.BindEnv(vp, option.EnableMasqueradeRouteSource)
 
-	flags.Bool(option.EnableIPv4EgressGateway, false, "Enable egress gateway for IPv4")
-	flags.MarkDeprecated(option.EnableIPv4EgressGateway, "Use --enable-egress-gateway instead")
-	option.BindEnv(vp, option.EnableIPv4EgressGateway)
-
 	flags.Bool(option.EnableEgressGateway, false, "Enable egress gateway")
 	option.BindEnv(vp, option.EnableEgressGateway)
 

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -67,10 +67,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.DisableCiliumEndpointCRDName)
 	option.BindEnv(vp, option.DisableCiliumEndpointCRDName)
 
-	flags.Bool(option.EnableIPv4EgressGateway, false, "")
-	flags.MarkHidden(option.EnableIPv4EgressGateway)
-	option.BindEnv(vp, option.EnableIPv4EgressGateway)
-
 	flags.Bool(option.EnableEgressGateway, false, "")
 	flags.MarkHidden(option.EnableEgressGateway)
 	option.BindEnv(vp, option.EnableEgressGateway)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -301,9 +301,6 @@ const (
 	// EnableIPMasqAgent enables BPF ip-masq-agent
 	EnableIPMasqAgent = "enable-ip-masq-agent"
 
-	// EnableIPv4EgressGateway enables the IPv4 egress gateway
-	EnableIPv4EgressGateway = "enable-ipv4-egress-gateway"
-
 	// EnableEgressGateway enables the egress gateway
 	EnableEgressGateway = "enable-egress-gateway"
 
@@ -2519,7 +2516,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.LocalRouterIPv6 = vp.GetString(LocalRouterIPv6)
 	c.EnableBPFClockProbe = vp.GetBool(EnableBPFClockProbe)
 	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
-	c.EnableEgressGateway = vp.GetBool(EnableEgressGateway) || vp.GetBool(EnableIPv4EgressGateway)
+	c.EnableEgressGateway = vp.GetBool(EnableEgressGateway)
 	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)
 	c.AgentHealthRequireK8sConnectivity = vp.GetBool(AgentHealthRequireK8sConnectivity)
 	c.InstallIptRules = vp.GetBool(InstallIptRules)


### PR DESCRIPTION
Remove a deprecated config option, and consolidate a bit of BPF code.

```release-note
The previously deprecated ``--enable-ipv4-egress-gateway`` flag has been removed. To enable the corresponding features, users must set ``--enable-egress-gateway=true``.
```
