### PR TITLE
bpf: drop unknown transport protocols

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1475,8 +1475,11 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 			goto skip_service_lookup;
 		}
 		if (ret == DROP_UNKNOWN_L4) {
-			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
-			return CTX_ACT_OK;
+			lb6_fill_key(&key, &tuple);
+			if (!lb6_lookup_wildcard(&key)) {
+				ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
+				return CTX_ACT_OK;
+			}
 		}
 		return ret;
 	}
@@ -2852,8 +2855,11 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 			goto skip_service_lookup;
 		}
 		if (ret == DROP_UNKNOWN_L4) {
-			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
-			return CTX_ACT_OK;
+			lb4_fill_key(&key, &tuple);
+			if (!lb4_lookup_wildcard(&key)) {
+				ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
+				return CTX_ACT_OK;
+			}
 		}
 		return ret;
 	}

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -237,3 +237,47 @@ v6_wireguard_proto_mismatch = (
     IPv6(src=v6_node_one, dst=v6_node_two) /
     TCP(sport=wireguard_port, dport=wireguard_port)
 )
+
+## Layer 4 protocols unsupported by NodePort
+
+v4_gre_v4_udp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    GRE() /
+    IP(src=v4_ext_two, dst=v4_svc_two) /
+    UDP(sport=tcp_src_three, dport=tcp_svc_three) /
+    Raw(default_data)
+)
+v6_gre_v4_udp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    GRE() /
+    IP(src=v4_ext_two, dst=v4_svc_two) /
+    UDP(sport=tcp_src_three, dport=tcp_svc_three) /
+    Raw(default_data)
+)
+
+v4_esp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    ESP(spi=123456789, seq=12345, data=default_data)
+)
+v6_esp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    ESP(spi=123456789, seq=12345, data=default_data)
+)
+
+load_contrib("rsvp")
+v4_rsvp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    RSVP() /
+    RSVP_Object()
+)
+v6_rsvp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    RSVP() /
+    RSVP_Object()
+)

--- a/bpf/tests/tc_nodeport_lb4_unknownl4_drop.c
+++ b/bpf/tests/tc_nodeport_lb4_unknownl4_drop.c
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+#include "scapy.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define SERVICE_NO_BACKEND_RESPONSE
+
+#define SERVICE_IP	v4_svc_one
+#define SERVICE_PORT	tcp_svc_three
+
+#include "lib/bpf_host.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/nodeport.h"
+
+static __always_inline void setup_services(struct __ctx_buff *ctx __maybe_unused)
+{
+	lb_v4_add_service(SERVICE_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1);
+	lb_v4_add_service(SERVICE_IP, SERVICE_PORT, IPPROTO_UDP, 1, 1);
+	lb_v4_add_service(SERVICE_IP, LB_SVC_WILDCARD_DPORT, LB_SVC_WILDCARD_PROTO, 1, 1);
+}
+
+#define __assert_status(__ctx, __expected) do {			\
+	void *__data = (void *)(long)(__ctx)->data;		\
+	void *__data_end = (void *)(long)(__ctx)->data_end;	\
+	if (__data + sizeof(__u32) > __data_end) {		\
+		test_fatal("status code out of bounds");	\
+	}							\
+	assert(*(__u32 *)__data == (__expected));		\
+} while (0)
+
+/* Test UNKNOWN_L4 with GRE */
+PKTGEN("tc", "tc_nodeport_lb4_unknownl4_drop_gre")
+int tc_nodeport_lb4_unknownl4_drop_gre_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(GRE_PKT, v4_gre_v4_udp);
+	BUILDER_PUSH_BUF(builder, GRE_PKT);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_unknownl4_drop_gre")
+int tc_nodeport_lb4_unknownl4_drop_gre_setup(struct __ctx_buff *ctx)
+{
+	setup_services(ctx);
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb4_unknownl4_drop_gre")
+int tc_nodeport_lb4_unknownl4_drop_gre_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(GRE_EXP, v4_gre_v4_udp);
+	ASSERT_CTX_BUF_OFF("gre_ok", "Ether", ctx, sizeof(__u32),
+			   GRE_EXP, sizeof(BUF(GRE_EXP)));
+	__assert_status(ctx, CTX_ACT_DROP);
+
+	test_finish();
+	return 0;
+}
+
+/* Test UNKNOWN_L4 with ESP */
+PKTGEN("tc", "tc_nodeport_lb4_unknownl4_drop_esp")
+int tc_nodeport_lb4_unknownl4_drop_esp_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(ESP_PKT, v4_esp);
+	BUILDER_PUSH_BUF(builder, ESP_PKT);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_unknownl4_drop_esp")
+int tc_nodeport_lb4_unknownl4_drop_esp_setup(struct __ctx_buff *ctx)
+{
+	setup_services(ctx);
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb4_unknownl4_drop_esp")
+int tc_nodeport_lb4_unknownl4_drop_esp_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(ESP_EXP, v4_esp);
+	ASSERT_CTX_BUF_OFF("esp_ok", "Ether", ctx, sizeof(__u32),
+			   ESP_EXP, sizeof(BUF(ESP_EXP)));
+	__assert_status(ctx, CTX_ACT_DROP);
+
+	test_finish();
+	return 0;
+}
+
+/* Test UNKNOWN_L4 with RSVP */
+PKTGEN("tc", "tc_nodeport_lb4_unknownl4_drop_rsvp")
+int tc_nodeport_lb4_unknownl4_drop_rsvp_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(RSVP_PKT, v4_rsvp);
+	BUILDER_PUSH_BUF(builder, RSVP_PKT);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_unknownl4_drop_rsvp")
+int tc_nodeport_lb4_unknownl4_drop_rsvp_setup(struct __ctx_buff *ctx)
+{
+	setup_services(ctx);
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb4_unknownl4_drop_rsvp")
+int tc_nodeport_lb4_unknownl4_drop_rsvp_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(RSVP_EXP, v4_rsvp);
+	ASSERT_CTX_BUF_OFF("rsvp_ok", "Ether", ctx, sizeof(__u32),
+			   RSVP_EXP, sizeof(BUF(RSVP_EXP)));
+	__assert_status(ctx, CTX_ACT_DROP);
+
+	test_finish();
+	return 0;
+}

