### PR TITLE
pkg/bpf: re-enable errors for unused maps unless `ErrRestrictedKernel`

### DIFF
--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -253,7 +253,9 @@ func LoadCollection(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *Collec
 
 	if logger.Enabled(context.Background(), slog.LevelDebug) {
 		if err := verifyUnusedMaps(coll, keep); err != nil {
-			logger.Debug(fmt.Sprintf("verifying unused maps: %v", err))
+			if !errors.Is(err, ebpf.ErrRestrictedKernel) {
+				return nil, nil, fmt.Errorf("verifying unused maps: %w", err)
+			}
 		} else {
 			logger.Debug("Verified no unused maps after loading Collection")
 		}


### PR DESCRIPTION
In #41379 we stopped returning errors from unused map verification because on systems with sysctls set to restrict instruction readback the verification would always fail and block CI.

In cilium/ebpf#1858 an `ErrRestrictedKernel` error was added to indicate this specific case.

This allows us to now differentiate between genuine unused map errors and the restricted kernel case, and only ignore the latter. Thus we can re-enable unused map verification errors on systems that support it.

Fixes: #41245