### PR TITLE
workflows/kpr: Fix dependencies for artifact collection

### DIFF
--- a/.github/workflows/conformance-kpr.yaml
+++ b/.github/workflows/conformance-kpr.yaml
@@ -136,10 +136,10 @@ jobs:
   merge-upload-and-status:
     name: Merge Upload and Status
     if: ${{ always() }}
-    needs: [conformance-eks-kpr]
+    needs: [conformance-eks-kpr, conformance-eks-kpr-ipsec, conformance-eks-kpr-wireguard]
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      result: ${{ needs.conformance-eks-kpr.result == 'failure' && 'failure' || 'success' }}
+      result: ${{ (needs.conformance-eks-kpr.result == 'failure' || needs.conformance-eks-kpr-ipsec.result == 'failure' || needs.conformance-eks-kpr-wireguard.result == 'failure') && 'failure' || 'success' }}


### PR DESCRIPTION
Some dependencies were missed when adding coverage for IPsec and WireGuard with EKS.

Fixes: https://github.com/cilium/cilium/pull/41877.