### PR TITLE
.github/renovate: add missing search paths

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,8 +20,12 @@
   "gitAuthor": "cilium-renovate[bot] <134692979+cilium-renovate[bot]@users.noreply.github.com>",
   "includePaths": [
     ".github/actions/bpftrace/**",
+    ".github/actions/cosign/**",
     ".github/actions/e2e/**",
     ".github/actions/kvstore/**",
+    ".github/actions/gather-metrics/**",
+    ".github/actions/merge-artifacts/**",
+    ".github/actions/post-logic/**",
     ".github/actions/ginkgo/**",
     ".github/actions/lvh-kind/**",
     ".github/actions/set-env-variables/action.yml",


### PR DESCRIPTION
Some of the .github/actions were not being updated by renovate automatically due the missing search paths in its configuration.