### PR TITLE
ipam: register ipam as status object in hive cell

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
@@ -156,8 +155,6 @@ func configureDaemon(ctx context.Context, cleaner *daemonCleanup, params daemonP
 		params.Logger.Error("error while opening/creating BPF maps", logfields.Error, err)
 		return fmt.Errorf("error while opening/creating BPF maps: %w", err)
 	}
-
-	debug.RegisterStatusObject("ipam", params.IPAM)
 
 	if option.Config.DNSPolicyUnloadOnShutdown {
 		params.Logger.Debug(

--- a/pkg/ipam/cell/cell.go
+++ b/pkg/ipam/cell/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapathTypes "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamapi "github.com/cilium/cilium/pkg/ipam/api"
@@ -61,6 +62,8 @@ type ipamParams struct {
 
 func newIPAddressManager(params ipamParams) *ipam.IPAM {
 	ipam := ipam.NewIPAM(params.Logger, params.NodeAddressing, params.AgentConfig, params.NodeDiscovery, params.LocalNodeStore, params.K8sEventReporter, params.NodeResource, params.MTU, params.Clientset, params.IPAMMetadataManager, params.Sysctl, params.IPMasqAgent)
+
+	debug.RegisterStatusObject("ipam", ipam)
 
 	params.EndpointManager.Subscribe(ipam)
 


### PR DESCRIPTION
This commit moves the registration of IPAM as debug status object from the daemon to the IPAM hive cell.