### PR TITLE
feat(chart): Add ability to configure emptyDir (sizeLimit/medium)

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2460,6 +2460,10 @@
      - base64 encoded PEM values for the Hubble UI client key (deprecated). Use existingSecret instead.
      - string
      - ``""``
+   * - :spelling:ignore:`hubble.ui.tmpVolume`
+     - Configure temporary volume for hubble-ui
+     - object
+     - ``{}``
    * - :spelling:ignore:`hubble.ui.tolerations`
      - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
@@ -3640,6 +3644,10 @@
      - Name of TLS Interception secret namespace.
      - string
      - ``"cilium-secrets"``
+   * - :spelling:ignore:`tmpVolume`
+     - Configure temporary volume for cilium-agent
+     - object
+     - ``{}``
    * - :spelling:ignore:`tolerations`
      - Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -665,6 +665,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.tls.client.cert | string | `""` | base64 encoded PEM values for the Hubble UI client certificate (deprecated). Use existingSecret instead. |
 | hubble.ui.tls.client.existingSecret | string | `""` | Name of the Secret containing the client certificate and key for Hubble UI If specified, cert and key are ignored. |
 | hubble.ui.tls.client.key | string | `""` | base64 encoded PEM values for the Hubble UI client key (deprecated). Use existingSecret instead. |
+| hubble.ui.tmpVolume | object | `{}` | Configure temporary volume for hubble-ui |
 | hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | hubble.ui.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for hubble-ui |
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
@@ -960,6 +961,7 @@ contributors across the globe, there is almost always someone available to help.
 | tls.secretsNamespace | object | `{"create":true,"name":"cilium-secrets"}` | Configures where secrets used in CiliumNetworkPolicies will be looked for |
 | tls.secretsNamespace.create | bool | `true` | Create secrets namespace for TLS Interception secrets. |
 | tls.secretsNamespace.name | string | `"cilium-secrets"` | Name of TLS Interception secret namespace. |
+| tmpVolume | object | `{}` | Configure temporary volume for cilium-agent |
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | tunnelPort | int | Port 8472 for VXLAN, Port 6081 for Geneve | Configure VXLAN and Geneve tunnel port. |
 | tunnelProtocol | string | `"vxlan"` | Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -851,7 +851,11 @@ spec:
       {{- if $buildDaemonConfig }}
       # For sharing configuration between the "config" initContainer and the agent
       - name: tmp
+        {{- if .Values.tmpVolume }}
+          {{- toYaml .Values.tmpVolume | nindent 8 }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       {{- else }}
       # To read the configuration from the config map
       - name: cilium-config-path

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -184,8 +184,12 @@ spec:
           defaultMode: 420
           name: hubble-ui-nginx
         name: hubble-ui-nginx-conf
-      - emptyDir: {}
-        name: tmp-dir
+      - name: tmp-dir
+        {{- if .Values.hubble.ui.tmpVolume }}
+          {{- toYaml .Values.hubble.ui.tmpVolume | nindent 8 }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
       {{- if .Values.hubble.relay.tls.server.enabled }}
       - name: hubble-ui-client-certs
       {{- if .Values.hubble.ui.standalone.enabled }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3781,6 +3781,9 @@
               },
               "type": "object"
             },
+            "tmpVolume": {
+              "type": "object"
+            },
             "tolerations": {
               "items": {},
               "type": "array"
@@ -5929,6 +5932,9 @@
           "type": "object"
         }
       },
+      "type": "object"
+    },
+    "tmpVolume": {
       "type": "object"
     },
     "tolerations": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -863,6 +863,12 @@ daemon:
   #
   # By default, this functionality is enabled
   enableSourceIPVerification: true
+# -- Configure temporary volume for cilium-agent
+tmpVolume: {}
+# emptyDir:
+#   sizeLimit: "100Mi"
+#   medium: "Memory"
+
 # -- Specify which network interfaces can run the eBPF datapath. This means
 # that a packet sent from a pod to a destination outside the cluster will be
 # masqueraded (to an output device IPv4 address), if the output device runs the
@@ -1938,6 +1944,11 @@ hubble:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+    # -- Configure temporary volume for hubble-ui
+    tmpVolume: {}
+    # emptyDir:
+    #   # sizeLimit: "100Mi"
+    #   # medium: "Memory"
   # -- Hubble flows export.
   export:
     # --- Static exporter configuration.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -867,6 +867,13 @@ daemon:
   #
   # By default, this functionality is enabled
   enableSourceIPVerification: true
+
+# -- Configure temporary volume for cilium-agent
+tmpVolume: {}
+  # emptyDir:
+  #   sizeLimit: "100Mi"
+  #   medium: "Memory"
+
 # -- Specify which network interfaces can run the eBPF datapath. This means
 # that a packet sent from a pod to a destination outside the cluster will be
 # masqueraded (to an output device IPv4 address), if the output device runs the
@@ -1948,6 +1955,13 @@ hubble:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+
+    # -- Configure temporary volume for hubble-ui
+    tmpVolume: {}
+      # emptyDir:
+      #   # sizeLimit: "100Mi"
+      #   # medium: "Memory"
+
   # -- Hubble flows export.
   export:
     # --- Static exporter configuration.


### PR DESCRIPTION
The use case for this change is that we set `sizeLimit` on all `emptyDir`s within our platform. I am unsure whether to be generic as in my approach or if you prefer a single field which sets only the sizeLimit field.

Sadly there is not yet a standard within the Helm community how this field should be named. At least `tmpVolume` follows `kubernetes-sigs/metrics-server`, argo-workflows and kyverno policy-reporter no name a few known projects.

---
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
