### PR TITLE
encrypt status: also check tcx attachment on interfaces

### DIFF
--- a/cilium-dbg/cmd/encrypt_status.go
+++ b/cilium-dbg/cmd/encrypt_status.go
@@ -19,6 +19,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/ebpf"
+	ebpf_link "github.com/cilium/ebpf/link"
+
 	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/command"
@@ -231,6 +234,32 @@ func isDecryptionInterface(link netlink.Link) (bool, error) {
 			}
 		}
 	}
+
+	progs, err := ebpf_link.QueryPrograms(
+		ebpf_link.QueryOptions{
+			Target: link.Attrs().Index,
+			Attach: ebpf.AttachTCXIngress,
+		},
+	)
+	if err != nil {
+		// probably not supported
+		return false, nil
+	}
+
+	for _, p := range progs.Programs {
+		prog, err := ebpf.NewProgramFromID(p.ID)
+		if err != nil {
+			return false, fmt.Errorf("failed to find program: %w for %d", err, p.ID)
+		}
+
+		if progInfo, err := prog.Info(); err == nil {
+			if strings.Contains(progInfo.Name, "cil_from_network") ||
+				strings.Contains(progInfo.Name, "cil_from_netdev") {
+				return true, nil
+			}
+		}
+	}
+
 	return false, nil
 }
 


### PR DESCRIPTION
right now, encrypt status doesn't show any interfaces when encryption is enabled and tcx attachment is used. in this commit, in addition to tc filter attach,
look for tcx attachments to determine the decryption interface

```
Fix `cilium encrypt status` command not displaying encryption interfaces when tcx attachment is used.
```
