### PR TITLE
gh:conformance:multi-pool: fix multi-pool test workflow config

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -115,9 +115,7 @@ jobs:
           destination_directory="/tmp/generated/multi-pool"
           mkdir -p "${destination_directory}"
 
-          cat ${work_dir}/{misc,wireguard}.yaml > "${destination_directory}/configs_merged.yaml"
-
-          yq -o=json "${destination_directory}/configs_merged.yaml" | jq . > "${destination_directory}/matrix.json"
+          yq -o=json "${work_dir}/configs.yaml" | jq . > "${destination_directory}/matrix.json"
 
       - name: Generate Matrix
         id: generate-matrix


### PR DESCRIPTION
PR https://github.com/cilium/cilium/pull/41994 erroneously changed the referenced `configs.yaml` file in the multi-pool conformance test. The erroneous change is due to the renaming of .github/actions/e2e/configs.yaml into .github/actions/e2e/misc.yaml. I misread the work_dir parameter in the multi-pool workflow, so I assumed it was referencing the same file, thus I changed the naming.

Let's restore the previous naming to refer the right multi-pool config in .github/actions/multi-pool/configs.yaml.