### PR TITLE
fix: advertise Gateway API services via local proxy detection

### DIFF
--- a/pkg/bgp/test/commands/svc.go
+++ b/pkg/bgp/test/commands/svc.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/hive/script"
+
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+)
+
+// SvcScriptCmds returns script commands for manipulating services in tests.
+func SvcScriptCmds(w *writer.Writer) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"svc/set-proxy-redirect": SvcSetProxyRedirectCmd(w),
+	}
+}
+
+// SvcSetProxyRedirectCmd sets ProxyRedirect on a service, simulating that the
+// local Envoy proxy is configured to handle traffic for this service.
+// This is used to test BGP advertisement of Gateway API/Ingress services.
+func SvcSetProxyRedirectCmd(w *writer.Writer) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Set ProxyRedirect on a service to simulate local Envoy proxy",
+			Args:    "namespace/name [proxy-port]",
+			Detail: []string{
+				"Sets ProxyRedirect on the specified service, indicating that the local",
+				"Envoy proxy is configured to handle traffic for this service.",
+				"",
+				"This simulates the behavior of CiliumEnvoyConfig reconciler when Envoy",
+				"is running locally. Used for testing BGP advertisement of Gateway API",
+				"and Ingress services.",
+				"",
+				"The proxy-port argument is optional (default: 10000).",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) < 1 {
+				return nil, fmt.Errorf("usage: svc/set-proxy-redirect namespace/name [proxy-port]")
+			}
+
+			parts := strings.Split(args[0], "/")
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid service name format %q, expected namespace/name", args[0])
+			}
+			namespace, name := parts[0], parts[1]
+
+			proxyPort := uint16(10000)
+			if len(args) > 1 {
+				port, err := strconv.ParseUint(args[1], 10, 16)
+				if err != nil {
+					return nil, fmt.Errorf("invalid proxy port %q: %w", args[1], err)
+				}
+				proxyPort = uint16(port)
+			}
+
+			return func(*script.State) (stdout, stderr string, err error) {
+				svcName := loadbalancer.NewServiceName(namespace, name)
+
+				wtxn := w.WriteTxn()
+				defer wtxn.Abort()
+
+				// Get and update the service
+				svc, _, found := w.Services().Get(wtxn, loadbalancer.ServiceByName(svcName))
+				if !found {
+					return "", "", fmt.Errorf("service %s not found", svcName)
+				}
+
+				// Clone and set ProxyRedirect
+				svc = svc.Clone()
+				svc.ProxyRedirect = &loadbalancer.ProxyRedirect{
+					ProxyPort: proxyPort,
+					Ports:     []uint16{80, 443},
+				}
+
+				// UpsertService also calls updateServiceReferences internally,
+				// which updates all frontends to point to the new service.
+				if _, err := w.UpsertService(wtxn, svc); err != nil {
+					return "", "", fmt.Errorf("failed to upsert service: %w", err)
+				}
+
+				wtxn.Commit()
+				return fmt.Sprintf("Set ProxyRedirect (port=%d) on service %s\n", proxyPort, svcName), "", nil
+			}, nil
+		},
+	)
+}

