### PR TITLE
policy: Fix rare Endpoint Selector Policy deadlock

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1527,11 +1527,17 @@ func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 	// In the case of an policy update it is possible that an
 	// endpoint has started regeneration before the policy was
 	// updated, and that the policy was updated before the said
-	// endpoint reached this point. In this case the endpoint's
-	// policy is going to be recomputed soon after and we do
-	// nothing here.
+	// endpoint reached this point. In this case, we need to
+	// ensure that the endpoint will be regenerated at least once
+	// afterward. This to ensure it doesn't get stuck with a
+	// detached policy.
 	if l4.users != nil {
 		l4.users[user] = struct{}{}
+	} else {
+		go user.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+			Reason:            "selector policy has changed because of another endpoint with the same identity",
+			RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+		})
 	}
 
 	l4.mutex.Unlock()


### PR DESCRIPTION
This fixes a policy deadlock that causes endpoints to be stuck with a detached policy for an extended period of time.

This is the same kind of deadlock as https://github.com/cilium/cilium/pull/37910, just a different code path. Ideally we could solve this better than triggering this kind or regeneration in a loop - but it will at least mitigate the problem. We are seeing this issue extensively on v1.15+ (both the issue fixed in this PR, and #37910), and backporting these patches fixes the issues. It is however causing a lot of additional regeneration on some workloads, but in v1.17+ that should most likely not be that big of a deal - but we haven't been able to test that much. 

This is not a very common edge case, but across a large set of nodes and clusters, this is most likely happening for a lot of users, causing policy drops that are very hard to debug.

Also attaching the commit message here for more details;

--- 

This is similar to the race fixed in
12565044 ("policy: Fix Endpoint Selector Policy Deadlock"), where two endpoints with the same identity are regenerated concurrently.

This can happen, as described in the existing comment, when the selectorPolicy is detached _before_ the endpoint runs DistillPolicy. This can happen if the first endpoint is running "updateSelectorPolicy" on one revision, while the other endpoint runs with a newer revision, replacing the old selector policy before the first endpoint run "DistillPolicy". Then, the existing patch does not trigger a regeneration of the said endpoint, causing it to be stuck on the old policy until its regenerated.

In v1.17, after 2e57d3c ("endpoints: periodically regenerate all endpoints"), this happens once on an interval - so its eventually fixed. On older versions, an endpoint could be stuck in this state permanently.

Reproducing this is pretty difficult, but can be done by:
- Having two endpoints on the same node, with the same identity
- Concurrently churning policies not triggering regenerations of the two endpoints
- Forcing it to sleep via eg. "time.Sleep" during policy regeneration
- Forcing regeneration of the two endpoints, eg. by a policy selecting them.

Fixes: 1c9f67d ("policy: Add distillery package")

---

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
policy: Fix rare Endpoint Selector Policy Deadlock causing policies to not be updated with new identities
```
