### PR TITLE
kind: allow for configuring more logs in containers

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -244,6 +244,11 @@ kubeadmConfigPatches:
       extraArgs:
         authorization-always-allow-paths: /healthz,/readyz,/livez,/metrics
         bind-address: 0.0.0.0
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        container-log-max-size: "10M"
 EOF
 
 if [ "${secondary_network_flag}" = true ]; then


### PR DESCRIPTION
10MB is the default configuration for kubelet.
Sometimes you just want more logs.
