### PR TITLE
Deflake TestNodeManagerAbortReleaseIPReassignment

### DIFF
--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	operatorK8s "github.com/cilium/cilium/operator/k8s"
-	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam/metrics"
@@ -132,6 +131,9 @@ type Node struct {
 
 	// logLimiter rate limits potentially repeating warning logs
 	logLimiter logging.Limiter
+
+	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
+	excessIPReleaseDelay time.Duration
 }
 
 // ipAllocAttrs represents IP-specific allocation attributes.
@@ -301,6 +303,10 @@ func (n *Node) getStaticIPTags() ipamTypes.Tags {
 // A negative number is returned to indicate release of addresses.
 func (n *Node) GetNeededAddresses() int {
 	stats := n.Stats()
+
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
+
 	if stats.IPv4.NeededIPs > 0 {
 		return stats.IPv4.NeededIPs
 	}
@@ -858,7 +864,7 @@ func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (insta
 			continue
 		}
 		// Check if the IP release waiting period elapsed
-		if ts.Add(time.Duration(operatorOption.Config.ExcessIPReleaseDelay) * time.Second).After(time.Now()) {
+		if ts.Add(n.excessIPReleaseDelay).After(time.Now()) {
 			continue
 		}
 		// Handling for IPs we've already heard back from agent.
@@ -890,10 +896,13 @@ func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (insta
 
 	if len(ipsToRelease) > 0 {
 		a.release.IPsToRelease = ipsToRelease
+
+		nodeStats := n.Stats()
+
 		scopedLog := n.logger.Load().With(
-			logfields.Available, n.stats.IPv4.AvailableIPs,
-			logfields.Used, n.stats.IPv4.UsedIPs,
-			logfields.Excess, n.stats.IPv4.ExcessIPs,
+			logfields.Available, nodeStats.IPv4.AvailableIPs,
+			logfields.Used, nodeStats.IPv4.UsedIPs,
+			logfields.Excess, nodeStats.IPv4.ExcessIPs,
 			logfields.ExcessIPs, a.release.IPsToRelease,
 			logfields.Releasing, ipsToRelease,
 			logfields.SelectedInterface, a.release.InterfaceID,
@@ -984,12 +993,17 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 	}
 
 	if len(n.getStaticIPTags()) > 0 {
-		if n.stats.IPv4.AssignedStaticIP == "" {
+		nodeStats := n.Stats()
+
+		if nodeStats.IPv4.AssignedStaticIP == "" {
 			ip, err := n.ops.AllocateStaticIP(ctx, n.getStaticIPTags())
 			if err != nil {
 				return false, err
 			}
+
+			n.mutex.Lock()
 			n.stats.IPv4.AssignedStaticIP = ip
+			n.mutex.Unlock()
 		}
 	}
 

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -13,6 +13,7 @@ import (
 
 	"golang.org/x/sync/semaphore"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"
 	ipamStats "github.com/cilium/cilium/pkg/ipam/stats"
@@ -300,6 +301,7 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 				ipsMarkedForRelease: make(map[string]time.Time),
 				ipReleaseStatus:     make(map[string]string),
 			},
+			excessIPReleaseDelay: time.Duration(operatorOption.Config.ExcessIPReleaseDelay) * time.Second,
 		}
 		node.logger.Store(node.rootLogger.With(fieldName, resource.Name))
 

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -689,7 +689,12 @@ func TestNodeManagerAbortReleaseIPReassignment(t *testing.T) {
 
 	// Run maintenance process again to process the acknowledgment
 	err = node.MaintainIPPool(context.Background())
-	require.NoError(t, err)
+
+	// Handle the case where the MaintainIPPool trigger runs first
+	expectedErrorStr := fmt.Sprintf("unable to release IP %s: IP %s not found", releasedIP, releasedIP)
+	require.Condition(t, func() bool {
+		return err == nil || err.Error() == expectedErrorStr
+	})
 
 	// Resync one more time to process acknowledgements.
 	node.instanceSync.Trigger()

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -680,9 +680,13 @@ func TestNodeManagerAbortReleaseIPReassignment(t *testing.T) {
 
 	node.PopulateIPReleaseStatus(node.resource)
 
+	node.mutex.Lock()
+
 	// Verify it's marked for release in the CiliumNode resource
 	require.Contains(t, node.resource.Status.IPAM.ReleaseIPs, releasedIP)
 	require.Equal(t, ipamOption.IPAMMarkForRelease, string(node.resource.Status.IPAM.ReleaseIPs[releasedIP]))
+
+	node.mutex.Unlock()
 
 	// Fake acknowledge IP for release like agent would
 	testipam.FakeAcknowledgeReleaseIps(node.resource)

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -33,7 +33,10 @@ var (
 	k8sapi = &k8sMock{}
 )
 
-const testPoolID = ipamTypes.PoolID("global")
+const (
+	testPoolID               = ipamTypes.PoolID("global")
+	testExcessIPReleaseDelay = 2
+)
 
 type allocationImplementationMock struct {
 	// mutex protects all fields of this structure
@@ -454,7 +457,7 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 // - PreAllocate 4
 // - MaxAboveWatermark 4
 func TestNodeManagerReleaseAddress(t *testing.T) {
-	operatorOption.Config.ExcessIPReleaseDelay = 2
+	operatorOption.Config.ExcessIPReleaseDelay = testExcessIPReleaseDelay
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
 	mngr, err := NewNodeManager(hivetest.Logger(t), am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false)
@@ -525,7 +528,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 // being resolved
 func TestNodeManagerAbortRelease(t *testing.T) {
 	var wg sync.WaitGroup
-	operatorOption.Config.ExcessIPReleaseDelay = 2
+	operatorOption.Config.ExcessIPReleaseDelay = testExcessIPReleaseDelay
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
 	mngr, err := NewNodeManager(hivetest.Logger(t), am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false)
@@ -602,7 +605,8 @@ func TestNodeManagerAbortRelease(t *testing.T) {
 // 3. Before being removed from status.ipam.release-ips, the same IP is reassigned to the pool (ie. AWS ENI in the case of AWS ENI IPAM)
 // 4. The IP is no longer considered excess, so the release handshake is aborted and the IP is deleted from status.ipam.release-ips
 func TestNodeManagerAbortReleaseIPReassignment(t *testing.T) {
-	operatorOption.Config.ExcessIPReleaseDelay = 2
+	operatorOption.Config.ExcessIPReleaseDelay = testExcessIPReleaseDelay
+
 	am := newAllocationImplementationMock()
 	require.NotNil(t, am)
 	mngr, err := NewNodeManager(hivetest.Logger(t), am, k8sapi, metricsmock.NewMockMetrics(), 10, true, false)
@@ -651,7 +655,7 @@ func TestNodeManagerAbortReleaseIPReassignment(t *testing.T) {
 		}
 
 		for _, ts := range node.ipv4Alloc.ipsMarkedForRelease {
-			if ts.Add(time.Duration(operatorOption.Config.ExcessIPReleaseDelay) * time.Second).Before(time.Now()) {
+			if ts.Add(time.Duration(testExcessIPReleaseDelay) * time.Second).Before(time.Now()) {
 				return true
 			}
 		}
@@ -686,10 +690,10 @@ func TestNodeManagerAbortReleaseIPReassignment(t *testing.T) {
 	require.Contains(t, node.resource.Status.IPAM.ReleaseIPs, releasedIP)
 	require.Equal(t, ipamOption.IPAMMarkForRelease, string(node.resource.Status.IPAM.ReleaseIPs[releasedIP]))
 
-	node.mutex.Unlock()
-
 	// Fake acknowledge IP for release like agent would
 	testipam.FakeAcknowledgeReleaseIps(node.resource)
+
+	node.mutex.Unlock()
 
 	// Run maintenance process again to process the acknowledgment
 	err = node.MaintainIPPool(context.Background())


### PR DESCRIPTION
This PR has a few of small changes to stabilize the node manager test `TestNodeManagerAbortReleaseIPReassignment`.

Each of the commits are self-contained fixes for individual issues which were causing flakiness.

Running locally, the failure rate using `stress` was ~4% after 2500 runs. After these four changes, the test has run for +250,000 iterations without failure.

--- 

**1. Wait for Node Stats to Be Updated**

The first fix is adding a waiting mechanism to the last check in the test. The assertion relied on a background goroutine to be triggered and update the stats used in the assertion. Occasionally that goroutine did not run in time resulting in a flaky failure.

**2. Handling Race Condition to Release IP**

This fix was similar to the first. 

There is a background goroutine that is periodically triggered to call `MaintainIPPool()` which will updated some node data depending on which IP addresses have been marked for release. I believe because of a potential exponential backoff period within the`MaintainIPPool()` trigger, the test writer manually calls this `MaintainIPPool()` from within the test itself.

Occasionally, that background `MaintainIPPool()` trigger runs first causing a flaky error due to the target IP already being released. The fix was to handle that error.

**3. Adding Locks in TestNodeManagerAbortReleaseIPReassignment**

At a couple of points in the test code, the internal data structures of the node object used in the test are either read from or written to. This was causing the occasional panic due to a concurrent read/write.

In those cases, the node mutex lock is used.

**4. Adding Locks in node.go**

In the `MaintainIPPool()` hook a function `handleIPRelease` reads and writes to a couple of data structures on the node struct without acquiring the mutex lock first.

I think this might not be an issue in production because the `MaintainIPPool()` trigger might be the only goroutine that is accessing this data. But it is an issue in  `TestNodeManagerAbortReleaseIPReassignment` because the test is reading and writing to these data structures.

Either way, I think it would be safest to make no assumptions on what might be accessing this data and simply use a mutex lock.

I didn't want to make too invasive a change here so I just removed the lock from `handleIPReleaseResponse` to avoid deadlock. This function was the only place it was being called.

Let me know if you'd like me to refactor this a bit more.

I also made sure there weren't any I/O calls being done inside the `Lock/Unlock` block.

**5. Small Final Concurrency Fix**

Added a small fix for a instance of the test accessing node data without a lock causing a rare flaky failure.

---

**Commands Used to Deflake**

Stress Command
```
cd ./pkg/ipam
go test -c -o ipam.test

stress ./ipam.test
```

Go Test with Race Condition Flag
```
go test --race ./pkg/ipam
```


Fixes: #42183 