### PR TITLE
gha: allow configuring runner for workflows building Cilium binaries

### DIFF
--- a/.github/workflows/build-go-caches.yaml
+++ b/.github/workflows/build-go-caches.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   build_go_caches:
     name: Build Go Caches
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     timeout-minutes: 20
     strategy:
       matrix:

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -85,7 +85,7 @@ jobs:
 
   build-commits-cilium:
     name: Check if cilium builds for every commit
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     needs: [compute-vars]
     timeout-minutes: 180
     steps:
@@ -171,7 +171,7 @@ jobs:
 
   build-commits-hubble-cli:
     name: Check if hubble-cli builds for every commit
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     needs: [compute-vars]
     timeout-minutes: 180
     steps:
@@ -263,7 +263,7 @@ jobs:
 
   build-commits-bpf:
     name: Check if bpf builds for every commit
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     needs: [compute-vars]
     # Runs only if code under bpf/ is changed.
     if: needs.compute-vars.outputs.build-bpf == 'true'
@@ -356,7 +356,7 @@ jobs:
 
   build-commits-test:
     name: Check if test builds for every commit
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     needs: [compute-vars]
     # Runs only if code under test/ is changed.
     if: needs.compute-vars.outputs.build-test == 'true'


### PR DESCRIPTION
Let's match the configuration already used for building the actual images, and also switch the `Build Commits` and `Build Go Caches` workflows to allow configuring the runner via the dedicated environment variable. The default value matches the current setting, so that nothing changes if not specified.