### PR TITLE
bpf: host: streamline the lxc/host policy tailcall program

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1749,10 +1749,9 @@ static __always_inline int
 /* Handles packet from a local endpoint entering the host namespace. Applies
  * ingress host policies.
  */
-to_host_from_lxc(struct __ctx_buff *ctx)
+to_host_from_lxc(struct __ctx_buff *ctx, __s8 *ext_err)
 {
 	int ret = CTX_ACT_OK;
-	__s8 ext_err = 0;
 	__u16 proto = 0;
 
 	if (!validate_ethertype(ctx, &proto)) {
@@ -1772,7 +1771,7 @@ to_host_from_lxc(struct __ctx_buff *ctx)
 		ctx_store_meta(ctx, CB_TRACED, 1);
 		if ((is_defined(ENABLE_IPV4) && is_defined(ENABLE_IPV6)) || is_defined(DEBUG))
 			ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_TO_HOST_POLICY_ONLY,
-						 &ext_err);
+						 ext_err);
 		else
 			ret = tail_ipv6_host_policy_ingress(ctx);
 		break;
@@ -1783,7 +1782,7 @@ to_host_from_lxc(struct __ctx_buff *ctx)
 		ctx_store_meta(ctx, CB_TRACED, 1);
 		if ((is_defined(ENABLE_IPV4) && is_defined(ENABLE_IPV6)) || is_defined(DEBUG))
 			ret = tail_call_internal(ctx, CILIUM_CALL_IPV4_TO_HOST_POLICY_ONLY,
-						 &ext_err);
+						 ext_err);
 		else
 			ret = tail_ipv4_host_policy_ingress(ctx);
 		break;
@@ -1794,9 +1793,6 @@ to_host_from_lxc(struct __ctx_buff *ctx)
 	}
 
 out:
-	if (IS_ERR(ret))
-		return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-						  METRIC_INGRESS);
 	return ret;
 }
 
