### PR TITLE
loadbalancer: fix up code comment

### DIFF
--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -41,7 +41,7 @@ type FrontendParams struct {
 
 	// ServicePort is the associated "ClusterIP" port of this frontend.
 	// Same as [Address.L4Addr.Port] except when [Type] NodePort or
-	//  This is used to match frontends with the [Ports] of
+	// LoadBalancer. This is used to match frontends with the [Ports] of
 	// [Service.ProxyRedirect].
 	ServicePort uint16
 }


### PR DESCRIPTION
The `LoadBalancer` part was accidentally removed by 2e25b6f81edf ("loadbalancer: Move core types to loadbalancer package").