### PR TITLE
bpf: Align LRU map sizing with kernel rounding rules

### DIFF
--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -369,6 +369,8 @@ func NewConfig(log *slog.Logger, userConfig UserConfig, deprecatedConfig Depreca
 		log.Info(fmt.Sprintf("option %s set by dynamic sizing to %v", LBSockRevNatEntriesName, cfg.LBSockRevNatEntries)) // FIXME
 	}
 
+	cfg.LBSockRevNatEntries = dcfg.AlignMapSizeForLRU(log, LBSockRevNatEntriesName, cfg.LBSockRevNatEntries)
+
 	if cfg.LBSockRevNatEntries < option.LimitTableMin {
 		return Config{}, fmt.Errorf("specified Socket Reverse NAT table size %d must be greater or equal to %d",
 			cfg.LBSockRevNatEntries, option.LimitTableMin)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3196,9 +3196,8 @@ func (c *DaemonConfig) normalizeLRUBackedMapSizes(logger *slog.Logger) {
 //
 // The kernel rounds max_entries in htab_map_alloc() when BPF_F_NO_COMMON_LRU is set:
 //
-//   if (percpu_lru)
-//       htab->map.max_entries = roundup(attr->max_entries, num_possible_cpus());
-//
+//	if (percpu_lru)
+//	    htab->map.max_entries = roundup(attr->max_entries, num_possible_cpus());
 func (c *DaemonConfig) AlignMapSizeForLRU(logger *slog.Logger, optionName string, value int) int {
 	if value <= 0 || !c.BPFDistributedLRU {
 		return value
@@ -3207,11 +3206,7 @@ func (c *DaemonConfig) AlignMapSizeForLRU(logger *slog.Logger, optionName string
 	possibleCPUs := getPossibleCPUs(logger)
 	aligned := alignDistributedLRUSize(value, possibleCPUs)
 	if aligned != value {
-		logger.Debug("Aligning distributed LRU map size to kernel expectations",
-			logfields.BPFMapName, optionName,
-			"oldValue", value,
-			"newValue", aligned,
-			"possibleCPUs", possibleCPUs)
+		logger.Debug(fmt.Sprintf("Aligning distributed LRU map %s: %d -> %d (CPUs: %d)", optionName, value, aligned, possibleCPUs))
 	}
 	return aligned
 }


### PR DESCRIPTION
## Summary

Fixes the infinite map recreation loop that occurs when `bpf-distributed-lru` is enabled on nodes where the configured map size isn't divisible by `num_possible_cpus()`.

## Background

This issue was partially addressed in PR #38978 by Daniel Borkmann (commit 6d119aa8d2d8), which fixed the dynamic sizing calculator to round map sizes. That PR resolved the immediate crisis reported in #39009 where nodes became completely unavailable with memory exhaustion errors.

However, that fix only applied to dynamically-sized maps and didn't cover:
- Statically/explicitly configured map sizes
- The SockRevNAT map in the loadbalancer subsystem

This PR completes that work by normalizing **all** distributed LRU map sizes after config parsing.

## Motivation

When `bpf-distributed-lru` is enabled, the kernel rounds each LRU map's `max_entries` up to a multiple of `num_possible_cpus()`. On nodes with CPU counts like 12, 18, 36, 48, or 72 cores, user-configured sizes (e.g., 131,072) get rounded up by the kernel (e.g., to 131,076).

### Kernel Behavior

The Linux kernel enforces this rounding in [`kernel/bpf/hashtab.c`](https://github.com/torvalds/linux/blob/master/kernel/bpf/hashtab.c) within the `htab_map_alloc` function:

**For distributed (per-CPU) LRU maps (`BPF_F_NO_COMMON_LRU` flag set):**
```c
if (percpu_lru) {
    /* ensure each CPU's lru list has >=1 elements.
     * since we are at it, make each lru list has the same
     * number of elements.
     */
    htab->map.max_entries = roundup(attr->max_entries,
                                    num_possible_cpus());
    if (htab->map.max_entries < attr->max_entries)
        htab->map.max_entries = rounddown(attr->max_entries,
                                          num_possible_cpus());
}
```

**Note:** For shared (non-distributed) LRU maps, the kernel does NOT round `max_entries`, so no alignment is needed in that case.

### The Problem

Cilium's reconciliation loop detects the mismatch between configured and actual kernel sizes, deletes the map, and recreates it with the original size. The kernel rounds it again, creating an infinite loop that:
- Floods the system with map recreations
- Exhausts memory through repeated per-CPU allocations  
- Crashes the agent on single-NUMA, high-thread-count instances

## Changes

- Add `DaemonConfig.AlignMapSizeForLRU()` to align map sizes to kernel rounding (multiple of `num_possible_cpus()`)
- Normalize CT/NAT/neigh/SockRevNAT map sizes after config parsing
- Add unit tests for alignment logic

## Testing

```bash
docker run --rm -v $(pwd):/workspace -w /workspace golang:1.25 go test ./pkg/option ./pkg/loadbalancer
```

All tests pass.

## Related

- Fixes remaining cases from #39009
- Builds on #38978