### PR TITLE
cilium-cli: add connectivity test for service loopback

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -356,6 +356,7 @@ Makefile* @cilium/build
 /cilium-cli/connectivity/builder/pod_to_ingress_service.go @cilium/sig-servicemesh
 /cilium-cli/connectivity/builder/pod_to_pod_encryption.go @cilium/sig-encryption
 /cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go @cilium/sig-encryption
+/cilium-cli/connectivity/builder/service_loopback.go @cilium/sig-lb
 /cilium-cli/connectivity/perf/** @cilium/sig-scalability
 /cilium-cli/connectivity/tests/bgp.go @cilium/sig-bgp
 /cilium-cli/connectivity/tests/clustermesh-endpointslice-sync.go @cilium/sig-clustermesh

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -310,6 +310,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		echoIngressMutualAuthSpiffe{},
 		podToIngressService{},
 		outsideToIngressService{},
+		serviceLoopback{},
 		l7LB{},
 		dnsOnly{},
 		toFqdns{},

--- a/cilium-cli/connectivity/builder/service_loopback.go
+++ b/cilium-cli/connectivity/builder/service_loopback.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+type serviceLoopback struct{}
+
+func (t serviceLoopback) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("pod-to-itself-via-service", ct).
+		WithScenarios(tests.PodToItselfViaService()).
+		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
+			return check.ResultOK, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -83,6 +83,7 @@ type ConnectivityTest struct {
 	echoExternalServices map[string]Service
 	ingressService       map[string]Service
 	l7LBService          map[string]Service
+	l7LBNonL7Service     map[string]Service
 	k8sService           Service
 	lrpClientPods        map[string]Pod
 	lrpBackendPods       map[string]Pod
@@ -246,6 +247,7 @@ func NewConnectivityTest(
 		echoExternalServices:     make(map[string]Service),
 		ingressService:           make(map[string]Service),
 		l7LBService:              make(map[string]Service),
+		l7LBNonL7Service:         make(map[string]Service),
 		hostNetNSPodsByNode:      make(map[string]Pod),
 		secondaryNetworkNodeIPv4: make(map[string]string),
 		secondaryNetworkNodeIPv6: make(map[string]string),
@@ -1211,6 +1213,10 @@ func (ct *ConnectivityTest) IngressService() map[string]Service {
 
 func (ct *ConnectivityTest) L7LBService() map[string]Service {
 	return ct.l7LBService
+}
+
+func (ct *ConnectivityTest) L7LBNonL7Service() map[string]Service {
+	return ct.l7LBNonL7Service
 }
 
 func (ct *ConnectivityTest) K8sService() Service {

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1696,67 +1696,85 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		}
 	}
 
-	if ct.Features[features.L7LoadBalancer].Enabled {
-		_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, loadbalancerL7DeploymentName, metav1.GetOptions{})
-		if err != nil {
-			ct.Logf("✨ [%s] Deploying same-node deployment...", ct.clients.src.ClusterName())
-			containerPort := 8080
-			l7lbDeployment := newDeploymentWithDNSTestServer(deploymentParameters{
-				Name:  loadbalancerL7DeploymentName,
-				Kind:  kindL7LBName,
-				Image: ct.params.EchoImage,
-				Args: []string{
-					"--tcp=9090", "--port=8080", "--grpc=7070", "--port=8443", "--tls=8443", "--crt=/cert.crt", "--key=/cert.key",
-				},
-				Labels: map[string]string{"kind": "l7-lb"},
-				Affinity: &corev1.Affinity{
-					PodAffinity: &corev1.PodAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{loadbalancerL7DeploymentName}},
-									},
+	_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, loadbalancerL7DeploymentName, metav1.GetOptions{})
+	if err != nil {
+		ct.Logf("✨ [%s] Deploying same-node deployment...", ct.clients.src.ClusterName())
+		containerPort := 8080
+		l7lbDeployment := newDeploymentWithDNSTestServer(deploymentParameters{
+			Name:  loadbalancerL7DeploymentName,
+			Kind:  kindL7LBName,
+			Image: ct.params.EchoImage,
+			Args: []string{
+				"--tcp=9090", "--port=8080", "--grpc=7070", "--port=8443", "--tls=8443", "--crt=/cert.crt", "--key=/cert.key",
+			},
+			Labels: map[string]string{"kind": "l7-lb"},
+			Affinity: &corev1.Affinity{
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{loadbalancerL7DeploymentName}},
 								},
-								TopologyKey: corev1.LabelHostname,
 							},
+							TopologyKey: corev1.LabelHostname,
 						},
 					},
-					NodeAffinity: ct.maybeNodeToNodeEncryptionAffinity(),
 				},
-				ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
-				Tolerations:    ct.params.GetTolerations(),
-			}, ct.params.DNSTestServerImage)
-			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(loadbalancerL7DeploymentName), metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create service account %s: %w", loadbalancerL7DeploymentName, err)
-			}
-			_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, l7lbDeployment, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create deployment %s: %w", loadbalancerL7DeploymentName, err)
-			}
-		}
-
-		_, err = ct.clients.dst.GetService(ctx, ct.params.TestNamespace, loadbalancerL7DeploymentName, metav1.GetOptions{})
+				NodeAffinity: ct.maybeNodeToNodeEncryptionAffinity(),
+			},
+			ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
+			Tolerations:    ct.params.GetTolerations(),
+		}, ct.params.DNSTestServerImage)
+		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(loadbalancerL7DeploymentName), metav1.CreateOptions{})
 		if err != nil {
-			ct.Logf("✨ [%s] Deploying %s service...", ct.clients.dst.ClusterName(), loadbalancerL7DeploymentName)
-			svc := newService(
-				loadbalancerL7DeploymentName,
-				map[string]string{"name": loadbalancerL7DeploymentName},
-				map[string]string{"name": loadbalancerL7DeploymentName, "kind": kindL7LBName},
-				"http",
-				8080,
-				ct.Params().ServiceType)
-
-			svc.ObjectMeta.Annotations = map[string]string{
-				"service.cilium.io/lb-l7": "enabled",
-			}
-			_, err = ct.clients.dst.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
-			if err != nil {
-				return err
-			}
+			return fmt.Errorf("unable to create service account %s: %w", loadbalancerL7DeploymentName, err)
+		}
+		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, l7lbDeployment, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create deployment %s: %w", loadbalancerL7DeploymentName, err)
 		}
 	}
+
+	_, err = ct.clients.dst.GetService(ctx, ct.params.TestNamespace, loadbalancerL7DeploymentName, metav1.GetOptions{})
+	if err != nil {
+		ct.Logf("✨ [%s] Deploying %s service...", ct.clients.dst.ClusterName(), loadbalancerL7DeploymentName)
+		svc := newService(
+			loadbalancerL7DeploymentName,
+			map[string]string{"name": loadbalancerL7DeploymentName},
+			map[string]string{"name": loadbalancerL7DeploymentName, "kind": kindL7LBName},
+			"http",
+			8080,
+			ct.Params().ServiceType)
+
+		svc.ObjectMeta.Annotations = map[string]string{
+			"service.cilium.io/lb-l7": "enabled",
+		}
+		_, err = ct.clients.dst.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create additional non-L7 service for L7LBClientPods to test BPF hairpinning
+	_, err = ct.clients.dst.GetService(ctx, ct.params.TestNamespace, loadbalancerL7DeploymentName+"-non-l7", metav1.GetOptions{})
+	if err != nil {
+		ct.Logf("✨ [%s] Deploying %s non-L7 service...", ct.clients.dst.ClusterName(), loadbalancerL7DeploymentName)
+		svcNonL7 := newService(
+			loadbalancerL7DeploymentName+"-non-l7",
+			map[string]string{"name": loadbalancerL7DeploymentName},
+			map[string]string{"name": loadbalancerL7DeploymentName, "kind": kindL7LBName},
+			"http",
+			8080,
+			ct.Params().ServiceType)
+
+		// No L7 annotation for this service - will use BPF hairpinning
+		_, err = ct.clients.dst.CreateService(ctx, ct.params.TestNamespace, svcNonL7, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -3017,32 +3035,44 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 	}
 
-	if ct.Features[features.L7LoadBalancer].Enabled {
-		l7LBPods, err := ct.client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindL7LBName})
-		if err != nil {
-			return fmt.Errorf("unable to list client pods: %w", err)
-		}
+	l7LBPods, err := ct.client.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindL7LBName})
+	if err != nil {
+		return fmt.Errorf("unable to list client pods: %w", err)
+	}
 
-		for _, pod := range l7LBPods.Items {
-			ct.l7LBClientPods[pod.Name] = Pod{
-				K8sClient: ct.client,
-				Pod:       pod.DeepCopy(),
-			}
+	for _, pod := range l7LBPods.Items {
+		ct.l7LBClientPods[pod.Name] = Pod{
+			K8sClient: ct.client,
+			Pod:       pod.DeepCopy(),
 		}
+	}
 
-		service, err := ct.client.ListServices(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindL7LBName})
-		if err != nil {
-			return fmt.Errorf("unable to list L7 service: %w", err)
-		}
+	service, err := ct.client.ListServices(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + kindL7LBName})
+	if err != nil {
+		return fmt.Errorf("unable to list L7 service: %w", err)
+	}
 
-		testClient := ct.RandomClientPod()
-		for _, svc := range service.Items {
-			s := Service{Service: svc.DeepCopy()}
-			if err := WaitForService(ctx, ct, *testClient, s); err != nil {
-				return err
-			}
-			ct.l7LBService[svc.Name] = s
+	testClient := ct.RandomClientPod()
+	for _, svc := range service.Items {
+		s := Service{Service: svc.DeepCopy()}
+		if err := WaitForService(ctx, ct, *testClient, s); err != nil {
+			return err
 		}
+		ct.l7LBService[svc.Name] = s
+	}
+
+	// Retrieve and wait for the non-L7 service for L7LBClientPods
+	nonL7Service, err := ct.client.ListServices(ctx, ct.params.TestNamespace, metav1.ListOptions{FieldSelector: "metadata.name=" + loadbalancerL7DeploymentName + "-non-l7"})
+	if err != nil {
+		return fmt.Errorf("unable to list L7 non-L7 service: %w", err)
+	}
+
+	for _, svc := range nonL7Service.Items {
+		s := Service{Service: svc.DeepCopy()}
+		if err := WaitForService(ctx, ct, *testClient, s); err != nil {
+			return err
+		}
+		ct.l7LBNonL7Service[svc.Name] = s
 	}
 
 	return nil


### PR DESCRIPTION
Connectivity tests to catch regressions after service loopback support for IPv6 is [available](https://github.com/cilium/cilium/pull/39594).

```release-note
Connectivity tests for service loopback to catch regressions
```

Fixes: #33194