### PR TITLE
daemon: Fail agent startup on incompatible datapath mode

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -391,8 +391,11 @@ func configureDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonP
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the
 	// endpoint not being able to be restored.
-	params.EndpointRestorer.RestoreOldEndpoints()
-	bootstrapStats.restore.End(true)
+	err = params.EndpointRestorer.RestoreOldEndpoints()
+	bootstrapStats.restore.EndError(err)
+	if err != nil {
+		return err
+	}
 
 	// We must do this after IPAM because we must wait until the
 	// K8s resources have been synced.

--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -17,6 +17,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
@@ -129,6 +130,67 @@ type endpointRestoreState struct {
 func (r *endpointRestorer) checkLink(linkName string) error {
 	_, err := safenetlink.LinkByName(linkName)
 	return err
+}
+
+// validateDatapathModeCompatibility checks if endpoints being restored are compatible
+// with the current datapath mode. If the agent is configured with netkit/veth mode and
+// detects existing endpoints using veth/netkit, it will exit with a fatal error describing
+// the compatibility issue
+func (r *endpointRestorer) validateDatapathModeCompatibility(endpoints map[uint16]*endpoint.Endpoint) error {
+	var incompatibleEndpoints []string
+	var incompatibleType string
+
+	// Determine what type of endpoints are incompatible with current mode
+	currentDatapathMode := option.Config.DatapathMode
+	isNetkitMode := currentDatapathMode == datapathOption.DatapathModeNetkit || currentDatapathMode == datapathOption.DatapathModeNetkitL2
+	isVethMode := currentDatapathMode == datapathOption.DatapathModeVeth
+
+	for _, ep := range endpoints {
+		// Only check pod endpoints, skip host endpoint, health endpoint, and other special endpoints
+		if !ep.K8sNamespaceAndPodNameIsSet() {
+			continue
+		}
+
+		// Skip fake endpoints
+		if ep.IsProperty(endpoint.PropertyFakeEndpoint) {
+			continue
+		}
+
+		ifName := ep.HostInterface()
+		link, err := safenetlink.LinkByName(ifName)
+		if err != nil {
+			r.logger.Debug("Failed to check endpoint link type, skipping",
+				logfields.EndpointID, ep.ID,
+				logfields.Error, err,
+			)
+			continue
+		}
+
+		// Check for incompatibility
+		isIncompatible := false
+		if isNetkitMode && link.Type() == "veth" {
+			isIncompatible = true
+			incompatibleType = "veth"
+		} else if isVethMode && link.Type() == "netkit" {
+			isIncompatible = true
+			incompatibleType = "netkit"
+		}
+
+		if isIncompatible {
+			epName := fmt.Sprintf("%s/%s (endpoint-%d)", ep.K8sNamespace, ep.K8sPodName, ep.ID)
+			incompatibleEndpoints = append(incompatibleEndpoints, epName)
+		}
+	}
+
+	if len(incompatibleEndpoints) > 0 {
+		return fmt.Errorf(
+			"Cannot start cilium-agent with datapath-mode=%s: detected %d existing endpoint(s) using %s datapath mode. "+
+				"Endpoints using %s datapath mode: %v. "+
+				"Please delete these pods or change the datapath mode back to %s before starting the agent with %s mode",
+			currentDatapathMode, len(incompatibleEndpoints), incompatibleType, incompatibleType, incompatibleEndpoints, incompatibleType, currentDatapathMode)
+	}
+
+	return nil
 }
 
 // validateEndpoint attempts to determine that the restored endpoint is valid, ie it
@@ -252,7 +314,7 @@ func (r *endpointRestorer) GetState() *endpointRestoreState {
 // endpoints into the endpoints list. It needs to be followed by a call to
 // regenerateRestoredEndpoints() once the endpoint builder is ready.
 // Endpoints which cannot be associated with a container workload are deleted.
-func (r *endpointRestorer) RestoreOldEndpoints() {
+func (r *endpointRestorer) RestoreOldEndpoints() error {
 	failed := 0
 	defer func() {
 		r.restoreState.possible = nil
@@ -260,10 +322,15 @@ func (r *endpointRestorer) RestoreOldEndpoints() {
 
 	if !option.Config.RestoreState {
 		r.logger.Info("Endpoint restore is disabled, skipping restore step")
-		return
+		return nil
 	}
 
 	r.logger.Info("Restoring endpoints...")
+
+	// Validate that endpoints are compatible with the current datapath mode
+	if err := r.validateDatapathModeCompatibility(r.restoreState.possible); err != nil {
+		return err
+	}
 
 	var (
 		existingEndpoints map[string]lxcmap.EndpointInfo
@@ -329,6 +396,8 @@ func (r *endpointRestorer) RestoreOldEndpoints() {
 			}
 		}
 	}
+
+	return nil
 }
 
 func (r *endpointRestorer) regenerateRestoredEndpoints(state *endpointRestoreState) {


### PR DESCRIPTION
Cilium does not currently support migrating a live node with pods between `netkit` and `veth` datapath modes
([ref](https://docs.cilium.io/en/stable/operations/performance/tuning/#netkit-device-mode)). But there is currently no safety mechanisms to safeguard against it. This means that is it currently possible to accidentally switch datapath mode on a node and end up in an undefined and unexpected state.

This PR aims to ensure this can not happen by adding a check in the endpoint restore logic to check the restored endpoint link type against the configured datapath mode and make the agent crash in case of incompatibility.

The new errors look like this:
<img width="817" height="554" alt="image" src="https://github.com/user-attachments/assets/518362da-aa76-493c-8be3-973793c0b3dd" />

For context, we accidentally enabled netkit on nodes that had existing veth endpoints and it took us a while to understand that this was the issue as what we observed was a high volume of dropped ARP packets with reason `Unsupported L3 protocol` and protocol `unknown l4`. This is because since netkit runs in L3 mode, netkit bpf programs are compiled without ARP support.
