### PR TITLE
test: ginkgo: enable loopback testing for IPv6 ClusterIPs

### DIFF
--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	appServiceName  = "app1-service"
-	echoServiceName = "echo"
-	echoPodLabel    = "name=echo"
-	// echoServiceNameIPv6 = "echo-ipv6"
+	appServiceName      = "app1-service"
+	echoServiceName     = "echo"
+	echoPodLabel        = "name=echo"
+	echoServiceNameIPv6 = "echo-ipv6"
 
 	testDSClient = "zgroup=testDSClient"
 	testDS       = "zgroup=testDS"
@@ -137,11 +137,9 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 		// doesn't require any special handling for hairpin service flows.
 		SkipItIf(helpers.RunsWithKubeProxyReplacement, "Checks service accessing itself (hairpin flow)", func() {
 			serviceNames := []string{echoServiceName}
-			// Hairpin flow mode is currently not supported for IPv6.
-			// TODO: Uncomment after https://github.com/cilium/cilium/pull/14138 is merged
-			// if helpers.DualStackSupported() {
-			// }
-			// 	serviceNames = append(serviceNames, // )
+			if helpers.DualStackSupported() {
+				serviceNames = append(serviceNames, echoServiceNameIPv6)
+			}
 
 			for _, svcName := range serviceNames {
 				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, svcName)


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/39594 added the long-missing IPv6 support for this feature, wire up the relevant test bits.

https://github.com/cilium/cilium/issues/33194 tracks the need for corresponding connectivity tests in the CLI.