### PR TITLE
[v1.18] gh: ginkgo: replace rhel8 with 5.10 kernel

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -14,7 +14,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.32.0@sha256:22cf2864f90cfab0d442fda2decf2eae107edd03483053a902614dec637eff76"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20250812.093650"
+    kernel: "5.10-20251021.054756"
     kernel-type: "oldstable"
 
   - k8s-version: "1.31"
@@ -22,7 +22,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.31.0@sha256:d2b2a8cd6fa282b9a4126938341a4d2924dfa96f60b1f983d519498c9cde1a99"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20250812.093650"
+    kernel: "5.10-20251021.054756"
     kernel-type: "oldstable"
 
   - k8s-version: "1.30"


### PR DESCRIPTION
Manual backport of
* [ ] #42084 (trivial fixups for the version strings)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 42084
```