--- a/bpf/tests/tc_nodeport_lb6_unknownl4_drop.c
+++ b/bpf/tests/tc_nodeport_lb6_unknownl4_drop.c
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+#include "scapy.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6
+#define ENABLE_SRV6
+#define ENABLE_SRV6_SRH_ENCAP
+#define ENABLE_NODEPORT
+#define SERVICE_NO_BACKEND_RESPONSE
+
+#define SERVICE_IP	v6_svc_one
+#define SERVICE_PORT	tcp_svc_three
+
+#include "lib/bpf_host.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/nodeport.h"
+
+static __always_inline void setup_services(struct __ctx_buff *ctx __maybe_unused)
+{
+	const union v6addr *svc_ip = (const union v6addr *)&SERVICE_IP;
+
+	lb_v6_add_service(svc_ip, SERVICE_PORT, IPPROTO_TCP, 1, 1);
+	lb_v6_add_service(svc_ip, SERVICE_PORT, IPPROTO_UDP, 1, 1);
+	lb_v6_add_service(svc_ip, LB_SVC_WILDCARD_DPORT, LB_SVC_WILDCARD_PROTO, 1, 1);
+}
+
+#define __assert_status(__ctx, __expected) do {			\
+	void *__data = (void *)(long)(__ctx)->data;		\
+	void *__data_end = (void *)(long)(__ctx)->data_end;	\
+	if (__data + sizeof(__u32) > __data_end) {		\
+		test_fatal("status code out of bounds");	\
+	}							\
+	assert(*(__u32 *)__data == (__expected));		\
+} while (0)
+
+/* Test UNKNOWN_L4 with GRE */
+PKTGEN("tc", "tc_nodeport_lb6_unknownl4_drop_gre")
+int tc_nodeport_lb6_unknownl4_drop_gre_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(GRE_PKT6, v6_gre_v4_udp);
+	BUILDER_PUSH_BUF(builder, GRE_PKT6);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb6_unknownl4_drop_gre")
+int tc_nodeport_lb6_unknownl4_drop_gre_setup(struct __ctx_buff *ctx)
+{
+	setup_services(ctx);
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb6_unknownl4_drop_gre")
+int tc_nodeport_lb6_unknownl4_drop_gre_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(GRE_EXP6, v6_gre_v4_udp);
+	ASSERT_CTX_BUF_OFF("gre_ok", "Ether", ctx, sizeof(__u32),
+			   GRE_EXP6, sizeof(BUF(GRE_EXP6)));
+	__assert_status(ctx, CTX_ACT_DROP);
+
+	test_finish();
+	return 0;
+}
+
+/* Test UNKNOWN_L4 with ESP */
+PKTGEN("tc", "tc_nodeport_lb6_unknownl4_drop_esp")
+int tc_nodeport_lb6_unknownl4_drop_esp_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(ESP_PKT6, v6_esp);
+	BUILDER_PUSH_BUF(builder, ESP_PKT6);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb6_unknownl4_drop_esp")
+int tc_nodeport_lb6_unknownl4_drop_esp_setup(struct __ctx_buff *ctx)
+{
+	setup_services(ctx);
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb6_unknownl4_drop_esp")
+int tc_nodeport_lb6_unknownl4_drop_esp_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(ESP_EXP6, v6_esp);
+	ASSERT_CTX_BUF_OFF("esp_ok", "Ether", ctx, sizeof(__u32),
+			   ESP_EXP6, sizeof(BUF(ESP_EXP6)));
+	__assert_status(ctx, CTX_ACT_DROP);
+
+	test_finish();
+	return 0;
+}
+
+/* Test UNKNOWN_L4 with RSVP */
+PKTGEN("tc", "tc_nodeport_lb6_unknownl4_drop_rsvp")
+int tc_nodeport_lb6_unknownl4_drop_rsvp_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(RSVP_PKT6, v6_rsvp);
+	BUILDER_PUSH_BUF(builder, RSVP_PKT6);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb6_unknownl4_drop_rsvp")
+int tc_nodeport_lb6_unknownl4_drop_rsvp_setup(struct __ctx_buff *ctx)
+{
+	setup_services(ctx);
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb6_unknownl4_drop_rsvp")
+int tc_nodeport_lb6_unknownl4_drop_rsvp_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(RSVP_EXP6, v6_rsvp);
+	ASSERT_CTX_BUF_OFF("rsvp_ok", "Ether", ctx, sizeof(__u32),
+			   RSVP_EXP6, sizeof(BUF(RSVP_EXP6)));
+	__assert_status(ctx, CTX_ACT_DROP);
+
+	test_finish();
+	return 0;
+}