--- a/pkg/bgp/test/testdata/svc-gateway-proxy-redirect.txtar
+++ b/pkg/bgp/test/testdata/svc-gateway-proxy-redirect.txtar
@@ -1,0 +1,136 @@
+#! --test-peering-ips=10.99.5.101,10.99.5.102
+
+# Tests BGP advertisement of Gateway API / Ingress services with local proxy (Envoy).
+# These services should be advertised via BGP even with externalTrafficPolicy: Local
+# and no local backends, because traffic is handled by the local Envoy proxy.
+#
+# The BGP reconciler uses Service.ProxyRedirect to detect if local Envoy is handling
+# the service. When ProxyRedirect is non-nil, the service is advertised regardless
+# of backend availability.
+
+# Start the hive
+hive start
+
+# Configure gobgp server
+gobgp/add-server test 65010 10.99.5.101 1790
+
+# Configure peers on GoBGP
+gobgp/add-peer 10.99.5.102 65001
+
+# Add Gateway service (without endpoints)
+k8s/add service-gateway.yaml
+
+# Configure BGP on Cilium
+k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
+
+# Wait for peering to be established
+gobgp/wait-state 10.99.5.102 ESTABLISHED
+
+# Set ProxyRedirect on the service to simulate local Envoy proxy handling traffic.
+# This triggers BGP reconciliation and causes the service to be advertised.
+svc/set-proxy-redirect default/cilium-gateway-my-gateway
+
+# Validate that LoadBalancer IP is advertised with eTP=Local and no backends
+# (because ProxyRedirect is set, indicating local Envoy is handling traffic)
+gobgp/routes -o routes.actual
+* cmp gobgp-routes-gateway.expected routes.actual
+
+#####
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  addresses:
+  - ip: 10.99.5.102
+    type: InternalIP
+  ipam:
+    podCIDRs:
+    - 10.244.1.0/24
+
+-- bgp-node-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfig
+metadata:
+  name: test-node
+spec:
+  bgpInstances:
+  - localASN: 65001
+    name: tor-65001
+    peers:
+    - name: gobgp-peer-1
+      peerASN: 65010
+      peerAddress: 10.99.5.101
+      localAddress: 10.99.5.102
+      peerConfigRef:
+        name: gobgp-peer-config
+
+-- bgp-peer-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: gobgp-peer-config
+spec:
+  transport:
+    peerPort: 1790
+  timers:
+    connectRetryTimeSeconds: 1
+  families:
+  - afi: ipv4
+    safi: unicast
+    advertisements:
+      matchLabels:
+        advertise: bgp
+
+-- bgp-advertisement.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  name: lb-only
+  labels:
+    advertise: bgp
+spec:
+  advertisements:
+  - advertisementType: Service
+    service:
+      addresses:
+        - LoadBalancerIP
+    selector:
+      matchExpressions:
+        - { key: io.cilium/gateway-api, operator: In, values: [ "true" ] }
+
+-- service-gateway.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-my-gateway
+  namespace: default
+  labels:
+    io.cilium/gateway-api: "true"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  clusterIP: 10.96.100.1
+  clusterIPs:
+  - 10.96.100.1
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    io.cilium/gateway-owning-gateway: my-gateway
+  sessionAffinity: None
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.18.255.200
+
+-- gobgp-routes-gateway.expected --
+Prefix              NextHop       Attrs
+172.18.255.200/32   10.99.5.102   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.5.102}]

--- a/pkg/bgp/test/testdata/svc-traffic-policy.txtar
+++ b/pkg/bgp/test/testdata/svc-traffic-policy.txtar
@@ -42,7 +42,7 @@ gobgp/routes -o routes.actual
 # Update endpoints for the LB service (local endpoint exists)
 k8s/update endpoints-local.yaml
 
-# Validate that all svc IPs are advertised again
+# Validate that all svc IPs are advertised now
 gobgp/routes -o routes.actual
 * cmp gobgp-routes-all.expected routes.actual
 

--- a/pkg/datapath/linux/route/route_darwin.go
+++ b/pkg/datapath/linux/route/route_darwin.go
@@ -9,15 +9,14 @@ import (
 	"fmt"
 
 	"github.com/vishvananda/netlink"
-
-	"github.com/cilium/cilium/pkg/mtu"
 )
 
 // errUnsupportedOp is a common error
 var errUnsupportedOp = fmt.Errorf("Route operations not supported on Darwin")
 
 // Replace is not supported on Darwin and will return an error at runtime.
-func Replace(route Route, mtuConfig mtu.Configuration) error {
+// The mtuConfig parameter is ignored as this is a stub implementation.
+func Replace(route Route, mtuConfig any) error {
 	return errUnsupportedOp
 }
 


### PR DESCRIPTION
## Summary

Gateway API and Ingress services use dummy endpoints (192.192.192.192:9999) because traffic goes through Envoy, not actual pod backends. The BGP reconciler was checking `externalTrafficPolicy=Local` and wouldn't advertise when there were "no local endpoints."

**Changes:**
1. Detect Gateway/Ingress services by label (`io.cilium/gateway-api`, `io.cilium.gateway/owning-gateway`, `cilium.io/ingress`)
2. Only advertise from nodes where Envoy is running and ready
3. Verify Envoy readiness by querying the admin socket's `/ready` endpoint

This handles deployments where `cilium-envoy` has a `nodeSelector` - nodes without Envoy won't advertise Gateway routes.

Fixes #41680

## Test plan
- [x] Unit tests updated with mock `hasLocalEnvoyFunc`
- [x] Script tests use mock Envoy HTTP server on Unix socket
- [x] Existing `svc-gateway-dummy-endpoints.txtar` validates Gateway advertisement

```release-note
Fix BGP advertisement of Cilium Ingress / Gateway service's LoadBalancer IP with externalTrafficPolicy=Local
```