### PR TITLE
bpf: use explicit __be32 type for egress gateway policy IP fields

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -404,13 +404,13 @@ struct metrics_value {
 
 struct egress_gw_policy_key {
 	struct bpf_lpm_trie_key lpm_key;
-	__u32 saddr;
-	__u32 daddr;
+	__be32 saddr;
+	__be32 daddr;
 };
 
 struct egress_gw_policy_entry {
-	__u32 egress_ip;
-	__u32 gateway_ip;
+	__be32 egress_ip;
+	__be32 gateway_ip;
 };
 
 struct egress_gw_policy_key6 {
@@ -421,7 +421,7 @@ struct egress_gw_policy_key6 {
 
 struct egress_gw_policy_entry6 {
 	union v6addr egress_ip;
-	__u32 gateway_ip;
+	__be32 gateway_ip;
 	__u32 reserved[3]; /* reserved for future extension, e.g. v6 gateway_ip */
 	__u32 egress_ifindex;
 	__u32 reserved2; /* for even more future extension */


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

---

<!-- Description of change -->

The egress gateway policy structures store IPv4 addresses that are used in big-endian byte order throughout the BPF code. This change makes the byte order explicit by using __be32 instead of __u32 for these fields.
