### PR TITLE
[cilium-envoy] Make affinity and updateStrategy extensible

### DIFF
--- a/install/kubernetes/cilium/templates/_extensions.tpl
+++ b/install/kubernetes/cilium/templates/_extensions.tpl
@@ -154,3 +154,23 @@ The template needs to allow overriding ports spec not just adding.
         {{- end }}
 {{- end }}
 
+{{/*
+Allow packagers to define update strategy for cilium-envoy pods.
+*/}}
+{{- define "envoy.updateStrategy" -}}
+{{- with .Values.envoy.updateStrategy }}
+updateStrategy:
+  {{- toYaml . | trim | nindent 2 }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Allow packagers to define affinity for cilium-envoy pods.
+*/}}
+{{- define "envoy.affinity" -}}
+{{- with .Values.envoy.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}     
+{{- end }}
+{{- end }}
+

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -22,10 +22,7 @@ spec:
   selector:
     matchLabels:
       k8s-app: cilium-envoy
-  {{- with .Values.envoy.updateStrategy }}
-  updateStrategy:
-    {{- toYaml . | trim | nindent 4 }}
-  {{- end }}
+  {{- include "envoy.updateStrategy" . | nindent 2 }}
   template:
     metadata:
       annotations:
@@ -224,10 +221,7 @@ spec:
       {{- if .Values.envoy.dnsPolicy }}
       dnsPolicy: {{ .Values.envoy.dnsPolicy }}
       {{- end }}
-      {{- with .Values.envoy.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "envoy.affinity" . | nindent 6  }}
       {{- with .Values.envoy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!-- Description of change -->

This change makes it possible to extend `affinity` and `updateStrategy` properties for Envoy daemonset. While users can now configure those values via helm chart there is no possibility to configure conditional values for those settings (e.g. if property X is enabled configure affinity with A and if X is disabled configure affinity with B).

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
