### PR TITLE
envoy: use hive jobs for long-running xDS- and accesslog server

### DIFF
--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -82,7 +82,7 @@ func TestEnvoy(t *testing.T) {
 		nil)
 	require.NotNil(t, xdsServer)
 
-	err = xdsServer.start()
+	err = xdsServer.start(t.Context())
 	require.NoError(t, err)
 	defer xdsServer.stop()
 
@@ -199,7 +199,7 @@ func TestEnvoyNACK(t *testing.T) {
 		}, nil)
 	require.NotNil(t, xdsServer)
 
-	err = xdsServer.start()
+	err = xdsServer.start(t.Context())
 	require.NoError(t, err)
 	defer xdsServer.stop()
 

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -88,7 +88,7 @@ func TestEnvoy(t *testing.T) {
 
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
 	require.NotNil(t, accessLogServer)
-	err = accessLogServer.start()
+	err = accessLogServer.start(t.Context())
 	require.NoError(t, err)
 	defer accessLogServer.stop()
 
@@ -205,7 +205,7 @@ func TestEnvoyNACK(t *testing.T) {
 
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
 	require.NotNil(t, accessLogServer)
-	err = accessLogServer.start()
+	err = accessLogServer.start(t.Context())
 	require.NoError(t, err)
 	defer accessLogServer.stop()
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -246,15 +246,8 @@ func newXDSServer(logger *slog.Logger, restorerPromise promise.Promise[endpoints
 	return xdsServer
 }
 
-func (s *xdsServer) start() error {
-	socketListener, err := s.newSocketListener()
-	if err != nil {
-		return fmt.Errorf("failed to create socket listener: %w", err)
-	}
-
-	s.stopFunc = s.startXDSGRPCServer(socketListener, s.resourceConfig)
-
-	return nil
+func (s *xdsServer) start(ctx context.Context) error {
+	return s.startXDSGRPCServer(ctx, s.resourceConfig)
 }
 
 func (s *xdsServer) initializeXdsConfigs() {
@@ -1678,7 +1671,6 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Pol
 			})
 			return true
 		})
-
 	}
 	if len(PerPortPolicies) == 0 || len(PerPortPolicies) == 0 && wildcardAllowAll {
 		return nil


### PR DESCRIPTION
This PR replaces the long-running Envoy xDS & accesslog server go routines with Hive oneshot jobs. This provides module health integration and better error reporting & handling (e.g. shut down in case of error in the job - using `job.WithShutdown()`).

```
cilium-dbg status --verbose
...
Modules Health:                            
agent
├── controlplane
...
│   ├── envoy-proxy
│   │   ├── job-accesslog-server                            [OK] Running (15m, x1)
│   │   ├── job-xds-server                                  [OK] Running (15m, x1)
│   │   ├── observer-job-k8s-secrets-resource-events-cilium-secrets    [OK] Primed (15m, x1)
│   │   └── timer-job-version-check                         [OK] OK (2.371312ms) (81s, x1)
...
```
