### PR TITLE
codeowners: Make `cilium/gke` responsible for GKE workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -126,6 +126,7 @@
 # - @cilium/alibabacloud
 # - @cilium/aws
 # - @cilium/azure
+# - @cilium/gke
 #
 # Cilium Internals
 # ++++++++++++++++
@@ -262,6 +263,7 @@
 /.github/workflows/conformance-aks.yaml @cilium/azure @cilium/ipsec @cilium/github-sec @cilium/ci-structure
 /.github/workflows/conformance-aws-cni.yaml @cilium/aws @cilium/github-sec @cilium/ci-structure
 /.github/workflows/conformance-eks.yaml @cilium/aws @cilium/ipsec @cilium/github-sec @cilium/ci-structure
+/.github/workflows/conformance-gke.yaml @cilium/gke @cilium/ipsec @cilium/github-sec @cilium/ci-structure
 /.github/workflows/conformance-kind-proxy-embedded.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure
 /.github/workflows/tests-ces-migrate.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
 /.gitignore @cilium/contributing

--- a/Documentation/codeowners.rst
+++ b/Documentation/codeowners.rst
@@ -129,6 +129,7 @@ specific cloud providers:
 - `@cilium/alibabacloud <https://github.com/orgs/cilium/teams/alibabacloud>`__
 - `@cilium/aws <https://github.com/orgs/cilium/teams/aws>`__
 - `@cilium/azure <https://github.com/orgs/cilium/teams/azure>`__
+- `@cilium/gke <https://github.com/orgs/cilium/teams/gke>`__
 
 Cilium Internals
 ++++++++++++++++


### PR DESCRIPTION
Make [cilium/gke](https://github.com/orgs/cilium/teams/gke) responsible for GKE workflows.

* Corresponding teams change in cilium/community: https://github.com/cilium/community/pull/316