### PR TITLE
iptables: add ACCEPT rule for ipsec packets

### DIFF
--- a/pkg/datapath/iptables/encryption.go
+++ b/pkg/datapath/iptables/encryption.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptables
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+)
+
+// insertAcceptEncryptMark adds an accept rule to a `chain` on a `table` for traffic matching the encryption skb marks
+func insertAcceptEncryptMark(ipt iptablesInterface, table, chain string) error {
+	matchDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
+	matchEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+
+	comment := "exclude encrypt/decrypt marks from " + table + " " + chain + " chain"
+
+	if err := ipt.runProg([]string{
+		"-t", table,
+		"-A", chain,
+		"-m", "mark", "--mark", matchEncrypt,
+		"-m", "comment", "--comment", comment,
+		"-j", "ACCEPT"}); err != nil {
+		return err
+	}
+
+	return ipt.runProg([]string{
+		"-t", table,
+		"-A", chain,
+		"-m", "mark", "--mark", matchDecrypt,
+		"-m", "comment", "--comment", comment,
+		"-j", "ACCEPT"})
+}
+
+// insertAcceptEncryptIpsec adds an accept rule to a `chain` on a `table` for traffic matching esp protocol
+func insertAcceptEncryptIpsec(ipt iptablesInterface, table, chain string) error {
+	comment := "exclude esp proto from " + table + " " + chain + " chain"
+
+	return ipt.runProg([]string{
+		"-t", table,
+		"-A", chain,
+		"-p", "esp",
+		"-m", "comment", "--comment", comment,
+		"-j", "ACCEPT"})
+}


### PR DESCRIPTION
ipsec packets right now dont get the mark before iptables processing, causing them to
not match the accept rule added by cilium. in case the iptables policy for OUTPUT is drop, ipsec packets won't make it.

this commit inserts the rule matching ipsec protocol instead, if ipsec encryption is enabled.

Fixes: #42121

```release-note
Add iptables rule to allow esp packets when ipsec encryption is enabled
```
