### PR TITLE
contrib: update suggested command to fix testdata divergences

### DIFF
--- a/contrib/scripts/check-go-testdata.sh
+++ b/contrib/scripts/check-go-testdata.sh
@@ -5,4 +5,4 @@
 set -e
 
 make -C pkg/bpf/testdata docker
-test -z "$(git status pkg/bpf/testdata --porcelain)" || (echo "please run 'make -C pkg/bpf/testdata build' and submit your changes"; exit 1)
+test -z "$(git status pkg/bpf/testdata --porcelain)" || (echo "please run 'make -C pkg/bpf/testdata docker' and submit your changes"; exit 1)


### PR DESCRIPTION
Update the message printed in case of testdata divergences to make use of the `docker` Makefile target, instead of `build` one. Indeed, the latter makes use of the host's toolchain, and may unexpectedly fail due to incompatibilities. This also aligns the command with the one actually used for the checks themselves.