### PR DESCRIPTION
Modifies the data path to drop unknown Layer4 transport protocols on IPs that Cilium manages. Currently, such packets are punted and likely forwarded back out to the network until a TTL reaches zero.

Example, when using Scapy to inject an IPv4 GRE packet towards a Load Balancer IP `10.244.255.200`, source is `10.244.123.123`, and TTL is set to 4.

**Current v1.19-dev (b4b005440a)**
```
$ sudo tcpdump -ni any host 10.244.123.123
...
14:07:07.975775 br-kind-cilium Out IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)
14:07:07.975787 vethbe1ceed Out IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)
14:07:07.975836 vethbe1ceed P   IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)
14:07:07.975836 br-kind-cilium In  IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)
14:07:07.975853 br-kind-cilium Out IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)
14:07:07.975855 vethbe1ceed Out IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)
14:07:07.975924 vethbe1ceed P   IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)
14:07:07.975924 br-kind-cilium In  IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)

$ hubble observe -P -f --ip 10.244.123.123
...
Oct 29 14:07:07.975: 10.244.123.123 (world-ipv4) <> 10.244.255.200 (world-ipv4) from-network FORWARDED (IPv4)
Oct 29 14:07:07.975: 10.244.123.123 (world-ipv4) <> 10.244.255.200 (world-ipv4) to-network FORWARDED (IPv4)
Oct 29 14:07:07.975: 10.244.123.123 (world-ipv4) <> 10.244.255.200 (world-ipv4) from-network FORWARDED (IPv4)
Oct 29 14:07:07.975: 10.244.123.123 (world-ipv4) <> 10.244.255.200 (world-ipv4) to-network FORWARDED (IPv4)
Oct 29 14:07:07.975: 172.19.0.1 (world-ipv4) <> 10.244.123.123 (world-ipv4) from-network FORWARDED (ICMPv4 TimeExceeded(TTLExceeded))
Oct 29 14:07:07.975: 172.19.0.1 (world-ipv4) <> 10.244.123.123 (world-ipv4) to-network FORWARDED (ICMPv4 TimeExceeded(TTLExceeded))
```

**With this PR**

```
$ sudo tcpdump -ni any host 10.244.123.123
...
14:14:51.625649 br-kind-cilium Out IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)
14:14:51.625659 veth1fc4d7a Out IP 10.244.123.123 > 10.244.255.200: GREv0, length 64: IP 192.168.1.10.44444 > 192.168.1.20.domain: 0+ A? news.bbc.co.uk. (32)

$ hubble observe -P -f --ip 10.244.123.123
...
Oct 29 14:14:51.625: 10.244.123.123 (world-ipv4) <> 10.244.255.200 (world-ipv4) from-network FORWARDED (IPv4)
Oct 29 14:14:51.625: 10.244.123.123 (world-ipv4) <> 10.244.255.200 (world-ipv4) Unknown L4 protocol DROPPED (IPv4)
```

**Release Notes**

```release-note
Drop unsupported Layer4 transport protocols when received towards a ClusterIP or LoadBalancer IP to mitigate risk of packet loops.
```
