### PR TITLE
oper/bgp: Disable PeerConfigStatusReconciler with empty bgp-secrets-namespace

### DIFF
--- a/operator/pkg/bgpv2/peer.go
+++ b/operator/pkg/bgpv2/peer.go
@@ -75,10 +75,14 @@ func registerPeerConfigStatusReconciler(in peerConfigStatusReconcilerIn) {
 		return
 	}
 
-	in.JobGroup.Add(job.OneShot(
-		"peer-config-status-reconciler",
-		u.reconcileStatus,
-	))
+	if in.SecretResource != nil {
+		// ATM the sole purpose of this reconciliation is to populate MissingAuthSecret condition,
+		// so we don't need to run it if the SecretResource is not provided (bgp-secrets-namespace is not set).
+		in.JobGroup.Add(job.OneShot(
+			"peer-config-status-reconciler",
+			u.reconcileStatus,
+		))
+	}
 }
 
 func (u *peerConfigStatusReconciler) reconcileStatus(ctx context.Context, health cell.Health) error {


### PR DESCRIPTION
The sole purpose of the `peer-config-status-reconciler` job ATM is to set `MissingAuthSecret` condition when BGP secrets are used. When `BGPSecretsNamespace` is not set and `Resource[*Secret]` is nil, we should not run the `peer-config-status-reconciler` job (otherwise it crashes ATM). We should however still run the `cleanup-peer-config-status job`.

Fixes: #42408

```release-note
Fix BGP operator crash when bgp-secrets-namespace not set.
```
