### PR TITLE
iptables: Don't track tunneling traffic (v2)

### DIFF
--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -26,11 +27,13 @@ var Cell = cell.Module(
 	cell.Config(defaultConfig),
 	cell.ProvidePrivate(func(
 		cfg *option.DaemonConfig,
+		tunnelCfg tunnel.Config,
 		ipsecCfg datapath.IPsecConfig,
 		wgConfig wgTypes.WireguardConfig,
 	) SharedConfig {
 		return SharedConfig{
 			TunnelingEnabled:                cfg.TunnelingEnabled(),
+			TunnelPort:                      tunnelCfg.Port(),
 			NodeIpsetNeeded:                 cfg.NodeIpsetNeeded(),
 			IptablesMasqueradingIPv4Enabled: cfg.IptablesMasqueradingIPv4Enabled(),
 			IptablesMasqueradingIPv6Enabled: cfg.IptablesMasqueradingIPv6Enabled(),
@@ -91,6 +94,7 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 
 type SharedConfig struct {
 	TunnelingEnabled                bool
+	TunnelPort                      uint16
 	NodeIpsetNeeded                 bool
 	IptablesMasqueradingIPv4Enabled bool
 	IptablesMasqueradingIPv6Enabled bool

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/proxy/ipfamily"
@@ -339,6 +340,8 @@ type params struct {
 	JobGroup job.Group
 	DB       *statedb.DB
 	Devices  statedb.Table[*tables.Device]
+
+	TunnelCfg tunnel.Config
 }
 
 func newIptablesManager(p params) datapath.IptablesManager {
@@ -633,6 +636,51 @@ func (m *Manager) iptProxyRule(rules string, prog runnable, l4proto, ip string, 
 		"--on-port", tProxyPort,
 	}
 	return prog.runProg(rule)
+}
+
+func (m *Manager) installTunnelNoTrackRules(ip4tables, ip6tables runnable) error {
+	port := m.sharedCfg.TunnelPort
+
+	if !m.sharedCfg.TunnelingEnabled || port == 0 {
+		return nil
+	}
+
+	input := []string{
+		"-t", "raw",
+		"-A", ciliumPreRawChain,
+		"-p", "udp",
+		"--dport", strconv.Itoa(int(port)),
+		"-m", "comment", "--comment", "cilium: NOTRACK for tunnel traffic",
+		"-j", "CT", "--notrack",
+	}
+	output := []string{
+		"-t", "raw",
+		"-A", ciliumOutputRawChain,
+		"-p", "udp",
+		"--dport", strconv.Itoa(int(port)),
+		"-m", "comment", "--comment", "cilium: NOTRACK for tunnel traffic",
+		"-j", "CT", "--notrack",
+	}
+
+	if m.sharedCfg.EnableIPv4 && ip4tables != nil {
+		if err := ip4tables.runProg(input); err != nil {
+			return err
+		}
+		if err := ip4tables.runProg(output); err != nil {
+			return err
+		}
+	}
+
+	if m.sharedCfg.EnableIPv6 && ip6tables != nil {
+		if err := ip6tables.runProg(input); err != nil {
+			return err
+		}
+		if err := ip6tables.runProg(output); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (m *Manager) installStaticProxyRules() error {
@@ -1632,6 +1680,10 @@ func (m *Manager) installRules(state desiredState) error {
 
 			return fmt.Errorf("cannot add custom chain %s: %w", c.name, err)
 		}
+	}
+
+	if err := m.installTunnelNoTrackRules(m.ip4tables, m.ip6tables); err != nil {
+		return fmt.Errorf("cannot install tunnel no track rules: %w", err)
 	}
 
 	if err := m.installStaticProxyRules(); err != nil {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1694,6 +1694,10 @@ func (m *Manager) installRules(state desiredState) error {
 		return fmt.Errorf("cannot install encryption rules: %w", err)
 	}
 
+	if err := m.addCiliumAcceptTunnelRules(); err != nil {
+		return fmt.Errorf("cannot install accept tunnel rules: %w", err)
+	}
+
 	localDeliveryInterface := m.getDeliveryInterface(defaults.HostDevice)
 
 	if err := m.installForwardChainRules(defaults.HostDevice, localDeliveryInterface, ciliumForwardChain); err != nil {
@@ -1884,6 +1888,37 @@ func (m *Manager) addCiliumNoTrackEncryptionRules() (err error) {
 	if m.sharedCfg.EnableIPv6 {
 		return m.ciliumNoTrackEncryptionRules(m.ip6tables, "-I")
 	}
+	return nil
+}
+
+func (m *Manager) addCiliumAcceptTunnelRules() (err error) {
+	port := m.sharedCfg.TunnelPort
+
+	if !m.sharedCfg.TunnelingEnabled || port == 0 {
+		return nil
+	}
+
+	cmd := []string{
+		"-t", "filter",
+		"-A", ciliumOutputChain,
+		"-p", "udp",
+		"--dport", strconv.Itoa(int(port)),
+		"-m", "comment", "--comment", "cilium: ACCEPT for tunnel traffic",
+		"-j", "ACCEPT",
+	}
+
+	if m.sharedCfg.EnableIPv4 {
+		if err := m.ip4tables.runProg(cmd); err != nil {
+			return err
+		}
+	}
+
+	if m.sharedCfg.EnableIPv6 {
+		if err := m.ip6tables.runProg(cmd); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -873,6 +873,74 @@ func TestAllEgressMasqueradeCmds(t *testing.T) {
 	}
 }
 
+func testTunnelNoTrackRulesTunnelingEnabled(t *testing.T, port uint16) {
+	mockManager := &Manager{
+		sharedCfg: SharedConfig{
+			EnableIPv4:       true,
+			EnableIPv6:       true,
+			TunnelingEnabled: true,
+			TunnelPort:       port,
+		},
+	}
+
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
+
+	expected := "-t raw -A %s -p udp --dport %d -m comment --comment cilium: NOTRACK for tunnel traffic -j CT --notrack"
+
+	mockIp4tables.expectations = []expectation{
+		{args: fmt.Sprintf(expected, "CILIUM_PRE_raw", port)},
+		{args: fmt.Sprintf(expected, "CILIUM_OUTPUT_raw", port)},
+	}
+	mockIp6tables.expectations = mockIp4tables.expectations
+
+	if err := mockManager.installTunnelNoTrackRules(mockIp4tables, mockIp6tables); err != nil {
+		t.Error(err)
+	}
+
+	if err := mockIp4tables.checkExpectations(); err != nil {
+		t.Error(err)
+	}
+	if err := mockIp6tables.checkExpectations(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTunnelVxlanNoTrackRulesTunnelingEnabled(t *testing.T) {
+	testTunnelNoTrackRulesTunnelingEnabled(t, 8472)
+}
+
+func TestTunnelGeneveNoTrackRulesTunnelingEnabled(t *testing.T) {
+	testTunnelNoTrackRulesTunnelingEnabled(t, 6081)
+}
+
+func TestTunnelNoTrackRulesTunnelingDisabled(t *testing.T) {
+	mockManager := &Manager{
+		sharedCfg: SharedConfig{
+			EnableIPv4:       true,
+			EnableIPv6:       true,
+			TunnelingEnabled: false,
+		},
+	}
+
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
+	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
+
+	// With tunneling disabled, we don't expect any `iptables` or `ip6tables`
+	// rules to be added, so leave `mockIp6tables.expectations` empty.
+
+	if err := mockManager.installTunnelNoTrackRules(mockIp4tables, mockIp6tables); err != nil {
+		t.Error(err)
+	}
+
+	if err := mockIp4tables.checkExpectations(); err != nil {
+		t.Error(err)
+	}
+	if err := mockIp6tables.checkExpectations(); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestNoTrackHostPorts(t *testing.T) {
 	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}


### PR DESCRIPTION
Reintroduces https://github.com/cilium/cilium/pull/38782, which was reverted because it caused GKE tests to break due to pod to pod traffic being dropped when in tunnel mode. the goal of that change is to reduce pressure in handling conntrack states in the kernel for tunnel (node to node) packets.

the reason for it to make GKE tests fail is that for the GKE deployment, the OUTPUT chain in the filter table has its policy set to DROP. Cilium, currently does not install any rules that explicitly allow tunnel traffic in the outbound direction. however, tunnel traffic was still allowed in the GKE nodes because among other customizations in the iptables rules done by the provider we have an entry that accepts packets with NEW ctstate:

```
-A OUTPUT -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
```

when https://github.com/cilium/cilium/pull/38782 added a rule and we were no longer creating ctstates for tunnel packets, the rule above no longer matched such packets, which ended up getting dropped by the chain policy.

in this PR we bring back the original commit to not create conntrack entries for tunnel packets, and also add explicit rules to allow tunnel packets in the outbound direction.

Fixes: #42121

```release-note
Add iptables rule to allow tunnel traffic egressing the node when tunnel routing mode is used
```
