### PR TITLE
workflows/aks: Don't run tests twice when IPsec is enabled

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -254,12 +254,6 @@ jobs:
             OWNER="${OWNER//[.\/]/-}"
           fi
 
-          # Check if ipsec is requested via extra-args
-          IPSEC=$(echo '${{ inputs.extra-args }}' | sed 's/^""$/{}/' | jq -r '.["ipsec"] // false')
-          if [[ "$IPSEC" == "true" ]]; then
-            echo "::notice::IPsec enabled - setting ipsec=true for all matrix entries"
-          fi
-
           # We explicity set the cluster-pool Pod CIDR here to not clash with the AKS default Service CIDRs
           # which are 10.0.0.0/16 and fd12:3456:789a:1::/108
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
@@ -273,6 +267,14 @@ jobs:
             --helm-set=ipv6.enabled=true \
             --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16 \
             --helm-set ipam.operator.clusterPoolIPv6PodCIDRList=fd00::/104"
+
+          # Check if ipsec is requested via extra-args
+          IPSEC=$(echo '${{ inputs.extra-args }}' | sed 's/^""$/{}/' | jq -r '.["ipsec"] // false')
+          if [[ "$IPSEC" == "true" ]]; then
+            echo "::notice::IPsec enabled - setting ipsec=true for all matrix entries"
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true \
+              --helm-set encryption.type=ipsec"
+          fi
 
           CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
 
@@ -329,6 +331,11 @@ jobs:
           sparse-checkout: |
             install/kubernetes/cilium
 
+      - name: Create custom IPsec secret
+        if: ${{ steps.vars.outputs.ipsec == 'true' }}
+        run: |
+          cilium encrypt create-key --auth-algo rfc4106-gcm-aes
+
       - name: Install Cilium
         id: install-cilium
         run: |
@@ -368,48 +375,8 @@ jobs:
           json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1"
 
       - name: Clean up Cilium
-        if: ${{ steps.vars.outputs.ipsec == 'true' }}
         run: |
           cilium uninstall --wait
-
-      - name: Create custom IPsec secret
-        if: ${{ steps.vars.outputs.ipsec == 'true' }}
-        run: |
-          cilium encrypt create-key --auth-algo rfc4106-gcm-aes
-
-      - name: Install Cilium with encryption
-        if: ${{ steps.vars.outputs.ipsec == 'true' }}
-        run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
-            --helm-set encryption.enabled=true \
-            --helm-set encryption.type=ipsec
-
-      - name: Enable Relay
-        if: ${{ steps.vars.outputs.ipsec == 'true' }}
-        run: |
-          cilium hubble enable
-
-      - name: Wait for Cilium status to be ready
-        if: ${{ steps.vars.outputs.ipsec == 'true' }}
-        run: |
-          cilium status --wait --interactive=false --wait-duration=10m
-
-      - name: Run sequential connectivity test with IPSec (${{ join(matrix.*, ', ') }})
-        if: ${{ steps.vars.outputs.ipsec == 'true' }}
-        run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
-          --test "seq-.*" \
-          --junit-file "cilium-junits/${{ env.job_name }}-sequential-ipsec (${{ join(matrix.*, ', ') }}).xml" \
-          --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
-
-      - name: Run concurrent connectivity test with IPSec (${{ join(matrix.*, ', ') }})
-        if: ${{ steps.vars.outputs.ipsec == 'true' }}
-        run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
-          --test-concurrency=${{ env.test_concurrency }} \
-          --test "!seq-.*" \
-          --junit-file "cilium-junits/${{ env.job_name }}-concurrent-ipsec (${{ join(matrix.*, ', ') }}).xml" \
-          --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
 
       - name: Run common post steps
         if: ${{ always() }}


### PR DESCRIPTION
Right now, when Conformance AKS is ran with IPsec enabled (i.e., in the context of Conformance IPsec), the Cilium installation and connectivity tests all run twice, once with IPsec disabled and once with it enabled. I don't think that was the intention. Instead, it should all run with IPsec disabled in the context of Conformance AKS scheduled runs and with IPsec enabled in the context of Conformance IPsec.

This pull request fixes it by removing the duplicate IPsec steps and instead enabling IPsec if requested when we first install Cilium.

Fixes: https://github.com/cilium/cilium/pull/40623.