### PR TITLE
renovate: disable major.minor update to goswagger on stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -292,6 +292,22 @@
         "docker.io/library/golang"
       ],
     },
+    // Do not allow any updates for major.minor on stable release branches to avoid churn from linters.
+    {
+      enabled: false,
+      matchPackageNames: [
+        'quay.io/goswagger/swagger',
+      ],
+      matchBaseBranches: [
+        "v1.18",
+        "v1.17",
+        "v1.16",
+      ],
+      matchUpdateTypes: [
+        'major',
+        'minor',
+      ],
+    },
     {
       // Do not allow any major and minor updates into stable branches.
       "enabled": false,


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
Update the renovate config to disable major and minor version updates to goswagger on stable release branches to avoid unnecessary churn from linter changes.


Related to: https://github.com/cilium/cilium/pull/42116

```release-note
Disable goswagger major and minor updates on stable release branches
```
