### PR TITLE
policy: reject endpoint updates using old identity

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -125,6 +125,7 @@ type policyGenerateResult struct {
 	policyRevision   uint64
 	endpointPolicy   *policy.EndpointPolicy
 	identityRevision int
+	identity         identityPkg.NumericIdentity
 }
 
 // Release resources held for the new policy
@@ -205,6 +206,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 
 	result := &policyGenerateResult{
 		endpointPolicy:   e.desiredPolicy,
+		identity:         e.getIdentity(),
 		identityRevision: e.identityRevision,
 	}
 	e.unlock()
@@ -299,14 +301,25 @@ func (e *Endpoint) setDesiredPolicy(datapathRegenCtxt *datapathRegenerationConte
 
 		return nil
 	}
+
 	// if the security identity changed, reject the policy computation
-	if e.identityRevision != res.identityRevision {
+	if e.getIdentity() != res.identity {
 		// Detach the rejected endpoint policy.
 		// This is needed to release resources held for the EndpointPolicy
 		res.release(e.getLogger())
 
 		e.getLogger().Info("Endpoint SecurityIdentity changed during policy regeneration")
 		return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration", e.ID)
+	}
+
+	// if the security identity revision changed, reject the policy computation
+	if e.identityRevision != res.identityRevision {
+		// Detach the rejected endpoint policy.
+		// This is needed to release resources held for the EndpointPolicy
+		res.release(e.getLogger())
+
+		e.getLogger().Info("Endpoint SecurityIdentity revision changed during policy regeneration")
+		return fmt.Errorf("endpoint %d SecurityIdentity revision changed during policy regeneration", e.ID)
 	}
 
 	oldNextPolicyRevision := e.nextPolicyRevision


### PR DESCRIPTION
Properly reject endpoint updates using the old identity of an endpoint. See the message above for more information

---
Commit message:

```
    policy: reject endpoint updates using old identity

    This ensures we use the actual identity rather than the identity
    revision when rejecting a policy update. The identity revision cannot
    currently be used as a 1:1 proxy for when an endpoint changes its
    identity, since the revision is increased when the identity labels are
    changed - not when the identity is changed. For most cases this is
    effectively the same, but we are seeing issues, especially in v1.16 and
    lower where this causes issues when endpoints change their identity.

    Due to how v1.17 sets the the e.forcePolicyCompute=true this should for
    the most part be a noop - but it will make the behavior more explicit
    about it rejecting setting a policy for an old identity. This will help
    avoid similar bugs in the future, potentially causing endpoints to be
    stuck permanently due to such an issue.

    We still want to reject here when the identity is the same but the
    revision is different, since that means the endpoint is waiting for a
    new identity.

    In v1.16 and older, this patch will fix a deadlock where the endpoint
    will hold on to the selectorPolicy that matches the old identity it had
    previously. This will mean it will continue to calculate the correct
    selector policy, but do the actual attachment on the the old selector
    policy - effectively being stuck on the old detached one until it has
    its identity changed.
```

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Fix potential policy deadlock causing endpoint to use previous identity for policy calculation when endpoint changes identity
```
