### PR TITLE
pkg/aws/ec2: Explicitly set network card index 0

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -762,6 +762,18 @@ func (c *Client) AttachNetworkInterface(ctx context.Context, index int32, instan
 		DeviceIndex:        aws.Int32(index),
 		InstanceId:         aws.String(instanceID),
 		NetworkInterfaceId: aws.String(eniID),
+		// NetworkCardIndex is the index of the physical network card on the instance (default is 0)
+		//
+		// While some instance types support multiple NICs, Cilium is only set up to use the primary NIC.
+		// In the future, if multi-NIC support is introduced, this hard-coded value will need to be replaced by
+		// a dynamic value.
+		//
+		// AWS is experiencing a bug in the validation of available device indexes when the network card index
+		// is not set explicitly on instances supporting multiple network cards.
+		// This workaround can be removed once AWS rolls out a fix, which is scheduled by January 30, 2026
+		//
+		// See https://github.com/cilium/cilium/pull/42512
+		NetworkCardIndex: aws.Int32(0),
 	}
 
 	c.limiter.Limit(ctx, AttachNetworkInterface)


### PR DESCRIPTION
A bug was detected in AWS’s ENI attachment API. The validation of available ENI attachment slots fails on instances with multiple network cards when the network card index is not set explicitly. AWS is working on a fix that is expected to be released by January 30, 2026. In the meantime, this change resolves the issue on the Cilium side.

# Example

If an instance with 2 network cards is used and interfaces are attached to the following slots:
- Card Index 0, Device Index 0
- Card Index 1, Device Index 1

This means that the slot (Card Index 0, Device Index 1) is available. But if I try to attach an ENI to it without specifying the network card index and rely on the parameter's default value of 0, I get this error:
```
An error occurred (InvalidParameterValue) when calling the AttachNetworkInterface operation: Instance '<instance-id>' already has an interface attached at device index '1'.
```
If I then retry by explicitly setting Network Card Index to 0, the API call works and the ENI is attached as expected.

# Side note

Cilium only supports the use of one NIC (the primary NIC) on AWS instances. This change does not introduce any new limits on network attachment slots.

## Release note
```release-note
AWS EC2: Fix ENI attachment on multi-network card instances with high-performance networking (EFA) setups
```
