### PR TITLE
metrics: fix counting of error and warning logs

### DIFF
--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -116,10 +116,7 @@ func (h *LoggingHook) Handle(ctx context.Context, record slog.Record) error {
 			panic(fmt.Sprintf("more than one subsys found in %s", record.Message))
 		}
 	}
-	if !logSysPresent {
-		return fmt.Errorf("log entry doesn't contain 'subsys' field: %s", record.Message)
-	}
-	if logSysValue.Kind() != slog.KindString {
+	if logSysPresent && logSysValue.Kind() != slog.KindString {
 		return fmt.Errorf("type of the 'subsystem' log entry field is not string but %s", logSysValue)
 	}
 
@@ -132,7 +129,11 @@ func (h *LoggingHook) Handle(ctx context.Context, record slog.Record) error {
 	}
 
 	// Increment the metric.
-	ErrorsWarnings.WithLabelValues(record.Level.String(), logSysValue.String()).Inc()
+	if logSysPresent {
+		ErrorsWarnings.WithLabelValues(record.Level.String(), logSysValue.String()).Inc()
+	} else {
+		ErrorsWarnings.WithLabelValues(record.Level.String(), "unspecified").Inc()
+	}
 
 	return nil
 }


### PR DESCRIPTION
Previously, error and warning logs that did not have a subsystem as attribute weren't reported in
`cilium_errors_warnings_total` metric. Instead, let's start reporting them with subsystem=unspecified label.

I would consider this as a bug, as some of the errors that previously were shown in  `cilium_errors_warnings_total` for version 1.17 were no longer visible on main, probably due to slog migration. 

```release-note
metrics: fix cilium_errors_warnings_total metric to report all errors and warnings. Previously, logs without subsystem attribute were not reported. Now they are reported with `unspecified` value of `subsystem` label. 
```
