### PR TITLE
pkg/logging: make multihandler logging handler immutable to prevent deadlocks

### DIFF
--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -281,7 +281,7 @@ func (h *ConfigModifyEventHandler) changedOption(key string, value option.Option
 		// Reflect log level change to proxies
 		// Might not be initialized yet
 		if option.Config.EnableL7Proxy {
-			h.l7Proxy.ChangeLogLevel(logging.GetSlogLevel(h.logger))
+			h.l7Proxy.ChangeLogLevel(logging.GetGlobalLevel())
 		}
 	}
 	h.policy.BumpRevision() // force policy recalculation

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -109,8 +109,15 @@ func SetLogLevelToDebug() {
 }
 
 // AddHandlers adds additional logrus hook to default logger
+// SetupLogging creates a new defaultMultiSlogHandler from scratch, all calls to
+// AddHandlers should come after that to avoid overwriting previously added
+// handlers.
+// AddHandlers should also not be run concurrently while accessing the default logger.
 func AddHandlers(hooks ...slog.Handler) {
-	defaultMultiSlogHandler.AddHandlers(hooks...)
+	defaultMultiSlogHandler = defaultMultiSlogHandler.AddHandlers(hooks...)
+	DefaultSlogLogger = slog.New(defaultMultiSlogHandler)
+	// Need to reset klog loggers to the new default logger.
+	initializeKLog(DefaultSlogLogger)
 }
 
 // SetupLogging sets up each logging service provided in loggers and configures

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -126,6 +126,14 @@ func TestSetupLogging(t *testing.T) {
 	err = SetupLogging([]string{}, logOpts, "", true)
 	assert.NoError(t, err)
 	require.Equal(t, slog.LevelDebug, GetSlogLevel(DefaultSlogLogger))
+
+	// Check if we can change logging live.
+	SetLogLevel(slog.LevelError)
+	require.Equal(t, slog.LevelError, GetSlogLevel(DefaultSlogLogger))
+
+	// Check if we can change logging live.
+	SetDefaultLogLevel()
+	require.Equal(t, DefaultLogLevel, GetSlogLevel(DefaultSlogLogger))
 }
 
 func TestSetupLogging3(t *testing.T) {

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -45,12 +45,14 @@ var DefaultSlogLogger = slog.New(defaultMultiSlogHandler)
 // Approximates the logrus output via slog for job groups during the transition
 // phase.
 func initializeSlog(logOpts LogOptions, loggers []string) {
+	// Create new instance of opts to avoid handing global slogHandlerOpts
+	// over to new logger.
+	// Note: The single leveler is shared, and can safely be changed concurrently.
 	opts := *slogHandlerOpts
-	opts.Level = logOpts.GetLogLevel()
+	SetLogLevel(logOpts.GetLogLevel())
 	if opts.Level == slog.LevelDebug {
 		opts.AddSource = true
 	}
-
 	writer := os.Stderr
 	switch logOpts[WriterOpt] {
 	case StdErrOpt:

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -34,6 +34,12 @@ var slogLeveler = func() *slog.LevelVar {
 	return &levelVar
 }()
 
+// GetGlobalLevel gets the currently set level, as it is set in the global
+// slog leveler reference.
+func GetGlobalLevel() slog.Level {
+	return slogLeveler.Level()
+}
+
 var defaultMultiSlogHandler = NewMultiSlogHandler(slog.NewTextHandler(
 	os.Stderr,
 	slogHandlerOpts,

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -470,8 +470,7 @@ func (cmd *Cmd) setupLogging(n *types.NetConf) error {
 
 	if len(n.LogFile) != 0 {
 		logging.AddHandlers(hooks.NewFileRotationLogHook(
-			// slogloggercheck: the logger has been initialized with default settings
-			logging.GetSlogLevel(logging.DefaultSlogLogger),
+			logging.GetGlobalLevel(),
 			n.LogFile,
 			hooks.EnableCompression(),
 			hooks.WithMaxBackups(defaultLogMaxBackups),


### PR DESCRIPTION
The multihandler handler type currently requires locks to mutate its internal handler list.
This is dangerous as if such a handler is ever shared among other multihandlers (or called by other goroutines) this may result in ambiguous lock ordering of the multihandler - resulting in potential deadlocks.

Specifically, I've been seeing some odd race-detector CI job failures that look like potentially this problem.

To avoid this whole class of problems, let's just make the handler immutable and modify the API to only every return new instances of the handler.

To avoid having to require a lock to access the default logger, we make the assumption that `logging.SetupLogging(...)` is called before (and not concurrently) to any usage of the default logger.
Examining the code this assumption appears true in most places we have to setup logging like cilium daemon, cilium-dbg, clustermesh-api and cilium-cni.

I've seen some examples of races and locking issues in ci-conformance-race runs such as this one: https://github.com/cilium/cilium/actions/runs/18757377034 

```release-note
Fix potential deadlock resulting from usage of locks in logger and fix issue where loglevel could not be adjusted at runtime.
```