### PR TITLE
helm: revert back cert job to use checksum generated name

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -357,7 +357,12 @@ jobs:
 
           CILIUM_INSTALL_INGRESS=""
           if [ "${{ matrix.kube-proxy }}" == "none" ]; then
-            CILIUM_INSTALL_INGRESS="--helm-set=ingressController.enabled=true"
+            CILIUM_INSTALL_INGRESS="--helm-set=ingressController.enabled=true --helm-set=ingressController.service.type=NodePort"
+          fi
+
+          CILIUM_INSTALL_WAIT=""
+          if [ "${{ matrix.tls-auto-method }}" != "certmanager" ]; then
+            CILIUM_INSTALL_WAIT="--wait"
           fi
 
           CILIUM_INSTALL_MULTIPOOL_IPAM=""
@@ -405,7 +410,7 @@ jobs:
               --test='!/pod-to-cidr'"
           fi
 
-          echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} \
+          echo cilium_install_defaults="${CILIUM_INSTALL_WAIT} ${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} \
             ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_ENCRYPTION} ${CILIUM_INSTALL_INGRESS} ${CILIUM_INSTALL_MULTIPOOL_IPAM}" >> $GITHUB_OUTPUT
           echo cilium_install_multipool_ipam_cluster1="${CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER1}" >> $GITHUB_OUTPUT
           echo cilium_install_multipool_ipam_cluster2="${CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER2}" >> $GITHUB_OUTPUT

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -483,7 +483,7 @@
    * - :spelling:ignore:`certgen`
      - Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually.
      - object
