### PR TITLE
modularization:wireguard:ipsec inject C macros from cell

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -233,14 +233,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_SCTP"] = "1"
 	}
 
-	if cfg.EnableWireguard {
-		cDefinesMap["ENABLE_WIREGUARD"] = "1"
-
-		if option.Config.EncryptNode {
-			cDefinesMap["ENABLE_NODE_ENCRYPTION"] = "1"
-		}
-	}
-
 	if option.Config.ServiceNoBackendResponse == option.ServiceNoBackendResponseReject {
 		cDefinesMap["SERVICE_NO_BACKEND_RESPONSE"] = "1"
 	}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -233,10 +233,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_SCTP"] = "1"
 	}
 
-	if cfg.EnableIPSec {
-		cDefinesMap["ENABLE_IPSEC"] = "1"
-	}
-
 	if cfg.EnableWireguard {
 		cDefinesMap["ENABLE_WIREGUARD"] = "1"
 

--- a/pkg/datapath/linux/ipsec/cell.go
+++ b/pkg/datapath/linux/ipsec/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/maps/encrypt"
 	"github.com/cilium/cilium/pkg/node"
@@ -39,9 +40,20 @@ type params struct {
 	EncryptMap     encrypt.EncryptMap
 }
 
-// newIPsecAgent returns the [*Agent] as an interface [types.IPsecAgent].
-func newIPsecAgent(p params) types.IPsecAgent {
-	return newAgent(p.Lifecycle, p.Log, p.JobGroup, p.LocalNodeStore, p.Config, p.EncryptMap)
+// newIPsecAgent returns the [*Agent] as an interface [types.IPsecAgent]
+// and the map of macros [defines.NodeOut] for datapath compilation.
+func newIPsecAgent(p params) (out struct {
+	cell.Out
+	types.IPsecAgent
+	defines.NodeOut
+}) {
+	out.IPsecAgent = newAgent(p.Lifecycle, p.Log, p.JobGroup, p.LocalNodeStore, p.Config, p.EncryptMap)
+	if out.IPsecAgent.Enabled() {
+		out.NodeDefines = map[string]string{
+			"ENABLE_IPSEC": "1",
+		}
+	}
+	return
 }
 
 // newIPsecAgent returns the [Config] as an interface [types.IPsecConfig].


### PR DESCRIPTION
With the IPSec and WireGuard agent modularization being merged, we can now move the flag definition from WriteNodeConfig to the cells. The IPSec and Wireguard cells now return the map of C defines to be injected in the compilation (ENABLE_IPSEC, ENABLE_WIREGUARD, ENABLE_NODE_ENCRYPTION), alongside the agents .