### PR TITLE
ciliumendpoint-gc: skip ciliumendpoints which are too new

### DIFF
--- a/operator/endpointgc/gc_test.go
+++ b/operator/endpointgc/gc_test.go
@@ -58,7 +58,7 @@ func TestRegisterController(t *testing.T) {
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	// wait for all CEPs to be deleted except for those with running pods or
 	// cilium node owner reference
-	waitForCEPs(t, cepStore, 2)
+	waitForCEPs(t, cepStore, 3)
 	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
@@ -134,7 +134,7 @@ func TestRegisterControllerWithCRDDisabled(t *testing.T) {
 	// wait for potential GC
 	time.Sleep(500 * time.Millisecond)
 	// gc is disabled so no CEPs should be deleted
-	waitForCEPs(t, cepStore, 6)
+	waitForCEPs(t, cepStore, 7)
 	if err := hive.Stop(tlog, t.Context()); err != nil {
 		t.Fatalf("failed to stop: %s", err)
 	}
@@ -170,6 +170,10 @@ func prepareCiliumEndpoints(t *testing.T, fakeClient *k8sClient.FakeClientset) {
 	cepWithOwnerPodDoesntExist := createCiliumEndpoint("cep6", "ns")
 	cepWithOwnerPodDoesntExist.OwnerReferences = []meta_v1.OwnerReference{createOwnerReference("Pod", "pod6")}
 	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(t.Context(), cepWithOwnerPodDoesntExist, meta_v1.CreateOptions{})
+	// - CEP that is just created
+	cepWithRecentCreationTime := createCiliumEndpoint("cep7", "ns")
+	cepWithRecentCreationTime.CreationTimestamp = meta_v1.Now()
+	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(t.Context(), cepWithRecentCreationTime, meta_v1.CreateOptions{})
 
 	// Create Pods
 	// - pod that is running for cep2


### PR DESCRIPTION
I have see real production occurrences when a ciliumendpoint was just created, but then immediately deleted by cilium operator. The timing is a strong indicator that we have hit this [known flaw][1] where it is possible to delete a ciliumendpoint because the operator haven't received the pod notification. To reduce the chance of this happenning further, I propose that we wait for at least one interval before starting to delete a just-created ciliumendpoint.

[1]: https://github.com/cilium/cilium/blob/2e216d1d735073932074497e1687c73bc2f56d1f/operator/endpointgc/gc.go#L134-L137

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

```release-note
cilium-operator: ciliumendpoints are not garbage collected until a minimum age is reached (5m by default)
```
