### PR TITLE
ci: Add automatic retry mechanism for image build failures

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -49,6 +49,7 @@ jobs:
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: cilium
@@ -433,3 +434,16 @@ jobs:
         run: |
           echo ${TOKEN} | gh auth login --with-token
           gh pr --repo ${GITHUB_REPOSITORY} comment ${PULL_REQUEST_NUMBER} --body "/test"
+
+  rerun-on-failure:
+    name: Re-run on failure
+    needs: build-and-push-prs
+    # Only re-run if the job failed, the run attempt is less than 3, and the PR is not a draft.
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-run workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci-re-run.yaml --ref ${{ github.ref_name }} -F run_id=${{ github.run_id }}

--- a/.github/workflows/workflow-re-run.yaml
+++ b/.github/workflows/workflow-re-run.yaml
@@ -1,0 +1,21 @@
+name: Rerun Failed Jobs of a Workflow Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "The ID of the workflow run to rerun"
+        required: true
+
+jobs:
+  re-run-workflow:
+    name: Re-run Workflow
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Re-running ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
Add rerun-on-failure jobs to critical CI workflows to automatically retry failed runs up to 2 additional times (3 total attempts). This will help to mitigate transient infrastructure issues that can cause spurious CI failures related with the image builds.