### PR TITLE
fqdn: Fix fqdn subsystem correctness issues causing packet drops

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -424,7 +424,7 @@ func (c *DNSCache) partialRestoreFromCache(update *DNSCache, namesToUpdate []str
 // dns code path is the one doing the ipcache upsert correctly so the lookups can correctly
 // wait for ipcache propagation of new IPs. We also do this to ensure IPs are correctly upserted,
 // since they will not be upserted during the GC cycle.
-func (c *DNSCache) ReplaceFromCacheByNames(namesToUpdate []string, updates ...*DNSCache) {
+func (c *DNSCache) ReplaceFromCacheByNames(namesToUpdate []string, updates ...*DNSCache) map[netip.Addr][]string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -449,6 +449,7 @@ func (c *DNSCache) ReplaceFromCacheByNames(namesToUpdate []string, updates ...*D
 	}
 
 	c.updated.Clear()
+	return oldEntries
 }
 
 // Lookup returns a set of unique IPs that are currently unexpired for name, if

--- a/pkg/fqdn/messagehandler/message_handler.go
+++ b/pkg/fqdn/messagehandler/message_handler.go
@@ -303,8 +303,10 @@ func (h *dnsMessageHandler) UpdateOnDNSMsg(lookupTime time.Time, ep *endpoint.En
 	// consistent if a regeneration happens between the two steps. If an update
 	// doesn't happen in the case, we play it safe and don't purge the zombie
 	// in case of races.
-	if updated := ep.DNSHistory.Update(lookupTime, qname, responseIPs, int(TTL)); updated {
-		ep.DNSZombies.ForceExpireByNameIP(lookupTime, qname, responseIPs...)
+	if updated, upserted := ep.DNSHistory.Update(lookupTime, qname, responseIPs, int(TTL)); updated {
+		if upserted {
+			ep.DNSZombies.ForceExpireByNameIP(lookupTime, qname, responseIPs...)
+		}
 		ep.SyncEndpointHeaderFile()
 	}
 

--- a/pkg/fqdn/messagehandler/message_handler.go
+++ b/pkg/fqdn/messagehandler/message_handler.go
@@ -303,8 +303,8 @@ func (h *dnsMessageHandler) UpdateOnDNSMsg(lookupTime time.Time, ep *endpoint.En
 	// consistent if a regeneration happens between the two steps. If an update
 	// doesn't happen in the case, we play it safe and don't purge the zombie
 	// in case of races.
-	if updated, upserted := ep.DNSHistory.Update(lookupTime, qname, responseIPs, int(TTL)); updated {
-		if upserted {
+	if res := ep.DNSHistory.Update(lookupTime, qname, responseIPs, int(TTL)); res.Updated {
+		if res.Upserted {
 			ep.DNSZombies.ForceExpireByNameIP(lookupTime, qname, responseIPs...)
 		}
 		ep.SyncEndpointHeaderFile()

--- a/pkg/fqdn/messagehandler/message_handler.go
+++ b/pkg/fqdn/messagehandler/message_handler.go
@@ -320,7 +320,7 @@ func (h *dnsMessageHandler) UpdateOnDNSMsg(lookupTime time.Time, ep *endpoint.En
 	dpUpdates := h.nameManager.UpdateGenerateDNS(updateCtx, lookupTime, qname, &fqdn.DNSIPRecords{
 		IPs: responseIPs,
 		TTL: int(TTL),
-	})
+	}, ep.DNSHistory)
 
 	stat.PolicyGenerationTime.End(true)
 	stat.DataplaneTime.Start()

--- a/pkg/fqdn/namemanager/api.go
+++ b/pkg/fqdn/namemanager/api.go
@@ -179,7 +179,7 @@ func (n *manager) deleteDNSLookups(expireLookupsBefore time.Time, matchPatternSt
 	namesToRegen := n.cache.ForceExpire(expireLookupsBefore, nameMatcher)
 	for _, ep := range n.params.EPMgr.GetEndpoints() {
 		namesToRegen = namesToRegen.Union(ep.DNSHistory.ForceExpire(expireLookupsBefore, nameMatcher))
-		n.cache.UpdateFromCache(ep.DNSHistory, nil)
+		n.cache.UpdateFromCache(ep.DNSHistory)
 
 		namesToRegen.Insert(ep.DNSZombies.ForceExpire(expireLookupsBefore, nameMatcher)...)
 		activeConnections := fqdn.NewDNSCache(0)
@@ -191,7 +191,7 @@ func (n *manager) deleteDNSLookups(expireLookupsBefore time.Time, matchPatternSt
 				activeConnections.Update(lookupTime, name, []netip.Addr{zombie.IP}, 0)
 			}
 		}
-		n.cache.UpdateFromCache(activeConnections, nil)
+		n.cache.UpdateFromCache(activeConnections)
 
 		// Persist the changes made to DNS{History, Zombies} for the endpoint.
 		if len(namesToRegen) > 0 || len(dead) > 0 {

--- a/pkg/fqdn/namemanager/cell.go
+++ b/pkg/fqdn/namemanager/cell.go
@@ -133,7 +133,7 @@ type NameManager interface {
 	UnregisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64)
 	// UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 	// have changed for a name they will be reflected in updatedDNSIPs.
-	UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, name string, record *fqdn.DNSIPRecords) <-chan error
+	UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, name string, record *fqdn.DNSIPRecords, caches ...*fqdn.DNSCache) <-chan error
 
 	// LockName is used to serialize  parallel end-to-end updates to the same name.
 	LockName(name string)

--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -51,10 +51,6 @@ func (n *manager) doGC(ctx context.Context) error {
 	namesToClean := make(sets.Set[string])
 	initialNames := n.cache.DumpNames()
 
-	// Take a snapshot of the *entire* reverse cache, so we can compute the set of
-	// IPs that have been completely removed and safely delete their metadata.
-	maybeStaleIPs := n.cache.GetIPs()
-
 	allEndpointNames := make(sets.Set[string])
 
 	// Cleanup each endpoint cache, deferring deletions via DNSZombies.
@@ -136,7 +132,9 @@ func (n *manager) doGC(ctx context.Context) error {
 
 	namesToCleanSlice := namesToClean.UnsortedList()
 
-	n.cache.ReplaceFromCacheByNames(namesToCleanSlice, caches...)
+	// Take a snapshot of the *entire* reverse cache, so we can compute the set of
+	// IPs that have been completely removed and safely delete their metadata.
+	maybeStaleIPs := n.cache.ReplaceFromCacheByNames(namesToCleanSlice, caches...)
 
 	metrics.FQDNGarbageCollectorCleanedTotal.Add(float64(len(namesToCleanSlice)))
 	namesCount := len(namesToCleanSlice)

--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -177,7 +177,7 @@ func (n *manager) RestoreCache(eps map[uint16]*endpoint.Endpoint) {
 			// We do not stop the agent here. It is safer to continue with best effort
 			// than to enter crash backoffs when this file is broken.
 		} else {
-			n.cache.UpdateFromCache(precache, nil)
+			n.cache.UpdateFromCache(precache)
 		}
 	}
 
@@ -190,7 +190,7 @@ func (n *manager) RestoreCache(eps map[uint16]*endpoint.Endpoint) {
 	for _, possibleEP := range eps {
 		// Upgrades from old ciliums have this nil
 		if possibleEP.DNSHistory != nil {
-			n.cache.UpdateFromCache(possibleEP.DNSHistory, []string{})
+			n.cache.UpdateFromCache(possibleEP.DNSHistory)
 			if names, ips := possibleEP.DNSHistory.Count(); names > 0 {
 				n.logger.Info("restored DNS history from endpoint",
 					logfields.EndpointID, possibleEP.ID,

--- a/pkg/fqdn/namemanager/manager.go
+++ b/pkg/fqdn/namemanager/manager.go
@@ -301,9 +301,10 @@ func (n *manager) updateDNSIPs(lookupTime time.Time, dnsName string, lookupIPs *
 
 // updateIPsName will update the IPs for dnsName. It always retains a copy of
 // newIPs.
-// updated is true when the new IPs differ from the old IPs
-func (n *manager) updateIPsForName(lookupTime time.Time, dnsName string, newIPs []netip.Addr, ttl int, caches ...*fqdn.DNSCache) (updated bool) {
-	return n.cache.UpdateAndCompare(lookupTime, dnsName, newIPs, ttl, caches...)
+// upserted is true when the new IPs differ from the old IPs
+func (n *manager) updateIPsForName(lookupTime time.Time, dnsName string, newIPs []netip.Addr, ttl int, caches ...*fqdn.DNSCache) (upserted bool) {
+	_, upserted = n.cache.Update(lookupTime, dnsName, newIPs, ttl, caches...)
+	return upserted
 }
 
 func ipcacheResource(dnsName string) ipcacheTypes.ResourceID {

--- a/pkg/fqdn/namemanager/manager.go
+++ b/pkg/fqdn/namemanager/manager.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net/netip"
 	"regexp"
-	"slices"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -21,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -213,12 +211,12 @@ func (n *manager) UnregisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevi
 
 // UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 // have changed for a name they will be reflected in updatedDNSIPs.
-func (n *manager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, name string, record *fqdn.DNSIPRecords) <-chan error {
+func (n *manager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, name string, record *fqdn.DNSIPRecords, caches ...*fqdn.DNSCache) <-chan error {
 	n.RWMutex.Lock()
 	defer n.RWMutex.Unlock()
 
 	// Update IPs in n
-	updated, ipcacheRevision := n.updateDNSIPs(lookupTime, name, record)
+	updated, ipcacheRevision := n.updateDNSIPs(lookupTime, name, record, caches...)
 	if updated {
 		n.logger.Debug(
 			"Updated FQDN with new IPs",
@@ -256,8 +254,8 @@ func (n *manager) waitForEndpointRestore(ctx context.Context) error {
 
 // updateDNSIPs updates the IPs for a DNS name. It returns whether the name's IPs
 // changed and ipcacheRevision, a revision number to pass to WaitForRevision()
-func (n *manager) updateDNSIPs(lookupTime time.Time, dnsName string, lookupIPs *fqdn.DNSIPRecords) (updated bool, ipcacheRevision uint64) {
-	updated = n.updateIPsForName(lookupTime, dnsName, lookupIPs.IPs, lookupIPs.TTL)
+func (n *manager) updateDNSIPs(lookupTime time.Time, dnsName string, lookupIPs *fqdn.DNSIPRecords, caches ...*fqdn.DNSCache) (updated bool, ipcacheRevision uint64) {
+	updated = n.updateIPsForName(lookupTime, dnsName, lookupIPs.IPs, lookupIPs.TTL, caches...)
 
 	// The IPs didn't change. No more to be done for this dnsName
 	if !updated && n.bootstrapCompleted {
@@ -304,31 +302,8 @@ func (n *manager) updateDNSIPs(lookupTime time.Time, dnsName string, lookupIPs *
 // updateIPsName will update the IPs for dnsName. It always retains a copy of
 // newIPs.
 // updated is true when the new IPs differ from the old IPs
-func (n *manager) updateIPsForName(lookupTime time.Time, dnsName string, newIPs []netip.Addr, ttl int) (updated bool) {
-	oldCacheIPs := n.cache.Lookup(dnsName)
-
-	if n.params.Config.MinTTL > ttl {
-		ttl = n.params.Config.MinTTL
-	}
-
-	changed := n.cache.Update(lookupTime, dnsName, newIPs, ttl)
-	if !changed { // Changed may have false positives, but not false negatives
-		return false
-	}
-
-	newCacheIPs := n.cache.Lookup(dnsName) // DNSCache returns IPs unsorted
-
-	// The 0 checks below account for an unlike race condition where this
-	// function is called with already expired data and if other cache data
-	// from before also expired.
-	if len(oldCacheIPs) != len(newCacheIPs) || len(oldCacheIPs) == 0 {
-		return true
-	}
-
-	ip.SortAddrList(oldCacheIPs) // sorts in place
-	ip.SortAddrList(newCacheIPs)
-
-	return !slices.Equal(oldCacheIPs, newCacheIPs)
+func (n *manager) updateIPsForName(lookupTime time.Time, dnsName string, newIPs []netip.Addr, ttl int, caches ...*fqdn.DNSCache) (updated bool) {
+	return n.cache.UpdateAndCompare(lookupTime, dnsName, newIPs, ttl, caches...)
 }
 
 func ipcacheResource(dnsName string) ipcacheTypes.ResourceID {

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -64,9 +64,8 @@ func TestMapIPsToSelectors(t *testing.T) {
 
 	// Just one IP.
 	ciliumIOName := prepareMatchName(ciliumIOSel.MatchName)
-	updated, upserted := cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1}, 100)
-	require.True(t, updated)
-	require.True(t, upserted)
+	res := cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1}, 100)
+	require.Equal(t, fqdn.UpdateStatus{Updated: true, Upserted: true}, res)
 	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
 	require.Len(t, nameIPMapping, 1)
 	println(ciliumIOSel.MatchName)
@@ -76,9 +75,8 @@ func TestMapIPsToSelectors(t *testing.T) {
 	require.Equal(t, ciliumIP1, ciliumIPs[0])
 
 	// Two IPs now.
-	updated, upserted = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 100)
-	require.True(t, updated)
-	require.True(t, upserted)
+	res = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 100)
+	require.Equal(t, fqdn.UpdateStatus{Updated: true, Upserted: true}, res)
 	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
 	require.Len(t, nameIPMapping, 1)
 	ciliumIPs, ok = nameIPMapping[ciliumIOName]
@@ -89,9 +87,8 @@ func TestMapIPsToSelectors(t *testing.T) {
 	require.Equal(t, ciliumIP2, ciliumIPs[1])
 
 	// Two IPs again with long ttl.
-	updated, upserted = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 101)
-	require.True(t, updated)
-	require.False(t, upserted)
+	res = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 101)
+	require.Equal(t, fqdn.UpdateStatus{Updated: true, Upserted: false}, res)
 	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
 	require.Len(t, nameIPMapping, 1)
 	ciliumIPs, ok = nameIPMapping[ciliumIOName]
@@ -102,9 +99,8 @@ func TestMapIPsToSelectors(t *testing.T) {
 	require.Equal(t, ciliumIP2, ciliumIPs[1])
 
 	// Two IPs again with short ttl.
-	updated, upserted = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 1)
-	require.False(t, updated)
-	require.False(t, upserted)
+	res = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 1)
+	require.Equal(t, fqdn.UpdateStatus{Updated: false, Upserted: false}, res)
 	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
 	require.Len(t, nameIPMapping, 1)
 	ciliumIPs, ok = nameIPMapping[ciliumIOName]

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -64,8 +64,9 @@ func TestMapIPsToSelectors(t *testing.T) {
 
 	// Just one IP.
 	ciliumIOName := prepareMatchName(ciliumIOSel.MatchName)
-	changed := cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1}, 100)
-	require.True(t, changed)
+	updated, upserted := cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1}, 100)
+	require.True(t, updated)
+	require.True(t, upserted)
 	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
 	require.Len(t, nameIPMapping, 1)
 	println(ciliumIOSel.MatchName)
@@ -75,8 +76,35 @@ func TestMapIPsToSelectors(t *testing.T) {
 	require.Equal(t, ciliumIP1, ciliumIPs[0])
 
 	// Two IPs now.
-	changed = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 100)
-	require.True(t, changed)
+	updated, upserted = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 100)
+	require.True(t, updated)
+	require.True(t, upserted)
+	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
+	require.Len(t, nameIPMapping, 1)
+	ciliumIPs, ok = nameIPMapping[ciliumIOName]
+	require.True(t, ok)
+	require.Len(t, ciliumIPs, 2)
+	ip.SortAddrList(ciliumIPs)
+	require.Equal(t, ciliumIP1, ciliumIPs[0])
+	require.Equal(t, ciliumIP2, ciliumIPs[1])
+
+	// Two IPs again with long ttl.
+	updated, upserted = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 101)
+	require.True(t, updated)
+	require.False(t, upserted)
+	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
+	require.Len(t, nameIPMapping, 1)
+	ciliumIPs, ok = nameIPMapping[ciliumIOName]
+	require.True(t, ok)
+	require.Len(t, ciliumIPs, 2)
+	ip.SortAddrList(ciliumIPs)
+	require.Equal(t, ciliumIP1, ciliumIPs[0])
+	require.Equal(t, ciliumIP2, ciliumIPs[1])
+
+	// Two IPs again with short ttl.
+	updated, upserted = cache.Update(now, ciliumIOName, []netip.Addr{ciliumIP1, ciliumIP2}, 1)
+	require.False(t, updated)
+	require.False(t, upserted)
 	nameIPMapping = nameManager.mapSelectorsToNamesLocked(ciliumIOSel)
 	require.Len(t, nameIPMapping, 1)
 	ciliumIPs, ok = nameIPMapping[ciliumIOName]

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -6,7 +6,6 @@ package namemanager
 import (
 	"context"
 	"fmt"
-	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"log/slog"
 	"net/netip"
 	"regexp"
@@ -247,7 +246,14 @@ func TestNameManagerGCConsistency(t *testing.T) {
 		DNSHistory: fqdn.NewDNSCache(1),
 	}
 	ep.UpdateLogger(nil)
-	ipc := newMockIPCache()
+	ipc := ipcache.NewIPCache(&ipcache.Configuration{
+		Context:           t.Context(),
+		Logger:            logger,
+		IdentityAllocator: testidentity.NewMockIdentityAllocator(nil),
+		IdentityUpdater:   &dummyIdentityUpdater{},
+	})
+	ipc.TriggerLabelInjection()
+	defer ipc.Shutdown()
 	nameManager := New(ManagerParams{
 		Logger: logger,
 		Config: NameManagerConfig{
@@ -260,7 +266,8 @@ func TestNameManagerGCConsistency(t *testing.T) {
 	})
 	// Manually configure bootstrap to be done to fully test manager end-to-end
 	nameManager.bootstrapCompleted = true
-	nameManager.RegisterFQDNSelector(ciliumIOSel)
+	err := ipc.WaitForRevision(t.Context(), nameManager.RegisterFQDNSelector(ciliumIOSel))
+	require.NoError(t, err)
 
 	// Add initial IP to local cache before adding endpoint to manager
 	// We do this to mimic the GC starting and dumping endpoints before the endpoint is added to the manager
@@ -268,19 +275,37 @@ func TestNameManagerGCConsistency(t *testing.T) {
 
 	// Run GC to ensure the IP<>name mapping is not added to the global cache
 	require.NoError(t, nameManager.doGC(t.Context()))
+
+	// Ensure all IPcache operations done by GC have been processed
+	err = ipc.WaitForRevision(t.Context(), ipc.UpsertMetadataBatch())
+	require.NoError(t, err)
+
 	require.Empty(t, nameManager.cache.LookupIP(prefixOne.AsPrefix().Addr()))
-	require.Empty(t, ipc.labelsForPrefix(prefixOne))
+	_, found := ipc.LookupByPrefix(prefixOne.String())
+	require.False(t, found)
 	require.NotContains(t, nameManager.cache.LookupIP(prefixOne.AsPrefix().Addr()), dns.FQDN("cilium.io"))
 
 	// Upsert to global cache and ensure its present
-	nameManager.UpdateGenerateDNS(t.Context(), lookupTime, dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixOne.AsPrefix().Addr()}}, ep.DNSHistory)
-	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixOne))
+	<-nameManager.UpdateGenerateDNS(t.Context(), lookupTime, dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixOne.AsPrefix().Addr()}}, ep.DNSHistory)
+
+	id, found := ipc.LookupByPrefix(prefixOne.String())
+	require.True(t, found)
+	ident := ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 	require.Contains(t, nameManager.cache.LookupIP(prefixOne.AsPrefix().Addr()), dns.FQDN("cilium.io"))
 
 	// Run GC and ensure it's still present
 	// This is again assuming the GC started before the endpoint was created, so the manager still does not know about the endpoint
 	require.NoError(t, nameManager.doGC(t.Context()))
-	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixOne))
+
+	// Ensure all IPcache operations done by GC have been processed
+	err = ipc.WaitForRevision(t.Context(), ipc.UpsertMetadataBatch())
+	require.NoError(t, err)
+
+	id, found = ipc.LookupByPrefix(prefixOne.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 	require.Contains(t, nameManager.cache.LookupIP(prefixOne.AsPrefix().Addr()), dns.FQDN("cilium.io"))
 
 	// Add endpoint to the manager
@@ -288,16 +313,32 @@ func TestNameManagerGCConsistency(t *testing.T) {
 
 	// After endpoint is added, ensure it's still in the cache
 	require.NoError(t, nameManager.doGC(t.Context()))
-	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixOne))
+
+	// Ensure all IPcache operations done by GC have been processed
+	err = ipc.WaitForRevision(t.Context(), ipc.UpsertMetadataBatch())
+	require.NoError(t, err)
+
+	id, found = ipc.LookupByPrefix(prefixOne.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 	require.Contains(t, nameManager.cache.LookupIP(prefixOne.AsPrefix().Addr()), dns.FQDN("cilium.io"))
 
 	// Insert old prefix that will end up as zombie
 	ep.DNSHistory.Update(lookupTime.Add(-time.Hour), dns.FQDN("cilium.io"), []netip.Addr{prefixTwo.AsPrefix().Addr()}, 10)
-	nameManager.UpdateGenerateDNS(t.Context(), lookupTime, dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixTwo.AsPrefix().Addr()}}, ep.DNSHistory)
+	<-nameManager.UpdateGenerateDNS(t.Context(), lookupTime, dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixTwo.AsPrefix().Addr()}}, ep.DNSHistory)
 
 	// Run GC and check that the prefix is upserted to the ipcache
 	require.NoError(t, nameManager.doGC(t.Context()))
-	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixTwo))
+
+	// Ensure all IPcache operations done by GC have been processed
+	err = ipc.WaitForRevision(t.Context(), ipc.UpsertMetadataBatch())
+	require.NoError(t, err)
+
+	id, found = ipc.LookupByPrefix(prefixTwo.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 	require.Contains(t, nameManager.cache.LookupIP(prefixTwo.AsPrefix().Addr()), dns.FQDN("cilium.io"))
 
 	// Add another prefix to local cache
@@ -305,24 +346,47 @@ func TestNameManagerGCConsistency(t *testing.T) {
 
 	// Run GC to ensure the IP<>name mapping is not added to the global cache yet
 	require.NoError(t, nameManager.doGC(t.Context()))
+
+	// Ensure all IPcache operations done by GC have been processed
+	err = ipc.WaitForRevision(t.Context(), ipc.UpsertMetadataBatch())
+	require.NoError(t, err)
+
 	require.Empty(t, nameManager.cache.LookupIP(prefixThree.AsPrefix().Addr()))
-	require.Empty(t, ipc.labelsForPrefix(prefixThree))
+
+	_, found = ipc.LookupByPrefix(prefixThree.String())
+	require.False(t, found)
 	require.NotContains(t, nameManager.cache.LookupIP(prefixThree.AsPrefix().Addr()), dns.FQDN("cilium.io"))
 
 	// Upsert to global cache and ensure its present
-	nameManager.UpdateGenerateDNS(t.Context(), lookupTime, dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixThree.AsPrefix().Addr()}}, ep.DNSHistory)
-	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixThree))
+	<-nameManager.UpdateGenerateDNS(t.Context(), lookupTime, dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixThree.AsPrefix().Addr()}}, ep.DNSHistory)
+
+	id, found = ipc.LookupByPrefix(prefixThree.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 	require.Contains(t, nameManager.cache.LookupIP(prefixThree.AsPrefix().Addr()), dns.FQDN("cilium.io"))
 
 	// Run GC and ensure it's still present
 	require.NoError(t, nameManager.doGC(t.Context()))
-	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixThree))
+
+	// Ensure all IPcache operations done by GC have been processed
+	err = ipc.WaitForRevision(t.Context(), ipc.UpsertMetadataBatch())
+	require.NoError(t, err)
+
+	id, found = ipc.LookupByPrefix(prefixThree.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 
 	// Lock endpoint manager to freeze GC in time
 	epMgr.mu.Lock()
 	wg := sync.WaitGroup{}
 	wg.Go(func() {
 		require.NoError(t, nameManager.doGC(t.Context()))
+
+		// Ensure all IPcache operations done by GC have been processed
+		err = ipc.WaitForRevision(t.Context(), ipc.UpsertMetadataBatch())
+		require.NoError(t, err)
 	})
 
 	// Sleep for a short while to be sure GC is blocked by epMgr lock
@@ -330,8 +394,11 @@ func TestNameManagerGCConsistency(t *testing.T) {
 
 	// Insert a "back in time" lookup to both local and global cache. This to ensure its immediately put in zombies
 	ep.DNSHistory.Update(lookupTime.Add(-time.Hour), dns.FQDN("cilium.io"), []netip.Addr{prefixFour.AsPrefix().Addr()}, 10)
-	nameManager.UpdateGenerateDNS(t.Context(), lookupTime.Add(-time.Hour), dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixFour.AsPrefix().Addr()}}, ep.DNSHistory)
-	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixFour))
+	<-nameManager.UpdateGenerateDNS(t.Context(), lookupTime.Add(-time.Hour), dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixFour.AsPrefix().Addr()}}, ep.DNSHistory)
+	id, found = ipc.LookupByPrefix(prefixFour.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 	require.Contains(t, nameManager.cache.LookupIP(prefixFour.AsPrefix().Addr()), dns.FQDN("cilium.io"))
 
 	// Explicitly GC the local cache to ensure the IP goes fully unused by any endpoint - except for the zombie.
@@ -348,13 +415,17 @@ func TestNameManagerGCConsistency(t *testing.T) {
 	require.NoError(t, nameManager.doGC(t.Context()))
 	require.NoError(t, nameManager.doGC(t.Context()))
 
-	// Ensure all IPs are gone
-	require.Empty(t, ipc.labelsForPrefix(prefixOne))
-	require.Empty(t, ipc.labelsForPrefix(prefixTwo))
-	require.Empty(t, ipc.labelsForPrefix(prefixThree))
-	require.Empty(t, ipc.labelsForPrefix(prefixFour))
+	// Ensure all IPcache operations done by GC have been processed
+	err = ipc.WaitForRevision(t.Context(), ipc.UpsertMetadataBatch())
+	require.NoError(t, err)
+
 	require.Empty(t, nameManager.cache.Dump())
 
+	// Ensure all IPs are gone, even if selector is still registered
+	for _, p := range []cmtypes.PrefixCluster{prefixOne, prefixTwo, prefixThree, prefixFour} {
+		id, found = ipc.LookupByPrefix(p.String())
+		require.False(t, found)
+	}
 }
 
 func Test_deriveLabelsForNames(t *testing.T) {
@@ -449,63 +520,4 @@ func (mgr *mgrMock) GetEndpoints() []*endpoint.Endpoint {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 	return mgr.eps.UnsortedList()
-}
-
-type mockIPCache struct {
-	metadata map[cmtypes.PrefixCluster]map[ipcacheTypes.ResourceID]labels.Labels
-}
-
-func newMockIPCache() *mockIPCache {
-	return &mockIPCache{
-		metadata: make(map[cmtypes.PrefixCluster]map[ipcacheTypes.ResourceID]labels.Labels),
-	}
-}
-
-func (m *mockIPCache) labelsForPrefix(prefix cmtypes.PrefixCluster) labels.Labels {
-	lbls := labels.Labels{}
-	for _, l := range m.metadata[prefix] {
-		lbls.MergeLabels(l)
-	}
-	return lbls
-}
-
-func (m *mockIPCache) UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64) {
-	for _, mu := range updates {
-		prefixMetadata, ok := m.metadata[mu.Prefix]
-		if !ok {
-			prefixMetadata = make(map[ipcacheTypes.ResourceID]labels.Labels)
-		}
-
-		for _, aux := range mu.Metadata {
-			if lbls, ok := aux.(labels.Labels); ok {
-				prefixMetadata[mu.Resource] = lbls
-				break
-			}
-		}
-
-		m.metadata[mu.Prefix] = prefixMetadata
-	}
-
-	return 0
-}
-
-func (m *mockIPCache) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64) {
-	for _, mu := range updates {
-		for _, aux := range mu.Metadata {
-			if _, ok := aux.(labels.Labels); ok {
-				delete(m.metadata[mu.Prefix], mu.Resource)
-				break
-			}
-		}
-
-		if len(m.metadata[mu.Prefix]) == 0 {
-			delete(m.metadata, mu.Prefix)
-		}
-	}
-
-	return 0
-}
-
-func (m *mockIPCache) WaitForRevision(ctx context.Context, rev uint64) error {
-	return nil
 }

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -5,21 +5,29 @@ package namemanager
 
 import (
 	"context"
+	"fmt"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"log/slog"
 	"net/netip"
 	"regexp"
+	"sync"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -217,6 +225,130 @@ func TestNameManagerIPCacheUpdates(t *testing.T) {
 
 }
 
+// Test TestNameManagerGCConsistency test edge-cases around ordering of cache upserts,
+// as well as endpoints coming online. It helps catch correctness issues involving IPs
+// race between the global and the local dns caches where some operations are not in sync
+func TestNameManagerGCConsistency(t *testing.T) {
+	logger := hivetest.Logger(t)
+	lookupTime := time.Now()
+	prefixOne := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("1.1.1.1/32"))
+	prefixTwo := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("2.1.1.1/32"))
+	prefixThree := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("3.1.1.1/32"))
+	prefixFour := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("4.1.1.1/32"))
+
+	epMgr := mgrMock{
+		logger: logger,
+		eps:    make(sets.Set[*endpoint.Endpoint]),
+	}
+	ep := &endpoint.Endpoint{ID: uint16(1), IPv4: netip.MustParseAddr("10.96.0.1"), SecurityIdentity: &identity.Identity{
+		ID: identity.NumericIdentity(int(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))),
+	},
+		DNSZombies: fqdn.NewDNSZombieMappings(logger, 10000, 10000),
+		DNSHistory: fqdn.NewDNSCache(1),
+	}
+	ep.UpdateLogger(nil)
+	ipc := newMockIPCache()
+	nameManager := New(ManagerParams{
+		Logger: logger,
+		Config: NameManagerConfig{
+			MinTTL:            1,
+			DNSProxyLockCount: defaults.DNSProxyLockCount,
+			StateDir:          option.Config.StateDir,
+		},
+		EPMgr:   &epMgr,
+		IPCache: ipc,
+	})
+	// Manually configure bootstrap to be done to fully test manager end-to-end
+	nameManager.bootstrapCompleted = true
+	nameManager.RegisterFQDNSelector(ciliumIOSel)
+
+	// Add initial IP to local cache before adding endpoint to manager
+	// We do this to mimic the GC starting and dumping endpoints before the endpoint is added to the manager
+	ep.DNSHistory.Update(lookupTime, dns.FQDN("cilium.io"), []netip.Addr{prefixOne.AsPrefix().Addr()}, 10)
+
+	// Run GC to ensure the IP<>name mapping is not added to the global cache
+	require.NoError(t, nameManager.doGC(t.Context()))
+	require.Empty(t, nameManager.cache.LookupIP(prefixOne.AsPrefix().Addr()))
+	require.Empty(t, ipc.labelsForPrefix(prefixOne))
+
+	// Upsert to global cache and ensure its present
+	nameManager.UpdateGenerateDNS(t.Context(), lookupTime, dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixOne.AsPrefix().Addr()}}, ep.DNSHistory)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixOne))
+
+	// Run GC and ensure it's still present
+	// This is again assuming the GC started before the endpoint was created, so the manager still does not know about the endpoint
+	require.NoError(t, nameManager.doGC(t.Context()))
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixOne))
+
+	// Add endpoint to the manager
+	epMgr.UpsertEndpoint(ep)
+
+	// After endpoint is added, ensure it's still in the cache
+	require.NoError(t, nameManager.doGC(t.Context()))
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixOne))
+
+	// Insert old prefix that will end up as zombie
+	ep.DNSHistory.Update(lookupTime.Add(-time.Hour), dns.FQDN("cilium.io"), []netip.Addr{prefixTwo.AsPrefix().Addr()}, 10)
+	nameManager.UpdateGenerateDNS(t.Context(), lookupTime, dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixTwo.AsPrefix().Addr()}}, ep.DNSHistory)
+
+	// Run GC and check that the prefix is upserted to the ipcache
+	require.NoError(t, nameManager.doGC(t.Context()))
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixTwo))
+
+	// Add another prefix to local cache
+	ep.DNSHistory.Update(lookupTime, dns.FQDN("cilium.io"), []netip.Addr{prefixThree.AsPrefix().Addr()}, 10)
+
+	// Run GC to ensure the IP<>name mapping is not added to the global cache yet
+	require.NoError(t, nameManager.doGC(t.Context()))
+	require.Empty(t, nameManager.cache.LookupIP(prefixThree.AsPrefix().Addr()))
+	require.Empty(t, ipc.labelsForPrefix(prefixThree))
+
+	// Upsert to global cache and ensure its present
+	nameManager.UpdateGenerateDNS(t.Context(), lookupTime, dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixThree.AsPrefix().Addr()}}, ep.DNSHistory)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixThree))
+
+	// Run GC and ensure it's still present
+	require.NoError(t, nameManager.doGC(t.Context()))
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixThree))
+
+	// Lock endpoint manager to freeze GC in time
+	epMgr.mu.Lock()
+	wg := sync.WaitGroup{}
+	wg.Go(func() {
+		require.NoError(t, nameManager.doGC(t.Context()))
+	})
+
+	// Sleep for a short while to be sure GC is blocked by epMgr lock
+	time.Sleep(100 * time.Millisecond)
+
+	// Insert a "back in time" lookup to both local and global cache. This to ensure its immediately put in zombies
+	ep.DNSHistory.Update(lookupTime.Add(-time.Hour), dns.FQDN("cilium.io"), []netip.Addr{prefixFour.AsPrefix().Addr()}, 10)
+	nameManager.UpdateGenerateDNS(t.Context(), lookupTime.Add(-time.Hour), dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 10, IPs: []netip.Addr{prefixFour.AsPrefix().Addr()}}, ep.DNSHistory)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}), ipc.labelsForPrefix(prefixFour))
+
+	// Explicitly GC the local cache to ensure the IP goes fully unused by any endpoint - except for the zombie.
+	// However, since the endpoint is deleted by the time of the next endpointManager GC, it won't be seen by the
+	// endpoint. This can effectively not happen, but it's a good test to ensure that GC won't delete an IP<>name mapping
+	// without cleaning it up from the ipcache.
+	ep.DNSHistory.GC(time.Now(), ep.DNSZombies)
+
+	epMgr.RemoveEndpointLocked(ep)
+	epMgr.mu.Unlock()
+
+	wg.Wait()
+	// Run GC again twice to ensure all pending lookups have been processed.
+	require.NoError(t, nameManager.doGC(t.Context()))
+	require.NoError(t, nameManager.doGC(t.Context()))
+
+	// Ensure all IPs are gone
+	require.Empty(t, ipc.labelsForPrefix(prefixOne))
+	require.Empty(t, ipc.labelsForPrefix(prefixTwo))
+	require.Empty(t, ipc.labelsForPrefix(prefixThree))
+	require.Empty(t, ipc.labelsForPrefix(prefixFour))
+	require.Empty(t, nameManager.cache.Dump())
+
+}
+
 func Test_deriveLabelsForNames(t *testing.T) {
 	ciliumIORe, err := ciliumIOSel.ToRegex()
 	require.NoError(t, err)
@@ -278,4 +410,94 @@ func (*dummyIdentityUpdater) UpdateIdentities(added, deleted identity.IdentityMa
 	c := make(chan struct{})
 	close(c)
 	return c
+}
+
+type mgrMock struct {
+	logger *slog.Logger
+	eps    sets.Set[*endpoint.Endpoint]
+	mu     lock.Mutex
+}
+
+func (mgr *mgrMock) Lookup(id string) (*endpoint.Endpoint, error) {
+	return nil, fmt.Errorf("Lookup not implemented")
+}
+
+func (mgr *mgrMock) UpsertEndpoint(ep *endpoint.Endpoint) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	mgr.eps.Insert(ep)
+}
+func (mgr *mgrMock) RemoveEndpoint(ep *endpoint.Endpoint) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	mgr.eps.Delete(ep)
+}
+
+func (mgr *mgrMock) RemoveEndpointLocked(ep *endpoint.Endpoint) {
+	mgr.eps.Delete(ep)
+}
+
+func (mgr *mgrMock) GetEndpoints() []*endpoint.Endpoint {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	return mgr.eps.UnsortedList()
+}
+
+type mockIPCache struct {
+	metadata map[cmtypes.PrefixCluster]map[ipcacheTypes.ResourceID]labels.Labels
+}
+
+func newMockIPCache() *mockIPCache {
+	return &mockIPCache{
+		metadata: make(map[cmtypes.PrefixCluster]map[ipcacheTypes.ResourceID]labels.Labels),
+	}
+}
+
+func (m *mockIPCache) labelsForPrefix(prefix cmtypes.PrefixCluster) labels.Labels {
+	lbls := labels.Labels{}
+	for _, l := range m.metadata[prefix] {
+		lbls.MergeLabels(l)
+	}
+	return lbls
+}
+
+func (m *mockIPCache) UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64) {
+	for _, mu := range updates {
+		prefixMetadata, ok := m.metadata[mu.Prefix]
+		if !ok {
+			prefixMetadata = make(map[ipcacheTypes.ResourceID]labels.Labels)
+		}
+
+		for _, aux := range mu.Metadata {
+			if lbls, ok := aux.(labels.Labels); ok {
+				prefixMetadata[mu.Resource] = lbls
+				break
+			}
+		}
+
+		m.metadata[mu.Prefix] = prefixMetadata
+	}
+
+	return 0
+}
+
+func (m *mockIPCache) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64) {
+	for _, mu := range updates {
+		for _, aux := range mu.Metadata {
+			if _, ok := aux.(labels.Labels); ok {
+				delete(m.metadata[mu.Prefix], mu.Resource)
+				break
+			}
+		}
+
+		if len(m.metadata[mu.Prefix]) == 0 {
+			delete(m.metadata, mu.Prefix)
+		}
+	}
+
+	return 0
+}
+
+func (m *mockIPCache) WaitForRevision(ctx context.Context, rev uint64) error {
+	return nil
 }


