### PR TITLE
Add validation for HTTPRoute head modifier

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -861,6 +861,11 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 
 		// Route-specific checks will go in here separately if required.
 
+		// Validate the HTTPRoute header name
+		if err := i.ValidateHeaderModifier(); err != nil {
+			return r.handleHTTPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, hr)
+		}
+
 		// Checks finished, apply the status to the actual objects.
 		if err := r.updateHTTPRouteStatus(ctx, scopedLog, &original, hr); err != nil {
 			return fmt.Errorf("failed to update HTTPRoute status: %w", err)

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -187,3 +187,19 @@ func (t *HTTPRouteRule) GetBackendRefs() []gatewayv1.BackendRef {
 	}
 	return refs
 }
+
+// Validates the HTTPRoute header
+func (r *HTTPRouteInput) ValidateHeaderModifier() error {
+	for _, backendref := range r.HTTPRoute.Spec.Rules {
+		for _, f := range backendref.Filters {
+			if f.Type == gatewayv1.HTTPRouteFilterRequestHeaderModifier {
+				for _, set := range f.RequestHeaderModifier.Set {
+					if set.Name == "Host" {
+						return fmt.Errorf("Invalid HTTPRoute header: %q", set.Name)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
Adding a validation on the HTTPRoute to check if the `RequestHeaderModification` is attempting to change the `Host` header, which isn't allowed in Envoy. 

Fixes: #39588 

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
