### PR TITLE
gh: datapath-verifier: stop testing complexity on RHEL 8.6

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -86,9 +86,6 @@ jobs:
       matrix:
         include:
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: 'rhel8.6-20250812.093650'
-            ci-kernel: '510'
-          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '5.10-20251008.075427'
             ci-kernel: '510'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test


### PR DESCRIPTION
The new complexity tester is a lot more exhaustive, and will find configs that we have no intention of fixing. Given RHEL8's subpar verifier functionality (compared to the required 5.10 kernel), it doesn't make sense to play whack-a-mole and chase after issues that only affect RHEL8 in exotic configurations.

Users that still care about RHEL8 are encouraged to bring this testing back in form of a scheduled-only GH run, and/or to add "blessed" RHEL8 configs to the e2e-upgrade workflow (also scheduled-only).