### PR TITLE
v1.18 backport 2025 10 20

### DIFF
--- a/Documentation/network/concepts/fragmentation.rst
+++ b/Documentation/network/concepts/fragmentation.rst
@@ -28,17 +28,4 @@ To check whether fragmentation occurred, check the value of the following metric
 
 If they're non-zero, it means that fragmented packets were processed.
 
-.. note::
-
-    When running Cilium with kube-proxy, fragmented NodePort traffic may break due
-    to a kernel bug where route MTU is not respected for forwarded packets. Cilium
-    fragments tracking requires the first logical fragment to arrive first. Due to the
-    kernel bug, additional fragmentation on the outer encapsulation layer may happen
-    that causes packet reordering and results in a failure in tracking the fragments.
-
-    The kernel bug has been `fixed <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=02a1b175b0e92d9e0fa5df3957ade8d733ceb6a0>`_
-    and backported to all maintained kernel versions. If you observe connectivity problems,
-    ensure that the kernel package on your nodes has been upgraded recently before
-    reporting an issue.
-
 .. include:: ../../beta.rst

--- a/Documentation/network/concepts/fragmentation.rst
+++ b/Documentation/network/concepts/fragmentation.rst
@@ -6,8 +6,8 @@
 
 .. _concepts_fragmentation:
 
-IPv4 Fragment Handling
-======================
+Fragment Handling
+=================
 
 By default, Cilium configures the eBPF datapath to perform IP fragment tracking
 to allow protocols that do not support segmentation (such as UDP) to
@@ -16,10 +16,17 @@ configured using the following options:
 
 - ``--enable-ipv4-fragment-tracking``: Enable or disable IPv4 fragment
   tracking. Enabled by default.
+- ``--enable-ipv6-fragment-tracking``: Enable or disable IPv6 fragment
+  tracking. Enabled by default.
 - ``--bpf-fragments-map-max``: Control the maximum number of active concurrent
   connections using IP fragmentation. For the defaults, see `bpf_map_limitations`.
 
-To check whether fragmentation occurred, check the value of ``cilium_bpf_map_pressure{map_name="cilium_ipv4_frag_datagrams"}`` metric. If it's non-zero, it means that fragmentation occurred.
+To check whether fragmentation occurred, check the value of the following metrics:
+
+- ``cilium_bpf_map_pressure{map_name="cilium_ipv4_frag_datagrams"}``
+- ``cilium_bpf_map_pressure{map_name="cilium_ipv6_frag_datagrams"}``
+
+If they're non-zero, it means that fragmented packets were processed.
 
 .. note::
 

--- a/images/cache/Dockerfile
+++ b/images/cache/Dockerfile
@@ -1,7 +1,9 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-FROM docker.io/library/alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412 AS import-cache
+ARG ALPINE_IMAGE=docker.io/library/alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
+
+FROM ${ALPINE_IMAGE} AS import-cache
 
 RUN --mount=type=bind,target=/host-tmp \
     --mount=type=cache,target=/root/.cache \

--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -147,8 +147,10 @@ func registerGC(p params) {
 				// CRD mode GC runs in an additional goroutine
 				gc.mgr.RemoveAllAndWait()
 			}
-			gc.rateLimiter.Stop()
+			// Close the worker pool first to ensure all goroutines complete
+			// before stopping the rate limiter they depend on
 			gc.wp.Close()
+			gc.rateLimiter.Stop()
 
 			return nil
 		},

--- a/operator/pkg/gateway-api/gatewayclass_reconcile.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile.go
@@ -61,20 +61,9 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return controllerruntime.Fail(nil)
 		}
 
