### PR TITLE
MAINTAINERS: Correctly link Arthur's GitHub profile

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -79,6 +79,7 @@ project.
 [Aditi Ghag]: https://github.com/aditighag
 [Alexandre Perrin]: https://github.com/kaworu
 [André Martins]: https://github.com/aanm
+[Arthur Outhenin-Chalandre]: https://github.com/MrFreezeex
 [Beatriz Martínez]: https://github.com/b3a-dev
 [Bill Mulligan]: https://github.com/xmulligan
 [Bruno M. Custódio]: https://github.com/bmcustodio


### PR DESCRIPTION
The blamed commit added Arthur to the MAINTAINERS file, but missed linking his GitHub profile. Let's get that fixed.