### PR TITLE
Add a global source to fqdn cache list command

### DIFF
--- a/pkg/fqdn/namemanager/api.go
+++ b/pkg/fqdn/namemanager/api.go
@@ -24,6 +24,7 @@ import (
 var (
 	DNSSourceLookup     = "lookup"
 	DNSSourceConnection = "connection"
+	DNSSourceGlobal     = "global"
 )
 
 type NoEndpointIDMatch struct {
@@ -57,10 +58,31 @@ func (n *manager) model() *models.NameManager {
 // endpoint's DNSHistory. These are filtered by the specified matchers if
 // they are non-empty.
 //
-// Note that this does *NOT* dump the NameManager's own global DNSCache.
-//
 // endpointID may be "" in order to get DNS history for all endpoints.
 func (n *manager) dnsHistoryModel(endpointID string, prefixMatcher fqdn.PrefixMatcherFunc, nameMatcher fqdn.NameMatcherFunc, source string) (lookups []*models.DNSLookup, err error) {
+	if source == DNSSourceGlobal {
+		globalSourceEntries := []*models.DNSLookup{}
+		for _, lookup := range n.cache.Dump() {
+			// The API model needs strings
+			IPStrings := make([]string, 0, len(lookup.IPs))
+
+			for _, ip := range lookup.IPs {
+				IPStrings = append(IPStrings, ip.String())
+			}
+
+			globalSourceEntries = append(globalSourceEntries, &models.DNSLookup{
+				Fqdn:           lookup.Name,
+				Ips:            IPStrings,
+				LookupTime:     strfmt.DateTime(lookup.LookupTime),
+				TTL:            int64(lookup.TTL),
+				ExpirationTime: strfmt.DateTime(lookup.ExpirationTime),
+				EndpointID:     0,
+				Source:         DNSSourceGlobal,
+			})
+		}
+		return globalSourceEntries, nil
+	}
+
 	var eps []*endpoint.Endpoint
 	if endpointID == "" {
 		eps = n.params.EPMgr.GetEndpoints()


### PR DESCRIPTION
From the commit:

```
This commit allows for the dumping of the global fqdn cache by passing
the "global" source to the fqdn list command via -s "global".
```

Adding the ability to dump the global FQDN cache is very useful when debugging FQDN related issues. This was particularly useful when troubleshooting this leak in the global cache https://github.com/cilium/cilium/pull/42485.

Example:

```
# Endpoints
$ kubectl exec -n kube-system cilium-8qsn8 -- cilium-dbg fqdn cache list
Endpoint   Source       FQDN          TTL   ExpirationTime             IPs
2296       lookup       yahoo.com.    30    2025-10-29T21:25:06.199Z   98.137.11.163,74.6.231.20,98.137.11.164,74.6.143.25,74.6.143.26,74.6.231.21
2296       connection   google.com.   0     2025-10-29T21:31:24.977Z   142.250.81.238

# Global
$ kubectl exec -n kube-system cilium-8qsn8 -- cilium-dbg fqdn cache list -s global
Endpoint   Source   FQDN          TTL   ExpirationTime             IPs
0          global   google.com.   120   2025-10-29T21:26:54.587Z   142.250.81.238
0          global   yahoo.com.    30    2025-10-29T21:25:06.199Z   98.137.11.163,74.6.231.20,98.137.11.164,74.6.143.25,74.6.143.26,74.6.231.21
```