### PR TITLE
ci: Add workflow permissions for auto-approve and renovate

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -10,6 +10,7 @@ jobs:
     # Avoid running the 'auto-approve' environment if we don't need to.
     name: Pre-Approve
     runs-on: ubuntu-24.04
+    permissions: {}
     if: ${{
          github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
          (github.triggering_actor == 'cilium-renovate[bot]' ||
@@ -28,6 +29,7 @@ jobs:
     needs: pre-approve
     environment: auto-approve
     runs-on: ubuntu-24.04
+    permissions: {}
     steps:
     - name: Debug
       run: |

--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -10,6 +10,8 @@
   jobs:
     call-backport-label-updater:
       name: Update backport labels for upstream PR
+      permissions:
+        pull-requests: write
       if: |
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.body, 'upstream-prs') &&

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -10,6 +10,8 @@ jobs:
   validate:
     name: Validate Renovate configuration
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout configuration
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,6 +17,8 @@ jobs:
   renovate:
     name: Run self-hosted Renovate
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       # we need special permission to be able to operate renovate (view, list,
       # create issues, PR, etc.) and we use a GitHub application with fine


### PR DESCRIPTION
Add missing workflow permissions for the auto-approve, renovate, and call-backport-label-updater workflows.