### PR TITLE
datapath/utime: use  hive jobs instead of controller for sync

### DIFF
--- a/pkg/datapath/linux/utime/cell.go
+++ b/pkg/datapath/linux/utime/cell.go
@@ -4,23 +4,14 @@
 package utime
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 
-	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/time"
 )
-
-const (
-	syncControllerName     = "sync-utime"
-	syncControllerInterval = 1 * time.Minute
-)
-
-var syncControllerGroupName = controller.NewGroup("sync-utime")
 
 // Cell initializes and manages the utime offset synchronization.
 var Cell = cell.Module(
@@ -30,31 +21,14 @@ var Cell = cell.Module(
 	cell.Invoke(initUtimeSync),
 )
 
-func initUtimeSync(lifecycle cell.Lifecycle, configMap configmap.Map, logger *slog.Logger) {
-	controllerManager := controller.NewManager()
+func initUtimeSync(jobGroup job.Group, configMap configmap.Map, logger *slog.Logger) {
+	utimeCtrl := &utimeController{logger: logger, configMap: configMap}
 
-	lifecycle.Append(cell.Hook{
-		OnStart: func(startCtx cell.HookContext) error {
-			ctrl := &utimeController{logger: logger, configMap: configMap}
+	// use trigger to enforce first execution immediately when the timer job starts
+	tr := job.NewTrigger()
+	tr.Trigger()
 
-			// Add controller for keeping clock in sync for NTP time jumps and any difference
-			// between monotonic and boottime clocks.
-			controllerManager.UpdateController(syncControllerName,
-				controller.ControllerParams{
-					Group: syncControllerGroupName,
-					DoFunc: func(ctx context.Context) error {
-						return ctrl.sync()
-					},
-					RunInterval: syncControllerInterval,
-				},
-			)
-			return nil
-		},
-		OnStop: func(stopCtx cell.HookContext) error {
-			if err := controllerManager.RemoveController(syncControllerName); err != nil {
-				return fmt.Errorf("failed to remove controller: %w", err)
-			}
-			return nil
-		},
-	})
+	// Add timer job for keeping clock in sync for NTP time jumps and any difference
+	// between monotonic and boottime clocks.
+	jobGroup.Add(job.Timer("sync-userspace-and-datapath", utimeCtrl.sync, 1*time.Minute, job.WithTrigger(tr)))
 }

--- a/pkg/datapath/linux/utime/utime.go
+++ b/pkg/datapath/linux/utime/utime.go
@@ -5,6 +5,7 @@ package utime
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -66,7 +67,7 @@ type utimeController struct {
 	offset    UTime
 }
 
-func (u *utimeController) sync() error {
+func (u *utimeController) sync(_ context.Context) error {
 	offset := getCurrentUTimeOffset(u.logger)
 	if offset != u.offset {
 		if err := u.configMap.Update(configmap.UTimeOffset, uint64(offset)); err != nil {


### PR DESCRIPTION
This commit refactors the utime userspace<->datapath sync to use a Hive timer job instead of a controller.