### PR TITLE
cilium-cli: add own type for root command parameters

### DIFF
--- a/cilium-cli/cli/bgp.go
+++ b/cilium-cli/cli/bgp.go
@@ -36,9 +36,9 @@ func newCmdBgpPeers() *cobra.Command {
 		Short:   "Lists BGP peering state",
 		Long:    "This command lists the BGP state from all nodes in the cluster",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
+			params.CiliumNamespace = RootParams.Namespace
 
-			s := bgp.NewStatus(k8sClient, params)
+			s := bgp.NewStatus(RootK8sClient, params)
 			err := s.GetPeeringState(context.Background())
 			if err != nil {
 				fatalf("Unable to get peering status: %s", err)
@@ -73,9 +73,9 @@ func newCmdBgpRoutes() *cobra.Command {
     cilium bgp routes advertised ipv4 unicast peer 10.0.0.1`,
 
 		RunE: func(_ *cobra.Command, args []string) error {
-			params.CiliumNamespace = namespace
+			params.CiliumNamespace = RootParams.Namespace
 
-			s := bgp.NewStatus(k8sClient, params)
+			s := bgp.NewStatus(RootK8sClient, params)
 			err := s.GetRoutes(context.Background(), args)
 			if err != nil {
 				fatalf("Unable to get BGP routes: %s", err)

--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -47,9 +47,9 @@ func newCmdClusterMeshStatus() *cobra.Command {
 		Short: "Show status of ClusterMesh",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.Namespace = namespace
-			params.ImpersonateAs = impersonateAs
-			params.ImpersonateGroups = impersonateGroups
+			params.Namespace = RootParams.Namespace
+			params.ImpersonateAs = RootParams.ImpersonateAs
+			params.ImpersonateGroups = RootParams.ImpersonateGroups
 
 			if params.Output == status.OutputJSON {
 				// Write status log messages to stderr to make sure they don't
@@ -57,7 +57,7 @@ func newCmdClusterMeshStatus() *cobra.Command {
 				params.Writer = os.Stderr
 			}
 
-			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
+			cm := clustermesh.NewK8sClusterMesh(RootK8sClient, params)
 			if _, err := cm.Status(context.Background()); err != nil {
 				fatalf("Unable to determine status:  %s", err)
 			}
@@ -82,13 +82,13 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 		Short: "Enable ClusterMesh ability in a cluster using Helm",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			params.Namespace = namespace
-			params.ImpersonateAs = impersonateAs
-			params.ImpersonateGroups = impersonateGroups
-			params.HelmReleaseName = helmReleaseName
+			params.Namespace = RootParams.Namespace
+			params.ImpersonateAs = RootParams.ImpersonateAs
+			params.ImpersonateGroups = RootParams.ImpersonateGroups
+			params.HelmReleaseName = RootParams.HelmReleaseName
 			ctx := context.Background()
 			params.EnableKVStoreMeshChanged = cmd.Flags().Changed("enable-kvstoremesh")
-			if err := clustermesh.EnableWithHelm(ctx, k8sClient, params); err != nil {
+			if err := clustermesh.EnableWithHelm(ctx, RootK8sClient, params); err != nil {
 				fatalf("Unable to enable ClusterMesh: %s", err)
 			}
 			return nil
@@ -111,12 +111,12 @@ func newCmdClusterMeshDisableWithHelm() *cobra.Command {
 		Short: "Disable ClusterMesh ability in a cluster using Helm",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.Namespace = namespace
-			params.ImpersonateAs = impersonateAs
-			params.ImpersonateGroups = impersonateGroups
-			params.HelmReleaseName = helmReleaseName
+			params.Namespace = RootParams.Namespace
+			params.ImpersonateAs = RootParams.ImpersonateAs
+			params.ImpersonateGroups = RootParams.ImpersonateGroups
+			params.HelmReleaseName = RootParams.HelmReleaseName
 			ctx := context.Background()
-			if err := clustermesh.DisableWithHelm(ctx, k8sClient, params); err != nil {
+			if err := clustermesh.DisableWithHelm(ctx, RootK8sClient, params); err != nil {
 				fatalf("Unable to disable ClusterMesh: %s", err)
 			}
 			return nil
@@ -136,11 +136,11 @@ func newCmdClusterMeshConnectWithHelm() *cobra.Command {
 		Short: "Connect to a remote cluster",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.Namespace = namespace
-			params.ImpersonateAs = impersonateAs
-			params.ImpersonateGroups = impersonateGroups
-			params.HelmReleaseName = helmReleaseName
-			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
+			params.Namespace = RootParams.Namespace
+			params.ImpersonateAs = RootParams.ImpersonateAs
+			params.ImpersonateGroups = RootParams.ImpersonateGroups
+			params.HelmReleaseName = RootParams.HelmReleaseName
+			cm := clustermesh.NewK8sClusterMesh(RootK8sClient, params)
 			if err := cm.ConnectWithHelm(context.Background()); err != nil {
 				fatalf("Unable to connect cluster: %s", err)
 			}
@@ -162,11 +162,11 @@ func newCmdClusterMeshDisconnectWithHelm() *cobra.Command {
 		Use:   "disconnect",
 		Short: "Disconnect from a remote cluster",
 		Run: func(_ *cobra.Command, _ []string) {
-			params.Namespace = namespace
-			params.ImpersonateAs = impersonateAs
-			params.ImpersonateGroups = impersonateGroups
-			params.HelmReleaseName = helmReleaseName
-			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
+			params.Namespace = RootParams.Namespace
+			params.ImpersonateAs = RootParams.ImpersonateAs
+			params.ImpersonateGroups = RootParams.ImpersonateGroups
+			params.HelmReleaseName = RootParams.HelmReleaseName
+			cm := clustermesh.NewK8sClusterMesh(RootK8sClient, params)
 			if err := cm.DisconnectWithHelm(context.Background()); err != nil {
 				fatalf("Unable to disconnect clusters: %s", err)
 			}
@@ -191,14 +191,14 @@ func newCmdClusterMeshPolicyDefaultClusterInspect() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			var err error
 			if namespace == "" {
-				if namespace, _, err = k8sClient.RESTClientGetter.ToRawKubeConfigLoader().Namespace(); err != nil {
+				if namespace, _, err = RootK8sClient.RESTClientGetter.ToRawKubeConfigLoader().Namespace(); err != nil {
 					namespace = metav1.NamespaceDefault
 				}
 			}
 			if allNamespaces {
 				namespace = corev1.NamespaceAll
 			}
-			res, err := clustermesh.PolicyDefaultLocalClusterInspect(cmd.Context(), k8sClient, namespace)
+			res, err := clustermesh.PolicyDefaultLocalClusterInspect(cmd.Context(), RootK8sClient, namespace)
 			if err != nil {
 				fatalf("Unable to inspect policy default local cluster: %s", err)
 			}

--- a/cilium-cli/cli/cmd.go
+++ b/cilium-cli/cli/cmd.go
@@ -17,15 +17,18 @@ import (
 
 const ciliumNamespaceEnvVar = "CILIUM_NAMESPACE"
 
-var (
-	contextName       string
-	namespace         string
-	impersonateAs     string
-	impersonateGroups []string
-	helmReleaseName   string
-	kubeConfig        string
+type RootParameters struct {
+	ContextName       string
+	Namespace         string
+	ImpersonateAs     string
+	ImpersonateGroups []string
+	HelmReleaseName   string
+	KubeConfig        string
+}
 
-	k8sClient *k8s.Client
+var (
+	RootParams    RootParameters
+	RootK8sClient *k8s.Client
 )
 
 // NewDefaultCiliumCommand returns a new "cilium" cli cobra command without any additional hooks.
@@ -50,14 +53,20 @@ func NewCiliumCommand(hooks api.Hooks) *cobra.Command {
 				}
 			}
 
-			c, err := k8s.NewClient(contextName, kubeConfig, namespace, impersonateAs, impersonateGroups)
+			var err error
+			RootK8sClient, err = k8s.NewClient(
+				RootParams.ContextName,
+				RootParams.KubeConfig,
+				RootParams.Namespace,
+				RootParams.ImpersonateAs,
+				RootParams.ImpersonateGroups,
+			)
 			if err != nil {
 				return fmt.Errorf("unable to create Kubernetes client: %w", err)
 			}
 
-			k8sClient = c
-			ctx := api.SetNamespaceContextValue(context.Background(), namespace)
-			ctx = api.SetK8sClientContextValue(ctx, k8sClient)
+			ctx := api.SetNamespaceContextValue(context.Background(), RootParams.Namespace)
+			ctx = api.SetK8sClientContextValue(ctx, RootK8sClient)
 			cmd.SetContext(ctx)
 			return nil
 		},
@@ -92,17 +101,17 @@ Perform a connectivity test
 		SilenceUsage:  true, // avoid showing help when usage is correct but an error occurred
 	}
 
-	cmd.PersistentFlags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
+	cmd.PersistentFlags().StringVar(&RootParams.ContextName, "context", "", "Kubernetes configuration context")
 
 	defaultNamespace := "kube-system"
 	if envNamespace := os.Getenv(ciliumNamespaceEnvVar); envNamespace != "" {
 		defaultNamespace = envNamespace
 	}
-	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", defaultNamespace, "Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var")
-	cmd.PersistentFlags().StringVar(&impersonateAs, "as", "", "Username to impersonate for the operation. User could be a regular user or a service account in a namespace.")
-	cmd.PersistentFlags().StringArrayVar(&impersonateGroups, "as-group", []string{}, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups.")
-	cmd.PersistentFlags().StringVar(&helmReleaseName, "helm-release-name", "cilium", "Helm release name")
-	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "Path to the kubeconfig file")
+	cmd.PersistentFlags().StringVarP(&RootParams.Namespace, "namespace", "n", defaultNamespace, "Namespace Cilium is running in. Can also be set via CILIUM_NAMESPACE env var")
+	cmd.PersistentFlags().StringVar(&RootParams.ImpersonateAs, "as", "", "Username to impersonate for the operation. User could be a regular user or a service account in a namespace.")
+	cmd.PersistentFlags().StringArrayVar(&RootParams.ImpersonateGroups, "as-group", []string{}, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups.")
+	cmd.PersistentFlags().StringVar(&RootParams.HelmReleaseName, "helm-release-name", "cilium", "Helm release name")
+	cmd.PersistentFlags().StringVar(&RootParams.KubeConfig, "kubeconfig", "", "Path to the kubeconfig file")
 
 	cmd.AddCommand(
 		newCmdBgp(),

--- a/cilium-cli/cli/config.go
+++ b/cilium-cli/cli/config.go
@@ -39,9 +39,9 @@ func newCmdConfigView() *cobra.Command {
 		Short: "View current configuration",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.Namespace = namespace
+			params.Namespace = RootParams.Namespace
 
-			check := config.NewK8sConfig(k8sClient, params)
+			check := config.NewK8sConfig(RootK8sClient, params)
 			out, err := check.View(context.Background())
 			if err != nil {
 				fatalf("Unable to view config:  %s", err)
@@ -65,9 +65,9 @@ func newCmdConfigSet() *cobra.Command {
 		Long:  ``,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			params.Namespace = namespace
+			params.Namespace = RootParams.Namespace
 
-			check := config.NewK8sConfig(k8sClient, params)
+			check := config.NewK8sConfig(RootK8sClient, params)
 			if err := check.Set(context.Background(), args[0], args[1], params); err != nil {
 				fatalf("Unable to set config:  %s", err)
 			}
@@ -90,9 +90,9 @@ func newCmdConfigDelete() *cobra.Command {
 		Long:  ``,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			params.Namespace = namespace
+			params.Namespace = RootParams.Namespace
 
-			check := config.NewK8sConfig(k8sClient, params)
+			check := config.NewK8sConfig(RootK8sClient, params)
 			if err := check.Delete(context.Background(), args[0], params); err != nil {
 				fatalf("Unable to delete config:  %s", err)
 			}

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -54,9 +54,9 @@ var tests []string
 
 func RunE(hooks api.Hooks) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, _ []string) error {
-		params.CiliumNamespace = namespace
-		params.ImpersonateAs = impersonateAs
-		params.ImpersonateGroups = impersonateGroups
+		params.CiliumNamespace = RootParams.Namespace
+		params.ImpersonateAs = RootParams.ImpersonateAs
+		params.ImpersonateGroups = RootParams.ImpersonateGroups
 
 		for _, test := range tests {
 			if strings.HasPrefix(test, "!") {
@@ -328,7 +328,7 @@ func newConnectivityTests(
 		}
 		params.ExternalDeploymentPort += i
 		params.EchoServerHostPort += i
-		cc, err := check.NewConnectivityTest(k8sClient, params, hooks, logger, owners)
+		cc, err := check.NewConnectivityTest(RootK8sClient, params, hooks, logger, owners)
 		if err != nil {
 			return nil, err
 		}

--- a/cilium-cli/cli/context.go
+++ b/cilium-cli/cli/context.go
@@ -12,17 +12,19 @@ import (
 func newCmdContext() *cobra.Command {
 	cmd := &cobra.Command{
 		Run: func(_ *cobra.Command, _ []string) {
+			contextName := RootParams.ContextName
+
 			if contextName == "" {
-				contextName = k8sClient.RawConfig.CurrentContext
+				contextName = RootK8sClient.RawConfig.CurrentContext
 			}
 
 			fmt.Printf("Context: %s\n", contextName)
 
-			if context, ok := k8sClient.RawConfig.Contexts[contextName]; ok {
+			if context, ok := RootK8sClient.RawConfig.Contexts[contextName]; ok {
 				fmt.Printf("Cluster: %s\n", context.Cluster)
 				fmt.Printf("Auth: %s\n", context.AuthInfo)
 
-				if cluster, ok := k8sClient.RawConfig.Clusters[context.Cluster]; ok {
+				if cluster, ok := RootK8sClient.RawConfig.Clusters[context.Cluster]; ok {
 					fmt.Printf("Host: %s\n", cluster.Server)
 					fmt.Printf("TLS server name: %s\n", cluster.TLSServerName)
 					fmt.Printf("CA path: %s\n", cluster.CertificateAuthority)

--- a/cilium-cli/cli/encrypt.go
+++ b/cilium-cli/cli/encrypt.go
@@ -36,8 +36,8 @@ func newCmdEncryptStatus() *cobra.Command {
 		Short: "Display encryption status",
 		Long:  "This command returns encryption status from all nodes in the cluster",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
-			s := encrypt.NewEncrypt(k8sClient, params)
+			params.CiliumNamespace = RootParams.Namespace
+			s := encrypt.NewEncrypt(RootK8sClient, params)
 			if err := s.PrintEncryptStatus(context.Background()); err != nil {
 				fatalf("Unable to print encryption status: %s", err)
 			}
@@ -59,11 +59,11 @@ func newCmdIPsecRotateKey() *cobra.Command {
 		Short: "Rotate IPsec key",
 		Long:  "This command rotates IPsec encryption key in the cluster",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
+			params.CiliumNamespace = RootParams.Namespace
 			if err := checkParams(params); err != nil {
 				fatalf("Input params are invalid: %s", err)
 			}
-			s := encrypt.NewEncrypt(k8sClient, params)
+			s := encrypt.NewEncrypt(RootK8sClient, params)
 			if err := s.IPsecRotateKey(context.Background()); err != nil {
 				fatalf("Unable to rotate IPsec key: %s", err)
 			}
@@ -83,8 +83,8 @@ func newCmdIPsecKeyStatus() *cobra.Command {
 		Short:   "Display IPsec key",
 		Long:    "This command displays IPsec encryption key",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
-			s := encrypt.NewEncrypt(k8sClient, params)
+			params.CiliumNamespace = RootParams.Namespace
+			s := encrypt.NewEncrypt(RootK8sClient, params)
 			if err := s.IPsecKeyStatus(context.Background()); err != nil {
 				fatalf("Unable to display IPsec key: %s", err)
 			}
@@ -103,11 +103,11 @@ func newCmdNewIPsecKey() *cobra.Command {
 		Short: "Create IPsec key",
 		Long:  "This command creates IPsec encryption key for the cluster",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
+			params.CiliumNamespace = RootParams.Namespace
 			if err := checkParams(params); err != nil {
 				fatalf("Input params are invalid: %s", err)
 			}
-			s := encrypt.NewEncrypt(k8sClient, params)
+			s := encrypt.NewEncrypt(RootK8sClient, params)
 			if err := s.IPsecNewKey(context.Background()); err != nil {
 				fatalf("Unable to create IPsec key: %s", err)
 			}

--- a/cilium-cli/cli/features.go
+++ b/cilium-cli/cli/features.go
@@ -62,9 +62,9 @@ func newCmdFeaturesStatus() *cobra.Command {
 		Short: "Display features status",
 		Long:  "This command returns features enabled from all nodes in the cluster",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
-			params.CiliumOperatorNamespace = namespace
-			s := features.NewFeatures(k8sClient, params)
+			params.CiliumNamespace = RootParams.Namespace
+			params.CiliumOperatorNamespace = RootParams.Namespace
+			s := features.NewFeatures(RootK8sClient, params)
 			if err := s.PrintFeatureStatus(context.Background()); err != nil {
 				fatalf("Unable to print features status: %s", err)
 			}

--- a/cilium-cli/cli/hubble.go
+++ b/cilium-cli/cli/hubble.go
@@ -42,8 +42,8 @@ func newCmdPortForwardCommand() *cobra.Command {
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, os.Kill)
 			defer cancel()
 
-			params.Namespace = namespace
-			if err := params.RelayPortForwardCommand(ctx, k8sClient); err != nil {
+			params.Namespace = RootParams.Namespace
+			if err := params.RelayPortForwardCommand(ctx, RootK8sClient); err != nil {
 				fatalf("Unable to port forward: %s", err)
 			}
 			return nil
@@ -67,8 +67,8 @@ func newCmdUI() *cobra.Command {
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, os.Kill)
 			defer cancel()
 
-			params.Namespace = namespace
-			if err := params.UIPortForwardCommand(ctx, k8sClient); err != nil {
+			params.Namespace = RootParams.Namespace
+			if err := params.UIPortForwardCommand(ctx, RootK8sClient); err != nil {
 				fatalf("Unable to port forward: %s", err)
 			}
 			return nil
@@ -97,10 +97,10 @@ func newCmdHubbleEnableWithHelm() *cobra.Command {
 		Short: "Enable Hubble observability using Helm",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.Namespace = namespace
-			params.HelmReleaseName = helmReleaseName
+			params.Namespace = RootParams.Namespace
+			params.HelmReleaseName = RootParams.HelmReleaseName
 			ctx := context.Background()
-			if err := hubble.EnableWithHelm(ctx, k8sClient, params); err != nil {
+			if err := hubble.EnableWithHelm(ctx, RootK8sClient, params); err != nil {
 				fatalf("Unable to enable Hubble: %s", err)
 			}
 			return nil
@@ -121,10 +121,10 @@ func newCmdHubbleDisableWithHelm() *cobra.Command {
 		Short: "Disable Hubble observability using Helm",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.Namespace = namespace
-			params.HelmReleaseName = helmReleaseName
+			params.Namespace = RootParams.Namespace
+			params.HelmReleaseName = RootParams.HelmReleaseName
 			ctx := context.Background()
-			if err := hubble.DisableWithHelm(ctx, k8sClient, params); err != nil {
+			if err := hubble.DisableWithHelm(ctx, RootK8sClient, params); err != nil {
 				fatalf("Unable to disable Hubble:  %s", err)
 			}
 			return nil

--- a/cilium-cli/cli/multicast.go
+++ b/cilium-cli/cli/multicast.go
@@ -50,8 +50,8 @@ func newCmdMulticastListGroup() *cobra.Command {
 		Use:   "group",
 		Short: "Show list of multicast groups in every node",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
-			mc := multicast.NewMulticast(k8sClient, params)
+			params.CiliumNamespace = RootParams.Namespace
+			mc := multicast.NewMulticast(RootK8sClient, params)
 			err := mc.ListGroups()
 			if err != nil {
 				fatalf("Unable to list multicast groups: %s", err)
@@ -73,8 +73,8 @@ func newCmdMulticastListSubscriber() *cobra.Command {
 		Use:   "subscriber",
 		Short: "Show list of subscribers belonging to the specified multicast group",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
-			mc := multicast.NewMulticast(k8sClient, params)
+			params.CiliumNamespace = RootParams.Namespace
+			mc := multicast.NewMulticast(RootK8sClient, params)
 			err := mc.ListSubscribers()
 			if err != nil {
 				fatalf("Unable to list subscribers of the multicast group: %s", err)
@@ -98,8 +98,8 @@ func newCmdMulticastAdd() *cobra.Command {
 		Use:   "add",
 		Short: "Add all nodes to the specified multicast group as subscribers in every cilium-agent",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
-			mc := multicast.NewMulticast(k8sClient, params)
+			params.CiliumNamespace = RootParams.Namespace
+			mc := multicast.NewMulticast(RootK8sClient, params)
 			err := mc.AddAllNodes()
 			if err != nil {
 				fatalf("Unable to add all nodes: %s", err)
@@ -120,8 +120,8 @@ func newCmdMulticastDel() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete the specified multicast group in every cilium-agent",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.CiliumNamespace = namespace
-			mc := multicast.NewMulticast(k8sClient, params)
+			params.CiliumNamespace = RootParams.Namespace
+			mc := multicast.NewMulticast(RootK8sClient, params)
 			err := mc.DelAllNodes()
 			if err != nil {
 				fatalf("Unable to delete all nodes: %s", err)

--- a/cilium-cli/cli/status.go
+++ b/cilium-cli/cli/status.go
@@ -24,10 +24,10 @@ func newCmdStatus() *cobra.Command {
 		Short: "Display status",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			params.Namespace = namespace
-			params.HelmReleaseName = helmReleaseName
+			params.Namespace = RootParams.Namespace
+			params.HelmReleaseName = RootParams.HelmReleaseName
 
-			collector, err := status.NewK8sStatusCollector(k8sClient, params)
+			collector, err := status.NewK8sStatusCollector(RootK8sClient, params)
 			if err != nil {
 				return err
 			}

--- a/cilium-cli/cli/sysdump.go
+++ b/cilium-cli/cli/sysdump.go
@@ -31,11 +31,11 @@ func newCmdSysdump(hooks sysdump.Hooks) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Honor --namespace global flag in case it is set and --cilium-namespace is not set
 			if sysdumpOptions.CiliumNamespace == "" && cmd.Flags().Changed("namespace") {
-				sysdumpOptions.CiliumNamespace = namespace
+				sysdumpOptions.CiliumNamespace = RootParams.Namespace
 			}
 			if sysdumpOptions.CiliumOperatorNamespace == "" {
 				if cmd.Flags().Changed("namespace") {
-					sysdumpOptions.CiliumOperatorNamespace = namespace
+					sysdumpOptions.CiliumOperatorNamespace = RootParams.Namespace
 				} else {
 					// Assume the same namespace for operator as for agent if not specified
 					sysdumpOptions.CiliumOperatorNamespace = sysdumpOptions.CiliumNamespace
@@ -43,12 +43,12 @@ func newCmdSysdump(hooks sysdump.Hooks) *cobra.Command {
 			}
 			// Honor --helm-release-name global flag in case it is set and --cilium-helm-release-name is not set
 			if sysdumpOptions.CiliumHelmReleaseName == "" && cmd.Flags().Changed("helm-release-name") {
-				sysdumpOptions.CiliumHelmReleaseName = helmReleaseName
+				sysdumpOptions.CiliumHelmReleaseName = RootParams.HelmReleaseName
 			}
 			// Silence klog to avoid displaying "throttling" messages - those are expected.
 			klog.SetOutput(io.Discard)
 			// Collect the sysdump.
-			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, hooks, time.Now())
+			collector, err := sysdump.NewCollector(RootK8sClient, sysdumpOptions, hooks, time.Now())
 			if err != nil {
 				return fmt.Errorf("failed to create sysdump collector: %w", err)
 			}

--- a/cilium-cli/cli/version.go
+++ b/cilium-cli/cli/version.go
@@ -44,7 +44,7 @@ func newCmdVersion() *cobra.Command {
 			if clientOnly {
 				return nil
 			}
-			version, err := k8sClient.GetRunningCiliumVersion(helmReleaseName)
+			version, err := RootK8sClient.GetRunningCiliumVersion(RootParams.HelmReleaseName)
 			if err != nil {
 				fmt.Printf("cilium image (running): unknown. Unable to obtain cilium version. Reason: %s\n", err.Error())
 			} else {


### PR DESCRIPTION
Add the `RootParameters` type to hold the CLI parameters of the root command. This makes it a bit more obvious that these are values inherited from the root command when accessing them. Also export the global parameters and the k8s client so it can be accessed by sub-commands outside the `cilium-cli/cli` package in the future.
