### PR TITLE
helm: Run spire server as unprivilaged 1000 user by default

### DIFF
--- a/install/kubernetes/cilium/files/spire/chown-data.bash
+++ b/install/kubernetes/cilium/files/spire/chown-data.bash
@@ -1,0 +1,19 @@
+# shellcheck disable=SC2086
+# shellcheck disable=SC2139
+set -e
+
+{{- $uid := 1000 }}
+{{- $gid := 1000 }}
+{{- with .Values.authentication.mutual.spire.install.server.securityContext }}
+{{- if .runAsUser }}
+{{- $uid = .runAsUser }}
+{{- end }}
+{{- if .runAsGroup }}
+{{- $gid = .runAsGroup }}
+{{- end }}
+{{- end }}
+
+echo "Setting ownership of spire data directories"
+chown -R {{ $uid }}:{{ $gid }} /run/spire/data
+chown -R {{ $uid }}:{{ $gid }} /tmp/spire-server
+echo "Ownership set successfully"

--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -51,9 +51,21 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if gt (len .Values.authentication.mutual.spire.install.server.initContainers) 0 }}
       initContainers:
+      {{- if gt (len .Values.authentication.mutual.spire.install.server.initContainers) 0 }}
         {{- toYaml .Values.authentication.mutual.spire.install.server.initContainers | nindent 8 }}
+      {{- else }}
+      - name: chown-data
+        image: {{ include "cilium.image" .Values.authentication.mutual.spire.install.initImage | quote }}
+        imagePullPolicy: {{ .Values.authentication.mutual.spire.install.initImage.pullPolicy }}
+        command:
+          - /bin/sh
+          - -c
+          - |
+            {{- tpl (.Files.Get "files/spire/chown-data.bash") . | nindent 12 }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
       {{- end }}
       containers:
       - name: cilium-init
@@ -64,6 +76,13 @@ spec:
           - -c
           - |
             {{- tpl (.Files.Get "files/spire/init.bash") . | nindent 12 }}
+        securityContext:
+        {{- with .Values.authentication.mutual.spire.install.server.securityContext }}
+          {{- toYaml . | nindent 10 }}
+        {{- else }}
+          runAsUser: 1000
+          runAsGroup: 1000
+        {{- end }}
       - name: spire-server
         {{- if eq (typeOf .Values.authentication.mutual.spire.install.server.image) "string" }}
         image: {{ .Values.authentication.mutual.spire.install.server.image }}
@@ -107,9 +126,12 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 5
-        {{- with .Values.authentication.mutual.spire.install.server.securityContext }}
         securityContext:
+        {{- with .Values.authentication.mutual.spire.install.server.securityContext }}
           {{- toYaml . | nindent 10 }}
+        {{- else }}
+          runAsUser: 1000
+          runAsGroup: 1000
         {{- end }}
       {{- with .Values.authentication.mutual.spire.install.server.affinity }}
       affinity:

--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -43,9 +43,13 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.authentication.mutual.spire.install.server.priorityClassName "system-node-critical") }}
       serviceAccountName: {{ .Values.authentication.mutual.spire.install.server.serviceAccount.name }}
       shareProcessNamespace: true
-      {{- with .Values.authentication.mutual.spire.install.server.podSecurityContext }}
       securityContext:
+      {{- with .Values.authentication.mutual.spire.install.server.podSecurityContext }}
         {{- toYaml . | nindent 8 }}
+      {{- else }}
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -55,6 +59,8 @@ spec:
       {{- if gt (len .Values.authentication.mutual.spire.install.server.initContainers) 0 }}
         {{- toYaml .Values.authentication.mutual.spire.install.server.initContainers | nindent 8 }}
       {{- else }}
+      # This is a temporary fix to correct invalid permissions on spire-data directory for existing
+      # deployments. After 1.18 reach EOL it should be safe to remove this
       - name: chown-data
         image: {{ include "cilium.image" .Values.authentication.mutual.spire.install.initImage | quote }}
         imagePullPolicy: {{ .Values.authentication.mutual.spire.install.initImage.pullPolicy }}
@@ -76,12 +82,9 @@ spec:
           - -c
           - |
             {{- tpl (.Files.Get "files/spire/init.bash") . | nindent 12 }}
-        securityContext:
         {{- with .Values.authentication.mutual.spire.install.server.securityContext }}
+        securityContext:
           {{- toYaml . | nindent 10 }}
-        {{- else }}
-          runAsUser: 1000
-          runAsGroup: 1000
         {{- end }}
       - name: spire-server
         {{- if eq (typeOf .Values.authentication.mutual.spire.install.server.image) "string" }}
@@ -126,12 +129,9 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 5
-        securityContext:
         {{- with .Values.authentication.mutual.spire.install.server.securityContext }}
+        securityContext:
           {{- toYaml . | nindent 10 }}
-        {{- else }}
-          runAsUser: 1000
-          runAsGroup: 1000
         {{- end }}
       {{- with .Values.authentication.mutual.spire.install.server.affinity }}
       affinity:
@@ -150,9 +150,7 @@ spec:
         configMap:
           name: spire-server
       - name: spire-server-socket
-        hostPath:
-          path: /var/run/spire-server/sockets
-          type: DirectoryOrCreate
+        emptyDir: {}
   {{- if .Values.authentication.mutual.spire.install.server.dataStorage.enabled }}
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
New spire images are build with uid and gid of 1000 and are required to be ran in this context. This PR sets the default uid and gid of spire-server containers to the 1000.
It additionally adds a transition chown script for existing deployments to update permissions on existing installations. The script should be only needed for update of existing clusters.

Reference documentation https://github.com/spiffe/spire/blob/4c86982b82f31729591fefd549d04ea61960c402/doc/docker_images.md?plain=1#L48

Fixes: #40533

```release-note
Use upstream image uid and gid for spire data in spire-server
```
