### PR TITLE
contrib:verifier_diff.py: Account for minimal plot height

### DIFF
--- a/contrib/scripts/verifier_diff.py
+++ b/contrib/scripts/verifier_diff.py
@@ -116,8 +116,11 @@ def plot_comparison(file1: str, file2: str, outdir: str):
         # Plot
         y_pos = np.arange(len(filtered_programs))
         bar_height = 0.35
+        fig_width = 10
+        fig_height = min(fig_width, max(fig_width//2,
+                                        bar_height * len(filtered_programs)))
 
-        plt.figure(figsize=(12, len(filtered_programs) * 0.5))
+        plt.figure(figsize=(fig_width, fig_height))
         bars_before = plt.barh(y_pos + bar_height/2, before_vals,
                                bar_height, label="Before", alpha=0.7)
         bars_after = plt.barh(y_pos - bar_height/2, after_vals,

--- a/contrib/scripts/verifier_diff.py
+++ b/contrib/scripts/verifier_diff.py
@@ -115,13 +115,13 @@ def plot_comparison(file1: str, file2: str, outdir: str):
 
         # Plot
         y_pos = np.arange(len(filtered_programs))
-        height = 0.35  # thickness of bars
+        bar_height = 0.35
 
         plt.figure(figsize=(12, len(filtered_programs) * 0.5))
-        bars_before = plt.barh(y_pos + height/2, before_vals,
-                               height, label="Before", alpha=0.7)
-        bars_after = plt.barh(y_pos - height/2, after_vals,
-                              height, label="After", alpha=0.7)
+        bars_before = plt.barh(y_pos + bar_height/2, before_vals,
+                               bar_height, label="Before", alpha=0.7)
+        bars_after = plt.barh(y_pos - bar_height/2, after_vals,
+                              bar_height, label="After", alpha=0.7)
 
         plt.yticks(y_pos, filtered_programs)
         plt.xlabel("insns_processed")


### PR DESCRIPTION
When plotting the verifier diff results, ensure that the plot height is
at least a certain minimum to maintain readability, even when there are
few programs being compared. This solves the case with only 1 column
to be displayed, which resulted in an overly compressed and unreadable plot.

Case with only 1 row:
<img width="991" height="490" alt="image" src="https://github.com/user-attachments/assets/d10b0dbc-6339-409e-8c2c-f91094350213" />

Case with maximum row:
<img width="904" height="908" alt="image" src="https://github.com/user-attachments/assets/a12fc400-a23a-4cb6-88ca-dde164b4810b" />

