### PR TITLE
ci: Setup CodeQL

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,133 @@
+name: CodeQL
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['actions']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.30.0
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.30.0
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.30.0
+        with:
+          category: '/language:${{matrix.language}}'
+          output: sarif-results
+          upload: false
+
+      - name: Checking for missing-workflow-permissions issues
+        run: |
+          set -euo pipefail
+
+          SARIF_FILE="sarif-results/${{ matrix.language }}.sarif"
+          if [[ ! -f "$SARIF_FILE" ]]; then
+            echo "No SARIF file found"
+            touch /tmp/affected_files.txt
+            exit 0
+          fi
+
+          AFFECTED_FILES=$(jq -r '
+            .runs[].results // [] |
+            .[] |
+            select(.ruleId == "actions/missing-workflow-permissions") |
+            .locations[0].physicalLocation.artifactLocation.uri
+          ' "$SARIF_FILE" | sort -u)
+
+          if [[ -z "$AFFECTED_FILES" ]]; then
+            echo "✅  No issues found"
+            touch /tmp/affected_files.txt
+            exit 0
+          fi
+
+          echo "$AFFECTED_FILES" > /tmp/affected_files.txt
+          echo "Found issues in $(echo "$AFFECTED_FILES" | wc -l) files"
+
+      - name: Get modified files
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            MODIFIED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+          else
+            MODIFIED_FILES=$(git diff --name-only HEAD~1)
+          fi
+
+          echo "$MODIFIED_FILES" > /tmp/modified_files.txt
+          echo "Found $(echo "$MODIFIED_FILES" | wc -l) modified files"
+
+      - name: Check for issues in modified files
+        run: |
+          set -euo pipefail
+
+          SARIF_FILE="sarif-results/${{ matrix.language }}.sarif"
+          AFFECTED_FILES=$(cat /tmp/affected_files.txt)
+          MODIFIED_FILES=$(cat /tmp/modified_files.txt)
+
+          # If no affected files, skip check
+          if [[ -z "$AFFECTED_FILES" ]]; then
+            echo "✅ No issues in modified files"
+            exit 0
+          fi
+
+          # Check for issues in modified files
+          FAILED=false
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            if echo "$MODIFIED_FILES" | grep -qx "$file"; then
+              echo "❌ Missing permissions in modified file: $file"
+              jq -r --arg file "$file" '
+                .runs[].results // [] |
+                .[] |
+                select(.ruleId == "actions/missing-workflow-permissions" and
+                       .locations[0].physicalLocation.artifactLocation.uri == $file) |
+                "  Line \(.locations[0].physicalLocation.region.startLine): \(.message.text)"
+              ' "$SARIF_FILE"
+              FAILED=true
+            fi
+          done <<< "$AFFECTED_FILES"
+
+          if [[ "$FAILED" == "true" ]]; then
+            echo ""
+            echo "❌ Pipeline failed: Modified files have missing workflow permissions"
+            exit 1
+          fi
+
+          echo "✅ No issues in modified files"
+
+      - name: Upload SARIF as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: codeql-sarif-${{ matrix.language }}
+          path: sarif-results/${{ matrix.language }}.sarif
+          retention-days: 7
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.30.0
+        with:
+          sarif_file: sarif-results/${{ matrix.language }}.sarif
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
Add CodeQL `actions` scanning that runs on `pull_request`.

This will enforce workflow permission checks if a workflow is being modified/added.

Working example [here](https://github.com/cilium/cilium/actions/runs/19134140391/job/54681882891)
