### PR TITLE
test/helpers: drop support for manifests specific for integration/k8s version

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -292,39 +292,8 @@ func reportMapContext(ctx context.Context, path string, reportCmds map[string]st
 	}
 }
 
-// ManifestGet returns the full path of the given manifest corresponding to the
-// Kubernetes version being tested, if such a manifest exists, if not it
-// returns the global manifest file.
-// The paths are checked in order:
-// 1- base_path/integration/filename
-// 2- base_path/k8s_version/integration/filename
-// 3- base_path/k8s_version/filename
-// 4- base_path/filename
+// ManifestGet returns the full path of the given manifest.
 func ManifestGet(base, manifestFilename string) string {
-	// Try dependent integration file only if we have one configured. This is
-	// needed since no integration is "" and that causes us to find the
-	// base_path/filename before we check the base_path/k8s_version/filename
-	if integration := GetCurrentIntegration(); integration != "" {
-		fullPath := filepath.Join(K8sManifestBase, integration, manifestFilename)
-		_, err := os.Stat(fullPath)
-		if err == nil {
-			return filepath.Join(base, fullPath)
-		}
-
-		// try dependent k8s version and integration file
-		fullPath = filepath.Join(K8sManifestBase, GetCurrentK8SEnv(), integration, manifestFilename)
-		_, err = os.Stat(fullPath)
-		if err == nil {
-			return filepath.Join(base, fullPath)
-		}
-	}
-
-	// try dependent k8s version
-	fullPath := filepath.Join(K8sManifestBase, GetCurrentK8SEnv(), manifestFilename)
-	_, err := os.Stat(fullPath)
-	if err == nil {
-		return filepath.Join(base, fullPath)
-	}
 	return filepath.Join(base, K8sManifestBase, manifestFilename)
 }
 


### PR DESCRIPTION
Manifests specific to a CI integration environment and/or a k8s version haven't been used in a long time and are unlikely to reappear given the Ginkgo test suite is deprecated.