### PR TITLE
test: ginkgo: remove support for cloud environments

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -89,7 +89,6 @@ include:
     cliFocus: "K8sAgentPolicyTest Basic|K8sPolicyTestExtended"
 
   ###
-  # K8sDatapathConfig Host firewall Check connectivity with IPv6 disabled
   # K8sDatapathConfig Host firewall With native routing
   # K8sDatapathConfig Host firewall With native routing and endpoint routes
   # K8sDatapathConfig Host firewall With VXLAN

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -53,12 +53,6 @@ const (
 	// https://github.com/kubernetes/dns/blob/80fdd88276adba36a87c4f424b66fdf37cd7c9a8/pkg/dns/dns.go#L53
 	DNSHelperTimeout = 7 * time.Minute
 
-	// CIIntegrationEKSChaining contains the constants to be used when running tests on EKS with aws-cni in chaining mode.
-	CIIntegrationEKSChaining = "eks-chaining"
-
-	// CIIntegrationEKS contains the constants to be used when running tests on EKS in ENI mode.
-	CIIntegrationEKS = "eks"
-
 	// CIIntegrationAKS contains the constants to be used when running tests on AKS.
 	CIIntegrationAKS = "aks"
 
@@ -146,24 +140,6 @@ var (
 		"connectivityProbeFrequencyRatio": "0",
 	}
 
-	eksChainingHelmOverrides = map[string]string{
-		"k8s.requireIPv4PodCIDR": "false",
-		"cni.chainingMode":       "aws-cni",
-		"masquerade":             "false",
-		"routingMode":            "native",
-		"nodeinit.enabled":       "true",
-	}
-
-	eksHelmOverrides = map[string]string{
-		"egressMasqueradeInterfaces": "eth0",
-		"eni.enabled":                "true",
-		"ipam.mode":                  "eni",
-		"ipv6.enabled":               "false",
-		"k8s.requireIPv4PodCIDR":     "false",
-		"nodeinit.enabled":           "true",
-		"routingMode":                "native",
-	}
-
 	aksHelmOverrides = map[string]string{
 		"ipam.mode":                           "delegated-plugin",
 		"routingMode":                         "native",
@@ -207,12 +183,10 @@ var (
 	// specific CI environment integrations.
 	// The key must be a string consisting of lower case characters.
 	helmOverrides = map[string]map[string]string{
-		CIIntegrationEKSChaining: eksChainingHelmOverrides,
-		CIIntegrationEKS:         eksHelmOverrides,
-		CIIntegrationAKS:         aksHelmOverrides,
-		CIIntegrationKind:        kindHelmOverrides,
-		CIIntegrationMicrok8s:    microk8sHelmOverrides,
-		CIIntegrationMinikube:    minikubeHelmOverrides,
+		CIIntegrationAKS:      aksHelmOverrides,
+		CIIntegrationKind:     kindHelmOverrides,
+		CIIntegrationMicrok8s: microk8sHelmOverrides,
+		CIIntegrationMinikube: minikubeHelmOverrides,
 	}
 
 	// resourcesToClean is the list of resources which should be cleaned

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -53,9 +53,6 @@ const (
 	// https://github.com/kubernetes/dns/blob/80fdd88276adba36a87c4f424b66fdf37cd7c9a8/pkg/dns/dns.go#L53
 	DNSHelperTimeout = 7 * time.Minute
 
-	// CIIntegrationAKS contains the constants to be used when running tests on AKS.
-	CIIntegrationAKS = "aks"
-
 	// CIIntegrationKind contains the constant to be used when running tests on kind.
 	CIIntegrationKind = "kind"
 
@@ -140,25 +137,6 @@ var (
 		"connectivityProbeFrequencyRatio": "0",
 	}
 
-	aksHelmOverrides = map[string]string{
-		"ipam.mode":                           "delegated-plugin",
-		"routingMode":                         "native",
-		"endpointRoutes.enabled":              "true",
-		"extraArgs":                           "{--local-router-ipv4=169.254.23.0}",
-		"k8s.requireIPv4PodCIDR":              "false",
-		"ipv6.enabled":                        "false",
-		"ipv4NativeRoutingCIDR":               NativeRoutingCIDR(),
-		"enableIPv4Masquerade":                "false",
-		"install-no-conntrack-iptables-rules": "false",
-		"l7Proxy":                             "false",
-		"hubble.enabled":                      "false",
-		"kubeProxyReplacement":                "true",
-		"endpointHealthChecking.enabled":      "false",
-		"cni.install":                         "true",
-		"cni.customConf":                      "true",
-		"cni.configMap":                       "cni-configuration",
-	}
-
 	microk8sHelmOverrides = map[string]string{
 		"cni.confPath":      "/var/snap/microk8s/current/args/cni-network",
 		"cni.binPath":       "/var/snap/microk8s/current/opt/cni/bin",
@@ -183,7 +161,6 @@ var (
 	// specific CI environment integrations.
 	// The key must be a string consisting of lower case characters.
 	helmOverrides = map[string]map[string]string{
-		CIIntegrationAKS:      aksHelmOverrides,
 		CIIntegrationKind:     kindHelmOverrides,
 		CIIntegrationMicrok8s: microk8sHelmOverrides,
 		CIIntegrationMinikube: minikubeHelmOverrides,

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -420,16 +420,6 @@ func DoesNotRunOn54OrLaterKernel() bool {
 	return !RunsOn54OrLaterKernel()
 }
 
-// RunsOnGKE returns true if the tests are running on GKE.
-func RunsOnGKE() bool {
-	return GetCurrentIntegration() == CIIntegrationGKE
-}
-
-// DoesNotRunOnGKE is the complement function of DoesNotRunOnGKE.
-func DoesNotRunOnGKE() bool {
-	return !RunsOnGKE()
-}
-
 // RunsOnAKS returns true if the tests are running on AKS.
 func RunsOnAKS() bool {
 	return GetCurrentIntegration() == CIIntegrationAKS
@@ -444,7 +434,7 @@ func DoesNotRunOnAKS() bool {
 // kube-proxy replacement. Note that kube-proxy may still be running
 // alongside Cilium.
 func RunsWithKubeProxyReplacement() bool {
-	return RunsOnGKE() || RunsOn54OrLaterKernel()
+	return RunsOn54OrLaterKernel()
 }
 
 // DoesNotRunWithKubeProxyReplacement is the complement function of

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -406,10 +406,6 @@ func DoesNotRunOn54Kernel() bool {
 	return !RunsOn54Kernel()
 }
 
-func NativeRoutingCIDR() string {
-	return os.Getenv("NATIVE_CIDR")
-}
-
 // RunsOn54OrLaterKernel checks whether a test case is running on 5.4 or later kernel
 func RunsOn54OrLaterKernel() bool {
 	return RunsOnNetNextKernel() || RunsOn54Kernel()
@@ -418,16 +414,6 @@ func RunsOn54OrLaterKernel() bool {
 // DoesNotRunOn54OrLaterKernel is the complement function of RunsOn54OrLaterKernel
 func DoesNotRunOn54OrLaterKernel() bool {
 	return !RunsOn54OrLaterKernel()
-}
-
-// RunsOnAKS returns true if the tests are running on AKS.
-func RunsOnAKS() bool {
-	return GetCurrentIntegration() == CIIntegrationAKS
-}
-
-// DoesNotRunOnAKS is the complement function of DoesNotRunOnAKS.
-func DoesNotRunOnAKS() bool {
-	return !RunsOnAKS()
 }
 
 // RunsWithKubeProxyReplacement returns true if the kernel supports our
@@ -539,11 +525,6 @@ func SkipRaceDetectorEnabled() bool {
 // DualStackSupported returns whether the current environment has DualStack IPv6
 // enabled or not for the cluster.
 func DualStackSupported() bool {
-	// AKS does not support dual stack yet
-	if IsIntegration(CIIntegrationAKS) {
-		return false
-	}
-
 	// We only have DualStack enabled in KIND.
 	return GetCurrentIntegration() == "" || IsIntegration(CIIntegrationKind)
 }
@@ -551,11 +532,6 @@ func DualStackSupported() bool {
 // DualStackSupportBeta returns true if the environment has a Kubernetes version that
 // has support for k8s DualStack beta API types.
 func DualStackSupportBeta() bool {
-	// AKS does not support dual stack yet
-	if IsIntegration(CIIntegrationAKS) {
-		return false
-	}
-
 	return GetCurrentIntegration() == "" || IsIntegration(CIIntegrationKind)
 }
 

--- a/test/k8s/assertion_helpers.go
+++ b/test/k8s/assertion_helpers.go
@@ -172,22 +172,9 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, optio
 	forceDNSRedeploy := optionChangeRequiresPodRedeploy(prevOptions, options)
 	vm.RedeployKubernetesDnsIfNecessary(forceDNSRedeploy)
 
-	switch helpers.GetCurrentIntegration() {
-	case helpers.CIIntegrationGKE:
-		if helpers.LogGathererNamespace != helpers.KubeSystemNamespace {
-			vm.RestartUnmanagedPodsInNamespace(helpers.KubeSystemNamespace)
-		}
-	}
-
 	err := vm.CiliumPreFlightCheck()
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium pre-flight checks failed")
 	ExpectCiliumOperatorReady(vm)
-
-	switch helpers.GetCurrentIntegration() {
-	case helpers.CIIntegrationGKE:
-		err := vm.WaitforPods(helpers.KubeSystemNamespace, "", longTimeout)
-		ExpectWithOffset(1, err).Should(BeNil(), "kube-system pods were not able to get into ready state after restart")
-	}
 }
 
 // SkipIfIntegration will skip a test if it's running with any of the specified

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -315,7 +315,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			kubectl.Exec("kubectl label nodes --all status-")
 		})
 
-		SkipItIf(helpers.RunsOnAKS, "With VXLAN", func() {
+		It("With VXLAN", func() {
 			options := map[string]string{
 				"hostFirewall.enabled": "true",
 			}
@@ -323,9 +323,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			testHostFirewall(kubectl)
 		})
 
-		SkipItIf(func() bool {
-			return helpers.RunsOnAKS()
-		}, "With VXLAN and endpoint routes", func() {
+		It("With VXLAN and endpoint routes", func() {
 			options := map[string]string{
 				"hostFirewall.enabled":   "true",
 				"endpointRoutes.enabled": "true",

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -179,11 +179,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		enableVXLANTunneling := func(options map[string]string) {
 			options["tunnelProtocol"] = "vxlan"
-			if helpers.RunsOnGKE() {
-				// We need to disable gke.enabled as it disables tunneling.
-				options["gke.enabled"] = "false"
-				options["endpointRoutes.enabled"] = "true"
-			}
 		}
 
 		It("Check iptables masquerading with random-fully", func() {
@@ -320,24 +315,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 			kubectl.Exec("kubectl label nodes --all status-")
 		})
 
-		SkipItIf(func() bool {
-			return !helpers.IsIntegration(helpers.CIIntegrationGKE)
-		}, "Check connectivity with IPv6 disabled", func() {
-			deploymentManager.DeployCilium(map[string]string{
-				"ipv4.enabled":         "true",
-				"ipv6.enabled":         "false",
-				"hostFirewall.enabled": "true",
-			}, DeployCiliumOptionsAndDNS)
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-		})
-
 		SkipItIf(helpers.RunsOnAKS, "With VXLAN", func() {
 			options := map[string]string{
 				"hostFirewall.enabled": "true",
-			}
-			if helpers.RunsOnGKE() {
-				options["gke.enabled"] = "false"
-				options["tunnelProtocol"] = "vxlan"
 			}
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
@@ -350,10 +330,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"hostFirewall.enabled":   "true",
 				"endpointRoutes.enabled": "true",
 			}
-			if helpers.RunsOnGKE() {
-				options["gke.enabled"] = "false"
-				options["tunnelProtocol"] = "vxlan"
-			}
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})
@@ -363,13 +339,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"hostFirewall.enabled": "true",
 				"routingMode":          "native",
 			}
-			// We don't want to run with per-endpoint routes (enabled by
-			// gke.enabled) for this test.
-			if helpers.RunsOnGKE() {
-				options["gke.enabled"] = "false"
-			} else {
-				options["autoDirectNodeRoutes"] = "true"
-			}
+			options["autoDirectNodeRoutes"] = "true"
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})
@@ -380,9 +350,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"routingMode":            "native",
 				"endpointRoutes.enabled": "true",
 			}
-			if !helpers.RunsOnGKE() {
-				options["autoDirectNodeRoutes"] = "true"
-			}
+			options["autoDirectNodeRoutes"] = "true"
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 			testHostFirewall(kubectl)
 		})
@@ -390,7 +358,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	Context("Iptables", func() {
 		SkipItIf(func() bool {
-			return helpers.IsIntegration(helpers.CIIntegrationGKE) || helpers.DoesNotRunWithKubeProxyReplacement()
+			return helpers.DoesNotRunWithKubeProxyReplacement()
 		}, "Skip conntrack for pod traffic", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"routingMode":                     "native",

--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -293,7 +293,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 		connectivityTest()
 	})
 
-	SkipItIf(helpers.RunsOnAKS, "Validate that multiple specs are working correctly", func() {
+	It("Validate that multiple specs are working correctly", func() {
 		// To make sure that UUID in multiple specs are plumbed correctly to
 		// Cilium Policy
 		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")
@@ -329,7 +329,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 		res.ExpectFail("Can connect to a valid target when it should NOT work")
 	})
 
-	SkipItIf(helpers.RunsOnAKS, "Validate that FQDN policy continues to work after being updated", func() {
+	It("Validate that FQDN policy continues to work after being updated", func() {
 		// To make sure that UUID in multiple specs are plumbed correctly to
 		// Cilium Policy
 		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -24,7 +24,7 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 	// replacement, as the trace events depend on it. We thus run the tests
 	// on GKE and our 4.19 pipeline.
 	SkipContextIf(func() bool {
-		return helpers.RunsOnNetNextKernel() || helpers.RunsOnAKS()
+		return helpers.RunsOnNetNextKernel()
 	}, "Hubble Observe", func() {
 		var (
 			kubectl        *helpers.Kubectl

--- a/test/k8s/kafka_policies.go
+++ b/test/k8s/kafka_policies.go
@@ -53,7 +53,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 	})
 
 	// Tests involving the L7 proxy do not work when built with -race, see issue #13757.
-	SkipContextIf(func() bool { return helpers.SkipRaceDetectorEnabled() || helpers.RunsOnAKS() }, "Kafka Policy Tests", func() {
+	SkipContextIf(func() bool { return helpers.SkipRaceDetectorEnabled() }, "Kafka Policy Tests", func() {
 		createTopicCmd := func(topic string) string {
 			return fmt.Sprintf("/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh --create "+
 				"--zookeeper localhost:2181 --replication-factor 1 "+

--- a/test/k8s/lrp.go
+++ b/test/k8s/lrp.go
@@ -18,7 +18,7 @@ import (
 
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.DoesNotRunOnAKS() }, "K8sDatapathLRPTests", func() {
+var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() }, "K8sDatapathLRPTests", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string
@@ -43,7 +43,7 @@ var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.
 		kubectl.CiliumReport("cilium-dbg lrp list", "cilium-dbg service list")
 	})
 
-	SkipContextIf(func() bool { return helpers.RunsOnAKS() }, "Checks local redirect policy", func() {
+	Context("Checks local redirect policy", func() {
 		const (
 			lrpServiceName = "lrp-demo-service"
 			be1Name        = "k8s1-backend"

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -27,7 +27,7 @@ var _ = SkipDescribeIf(func() bool {
 	// and the third node. Other CI jobs are not expected to increase
 	// code coverage.
 	//
-	return helpers.RunsOn54Kernel() || helpers.RunsOnAKS()
+	return helpers.RunsOn54Kernel()
 }, "K8sAgentPolicyTest", func() {
 
 	var (

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -27,8 +27,7 @@ var _ = SkipDescribeIf(func() bool {
 	// and the third node. Other CI jobs are not expected to increase
 	// code coverage.
 	//
-	// For GKE coverage, see the K8sPolicyTestExtended Describe block below.
-	return helpers.RunsOnGKE() || helpers.RunsOn54Kernel() || helpers.RunsOnAKS()
+	return helpers.RunsOn54Kernel() || helpers.RunsOnAKS()
 }, "K8sAgentPolicyTest", func() {
 
 	var (
@@ -1512,7 +1511,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn54OrLaterKernel,
 					defer GinkgoRecover()
 					defer wg.Done()
 					switch helpers.GetCurrentIntegration() {
-					case helpers.CIIntegrationEKS, helpers.CIIntegrationEKSChaining, helpers.CIIntegrationGKE:
+					case helpers.CIIntegrationEKS, helpers.CIIntegrationEKSChaining:
 						By("Checking ingress connectivity from k8s1 node to k8s1 pod (host)")
 					default:
 						// We need to bypass this check as in a non-managed
@@ -1534,7 +1533,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn54OrLaterKernel,
 					defer GinkgoRecover()
 					defer wg.Done()
 					switch helpers.GetCurrentIntegration() {
-					case helpers.CIIntegrationEKS, helpers.CIIntegrationEKSChaining, helpers.CIIntegrationGKE:
+					case helpers.CIIntegrationEKS, helpers.CIIntegrationEKSChaining:
 						By("Checking ingress connectivity from k8s1 node to k8s2 pod (remote-node)")
 					default:
 						// We need to bypass this check as in a two node

--- a/test/k8s/pod_mac_address.go
+++ b/test/k8s/pod_mac_address.go
@@ -16,7 +16,7 @@ import (
 
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.DoesNotRunOnAKS() }, "K8sSpecificMACAddressTests", func() {
+var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() }, "K8sSpecificMACAddressTests", func() {
 	var (
 		kubectl        *helpers.Kubectl
 		ciliumFilename string
@@ -41,7 +41,7 @@ var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.
 		kubectl.CiliumReport("cilium-dbg endpoint list -o jsonpath='{range [*]}{@.id}{\"=\"}{@.status.networking.mac}{\"\\n\"}{end}'")
 	})
 
-	SkipContextIf(func() bool { return helpers.RunsOnAKS() }, "Check whether the pod is created", func() {
+	Context("Check whether the pod is created", func() {
 		const specificMACAddress = "specific-mac-address=specific-mac-address"
 		var podYAML string
 

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -421,33 +420,6 @@ func testNodePort(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, bpfNodePort, 
 			getHTTPLink(ni.PrimaryK8s2IPv6, v6Data.Spec.Ports[0].NodePort),
 			getTFTPLink(ni.PrimaryK8s2IPv6, v6Data.Spec.Ports[1].NodePort),
 		)
-	}
-
-	if helpers.RunsOnGKE() {
-		k8s1ExternalIP, err := kubectl.GetNodeIPByLabel(helpers.K8s1, true)
-		Expect(err).Should(BeNil(), "Cannot retrieve Node External IP for %s", helpers.K8s1)
-		k8s2ExternalIP, err := kubectl.GetNodeIPByLabel(helpers.K8s2, true)
-		Expect(err).Should(BeNil(), "Cannot retrieve Node External IP for %s", helpers.K8s2)
-		testURLsFromPods = append(testURLsFromPods,
-			getHTTPLink(k8s1ExternalIP, data.Spec.Ports[0].NodePort),
-			getTFTPLink(k8s1ExternalIP, data.Spec.Ports[1].NodePort),
-			getHTTPLink(k8s2ExternalIP, data.Spec.Ports[0].NodePort),
-			getTFTPLink(k8s2ExternalIP, data.Spec.Ports[1].NodePort),
-		)
-
-		// Testing LoadBalancer types subject to bpf_sock.
-		lbIP, err := kubectl.GetLoadBalancerIP(helpers.DefaultNamespace, "test-lb", 60*time.Second)
-		Expect(err).Should(BeNil(), "Cannot retrieve loadbalancer IP for test-lb")
-
-		testURLsFromHosts = append(testURLsFromHosts, []string{
-			getHTTPLink(lbIP, 80),
-			getHTTPLink("::ffff:"+lbIP, 80),
-		}...)
-
-		testURLsFromPods = append(testURLsFromPods, []string{
-			getHTTPLink(lbIP, 80),
-			getHTTPLink("::ffff:"+lbIP, 80),
-		}...)
 	}
 
 	testURLsFromOutside := []string{}

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -622,12 +622,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 
 		It("Supports IPv4 fragments", func() {
 			options := map[string]string{}
-			// On GKE we need to disable endpoint routes as fragment tracking
-			// isn't compatible with that options. See #15958.
-			if helpers.RunsOnGKE() {
-				options["gke.enabled"] = "false"
-				options["routingMode"] = "native"
-			}
 
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 
@@ -637,7 +631,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 			testIPv4FragmentSupport(kubectl, ni)
 		})
 
-		SkipContextIf(helpers.RunsOnGKE, "With host policy", func() {
+		Context("With host policy", func() {
 			hostPolicyFilename := "ccnp-host-policy-nodeport-tests.yaml"
 			var ccnpHostPolicy string
 

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -117,7 +117,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 				testFailBind(kubectl, ni)
 			})
 
-			SkipContextIf(helpers.RunsOnAKS, "with L7 policy", func() {
+			Context("with L7 policy", func() {
 				AfterAll(func() {
 					kubectl.Delete(demoPolicyL7)
 					// Remove CT entries to avoid packet drops which could happen
@@ -187,7 +187,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 			})
 		})
 
-		SkipContextIf(func() bool { return helpers.RunsWithKubeProxyReplacement() || helpers.RunsOnAKS() }, "TFTP with DNS Proxy port collision", func() {
+		SkipContextIf(func() bool { return helpers.RunsWithKubeProxyReplacement() }, "TFTP with DNS Proxy port collision", func() {
 			var (
 				demoPolicy    string
 				ciliumPodK8s1 string
@@ -281,7 +281,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 		})
 
 		SkipContextIf(func() bool {
-			return helpers.RunsWithKubeProxyReplacement() || helpers.RunsOnAKS()
+			return helpers.RunsWithKubeProxyReplacement()
 		}, "with L7 policy", func() {
 			var demoPolicyL7 string
 


### PR DESCRIPTION
We've only been running the Ginkgo test suite on-top of kind clusters for a long time now. Get rid of all the dead code that is specific to running on AKS / EKS / GKE.