### PR TITLE
bpf: limit trace notifications for IPv4 traffic in host fw path

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1720,7 +1720,7 @@ int tail_ipv4_host_policy_ingress(struct __ctx_buff *ctx)
 {
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
-		.monitor = TRACE_PAYLOAD_LEN,
+		.monitor = 0,
 	};
 	__u32 src_id = ctx_load_meta(ctx, CB_SRC_LABEL);
 	bool traced = ctx_load_meta(ctx, CB_TRACED);


### PR DESCRIPTION
In PR https://github.com/cilium/cilium/pull/19185, more specifically commit https://github.com/cilium/cilium/commit/a29acdb5f658714962ff3d1ce73dc557795a1a35, we refactored `ipv{4,6}_host_policy_ingress` functions to accept a `struct trace_ctx *`, so that we could leverage the `monitor` value retrieved during the conntrack lookup. We then introduced the trace context in all the codepaths involved. However, while we always set `monitor = 0` to limit trace notifications, in the IPv4 tailcall we use `monitor = TRACE_PAYLOAD_LEN`. By looking at all the code changes of that PR, which also include nodeport codepaths, I believe the TRACE_PAYLOAD_LEN was unintentional.

Let's switch back to the default `monitor = 0`, so that the trace notification does not get emitted by default. It CAN still be emitted in case the conntrack lookup changes it in `ipv{4,6}_host_policy_ingress`.

Traces before:

```
> network flow 0x2b89e7c5 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:59418 -> 172.18.0.4:4240 tcp ACK
-> network flow 0x94c8a368 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:56204 -> 172.18.0.4:6443 tcp ACK
-> stack flow 0xb529d057 , identity health->unknown state reply ifindex cilium_host orig-ip 0.0.0.0: 10.244.0.232:4240 -> 10.244.1.5:60522 tcp ACK
-> overlay flow 0x2211d9ba , identity remote-node->health state established ifindex cilium_vxlan orig-ip 0.0.0.0: 10.244.1.5:60522 -> 10.244.0.232:4240 tcp ACK
-> network flow 0x2211d9ba , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 10.244.1.5:60522 -> 10.244.0.232:4240 tcp ACK [tunnel 172.18.0.3:60521 -> 172.18.0.4:8472 vxlan]
-> network flow 0x20ba6397 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:55512 -> 172.18.0.4:6443 tcp ACK
-> stack flow 0xbaf86574 , identity health->remote-node state reply ifindex 0 orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.2.239:43792 tcp ACK
-> overlay flow 0xbaf86574 , identity health->remote-node state unknown ifindex cilium_vxlan orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.2.239:43792 tcp ACK
-> network flow 0xbaf86574 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.2.239:43792 tcp ACK [tunnel 172.18.0.3:57420 -> 172.18.0.2:8472 vxlan]
-> endpoint 438 flow 0x9f2c399e , identity remote-node->health state established ifindex lxc_health orig-ip 10.244.2.239: 10.244.2.239:43792 -> 10.244.1.220:4240 tcp ACK
-> network flow 0x15287f7b , identity host->unknown state reply ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:10250 -> 172.18.0.4:37714 tcp ACK
-> network flow 0xf9e098 , identity host->unknown state reply ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:4240 -> 172.18.0.2:52120 tcp ACK
-> network flow 0x94c8a368 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:56204 -> 172.18.0.4:6443 tcp ACK
-> network flow 0x15287f7b , identity host->unknown state reply ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:10250 -> 172.18.0.4:37714 tcp ACK
-> endpoint 438 flow 0x0 , identity host->health state new ifindex lxc_health orig-ip 10.244.1.5: 10.244.1.5 -> 10.244.1.220 icmp EchoRequest
-> endpoint 438 flow 0xf924b74d , identity host->health state new ifindex lxc_health orig-ip 10.244.1.5: 10.244.1.5:42218 -> 10.244.1.220:4240 tcp SYN
-> host from flow 0x0 , identity health->host state reply ifindex cilium_net orig-ip 0.0.0.0: 10.244.1.220 -> 10.244.1.5 icmp EchoReply
-> stack flow 0x0 , identity health->unknown state reply ifindex cilium_host orig-ip 0.0.0.0: 10.244.1.220 -> 10.244.1.5 icmp EchoReply
-> host from flow 0x5a92622a , identity health->host state reply ifindex cilium_net orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.1.5:42218 tcp SYN, ACK
-> stack flow 0x5a92622a , identity health->unknown state reply ifindex cilium_host orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.1.5:42218 tcp SYN, ACK
-> endpoint 438 flow 0xf924b74d , identity host->health state established ifindex lxc_health orig-ip 10.244.1.5: 10.244.1.5:42218 -> 10.244.1.220:4240 tcp ACK
-> endpoint 438 flow 0xf924b74d , identity host->health state established ifindex lxc_health orig-ip 10.244.1.5: 10.244.1.5:42218 -> 10.244.1.220:4240 tcp ACK
-> host from flow 0x5a92622a , identity health->host state reply ifindex cilium_net orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.1.5:42218 tcp ACK
-> stack flow 0x5a92622a , identity health->unknown state reply ifindex cilium_host orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.1.5:42218 tcp ACK
-> network flow 0x20ba6397 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:55512 -> 172.18.0.4:6443 tcp ACK
```