### PR DESCRIPTION
tl;dr this fixes a very bad issue in the fqdn subsystem that cause a permanent broken state where certain IPs get stuck in a state where they cannot be used until they are flushed from the fqdn cache and re-added. That is very problematic when the given fqdn keep returning the same IP(s).

This is still work in progress since its a pretty big change, so want to run test to see if its anything very obviously wrong with it.

Implemented together with @sjdot.

This affects v1.15+, and TODO on me to add the correct `Fixes: ` tag.

Comment message
```
    fqdn: Fix fqdn subsystem correctness issues causing packet drops

    To ensure we never leak/fail to upsert identities, we ensure we only add
    IPs that were already present in the local cache.

    The error we are fixing here is the one where the domain is already in
    the FQDN cache, AND a lookup is in flight. If its added to to local
    endpoint cache before the GC ReplaceFromCacheByNames is executed, it
    could result in it being added to the global cache by the GC,
    hence it never being upserted by the dns lookup code. This leads to a
    situation where the toFQDN won't allow egress to the given IP - and the
    only way to recover for the given IP is to wait until its removed from
    the fqdn cache and a new lookup returns the same IP. This is however not
    very likely, since the same domain can continue to return the same IP
    forever, keeping it constantly in the fqdn cache.

    The same partially applies to endpoint created during the GC iteration,
    resulting in the GC evicting some of the IPs upserted to the global
    cache by that endpoint. That situation could also result in a leak where
    its removed from the fqdn cache, but still be leaked in the ipcache.

    This still needs extensive testing to ensure it doesn't uncover other
    issues that rely on the GC upserting new IPs into the global cache - as
    those could now become even more problematic. We have been running a
    version of this in v1.15 and v1.16 with great success, and without this
    patch we see loads of issues and packet drops due to this issue. We have
    not been testing this in high scale in newer versions than those
    mentioned, and due to other changes in the fqdn subsystem, we need to
    sanity check this thoroughly.

    This is still in works, and will be split into multiple commits, and
    potentially multiple PRs.
```



