### PR TITLE
bpf: drop const qualifier from srv6_load_meta_sid's sid argument

### DIFF
--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -397,7 +397,7 @@ srv6_handling(struct __ctx_buff *ctx, struct in6_addr *dst_sid)
 }
 
 static __always_inline void
-srv6_load_meta_sid(struct __ctx_buff *ctx, const struct in6_addr *sid)
+srv6_load_meta_sid(struct __ctx_buff *ctx, struct in6_addr *sid)
 {
 	ctx_load_meta_ipv6(ctx, (union v6addr *)sid, CB_SRV6_SID_1);
 }

--- a/contrib/coccinelle/const.cocci
+++ b/contrib/coccinelle/const.cocci
@@ -17,7 +17,7 @@ cnt = 0
 identifier f, fn, x, z, s1, s2;
 assignment operator op;
 expression e;
-type T0, T;
+type T0, T, T1;
 position p;
 @@
 
@@ -47,6 +47,10 @@ position p;
       when != WRITE_ONCE(x->z[...], ...)
       when != f(..., x, ...)
       when != f(..., x->z, ...)
+      when != f(..., (T1)x, ...)
+      when != f(..., (T1 *)x, ...)
+      when != f(..., (T1)x->z, ...)
+      when != f(..., (T1 *)x->z, ...)
       when != struct s1 s2 = { ..., .z = x, ... };
   }
 )


### PR DESCRIPTION
Running `make -C bpf` with my local LLVM 21 toolchain results in the following
error:

```
In file included from bpf_lxc.c:51:
./lib/srv6.h:418:27: error: variable 'dst_sid' is uninitialized when passed as a const pointer argument
      here [-Werror,-Wuninitialized-const-pointer]
  418 |         srv6_load_meta_sid(ctx, &dst_sid);
      |                                  ^~~~~~~
1 error generated.
```

Drop the const qualifier from srv6_load_meta_sid's sid argument. The function
wraps ctx_load_meta_ipv6, which doesn't take a const pointer and does actually
mutate the pointed-to object, so this is not super useful.

Found a similar case in https://github.com/curl/curl/pull/18420 since -Wuninitialized-const-pointer was
only just added to LLVM.

Also updated const.cocci to not freak out when passing a cast pointer to another function.

```release-note
Make sure the datapath builds with LLVM 21.
```