Traces after (no more TRACE_TO_STACK with cilium_host interface):

```
-> network flow 0x869cae3f , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:61491 -> 172.18.0.4:6443 tcp ACK
-> network flow 0x56330820 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:44346 -> 172.18.0.4:6443 tcp ACK
-> network flow 0x280ff8d7 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:3216 -> 172.18.0.4:6443 tcp ACK
-> network flow 0xad505e1d , identity host->unknown state reply ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:10250 -> 172.18.0.4:43778 tcp ACK
-> network flow 0xf8f6f162 , identity host->unknown state new ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:41586 -> 172.18.0.2:4240 tcp SYN
-> network flow 0xf8f6f162 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:41586 -> 172.18.0.2:4240 tcp ACK
-> network flow 0x0 , identity host->unknown state new ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3 -> 172.18.0.2 icmp EchoRequest
-> network flow 0xf8f6f162 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:41586 -> 172.18.0.2:4240 tcp ACK
-> endpoint 1792 flow 0x0 , identity remote-node->health state new ifindex lxc_health orig-ip 10.244.2.239: 10.244.2.239 -> 10.244.1.220 icmp EchoRequest
-> endpoint 1792 flow 0x15cee87e , identity remote-node->health state new ifindex lxc_health orig-ip 10.244.2.239: 10.244.2.239:54814 -> 10.244.1.220:4240 tcp SYN
-> stack flow 0x0 , identity health->remote-node state reply ifindex 0 orig-ip 0.0.0.0: 10.244.1.220 -> 10.244.2.239 icmp EchoReply
-> overlay flow 0x0 , identity health->remote-node state unknown ifindex cilium_vxlan orig-ip 0.0.0.0: 10.244.1.220 -> 10.244.2.239 icmp EchoReply
-> network flow 0x0 , identity host->unknown state new ifindex eth0 orig-ip 0.0.0.0: 10.244.1.220 -> 10.244.2.239 icmp EchoReply [tunnel 172.18.0.3:54966 -> 172.18.0.2:8472 vxlan]
-> stack flow 0x45f5bafb , identity health->remote-node state reply ifindex 0 orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.2.239:54814 tcp SYN, ACK
-> overlay flow 0x45f5bafb , identity health->remote-node state unknown ifindex cilium_vxlan orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.2.239:54814 tcp SYN, ACK
-> network flow 0x45f5bafb , identity host->unknown state new ifindex eth0 orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.2.239:54814 tcp SYN, ACK [tunnel 172.18.0.3:60895 -> 172.18.0.2:8472 vxlan]
-> endpoint 1792 flow 0x15cee87e , identity remote-node->health state established ifindex lxc_health orig-ip 10.244.2.239: 10.244.2.239:54814 -> 10.244.1.220:4240 tcp ACK
-> endpoint 1792 flow 0x15cee87e , identity remote-node->health state established ifindex lxc_health orig-ip 10.244.2.239: 10.244.2.239:54814 -> 10.244.1.220:4240 tcp ACK
-> overlay flow 0x45f5bafb , identity health->remote-node state unknown ifindex cilium_vxlan orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.2.239:54814 tcp ACK
-> stack flow 0x45f5bafb , identity health->remote-node state reply ifindex 0 orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.2.239:54814 tcp ACK
-> overlay flow 0x45f5bafb , identity health->remote-node state unknown ifindex cilium_vxlan orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.2.239:54814 tcp ACK
-> endpoint 1792 flow 0xcb05b721 , identity remote-node->health state new ifindex lxc_health orig-ip 10.244.0.31: 10.244.0.31:37186 -> 10.244.1.220:4240 tcp SYN
-> stack flow 0x30b9b80f , identity health->remote-node state reply ifindex 0 orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.0.31:37186 tcp SYN, ACK
-> overlay flow 0x30b9b80f , identity health->remote-node state unknown ifindex cilium_vxlan orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.0.31:37186 tcp SYN, ACK
-> network flow 0x30b9b80f , identity host->unknown state new ifindex eth0 orig-ip 0.0.0.0: 10.244.1.220:4240 -> 10.244.0.31:37186 tcp SYN, ACK [tunnel 172.18.0.3:47844 -> 172.18.0.4:8472 vxlan]
```

Fixes: #42561.

```release-note
Fix trace aggregation for IPv4 Host Firewall, reducing the amount of generated events.
```