### PR TITLE
datapath/linux/probes: Tolerate `ErrRestrictedKernel`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/cilium/charts v0.0.0-20251001191925-641dfafd068d
 	github.com/cilium/coverbee v0.3.3-0.20240723084546-664438750fce
 	github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
-	github.com/cilium/ebpf v0.19.1-0.20251013125301-c27ff922fc6a
+	github.com/cilium/ebpf v0.19.1-0.20251016154102-8f23ed69cf93
 	github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c
 	github.com/cilium/fake v0.7.0
 	github.com/cilium/hive v0.0.0-20251008073947-21f6f6e081b5

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62 h1:MOWY9eqnrr
 github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62/go.mod h1:9EU8oWNwEP6f98xJz/YjWw7yOLHK7p90MKmaPu1wBcE=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a h1:PRGN7B+72mj3OtLL2DM3F/9jp+ItgqgNS7mecgCmwsQ=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
-github.com/cilium/ebpf v0.19.1-0.20251013125301-c27ff922fc6a h1:fJ1fWcsXJzuYqUXC4I5IOs/Liu+8L5addmXkdO2v55s=
-github.com/cilium/ebpf v0.19.1-0.20251013125301-c27ff922fc6a/go.mod h1:pzLjFymM+uZPLk/IXZUL63xdx5VXEo+enTzxkZXdycw=
+github.com/cilium/ebpf v0.19.1-0.20251016154102-8f23ed69cf93 h1:lLkfSIKtk6cOpkbmh6E9xx6inCM7kLvz7H/IxhmA/Po=
+github.com/cilium/ebpf v0.19.1-0.20251016154102-8f23ed69cf93/go.mod h1:pzLjFymM+uZPLk/IXZUL63xdx5VXEo+enTzxkZXdycw=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba h1:Ddc5e+pz0/nY0XiAEW/UcIlvnaHACSuF77ePyMNX510=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba/go.mod h1:9MPoeojWVEBLFnioKXTvRoqGWTs9Dt252r1ACFsi8K8=
 github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c h1:+/SPdDam5Mha4QzOByEoBE7hfq8aUxnioItyKM48U6M=

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -191,7 +191,7 @@ var HaveBPFJIT = sync.OnceValue(func() error {
 	if err != nil {
 		return fmt.Errorf("get prog info: %w", err)
 	}
-	if _, err := info.JitedSize(); err != nil {
+	if _, err := info.JitedSize(); err != nil && !errors.Is(err, ebpf.ErrRestrictedKernel) {
 		return fmt.Errorf("get JITed prog size: %w", err)
 	}
 
@@ -411,7 +411,9 @@ func HaveDeadCodeElim() error {
 		return fmt.Errorf("get prog info: %w", err)
 	}
 	infoInst, err := info.Instructions()
-	if err != nil {
+	if errors.Is(err, ebpf.ErrRestrictedKernel) {
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("get instructions: %w", err)
 	}
 

--- a/vendor/github.com/cilium/ebpf/internal/feature.go
+++ b/vendor/github.com/cilium/ebpf/internal/feature.go
@@ -16,6 +16,10 @@ var ErrNotSupported = errors.New("not supported")
 // operating system.
 var ErrNotSupportedOnOS = fmt.Errorf("%w on %s", ErrNotSupported, runtime.GOOS)
 
+// ErrRestrictedKernel is returned when kernel address information is restricted
+// by kernel.kptr_restrict and/or net.core.bpf_jit_harden sysctls.
+var ErrRestrictedKernel = errors.New("restricted by kernel.kptr_restrict and/or net.core.bpf_jit_harden sysctls")
+
 // UnsupportedFeatureError is returned by FeatureTest() functions.
 type UnsupportedFeatureError struct {
 	// The minimum version required for this feature.

--- a/vendor/github.com/cilium/ebpf/internal/sys/ptr.go
+++ b/vendor/github.com/cilium/ebpf/internal/sys/ptr.go
@@ -28,6 +28,10 @@ type TypedPointer[T any] struct {
 	ptr Pointer
 }
 
+func (p TypedPointer[T]) IsNil() bool {
+	return p.ptr.ptr == nil
+}
+
 // SlicePointer creates a [TypedPointer] from a slice.
 func SlicePointer[T comparable](s []T) TypedPointer[T] {
 	return TypedPointer[T]{ptr: UnsafeSlicePointer(s)}

--- a/vendor/github.com/cilium/ebpf/internal/unix/errno_windows.go
+++ b/vendor/github.com/cilium/ebpf/internal/unix/errno_windows.go
@@ -37,6 +37,7 @@ const (
 	EILSEQ      Errno = 42
 	ENOTSUP     Errno = 129
 	EOPNOTSUPP  Errno = 130
+	EOTHER      Errno = 131
 	ETIMEDOUT   Errno = 138
 	EWOULDBLOCK Errno = 140
 )

--- a/vendor/github.com/cilium/ebpf/linker.go
+++ b/vendor/github.com/cilium/ebpf/linker.go
@@ -523,8 +523,11 @@ func resolveKsymReferences(insns asm.Instructions) error {
 		return nil
 	}
 
-	if err := kallsyms.AssignAddresses(symbols); err != nil {
-		return fmt.Errorf("resolve ksym addresses: %w", err)
+	err := kallsyms.AssignAddresses(symbols)
+	// Tolerate ErrRestrictedKernel during initial lookup, user may have all weak
+	// ksyms and a fallback path.
+	if err != nil && !errors.Is(err, ErrRestrictedKernel) {
+		return fmt.Errorf("resolve ksyms: %w", err)
 	}
 
 	var missing []string
@@ -542,6 +545,11 @@ func resolveKsymReferences(insns asm.Instructions) error {
 	}
 
 	if len(missing) > 0 {
+		if err != nil {
+			// Program contains required ksyms, return the error from above.
+			return fmt.Errorf("resolve required ksyms: %s: %w", strings.Join(missing, ","), err)
+		}
+
 		return fmt.Errorf("kernel is missing symbol: %s", strings.Join(missing, ","))
 	}
 

--- a/vendor/github.com/cilium/ebpf/struct_ops.go
+++ b/vendor/github.com/cilium/ebpf/struct_ops.go
@@ -1,0 +1,120 @@
+package ebpf
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/internal"
+)
+
+const structOpsValuePrefix = "bpf_struct_ops_"
+
+// structOpsFindInnerType returns the "inner" struct inside a value struct_ops type.
+//
+// Given a value like:
+//
+//	struct bpf_struct_ops_bpf_testmod_ops {
+//	    struct bpf_struct_ops_common common;
+//	    struct bpf_testmod_ops data;
+//	};
+//
+// this function returns the *btf.Struct for "bpf_testmod_ops" along with the
+// byte offset of the "data" member inside the value type.
+//
+// The inner struct name is derived by trimming the "bpf_struct_ops_" prefix
+// from the value's name.
+func structOpsFindInnerType(vType *btf.Struct) (*btf.Struct, uint32, error) {
+	innerName := strings.TrimPrefix(vType.Name, structOpsValuePrefix)
+
+	for _, m := range vType.Members {
+		if st, ok := btf.As[*btf.Struct](m.Type); ok && st.Name == innerName {
+			return st, m.Offset.Bytes(), nil
+		}
+	}
+
+	return nil, 0, fmt.Errorf("inner struct %q not found in %s", innerName, vType.Name)
+}
+
+// structOpsFindTarget resolves the kernel-side "value struct" for a struct_ops map.
+func structOpsFindTarget(userType *btf.Struct, cache *btf.Cache) (vType *btf.Struct, id btf.TypeID, module *btf.Handle, err error) {
+	// the kernel value type name, e.g. "bpf_struct_ops_<name>"
+	vTypeName := structOpsValuePrefix + userType.Name
+
+	target := btf.Type((*btf.Struct)(nil))
+	spec, module, err := findTargetInKernel(vTypeName, &target, cache)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("lookup value type %q: %w", vTypeName, err)
+	}
+
+	id, err = spec.TypeID(target)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	return target.(*btf.Struct), id, module, nil
+}
+
+// structOpsPopulateValue writes a `prog FD` which references to `p` into the
+// struct_ops value buffer `kernVData` at byte offset `dstOff` corresponding to
+// the member `km`.
+func structOpsPopulateValue(km btf.Member, kernVData []byte, p *Program) error {
+	kmPtr, ok := btf.As[*btf.Pointer](km.Type)
+	if !ok {
+		return fmt.Errorf("member %s is not a func pointer", km.Name)
+	}
+
+	if _, isFuncProto := btf.As[*btf.FuncProto](kmPtr.Target); !isFuncProto {
+		return fmt.Errorf("member %s is not a func pointer", km.Name)
+	}
+
+	dstOff := int(km.Offset.Bytes())
+	if dstOff < 0 || dstOff+8 > len(kernVData) {
+		return fmt.Errorf("member %q: value buffer too small for func ptr", km.Name)
+	}
+
+	internal.NativeEndian.PutUint64(kernVData[dstOff:dstOff+8], uint64(p.FD()))
+	return nil
+}
+
+// structOpsCopyMember copies a single member from the user struct (m)
+// into the kernel value struct (km) for struct_ops.
+func structOpsCopyMember(m, km btf.Member, data []byte, kernVData []byte) error {
+	mSize, err := btf.Sizeof(m.Type)
+	if err != nil {
+		return fmt.Errorf("sizeof(user.%s): %w", m.Name, err)
+	}
+	kSize, err := btf.Sizeof(km.Type)
+	if err != nil {
+		return fmt.Errorf("sizeof(kernel.%s): %w", km.Name, err)
+	}
+	if mSize != kSize {
+		return fmt.Errorf("size mismatch for %s: user=%d kernel=%d", m.Name, mSize, kSize)
+	}
+	if km.BitfieldSize > 0 || m.BitfieldSize > 0 {
+		return fmt.Errorf("bitfield %s not supported", m.Name)
+	}
+
+	srcOff := int(m.Offset.Bytes())
+	dstOff := int(km.Offset.Bytes())
+
+	if srcOff < 0 || srcOff+mSize > len(data) {
+		return fmt.Errorf("member %q: userdata is too small", m.Name)
+	}
+
+	if dstOff < 0 || dstOff+mSize > len(kernVData) {
+		return fmt.Errorf("member %q: value type is too small", m.Name)
+	}
+
+	// skip mods(const, restrict, volatile and typetag)
+	// and typedef to check type compatibility
+	mType := btf.UnderlyingType(m.Type)
+	kernMType := btf.UnderlyingType(km.Type)
+	if reflect.TypeOf(mType) != reflect.TypeOf(kernMType) {
+		return fmt.Errorf("unmatched member type %s != %s (kernel)", m.Name, km.Name)
+	}
+
+	copy(kernVData[dstOff:dstOff+mSize], data[srcOff:srcOff+mSize])
+	return nil
+}

--- a/vendor/github.com/cilium/ebpf/types.go
+++ b/vendor/github.com/cilium/ebpf/types.go
@@ -144,7 +144,7 @@ func (mt MapType) hasPerCPUValue() bool {
 // canStoreMapOrProgram returns true if the Map stores references to another Map
 // or Program.
 func (mt MapType) canStoreMapOrProgram() bool {
-	return mt.canStoreMap() || mt.canStoreProgram()
+	return mt.canStoreMap() || mt.canStoreProgram() || mt == StructOpsMap
 }
 
 // canStoreMap returns true if the map type accepts a map fd

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -264,7 +264,7 @@ github.com/cilium/deepequal-gen/generators
 # github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
 ## explicit; go 1.18
 github.com/cilium/dns
-# github.com/cilium/ebpf v0.19.1-0.20251013125301-c27ff922fc6a
+# github.com/cilium/ebpf v0.19.1-0.20251016154102-8f23ed69cf93
 ## explicit; go 1.24.0
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm


### PR DESCRIPTION
Environments like GKE COS enable BPF JIT hardening (`net.core.bpf_jit_harden=2`). With this enabled, `BPF_OBJ_GET_INFO_BY_FD` does not provide xlated instructions, JITed instructions, or other related info in its response when querying program info. So, any Cilium feature that relies on these fields won't work. Currently, there are three such places:
    
1. The `HaveBPFJIT` probe calls info.JitedSize() to determine if the program was JITed.
2. The `HaveDeadCodeElim` probe calls info.Instructions() to inspect the final BPF instructions to see if dead code elimination was applied.
3. `verifyUnusedMaps` calls info.Instructions() in an attempt to walk the final program instructions and see which maps are referenced after dead code elimination.

Recently, cilium/ebpf#1858 started returning `ErrRestrictedKernel` when querying these fields in such environments. Before, these probes would silently fail, but now they fail loudly blocking Cilium startup.
    
`verifyUnusedMaps` hits ErrRestrictedKernel when querying program instructions. AFAICT this does not impact functionality.
    
```
msg="verifying unused maps: getting instructions for program tail_icmp6_send_time_exceeded: instructions: restricted by kernel.kptr_restrict and/or net.core.bpf_jit_harden sysctls" module=agent.datapath.loader
```

The version bump to cilium/ebpf in cilium/cilium was reverted in cilium/cilium#42327 to fix these probe failures, so undo this and forward fix Cilium by tolerating ErrRestrictedKernel in the probes. This reverts Cilium back to its previous behavior, silently ignoring these probe failures in environments where BPF JIT hardening is enabled, while allowing cilium/ebpf to be upgraded.

Signed-off-by: Jordan Rife <jrife@google.com>
