### PR TITLE
allow disabling Cilium Node CRD

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -81,6 +81,12 @@ func configureDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonP
 		}
 	}
 
+	if params.IPsecAgent.Enabled() || params.WGAgent.Enabled() {
+		if !option.Config.EnableCiliumNodeCRD {
+			return fmt.Errorf("CiliumNode CRD cannot be disabled when encryption is enabled with WireGuard (--%s) or IPsec (--%s)", wgTypes.EnableWireguard, datapath.EnableIPSec)
+		}
+	}
+
 	// IPAMENI IPSec is configured from Reinitialize() to pull in devices
 	// that may be added or removed at runtime.
 	if params.IPsecAgent.Enabled() &&
@@ -404,7 +410,9 @@ func configureDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonP
 	}
 
 	// Must occur after d.allocateIPs(), see GH-14245 and its fix.
-	params.NodeDiscovery.StartDiscovery(ctx)
+	if option.Config.EnableCiliumNodeCRD {
+		params.NodeDiscovery.StartDiscovery(ctx)
+	}
 
 	// Annotation of the k8s node must happen after discovery of the
 	// PodCIDR range and allocation of the health IPs.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -846,6 +846,10 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Uint8(option.IPTracingOptionType, 0, "Specifies what IPv4 option type should be used to extract trace information from a packet; a value of 0 (default) disables IP tracing.")
 	option.BindEnv(vp, option.IPTracingOptionType)
 
+	flags.Bool(option.EnableCiliumNodeCRDName, defaults.EnableCiliumNodeCRD, "Enable use of CiliumNode CRD")
+	flags.MarkHidden(option.EnableCiliumNodeCRDName)
+	option.BindEnv(vp, option.EnableCiliumNodeCRDName)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		logging.Fatal(logger, "BindPFlags failed", logfields.Error, err)
 	}
@@ -888,6 +892,8 @@ func initDaemonConfigAndLogging(vp *viper.Viper) {
 
 	// slogloggercheck: using default logger for configuration initialization
 	option.Config.Populate(logging.DefaultSlogLogger, vp)
+	// slogloggercheck: using default logger for configuration initialization
+	option.Config.PopulateEnableCiliumNodeCRD(logging.DefaultSlogLogger, vp)
 
 	// add hooks after setting up metrics in the option.Config
 	logging.AddHandlers(metrics.NewLoggingHook())

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -230,6 +230,7 @@ func (ds *DaemonSuite) setupConfigOptions() {
 	ds.hive.RegisterFlags(mockCmd.Flags())
 	InitGlobalFlags(ds.log, mockCmd, ds.hive.Viper())
 	option.Config.Populate(ds.log, ds.hive.Viper())
+	option.Config.PopulateEnableCiliumNodeCRD(ds.log, ds.hive.Viper())
 	option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore
 	option.Config.DryMode = true
 	option.Config.Opts = option.NewIntOptions(&option.DaemonMutableOptionLibrary)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -287,6 +287,10 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableNodeSelectorLabels, defaults.EnableNodeSelectorLabels, "Enable use of node label based identity")
 	option.BindEnv(vp, option.EnableNodeSelectorLabels)
 
+	flags.Bool(option.EnableCiliumNodeCRDName, defaults.EnableCiliumNodeCRD, "Enable CiliumNode CRD")
+	flags.MarkHidden(option.EnableCiliumNodeCRDName)
+	option.BindEnv(vp, option.EnableCiliumNodeCRDName)
+
 	vp.BindPFlags(flags)
 }
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -421,6 +421,7 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 	option.Config.SetupLogging(vp, binaryName)
 	// Populate the global config with the options from Viper
 	option.Config.Populate(logger, vp)
+	option.Config.PopulateEnableCiliumNodeCRD(logger, vp)
 
 	// Populate the operator config with the options from Viper
 	operatorOption.Config.Populate(logger, vp)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -551,6 +551,9 @@ const (
 
 	// IPTracingOptionType is the default value for option.IPTracingOptionType
 	IPTracingOptionType = 0
+
+	// EnableCiliumNodeCRD is the default value for option.EnableCiliumNodeCRD
+	EnableCiliumNodeCRD = true
 )
 
 var (

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -42,7 +42,6 @@ func CRDResourceName(crd string) string {
 
 func agentCRDResourceNames() []string {
 	result := []string{
-		CRDResourceName(v2.CNName),
 		CRDResourceName(v2.CIDName),
 		CRDResourceName(v2alpha1.CPIPName),
 	}
@@ -52,6 +51,10 @@ func agentCRDResourceNames() []string {
 		if option.Config.EnableCiliumEndpointSlice {
 			result = append(result, CRDResourceName(v2alpha1.CESName))
 		}
+	}
+
+	if option.Config.EnableCiliumNodeCRD {
+		result = append(result, CRDResourceName(v2.CNName))
 	}
 
 	if option.Config.EnableCiliumNetworkPolicy {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -82,6 +82,11 @@ func NewNodeDiscovery(
 	cniConfigManager cni.CNIConfigManager,
 	k8sNodeWatcher *watchers.K8sCiliumNodeWatcher,
 ) *NodeDiscovery {
+	if !option.Config.EnableCiliumNodeCRD {
+		logger.Info("CiliumNode CRD is disabled; skipping CiliumNode resource management")
+		return &NodeDiscovery{}
+	}
+
 	return &NodeDiscovery{
 		logger:           logger,
 		Manager:          manager,
@@ -158,6 +163,10 @@ func (n *NodeDiscovery) StartDiscovery(ctx context.Context) {
 // WaitForKVStoreSync blocks until kvstore synchronization of node information
 // completed. It returns immediately in CRD mode.
 func (n *NodeDiscovery) WaitForKVStoreSync(ctx context.Context) error {
+	if !option.Config.EnableCiliumNodeCRD { // Do not block if CiliumNode CRD is disabled
+		return nil
+	}
+
 	select {
 	case <-n.Registered:
 		return nil

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -678,6 +678,12 @@ func (d *statusCollector) getProbes() []Probe {
 					return backoff.CalculateDuration(5*time.Second, 2*time.Minute, 2.0, false, failures)
 				}
 
+				if !option.Config.EnableCiliumNodeCRD {
+					// When CiliumNode CRD is disabled, just use a constant base interval
+					// to validate connectivity.
+					return backoff.ClusterSizeDependantInterval(2*time.Minute, 0)
+				}
+
 				// The base interval is dependant on the
 				// cluster size. One status interval does not
 				// automatically translate to an apiserver


### PR DESCRIPTION
Add a hidden option to disable the CiliumNode CRD.

In certain cases, such as with IPAM mode DelegatedIPAM and when we don't use features such as encryption, the CiliumNode CRDs scale proportionally to cluster size while not being used. This is a limiting factor to achieving high cluster scale.

This PR will be followed up with a PR to GC the unused CiliumNodes.

(I think it is preferable not to have a release note for this change at this point, let me know if we feel differently.)