### PR TITLE
cilium-cni: Fix bootstrapping agent detection check

### DIFF
--- a/plugins/cilium-cni/lib/deletion_queue.go
+++ b/plugins/cilium-cni/lib/deletion_queue.go
@@ -179,14 +179,14 @@ func (dc *DeletionFallbackClient) deleteEndpointsBatch(req *models.EndpointBatch
 		// reduce contention.
 		// Instead, we wait for it to complete its bootstrap and retry to
 		// connect again later.
-		var dirNotExists, socketNotExists bool
-		if _, err := os.Stat(filepath.Dir(client.DefaultSockPath())); errors.Is(err, fs.ErrNotExist) {
-			dirNotExists = true
+		var dirExists, socketNotExists bool
+		if _, err := os.Stat(filepath.Dir(client.DefaultSockPath())); err == nil {
+			dirExists = true
 		}
 		if _, err := os.Stat(client.DefaultSockPath()); errors.Is(err, fs.ErrNotExist) {
 			socketNotExists = true
 		}
-		if !dirNotExists || !socketNotExists {
+		if !dirExists || !socketNotExists {
 			// Agent is not bootstrapping
 			return true, err
 		}

--- a/plugins/cilium-cni/lib/deletion_queue_test.go
+++ b/plugins/cilium-cni/lib/deletion_queue_test.go
@@ -173,7 +173,7 @@ func TestDeletionFallbackClient(t *testing.T) {
 				errorMock:       newClientErrorOnce,
 				clientErrorMock: deletionClientErrorOnce,
 			},
-			shouldQueueDeletion: false,
+			shouldQueueDeletion: true,
 		},
 		{
 			newClientCreator: fakeCiliumClientCreator{


### PR DESCRIPTION
An agent that is bootstrapping after a restart can be detected by:

- the presence of the runtime directory (e.g: "/var/run/cilium")
- the absence of the Cilium UNIX domain socket in the directory above (e.g: "/var/run/cilium/cilium.sock")

Fix the check introduced in the previous commit using the conditions above. Specifically, the previous commit erroneously checked for the absence of the runtime directory, while that directory should already be present in case of a restart.

Fixes: 66a4e8e451 ("plugins/cilium-cni: Busy wait for a bootstrapping agent")
Related: https://github.com/cilium/cilium/pull/42074