### PR TITLE
fqdn: ensure bootstrap is completed before GC

### DIFF
--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -38,11 +38,6 @@ const dnsGCJobName = "dns-garbage-collector-job"
 // finally deleted from the global DNSCache. Until then, each of these IPs is
 // inserted into the global cache as a synthetic DNS lookup.
 func (n *manager) doGC(ctx context.Context) error {
-	if !n.hasBootstrapCompleted() {
-		n.logger.Debug("Skipping DNS GC since bootstrap is not yet completed")
-		return nil
-	}
-
 	var (
 		GCStart = time.Now()
 

--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -38,6 +38,11 @@ const dnsGCJobName = "dns-garbage-collector-job"
 // finally deleted from the global DNSCache. Until then, each of these IPs is
 // inserted into the global cache as a synthetic DNS lookup.
 func (n *manager) doGC(ctx context.Context) error {
+	if !n.hasBootstrapCompleted() {
+		n.logger.Debug("Skipping DNS GC since bootstrap is not yet completed")
+		return nil
+	}
+
 	var (
 		GCStart = time.Now()
 

--- a/pkg/fqdn/namemanager/manager.go
+++ b/pkg/fqdn/namemanager/manager.go
@@ -244,6 +244,12 @@ func (n *manager) waitForEndpointRestore(ctx context.Context, _ cell.Health) err
 	return nil
 }
 
+func (n *manager) hasBootstrapCompleted() bool {
+	n.RLock()
+	defer n.RUnlock()
+	return n.bootstrapCompleted
+}
+
 // updateDNSIPs updates the IPs for a DNS name. It returns whether the name's IPs
 // changed and ipcacheRevision, a revision number to pass to WaitForRevision()
 func (n *manager) updateDNSIPs(lookupTime time.Time, dnsName string, lookupIPs *fqdn.DNSIPRecords) (updated bool, ipcacheRevision uint64) {


### PR DESCRIPTION
tl;dr is that this fixes an issue causing a lot of issues in the fqdn subsystem where packets
to ips are constantly being dropped. More details below.

This has been an issue for a while, but got significantly worse after the changes in v1.15 around how the global FQDN cache works.

The commit message:

```
    fqdn: ensure bootstrap is completed before GC

    If GC is executed while endpoints are not yet restored, it might end up
    GCing IPs and names from the global cache, even if the IPs are present
    in the endpoint caches that later will be restored. The same applies if
    some endpoints are restored, while not all.

    There is always a race here between endpoints being created and them
    being picked up here (as in a logical race, not actual memory issues),
    but that has to be mitigated in another change.

    This will fix issues where suddenly IPs are present in the global cache
    but not in the ipcache. That will happen because of the issue mentioned
    above, resulting in the next GC iteration adding it to the global cache.
    However, since it deleted it from the ipcache in the previous iteration
    and not upserting it while adding it, it will not be present in the
    ipcache.

    The very bad situation comes from the fact that new lookups to this
    exact same IP will then _not_ result in it being upserted, and then all
    connections will then fail until its fully deleted from the global cache
    and re-added via a new lookup after that.
```

```release-note
Fix issue where fqdn GC starts too early that results in potentially missed ips in the IPCache
```