-     - ``{"affinity":{},"annotations":{"cronJob":{},"job":{}},"extraVolumeMounts":[],"extraVolumes":[],"generateCA":true,"image":{"digest":"sha256:de7b97b1d19a34b674d0c4bc1da4db999f04ae355923a9a994ac3a81e1a1b5ff","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.2.4","useDigest":true},"nodeSelector":{},"podLabels":{},"priorityClassName":"","resources":{},"tolerations":[],"ttlSecondsAfterFinished":1800}``
+     - ``{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":3},"extraVolumeMounts":[],"extraVolumes":[],"generateCA":true,"image":{"digest":"sha256:de7b97b1d19a34b674d0c4bc1da4db999f04ae355923a9a994ac3a81e1a1b5ff","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.2.4","useDigest":true},"nodeSelector":{},"podLabels":{},"priorityClassName":"","resources":{},"tolerations":[],"ttlSecondsAfterFinished":null}``
    * - :spelling:ignore:`certgen.affinity`
      - Affinity for certgen
      - object
@@ -492,6 +492,14 @@
      - Annotations to be added to the hubble-certgen initial Job and CronJob
      - object
      - ``{"cronJob":{},"job":{}}``
+   * - :spelling:ignore:`certgen.cronJob.failedJobsHistoryLimit`
+     - The number of failed finished jobs to keep
+     - int
+     - ``1``
+   * - :spelling:ignore:`certgen.cronJob.successfulJobsHistoryLimit`
+     - The number of successful finished jobs to keep
+     - int
+     - ``3``
    * - :spelling:ignore:`certgen.extraVolumeMounts`
      - Additional certgen volumeMounts.
      - list
@@ -526,8 +534,8 @@
      - ``[]``
    * - :spelling:ignore:`certgen.ttlSecondsAfterFinished`
      - Seconds after which the completed job pod will be deleted
-     - int
-     - ``1800``
+     - string
+     - ``nil``
    * - :spelling:ignore:`cgroup`
      - Configure cgroup related configuration
      - object

--- a/Documentation/observability/hubble/configuration/tls.rst
+++ b/Documentation/observability/hubble/configuration/tls.rst
@@ -242,31 +242,6 @@ If you encounter issues after enabling TLS, you can use the following instructio
 
                 Then configure an issuer and install Cilium.
 
-    .. group-tab:: CronJob (certgen)
-
-        If you are using ArgoCD, you may encounter issues on the initial
-        installation because of how ArgoCD handles Helm hooks specified in the
-        ``helm.sh/hook`` annotation.
-
-        The ``hubble-generate-certs`` Job specifies a ``post-install`` Helm
-        hook in order to generate the required Certificates at initial install time, since
-        the CronJob will only run on the configured schedule which could be
-        hours or days after the initial installation.
-
-        Since ArgoCD will only run ``post-install`` hooks after all pods are
-        ready and running, you may encounter a situation where the
-        ``hubble-generate-certs`` Job is never run.
-
-        It cannot be configured as a ``pre-install`` hook because it requires Cilium
-        to be running first, and Hubble Relay cannot become ready until
-        certificates are provisioned.
-
-        To work around this, you can manually run the ``certgen`` CronJob:
-
-        .. code-block:: shell-session
-
-            $ kubectl -n kube-system create job hubble-generate-certs-initial --from cronjob/hubble-generate-certs
-
     .. group-tab:: Helm
 
         When using Helm certificates are not automatically renewed. If you

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -322,6 +322,12 @@ communicating via the proxy must reconnect to re-establish connections.
 * The previously deprecated ``CiliumBGPPeeringPolicy`` CRD and its control plane (BGPv1) has been removed.
   Please migrate to ``cilium.io/v2`` CRDs (``CiliumBGPClusterConfig``, ``CiliumBGPPeerConfig``,
   ``CiliumBGPAdvertisement``, ``CiliumBGPNodeConfigOverride``) before upgrading.
+* Certificate generation with the CronJob method for Hubble and ClusterMesh has
+  changed. The Job resource to generate certificates is now created like any other
+  resource and is no longer part of Helm post-install or post-upgrade hooks. This
+  makes it compatible by default with the Helm ``--wait`` option or through ArgoCD.
+  You are no longer expected to create a Job manually or as part of your own
+  automation when bootstrapping your clusters.
 
 Removed Options
 ~~~~~~~~~~~~~~~
@@ -382,7 +388,7 @@ Changed Metrics
 The following metrics previously had instances (i.e. for some watcher K8s resource type labels) under ``workqueue_``.
 In this release any such metrics have been renamed and combined into the correct metric name prefixed with ``cilium_operator_``.
 
-As well, any remaining Operator k8s workqueue metrics that use the label ``queue_name`` have had it renamed to 
+As well, any remaining Operator k8s workqueue metrics that use the label ``queue_name`` have had it renamed to
 ``name`` to be consistent with agent k8s workqueue metrics.
 
 * The metric ``workqueue_adds_total`` has been renamed and combined into to ``cilium_operator_k8s_workqueue_adds_total``, the label ``queue_name`` has been renamed to ``name``.

--- a/Makefile.kind
+++ b/Makefile.kind
@@ -140,7 +140,7 @@ $(eval $(call KIND_ENV,kind-install-cilium-clustermesh))
 kind-install-cilium-clustermesh: check_deps kind-clustermesh-ready ## Install a local Cilium version into the clustermesh clusters and enable clustermesh.
 	@echo "  INSTALL cilium on clustermesh1 cluster"
 	-$(CILIUM_CLI) --context=kind-clustermesh1 uninstall >/dev/null
-	$(CILIUM_CLI) --context=kind-clustermesh1 install \
+	$(CILIUM_CLI) --context=kind-clustermesh1 install --wait \
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
 		--values=$(ROOT_DIR)/contrib/testing/kind-clustermesh1.yaml \
 		--set=image.override=$(LOCAL_AGENT_IMAGE) \
@@ -152,7 +152,7 @@ kind-install-cilium-clustermesh: check_deps kind-clustermesh-ready ## Install a 
 	-$(CILIUM_CLI) --context=kind-clustermesh2 uninstall >/dev/null
 	$(KUBECTL) --context=kind-clustermesh1 get secret -n kube-system cilium-ca -o yaml | \
 		$(KUBECTL) --context=kind-clustermesh2 replace --force -f -
-	$(CILIUM_CLI) --context=kind-clustermesh2 install \
+	$(CILIUM_CLI) --context=kind-clustermesh2 install --wait \
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
 		--values=$(ROOT_DIR)/contrib/testing/kind-clustermesh2.yaml \
 		--set=image.override=$(LOCAL_AGENT_IMAGE) \

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -170,9 +170,11 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY (beta) to reduce reliance on iptables rules for implementing Layer 7 policy. |
 | bpf.vlanBypass | list | `[]` | Configure explicitly allowed VLAN id's for bpf logic bypass. [0] will allow all VLAN id's without any filtering. |
 | bpfClockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
-| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"extraVolumeMounts":[],"extraVolumes":[],"generateCA":true,"image":{"digest":"sha256:de7b97b1d19a34b674d0c4bc1da4db999f04ae355923a9a994ac3a81e1a1b5ff","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.2.4","useDigest":true},"nodeSelector":{},"podLabels":{},"priorityClassName":"","resources":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":3},"extraVolumeMounts":[],"extraVolumes":[],"generateCA":true,"image":{"digest":"sha256:de7b97b1d19a34b674d0c4bc1da4db999f04ae355923a9a994ac3a81e1a1b5ff","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.2.4","useDigest":true},"nodeSelector":{},"podLabels":{},"priorityClassName":"","resources":{},"tolerations":[],"ttlSecondsAfterFinished":null}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.affinity | object | `{}` | Affinity for certgen |
 | certgen.annotations | object | `{"cronJob":{},"job":{}}` | Annotations to be added to the hubble-certgen initial Job and CronJob |
+| certgen.cronJob.failedJobsHistoryLimit | int | `1` | The number of failed finished jobs to keep |
+| certgen.cronJob.successfulJobsHistoryLimit | int | `3` | The number of successful finished jobs to keep |
 | certgen.extraVolumeMounts | list | `[]` | Additional certgen volumeMounts. |
 | certgen.extraVolumes | list | `[]` | Additional certgen volumes. |
 | certgen.generateCA | bool | `true` | When set to true the certificate authority secret is created. |
@@ -181,7 +183,7 @@ contributors across the globe, there is almost always someone available to help.
 | certgen.priorityClassName | string | `""` | Priority class for certgen ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass |
 | certgen.resources | object | `{}` | Resource limits for certgen ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers |
 | certgen.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
-| certgen.ttlSecondsAfterFinished | int | `1800` | Seconds after which the completed job pod will be deleted |
+| certgen.ttlSecondsAfterFinished | string | `nil` | Seconds after which the completed job pod will be deleted |
 | cgroup | object | `{"autoMount":{"enabled":true,"resources":{}},"hostRoot":"/run/cilium/cgroupv2"}` | Configure cgroup related configuration |
 | cgroup.autoMount.enabled | bool | `true` | Enable auto mount of cgroup2 filesystem. When `autoMount` is enabled, cgroup2 filesystem is mounted at `cgroup.hostRoot` path on the underlying host and inside the cilium agent pod. If users disable `autoMount`, it's expected that users have mounted cgroup2 filesystem at the specified `cgroup.hostRoot` volume, and then the volume will be mounted inside the cilium agent pod at the same path. |
 | cgroup.autoMount.resources | object | `{}` | Init Container Cgroup Automount resource limits & requests |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -119,5 +119,7 @@ spec:
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-  ttlSecondsAfterFinished: {{ .Values.certgen.ttlSecondsAfterFinished }}
+  {{- with .Values.certgen.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+  {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
@@ -16,6 +16,8 @@ metadata:
     {{- end }}
 spec:
   schedule: {{ .Values.clustermesh.apiserver.tls.auto.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.certgen.cronJob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.certgen.cronJob.failedJobsHistoryLimit }}
   concurrencyPolicy: Forbid
   jobTemplate:
 {{- include "clustermesh-apiserver-generate-certs.job.spec" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
@@ -1,9 +1,18 @@
 {{- if and (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal")) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") }}
+{{/*
+Because Kubernetes job specs are immutable, Helm will fail patch this job if
+the spec changes between releases. To avoid breaking the upgrade path, we
+generate a name for the job here which is based on the checksum of the spec.
+This will cause the name of the job to change if its content changes,
+and in turn cause Helm to do delete the old job and replace it with a new one.
+*/}}
+{{- $jobSpec := include "clustermesh-apiserver-generate-certs.job.spec" . -}}
+{{- $checkSum := $jobSpec | sha256sum | trunc 10 -}}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: clustermesh-apiserver-generate-certs
+  name: clustermesh-apiserver-generate-certs-{{$checkSum}}
   namespace: {{ include "cilium.namespace" . }}
   labels:
     k8s-app: clustermesh-apiserver-generate-certs
@@ -11,13 +20,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     app.kubernetes.io/part-of: cilium
+  {{- if or .Values.certgen.annotations.job .Values.clustermesh.annotations }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
     {{- with .Values.certgen.annotations.job }}
-    {{- toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with .Values.clustermesh.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-{{ include "clustermesh-apiserver-generate-certs.job.spec" . }}
+  {{- end }}
+{{ $jobSpec }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
@@ -152,5 +152,7 @@ spec:
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-  ttlSecondsAfterFinished: {{ .Values.certgen.ttlSecondsAfterFinished }}
+  {{- with .Values.certgen.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+  {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
@@ -23,6 +23,8 @@ metadata:
   {{- end }}
 spec:
   schedule: {{ .Values.hubble.tls.auto.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.certgen.cronJob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.certgen.cronJob.failedJobsHistoryLimit }}
   concurrencyPolicy: Forbid
   jobTemplate:
     {{- include "hubble-generate-certs.job.spec" . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
@@ -1,9 +1,18 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") }}
+{{/*
+Because Kubernetes job specs are immutable, Helm will fail patch this job if
+the spec changes between releases. To avoid breaking the upgrade path, we
+generate a name for the job here which is based on the checksum of the spec.
+This will cause the name of the job to change if its content changes,
+and in turn cause Helm to do delete the old job and replace it with a new one.
+*/}}
+{{- $jobSpec := include "hubble-generate-certs.job.spec" . -}}
+{{- $checkSum := $jobSpec | sha256sum | trunc 10 -}}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hubble-generate-certs
+  name: hubble-generate-certs-{{$checkSum}}
   namespace: {{ include "cilium.namespace" . }}
   labels:
     k8s-app: hubble-generate-certs
@@ -12,13 +21,14 @@ metadata:
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if or .Values.certgen.annotations.job .Values.hubble.annotations }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
     {{- with .Values.certgen.annotations.job }}
-    {{- toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with .Values.hubble.annotations }}
-    {{- toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
-{{ include "hubble-generate-certs.job.spec" . }}
+  {{- end }}
+{{ $jobSpec }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -728,6 +728,17 @@
           },
           "type": "object"
         },
+        "cronJob": {
+          "properties": {
+            "failedJobsHistoryLimit": {
+              "type": "integer"
+            },
+            "successfulJobsHistoryLimit": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
         "extraVolumeMounts": {
           "items": {},
           "type": "array"
@@ -782,7 +793,10 @@
           "type": "array"
         },
         "ttlSecondsAfterFinished": {
-          "type": "integer"
+          "type": [
+            "null",
+            "integer"
+          ]
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1189,8 +1189,11 @@ certgen:
     digest: "sha256:de7b97b1d19a34b674d0c4bc1da4db999f04ae355923a9a994ac3a81e1a1b5ff"
     useDigest: true
     pullPolicy: "Always"
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Seconds after which the completed job pod will be deleted
-  ttlSecondsAfterFinished: 1800
+  ttlSecondsAfterFinished: null
   # -- Labels to be added to hubble-certgen pods
   podLabels: {}
   # -- Annotations to be added to the hubble-certgen initial Job and CronJob
@@ -1215,6 +1218,11 @@ certgen:
   extraVolumeMounts: []
   # -- Affinity for certgen
   affinity: {}
+  cronJob:
+    # -- The number of successful finished jobs to keep
+    successfulJobsHistoryLimit: 3
+    # -- The number of failed finished jobs to keep
+    failedJobsHistoryLimit: 1
 hubble:
   # -- Enable Hubble (true by default).
   enabled: true

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1199,8 +1199,11 @@ certgen:
     digest: "${CERTGEN_DIGEST}"
     useDigest: true
     pullPolicy: "${PULL_POLICY}"
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Seconds after which the completed job pod will be deleted
-  ttlSecondsAfterFinished: 1800
+  ttlSecondsAfterFinished: null
   # -- Labels to be added to hubble-certgen pods
   podLabels: {}
   # -- Annotations to be added to the hubble-certgen initial Job and CronJob
@@ -1225,6 +1228,11 @@ certgen:
   extraVolumeMounts: []
   # -- Affinity for certgen
   affinity: {}
+  cronJob:
+    # -- The number of successful finished jobs to keep
+    successfulJobsHistoryLimit: 3
+    # -- The number of failed finished jobs to keep
+    failedJobsHistoryLimit: 1
 hubble:
   # -- Enable Hubble (true by default).
   enabled: true


### PR DESCRIPTION
See the commit description for (too many :sweat_smile:) details about this.

Fixes: #40381 
Fixes: #42045

```release-note
clustermesh: hubble: remove the needs to manually trigger the cert generation job for initial installation when using ArgoCD or helm with the "--wait" option and the cronjob method
```