### PR TITLE
daemon: move removeOldRouterState to infraIPAllocator

### DIFF
--- a/daemon/cmd/daemon_privileged_test.go
+++ b/daemon/cmd/daemon_privileged_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"net"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -12,86 +11,9 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
-	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
-
-func TestPrivilegedRemoveOldRouterState(t *testing.T) {
-	testutils.PrivilegedTest(t)
-
-	t.Run("test-1", func(t *testing.T) {
-		ns := netns.NewNetNS(t)
-
-		ns.Do(func() error {
-			createDevices(t)
-
-			// Assert that the old router IP (192.0.2.1) was removed because we are
-			// restoring a different one (10.0.0.1).
-			assert.NoError(t, removeOldRouterState(hivetest.Logger(t), false, net.ParseIP("10.0.0.1")))
-			addrs, err := netlink.AddrList(&netlink.Dummy{
-				LinkAttrs: netlink.LinkAttrs{
-					Name: defaults.HostDevice,
-				},
-			}, netlink.FAMILY_V4)
-			assert.NoError(t, err)
-			assert.Empty(t, addrs)
-
-			// Assert no errors in the case we have no IPs to remove from cilium_host.
-			assert.NoError(t, removeOldRouterState(hivetest.Logger(t), false, nil))
-
-			return nil
-		})
-	})
-
-	t.Run("test-2", func(t *testing.T) {
-		ns := netns.NewNetNS(t)
-
-		ns.Do(func() error {
-			createDevices(t)
-
-			// Remove the cilium_host device and assert no error on "link not found"
-			// error.
-			link, err := safenetlink.LinkByName(defaults.HostDevice)
-			assert.NoError(t, err)
-			assert.NotNil(t, link)
-			assert.NoError(t, netlink.LinkDel(link))
-			assert.NoError(t, removeOldRouterState(hivetest.Logger(t), false, nil))
-
-			return nil
-		})
-	})
-}
-
-// createDevices creates the necessary devices for this test suite. Assumes it
-// is executing within the new network namespace.
-func createDevices(t *testing.T) {
-	t.Helper()
-
-	hostMac, err := mac.GenerateRandMAC()
-	if err != nil {
-		assert.NoError(t, err)
-	}
-	veth := &netlink.Dummy{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:         defaults.HostDevice,
-			HardwareAddr: net.HardwareAddr(hostMac),
-			TxQLen:       1000,
-		},
-	}
-	if err := netlink.LinkAdd(veth); err != nil {
-		assert.NoError(t, err)
-	}
-	ciliumHost, err := safenetlink.LinkByName(defaults.HostDevice)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-
-	_, ipnet, _ := net.ParseCIDR("192.0.2.1/32")
-	addr := &netlink.Addr{IPNet: ipnet}
-	assert.NoError(t, netlink.AddrAdd(ciliumHost, addr))
-}
 
 func TestPrivilegedRemoveStaleEPIfaces(t *testing.T) {
 	testutils.PrivilegedTest(t)

--- a/daemon/cmd/ipam_infra_ip_allocation_test.go
+++ b/daemon/cmd/ipam_infra_ip_allocation_test.go
@@ -10,9 +10,15 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
 func TestCoalesceCIDRs(t *testing.T) {
@@ -146,4 +152,83 @@ func TestDaemon_reallocateDatapathIPs(t *testing.T) {
 	result = infraIPAllocator.reallocateDatapathIPs(fromK8s, invalidFromFS)
 	assert.NotNil(t, result)
 	assert.Equal(t, result.IP, fromK8s)
+}
+
+func TestPrivilegedRemoveOldRouterState(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	infraIPAllocator := &infraIPAllocator{
+		logger: hivetest.Logger(t),
+	}
+
+	t.Run("test-1", func(t *testing.T) {
+		ns := netns.NewNetNS(t)
+
+		ns.Do(func() error {
+			createDevices(t)
+
+			// Assert that the old router IP (192.0.2.1) was removed because we are
+			// restoring a different one (10.0.0.1).
+			assert.NoError(t, infraIPAllocator.removeOldRouterState(false, net.ParseIP("10.0.0.1")))
+			addrs, err := netlink.AddrList(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: defaults.HostDevice,
+				},
+			}, netlink.FAMILY_V4)
+			assert.NoError(t, err)
+			assert.Empty(t, addrs)
+
+			// Assert no errors in the case we have no IPs to remove from cilium_host.
+			assert.NoError(t, infraIPAllocator.removeOldRouterState(false, nil))
+
+			return nil
+		})
+	})
+
+	t.Run("test-2", func(t *testing.T) {
+		ns := netns.NewNetNS(t)
+
+		ns.Do(func() error {
+			createDevices(t)
+
+			// Remove the cilium_host device and assert no error on "link not found"
+			// error.
+			link, err := safenetlink.LinkByName(defaults.HostDevice)
+			assert.NoError(t, err)
+			assert.NotNil(t, link)
+			assert.NoError(t, netlink.LinkDel(link))
+			assert.NoError(t, infraIPAllocator.removeOldRouterState(false, nil))
+
+			return nil
+		})
+	})
+}
+
+// createDevices creates the necessary devices for this test suite. Assumes it
+// is executing within the new network namespace.
+func createDevices(t *testing.T) {
+	t.Helper()
+
+	hostMac, err := mac.GenerateRandMAC()
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	veth := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:         defaults.HostDevice,
+			HardwareAddr: net.HardwareAddr(hostMac),
+			TxQLen:       1000,
+		},
+	}
+	if err := netlink.LinkAdd(veth); err != nil {
+		assert.NoError(t, err)
+	}
+	ciliumHost, err := safenetlink.LinkByName(defaults.HostDevice)
+	if err != nil {
+		assert.NoError(t, err)
+	}
+
+	_, ipnet, _ := net.ParseCIDR("192.0.2.1/32")
+	addr := &netlink.Addr{IPNet: ipnet}
+	assert.NoError(t, netlink.AddrAdd(ciliumHost, addr))
 }


### PR DESCRIPTION
This commit refactors the function `removeOldRouterState` from `daemon.go` to a method of the `infraIPAllocator`. This also includes moving the tests.

Follow up of: https://github.com/cilium/cilium/pull/42067