### PR TITLE
bpf: Migrate CLUSTER_ID_MAX to runtime config

### DIFF
--- a/bpf/lib/clustermesh.h
+++ b/bpf/lib/clustermesh.h
@@ -4,6 +4,17 @@
 
 #include "lib/utils.h"
 
+NODE_CONFIG(__u32, cluster_id_max, "Max number of clusters that can be connected in Clustermesh")
+ASSIGN_CONFIG(__u32, cluster_id_max, 255)
+
+#ifndef get_cluster_id_max
+static __always_inline __u32
+get_cluster_id_max()
+{
+	return CONFIG(cluster_id_max);
+}
+#endif /* get_cluster_id_max() */
+
 #define CLUSTER_ID_LOWER_MASK 0x000000FF
 
 #ifndef __CLUSTERMESH_HELPERS__
@@ -37,7 +48,7 @@ extract_cluster_id_from_identity(__u32 identity)
 static __always_inline __maybe_unused __u32
 get_cluster_id_upper_mask()
 {
-	return (CLUSTER_ID_MAX & ~CLUSTER_ID_LOWER_MASK) << (8 + IDENTITY_LEN);
+	return (get_cluster_id_max() & ~CLUSTER_ID_LOWER_MASK) << (8 + IDENTITY_LEN);
 }
 
 static __always_inline __maybe_unused __u32
@@ -57,7 +68,7 @@ ctx_get_cluster_id_mark(const struct __ctx_buff *ctx __maybe_unused)
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_CLUSTER_ID)
 		return 0;
 
-	return (cluster_id_upper | cluster_id_lower) & CLUSTER_ID_MAX;
+	return (cluster_id_upper | cluster_id_lower) & get_cluster_id_max();
 #else /* __ctx_is == __ctx_xdp */
 	return 0;
 #endif /* __ctx_is == __ctx_xdp */

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -53,7 +53,7 @@ get_identity(const struct __ctx_buff *ctx __maybe_unused)
  * to a value other than the default 255, the most significant bits are taken
  * from identity and used for the most significant bits of cluster_id.
  *
- * An agent with 'max-connected-clusters=512' would set identity in the mark
+ * An agent with 'max-connected-clusters=511' would set identity in the mark
  * like the following:
  * CIIIIIII IIIIIIII XXXXXXXX CCCCCCCC
  */

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -62,7 +62,7 @@ set_identity_mark(struct __ctx_buff *ctx __maybe_unused, __u32 identity __maybe_
 		  __u32 magic __maybe_unused)
 {
 #if __ctx_is == __ctx_skb
-	__u32 cluster_id = (identity >> IDENTITY_LEN) & CLUSTER_ID_MAX;
+	__u32 cluster_id = (identity >> IDENTITY_LEN) & get_cluster_id_max();
 	__u32 cluster_id_lower = cluster_id & 0xFF;
 	__u32 cluster_id_upper = ((cluster_id & 0xFFFFFF00) << (8 + IDENTITY_LEN));
 

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -224,11 +224,6 @@ return false;
 # define NAT_46X64_PREFIX_3 0
 #endif
 
-#ifndef __CLUSTERMESH_IDENTITY__
-#define __CLUSTERMESH_IDENTITY__
-#define CLUSTER_ID_MAX 255
-#endif
-
 #ifndef __CLUSTERMESH_HELPERS__
 #define __CLUSTERMESH_HELPERS__
 #define IDENTITY_LEN 16

--- a/bpf/tests/bpf_skb_255_tests.c
+++ b/bpf/tests/bpf_skb_255_tests.c
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#ifndef __CLUSTERMESH_IDENTITY__
-#define __CLUSTERMESH_IDENTITY__
-#define CLUSTER_ID_MAX 255
-#endif
-
 #ifndef __CLUSTERMESH_HELPERS__
 #define __CLUSTERMESH_HELPERS__
 #define IDENTITY_LEN 8
 #define IDENTITY_MAX 255
 #endif
+
+#define get_cluster_id_max() 255
 
 #include <bpf/ctx/skb.h>
 #include <lib/overloadable.h>

--- a/bpf/tests/bpf_skb_511_tests.c
+++ b/bpf/tests/bpf_skb_511_tests.c
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#ifndef __CLUSTERMESH_IDENTITY__
-#define __CLUSTERMESH_IDENTITY__
-#define CLUSTER_ID_MAX 511
-#endif
-
 #ifndef __CLUSTERMESH_HELPERS__
 #define __CLUSTERMESH_HELPERS__
 #define IDENTITY_LEN 15
 #define IDENTITY_MAX 32767
 #endif
+
+#define get_cluster_id_max() 511
 
 #include <bpf/ctx/skb.h>
 #include <lib/overloadable.h>

--- a/pkg/datapath/config/config.go
+++ b/pkg/datapath/config/config.go
@@ -11,6 +11,7 @@ import (
 
 func NodeConfig(lnc *datapath.LocalNodeConfiguration) Node {
 	node := *NewNode()
+	node.ClusterIDMax = option.Config.MaxConnectedClusters
 
 	if lnc.ServiceLoopbackIPv4 != nil {
 		node.ServiceLoopbackIPv4 = [4]byte(lnc.ServiceLoopbackIPv4.To4())

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -9,6 +9,8 @@ package config
 // instantiate directly! Always use [NewNode] to ensure the default values
 // configured in the ELF are honored.
 type Node struct {
+	// Max number of clusters that can be connected in Clustermesh.
+	ClusterIDMax uint32 `config:"cluster_id_max"`
 	// Index of the interface used to connect nodes in the cluster.
 	DirectRoutingDevIfindex uint32 `config:"direct_routing_dev_ifindex"`
 	// Enable hybrid mode routing based on subnet IDs.
@@ -32,7 +34,7 @@ type Node struct {
 }
 
 func NewNode() *Node {
-	return &Node{0x0, false, false,
+	return &Node{0xff, 0x0, false, false,
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0},
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -620,9 +620,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENCAP6_IFINDEX"] = "0"
 	}
 
-	// Write Identity and ClusterID related macros.
-	cDefinesMap["CLUSTER_ID_MAX"] = fmt.Sprintf("%d", option.Config.MaxConnectedClusters)
-
+	// Write Identity related macros.
 	fmt.Fprint(fw, declareConfig("identity_length", identity.GetClusterIDShift(), "Identity length in bits"))
 	fmt.Fprint(fw, assignConfig("identity_length", identity.GetClusterIDShift()))
 


### PR DESCRIPTION
Migrate CLUSTER_ID_MAX to runtime config.

Related: #38370