### PR TITLE
datapath/loader: Add route reconciler initializer

### DIFF
--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -4,17 +4,28 @@
 package loader
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net"
 	"path/filepath"
 	"testing"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	"github.com/spf13/afero"
 
 	"github.com/cilium/cilium/pkg/cidr"
+	routeReconciler "github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
 )
 
 var (
@@ -51,13 +62,48 @@ func setupCompilationDirectories(tb testing.TB) {
 
 func newTestLoader(tb testing.TB) *loader {
 	setupCompilationDirectories(tb)
-	logger := hivetest.Logger(tb)
 
-	l := newLoader(Params{
-		Logger: logger,
-		Sysctl: sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
-	})
-	cw := configWriterForTest(tb)
-	l.templateCache = newObjectCache(logger, cw, tb.TempDir())
+	var l *loader
+	err := hive.New(
+		cell.Invoke(func(ld datapath.Loader) {
+			l = ld.(*loader)
+		}),
+		Cell,
+
+		routeReconciler.TableCell,
+		cell.Provide(tables.NewDeviceTable), cell.Provide(statedb.RWTable[*tables.Device].ToTable),
+		cell.Provide(func() (
+			sysctl.Sysctl,
+			datapath.ConfigWriter,
+			*manager.NodeConfigNotifier,
+			promise.Promise[endpointstate.Restorer],
+			datapath.PreFilter,
+		) {
+			resolver, promise := promise.New[endpointstate.Restorer]()
+			resolver.Resolve(&FakeRestorer{})
+			return sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
+				configWriterForTest(tb),
+				&manager.NodeConfigNotifier{},
+				promise,
+				&FakePreFilter{}
+		}),
+	).Populate(hivetest.Logger(tb))
+	if err != nil {
+		tb.Fatal(err)
+	}
+
 	return l
 }
+
+type FakeRestorer struct{}
+
+func (fr *FakeRestorer) WaitForEndpointRestore(ctx context.Context) error { return nil }
+func (fr *FakeRestorer) WaitForInitialPolicy(ctx context.Context) error   { return nil }
+
+type FakePreFilter struct{}
+
+func (fpf *FakePreFilter) Enabled() bool                                  { return true }
+func (fpf *FakePreFilter) WriteConfig(fw io.Writer)                       {}
+func (fpf *FakePreFilter) Dump(to []string) ([]string, int64)             { return nil, 0 }
+func (fpf *FakePreFilter) Insert(revision int64, cidrs []net.IPNet) error { return nil }
+func (fpf *FakePreFilter) Delete(revision int64, cidrs []net.IPNet) error { return nil }


### PR DESCRIPTION
In a previous PR we switched the loader over to using the route reconciler to install routes. But we missed adding of an initializer.

This resulted dropped packets in the brief moment between pruning and re-adding the routes.

An initializer ensures the route reconciler does not start removing routes from the kernel before we had a chance to initially populate the desired routes. Preventing the temporary loss of connectivity.

This commit adds logic that registers the initializer during loader construction and adds a one-shot job to the loader which waits for the endpoint restorer to signal it is done restoring endpoints, and then finalizes the route reconciler initializer.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