-		if ref.Namespace == nil || ref.Name == "" {
-			scopedLog.Error("ParametersRef must specify namespace and name")
-			setGatewayClassAccepted(gwc, false)
-			if err := r.ensureStatus(ctx, gwc, original); err != nil {
-				scopedLog.ErrorContext(ctx, "Failed to update GatewayClass status", logfields.Error, err)
-				return controllerruntime.Fail(err)
-			}
-			return controllerruntime.Fail(nil)
-		}
-
 		cgcc := &v2alpha1.CiliumGatewayClassConfig{}
 		key := client.ObjectKey{
-			Namespace: string(*ref.Namespace),
-			Name:      ref.Name,
+			Name: ref.Name,
 		}
 		if err := r.Client.Get(ctx, key, cgcc); err != nil {
 			setGatewayClassAccepted(gwc, false)

--- a/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
@@ -27,8 +27,7 @@ var (
 	cgwccFixture = []client.Object{
 		&v2alpha1.CiliumGatewayClassConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "dummy-gateway-class-config",
-				Namespace: "default",
+				Name: "dummy-gateway-class-config",
 			},
 			Spec: v2alpha1.CiliumGatewayClassConfigSpec{},
 		},
@@ -63,10 +62,9 @@ var (
 			Spec: gatewayv1.GatewayClassSpec{
 				ControllerName: "io.cilium/gateway-controller",
 				ParametersRef: &gatewayv1.ParametersReference{
-					Group:     "cilium.io",
-					Kind:      "CiliumGatewayClassConfig",
-					Name:      "dummy-gateway-class-config",
-					Namespace: ptr.To(gatewayv1.Namespace("default")),
+					Group: "cilium.io",
+					Kind:  "CiliumGatewayClassConfig",
+					Name:  "dummy-gateway-class-config",
 				},
 			},
 		},

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -59,6 +59,10 @@ func TestConflictResolution(t *testing.T) {
 		}
 	}
 
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 1 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 1 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
+	}
+
 	// Phase 2, resolving the conflict
 
 	// Remove the conflicting range
@@ -72,6 +76,10 @@ func TestConflictResolution(t *testing.T) {
 	poolB = fixture.GetPool("pool-b")
 	if isPoolConflicting(poolB) {
 		t.Fatal("Pool B should no longer be conflicting")
+	}
+
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 0 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 0 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
 	}
 }
 
@@ -88,6 +96,10 @@ func TestPoolInternalConflict(t *testing.T) {
 		t.Fatal("Pool A should be conflicting")
 	}
 
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 1 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 1 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
+	}
+
 	poolA.Spec.Blocks = []cilium_api_v2.CiliumLoadBalancerIPPoolIPBlock{
 		{
 			Cidr: "10.0.10.0/24",
@@ -98,6 +110,10 @@ func TestPoolInternalConflict(t *testing.T) {
 
 	if isPoolConflicting(poolA) {
 		t.Fatal("Expected pool to be un-marked conflicting")
+	}
+
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 0 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 0 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
 	}
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -161,7 +161,7 @@ func createDirectRouteSpec(log *slog.Logger, CIDR *cidr.CIDR, nodeIP net.IP, ski
 
 	if routes[0].Gw != nil && !routes[0].Gw.IsUnspecified() && !routes[0].Gw.Equal(nodeIP) {
 		if skipUnreachable {
-			log.Warn("route to destination contains gateway, skipping route as not directly reachable",
+			log.Debug("route to destination contains gateway, skipping route as not directly reachable",
 				logfields.NodeIP, nodeIP,
 				logfields.GatewayIP, routes[0].Gw)
 			addRoute = false


### PR DESCRIPTION
v1.18 backports 2025-10-20

 - [ ] #42108 -- ci: Allow for alpine image overwrite within cache Dockerfile (@jpayne3506)
 - [ ] #41999 -- lbipam: fix incorrect conflicting pools metric (@hanapedia)
 - [x] #42210 -- cilium, routes: Downgrade warning on direct-routing-skip-unreachable (@borkmann)
 - [ ] #41748 -- Docs: update fragmentation docs to reflect ipv6 (@tommyp1ckles)
 - [x] #42217 -- operator: Prevent panic when GCing identities (@HadrienPatte)
 - [ ] #42172 -- gatewayAPI: fix reference to cluster-scoped CGCC resource (@oblazek)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
42108 41999 42210 41748 42217 42172
```