### PR TITLE
bpf: use NULL instead of 0 to initialize pointers, constify

### DIFF
--- a/bpf/lib/mcast.h
+++ b/bpf/lib/mcast.h
@@ -109,7 +109,7 @@ static __always_inline __s32 mcast_ipv4_igmp_type(const struct iphdr *ip4,
 
 /* add a subscriber to a subscriber map */
 /* returns 1 on success or DROP_INVALID for error */
-static __always_inline __s32 mcast_ipv4_add_subscriber(void *map,
+static __always_inline __s32 mcast_ipv4_add_subscriber(const void *map,
 						       struct mcast_subscriber_v4 *sub)
 {
 	if ((map_update_elem(map, &sub->saddr, sub, BPF_ANY) != 0))
@@ -119,7 +119,7 @@ static __always_inline __s32 mcast_ipv4_add_subscriber(void *map,
 
 /* remove a subscriber to a subscriber map */
 /* always returns 1 */
-static __always_inline void mcast_ipv4_remove_subscriber(void *map,
+static __always_inline void mcast_ipv4_remove_subscriber(const void *map,
 							 struct mcast_subscriber_v4 *sub)
 {
 	map_delete_elem(map, &sub->saddr);
@@ -137,9 +137,9 @@ static __always_inline __s32 mcast_ipv4_handle_v3_membership_report(void *ctx,
 	};
 	const struct igmpv3_report *rep;
 	const struct igmpv3_grec *rec;
+	const void *sub_map = NULL;
 	int ip_len = ip4->ihl * 4;
 	__s32 subscribed = 0;
-	void *sub_map = 0;
 	__u16 ngrec = 0;
 	__u32 i = 0;
 
@@ -220,9 +220,9 @@ static __always_inline __s32 mcast_ipv4_handle_v2_membership_report(void *ctx,
 		.saddr = ip4->saddr,
 		.ifindex = ctx_get_ingress_ifindex(ctx)
 	};
+	const void *sub_map = NULL;
 	int ip_len = ip4->ihl * 4;
 	const struct igmphdr *hdr;
-	void *sub_map = 0;
 
 	if (data + ETH_HLEN + ip_len + sizeof(struct igmphdr) > data_end)
 		return DROP_INVALID;
@@ -251,9 +251,9 @@ static __always_inline __s32 mcast_ipv4_handle_igmp_leave(void *group_map,
 	struct mcast_subscriber_v4 subscriber = {
 		.saddr = ip4->saddr,
 	};
+	const void *sub_map = NULL;
 	int ip_len = ip4->ihl * 4;
 	const struct igmphdr *hdr;
-	void *sub_map = 0;
 
 	if (data + ETH_HLEN + ip_len + sizeof(struct igmphdr) > data_end)
 		return DROP_INVALID;
@@ -406,10 +406,10 @@ int tail_mcast_ep_delivery(struct __ctx_buff *ctx)
 		.ctx = ctx,
 		.ret = 0
 	};
+	struct iphdr *ip4 = NULL;
 	union macaddr mac = {0};
 	void *data, *data_end;
-	struct iphdr *ip4 = 0;
-	void *sub_map = 0;
+	void *sub_map = NULL;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;

--- a/bpf/tests/common.h
+++ b/bpf/tests/common.h
@@ -204,7 +204,7 @@ static void *(*test_bpf_map_lookup_elem)(void *map, const void *key) = (void *)1
 /*   write the amount of bytes used after a test is done. */
 #define test_init()							  \
 	char suite_result = TEST_PASS;					  \
-	__maybe_unused char *test_result_status = 0;			  \
+	__maybe_unused char *test_result_status = NULL;			  \
 	char *suite_result_cursor;					  \
 	{								  \
 		__u32 __key = 0;						  \
@@ -214,7 +214,7 @@ static void *(*test_bpf_map_lookup_elem)(void *map, const void *key) = (void *)1
 			return TEST_ERROR;				  \
 		}							  \
 	}								  \
-	__maybe_unused char *test_result_cursor = 0;			  \
+	__maybe_unused char *test_result_cursor = NULL;			  \
 	__maybe_unused __u16 test_result_size;				  \
 	do {
 /* */


### PR DESCRIPTION
Follow the style used in the rest of the code base and in the kernel. While at it, also constify the touched pointer declarations where applicable.