### PR TITLE
v1.16: endpoint: stop tracking selectorPolicy

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -377,10 +377,6 @@ type Endpoint struct {
 
 	hasBPFProgram chan struct{}
 
-	// selectorPolicy represents a reference to the shared SelectorPolicy
-	// for all endpoints that have the same Identity.
-	selectorPolicy policy.SelectorPolicy
-
 	// desiredPolicy is the policy calculated during regeneration. After
 	// successful regeneration, it is copied to realizedPolicy
 	// To write, both ep.mutex and ep.buildMutex must be held.
@@ -595,6 +591,8 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 		logLimiter:       logging.NewLimiter(10*time.Second, 3), // 1 log / 10 secs, burst of 3
 		noTrackPort:      0,
 		properties:       map[string]interface{}{},
+
+		forcePolicyCompute: true,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -951,6 +949,7 @@ func parseEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, name
 	ep.hasBPFProgram = make(chan struct{})
 	ep.desiredPolicy = policy.NewEndpointPolicy(policyGetter.GetPolicyRepository())
 	ep.realizedPolicy = ep.desiredPolicy
+	ep.forcePolicyCompute = true
 	ep.controllers = controller.NewManager()
 	ep.regenFailedChan = make(chan struct{}, 1)
 

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -171,6 +171,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	// Continuously compute policy for the pod and ensure we never missed an incremental update.
 	for {
 		t.Log("Calculating policy...")
+		ep.forcePolicyCompute = true
 		res, err := ep.regeneratePolicy(stats)
 		assert.Nil(t, err)
 


### PR DESCRIPTION
This backports f99742e3f636812138a1b40ee149b45fad11919a in order to fix a policy deadlock often seen in v1.16. Its somewhat hard to reproduce, but when it happens, its very hard (if not impossible) to debug, and the endpoint looks healthy - but its completely stuck until it gets a new identity.

We have also reproduced this issue on v1.15 as well, but only opening this on v1.16 for now given v1.15 OSS is EOL.

This is also somewhat related to https://github.com/cilium/cilium/pull/42420, since these two bugs together is the cause of the endpoint deadlock.

```

    endpoint: stop tracking selectorPolicy

    The selectorPolicy is a static handle to a cache entry; we never
    actually *read* from it except to determine that an endpoint is new.

    So, in the single interesting case, set `forcePolicyCompute`. Then we
    can get rid of this field.

    [ upstream commit f99742e3f636812138a1b40ee149b45fad11919a ]

    Cherry-pick comment: This cherry-pick had a few conflicts I had to sort out. The
    main reason for backport is that in v1.16 and prior, there is an issue
    this commit fixes in v1.17+, where an endpoint gets stuck with the
    selectorPolicy of an old identity after changing to a new one. This
    results in the endpoint being stuck regenerating a policy for the new
    identity, but using and running Consume on the old one. The only way to
    get out of that state is currently to change identity.

    Even if the mentioned above edge case is fixed, this will help guard
    against similar issues that can aries where the reference to an old
    identity is there and never cleaned up.
```

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Stop tracking selectorPolicy in endpoint to fix policy deadlock referencing the the old identity after an identity change
```
