### PR TITLE
[v1.18] test: ginkgo: skip BPF masq tests on configs without external node

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -225,6 +225,11 @@ exclude:
   - k8s-version: "1.32"
     focus: "f05-agent-policy-multi-node-2"
 
+  # These tests require an external node which is only available on
+  # "net-next". So there's no point on running them.
+  - k8s-version: "1.32"
+    focus: "f09-datapath-misc-2"
+
   # These tests require kernel net-next so there's no point on running them
   - k8s-version: "1.32"
     focus: "f11-datapath-service-ns-tc"
@@ -242,6 +247,11 @@ exclude:
   # / net-next so there's no point on running them
   - k8s-version: "1.31"
     focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require an external node which is only available on
+  # "net-next". So there's no point on running them.
+  - k8s-version: "1.31"
+    focus: "f09-datapath-misc-2"
 
   # These tests require kernel net-next so there's no point on running them
   - k8s-version: "1.31"
@@ -268,6 +278,11 @@ exclude:
 
   - k8s-version: "1.30"
     focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require an external node which is only available on
+  # "net-next". So there's no point on running them.
+  - k8s-version: "1.30"
+    focus: "f09-datapath-misc-2"
 
   - k8s-version: "1.30"
     focus: "f11-datapath-service-ns-tc"


### PR DESCRIPTION
Partial backport of
* [ ] #42447