### PR TITLE
pkg/hubble/container: replace reflect.DeepEqual with assert.Equal in pkg/hubble/container

### DIFF
--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
 	"sync"
 	"testing"
 
@@ -397,9 +396,7 @@ func TestRing_Read(t *testing.T) {
 					t.Errorf("LostEvent mismatch (-want +got):\n%s", diff)
 				}
 			} else {
-				if !reflect.DeepEqual(got, tt.want) {
-					t.Errorf("Ring.read() got = %v, want %v", got, tt.want)
-				}
+				assert.Equal(t, tt.want, got)
 			}
 			if !errors.Is(got1, tt.wantErr) {
 				t.Errorf("Ring.read() got1 = %v, want %v", got1, tt.wantErr)
@@ -489,7 +486,7 @@ func TestRing_Write(t *testing.T) {
 				data: tt.want.data,
 			}
 			want.write.Store(tt.want.write)
-			reflect.DeepEqual(want, r)
+			assert.Equal(t, want, r)
 		})
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 2 usages of `reflect.DeepEqual` in the `pkg/hubble/container/` package:

- `pkg/hubble/container/ring_test.go` (2 usages)

## Testing

All existing tests in `pkg/hubble/container/` continue to pass:

```bash
$ go test ./pkg/hubble/container/... -v
PASS
ok  	github.com/cilium/cilium/pkg/hubble/container	0.247s
```

## Follow-up

This is an incremental change affecting a single package. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185 (pkg/auth - merged)
- #42186 (pkg/hubble/filters - merged)
- #42322 (pkg/labelsfilter)

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/hubble/container tests for better error messages
```