### PR TITLE
bpf: wireguard: let strict-mode capture traffic to HOST_ID

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -226,7 +226,7 @@ strict_allow(struct __ctx_buff *ctx, __be16 proto) {
 #if defined(TUNNEL_MODE) || defined(STRICT_IPV4_OVERLAPPING_CIDR)
 		/* Allow pod to remote-node communication */
 		dest_info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-		if (dest_info && identity_is_node(dest_info->sec_identity))
+		if (dest_info && identity_is_remote_node(dest_info->sec_identity))
 			return true;
 #endif /* TUNNEL_MODE || STRICT_IPV4_OVERLAPPING_CIDR */
 		return !in_strict_cidr;


### PR DESCRIPTION
Use the correct helper, so that we can catch traffic that was intended for the local host but is now leaving the node.

```release-note
When using the Egress Strict Mode for Transparent Encryption with Wireguard, packets destined to the local host are no longer excluded from encryption enforcement (when leaving the node), and will be dropped.
```
