### PR TITLE
conformance-aws-cni: disable l7 proxy with aws-cni

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -204,7 +204,6 @@ jobs:
           external-target: 'amazon.com.'
           hubble: false
           test-concurrency: 3
-          tests: '!fqdn,!l7' # L7 policies are not supported in chaining mode.
 
       - name: Set up job variables
         id: vars
@@ -226,6 +225,7 @@ jobs:
             --helm-set=cni.chainingMode=aws-cni \
             --helm-set=eni.enabled=false \
             --helm-set=ipam.mode=cluster-pool \
+            --helm-set=enable-l7-proxy=false \
             --helm-set=routingMode=native \
             --helm-set=bandwidthManager.enabled=false \
             --helm-set=extraArgs={--enable-identity-mark=false} \


### PR DESCRIPTION
AWS-CNI chaining does not support L7 policies and such we should not deploy it to prevent the L7 tests from being tested.