### PR TITLE
CODEOWNERS: let sig-policy own allocator and idpool packages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -493,7 +493,7 @@ Makefile* @cilium/build
 /pkg/annotation @cilium/sig-k8s
 /pkg/alibabacloud/ @cilium/alibabacloud
 /pkg/alignchecker/ @cilium/sig-datapath @cilium/loader
-/pkg/allocator/ @cilium/kvstore
+/pkg/allocator/ @cilium/sig-policy
 /pkg/api/ @cilium/api
 /pkg/auth/ @cilium/sig-servicemesh
 /pkg/aws/ @cilium/aws
@@ -564,7 +564,7 @@ Makefile* @cilium/build
 /pkg/iana/ @cilium/sig-agent
 /pkg/identity @cilium/sig-policy
 /pkg/identity/restoration @cilium/sig-policy @cilium/ipcache
-/pkg/idpool/ @cilium/kvstore
+/pkg/idpool/ @cilium/sig-policy
 /pkg/ip/ @cilium/sig-agent
 /pkg/ipalloc/ @cilium/sig-ipam
 /pkg/ipam/ @cilium/sig-ipam


### PR DESCRIPTION
The allocator and idpool packages are currently owned by the kvstore team, for historical reasons. However, they have since been generalized as a higher level abstraction suitable both for CRD and kvstore allocation modes. Hence, let's move them under sig-policy, which is in a better position to scrutinize the changes in this area.

The kvstore allocation backend (i.e., pkg/kvstore/allocator), instead, remains owned by the kvstore team.

/cc @cilium/sig-policy 
/cc @cilium/kvstore 