### PR TITLE
operator/ciliumenvoyconfig: consistently propagate --http-stream-idle-timeout value

### DIFF
--- a/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
+++ b/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
@@ -34,12 +34,13 @@ func newCiliumEnvoyConfigReconciler(c client.Client, logger *slog.Logger, defaul
 		client: c,
 		logger: logger,
 
-		algorithm:          defaultAlgorithm,
-		ports:              ports,
-		maxRetries:         maxRetries,
-		idleTimeoutSeconds: idleTimeoutSeconds,
-		enableIpv4:         enableIpv4,
-		enableIpv6:         enableIpv6,
+		algorithm:                defaultAlgorithm,
+		ports:                    ports,
+		maxRetries:               maxRetries,
+		idleTimeoutSeconds:       idleTimeoutSeconds,
+		streamIdleTimeoutSeconds: streamIdleTimeoutSeconds,
+		enableIpv4:               enableIpv4,
+		enableIpv6:               enableIpv6,
 	}
 }
 


### PR DESCRIPTION
The referenced commit missed to set the value passed to `newCiliumEnvoyConfigReconciler` (from the `--http-stream-idle-timeout` config option) in the returned `*ciliumEnvoyConfigReconciler` which is used to set the idle timeout in the `HttpConnectionManager`.

Found when running unparam against the Cilium code base.

Fixes: 93018d28b419 ("envoy: add stream idle timeout configuration option")