### PR TITLE
[v1.17] test: ginkgo: skip BPF masq tests on configs without external node

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -228,6 +228,11 @@ exclude:
   - k8s-version: "1.31"
     focus: "f05-agent-policy-multi-node-2"
 
+  # These tests require an external node which is only available on
+  # "net-next". So there's no point on running them.
+  - k8s-version: "1.31"
+    focus: "f09-datapath-misc-2"
+
   # These tests require kernel net-next so there's no point on running them
   - k8s-version: "1.31"
     focus: "f11-datapath-service-ns-tc"
@@ -245,6 +250,11 @@ exclude:
   # / net-next so there's no point on running them
   - k8s-version: "1.30"
     focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require an external node which is only available on
+  # "net-next". So there's no point on running them.
+  - k8s-version: "1.30"
+    focus: "f09-datapath-misc-2"
 
   # These tests require kernel net-next so there's no point on running them
   - k8s-version: "1.30"
@@ -271,6 +281,11 @@ exclude:
 
   - k8s-version: "1.29"
     focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require an external node which is only available on
+  # "net-next". So there's no point on running them.
+  - k8s-version: "1.29"
+    focus: "f09-datapath-misc-2"
 
   - k8s-version: "1.29"
     focus: "f11-datapath-service-ns-tc"


### PR DESCRIPTION
Partial backport of
* [ ] #42447