### PR TITLE
v1.16 backport 2025 10 21

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -10,6 +10,7 @@ jobs:
     # Avoid running the 'auto-approve' environment if we don't need to.
     name: Pre-Approve
     runs-on: ubuntu-latest
+    permissions: {}
     if: ${{
          github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
          (github.triggering_actor == 'cilium-renovate[bot]' ||
@@ -28,6 +29,7 @@ jobs:
     needs: pre-approve
     environment: auto-approve
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
     - name: Debug
       run: |

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -224,6 +224,7 @@ jobs:
           path: Makefile.digests
 
   call-post-release:
+    if: github.repository_owner == 'cilium'
     name: Call Post-Release Tool
     uses: cilium/cilium/.github/workflows/release.yaml@main
     needs: image-digests
@@ -242,6 +243,7 @@ jobs:
       CILIUM_RELEASE_BOT_APP_ID: ${{ secrets.CILIUM_RELEASE_BOT_APP_ID }}
 
   call-publish-helm:
+    if: github.repository_owner == 'cilium'
     name: Publish Helm Chart
     uses: cilium/cilium/.github/workflows/release.yaml@main
     needs: image-digests

--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -10,6 +10,8 @@
   jobs:
     call-backport-label-updater:
       name: Update backport labels for upstream PR
+      permissions:
+        pull-requests: write
       if: |
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.body, 'upstream-prs') &&

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -46,6 +46,10 @@ func TestConflictResolution(t *testing.T) {
 		}
 	}
 
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 1 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 1 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
+	}
+
 	// Phase 2, resolving the conflict
 
 	// Remove the conflicting range
@@ -59,6 +63,10 @@ func TestConflictResolution(t *testing.T) {
 	poolB = fixture.GetPool("pool-b")
 	if isPoolConflicting(poolB) {
 		t.Fatal("Pool B should no longer be conflicting")
+	}
+
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 0 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 0 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
 	}
 }
 
@@ -85,6 +93,10 @@ func TestPoolInternalConflict(t *testing.T) {
 
 	if isPoolConflicting(poolA) {
 		t.Fatal("Expected pool to be un-marked conflicting")
+	}
+
+	if fixture.lbipam.metrics.ConflictingPools.Get() != 0 {
+		t.Fatalf("cilium_operator_lbipam_conflicting_pools should report 0 but got %d", int(fixture.lbipam.metrics.ConflictingPools.Get()))
 	}
 }
 


### PR DESCRIPTION
v1.16 backports 2025-10-21

 - [ ] #41999 -- lbipam: fix incorrect conflicting pools metric (@hanapedia)
 - [ ] #42281 -- ci: Add workflow permissions for auto-approve and renovate (@kyle-c-simmons)
 - [ ] #42279 -- fix: run post-release and publish-helm workflows on cilium org (@sekhar-isovalent)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
41999 42281 42279
```
