### PR TITLE
bpf: constify ipcache map access

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -108,7 +108,7 @@ static __always_inline __u32
 resolve_srcid_ipv6(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		   __u32 real_sec_identity, __u32 *ipcache_sec_identity)
 {
-	struct remote_endpoint_info *info = NULL;
+	const struct remote_endpoint_info *info = NULL;
 	union v6addr *src;
 
 	/* Packets from the proxy will already have a real identity. */
@@ -258,7 +258,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	struct ipv6hdr *ip6;
 	union v6addr *dst;
 	int l3_off = ETH_HLEN;
-	struct remote_endpoint_info *info = NULL;
+	const struct remote_endpoint_info *info = NULL;
 	const struct endpoint_info *ep;
 	int ret __maybe_unused;
 	__u32 magic = MARK_MAGIC_IDENTITY;
@@ -553,7 +553,7 @@ static __always_inline __u32
 resolve_srcid_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4,
 		   __u32 real_sec_identity, __u32 *ipcache_sec_identity)
 {
-	struct remote_endpoint_info *info = NULL;
+	const struct remote_endpoint_info *info = NULL;
 
 	/* Packets from the proxy will already have a real identity. */
 	if (identity_is_reserved(real_sec_identity)) {
@@ -683,7 +683,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	__u32 __maybe_unused from_host_raw;
 	void *data, *data_end;
 	struct iphdr *ip4;
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	const struct endpoint_info *ep;
 	int ret __maybe_unused;
 	__u32 magic = MARK_MAGIC_IDENTITY;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -446,7 +446,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 						__s8 *ext_err)
 {
 	struct ct_state *ct_state, ct_state_new = {};
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
 	union macaddr router_mac = CONFIG(interface_mac);
@@ -885,7 +885,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 						__s8 *ext_err)
 {
 	struct ct_state *ct_state, ct_state_new = {};
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	struct remote_endpoint_info __maybe_unused fake_info = {0};
 	struct ipv4_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
@@ -1642,8 +1642,9 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 					      &policy_match_type, &audited, ext_err, proxy_port,
 					      &cookie);
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
-			struct remote_endpoint_info *sep = lookup_ip6_remote_endpoint(&orig_sip, 0);
+			const struct remote_endpoint_info *sep;
 
+			sep = lookup_ip6_remote_endpoint(&orig_sip, 0);
 			if (sep) {
 				auth_type = (__u8)*ext_err;
 				verdict = auth_lookup(ctx, SECLABEL_IPV6, src_label,
@@ -1783,8 +1784,8 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 
 	/* Packets from the proxy will already have a real identity. */
 	if (identity_is_reserved(src_sec_identity)) {
-		union v6addr *src = (union v6addr *)&ip6->saddr;
-		struct remote_endpoint_info *info;
+		const union v6addr *src = (union v6addr *)&ip6->saddr;
+		const struct remote_endpoint_info *info;
 
 		info = lookup_ip6_remote_endpoint(src, 0);
 		if (info != NULL) {
@@ -1951,8 +1952,9 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 					      &policy_match_type, &audited, ext_err, proxy_port,
 					      &cookie);
 		if (verdict == DROP_POLICY_AUTH_REQUIRED) {
-			struct remote_endpoint_info *sep = lookup_ip4_remote_endpoint(orig_sip, 0);
+			const struct remote_endpoint_info *sep;
 
+			sep = lookup_ip4_remote_endpoint(orig_sip, 0);
 			if (sep) {
 				auth_type = (__u8)*ext_err;
 				verdict = auth_lookup(ctx, SECLABEL_IPV4, src_label,
@@ -2099,7 +2101,7 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 
 	/* Packets from the proxy will already have a real identity. */
 	if (identity_is_reserved(src_sec_identity)) {
-		struct remote_endpoint_info *info;
+		const struct remote_endpoint_info *info;
 
 		info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 		if (info != NULL) {

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -103,7 +103,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	 */
 	if (identity_is_remote_node(*identity) ||
 	    (is_dsr && identity_is_world_ipv6(*identity))) {
-		struct remote_endpoint_info *info;
+		const struct remote_endpoint_info *info;
 
 		info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
 		if (info)
@@ -380,7 +380,7 @@ skip_vtep:
 	/* See comment at equivalent code in handle_ipv6() */
 	if (identity_is_remote_node(*identity) ||
 	    (is_dsr && identity_is_world_ipv4(*identity))) {
-		struct remote_endpoint_info *info;
+		const struct remote_endpoint_info *info;
 
 		info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 		if (info)

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -172,7 +172,7 @@ sock4_skip_xlate(struct lb4_service *svc, __be32 address)
 		return true;
 	if ((lb4_svc_is_external_ip(svc) && !is_defined(DISABLE_EXTERNAL_IP_MITIGATION)) ||
 	    (lb4_svc_is_hostport(svc) && !is_v4_loopback(address))) {
-		struct remote_endpoint_info *info;
+		const struct remote_endpoint_info *info;
 
 		info = lookup_ip4_remote_endpoint(address, 0);
 		if (!info || info->sec_identity != HOST_ID)
@@ -189,7 +189,7 @@ sock4_wildcard_lookup(struct lb4_key *key __maybe_unused,
 		      const bool inv_match __maybe_unused,
 		      const bool in_hostns __maybe_unused)
 {
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	__u16 service_port;
 
 	service_port = bpf_ntohs(key->dport);
@@ -717,7 +717,7 @@ sock6_skip_xlate(struct lb6_service *svc, const union v6addr *address)
 		return true;
 	if ((lb6_svc_is_external_ip(svc) && !is_defined(DISABLE_EXTERNAL_IP_MITIGATION)) ||
 	    (lb6_svc_is_hostport(svc) && !is_v6_loopback(address))) {
-		struct remote_endpoint_info *info;
+		const struct remote_endpoint_info *info;
 
 		info = lookup_ip6_remote_endpoint(address, 0);
 		if (!info || info->sec_identity != HOST_ID)
@@ -734,7 +734,7 @@ sock6_wildcard_lookup(struct lb6_key *key __maybe_unused,
 		      const bool inv_match __maybe_unused,
 		      const bool in_hostns __maybe_unused)
 {
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	__u16 service_port;
 
 	service_port = bpf_ntohs(key->dport);

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -44,8 +44,8 @@ static __always_inline __u32
 resolve_srcid_ipv6(struct __ctx_buff *ctx, struct ipv6hdr *ip6)
 {
 	__u32 srcid = WORLD_IPV6_ID;
-	struct remote_endpoint_info *info = NULL;
-	union v6addr *src;
+	const struct remote_endpoint_info *info = NULL;
+	const union v6addr *src;
 
 	if (CONFIG(secctx_from_ipcache)) {
 		src = (union v6addr *)&ip6->saddr;
@@ -144,7 +144,7 @@ static __always_inline __u32
 resolve_srcid_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4)
 {
 	__u32 srcid = WORLD_IPV4_ID;
-	struct remote_endpoint_info *info = NULL;
+	const struct remote_endpoint_info *info = NULL;
 
 	if (CONFIG(secctx_from_ipcache)) {
 		info = lookup_ip4_remote_endpoint(ip4->saddr, 0);

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -195,7 +195,7 @@ static __always_inline
 bool egress_gw_snat_needed_hook(__be32 saddr, __be32 daddr, __be32 *snat_addr,
 				__u32 *egress_ifindex)
 {
-	struct remote_endpoint_info *remote_ep;
+	const struct remote_endpoint_info *remote_ep;
 
 	remote_ep = lookup_ip4_remote_endpoint(daddr, 0);
 	/* If the packet is destined to an entity inside the cluster, either EP
@@ -214,7 +214,7 @@ bool egress_gw_reply_needs_redirect_hook(struct iphdr *ip4, __u32 *tunnel_endpoi
 					 __u32 *dst_sec_identity)
 {
 	if (egress_gw_reply_matches_policy(ip4)) {
-		struct remote_endpoint_info *info;
+		const struct remote_endpoint_info *info;
 
 		info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 		if (!info || !info->flag_has_tunnel_ep)
@@ -346,7 +346,7 @@ static __always_inline
 bool egress_gw_snat_needed_hook_v6(union v6addr *saddr, union v6addr *daddr,
 				   union v6addr *snat_addr, __u32 *egress_ifindex)
 {
-	struct remote_endpoint_info *remote_ep;
+	const struct remote_endpoint_info *remote_ep;
 
 	remote_ep = lookup_ip6_remote_endpoint(daddr, 0);
 	/* If the packet is destined to an entity inside the cluster, either EP
@@ -395,10 +395,10 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 
 static __always_inline
 bool egress_gw_reply_needs_redirect_hook_v6(struct ipv6hdr *ip6,
-					    struct remote_endpoint_info **info)
+					    const struct remote_endpoint_info **info)
 {
 	if (egress_gw_reply_matches_policy_v6(ip6)) {
-		struct remote_endpoint_info *egw_info;
+		const struct remote_endpoint_info *egw_info;
 
 		egw_info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
 		if (!egw_info || egw_info->tunnel_endpoint.ip4 == 0)
@@ -441,7 +441,7 @@ int egress_gw_handle_request(struct __ctx_buff *ctx, __be16 proto,
 	struct ipv4_ct_tuple tuple4 = {};
 	struct ipv6_ct_tuple __maybe_unused tuple6 = {};
 	int l4_off;
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	const struct endpoint_info *src_ep;
 	bool is_reply;
 	fraginfo_t fraginfo;

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -91,7 +91,7 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx,
  */
 static __always_inline int
 encap_and_redirect_with_nodeid(struct __ctx_buff *ctx,
-			       struct remote_endpoint_info *info,
+			       const struct remote_endpoint_info *info,
 			       __u32 seclabel, __u32 dstid,
 			       const struct trace_ctx *trace,
 			       __be16 proto)
@@ -105,7 +105,7 @@ encap_and_redirect_with_nodeid(struct __ctx_buff *ctx,
  * a DROP_* reason on error.
  */
 static __always_inline int
-encap_and_redirect_lxc(struct __ctx_buff *ctx, struct remote_endpoint_info *info,
+encap_and_redirect_lxc(struct __ctx_buff *ctx, const struct remote_endpoint_info *info,
 		       __u32 seclabel, __u32 dstid, const struct trace_ctx *trace, __be16 proto)
 {
 	return encap_and_redirect_with_nodeid(ctx, info, seclabel, dstid, trace, proto);

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -81,7 +81,8 @@ ipsec_encode_encryption_mark(__u8 key, __u32 node_id)
 }
 
 static __always_inline int
-set_ipsec_encrypt(struct __ctx_buff *ctx, struct remote_endpoint_info *info,
+set_ipsec_encrypt(struct __ctx_buff *ctx,
+		  const struct remote_endpoint_info *info,
 		  __u32 seclabel, bool use_meta)
 {
 	/* IPSec is performed by the stack on any packets with the
@@ -197,8 +198,8 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 				__u32 src_sec_identity)
 {
 	struct remote_endpoint_info __maybe_unused fake_info = {0};
-	struct remote_endpoint_info __maybe_unused *dst = NULL;
-	struct remote_endpoint_info __maybe_unused *src = NULL;
+	const struct remote_endpoint_info __maybe_unused *dst = NULL;
+	const struct remote_endpoint_info __maybe_unused *src = NULL;
 	void *data __maybe_unused, *data_end __maybe_unused;
 	struct iphdr __maybe_unused *ip4;
 	struct ipv6hdr __maybe_unused *ip6;
@@ -332,7 +333,7 @@ do_decrypt(struct __ctx_buff __maybe_unused *ctx, __u16 __maybe_unused proto)
 /* strict_allow checks whether the packet is allowed to pass through the strict mode. */
 static __always_inline bool
 strict_allow(struct __ctx_buff *ctx, __be16 proto) {
-	struct remote_endpoint_info __maybe_unused *dest_info;
+	const struct remote_endpoint_info __maybe_unused *dest_info;
 	bool __maybe_unused in_strict_cidr = false;
 	struct iphdr __maybe_unused *ip4;
 	void *data, *data_end;

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -85,7 +85,7 @@ struct {
 
 #define V6_CACHE_KEY_LEN (sizeof(union v6addr)*8)
 
-static __always_inline __maybe_unused struct remote_endpoint_info *
+static __always_inline __maybe_unused const struct remote_endpoint_info *
 ipcache_lookup6(const void *map, const union v6addr *addr,
 		__u32 prefix, __u32 cluster_id)
 {
@@ -107,7 +107,7 @@ ipcache_lookup6(const void *map, const union v6addr *addr,
 
 #define V4_CACHE_KEY_LEN (sizeof(__u32)*8)
 
-static __always_inline __maybe_unused struct remote_endpoint_info *
+static __always_inline __maybe_unused const struct remote_endpoint_info *
 ipcache_lookup4(const void *map, __be32 addr, __u32 prefix, __u32 cluster_id)
 {
 	struct ipcache_key key = {

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -76,7 +76,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		return CTX_ACT_OK;
 
 	if (is_host_id) {
-		struct remote_endpoint_info *info;
+		const struct remote_endpoint_info *info;
 		__u32 tunnel_endpoint = 0;
 
 		/* Retrieve destination identity. */
@@ -159,7 +159,7 @@ ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 				struct ct_buffer6 *ct_buffer)
 {
 	__u32 dst_sec_identity = WORLD_IPV6_ID;
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
 	int hdrlen;
 
@@ -205,7 +205,7 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 	__u8 audited = 0;
 	__u8 auth_type = 0;
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	bool is_untracked_fragment = false;
 	__u16 proxy_port = 0;
 	__u32 cookie = 0;
@@ -360,7 +360,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	 */
 
 	if (is_host_id) {
-		struct remote_endpoint_info *info;
+		const struct remote_endpoint_info *info;
 		__u32 tunnel_endpoint = 0;
 
 		/* Retrieve destination identity. */
@@ -442,7 +442,7 @@ ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
 				struct ct_buffer4 *ct_buffer)
 {
 	__u32 dst_sec_identity = WORLD_IPV4_ID;
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	struct ipv4_ct_tuple *tuple = &ct_buffer->tuple;
 	int l3_off = ETH_HLEN;
 
@@ -480,7 +480,7 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 	__u8 audited = 0;
 	__u8 auth_type = 0;
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	fraginfo_t fraginfo __maybe_unused;
 	bool is_untracked_fragment = false;
 	__u16 proxy_port = 0;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -609,7 +609,7 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 struct ipv4_nat_target *target __maybe_unused)
 {
 	const struct endpoint_info *local_ep __maybe_unused;
-	struct remote_endpoint_info *remote_ep __maybe_unused;
+	const struct remote_endpoint_info *remote_ep __maybe_unused;
 	int ret;
 
 	ret = snat_v4_needs_masquerade_hook(ctx, target);
@@ -1668,7 +1668,7 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 struct ipv6_nat_target *target __maybe_unused)
 {
 	union v6addr masq_addr __maybe_unused = CONFIG(nat_ipv6_masquerade);
-	struct remote_endpoint_info *remote_ep __maybe_unused;
+	const struct remote_endpoint_info *remote_ep __maybe_unused;
 	const struct endpoint_info *local_ep __maybe_unused;
 
 	/* See comments in snat_v4_needs_masquerade(). */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -391,7 +391,7 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 						 __be16 svc_port,
 						 int *ifindex, int *ohead)
 {
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple tuple __align_stack_8 = {};
 	struct geneve_dsr_opt6 gopt;
 	union v6addr *dst;
@@ -911,7 +911,7 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, enum ct_dir dir,
 		},
 	};
 	int ret, l4_off;
-	struct remote_endpoint_info *info __maybe_unused;
+	const struct remote_endpoint_info *info __maybe_unused;
 	struct ipv6_ct_tuple tuple __align_stack_8 = {};
 	struct ct_state ct_state = {};
 	void *data, *data_end;
@@ -1197,7 +1197,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	fraginfo_t fraginfo;
 	__s8 ext_err = 0;
 #ifdef TUNNEL_MODE
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	union v6addr *dst;
 #endif
 
@@ -1726,7 +1726,7 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, int l3_
 						 struct iphdr *ip4, __be32 svc_addr,
 						 __be16 svc_port, int *ifindex, __be16 *ohead)
 {
-	struct remote_endpoint_info *info __maybe_unused;
+	const struct remote_endpoint_info *info __maybe_unused;
 	struct geneve_dsr_opt4 gopt __align_stack_8;
 	bool need_opt = true;
 	__u16 encap_len = sizeof(struct iphdr) + sizeof(struct udphdr) +
@@ -2239,7 +2239,7 @@ nodeport_rev_dnat_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 			.ifindex	= ctx_get_ifindex(ctx),
 		},
 	};
-	struct remote_endpoint_info *info __maybe_unused = NULL;
+	const struct remote_endpoint_info *info __maybe_unused = NULL;
 	int ifindex = 0, ret, l3_off = ETH_HLEN, l4_off;
 	struct ipv4_ct_tuple tuple = {};
 	struct ct_state ct_state = {};
@@ -2546,7 +2546,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 #ifdef TUNNEL_MODE
 	__u32 src_sec_identity = ctx_load_meta(ctx, CB_SRC_LABEL);
 	__u8 cluster_id __maybe_unused = (__u8)ctx_load_meta(ctx, CB_CLUSTER_ID_EGRESS);
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	__be32 tunnel_endpoint = 0;
 #endif
 

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -64,8 +64,8 @@ static __always_inline int
 wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 			     __u32 src_sec_identity)
 {
-	struct remote_endpoint_info *dst = NULL;
-	struct remote_endpoint_info __maybe_unused *src = NULL;
+	const struct remote_endpoint_info *dst = NULL;
+	const struct remote_endpoint_info __maybe_unused *src = NULL;
 	void *data, *data_end;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;

--- a/bpf/tests/remote_node_masquerade_skip_test.c
+++ b/bpf/tests/remote_node_masquerade_skip_test.c
@@ -22,7 +22,7 @@
 /* #undef TUNNEL_MODE (implicitly undefined) */
 #include <lib/eps.h>
 /* Mock for lookup_ip4_remote_endpoint */
-static struct remote_endpoint_info *mocked_remote_endpoint;
+static const struct remote_endpoint_info *mocked_remote_endpoint;
 #undef lookup_ip4_remote_endpoint
 #define lookup_ip4_remote_endpoint(addr, cluster_id) \
     (mocked_remote_endpoint)

--- a/bpf/tests/remote_node_masquerade_test.c
+++ b/bpf/tests/remote_node_masquerade_test.c
@@ -23,7 +23,7 @@
 
 #include <lib/eps.h>
 /* Mock for lookup_ip4_remote_endpoint */
-static struct remote_endpoint_info *mocked_remote_endpoint;
+static const struct remote_endpoint_info *mocked_remote_endpoint;
 #undef lookup_ip4_remote_endpoint
 #define lookup_ip4_remote_endpoint(addr, cluster_id) \
     (mocked_remote_endpoint)

--- a/bpf/tests/wildcard_lookup.c
+++ b/bpf/tests/wildcard_lookup.c
@@ -101,7 +101,7 @@ static inline void __setup_v4(void)
 CHECK("xdp", "sock4_wildcard_lookup_test")
 int test_v4_check(__maybe_unused struct xdp_md *ctx)
 {
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	struct lb4_service *ret;
 	struct lb4_key key = {
 		.address = 0,		/* will set for individual tests */
@@ -309,7 +309,7 @@ static inline void __setup_v6_hostport(const union v6addr *HOST_IP6)
 CHECK("xdp", "sock6_wildcard_lookup_test")
 int test_v6_check(__maybe_unused struct xdp_md *ctx)
 {
-	struct remote_endpoint_info *info;
+	const struct remote_endpoint_info *info;
 	struct lb6_service *ret;
 	struct lb6_key key = {
 		.address = {},		/* will set for individual tests */


### PR DESCRIPTION
Protect against accidental writes to the ipcache map entry. This should help to catch cases like the one fixed in commit 7217a75ec819 ("bpf: Do not accidentally update IPcache in cluster-aware routing") at build time.

As suggested by @julianwiedmann

Related #42473