### PR TITLE
policy: Detach selector policy on last user

### DIFF
--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -690,8 +690,8 @@ type testSelectorPolicy struct {
 	policyType PolicyType
 }
 
-func (sp *testSelectorPolicy) DistillPolicy(logger *slog.Logger, owner policy.PolicyOwner, redirects map[string]uint16) *policy.EndpointPolicy {
-	return nil
+func (sp *testSelectorPolicy) DistillPolicy(logger *slog.Logger, owner policy.PolicyOwner, redirects map[string]uint16) (*policy.EndpointPolicy, error) {
+	return nil, nil
 }
 
 func (sp *testSelectorPolicy) RedirectFilters() iter.Seq2[*policy.L4Filter, policy.PerSelectorPolicyTuple] {

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -230,13 +230,13 @@ func (td *testData) validateResolvedPolicy(t *testing.T, selPolicy *selectorPoli
 	sp, err := td.repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
 
-	epp := sp.DistillPolicy(logger, DummyOwner{logger: logger}, nil)
+	epp, err := sp.DistillPolicy(logger, DummyOwner{logger: logger}, nil)
+	require.NoError(t, err)
 	require.NotNil(t, epp)
 	epp.Ready()
 
 	closer, _ := epPolicy.ConsumeMapChanges()
 	closer()
-	epPolicy.Ready()
 
 	require.True(t, epPolicy.policyMapState.Equal(&epp.policyMapState), epPolicy.policyMapState.diff(&epp.policyMapState))
 
@@ -270,11 +270,12 @@ func (td *testData) policyMapEquals(t *testing.T, expectedIn, expectedOut L4Poli
 
 	selPolicy, err := td.repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer selPolicy.detach(true, 0)
 
 	// Distill Selector policy to Endpoint Policy
-	epPolicy := selPolicy.DistillPolicy(logger, DummyOwner{logger: logger}, nil)
+	epPolicy, err := selPolicy.DistillPolicy(logger, DummyOwner{logger: logger}, nil)
+	require.NoError(t, err)
 	epPolicy.Ready()
+	defer epPolicy.Detach(logger)
 
 	td.validateResolvedPolicy(t, selPolicy, epPolicy, expectedIn, expectedOut)
 

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2079,10 +2079,12 @@ func TestDenyPreferredInsertLogic(t *testing.T) {
 	td.bootstrapRepo(GenerateCIDRDenyRules, 1000, t)
 	p, _ := td.repo.resolvePolicyLocked(fooIdentity)
 
-	epPolicy := p.DistillPolicy(hivetest.Logger(t), DummyOwner{logger: hivetest.Logger(t)}, nil)
+	epPolicy, err := p.DistillPolicy(hivetest.Logger(t), DummyOwner{logger: hivetest.Logger(t)}, nil)
+	require.NoError(t, err)
 	epPolicy.Ready()
+	epPolicy.Detach(hivetest.Logger(t))
 
 	n := epPolicy.policyMapState.Len()
-	p.detach(true, 0)
+	p.detach()
 	assert.Positive(t, n)
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -45,6 +45,11 @@ type PolicyRepository interface {
 	// calculation.
 	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error)
 
+	// GetCurrentPolicy returns a snapshot of the current policy for the given identity.
+	// Returned policy can already be stale, but generally is the revision that was previously
+	// plumbed to the datapath.
+	GetCurrentPolicy(id *identity.Identity) SelectorPolicy
+
 	// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
 	GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy
 	GetRevision() uint64
@@ -581,4 +586,11 @@ func (p *Repository) GetPolicySnapshot() map[identity.NumericIdentity]SelectorPo
 	defer p.mutex.RUnlock()
 
 	return p.policyCache.GetPolicySnapshot()
+}
+
+// GetCurrentPolicy returns the current SelectorPolicy for the given identity.
+func (p *Repository) GetCurrentPolicy(id *identity.Identity) SelectorPolicy {
+	// repo locking not needed as 'p.policyCache' is set when Repositoryy is created, and
+	// it has its own locking.
+	return p.policyCache.GetCurrentPolicy(id)
 }

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1685,7 +1685,7 @@ func TestIngressL4AllowAll(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idC)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.detach()
 
 	filter := pol.L4Policy.Ingress.PortRules.ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)
@@ -1719,7 +1719,7 @@ func TestIngressL4AllowAllNamedPort(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idC)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.detach()
 
 	filter := pol.L4Policy.Ingress.PortRules.ExactLookup("port-80", 0, "TCP")
 	require.NotNil(t, filter)
@@ -1779,7 +1779,7 @@ func TestEgressL4AllowAll(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.detach()
 
 	t.Log(pol.L4Policy.Egress.PortRules)
 	filter := pol.L4Policy.Egress.PortRules.ExactLookup("80", 0, "TCP")
@@ -1821,7 +1821,7 @@ func TestEgressL4AllowWorld(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.detach()
 
 	filter := pol.L4Policy.Egress.PortRules.ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)
@@ -1861,7 +1861,7 @@ func TestEgressL4AllowAllEntity(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.detach()
 
 	filter := pol.L4Policy.Egress.PortRules.ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)


### PR DESCRIPTION
Detach selector policy on last user, rather than on the first user that finds that the policy needs to be updated. Propagate stale policy status up the call chain so that the endpoint can retry after hitting a stale selector policy.

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
