### PR TITLE
Log proxy instance creation at debug level

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -254,7 +254,7 @@ func (p *Proxy) createNewRedirect(
 		return 0, fmt.Errorf("unable to set rules on redirect: %w", err), nil
 	}
 
-	scopedLog.Info("Created new proxy instance",
+	scopedLog.Debug("Created new proxy instance",
 		logfields.Object, redirect,
 		logfields.ProxyPort, pp.ProxyPort)
 


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/35642 changed the "Created new proxy instance" log line to `Info` from `Debug`.

After that change every endpoint creation logs this log line once per protocol for any endpoint that has policies allowing access via the DNS proxy.

This results in a huge volume of not particularly useful logs in clusters with many nodes that churn through endpoints frequently e.g. 100s of nodes with many endpoints.

This commit reverts back to `Debug` level to reduce the log volume.