### PR TITLE
ci: Fix call-backport-label-updater permissions

### DIFF
--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -12,6 +12,7 @@
       name: Update backport labels for upstream PR
       permissions:
         pull-requests: write
+        repository-projects: read
       if: |
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.body, 'upstream-prs') &&


### PR DESCRIPTION
Update the `call-backport-label-updater.yaml` workflow with the permission `repository-projects: read` to resolve an error mentioned [here](https://github.com/cilium/cilium/pull/42281#issuecomment-3471883007)