### PR TITLE
Cleanup FQDNs that have leaked into the global FQDN cache

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -693,6 +693,16 @@ func (c *DNSCache) Dump() (lookups []*cacheEntry) {
 	return deduped
 }
 
+func (c *DNSCache) DumpNames() sets.Set[string] {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	names := make(sets.Set[string])
+	for name := range c.forward {
+		names.Insert(name)
+	}
+	return names
+}
+
 // Count returns two values, the count of still-valid FQDNs inside the DNS
 // cache and the count of the still-valid entries (IPs) in the DNS cache.
 //


### PR DESCRIPTION
From the commit:

```
When an endpoint is deleted if it has any fqdn cache entries they will
only be cleaned up by the FQDN GC routine when another endpoint also
lookups those FQDNs in the future. The FQDN is essentially the key for
what to clean up in a GC run.

Some workloads we have observed result in names with unique hashes being
looked up, which means they never get looked up again by any future
endpoints and so permanently leaking the deleted FQDNs into the
global cache.

This commit finds any FQDNs present in the global cache but not any
endpoint caches and adds them to the namesToClean list to ensure they
are cleaned up.
```

You can repro this on a vanilla cilium install by creating an pod that has a policy allowing access to some name (`google.com` for example) and then connecting to it from the pod and quickly deleting it. This will result in a leaked FQDN cache entry in the global cache (that can only be observed by adding a command to dump the global cache which I am doing in a separate PR to be linked).

I'm adding `DumpNames` to get all of the names present in the given cache which enables the comparison of all the names in the global cache to all those in the endpoint caches.