### PR TITLE
daemon: extract map sweeper lifecycle into hive cell

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/linux/utime"
 	"github.com/cilium/cilium/pkg/datapath/loader"
+	datapathmaps "github.com/cilium/cilium/pkg/datapath/maps"
 	"github.com/cilium/cilium/pkg/datapath/neighbor"
 	"github.com/cilium/cilium/pkg/datapath/node"
 	"github.com/cilium/cilium/pkg/datapath/orchestrator"
@@ -52,6 +53,9 @@ var Cell = cell.Module(
 
 	// Provides all BPF Map which are already provided by via hive cell.
 	maps.Cell,
+
+	// Cleanup of stale and disabled BPF maps
+	datapathmaps.Cell,
 
 	// Utime synchronizes utime from userspace to datapath via configmap.Map.
 	utime.Cell,

--- a/pkg/datapath/maps/cell.go
+++ b/pkg/datapath/maps/cell.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package maps
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/kpr"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+var Cell = cell.Module(
+	"maps-cleanup",
+	"Cleanup of stale and disabled BPF maps",
+	cell.Invoke(registerMapSweeper),
+)
+
+type mapSweeperParams struct {
+	cell.In
+
+	Logger   *slog.Logger
+	JobGroup job.Group
+
+	EndpointRestorerPromise promise.Promise[endpointstate.Restorer]
+	EndpointManager         endpointmanager.EndpointManager
+	BandwidthManager        datapath.BandwidthManager
+	LBConfig                loadbalancer.Config
+	KPRConfig               kpr.KPRConfig
+}
+
+func registerMapSweeper(params mapSweeperParams) {
+	ms := newMapSweeper(
+		params.Logger,
+		&EndpointMapManager{
+			logger:          params.Logger,
+			EndpointManager: params.EndpointManager,
+		},
+		params.BandwidthManager,
+		params.LBConfig,
+		params.KPRConfig)
+
+	params.JobGroup.Add(job.OneShot("cleanup", func(ctx context.Context, health cell.Health) error {
+		restorer, err := params.EndpointRestorerPromise.Await(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to wait for endpoint restorer: %w", err)
+		}
+
+		if err := restorer.WaitForEndpointRestore(ctx); err != nil {
+			return fmt.Errorf("failed to wait for endpoint restoration: %w", err)
+		}
+
+		ms.CollectStaleMapGarbage()
+		ms.RemoveDisabledMaps()
+
+		return nil
+	}))
+}

--- a/pkg/datapath/maps/endpoint_map_manager.go
+++ b/pkg/datapath/maps/endpoint_map_manager.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package maps
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+)
+
+// EndpointMapManager is a wrapper around an endpointmanager as well as the
+// filesystem for removing maps related to endpoints from the filesystem.
+type EndpointMapManager struct {
+	logger *slog.Logger
+	endpointmanager.EndpointManager
+}
+
+// RemoveDatapathMapping unlinks the endpointID from the global policy map, preventing
+// packets that arrive on this node from being forwarded to the endpoint that
+// used to exist with the specified ID.
+func (e *EndpointMapManager) RemoveDatapathMapping(endpointID uint16) error {
+	return policymap.RemoveGlobalMapping(e.logger, uint32(endpointID))
+}
+
+// RemoveMapPath removes the specified path from the filesystem.
+func (e *EndpointMapManager) RemoveMapPath(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		e.logger.Warn(
+			"Error while deleting stale map file",
+			logfields.Path, path,
+		)
+	} else {
+		e.logger.Info(
+			"Removed stale bpf map",
+			logfields.Path, path,
+		)
+	}
+}
+
+// ListMapsDir gives names of files (or subdirectories) found in the specified path.
+func (e *EndpointMapManager) ListMapsDir(path string) []string {
+	var maps []string
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		e.logger.Warn(
+			"Error while listing maps dir",
+			logfields.Path, path,
+			logfields.Error, err,
+		)
+		return maps
+	}
+
+	for _, e := range entries {
+		maps = append(maps, e.Name())
+	}
+
+	return maps
+}

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -56,11 +56,11 @@ type MapSweeper struct {
 	kprCfg    kpr.KPRConfig
 }
 
-// NewMapSweeper creates an object that walks map paths and garbage-collects
+// newMapSweeper creates an object that walks map paths and garbage-collects
 // them.
-func NewMapSweeper(defaultLogger *slog.Logger, g endpointManager, bwm dptypes.BandwidthManager, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig) *MapSweeper {
+func newMapSweeper(logger *slog.Logger, g endpointManager, bwm dptypes.BandwidthManager, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig) *MapSweeper {
 	return &MapSweeper{
-		logger:          defaultLogger.With(logfields.LogSubsys, "datapath-maps"),
+		logger:          logger,
 		endpointManager: g,
 		bwManager:       bwm,
 		lbConfig:        lbConfig,

--- a/pkg/datapath/maps/map_test.go
+++ b/pkg/datapath/maps/map_test.go
@@ -60,7 +60,6 @@ func newTestBWManager() types.BandwidthManager {
 }
 
 func TestCollectStaleMapGarbage(t *testing.T) {
-
 	testCases := []struct {
 		name            string
 		endpoints       []uint16
@@ -190,7 +189,7 @@ func TestCollectStaleMapGarbage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testEPManager := newTestEPManager(tt.paths)
 			bwManager := newTestBWManager()
-			sweeper := NewMapSweeper(hivetest.Logger(t), testEPManager, bwManager, loadbalancer.DefaultConfig, kpr.KPRConfig{})
+			sweeper := newMapSweeper(hivetest.Logger(t), testEPManager, bwManager, loadbalancer.DefaultConfig, kpr.KPRConfig{})
 
 			for _, ep := range tt.endpoints {
 				testEPManager.addEndpoint(ep)
@@ -225,7 +224,7 @@ func TestRemoveDisabledMaps(t *testing.T) {
 			"cilium_policy_01234",
 		}
 		bwManager := newTestBWManager()
-		sweeper := NewMapSweeper(hivetest.Logger(t), testEPManager, bwManager, loadbalancer.DefaultConfig, kpr.KPRConfig{})
+		sweeper := newMapSweeper(hivetest.Logger(t), testEPManager, bwManager, loadbalancer.DefaultConfig, kpr.KPRConfig{})
 
 		sweeper.RemoveDisabledMaps()
 		require.Equal(t, depricatedMaps, testEPManager.removedPaths)


### PR DESCRIPTION
This commit extracts the lifecycle aspect of the map sweeper (cleanup stale and disabled maps after endpoint restoration) into a new Hive Cell in the package `pkg/datapath/maps` - using Hive Jobs.