This also has some improvements in terms of performance as well using the existing `UpdateGenerateDNS` benchmark;
```diff
# based on: go test -bench ^BenchmarkUpdateGenerateDNS$ ./ -benchmem -v -benchtime=20x -count=10
                     │   /tmp/old   │            /tmp/new            │
                     │    sec/op    │    sec/op     vs base          │
UpdateGenerateDNS-12   332.2m ± 20%   356.1m ± 13%  ~ (p=0.529 n=10)

                     │   /tmp/old   │               /tmp/new               │
                     │     B/op     │     B/op      vs base                │
UpdateGenerateDNS-12   5.363Mi ± 2%   4.418Mi ± 2%  -17.62% (p=0.000 n=10)

                     │  /tmp/old   │              /tmp/new              │
                     │  allocs/op  │  allocs/op   vs base               │
UpdateGenerateDNS-12   46.10k ± 0%   42.20k ± 0%  -8.46% (p=0.000 n=10)
```

By patching in another case in the benchmark to show FQDNs with a lot of IPs, the diff is even more evident;
```diff
diff --git a/pkg/fqdn/namemanager/bench_test.go b/pkg/fqdn/namemanager/bench_test.go
index dc5a08cef8..8ffb8e20de 100644
--- a/pkg/fqdn/namemanager/bench_test.go
+++ b/pkg/fqdn/namemanager/bench_test.go
@@ -80,6 +80,11 @@ func BenchmarkUpdateGenerateDNS(b *testing.B) {
                        TTL: 60,
                        IPs: []netip.Addr{ip},
                })
+
+               nameManager.UpdateGenerateDNS(context.Background(), t, dns.FQDN("example.com"), &fqdn.DNSIPRecords{
+                       TTL: 60,
+                       IPs: []netip.Addr{ip},
+               })
        }
 }
```

```
# based on: go test -bench ^BenchmarkUpdateGenerateDNS$ ./ -benchmem -v -benchtime=20x -count=10
                     │ /tmp/old-with-change │         /tmp/new-with-change         │
                     │        sec/op        │    sec/op     vs base                │
UpdateGenerateDNS-12          1116.9m ± 66%   350.4m ± 14%  -68.63% (p=0.000 n=10)

                     │ /tmp/old-with-change │         /tmp/new-with-change         │
                     │         B/op         │     B/op      vs base                │
UpdateGenerateDNS-12         471.672Mi ± 0%   5.516Mi ± 3%  -98.83% (p=0.000 n=10)

                     │ /tmp/old-with-change │        /tmp/new-with-change         │
                     │      allocs/op       │  allocs/op   vs base                │
UpdateGenerateDNS-12            59.15k ± 0%   53.20k ± 0%  -10.06% (p=0.000 n=10)
```


Fixes: #issue-number

```release-note
fqdn: Fix fqdn subsystem correctness issues causing packet drops and inconsistent ipcache
```


