### PR TITLE
config: migrate two config options to their relevant cells

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -64,6 +64,7 @@ cilium-agent hive [flags]
       --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-gops                                               Enable gops server (default true)
+      --enable-health-check-loadbalancer-ip                       Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs --enable-health-check-nodeport to be enabled
       --enable-health-check-nodeport                              Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
       --enable-health-checking                                    Enable connectivity health checking (default true)
       --enable-hubble                                             Enable hubble server

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -185,6 +185,7 @@ cilium-agent hive [flags]
       --metrics strings                                           Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo, -metric_bar to disable metric_bar)
       --metrics-sampling-interval duration                        Set the internal metrics sampling interval (default 5m0s)
       --monitor-queue-size int                                    Size of the event queue when reading monitor events
+      --mtu int                                                   Overwrite auto-detected MTU of underlying network
       --multicast-enabled                                         Enables multicast in Cilium
       --nat-map-stats-entries int                                 Number k top stats entries to store locally in statedb (default 32)
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -190,6 +190,7 @@ cilium-agent hive dot-graph [flags]
       --metrics strings                                           Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo, -metric_bar to disable metric_bar)
       --metrics-sampling-interval duration                        Set the internal metrics sampling interval (default 5m0s)
       --monitor-queue-size int                                    Size of the event queue when reading monitor events
+      --mtu int                                                   Overwrite auto-detected MTU of underlying network
       --multicast-enabled                                         Enables multicast in Cilium
       --nat-map-stats-entries int                                 Number k top stats entries to store locally in statedb (default 32)
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -70,6 +70,7 @@ cilium-agent hive dot-graph [flags]
       --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-gops                                               Enable gops server (default true)
+      --enable-health-check-loadbalancer-ip                       Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs --enable-health-check-nodeport to be enabled
       --enable-health-check-nodeport                              Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
       --enable-health-checking                                    Enable connectivity health checking (default true)
       --enable-hubble                                             Enable hubble server

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -552,9 +552,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 		"Level of monitor aggregation for traces from the datapath")
 	option.BindEnvWithLegacyEnvFallback(vp, option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
 
-	flags.Int(option.MTUName, 0, "Overwrite auto-detected MTU of underlying network")
-	option.BindEnv(vp, option.MTUName)
-
 	flags.Int(option.RouteMetric, 0, "Overwrite the metric used by cilium when adding routes to its 'cilium_host' device")
 	option.BindEnv(vp, option.RouteMetric)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -226,9 +226,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.AgentHealthRequireK8sConnectivity, true, "Require Kubernetes connectivity in agent health endpoint")
 	option.BindEnv(vp, option.AgentHealthRequireK8sConnectivity)
 
