### PR TITLE
allocator: crd: jitter identity creation

### DIFF
--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -310,6 +310,10 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 		} else {
 			allocOptions = append(allocOptions, allocator.WithMasterKeyProtection())
 		}
+		if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD ||
+			option.Config.IdentityAllocationMode == option.IdentityAllocationModeDoubleWriteReadKVstore {
+			allocOptions = append(allocOptions, allocator.WithInitialJitter()) // crd mode can have collisions, jitter allocs
+		}
 		if m.maxAllocAttempts > 0 {
 			allocOptions = append(allocOptions, allocator.WithMaxAllocAttempts(m.maxAllocAttempts))
 		}


### PR DESCRIPTION
This adds some jitter to the allocator backoff, as well as waiting a random time before first allocation. This aims to reduce collisions where a duplicate identity is created for the same set of labels.

This is only enabled for the CRD allocator, as it can collide when allocating the same identity. The kvstore allocator does not suffer this problem.

This works in concert with #38031, which can delay _re-allocations_ for up to 30 seconds. That option protects against overload when a large namespace is re-labeled. This is smaller in scope, with less delay, intended only to reduce duplicates.
