### PR TITLE
feat: Allow configuration of daemon hive.Run options

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -209,6 +209,9 @@ cilium-agent [flags]
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
       --health-check-icmp-failure-threshold int                   Number of ICMP requests sent for each run of the health checker. If at least one ICMP response is received, the node or endpoint is marked as healthy. (default 3)
   -h, --help                                                      help for cilium-agent
+      --hive-log-threshold duration                               Time limit after which a slow hook is logged at Info level (default 100ms)
+      --hive-start-timeout duration                               Maximum time to wait for startup hooks to complete before timing out (default 5m0s)
+      --hive-stop-timeout duration                                Maximum time to wait for stop hooks to complete before timing out (default 1m0s)
       --http-idle-timeout uint                                    Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
       --http-max-grpc-timeout uint                                Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
       --http-normalize-path                                       Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution. (default true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -167,6 +167,9 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	})
 
 	// Env bindings
+
+	hive.RegisterFlags(vp, flags)
+
 	flags.Int(option.AgentHealthPort, defaults.AgentHealthPort, "TCP port for agent health status API")
 	option.BindEnv(vp, option.AgentHealthPort)
 

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -49,7 +49,7 @@ func NewAgentCmd(hfn func() *hive.Hive) *cobra.Command {
 			// Initialize the daemon configuration and logging with the
 			// DefaultSlogLogger without any logfields.
 			// slogloggercheck: the logger has been initialized in the cobra.OnInitialize
-			if err := h.Run(logging.DefaultSlogLogger); err != nil {
+			if err := h.Run(logging.DefaultSlogLogger, hive.GetOptions(option.Config.HiveConfig)...); err != nil {
 				logging.Fatal(daemonLogger, fmt.Sprintf("unable to run agent: %s", err))
 			} else {
 				// If h.Run() exits with no errors, it means the agent gracefully shut down.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -7,6 +7,18 @@ import (
 	"time"
 )
 
+// Hive options
+const (
+	// HiveStartTimeout is the default value for option.HiveStartTimeout
+	HiveStartTimeout = 5 * time.Minute
+
+	// HiveStopTimeout is the default value for option.HiveStopTimeout
+	HiveStopTimeout = time.Minute
+
+	// HiveLogThreshold is the default value for option.HiveLogThreshold
+	HiveLogThreshold = 100 * time.Millisecond
+)
+
 const (
 	// AgentHealthPort is the default value for option.AgentHealthPort
 	AgentHealthPort = 9879

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -9,19 +9,23 @@ import (
 	"reflect"
 	"runtime/pprof"
 	"slices"
-	"time"
 
 	upstream "github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive/health"
 	"github.com/cilium/cilium/pkg/hive/health/types"
 	watcherMetrics "github.com/cilium/cilium/pkg/k8s/watchers/metrics"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 type (
@@ -104,12 +108,31 @@ func New(cells ...cell.Cell) *Hive {
 			ModulePrivateProviders: modulePrivateProviders,
 			ModuleDecorators:       moduleDecorators,
 			DecodeHooks:            decodeHooks,
-			StartTimeout:           5 * time.Minute,
-			StopTimeout:            1 * time.Minute,
-			LogThreshold:           100 * time.Millisecond,
+			StartTimeout:           defaults.HiveStartTimeout,
+			StopTimeout:            defaults.HiveStopTimeout,
+			LogThreshold:           defaults.HiveLogThreshold,
 		},
 		cells...,
 	)
+}
+
+func RegisterFlags(vp *viper.Viper, flags *pflag.FlagSet) {
+	flags.Duration(option.HiveStartTimeout, defaults.HiveStartTimeout, "Maximum time to wait for startup hooks to complete before timing out")
+	option.BindEnv(vp, option.HiveStartTimeout)
+
+	flags.Duration(option.HiveStopTimeout, defaults.HiveStopTimeout, "Maximum time to wait for stop hooks to complete before timing out")
+	option.BindEnv(vp, option.HiveStopTimeout)
+
+	flags.Duration(option.HiveLogThreshold, defaults.HiveLogThreshold, "Time limit after which a slow hook is logged at Info level")
+	option.BindEnv(vp, option.HiveLogThreshold)
+}
+
+func GetOptions(cfg option.HiveConfig) []upstream.RunOptionFunc {
+	return []upstream.RunOptionFunc{
+		upstream.WithStartTimeout(cfg.StartTimeout),
+		upstream.WithStopTimeout(cfg.StopTimeout),
+		upstream.WithLogThreshold(cfg.LogThreshold),
+	}
 }
 
 var decodeHooks = cell.DecodeHooks{


### PR DESCRIPTION
This change introduces the ability to configure the options passed to `hive.Run` for the Cilium daemon. Previously, these opts were hardcoded within `pkg/hive.New()` which made it impossible to modify without recompiling.

This commit adds a new `HiveConfig` structure to `pkg/option` which holds the parameters that can now be overridden in `cilium/hive.Run()`. By default, the values are set to be identical to the ones previously hardcoded in `pkg/hive.New()`, ensuring no functional change unless explicitly configured.

Change in `cilium/hive` which introduced Run options: https://github.com/cilium/hive/pull/60

Fixes: #41857 