-	flags.Bool(option.EnableHealthCheckLoadBalancerIP, defaults.EnableHealthCheckLoadBalancerIP, "Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs --enable-health-check-nodeport to be enabled")
-	option.BindEnv(vp, option.EnableHealthCheckLoadBalancerIP)
-
 	flags.Int(option.HealthCheckICMPFailureThreshold, defaults.HealthCheckICMPFailureThreshold, "Number of ICMP requests sent for each run of the health checker. If at least one ICMP response is received, the node or endpoint is marked as healthy.")
 	option.BindEnv(vp, option.HealthCheckICMPFailureThreshold)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -249,10 +249,6 @@ const (
 	// EnableEndpointHealthChecking
 	EnableEndpointHealthChecking = true
 
-	// EnableHealthCheckLoadBalancerIP is the default value for
-	// EnableHealthCheckLoadBalancerIP
-	EnableHealthCheckLoadBalancerIP = false
-
 	// HealthCheckICMPFailureThreshold is the default value for HealthCheckICMPFailureThreshold
 	HealthCheckICMPFailureThreshold = 3
 

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -80,6 +80,9 @@ const (
 	// level annotation for configuring bpf loadbalancing algorithm.
 	AlgorithmAnnotationName = "bpf-lb-algorithm-annotation"
 
+	// EnableHealthCheckLoadBalancerIP is the name of the EnableHealthCheckLoadBalancerIP option
+	EnableHealthCheckLoadBalancerIP = "enable-health-check-loadbalancer-ip"
+
 	// EnableHealthCheckNodePort is the name of the EnableHealthCheckNodePort option
 	EnableHealthCheckNodePortName = "enable-health-check-nodeport"
 
@@ -186,6 +189,10 @@ type UserConfig struct {
 	// AlgorithmAnnotation tells whether controller should check service
 	// level annotation for configuring bpf load balancing algorithm.
 	AlgorithmAnnotation bool `mapstructure:"bpf-lb-algorithm-annotation"`
+
+	// EnableHealthCheckLoadBalancerIP enables health checking of LoadBalancerIP
+	// by cilium
+	EnableHealthCheckLoadBalancerIP bool `mapstructure:"enable-health-check-loadbalancer-ip"`
 
 	// EnableHealthCheckNodePort enables health checking of NodePort by
 	// cilium
@@ -315,6 +322,7 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 
 	flags.Bool(AlgorithmAnnotationName, def.AlgorithmAnnotation, "Enable service-level annotation for configuring BPF load balancing algorithm")
 
+	flags.Bool(EnableHealthCheckLoadBalancerIP, def.EnableHealthCheckLoadBalancerIP, "Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs --enable-health-check-nodeport to be enabled")
 	flags.Bool(EnableHealthCheckNodePortName, def.EnableHealthCheckNodePort, "Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set")
 
 	flags.Duration("lb-pressure-metrics-interval", def.LBPressureMetricsInterval, "Interval for reporting pressure metrics for load-balancing BPF maps. 0 disables reporting.")
@@ -494,7 +502,8 @@ var DefaultUserConfig = UserConfig{
 
 	AlgorithmAnnotation: false,
 
-	EnableHealthCheckNodePort: true,
+	EnableHealthCheckLoadBalancerIP: false,
+	EnableHealthCheckNodePort:       true,
 
 	EnableServiceTopology: false,
 
@@ -529,7 +538,6 @@ type ExternalConfig struct {
 	BPFSocketLBHostnsOnly                  bool
 	EnableSocketLB                         bool
 	EnableSocketLBPodConnectionTermination bool
-	EnableHealthCheckLoadBalancerIP        bool
 }
 
 // NewExternalConfig maps the daemon config to [ExternalConfig].
@@ -542,7 +550,6 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
 		BPFSocketLBHostnsOnly:                  cfg.BPFSocketLBHostnsOnly,
 		EnableSocketLB:                         kprCfg.EnableSocketLB,
 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,
-		EnableHealthCheckLoadBalancerIP:        cfg.EnableHealthCheckLoadBalancerIP,
 	}
 }
 

--- a/pkg/loadbalancer/healthserver/healthserver.go
+++ b/pkg/loadbalancer/healthserver/healthserver.go
@@ -169,7 +169,7 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 					s.params.Writer.DeleteBackendsOfService(wtxn, healthServiceName, source.Local)
 					s.params.Writer.DeleteServiceAndFrontends(wtxn, healthServiceName)
 					wtxn.Commit()
-				} else if extCfg.EnableHealthCheckLoadBalancerIP {
+				} else if s.params.Config.EnableHealthCheckLoadBalancerIP {
 					// Create a LoadBalancer service to expose the health server on the $LB_VIP.
 					// For NodePort we don't need anything as the HealthServer is already listening on
 					// all node addresses.

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -93,9 +93,8 @@ func TestScript(t *testing.T) {
 					source.NewSources,
 					func(cfg loadbalancer.TestConfig) *option.DaemonConfig {
 						return &option.DaemonConfig{
-							EnableIPv4:                      true,
-							EnableIPv6:                      true,
-							EnableHealthCheckLoadBalancerIP: true,
+							EnableIPv4: true,
+							EnableIPv6: true,
 						}
 					},
 					func() kpr.KPRConfig {
@@ -113,6 +112,7 @@ func TestScript(t *testing.T) {
 			flags.Set("lb-retry-backoff-min", "10ms") // as we're doing fault injection we want
 			flags.Set("lb-retry-backoff-max", "10ms") // tiny backoffs
 			flags.Set("bpf-lb-maglev-table-size", "1021")
+			flags.Set("enable-health-check-loadbalancer-ip", "true")
 
 			// Parse the shebang arguments in the script.
 			require.NoError(t, flags.Parse(args), "flags.Parse")

--- a/pkg/loadbalancer/zz_generated.deepequal.go
+++ b/pkg/loadbalancer/zz_generated.deepequal.go
@@ -209,6 +209,9 @@ func (in *UserConfig) DeepEqual(other *UserConfig) bool {
 	if in.AlgorithmAnnotation != other.AlgorithmAnnotation {
 		return false
 	}
+	if in.EnableHealthCheckLoadBalancerIP != other.EnableHealthCheckLoadBalancerIP {
+		return false
+	}
 	if in.EnableHealthCheckNodePort != other.EnableHealthCheckNodePort {
 		return false
 	}

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -64,14 +64,17 @@ type mtuParams struct {
 type Config struct {
 	// Enable route MTU for pod netns when CNI chaining is used
 	EnableRouteMTUForCNIChaining bool
+	MTU                          int
 }
 
 var defaultConfig = Config{
 	EnableRouteMTUForCNIChaining: false,
+	MTU:                          0,
 }
 
 func (c Config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-route-mtu-for-cni-chaining", c.EnableRouteMTUForCNIChaining, "Enable route MTU for pod netns when CNI chaining is used")
+	flags.Int("mtu", c.MTU, "Overwrite auto-detected MTU of underlying network")
 }
 
 func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
@@ -89,7 +92,7 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 				tunnelOverIPv6,
 			)
 
-			configuredMTU := option.Config.MTU
+			configuredMTU := cc.MTU
 			if mtu := p.CNI.GetMTU(); mtu > 0 {
 				configuredMTU = mtu
 				p.Log.Info("Overwriting MTU based on CNI configuration", logfields.MTU, configuredMTU)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -729,9 +729,6 @@ const (
 	// EnableEndpointHealthChecking is the name of the EnableEndpointHealthChecking option
 	EnableEndpointHealthChecking = "enable-endpoint-health-checking"
 
-	// EnableHealthCheckLoadBalancerIP is the name of the EnableHealthCheckLoadBalancerIP option
-	EnableHealthCheckLoadBalancerIP = "enable-health-check-loadbalancer-ip"
-
 	// HealthCheckICMPFailureThreshold is the name of the HealthCheckICMPFailureThreshold option
 	HealthCheckICMPFailureThreshold = "health-check-icmp-failure-threshold"
 
@@ -1508,10 +1505,6 @@ type DaemonConfig struct {
 	// health endpoints
 	EnableEndpointHealthChecking bool
 
-	// EnableHealthCheckLoadBalancerIP enables health checking of LoadBalancerIP
-	// by cilium
-	EnableHealthCheckLoadBalancerIP bool
-
 	// HealthCheckICMPFailureThreshold is the number of ICMP packets sent for each health
 	// checking run. If at least an ICMP response is received, the node or endpoint
 	// is marked as healthy.
@@ -1889,7 +1882,6 @@ var (
 		IPAMDefaultIPPool:               defaults.IPAMDefaultIPPool,
 		EnableHealthChecking:            defaults.EnableHealthChecking,
 		EnableEndpointHealthChecking:    defaults.EnableEndpointHealthChecking,
-		EnableHealthCheckLoadBalancerIP: defaults.EnableHealthCheckLoadBalancerIP,
 		HealthCheckICMPFailureThreshold: defaults.HealthCheckICMPFailureThreshold,
 		EnableIPv4:                      defaults.EnableIPv4,
 		EnableIPv6:                      defaults.EnableIPv6,
@@ -2470,7 +2462,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.EnableEndpointRoutes = vp.GetBool(EnableEndpointRoutes)
 	c.EnableHealthChecking = vp.GetBool(EnableHealthChecking)
 	c.EnableEndpointHealthChecking = vp.GetBool(EnableEndpointHealthChecking)
-	c.EnableHealthCheckLoadBalancerIP = vp.GetBool(EnableHealthCheckLoadBalancerIP)
 	c.HealthCheckICMPFailureThreshold = vp.GetInt(HealthCheckICMPFailureThreshold)
 	c.EnableLocalNodeRoute = vp.GetBool(EnableLocalNodeRoute)
 	c.EnablePolicy = strings.ToLower(vp.GetString(EnablePolicy))

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -414,9 +414,6 @@ const (
 	// to disable transparent mode even if IPSec is enabled
 	DNSProxyInsecureSkipTransparentModeCheck = "dnsproxy-insecure-skip-transparent-mode-check"
 
-	// MTUName is the name of the MTU option
-	MTUName = "mtu"
-
 	// RouteMetric is the name of the route-metric option
 	RouteMetric = "route-metric"
 
@@ -2525,7 +2522,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.InstallIptRules = vp.GetBool(InstallIptRules)
 	c.MonitorAggregation = vp.GetString(MonitorAggregationName)
 	c.MonitorAggregationInterval = vp.GetDuration(MonitorAggregationInterval)
-	c.MTU = vp.GetInt(MTUName)
 	c.PreAllocateMaps = vp.GetBool(PreAllocateMapsName)
 	c.ProcFs = vp.GetString(ProcFs)
 	c.RestoreState = vp.GetBool(Restore)


### PR DESCRIPTION
Chip away at the global config definitions, and move two of them into a more fitting place.
