### PR TITLE
all: fix golangci-lint 2.6.0 govet errors

### DIFF
--- a/cilium-dbg/cmd/encrypt_status.go
+++ b/cilium-dbg/cmd/encrypt_status.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Cilium
 
 //go:build linux
-// +build linux
 
 package cmd
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -584,7 +584,7 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (err error
 	if datapathRegenCtxt.regenerationLevel > regeneration.RegenerateWithoutDatapath {
 		if e.Options.IsEnabled(option.Debug) {
 			debugFunc := func(format string, args ...interface{}) {
-				e.getLogger().Debug(fmt.Sprintf(format, args))
+				e.getLogger().Debug(fmt.Sprintf(format, args...))
 			}
 			ctx, cancel := context.WithCancel(regenContext.parentContext)
 			defer cancel()

--- a/pkg/metrics/plot.go
+++ b/pkg/metrics/plot.go
@@ -125,7 +125,7 @@ func PlotSamples(w io.Writer, rate bool, name, labels string, timeSpan, sampling
 	}
 
 	// Render the labels and the box.
-	writeText(0, originX-1, "╭"+strings.Repeat("─", width-originX-1)+"╮")
+	writeText(0, originX-1, "╭%s╮", strings.Repeat("─", width-originX-1))
 	writeText(1, 1, "%8s ┤", fmtY(maxY))
 	writeText(1, width-1, "│")
 	writeText(2, originX-1, "│")
@@ -140,7 +140,7 @@ func PlotSamples(w io.Writer, rate bool, name, labels string, timeSpan, sampling
 	writeText(6, width-1, "│")
 	writeText(7, 1, "%8s ┤", fmtY(minY))
 	writeText(7, width-1, "│")
-	writeText(8, originX-1, "╰"+strings.Repeat("─", width-originX-1)+"╯")
+	writeText(8, originX-1, "╰%s╯", strings.Repeat("─", width-originX-1))
 	writeText(8, originX+3, "┬")
 	writeText(9, originX, "-%.0fmin", timeSpan.Minutes())
 	writeText(8, originX+3, "┬")


### PR DESCRIPTION
Fix the following errors appearing when [updating to golangci-lint 2.6.0](https://github.com/cilium/cilium/pull/42514):

```
2025-10-31T11:18:01.5671846Z ##[error]cilium-dbg/cmd/encrypt_status.go:5:1: buildtag: +build line is no longer needed (govet)
2025-10-31T11:18:01.5673091Z // +build linux
2025-10-31T11:18:01.5673532Z ^
2025-10-31T11:18:01.5674421Z ##[error]pkg/endpoint/bpf.go:587:25: printf: missing ... in args forwarded to printf-like function (govet)
2025-10-31T11:18:01.5675531Z 				e.getLogger().Debug(fmt.Sprintf(format, args))
2025-10-31T11:18:01.5676128Z 				                    ^
2025-10-31T11:18:01.5677278Z ##[error]pkg/metrics/plot.go:128:26: printf: non-constant format string in call to writeText (govet)
2025-10-31T11:18:01.5678555Z 	writeText(0, originX-1, "╭"+strings.Repeat("─", width-originX-1)+"╮")
2025-10-31T11:18:01.5678972Z 	                        ^
2025-10-31T11:18:01.5679670Z ##[error]pkg/metrics/plot.go:143:26: printf: non-constant format string in call to writeText (govet)
2025-10-31T11:18:01.5680636Z 	writeText(8, originX-1, "╰"+strings.Repeat("─", width-originX-1)+"╯")
```

(from https://github.com/cilium/cilium/actions/runs/18970710287/job/54177614867?pr=42514)