### PR TITLE
pkg/nodediscover: Don't log warnings for intermittent updates

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -231,13 +231,11 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 			var err error
 			nodeResource, err = n.k8sGetters.GetCiliumNode(ctx, nodeTypes.GetName())
 			if err != nil {
-				if retryCount == maxRetryCount {
-					n.logger.Warn(
-						"Unable to get CiliumNode resource",
-						logfields.Error, err,
-						logfields.Retries, maxRetryCount,
-					)
-				}
+				n.logger.Info(
+					"Unable to get CiliumNode resource",
+					logfields.Error, err,
+					logfields.Retries, retryCount,
+				)
 				performUpdate = false
 				nodeResource = &ciliumv2.CiliumNode{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -251,7 +251,7 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 			n.logger.Warn(
 				"Unable to mutate nodeResource",
 				logfields.Error, err,
-				logfields.Retries, maxRetryCount,
+				logfields.Retries, retryCount,
 			)
 			continue
 		}

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -265,7 +265,7 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 		if performUpdate {
 			if _, err := n.clientset.CiliumV2().CiliumNodes().Update(ctx, nodeResource, metav1.UpdateOptions{}); err != nil {
 				if k8serrors.IsConflict(err) {
-					n.logger.Warn("Unable to update CiliumNode resource, will retry", logfields.Error, err)
+					n.logger.Info("Unable to update CiliumNode resource, will retry", logfields.Error, err)
 					// Backoff before retrying
 					time.Sleep(backoffDuration)
 					continue
@@ -277,7 +277,7 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 		} else {
 			if _, err := n.clientset.CiliumV2().CiliumNodes().Create(ctx, nodeResource, metav1.CreateOptions{}); err != nil {
 				if k8serrors.IsConflict(err) || k8serrors.IsAlreadyExists(err) {
-					n.logger.Warn("Unable to create CiliumNode resource, will retry", logfields.Error, err)
+					n.logger.Info("Unable to create CiliumNode resource, will retry", logfields.Error, err)
 					// Backoff before retrying
 					time.Sleep(backoffDuration)
 					continue


### PR DESCRIPTION
The code previously logged TOCTOU warning messages for the cases where CiliumNode resource was already created, but not synced to the k8s resources store.

This can lead to CI flakes such as -

```
:x: 1/4 tests failed (1/70 actions), 150 tests skipped, 0 scenarios skipped:
Test [check-log-errors]:
  :large_red_square: check-log-errors/no-errors-in-logs:pkg/nodediscovery:xxxx-1-0/kube-system/cilium-gr7sz (cilium-agent): Found 1 logs in xxxx-1-0/kube-system/cilium-gr7sz (cilium-agent) matching list of errors that must be investigated:
time=2025-10-21T20:54:16.382391284Z level=warn source=/go/src/github.com/cilium/cilium/pkg/nodediscovery/nodediscovery.go:280 msg="Unable to create CiliumNode resource, will retry" module=agent.controlplane.nodediscovery error="ciliumnodes.cilium.io \"aks-rrnodepool-37229117-vmss000000\" already exists" (2 occurrences)

```

Signed-off-by: Aditi Ghag <aditi@cilium.io>