### PR TITLE
bpf: nodeport: consolidate NAT_46X64 recircle logic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -24,6 +24,8 @@
 # define VLAN_FILTER(ifindex, vlan_id) return false;
 #endif
 
+#define	NODEPORT_USE_NAT_46x64		1
+
 #include "lib/common.h"
 #include "lib/config_map.h"
 #include "lib/edt.h"
@@ -622,13 +624,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 
 			int ret = nodeport_lb4(ctx, ip4, ETH_HLEN, secctx, punt_to_stack,
 					       ext_err, &is_dsr);
-#ifdef ENABLE_IPV6
-			if (ret == NAT_46X64_RECIRC) {
-				ctx_store_meta(ctx, CB_SRC_LABEL, secctx);
-				return tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV,
-							  ext_err);
-			}
-#endif
+
 			/* nodeport_lb4() returns with TC_ACT_REDIRECT for
 			 * traffic to L7 LB. Policy enforcement needs to take
 			 * place after L7 LB has processed the packet, so we

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -37,6 +37,8 @@
  */
 #undef ENABLE_HEALTH_CHECK
 
+#define	NODEPORT_USE_NAT_46x64		1
+
 #include "lib/common.h"
 #include "lib/drop.h"
 #include "lib/eps.h"
@@ -184,9 +186,6 @@ no_encap:
 #endif /* ENABLE_DSR && !ENABLE_DSR_BYUSER && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE */
 
 		ret = nodeport_lb4(ctx, ip4, l3_off, UNKNOWN_ID, &punt_to_stack, &ext_err, &is_dsr);
-		if (ret == NAT_46X64_RECIRC)
-			ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV,
-						 &ext_err);
 	}
 
 out:

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -226,7 +226,6 @@ struct srv6_policy_key6 {
 #define NAT_PUNT_TO_STACK	DROP_NAT_NOT_NEEDED
 
 #define NAT_NEEDED		CTX_ACT_OK
-#define NAT_46X64_RECIRC	100
 
 /* Cilium metrics reasons for forwarding packets and other stats.
  * If reason is larger than below then this is a drop reason and

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2802,9 +2802,15 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 	}
 #endif
 	if (lb4_to_lb6_service(svc)) {
+		if (!is_defined(ENABLE_IPV6) || !is_defined(NODEPORT_USE_NAT_46x64))
+			return DROP_NO_SERVICE;
+
 		ret = lb4_to_lb6(ctx, ip4, l3_off);
-		if (!ret)
-			return NAT_46X64_RECIRC;
+		if (!ret) {
+			ctx_store_meta(ctx, CB_SRC_LABEL, src_sec_identity);
+			return tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV,
+						  ext_err);
+		}
 	} else {
 		ret = lb4_local(get_ct_map4(tuple), ctx, fraginfo, l4_off,
 				key, tuple, svc, &ct_state_svc, &backend,


### PR DESCRIPTION
Make the NAT46x64 codeflow a bit easier to follow by the casual reader.

Right now we return a special return value to the calling program, which then tail-calls back into nodeport.h logic. But instead we can just perform the tail-call straight from the nodeport code flow.

While at it also fully constrain this handling to the usage by XDP and from-netdev. And consistently check whether IPv6 is enabled.