### PR TITLE
bpf: remove compat handling for some runtime configs

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1589,7 +1589,7 @@ exit:
 		goto drop_err;
 
 	send_trace_notify(ctx, TRACE_TO_NETWORK, src_sec_identity, dst_sec_identity,
-			  TRACE_EP_ID_UNKNOWN, THIS_INTERFACE_IFINDEX,
+			  TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
 			  trace.reason, trace.monitor, proto);
 
 	return ret;
@@ -1687,7 +1687,7 @@ int cil_to_host(struct __ctx_buff *ctx)
 	 * from 'cilium_host', mark the packet with MARK_MAGIC_SKIP_TPROXY
 	 * and allow it to enter the foward path once punted to stack.
 	 */
-	if (ctx->mark == 0 && THIS_INTERFACE_IFINDEX == CILIUM_NET_IFINDEX)
+	if (ctx->mark == 0 && CONFIG(interface_ifindex) == CILIUM_NET_IFINDEX)
 		ctx->mark = MARK_MAGIC_SKIP_TPROXY;
 #endif /* !TUNNEL_MODE */
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -449,7 +449,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
-	union macaddr router_mac = THIS_INTERFACE_MAC;
+	union macaddr router_mac = CONFIG(interface_mac);
 #endif
 	struct ct_buffer6 *ct_buffer;
 	void *data, *data_end;
@@ -888,7 +888,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	struct remote_endpoint_info *info;
 	struct ipv4_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
-	union macaddr router_mac = THIS_INTERFACE_MAC;
+	union macaddr router_mac = CONFIG(interface_mac);
 #endif
 	void *data, *data_end;
 	struct iphdr *ip4;