@@ -1878,12 +1874,21 @@ int cil_host_policy(struct __ctx_buff *ctx __maybe_unused)
 {
 #ifdef ENABLE_HOST_FIREWALL
 	bool from_host = ctx_load_meta(ctx, CB_FROM_HOST);
+	__u32 src_sec_identity;
+	enum metric_dir dir;
+	__s8 ext_err = 0;
+	int ret;
+
+	if (from_host) {
+		src_sec_identity = HOST_ID;
+		dir = METRIC_EGRESS;
+	} else {
+		src_sec_identity = UNKNOWN_ID;
+		dir = METRIC_INGRESS;
+	}
 
 	if (from_host) {
 		__u32 lxc_id = ctx_load_meta(ctx, CB_DST_ENDPOINT_ID);
-		__u32 src_sec_identity = HOST_ID;
-		__s8 ext_err = 0;
-		int ret;
 
 		ret = from_host_to_lxc(ctx, &ext_err);
 		if (IS_ERR(ret))
@@ -1892,13 +1897,16 @@ int cil_host_policy(struct __ctx_buff *ctx __maybe_unused)
 		local_delivery_fill_meta(ctx, src_sec_identity, false,
 					 true, false, 0);
 		ret = tail_call_policy(ctx, (__u16)lxc_id);
-
-drop_err:
-		return send_drop_notify_error_ext(ctx, src_sec_identity,
-						  ret, ext_err, METRIC_EGRESS);
+	} else {
+		ret = to_host_from_lxc(ctx, &ext_err);
 	}
 
-	return to_host_from_lxc(ctx);
+drop_err:
+	if (IS_ERR(ret))
+		return send_drop_notify_error_ext(ctx, src_sec_identity,
+						  ret, ext_err, dir);
+
+	return ret;
 #else
 	return 0;
 #endif /* ENABLE_HOST_FIREWALL */

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1749,15 +1749,9 @@ static __always_inline int
 /* Handles packet from a local endpoint entering the host namespace. Applies
  * ingress host policies.
  */
-to_host_from_lxc(struct __ctx_buff *ctx, __s8 *ext_err)
+to_host_from_lxc(struct __ctx_buff *ctx, __be16 proto, __s8 *ext_err)
 {
 	int ret = CTX_ACT_OK;
-	__u16 proto = 0;
-
-	if (!validate_ethertype(ctx, &proto)) {
-		ret = DROP_UNSUPPORTED_L2;
-		goto out;
-	}
 
 	switch (proto) {
 # if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER
@@ -1792,7 +1786,6 @@ to_host_from_lxc(struct __ctx_buff *ctx, __s8 *ext_err)
 		break;
 	}
 
-out:
 	return ret;
 }
 
@@ -1801,7 +1794,7 @@ out:
  * control back to bpf_lxc.
  */
 static __always_inline int
-from_host_to_lxc(struct __ctx_buff *ctx, __s8 *ext_err)
+from_host_to_lxc(struct __ctx_buff *ctx, __be16 proto, __s8 *ext_err)
 {
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
@@ -1811,10 +1804,6 @@ from_host_to_lxc(struct __ctx_buff *ctx, __s8 *ext_err)
 	void *data, *data_end;
 	struct iphdr *ip4 __maybe_unused;
 	struct ipv6hdr *ip6 __maybe_unused;
-	__u16 proto = 0;
-
-	if (!validate_ethertype(ctx, &proto))
-		return DROP_UNSUPPORTED_L2;
 
 	switch (proto) {
 # if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER
@@ -1876,6 +1865,7 @@ int cil_host_policy(struct __ctx_buff *ctx __maybe_unused)
 	bool from_host = ctx_load_meta(ctx, CB_FROM_HOST);
 	__u32 src_sec_identity;
 	enum metric_dir dir;
+	__be16 proto = 0;
 	__s8 ext_err = 0;
 	int ret;
 
@@ -1887,10 +1877,15 @@ int cil_host_policy(struct __ctx_buff *ctx __maybe_unused)
 		dir = METRIC_INGRESS;
 	}
 
+	if (!validate_ethertype(ctx, &proto)) {
+		ret = DROP_UNSUPPORTED_L2;
+		goto drop_err;
+	}
+
 	if (from_host) {
 		__u32 lxc_id = ctx_load_meta(ctx, CB_DST_ENDPOINT_ID);
 
-		ret = from_host_to_lxc(ctx, &ext_err);
+		ret = from_host_to_lxc(ctx, proto, &ext_err);
 		if (IS_ERR(ret))
 			goto drop_err;
 
@@ -1898,7 +1893,7 @@ int cil_host_policy(struct __ctx_buff *ctx __maybe_unused)
 					 true, false, 0);
 		ret = tail_call_policy(ctx, (__u16)lxc_id);
 	} else {
-		ret = to_host_from_lxc(ctx, &ext_err);
+		ret = to_host_from_lxc(ctx, proto, &ext_err);
 	}
 
 drop_err:

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1869,6 +1869,7 @@ int cil_host_policy(struct __ctx_buff *ctx __maybe_unused)
 		src_sec_identity = HOST_ID;
 		dir = METRIC_EGRESS;
 	} else {
+		/* TODO: in a future release, use CB_SRC_LABEL here */
 		src_sec_identity = UNKNOWN_ID;
 		dir = METRIC_INGRESS;
 	}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -677,6 +677,7 @@ ct_recreate6:
 	 * enabled, jump to the bpf_host program to enforce ingress host policies.
 	 */
 	if (*dst_sec_identity == HOST_ID) {
+		ctx_store_meta(ctx, CB_SRC_LABEL, SECLABEL_IPV6);
 		ctx_store_meta(ctx, CB_FROM_HOST, 0);
 		ret = tail_call_policy(ctx, CONFIG(host_ep_id));
 
@@ -1149,6 +1150,7 @@ ct_recreate4:
 	 * program may not yet be present at this time.
 	 */
 	if (*dst_sec_identity == HOST_ID) {
+		ctx_store_meta(ctx, CB_SRC_LABEL, SECLABEL_IPV4);
 		ctx_store_meta(ctx, CB_FROM_HOST, 0);
 		ret = tail_call_policy(ctx, CONFIG(host_ep_id));
 


### PR DESCRIPTION
For HostFW policy enforcement in endpoint-routing configurations, `bpf_host` provides a special policy tailcall program which is invoked by bpf_lxc (for packets that bypassed the usual `cilium_host` /`cilium_net` path).

Clean this code up a bit, so that the error handling is consistent and it's better aligned with the usual HostFW policy path.