### PR TITLE
pkg/driftchecker: replace reflect.DeepEqual with assert.Equal in tests

### DIFF
--- a/pkg/driftchecker/checker_test.go
+++ b/pkg/driftchecker/checker_test.go
@@ -6,7 +6,6 @@ package driftchecker
 import (
 	"context"
 	"log/slog"
-	"reflect"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
 	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/dynamicconfig"
@@ -143,9 +143,7 @@ func TestComputeDelta(t *testing.T) {
 				ignoredFlags: sets.New[string](tt.ignored...),
 			}
 			result := c.computeDelta(tt.desired, tt.actual)
-			if !reflect.DeepEqual(tt.expected, result) {
-				t.Errorf("Expected %v, but got %v", tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 1 usage of `reflect.DeepEqual` in the `pkg/driftchecker/` package:

- `pkg/driftchecker/checker_test.go` (1 usage)

## Testing

All existing tests in `pkg/driftchecker/` continue to pass:

```bash
$ go test ./pkg/driftchecker/... -v
PASS
ok  	github.com/cilium/cilium/pkg/driftchecker	0.075s
```

## Follow-up

This is an incremental change affecting a single package. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185 (pkg/auth - merged)
- #42186 (pkg/hubble/filters - merged)
- #42322 (pkg/labelsfilter)

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/driftchecker tests for better error messages
```

