### PR TITLE
docs: tuning: remove some references to old kernels

### DIFF
--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -171,7 +171,6 @@ in any of the Cilium pods and look for the line reporting the status for
 
 **Requirements:**
 
-* Kernel >= 5.10
 * eBPF-based kube-proxy replacement
 * eBPF-based masquerading
 
@@ -344,7 +343,6 @@ bypassing the iptables connection tracker.
 
 **Requirements:**
 
-* Kernel >= 4.19.57, >= 5.1.16, >= 5.2
 * Direct-routing configuration
 * eBPF-based kube-proxy replacement
 * eBPF-based masquerading or no masquerading
@@ -810,8 +808,8 @@ any of the Cilium Pods and look for the line ``Clock Source for BPF``.
 Linux Kernel
 ============
 
-In general, we highly recommend using the most recent LTS stable kernel (such
-as >= 5.10) provided by the `kernel community <https://www.kernel.org/category/releases.html>`_
+In general, we highly recommend using the most recent LTS stable kernel
+provided by the `kernel community <https://www.kernel.org/category/releases.html>`_
 or by a downstream distribution of your choice. The newer the kernel, the more
 likely it is that various datapath optimizations can be used.
 


### PR DESCRIPTION
With v5.10 being the minimum kernel for Cilium v1.18 and newer, we can clean up some stale version references.