### PR TITLE
bpf: adding a special case for service loopback IPv6 during icmp routing

### DIFF
--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -359,6 +359,18 @@ static __always_inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 		return icmp6_send_ndisc_adv(ctx, nh_off, &router_mac, true);
 	}
 
+#ifdef USE_LOOPBACK_LB
+	union v6addr service_loopback = CONFIG(service_loopback_ipv6);
+
+	if (ipv6_addr_equals(&target, &service_loopback)) {
+		union macaddr source_mac;
+
+		if (ctx_load_bytes(ctx, ETH_ALEN, source_mac.addr, ETH_ALEN) < 0)
+			return DROP_INVALID;
+		return icmp6_send_ndisc_adv(ctx, nh_off, &source_mac, false);
+	}
+#endif
+
 	ep = __lookup_ip6_endpoint(&target);
 	if (ep) {
 		if (ep->flags & ENDPOINT_F_HOST) {


### PR DESCRIPTION
[Previously,](https://github.com/cilium/cilium/pull/39594) the service loopback address for IPv6 is not recognized during icmp routing. So, a special case is needed to handle for it (Suggested by @pchaigno).

Fixes: #42460 


```release-note
bpf: adding a speical case for service loopback IPv6 during icmp routing 
```