@@ -1436,12 +1436,12 @@ int tail_handle_ipv4(struct __ctx_buff *ctx)
 #ifdef ENABLE_ARP_RESPONDER
 /*
  * ARP responder for ARP requests from container
- * Respond to IPV4_GATEWAY with THIS_INTERFACE_MAC
+ * Respond to IPV4_GATEWAY with CONFIG(interface_mac)
  */
 __declare_tail(CILIUM_CALL_ARP)
 int tail_handle_arp(struct __ctx_buff *ctx)
 {
-	union macaddr mac = THIS_INTERFACE_MAC;
+	union macaddr mac = CONFIG(interface_mac);
 	union macaddr smac;
 	__be32 sip;
 	__be32 tip;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1545,7 +1545,7 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 	    bool from_tunnel)
 {
 	struct ct_state *ct_state, ct_state_new = {};
-	int ifindex = THIS_INTERFACE_IFINDEX;
+	int ifindex = CONFIG(interface_ifindex);
 	struct ipv6_ct_tuple *tuple;
 	bool is_untracked_fragment = false;
 	fraginfo_t fraginfo;
@@ -1742,7 +1742,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 #endif /* !ENABLE_ROUTING && !ENABLE_NODEPORT */
 
 		if (do_redirect)
-			ret = redirect_ep(ctx, THIS_INTERFACE_IFINDEX, from_host,
+			ret = redirect_ep(ctx, CONFIG(interface_ifindex), from_host,
 					  from_tunnel);
 		break;
 	default:
@@ -1845,7 +1845,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 	    bool from_tunnel)
 {
 	struct ct_state *ct_state, ct_state_new = {};
-	int ifindex = THIS_INTERFACE_IFINDEX;
+	int ifindex = CONFIG(interface_ifindex);
 	struct ipv4_ct_tuple *tuple;
 	fraginfo_t fraginfo;
 	bool is_untracked_fragment = false;
@@ -2063,7 +2063,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 #endif /* !ENABLE_ROUTING && !ENABLE_NODEPORT */
 
 		if (do_redirect)
-			ret = redirect_ep(ctx, THIS_INTERFACE_IFINDEX, from_host,
+			ret = redirect_ep(ctx, CONFIG(interface_ifindex), from_host,
 					  from_tunnel);
 		break;
 	default:

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -126,7 +126,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 #endif /* ENABLE_LOCAL_REDIRECT_POLICY && ENABLE_SOCKET_LB_FULL */
 		ret = lb4_local(get_ct_map4(&tuple), ctx, ETH_HLEN, fraginfo,
 				l4_off, &key, &tuple, svc, &ct_state_new,
-				false, &cluster_id, ext_err, ENDPOINT_NETNS_COOKIE);
+				false, &cluster_id, ext_err, CONFIG(endpoint_netns_cookie));
 
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {
@@ -202,7 +202,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 #endif /* ENABLE_LOCAL_REDIRECT_POLICY && ENABLE_SOCKET_LB_FULL */
 		ret = lb6_local(get_ct_map6(&tuple), ctx, ETH_HLEN, fraginfo,
 				l4_off, &key, &tuple, svc, &ct_state_new,
-				false, ext_err, ENDPOINT_NETNS_COOKIE);
+				false, ext_err, CONFIG(endpoint_netns_cookie));
 
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -169,7 +169,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	 */
 	if (1) {
 		union macaddr host_mac = CILIUM_HOST_MAC;
-		union macaddr router_mac = THIS_INTERFACE_MAC;
+		union macaddr router_mac = CONFIG(interface_mac);
 
 		ret = ipv6_l3(ctx, ETH_HLEN, (__u8 *)&router_mac.addr,
 			      (__u8 *)&host_mac.addr, METRIC_INGRESS);
@@ -202,7 +202,7 @@ static __always_inline int ipv4_host_delivery(struct __ctx_buff *ctx, struct iph
 {
 	if (1) {
 		union macaddr host_mac = CILIUM_HOST_MAC;
-		union macaddr router_mac = THIS_INTERFACE_MAC;
+		union macaddr router_mac = CONFIG(interface_mac);
 		int ret;
 
 		ret = ipv4_l3(ctx, ETH_HLEN, (__u8 *)&router_mac.addr,
@@ -476,7 +476,7 @@ __declare_tail(CILIUM_CALL_ARP)
 int tail_handle_arp(struct __ctx_buff *ctx)
 {
 	struct remote_endpoint_info fake_info = {0};
-	union macaddr mac = THIS_INTERFACE_MAC;
+	union macaddr mac = CONFIG(interface_mac);
 	union macaddr smac;
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_CT_REPLY,

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -364,7 +364,7 @@ out:
 #endif /* ENABLE_NODEPORT */
 
 	send_trace_notify(ctx, TRACE_TO_CRYPTO, src_sec_identity, UNKNOWN_ID,
-			  TRACE_EP_ID_UNKNOWN, THIS_INTERFACE_IFINDEX,
+			  TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
 			  trace.reason, trace.monitor, proto);
 
 	return TC_ACT_OK;

--- a/bpf/include/bpf/config/global.h
+++ b/bpf/include/bpf/config/global.h
@@ -11,7 +11,6 @@
 #include <lib/static_data.h>
 
 DECLARE_CONFIG(union macaddr, interface_mac, "MAC address of the interface the bpf program is attached to")
-#define THIS_INTERFACE_MAC CONFIG(interface_mac) /* Backwards compatibility */
 
 DECLARE_CONFIG(__u32, interface_ifindex, "ifindex of the interface the bpf program is attached to")
 

--- a/bpf/include/bpf/config/global.h
+++ b/bpf/include/bpf/config/global.h
@@ -14,6 +14,5 @@ DECLARE_CONFIG(union macaddr, interface_mac, "MAC address of the interface the b
 #define THIS_INTERFACE_MAC CONFIG(interface_mac) /* Backwards compatibility */
 
 DECLARE_CONFIG(__u32, interface_ifindex, "ifindex of the interface the bpf program is attached to")
-#define THIS_INTERFACE_IFINDEX CONFIG(interface_ifindex) /* Backwards compatibility */
 
 DECLARE_CONFIG(bool, secctx_from_ipcache, "Pull security context from IP cache")

--- a/bpf/include/bpf/config/lxc.h
+++ b/bpf/include/bpf/config/lxc.h
@@ -16,4 +16,3 @@ DECLARE_CONFIG(union v4addr, endpoint_ipv4, "The endpoint's IPv4 address")
 DECLARE_CONFIG(union v6addr, endpoint_ipv6, "The endpoint's IPv6 address")
 
 DECLARE_CONFIG(__u64, endpoint_netns_cookie, "The endpoint's network namespace cookie")
-#define ENDPOINT_NETNS_COOKIE CONFIG(endpoint_netns_cookie) /* Backwards compatibility */

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -42,7 +42,7 @@ static __always_inline int icmp6_load_type(struct __ctx_buff *ctx, int l4_off, _
 static __always_inline
 int icmp6_send_reply(struct __ctx_buff *ctx, int nh_off, union v6addr new_sip)
 {
-	union macaddr smac, dmac = THIS_INTERFACE_MAC;
+	union macaddr smac, dmac = CONFIG(interface_mac);
 	const int csum_off = nh_off + ICMP6_CSUM_OFFSET;
 	union v6addr sip, dip;
 	__be32 sum;
@@ -347,7 +347,7 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 {
 	union v6addr target, router = CONFIG(router_ipv6);
 	struct endpoint_info *ep;
-	union macaddr router_mac = THIS_INTERFACE_MAC;
+	union macaddr router_mac = CONFIG(interface_mac);
 
 	if (ctx_load_bytes(ctx, nh_off + ICMP6_ND_TARGET_OFFSET, target.addr,
 			   sizeof(((struct ipv6hdr *)NULL)->saddr)) < 0)

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -31,7 +31,6 @@ DECLARE_CONFIG(bool, enable_no_service_endpoints_routable,
 	       "Enable routes when service has 0 endpoints")
 DECLARE_CONFIG(__u16, device_mtu, "MTU of the device the bpf program is attached to (default: MTU set in node_config.h by agent)")
 ASSIGN_CONFIG(__u16, device_mtu, MTU)
-#define THIS_MTU CONFIG(device_mtu) /* Backwards compatibility */
 
 /* Evaluate the input values for detecting compilation errors.
  * Just blindly substituting this macro with the CTX_ACT_OK
@@ -181,7 +180,7 @@ static __always_inline bool dsr_is_too_big(struct __ctx_buff *ctx __maybe_unused
 					   __u16 expanded_len __maybe_unused)
 {
 #ifdef ENABLE_DSR_ICMP_ERRORS
-	if (expanded_len > THIS_MTU)
+	if (expanded_len > CONFIG(device_mtu))
 		return true;
 #endif
 	return false;
@@ -599,7 +598,7 @@ static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
 	union macaddr smac, dmac;
 	struct icmp6hdr icmp __align_stack_8 = {
 		.icmp6_type	= ICMPV6_PKT_TOOBIG,
-		.icmp6_mtu	= bpf_htonl(THIS_MTU - ohead),
+		.icmp6_mtu	= bpf_htonl(CONFIG(device_mtu) - ohead),
 	};
 	__u64 payload_len = sizeof(*ip6) + sizeof(icmp) + orig_dgram;
 	struct ipv6hdr ip __align_stack_8 = {
@@ -1984,7 +1983,7 @@ static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 		.code		= ICMP_FRAG_NEEDED,
 		.un = {
 			.frag = {
-				.mtu = bpf_htons(THIS_MTU - ohead),
+				.mtu = bpf_htons(CONFIG(device_mtu) - ohead),
 			},
 		},
 	};

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -202,7 +202,7 @@ nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
 		oif = fib_params->l.ifindex;
 
-		if (oif == THIS_INTERFACE_IFINDEX)
+		if (oif == CONFIG(interface_ifindex))
 			return CTX_ACT_OK;
 
 		return fib_do_redirect(ctx, true, fib_params, true, ret, oif, ext_err);
@@ -1335,7 +1335,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 
 		send_trace_notify(ctx, TRACE_TO_PROXY, src_sec_identity, UNKNOWN_ID,
 				  bpf_ntohs((__u16)svc->l7_lb_proxy_port),
-				  THIS_INTERFACE_IFINDEX, TRACE_REASON_POLICY, monitor,
+				  CONFIG(interface_ifindex), TRACE_REASON_POLICY, monitor,
 				  bpf_htons(ETH_P_IPV6));
 
 #  if defined(ENABLE_TPROXY)
@@ -2688,7 +2688,7 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 
 		send_trace_notify(ctx, TRACE_TO_PROXY, src_sec_identity, UNKNOWN_ID,
 				  bpf_ntohs(proxy_port),
-				  THIS_INTERFACE_IFINDEX, TRACE_REASON_POLICY, monitor,
+				  CONFIG(interface_ifindex), TRACE_REASON_POLICY, monitor,
 				  bpf_htons(ETH_P_IP));
 
 #  if defined(ENABLE_TPROXY)

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -85,7 +85,7 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
 	if (target.egress_gateway) {
 		/* Stay on the desired egress interface: */
-		if (target.ifindex && target.ifindex == THIS_INTERFACE_IFINDEX)
+		if (target.ifindex && target.ifindex == CONFIG(interface_ifindex))
 			goto apply_snat;
 
 		/* Send packet to the correct egress interface, and SNAT it there. */
@@ -141,7 +141,7 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 	 */
 	if (ret == CTX_ACT_OK)
 		send_trace_notify6(ctx, NODEPORT_OBS_POINT_EGRESS, src_id, UNKNOWN_ID,
-				   &saddr, TRACE_EP_ID_UNKNOWN, THIS_INTERFACE_IFINDEX,
+				   &saddr, TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
 				   trace.reason, trace.monitor);
 
 	return ret;
@@ -274,7 +274,7 @@ int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 
 	if (ret == CTX_ACT_OK)
 		send_trace_notify(ctx, NODEPORT_OBS_POINT_EGRESS, src_id, UNKNOWN_ID,
-				  TRACE_EP_ID_UNKNOWN, THIS_INTERFACE_IFINDEX,
+				  TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
 				  trace.reason, trace.monitor, bpf_htons(ETH_P_IPV6));
 
 	return ret;
@@ -343,7 +343,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 		struct endpoint_info *ep;
 
 		ep = __lookup_ip4_endpoint(ip4->saddr);
-		if (ep && ep->parent_ifindex && ep->parent_ifindex != THIS_INTERFACE_IFINDEX) {
+		if (ep && ep->parent_ifindex && ep->parent_ifindex != CONFIG(interface_ifindex)) {
 			/* This packet came from an endpoint with a parent interface and
 			 * it is currently not egressing on its parent interface.
 			 * Check if its a reply packet, if it is, redirect it to the
@@ -371,7 +371,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
 	if (target.egress_gateway) {
 		/* Stay on the desired egress interface: */
-		if (target.ifindex && target.ifindex == THIS_INTERFACE_IFINDEX)
+		if (target.ifindex && target.ifindex == CONFIG(interface_ifindex))
 			goto apply_snat;
 
 		/* Send packet to the correct egress interface, and SNAT it there. */
@@ -435,7 +435,7 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 	 */
 	if (ret == CTX_ACT_OK)
 		send_trace_notify4(ctx, NODEPORT_OBS_POINT_EGRESS, src_id, UNKNOWN_ID,
-				   saddr, TRACE_EP_ID_UNKNOWN, THIS_INTERFACE_IFINDEX,
+				   saddr, TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
 				   trace.reason, trace.monitor);
 
 	return ret;
@@ -576,7 +576,7 @@ int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 
 	if (ret == CTX_ACT_OK)
 		send_trace_notify(ctx, NODEPORT_OBS_POINT_EGRESS, src_id, UNKNOWN_ID,
-				  TRACE_EP_ID_UNKNOWN, THIS_INTERFACE_IFINDEX,
+				  TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
 				  trace.reason, trace.monitor, bpf_htons(ETH_P_IP));
 
 	return ret;

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -26,7 +26,7 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, struct iphdr *ip4,
 {
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
 	union macaddr host_mac = CILIUM_HOST_MAC;
-	union macaddr router_mac = THIS_INTERFACE_MAC;
+	union macaddr router_mac = CONFIG(interface_mac);
 #endif
 	int ret = 0;
 

--- a/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
+++ b/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
@@ -13,7 +13,9 @@
 
 #include "lib/bpf_lxc.h"
 
-ASSIGN_CONFIG(__u64, endpoint_netns_cookie, 5000)
+#define NETNS_COOKIE	5000
+
+ASSIGN_CONFIG(__u64, endpoint_netns_cookie, NETNS_COOKIE)
 
 #include "lib/lb.h"
 #include "lib/ipcache.h"
@@ -59,7 +61,7 @@ int v4_local_backend_to_service_setup(struct __ctx_buff *ctx)
 
 	/* Add the service in cilium_skip_lb4 to skip service translation for request originating from the local backend */
 	struct skip_lb4_key key = {
-		.netns_cookie = ENDPOINT_NETNS_COOKIE,
+		.netns_cookie = NETNS_COOKIE,
 		.address = V4_SERVICE_IP,
 		.port = SERVICE_PORT,
 	};
@@ -154,7 +156,7 @@ int v6_local_backend_to_service_setup(struct __ctx_buff *ctx)
 
 	/* Add the service in cilium_skip_lb6 to skip service translation for request originating from the local backend */
 	struct skip_lb6_key key __align_stack_8 = {
-		.netns_cookie = ENDPOINT_NETNS_COOKIE,
+		.netns_cookie = NETNS_COOKIE,
 		.port = SERVICE_PORT,
 	};
 	__u8 val = 0;

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -662,7 +662,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	fmt.Fprint(fw, assignConfig("identity_length", identity.GetClusterIDShift()))
 
 	fmt.Fprint(fw, declareConfig("interface_ifindex", uint32(0), "ifindex of the interface the bpf program is attached to"))
-	cDefinesMap["THIS_INTERFACE_IFINDEX"] = "CONFIG(interface_ifindex)"
 
 	// --- WARNING: THIS CONFIGURATION METHOD IS DEPRECATED, SEE FUNCTION DOC ---
 


### PR DESCRIPTION
Complete the switch-over for a few runtime configs where the code was still accessing them in the old style.
