### PR TITLE
bpf: conntrack: don't signal CT GC when inserting to CT map fails

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1024,7 +1024,7 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 
 		err = map_update_elem(map_related, &icmp_tuple, &entry, 0);
 		if (unlikely(err < 0))
-			goto err_ct_fill_up;
+			goto drop_err;
 	}
 
 #ifdef CONNTRACK_ACCOUNTING
@@ -1034,15 +1034,13 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 
 	err = map_update_elem(map_main, tuple, &entry, 0);
 	if (unlikely(err < 0))
-		goto err_ct_fill_up;
+		goto drop_err;
 
 	return 0;
 
-err_ct_fill_up:
+drop_err:
 	if (ext_err)
 		*ext_err = (__s8)err;
-	if (err == -ENOMEM)
-		send_signal_ct_fill_up(ctx, SIGNAL_PROTO_V6);
 	return DROP_CT_CREATE_FAILED;
 }
 
@@ -1081,7 +1079,7 @@ static __always_inline int ct_create4(const void *map_main,
 
 		err = map_update_elem(map_related, &icmp_tuple, &entry, 0);
 		if (unlikely(err < 0))
-			goto err_ct_fill_up;
+			goto drop_err;
 	}
 
 #ifdef CONNTRACK_ACCOUNTING
@@ -1095,15 +1093,13 @@ static __always_inline int ct_create4(const void *map_main,
 	 */
 	err = map_update_elem(map_main, tuple, &entry, 0);
 	if (unlikely(err < 0))
-		goto err_ct_fill_up;
+		goto drop_err;
 
 	return 0;
 
-err_ct_fill_up:
+drop_err:
 	if (ext_err)
 		*ext_err = (__s8)err;
-	if (err == -ENOMEM)
-		send_signal_ct_fill_up(ctx, SIGNAL_PROTO_V4);
 	return DROP_CT_CREATE_FAILED;
 }
 


### PR DESCRIPTION
e26284484c55 ("bpf: Only send fillup signal to agent on ENOMEM error") recently fine-tuned the SIGNAL_PROTO_V* path when inserting a CT entry fails.

As Daniel described in https://github.com/cilium/cilium/pull/41864, there's only one exotic case in the kernel code that returns an -ENOMEM. And it's not specififically related to the CT map - so we shouldn't expect a CT garbage-collection (expensive!) to make any noticeable difference to this condition.

Thus don't bother with special-casing ENOMEM here, and simplify the error path. We continue to send SIGNAL_PROTO_V* from the NAT engine when we expect a CT GC to free up stale NAT ports.