### PR TITLE
Use modern Go constructs

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -59,8 +59,8 @@ func RunE(hooks api.Hooks) func(cmd *cobra.Command, args []string) error {
 		params.ImpersonateGroups = impersonateGroups
 
 		for _, test := range tests {
-			if strings.HasPrefix(test, "!") {
-				rgx, err := regexp.Compile(strings.TrimPrefix(test, "!"))
+			if after, ok := strings.CutPrefix(test, "!"); ok {
+				rgx, err := regexp.Compile(after)
 				if err != nil {
 					return fmt.Errorf("test filter: %w", err)
 				}

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -370,10 +371,7 @@ func (ct *ConnectivityTest) detectFeatures(ctx context.Context) error {
 
 	for _, ciliumPod := range ct.ciliumPods {
 		// Start with cluster-wide features
-		features := make(features.Set)
-		for k, v := range clusterFeatures {
-			features[k] = v
-		}
+		features := maps.Clone(clusterFeatures)
 
 		// Extract pod-specific features
 		err = ct.extractFeaturesFromRuntimeConfig(ctx, ciliumPod, features)

--- a/pkg/bgp/test/commands/gobgp.go
+++ b/pkg/bgp/test/commands/gobgp.go
@@ -242,8 +242,8 @@ func GoBGPAddPeerCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
 			if families == "" {
 				return nil, fmt.Errorf("families have to be specified for the peer")
 			}
-			afiSafis := strings.Split(families, ",")
-			for _, afiSafi := range afiSafis {
+			afiSafis := strings.SplitSeq(families, ",")
+			for afiSafi := range afiSafis {
 				afiSafiArr := strings.Split(afiSafi, "/")
 				if len(afiSafiArr) != 2 {
 					return nil, fmt.Errorf("invalid afi/safi format: %s", afiSafi)

--- a/pkg/clustermesh/mcsapi/types/ipfamilies.go
+++ b/pkg/clustermesh/mcsapi/types/ipfamilies.go
@@ -21,7 +21,7 @@ func IPFamiliesFromString(s string) ([]corev1.IPFamily, error) {
 		return nil, nil
 	}
 	ipfamilies := make([]corev1.IPFamily, 0, 2)
-	for _, ipfamily := range strings.Split(s, ",") {
+	for ipfamily := range strings.SplitSeq(s, ",") {
 		ipfamily = strings.TrimSpace(ipfamily)
 		switch ipfamily {
 		case string(corev1.IPv4Protocol):

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+	"maps"
 	"net/netip"
 
 	"github.com/cilium/cilium/pkg/lock"
@@ -386,9 +387,7 @@ func (in *Subnet) DeepCopyInto(out *Subnet) {
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make(Tags, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
+		maps.Copy((*out), *in)
 	}
 }
 

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -1122,9 +1122,7 @@ type mockUpdater struct {
 }
 
 func (m *mockUpdater) UpdateIdentities(added, deleted identity.IdentityMap) <-chan struct{} {
-	for nid, lbls := range added {
-		m.identities[nid] = lbls
-	}
+	maps.Copy(m.identities, added)
 
 	for nid := range deleted {
 		delete(m.identities, nid)

--- a/pkg/k8s/client/testutils/object_tracker.go
+++ b/pkg/k8s/client/testutils/object_tracker.go
@@ -712,7 +712,7 @@ func objectMatchesFieldSelector(obj runtime.Object, sel fields.Selector) bool {
 	return true
 }
 
-func getFieldPathValue(obj interface{}, fieldPath string) (string, error) {
+func getFieldPathValue(obj any, fieldPath string) (string, error) {
 	p := jsonpath.New("").AllowMissingKeys(false)
 	if err := p.Parse("{$." + fieldPath + "}"); err != nil {
 		return "", err

--- a/pkg/wal/wal_test.go
+++ b/pkg/wal/wal_test.go
@@ -190,10 +190,7 @@ type SmallReadsReader struct {
 }
 
 func (r *SmallReadsReader) Read(p []byte) (int, error) {
-	l := len(p)
-	if l > 8 {
-		l = 8
-	}
+	l := min(len(p), 8)
 	if l > len(r.data) {
 		l = len(r.data)
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1030,7 +1030,7 @@ func (kub *Kubectl) getNodeIPByLabel(label string, external bool, ipFamily v1.IP
 		return "", fmt.Errorf("no matching node to read IP with label '%v'", label)
 	}
 
-	for _, ipStr := range strings.Fields(out) {
+	for ipStr := range strings.FieldsSeq(out) {
 		ip := net.ParseIP(ipStr)
 		switch ipFamily {
 		case v1.IPv4Protocol:


### PR DESCRIPTION
This PR is essentially the same thing as #38652 and related PRs.

I split the diff one commit per [`modernize`](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize) category for easier code review, happy to squash those commits if it is preferred.

I skipped the following categories because they had larger diffs or potential compatibility impacts and should probably be handled in dedicated PRs:

  - omitzero: replace omitempty by omitzero on structs, added in go1.24.

  - bloop: replace "for i := range b.N" or "for range b.N" in a benchmark with "for b.Loop()", and remove any preceding calls to b.StopTimer, b.StartTimer, and b.ResetTimer.

    B.Loop intentionally defeats compiler optimizations such as inlining so that the benchmark is not entirely optimized away. Currently, however, it may cause benchmarks to become slower in some cases due to increased allocation; see https://go.dev/issue/73137.

  - rangeint: replace a 3-clause "for i := 0; i < n; i++" loop by "for i := range n", added in go1.22.

  - waitgroup: replace old complex usages of sync.WaitGroup by less complex WaitGroup.Go method in go1.25.

Ideally we would add `modernize` to the CI test suite to ensure the codebase continues to follow those standards going forward, but modernize is not currently available as a golangci-lint plugin although there's ongoing work in that direction, see https://github.com/golangci/golangci-lint/issues/686#issuecomment-2996954711.
In the meantime, we could run `modernize` standalone alongside golangci-lint.