### PR TITLE
v1.17 backport 2025 10 21

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -10,6 +10,7 @@ jobs:
     # Avoid running the 'auto-approve' environment if we don't need to.
     name: Pre-Approve
     runs-on: ubuntu-latest
+    permissions: {}
     if: ${{
          github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
          (github.triggering_actor == 'cilium-renovate[bot]' ||
@@ -28,6 +29,7 @@ jobs:
     needs: pre-approve
     environment: auto-approve
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
     - name: Debug
       run: |

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -210,6 +210,7 @@ jobs:
           path: Makefile.digests
 
   call-post-release:
+    if: github.repository_owner == 'cilium'
     name: Call Post-Release Tool
     uses: cilium/cilium/.github/workflows/release.yaml@main
     needs: image-digests
@@ -228,6 +229,7 @@ jobs:
       CILIUM_RELEASE_BOT_APP_ID: ${{ secrets.CILIUM_RELEASE_BOT_APP_ID }}
 
   call-publish-helm:
+    if: github.repository_owner == 'cilium'
     name: Publish Helm Chart
     uses: cilium/cilium/.github/workflows/release.yaml@main
     needs: image-digests

--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -10,6 +10,8 @@
   jobs:
     call-backport-label-updater:
       name: Update backport labels for upstream PR
+      permissions:
+        pull-requests: write
       if: |
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.body, 'upstream-prs') &&

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1814,6 +1814,20 @@ func (ipam *LBIPAM) settleConflicts(ctx context.Context) error {
 		}
 	}
 
+	// Count the number of conflicting pools and update the metric.
+	var conflictingPools float64
+	for _, pool := range ipam.pools {
+		lbRanges, _ := ipam.rangesStore.GetRangesForPool(pool.GetName())
+		// When a pool is marked as conflicting, all of its lbRanges are
+		// internally disabled. Therefore, checking a single lbRange
+		// is sufficient to conclude that the pool is conflicting.
+		if len(lbRanges) > 0 && lbRanges[0].internallyDisabled {
+			conflictingPools++
+		}
+	}
+
+	ipam.metrics.ConflictingPools.Set(conflictingPools)
+
 	return nil
 }
 
@@ -1827,8 +1841,6 @@ func (ipam *LBIPAM) markPoolConflicting(
 	if isPoolConflicting(targetPool) {
 		return nil
 	}
-
-	ipam.metrics.ConflictingPools.Inc()
 
 	ipam.logger.Warn(
 		fmt.Sprintf("Pool '%s' conflicts since range '%s' overlaps range '%s' from IP Pool '%s'",
@@ -1872,8 +1884,6 @@ func (ipam *LBIPAM) unmarkPool(ctx context.Context, targetPool *cilium_api_v2alp
 	for _, poolRange := range targetPoolRanges {
 		poolRange.internallyDisabled = false
 	}
-
-	ipam.metrics.ConflictingPools.Dec()
 
 	if ipam.setPoolCondition(targetPool, ciliumPoolConflict, meta_v1.ConditionFalse, "resolved", "") {
 		err := ipam.patchPoolStatus(ctx, targetPool)

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -46,6 +46,10 @@ func TestConflictResolution(t *testing.T) {
 		}
 	}
 
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 1 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 1 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
+	}
+
 	// Phase 2, resolving the conflict
 
 	// Remove the conflicting range
@@ -59,6 +63,10 @@ func TestConflictResolution(t *testing.T) {
 	poolB = fixture.GetPool("pool-b")
 	if isPoolConflicting(poolB) {
 		t.Fatal("Pool B should no longer be conflicting")
+	}
+
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 0 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 0 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
 	}
 }
 
@@ -85,6 +93,10 @@ func TestPoolInternalConflict(t *testing.T) {
 
 	if isPoolConflicting(poolA) {
 		t.Fatal("Expected pool to be un-marked conflicting")
+	}
+
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 0 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 0 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
 	}
 }
 


### PR DESCRIPTION
v1.17 backports 2025-10-21

 - [x] #41999 -- lbipam: fix incorrect conflicting pools metric (@hanapedia)
 - [x] #42281 -- ci: Add workflow permissions for auto-approve and renovate (@kyle-c-simmons)
 - [x] #42279 -- fix: run post-release and publish-helm workflows on cilium org (@sekhar-isovalent)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
41999 42281 42279
```
