### PR TITLE
envoy: pass stream idle timeout from Helm to configmap

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1381,6 +1381,7 @@ data:
   proxy-idle-timeout-seconds: {{ .Values.envoy.idleTimeoutDurationSeconds | quote }}
   proxy-max-concurrent-retries: {{ .Values.envoy.maxConcurrentRetries | quote }}
   http-retry-count: {{ .Values.envoy.httpRetryCount | quote }}
+  http-stream-idle-timeout: {{ .Values.envoy.streamIdleTimeoutDurationSeconds | quote }}
 
   external-envoy-proxy: {{ include "envoyDaemonSetEnabled" . | quote }}
   envoy-base-id: {{ .Values.envoy.baseID | quote }}


### PR DESCRIPTION
PR #34592 introduced the Operator flag `proxy-stream-idle-timeout-seconds` and corresponding Helm value `envoy.streamIdleTimeoutDurationSeconds`.

But the Helm value is only used in the Envoy bootstrap config, but is never passed to the Operator via cilium-configmap.

This commit fixes this.

Related issue that got fixed: https://github.com/cilium/cilium/pull/42495
Fixes: #34592
