### PR TITLE
daemon: extract ctmap GC initialization

### DIFF
--- a/daemon/cmd/bootstrap_statistics.go
+++ b/daemon/cmd/bootstrap_statistics.go
@@ -10,21 +10,20 @@ import (
 )
 
 type bootstrapStatistics struct {
-	overall         spanstat.SpanStat
-	earlyInit       spanstat.SpanStat
-	k8sInit         spanstat.SpanStat
-	restore         spanstat.SpanStat
-	healthCheck     spanstat.SpanStat
-	ingressIPAM     spanstat.SpanStat
-	cleanup         spanstat.SpanStat
-	bpfBase         spanstat.SpanStat
-	ipam            spanstat.SpanStat
-	daemonInit      spanstat.SpanStat
-	mapsInit        spanstat.SpanStat
-	fqdn            spanstat.SpanStat
-	enableConntrack spanstat.SpanStat
-	kvstore         spanstat.SpanStat
-	deleteQueue     spanstat.SpanStat
+	overall     spanstat.SpanStat
+	earlyInit   spanstat.SpanStat
+	k8sInit     spanstat.SpanStat
+	restore     spanstat.SpanStat
+	healthCheck spanstat.SpanStat
+	ingressIPAM spanstat.SpanStat
+	cleanup     spanstat.SpanStat
+	bpfBase     spanstat.SpanStat
+	ipam        spanstat.SpanStat
+	daemonInit  spanstat.SpanStat
+	mapsInit    spanstat.SpanStat
+	fqdn        spanstat.SpanStat
+	kvstore     spanstat.SpanStat
+	deleteQueue spanstat.SpanStat
 }
 
 func (b *bootstrapStatistics) updateMetrics() {
@@ -44,20 +43,19 @@ func (b *bootstrapStatistics) updateMetrics() {
 
 func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 	return map[string]*spanstat.SpanStat{
-		"overall":         &b.overall,
-		"earlyInit":       &b.earlyInit,
-		"k8sInit":         &b.k8sInit,
-		"restore":         &b.restore,
-		"healthCheck":     &b.healthCheck,
-		"ingressIPAM":     &b.ingressIPAM,
-		"cleanup":         &b.cleanup,
-		"bpfBase":         &b.bpfBase,
-		"ipam":            &b.ipam,
-		"daemonInit":      &b.daemonInit,
-		"mapsInit":        &b.mapsInit,
-		"fqdn":            &b.fqdn,
-		"enableConntrack": &b.enableConntrack,
-		"kvstore":         &b.kvstore,
-		"deleteQueue":     &b.deleteQueue,
+		"overall":     &b.overall,
+		"earlyInit":   &b.earlyInit,
+		"k8sInit":     &b.k8sInit,
+		"restore":     &b.restore,
+		"healthCheck": &b.healthCheck,
+		"ingressIPAM": &b.ingressIPAM,
+		"cleanup":     &b.cleanup,
+		"bpfBase":     &b.bpfBase,
+		"ipam":        &b.ipam,
+		"daemonInit":  &b.daemonInit,
+		"mapsInit":    &b.mapsInit,
+		"fqdn":        &b.fqdn,
+		"kvstore":     &b.kvstore,
+		"deleteQueue": &b.deleteQueue,
 	}
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1261,26 +1261,22 @@ type daemonParams struct {
 	Namespaces          statedb.Table[agentK8s.Namespace]
 	Devices             statedb.Table[*datapathTables.Device]
 	DirectRoutingDevice datapathTables.DirectRoutingDevice
-	// Grab the GC object so that we can start the CT/NAT map garbage collection.
-	// This is currently necessary because these maps have not yet been modularized,
-	// and because it depends on parameters which are not provided through hive.
-	CTNATMapGC        ctmap.GCRunner
-	IPIdentityWatcher *ipcache.LocalIPIdentityWatcher
-	ClusterInfo       cmtypes.ClusterInfo
-	IPsecAgent        datapath.IPsecAgent
-	SyncHostIPs       *syncHostIPs
-	NodeDiscovery     *nodediscovery.NodeDiscovery
-	IPAM              *ipam.IPAM
-	CRDSyncPromise    promise.Promise[k8sSynced.CRDSync]
-	IdentityManager   identitymanager.IDManager
-	MaglevConfig      maglev.Config
-	DNSProxy          bootstrap.FQDNProxyBootstrapper
-	DNSNameManager    namemanager.NameManager
-	KPRConfig         kpr.KPRConfig
-	KPRInitializer    kprinitializer.KPRInitializer
-	IPSecConfig       datapath.IPsecConfig
-	HealthConfig      healthconfig.CiliumHealthConfig
-	InfraIPAllocator  *infraIPAllocator
+	IPIdentityWatcher   *ipcache.LocalIPIdentityWatcher
+	ClusterInfo         cmtypes.ClusterInfo
+	IPsecAgent          datapath.IPsecAgent
+	SyncHostIPs         *syncHostIPs
+	NodeDiscovery       *nodediscovery.NodeDiscovery
+	IPAM                *ipam.IPAM
+	CRDSyncPromise      promise.Promise[k8sSynced.CRDSync]
+	IdentityManager     identitymanager.IDManager
+	MaglevConfig        maglev.Config
+	DNSProxy            bootstrap.FQDNProxyBootstrapper
+	DNSNameManager      namemanager.NameManager
+	KPRConfig           kpr.KPRConfig
+	KPRInitializer      kprinitializer.KPRInitializer
+	IPSecConfig         datapath.IPsecConfig
+	HealthConfig        healthconfig.CiliumHealthConfig
+	InfraIPAllocator    *infraIPAllocator
 }
 
 func daemonLegacyInitialization(params daemonParams) legacy.DaemonInitialization {
@@ -1379,13 +1375,6 @@ func startDaemon(ctx context.Context, params daemonParams) error {
 	}
 
 	params.EndpointRestorer.InitRestore()
-
-	bootstrapStats.enableConntrack.Start()
-	params.Logger.Info("Starting connection tracking garbage collector")
-	params.CTNATMapGC.Enable()
-	params.CTNATMapGC.Observe4().Observe(ctx, ctmap.NatMapNext4, func(err error) {})
-	params.CTNATMapGC.Observe6().Observe(ctx, ctmap.NatMapNext6, func(err error) {})
-	bootstrapStats.enableConntrack.End(true)
 
 	if params.EndpointManager.HostEndpointExists() {
 		params.EndpointManager.InitHostEndpointLabels(ctx)

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -607,7 +607,6 @@ func (c *CtEntry) flagsString() string {
 }
 
 func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
-
 	var timeDiff string
 	if toRemSecs != nil {
 		timeDiff = fmt.Sprintf(" (%s)", toRemSecs(c.Lifetime))
@@ -638,9 +637,6 @@ func (c *CtEntry) String() string {
 func (c *CtEntry) New() bpf.MapValue { return &CtEntry{} }
 
 type GCRunner interface {
-	// Enable enables the periodic execution of the connection tracking garbage collection.
-	Enable()
-
 	// Run runs the oneshot connection tracking garbage collection.
 	Run(m *Map, filter GCFilter) (int, error)
 
@@ -654,8 +650,6 @@ type GCRunner interface {
 type fakeCTMapGC struct{}
 
 func NewFakeGCRunner() GCRunner { return fakeCTMapGC{} }
-
-func (fakeCTMapGC) Enable() {}
 
 func (g fakeCTMapGC) Run(m *Map, filter GCFilter) (int, error) {
 	return 0, nil


### PR DESCRIPTION
This PR extracts the ctmap GC initialization logic into the respective hive cell. The explicit call to `GC.Enable()` from the legacy daemon init logic is replaced with Hive jobs.

The following Hive Jobs are added:

* GC start/enable (it's just the initialization; kicking off the actual Go routines & controllers)
* Observe GC events for natmap4/6

Job view in `cilium-dbg status --verbose`
```
│   ├── maps
│   │   └── ct-nat-map-gc
│   │       ├── job-enable-gc                               [OK] Running (5s, x1)
│   │       ├── observer-job-nat-map-next4                  [OK] Primed (5s, x1)
│   │       └── observer-job-nat-map-next6                  [OK] Primed (5s, x1)
```

Note: The ctmap GC lifecycle itself is still executed with raw Go routines and controllers. A [follow-up PR](https://github.com/cilium/cilium/pull/42494) will migrate these aspects into Hive Jobs. This PR is about the extraction of the init logic from the daemon.

Note2: The `enableConntrack` bootstrapstat are no longer populated. IMO there's not much sense in this specific metric - because it doesn't even contain the times of the initial GC run.