### PR TITLE
bgp: Add SourceInterface configuration option into CiliumBGPTransport

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-configuration.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-configuration.rst
@@ -381,11 +381,16 @@ Default value of ``RestartTime`` is 120 seconds. More details on graceful restar
 Transport
 ---------
 
-The transport section of ``CiliumBGPPeerConfig`` can be used to configure a custom
-destination port for a peer's BGP session.
+The transport section of ``CiliumBGPPeerConfig`` can be used to tweak connection settings for a peer's BGP session.
 
 By default, when BGP is operating in `active mode <https://datatracker.ietf.org/doc/html/rfc4271#section-8.2.1>`_
 (with the Cilium agent initiating the TCP connection), the destination port is 179 and the source port is ephemeral.
+The ``peerPort`` field can be used to configure a custom destination port.
+
+The source IP address for the BGP session is by default auto-detected based on the egress interface.
+The ``sourceInterface`` field can be used to override this with the IP address applied in the provided
+network interface. The interface must not have more than one non-loopback, non-multicast
+and non-link-local-IPv6 address per address family.
 
 Here is an example of setting the transport configuration:
 
@@ -398,6 +403,7 @@ Here is an example of setting the transport configuration:
     spec:
       transport:
         peerPort: 179
+        sourceInterface: lo
 
 
 .. _bgp_peer_configuration_afi:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgppeerconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgppeerconfigs.yaml
@@ -252,6 +252,15 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  sourceInterface:
+                    description: |-
+                      SourceInterface is the name of a local interface, which IP address will be used
+                      as the source IP address for the BGP session. The interface must not have more than one
+                      non-loopback, non-multicast and non-link-local-IPv6 address per address family.
+
+                      If not specified, or if the provided interface is not found or missing a usable IP address,
+                      the source IP address will be auto-detected based on the egress interface.
+                    type: string
                 type: object
             type: object
           status:

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.32.3"
+	CustomResourceDefinitionSchemaVersion = "1.32.4"
 )

--- a/pkg/k8s/apis/cilium.io/v2/bgp_peer_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/bgp_peer_types.go
@@ -172,6 +172,16 @@ type CiliumBGPTransport struct {
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:default=179
 	PeerPort *int32 `json:"peerPort,omitempty"`
+
+	// SourceInterface is the name of a local interface, which IP address will be used
+	// as the source IP address for the BGP session. The interface must not have more than one
+	// non-loopback, non-multicast and non-link-local-IPv6 address per address family.
+	//
+	// If not specified, or if the provided interface is not found or missing a usable IP address,
+	// the source IP address will be auto-detected based on the egress interface.
+	//
+	// +kubebuilder:validation:Optional
+	SourceInterface *string `json:"sourceInterface,omitempty"`
 }
 
 func (t *CiliumBGPTransport) SetDefaults() {

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
@@ -1113,6 +1113,11 @@ func (in *CiliumBGPTransport) DeepCopyInto(out *CiliumBGPTransport) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.SourceInterface != nil {
+		in, out := &in.SourceInterface, &out.SourceInterface
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -1116,6 +1116,14 @@ func (in *CiliumBGPTransport) DeepEqual(other *CiliumBGPTransport) bool {
 		}
 	}
 
+	if (in.SourceInterface == nil) != (other.SourceInterface == nil) {
+		return false
+	} else if in.SourceInterface != nil {
+		if *in.SourceInterface != *other.SourceInterface {
+			return false
+		}
+	}
+
 	return true
 }
 


### PR DESCRIPTION
 Add a new configuration option `SourceInterface` into `CiliumBGPTransport`. This allows providing the name of a local interface, which IP address will be used as the source IP address for the BGP session, instead of the auto-detected source IP based on the egress interface, e.g.:

```yaml
apiVersion: cilium.io/v2
kind: CiliumBGPPeerConfig
metadata:
  name: cilium-peer
spec:
  transport:
    sourceInterface: lo
```

```
bgp: Add SourceInterface configuration option into CiliumBGPTransport
```
