### PR TITLE
policy: Small fixes and improvements

### DIFF
--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -163,10 +163,9 @@ func (ls LabelArray) Has(key string) bool {
 // ["k8s.foo=bar"].Get("any.foo") => "bar"
 // ["any.foo=bar"].Get("k8s.foo") => ""
 //
-// If the key is of source "cidr", this will also match
-// broader keys.
-// ["cidr:1.1.1.1/32"].Has("cidr.1.0.0.0/8") => true
-// ["cidr:1.0.0.0/8"].Has("cidr.1.1.1.1/32") => false
+// Note that Get is not useful for labels that have no values,
+// as then Get will return an empty string whether or not key
+// matches any label in the array.
 func (ls LabelArray) Get(key string) string {
 	keyLabel := parseSelectLabel(key, '.')
 	for _, l := range ls {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -383,20 +383,18 @@ func (l *Label) HasKey(target *Label) bool {
 		tc := target.cidr
 		if tc == nil {
 			v, err := LabelToPrefix(target.Key)
-			if err != nil {
+			if err == nil {
 				tc = &v
 			}
 		}
 		lc := l.cidr
 		if lc == nil {
 			v, err := LabelToPrefix(l.Key)
-			if err != nil {
+			if err == nil {
 				lc = &v
 			}
 		}
-		if tc != nil && lc != nil && tc.Bits() <= lc.Bits() && tc.Contains(lc.Addr()) {
-			return true
-		}
+		return tc != nil && lc != nil && tc.Bits() <= lc.Bits() && tc.Contains(lc.Addr())
 	}
 
 	return l.Key == target.Key

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -362,7 +362,7 @@ func serviceSelectorMatches(sel *api.K8sServiceSelectorNamespace, svc serviceDet
 
 type labelsMatcher labels.Labels
 
-// Get implements labels.Labels.
+// Get implements k8sLabels.Labels.
 func (l labelsMatcher) Get(label string) (value string) {
 	v, ok := labels.Labels(l)[label]
 	if ok {
@@ -371,11 +371,12 @@ func (l labelsMatcher) Get(label string) (value string) {
 	return
 }
 
-// Has implements labels.Labels.
+// Has implements k8sLabels.Labels.
 func (l labelsMatcher) Has(label string) (exists bool) {
 	return labels.Labels(l).HasLabelWithKey(label)
 }
 
+// Lookup implements k8sLabels.Labels.
 func (l labelsMatcher) Lookup(label string) (value string, exists bool) {
 	v, ok := labels.Labels(l)[label]
 	return v.Value, ok

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -332,6 +332,7 @@ func (td *testData) policyValid(t *testing.T, rules ...*api.Rule) {
 
 // testPolicyContexttype is a dummy context used when evaluating rules.
 type testPolicyContextType struct {
+	isIngress          bool
 	isDeny             bool
 	ns                 string
 	sc                 *SelectorCache
@@ -339,6 +340,15 @@ type testPolicyContextType struct {
 	defaultDenyIngress bool
 	defaultDenyEgress  bool
 	logger             *slog.Logger
+}
+
+// IsIngress returns 'true' if processing ingress rules, 'false' for egress.
+func (p *testPolicyContextType) IsIngress() bool {
+	return p.isIngress
+}
+
+func (p *testPolicyContextType) SetIngress(ingress bool) {
+	p.isIngress = ingress
 }
 
 func (p *testPolicyContextType) GetNamespace() string {
@@ -2620,7 +2630,7 @@ func TestDefaultAllowL7Rules(t *testing.T) {
 
 			toEndpoints := policytypes.PeerSelectorSlice{api.NewESFromLabels(labels.ParseSelectLabel("foo"))}
 
-			l4Filter, err := createL4EgressFilter(ctx, toEndpoints, nil, egressRule, portProto, tc.proto)
+			l4Filter, err := createL4Filter(ctx, toEndpoints, nil, egressRule, portProto, tc.proto)
 
 			require.NoError(t, err)
 			require.NotNil(t, l4Filter)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -347,6 +347,10 @@ func (p *testPolicyContextType) IsIngress() bool {
 	return p.isIngress
 }
 
+func (p *testPolicyContextType) AllowLocalhost() bool {
+	return p.isIngress && option.Config.AlwaysAllowLocalhost()
+}
+
 func (p *testPolicyContextType) SetIngress(ingress bool) {
 	p.isIngress = ingress
 }

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -56,6 +56,7 @@ type testData struct {
 	cachedSelectorC        CachedSelector
 	cachedSelectorHost     CachedSelector
 	wildcardCachedSelector CachedSelector
+	cachedSelectorCIDR     CachedSelector
 
 	cachedFooSelector CachedSelector
 	cachedBazSelector CachedSelector
@@ -80,6 +81,11 @@ func newTestData(logger *slog.Logger) *testData {
 	td.repo.selectorCache = td.sc
 
 	td.wildcardCachedSelector, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, api.WildcardEndpointSelector)
+	td.cachedSelectorCIDR = func(cidr api.CIDR) CachedSelector {
+		ess := api.CIDRSlice{cidr}.GetAsEndpointSelectors()
+		cs, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, ess[0])
+		return cs
+	}(api.CIDR("10.1.1.1"))
 
 	td.cachedSelectorA = td.getCachedSelectorForTest(endpointSelectorA, idA.ID)
 	td.cachedSelectorB = td.getCachedSelectorForTest(endpointSelectorB, idB.ID)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -2630,7 +2630,7 @@ func TestDefaultAllowL7Rules(t *testing.T) {
 
 			toEndpoints := policytypes.PeerSelectorSlice{api.NewESFromLabels(labels.ParseSelectLabel("foo"))}
 
-			l4Filter, err := createL4Filter(ctx, toEndpoints, nil, egressRule, portProto, tc.proto)
+			l4Filter, err := createL4Filter(ctx, toEndpoints, nil, egressRule, portProto)
 
 			require.NoError(t, err)
 			require.NotNil(t, l4Filter)

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -140,6 +141,11 @@ func TestParserTypeMerge(t *testing.T) {
 }
 
 func TestCreateL4Filter(t *testing.T) {
+	// disable allow local host to simplify the this test
+	oldLocalhostOpt := option.Config.AllowLocalhost
+	option.Config.AllowLocalhost = option.AllowLocalhostPolicy
+	defer func() { option.Config.AllowLocalhost = oldLocalhostOpt }()
+
 	td := newTestData(hivetest.Logger(t))
 	tuple := api.PortProtocol{Port: "80", Protocol: api.ProtoTCP}
 	portrule := &api.PortRule{
@@ -160,7 +166,7 @@ func TestCreateL4Filter(t *testing.T) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		filter, err := createL4IngressFilter(td.testPolicyContext, eps, nil, nil, portrule, tuple, tuple.Protocol)
+		filter, err := createL4IngressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -183,6 +189,11 @@ func TestCreateL4Filter(t *testing.T) {
 }
 
 func TestCreateL4FilterAuthRequired(t *testing.T) {
+	// disable allow local host to simplify the this test
+	oldLocalhostOpt := option.Config.AllowLocalhost
+	option.Config.AllowLocalhost = option.AllowLocalhostPolicy
+	defer func() { option.Config.AllowLocalhost = oldLocalhostOpt }()
+
 	td := newTestData(hivetest.Logger(t))
 	tuple := api.PortProtocol{Port: "80", Protocol: api.ProtoTCP}
 	portrule := &api.PortRule{
@@ -204,7 +215,7 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		filter, err := createL4IngressFilter(td.testPolicyContext, eps, auth, nil, portrule, tuple, tuple.Protocol)
+		filter, err := createL4IngressFilter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -254,7 +265,7 @@ func TestCreateL4FilterMissingSecret(t *testing.T) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		_, err := createL4IngressFilter(td.testPolicyContext, eps, nil, nil, portrule, tuple, tuple.Protocol)
+		_, err := createL4IngressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
 		require.Error(t, err)
 
 		_, err = createL4EgressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -167,7 +167,7 @@ func TestCreateL4Filter(t *testing.T) {
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
 		td.testPolicyContext.SetIngress(true)
-		filter, err := createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
+		filter, err := createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -178,7 +178,7 @@ func TestCreateL4Filter(t *testing.T) {
 		}
 
 		td.testPolicyContext.SetIngress(false)
-		filter, err = createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
+		filter, err = createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -218,7 +218,7 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
 		td.testPolicyContext.SetIngress(true)
-		filter, err := createL4Filter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol)
+		filter, err := createL4Filter(td.testPolicyContext, eps, auth, portrule, tuple)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -229,7 +229,7 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 		}
 
 		td.testPolicyContext.SetIngress(false)
-		filter, err = createL4Filter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol)
+		filter, err = createL4Filter(td.testPolicyContext, eps, auth, portrule, tuple)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -270,11 +270,11 @@ func TestCreateL4FilterMissingSecret(t *testing.T) {
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
 		td.testPolicyContext.SetIngress(true)
-		_, err := createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
+		_, err := createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple)
 		require.Error(t, err)
 
 		td.testPolicyContext.SetIngress(false)
-		_, err = createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
+		_, err = createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple)
 		require.Error(t, err)
 	}
 }

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -166,7 +166,8 @@ func TestCreateL4Filter(t *testing.T) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		filter, err := createL4IngressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
+		td.testPolicyContext.SetIngress(true)
+		filter, err := createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -176,7 +177,8 @@ func TestCreateL4Filter(t *testing.T) {
 			require.Equal(t, redirectTypeEnvoy, sp.redirectType())
 		}
 
-		filter, err = createL4EgressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
+		td.testPolicyContext.SetIngress(false)
+		filter, err = createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -215,7 +217,8 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		filter, err := createL4IngressFilter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol)
+		td.testPolicyContext.SetIngress(true)
+		filter, err := createL4Filter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -225,7 +228,8 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 			require.Equal(t, redirectTypeEnvoy, sp.redirectType())
 		}
 
-		filter, err = createL4EgressFilter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol)
+		td.testPolicyContext.SetIngress(false)
+		filter, err = createL4Filter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, sp := range filter.PerSelectorPolicies {
@@ -265,10 +269,12 @@ func TestCreateL4FilterMissingSecret(t *testing.T) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		_, err := createL4IngressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
+		td.testPolicyContext.SetIngress(true)
+		_, err := createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
 		require.Error(t, err)
 
-		_, err = createL4EgressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
+		td.testPolicyContext.SetIngress(false)
+		_, err = createL4Filter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol)
 		require.Error(t, err)
 	}
 }

--- a/pkg/policy/metrics.go
+++ b/pkg/policy/metrics.go
@@ -5,34 +5,16 @@ package policy
 
 import (
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/policy/types"
 
 	"github.com/prometheus/client_golang/prometheus"
-)
-
-const (
-	// LabelSelectorClass indicates the class of selector being measured
-	LabelSelectorClass = "class"
-
-	// LabelValueSCFQDN is used for regular security identities
-	// shared between all nodes in the cluster.
-	LabelValueSCFQDN = "fqdn"
-
-	// LabelValueSCCluster is used for the cluster entity.
-	LabelValueSCCluster = "cluster"
-
-	// LabelValueSCWorld is used for the world entity.
-	LabelValueSCWorld = "world"
-
-	// LabelValueSCOther is used for security identities allocated locally
-	// on the current node.
-	LabelValueSCOther = "other"
 )
 
 var (
 	selectorCacheMetricsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(metrics.CiliumAgentNamespace, "policy_selector", "match_count_max"),
 		"The maximum number of identities selected by a network policy peer selector",
-		[]string{LabelSelectorClass},
+		[]string{types.LabelSelectorClass},
 		nil,
 	)
 )
@@ -44,10 +26,10 @@ type selectorStats struct {
 func newSelectorStats() selectorStats {
 	return selectorStats{
 		maxCardinalityByClass: map[string]int{
-			LabelValueSCFQDN:    0,
-			LabelValueSCCluster: 0,
-			LabelValueSCWorld:   0,
-			LabelValueSCOther:   0,
+			types.LabelValueSCFQDN:    0,
+			types.LabelValueSCCluster: 0,
+			types.LabelValueSCWorld:   0,
+			types.LabelValueSCOther:   0,
 		},
 	}
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -327,7 +327,8 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 	}
 
 	if ingressEnabled {
-		newL4IngressPolicy, err := matchingRules.resolveL4IngressPolicy(&policyCtx)
+		policyCtx.SetIngress(true)
+		newL4IngressPolicy, err := matchingRules.resolveL4Policy(&policyCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +336,8 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 	}
 
 	if egressEnabled {
-		newL4EgressPolicy, err := matchingRules.resolveL4EgressPolicy(&policyCtx)
+		policyCtx.SetIngress(false)
+		newL4EgressPolicy, err := matchingRules.resolveL4Policy(&policyCtx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -27,6 +28,10 @@ type PolicyContext interface {
 	// IsIngress returns 'true' if processing ingress rules, 'false' for egress.
 	IsIngress() bool
 	SetIngress(bool)
+
+	// AllowLocalhost returns true if policy should allow ingress from local host.
+	// Always returns false for egress.
+	AllowLocalhost() bool
 
 	// return the namespace in which the policy rule is being resolved
 	GetNamespace() string
@@ -96,6 +101,10 @@ func (p *policyContext) IsIngress() bool {
 
 func (p *policyContext) SetIngress(ingress bool) {
 	p.isIngress = ingress
+}
+
+func (p *policyContext) AllowLocalhost() bool {
+	return p.isIngress && option.Config.AlwaysAllowLocalhost()
 }
 
 // GetNamespace() returns the namespace for the policy rule being resolved

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -24,6 +24,10 @@ import (
 // PolicyContext is an interface policy resolution functions use to access the Repository.
 // This way testing code can run without mocking a full Repository.
 type PolicyContext interface {
+	// IsIngress returns 'true' if processing ingress rules, 'false' for egress.
+	IsIngress() bool
+	SetIngress(bool)
+
 	// return the namespace in which the policy rule is being resolved
 	GetNamespace() string
 
@@ -69,6 +73,8 @@ type PolicyContext interface {
 type policyContext struct {
 	repo *Repository
 	ns   string
+	// isIngress is set to true for ingress rule processing, false for egress
+	isIngress bool
 	// isDeny this field is set to true if the given policy computation should
 	// be done for the policy deny.
 	isDeny             bool
@@ -82,6 +88,15 @@ type policyContext struct {
 }
 
 var _ PolicyContext = &policyContext{}
+
+// IsIngress returns 'true' if processing ingress rules, 'false' for egress.
+func (p *policyContext) IsIngress() bool {
+	return p.isIngress
+}
+
+func (p *policyContext) SetIngress(ingress bool) {
+	p.isIngress = ingress
+}
 
 // GetNamespace() returns the namespace for the policy rule being resolved
 func (p *policyContext) GetNamespace() string {

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -193,6 +193,17 @@ func (td *testData) bootstrapRepo(ruleGenFunc func(int) (api.Rules, identity.Ide
 	td.repo.MustAddList(apiRules)
 }
 
+func BenchmarkResolveCIDRPolicyRules(b *testing.B) {
+	td := newTestData(hivetest.Logger(b))
+	td.bootstrapRepo(GenerateCIDRRules, 1000, b)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
+		ip.detach(true, 0)
+	}
+}
+
 func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 	td := newTestData(hivetest.Logger(b))
 	td.bootstrapRepo(GenerateCIDRRules, 1000, b)
@@ -207,6 +218,17 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 	}
 	ip.detach(true, 0)
 	b.Logf("Number of MapState entries: %d\n", owner.mapStateSize)
+}
+
+func BenchmarkResolveL3IngressPolicyRules(b *testing.B) {
+	td := newTestData(hivetest.Logger(b))
+	td.bootstrapRepo(GenerateL3IngressRules, 1000, b)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
+		ip.detach(true, 0)
+	}
 }
 
 func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -760,11 +760,9 @@ func TestMapStateWithIngress(t *testing.T) {
 		}),
 	}
 
-	// Have to remove circular reference before testing for Equality to avoid an infinite loop
-	policy.SelectorPolicy.detach(true, 0)
-
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
+	policy.SelectorPolicy.detach(true, 0)
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.Nil(t, cachedSelectorTest)
 

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -153,7 +153,9 @@ func (l7Rules *PerSelectorPolicy) mergeRedirect(newL7Rules *PerSelectorPolicy) e
 
 // mergePortProto merges the L7-related data from the filter to merge
 // with the L7-related data already in the existing filter.
-func mergePortProto(policyCtx PolicyContext, existingFilter, filterToMerge *L4Filter, selectorCache *SelectorCache) (err error) {
+func (existingFilter *L4Filter) mergePortProto(policyCtx PolicyContext, filterToMerge *L4Filter) (err error) {
+	selectorCache := policyCtx.GetSelectorCache()
+
 	for cs, newL7Rules := range filterToMerge.PerSelectorPolicies {
 		// 'cs' will be merged or moved (see below), either way it needs
 		// to be removed from the map it is in now.
@@ -317,31 +319,34 @@ func mergePortProto(policyCtx PolicyContext, existingFilter, filterToMerge *L4Fi
 	return nil
 }
 
-// mergeIngressPortProto merges all rules which share the same port & protocol that
+// addFilter merges all rules which share the same port & protocol that
 // select a given set of endpoints. It updates the L4Filter mapped to by the specified
 // port and protocol with the contents of the provided PortRule. If the rule
 // being merged has conflicting L7 rules with those already in the provided
 // L4PolicyMap for the specified port-protocol tuple, it returns an error.
-func mergeIngressPortProto(policyCtx PolicyContext, endpoints types.PeerSelectorSlice, auth *api.Authentication,
-	r api.Ports, p api.PortProtocol, proto api.L4Proto, resMap L4PolicyMap) (int, error) {
+func (resMap *l4PolicyMap) addFilter(policyCtx PolicyContext, endpoints types.PeerSelectorSlice, auth *api.Authentication,
+	r api.Ports, p api.PortProtocol, proto api.L4Proto) (int, error) {
 	// Create a new L4Filter
-	filterToMerge, err := createL4IngressFilter(policyCtx, endpoints, auth, r, p, proto)
+	filterToMerge, err := createL4Filter(policyCtx, endpoints, auth, r, p, proto)
 	if err != nil {
 		return 0, err
 	}
 
-	err = addL4Filter(policyCtx, resMap, p, proto, filterToMerge)
+	err = resMap.addL4Filter(policyCtx, p, proto, filterToMerge)
 	if err != nil {
 		return 0, err
 	}
 	return 1, err
 }
 
-func mergeIngress(policyCtx PolicyContext, fromEndpoints types.PeerSelectorSlice, auth *api.Authentication, toPorts api.PortsIterator, resMap L4PolicyMap) (int, error) {
+func (resMap *l4PolicyMap) mergeL4Filter(policyCtx PolicyContext, rule *rule) (int, error) {
 	found := 0
 
+	peerEndpoints := rule.L3
+	auth := rule.Authentication
+
 	// short-circuit if no endpoint is selected
-	if fromEndpoints == nil {
+	if peerEndpoints == nil {
 		return found, nil
 	}
 
@@ -350,9 +355,9 @@ func mergeIngress(policyCtx PolicyContext, fromEndpoints types.PeerSelectorSlice
 		err error
 	)
 
-	// L3-only rule (with requirements folded into fromEndpoints).
-	if toPorts.Len() == 0 && len(fromEndpoints) > 0 {
-		cnt, err = mergeIngressPortProto(policyCtx, fromEndpoints, auth, &api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, resMap)
+	// L3-only rule (with requirements folded into peerEndpoints).
+	if rule.L4.Len() == 0 && len(peerEndpoints) > 0 {
+		cnt, err = resMap.addFilter(policyCtx, peerEndpoints, auth, &api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny)
 		if err != nil {
 			return found, err
 		}
@@ -360,20 +365,20 @@ func mergeIngress(policyCtx PolicyContext, fromEndpoints types.PeerSelectorSlice
 
 	found += cnt
 
-	err = toPorts.Iterate(func(r api.Ports) error {
+	err = rule.L4.Iterate(func(ports api.Ports) error {
 		// For L4 Policy, an empty slice of EndpointSelector indicates that the
 		// rule allows all at L3 - explicitly specify this by creating a slice
 		// with the WildcardEndpointSelector.
-		if len(fromEndpoints) == 0 {
-			fromEndpoints = types.PeerSelectorSlice{api.WildcardEndpointSelector}
+		if len(peerEndpoints) == 0 {
+			peerEndpoints = types.PeerSelectorSlice{api.WildcardEndpointSelector}
 		}
 		if !policyCtx.IsDeny() {
-			policyCtx.PolicyTrace("      Allows port %v\n", r.GetPortProtocols())
+			policyCtx.PolicyTrace("      Allows port %v\n", ports.GetPortProtocols())
 		} else {
-			policyCtx.PolicyTrace("      Denies port %v\n", r.GetPortProtocols())
+			policyCtx.PolicyTrace("      Denies port %v\n", ports.GetPortProtocols())
 		}
 
-		pr := r.GetPortRule()
+		pr := ports.GetPortRule()
 		if pr != nil {
 			if pr.Rules != nil && pr.Rules.L7Proto != "" {
 				policyCtx.PolicyTrace("        l7proto: \"%s\"\n", pr.Rules.L7Proto)
@@ -391,7 +396,7 @@ func mergeIngress(policyCtx PolicyContext, fromEndpoints types.PeerSelectorSlice
 			}
 		}
 
-		for _, p := range r.GetPortProtocols() {
+		for _, p := range ports.GetPortProtocols() {
 			protocols := []api.L4Proto{p.Protocol}
 			if p.Protocol.IsAny() {
 				protocols = []api.L4Proto{
@@ -401,7 +406,7 @@ func mergeIngress(policyCtx PolicyContext, fromEndpoints types.PeerSelectorSlice
 				}
 			}
 			for _, protocol := range protocols {
-				cnt, err := mergeIngressPortProto(policyCtx, fromEndpoints, auth, r, p, protocol, resMap)
+				cnt, err := resMap.addFilter(policyCtx, peerEndpoints, auth, ports, p, protocol)
 				if err != nil {
 					return err
 				}
@@ -414,25 +419,33 @@ func mergeIngress(policyCtx PolicyContext, fromEndpoints types.PeerSelectorSlice
 	return found, err
 }
 
-// resolveIngressPolicy analyzes the rule against the given SearchContext, and
+// resolveL4Policy analyzes the rule against the given SearchContext, and
 // merges it with any prior-generated policy within the provided L4Policy.
-func (r *rule) resolveIngressPolicy(
+//
+// If policyCtx.IsIngress() returns true, an ingress policy isresolved,
+// otherwise an egress policy is resolved.
+func (result *l4PolicyMap) resolveL4Policy(
 	policyCtx PolicyContext,
 	state *traceState,
-	result L4PolicyMap,
+	r *rule,
 ) error {
 	state.selectRule(policyCtx, r)
 	found, foundDeny := 0, 0
 
 	policyCtx.SetOrigin(r.origin())
 
-	if !r.Ingress {
-		policyCtx.PolicyTrace("    No ingress rules\n")
+	if r.Ingress != policyCtx.IsIngress() {
+		msg := "    No egress rules\n"
+		if policyCtx.IsIngress() {
+			msg = "    No ingress rules\n"
+		}
+		policyCtx.PolicyTrace(msg)
 		return nil
 	}
 
+	policyCtx.SetDeny(false)
 	if !r.Deny {
-		cnt, err := mergeIngress(policyCtx, r.L3, r.Authentication, r.L4, result)
+		cnt, err := result.mergeL4Filter(policyCtx, r)
 		if err != nil {
 			return err
 		}
@@ -441,13 +454,9 @@ func (r *rule) resolveIngressPolicy(
 		}
 	}
 
-	oldDeny := policyCtx.SetDeny(true)
-	defer func() {
-		policyCtx.SetDeny(oldDeny)
-	}()
-
+	policyCtx.SetDeny(true)
 	if r.Deny {
-		cnt, err := mergeIngress(policyCtx, r.L3, r.Authentication, r.L4, result)
+		cnt, err := result.mergeL4Filter(policyCtx, r)
 		if err != nil {
 			return err
 		}
@@ -490,150 +499,4 @@ func (r *rule) getSubjects() []identity.NumericIdentity {
 	}
 
 	return r.subjectSelector.GetSelections(versioned.Latest())
-}
-
-// ****************** EGRESS POLICY ******************
-
-func mergeEgress(policyCtx PolicyContext, toEndpoints types.PeerSelectorSlice, auth *api.Authentication, toPorts api.PortsIterator, resMap L4PolicyMap) (int, error) {
-	found := 0
-
-	// short-circuit if no endpoint is selected
-	if toEndpoints == nil {
-		return found, nil
-	}
-
-	var (
-		cnt int
-		err error
-	)
-
-	// L3-only rule (with requirements folded into toEndpoints).
-	if toPorts.Len() == 0 && len(toEndpoints) > 0 {
-		cnt, err = mergeEgressPortProto(policyCtx, toEndpoints, auth, &api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, resMap)
-		if err != nil {
-			return found, err
-		}
-	}
-
-	found += cnt
-
-	err = toPorts.Iterate(func(r api.Ports) error {
-		// For L4 Policy, an empty slice of EndpointSelector indicates that the
-		// rule allows all at L3 - explicitly specify this by creating a slice
-		// with the WildcardEndpointSelector.
-		if len(toEndpoints) == 0 {
-			toEndpoints = types.PeerSelectorSlice{api.WildcardEndpointSelector}
-		}
-		if !policyCtx.IsDeny() {
-			policyCtx.PolicyTrace("      Allows port %v\n", r.GetPortProtocols())
-		} else {
-			policyCtx.PolicyTrace("      Denies port %v\n", r.GetPortProtocols())
-		}
-
-		pr := r.GetPortRule()
-		if pr != nil {
-			if !pr.Rules.IsEmpty() {
-				for _, l7 := range pr.Rules.HTTP {
-					policyCtx.PolicyTrace("          %+v\n", l7)
-				}
-				for _, l7 := range pr.Rules.Kafka {
-					policyCtx.PolicyTrace("          %+v\n", l7)
-				}
-				for _, l7 := range pr.Rules.L7 {
-					policyCtx.PolicyTrace("          %+v\n", l7)
-				}
-			}
-		}
-
-		for _, p := range r.GetPortProtocols() {
-			protocols := []api.L4Proto{p.Protocol}
-			if p.Protocol.IsAny() {
-				protocols = []api.L4Proto{
-					api.ProtoTCP,
-					api.ProtoUDP,
-					api.ProtoSCTP,
-				}
-			}
-			for _, protocol := range protocols {
-				cnt, err := mergeEgressPortProto(policyCtx, toEndpoints, auth, r, p, protocol, resMap)
-				if err != nil {
-					return err
-				}
-				found += cnt
-			}
-		}
-		return nil
-	})
-
-	return found, err
-}
-
-// mergeEgressPortProto merges all rules which share the same port & protocol that
-// select a given set of endpoints. It updates the L4Filter mapped to by the specified
-// port and protocol with the contents of the provided PortRule. If the rule
-// being merged has conflicting L7 rules with those already in the provided
-// L4PolicyMap for the specified port-protocol tuple, it returns an error.
-func mergeEgressPortProto(policyCtx PolicyContext, endpoints types.PeerSelectorSlice, auth *api.Authentication, r api.Ports, p api.PortProtocol,
-	proto api.L4Proto, resMap L4PolicyMap) (int, error) {
-	// Create a new L4Filter
-	filterToMerge, err := createL4EgressFilter(policyCtx, endpoints, auth, r, p, proto)
-	if err != nil {
-		return 0, err
-	}
-
-	err = addL4Filter(policyCtx, resMap, p, proto, filterToMerge)
-	if err != nil {
-		return 0, err
-	}
-	return 1, err
-}
-
-func (r *rule) resolveEgressPolicy(
-	policyCtx PolicyContext,
-	state *traceState,
-	result L4PolicyMap,
-) error {
-
-	state.selectRule(policyCtx, r)
-	found, foundDeny := 0, 0
-	policyCtx.SetOrigin(r.origin())
-
-	if r.Ingress {
-		policyCtx.PolicyTrace("    No egress rules\n")
-		return nil
-	}
-
-	if !r.Deny {
-		cnt, err := mergeEgress(policyCtx, r.L3, r.Authentication, r.L4, result)
-		if err != nil {
-			return err
-		}
-		if cnt > 0 {
-			found += cnt
-		}
-	}
-
-	oldDeny := policyCtx.SetDeny(true)
-	defer func() {
-		policyCtx.SetDeny(oldDeny)
-	}()
-
-	if r.Deny {
-		cnt, err := mergeEgress(policyCtx, r.L3, nil, r.L4, result)
-		if err != nil {
-			return err
-		}
-		if cnt > 0 {
-			foundDeny += cnt
-		}
-	}
-
-	if found != 0 {
-		state.matchedRules++
-	}
-	if foundDeny != 0 {
-		state.matchedDenyRules++
-	}
-
-	return nil
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -12,8 +12,6 @@ import (
 	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
-	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
@@ -324,16 +322,10 @@ func mergePortProto(policyCtx PolicyContext, existingFilter, filterToMerge *L4Fi
 // port and protocol with the contents of the provided PortRule. If the rule
 // being merged has conflicting L7 rules with those already in the provided
 // L4PolicyMap for the specified port-protocol tuple, it returns an error.
-//
-// If any rules contain L7 rules that select Host or Remote Node and we should
-// accept all traffic from host, the L7 rules will be translated into L7
-// wildcards via 'hostWildcardL7'. That is to say, traffic will be
-// forwarded to the proxy for endpoints matching those labels, but the proxy
-// will allow all such traffic.
-func mergeIngressPortProto(policyCtx PolicyContext, endpoints types.PeerSelectorSlice, auth *api.Authentication, hostWildcardL7 []string,
+func mergeIngressPortProto(policyCtx PolicyContext, endpoints types.PeerSelectorSlice, auth *api.Authentication,
 	r api.Ports, p api.PortProtocol, proto api.L4Proto, resMap L4PolicyMap) (int, error) {
 	// Create a new L4Filter
-	filterToMerge, err := createL4IngressFilter(policyCtx, endpoints, auth, hostWildcardL7, r, p, proto)
+	filterToMerge, err := createL4IngressFilter(policyCtx, endpoints, auth, r, p, proto)
 	if err != nil {
 		return 0, err
 	}
@@ -353,16 +345,6 @@ func mergeIngress(policyCtx PolicyContext, fromEndpoints types.PeerSelectorSlice
 		return found, nil
 	}
 
-	// Daemon options may induce L3 allows for host/world. In this case, if
-	// we find any L7 rules matching host/world then we need to turn any L7
-	// restrictions on these endpoints into L7 allow-all so that the
-	// traffic is always allowed, but is also always redirected through the
-	// proxy
-	hostWildcardL7 := make([]string, 0, 2)
-	if option.Config.AlwaysAllowLocalhost() {
-		hostWildcardL7 = append(hostWildcardL7, labels.IDNameHost)
-	}
-
 	var (
 		cnt int
 		err error
@@ -370,7 +352,7 @@ func mergeIngress(policyCtx PolicyContext, fromEndpoints types.PeerSelectorSlice
 
 	// L3-only rule (with requirements folded into fromEndpoints).
 	if toPorts.Len() == 0 && len(fromEndpoints) > 0 {
-		cnt, err = mergeIngressPortProto(policyCtx, fromEndpoints, auth, hostWildcardL7, &api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, resMap)
+		cnt, err = mergeIngressPortProto(policyCtx, fromEndpoints, auth, &api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, resMap)
 		if err != nil {
 			return found, err
 		}
@@ -419,7 +401,7 @@ func mergeIngress(policyCtx PolicyContext, fromEndpoints types.PeerSelectorSlice
 				}
 			}
 			for _, protocol := range protocols {
-				cnt, err := mergeIngressPortProto(policyCtx, fromEndpoints, auth, hostWildcardL7, r, p, protocol, resMap)
+				cnt, err := mergeIngressPortProto(policyCtx, fromEndpoints, auth, r, p, protocol, resMap)
 				if err != nil {
 					return err
 				}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -325,14 +325,14 @@ func (existingFilter *L4Filter) mergePortProto(policyCtx PolicyContext, filterTo
 // being merged has conflicting L7 rules with those already in the provided
 // L4PolicyMap for the specified port-protocol tuple, it returns an error.
 func (resMap *l4PolicyMap) addFilter(policyCtx PolicyContext, endpoints types.PeerSelectorSlice, auth *api.Authentication,
-	r api.Ports, p api.PortProtocol, proto api.L4Proto) (int, error) {
+	r api.Ports, p api.PortProtocol) (int, error) {
 	// Create a new L4Filter
-	filterToMerge, err := createL4Filter(policyCtx, endpoints, auth, r, p, proto)
+	filterToMerge, err := createL4Filter(policyCtx, endpoints, auth, r, p)
 	if err != nil {
 		return 0, err
 	}
 
-	err = resMap.addL4Filter(policyCtx, p, proto, filterToMerge)
+	err = resMap.addL4Filter(policyCtx, p, filterToMerge)
 	if err != nil {
 		return 0, err
 	}
@@ -357,7 +357,7 @@ func (resMap *l4PolicyMap) mergeL4Filter(policyCtx PolicyContext, rule *rule) (i
 
 	// L3-only rule (with requirements folded into peerEndpoints).
 	if rule.L4.Len() == 0 && len(peerEndpoints) > 0 {
-		cnt, err = resMap.addFilter(policyCtx, peerEndpoints, auth, &api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny)
+		cnt, err = resMap.addFilter(policyCtx, peerEndpoints, auth, &api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny})
 		if err != nil {
 			return found, err
 		}
@@ -406,7 +406,8 @@ func (resMap *l4PolicyMap) mergeL4Filter(policyCtx PolicyContext, rule *rule) (i
 				}
 			}
 			for _, protocol := range protocols {
-				cnt, err := resMap.addFilter(policyCtx, peerEndpoints, auth, ports, p, protocol)
+				p.Protocol = protocol
+				cnt, err := resMap.addFilter(policyCtx, peerEndpoints, auth, ports, p)
 				if err != nil {
 					return err
 				}

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -11,36 +11,19 @@ import (
 // to be written with []*rule as a receiver.
 type ruleSlice []*rule
 
-func (rules ruleSlice) resolveL4IngressPolicy(policyCtx PolicyContext) (L4PolicyMap, error) {
+func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext) (L4PolicyMap, error) {
 	result := NewL4PolicyMap()
 
-	policyCtx.PolicyTrace("Resolving ingress policy")
-
-	state := traceState{}
-
-	for _, r := range rules {
-		err := r.resolveIngressPolicy(policyCtx, &state, result)
-		if err != nil {
-			return nil, err
-		}
-		state.ruleID++
+	ingress := policyCtx.IsIngress()
+	msg := "Resolving egress policy"
+	if ingress {
+		msg = "Resolving ingress policy"
 	}
-
-	state.trace(len(rules), policyCtx)
-
-	return result, nil
-}
-
-func (rules ruleSlice) resolveL4EgressPolicy(policyCtx PolicyContext) (L4PolicyMap, error) {
-	result := NewL4PolicyMap()
-
-	policyCtx.PolicyTrace("resolving egress policy")
+	policyCtx.PolicyTrace(msg)
 
 	state := traceState{}
-
-	for i, r := range rules {
-		state.ruleID = i
-		err := r.resolveEgressPolicy(policyCtx, &state, result)
+	for _, r := range rules {
+		err := result.resolveL4Policy(policyCtx, &state, r)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -19,9 +19,9 @@ import (
 	"github.com/cilium/cilium/pkg/policy/types"
 )
 
-type CachedSelector types.CachedSelector
-type CachedSelectorSlice types.CachedSelectorSlice
-type CachedSelectionUser types.CachedSelectionUser
+type CachedSelector = types.CachedSelector
+type CachedSelectorSlice = types.CachedSelectorSlice
+type CachedSelectionUser = types.CachedSelectionUser
 
 // identitySelector is the internal type for all selectors in the
 // selector cache.
@@ -79,7 +79,7 @@ func (i *identitySelector) MaySelectPeers() bool {
 }
 
 // identitySelector implements CachedSelector
-var _ types.CachedSelector = (*identitySelector)(nil)
+var _ CachedSelector = (*identitySelector)(nil)
 
 type selectorSource interface {
 	matches(scIdentity) bool

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -109,7 +109,7 @@ func (f *fqdnSelector) matches(identity scIdentity) bool {
 }
 
 func (f *fqdnSelector) metricsClass() string {
-	return LabelValueSCFQDN
+	return types.LabelValueSCFQDN
 }
 
 type labelIdentitySelector struct {
@@ -146,16 +146,16 @@ func (l *labelIdentitySelector) remove(_ identityNotifier) {
 }
 
 func (l *labelIdentitySelector) metricsClass() string {
-	if l.selector.DeepEqual(&api.EntitySelectorMapping[api.EntityCluster][0]) {
-		return LabelValueSCCluster
+	if l.selector.CachedString() == api.EntitySelectorMapping[api.EntityCluster][0].CachedString() {
+		return types.LabelValueSCCluster
 	}
 	for _, entity := range api.EntitySelectorMapping[api.EntityWorld] {
-		if l.selector.DeepEqual(&entity) {
-			return LabelValueSCWorld
+		if l.selector.CachedString() == entity.CachedString() {
+			return types.LabelValueSCWorld
 		}
 	}
 
-	return LabelValueSCOther
+	return types.LabelValueSCOther
 }
 
 // lock must be held

--- a/pkg/policy/types/metrics.go
+++ b/pkg/policy/types/metrics.go
@@ -3,6 +3,25 @@
 
 package types
 
+const (
+	// LabelSelectorClass indicates the class of selector being measured
+	LabelSelectorClass = "class"
+
+	// LabelValueSCFQDN is used for regular security identities
+	// shared between all nodes in the cluster.
+	LabelValueSCFQDN = "fqdn"
+
+	// LabelValueSCCluster is used for the cluster entity.
+	LabelValueSCCluster = "cluster"
+
+	// LabelValueSCWorld is used for the world entity.
+	LabelValueSCWorld = "world"
+
+	// LabelValueSCOther is used for security identities allocated locally
+	// on the current node.
+	LabelValueSCOther = "other"
+)
+
 type PolicyMetrics interface {
 	AddRule(r PolicyEntry)
 	DelRule(r PolicyEntry)


### PR DESCRIPTION
This PR provides the following small fixes to the policy package (mainly):
- policy: Add policy resolve benchmarks
- policy: Add CIDR test coverage
- policy: Remove dead code (MatchesLabels)
- policy: fix comments
- labels: Fix error handling, skip futile test
- labels: Fix comment
- policy: Only test exported fields round 2
- policy: Move metrics constants to types, simplify comparison
- policy: Improve readability with type aliases
- policy: Move allow localhost handling to attach()
- policy: Merge ingress and egress policy resolution code