### PR TITLE
endpoint/api: wait until endpoints are restored

### DIFF
--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -97,13 +97,22 @@ func newTestLoader(tb testing.TB) *loader {
 
 type FakeRestorer struct{}
 
+func (fr *FakeRestorer) WaitForEndpointRestoreWithoutRegeneration(ctx context.Context) error {
+	return nil
+}
+
 func (fr *FakeRestorer) WaitForEndpointRestore(ctx context.Context) error { return nil }
-func (fr *FakeRestorer) WaitForInitialPolicy(ctx context.Context) error   { return nil }
+
+func (fr *FakeRestorer) WaitForInitialPolicy(ctx context.Context) error { return nil }
 
 type FakePreFilter struct{}
 
-func (fpf *FakePreFilter) Enabled() bool                                  { return true }
-func (fpf *FakePreFilter) WriteConfig(fw io.Writer)                       {}
-func (fpf *FakePreFilter) Dump(to []string) ([]string, int64)             { return nil, 0 }
+func (fpf *FakePreFilter) Enabled() bool { return true }
+
+func (fpf *FakePreFilter) WriteConfig(fw io.Writer) {}
+
+func (fpf *FakePreFilter) Dump(to []string) ([]string, int64) { return nil, 0 }
+
 func (fpf *FakePreFilter) Insert(revision int64, cidrs []net.IPNet) error { return nil }
+
 func (fpf *FakePreFilter) Delete(revision int64, cidrs []net.IPNet) error { return nil }

--- a/pkg/endpoint/api/cell.go
+++ b/pkg/endpoint/api/cell.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
@@ -116,8 +117,16 @@ type endpointAPIHandlerOut struct {
 
 func newEndpointAPIHandler(params endpointAPIHandlerParams) endpointAPIHandlerOut {
 	endpointStateRestoreCompleteWaitFn := func(ctx context.Context) error {
-		_, err := params.EndpointRestorerPromise.Await(ctx)
-		return err
+		restorer, err := params.EndpointRestorerPromise.Await(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to wait for restorer promise: %w", err)
+		}
+
+		if err := restorer.WaitForEndpointRestoreWithoutRegeneration(ctx); err != nil {
+			return fmt.Errorf("failed to wait for initiated endpoint restoration: %w", err)
+		}
+
+		return nil
 	}
 
 	return endpointAPIHandlerOut{

--- a/pkg/endpointcleanup/cleanup_test.go
+++ b/pkg/endpointcleanup/cleanup_test.go
@@ -264,11 +264,14 @@ func cep(name, ns, nodeIP string) types.CiliumEndpoint {
 	}
 }
 
-type fakeRestorer struct {
-}
+type fakeRestorer struct{}
 
 func (r *fakeRestorer) Await(context.Context) (endpointstate.Restorer, error) {
 	return r, nil
+}
+
+func (r *fakeRestorer) WaitForEndpointRestoreWithoutRegeneration(ctx context.Context) error {
+	return nil
 }
 
 func (r *fakeRestorer) WaitForEndpointRestore(_ context.Context) error {

--- a/pkg/endpointstate/restorer.go
+++ b/pkg/endpointstate/restorer.go
@@ -7,8 +7,12 @@ import "context"
 
 // Restorer wraps a method to wait for endpoints restoration.
 type Restorer interface {
+	// WaitForEndpointRestoreWithoutRegeneration blocks the caller until either the context is
+	// cancelled or all the endpoints from a previous run have been restored.
+	WaitForEndpointRestoreWithoutRegeneration(ctx context.Context) error
+
 	// WaitForEndpointRestore blocks the caller until either the context is
-	// cancelled or all the endpoints have been restored from a previous run.
+	// cancelled or all the endpoints from a previous run have been restored and regenerated.
 	WaitForEndpointRestore(ctx context.Context) error
 
 	// WaitForInitialPolicy blocks the caller until either the context is


### PR DESCRIPTION
Currently, the endpoint api handlers and deletion queue only await the
endpoint restorer promise to be resolved - but they don't wait for the
actual endpoint restoration.

In the past this was intended because the endpoint restorer promise
has been resolved once the legacy daemon start finished (`startDaemon`) -
and this included the call to `InitRestore` on the endpoint restorer.
But with the removal of the `Daemon` struct and promise (#42071), this is no longer
the case - the endpoint restorer promise is immediately resolved during
Hive config phase and only exists to prevent circular dependencies.

Furthermore, waiting for the full endpoint restoration (incl. regeneration)
would result in a deadlock.

Therefore, this commit introduces a new method `WaitForEndpointRestoreWithoutRegeneration`
on the endpoint restorer. It unblocks as soon as the endpoints are
restored (`InitRestore` finished) - but the endpoint restoration might
still be running. In addition the endpoint api handlers & deletion queue
use this new method to wait for the endpoint restoration to finish.

Related PR with discussion: https://github.com/cilium/cilium/pull/42556
Fixes: https://github.com/cilium/cilium/pull/42071