### PR TITLE
[envoy] Make useOrginalSourceAddress configurable

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1636,6 +1636,10 @@
      - cilium-envoy update strategy ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#updating-a-daemonset
      - object
      - ``{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}``
+   * - :spelling:ignore:`envoy.useOriginalSourceAddress`
+     - For cases when CiliumEnvoyConfig is not used directly (Ingress, Gateway), configures Cilium BPF Metadata listener filter  to use the original source address when extracting the metadata for a request.
+     - bool
+     - ``true``
    * - :spelling:ignore:`envoy.xffNumTrustedHopsL7PolicyEgress`
      - Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -459,6 +459,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for cilium-envoy DaemonSet. |
 | envoy.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for envoy scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | envoy.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | cilium-envoy update strategy ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#updating-a-daemonset |
+| envoy.useOriginalSourceAddress | bool | `true` | For cases when CiliumEnvoyConfig is not used directly (Ingress, Gateway), configures Cilium BPF Metadata listener filter  to use the original source address when extracting the metadata for a request. |
 | envoy.xffNumTrustedHopsL7PolicyEgress | int | `0` | Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners. |
 | envoy.xffNumTrustedHopsL7PolicyIngress | int | `0` | Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners. |
 | envoyConfig.enabled | bool | `false` | Enable CiliumEnvoyConfig CRD CiliumEnvoyConfig CRD can also be implicitly enabled by other options. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1368,6 +1368,7 @@ data:
   proxy-max-connection-duration-seconds: {{ .Values.envoy.maxConnectionDurationSeconds | quote }}
   proxy-idle-timeout-seconds: {{ .Values.envoy.idleTimeoutDurationSeconds | quote }}
   proxy-max-concurrent-retries: {{ .Values.envoy.maxConcurrentRetries | quote }}
+  proxy-use-original-source-address: {{ .Values.envoy.useOriginalSourceAddress | quote }}
   http-retry-count: {{ .Values.envoy.httpRetryCount | quote }}
 
   external-envoy-proxy: {{ include "envoyDaemonSetEnabled" . | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2477,6 +2477,9 @@
           },
           "type": "object"
         },
+        "useOriginalSourceAddress": {
+          "type": "boolean"
+        },
         "xffNumTrustedHopsL7PolicyEgress": {
           "type": "integer"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2472,6 +2472,9 @@ envoy:
   xffNumTrustedHopsL7PolicyIngress: 0
   # -- Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
   xffNumTrustedHopsL7PolicyEgress: 0
+  # -- For cases when CiliumEnvoyConfig is not used directly (Ingress, Gateway), configures Cilium BPF Metadata listener filter 
+  # to use the original source address when extracting the metadata for a request.
+  useOriginalSourceAddress: true
   # @schema
   # type: [null, string]
   # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2493,6 +2493,9 @@ envoy:
   xffNumTrustedHopsL7PolicyIngress: 0
   # -- Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
   xffNumTrustedHopsL7PolicyEgress: 0
+  # -- For cases when CiliumEnvoyConfig is not used directly (Ingress, Gateway), configures Cilium BPF Metadata listener filter 
+  # to use the original source address when extracting the metadata for a request.
+  useOriginalSourceAddress: true
   # @schema
   # type: [null, string]
   # @schema

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -71,14 +71,19 @@ type Config struct {
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
 	EnableXTSocketFallback bool
+
+	// Controls if an L7 proxy can use POD's original source address and port in
+	// the upstream connection.
+	ProxyUseOriginalSourceAddress bool
 }
 
 var defaultConfig = Config{
-	IPTablesLockTimeout:        5 * time.Second,
-	PrependIptablesChains:      true,
-	DisableIptablesFeederRules: []string{},
-	IPTablesRandomFully:        false,
-	EnableXTSocketFallback:     true,
+	IPTablesLockTimeout:           5 * time.Second,
+	PrependIptablesChains:         true,
+	DisableIptablesFeederRules:    []string{},
+	IPTablesRandomFully:           false,
+	EnableXTSocketFallback:        true,
+	ProxyUseOriginalSourceAddress: true,
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
@@ -87,6 +92,8 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("iptables-random-fully", def.IPTablesRandomFully, "Set iptables flag random-fully on masquerading rules")
 	flags.Bool("prepend-iptables-chains", def.PrependIptablesChains, "Prepend custom iptables chains instead of appending")
 	flags.Bool("enable-xt-socket-fallback", def.EnableXTSocketFallback, "Enable fallback for missing xt_socket module")
+	flags.Bool("proxy-use-original-source-address", false, "For cases when CiliumEnvoyConfig is not used directly (Ingress, Gateway), controls if Cilium BPF Metadata listener filter should use the original source address when extracting the metadata for a request.")
+
 }
 
 type SharedConfig struct {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -539,9 +539,9 @@ func (m *Manager) disableIPEarlyDemux() {
 // the upstream connection to allow the destination to properly derive the source security ID from
 // the source IP address.
 func (m *Manager) SupportsOriginalSourceAddr() bool {
-	// Original source address use works if xt_socket match is supported, or if ip early demux
-	// is disabled
-	return m.haveSocketMatch || m.ipEarlyDemuxDisabled
+	// Original source address will be used if `ProxyUseOriginalSourceAddress` is enabled via config
+	// and if either xt_socket match is supported or if ip early demux is disabled.
+	return m.cfg.ProxyUseOriginalSourceAddress && (m.haveSocketMatch || m.ipEarlyDemuxDisabled)
 }
 
 // removeRules removes iptables rules installed by Cilium.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
For cases when CiliumEnvoyConfig is not used directly (Ingress, Gateway), make it possible to configure Cilium BPF Metadata listener filter to use the original source address when extracting the metadata for a request. With current implementation, is not configurable and will be set to true if either `xt_socket match is supported, or if ip early demux is disabled`.

Fixes: #issue-number

