### PR TITLE
gh: fine-tune renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -331,17 +331,6 @@
       ]
     },
     {
-      // Do not ping helm/kind since the last version (1.10.0) has a bug which
-      // prevents it from downloading kubectl in older versions.
-      "enabled": false,
-      "matchDepNames": [
-        "helm/kind-action"
-      ],
-      "matchUpdateTypes": [
-        "digest"
-      ]
-    },
-    {
       "matchFiles": [
         "install/kubernetes/Makefile.values"
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -220,12 +220,6 @@
       "matchUpdateTypes": [
         "patch"
       ],
-      matchBaseBranches: [
-        "main",
-        "v1.18",
-        "v1.17",
-        "v1.16",
-      ]
     },
     {
       // Do not allow any updates into stable branches.
@@ -439,12 +433,6 @@
       "matchDepNames": [
         "cilium/cilium-cli"
       ],
-      "matchBaseBranches": [
-        "main",
-        "v1.18",
-        "v1.17",
-        "v1.16",
-      ]
     },
     {
       "groupName": "Hubble CLI",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -231,9 +231,7 @@
         "go.sum"
       ],
       matchBaseBranches: [
-        "v1.18",
-        "v1.17",
-        "v1.16"
+        "!main",
       ]
     },
     {
@@ -297,9 +295,7 @@
         'quay.io/goswagger/swagger',
       ],
       matchBaseBranches: [
-        "v1.18",
-        "v1.17",
-        "v1.16",
+        "!main",
       ],
       matchUpdateTypes: [
         'major',
@@ -319,9 +315,7 @@
         "minor",
       ],
       matchBaseBranches: [
-        "v1.18",
-        "v1.17",
-        "v1.16",
+        "!main",
       ]
     },
     {
@@ -464,9 +458,7 @@
         "golangci/golangci-lint"
       ],
       "matchBaseBranches": [
-        "v1.18",
-        "v1.17",
-        "v1.16",
+        "!main",
       ]
     },
     {
@@ -496,9 +488,7 @@
       ],
       "allowedVersions": "!/bpf-next-.*/",
       "matchBaseBranches": [
-        "v1.18",
-        "v1.17",
-        "v1.16",
+        "!main",
       ],
     },
     {
@@ -753,9 +743,7 @@
         "major"
       ],
       "matchBaseBranches": [
-        "v1.18",
-        "v1.17",
-        "v1.16",
+        "!main",
       ]
     },
     {
@@ -769,9 +757,7 @@
         "minor",
       ],
       "matchBaseBranches": [
-        "v1.18",
-        "v1.17",
-        "v1.16",
+        "!main",
       ]
     }
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -397,17 +397,6 @@
       ]
     },
     {
-      "matchPackageNames": [
-        "quay.io/cilium/certgen",
-      ],
-      "allowedVersions": "<0.2.0",
-      "matchBaseBranches": [
-        "v1.18",
-        "v1.17",
-        "v1.16",
-      ]
-    },
-    {
       // Disable major updates for go-github as those require updating import paths
       "enabled": false,
       "matchPackageNames": [


### PR DESCRIPTION
Remove some stale dependency configs. Also simplify the `matchBaseBranches` statement in a few places, so that we don't need to refresh them on every minor release.