### PR TITLE
bpf: constify map access

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -259,7 +259,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	union v6addr *dst;
 	int l3_off = ETH_HLEN;
 	struct remote_endpoint_info *info = NULL;
-	struct endpoint_info *ep;
+	const struct endpoint_info *ep;
 	int ret __maybe_unused;
 	__u32 magic = MARK_MAGIC_IDENTITY;
 	bool from_proxy = false;
@@ -684,7 +684,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	void *data, *data_end;
 	struct iphdr *ip4;
 	struct remote_endpoint_info *info;
-	struct endpoint_info *ep;
+	const struct endpoint_info *ep;
 	int ret __maybe_unused;
 	__u32 magic = MARK_MAGIC_IDENTITY;
 	bool from_proxy = false;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -686,7 +686,7 @@ ct_recreate6:
 #endif /* ENABLE_HOST_FIREWALL && !ENABLE_ROUTING */
 
 	if (is_defined(ENABLE_ROUTING) || hairpin_flow || is_defined(ENABLE_HOST_ROUTING)) {
-		struct endpoint_info *ep;
+		const struct endpoint_info *ep;
 		union v6addr daddr;
 
 		ipv6_addr_copy(&daddr, (union v6addr *)&ip6->daddr);
@@ -1172,7 +1172,7 @@ ct_recreate4:
 	if (is_defined(ENABLE_ROUTING) || hairpin_flow ||
 	    is_defined(ENABLE_HOST_ROUTING)) {
 		__be32 daddr = ip4->daddr;
-		struct endpoint_info *ep;
+		const struct endpoint_info *ep;
 
 		/* Loopback replies are addressed to config service_loopback_ipv4,
 		 * so an endpoint lookup with ip4->daddr won't work.

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -59,7 +59,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	int ret, l3_off = ETH_HLEN;
 	void *data_end, *data;
 	struct ipv6hdr *ip6;
-	struct endpoint_info *ep;
+	const struct endpoint_info *ep;
 	bool __maybe_unused is_dsr = false;
 	fraginfo_t fraginfo __maybe_unused;
 
@@ -224,7 +224,7 @@ static __always_inline int handle_inter_cluster_revsnat(struct __ctx_buff *ctx,
 	struct iphdr *ip4;
 	__u32 cluster_id = 0;
 	void *data_end, *data;
-	struct endpoint_info *ep;
+	const struct endpoint_info *ep;
 	__u32 cluster_id_from_identity =
 		extract_cluster_id_from_identity(src_sec_identity);
 	const struct ipv4_nat_target target = {
@@ -292,7 +292,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 {
 	void *data_end, *data;
 	struct iphdr *ip4;
-	struct endpoint_info *ep;
+	const struct endpoint_info *ep;
 	bool __maybe_unused is_dsr = false;
 	fraginfo_t fraginfo __maybe_unused;
 	int ret;

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -65,7 +65,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 identity, __s8 *ext_err __maybe_unused
 {
 	void *data_end, *data;
 	struct ipv6hdr *ip6;
-	struct endpoint_info *ep;
+	const struct endpoint_info *ep;
 	fraginfo_t __maybe_unused fraginfo;
 
 	/* See the equivalent v4 path for comments */
@@ -163,7 +163,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 identity, __s8 *ext_err __maybe_unused
 {
 	void *data_end, *data;
 	struct iphdr *ip4;
-	struct endpoint_info *ep;
+	const struct endpoint_info *ep;
 	fraginfo_t __maybe_unused fraginfo;
 
 	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))

--- a/bpf/lib/auth.h
+++ b/bpf/lib/auth.h
@@ -22,7 +22,7 @@ static __always_inline int
 auth_lookup(struct __ctx_buff *ctx, __u32 local_id, __u32 remote_id, __u32 remote_node_ip,
 	    __u8 auth_type)
 {
-	struct node_value *node_value = NULL;
+	const struct node_value *node_value = NULL;
 	struct auth_info *auth;
 	struct auth_key key = {
 		.local_sec_label = local_id,

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -87,8 +87,8 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 }
 
 # ifdef ENABLE_EGRESS_GATEWAY
-static __always_inline
-struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 daddr)
+static __always_inline const struct egress_gw_policy_entry *
+lookup_ip4_egress_gw_policy(__be32 saddr, __be32 daddr)
 {
 	struct egress_gw_policy_key key = {
 		.lpm_key = { EGRESS_IPV4_PREFIX, {} },
@@ -104,7 +104,7 @@ egress_gw_request_needs_redirect(struct ipv4_ct_tuple *rtuple __maybe_unused,
 				 __be32 *gateway_ip __maybe_unused)
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
-	struct egress_gw_policy_entry *egress_gw_policy;
+	const struct egress_gw_policy_entry *egress_gw_policy;
 
 	egress_gw_policy = lookup_ip4_egress_gw_policy(ipv4_ct_reverse_tuple_saddr(rtuple),
 						       ipv4_ct_reverse_tuple_daddr(rtuple));
@@ -133,7 +133,7 @@ bool egress_gw_snat_needed(__be32 saddr __maybe_unused,
 			   __u32 *egress_ifindex __maybe_unused)
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
-	struct egress_gw_policy_entry *egress_gw_policy;
+	const struct egress_gw_policy_entry *egress_gw_policy;
 
 	egress_gw_policy = lookup_ip4_egress_gw_policy(saddr, daddr);
 	if (!egress_gw_policy)
@@ -158,7 +158,7 @@ static __always_inline
 bool egress_gw_reply_matches_policy(struct iphdr *ip4 __maybe_unused)
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
-	struct egress_gw_policy_entry *egress_policy;
+	const struct egress_gw_policy_entry *egress_policy;
 
 	/* Find a matching policy by looking up the reverse address tuple: */
 	egress_policy = lookup_ip4_egress_gw_policy(ip4->daddr, ip4->saddr);
@@ -246,9 +246,8 @@ int egress_gw_handle_packet(struct ipv4_ct_tuple *tuple,
 
 #ifdef ENABLE_IPV6
 #ifdef ENABLE_EGRESS_GATEWAY
-static __always_inline
-struct egress_gw_policy_entry6 *lookup_ip6_egress_gw_policy(const union v6addr *saddr,
-							    const union v6addr *daddr)
+static __always_inline const struct egress_gw_policy_entry6 *
+lookup_ip6_egress_gw_policy(const union v6addr *saddr, const union v6addr *daddr)
 {
 	struct egress_gw_policy_key6 key = {
 		.lpm_key = { EGRESS_IPV6_PREFIX, {} },
@@ -264,7 +263,7 @@ egress_gw_request_needs_redirect_v6(struct ipv6_ct_tuple *rtuple __maybe_unused,
 				    __be32 *gateway_ip __maybe_unused)
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
-	struct egress_gw_policy_entry6 *egress_gw_policy;
+	const struct egress_gw_policy_entry6 *egress_gw_policy;
 	union v6addr saddr, daddr;
 
 	saddr = ipv6_ct_reverse_tuple_saddr(rtuple);
@@ -296,7 +295,7 @@ bool egress_gw_snat_needed_v6(union v6addr *saddr __maybe_unused,
 			      __u32 *egress_ifindex __maybe_unused)
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
-	struct egress_gw_policy_entry6 *egress_gw_policy;
+	const struct egress_gw_policy_entry6 *egress_gw_policy;
 
 	egress_gw_policy = lookup_ip6_egress_gw_policy(saddr, daddr);
 	if (!egress_gw_policy)
@@ -319,7 +318,7 @@ static __always_inline
 bool egress_gw_reply_matches_policy_v6(struct ipv6hdr *ip6 __maybe_unused)
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
-	struct egress_gw_policy_entry6 *egress_policy;
+	const struct egress_gw_policy_entry6 *egress_policy;
 
 	egress_policy = lookup_ip6_egress_gw_policy((union v6addr *)&ip6->daddr,
 						    (union v6addr *)&ip6->saddr);

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -433,7 +433,7 @@ int egress_gw_handle_request(struct __ctx_buff *ctx, __be16 proto,
 			     struct trace_ctx *trace)
 {
 	struct remote_endpoint_info fake_info = {0};
-	struct endpoint_info *gateway_node_ep;
+	const struct endpoint_info *gateway_node_ep;
 	__be32 gateway_ip = 0;
 	void *data, *data_end;
 	struct iphdr *ip4;
@@ -442,7 +442,7 @@ int egress_gw_handle_request(struct __ctx_buff *ctx, __be16 proto,
 	struct ipv6_ct_tuple __maybe_unused tuple6 = {};
 	int l4_off;
 	struct remote_endpoint_info *info;
-	struct endpoint_info *src_ep;
+	const struct endpoint_info *src_ep;
 	bool is_reply;
 	fraginfo_t fraginfo;
 	int ret;

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -92,7 +92,7 @@ set_ipsec_encrypt(struct __ctx_buff *ctx, struct remote_endpoint_info *info,
 	 * bpf_host to send ctx onto tunnel for encap.
 	 */
 
-	struct node_value *node_value = NULL;
+	const struct node_value *node_value = NULL;
 	__u32 mark;
 	__u8 spi;
 

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -17,7 +17,7 @@ struct {
 	__uint(map_flags, CONDITIONAL_PREALLOC);
 } cilium_lxc __section_maps_btf;
 
-static __always_inline __maybe_unused struct endpoint_info *
+static __always_inline __maybe_unused const struct endpoint_info *
 __lookup_ip6_endpoint(const union v6addr *ip6)
 {
 	struct endpoint_key key = {};
@@ -28,13 +28,13 @@ __lookup_ip6_endpoint(const union v6addr *ip6)
 	return map_lookup_elem(&cilium_lxc, &key);
 }
 
-static __always_inline __maybe_unused struct endpoint_info *
+static __always_inline __maybe_unused const struct endpoint_info *
 lookup_ip6_endpoint(const struct ipv6hdr *ip6)
 {
 	return __lookup_ip6_endpoint((union v6addr *)&ip6->daddr);
 }
 
-static __always_inline __maybe_unused struct endpoint_info *
+static __always_inline __maybe_unused const struct endpoint_info *
 __lookup_ip4_endpoint(__u32 ip)
 {
 	struct endpoint_key key = {};
@@ -45,7 +45,7 @@ __lookup_ip4_endpoint(__u32 ip)
 	return map_lookup_elem(&cilium_lxc, &key);
 }
 
-static __always_inline __maybe_unused struct endpoint_info *
+static __always_inline __maybe_unused const struct endpoint_info *
 lookup_ip4_endpoint(const struct iphdr *ip4)
 {
 	return __lookup_ip4_endpoint(ip4->daddr);

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -127,7 +127,7 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 			return DROP_WRITE_ERROR;
 	} else {
 		union macaddr smac = NATIVE_DEV_MAC_BY_IFINDEX(oif);
-		union macaddr *dmac = NULL;
+		const union macaddr *dmac = NULL;
 
 		if (allow_neigh_map) {
 			/* The neigh_record_ip{4,6} locations are mainly from

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -346,7 +346,7 @@ static __always_inline int icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 {
 	union v6addr target, router = CONFIG(router_ipv6);
-	struct endpoint_info *ep;
+	const struct endpoint_info *ep;
 	union macaddr router_mac = CONFIG(interface_mac);
 
 	if (ctx_load_bytes(ctx, nh_off + ICMP6_ND_TARGET_OFFSET, target.addr,

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -608,7 +608,7 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 int l4_off __maybe_unused,
 			 struct ipv4_nat_target *target __maybe_unused)
 {
-	struct endpoint_info *local_ep __maybe_unused;
+	const struct endpoint_info *local_ep __maybe_unused;
 	struct remote_endpoint_info *remote_ep __maybe_unused;
 	int ret;
 
@@ -1669,7 +1669,7 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 {
 	union v6addr masq_addr __maybe_unused = CONFIG(nat_ipv6_masquerade);
 	struct remote_endpoint_info *remote_ep __maybe_unused;
-	struct endpoint_info *local_ep __maybe_unused;
+	const struct endpoint_info *local_ep __maybe_unused;
 
 	/* See comments in snat_v4_needs_masquerade(). */
 #if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)

--- a/bpf/lib/neigh.h
+++ b/bpf/lib/neigh.h
@@ -41,12 +41,13 @@ static __always_inline int neigh_record_ip6(struct __ctx_buff *ctx)
 	return 0;
 }
 
-static __always_inline union macaddr *neigh_lookup_ip6(const union v6addr *addr)
+static __always_inline const union macaddr *
+neigh_lookup_ip6(const union v6addr *addr)
 {
 	return map_lookup_elem(&cilium_nodeport_neigh6, addr);
 }
 #else
-static __always_inline union macaddr *
+static __always_inline const union macaddr *
 neigh_lookup_ip6(const union v6addr *addr __maybe_unused)
 {
 	return NULL;
@@ -85,12 +86,13 @@ static __always_inline int neigh_record_ip4(struct __ctx_buff *ctx)
 	return 0;
 }
 
-static __always_inline union macaddr *neigh_lookup_ip4(const __be32 *addr)
+static __always_inline const union macaddr *
+neigh_lookup_ip4(const __be32 *addr)
 {
 	return map_lookup_elem(&cilium_nodeport_neigh4, addr);
 }
 #else
-static __always_inline union macaddr *
+static __always_inline const union macaddr *
 neigh_lookup_ip4(const __be32 *addr __maybe_unused)
 {
 	return NULL;

--- a/bpf/lib/node.h
+++ b/bpf/lib/node.h
@@ -16,7 +16,7 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } cilium_node_map_v2 __section_maps_btf;
 
-static __always_inline struct node_value *
+static __always_inline const struct node_value *
 lookup_ip4_node(__be32 ip4)
 {
 	struct node_key key = {};
@@ -30,7 +30,7 @@ lookup_ip4_node(__be32 ip4)
 static __always_inline __u16
 lookup_ip4_node_id(__be32 ip4)
 {
-	struct node_value *node_value;
+	const struct node_value *node_value;
 
 	node_value = lookup_ip4_node(ip4);
 	if (!node_value)
@@ -41,7 +41,7 @@ lookup_ip4_node_id(__be32 ip4)
 }
 
 # ifdef ENABLE_IPV6
-static __always_inline struct node_value *
+static __always_inline const struct node_value *
 lookup_ip6_node(const union v6addr *ip6)
 {
 	struct node_key key = {};
@@ -55,7 +55,7 @@ lookup_ip6_node(const union v6addr *ip6)
 static __always_inline __u16
 lookup_ip6_node_id(const union v6addr *ip6)
 {
-	struct node_value *node_value;
+	const struct node_value *node_value;
 
 	node_value = lookup_ip6_node(ip6);
 	if (!node_value)
@@ -66,7 +66,7 @@ lookup_ip6_node_id(const union v6addr *ip6)
 }
 # endif /* ENABLE_IPV6 */
 
-static __always_inline struct node_value *
+static __always_inline const struct node_value *
 lookup_node(const struct remote_endpoint_info *info)
 {
 # ifdef ENABLE_IPV6

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -340,7 +340,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 
 	if (is_defined(IS_BPF_HOST) && is_defined(ENABLE_MASQUERADE_IPV4)) {
-		struct endpoint_info *ep;
+		const struct endpoint_info *ep;
 
 		ep = __lookup_ip4_endpoint(ip4->saddr);
 		if (ep && ep->parent_ifindex && ep->parent_ifindex != CONFIG(interface_ifindex)) {

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -77,7 +77,7 @@ struct {
 } cilium_policy_v2 __section_maps_btf;
 
 static __always_inline int
-__policy_check(struct policy_entry *policy, const struct policy_entry *policy2, __s8 *ext_err,
+__policy_check(const struct policy_entry *policy, const struct policy_entry *policy2, __s8 *ext_err,
 	       __u16 *proxy_port, __u32 *cookie)
 {
 	/* auth_type is derived from the matched policy entry, except if both L3/L4 and L4-only
@@ -129,8 +129,8 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		    bool is_untracked_fragment, __u8 *match_type, __s8 *ext_err,
 		    __u16 *proxy_port, __u32 *cookie)
 {
-	struct policy_entry *policy;
-	struct policy_entry *l4policy;
+	const struct policy_entry *policy;
+	const struct policy_entry *l4policy;
 	struct policy_key key = {
 		.lpm_key = { POLICY_FULL_PREFIX, {} }, /* always look up with unwildcarded data */
 		.sec_label = remote_id,


### PR DESCRIPTION
Start adding some low-effort protection against accidental writes to BPF map entries.

This doesn't cover all relevant maps.
