### PR TITLE
pkg/labelsfilter: Replace reflect.DeepEqual with assert.Equal in pkg/labelsfilter

### DIFF
--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -4,11 +4,11 @@
 package labelsfilter
 
 import (
-	"reflect"
 	"regexp"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -244,9 +244,8 @@ func TestFilterLabelsByRegex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FilterLabelsByRegex(tt.args.excludePatterns, tt.args.labels); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FilterLabelsByRegex() = %v, want %v", got, tt.want)
-			}
+			got := FilterLabelsByRegex(tt.args.excludePatterns, tt.args.labels)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 1 usage of `reflect.DeepEqual` in the `pkg/labelsfilter/` package:

- `pkg/labelsfilter/filter_test.go` (1 usage)

## Testing

All existing tests in `pkg/labelsfilter/` continue to pass:

```bash
$ go test ./pkg/labelsfilter/... -v
PASS
ok  	github.com/cilium/cilium/pkg/labelsfilter	0.007s
```

## Follow-up

This is an incremental change affecting a single package. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185 (pkg/auth - merged)
- #42186 (pkg/hubble/filters - merged)

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/labelsfilter tests for better error messages
```

